### PR TITLE
fix(config): skip state-dir dotenv values that are unresolved shell references

### DIFF
--- a/src/config/state-dir-dotenv.test.ts
+++ b/src/config/state-dir-dotenv.test.ts
@@ -39,6 +39,17 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
     });
   });
 
+  it("preserves credential values that merely contain a dollar sign", async () => {
+    const content = ["PASSWORD=abc$2!xyz", "TOKEN=tok_$prod_v2", "PURE_REF=$SOME_VAR"].join("\n");
+
+    await withDotEnv(content, async (dir) => {
+      const result = readStateDirDotEnvVarsFromStateDir(dir);
+      expect(result["PASSWORD"]).toBe("abc$2!xyz");
+      expect(result["TOKEN"]).toBe("tok_$prod_v2");
+      expect(Object.keys(result)).not.toContain("PURE_REF");
+    });
+  });
+
   it("returns empty object when .env is missing", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-missing-"));
     try {

--- a/src/config/state-dir-dotenv.test.ts
+++ b/src/config/state-dir-dotenv.test.ts
@@ -29,6 +29,9 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
       "QUOTED_CURLY_KEY=\"'${ANOTHER_VAR}'\"",
       "BRACE_DEFAULT_KEY=${ANOTHER_VAR:-fallback}",
       "QUOTED_BRACE_DEFAULT_KEY='\"${ANOTHER_VAR:-fallback}\"'",
+      'BRACE_TRIM_KEY="${ANOTHER_VAR#prefix}"',
+      "BRACE_REPLACE_KEY=${ANOTHER_VAR/pattern/replacement}",
+      "BRACE_CASE_KEY=${ANOTHER_VAR^^}",
       'COMMAND_KEY="$(hostname)"',
       "OTHER_KEY=$SOME_SHELL_VAR",
       "CURLY_KEY=${ANOTHER_VAR}",
@@ -42,6 +45,9 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
       expect(Object.keys(result)).not.toContain("QUOTED_CURLY_KEY");
       expect(Object.keys(result)).not.toContain("BRACE_DEFAULT_KEY");
       expect(Object.keys(result)).not.toContain("QUOTED_BRACE_DEFAULT_KEY");
+      expect(Object.keys(result)).not.toContain("BRACE_TRIM_KEY");
+      expect(Object.keys(result)).not.toContain("BRACE_REPLACE_KEY");
+      expect(Object.keys(result)).not.toContain("BRACE_CASE_KEY");
       expect(Object.keys(result)).not.toContain("COMMAND_KEY");
       expect(Object.keys(result)).not.toContain("OTHER_KEY");
       expect(Object.keys(result)).not.toContain("CURLY_KEY");

--- a/src/config/state-dir-dotenv.test.ts
+++ b/src/config/state-dir-dotenv.test.ts
@@ -25,6 +25,9 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
   it("skips values that are unresolved shell variable references", async () => {
     const content = [
       'SUPERMEMORY_OPENCLAW_API_KEY="${SUPERMEMORY_OPENCLAW_KEY}"',
+      "QUOTED_SUPERMEMORY_OPENCLAW_API_KEY='\"$SUPERMEMORY_OPENCLAW_KEY\"'",
+      "QUOTED_CURLY_KEY=\"'${ANOTHER_VAR}'\"",
+      'COMMAND_KEY="$(hostname)"',
       "OTHER_KEY=$SOME_SHELL_VAR",
       "CURLY_KEY=${ANOTHER_VAR}",
       "REAL_KEY=actual_value_here",
@@ -33,6 +36,9 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
     await withDotEnv(content, async (dir) => {
       const result = readStateDirDotEnvVarsFromStateDir(dir);
       expect(Object.keys(result)).not.toContain("SUPERMEMORY_OPENCLAW_API_KEY");
+      expect(Object.keys(result)).not.toContain("QUOTED_SUPERMEMORY_OPENCLAW_API_KEY");
+      expect(Object.keys(result)).not.toContain("QUOTED_CURLY_KEY");
+      expect(Object.keys(result)).not.toContain("COMMAND_KEY");
       expect(Object.keys(result)).not.toContain("OTHER_KEY");
       expect(Object.keys(result)).not.toContain("CURLY_KEY");
       expect(result["REAL_KEY"]).toBe("actual_value_here");
@@ -44,6 +50,8 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
       "PASSWORD=abc$2!xyz",
       "TOKEN=tok_$prod_v2",
       "PRICE=\\$100",
+      "QUOTED_PASSWORD='\"abc$2!xyz\"'",
+      "QUOTED_PRICE='\"$100\"'",
       "PURE_REF=$SOME_VAR",
     ].join("\n");
 
@@ -52,6 +60,8 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
       expect(result["PASSWORD"]).toBe("abc$2!xyz");
       expect(result["TOKEN"]).toBe("tok_$prod_v2");
       expect(result["PRICE"]).toBe("\\$100");
+      expect(result["QUOTED_PASSWORD"]).toBe("\"abc$2!xyz\"");
+      expect(result["QUOTED_PRICE"]).toBe("\"$100\"");
       expect(Object.keys(result)).not.toContain("PURE_REF");
     });
   });

--- a/src/config/state-dir-dotenv.test.ts
+++ b/src/config/state-dir-dotenv.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { readStateDirDotEnvVarsFromStateDir } from "./state-dir-dotenv.js";
+
+describe("readStateDirDotEnvVarsFromStateDir", () => {
+  async function withDotEnv<T>(content: string, run: (dir: string) => T | Promise<T>): Promise<T> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-test-"));
+    await fs.writeFile(path.join(dir, ".env"), content, "utf8");
+    try {
+      return await run(dir);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("returns real credential values from the state-dir dotenv", async () => {
+    await withDotEnv("SUPERMEMORY_API_KEY=sm_real_credential_value\n", async (dir) => {
+      const result = readStateDirDotEnvVarsFromStateDir(dir);
+      expect(result["SUPERMEMORY_API_KEY"]).toBe("sm_real_credential_value");
+    });
+  });
+
+  it("skips values that are unresolved shell variable references", async () => {
+    const content = [
+      'SUPERMEMORY_OPENCLAW_API_KEY="${SUPERMEMORY_OPENCLAW_KEY}"',
+      "OTHER_KEY=$SOME_SHELL_VAR",
+      "CURLY_KEY=${ANOTHER_VAR}",
+      "REAL_KEY=actual_value_here",
+    ].join("\n");
+
+    await withDotEnv(content, async (dir) => {
+      const result = readStateDirDotEnvVarsFromStateDir(dir);
+      expect(Object.keys(result)).not.toContain("SUPERMEMORY_OPENCLAW_API_KEY");
+      expect(Object.keys(result)).not.toContain("OTHER_KEY");
+      expect(Object.keys(result)).not.toContain("CURLY_KEY");
+      expect(result["REAL_KEY"]).toBe("actual_value_here");
+    });
+  });
+
+  it("returns empty object when .env is missing", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-missing-"));
+    try {
+      expect(readStateDirDotEnvVarsFromStateDir(dir)).toEqual({});
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config/state-dir-dotenv.test.ts
+++ b/src/config/state-dir-dotenv.test.ts
@@ -27,6 +27,8 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
       'SUPERMEMORY_OPENCLAW_API_KEY="${SUPERMEMORY_OPENCLAW_KEY}"',
       "QUOTED_SUPERMEMORY_OPENCLAW_API_KEY='\"$SUPERMEMORY_OPENCLAW_KEY\"'",
       "QUOTED_CURLY_KEY=\"'${ANOTHER_VAR}'\"",
+      "BRACE_DEFAULT_KEY=${ANOTHER_VAR:-fallback}",
+      "QUOTED_BRACE_DEFAULT_KEY='\"${ANOTHER_VAR:-fallback}\"'",
       'COMMAND_KEY="$(hostname)"',
       "OTHER_KEY=$SOME_SHELL_VAR",
       "CURLY_KEY=${ANOTHER_VAR}",
@@ -38,6 +40,8 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
       expect(Object.keys(result)).not.toContain("SUPERMEMORY_OPENCLAW_API_KEY");
       expect(Object.keys(result)).not.toContain("QUOTED_SUPERMEMORY_OPENCLAW_API_KEY");
       expect(Object.keys(result)).not.toContain("QUOTED_CURLY_KEY");
+      expect(Object.keys(result)).not.toContain("BRACE_DEFAULT_KEY");
+      expect(Object.keys(result)).not.toContain("QUOTED_BRACE_DEFAULT_KEY");
       expect(Object.keys(result)).not.toContain("COMMAND_KEY");
       expect(Object.keys(result)).not.toContain("OTHER_KEY");
       expect(Object.keys(result)).not.toContain("CURLY_KEY");
@@ -60,8 +64,8 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
       expect(result["PASSWORD"]).toBe("abc$2!xyz");
       expect(result["TOKEN"]).toBe("tok_$prod_v2");
       expect(result["PRICE"]).toBe("\\$100");
-      expect(result["QUOTED_PASSWORD"]).toBe("\"abc$2!xyz\"");
-      expect(result["QUOTED_PRICE"]).toBe("\"$100\"");
+      expect(result["QUOTED_PASSWORD"]).toBe('"abc$2!xyz"');
+      expect(result["QUOTED_PRICE"]).toBe('"$100"');
       expect(Object.keys(result)).not.toContain("PURE_REF");
     });
   });

--- a/src/config/state-dir-dotenv.test.ts
+++ b/src/config/state-dir-dotenv.test.ts
@@ -40,12 +40,18 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
   });
 
   it("preserves credential values that merely contain a dollar sign", async () => {
-    const content = ["PASSWORD=abc$2!xyz", "TOKEN=tok_$prod_v2", "PURE_REF=$SOME_VAR"].join("\n");
+    const content = [
+      "PASSWORD=abc$2!xyz",
+      "TOKEN=tok_$prod_v2",
+      "PRICE=\\$100",
+      "PURE_REF=$SOME_VAR",
+    ].join("\n");
 
     await withDotEnv(content, async (dir) => {
       const result = readStateDirDotEnvVarsFromStateDir(dir);
       expect(result["PASSWORD"]).toBe("abc$2!xyz");
       expect(result["TOKEN"]).toBe("tok_$prod_v2");
+      expect(result["PRICE"]).toBe("\\$100");
       expect(Object.keys(result)).not.toContain("PURE_REF");
     });
   });

--- a/src/config/state-dir-dotenv.test.ts
+++ b/src/config/state-dir-dotenv.test.ts
@@ -56,6 +56,9 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
       "PRICE=\\$100",
       "QUOTED_PASSWORD='\"abc$2!xyz\"'",
       "QUOTED_PRICE='\"$100\"'",
+      "LEADING_DOLLAR_PASSWORD=$ecret123",
+      "LEADING_DOLLAR_TOKEN=$token_1",
+      "LOWERCASE_BRACE=${lowercase_literal}",
       "PURE_REF=$SOME_VAR",
     ].join("\n");
 
