### PR TITLE
fix(gateway): hide phantom agent store rows from sessions.list

### DIFF
--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -553,3 +553,23 @@ test("sessions.list configuredAgentsOnly keeps configured-agent children and hid
     "agent:local:main",
   ]);
 });
+
+test("sessions.list hides phantom agent store placeholder rows", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      sessions: {},
+      main: {
+        sessionId: "sess-main",
+        updatedAt: 20,
+      },
+    },
+  });
+
+  const listed = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
+    "sessions.list",
+    { includeGlobal: false, includeUnknown: false },
+  );
+  expect(listed.ok).toBe(true);
+  expect(listed.payload?.sessions.map((session) => session.key)).toEqual(["agent:main:main"]);
+});

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1916,6 +1916,21 @@ describe("listSessionsFromStore selected model display", () => {
     });
   });
 
+  test("filters phantom agent store placeholder rows from session lists", () => {
+    const now = Date.now();
+    const result = listSessionsFromStore({
+      cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:sessions": {} as SessionEntry,
+        "agent:main:main": { sessionId: "sess-main", updatedAt: now } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions.map((session) => session.key)).toEqual(["agent:main:main"]);
+  });
+
   test("shows the selected override model even when a fallback runtime model exists", () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-6",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -2507,6 +2507,9 @@ function filterSessionEntries(params: {
       return true;
     })
     .filter(([key, entry]) => {
+      if (isPhantomAgentStoreListEntry(key, entry)) {
+        return false;
+      }
       if (!spawnedBy) {
         return true;
       }
@@ -2578,6 +2581,15 @@ function filterSessionEntries(params: {
   }
 
   return entries;
+}
+
+function isPhantomAgentStoreListEntry(key: string, entry: SessionEntry | undefined): boolean {
+  const parsed = parseAgentSessionKey(key);
+  return (
+    parsed?.rest === "sessions" &&
+    !normalizeOptionalString(entry?.sessionId) &&
+    entry?.updatedAt == null
+  );
 }
 
 function selectSessionEntries(params: {


### PR DESCRIPTION
Closes #57376

## Summary

`sessions.list` was allowing the agent store placeholder key (`agent:<id>:sessions`) to leak into the returned session rows when that placeholder entry had no `sessionId` and no `updatedAt`.

This patch filters only that narrow placeholder shape before row construction:

- `parseAgentSessionKey(key)?.rest === "sessions"`
- missing/empty `sessionId`
- `updatedAt == null`

Real session rows remain listable, including normal `agent:<id>:main` and other agent-scoped session keys.

Regression coverage added at two levels:

- `listSessionsFromStore(...)` excludes the phantom placeholder row
- `sessions.list` RPC excludes the same placeholder row after loading the seeded store

## Real behavior proof

**Behavior addressed:** `sessions.list` can return a phantom store placeholder row such as `agent:main:sessions` with `updatedAt: null` and no `sessionId`, which shows up as a blank/broken session entry.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, commit `8007486ce278a0ada71b23feb158725a681a580b`

**Exact steps or command run after this patch:**

1. Run the Gateway session list regression tests:

```bash
node scripts/run-vitest.mjs src/gateway/session-utils.test.ts src/gateway/server.sessions.store-rpc.test.ts
```

2. Run the actual session listing code path used by `sessions.list` row construction with a seeded placeholder entry and one real session entry:

```bash
./node_modules/.bin/tsx -e "import { listSessionsFromStore } from './src/gateway/session-utils.ts'; const cfg = { agents: { defaults: { model: { primary: 'openai/gpt-5.4' } } } } as any; const store = { 'agent:main:sessions': {}, 'agent:main:main': { sessionId: 'sess-main', updatedAt: 20 } } as any; const result = listSessionsFromStore({ cfg, storePath: '/tmp/sessions.json', store, opts: { includeGlobal: false, includeUnknown: false } }); console.log(JSON.stringify({ keys: result.sessions.map((session) => session.key), rows: result.sessions.length }, null, 2));"
```

**Evidence after fix:**

Regression tests:

```text
Test Files  2 passed (2)
     Tests  100 passed (100)
[test] passed 1 Vitest shard in 23.38s
```

Direct runtime output from `listSessionsFromStore(...)`:

```json
{
  "keys": [
    "agent:main:main"
  ],
  "rows": 1
}
```

**Observed result after fix:** the placeholder key is no longer surfaced as a session row. The real session row (`agent:main:main`) still appears in the list, and the list contains exactly one row.

**What was not tested:** Control UI rendering against a live desktop build. No store migration behavior was changed, only list-time filtering.
