### PR TITLE
fix #88274: Bug: gateway service env renders Supermemory API key as literal env reference

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -1134,6 +1134,33 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
     );
   });
 
+  it("does not retain nested .env references for macOS LaunchAgent env files", async () => {
+    await writeStateDirDotEnv(
+      "SUPERMEMORY_OPENCLAW_API_KEY=$SUPERMEMORY_OPENCLAW_KEY\nTAVILY_API_KEY=dotenv-tavily\n",
+      {
+        stateDir: path.join(tmpDir, ".openclaw"),
+      },
+    );
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        HOME: "/from-service",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: { HOME: tmpDir },
+      port: 3000,
+      runtime: "node",
+      platform: "darwin",
+    });
+
+    expect(plan.environment.SUPERMEMORY_OPENCLAW_API_KEY).toBeUndefined();
+    expect(plan.environment.TAVILY_API_KEY).toBe("dotenv-tavily");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("TAVILY_API_KEY");
+  });
+
   it("does not retain config env values for macOS LaunchAgent env files", async () => {
     await writeStateDirDotEnv("OPENROUTER_API_KEY=or-dotenv\nTAVILY_API_KEY=dotenv-tavily\n", {
       stateDir: path.join(tmpDir, ".openclaw"),

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -179,6 +179,7 @@ describe("config env vars", () => {
           "BRACED_REF=${SUPERMEMORY_OPENCLAW_KEY}",
           'QUOTED_REF="$SUPERMEMORY_OPENCLAW_KEY"',
           "ESCAPED_DOLLAR=$$SUPERMEMORY_OPENCLAW_KEY",
+          "EMBEDDED_DOLLAR=sm_$SUPERMEMORY_OPENCLAW_KEY",
           "VALID=ok",
           "",
         ].join("\n"),
@@ -191,6 +192,7 @@ describe("config env vars", () => {
       expect(vars.BRACED_REF).toBeUndefined();
       expect(vars.QUOTED_REF).toBeUndefined();
       expect(vars.ESCAPED_DOLLAR).toBe("$$SUPERMEMORY_OPENCLAW_KEY");
+      expect(vars.EMBEDDED_DOLLAR).toBe("sm_$SUPERMEMORY_OPENCLAW_KEY");
       expect(vars.VALID).toBe("ok");
     });
   });

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -169,14 +169,28 @@ describe("config env vars", () => {
     });
   });
 
-  it("drops dangerous and empty values from the state-dir .env file", async () => {
+  it("drops dangerous, empty, and nested reference values from the state-dir .env file", async () => {
     await withTempHome(async (_home) => {
-      await writeStateDirDotEnv("NODE_OPTIONS=--require /tmp/evil.js\nEMPTY=\nVALID=ok\n", {
-        env: process.env,
-      });
+      await writeStateDirDotEnv(
+        [
+          "NODE_OPTIONS=--require /tmp/evil.js",
+          "EMPTY=",
+          "LITERAL_REF=$SUPERMEMORY_OPENCLAW_KEY",
+          "BRACED_REF=${SUPERMEMORY_OPENCLAW_KEY}",
+          'QUOTED_REF="$SUPERMEMORY_OPENCLAW_KEY"',
+          "ESCAPED_DOLLAR=$$SUPERMEMORY_OPENCLAW_KEY",
+          "VALID=ok",
+          "",
+        ].join("\n"),
+        { env: process.env },
+      );
       const vars = readStateDirDotEnvVars(process.env);
       expect(vars.NODE_OPTIONS).toBeUndefined();
       expect(vars.EMPTY).toBeUndefined();
+      expect(vars.LITERAL_REF).toBeUndefined();
+      expect(vars.BRACED_REF).toBeUndefined();
+      expect(vars.QUOTED_REF).toBeUndefined();
+      expect(vars.ESCAPED_DOLLAR).toBe("$$SUPERMEMORY_OPENCLAW_KEY");
       expect(vars.VALID).toBe("ok");
     });
   });

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -14,10 +14,11 @@ function isBlockedServiceEnvVar(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
 }
 
-const SHELL_ENV_VAR_REFERENCE_PATTERN = /(^|[^$])\$(?:\{[A-Z_][A-Z0-9_]*\}|[A-Z_][A-Z0-9_]*)/;
+const SHELL_ENV_VAR_REFERENCE_PATTERN =
+  /^(?:["'])?\$(?:\{[A-Z_][A-Z0-9_]*\}|[A-Z_][A-Z0-9_]*)(?:["'])?$/;
 
-function containsShellEnvVarReference(value: string): boolean {
-  return SHELL_ENV_VAR_REFERENCE_PATTERN.test(value);
+function isShellEnvVarReference(value: string): boolean {
+  return SHELL_ENV_VAR_REFERENCE_PATTERN.test(value.trim());
 }
 
 function parseStateDirDotEnvContent(content: string): Record<string, string> {
@@ -34,7 +35,7 @@ function parseStateDirDotEnvContent(content: string): Record<string, string> {
     if (isBlockedServiceEnvVar(key)) {
       continue;
     }
-    if (containsShellEnvVarReference(value)) {
+    if (isShellEnvVarReference(value)) {
       continue;
     }
     entries[key] = value;

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -14,6 +14,12 @@ function isBlockedServiceEnvVar(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
 }
 
+const SHELL_ENV_VAR_REFERENCE_PATTERN = /(^|[^$])\$(?:\{[A-Z_][A-Z0-9_]*\}|[A-Z_][A-Z0-9_]*)/;
+
+function containsShellEnvVarReference(value: string): boolean {
+  return SHELL_ENV_VAR_REFERENCE_PATTERN.test(value);
+}
+
 function parseStateDirDotEnvContent(content: string): Record<string, string> {
   const parsed = dotenv.parse(content);
   const entries: Record<string, string> = {};
@@ -26,6 +32,9 @@ function parseStateDirDotEnvContent(content: string): Record<string, string> {
       continue;
     }
     if (isBlockedServiceEnvVar(key)) {
+      continue;
+    }
+    if (containsShellEnvVarReference(value)) {
       continue;
     }
     entries[key] = value;


### PR DESCRIPTION
## Summary

- Drop state-dir `.env` values only when the whole value is an unresolved shell-style `$VAR` / `${VAR}` reference before durable gateway service env planning.
- Preserve safe state-dir `.env` values, including literal credential strings that contain an embedded dollar sign.
- Add regression coverage for bare, braced, quoted, escaped, embedded-dollar, and LaunchAgent service env planning cases.

Closes #88274.

## Real behavior proof

- **Behavior or issue addressed:** Gateway service env planning no longer persists a literal Supermemory-style value such as `SUPERMEMORY_OPENCLAW_API_KEY="$SUPERMEMORY_OPENCLAW_KEY"`; the unresolved reference is omitted while normal `.env` values and embedded-dollar literal credentials remain available to the generated service env plan.
- **Real environment tested:** Local function boundary from the patched worktree on Linux, using a temporary state dir and the real `readStateDirDotEnvVarsFromStateDir` plus `buildGatewayInstallPlan({ platform: "darwin" })` code path.
- **Exact steps or command run after this patch:** `node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-88274-evidence/service-env-reference-proof.ts`; targeted Vitest and TypeScript checks listed below.
- **Evidence after fix:** Redacted terminal output from the real function-boundary proof:

```json
{
  "parsedHasLiteralReference": false,
  "parsedSafeValue": "or-real-value",
  "parsedEmbeddedDollarValue": "sm_$SUPERMEMORY_OPENCLAW_KEY",
  "planHasLiteralReference": false,
  "planSafeValue": "or-real-value",
  "planEmbeddedDollarValue": "sm_$SUPERMEMORY_OPENCLAW_KEY",
  "managedKeys": "EMBEDDED_DOLLAR_KEY,OPENROUTER_API_KEY"
}
```

Supporting local artifacts: `/media/vdc/code/ai/aispace/openclaw-issue-88274-evidence/service-env-reference-proof-rerun.json`; `/media/vdc/code/ai/aispace/openclaw-issue-88274-evidence/vitest-new-regression-rerun.log`; `/media/vdc/code/ai/aispace/openclaw-issue-88274-evidence/vitest-related-rerun.log`; `/media/vdc/code/ai/aispace/openclaw-issue-88274-evidence/tsgo-core-test-rerun.log`; `/media/vdc/code/ai/aispace/openclaw-issue-88274-evidence/git-diff-check-rerun.log`; `/media/vdc/code/ai/aispace/openclaw-issue-88274-evidence/main-baseline-passenv-failure.log`.
- **Observed result after fix:** The unresolved Supermemory-style value is absent from both parsed state-dir `.env` output and the macOS service-env plan. A normal safe value is retained, and an embedded-dollar literal (`sm_$SUPERMEMORY_OPENCLAW_KEY`) is retained in both parsed output and the service-env plan.
- **What was not tested:** A live macOS LaunchAgent install/restart was not run in this Linux environment. The full issue acceptance command still hits an unrelated current-main baseline failure in `daemon-install-helpers.test.ts` passEnv tests; the same focused passEnv test fails on a clean `origin/main` worktree, and that baseline evidence is included above.
- **Target test file:** `src/config/config.env-vars.test.ts`

## Regression Test Plan

- `node scripts/run-vitest.mjs src/config/config.env-vars.test.ts src/commands/daemon-install-helpers.test.ts -t "drops dangerous, empty, and nested reference values|does not retain nested .env references"`
- `node scripts/run-vitest.mjs src/config/config.env-vars.test.ts src/daemon/launchd.test.ts src/daemon/systemd.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check origin/main...HEAD`

## Root Cause

- **Root cause:** The runtime config env path already avoids unresolved `${VAR}` placeholders, but the durable service env path accepted state-dir `.env` values as-is. On macOS, LaunchAgent service env planning re-inlines managed state-dotenv values for the generated owner-only env file, and LaunchAgent rendering single-quotes values, so whole-value shell references such as `$SUPERMEMORY_OPENCLAW_KEY` survive literally instead of resolving or being omitted.
