### PR TITLE
fix(update): guard Windows task autostart during package updates

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -28,6 +28,8 @@ const resolveGlobalManager = vi.fn();
 const serviceLoaded = vi.fn();
 const serviceStop = vi.fn();
 const serviceRestart = vi.fn();
+const suspendScheduledTaskAutoStartForUpdate = vi.fn();
+const resumeScheduledTaskAutoStartAfterUpdate = vi.fn();
 const prepareRestartScript = vi.fn();
 const runRestartScript = vi.fn();
 const mockedRunDaemonInstall = vi.fn();
@@ -41,6 +43,23 @@ const probeGateway = vi.fn();
 const pathExists = vi.fn();
 const syncPluginsForUpdateChannel = vi.fn();
 const updateNpmInstalledPlugins = vi.fn();
+type PostCorePluginConvergenceMockResult = {
+  changes: unknown[];
+  warnings: Array<{ pluginId?: string; message: string; guidance?: string[] }>;
+  errored: boolean;
+  smokeFailures: unknown[];
+  installRecords: unknown;
+};
+type RunPostCorePluginConvergenceMock = (params: {
+  baselineInstallRecords?: unknown;
+}) => Promise<PostCorePluginConvergenceMockResult>;
+const runPostCorePluginConvergence = vi.fn<RunPostCorePluginConvergenceMock>(async (params) => ({
+  changes: [],
+  warnings: [],
+  errored: false,
+  smokeFailures: [],
+  installRecords: params.baselineInstallRecords ?? {},
+}));
 const loadInstalledPluginIndexInstallRecords = vi.fn(
   async (params: { config?: OpenClawConfig } = {}) => params.config?.plugins?.installs ?? {},
 );
@@ -245,13 +264,8 @@ vi.mock("./update-cli/post-core-plugin-convergence.js", () => ({
       })),
     errored: convergence.errored,
   }),
