### PR TITLE
fix(infra): prefer npm-shrinkwrap.json over packageManager field for npm detection

### DIFF
--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -62,4 +62,22 @@ describe("detectPackageManager", () => {
       },
     );
   });
+
+  it("returns npm for npm-shrinkwrap.json even when packageManager field says pnpm", async () => {
+    await withPackageManagerRoot(
+      [
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@10.8.1" }) },
+        { path: "npm-shrinkwrap.json", content: "{}" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("npm");
+      },
+    );
+  });
+
+  it("returns npm for npm-shrinkwrap.json when no packageManager field is present", async () => {
+    await withPackageManagerRoot([{ path: "npm-shrinkwrap.json", content: "{}" }], async (root) => {
+      await expect(detectPackageManager(root)).resolves.toBe("npm");
+    });
+  });
 });

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -4,12 +4,20 @@ import { readPackageManagerSpec } from "./package-json.js";
 type DetectedPackageManager = "pnpm" | "bun" | "npm";
 
 export async function detectPackageManager(root: string): Promise<DetectedPackageManager | null> {
+  const files = await fs.readdir(root).catch((): string[] => []);
+
+  // npm-shrinkwrap.json is the canonical npm published-package lockfile.
+  // Check it before the packageManager field so a pnpm development workspace
+  // does not misidentify a package that was installed by npm.
+  if (files.includes("npm-shrinkwrap.json")) {
+    return "npm";
+  }
+
   const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (pm === "pnpm" || pm === "bun" || pm === "npm") {
     return pm;
   }
 
-  const files = await fs.readdir(root).catch((): string[] => []);
   if (files.includes("pnpm-lock.yaml")) {
     return "pnpm";
   }

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -9,7 +9,10 @@ export async function detectPackageManager(root: string): Promise<DetectedPackag
   // npm-shrinkwrap.json is the canonical npm published-package lockfile.
   // Check it before the packageManager field so a pnpm development workspace
   // does not misidentify a package that was installed by npm.
-  if (files.includes("npm-shrinkwrap.json")) {
+  // Guard against a pnpm monorepo that also ships npm-shrinkwrap.json: if
+  // pnpm-lock.yaml is present alongside npm-shrinkwrap.json, this is a pnpm
+  // development workspace, not an npm-installed package.
+  if (files.includes("npm-shrinkwrap.json") && !files.includes("pnpm-lock.yaml")) {
     return "npm";
   }
 

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -230,6 +230,24 @@ describe("checkDepsStatus", () => {
       expect(okDeps.status).toBe("ok");
     });
   });
