### PR TITLE
fix(agents): strip leaked arg_value suffixes

### DIFF
--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -10,6 +10,7 @@ import {
   recordAdjustedParamsForToolCall,
   runBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
+import { stripXmlArgValueSuffixFromToolParams } from "./agent-tools.params.js";
 import {
   getCodeModeExecBeforeHookMetadata,
   normalizeCodeModeExecBeforeHookParams,
@@ -328,11 +329,18 @@ export function toToolDefinitions(
       parameters: tool.parameters,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
-        let executeParams = params;
+        const normalizedParams = stripXmlArgValueSuffixFromToolParams(name, params);
+        let executeParams = normalizedParams;
         try {
           if (!beforeHookWrapped) {
-            const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params });
-            const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params });
+            const hookParams = normalizeCodeModeExecBeforeHookParams({
+              tool,
+              params: normalizedParams,
+            });
+            const hookMetadata = getCodeModeExecBeforeHookMetadata({
+              tool,
+              params: normalizedParams,
+            });
             const hookOutcome = await runBeforeToolCallHook({
               toolName: name,
               params: hookParams,
@@ -349,11 +357,15 @@ export function toToolDefinitions(
               }
               throw new Error(hookOutcome.reason);
             }
+            const normalizedHookOutcomeParams = stripXmlArgValueSuffixFromToolParams(
+              name,
+              hookOutcome.params,
+            );
             executeParams = reconcileCodeModeExecBeforeHookParams({
               tool,
-              originalParams: params,
+              originalParams: normalizedParams,
               hookParams,
-              adjustedParams: hookOutcome.params,
+              adjustedParams: normalizedHookOutcomeParams,
             });
             recordAdjustedParamsForToolCall(toolCallId, executeParams, hookContext?.runId);
           }

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -77,6 +77,35 @@ describe("before_tool_call loop detection behavior", () => {
     );
   }
 
+  it("normalizes leaked arg_value suffixes before hooks and execution", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runBeforeToolCall.mockResolvedValue(undefined);
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+    const tool = createWrappedTool("exec", execute, disabledLoopDetectionContext);
+
+    await tool.execute("tool-call-arg-value", {
+      command: "echo ok</arg_value>>",
+      env: { KEEP: "</arg_value>>" },
+    });
+
+    const event = hookRunner.runBeforeToolCall.mock.calls[0]?.[0] as
+      | { params?: Record<string, unknown> }
+      | undefined;
+    expect(event?.params).toMatchObject({
+      command: "echo ok",
+      env: { KEEP: "</arg_value>>" },
+    });
+    expect(execute).toHaveBeenCalledWith(
+      "tool-call-arg-value",
+      {
+        command: "echo ok",
+        env: { KEEP: "</arg_value>>" },
+      },
+      undefined,
+      undefined,
+    );
+  });
+
   async function withToolLoopEvents(
     run: (emitted: DiagnosticToolLoopEvent[]) => Promise<void>,
     filter: (evt: DiagnosticToolLoopEvent) => boolean = () => true,
@@ -981,6 +1010,58 @@ describe("before_tool_call requireApproval handling", () => {
     expect(result.blocked).toBe(true);
     expect(result).toHaveProperty("reason", "Blocked by security plugin");
     expect(mockCallGateway).not.toHaveBeenCalled();
+  });
+
+  it("normalizes leaked arg_value suffixes for direct hook callers", async () => {
+    hookRunner.runBeforeToolCall.mockResolvedValue(undefined);
+
+    const execResult = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: {
+        command: "echo ok</arg_value>>",
+        env: { KEEP: "</arg_value>>" },
+      },
+      toolCallId: "call-direct-exec",
+    });
+    const codeModeResult = await runBeforeToolCallHook({
+      toolName: "code_mode_exec",
+      params: {
+        code: "return 1;</arg_value>>",
+        content: "literal </arg_value>>",
+      },
+      toolCallId: "call-direct-code-mode",
+    });
+
+    expect(execResult).toEqual({
+      blocked: false,
+      params: {
+        command: "echo ok",
+        env: { KEEP: "</arg_value>>" },
+      },
+    });
+    expect(codeModeResult).toEqual({
+      blocked: false,
+      params: {
+        code: "return 1;",
+        content: "literal </arg_value>>",
+      },
+    });
+    expectRecordFields(requireHookCall(0)[0], {
+      toolName: "exec",
+      toolCallId: "call-direct-exec",
+      params: {
+        command: "echo ok",
+        env: { KEEP: "</arg_value>>" },
+      },
+    });
+    expectRecordFields(requireHookCall(1)[0], {
+      toolName: "code_mode_exec",
+      toolCallId: "call-direct-code-mode",
+      params: {
+        code: "return 1;",
+        content: "literal </arg_value>>",
+      },
+    });
   });
 
   it("blocks when before_tool_call hook execution throws", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -43,6 +43,7 @@ import {
 import type { SkillSnapshot, SkillTelemetrySource } from "../skills/types.js";
 import { isPlainObject } from "../utils.js";
 import { adjustedParamsByToolCallId } from "./agent-tools.before-tool-call.state.js";
+import { stripXmlArgValueSuffixFromToolParams } from "./agent-tools.params.js";
 import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
 import {
   getCodeModeExecBeforeHookMetadata,
@@ -714,7 +715,7 @@ export async function runBeforeToolCallHook(args: {
   approvalMode?: "request" | "report" | "defer";
 }): Promise<HookOutcome> {
   const toolName = normalizeToolName(args.toolName || "tool");
-  const params = args.params;
+  const params = stripXmlArgValueSuffixFromToolParams(toolName, args.params);
 
   if (args.ctx?.sessionKey) {
     const { getDiagnosticSessionState, logToolLoopAction, detectToolCallLoop, recordToolCall } =
@@ -1033,8 +1034,9 @@ export function wrapToolWithBeforeToolCallHook(
   const wrappedTool: AnyAgentTool = {
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
-      const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params });
-      const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params });
+      const normalizedParams = stripXmlArgValueSuffixFromToolParams(toolName, params);
+      const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params: normalizedParams });
+      const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params: normalizedParams });
       const outcome = await runBeforeToolCallHook({
         toolName,
         params: hookParams,
@@ -1044,6 +1046,7 @@ export function wrapToolWithBeforeToolCallHook(
         signal,
         approvalMode: hookOptions.approvalMode,
       });
+      const outcomeParams = stripXmlArgValueSuffixFromToolParams(toolName, outcome.params);
       if (outcome.blocked) {
         if (outcome.kind !== "veto") {
           throw new Error(outcome.reason);
@@ -1060,7 +1063,7 @@ export function wrapToolWithBeforeToolCallHook(
           toolName: normalizedToolName,
           ...diagnosticIdentity,
           ...(toolCallId && { toolCallId }),
-          paramsSummary: summarizeToolParams(outcome.params ?? hookParams),
+          paramsSummary: summarizeToolParams(outcomeParams ?? hookParams),
         };
         if (hookOptions.emitDiagnostics) {
           emitTrustedDiagnosticEvent({
@@ -1077,7 +1080,7 @@ export function wrapToolWithBeforeToolCallHook(
         await recordLoopOutcome({
           ctx,
           toolName: normalizedToolName,
-          toolParams: outcome.params ?? hookParams,
+          toolParams: outcomeParams ?? hookParams,
           toolCallId,
           result: blockedResult,
         });
@@ -1085,9 +1088,9 @@ export function wrapToolWithBeforeToolCallHook(
       }
       const executeParams = reconcileCodeModeExecBeforeHookParams({
         tool,
-        originalParams: params,
+        originalParams: normalizedParams,
         hookParams,
-        adjustedParams: outcome.params,
+        adjustedParams: outcomeParams,
       });
       recordAdjustedParamsForToolCall(toolCallId, executeParams, ctx?.runId);
       const normalizedToolName = normalizeToolName(toolName || "tool");

--- a/src/agents/agent-tools.params.test.ts
+++ b/src/agents/agent-tools.params.test.ts
@@ -3,6 +3,10 @@ import {
   assertRequiredParams,
   REQUIRED_PARAM_GROUPS,
   getToolParamsRecord,
+  stripXmlArgValueSuffix,
+  stripXmlArgValueSuffixFromParams,
+  stripXmlArgValueSuffixFromToolParams,
+  XML_ARG_VALUE_SUFFIX_PARAM_KEYS,
   wrapToolParamValidation,
 } from "./agent-tools.params.js";
 
@@ -166,5 +170,54 @@ describe("assertRequiredParams", () => {
         "write",
       ),
     ).toBeUndefined();
+  });
+});
+
+describe("stripXmlArgValueSuffix", () => {
+  it("strips leaked arg_value suffixes from command and path values", () => {
+    expect(stripXmlArgValueSuffix('echo "test</arg_value>>')).toBe('echo "test');
+    expect(stripXmlArgValueSuffix("src/index.ts</arg_value>>>>>")).toBe("src/index.ts");
+  });
+
+  it("leaves embedded XML-like text unchanged", () => {
+    expect(stripXmlArgValueSuffix("before </arg_value>> after")).toBe("before </arg_value>> after");
+    expect(stripXmlArgValueSuffix("before </arg_value>")).toBe("before </arg_value>");
+  });
+
+  it("normalizes only selected fields", () => {
+    const params = {
+      path: "src/index.ts</arg_value>>",
+      content: "keep this literal </arg_value>>",
+    };
+
+    expect(stripXmlArgValueSuffixFromParams(params, XML_ARG_VALUE_SUFFIX_PARAM_KEYS.path)).toEqual({
+      path: "src/index.ts",
+      content: "keep this literal </arg_value>>",
+    });
+    expect(params.path).toBe("src/index.ts</arg_value>>");
+  });
+
+  it("normalizes only tool-owned argument fields", () => {
+    const params = {
+      path: "notes.txt</arg_value>>",
+      content: "literal content </arg_value>>",
+    };
+
+    expect(stripXmlArgValueSuffixFromToolParams("write", params)).toEqual({
+      path: "notes.txt",
+      content: "literal content </arg_value>>",
+    });
+    expect(stripXmlArgValueSuffixFromToolParams("message", params)).toBe(params);
+    expect(
+      stripXmlArgValueSuffixFromToolParams("exec", {
+        code: "return 1;</arg_value>>",
+        command: "echo ok</arg_value>>",
+        content: "literal content </arg_value>>",
+      }),
+    ).toEqual({
+      code: "return 1;",
+      command: "echo ok",
+      content: "literal content </arg_value>>",
+    });
   });
 });

--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -8,6 +8,12 @@ export type RequiredParamGroup = {
 };
 
 const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
+const XML_ARG_VALUE_SUFFIX_RE = /<\/arg_value>>+$/u;
+
+export const XML_ARG_VALUE_SUFFIX_PARAM_KEYS = {
+  path: ["path"],
+  exec: ["ask", "code", "command", "host", "node", "security", "workdir"],
+} as const;
 
 function parameterValidationError(message: string): Error {
   return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
@@ -92,6 +98,55 @@ export const REQUIRED_PARAM_GROUPS = {
 
 export function getToolParamsRecord(params: unknown): Record<string, unknown> | undefined {
   return params && typeof params === "object" ? (params as Record<string, unknown>) : undefined;
+}
+
+export function stripXmlArgValueSuffix(value: string): string {
+  if (!value.includes("</arg_value>")) {
+    return value;
+  }
+  return value.replace(XML_ARG_VALUE_SUFFIX_RE, "");
+}
+
+export function stripXmlArgValueSuffixFromParams(
+  params: unknown,
+  keys: readonly string[],
+): unknown {
+  const record = getToolParamsRecord(params);
+  if (!record) {
+    return params;
+  }
+  let normalized: Record<string, unknown> | undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const stripped = stripXmlArgValueSuffix(value);
+    if (stripped === value) {
+      continue;
+    }
+    normalized ??= { ...record };
+    normalized[key] = stripped;
+  }
+  return normalized ?? params;
+}
+
+export function stripXmlArgValueSuffixFromToolParams(
+  toolName: string | undefined,
+  params: unknown,
+): unknown {
+  switch (toolName?.trim().toLowerCase()) {
+    case "bash":
+    case "code_mode_exec":
+    case "exec":
+      return stripXmlArgValueSuffixFromParams(params, XML_ARG_VALUE_SUFFIX_PARAM_KEYS.exec);
+    case "edit":
+    case "read":
+    case "write":
+      return stripXmlArgValueSuffixFromParams(params, XML_ARG_VALUE_SUFFIX_PARAM_KEYS.path);
+    default:
+      return params;
+  }
 }
 
 export function assertRequiredParams(

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -23,6 +23,7 @@ import {
   type ProcessSession,
 } from "./bash-process-registry.js";
 import { createExecTool, createProcessTool } from "./bash-tools.js";
+import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { resolveShellFromPath, sanitizeBinaryOutput } from "./shell-utils.js";
 
 vi.mock("../infra/channel-summary.js", () => ({
@@ -688,6 +689,20 @@ beforeEach(() => {
 
 describe("exec tool backgrounding", () => {
   useCapturedEnv([...SHELL_ENV_KEYS], applyDefaultShellEnv);
+
+  it("strips leaked arg_value suffixes from command values before execution", async () => {
+    const wrappedExecTool = wrapToolWithBeforeToolCallHook(execTool, {
+      loopDetection: { enabled: false },
+    }) as ExecToolInstance;
+    const result = await executeExecCommand(
+      wrappedExecTool,
+      `${shellEcho("xml-suffix-ok")}</arg_value>>`,
+    );
+    const output = readTextContent(result.content) ?? "";
+
+    expect(output).toContain("xml-suffix-ok");
+    expect(output).not.toContain("arg_value");
+  });
 
   it(
     "backgrounds after yield and can be polled",


### PR DESCRIPTION
Summary
- Strip leaked malformed `</arg_value>>` suffixes from exec/read/write/edit path and executable argument fields before before_tool_call/trusted policy, diagnostics, and execution.
- Cover shell exec `command`, code-mode exec `code`, and direct `runBeforeToolCallHook` callers used by native hook relay.
- Preserve normal content/env payload fields and ordinary `</arg_value>` text.

Verification
- `node scripts/run-vitest.mjs src/agents/agent-tools.params.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts src/agents/bash-tools.test.ts src/agents/agent-tool-definition-adapter.test.ts src/agents/agent-tool-definition-adapter.after-tool-call.test.ts`
- `git diff --check HEAD~1..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the corrected OpenClaw stage-4 fix for https://github.com/openclaw/openclaw/issues/48780..."` -> clean, no accepted/actionable findings
- Native Windows CI: https://github.com/openclaw/openclaw/actions/runs/26681964127/job/78643828444 (`checks-windows-node-test`, success)
- Windows/WSL probe: https://github.com/openclaw/openclaw/actions/runs/26682064495/job/78644090222 (native Windows success; WSL default version 2 present, but no distro installed, `wsl_exec_exit=-1`, `wsl2_ok=false`)

Behavior addressed
Malformed provider tool-call output can append `</arg_value>>` to exec/read/write/edit arguments on Windows, corrupting command/path execution.

Real environment tested
Focused local wrapper and hook-boundary tests in the OpenClaw agent test harness, plus native Windows runner proof on `blacksmith-16vcpu-windows-2025`.

Exact steps or command run after this patch
`node scripts/run-vitest.mjs src/agents/agent-tools.params.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts src/agents/bash-tools.test.ts src/agents/agent-tool-definition-adapter.test.ts src/agents/agent-tool-definition-adapter.after-tool-call.test.ts`

Evidence after fix
The tests prove suffix cleanup happens before hooks and execution, including direct hook callers, while content/env fields retain literal XML-like text. Native Windows CI passed on the exact PR SHA.

Observed result after fix
Malformed suffixes are stripped from command/path/code fields before policy and execution observe them.

What was not tested
A real WSL command path was not exercised because the Windows runner has WSL2 as the default version but no installed WSL distribution; the quick probe reported `wsl2_ok=false`. The slower import/feature probe was cancelled after the quick probe gave the actionable runner state.

Fixes #48780