-  runPostCorePluginConvergence: vi.fn(async (params: { baselineInstallRecords?: unknown }) => ({
-    changes: [],
-    warnings: [],
-    errored: false,
-    smokeFailures: [],
-    installRecords: params.baselineInstallRecords ?? {},
-  })),
+  runPostCorePluginConvergence: (...args: Parameters<RunPostCorePluginConvergenceMock>) =>
+    runPostCorePluginConvergence(...args),
 }));
 
 vi.mock("../daemon/service.js", () => ({
@@ -283,6 +297,13 @@ vi.mock("../daemon/service.js", () => ({
     stop: (...args: unknown[]) => serviceStop(...args),
     restart: (...args: unknown[]) => serviceRestart(...args),
   })),
+}));
+
+vi.mock("../daemon/schtasks.js", () => ({
+  suspendScheduledTaskAutoStartForUpdate: (...args: unknown[]) =>
+    suspendScheduledTaskAutoStartForUpdate(...args),
+  resumeScheduledTaskAutoStartAfterUpdate: (...args: unknown[]) =>
+    resumeScheduledTaskAutoStartAfterUpdate(...args),
 }));
 
 vi.mock("../daemon/launchd.js", async (importOriginal) => ({
@@ -430,6 +451,96 @@ describe("update-cli", () => {
         markerPath: null,
       },
     });
+  };
+
+  const setupRunningManagedPackageUpdate = async (prefix: string) => {
+    const tempDir = await createTrackedTempDir(prefix);
+    const nodeModules = path.join(tempDir, "node_modules");
+    const pkgRoot = path.join(nodeModules, "openclaw");
+    const entryPath = path.join(pkgRoot, "dist", "index.js");
+    mockPackageInstallStatus(pkgRoot);
+    await fs.mkdir(path.dirname(entryPath), { recursive: true });
+    await fs.writeFile(
+      path.join(pkgRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.21" }),
+      "utf-8",
+    );
+    await fs.writeFile(entryPath, "export {};\n", "utf-8");
+    await writePackageDistInventory(pkgRoot);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "run"],
+      environment: {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      },
+    });
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 4242,
+      state: "running",
+    });
+    pathExists.mockImplementation(async (candidate: string) => {
+      try {
+        await fs.access(candidate);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
+        return {
+          stdout: `${nodeModules}\n`,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (
+        Array.isArray(argv) &&
+        argv[0] === "npm" &&
+        argv[1] === "i" &&
+        argv.includes("--prefix")
+      ) {
+        await writeStagedOpenClawPackageInstall(argv);
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+    return { entryPath, nodeModules, pkgRoot, tempDir };
+  };
+
+  const writeStagedOpenClawPackageInstall = async (argv: string[], version = "9999.0.0") => {
+    const prefixIndex = argv.indexOf("--prefix");
+    if (prefixIndex < 0) {
+      return;
+    }
+    const stagePrefix = argv[prefixIndex + 1];
+    if (typeof stagePrefix !== "string") {
+      throw new Error("missing stage prefix");
+    }
+    const stageRoot =
+      process.platform === "win32"
+        ? path.join(stagePrefix, "node_modules", "openclaw")
+        : path.join(stagePrefix, "lib", "node_modules", "openclaw");
+    const entryPath = path.join(stageRoot, "dist", "index.js");
+    await fs.mkdir(path.dirname(entryPath), { recursive: true });
+    await fs.writeFile(
+      path.join(stageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version }),
+      "utf-8",
+    );
+    await fs.writeFile(entryPath, "export {};\n", "utf-8");
+    await writePackageDistInventory(stageRoot);
   };
 
   const expectUpdateCallChannel = (channel: string) => {
@@ -597,16 +708,17 @@ describe("update-cli", () => {
       expect(packagePackCommandCall()).toBeUndefined();
     }
     const call = packageInstallCommandCall();
-    expect(call?.[0]).toEqual([
-      "npm",
-      "i",
-      "-g",
-      installSpec,
-      "--no-fund",
-      "--no-audit",
-      "--loglevel=error",
-      "--min-release-age=0",
-    ]);
+    const argv = call?.[0] ?? [];
+    expect(argv.slice(0, 3)).toEqual(["npm", "i", "-g"]);
+    if (argv.includes("--prefix")) {
+      expect(typeof argv[argv.indexOf("--prefix") + 1]).toBe("string");
+    }
+    expect(argv).toEqual(
+      expect.arrayContaining([installSpec, "--no-fund", "--no-audit", "--loglevel=error"]),
+    );
+    expect(argv.some((arg) => arg === "--min-release-age=0" || /^--before=.+/u.test(arg))).toBe(
+      true,
+    );
     if (call?.[1] === undefined) {
       throw new Error("Expected package install command options");
     }
@@ -785,6 +897,8 @@ describe("update-cli", () => {
     resolveGlobalManager.mockResolvedValue("npm");
     serviceStop.mockResolvedValue(undefined);
     serviceRestart.mockResolvedValue({ outcome: "completed" });
+    suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(false);
+    resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(false);
     serviceLoaded.mockResolvedValue(false);
     serviceReadCommand.mockImplementation(async () =>
       (await serviceLoaded()) ? { programArguments: ["openclaw", "gateway", "run"] } : null,
@@ -837,6 +951,15 @@ describe("update-cli", () => {
       config: baseConfig,
       outcomes: [],
     });
+    runPostCorePluginConvergence.mockImplementation(
+      async (params: { baselineInstallRecords?: unknown }) => ({
+        changes: [],
+        warnings: [],
+        errored: false,
+        smokeFailures: [],
+        installRecords: params.baselineInstallRecords ?? {},
+      }),
+    );
     checkShellCompletionStatus.mockResolvedValue({
       shell: "zsh",
       profileInstalled: false,
@@ -2709,6 +2832,170 @@ describe("update-cli", () => {
     expect(requiredServiceStopCallOrder).toBeLessThan(requiredNpmInstallCallOrder);
   });
 
+  it("suspends Windows Scheduled Task autostart around package replacement", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      await setupRunningManagedPackageUpdate("openclaw-update-windows-task-");
+      suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+      resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
+
+      await withEnvAsync(
+        {
+          OPENCLAW_SERVICE_MARKER: "openclaw",
+          OPENCLAW_SERVICE_KIND: "gateway",
+        },
+        async () => {
+          await updateCommand({ yes: true });
+        },
+      );
+
+      const npmInstallCallIndex = vi
+        .mocked(runCommandWithTimeout)
+        .mock.calls.findIndex(
+          (call) => Array.isArray(call[0]) && call[0][0] === "npm" && call[0][1] === "i",
+        );
+      const npmInstallCallOrder =
+        vi.mocked(runCommandWithTimeout).mock.invocationCallOrder[npmInstallCallIndex];
+      const serviceEnv = {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      };
+      expect(suspendScheduledTaskAutoStartForUpdate).toHaveBeenCalledWith(
+        expect.objectContaining(serviceEnv),
+      );
+      expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledWith(
+        expect.objectContaining(serviceEnv),
+      );
+
+      const suspendOrder = suspendScheduledTaskAutoStartForUpdate.mock.invocationCallOrder[0];
+      const stopOrder = serviceStop.mock.invocationCallOrder[0];
+      const resumeOrder = resumeScheduledTaskAutoStartAfterUpdate.mock.invocationCallOrder[0];
+      expect(requireValue(suspendOrder, "Scheduled Task suspend order")).toBeLessThan(
+        requireValue(stopOrder, "service stop order"),
+      );
+      expect(requireValue(stopOrder, "service stop order")).toBeLessThan(
+        requireValue(npmInstallCallOrder, "npm install call order"),
+      );
+      expect(requireValue(npmInstallCallOrder, "npm install call order")).toBeLessThan(
+        requireValue(resumeOrder, "Scheduled Task resume order"),
+      );
+      expect(spawn).toHaveBeenCalled();
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("reports a failed Windows Scheduled Task resume after service stop fails", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      await setupRunningManagedPackageUpdate("openclaw-update-windows-task-stop-fail-");
+      suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+      serviceStop.mockRejectedValueOnce(new Error("stop failed"));
+      resumeScheduledTaskAutoStartAfterUpdate.mockRejectedValueOnce(new Error("enable failed"));
+
+      await withEnvAsync(
+        {
+          OPENCLAW_SERVICE_MARKER: "openclaw",
+          OPENCLAW_SERVICE_KIND: "gateway",
+        },
+        async () => {
+          await updateCommand({ yes: true });
+        },
+      );
+
+      const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+      expect(errors.join("\n")).toContain(
+        "Failed to resume Windows Scheduled Task autostart after service stop failed: Error: enable failed",
+      );
+      expect(errors.join("\n")).toContain("Original stop failure: Error: stop failed");
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+      expect(
+        vi
+          .mocked(runCommandWithTimeout)
+          .mock.calls.some(([argv]) => Array.isArray(argv) && argv[0] === "npm" && argv[1] === "i"),
+      ).toBe(false);
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    { name: "stopped runtime with restart", restart: true, runtimeStatus: "stopped" },
+    { name: "stopped runtime with --no-restart", restart: false, runtimeStatus: "stopped" },
+    { name: "unknown runtime with restart", restart: true, runtimeStatus: "unknown" },
+    { name: "unknown runtime with --no-restart", restart: false, runtimeStatus: "unknown" },
+  ])(
+    "suspends Windows Scheduled Task autostart while updating an installed gateway with $name",
+    async ({ restart, runtimeStatus }) => {
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      try {
+        await setupRunningManagedPackageUpdate("openclaw-update-windows-task-stopped-");
+        serviceLoaded.mockResolvedValue(false);
+        serviceReadRuntime.mockResolvedValue({
+          status: runtimeStatus,
+          state: runtimeStatus,
+        });
+        suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+        resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
+
+        await updateCommand(restart ? { yes: true } : { yes: true, restart: false });
+
+        const npmInstallCallIndex = vi
+          .mocked(runCommandWithTimeout)
+          .mock.calls.findIndex(
+            (call) => Array.isArray(call[0]) && call[0][0] === "npm" && call[0][1] === "i",
+          );
+        const npmInstallCallOrder =
+          vi.mocked(runCommandWithTimeout).mock.invocationCallOrder[npmInstallCallIndex];
+        const suspendOrder = suspendScheduledTaskAutoStartForUpdate.mock.invocationCallOrder[0];
+        const resumeOrder = resumeScheduledTaskAutoStartAfterUpdate.mock.invocationCallOrder[0];
+        expect(serviceStop).not.toHaveBeenCalled();
+        expect(serviceRestart).not.toHaveBeenCalled();
+        expect(requireValue(suspendOrder, "Scheduled Task suspend order")).toBeLessThan(
+          requireValue(npmInstallCallOrder, "npm install call order"),
+        );
+        expect(requireValue(npmInstallCallOrder, "npm install call order")).toBeLessThan(
+          requireValue(resumeOrder, "Scheduled Task resume order"),
+        );
+      } finally {
+        platformSpy.mockRestore();
+      }
+    },
+  );
+
+  it("resumes Windows Scheduled Task autostart before post-core fresh-process handoff", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      await setupRunningManagedPackageUpdate("openclaw-update-windows-task-post-core-");
+      suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+      resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
+
+      await withEnvAsync(
+        {
+          OPENCLAW_SERVICE_MARKER: "openclaw",
+          OPENCLAW_SERVICE_KIND: "gateway",
+        },
+        async () => {
+          await updateCommand({ yes: true });
+        },
+      );
+
+      const resumeOrder = resumeScheduledTaskAutoStartAfterUpdate.mock.invocationCallOrder[0];
+      const spawnOrder = vi.mocked(spawn).mock.invocationCallOrder[0];
+      expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          OPENCLAW_SERVICE_MARKER: "openclaw",
+          OPENCLAW_SERVICE_KIND: "gateway",
+        }),
+      );
+      expect(requireValue(resumeOrder, "Scheduled Task resume order")).toBeLessThan(
+        requireValue(spawnOrder, "post-core fresh-process spawn order"),
+      );
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
   it("keeps managed service stop output off stdout during json package updates", async () => {
     const tempDir = await createTrackedTempDir("openclaw-update-json-stop-service-");
     const nodeModules = path.join(tempDir, "node_modules");
@@ -2891,6 +3178,14 @@ describe("update-cli", () => {
           termination: "exit",
         };
       }
+      if (
+        Array.isArray(argv) &&
+        argv[0] === "npm" &&
+        argv[1] === "i" &&
+        argv.includes("--prefix")
+      ) {
+        await writeStagedOpenClawPackageInstall(argv, "2026.4.23");
+      }
       return {
         stdout: "",
         stderr: "",
@@ -2960,6 +3255,14 @@ describe("update-cli", () => {
           termination: "exit",
         };
       }
+      if (
+        Array.isArray(argv) &&
+        argv[0] === "npm" &&
+        argv[1] === "i" &&
+        argv.includes("--prefix")
+      ) {
+        await writeStagedOpenClawPackageInstall(argv);
+      }
       return {
         stdout: "",
         stderr: "",
@@ -2975,29 +3278,19 @@ describe("update-cli", () => {
     const installArgvs = commandCalls()
       .map(([argv]) => argv)
       .filter((argv) => argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g");
-    expect(installArgvs).toEqual([
-      [
-        "npm",
-        "i",
-        "-g",
-        "openclaw@latest",
-        "--no-fund",
-        "--no-audit",
-        "--loglevel=error",
-        "--min-release-age=0",
-      ],
-      [
-        "npm",
-        "i",
-        "-g",
-        "openclaw@latest",
-        "--omit=optional",
-        "--no-fund",
-        "--no-audit",
-        "--loglevel=error",
-        "--min-release-age=0",
-      ],
-    ]);
+    expect(installArgvs).toHaveLength(2);
+    for (const [index, argv] of installArgvs.entries()) {
+      if (argv.includes("--prefix")) {
+        expect(typeof argv[argv.indexOf("--prefix") + 1]).toBe("string");
+      }
+      expect(argv).toEqual(
+        expect.arrayContaining(["openclaw@latest", "--no-fund", "--no-audit", "--loglevel=error"]),
+      );
+      expect(argv.some((arg) => arg === "--min-release-age=0" || /^--before=.+/u.test(arg))).toBe(
+        true,
+      );
+      expect(argv.includes("--omit=optional")).toBe(index === 1);
+    }
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -41,6 +41,10 @@ import {
 import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
 import { disableCurrentOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import { resolveGatewayRestartLogPath } from "../../daemon/restart-logs.js";
+import {
+  resumeScheduledTaskAutoStartAfterUpdate,
+  suspendScheduledTaskAutoStartForUpdate,
+} from "../../daemon/schtasks.js";
 import { summarizeGatewayServiceLayout } from "../../daemon/service-layout.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
 import {
@@ -757,6 +761,7 @@ type PrePackageServiceStop = {
   running: boolean;
   blockMessage?: string;
   serviceEnv?: NodeJS.ProcessEnv;
+  windowsTaskAutoStartSuspended?: boolean;
 };
 
 type ManagedServiceRootRedirect = {
@@ -820,6 +825,14 @@ function serviceControlStdoutForMode(jsonMode: boolean): NodeJS.WritableStream {
   return jsonMode ? JSON_MODE_SERVICE_STDOUT : process.stdout;
 }
 
+async function maybeSuspendWindowsTaskAutoStartForPackageUpdate(
+  serviceEnv: NodeJS.ProcessEnv | undefined,
+): Promise<boolean> {
+  return process.platform === "win32" && serviceEnv
+    ? await suspendScheduledTaskAutoStartForUpdate(serviceEnv)
+    : false;
+}
+
 async function maybeStopManagedServiceBeforePackageUpdate(params: {
   shouldRestart: boolean;
   jsonMode: boolean;
@@ -853,32 +866,44 @@ async function maybeStopManagedServiceBeforePackageUpdate(params: {
         ),
       );
     }
+    const windowsTaskAutoStartSuspended = !serviceState.running
+      ? await maybeSuspendWindowsTaskAutoStartForPackageUpdate(serviceState.env)
+      : false;
     return {
       stopped: false,
       inspected: true,
       runtimeInspected,
       running: serviceState.running,
       serviceEnv: serviceState.env,
+      ...(windowsTaskAutoStartSuspended ? { windowsTaskAutoStartSuspended } : {}),
     };
   }
 
   if (!runtimeInspected) {
+    const windowsTaskAutoStartSuspended = await maybeSuspendWindowsTaskAutoStartForPackageUpdate(
+      serviceState.env,
+    );
     return {
       stopped: false,
       inspected: true,
       runtimeInspected: false,
       running: false,
       serviceEnv: serviceState.env,
+      ...(windowsTaskAutoStartSuspended ? { windowsTaskAutoStartSuspended } : {}),
     };
   }
 
   if (!serviceState.running) {
+    const windowsTaskAutoStartSuspended = await maybeSuspendWindowsTaskAutoStartForPackageUpdate(
+      serviceState.env,
+    );
     return {
       stopped: false,
       inspected: true,
       runtimeInspected: true,
       running: false,
       serviceEnv: serviceState.env,
+      ...(windowsTaskAutoStartSuspended ? { windowsTaskAutoStartSuspended } : {}),
     };
   }
 
@@ -897,29 +922,82 @@ async function maybeStopManagedServiceBeforePackageUpdate(params: {
   if (!params.jsonMode) {
     defaultRuntime.log(theme.muted("Stopping managed gateway service before package update..."));
   }
-  await service.stop({
-    env: serviceState.env,
-    stdout: serviceControlStdoutForMode(params.jsonMode),
-  });
+  const windowsTaskAutoStartSuspended = await maybeSuspendWindowsTaskAutoStartForPackageUpdate(
+    serviceState.env,
+  );
+  try {
+    await service.stop({
+      env: serviceState.env,
+      stdout: serviceControlStdoutForMode(params.jsonMode),
+    });
+  } catch (err) {
+    if (windowsTaskAutoStartSuspended) {
+      try {
+        await resumeScheduledTaskAutoStartAfterUpdate(serviceState.env);
+      } catch (resumeErr) {
+        throw new Error(
+          [
+            `Failed to resume Windows Scheduled Task autostart after service stop failed: ${String(resumeErr)}`,
+            `Original stop failure: ${String(err)}`,
+          ].join("\n"),
+          { cause: resumeErr },
+        );
+      }
+    }
+    throw err;
+  }
   return {
     stopped: true,
     inspected: true,
     runtimeInspected: true,
     running: true,
     serviceEnv: serviceState.env,
+    ...(windowsTaskAutoStartSuspended ? { windowsTaskAutoStartSuspended } : {}),
   };
+}
+
+async function maybeResumeWindowsTaskAutoStartAfterPackageUpdate(params: {
+  prePackageServiceStop: PrePackageServiceStop | undefined;
+}): Promise<void> {
+  const stopState = params.prePackageServiceStop;
+  if (
+    process.platform !== "win32" ||
+    !stopState?.windowsTaskAutoStartSuspended ||
+    !stopState.serviceEnv
+  ) {
+    return;
+  }
+  await resumeScheduledTaskAutoStartAfterUpdate(stopState.serviceEnv);
+  stopState.windowsTaskAutoStartSuspended = false;
 }
 
 async function maybeRestartServiceAfterFailedPackageUpdate(params: {
   prePackageServiceStop: PrePackageServiceStop | undefined;
   jsonMode: boolean;
 }): Promise<void> {
-  if (!params.prePackageServiceStop?.stopped || !params.prePackageServiceStop.serviceEnv) {
+  const stopState = params.prePackageServiceStop;
+  if (!stopState?.serviceEnv) {
+    return;
+  }
+  try {
+    await maybeResumeWindowsTaskAutoStartAfterPackageUpdate({
+      prePackageServiceStop: stopState,
+    });
+  } catch (err) {
+    const message = `Failed to resume Windows Scheduled Task autostart after failed update: ${String(err)}`;
+    if (params.jsonMode) {
+      defaultRuntime.error(message);
+    } else {
+      defaultRuntime.log(theme.warn(message));
+    }
+    return;
+  }
+  if (!stopState.stopped) {
     return;
   }
   try {
     await resolveGatewayService().restart({
-      env: params.prePackageServiceStop.serviceEnv,
+      env: stopState.serviceEnv,
       stdout: serviceControlStdoutForMode(params.jsonMode),
     });
     if (!params.jsonMode) {
@@ -1950,6 +2028,7 @@ async function maybeRestartService(params: {
   shouldRestart: boolean;
   result: UpdateRunResult;
   opts: UpdateCommandOptions;
+  prePackageServiceStop?: PrePackageServiceStop;
   refreshServiceEnv: boolean;
   serviceEnv?: NodeJS.ProcessEnv;
   gatewayPort: number;
@@ -1957,6 +2036,14 @@ async function maybeRestartService(params: {
   invocationCwd?: string;
   nodeRunner?: string;
 }): Promise<boolean> {
+  const isPackageUpdate = isPackageManagerUpdateMode(params.result.mode);
+  const resumePackageTaskAutoStart = async () => {
+    if (isPackageUpdate) {
+      await maybeResumeWindowsTaskAutoStartAfterPackageUpdate({
+        prePackageServiceStop: params.prePackageServiceStop,
+      });
+    }
+  };
   const verifyRestartedGateway = async (expectedGatewayVersion: string | undefined) => {
     const restartAfterStaleCleanup = async () => {
       if (params.refreshServiceEnv && isPackageManagerUpdateMode(params.result.mode)) {
@@ -2065,10 +2152,9 @@ async function maybeRestartService(params: {
     }
 
     try {
-      const expectedGatewayVersion = isPackageManagerUpdateMode(params.result.mode)
+      const expectedGatewayVersion = isPackageUpdate
         ? normalizeOptionalString(params.result.after?.version)
         : undefined;
-      const isPackageUpdate = isPackageManagerUpdateMode(params.result.mode);
       let restarted = false;
       let restartInitiated = false;
       let refreshedGatewayAlreadyHealthy = false;
@@ -2092,6 +2178,7 @@ async function maybeRestartService(params: {
             defaultRuntime.log(theme.warn(message));
           }
           if (isPackageUpdate) {
+            await resumePackageTaskAutoStart();
             return false;
           }
         }
@@ -2118,10 +2205,12 @@ async function maybeRestartService(params: {
       // that already produced the expected gateway version, a second kickstart
       // would only race the healthy supervisor-owned process.
       if (!refreshedGatewayAlreadyHealthy && params.restartScriptPath) {
+        await resumePackageTaskAutoStart();
         await createUpdateConfigSnapshot();
         await runRestartScript(params.restartScriptPath);
         restartInitiated = true;
       } else if (!refreshedGatewayAlreadyHealthy && params.refreshServiceEnv && isPackageUpdate) {
+        await resumePackageTaskAutoStart();
         await createUpdateConfigSnapshot();
         restarted = await runUpdatedInstallGatewayRestart({
           result: params.result,
@@ -2137,7 +2226,10 @@ async function maybeRestartService(params: {
         await createUpdateConfigSnapshot();
         restarted = await runDaemonRestart();
       } else if (!refreshedGatewayAlreadyHealthy && !params.opts.json) {
+        await resumePackageTaskAutoStart();
         defaultRuntime.log(theme.muted("Gateway: restart skipped (no installed service found)."));
+      } else {
+        await resumePackageTaskAutoStart();
       }
 
       const shouldVerifyRestart =
@@ -2193,6 +2285,7 @@ async function maybeRestartService(params: {
     return true;
   }
 
+  await resumePackageTaskAutoStart();
   if (!params.opts.json) {
     defaultRuntime.log("");
     defaultRuntime.log(theme.muted("Gateway: restart skipped (--no-restart)."));
@@ -3328,6 +3421,17 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
 
     if (shouldBlockPackageUpdateFromGatewayServiceEnv({ prePackageServiceStop })) {
       stop();
+      try {
+        await maybeResumeWindowsTaskAutoStartAfterPackageUpdate({
+          prePackageServiceStop,
+        });
+      } catch (err) {
+        defaultRuntime.error(
+          `Failed to resume Windows Scheduled Task autostart after blocked package update: ${String(err)}`,
+        );
+        defaultRuntime.exit(1);
+        return;
+      }
       defaultRuntime.error(
         [
           "Package updates cannot run from inside the gateway service process.",
@@ -3434,6 +3538,18 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
       );
     }
     defaultRuntime.exit(0);
+    return;
+  }
+
+  try {
+    await maybeResumeWindowsTaskAutoStartAfterPackageUpdate({
+      prePackageServiceStop,
+    });
+  } catch (err) {
+    defaultRuntime.error(
+      `Failed to resume Windows Scheduled Task autostart after package update: ${String(err)}`,
+    );
+    defaultRuntime.exit(1);
     return;
   }
 
@@ -3610,6 +3726,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
     shouldRestart,
     result: resultWithPostUpdate,
     opts,
+    prePackageServiceStop,
     refreshServiceEnv: refreshGatewayServiceEnv,
     serviceEnv: gatewayServiceEnv,
     gatewayPort,

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -32,7 +32,12 @@ vi.mock("../utils.js", async () => {
   };
 });
 
-const { restartScheduledTask, stopScheduledTask } = await import("./schtasks.js");
+const {
+  restartScheduledTask,
+  resumeScheduledTaskAutoStartAfterUpdate,
+  stopScheduledTask,
+  suspendScheduledTaskAutoStartForUpdate,
+} = await import("./schtasks.js");
 const GATEWAY_PORT = 18789;
 const SUCCESS_RESPONSE = { code: 0, stdout: "", stderr: "" } as const;
 
@@ -108,6 +113,113 @@ afterEach(() => {
 });
 
 describe("Scheduled Task stop/restart cleanup", () => {
+  it("can suspend and resume Scheduled Task autostart without stopping the running task", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE },
+        {
+          ...SUCCESS_RESPONSE,
+          stdout: "<Task><Settings><Enabled>true</Enabled></Settings></Task>",
+        },
+        { ...SUCCESS_RESPONSE },
+      );
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(true);
+
+      pushSuccessfulSchtasksResponses(3);
+
+      await expect(resumeScheduledTaskAutoStartAfterUpdate(env)).resolves.toBe(true);
+
+      expect(schtasksCalls).toEqual([
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway", "/XML"],
+        ["/Change", "/TN", "OpenClaw Gateway", "/DISABLE"],
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway"],
+        ["/Change", "/TN", "OpenClaw Gateway", "/ENABLE"],
+      ]);
+      expect(killProcessTree).not.toHaveBeenCalled();
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not change Scheduled Task state when the task is not registered", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE },
+        {
+          code: 1,
+          stdout: "",
+          stderr: "ERROR: The system cannot find the file specified.",
+        },
+      );
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(false);
+
+      expect(schtasksCalls).toEqual([["/Query"], ["/Query", "/TN", "OpenClaw Gateway", "/XML"]]);
+    });
+  });
+
+  it("does not change Scheduled Task state when schtasks is unavailable", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push({
+        code: 1,
+        stdout: "",
+        stderr: "ERROR: Access is denied.",
+      });
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(false);
+
+      expect(schtasksCalls).toEqual([["/Query"]]);
+    });
+  });
+
+  it("does not resume a Scheduled Task that was already disabled", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE },
+        {
+          ...SUCCESS_RESPONSE,
+          stdout:
+            "<Task><Triggers><LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers><Settings><Enabled>false</Enabled></Settings></Task>",
+        },
+      );
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(false);
+
+      expect(schtasksCalls).toEqual([["/Query"], ["/Query", "/TN", "OpenClaw Gateway", "/XML"]]);
+    });
+  });
+
+  it("does not resume when Scheduled Task enabled state is unavailable", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push({ ...SUCCESS_RESPONSE }, { ...SUCCESS_RESPONSE, stdout: "<Task />" });
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(false);
+
+      expect(schtasksCalls).toEqual([["/Query"], ["/Query", "/TN", "OpenClaw Gateway", "/XML"]]);
+    });
+  });
+
+  it("reads NUL-separated Scheduled Task XML enabled state", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      const xml = "<Task><Settings><Enabled>true</Enabled></Settings></Task>";
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE },
+        { ...SUCCESS_RESPONSE, stdout: `\uFEFF${xml.split("").join("\u0000")}` },
+        { ...SUCCESS_RESPONSE },
+      );
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(true);
+
+      expect(schtasksCalls).toEqual([
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway", "/XML"],
+        ["/Change", "/TN", "OpenClaw Gateway", "/DISABLE"],
+      ]);
+    });
+  });
+
   it("kills lingering verified gateway listeners after schtasks stop", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
       pushSuccessfulSchtasksResponses(3);

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -119,7 +119,7 @@ describe("Scheduled Task stop/restart cleanup", () => {
         { ...SUCCESS_RESPONSE },
         {
           ...SUCCESS_RESPONSE,
-          stdout: "<Task><Settings><Enabled>true</Enabled></Settings></Task>",
+          stdout: "<Task><Settings><StartWhenAvailable>true</StartWhenAvailable></Settings></Task>",
         },
         { ...SUCCESS_RESPONSE },
       );
@@ -198,6 +198,28 @@ describe("Scheduled Task stop/restart cleanup", () => {
       await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(false);
 
       expect(schtasksCalls).toEqual([["/Query"], ["/Query", "/TN", "OpenClaw Gateway", "/XML"]]);
+    });
+  });
+
+  it("treats omitted Settings Enabled state as enabled", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE },
+        {
+          ...SUCCESS_RESPONSE,
+          stdout:
+            "<Task><Triggers><LogonTrigger><Enabled>false</Enabled></LogonTrigger></Triggers><Settings><Hidden>false</Hidden></Settings></Task>",
+        },
+        { ...SUCCESS_RESPONSE },
+      );
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(true);
+
+      expect(schtasksCalls).toEqual([
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway", "/XML"],
+        ["/Change", "/TN", "OpenClaw Gateway", "/DISABLE"],
+      ]);
     });
   });
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1280,6 +1280,63 @@ function isTaskNotRunning(res: { stdout: string; stderr: string; code: number })
   return detail.includes("not running");
 }
 
+function parseScheduledTaskXmlEnabled(output: string): boolean | null {
+  const normalizedOutput = output.replace(/^\uFEFF/u, "").replaceAll(String.fromCharCode(0), "");
+  const settings = /<Settings(?:\s[^>]*)?>([\s\S]*?)<\/Settings>/iu.exec(normalizedOutput);
+  const match = settings?.[1] ? /<Enabled>\s*(true|false)\s*<\/Enabled>/iu.exec(settings[1]) : null;
+  if (!match?.[1]) {
+    return null;
+  }
+  return match[1].toLowerCase() === "true";
+}
+
+async function changeScheduledTaskEnabledState(params: {
+  env: GatewayServiceEnv;
+  enabled: boolean;
+}): Promise<boolean> {
+  try {
+    await assertSchtasksAvailable();
+  } catch (err) {
+    if (!params.enabled) {
+      return false;
+    }
+    throw err;
+  }
+  const taskName = resolveTaskName(params.env);
+  if (params.enabled) {
+    if (!(await isRegisteredScheduledTask(params.env))) {
+      return false;
+    }
+  } else {
+    const query = await execSchtasks(["/Query", "/TN", taskName, "/XML"]);
+    if (query.code !== 0) {
+      return false;
+    }
+    if (parseScheduledTaskXmlEnabled(query.stdout) !== true) {
+      return false;
+    }
+  }
+  const action = params.enabled ? "/ENABLE" : "/DISABLE";
+  const res = await execSchtasks(["/Change", "/TN", taskName, action]);
+  if (res.code !== 0) {
+    const detail = (res.stderr || res.stdout).trim() || "unknown error";
+    throw new Error(`schtasks ${params.enabled ? "enable" : "disable"} failed: ${detail}`);
+  }
+  return true;
+}
+
+export async function suspendScheduledTaskAutoStartForUpdate(
+  env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+): Promise<boolean> {
+  return await changeScheduledTaskEnabledState({ env, enabled: false });
+}
+
+export async function resumeScheduledTaskAutoStartAfterUpdate(
+  env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+): Promise<boolean> {
+  return await changeScheduledTaskEnabledState({ env, enabled: true });
+}
+
 export async function stopScheduledTask({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const effectiveEnv = env ?? (process.env as GatewayServiceEnv);
   try {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1283,9 +1283,12 @@ function isTaskNotRunning(res: { stdout: string; stderr: string; code: number })
 function parseScheduledTaskXmlEnabled(output: string): boolean | null {
   const normalizedOutput = output.replace(/^\uFEFF/u, "").replaceAll(String.fromCharCode(0), "");
   const settings = /<Settings(?:\s[^>]*)?>([\s\S]*?)<\/Settings>/iu.exec(normalizedOutput);
-  const match = settings?.[1] ? /<Enabled>\s*(true|false)\s*<\/Enabled>/iu.exec(settings[1]) : null;
-  if (!match?.[1]) {
+  if (!settings?.[1]) {
     return null;
+  }
+  const match = /<Enabled>\s*(true|false)\s*<\/Enabled>/iu.exec(settings[1]);
+  if (!match?.[1]) {
+    return true;
   }
   return match[1].toLowerCase() === "true";
 }


### PR DESCRIPTION
## Summary
- disables enabled Windows Scheduled Task autostart while a managed package update replaces the OpenClaw package tree
- covers running, stopped, and unclassified installed task runtimes, including `--no-restart` stopped/unknown cases where the task can still logon-start during replacement
- re-enables only tasks this update actually disabled, before post-core handoff, restart handoff, blocked-update exits, or failed-update exits
- treats omitted `<Settings><Enabled>` in live Task Scheduler XML as enabled, matching native Windows output where enabled tasks are represented by absence of an explicit disabled state
- reports failed `/ENABLE` recovery if service stop fails after autostart was suspended, so the operator is not left with silently disabled logon autostart
- leaves startup-folder fallback installs, unavailable `schtasks`, missing tasks, unreadable XML state, and already-disabled tasks unchanged

Fixes #87993.

## Verification
- `node scripts/run-vitest.mjs src/daemon/schtasks.stop.test.ts src/cli/update-cli.test.ts -- --run` - 147 passed
- `node_modules/.bin/oxfmt --check src/daemon/schtasks.ts src/daemon/schtasks.stop.test.ts src/cli/update-cli/update-command.ts src/cli/update-cli.test.ts`
- `node_modules/.bin/oxlint src/daemon/schtasks.ts src/daemon/schtasks.stop.test.ts src/cli/update-cli/update-command.ts src/cli/update-cli.test.ts`
- `git diff --check origin/main...HEAD && git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, patch correct
- AWS Crabbox changed gate on rebased branch: `run_80f36e0c133e`, `pnpm check:changed` passed
- AWS Crabbox native Windows Task Scheduler XML proof: `run_16c0e77f1c9a`, `scheduled_task_disable_enable_xml_live=ok`
  - seeded a legacy-style LogonTrigger task with `PT3M` / `P9999D`
  - observed enabled live XML represented by absence of `<Settings><Enabled>false</Enabled>`
  - verified `/DISABLE` writes `<Settings><Enabled>false</Enabled>`
  - verified `/ENABLE` removes the explicit disabled state again
  - verified PT3M/P9999D repetition metadata survives disable/enable
- AWS Crabbox native Windows disabled-run probe: `run_373d5c3d81fc` observed `ERROR: The scheduled task "OCProof..." could not run because it is disabled.` The script intentionally failed because PowerShell promoted the expected stderr into a native-command error.

## Real behavior proof
Behavior addressed: Windows package updates no longer leave an enabled Scheduled Task free to relaunch the gateway while the package tree is being replaced. If the task was suspended and service stop then fails, failed `/ENABLE` recovery is now surfaced instead of hidden.

Real environment tested: Focused local regression tests on current branch SHA `da348c17f40`; AWS Crabbox Linux changed gate; AWS Crabbox native Windows Task Scheduler with a seeded legacy-style PT3M/P9999D task.

Exact steps or command run after this patch:
```sh
node scripts/run-vitest.mjs src/daemon/schtasks.stop.test.ts src/cli/update-cli.test.ts -- --run
node_modules/.bin/oxfmt --check src/daemon/schtasks.ts src/daemon/schtasks.stop.test.ts src/cli/update-cli/update-command.ts src/cli/update-cli.test.ts
node_modules/.bin/oxlint src/daemon/schtasks.ts src/daemon/schtasks.stop.test.ts src/cli/update-cli/update-command.ts src/cli/update-cli.test.ts
git diff --check origin/main...HEAD && git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"
```

Evidence after fix: Tests assert `/DISABLE` happens before service stop/package install and `/ENABLE` happens after install, before post-core fresh-process handoff. Tests also cover stopped and unknown installed task runtimes, `--no-restart` stopped/unknown runtimes, already-disabled task preservation, startup-fallback/no-schtasks no-op, Settings-level XML parsing, live-style omitted Settings Enabled defaults, NUL-separated XML output, and failed `/ENABLE` recovery after a service-stop failure. Native Windows proof showed Task Scheduler omits an explicit enabled setting for enabled tasks, writes explicit disabled state after `/DISABLE`, removes it after `/ENABLE`, and preserves legacy PT3M/P9999D repetition metadata.

Observed result after fix: package-update code suspends only a currently enabled Scheduled Task, resumes only if this update suspended it, and surfaces recovery failure if stop fails after suspension.

What was not tested: full native Windows OpenClaw package-update smoke remains unproven because the available AWS native Windows Crabbox image has `schtasks` but no Node/npm. WSL2 is not a touched runtime surface for this PR because WSL does not use the Windows Scheduled Task gateway service path.
