### PR TITLE
fix(gateway): honor configured remote probe budgets

### DIFF
--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -913,6 +913,22 @@ describe("gateway-status command", () => {
     expect(requireProbeCall("ws://127.0.0.1:18789").timeoutMs).toBe(15_000);
   });
 
+  it("passes the full caller timeout through to configured remote probes", async () => {
+    const { runtime } = createRuntimeCapture();
+    probeGateway.mockClear();
+    readBestEffortConfig.mockResolvedValueOnce({
+      gateway: {
+        mode: "remote",
+        remote: { url: "wss://remote.example:18789", token: "rtok" },
+        auth: { mode: "token", token: "ltok" },
+      },
+    } as never);
+
+    await runGatewayStatus(runtime, { timeout: "15000", json: true });
+
+    expect(requireProbeCall("wss://remote.example:18789").timeoutMs).toBe(15_000);
+  });
+
   it("uses configured handshake timeout as the default local probe budget", async () => {
     const { runtime } = createRuntimeCapture();
     probeGateway.mockClear();

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -369,7 +369,7 @@ describe("resolveProbeBudgetMs", () => {
     ).toBe(2_500);
   });
 
-  it("lets configured and explicit remote probes use the full caller budget", () => {
+  it("lets active configured and explicit remote probes use the full caller budget", () => {
     expect(
       resolveProbeBudgetMs(15_000, {
         kind: "configRemote",
@@ -384,6 +384,26 @@ describe("resolveProbeBudgetMs", () => {
         url: "wss://gateway.example/ws",
       }),
     ).toBe(15_000);
+  });
+
+  it("keeps inactive configured remote probes (local mode with a stale remote URL) on the short cap", () => {
+    // gateway.mode === "local" but a leftover gateway.remote.url is still present:
+    // resolveTargets marks the configRemote target active === false. A dead remote
+    // host must not consume the full caller budget before the active local probe.
+    expect(
+      resolveProbeBudgetMs(15_000, {
+        kind: "configRemote",
+        active: false,
+        url: "wss://stale-remote.example/ws",
+      }),
+    ).toBe(1500);
+    expect(
+      resolveProbeBudgetMs(500, {
+        kind: "configRemote",
+        active: false,
+        url: "wss://stale-remote.example/ws",
+      }),
+    ).toBe(500);
   });
 
   it("keeps ssh tunnel probes on the short cap", () => {

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -369,21 +369,24 @@ describe("resolveProbeBudgetMs", () => {
     ).toBe(2_500);
   });
 
-  it("keeps non-local probe caps unchanged", () => {
+  it("lets configured and explicit remote probes use the full caller budget", () => {
     expect(
       resolveProbeBudgetMs(15_000, {
         kind: "configRemote",
         active: true,
         url: "wss://gateway.example/ws",
       }),
-    ).toBe(1500);
+    ).toBe(15_000);
     expect(
       resolveProbeBudgetMs(15_000, {
         kind: "explicit",
         active: true,
         url: "wss://gateway.example/ws",
       }),
-    ).toBe(1500);
+    ).toBe(15_000);
+  });
+
+  it("keeps ssh tunnel probes on the short cap", () => {
     expect(
       resolveProbeBudgetMs(15_000, {
         kind: "sshTunnel",

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -133,8 +133,16 @@ export function resolveProbeBudgetMs(
   overallMs: number,
   target: Pick<GatewayStatusTarget, "kind" | "active" | "url">,
 ): number {
-  if (target.kind === "configRemote" || target.kind === "explicit") {
+  if (target.kind === "explicit") {
     return overallMs;
+  }
+  if (target.kind === "configRemote") {
+    // Active configured remote targets (gateway.mode === "remote") legitimately
+    // need the full caller budget for a healthy remote RPC. An *inactive*
+    // configured remote — e.g. local mode with a stale leftover gateway.remote.url
+    // — must keep the short remote cap so a dead remote host does not consume the
+    // entire caller timeout before the active local probe runs.
+    return target.active ? overallMs : Math.min(1500, overallMs);
   }
   if (target.kind === "sshTunnel") {
     return Math.min(2000, overallMs);

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -133,6 +133,9 @@ export function resolveProbeBudgetMs(
   overallMs: number,
   target: Pick<GatewayStatusTarget, "kind" | "active" | "url">,
 ): number {
+  if (target.kind === "configRemote" || target.kind === "explicit") {
+    return overallMs;
+  }
   if (target.kind === "sshTunnel") {
     return Math.min(2000, overallMs);
   }


### PR DESCRIPTION
## Summary
- honor the caller timeout budget for **active** configured remote and explicit remote gateway probes
- keep the short remote cap (1500ms) for **inactive** configured remote targets — i.e. local mode with a stale leftover `gateway.remote.url` — so a dead remote host cannot consume the entire caller timeout before the active local probe runs
- keep the shorter ssh tunnel cap unchanged
- cover the helper budget split (active vs inactive configRemote) and the `gateway probe` command path with regression tests, including local mode with a stale remote URL

Fixes #65355.

## Real behavior proof

**Behavior addressed:** `openclaw gateway probe --timeout <n>` previously capped `configRemote` probes at `1500ms`, so a healthy remote gateway could false-negative even when the caller supplied a larger budget. The fix now honors the full caller budget for **active** configured remote targets, while **inactive** configured remote targets (local mode with a stale `gateway.remote.url`) keep the short `1500ms` cap so an unreachable remote host does not burn the whole caller timeout ahead of the active local probe.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, PR HEAD `f86be96c9769dbee94bc7772d862468a789a952f` rebased onto upstream main `e9d01320d7f3cca9debe814bb909b3ffe9f9560d`.

**Exact steps or command run after this patch:**

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.unit-fast.config.ts \
  src/commands/gateway-status/helpers.test.ts --reporter=verbose

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.commands.config.ts \
  src/commands/gateway-status.test.ts --reporter=dot
```

**Evidence after fix:**

```
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.unit-fast.config.ts \
  src/commands/gateway-status/helpers.test.ts --reporter=verbose

 ✓ |unit-fast| src/commands/gateway-status/helpers.test.ts > resolveProbeBudgetMs > lets active local loopback probes use the full caller budget 0ms
 ✓ |unit-fast| src/commands/gateway-status/helpers.test.ts > resolveProbeBudgetMs > keeps inactive local loopback probes on the short cap 0ms
 ✓ |unit-fast| src/commands/gateway-status/helpers.test.ts > resolveProbeBudgetMs > lets explicit loopback URLs use the full caller budget 0ms
 ✓ |unit-fast| src/commands/gateway-status/helpers.test.ts > resolveProbeBudgetMs > lets active configured and explicit remote probes use the full caller budget 0ms
 ✓ |unit-fast| src/commands/gateway-status/helpers.test.ts > resolveProbeBudgetMs > keeps inactive configured remote probes (local mode with a stale remote URL) on the short cap 0ms
 ✓ |unit-fast| src/commands/gateway-status/helpers.test.ts > resolveProbeBudgetMs > keeps ssh tunnel probes on the short cap 0ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
```

```
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.commands.config.ts \
  src/commands/gateway-status.test.ts --reporter=dot

 RUN  v4.1.7 /media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-65355-fresh

·························

 Test Files  1 passed (1)
      Tests  25 passed (25)
```

The new helper test `keeps inactive configured remote probes (local mode with a stale remote URL) on the short cap` asserts `resolveProbeBudgetMs(15_000, { kind: "configRemote", active: false, url: "wss://stale-remote.example/ws" }) === 1500`, while `lets active configured and explicit remote probes use the full caller budget` asserts the active path still receives the full `15_000ms`.

**Observed result after fix:** `gateway probe --timeout 15000` passes the full `15000ms` budget to **active** `configRemote` and to `explicit` probe targets. An **inactive** `configRemote` target (local mode + stale `gateway.remote.url`) stays capped at `1500ms`. SSH tunnel probes remain capped at `2000ms`.

**What was not tested:** End-to-end `gateway probe` against a live remote gateway. The budget routing — including the inactive-target short cap — is covered by unit tests for both the helper and the command path. (Note: the 4 failing `daemon-install-helpers.test.ts` exec-SecretRef plugin-provider tests seen in the broader `commands-light` suite are pre-existing on upstream main and are not touched by this PR, which only changes `src/commands/gateway-status/helpers.ts` and its tests.)
