### PR TITLE
fix(microsoft-foundry): skip DeepSeek V4 thinking params on Foundry fallback

### DIFF
--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -733,6 +733,26 @@ describe("applyExtraParamsToAgent", () => {
     expect(messages[2]).not.toHaveProperty("reasoning_content");
   });
 
+  it("does not add DeepSeek V4 thinking params on the Foundry fallback path", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "microsoft-foundry",
+      applyModelId: "deepseek-v4-pro",
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "microsoft-foundry",
+        id: "deepseek-v4-pro",
+      } as Model<"openai-completions">,
+      payload: {
+        reasoning_effort: "high",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    expect(payload.reasoning_effort).toBe("high");
+    expect(payload).not.toHaveProperty("thinking");
+  });
+
   it("fills MiMo V2.6 reasoning_content for unowned OpenAI-compatible proxy models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "opencode",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -901,6 +901,7 @@ function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): bool
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
   return (
     model.api === "openai-completions" &&
+    model.provider !== "microsoft-foundry" &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
 }


### PR DESCRIPTION
## Summary
This PR fixes a request-shaping error for `microsoft-foundry/deepseek-v4-pro` when running on the OpenAI-compatible `openai-completions` route. 

Currently, OpenClaw injects generic DeepSeek V4 `thinking: { type: "enabled" }` parameter payloads to all models matching `deepseek-v4-flash` or `deepseek-v4-pro` on the `openai-completions` route. However, Microsoft Foundry's API gateway is strictly compliant with standard OpenAI payloads and rejects this non-standard parameter with a `400 Unrecognized request argument supplied: thinking` error.

This PR skips the generic DeepSeek V4 `thinking` wrapper specifically for the `microsoft-foundry` fallback provider, allowing Foundry-hosted DeepSeek models to be successfully queried.

## What changed
- Skips the generic DeepSeek V4 `thinking` wrapper for `microsoft-foundry` in `src/agents/embedded-agent-runner/extra-params.ts`.
- Adds a focused unit test verifying that `thinking` is omitted on the Foundry path in `src/agents/embedded-agent-runner-extraparams.test.ts`.

## Real behavior proof

- **Behavior addressed**: DeepSeek V4 (`microsoft-foundry/deepseek-v4-pro`) request-shaping/thinking-wrapper failures on OpenAI-compatible routes.
- **Real environment tested**: local macOS operator environment, source build of OpenClaw 2026.5.24 (`c950ac112e`).
- **Exact steps or command run after this patch**:
  Run live one-shot model inference to verify Foundry request execution:
  ```bash
  node openclaw.mjs infer model run --model microsoft-foundry/deepseek-v4-pro --prompt "Reply with exactly HELLO_FOUNDRY" --local --json
  ```
- **Evidence**: Copied CLI stdout of successful live model run.
- **Observed result**:
  Live inference correctly skipped `payload.thinking` and returned the successful completions response:
  ```json
  {
    "ok": true,
    "capability": "model.run",
    "transport": "local",
    "provider": "microsoft-foundry",
    "model": "deepseek-v4-pro",
    "outputs": [
      {
        "text": "HELLO_FOUNDRY",
        "mediaUrl": null
      }
    ]
  }
  ```
- **What was not tested**: None.

## Validation
Targeted unit tests run successfully:
- `pnpm exec vitest run src/agents/embedded-agent-runner-extraparams.test.ts` (130/130 tests passed)
- `npx oxlint src/agents/embedded-agent-runner/extra-params.ts src/agents/embedded-agent-runner-extraparams.test.ts` (0 warnings, 0 errors)
