### PR TITLE
fix(gateway): recover channels after reload stop timeout

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -124,14 +124,6 @@ async function waitForMicrotaskCondition(
   throw new Error(message);
 }
 
-function firstSleepWithAbortCall(): [number, AbortSignal | undefined] {
-  const call = hoisted.sleepWithAbort.mock.calls[0];
-  if (!call) {
-    throw new Error("expected sleepWithAbort call");
-  }
-  return call as [number, AbortSignal | undefined];
-}
-
 function firstStartAccountContext(
   startAccount: ReturnType<typeof vi.fn>,
 ): ChannelGatewayContext<TestAccount> {
@@ -378,14 +370,56 @@ describe("server-channels auto restart", () => {
     expect(manager.isManuallyStopped("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
 
     releaseFirstTask.resolve();
-    await flushMicrotasks();
-    await vi.advanceTimersByTimeAsync(10);
-    await flushMicrotasks();
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length === 2,
+      "expected timed-out recovery stop to restart without backoff",
+    );
 
     expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
   });
 
-  it("lets manual stops cancel recovery backoff after recovery stop times out", async () => {
+  it("restarts immediately when recovery stop timeout settles with an error", async () => {
+    const rejectFirstTask = createDeferred();
+    let startCount = 0;
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      startCount += 1;
+      abortSignal.addEventListener("abort", () => {}, { once: true });
+      if (startCount === 1) {
+        await rejectFirstTask.promise;
+        throw new Error("late worker exit");
+      }
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+
+    rejectFirstTask.resolve();
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length === 2,
+      "expected rejected timed-out recovery stop to restart without backoff",
+    );
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(account?.running).toBe(true);
+    expect(account?.restartPending).toBe(false);
+    expect(account?.lastError).toBeNull();
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+  });
+
+  it("lets manual stops cancel recovery restart after recovery stop times out", async () => {
     const releaseFirstTask = createDeferred();
     const startAccount = vi.fn(
       async ({ abortSignal }: { abortSignal: AbortSignal }) =>
@@ -408,16 +442,10 @@ describe("server-channels auto restart", () => {
     await vi.advanceTimersByTimeAsync(5_000);
     await recoveryStopTask;
 
+    const manualStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await manualStopTask;
     releaseFirstTask.resolve();
-    await waitForMicrotaskCondition(
-      () => hoisted.sleepWithAbort.mock.calls.length > 0,
-      "expected recovery restart backoff to be scheduled",
-    );
-    const sleepCall = firstSleepWithAbortCall();
-    expect(sleepCall[0]).toBe(10);
-    expect(sleepCall[1]).toBeInstanceOf(AbortSignal);
-
-    await manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
     await vi.advanceTimersByTimeAsync(10);
     await flushMicrotasks();
 
@@ -426,6 +454,7 @@ describe("server-channels auto restart", () => {
     expect(account?.running).toBe(false);
     expect(account?.restartPending).toBe(false);
     expect(manager.isManuallyStopped("discord", DEFAULT_ACCOUNT_ID)).toBe(true);
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
   });
 
   it("marks enabled/configured when account descriptors omit them", () => {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -568,6 +568,49 @@ describe("server-channels auto restart", () => {
     expect(hoisted.sleepWithAbort.mock.calls[0]?.[0]).toBe(10);
   });
 
+  it("lets explicit starts win after a manual timeout during recovery stop", async () => {
+    const releaseFirstTask = createDeferred();
+    let startCount = 0;
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      startCount += 1;
+      abortSignal.addEventListener("abort", () => {}, { once: true });
+      if (startCount === 1) {
+        await releaseFirstTask.promise;
+        return;
+      }
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+
+    const manualStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await manualStopTask;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    releaseFirstTask.resolve();
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length === 2,
+      "expected explicit start to clear manual stop and restart after old task exits",
+    );
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.running).toBe(true);
+    expect(account?.restartPending).toBe(false);
+    expect(manager.isManuallyStopped("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+  });
+
   it("marks enabled/configured when account descriptors omit them", () => {
     installTestRegistry(
       createTestPlugin({

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -405,6 +405,7 @@ describe("server-channels auto restart", () => {
     await vi.advanceTimersByTimeAsync(5_000);
     await recoveryStopTask;
 
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
     rejectFirstTask.resolve();
     await waitForMicrotaskCondition(
       () => startAccount.mock.calls.length === 2,
@@ -416,6 +417,53 @@ describe("server-channels auto restart", () => {
     expect(account?.running).toBe(true);
     expect(account?.restartPending).toBe(false);
     expect(account?.lastError).toBeNull();
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+  });
+
+  it("waits for an explicit start after recovery stop timeout", async () => {
+    const releaseFirstTask = createDeferred();
+    let startCount = 0;
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      startCount += 1;
+      abortSignal.addEventListener("abort", () => {}, { once: true });
+      if (startCount === 1) {
+        await releaseFirstTask.promise;
+        return;
+      }
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+
+    releaseFirstTask.resolve();
+    await waitForMicrotaskCondition(() => {
+      const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+      return account?.running === false && account.restartPending === false;
+    }, "expected timed-out recovery stop to settle without restarting");
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(account?.running).toBe(false);
+    expect(account?.restartPending).toBe(false);
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length === 2,
+      "expected explicit post-timeout start to restart the channel",
+    );
+
     expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
   });
 
@@ -453,6 +501,7 @@ describe("server-channels auto restart", () => {
       await vi.advanceTimersByTimeAsync(5_000);
       await recoveryStopTask;
 
+      await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
       releaseFirstTask.resolve();
       await waitForMicrotaskCondition(
         () =>

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -419,6 +419,59 @@ describe("server-channels auto restart", () => {
     expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
   });
 
+  it("consumes startup failures during immediate recovery restart", async () => {
+    const unhandledRejection = vi.fn();
+    process.on("unhandledRejection", unhandledRejection);
+    try {
+      const releaseFirstTask = createDeferred();
+      let isConfiguredCalls = 0;
+      const startAccount = vi.fn(
+        async ({ abortSignal }: { abortSignal: AbortSignal }) =>
+          await new Promise<void>((resolve) => {
+            abortSignal.addEventListener("abort", () => {}, { once: true });
+            void releaseFirstTask.promise.then(resolve);
+          }),
+      );
+      installTestRegistry(
+        createTestPlugin({
+          startAccount,
+          isConfigured: () => {
+            isConfiguredCalls += 1;
+            if (isConfiguredCalls > 1) {
+              throw new Error("restart config missing");
+            }
+            return true;
+          },
+        }),
+      );
+      const manager = createManager();
+
+      await manager.startChannels();
+      const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+        manual: false,
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await recoveryStopTask;
+
+      releaseFirstTask.resolve();
+      await waitForMicrotaskCondition(
+        () =>
+          manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]?.lastError ===
+          "restart config missing",
+        "expected immediate recovery restart failure to be recorded",
+      );
+      await flushMicrotasks();
+
+      const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+      expect(startAccount).toHaveBeenCalledTimes(1);
+      expect(account?.running).toBe(false);
+      expect(account?.restartPending).toBe(false);
+      expect(unhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandledRejection);
+    }
+  });
+
   it("lets manual stops cancel recovery restart after recovery stop times out", async () => {
     const releaseFirstTask = createDeferred();
     const startAccount = vi.fn(
@@ -455,6 +508,15 @@ describe("server-channels auto restart", () => {
     expect(account?.restartPending).toBe(false);
     expect(manager.isManuallyStopped("discord", DEFAULT_ACCOUNT_ID)).toBe(true);
     expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await waitForMicrotaskCondition(
+      () => hoisted.sleepWithAbort.mock.calls.length === 1,
+      "expected later ordinary exit to use restart backoff",
+    );
+
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(hoisted.sleepWithAbort.mock.calls[0]?.[0]).toBe(10);
   });
 
   it("marks enabled/configured when account descriptors omit them", () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -594,6 +594,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             })
             .then(async () => {
               if (manuallyStopped.has(rKey)) {
+                recoveryStopTimedOut.delete(rKey);
                 return;
               }
               if (recoveryStopTimedOut.has(rKey)) {
@@ -611,9 +612,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 if (store.aborts.get(id) === abort) {
                   store.aborts.delete(id);
                 }
-                await startChannelInternal(channelId, id, {
-                  preserveManualStop: true,
-                });
+                try {
+                  await startChannelInternal(channelId, id, {
+                    preserveManualStop: true,
+                  });
+                } catch {
+                  // abort or startup failure — runtime state was recorded by startChannelInternal
+                }
                 return;
               }
               const attempt = (restartAttempts.get(rKey) ?? 0) + 1;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -249,6 +249,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   // Tracks accounts that were manually stopped so we don't auto-restart them.
   const manuallyStopped = new Set<string>();
   const recoveryStopTimedOut = new Set<string>();
+  const recoveryStartRequested = new Set<string>();
 
   const restartKey = (channelId: ChannelId, accountId: string) => `${channelId}:${accountId}`;
   const ensureChannelLog = (channelId: ChannelId): SubsystemLogger => {
@@ -382,6 +383,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       store.runtimes.delete(id);
       restartAttempts.delete(restartKey(channelId, id));
       manuallyStopped.delete(restartKey(channelId, id));
+      recoveryStartRequested.delete(restartKey(channelId, id));
     }
   };
 
@@ -414,7 +416,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     const startup = await runTasksWithConcurrency({
       limit: CHANNEL_STARTUP_CONCURRENCY,
       tasks: accountIds.map((id) => async () => {
+        const rKey = restartKey(channelId, id);
         if (store.tasks.has(id)) {
+          if (recoveryStopTimedOut.has(rKey)) {
+            recoveryStartRequested.add(rKey);
+            setRuntime(channelId, id, { accountId: id, restartPending: true });
+          }
           return;
         }
         const existingStart = store.starting.get(id);
@@ -490,7 +497,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             return;
           }
 
-          const rKey = restartKey(channelId, id);
           if (!preserveManualStop) {
             manuallyStopped.delete(rKey);
           }
@@ -595,10 +601,25 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             .then(async () => {
               if (manuallyStopped.has(rKey)) {
                 recoveryStopTimedOut.delete(rKey);
+                recoveryStartRequested.delete(rKey);
                 return;
               }
               if (recoveryStopTimedOut.has(rKey)) {
                 recoveryStopTimedOut.delete(rKey);
+                if (!recoveryStartRequested.delete(rKey)) {
+                  setRuntime(channelId, id, {
+                    accountId: id,
+                    restartPending: false,
+                    reconnectAttempts: 0,
+                  });
+                  if (store.tasks.get(id) === trackedPromise) {
+                    store.tasks.delete(id);
+                  }
+                  if (store.aborts.get(id) === abort) {
+                    store.aborts.delete(id);
+                  }
+                  return;
+                }
                 restartAttempts.delete(rKey);
                 log.info?.(`[${id}] restarting after timed-out channel stop completed`);
                 setRuntime(channelId, id, {
@@ -774,6 +795,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           return;
         }
         recoveryStopTimedOut.delete(rKey);
+        recoveryStartRequested.delete(rKey);
         store.aborts.delete(id);
         store.tasks.delete(id);
         setRuntime(channelId, id, {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -419,6 +419,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         const rKey = restartKey(channelId, id);
         if (store.tasks.has(id)) {
           if (recoveryStopTimedOut.has(rKey)) {
+            if (!preserveManualStop) {
+              manuallyStopped.delete(rKey);
+            }
+            if (manuallyStopped.has(rKey)) {
+              return;
+            }
             recoveryStartRequested.add(rKey);
             setRuntime(channelId, id, { accountId: id, restartPending: true });
           }

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -596,6 +596,26 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               if (manuallyStopped.has(rKey)) {
                 return;
               }
+              if (recoveryStopTimedOut.has(rKey)) {
+                recoveryStopTimedOut.delete(rKey);
+                restartAttempts.delete(rKey);
+                log.info?.(`[${id}] restarting after timed-out channel stop completed`);
+                setRuntime(channelId, id, {
+                  accountId: id,
+                  restartPending: true,
+                  reconnectAttempts: 0,
+                });
+                if (store.tasks.get(id) === trackedPromise) {
+                  store.tasks.delete(id);
+                }
+                if (store.aborts.get(id) === abort) {
+                  store.aborts.delete(id);
+                }
+                await startChannelInternal(channelId, id, {
+                  preserveManualStop: true,
+                });
+                return;
+              }
               const attempt = (restartAttempts.get(rKey) ?? 0) + 1;
               restartAttempts.set(rKey, attempt);
               if (attempt > MAX_RESTART_ATTEMPTS) {
@@ -616,24 +636,15 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 restartPending: true,
                 reconnectAttempts: attempt,
               });
-              const recoveryRestartSleepAbort = recoveryStopTimedOut.has(rKey)
-                ? new AbortController()
-                : undefined;
-              if (recoveryRestartSleepAbort) {
-                store.aborts.set(id, recoveryRestartSleepAbort);
-              }
               try {
-                const restartSleepAbort = recoveryRestartSleepAbort?.signal ?? abort.signal;
-                await sleepWithAbort(delayMs, restartSleepAbort);
+                await sleepWithAbort(delayMs, abort.signal);
                 if (manuallyStopped.has(rKey)) {
-                  recoveryStopTimedOut.delete(rKey);
                   return;
                 }
-                recoveryStopTimedOut.delete(rKey);
                 if (store.tasks.get(id) === trackedPromise) {
                   store.tasks.delete(id);
                 }
-                if (store.aborts.get(id) === (recoveryRestartSleepAbort ?? abort)) {
+                if (store.aborts.get(id) === abort) {
                   store.aborts.delete(id);
                 }
                 await startChannelInternal(channelId, id, {
@@ -642,13 +653,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 });
               } catch {
                 // abort or startup failure — next crash will retry
-              } finally {
-                if (recoveryRestartSleepAbort) {
-                  recoveryStopTimedOut.delete(rKey);
-                  if (store.aborts.get(id) === recoveryRestartSleepAbort) {
-                    store.aborts.delete(id);
-                  }
-                }
               }
             })
             .finally(() => {


### PR DESCRIPTION
Summary:
- Recover channel restarts after a reload stop times out without leaving stale task handles behind.
- Defer timeout recovery to explicit restart callers so hot reload starts the post-reload channel implementation/config.
- Cover late worker exits, startup failures, manual cancellation, and manual start-after-timeout regressions.

Proof:
- Testbox tbx_01kswa1j5852611dv10n6kcs38: `node scripts/run-vitest.mjs run src/gateway/server-channels.test.ts --reporter=verbose` passed, 37 tests.
- Testbox tbx_01kswac9ss09tk6kn22zvkx4y5: `corepack pnpm check:changed` passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean; no accepted/actionable findings.
