### PR TITLE
fix(test): include workflow lint target in routing expectation

### DIFF
--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -422,6 +422,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/check-composite-action-input-interpolation.test.ts",
         "test/scripts/check-no-conflict-markers.test.ts",
         "test/scripts/ci-workflow-guards.test.ts",
+        "test/scripts/check-workflows.test.ts",
       ],
     });
   });


### PR DESCRIPTION
## Summary

- update the changed-target routing test to include `test/scripts/check-workflows.test.ts` for `scripts/check-workflows.mjs`
- keep the assertion aligned with the current resolver output so `build-artifacts`/`core-support-boundary` stops failing on unrelated PRs

## Verification

- `git diff --check origin/main...HEAD`
- `node_modules/.bin/oxfmt --check --threads=1 test/scripts/test-projects.test.ts`
- `node_modules/.bin/oxlint test/scripts/test-projects.test.ts`
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts --reporter=dot`
