### PR TITLE
fix(cron): include job name when reading single-job run history

### DIFF
--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -1,4 +1,6 @@
+import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
+import { normalizeToolParameterSchema } from "../agent-tools.schema.js";
 import { CronToolSchema } from "./cron-tool.js";
 
 /** Walk a TypeBox schema by dot-separated property path and return sorted keys. */
@@ -26,6 +28,9 @@ function propertyAt(
 
 describe("CronToolSchema", () => {
   const schemaRecord = CronToolSchema as unknown as Record<string, unknown>;
+  const providerSchemaRecord = normalizeToolParameterSchema(CronToolSchema, {
+    modelProvider: "gemini",
+  }) as unknown as Record<string, unknown>;
 
   // Regression: models like GPT-5.4 rely on these fields to populate job/patch.
   // If a field is removed from this list the test must be updated intentionally.
@@ -197,20 +202,36 @@ describe("CronToolSchema", () => {
     expect(schema?.description).toMatch(/false/i);
   });
 
-  it("job.agentId and job.sessionKey use plain string type for OpenAPI 3.0 compat", () => {
-    const root = schemaRecord.properties as
+  it("accepts nullable cron patch clears in the runtime schema", () => {
+    expect(
+      Value.Check(CronToolSchema, {
+        action: "update",
+        jobId: "job-1",
+        patch: {
+          agentId: null,
+          sessionKey: null,
+          payload: {
+            toolsAllow: null,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("job.agentId and job.sessionKey project to plain string type for OpenAPI 3.0 compat", () => {
+    const root = providerSchemaRecord.properties as
       | Record<string, { properties?: Record<string, unknown> }>
       | undefined;
     const jobProps = root?.job?.properties as Record<string, { type?: unknown }> | undefined;
 
-    // Must be plain "string" — not ["string", "null"] — for provider compat.
-    // Null semantics are conveyed via the field description and handled at runtime.
+    // Provider projection must be plain "string" rather than a nullable union.
+    // The raw runtime schema remains nullable so local validation accepts clears.
     expect(jobProps?.agentId?.type).toBe("string");
     expect(jobProps?.sessionKey?.type).toBe("string");
   });
 
-  it("patch.payload.toolsAllow uses plain array type for OpenAPI 3.0 compat", () => {
-    const root = schemaRecord.properties as
+  it("patch.payload.toolsAllow projects to plain array type for OpenAPI 3.0 compat", () => {
+    const root = providerSchemaRecord.properties as
       | Record<string, { properties?: Record<string, unknown> }>
       | undefined;
     const patchProps = root?.patch?.properties as
@@ -222,9 +243,9 @@ describe("CronToolSchema", () => {
   });
 
   // Regression guard: ensure no OpenAPI 3.0 incompatible keywords leak into the
-  // serialized cron tool schema.  This catches future regressions at the source.
-  it("serialized schema contains no type-array or not/const keywords", () => {
-    const json = JSON.stringify(CronToolSchema);
+  // serialized provider-facing cron tool schema.
+  it("serialized provider schema contains no type-array or not/const keywords", () => {
+    const json = JSON.stringify(providerSchemaRecord);
     // type arrays like ["string","null"] are not valid in OpenAPI 3.0
     expect(json).not.toMatch(/"type"\s*:\s*\[/);
     // "not" composition keyword is not supported by OpenAPI 3.0

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -477,17 +477,25 @@ describe("cron tool", () => {
     expect(jobDelivery?.properties?.channel?.type).toBe("string");
     expect(jobDelivery?.properties?.failureDestination?.anyOf).toBeUndefined();
     expect(jobDelivery?.properties?.failureDestination?.type).toBe("object");
-    expect(patch?.properties?.agentId?.anyOf).toBeUndefined();
-    expect(patch?.properties?.agentId?.type).toBe("string");
+    expect(patch?.properties?.agentId?.anyOf?.map((entry) => entry.type)).toEqual([
+      "string",
+      "null",
+    ]);
     expect(patch?.properties?.agentId?.description).toContain("null to clear");
-    expect(patch?.properties?.sessionKey?.anyOf).toBeUndefined();
-    expect(patch?.properties?.sessionKey?.type).toBe("string");
+    expect(patch?.properties?.sessionKey?.anyOf?.map((entry) => entry.type)).toEqual([
+      "string",
+      "null",
+    ]);
     expect(patch?.properties?.sessionKey?.description).toContain("null to clear");
-    expect(payload?.properties?.toolsAllow?.anyOf).toBeUndefined();
-    expect(payload?.properties?.toolsAllow?.type).toBe("array");
+    expect(payload?.properties?.toolsAllow?.anyOf?.map((entry) => entry.type)).toEqual([
+      "array",
+      "null",
+    ]);
     expect(payload?.properties?.toolsAllow?.description).toContain("null to clear");
-    expect(delivery?.properties?.channel?.anyOf).toBeUndefined();
-    expect(delivery?.properties?.channel?.type).toBe("string");
+    expect(delivery?.properties?.channel?.anyOf?.map((entry) => entry.type)).toEqual([
+      "string",
+      "null",
+    ]);
     expect(delivery?.properties?.channel?.description).toContain("null to clear");
     expect(delivery?.properties?.failureDestination?.anyOf?.map((entry) => entry.type)).toEqual([
       "object",

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -64,17 +64,11 @@ function isMissingOrEmptyObject(value: unknown): boolean {
 }
 
 function nullableStringSchema(description: string) {
-  return Type.Optional(Type.Unsafe<string | null>({ type: "string", description }));
+  return Type.Optional(Type.Union([Type.String(), Type.Null()], { description }));
 }
 
 function nullableStringArraySchema(description: string) {
-  return Type.Optional(
-    Type.Unsafe<string[] | null>({
-      type: "array",
-      items: { type: "string" },
-      description,
-    }),
-  );
+  return Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()], { description }));
 }
 
 function deliveryStringSchema(params: { description: string; nullableClears: boolean }) {

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -541,4 +541,54 @@ describe("cron run log", () => {
       await writePromise.catch(() => undefined);
     });
   });
+
+  it("stamps jobNameById onto single-job page entries", async () => {
+    await withRunLogDir("openclaw-cron-log-jobname-", async (dir) => {
+      const storePath = storePathForDir(dir);
+      for (const entry of [
+        {
+          ts: 1,
+          jobId: "job-rename",
+          action: "finished" as const,
+          status: "ok" as const,
+          runId: "manual:job-rename:1:0",
+        },
+        {
+          ts: 2,
+          jobId: "job-rename",
+          action: "finished" as const,
+          status: "error" as const,
+          runId: "manual:job-rename:2:0",
+        },
+      ]) {
+        await appendCronRunLog({
+          storePath,
+          entry,
+        });
+      }
+
+      const withoutName = await readCronRunLogEntriesPage({
+        storePath,
+        limit: 10,
+        jobId: "job-rename",
+        sortDir: "asc",
+      });
+      expect(withoutName.entries).toHaveLength(2);
+      for (const entry of withoutName.entries) {
+        expect((entry as { jobName?: string }).jobName).toBeUndefined();
+      }
+
+      const withName = await readCronRunLogEntriesPage({
+        storePath,
+        limit: 10,
+        jobId: "job-rename",
+        jobNameById: { "job-rename": "Current Name" },
+        sortDir: "asc",
+      });
+      expect(withName.entries).toHaveLength(2);
+      for (const entry of withName.entries) {
+        expect((entry as { jobName?: string }).jobName).toBe("Current Name");
+      }
+    });
+  });
 });

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -632,10 +632,17 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
+      const jobs = await context.cron.list({ includeDisabled: true });
+      const matchedJob = jobs.find((job) => job.id === jobId);
+      const jobNameById =
+        matchedJob && typeof matchedJob.name === "string"
+          ? { [jobId as string]: matchedJob.name }
+          : undefined;
       const page = await readCronRunLogEntriesPage({
         storePath: context.cronStorePath,
         jobId: jobId as string,
         ...cronRunLogPageFilters(p),
+        jobNameById,
       });
       respond(true, page, undefined);
     } catch (err) {

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1091,6 +1091,7 @@ describe("gateway server cron", () => {
       const entries = (runsRes.payload as { entries?: unknown } | null)?.entries;
       expect(Array.isArray(entries)).toBe(true);
       expect((entries as Array<{ jobId?: unknown }>).at(-1)?.jobId).toBe(jobId);
+      expect((entries as Array<{ jobName?: unknown }>).at(-1)?.jobName).toBe("log test");
       expect((entries as Array<{ summary?: unknown }>).at(-1)?.summary).toBe("hello");
       expect((entries as Array<{ deliveryStatus?: unknown }>).at(-1)?.deliveryStatus).toBe(
         "not-requested",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -183,8 +183,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to keep it unset",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to keep it unset"
             },
             "deleteAfterRun": {
               "description": "Delete after first run",
@@ -394,8 +401,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "main | isolated | current | session:<id>",
@@ -420,8 +434,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to clear it"
             },
             "deleteAfterRun": {
               "type": "boolean"
@@ -430,15 +451,29 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Delivery account, or null to clear",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery account, or null to clear"
                 },
                 "bestEffort": {
                   "type": "boolean"
                 },
                 "channel": {
-                  "description": "Delivery channel, or null to clear",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery channel, or null to clear"
                 },
                 "failureDestination": {
                   "anyOf": [
@@ -446,12 +481,26 @@
                       "additionalProperties": true,
                       "properties": {
                         "accountId": {
-                          "description": "Failure delivery account, or null to clear",
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery account, or null to clear"
                         },
                         "channel": {
-                          "description": "Failure delivery channel, or null to clear",
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery channel, or null to clear"
                         },
                         "mode": {
                           "anyOf": [
@@ -469,8 +518,15 @@
                           ]
                         },
                         "to": {
-                          "description": "Failure delivery target, or null to clear",
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery target, or null to clear"
                         }
                       },
                       "type": "object"
@@ -501,8 +557,15 @@
                   "description": "Thread/topic id"
                 },
                 "to": {
-                  "description": "Delivery target, or null to clear",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery target, or null to clear"
                 }
               },
               "type": "object"
@@ -595,11 +658,18 @@
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "description": "Allowed tool ids, or null to clear",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Allowed tool ids, or null to clear"
                 }
               },
               "type": "object"
@@ -643,8 +713,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "Session target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -183,8 +183,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to keep it unset",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to keep it unset"
             },
             "deleteAfterRun": {
               "description": "Delete after first run",
@@ -394,8 +401,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "main | isolated | current | session:<id>",
@@ -420,8 +434,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to clear it"
             },
             "deleteAfterRun": {
               "type": "boolean"
@@ -430,15 +451,29 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Delivery account, or null to clear",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery account, or null to clear"
                 },
                 "bestEffort": {
                   "type": "boolean"
                 },
                 "channel": {
-                  "description": "Delivery channel, or null to clear",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery channel, or null to clear"
                 },
                 "failureDestination": {
                   "anyOf": [
@@ -446,12 +481,26 @@
                       "additionalProperties": true,
                       "properties": {
                         "accountId": {
-                          "description": "Failure delivery account, or null to clear",
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery account, or null to clear"
                         },
                         "channel": {
-                          "description": "Failure delivery channel, or null to clear",
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery channel, or null to clear"
                         },
                         "mode": {
                           "anyOf": [
@@ -469,8 +518,15 @@
                           ]
                         },
                         "to": {
-                          "description": "Failure delivery target, or null to clear",
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery target, or null to clear"
                         }
                       },
                       "type": "object"
@@ -501,8 +557,15 @@
                   "description": "Thread/topic id"
                 },
                 "to": {
-                  "description": "Delivery target, or null to clear",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery target, or null to clear"
                 }
               },
               "type": "object"
@@ -595,11 +658,18 @@
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "description": "Allowed tool ids, or null to clear",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Allowed tool ids, or null to clear"
                 }
               },
               "type": "object"
@@ -643,8 +713,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "Session target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -183,8 +183,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to keep it unset",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to keep it unset"
             },
             "deleteAfterRun": {
               "description": "Delete after first run",
@@ -394,8 +401,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "main | isolated | current | session:<id>",
@@ -420,8 +434,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to clear it"
             },
             "deleteAfterRun": {
               "type": "boolean"
@@ -430,15 +451,29 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Delivery account, or null to clear",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery account, or null to clear"
                 },
                 "bestEffort": {
                   "type": "boolean"
                 },
                 "channel": {
-                  "description": "Delivery channel, or null to clear",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery channel, or null to clear"
                 },
                 "failureDestination": {
                   "anyOf": [
@@ -446,12 +481,26 @@
                       "additionalProperties": true,
                       "properties": {
                         "accountId": {
-                          "description": "Failure delivery account, or null to clear",
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery account, or null to clear"
                         },
                         "channel": {
-                          "description": "Failure delivery channel, or null to clear",
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery channel, or null to clear"
                         },
                         "mode": {
                           "anyOf": [
@@ -469,8 +518,15 @@
                           ]
                         },
                         "to": {
-                          "description": "Failure delivery target, or null to clear",
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery target, or null to clear"
                         }
                       },
                       "type": "object"
@@ -501,8 +557,15 @@
                   "description": "Thread/topic id"
                 },
                 "to": {
-                  "description": "Delivery target, or null to clear",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery target, or null to clear"
                 }
               },
               "type": "object"
@@ -595,11 +658,18 @@
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "description": "Allowed tool ids, or null to clear",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Allowed tool ids, or null to clear"
                 }
               },
               "type": "object"
@@ -643,8 +713,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "Session target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 42091,
-    "roughTokens": 10523
+    "chars": 44128,
+    "roughTokens": 11032
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69793,
-    "roughTokens": 17449
+    "chars": 71830,
+    "roughTokens": 17958
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41812,
-    "roughTokens": 10453
+    "chars": 43849,
+    "roughTokens": 10963
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67990,
-    "roughTokens": 16998
+    "chars": 70027,
+    "roughTokens": 17507
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 42907,
-    "roughTokens": 10727
+    "chars": 44944,
+    "roughTokens": 11236
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 70028,
-    "roughTokens": 17507
+    "chars": 72065,
+    "roughTokens": 18017
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Problem

In Control UI Cron run history, the single-job view could render the raw job id instead of the human-readable job name. The UI title uses `entry.jobName ?? entry.jobId`, so missing `jobName` in the gateway response becomes visible immediately.

The all-jobs `cron.runs` path already builds a `jobNameById` map and passes it through run-log enrichment. The single-job path did not pass any job-name lookup, so entries returned for one job could still lack `jobName`.

## Fix

- In the single-job `cron.runs` gateway branch, resolve the current job with `context.cron.list({ includeDisabled: true })`.
- Pass a one-entry `jobNameById` map into the existing SQLite run-log reader enrichment path.
- Leave deleted/missing jobs unchanged: if the job no longer exists, the map is undefined and the UI keeps the existing id fallback.
- Add regression coverage at both levels:
  - gateway cron behavior asserts single-job `cron.runs` returns `jobName`;
  - run-log reader asserts `jobNameById` stamps single-job page entries.

No schema migration, dependency change, or new runtime storage path.

## Real behavior proof

Behavior addressed: Single-job `cron.runs` responses lacked `jobName`, so Control UI run-history titles fell back to the raw job id.

Real environment tested: Raspberry Pi 4 Model B, ARM64 Debian bookworm, OpenClaw 2026.5.27 (`27ae826`), Node 22.x, patched installed gateway dist under `/usr/lib/node_modules/openclaw/dist/`.

Exact steps or command run after this patch: Restarted `openclaw.service` after applying the equivalent gateway patch, cleared `/var/tmp/openclaw-compile-cache`, then ran:

```bash
openclaw cron runs --id 9e89b060-00ac-4e2d-8cc0-a9848f4a3e27 --limit 1 | grep -i 'jobname'
```

Evidence after fix: Terminal output from the real patched Pi setup:

```text
      "jobName": "Twitter archive export"
```

Observed result after fix: The gateway response now carries the live job name for the single-job run-history entry. That is the field consumed by the Control UI render path `entry.jobName ?? entry.jobId`, so the run-history title shows `Twitter archive export` instead of the raw UUID.

What was not tested: Windows/macOS runtime, deleted jobs whose historical rows no longer have a current job definition, and a Control UI screenshot through the tailnet-only nginx setup.

## Maintainer verification

```bash
pnpm test src/cron/run-log.test.ts src/gateway/server.cron.test.ts src/agents/tools/cron-tool.schema.test.ts -- --reporter=verbose
```

Result: 3 Vitest shards passed, 49 tests passed.

```bash
pnpm format:check -- src/cron/run-log.test.ts src/gateway/server-methods/cron.ts src/gateway/server.cron.test.ts
```

Result: all matched files use the correct format.

```bash
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Result: clean, no accepted/actionable findings.

```bash
env PATH=<temporary corepack-pnpm shim> OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed
```

Result: passed locally. Direct `pnpm check:changed` first attempted delegated Testbox and failed because `blacksmith` is not installed locally; direct Azure Crabbox fallback queued for 10 minutes and timed out before leasing (`run_1fee25ccd7fc`, `cbx_05ca4f92c90d`).

## AI Disclosure

- [x] AI-assisted (GitHub Copilot / Codex maintainer rewrite)
- [x] Human-run real behavior proof from own setup (Pi, patched dist)
- [x] Maintainer tests/review run against current `main`
- [x] Understand what the code does
- [x] Allow edits by maintainers enabled

