### PR TITLE
fix(gateway): unref WS socket in beginStop() to fix CLI hang

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -32,6 +32,9 @@ class MockWebSocket {
   terminateCalls = 0;
   autoCloseOnClose = true;
   readyState = MockWebSocket.CONNECTING;
+  // Simulate the internal `_socket` exposed by the `ws` package so tests can
+  // assert that beginStop() unrefs it.
+  _socket: { unref: ReturnType<typeof vi.fn> } = { unref: vi.fn() };
 
   constructor(_url: string, _options?: unknown) {
     wsInstances.push(this);
@@ -416,6 +419,32 @@ describe("GatewayClient close handling", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("unrefs the underlying socket on stop so the event loop can drain (issue #88230)", () => {
+    // The CLI `openclaw message send` path calls client.stop() after delivery
+    // and relies on a natural process exit.  If the socket's file descriptor
+    // stays ref'd, Node's event loop never drains and the process hangs
+    // indefinitely.  beginStop() must call _socket.unref() immediately after
+    // ws.close() so both the explicit-process.exit and natural-drain paths
+    // work correctly.
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    // Disable auto-close so the socket stays in CLOSING state, mirroring a
+    // real-world scenario where the remote end hasn't replied to the close
+    // frame yet.
+    ws.autoCloseOnClose = false;
+
+    expect(ws._socket.unref).not.toHaveBeenCalled();
+
+    client.stop();
+
+    expect(ws.closeCalls).toBe(1);
+    expect(ws._socket.unref).toHaveBeenCalledTimes(1);
   });
 
   it("waits for a lingering socket to terminate in stopAndWait", async () => {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -397,6 +397,18 @@ export class GatewayClient {
     if (ws) {
       const stopPromise = this.createPendingStop(ws);
       ws.close();
+      // Unref the underlying socket so the event loop can drain naturally
+      // in CLI contexts (e.g. `openclaw message send`) where the caller exits
+      // after the send completes.  The TCP/unix close-handshake may outlive
+      // `process.exit()`, but we must not let the open socket block a natural
+      // exit (no explicit process.exit) — both cases are covered by unreffing.
+      // The forceTerminateTimer above is already .unref()'d; the socket itself
+      // must be too.
+      try {
+        (ws as unknown as { _socket?: { unref?(): void } })._socket?.unref?.();
+      } catch {
+        // _socket is internal to the `ws` package; ignore if unavailable.
+      }
       const forceTerminateTimer = setTimeout(() => {
         try {
           ws.terminate();


### PR DESCRIPTION
## Summary

- Call `_socket.unref()` on the WebSocket's underlying socket in `GatewayClient.beginStop()` immediately after `ws.close()`
- Fixes `openclaw message send` hanging indefinitely after successful message delivery (issue #88230)

## Motivation

Closes #88230.

After `openclaw message send` successfully delivers a message the CLI process never exits. The reporter observes `ep_poll` with 2 ESTAB unix sockets to the gateway — those sockets are the ref'd handles keeping the Node.js event loop alive. `beginStop()` calls `ws.close()` to initiate the close handshake, and the `forceTerminateTimer` is already `.unref()`'d, but the underlying `_socket` file descriptor itself is not. Because the socket stays ref'd, the event loop can never drain to zero handles, so a natural process exit never happens.

The fix adds a single `.unref()` call on `ws._socket` immediately after `ws.close()`, matching the pattern already used for `forceTerminateTimer`. The call is wrapped in `try/catch` because `_socket` is an internal property of the `ws` package with no public contract. `stopAndWait()` callers are unaffected — the socket is still closed and the pending-stop promise still resolves normally via the `close` event or the force-terminate timeout.

## Verification

- `npx vitest run src/gateway/client.test.ts` — 26 passed (25 existing + 1 new test that asserts `_socket.unref` is called on `stop()`)
- New test: `"unrefs the underlying socket on stop so the event loop can drain (issue #88230)"` verifies the exact behavior with `autoCloseOnClose = false` to simulate a slow close handshake
- Did NOT change: `stopAndWait()` semantics, `forceTerminateTimer` handling, or any call sites — the unref only affects whether the open socket holds the event loop open