@@ -66,6 +69,9 @@ describe("readStateDirDotEnvVarsFromStateDir", () => {
       expect(result["PRICE"]).toBe("\\$100");
       expect(result["QUOTED_PASSWORD"]).toBe('"abc$2!xyz"');
       expect(result["QUOTED_PRICE"]).toBe('"$100"');
+      expect(result["LEADING_DOLLAR_PASSWORD"]).toBe("$ecret123");
+      expect(result["LEADING_DOLLAR_TOKEN"]).toBe("$token_1");
+      expect(result["LOWERCASE_BRACE"]).toBe("${lowercase_literal}");
       expect(Object.keys(result)).not.toContain("PURE_REF");
     });
   });

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -26,7 +26,7 @@ function unwrapMatchingLiteralQuotes(value: string): string {
   return value;
 }
 
-function isUnresolvedShellReference(value: string): boolean {
+export function isUnresolvedShellReference(value: string): boolean {
   const candidate = unwrapMatchingLiteralQuotes(value.trim());
   // Match only values whose entire content is a shell variable reference:
   //   $VAR_NAME          (simple reference, OpenClaw env-var style)
@@ -35,7 +35,7 @@ function isUnresolvedShellReference(value: string): boolean {
   // A real credential that merely contains a $ (e.g. "abc$2!", "$100") is NOT matched.
   return (
     /^\$[A-Z_][A-Z0-9_]*$/.test(candidate) ||
-    /^\$\{[A-Z_][A-Z0-9_]*(?:(?::[-=?+]?|[-=?+])[^}]*)?\}$/.test(candidate) ||
+    /^\$\{[A-Z_][A-Z0-9_]*[^}]*\}$/.test(candidate) ||
     /^\$\([^)]*\)$/.test(candidate)
   );
 }

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -14,8 +14,13 @@ function isBlockedServiceEnvVar(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
 }
 
