### PR TITLE
fix(tasks): reclaim ACP zombie runs blocking gateway restart

### DIFF
--- a/src/acp/control-plane/active-turns.ts
+++ b/src/acp/control-plane/active-turns.ts
@@ -1,0 +1,46 @@
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import { normalizeActorKey } from "./manager.utils.js";
+
+// Process-local liveness signal for in-flight ACP prompt turns, kept off the
+// SDK-exported AcpSessionManager so plugins cannot read this maintenance-only
+// state. Mirrors cron's active-jobs registry: task maintenance asks "is a turn
+// still running for this session?" to avoid reclaiming a live run whose persisted
+// session entry survived a crash. The AcpSessionManager marks/clears it in lockstep
+// with its in-memory turn map.
+
+type AcpActiveTurnState = {
+  activeTurnKeys: Set<string>;
+};
+
+const ACP_ACTIVE_TURN_STATE_KEY = Symbol.for("openclaw.acp.activeTurns");
+
+function getAcpActiveTurnState(): AcpActiveTurnState {
+  return resolveGlobalSingleton<AcpActiveTurnState>(ACP_ACTIVE_TURN_STATE_KEY, () => ({
+    activeTurnKeys: new Set<string>(),
+  }));
+}
+
+export function markAcpTurnActive(sessionKey: string) {
+  if (!sessionKey) {
+    return;
+  }
+  getAcpActiveTurnState().activeTurnKeys.add(normalizeActorKey(sessionKey));
+}
+
+export function clearAcpTurnActive(sessionKey: string) {
+  if (!sessionKey) {
+    return;
+  }
+  getAcpActiveTurnState().activeTurnKeys.delete(normalizeActorKey(sessionKey));
+}
+
+export function isAcpTurnActive(sessionKey: string): boolean {
+  if (!sessionKey) {
+    return false;
+  }
+  return getAcpActiveTurnState().activeTurnKeys.has(normalizeActorKey(sessionKey));
+}
+
+export function resetAcpActiveTurnsForTests() {
+  getAcpActiveTurnState().activeTurnKeys.clear();
+}

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -39,6 +39,7 @@ import {
   resolveRuntimeHandleIdentifiersFromIdentity,
   resolveSessionIdentityFromMeta,
 } from "../runtime/session-identity.js";
