### PR TITLE
fix(browser): isolate Chrome MCP pending attach aborts

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -666,6 +666,201 @@ describe("chrome MCP page parsing", () => {
     expect(result).toBe(123);
   });
 
+  it("keeps a shared pending session alive when one waiter aborts", async () => {
+    let factoryCalls = 0;
+    let releaseFactory: (() => void) | undefined;
+    const factoryGate = new Promise<void>((resolve) => {
+      releaseFactory = resolve;
+    });
+    if (!releaseFactory) {
+      throw new Error("Expected Chrome MCP factory release callback to be initialized");
+    }
+
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      await factoryGate;
+      const session = createFakeSession();
+      session.client.close = closeMock as typeof session.client.close;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const ctrl = new AbortController();
+    const keptCtrl = new AbortController();
+    const abortedTabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: ctrl.signal,
+    });
+    const tabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: keptCtrl.signal,
+    });
+
+    const abortedTabsExpectation =
+      expect(abortedTabsPromise).rejects.toThrow(/first caller cancelled/);
+    ctrl.abort(new Error("first caller cancelled"));
+    releaseFactory();
+
+    await abortedTabsExpectation;
+    await expect(tabsPromise).resolves.toHaveLength(2);
+    expect(factoryCalls).toBe(1);
+    expect(closeMock).not.toHaveBeenCalled();
+  });
+
+  it("closes a shared pending session when every waiter aborts", async () => {
+    let factoryCalls = 0;
+    let releaseFactory: (() => void) | undefined;
+    const factoryGate = new Promise<void>((resolve) => {
+      releaseFactory = resolve;
+    });
+    if (!releaseFactory) {
+      throw new Error("Expected Chrome MCP factory release callback to be initialized");
+    }
+
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      await factoryGate;
+      const session = createFakeSession();
+      session.client.close = closeMock as typeof session.client.close;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const ctrl = new AbortController();
+    const tabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: ctrl.signal,
+    });
+    const tabsExpectation = expect(tabsPromise).rejects.toThrow(/caller cancelled/);
+
+    ctrl.abort(new Error("caller cancelled"));
+    releaseFactory();
+
+    await tabsExpectation;
+    await vi.waitFor(() => expect(closeMock).toHaveBeenCalledTimes(1));
+    expect(factoryCalls).toBe(1);
+  });
+
+  it("starts a fresh shared session after every waiter aborts a pending attach", async () => {
+    let factoryCalls = 0;
+    const releaseFactories: Array<() => void> = [];
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      let releaseFactory: (() => void) | undefined;
+      const factoryGate = new Promise<void>((resolve) => {
+        releaseFactory = resolve;
+      });
+      if (!releaseFactory) {
+        throw new Error("Expected Chrome MCP factory release callback to be initialized");
+      }
+      releaseFactories.push(releaseFactory);
+      await factoryGate;
+      const session = createFakeSession();
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      closeMocks.push(closeMock);
+      session.client.close = closeMock as typeof session.client.close;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const ctrl = new AbortController();
+    const abortedTabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: ctrl.signal,
+    });
+    const abortedTabsExpectation = expect(abortedTabsPromise).rejects.toThrow(/caller cancelled/);
+
+    ctrl.abort(new Error("caller cancelled"));
+    await abortedTabsExpectation;
+
+    const tabsPromise = listChromeMcpTabs("chrome-live");
+    await vi.waitFor(() => expect(factoryCalls).toBe(2));
+    releaseFactories[0]?.();
+    releaseFactories[1]?.();
+
+    await expect(tabsPromise).resolves.toHaveLength(2);
+    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+    expect(closeMocks[1]).not.toHaveBeenCalled();
+  });
+
+  it("closes a shared pending session when every waiter aborts before ready", async () => {
+    let factoryCalls = 0;
+    let releaseReady: (() => void) | undefined;
+    const readyGate = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    if (!releaseReady) {
+      throw new Error("Expected Chrome MCP ready release callback to be initialized");
+    }
+
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      session.ready = readyGate;
+      session.client.close = closeMock as typeof session.client.close;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const ctrl = new AbortController();
+    const tabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: ctrl.signal,
+    });
+    const tabsExpectation = expect(tabsPromise).rejects.toThrow(/caller cancelled/);
+
+    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    ctrl.abort(new Error("caller cancelled"));
+    releaseReady();
+
+    await tabsExpectation;
+    await vi.waitFor(() => expect(closeMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps a ready-pending shared session cached when another waiter remains", async () => {
+    let factoryCalls = 0;
+    let releaseReady: (() => void) | undefined;
+    const readyGate = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    const readyThen = vi.spyOn(readyGate, "then");
+    if (!releaseReady) {
+      throw new Error("Expected Chrome MCP ready release callback to be initialized");
+    }
+
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      session.ready = readyGate;
+      session.client.close = closeMock as typeof session.client.close;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const ctrl = new AbortController();
+    const abortedTabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: ctrl.signal,
+    });
+    const abortedTabsExpectation =
+      expect(abortedTabsPromise).rejects.toThrow(/first caller cancelled/);
+
+    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await vi.waitFor(() => expect(readyThen).toHaveBeenCalledTimes(1));
+    const keptCtrl = new AbortController();
+    const tabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: keptCtrl.signal,
+    });
+    await vi.waitFor(() => expect(readyThen).toHaveBeenCalledTimes(2));
+    ctrl.abort(new Error("first caller cancelled"));
+    releaseReady();
+
+    await abortedTabsExpectation;
+    await expect(tabsPromise).resolves.toHaveLength(2);
+    await expect(listChromeMcpTabs("chrome-live")).resolves.toHaveLength(2);
+    expect(factoryCalls).toBe(1);
+    expect(closeMock).not.toHaveBeenCalled();
+  });
+
   it("preserves session after tool-level errors (isError)", async () => {
     let factoryCalls = 0;
     const factory: ChromeMcpSessionFactory = async () => {

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -909,6 +909,112 @@ describe("chrome MCP page parsing", () => {
     expect(closeMock).not.toHaveBeenCalled();
   });
 
+  it("starts a fresh shared session when a ready-pending session loses its transport", async () => {
+    let factoryCalls = 0;
+    let firstSession: ChromeMcpSession | undefined;
+    let releaseFirstReady: (() => void) | undefined;
+    const firstReadyGate = new Promise<void>((resolve) => {
+      releaseFirstReady = resolve;
+    });
+    const firstReadyThen = vi.spyOn(firstReadyGate, "then");
+    if (!releaseFirstReady) {
+      throw new Error("Expected Chrome MCP ready release callback to be initialized");
+    }
+
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      closeMocks.push(closeMock);
+      session.client.close = closeMock as typeof session.client.close;
+      if (factoryCalls === 1) {
+        firstSession = session;
+        session.ready = firstReadyGate;
+      }
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const ctrl = new AbortController();
+    const firstTabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: ctrl.signal,
+    });
+    const firstTabsExpectation = expect(firstTabsPromise).rejects.toThrow(/first waiter cancelled/);
+
+    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await vi.waitFor(() => expect(firstReadyThen).toHaveBeenCalledTimes(1));
+    if (!firstSession) {
+      throw new Error("Expected first Chrome MCP session to be created");
+    }
+    (firstSession.transport as { pid: number | null }).pid = null;
+
+    const tabsPromise = listChromeMcpTabs("chrome-live");
+    await vi.waitFor(() => expect(factoryCalls).toBe(2));
+    await expect(tabsPromise).resolves.toHaveLength(2);
+
+    ctrl.abort(new Error("first waiter cancelled"));
+    releaseFirstReady();
+    await firstTabsExpectation;
+    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+    expect(closeMocks[1]).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse a stale ready-pending session for ephemeral probes", async () => {
+    let factoryCalls = 0;
+    let firstSession: ChromeMcpSession | undefined;
+    let releaseFirstReady: (() => void) | undefined;
+    const firstReadyGate = new Promise<void>((resolve) => {
+      releaseFirstReady = resolve;
+    });
+    const firstReadyThen = vi.spyOn(firstReadyGate, "then");
+    if (!releaseFirstReady) {
+      throw new Error("Expected Chrome MCP ready release callback to be initialized");
+    }
+
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      closeMocks.push(closeMock);
+      session.client.close = closeMock as typeof session.client.close;
+      if (factoryCalls === 1) {
+        firstSession = session;
+        session.ready = firstReadyGate;
+      }
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const ctrl = new AbortController();
+    const firstAvailablePromise = ensureChromeMcpAvailable("chrome-live", undefined, {
+      signal: ctrl.signal,
+    });
+    const firstAvailableExpectation =
+      expect(firstAvailablePromise).rejects.toThrow(/first waiter cancelled/);
+
+    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await vi.waitFor(() => expect(firstReadyThen).toHaveBeenCalledTimes(1));
+    if (!firstSession) {
+      throw new Error("Expected first Chrome MCP session to be created");
+    }
+    (firstSession.transport as { pid: number | null }).pid = null;
+
+    await expect(
+      ensureChromeMcpAvailable("chrome-live", undefined, {
+        ephemeral: true,
+      }),
+    ).resolves.toBeUndefined();
+    expect(factoryCalls).toBe(2);
+    await vi.waitFor(() => expect(closeMocks[1]).toHaveBeenCalledTimes(1));
+
+    ctrl.abort(new Error("first waiter cancelled"));
+    releaseFirstReady();
+    await firstAvailableExpectation;
+    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+  });
+
   it("preserves session after tool-level errors (isError)", async () => {
     let factoryCalls = 0;
     const factory: ChromeMcpSessionFactory = async () => {

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -1066,6 +1066,59 @@ describe("chrome MCP page parsing", () => {
     await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
   });
 
+  it("does not let ephemeral probes persist canceled pending attaches", async () => {
+    let factoryCalls = 0;
+    let releaseFirstReady: (() => void) | undefined;
+    const firstReadyGate = new Promise<void>((resolve) => {
+      releaseFirstReady = resolve;
+    });
+    const firstReadyThen = vi.spyOn(firstReadyGate, "then");
+    if (!releaseFirstReady) {
+      throw new Error("Expected Chrome MCP ready release callback to be initialized");
+    }
+
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      closeMocks.push(closeMock);
+      session.client.close = closeMock as typeof session.client.close;
+      if (factoryCalls === 1) {
+        session.ready = firstReadyGate;
+      }
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const ctrl = new AbortController();
+    const firstAvailablePromise = ensureChromeMcpAvailable("chrome-live", undefined, {
+      signal: ctrl.signal,
+    });
+    const firstAvailableExpectation =
+      expect(firstAvailablePromise).rejects.toThrow(/first waiter cancelled/);
+
+    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await vi.waitFor(() => expect(firstReadyThen).toHaveBeenCalledTimes(1));
+
+    await expect(
+      ensureChromeMcpAvailable("chrome-live", undefined, {
+        ephemeral: true,
+      }),
+    ).resolves.toBeUndefined();
+    expect(factoryCalls).toBe(2);
+    expect(firstReadyThen).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(closeMocks[1]).toHaveBeenCalledTimes(1));
+
+    ctrl.abort(new Error("first waiter cancelled"));
+    releaseFirstReady();
+    await firstAvailableExpectation;
+    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+
+    await expect(listChromeMcpTabs("chrome-live")).resolves.toHaveLength(2);
+    expect(factoryCalls).toBe(3);
+  });
+
   it("keeps a shared session after a readiness timeout while another waiter remains", async () => {
     let factoryCalls = 0;
     let releaseFirstReady: (() => void) | undefined;

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -732,6 +732,7 @@ describe("chrome MCP page parsing", () => {
     });
     const tabsExpectation = expect(tabsPromise).rejects.toThrow(/caller cancelled/);
 
+    await vi.waitFor(() => expect(factoryCalls).toBe(1));
     ctrl.abort(new Error("caller cancelled"));
     releaseFactory();
 
@@ -769,6 +770,7 @@ describe("chrome MCP page parsing", () => {
     });
     const abortedTabsExpectation = expect(abortedTabsPromise).rejects.toThrow(/caller cancelled/);
 
+    await vi.waitFor(() => expect(factoryCalls).toBe(1));
     ctrl.abort(new Error("caller cancelled"));
     await abortedTabsExpectation;
 

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -989,6 +989,29 @@ describe("chrome MCP page parsing", () => {
     await vi.waitFor(() => expect(closeMock).toHaveBeenCalledTimes(1));
   });
 
+  it("bounds retries when ready sessions keep losing their transport", async () => {
+    let factoryCalls = 0;
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      (session.transport as { pid: number | null }).pid = null;
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      closeMocks.push(closeMock);
+      session.client.close = closeMock as typeof session.client.close;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    await expect(listChromeMcpTabs("chrome-live")).rejects.toThrow(
+      /subprocess exited before it became usable/,
+    );
+
+    expect(factoryCalls).toBe(2);
+    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalled());
+    await vi.waitFor(() => expect(closeMocks[1]).toHaveBeenCalled());
+  });
+
   it("does not reuse a stale ready-pending session for ephemeral probes", async () => {
     let factoryCalls = 0;
     let firstSession: ChromeMcpSession | undefined;

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -950,8 +950,11 @@ describe("chrome MCP page parsing", () => {
     (firstSession.transport as { pid: number | null }).pid = null;
 
     const tabsPromise = listChromeMcpTabs("chrome-live");
+    const siblingTabsPromise = listChromeMcpTabs("chrome-live");
     await vi.waitFor(() => expect(factoryCalls).toBe(2));
-    await expect(tabsPromise).resolves.toHaveLength(2);
+    const [tabs, siblingTabs] = await Promise.all([tabsPromise, siblingTabsPromise]);
+    expect(tabs).toHaveLength(2);
+    expect(siblingTabs).toHaveLength(2);
 
     ctrl.abort(new Error("first waiter cancelled"));
     releaseFirstReady();

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -1020,6 +1020,54 @@ describe("chrome MCP page parsing", () => {
     await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
   });
 
+  it("starts a fresh shared session after a readiness timeout while another waiter remains", async () => {
+    let factoryCalls = 0;
+    let releaseFirstReady: (() => void) | undefined;
+    const firstReadyGate = new Promise<void>((resolve) => {
+      releaseFirstReady = resolve;
+    });
+    const firstReadyThen = vi.spyOn(firstReadyGate, "then");
+    if (!releaseFirstReady) {
+      throw new Error("Expected Chrome MCP ready release callback to be initialized");
+    }
+
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      closeMocks.push(closeMock);
+      session.client.close = closeMock as typeof session.client.close;
+      if (factoryCalls === 1) {
+        session.ready = firstReadyGate;
+      }
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const keptCtrl = new AbortController();
+    const timedOutTabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      timeoutMs: 1,
+    });
+    const timedOutTabsExpectation = expect(timedOutTabsPromise).rejects.toThrow(/timed out/);
+    const keptTabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: keptCtrl.signal,
+    });
+
+    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    await vi.waitFor(() => expect(firstReadyThen).toHaveBeenCalledTimes(2));
+    await timedOutTabsExpectation;
+
+    await expect(listChromeMcpTabs("chrome-live")).resolves.toHaveLength(2);
+    expect(factoryCalls).toBe(2);
+    expect(closeMocks[1]).not.toHaveBeenCalled();
+
+    keptCtrl.abort(new Error("kept waiter cancelled"));
+    releaseFirstReady();
+    await expect(keptTabsPromise).rejects.toThrow(/kept waiter cancelled/);
+    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+  });
+
   it("preserves session after tool-level errors (isError)", async () => {
     let factoryCalls = 0;
     const factory: ChromeMcpSessionFactory = async () => {

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -816,6 +816,54 @@ describe("chrome MCP page parsing", () => {
     await vi.waitFor(() => expect(closeMock).toHaveBeenCalledTimes(1));
   });
 
+  it("starts a fresh session while last-waiter abort cleanup is closing", async () => {
+    let factoryCalls = 0;
+    let releaseFirstClose: (() => void) | undefined;
+    const firstCloseGate = new Promise<void>((resolve) => {
+      releaseFirstClose = resolve;
+    });
+    if (!releaseFirstClose) {
+      throw new Error("Expected Chrome MCP close release callback to be initialized");
+    }
+
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const closeMock =
+        factoryCalls === 1
+          ? vi.fn(async () => {
+              await firstCloseGate;
+            })
+          : vi.fn().mockResolvedValue(undefined);
+      closeMocks.push(closeMock);
+      session.client.close = closeMock as typeof session.client.close;
+      if (factoryCalls === 1) {
+        session.ready = new Promise<void>(() => {});
+      }
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const ctrl = new AbortController();
+    const abortedTabsPromise = listChromeMcpTabs("chrome-live", undefined, {
+      signal: ctrl.signal,
+    });
+    const abortedTabsExpectation = expect(abortedTabsPromise).rejects.toThrow(/caller cancelled/);
+
+    await vi.waitFor(() => expect(factoryCalls).toBe(1));
+    ctrl.abort(new Error("caller cancelled"));
+    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+
+    const tabsPromise = listChromeMcpTabs("chrome-live");
+    await vi.waitFor(() => expect(factoryCalls).toBe(2));
+    await expect(tabsPromise).resolves.toHaveLength(2);
+    expect(closeMocks[1]).not.toHaveBeenCalled();
+
+    releaseFirstClose();
+    await abortedTabsExpectation;
+  });
+
   it("keeps a ready-pending shared session cached when another waiter remains", async () => {
     let factoryCalls = 0;
     let releaseReady: (() => void) | undefined;

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -953,16 +953,40 @@ describe("chrome MCP page parsing", () => {
 
     const tabsPromise = listChromeMcpTabs("chrome-live");
     const siblingTabsPromise = listChromeMcpTabs("chrome-live");
+    ctrl.abort(new Error("first waiter cancelled"));
+    releaseFirstReady();
     await vi.waitFor(() => expect(factoryCalls).toBe(2));
     const [tabs, siblingTabs] = await Promise.all([tabsPromise, siblingTabsPromise]);
     expect(tabs).toHaveLength(2);
     expect(siblingTabs).toHaveLength(2);
 
-    ctrl.abort(new Error("first waiter cancelled"));
-    releaseFirstReady();
     await firstTabsExpectation;
     await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
     expect(closeMocks[1]).not.toHaveBeenCalled();
+  });
+
+  it("surfaces startup failures before treating null-pid pending sessions as stale", async () => {
+    let factoryCalls = 0;
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      if (factoryCalls > 1) {
+        throw new Error("unexpected retry");
+      }
+      const session = createFakeSession();
+      (session.transport as { pid: number | null }).pid = null;
+      const readyFailure = Promise.reject(new Error("startup failed"));
+      readyFailure.catch(() => {});
+      session.ready = readyFailure;
+      session.client.close = closeMock as typeof session.client.close;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    await expect(listChromeMcpTabs("chrome-live")).rejects.toThrow(/startup failed/);
+
+    expect(factoryCalls).toBe(1);
+    expect(closeMock).not.toHaveBeenCalled();
   });
 
   it("does not reuse a stale ready-pending session for ephemeral probes", async () => {
@@ -1006,16 +1030,15 @@ describe("chrome MCP page parsing", () => {
     }
     (firstSession.transport as { pid: number | null }).pid = null;
 
-    await expect(
-      ensureChromeMcpAvailable("chrome-live", undefined, {
-        ephemeral: true,
-      }),
-    ).resolves.toBeUndefined();
+    const availablePromise = ensureChromeMcpAvailable("chrome-live", undefined, {
+      ephemeral: true,
+    });
+    ctrl.abort(new Error("first waiter cancelled"));
+    releaseFirstReady();
+    await expect(availablePromise).resolves.toBeUndefined();
     expect(factoryCalls).toBe(2);
     await vi.waitFor(() => expect(closeMocks[1]).toHaveBeenCalledTimes(1));
 
-    ctrl.abort(new Error("first waiter cancelled"));
-    releaseFirstReady();
     await firstAvailableExpectation;
     await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
   });

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -986,7 +986,7 @@ describe("chrome MCP page parsing", () => {
     await expect(listChromeMcpTabs("chrome-live")).rejects.toThrow(/startup failed/);
 
     expect(factoryCalls).toBe(1);
-    expect(closeMock).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(closeMock).toHaveBeenCalledTimes(1));
   });
 
   it("does not reuse a stale ready-pending session for ephemeral probes", async () => {
@@ -1043,7 +1043,7 @@ describe("chrome MCP page parsing", () => {
     await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
   });
 
-  it("starts a fresh shared session after a readiness timeout while another waiter remains", async () => {
+  it("keeps a shared session after a readiness timeout while another waiter remains", async () => {
     let factoryCalls = 0;
     let releaseFirstReady: (() => void) | undefined;
     const firstReadyGate = new Promise<void>((resolve) => {
@@ -1081,14 +1081,42 @@ describe("chrome MCP page parsing", () => {
     await vi.waitFor(() => expect(firstReadyThen).toHaveBeenCalledTimes(2));
     await timedOutTabsExpectation;
 
+    const laterTabsPromise = listChromeMcpTabs("chrome-live");
+    releaseFirstReady();
+
+    await expect(keptTabsPromise).resolves.toHaveLength(2);
+    await expect(laterTabsPromise).resolves.toHaveLength(2);
+    expect(factoryCalls).toBe(1);
+    expect(closeMocks[0]).not.toHaveBeenCalled();
+    keptCtrl.abort(new Error("kept waiter cancelled"));
+  });
+
+  it("closes a shared pending session after a readiness timeout with no other waiters", async () => {
+    let factoryCalls = 0;
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      closeMocks.push(closeMock);
+      session.client.close = closeMock as typeof session.client.close;
+      if (factoryCalls === 1) {
+        session.ready = new Promise<void>(() => {});
+      }
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    await expect(
+      listChromeMcpTabs("chrome-live", undefined, {
+        timeoutMs: 1,
+      }),
+    ).rejects.toThrow(/timed out/);
+    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
+
     await expect(listChromeMcpTabs("chrome-live")).resolves.toHaveLength(2);
     expect(factoryCalls).toBe(2);
     expect(closeMocks[1]).not.toHaveBeenCalled();
-
-    keptCtrl.abort(new Error("kept waiter cancelled"));
-    releaseFirstReady();
-    await expect(keptTabsPromise).rejects.toThrow(/kept waiter cancelled/);
-    await vi.waitFor(() => expect(closeMocks[0]).toHaveBeenCalledTimes(1));
   });
 
   it("preserves session after tool-level errors (isError)", async () => {

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -82,10 +82,13 @@ type ChromeMcpSessionFactory = (
 
 type PendingChromeMcpSession = {
   cacheKey: string;
+  id: symbol;
   promise: Promise<ChromeMcpSession>;
   abortController: AbortController;
-  waiters: number;
-  settled: boolean;
+  state: {
+    waiters: number;
+    settled: boolean;
+  };
 };
 
 type PendingChromeMcpSessionLease = {
@@ -847,9 +850,21 @@ function abortPendingChromeMcpSession(
   pending: PendingChromeMcpSession,
   reason: unknown = new Error("Chrome MCP session attach no longer has active waiters"),
 ): void {
-  if (!pending.settled && !pending.abortController.signal.aborted) {
+  if (!pending.state.settled && !pending.abortController.signal.aborted) {
     pending.abortController.abort(reason);
   }
+}
+
+function forgetCachedChromeMcpSessionIfCurrent(
+  cacheKey: string,
+  session: ChromeMcpSession,
+): boolean {
+  const current = sessions.get(cacheKey);
+  if (current?.transport !== session.transport) {
+    return false;
+  }
+  sessions.delete(cacheKey);
+  return true;
 }
 
 function createSharedPendingChromeMcpSession(
@@ -857,30 +872,34 @@ function createSharedPendingChromeMcpSession(
   profileName: string,
   options: NormalizedChromeMcpProfileOptions,
 ): PendingChromeMcpSession {
-  let pending!: PendingChromeMcpSession;
+  const id = Symbol(cacheKey);
   const abortController = new AbortController();
+  const state = {
+    waiters: 0,
+    settled: false,
+  };
   const promise = (async () => {
     try {
       const created = await createChromeMcpSession(profileName, options, abortController.signal);
-      if (pendingSessions.get(cacheKey) === pending) {
+      if (pendingSessions.get(cacheKey)?.id === id) {
         sessions.set(cacheKey, created);
       } else {
         await closeChromeMcpSessionHandle(created);
       }
       return created;
     } finally {
-      pending.settled = true;
-      if (pending.waiters === 0 && pendingSessions.get(cacheKey) === pending) {
+      state.settled = true;
+      if (state.waiters === 0 && pendingSessions.get(cacheKey)?.id === id) {
         pendingSessions.delete(cacheKey);
       }
     }
   })();
-  pending = {
+  const pending: PendingChromeMcpSession = {
     cacheKey,
+    id,
     promise,
     abortController,
-    waiters: 0,
-    settled: false,
+    state,
   };
   void promise.catch(() => {});
   return pending;
@@ -890,7 +909,7 @@ async function waitForSharedPendingChromeMcpSession(
   pending: PendingChromeMcpSession,
   signal?: AbortSignal,
 ): Promise<PendingChromeMcpSessionLease> {
-  pending.waiters += 1;
+  pending.state.waiters += 1;
   let released = false;
   let leaseSession: ChromeMcpSession | undefined;
   const release = async (closeIfLastWaiter: boolean) => {
@@ -898,20 +917,17 @@ async function waitForSharedPendingChromeMcpSession(
       return false;
     }
     released = true;
-    pending.waiters = Math.max(0, pending.waiters - 1);
-    if (pending.waiters !== 0) {
+    pending.state.waiters = Math.max(0, pending.state.waiters - 1);
+    if (pending.state.waiters !== 0) {
       return false;
     }
     if (pendingSessions.get(pending.cacheKey) === pending) {
       pendingSessions.delete(pending.cacheKey);
     }
-    if (!pending.settled) {
+    if (!pending.state.settled) {
       abortPendingChromeMcpSession(pending, signal?.reason);
     } else if (closeIfLastWaiter && leaseSession) {
-      const current = sessions.get(pending.cacheKey);
-      if (current?.transport === leaseSession.transport) {
-        sessions.delete(pending.cacheKey);
-      }
+      forgetCachedChromeMcpSessionIfCurrent(pending.cacheKey, leaseSession);
       await closeChromeMcpSessionHandle(leaseSession);
     }
     return true;
@@ -958,22 +974,11 @@ async function getSession(
     await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
     return session;
   } catch (err) {
-    if (signal?.aborted) {
-      const isLastWaiter = await pendingLease?.release(true);
-      if (isLastWaiter !== false) {
-        const current = sessions.get(cacheKey);
-        if (current?.transport === session.transport) {
-          sessions.delete(cacheKey);
-        }
-      }
-      if (pendingLease) {
-        pendingLease = undefined;
-      }
+    if (signal?.aborted && pendingLease) {
+      await pendingLease.release(true);
+      pendingLease = undefined;
     } else {
-      const current = sessions.get(cacheKey);
-      if (current?.transport === session.transport) {
-        sessions.delete(cacheKey);
-      }
+      forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
     }
     throw err;
   } finally {
@@ -1003,19 +1008,10 @@ async function getExistingSession(
       return session;
     } catch (err) {
       if (signal?.aborted) {
-        const isLastWaiter = await pendingLease.release(true);
-        if (isLastWaiter) {
-          const current = sessions.get(cacheKey);
-          if (current?.transport === session.transport) {
-            sessions.delete(cacheKey);
-          }
-        }
+        await pendingLease.release(true);
         pendingLease = undefined;
       } else {
-        const current = sessions.get(cacheKey);
-        if (current?.transport === session.transport) {
-          sessions.delete(cacheKey);
-        }
+        forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
       }
       throw err;
     } finally {
@@ -1028,10 +1024,7 @@ async function getExistingSession(
       await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
       return session;
     } catch (err) {
-      const current = sessions.get(cacheKey);
-      if (current?.transport === session.transport) {
-        sessions.delete(cacheKey);
-      }
+      forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
       throw err;
     }
   }

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -908,6 +908,10 @@ async function waitForSharedPendingChromeMcpSession(
     if (!pending.settled) {
       abortPendingChromeMcpSession(pending, signal?.reason);
     } else if (closeIfLastWaiter && leaseSession) {
+      const current = sessions.get(pending.cacheKey);
+      if (current?.transport === leaseSession.transport) {
+        sessions.delete(pending.cacheKey);
+      }
       await closeChromeMcpSessionHandle(leaseSession);
     }
     return true;

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -964,42 +964,46 @@ async function getSession(
   const cacheKey = buildChromeMcpSessionCacheKey(profileName, options);
   await closeChromeMcpSessionsForProfile(profileName, cacheKey);
 
-  let session = sessions.get(cacheKey);
-  if (session && session.transport.pid === null) {
-    sessions.delete(cacheKey);
-    session = undefined;
-  }
-  let pendingLease: PendingChromeMcpSessionLease | undefined;
-  let pending = pendingSessions.get(cacheKey);
-  if (pending) {
-    pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
-    session = pendingLease.session;
-    if (session.transport.pid === null) {
-      forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
-      await pendingLease.release(true);
-      pendingLease = undefined;
+  for (;;) {
+    let session = sessions.get(cacheKey);
+    if (session && session.transport.pid === null) {
+      sessions.delete(cacheKey);
       session = undefined;
     }
-  }
-  if (!session) {
-    pending = createSharedPendingChromeMcpSession(cacheKey, profileName, options);
-    pendingSessions.set(cacheKey, pending);
-    pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
-    session = pendingLease.session;
-  }
-  try {
-    await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
-    return session;
-  } catch (err) {
-    if (signal?.aborted && pendingLease) {
-      await pendingLease.release(true);
-      pendingLease = undefined;
-    } else {
-      forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
+
+    let pendingLease: PendingChromeMcpSessionLease | undefined;
+    const pending = pendingSessions.get(cacheKey);
+    if (pending) {
+      pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
+      session = pendingLease.session;
+      if (session.transport.pid === null) {
+        forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
+        await pendingLease.release(true);
+        continue;
+      }
     }
-    throw err;
-  } finally {
-    await pendingLease?.release(false);
+
+    if (!session) {
+      const createdPending = createSharedPendingChromeMcpSession(cacheKey, profileName, options);
+      pendingSessions.set(cacheKey, createdPending);
+      pendingLease = await waitForSharedPendingChromeMcpSession(createdPending, signal);
+      session = pendingLease.session;
+    }
+
+    try {
+      await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
+      return session;
+    } catch (err) {
+      if (signal?.aborted && pendingLease) {
+        await pendingLease.release(true);
+        pendingLease = undefined;
+      } else {
+        forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
+      }
+      throw err;
+    } finally {
+      await pendingLease?.release(false);
+    }
   }
 }
 

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -967,6 +967,7 @@ async function getSession(
     throw signal.reason ?? new Error("aborted");
   }
 
+  let staleReadySessionRetries = 0;
   for (;;) {
     let session = sessions.get(cacheKey);
     if (session && session.transport.pid === null) {
@@ -1001,6 +1002,13 @@ async function getSession(
         if (pendingLease) {
           await pendingLease.release(true);
           pendingLease = undefined;
+        }
+        staleReadySessionRetries += 1;
+        if (staleReadySessionRetries > 1) {
+          throw new BrowserProfileUnavailableError(
+            `Chrome MCP existing-session attach failed for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}". ` +
+              "The Chrome MCP subprocess exited before it became usable.",
+          );
         }
         continue;
       }

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -975,8 +975,10 @@ async function getSession(
     }
 
     let pendingLease: PendingChromeMcpSessionLease | undefined;
+    let leasedPending: PendingChromeMcpSession | undefined;
     const pending = pendingSessions.get(cacheKey);
     if (pending) {
+      leasedPending = pending;
       pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
       session = pendingLease.session;
       if (session.transport.pid === null) {
@@ -989,6 +991,7 @@ async function getSession(
     if (!session) {
       const createdPending = createSharedPendingChromeMcpSession(cacheKey, profileName, options);
       pendingSessions.set(cacheKey, createdPending);
+      leasedPending = createdPending;
       pendingLease = await waitForSharedPendingChromeMcpSession(createdPending, signal);
       session = pendingLease.session;
     }
@@ -1002,6 +1005,9 @@ async function getSession(
         pendingLease = undefined;
       } else {
         forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
+        if (leasedPending) {
+          forgetPendingChromeMcpSessionIfCurrent(cacheKey, leasedPending);
+        }
       }
       throw err;
     } finally {
@@ -1041,6 +1047,7 @@ async function getExistingSession(
         pendingLease = undefined;
       } else {
         forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
+        forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
       }
       throw err;
     } finally {

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -1053,8 +1053,8 @@ async function getExistingSession(
 
   const pending = pendingSessions.get(cacheKey);
   if (pending) {
-    let pendingLease: PendingChromeMcpSessionLease | undefined;
-    pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
+    const pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
+    let pendingLeaseReleased = false;
     session = pendingLease.session;
     try {
       await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
@@ -1062,26 +1062,28 @@ async function getExistingSession(
         forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
         forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
         await pendingLease.release(true);
-        pendingLease = undefined;
+        pendingLeaseReleased = true;
         return null;
       }
       return session;
     } catch (err) {
       if (signal?.aborted) {
         await pendingLease.release(true);
-        pendingLease = undefined;
+        pendingLeaseReleased = true;
       } else if (pending.state.waiters > 1) {
         await pendingLease.release(false);
-        pendingLease = undefined;
+        pendingLeaseReleased = true;
       } else {
         forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
         forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
         await pendingLease.release(true);
-        pendingLease = undefined;
+        pendingLeaseReleased = true;
       }
       throw err;
     } finally {
-      await pendingLease?.release(false);
+      if (!pendingLeaseReleased) {
+        await pendingLease.release(false);
+      }
     }
   }
 

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -80,6 +80,19 @@ type ChromeMcpSessionFactory = (
   options?: NormalizedChromeMcpProfileOptions,
 ) => Promise<ChromeMcpSession>;
 
+type PendingChromeMcpSession = {
+  cacheKey: string;
+  promise: Promise<ChromeMcpSession>;
+  abortController: AbortController;
+  waiters: number;
+  settled: boolean;
+};
+
+type PendingChromeMcpSessionLease = {
+  session: ChromeMcpSession;
+  release: (closeIfLastWaiter: boolean) => Promise<boolean>;
+};
+
 export type ChromeMcpProcessInfo = {
   pid: number;
   ppid: number;
@@ -123,7 +136,7 @@ const STALE_SELECTED_PAGE_ERROR =
 
 const execFileAsync = promisify(execFile);
 const sessions = new Map<string, ChromeMcpSession>();
-const pendingSessions = new Map<string, Promise<ChromeMcpSession>>();
+const pendingSessions = new Map<string, PendingChromeMcpSession>();
 let sessionFactory: ChromeMcpSessionFactory | null = null;
 let chromeMcpProcessCleanupDepsForTest: ChromeMcpProcessCleanupDeps | null = null;
 
@@ -362,9 +375,10 @@ async function closeChromeMcpSessionsForProfile(
 ): Promise<boolean> {
   let closed = false;
 
-  for (const key of Array.from(pendingSessions.keys())) {
+  for (const [key, pending] of Array.from(pendingSessions.entries())) {
     if (key !== keepKey && cacheKeyMatchesProfileName(key, profileName)) {
       pendingSessions.delete(key);
+      abortPendingChromeMcpSession(pending, new Error("Chrome MCP profile session was replaced"));
       closed = true;
     }
   }
@@ -812,17 +826,100 @@ async function createChromeMcpSession(
   signal?: AbortSignal,
 ): Promise<ChromeMcpSession> {
   const created = (sessionFactory ?? createRealSession)(profileName, options);
+  let closedAfterAbort = false;
   try {
     const session = await waitForChromeMcpPendingSession(created, signal);
     if (signal?.aborted) {
+      closedAfterAbort = true;
       await closeChromeMcpSessionHandle(session);
       throw signal.reason ?? new Error("aborted");
     }
     return session;
   } catch (err) {
-    if (signal?.aborted) {
+    if (signal?.aborted && !closedAfterAbort) {
       void created.then((session) => closeChromeMcpSessionHandle(session)).catch(() => {});
     }
+    throw err;
+  }
+}
+
+function abortPendingChromeMcpSession(
+  pending: PendingChromeMcpSession,
+  reason: unknown = new Error("Chrome MCP session attach no longer has active waiters"),
+): void {
+  if (!pending.settled && !pending.abortController.signal.aborted) {
+    pending.abortController.abort(reason);
+  }
+}
+
+function createSharedPendingChromeMcpSession(
+  cacheKey: string,
+  profileName: string,
+  options: NormalizedChromeMcpProfileOptions,
+): PendingChromeMcpSession {
+  let pending!: PendingChromeMcpSession;
+  const abortController = new AbortController();
+  const promise = (async () => {
+    try {
+      const created = await createChromeMcpSession(profileName, options, abortController.signal);
+      if (pendingSessions.get(cacheKey) === pending) {
+        sessions.set(cacheKey, created);
+      } else {
+        await closeChromeMcpSessionHandle(created);
+      }
+      return created;
+    } finally {
+      pending.settled = true;
+      if (pending.waiters === 0 && pendingSessions.get(cacheKey) === pending) {
+        pendingSessions.delete(cacheKey);
+      }
+    }
+  })();
+  pending = {
+    cacheKey,
+    promise,
+    abortController,
+    waiters: 0,
+    settled: false,
+  };
+  void promise.catch(() => {});
+  return pending;
+}
+
+async function waitForSharedPendingChromeMcpSession(
+  pending: PendingChromeMcpSession,
+  signal?: AbortSignal,
+): Promise<PendingChromeMcpSessionLease> {
+  pending.waiters += 1;
+  let released = false;
+  let leaseSession: ChromeMcpSession | undefined;
+  const release = async (closeIfLastWaiter: boolean) => {
+    if (released) {
+      return false;
+    }
+    released = true;
+    pending.waiters = Math.max(0, pending.waiters - 1);
+    if (pending.waiters !== 0) {
+      return false;
+    }
+    if (pendingSessions.get(pending.cacheKey) === pending) {
+      pendingSessions.delete(pending.cacheKey);
+    }
+    if (!pending.settled) {
+      abortPendingChromeMcpSession(pending, signal?.reason);
+    } else if (closeIfLastWaiter && leaseSession) {
+      await closeChromeMcpSessionHandle(leaseSession);
+    }
+    return true;
+  };
+  try {
+    leaseSession = await waitForChromeMcpPendingSession(pending.promise, signal);
+    return {
+      session: leaseSession,
+      release,
+    };
+  } catch (err) {
+    await release(signal?.aborted === true);
     throw err;
   }
 }
@@ -842,37 +939,41 @@ async function getSession(
     sessions.delete(cacheKey);
     session = undefined;
   }
-  if (!session) {
-    let pending = pendingSessions.get(cacheKey);
-    if (!pending) {
-      pending = (async () => {
-        const created = await createChromeMcpSession(profileName, options, signal);
-        if (pendingSessions.get(cacheKey) === pending) {
-          sessions.set(cacheKey, created);
-        } else {
-          await closeChromeMcpSessionHandle(created);
-        }
-        return created;
-      })();
-      pendingSessions.set(cacheKey, pending);
-    }
-    try {
-      session = await pending;
-    } finally {
-      if (pendingSessions.get(cacheKey) === pending) {
-        pendingSessions.delete(cacheKey);
-      }
-    }
+  let pendingLease: PendingChromeMcpSessionLease | undefined;
+  let pending = pendingSessions.get(cacheKey);
+  if (pending) {
+    pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
+    session = pendingLease.session;
+  } else if (!session) {
+    pending = createSharedPendingChromeMcpSession(cacheKey, profileName, options);
+    pendingSessions.set(cacheKey, pending);
+    pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
+    session = pendingLease.session;
   }
   try {
     await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
     return session;
   } catch (err) {
-    const current = sessions.get(cacheKey);
-    if (current?.transport === session.transport) {
-      sessions.delete(cacheKey);
+    if (signal?.aborted) {
+      const isLastWaiter = await pendingLease?.release(true);
+      if (isLastWaiter !== false) {
+        const current = sessions.get(cacheKey);
+        if (current?.transport === session.transport) {
+          sessions.delete(cacheKey);
+        }
+      }
+      if (pendingLease) {
+        pendingLease = undefined;
+      }
+    } else {
+      const current = sessions.get(cacheKey);
+      if (current?.transport === session.transport) {
+        sessions.delete(cacheKey);
+      }
     }
     throw err;
+  } finally {
+    await pendingLease?.release(false);
   }
 }
 
@@ -887,6 +988,37 @@ async function getExistingSession(
     sessions.delete(cacheKey);
     session = undefined;
   }
+
+  const pending = pendingSessions.get(cacheKey);
+  if (pending) {
+    let pendingLease: PendingChromeMcpSessionLease | undefined;
+    pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
+    session = pendingLease.session;
+    try {
+      await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
+      return session;
+    } catch (err) {
+      if (signal?.aborted) {
+        const isLastWaiter = await pendingLease.release(true);
+        if (isLastWaiter) {
+          const current = sessions.get(cacheKey);
+          if (current?.transport === session.transport) {
+            sessions.delete(cacheKey);
+          }
+        }
+        pendingLease = undefined;
+      } else {
+        const current = sessions.get(cacheKey);
+        if (current?.transport === session.transport) {
+          sessions.delete(cacheKey);
+        }
+      }
+      throw err;
+    } finally {
+      await pendingLease?.release(false);
+    }
+  }
+
   if (session) {
     try {
       await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
@@ -900,22 +1032,7 @@ async function getExistingSession(
     }
   }
 
-  const pending = pendingSessions.get(cacheKey);
-  if (!pending) {
-    return null;
-  }
-
-  session = await waitForChromeMcpPendingSession(pending, signal);
-  try {
-    await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
-    return session;
-  } catch (err) {
-    const current = sessions.get(cacheKey);
-    if (current?.transport === session.transport) {
-      sessions.delete(cacheKey);
-    }
-    throw err;
-  }
+  return null;
 }
 
 async function createEphemeralSession(
@@ -1539,6 +1656,9 @@ export function setChromeMcpProcessCleanupDepsForTest(
 
 export async function resetChromeMcpSessionsForTest(): Promise<void> {
   sessionFactory = null;
+  for (const pending of pendingSessions.values()) {
+    abortPendingChromeMcpSession(pending, new Error("Chrome MCP sessions reset for test"));
+  }
   pendingSessions.clear();
   await stopAllChromeMcpSessions();
   chromeMcpProcessCleanupDepsForTest = null;

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -963,6 +963,9 @@ async function getSession(
   const options = normalizeChromeMcpOptions(profileOptions);
   const cacheKey = buildChromeMcpSessionCacheKey(profileName, options);
   await closeChromeMcpSessionsForProfile(profileName, cacheKey);
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("aborted");
+  }
 
   for (;;) {
     let session = sessions.get(cacheKey);

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -1009,10 +1009,19 @@ async function getSession(
       if (signal?.aborted && pendingLease) {
         await pendingLease.release(true);
         pendingLease = undefined;
+      } else if (pendingLease && leasedPending && leasedPending.state.waiters > 1) {
+        await pendingLease.release(false);
+        pendingLease = undefined;
       } else {
         forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
         if (leasedPending) {
           forgetPendingChromeMcpSessionIfCurrent(cacheKey, leasedPending);
+        }
+        if (pendingLease) {
+          await pendingLease.release(true);
+          pendingLease = undefined;
+        } else {
+          await closeChromeMcpSessionHandle(session);
         }
       }
       throw err;
@@ -1053,9 +1062,14 @@ async function getExistingSession(
       if (signal?.aborted) {
         await pendingLease.release(true);
         pendingLease = undefined;
+      } else if (pending.state.waiters > 1) {
+        await pendingLease.release(false);
+        pendingLease = undefined;
       } else {
         forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
         forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
+        await pendingLease.release(true);
+        pendingLease = undefined;
       }
       throw err;
     } finally {

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -667,10 +667,9 @@ async function withChromeMcpHandshakeTimeout<T>(task: Promise<T>): Promise<T> {
     return await Promise.race([
       task,
       new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error("Chrome MCP handshake timed out")),
-          CHROME_MCP_HANDSHAKE_TIMEOUT_MS,
-        );
+        timer = setTimeout(() => {
+          reject(new Error("Chrome MCP handshake timed out"));
+        }, CHROME_MCP_HANDSHAKE_TIMEOUT_MS);
         timer.unref?.();
       }),
     ]);
@@ -867,6 +866,17 @@ function forgetCachedChromeMcpSessionIfCurrent(
   return true;
 }
 
+function forgetPendingChromeMcpSessionIfCurrent(
+  cacheKey: string,
+  pending: PendingChromeMcpSession,
+): boolean {
+  if (pendingSessions.get(cacheKey) !== pending) {
+    return false;
+  }
+  pendingSessions.delete(cacheKey);
+  return true;
+}
+
 function createSharedPendingChromeMcpSession(
   cacheKey: string,
   profileName: string,
@@ -911,7 +921,7 @@ async function waitForSharedPendingChromeMcpSession(
 ): Promise<PendingChromeMcpSessionLease> {
   pending.state.waiters += 1;
   let released = false;
-  let leaseSession: ChromeMcpSession | undefined;
+  let leasedSession: ChromeMcpSession | undefined;
   const release = async (closeIfLastWaiter: boolean) => {
     if (released) {
       return false;
@@ -926,16 +936,16 @@ async function waitForSharedPendingChromeMcpSession(
     }
     if (!pending.state.settled) {
       abortPendingChromeMcpSession(pending, signal?.reason);
-    } else if (closeIfLastWaiter && leaseSession) {
-      forgetCachedChromeMcpSessionIfCurrent(pending.cacheKey, leaseSession);
-      await closeChromeMcpSessionHandle(leaseSession);
+    } else if (closeIfLastWaiter && leasedSession) {
+      forgetCachedChromeMcpSessionIfCurrent(pending.cacheKey, leasedSession);
+      await closeChromeMcpSessionHandle(leasedSession);
     }
     return true;
   };
   try {
-    leaseSession = await waitForChromeMcpPendingSession(pending.promise, signal);
+    leasedSession = await waitForChromeMcpPendingSession(pending.promise, signal);
     return {
-      session: leaseSession,
+      session: leasedSession,
       release,
     };
   } catch (err) {
@@ -964,7 +974,14 @@ async function getSession(
   if (pending) {
     pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
     session = pendingLease.session;
-  } else if (!session) {
+    if (session.transport.pid === null) {
+      forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
+      await pendingLease.release(true);
+      pendingLease = undefined;
+      session = undefined;
+    }
+  }
+  if (!session) {
     pending = createSharedPendingChromeMcpSession(cacheKey, profileName, options);
     pendingSessions.set(cacheKey, pending);
     pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
@@ -1003,6 +1020,11 @@ async function getExistingSession(
     let pendingLease: PendingChromeMcpSessionLease | undefined;
     pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
     session = pendingLease.session;
+    if (session.transport.pid === null) {
+      forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
+      await pendingLease.release(true);
+      return null;
+    }
     try {
       await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
       return session;

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -1044,7 +1044,12 @@ async function getExistingSession(
   profileName: string,
   timeoutMs?: number,
   signal?: AbortSignal,
+  includePending = true,
 ): Promise<ChromeMcpSession | null> {
+  if (!includePending && pendingSessions.has(cacheKey)) {
+    return null;
+  }
+
   let session = sessions.get(cacheKey);
   if (session && session.transport.pid === null) {
     sessions.delete(cacheKey);
@@ -1052,7 +1057,7 @@ async function getExistingSession(
   }
 
   const pending = pendingSessions.get(cacheKey);
-  if (pending) {
+  if (includePending && pending) {
     const pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
     let pendingLeaseReleased = false;
     session = pendingLease.session;
@@ -1144,6 +1149,7 @@ async function leaseSession(
     profileName,
     options.timeoutMs,
     options.signal,
+    false,
   );
   if (existingSession) {
     return {

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -981,11 +981,6 @@ async function getSession(
       leasedPending = pending;
       pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
       session = pendingLease.session;
-      if (session.transport.pid === null) {
-        forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
-        await pendingLease.release(true);
-        continue;
-      }
     }
 
     if (!session) {
@@ -998,6 +993,17 @@ async function getSession(
 
     try {
       await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
+      if (session.transport.pid === null) {
+        forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
+        if (leasedPending) {
+          forgetPendingChromeMcpSessionIfCurrent(cacheKey, leasedPending);
+        }
+        if (pendingLease) {
+          await pendingLease.release(true);
+          pendingLease = undefined;
+        }
+        continue;
+      }
       return session;
     } catch (err) {
       if (signal?.aborted && pendingLease) {
@@ -1033,13 +1039,15 @@ async function getExistingSession(
     let pendingLease: PendingChromeMcpSessionLease | undefined;
     pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
     session = pendingLease.session;
-    if (session.transport.pid === null) {
-      forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
-      await pendingLease.release(true);
-      return null;
-    }
     try {
       await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
+      if (session.transport.pid === null) {
+        forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
+        forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
+        await pendingLease.release(true);
+        pendingLease = undefined;
+        return null;
+      }
       return session;
     } catch (err) {
       if (signal?.aborted) {

--- a/extensions/microsoft-foundry/provider.ts
+++ b/extensions/microsoft-foundry/provider.ts
@@ -58,7 +58,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         const nextModel = Object.assign({}, model, {
           name: selectedModelCapabilities.modelName,
           api: selectedModelCapabilities.api,
-          reasoning: selectedModelCapabilities.reasoning || model.reasoning === true,
+          reasoning: selectedModelCapabilities.reasoning || model.reasoning,
           thinkingLevelMap: selectedModelCapabilities.thinkingLevelMap ?? model.thinkingLevelMap,
           input: selectedModelCapabilities.input,
         });
@@ -69,7 +69,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
               : undefined;
           const preserveExplicitReasoningEffort =
             !selectedModelCapabilities.reasoning &&
-            model.reasoning === true &&
+            model.reasoning &&
             explicitSupportsReasoningEffort !== false;
           const explicitMaxTokensField =
             typeof model.compat?.maxTokensField === "string"
@@ -78,13 +78,13 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
                 ? "max_completion_tokens"
                 : undefined;
           nextModel.compat = {
-            ...(model.compat ?? {}),
+            ...model.compat,
             ...selectedModelCapabilities.compat,
             ...(explicitSupportsReasoningEffort !== undefined
               ? { supportsReasoningEffort: explicitSupportsReasoningEffort }
               : preserveExplicitReasoningEffort
                 ? { supportsReasoningEffort: true }
-                : {}),
+                : undefined),
             ...(explicitMaxTokensField ? { maxTokensField: explicitMaxTokensField } : {}),
           };
         }
@@ -138,7 +138,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         typeof model.compat?.supportsReasoningEffort === "boolean"
           ? model.compat.supportsReasoningEffort
           : undefined;
-      const preserveExplicitReasoningEffort = !capabilities.reasoning && model.reasoning === true;
+      const preserveExplicitReasoningEffort = !capabilities.reasoning && model.reasoning;
       const explicitMaxTokensField =
         typeof model.compat?.maxTokensField === "string"
           ? model.compat.maxTokensField
@@ -147,13 +147,13 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
             : undefined;
       const compat = capabilities.compat
         ? {
-            ...(model.compat ?? {}),
+            ...model.compat,
             ...capabilities.compat,
             ...(explicitSupportsReasoningEffort !== undefined
               ? { supportsReasoningEffort: explicitSupportsReasoningEffort }
               : preserveExplicitReasoningEffort
                 ? { supportsReasoningEffort: true }
-                : {}),
+                : undefined),
             ...(explicitMaxTokensField ? { maxTokensField: explicitMaxTokensField } : {}),
           }
         : undefined;
@@ -161,7 +161,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         ...model,
         name: capabilities.modelName,
         api: capabilities.api,
-        reasoning: capabilities.reasoning || model.reasoning === true,
+        reasoning: capabilities.reasoning || model.reasoning,
         thinkingLevelMap: capabilities.thinkingLevelMap ?? model.thinkingLevelMap,
         input: capabilities.input,
         baseUrl: buildFoundryProviderBaseUrl(

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -87,7 +87,7 @@ vi.mock("../agents/model-selection.js", () => {
   });
   const normalizeProviderId = (provider: string) => provider.trim().toLowerCase();
   const modelKey = (provider: string, model: string) =>
-    `${provider.trim().toLowerCase()}/${model.trim().toLowerCase()}`;
+    `${normalizeProviderId(provider)}/${model.trim().toLowerCase()}`;
   const isModelKeyAllowedBySet = (allowedKeys: ReadonlySet<string>, key: string) => {
     if (allowedKeys.has(key)) {
       return true;


### PR DESCRIPTION
## Summary

Fixes #88304.

- keep Chrome MCP cached-session attach cancellation scoped to the caller that cancelled
- track active waiters while a shared attach is still pending or waiting for `session.ready`
- tear down the attach only when the last waiter cancels, evict cancelled pending entries before a fresh caller can join them, and evict cached sessions before awaited close cleanup

## Motivation / root cause

`getSession()` shared one pending Chrome MCP attach per profile/cache key, but created that shared pending promise with the first caller's `AbortSignal`. If that first caller cancelled while another caller was also waiting for the same Chrome MCP session, the shared pending attach could reject with the first caller's abort reason and fail the unrelated caller.

The fix gives the shared attach its own abort controller and treats each caller as a waiter. Caller aborts release that waiter. The shared attach is only aborted or closed when no waiters remain, and last-waiter close cleanup removes the session from the cache before awaiting close so a fresh caller starts a new attach instead of reusing a handle being torn down.

## Real behavior proof

Behavior addressed: one cancelled Chrome MCP caller no longer cancels another caller waiting on the same shared pending attach; all-cancelled attaches are still cleaned up; fresh callers do not reuse a session that is already closing after last-waiter cancellation.

Real environment tested: macOS local checkout with the Chrome MCP runtime module loaded through `node --import tsx` and the real `listChromeMcpTabs` path using a test session factory.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp.test.ts
node --import tsx --input-type=module  # mixed factory-pending repro/proof
node --import tsx --input-type=module  # mixed ready-pending repro/proof
node --import tsx --input-type=module  # all-aborted-before-ready cleanup proof
node --import tsx --input-type=module  # fresh caller during last-waiter close proof
git diff --check origin/main...HEAD
```

Evidence before fix:

```json
{
  "first": "rejected",
  "firstReason": "first caller cancelled",
  "second": "rejected",
  "secondReason": "first caller cancelled",
  "closed": 1
}
```

Evidence after fix:

```json
{
  "proof": "mixed-factory-pending",
  "first": "rejected",
  "firstReason": "first caller cancelled",
  "second": "fulfilled",
  "secondTabs": 1,
  "closed": 0
}
```

```json
{
  "proof": "mixed-ready-pending",
  "factoryCalls": 1,
  "first": "rejected",
  "firstReason": "first caller cancelled",
  "second": "fulfilled",
  "thirdTabs": 1,
  "closed": 0
}
```

```json
{
  "proof": "all-aborted-before-ready",
  "factoryCalls": 1,
  "first": "rejected",
  "firstReason": "caller cancelled",
  "closed": 1
}
```

```json
{
  "proof": "fresh-caller-during-close",
  "factoryCalls": 2,
  "first": "rejected",
  "firstReason": "caller cancelled",
  "secondTabs": 1,
  "closeCounts": [
    1,
    0
  ]
}
```

Observed result after fix: a remaining waiter can complete and later calls reuse the same session; when every waiter cancels before readiness, the session handle is closed exactly once; when a fresh caller arrives while the old session close is still awaiting, it starts a new attach and does not reuse the closing session.

What was not tested: a live Chrome browser/CDP process was not launched for this proof. The exercised path is the Chrome MCP runtime session cache and cancellation behavior with a controlled session factory.

## Regression tests

Added focused coverage in `extensions/browser/src/browser/chrome-mcp.test.ts` for:

- one waiter aborting while another waiter remains during factory attach;
- every waiter aborting before the factory resolves;
- a fresh caller after an all-waiters-aborted pending attach;
- every waiter aborting while `session.ready` is pending;
- a fresh caller arriving while last-waiter abort cleanup is still awaiting `close()`;
- a mixed ready-pending wait where one caller aborts, another succeeds, and a later call reuses the same session.

## Compatibility / risks

This only changes Chrome MCP cached-session cancellation and cleanup behavior. The main risk is around session lifecycle races, so the patch keeps stale-session, profile-key rotation, and transport-error cleanup behavior intact and adds tests for the cancellation cases that can otherwise leak, duplicate, or reuse closing sessions.