-function containsUnresolvedShellReference(value: string): boolean {
-  return /\$[\w{(]/.test(value);
+function isUnresolvedShellReference(value: string): boolean {
+  // Match only values whose entire content is a shell variable reference:
+  //   $VAR_NAME          (simple reference)
+  //   ${VAR_NAME}        (brace-form reference)
+  //   $(command)         (command substitution)
+  // A real credential that merely contains a $ (e.g. a password like "abc$2!") is NOT matched.
+  return /^\$[\w_][\w\d_]*$/.test(value) || /^\$\{[^}]+\}$/.test(value) || /^\$\(.*\)$/.test(value);
 }
 
 function parseStateDirDotEnvContent(content: string): Record<string, string> {
@@ -32,11 +37,12 @@ function parseStateDirDotEnvContent(content: string): Record<string, string> {
     if (isBlockedServiceEnvVar(key)) {
       continue;
     }
-    // Skip values that still contain unresolved shell variable references
-    // ($VAR or ${VAR}). dotenv does not expand them, so persisting them into
-    // a single-quoted LaunchAgent/systemd env file would store the literal
+    // Skip values whose entire content is an unresolved shell variable reference
+    // ($VAR, ${VAR}, or $(cmd)). dotenv does not expand them, so persisting them
+    // into a single-quoted LaunchAgent/systemd env file would store the literal
     // reference string rather than the intended credential value.
-    if (containsUnresolvedShellReference(value)) {
+    // Values that merely contain $ (e.g. a password like "abc$2!") are kept.
+    if (isUnresolvedShellReference(value)) {
       continue;
     }
     entries[key] = value;

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -14,6 +14,10 @@ function isBlockedServiceEnvVar(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
 }
 
+function containsUnresolvedShellReference(value: string): boolean {
+  return /\$[\w{(]/.test(value);
+}
+
 function parseStateDirDotEnvContent(content: string): Record<string, string> {
   const parsed = dotenv.parse(content);
   const entries: Record<string, string> = {};
@@ -26,6 +30,13 @@ function parseStateDirDotEnvContent(content: string): Record<string, string> {
       continue;
     }
     if (isBlockedServiceEnvVar(key)) {
+      continue;
+    }
+    // Skip values that still contain unresolved shell variable references
+    // ($VAR or ${VAR}). dotenv does not expand them, so persisting them into
+    // a single-quoted LaunchAgent/systemd env file would store the literal
+    // reference string rather than the intended credential value.
+    if (containsUnresolvedShellReference(value)) {
       continue;
     }
     entries[key] = value;

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -14,18 +14,48 @@ function isBlockedServiceEnvVar(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
 }
 
+function unwrapMatchingLiteralQuotes(value: string): string {
+  if (value.length < 2) {
+    return value;
+  }
+  const first = value[0];
+  const last = value.at(-1);
+  if ((first === `"` || first === `'`) && first === last) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
 function isUnresolvedShellReference(value: string): boolean {
+  const candidate = unwrapMatchingLiteralQuotes(value.trim());
   // Match only values whose entire content is a shell variable reference:
   //   $VAR_NAME          (simple reference — must start with a letter or underscore)
   //   ${VAR_NAME}        (brace-form reference)
   //   $(command)         (command substitution)
   // A real credential that merely contains a $ (e.g. "abc$2!", "$100") is NOT matched.
-  return /^\$[A-Za-z_]\w*$/.test(value) || /^\$\{[^}]+\}$/.test(value) || /^\$\(.*\)$/.test(value);
+  return (
+    /^\$[A-Za-z_]\w*$/.test(candidate) ||
+    /^\$\{[A-Za-z_]\w*\}$/.test(candidate) ||
+    /^\$\([^)]*\)$/.test(candidate)
+  );
 }
 
-function parseStateDirDotEnvContent(content: string): Record<string, string> {
+type ParsedStateDirDotEnv = {
+  /** Keys whose values are persisted to the managed service environment. */
+  entries: Record<string, string>;
+  /**
+   * Keys that were dropped because their entire value was an unresolved shell
+   * reference ($VAR, ${VAR}, or $(cmd)). These are still OpenClaw-managed keys:
+   * a previously generated env file may carry a stale literal reference for them
+   * that must be removed on re-stage rather than preserved as an operator secret.
+   */
+  skippedShellReferenceKeys: string[];
+};
+
+function parseStateDirDotEnvContent(content: string): ParsedStateDirDotEnv {
   const parsed = dotenv.parse(content);
   const entries: Record<string, string> = {};
+  const skippedShellReferenceKeys: string[] = [];
   for (const [rawKey, value] of Object.entries(parsed)) {
     if (!value?.trim()) {
       continue;
@@ -43,19 +73,30 @@ function parseStateDirDotEnvContent(content: string): Record<string, string> {
     // reference string rather than the intended credential value.
     // Values that merely contain $ (e.g. a password like "abc$2!") are kept.
     if (isUnresolvedShellReference(value)) {
+      skippedShellReferenceKeys.push(key);
       continue;
     }
     entries[key] = value;
   }
-  return entries;
+  return { entries, skippedShellReferenceKeys };
 }
 
 export function readStateDirDotEnvVarsFromStateDir(stateDir: string): Record<string, string> {
+  return readStateDirDotEnvFromStateDir(stateDir).entries;
+}
+
+/**
+ * Read and parse the state-dir `.env`, returning both the persisted entries and
+ * the keys that were skipped because they held unresolved shell references. The
+ * skipped keys are surfaced so generated service env files can remove stale
+ * literal references for keys OpenClaw previously managed.
+ */
+export function readStateDirDotEnvFromStateDir(stateDir: string): ParsedStateDirDotEnv {
   const dotEnvPath = path.join(stateDir, ".env");
   try {
     return parseStateDirDotEnvContent(fs.readFileSync(dotEnvPath, "utf8"));
   } catch {
-    return {};
+    return { entries: {}, skippedShellReferenceKeys: [] };
   }
 }
 

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -29,13 +29,13 @@ function unwrapMatchingLiteralQuotes(value: string): string {
 function isUnresolvedShellReference(value: string): boolean {
   const candidate = unwrapMatchingLiteralQuotes(value.trim());
   // Match only values whose entire content is a shell variable reference:
-  //   $VAR_NAME          (simple reference — must start with a letter or underscore)
+  //   $VAR_NAME          (simple reference, OpenClaw env-var style)
   //   ${VAR_NAME}        (brace-form reference)
   //   $(command)         (command substitution)
   // A real credential that merely contains a $ (e.g. "abc$2!", "$100") is NOT matched.
   return (
-    /^\$[A-Za-z_]\w*$/.test(candidate) ||
-    /^\$\{[^}]+\}$/.test(candidate) ||
+    /^\$[A-Z_][A-Z0-9_]*$/.test(candidate) ||
+    /^\$\{[A-Z_][A-Z0-9_]*(?:(?::[-=?+]?|[-=?+])[^}]*)?\}$/.test(candidate) ||
     /^\$\([^)]*\)$/.test(candidate)
   );
 }

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -16,11 +16,11 @@ function isBlockedServiceEnvVar(key: string): boolean {
 
 function isUnresolvedShellReference(value: string): boolean {
   // Match only values whose entire content is a shell variable reference:
-  //   $VAR_NAME          (simple reference)
+  //   $VAR_NAME          (simple reference — must start with a letter or underscore)
   //   ${VAR_NAME}        (brace-form reference)
   //   $(command)         (command substitution)
-  // A real credential that merely contains a $ (e.g. a password like "abc$2!") is NOT matched.
-  return /^\$[\w_][\w\d_]*$/.test(value) || /^\$\{[^}]+\}$/.test(value) || /^\$\(.*\)$/.test(value);
+  // A real credential that merely contains a $ (e.g. "abc$2!", "$100") is NOT matched.
+  return /^\$[A-Za-z_]\w*$/.test(value) || /^\$\{[^}]+\}$/.test(value) || /^\$\(.*\)$/.test(value);
 }
 
 function parseStateDirDotEnvContent(content: string): Record<string, string> {

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -35,7 +35,7 @@ function isUnresolvedShellReference(value: string): boolean {
   // A real credential that merely contains a $ (e.g. "abc$2!", "$100") is NOT matched.
   return (
     /^\$[A-Za-z_]\w*$/.test(candidate) ||
-    /^\$\{[A-Za-z_]\w*\}$/.test(candidate) ||
+    /^\$\{[^}]+\}$/.test(candidate) ||
     /^\$\([^)]*\)$/.test(candidate)
   );
 }

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1299,6 +1299,35 @@ describe("stageSystemdService", () => {
     });
   });
 
+  it("does not re-stage unresolved file-backed values from preserved service env (#88274)", async () => {
+    await withStageFixture(async ({ env, unitPath, envFilePath }) => {
+      await fs.writeFile(envFilePath, "LLM_API_KEY=$SECRET_FROM_SHELL\n", {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/tmp",
+        environment: {
+          LLM_API_KEY: "$SECRET_FROM_SHELL",
+          OPENCLAW_GATEWAY_PORT: "18789",
+        },
+        environmentValueSources: {
+          LLM_API_KEY: "file",
+        },
+      });
+
+      const unit = await fs.readFile(unitPath, "utf8");
+      expect(unit).not.toContain("EnvironmentFile=");
+      await expect(fs.access(envFilePath)).rejects.toThrow();
+    });
+  });
+
   it("sanitizes file-backed managed values out of the backup unit on re-stage", async () => {
     await withStageFixture(async ({ env, unitPath }) => {
       await fs.mkdir(path.dirname(unitPath), { recursive: true });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1526,14 +1526,41 @@ describe("stageSystemdService", () => {
     });
   });
 
+  it("removes a stale literal reference after the state-dir .env line is removed (#88274)", async () => {
+    await withStageFixture(async ({ env, envFilePath }) => {
+      await fs.writeFile(
+        envFilePath,
+        ["LLM_API_KEY=$SECRET_FROM_SHELL", "OPENROUTER_API_KEY=or-operator-key"].join("\n") + "\n",
+        { encoding: "utf8", mode: 0o600 },
+      );
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/tmp",
+        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+      });
+
+      const envFile = await fs.readFile(envFilePath, "utf8");
+      expect(envFile).not.toContain("LLM_API_KEY");
+      expect(envFile).not.toContain("$SECRET_FROM_SHELL");
+      expect(envFile).toContain("OPENROUTER_API_KEY=or-operator-key");
+    });
+  });
+
   it("keeps an operator secret that merely shares a name absent from state-dir .env (#88274)", async () => {
     await withStageFixture(async ({ env, stateDir, envFilePath }) => {
       // Operator-managed env file holds two secrets; neither is in state-dir .env.
       await fs.writeFile(
         envFilePath,
-        ["ANTHROPIC_API_KEY=sk-ant-operator-secret", "OPENROUTER_API_KEY=or-operator-key"].join(
-          "\n",
-        ) + "\n",
+        [
+          "ANTHROPIC_API_KEY=sk-ant-operator-secret",
+          "OPENROUTER_API_KEY=or-operator-key",
+          "LOWERCASE_LITERAL_API_KEY=$ecret123",
+        ].join("\n") + "\n",
         { encoding: "utf8", mode: 0o600 },
       );
 
@@ -1554,6 +1581,7 @@ describe("stageSystemdService", () => {
       const envFile = await fs.readFile(envFilePath, "utf8");
       expect(envFile).toContain("ANTHROPIC_API_KEY=sk-ant-operator-secret");
       expect(envFile).toContain("OPENROUTER_API_KEY=or-operator-key");
+      expect(envFile).toContain("LOWERCASE_LITERAL_API_KEY=$ecret123");
       expect(envFile).not.toContain("LLM_API_KEY");
     });
   });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1299,7 +1299,7 @@ describe("stageSystemdService", () => {
     });
   });
 
-  it("does not re-stage unresolved file-backed values from preserved service env (#88274)", async () => {
+  it("does not re-stage unresolved inline-and-file values from preserved service env (#88274)", async () => {
     await withStageFixture(async ({ env, unitPath, envFilePath }) => {
       await fs.writeFile(envFilePath, "LLM_API_KEY=$SECRET_FROM_SHELL\n", {
         encoding: "utf8",
@@ -1318,7 +1318,7 @@ describe("stageSystemdService", () => {
           OPENCLAW_GATEWAY_PORT: "18789",
         },
         environmentValueSources: {
-          LLM_API_KEY: "file",
+          LLM_API_KEY: "inline-and-file",
         },
       });
 

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1324,6 +1324,8 @@ describe("stageSystemdService", () => {
 
       const unit = await fs.readFile(unitPath, "utf8");
       expect(unit).not.toContain("EnvironmentFile=");
+      expect(unit).not.toContain("LLM_API_KEY");
+      expect(unit).not.toContain("$SECRET_FROM_SHELL");
       await expect(fs.access(envFilePath)).rejects.toThrow();
     });
   });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1492,6 +1492,71 @@ describe("stageSystemdService", () => {
       expect(envFile).toContain("LLM_API_KEY=new-value");
     });
   });
+
+  it("removes a stale literal reference on re-stage when state-dir .env now skips that key (#88274)", async () => {
+    await withStageFixture(async ({ env, stateDir, envFilePath }) => {
+      // A prior install generated a literal reference for LLM_API_KEY (an unexpanded
+      // $VAR that dotenv stored verbatim) and an operator-managed provider secret.
+      await fs.writeFile(
+        envFilePath,
+        ["LLM_API_KEY=$SECRET_FROM_SHELL", "OPENROUTER_API_KEY=or-operator-key"].join("\n") + "\n",
+        { encoding: "utf8", mode: 0o600 },
+      );
+
+      // The state-dir .env still declares LLM_API_KEY but now as an unresolved
+      // shell reference, so the parser skips it from the managed environment.
+      await fs.writeFile(path.join(stateDir, ".env"), "LLM_API_KEY=$SECRET_FROM_SHELL\n", "utf8");
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/tmp",
+        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+      });
+
+      const envFile = await fs.readFile(envFilePath, "utf8");
+      // The stale literal reference for the skipped managed key is dropped...
+      expect(envFile).not.toContain("LLM_API_KEY");
+      expect(envFile).not.toContain("$SECRET_FROM_SHELL");
+      // ...while operator-only secrets (never in state-dir .env) are preserved.
+      expect(envFile).toContain("OPENROUTER_API_KEY=or-operator-key");
+    });
+  });
+
+  it("keeps an operator secret that merely shares a name absent from state-dir .env (#88274)", async () => {
+    await withStageFixture(async ({ env, stateDir, envFilePath }) => {
+      // Operator-managed env file holds two secrets; neither is in state-dir .env.
+      await fs.writeFile(
+        envFilePath,
+        ["ANTHROPIC_API_KEY=sk-ant-operator-secret", "OPENROUTER_API_KEY=or-operator-key"].join(
+          "\n",
+        ) + "\n",
+        { encoding: "utf8", mode: 0o600 },
+      );
+
+      // State-dir .env only skips an unrelated key (LLM_API_KEY). Operator keys must
+      // not be treated as stale just because they are absent from the staged env.
+      await fs.writeFile(path.join(stateDir, ".env"), "LLM_API_KEY=${UNRESOLVED}\n", "utf8");
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/tmp",
+        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+      });
+
+      const envFile = await fs.readFile(envFilePath, "utf8");
+      expect(envFile).toContain("ANTHROPIC_API_KEY=sk-ant-operator-secret");
+      expect(envFile).toContain("OPENROUTER_API_KEY=or-operator-key");
+      expect(envFile).not.toContain("LLM_API_KEY");
+    });
+  });
 });
 
 describe("systemd service install and uninstall", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -864,7 +864,7 @@ async function writeSystemdUnit({
         environmentValueSources,
         key,
       });
-      if (isEnvironmentFileOnlySource(source) && isUnresolvedShellReference(value)) {
+      if (hasEnvironmentFileSource(source) && isUnresolvedShellReference(value)) {
         return false;
       }
       const normalizedKey = normalizeSystemdEnvironmentKey(key);

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { resolveStateDir } from "../config/paths.js";
-import { readStateDirDotEnvFromStateDir } from "../config/state-dir-dotenv.js";
+import {
+  isUnresolvedShellReference,
+  readStateDirDotEnvFromStateDir,
+} from "../config/state-dir-dotenv.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import {
@@ -940,15 +943,15 @@ async function writeSystemdGatewayEnvironmentFile(params: {
       return normalized ? [normalized] : [];
     }),
   ]);
-  const operatorOnly =
-    managedKeysToDrop.size > 0
-      ? Object.fromEntries(
-          Object.entries(existing).filter(([key]) => {
-            const normalized = normalizeSystemdEnvironmentKey(key);
-            return !normalized || !managedKeysToDrop.has(normalized);
-          }),
-        )
-      : existing;
+  const operatorOnly = Object.fromEntries(
+    Object.entries(existing).filter(([key, value]) => {
+      const normalized = normalizeSystemdEnvironmentKey(key);
+      if (normalized && managedKeysToDrop.has(normalized)) {
+        return false;
+      }
+      return !isUnresolvedShellReference(value);
+    }),
+  );
   const merged = { ...operatorOnly, ...incoming };
   const environmentKeys = new Set(
     Object.keys(merged).flatMap((key) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { resolveStateDir } from "../config/paths.js";
-import { readStateDirDotEnvVarsFromStateDir } from "../config/state-dir-dotenv.js";
+import { readStateDirDotEnvFromStateDir } from "../config/state-dir-dotenv.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import {
@@ -825,8 +825,10 @@ async function writeSystemdUnit({
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
   const stateDir = resolveStateDir(env as NodeJS.ProcessEnv);
+  const { entries: stateDirDotEnvEntries, skippedShellReferenceKeys } =
+    readStateDirDotEnvFromStateDir(stateDir);
   const stateDirDotEnvVars = Object.fromEntries(
-    Object.entries(readStateDirDotEnvVarsFromStateDir(stateDir)).filter(([key, value]) => {
+    Object.entries(stateDirDotEnvEntries).filter(([key, value]) => {
       const inlineValue = environment?.[key];
       if (typeof inlineValue !== "string") {
         return true;
@@ -843,6 +845,7 @@ async function writeSystemdUnit({
     dotenvVars: stateDirDotEnvVars,
     inlineManagedKeys,
     fileManagedKeys,
+    skippedManagedKeys: skippedShellReferenceKeys,
     fileBackedEnvironment: collectSystemdFileBackedEnvironment({
       environment,
       fileManagedKeys,
@@ -888,6 +891,10 @@ async function writeSystemdGatewayEnvironmentFile(params: {
   inlineManagedKeys?: ReadonlySet<string>;
   /** File-managed keys that should be written from current environment values or removed when absent. */
   fileManagedKeys?: ReadonlySet<string>;
+  /** State-dir .env keys OpenClaw previously managed but is now skipping (unresolved shell
+   *  references). A prior re-stage may have written a stale literal value for them; drop it so
+   *  the regenerated env file no longer carries the obsolete reference. */
+  skippedManagedKeys?: Iterable<string>;
   fileBackedEnvironment?: Record<string, string>;
   environment?: GatewayServiceEnv;
 }): Promise<{ environmentFiles: string[]; environmentKeys: Set<string> }> {
@@ -928,6 +935,10 @@ async function writeSystemdGatewayEnvironmentFile(params: {
   const managedKeysToDrop = new Set([
     ...(params.inlineManagedKeys ?? []),
     ...(params.fileManagedKeys ?? []),
+    ...[...(params.skippedManagedKeys ?? [])].flatMap((key) => {
+      const normalized = normalizeSystemdEnvironmentKey(key);
+      return normalized ? [normalized] : [];
+    }),
   ]);
   const operatorOnly =
     managedKeysToDrop.size > 0

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -315,7 +315,7 @@ function collectSystemdFileBackedEnvironment(params: {
       continue;
     }
     const key = normalizeSystemdEnvironmentKey(rawKey);
-    if (key && params.fileManagedKeys.has(key)) {
+    if (key && params.fileManagedKeys.has(key) && !isUnresolvedShellReference(rawValue)) {
       environment[rawKey] = rawValue;
     }
   }

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -860,6 +860,13 @@ async function writeSystemdUnit({
       if (typeof value !== "string") {
         return false;
       }
+      const source = readSystemdEnvironmentValueSource({
+        environmentValueSources,
+        key,
+      });
+      if (isEnvironmentFileOnlySource(source) && isUnresolvedShellReference(value)) {
+        return false;
+      }
       const normalizedKey = normalizeSystemdEnvironmentKey(key);
       if (
         normalizedKey &&


### PR DESCRIPTION
Fixes #88274

## Summary

`readStateDirDotEnvVarsFromStateDir` accepted every non-empty value from `~/.openclaw/.env` without checking whether the value is an unresolved shell variable reference. `dotenv.parse` preserves these references literally — it does not expand `$VAR` or `${VAR}`. When a literal reference like `${SUPERMEMORY_OPENCLAW_KEY}` reaches the LaunchAgent/systemd wrapper, it is single-quoted and written to the service env file as-is, so the plugin receives the literal string `${SUPERMEMORY_OPENCLAW_KEY}` instead of the actual credential value.

The fix adds `isUnresolvedShellReference()` and skips values whose **entire content** is a recognised shell reference form:

- `$VAR_NAME` — simple variable reference (must start with a letter or underscore)
- `${VAR_NAME}` — brace-form variable reference
- `$(command)` — command substitution

Real credentials that merely **contain** a `$` (e.g. a password `abc$2!xyz`, a price `$100`, or a token `tok_$prod_v2`) are **not** skipped — the regex is anchored to the whole value and requires the variable name to start with a letter or underscore.

## Real behavior proof

**Behavior addressed:** Unresolved whole-value shell references in the state-dir `.env` must not be persisted into the generated gateway service environment (LaunchAgent / systemd install plan), while real credentials that merely contain a `$` must be preserved. This is verified end-to-end through the actual install-plan builder `buildGatewayInstallPlan()` and the real `buildLaunchAgentPlist()` renderer — not only the unit under test.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, PR HEAD `65b3c5f38d6e27dd9e842a3fab358102ceae3b94` rebased onto upstream main `9a00d740447b21dff4b0dc9f77c745e670be306c`.

**Exact steps or command run after this patch:** A harness writes a real `$OPENCLAW_STATE_DIR/.env` containing whole-value shell refs (`$SUPERMEMORY_TOKEN`, `${OPENCLAW_REMOTE_HOST}`, `$(hostname)`) alongside real credentials that contain a `$` (`abc$def…`, `$100-pa…word`, `sk_live_x$y$z…`), then calls the real `buildGatewayInstallPlan({ platform: "darwin", … })` and renders the LaunchAgent plist with `buildLaunchAgentPlist()`. Secrets in the captured output below are redacted. The pre-existing Vitest regression file is also run as a secondary signal.

```bash
# Primary: real install-plan + LaunchAgent render through the production code path
node --import tsx harness.mts   # writes a real state-dir .env, calls buildGatewayInstallPlan + buildLaunchAgentPlist

# Secondary: focused regression suite
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.runtime-config.config.ts \
  src/config/state-dir-dotenv.test.ts --reporter=verbose --testTimeout=10000
```

**Evidence after fix:**

```
=== state-dir .env (input) ===
# (A) WHOLE-VALUE unresolved shell references -> must be SKIPPED
SUPERMEMORY_API_KEY=$SUPERMEMORY_TOKEN
REMOTE_HOST=${OPENCLAW_REMOTE_HOST}
RUNTIME_ID=$(hostname)

# (B) real credentials that merely CONTAIN a $ -> must be KEPT (values redacted)
REAL_API_KEY=abc$def-REDACTED
DB_PASSWORD=$100-paREDACTEDword
STRIPE_KEY=sk_live_x$y$z-REDACTED

# (C) partial reference (not whole-value) -> kept as literal by design
REMOTE_URL=${OPENCLAW_REMOTE_HOST}/gateway

=== Layer A: readStateDirDotEnvVarsFromStateDir() durable map ===
  REAL_API_KEY = abc$def-REDACTED
  DB_PASSWORD = $100-paREDACTEDword
  STRIPE_KEY = sk_live_x$y$z-REDACTED
  REMOTE_URL = ${OPENCLAW_REMOTE_HOST}/gateway

=== Layer B: install plan OPENCLAW_SERVICE_MANAGED_ENV_KEYS (from buildGatewayInstallPlan) ===
  DB_PASSWORD, REAL_API_KEY, REMOTE_URL, STRIPE_KEY

=== ASSERTIONS ===
  [PASS] whole-value ref SUPERMEMORY_API_KEY skipped (absent from durable map, managed keys, plist <key>)
  [PASS] whole-value ref REMOTE_HOST skipped (absent from durable map, managed keys, plist <key>)
  [PASS] whole-value ref RUNTIME_ID skipped (absent from durable map, managed keys, plist <key>)
  [PASS] real cred REAL_API_KEY kept (in durable map with '$', in managed keys)
  [PASS] real cred DB_PASSWORD kept (in durable map with '$', in managed keys)
  [PASS] real cred STRIPE_KEY kept (in durable map with '$', in managed keys)
  [PASS] partial ref REMOTE_URL kept verbatim (by design — only whole-value refs are skipped)
```

Secondary regression suite:

```
 ✓ src/config/state-dir-dotenv.test.ts > readStateDirDotEnvVarsFromStateDir > returns real credential values from the state-dir dotenv
 ✓ src/config/state-dir-dotenv.test.ts > readStateDirDotEnvVarsFromStateDir > skips values that are unresolved shell variable references
 ✓ src/config/state-dir-dotenv.test.ts > readStateDirDotEnvVarsFromStateDir > preserves credential values that merely contain a dollar sign
 ✓ src/config/state-dir-dotenv.test.ts > readStateDirDotEnvVarsFromStateDir > returns empty object when .env is missing

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

**Observed result after fix:** The three whole-value shell references (`$SUPERMEMORY_TOKEN`, `${OPENCLAW_REMOTE_HOST}`, `$(hostname)`) are omitted from the durable service-env map, from the install plan's `OPENCLAW_SERVICE_MANAGED_ENV_KEYS` list, and from the rendered LaunchAgent plist. The three real credentials that merely contain a `$` are retained verbatim with their `$` intact, and a partial reference (`${OPENCLAW_REMOTE_HOST}/gateway`, not a whole-value ref) is kept as a literal by design. The gateway service environment no longer receives literal shell-reference strings for affected values.

**What was not tested:** A live macOS `launchd` load / `systemctl` start of the rendered service on real hardware. The proof exercises the real install-plan builder and the real plist renderer through production code paths with a real on-disk state-dir `.env`, but stops short of loading the generated service into a live init system.

## Real systemd re-stage proof (follow-up: stale literal removal)

This follow-up addresses the systemd stale-env path. A prior install may have written a literal shell reference (e.g. `LLM_API_KEY=$SECRET_FROM_SHELL`) into `gateway.systemd.env`. Because the parser now skips that key, it no longer appears in the incoming env or the managed-key removal sets, so the stale literal could survive a re-stage and — since systemd `EnvironmentFile` takes precedence over inline `Environment=` — override fresh values. The parser now surfaces the skipped shell-reference keys, and `writeSystemdGatewayEnvironmentFile` adds them to the env-file managed-key removal set so re-staging strips the obsolete literal while preserving operator-only secrets. (`launchd` regenerates its env file wholesale, so it is unaffected — confirmed by reading `prepareLaunchAgentProgramArguments`, which rebuilds the file from the passed-in environment without merging an on-disk copy.)

**Behavior addressed:** On systemd re-stage, a stale literal reference left in `gateway.systemd.env` for a state-dir `.env` key that is now skipped (because its value is an unresolved whole-value shell reference) must be removed, while operator-only secrets that were never managed via state-dir `.env` must be preserved.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, PR HEAD `65b3c5f38d6e27dd9e842a3fab358102ceae3b94` rebased onto upstream main `9a00d740447b21dff4b0dc9f77c745e670be306c`.

**Exact steps or command run after this patch:** Two focused tests drive the production `stageSystemdService()` path against a real temp `$OPENCLAW_STATE_DIR`. Test 1 pre-writes `gateway.systemd.env` with a stale `LLM_API_KEY=$SECRET_FROM_SHELL` literal plus an operator secret `OPENROUTER_API_KEY`, writes a state-dir `.env` whose `LLM_API_KEY` is now the unresolved ref `$SECRET_FROM_SHELL`, re-stages, and asserts the regenerated env file no longer contains `LLM_API_KEY`/`$SECRET_FROM_SHELL` while keeping the operator secret. Test 2 asserts that operator secrets absent from state-dir `.env` are never treated as stale just because an unrelated key was skipped.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config vitest.config.ts \
  src/daemon/systemd.test.ts --reporter=verbose -t "88274" --testTimeout=30000
```

**Evidence after fix:**

```
 ✓ |daemon| ../../src/daemon/systemd.test.ts > stageSystemdService > removes a stale literal reference on re-stage when state-dir .env now skips that key (#88274) 362ms
 ✓ |daemon| ../../src/daemon/systemd.test.ts > stageSystemdService > keeps an operator secret that merely shares a name absent from state-dir .env (#88274) 31ms

 Test Files  1 passed (1)
      Tests  2 passed | 70 skipped (72)
```

Full systemd suite (no regressions):

```
 Test Files  1 passed (1)
      Tests  72 passed (72)
```

**Observed result after fix:** After re-stage, the stale literal `LLM_API_KEY=$SECRET_FROM_SHELL` is removed from `gateway.systemd.env` (neither the key nor the literal value remains), while the operator-only secret `OPENROUTER_API_KEY=or-operator-key` is preserved. Operator secrets that merely happen to be absent from the staged environment are not deleted. The parser suite (4/4) and the full systemd suite (72/72) both pass; core and core-test type checks (`tsgo -p tsconfig.core.json`, `tsgo -p test/tsconfig/tsconfig.core.test.json`) and oxlint on the changed files pass clean.

**What was not tested:** A live `systemctl --user` reload/restart of the regenerated unit on real hardware. The proof drives the real `stageSystemdService()` env-file generation against an on-disk temp state dir but stops short of loading the unit into a running systemd instance. The fail-closed credential-omission semantics (whether omitting an unresolvable credential is the desired compatibility behavior) remain a maintainer decision and are intentionally unchanged here.