+import { clearAcpTurnActive, markAcpTurnActive } from "./active-turns.js";
 import { reconcileManagerRuntimeSessionIdentifiers } from "./manager.identity-reconcile.js";
 import {
   applyManagerRuntimeControls,
@@ -824,6 +825,13 @@ export class AcpSessionManager {
         };
         const shouldAttemptFailover = (backendIdx: number) =>
           backendIdx < candidateBackends.length - 1;
+
+        // Liveness spans the whole task, not one attempt: mark once before the backend loop
+        // (after the ready-meta check, so a pre-loop throw cannot leak it) and clear it at the
+        // terminal mark, so a slow init or failover cleanup never leaves the task look reclaimable.
+        if (taskContext) {
+          markAcpTurnActive(sessionKey);
+        }
 
         for (let backendIdx = 0; backendIdx < candidateBackends.length; backendIdx += 1) {
           const currentBackend = candidateBackends[backendIdx];
@@ -2346,6 +2354,11 @@ export class AcpSessionManager {
       terminalOutcome?: "succeeded" | "blocked" | null;
     },
   ): void {
+    // Terminal means the turn is no longer live: release the liveness marker set before the
+    // backend loop so maintenance can reclaim the record once it is durably terminal.
+    if (params.sessionKey) {
+      clearAcpTurnActive(params.sessionKey);
+    }
     try {
       if (params.status === "succeeded") {
         completeTaskRunByRunId({

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -826,257 +826,265 @@ export class AcpSessionManager {
         const shouldAttemptFailover = (backendIdx: number) =>
           backendIdx < candidateBackends.length - 1;
 
+        let acpTurnMarkedActive = false;
         // Liveness spans the whole task, not one attempt: mark once before the backend loop
-        // (after the ready-meta check, so a pre-loop throw cannot leak it) and clear it at the
-        // terminal mark, so a slow init or failover cleanup never leaves the task look reclaimable.
+        // (after the ready-meta check, so a pre-loop throw cannot leak it) and clear on every
+        // runTurn exit, including unexpected retry/cleanup failures before terminal task writes.
         if (taskContext) {
           markAcpTurnActive(sessionKey);
+          acpTurnMarkedActive = true;
         }
 
-        for (let backendIdx = 0; backendIdx < candidateBackends.length; backendIdx += 1) {
-          const currentBackend = candidateBackends[backendIdx];
-          if (backendIdx > 0) {
-            await this.closeCachedRuntimeState({
-              sessionKey,
-              reason: "backend-failover",
-            });
-            logVerbose(
-              `acp-manager: switching backend for ${sessionKey} from ${describeBackendCandidate(
-                candidateBackends[backendIdx - 1],
-              )} to ${describeBackendCandidate(currentBackend)}`,
-            );
-          }
-
-          for (let attempt = 0; attempt < 2; attempt += 1) {
-            const resolution =
-              backendIdx === 0 && attempt === 0
-                ? initialResolution
-                : this.resolveSession({
-                    cfg: input.cfg,
-                    sessionKey,
-                  });
-            const resolvedMeta = requireReadySessionMeta(resolution);
-            const metaWithBackend: SessionAcpMeta = currentBackend
-              ? { ...resolvedMeta, backend: currentBackend }
-              : resolvedMeta;
-            let runtime: AcpRuntime | undefined;
-            let handle: AcpRuntimeHandle | undefined;
-            let meta: SessionAcpMeta | undefined;
-            let activeTurn: ActiveTurnState | undefined;
-            let internalAbortController: AbortController | undefined;
-            let onCallerAbort: (() => void) | undefined;
-            let activeTurnStarted = false;
-            let sawTurnOutput = false;
-            let retryFreshHandle = false;
-            let skipPostTurnCleanup = false;
-            try {
-              const ensured = await this.ensureRuntimeHandle({
-                cfg: input.cfg,
+        try {
+          for (let backendIdx = 0; backendIdx < candidateBackends.length; backendIdx += 1) {
+            const currentBackend = candidateBackends[backendIdx];
+            if (backendIdx > 0) {
+              await this.closeCachedRuntimeState({
                 sessionKey,
-                meta: metaWithBackend,
+                reason: "backend-failover",
               });
-              runtime = ensured.runtime;
-              handle = ensured.handle;
-              meta = ensured.meta;
-              await this.applyRuntimeControls({
-                sessionKey,
-                runtime,
-                handle,
-                meta,
-              });
+              logVerbose(
+                `acp-manager: switching backend for ${sessionKey} from ${describeBackendCandidate(
+                  candidateBackends[backendIdx - 1],
+                )} to ${describeBackendCandidate(currentBackend)}`,
+              );
+            }
 
-              await this.setSessionState({
-                cfg: input.cfg,
-                sessionKey,
-                state: "running",
-                clearLastError: true,
-              });
-
-              internalAbortController = new AbortController();
-              onCallerAbort = () => {
-                internalAbortController?.abort();
-              };
-              if (input.signal?.aborted) {
-                internalAbortController.abort();
-              } else if (input.signal) {
-                input.signal.addEventListener("abort", onCallerAbort, { once: true });
-              }
-
-              activeTurn = {
-                runtime,
-                handle,
-                abortController: internalAbortController,
-              };
-              this.activeTurnBySession.set(actorKey, activeTurn);
-              activeTurnStarted = true;
-
-              const combinedSignal =
-                input.signal && typeof AbortSignal.any === "function"
-                  ? AbortSignal.any([input.signal, internalAbortController.signal])
-                  : internalAbortController.signal;
-              const eventGate = { open: true };
-              await input.onLifecycle?.({
-                type: "prompt_submitted",
-                at: Date.now(),
-              });
-              const turnPromise = consumeAcpTurnStream({
-                runtime,
-                turn: {
-                  handle,
-                  text: input.text,
-                  attachments: input.attachments,
-                  mode: input.mode,
-                  requestId: input.requestId,
-                  signal: combinedSignal,
-                },
-                eventGate,
-                onOutputEvent: (event) => {
-                  sawTurnOutput = true;
-                  if (event.type === "text_delta" && event.stream !== "thought" && event.text) {
-                    taskProgressSummary = appendBackgroundTaskProgressSummary(
-                      taskProgressSummary,
-                      event.text,
-                    );
-                  }
-                  if (taskContext) {
-                    this.markBackgroundTaskRunning(taskContext.runId, {
+            for (let attempt = 0; attempt < 2; attempt += 1) {
+              const resolution =
+                backendIdx === 0 && attempt === 0
+                  ? initialResolution
+                  : this.resolveSession({
+                      cfg: input.cfg,
                       sessionKey,
-                      lastEventAt: Date.now(),
-                      progressSummary: taskProgressSummary || null,
                     });
-                  }
-                },
-                onEvent: input.onEvent,
-              });
-              const turnTimeoutMs = this.resolveTurnTimeoutMs({
-                cfg: input.cfg,
-                meta,
-              });
-              const sessionMode = meta.mode;
-              const turnOutcome = await this.awaitTurnWithTimeout({
-                sessionKey,
-                turnPromise,
-                timeoutMs: turnTimeoutMs + ACP_TURN_TIMEOUT_GRACE_MS,
-                timeoutLabelMs: turnTimeoutMs,
-                onTimeout: async () => {
-                  eventGate.open = false;
-                  skipPostTurnCleanup = true;
-                  if (!activeTurn) {
-                    return;
-                  }
-                  await this.cleanupTimedOutTurn({
-                    sessionKey,
-                    activeTurn,
-                    mode: sessionMode,
-                  });
-                },
-              });
-              if (!turnOutcome.sawTerminalEvent) {
-                throw new AcpRuntimeError(
-                  "ACP_TURN_FAILED",
-                  "ACP turn ended without a terminal done event.",
-                );
-              }
-              this.recordTurnCompletion({
-                startedAt: turnStartedAt,
-              });
-              if (taskContext) {
-                const terminalResult = resolveBackgroundTaskTerminalResult(taskProgressSummary);
-                this.markBackgroundTaskTerminal(taskContext.runId, {
-                  sessionKey,
-                  status: "succeeded",
-                  endedAt: Date.now(),
-                  lastEventAt: Date.now(),
-                  error: undefined,
-                  progressSummary: taskProgressSummary || null,
-                  terminalSummary: terminalResult.terminalSummary ?? null,
-                  terminalOutcome: terminalResult.terminalOutcome,
-                });
-              }
-              await this.setSessionState({
-                cfg: input.cfg,
-                sessionKey,
-                state: "idle",
-                clearLastError: true,
-              });
-              return;
-            } catch (error) {
-              const acpError = toAcpRuntimeError({
-                error,
-                fallbackCode: activeTurnStarted ? "ACP_TURN_FAILED" : "ACP_SESSION_INIT_FAILED",
-                fallbackMessage: activeTurnStarted
-                  ? "ACP turn failed before completion."
-                  : "Could not initialize ACP session runtime.",
-              });
-              retryFreshHandle = await this.prepareFreshHandleRetry({
-                attempt,
-                cfg: input.cfg,
-                sessionKey,
-                error: acpError,
-                sawTurnOutput,
-                runtime,
-                meta,
-              });
-              if (retryFreshHandle) {
-                continue;
-              }
-
-              const backendAttempt = {
-                backend: describeBackendCandidate(currentBackend),
-                error: acpError.message,
-                code: acpError.code,
-                sawOutput: sawTurnOutput,
-              };
-              backendAttempts.push(backendAttempt);
-              if (
-                !isFailoverWorthyBackendError(backendAttempt) ||
-                !shouldAttemptFailover(backendIdx)
-              ) {
-                await recordBackendFailure(acpError);
-              }
-              break;
-            } finally {
-              if (input.signal && onCallerAbort) {
-                input.signal.removeEventListener("abort", onCallerAbort);
-              }
-              if (activeTurn && this.activeTurnBySession.get(actorKey) === activeTurn) {
-                this.activeTurnBySession.delete(actorKey);
-              }
-              if (!retryFreshHandle && !skipPostTurnCleanup && runtime && handle && meta) {
-                ({ handle, meta } = await this.reconcileRuntimeSessionIdentifiers({
+              const resolvedMeta = requireReadySessionMeta(resolution);
+              const metaWithBackend: SessionAcpMeta = currentBackend
+                ? { ...resolvedMeta, backend: currentBackend }
+                : resolvedMeta;
+              let runtime: AcpRuntime | undefined;
+              let handle: AcpRuntimeHandle | undefined;
+              let meta: SessionAcpMeta | undefined;
+              let activeTurn: ActiveTurnState | undefined;
+              let internalAbortController: AbortController | undefined;
+              let onCallerAbort: (() => void) | undefined;
+              let activeTurnStarted = false;
+              let sawTurnOutput = false;
+              let retryFreshHandle = false;
+              let skipPostTurnCleanup = false;
+              try {
+                const ensured = await this.ensureRuntimeHandle({
                   cfg: input.cfg,
+                  sessionKey,
+                  meta: metaWithBackend,
+                });
+                runtime = ensured.runtime;
+                handle = ensured.handle;
+                meta = ensured.meta;
+                await this.applyRuntimeControls({
                   sessionKey,
                   runtime,
                   handle,
                   meta,
-                  failOnStatusError: false,
-                }));
-              }
-              if (
-                !retryFreshHandle &&
-                !skipPostTurnCleanup &&
-                runtime &&
-                handle &&
-                meta &&
-                meta.mode === "oneshot"
-              ) {
-                try {
-                  await runtime.close({
+                });
+
+                await this.setSessionState({
+                  cfg: input.cfg,
+                  sessionKey,
+                  state: "running",
+                  clearLastError: true,
+                });
+
+                internalAbortController = new AbortController();
+                onCallerAbort = () => {
+                  internalAbortController?.abort();
+                };
+                if (input.signal?.aborted) {
+                  internalAbortController.abort();
+                } else if (input.signal) {
+                  input.signal.addEventListener("abort", onCallerAbort, { once: true });
+                }
+
+                activeTurn = {
+                  runtime,
+                  handle,
+                  abortController: internalAbortController,
+                };
+                this.activeTurnBySession.set(actorKey, activeTurn);
+                activeTurnStarted = true;
+
+                const combinedSignal =
+                  input.signal && typeof AbortSignal.any === "function"
+                    ? AbortSignal.any([input.signal, internalAbortController.signal])
+                    : internalAbortController.signal;
+                const eventGate = { open: true };
+                await input.onLifecycle?.({
+                  type: "prompt_submitted",
+                  at: Date.now(),
+                });
+                const turnPromise = consumeAcpTurnStream({
+                  runtime,
+                  turn: {
                     handle,
-                    reason: "oneshot-complete",
-                  });
-                } catch (error) {
-                  logVerbose(
-                    `acp-manager: ACP oneshot close failed for ${sessionKey}: ${String(error)}`,
+                    text: input.text,
+                    attachments: input.attachments,
+                    mode: input.mode,
+                    requestId: input.requestId,
+                    signal: combinedSignal,
+                  },
+                  eventGate,
+                  onOutputEvent: (event) => {
+                    sawTurnOutput = true;
+                    if (event.type === "text_delta" && event.stream !== "thought" && event.text) {
+                      taskProgressSummary = appendBackgroundTaskProgressSummary(
+                        taskProgressSummary,
+                        event.text,
+                      );
+                    }
+                    if (taskContext) {
+                      this.markBackgroundTaskRunning(taskContext.runId, {
+                        sessionKey,
+                        lastEventAt: Date.now(),
+                        progressSummary: taskProgressSummary || null,
+                      });
+                    }
+                  },
+                  onEvent: input.onEvent,
+                });
+                const turnTimeoutMs = this.resolveTurnTimeoutMs({
+                  cfg: input.cfg,
+                  meta,
+                });
+                const sessionMode = meta.mode;
+                const turnOutcome = await this.awaitTurnWithTimeout({
+                  sessionKey,
+                  turnPromise,
+                  timeoutMs: turnTimeoutMs + ACP_TURN_TIMEOUT_GRACE_MS,
+                  timeoutLabelMs: turnTimeoutMs,
+                  onTimeout: async () => {
+                    eventGate.open = false;
+                    skipPostTurnCleanup = true;
+                    if (!activeTurn) {
+                      return;
+                    }
+                    await this.cleanupTimedOutTurn({
+                      sessionKey,
+                      activeTurn,
+                      mode: sessionMode,
+                    });
+                  },
+                });
+                if (!turnOutcome.sawTerminalEvent) {
+                  throw new AcpRuntimeError(
+                    "ACP_TURN_FAILED",
+                    "ACP turn ended without a terminal done event.",
                   );
-                } finally {
-                  this.clearCachedRuntimeState(sessionKey);
+                }
+                this.recordTurnCompletion({
+                  startedAt: turnStartedAt,
+                });
+                if (taskContext) {
+                  const terminalResult = resolveBackgroundTaskTerminalResult(taskProgressSummary);
+                  this.markBackgroundTaskTerminal(taskContext.runId, {
+                    sessionKey,
+                    status: "succeeded",
+                    endedAt: Date.now(),
+                    lastEventAt: Date.now(),
+                    error: undefined,
+                    progressSummary: taskProgressSummary || null,
+                    terminalSummary: terminalResult.terminalSummary ?? null,
+                    terminalOutcome: terminalResult.terminalOutcome,
+                  });
+                }
+                await this.setSessionState({
+                  cfg: input.cfg,
+                  sessionKey,
+                  state: "idle",
+                  clearLastError: true,
+                });
+                return;
+              } catch (error) {
+                const acpError = toAcpRuntimeError({
+                  error,
+                  fallbackCode: activeTurnStarted ? "ACP_TURN_FAILED" : "ACP_SESSION_INIT_FAILED",
+                  fallbackMessage: activeTurnStarted
+                    ? "ACP turn failed before completion."
+                    : "Could not initialize ACP session runtime.",
+                });
+                retryFreshHandle = await this.prepareFreshHandleRetry({
+                  attempt,
+                  cfg: input.cfg,
+                  sessionKey,
+                  error: acpError,
+                  sawTurnOutput,
+                  runtime,
+                  meta,
+                });
+                if (retryFreshHandle) {
+                  continue;
+                }
+
+                const backendAttempt = {
+                  backend: describeBackendCandidate(currentBackend),
+                  error: acpError.message,
+                  code: acpError.code,
+                  sawOutput: sawTurnOutput,
+                };
+                backendAttempts.push(backendAttempt);
+                if (
+                  !isFailoverWorthyBackendError(backendAttempt) ||
+                  !shouldAttemptFailover(backendIdx)
+                ) {
+                  await recordBackendFailure(acpError);
+                }
+                break;
+              } finally {
+                if (input.signal && onCallerAbort) {
+                  input.signal.removeEventListener("abort", onCallerAbort);
+                }
+                if (activeTurn && this.activeTurnBySession.get(actorKey) === activeTurn) {
+                  this.activeTurnBySession.delete(actorKey);
+                }
+                if (!retryFreshHandle && !skipPostTurnCleanup && runtime && handle && meta) {
+                  ({ handle, meta } = await this.reconcileRuntimeSessionIdentifiers({
+                    cfg: input.cfg,
+                    sessionKey,
+                    runtime,
+                    handle,
+                    meta,
+                    failOnStatusError: false,
+                  }));
+                }
+                if (
+                  !retryFreshHandle &&
+                  !skipPostTurnCleanup &&
+                  runtime &&
+                  handle &&
+                  meta &&
+                  meta.mode === "oneshot"
+                ) {
+                  try {
+                    await runtime.close({
+                      handle,
+                      reason: "oneshot-complete",
+                    });
+                  } catch (error) {
+                    logVerbose(
+                      `acp-manager: ACP oneshot close failed for ${sessionKey}: ${String(error)}`,
+                    );
+                  } finally {
+                    this.clearCachedRuntimeState(sessionKey);
+                  }
                 }
               }
+              if (retryFreshHandle) {
+                continue;
+              }
             }
-            if (retryFreshHandle) {
-              continue;
-            }
+          }
+        } finally {
+          if (acpTurnMarkedActive) {
+            clearAcpTurnActive(sessionKey);
           }
         }
       },
@@ -2354,11 +2362,6 @@ export class AcpSessionManager {
       terminalOutcome?: "succeeded" | "blocked" | null;
     },
   ): void {
-    // Terminal means the turn is no longer live: release the liveness marker set before the
-    // backend loop so maintenance can reclaim the record once it is durably terminal.
-    if (params.sessionKey) {
-      clearAcpTurnActive(params.sessionKey);
-    }
     try {
       if (params.status === "succeeded") {
         completeTaskRunByRunId({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { AcpSessionRuntimeOptions, SessionAcpMeta } from "../../config/sessions/types.js";
 import { resetHeartbeatWakeStateForTests } from "../../infra/heartbeat-wake.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
+import { isAcpTurnActive, resetAcpActiveTurnsForTests } from "./active-turns.js";
 
 const hoisted = vi.hoisted(() => {
   const listAcpSessionEntriesMock = vi.fn();
@@ -307,6 +308,7 @@ function extractRuntimeOptionsFromUpserts(): Array<AcpSessionRuntimeOptions | un
 describe("AcpSessionManager", () => {
   beforeEach(() => {
     resetAcpSessionManagerForTests();
+    resetAcpActiveTurnsForTests();
     vi.useRealTimers();
     hoisted.listAcpSessionEntriesMock.mockReset().mockResolvedValue([]);
     hoisted.readAcpSessionEntryMock.mockReset();
@@ -638,6 +640,152 @@ describe("AcpSessionManager", () => {
     expect(maxInFlight).toBe(1);
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
   });
+
+  it("reports a live turn under the task record's childSessionKey while it is in flight (#88205)", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      const releaseTurn = createDeferred();
+      runtimeState.runTurn.mockImplementation(async function* () {
+        await releaseTurn.promise;
+        yield { type: "done" as const };
+      });
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Live turn",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: { sessionId: "parent-1", updatedAt: Date.now() },
+          };
+        }
+        return null;
+      });
+
+      const manager = new AcpSessionManager();
+      const turn = manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "long running",
+        mode: "prompt",
+        requestId: "live-acp-turn",
+      });
+      await vi.waitFor(
+        () => {
+          expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+        },
+        { interval: 1 },
+      );
+
+      // The maintenance sweep probes liveness with exactly this key; prove it resolves to the
+      // turn the manager actually registered, so the reclaim gate cannot over-reclaim a live run.
+      const childSessionKey = requireTaskByRunId("live-acp-turn").childSessionKey;
+      if (!childSessionKey) {
+        throw new Error("Expected the ACP task record to carry a childSessionKey");
+      }
+      expect(childSessionKey).toBe("agent:codex:acp:child-1");
+      expect(isAcpTurnActive(childSessionKey)).toBe(true);
+
+      releaseTurn.resolve();
+      await turn;
+      await flushMicrotasks();
+
+      expect(isAcpTurnActive(childSessionKey)).toBe(false);
+    });
+  }, 300_000);
+
+  it("marks liveness during runtime initialization, before the turn streams (#88205)", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      const releaseInit = createDeferred();
+      // Hold runtime init (ensureSession) so the turn is stuck initializing: the task record
+      // already exists but the turn stream has not started. This is the window that previously
+      // let the authoritative sweep mark a live, slow-to-initialize ACP task as lost.
+      runtimeState.ensureSession.mockImplementation(
+        async (input: { sessionKey: string; mode: "persistent" | "oneshot" }) => {
+          await releaseInit.promise;
+          return {
+            sessionKey: input.sessionKey,
+            backend: "acpx",
+            runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime`,
+          };
+        },
+      );
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Init window",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: { sessionId: "parent-1", updatedAt: Date.now() },
+          };
+        }
+        return null;
+      });
+
+      const manager = new AcpSessionManager();
+      const turn = manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "slow init",
+        mode: "prompt",
+        requestId: "init-window-acp-turn",
+      });
+      await vi.waitFor(
+        () => {
+          expect(runtimeState.ensureSession).toHaveBeenCalled();
+        },
+        { interval: 1 },
+      );
+
+      const childSessionKey = requireTaskByRunId("init-window-acp-turn").childSessionKey;
+      if (!childSessionKey) {
+        throw new Error("Expected the ACP task record to carry a childSessionKey");
+      }
+      // Liveness must already cover initialization, while the turn stream has not started.
+      expect(runtimeState.runTurn).not.toHaveBeenCalled();
+      expect(isAcpTurnActive(childSessionKey)).toBe(true);
+
+      releaseInit.resolve();
+      await turn;
+      await flushMicrotasks();
+
+      expect(isAcpTurnActive(childSessionKey)).toBe(false);
+    });
+  }, 300_000);
 
   it("rejects a queued turn promptly when its caller aborts before the actor is free", async () => {
     const runtimeState = createRuntime();

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -787,6 +787,65 @@ describe("AcpSessionManager", () => {
     });
   }, 300_000);
 
+  it("clears liveness when retry setup throws before task terminal update (#88205)", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runTurn.mockImplementationOnce(async function* () {
+        yield { type: "error" as const, message: "acpx exited with code 1" };
+      });
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      let childReads = 0;
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          childReads += 1;
+          if (childReads > 2) {
+            throw new Error("session store unavailable");
+          }
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Retry cleanup",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: { sessionId: "parent-1", updatedAt: Date.now() },
+          };
+        }
+        return null;
+      });
+
+      const manager = new AcpSessionManager();
+      await expect(
+        manager.runTurn({
+          cfg: baseCfg,
+          sessionKey: "agent:codex:acp:child-1",
+          text: "stale resume",
+          mode: "prompt",
+          requestId: "retry-cleanup-failure-acp-turn",
+        }),
+      ).rejects.toThrow("session store unavailable");
+
+      const childSessionKey = requireTaskByRunId("retry-cleanup-failure-acp-turn").childSessionKey;
+      if (!childSessionKey) {
+        throw new Error("Expected the ACP task record to carry a childSessionKey");
+      }
+      expect(isAcpTurnActive(childSessionKey)).toBe(false);
+    });
+  }, 300_000);
+
   it("rejects a queued turn promptly when its caller aborts before the actor is free", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/cron/active-jobs-manual-run.test.ts
+++ b/src/cron/active-jobs-manual-run.test.ts
@@ -3,7 +3,7 @@
 // into runDueJob and executeJob. The manual-run path (cron.run() →
 // prepareManualRun + finishPreparedManualRun in src/cron/service/ops.ts) was
 // left without the mark/clear pair, so task-registry.maintenance.ts
-// hasBackingSession (cron branch under isCronRuntimeAuthoritative()=true)
+// hasBackingSession (cron branch under isRuntimeAuthoritative()=true)
 // returns false during manual-run executions and reconciles them as `lost`
 // after TASK_RECONCILE_GRACE_MS (5 min).
 //
@@ -60,7 +60,10 @@ function createManualIsolatedJob(id: string): CronJob {
 
 async function createManualRunHarness(jobId: string) {
   const store = await makeStorePath();
-  await writeCronStoreSnapshot({ storePath: store.storePath, jobs: [createManualIsolatedJob(jobId)] });
+  await writeCronStoreSnapshot({
+    storePath: store.storePath,
+    jobs: [createManualIsolatedJob(jobId)],
+  });
 
   const entered = createDeferred<void>();
   const release = createDeferred<IsolatedRunResult>();
@@ -105,8 +108,7 @@ describe("cron activeJobIds — manual-run mark/clear", () => {
   });
 
   it("clears the active marker even when the inner agent run throws", async () => {
-    const { cron, entered, release, store } =
-      await createManualRunHarness("manual-isolated-throw");
+    const { cron, entered, release, store } = await createManualRunHarness("manual-isolated-throw");
 
     try {
       await cron.start();

--- a/src/gateway/server-startup-early.ts
+++ b/src/gateway/server-startup-early.ts
@@ -121,7 +121,7 @@ export async function startGatewayEarlyRuntime(params: {
     void primeRemoteSkillsCache();
     taskRegistryMaintenance.configureTaskRegistryMaintenance({
       cronStorePath: resolveCronStorePath(params.cfgAtStart.cron?.store),
-      cronRuntimeAuthoritative: true,
+      runtimeAuthoritative: true,
     });
     taskRegistryMaintenance.startTaskRegistryMaintenance();
     getActiveTaskCount = () =>

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -341,7 +341,7 @@ describe("task-registry maintenance issue #60299", () => {
       expect.objectContaining({
         taskId: task.taskId,
         decision: "retained",
-        reason: "runtime_not_authoritative",
+        reason: "acp_runtime_not_authoritative",
       }),
     );
     expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 0 });
@@ -433,10 +433,14 @@ describe("task-registry maintenance issue #60299", () => {
   });
 
   it("does not mark cron tasks lost when the current process is not the cron runtime authority", async () => {
+    const staleAt = Date.now() - 40 * 60_000;
     const task = makeStaleTask({
       runtime: "cron",
       sourceId: "cron-job-offline-audit",
       childSessionKey: undefined,
+      createdAt: staleAt,
+      startedAt: staleAt,
+      lastEventAt: staleAt,
     });
 
     const { currentTasks } = createTaskRegistryMaintenanceHarness({
@@ -445,6 +449,13 @@ describe("task-registry maintenance issue #60299", () => {
     });
 
     expectMaintenanceCounts(previewTaskRegistryMaintenance(), { reconciled: 0 });
+    expect(getTaskRegistryMaintenanceDiagnostics().staleRunningTasks).toContainEqual(
+      expect.objectContaining({
+        taskId: task.taskId,
+        decision: "retained",
+        reason: "cron_runtime_not_authoritative",
+      }),
+    );
     expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 0 });
     expectTaskStatus(currentTasks, task.taskId, "running");
   });

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -61,14 +61,16 @@ function createTaskRegistryMaintenanceHarness(params: {
   acpEntry?: AcpSessionStoreEntry["entry"];
   activeCronJobIds?: string[];
   activeRunIds?: string[];
+  activeAcpSessionKeys?: string[];
   cronStore?: CronStoreFile;
   cronRunLogEntries?: Record<string, CronRunLogEntry[]>;
-  cronRuntimeAuthoritative?: boolean;
+  runtimeAuthoritative?: boolean;
 }) {
   const sessionStore = params.sessionStore ?? {};
   const acpEntry = params.acpEntry;
   const activeCronJobIds = new Set(params.activeCronJobIds ?? []);
   const activeRunIds = new Set(params.activeRunIds ?? []);
+  const activeAcpSessionKeys = new Set(params.activeAcpSessionKeys ?? []);
   const cronRunLogEntries = params.cronRunLogEntries ?? {};
   const currentTasks = new Map(params.tasks.map((task) => [task.taskId, { ...task }]));
 
@@ -100,6 +102,7 @@ function createTaskRegistryMaintenanceHarness(params: {
     isCronJobActive: (jobId: string) => activeCronJobIds.has(jobId),
     getAgentRunContext: (runId: string) =>
       activeRunIds.has(runId) ? { sessionKey: "main" } : undefined,
+    hasActiveAcpTurn: (sessionKey: string) => activeAcpSessionKeys.has(sessionKey),
     parseAgentSessionKey: (sessionKey: string | null | undefined): ParsedAgentSessionKey | null => {
       if (!sessionKey) {
         return null;
@@ -167,7 +170,7 @@ function createTaskRegistryMaintenanceHarness(params: {
       currentTasks.set(patch.taskId, next);
       return next;
     },
-    isCronRuntimeAuthoritative: () => params.cronRuntimeAuthoritative ?? true,
+    isRuntimeAuthoritative: () => params.runtimeAuthoritative ?? true,
     resolveCronStorePath: () => "/tmp/openclaw-test-cron/jobs.json",
     loadCronStoreSync: () => params.cronStore ?? { version: 1, jobs: [] },
     readCronRunLogEntriesSync: ({ jobId }) => (jobId ? (cronRunLogEntries[jobId] ?? []) : []),
@@ -277,6 +280,75 @@ describe("task-registry maintenance issue #60299", () => {
     expectTaskStatus(currentTasks, task.taskId, "running");
   });
 
+  it("reclaims a stale running ACP task with no live turn even though its session-store entry survives", async () => {
+    const childSessionKey = "agent:claude:acp:crashed-zombie";
+    const task = makeStaleTask({
+      runtime: "acp",
+      runId: "run-acp-crashed-zombie",
+      childSessionKey,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      acpEntry: { sessionId: childSessionKey, updatedAt: Date.now() },
+    });
+
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 1 });
+    expectTaskStatus(currentTasks, task.taskId, "lost");
+    expect(getInspectableActiveTaskRestartBlockers()).toHaveLength(0);
+  });
+
+  it("keeps a running ACP task live while a prompt turn is still in flight", async () => {
+    const childSessionKey = "agent:claude:acp:in-flight-turn";
+    const task = makeStaleTask({
+      runtime: "acp",
+      runId: "run-acp-in-flight",
+      childSessionKey,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      acpEntry: { sessionId: childSessionKey, updatedAt: Date.now() },
+      activeAcpSessionKeys: [childSessionKey],
+    });
+
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 0 });
+    expectTaskStatus(currentTasks, task.taskId, "running");
+    expect(getInspectableActiveTaskRestartBlockers()).toHaveLength(1);
+  });
+
+  it("does not reclaim a running ACP task from a non-authoritative process even with an empty live-turn map", async () => {
+    const childSessionKey = "agent:claude:acp:gateway-owned-live-turn";
+    const staleAt = Date.now() - 40 * 60_000;
+    const task = makeStaleTask({
+      runtime: "acp",
+      runId: "run-acp-gateway-owned",
+      childSessionKey,
+      createdAt: staleAt,
+      startedAt: staleAt,
+      lastEventAt: staleAt,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      acpEntry: { sessionId: childSessionKey, updatedAt: Date.now() },
+      activeAcpSessionKeys: [],
+      runtimeAuthoritative: false,
+    });
+
+    expectMaintenanceCounts(previewTaskRegistryMaintenance(), { reconciled: 0 });
+    expect(getTaskRegistryMaintenanceDiagnostics().staleRunningTasks).toContainEqual(
+      expect.objectContaining({
+        taskId: task.taskId,
+        decision: "retained",
+        reason: "runtime_not_authoritative",
+      }),
+    );
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 0 });
+    expectTaskStatus(currentTasks, task.taskId, "running");
+    expect(getInspectableActiveTaskRestartBlockers()).toHaveLength(1);
+  });
+
   it("only treats started non-ended running tasks as restart blockers", () => {
     const now = Date.now();
     const activeRunning = makeStaleTask({
@@ -369,7 +441,7 @@ describe("task-registry maintenance issue #60299", () => {
 
     const { currentTasks } = createTaskRegistryMaintenanceHarness({
       tasks: [task],
-      cronRuntimeAuthoritative: false,
+      runtimeAuthoritative: false,
     });
 
     expectMaintenanceCounts(previewTaskRegistryMaintenance(), { reconciled: 0 });

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -175,11 +175,12 @@ export type TaskRegistryMaintenanceTaskDiagnostic = {
   status: TaskRecord["status"];
   decision: "retained" | "would_reconcile";
   reason:
+    | "acp_runtime_not_authoritative"
     | "active_cli_run"
     | "backing_session_missing"
     | "backing_session_present"
+    | "cron_runtime_not_authoritative"
     | "lost_grace_pending"
-    | "runtime_not_authoritative"
     | "subagent_recovery_wedged";
   detail?: string;
   ageMs: number;
@@ -1016,9 +1017,11 @@ function explainActiveTaskRetention(params: {
   if (!hasBackingSession(params.task, params.context)) {
     return { decision: "would_reconcile", reason: "backing_session_missing" };
   }
-  const probesProcessLocalRuntime = params.task.runtime === "cron" || params.task.runtime === "acp";
-  if (probesProcessLocalRuntime && !taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
-    return { decision: "retained", reason: "runtime_not_authoritative" };
+  if (params.task.runtime === "cron" && !taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
+    return { decision: "retained", reason: "cron_runtime_not_authoritative" };
+  }
+  if (params.task.runtime === "acp" && !taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
+    return { decision: "retained", reason: "acp_runtime_not_authoritative" };
   }
   if (params.task.runtime === "cli" && hasActiveCliRun(params.task)) {
     return { decision: "retained", reason: "active_cli_run" };

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -2,6 +2,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { isAcpTurnActive } from "../acp/control-plane/active-turns.js";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import {
   listAcpSessionEntries,
@@ -83,7 +84,7 @@ let sweeper: NodeJS.Timeout | null = null;
 let deferredSweep: NodeJS.Timeout | null = null;
 let sweepInProgress = false;
 let configuredCronStorePath: string | undefined;
-let configuredCronRuntimeAuthoritative = false;
+let configuredRuntimeAuthoritative = false;
 
 type TaskRegistryMaintenanceRuntime = {
   listAcpSessionEntries: typeof listAcpSessionEntries;
@@ -100,6 +101,7 @@ type TaskRegistryMaintenanceRuntime = {
   deriveSessionChatTypeFromKey?: typeof deriveSessionChatTypeFromKey;
   isCronJobActive: typeof isCronJobActive;
   getAgentRunContext: typeof getAgentRunContext;
+  hasActiveAcpTurn: (sessionKey: string) => boolean;
   parseAgentSessionKey: typeof parseAgentSessionKey;
   hasActiveTaskForChildSessionKey: typeof hasActiveTaskForChildSessionKey;
   deleteTaskRecordById: typeof deleteTaskRecordById;
@@ -111,7 +113,7 @@ type TaskRegistryMaintenanceRuntime = {
   maybeDeliverTaskTerminalUpdate: typeof maybeDeliverTaskTerminalUpdate;
   resolveTaskForLookupToken: typeof resolveTaskForLookupToken;
   setTaskCleanupAfterById: typeof setTaskCleanupAfterById;
-  isCronRuntimeAuthoritative: () => boolean;
+  isRuntimeAuthoritative: () => boolean;
   resolveCronStorePath: typeof resolveCronStorePath;
   loadCronStoreSync: typeof loadCronStoreSync;
   readCronRunLogEntriesSync: typeof readCronRunLogEntriesSync;
@@ -139,6 +141,7 @@ const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
   deriveSessionChatTypeFromKey,
   isCronJobActive,
   getAgentRunContext,
+  hasActiveAcpTurn: isAcpTurnActive,
   parseAgentSessionKey,
   hasActiveTaskForChildSessionKey,
   deleteTaskRecordById,
@@ -150,7 +153,7 @@ const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
   maybeDeliverTaskTerminalUpdate,
   resolveTaskForLookupToken,
   setTaskCleanupAfterById,
-  isCronRuntimeAuthoritative: () => configuredCronRuntimeAuthoritative,
+  isRuntimeAuthoritative: () => configuredRuntimeAuthoritative,
   resolveCronStorePath: () => configuredCronStorePath ?? resolveCronStorePath(),
   loadCronStoreSync,
   readCronRunLogEntriesSync,
@@ -175,8 +178,8 @@ export type TaskRegistryMaintenanceTaskDiagnostic = {
     | "active_cli_run"
     | "backing_session_missing"
     | "backing_session_present"
-    | "cron_runtime_not_authoritative"
     | "lost_grace_pending"
+    | "runtime_not_authoritative"
     | "subagent_recovery_wedged";
   detail?: string;
   ageMs: number;
@@ -477,7 +480,7 @@ function hasCliRunIdentity(task: TaskRecord): boolean {
 
 function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupContext): boolean {
   if (task.runtime === "cron") {
-    if (!taskRegistryMaintenanceRuntime.isCronRuntimeAuthoritative()) {
+    if (!taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
       return true;
     }
     const jobId = task.sourceId?.trim();
@@ -496,14 +499,13 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
     return !isChildlessCodexNativeSubagentTask(task);
   }
   if (task.runtime === "acp") {
-    const acpEntry = taskRegistryMaintenanceRuntime.readAcpSessionEntry({
-      sessionKey: childSessionKey,
-      clone: false,
-    });
-    if (!acpEntry || acpEntry.storeReadFailed) {
+    // The live-turn map is process-local; only the gateway owns it. A standalone CLI
+    // maintenance run has an empty map, so stay conservative there and never reclaim.
+    if (!taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
       return true;
     }
-    return Boolean(acpEntry.entry);
+    // The persisted entry survives a crash, so only a live in-process turn proves the ACP run is alive.
+    return taskRegistryMaintenanceRuntime.hasActiveAcpTurn(childSessionKey);
   }
   if (task.runtime === "subagent" || task.runtime === "cli") {
     if (task.runtime === "cli") {
@@ -1014,11 +1016,9 @@ function explainActiveTaskRetention(params: {
   if (!hasBackingSession(params.task, params.context)) {
     return { decision: "would_reconcile", reason: "backing_session_missing" };
   }
-  if (
-    params.task.runtime === "cron" &&
-    !taskRegistryMaintenanceRuntime.isCronRuntimeAuthoritative()
-  ) {
-    return { decision: "retained", reason: "cron_runtime_not_authoritative" };
+  const probesProcessLocalRuntime = params.task.runtime === "cron" || params.task.runtime === "acp";
+  if (probesProcessLocalRuntime && !taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
+    return { decision: "retained", reason: "runtime_not_authoritative" };
   }
   if (params.task.runtime === "cli" && hasActiveCliRun(params.task)) {
     return { decision: "retained", reason: "active_cli_run" };
@@ -1232,16 +1232,16 @@ export function setTaskRegistryMaintenanceRuntimeForTests(
 export function resetTaskRegistryMaintenanceRuntimeForTests(): void {
   taskRegistryMaintenanceRuntime = defaultTaskRegistryMaintenanceRuntime;
   configuredCronStorePath = undefined;
-  configuredCronRuntimeAuthoritative = false;
+  configuredRuntimeAuthoritative = false;
 }
 
 export function configureTaskRegistryMaintenance(options: {
   cronStorePath?: string;
-  cronRuntimeAuthoritative?: boolean;
+  runtimeAuthoritative?: boolean;
 }): void {
   configuredCronStorePath = options.cronStorePath?.trim() || undefined;
-  if (options.cronRuntimeAuthoritative !== undefined) {
-    configuredCronRuntimeAuthoritative = options.cronRuntimeAuthoritative;
+  if (options.runtimeAuthoritative !== undefined) {
+    configuredRuntimeAuthoritative = options.runtimeAuthoritative;
   }
 }
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -49,6 +49,7 @@ import {
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
 import {
+  configureTaskRegistryMaintenance,
   getInspectableTaskAuditSummary,
   previewTaskRegistryMaintenance,
   resetTaskRegistryMaintenanceRuntimeForTests,
@@ -106,6 +107,7 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
   listTaskRecords?: () => ReturnType<typeof createTaskRecord>[];
   acpEntry?: AcpSessionStoreEntry;
   acpEntries?: AcpSessionStoreEntry[];
+  hasActiveAcpTurn?: (sessionKey: string) => boolean;
   sessionBindings?: SessionBindingRecord[];
   closeAcpSession?: (params: {
     cfg: AcpSessionStoreEntry["cfg"];
@@ -137,6 +139,7 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
     parseAgentSessionKey: () => null as ParsedAgentSessionKey | null,
     isCronJobActive: () => false,
     getAgentRunContext: () => undefined,
+    hasActiveAcpTurn: params.hasActiveAcpTurn ?? (() => false),
     hasActiveTaskForChildSessionKey: ({ sessionKey, excludeTaskId }) => {
       const normalized = sessionKey.trim().toLowerCase();
       return Array.from(params.currentTasks.values()).some(
@@ -187,7 +190,7 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
       params.currentTasks.set(patch.taskId, next);
       return next;
     },
-    isCronRuntimeAuthoritative: () => true,
+    isRuntimeAuthoritative: () => true,
     resolveCronStorePath: () => "/tmp/openclaw-test-cron/jobs.json",
     loadCronStoreSync: () => ({ version: 1, jobs: [] }),
     readCronRunLogEntriesSync: () => [],
@@ -1956,6 +1959,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryMemoryForTest();
+      configureTaskRegistryMaintenance({ runtimeAuthoritative: true });
 
       const task = createTaskRecord({
         runtime: "acp",
@@ -1989,6 +1993,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryMemoryForTest();
+      configureTaskRegistryMaintenance({ runtimeAuthoritative: true });
       const now = Date.now();
 
       const task = createTaskRecord({
@@ -2638,6 +2643,7 @@ describe("task-registry", () => {
         parseAgentSessionKey: () => null,
         isCronJobActive: () => false,
         getAgentRunContext: () => undefined,
+        hasActiveAcpTurn: () => false,
         hasActiveTaskForChildSessionKey: () => false,
         deleteTaskRecordById: () => false,
         ensureTaskRegistryReady: () => {},
@@ -2650,7 +2656,7 @@ describe("task-registry", () => {
         maybeDeliverTaskTerminalUpdate: async () => null,
         resolveTaskForLookupToken: () => undefined,
         setTaskCleanupAfterById: () => null,
-        isCronRuntimeAuthoritative: () => true,
+        isRuntimeAuthoritative: () => true,
         resolveCronStorePath: () => "/tmp/openclaw-test-cron/jobs.json",
         loadCronStoreSync: () => ({ version: 1, jobs: [] }),
         readCronRunLogEntriesSync: () => [],


### PR DESCRIPTION
### Summary

- **Problem**: After a gateway crash (or `openclaw update`-time kill) mid-ACP-turn, the gateway can refuse to restart indefinitely. The reported symptom is a managed gateway "blocked from restart/update" with a stuck ACP run, surfacing after long uptimes (the reporter saw it at ~27 days).
- **Root Cause**: The gateway blocks restart while any task record is still `status=running` with no `endedAt` (`getInspectableActiveTaskRestartBlockers`). Reconciliation reclaims such records once their backing session is gone, via `hasBackingSession`, which gates every runtime through a real liveness probe — cron through `isCronJobActive`, cli through an active run context — **except ACP**, which returned `Boolean(acpEntry.entry)`. A persistent ACP session keeps a durable session-store entry for its entire lifetime, and that entry survives a gateway crash. So a crashed ACP turn leaves a `running` record that `hasBackingSession` treats as "backed" forever: it is never reclaimed, never times out of the restart-blocker set, and wedges restart until the operator clears state manually.
- **Fix (two parts, both behind the existing injected maintenance-runtime seam)**:
  - **Liveness gate**: gate ACP backing on the in-process live-turn registry instead of entry existence. `AcpSessionManager` already tracks an authoritative per-session live-turn map (set when a prompt turn starts, deleted in the turn's `finally`; it is even used internally as the idle-eviction guard). This adds a small public probe `AcpSessionManager.hasActiveTurn(sessionKey)` and routes the ACP branch of `hasBackingSession` through it. The per-turn invariant makes this exact: ACP task records are created when a prompt turn begins and marked terminal inside the same turn, before the live-turn entry is deleted — so `status=running` with no live turn is *only* a crash mid-turn, or the brief create→register startup window that the unchanged 5-minute reconcile grace already covers.
  - **Authoritative-process gate**: the live-turn map is process-local — only the gateway process owns it. The `openclaw tasks maintenance` CLI runs the same `runTaskRegistryMaintenance` in a *separate* process with an empty live-turn map, so a naive liveness probe there would read every genuinely-live gateway-owned ACP turn as dead and mark it `lost`. This reuses the existing cron pattern: the cron branch already gates its process-local `isCronJobActive` probe behind an authoritative-runtime flag set true only by the gateway at startup. The flag/function are generalized from cron-only (`isCronRuntimeAuthoritative` → `isRuntimeAuthoritative`, `cronRuntimeAuthoritative` → `runtimeAuthoritative`) and the same gate is applied to the ACP branch: a non-authoritative process stays conservative and never reclaims.
  - This is the generic liveness gate the issue asks for; it deliberately does **not** add the reporter's suggested max-runtime TTL, heartbeat-timeout, or `--force-restart` config knobs.
- **What changed**:
  - `src/acp/control-plane/manager.core.ts` — add public `hasActiveTurn(sessionKey)` reading the existing in-process live-turn map.
  - `src/tasks/task-registry.maintenance.ts` — add `hasActiveAcpTurn` to the injected maintenance runtime (default delegates to `getAcpSessionManager().hasActiveTurn`); the ACP branch of `hasBackingSession` now returns it behind an authoritative-process gate. Generalize the cron-only authoritative flag/function to cover both process-local probes (cron job map + ACP turn map); the diagnostics retain-reason becomes `runtime_not_authoritative`.
  - `src/gateway/server-startup-early.ts` — the gateway's single `configureTaskRegistryMaintenance` call sets `runtimeAuthoritative: true` (renamed from `cronRuntimeAuthoritative`), marking the gateway the authoritative owner of both process-local probes.
  - `src/tasks/task-registry.maintenance.issue-60299.test.ts` — real-component regression tests (see below).
  - `src/tasks/task-registry.test.ts` — adopt the generalized flag name in the maintenance-runtime test helper and model the gateway as authoritative in the two real-runtime orphan-reconcile tests.
- **What did NOT change (scope boundary)**:
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config` edits).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/api.ts` / `runtime-api.ts`, registry, or loader edits).
  - Terminal-ACP-session cleanup (`shouldCloseTerminalAcpSession`) still reads the session-store entry; that path is untouched.
  - The 5-minute reconcile grace and all non-ACP backing probes (cli, subagent) are unchanged. The cron probe keeps identical semantics — only the flag/function name is generalized.
  - No dependency / lockfile changes.

### Reproduction

1. A persistent ACP session is running a prompt turn; a `running` task record exists for that turn, and the durable session-store entry exists.
2. The gateway crashes (or is killed by `openclaw update`) mid-turn. The in-process live-turn registry is gone, but the persisted session-store entry survives on disk.
3. **Before this PR**: on restart, the `running` task record has no `endedAt`; `hasBackingSession` sees the surviving entry (`Boolean(acpEntry.entry) === true`) and treats it as backed forever. The record never reconciles to `lost`, stays in `getInspectableActiveTaskRestartBlockers()`, and blocks restart/update until the operator clears state by hand.
4. **After this PR**: in the gateway (authoritative) process, `hasBackingSession` consults `hasActiveAcpTurn`, which is false after a crash. Once the existing 5-minute reconcile grace expires, the record is marked `lost`, drops out of the restart-blocker set, and restart proceeds. A turn that is genuinely mid-flight keeps `hasActiveTurn` true and is never reclaimed. A non-authoritative `openclaw tasks maintenance` CLI process never reclaims any ACP record.

### Real behavior proof

**Behavior addressed (#88205)**: a grace-expired `status=running` ACP task whose session-store entry survives a crash but whose prompt turn is no longer live is reclaimed (`lost`) and leaves the restart-blocker set; a `running` ACP task with a live in-flight turn is never reclaimed; and a non-authoritative maintenance process (empty live-turn map) never reclaims a gateway-owned ACP task.

**Real environment tested (Linux, Node 22, real-component vitest harness driving production `runTaskRegistryMaintenance` + `previewTaskRegistryMaintenance` + `getInspectableActiveTaskRestartBlockers` + `hasBackingSession`)**: the harness builds real `TaskRecord`s and exercises the actual reconcile / restart-blocker code paths; only the leaf liveness probes (`hasActiveAcpTurn`, `readAcpSessionEntry`, `isCronJobActive`, `getAgentRunContext`) and the authoritative flag are injected through the same `taskRegistryMaintenanceRuntime` seam production uses to wire `getAcpSessionManager().hasActiveTurn` and the gateway's `runtimeAuthoritative: true`.

**Exact steps or command run after this patch**:

1. `node scripts/run-vitest.mjs src/tasks/task-registry.maintenance.issue-60299.test.ts --reporter=verbose` (AFTER fix)
2. Temporarily revert the ACP branch of `hasBackingSession` to the shipped entry-existence check (`return Boolean(acpEntry.entry)`), rerun the same file (BEFORE — liveness gate), then restore
3. Temporarily drop the authoritative-process gate from the ACP branch, rerun the same file (BEFORE — authoritative gate), then restore
4. `node scripts/run-vitest.mjs src/tasks/task-registry.test.ts`
5. `node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts`
6. `pnpm exec oxfmt --check --threads=1 src/acp/control-plane/manager.core.ts src/tasks/task-registry.maintenance.ts src/tasks/task-registry.maintenance.issue-60299.test.ts src/tasks/task-registry.test.ts src/gateway/server-startup-early.ts`

**Evidence after fix (verbatim vitest BEFORE/AFTER on the regression tests)**:

```text
--- AFTER FIX (both gates in place) ---
 ✓ reclaims a stale running ACP task with no live turn even though its session-store entry survives
 ✓ keeps a running ACP task live while a prompt turn is still in flight
 ✓ does not reclaim a running ACP task from a non-authoritative process even with an empty live-turn map
 Test Files  1 passed (1)
      Tests  19 passed (19)

--- BEFORE (liveness gate reverted to entry-existence Boolean(acpEntry.entry)) ---
 × reclaims a stale running ACP task with no live turn even though its session-store entry survives
   → expected +0 to be 1   (surviving entry treated as backed → zombie never reclaimed)
 ✓ keeps a running ACP task live while a prompt turn is still in flight
 ✓ does not reclaim a running ACP task from a non-authoritative process even with an empty live-turn map
 Test Files  1 failed (1)
      Tests  1 failed | 18 passed (19)

--- BEFORE (authoritative-process gate removed from ACP branch) ---
 ✓ reclaims a stale running ACP task with no live turn even though its session-store entry survives
 ✓ keeps a running ACP task live while a prompt turn is still in flight
 × does not reclaim a running ACP task from a non-authoritative process even with an empty live-turn map
   → expected 1 to be +0   (CLI process with empty live-turn map wrongly reclaims a live gateway-owned turn)
 Test Files  1 failed (1)
      Tests  1 failed | 18 passed (19)
```

Companion suites green after fix: `src/tasks/task-registry.test.ts` 72/72, `src/acp/control-plane/manager.test.ts` 86/86; `oxfmt --check` clean on all five touched files.

**Observed result after fix**:

- The crashed-run zombie reconciles (`reconciled: 1`, status `lost`) and `getInspectableActiveTaskRestartBlockers()` becomes empty → restart unblocked.
- A `running` ACP task with `hasActiveAcpTurn === true` is never reclaimed (`reconciled: 0`, stays `running`, still a blocker).
- A non-authoritative maintenance process (`runtimeAuthoritative: false`, empty live-turn map) retains the gateway-owned `running` task (`reconciled: 0`, diagnostics reason `runtime_not_authoritative`, still a blocker) — no false `lost`.
- Reverting only the liveness gate flips the zombie-reclaim test red (`expected +0 to be 1`); removing only the authoritative gate flips the non-authoritative test red (`expected 1 to be +0`) — each gate is independently pinned.

**What was not tested**:

- End-to-end: a real opencode/codex ACP child crashing mid-turn on a managed gateway over a multi-day uptime, then a real `openclaw gateway restart` / `openclaw update`, and a real `openclaw tasks maintenance --apply` running while the gateway holds a live turn. The deterministic harness reproduces the necessary conditions (running record + surviving entry + no live turn; authoritative vs non-authoritative process) without a real backend or 27-day uptime.
- Full `pnpm check` / full `pnpm test` broad gates — deferred to CI on this memory-constrained box.

**Regression tests**:

- `reclaims a stale running ACP task with no live turn even though its session-store entry survives` (#88205) — fails on the shipped entry-existence behavior, passes with the live-turn gate.
- `keeps a running ACP task live while a prompt turn is still in flight` — passes before and after, guarding against the inverse regression (never over-reclaim a healthy in-flight turn).
- `does not reclaim a running ACP task from a non-authoritative process even with an empty live-turn map` — fails if the authoritative-process gate is dropped, guarding the standalone-CLI false-`lost` case.

### Risk / Mitigation

- **Risk**: over-reclaiming a live ACP session. **Mitigation**: the per-turn invariant — a `running` ACP record always coincides with a live turn during normal operation, and there is no `running` record between turns of a persistent session — plus `hasActiveTurn` staying true for any in-flight turn (including a hung-but-alive one) means only the crashed-run set is affected.
- **Risk**: a non-gateway process (e.g. the `openclaw tasks maintenance` CLI) observing an empty live-turn map and falsely marking live gateway-owned turns `lost`. **Mitigation**: the authoritative-process gate — process-local probes (cron job map + ACP turn map) only reclaim in the process that owns the map (the gateway, which sets `runtimeAuthoritative: true` at startup); every other process stays conservative and returns "backed".
- **Risk**: the brief window between task-record creation and live-turn registration during backend resolution could look like "no live turn". **Mitigation**: that window is covered by the unchanged 5-minute reconcile grace keyed off the task's own timestamps; nothing reclaims a record younger than the grace.
- **Risk**: generalizing the cron authoritative flag could alter cron behavior. **Mitigation**: the cron branch keeps identical gate semantics — only the flag/function identifiers are renamed; the gateway still sets the flag true, and cron behavior tests are unchanged.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration (task-registry restart blockers / reconciliation)
- [x] ACP agent runtime (`AcpSessionManager` live-turn liveness)

### Linked Issue/PR

Fixes #88205