+
+  it("uses npm-shrinkwrap.json as the npm lockfile when package-lock.json is absent", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-shrinkwrap-" }, async (base) => {
+      await fs.writeFile(path.join(base, "npm-shrinkwrap.json"), "{}", "utf8");
+      const nodeModulesPath = path.join(base, "node_modules");
+      await fs.mkdir(nodeModulesPath, { recursive: true });
+
+      const staleDate = new Date(Date.now() - 10_000);
+      await fs.utimes(path.join(base, "npm-shrinkwrap.json"), staleDate, staleDate);
+      const freshDate = new Date(Date.now() + 2_000);
+      await fs.utimes(nodeModulesPath, freshDate, freshDate);
+
+      const result = await checkDepsStatus({ root: base, manager: "npm" });
+      expect(result.manager).toBe("npm");
+      expect(result.status).toBe("ok");
+      expect(result.lockfilePath).toContain("npm-shrinkwrap.json");
+    });
+  });
 });
 
 describe("checkUpdateStatus", () => {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -231,10 +231,20 @@ export async function checkDepsStatus(params: {
   manager: PackageManager;
 }): Promise<DepsStatus> {
   const root = path.resolve(params.root);
-  const { lockfilePath, markerPath } = resolveDepsMarker({
+  let { lockfilePath, markerPath } = resolveDepsMarker({
     root,
     manager: params.manager,
   });
+
+  // For npm, also accept npm-shrinkwrap.json as the lockfile when package-lock.json
+  // is absent. npm-shrinkwrap.json is the publishable npm lockfile format and takes
+  // precedence over package-lock.json at install time.
+  if (params.manager === "npm" && lockfilePath && !(await exists(lockfilePath))) {
+    const shrinkwrapPath = path.join(root, "npm-shrinkwrap.json");
+    if (await exists(shrinkwrapPath)) {
+      lockfilePath = shrinkwrapPath;
+    }
+  }
 
   if (!lockfilePath || !markerPath) {
     return {


### PR DESCRIPTION
Fixes #87732

## Summary

`detectPackageManager()` reads the `packageManager` field from `package.json` first and returns `pnpm` for `pnpm@...` values. This field reflects the *development* toolchain, not the *installed* package manager. When OpenClaw is installed via `npm install -g`, the package root has `npm-shrinkwrap.json` but still carries `packageManager: pnpm@...`, so the detector wrongly reports `pnpm`, causing the update/status flow to fail looking for `pnpm-lock.yaml`.

`npm-shrinkwrap.json` is the canonical npm published-package lockfile. The fix checks it before reading `packageManager`, but only when `pnpm-lock.yaml` is absent: if both files exist (a pnpm dev workspace that ships `npm-shrinkwrap.json` as part of the published npm artifact), the pnpm workspace is correctly detected as `pnpm`.

`checkDepsStatus` receives a secondary fix: for npm-managed roots, it falls back to `npm-shrinkwrap.json` as the lockfile path when `package-lock.json` is absent. A direct regression test is added for this path.

## Real behavior proof

**Behavior addressed:** `detectPackageManager()` wrongly returns `pnpm` for an npm-globally-installed OpenClaw package because `packageManager: pnpm@10.8.1` is read first. After the fix, `npm-shrinkwrap.json` takes precedence when `pnpm-lock.yaml` is absent.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, HEAD `cdb3e4d4986d0a2d5061ef4d6eaa02c8619d7482` based on `origin/main` `6399b6a4455d0a5373329dc8c71ff4b1da6f50c9`.

**Exact steps or command run after this patch:**

Run the patched detection logic with real temp directories:

```
node --input-type=module -e "
import fs from 'node:fs/promises'; import os from 'node:os'; import path from 'node:path';
async function readPm(root){try{return JSON.parse(await fs.readFile(path.join(root,'package.json'),'utf8'))?.packageManager??null;}catch{return null;}}
async function detect(root){
  const files=await fs.readdir(root).catch(()=>[]);
  if(files.includes('npm-shrinkwrap.json')&&!files.includes('pnpm-lock.yaml'))return 'npm';
  const pm=(await readPm(root))?.split('@')[0]?.trim();
  if(pm==='pnpm'||pm==='bun'||pm==='npm')return pm;
  return null;
}
const root=await fs.mkdtemp(path.join(os.tmpdir(),'proof-'));
await fs.writeFile(path.join(root,'package.json'),JSON.stringify({packageManager:'pnpm@10.8.1'}));
await fs.writeFile(path.join(root,'npm-shrinkwrap.json'),'{}');
const r1=await detect(root);
await fs.writeFile(path.join(root,'pnpm-lock.yaml'),'');
const r2=await detect(root);
await fs.rm(root,{recursive:true,force:true});
console.log('npm-only root (no pnpm-lock.yaml):', r1);
console.log('pnpm dev workspace (both files):', r2);
"
```

**Evidence after fix:**

```
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.infra.config.ts \
  src/infra/detect-package-manager.test.ts \
  --reporter=verbose --testTimeout=10000

 RUN  v4.1.7 /media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-87732

 ✓ |infra| src/infra/detect-package-manager.test.ts > detectPackageManager > prefers packageManager from package.json when supported 85ms
 ✓ |infra| src/infra/detect-package-manager.test.ts > detectPackageManager > falls back to lockfiles when 'uses bun.lock' 5ms
 ✓ |infra| src/infra/detect-package-manager.test.ts > detectPackageManager > falls back to lockfiles when 'uses bun.lockb' 3ms
 ✓ |infra| src/infra/detect-package-manager.test.ts > detectPackageManager > falls back to lockfiles when 'falls back to npm lockfiles for unsup…' 3ms
 ✓ |infra| src/infra/detect-package-manager.test.ts > detectPackageManager > returns null when no package manager markers exist 3ms
 ✓ |infra| src/infra/detect-package-manager.test.ts > detectPackageManager > returns npm for npm-shrinkwrap.json even when packageManager field says pnpm 2ms
 ✓ |infra| src/infra/detect-package-manager.test.ts > detectPackageManager > returns npm for npm-shrinkwrap.json when no packageManager field is present 2ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  02:57:20
   Duration  679ms (transform 283ms, setup 340ms, import 31ms, tests 107ms, environment 0ms)
```

Direct import of the patched built dist module (`pnpm build` completed successfully for this HEAD) against real temp directories:

```
$ node --input-type=module << 'EOF'
import { s as detectPackageManager } from './dist/update-check-D5UZaXta.js';
import fs from 'node:fs/promises'; import os from 'node:os'; import path from 'node:path';

const npmRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'pm-proof-npm-'));
await fs.writeFile(path.join(npmRoot, 'package.json'), JSON.stringify({ name: 'openclaw', packageManager: 'pnpm@10.8.1' }));
await fs.writeFile(path.join(npmRoot, 'npm-shrinkwrap.json'), '{}');

const pnpmRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'pm-proof-pnpm-'));
await fs.writeFile(path.join(pnpmRoot, 'package.json'), JSON.stringify({ name: 'openclaw', packageManager: 'pnpm@10.8.1' }));
await fs.writeFile(path.join(pnpmRoot, 'npm-shrinkwrap.json'), '{}');
await fs.writeFile(path.join(pnpmRoot, 'pnpm-lock.yaml'), '');

const r1 = await detectPackageManager(npmRoot);
const r2 = await detectPackageManager(pnpmRoot);
await fs.rm(npmRoot, { recursive: true, force: true });
await fs.rm(pnpmRoot, { recursive: true, force: true });
console.log('npm-installed root (npm-shrinkwrap.json only, packageManager: pnpm@10.8.1):', r1);
console.log('pnpm dev workspace (both files, packageManager: pnpm@10.8.1):', r2);
EOF

npm-installed root (npm-shrinkwrap.json only, packageManager: pnpm@10.8.1): npm
pnpm dev workspace (both files, packageManager: pnpm@10.8.1): pnpm
```

Both scenarios confirmed via the patched built dist: npm-installed roots report `npm`, pnpm workspaces with `pnpm-lock.yaml` remain `pnpm`.

**Observed result after fix:** `detectPackageManager()` returns `npm` for an npm-installed package root where only `npm-shrinkwrap.json` is present alongside `package.json` with `packageManager: pnpm@10.8.1`, while pnpm development workspaces with `pnpm-lock.yaml` remain `pnpm`. `checkDepsStatus` for npm falls back to `npm-shrinkwrap.json` as the lockfile when `package-lock.json` is absent (regression test added).

**What was not tested:** Running `openclaw status --json` against a real globally-installed npm package via the full update check flow. The detection path is directly exercised via the patched built dist module and regression tests using real temp directories.