### PR TITLE
fix(windows): repair doctor update fallback migration

### DIFF
--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -120,6 +120,8 @@ import { EXTERNAL_SERVICE_REPAIR_NOTE } from "./doctor-service-repair-policy.js"
 const originalStdinIsTTY = process.stdin.isTTY;
 const originalPlatform = process.platform;
 const originalUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+const originalParentSupportsConfigWrite =
+  process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE;
 
 function makeDoctorIo() {
   return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
@@ -352,6 +354,12 @@ describe("maybeRepairGatewayServiceConfig", () => {
       delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
     } else {
       process.env.OPENCLAW_UPDATE_IN_PROGRESS = originalUpdateInProgress;
+    }
+    if (originalParentSupportsConfigWrite === undefined) {
+      delete process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE;
+    } else {
+      process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE =
+        originalParentSupportsConfigWrite;
     }
   });
 
@@ -914,6 +922,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
       configurable: true,
     });
     process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+    process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE = "1";
 
     await withEnvAsync(
       {
@@ -990,6 +999,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
       configurable: true,
     });
     process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+    process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE = "1";
 
     await withEnvAsync(
       {
@@ -1027,12 +1037,63 @@ describe("maybeRepairGatewayServiceConfig", () => {
         );
         expectGatewayAuthToken(replaceOptions.nextConfig, "stale-token");
         expect(replaceOptions.afterWrite).toEqual({ mode: "auto" });
-        expect(replaceOptions.writeOptions).toEqual({
-          lastTouchedVersionOverride: "2026.5.14",
-        });
+        expect(replaceOptions.writeOptions).toEqual(
+          expect.objectContaining({
+            allowConfigSizeDrop: true,
+            skipPluginValidation: true,
+            lastTouchedVersionOverride: "2026.5.14",
+          }),
+        );
         expectCallConfigGatewayAuthToken(mocks.buildGatewayInstallPlan, "stale-token");
         expect(mocks.stage).not.toHaveBeenCalled();
         expect(mocks.install).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
+  it("leaves embedded service tokens untouched during legacy Windows update handoffs", async () => {
+    mockProcessPlatform("win32");
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+    delete process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE;
+
+    await withEnvAsync(
+      {
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+      },
+      async () => {
+        mocks.readCommand.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          environment: {
+            OPENCLAW_GATEWAY_TOKEN: "stale-token",
+            OPENCLAW_SERVICE_VERSION: "2026.5.25",
+          },
+        });
+        mocks.auditGatewayServiceConfig.mockResolvedValue({
+          ok: true,
+          issues: [],
+        });
+        mocks.buildGatewayInstallPlan.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          workingDirectory: "/tmp",
+          environment: {
+            OPENCLAW_SERVICE_VERSION: "2026.5.26",
+          },
+        });
+        mocks.readRuntime.mockResolvedValue({ status: "running" });
+
+        await runNonInteractiveRepair({ updateInProgress: true });
+
+        expectNoteContaining(
+          "Legacy update parent cannot persist gateway.auth.token before service repair",
+          "Gateway",
+        );
+        expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+        expect(mocks.stage).not.toHaveBeenCalled();
+        expect(mocks.install).not.toHaveBeenCalled();
       },
     );
   });

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -28,6 +28,7 @@ vi.mock("node:fs/promises", async () => {
 
 const mocks = vi.hoisted(() => ({
   readCommand: vi.fn(),
+  readRuntime: vi.fn(),
   stage: vi.fn(),
   install: vi.fn(),
   replaceConfigFile: vi.fn().mockResolvedValue(undefined),
@@ -79,6 +80,7 @@ vi.mock("../daemon/service-audit.js", () => ({
     gatewayManagedEnvEmbedded: testServiceAuditCodes.gatewayManagedEnvEmbedded,
     gatewayPortMismatch: testServiceAuditCodes.gatewayPortMismatch,
     gatewayProxyEnvEmbedded: testServiceAuditCodes.gatewayProxyEnvEmbedded,
+    gatewayVersionMismatch: testServiceAuditCodes.gatewayVersionMismatch,
     gatewayTokenMismatch: testServiceAuditCodes.gatewayTokenMismatch,
   },
 }));
@@ -86,6 +88,7 @@ vi.mock("../daemon/service-audit.js", () => ({
 vi.mock("../daemon/service.js", () => ({
   resolveGatewayService: () => ({
     readCommand: mocks.readCommand,
+    readRuntime: mocks.readRuntime,
     stage: mocks.stage,
     install: mocks.install,
   }),
@@ -155,6 +158,7 @@ async function runRepair(cfg: OpenClawConfig, options: { allowExecSecretRefs?: b
 async function runNonInteractiveRepair(params: {
   cfg?: OpenClawConfig;
   updateInProgress?: boolean;
+  lastTouchedVersionOverride?: string;
 }) {
   Object.defineProperty(process.stdin, "isTTY", {
     value: false,
@@ -176,6 +180,9 @@ async function runNonInteractiveRepair(params: {
         nonInteractive: true,
       },
     }),
+    params.lastTouchedVersionOverride
+      ? { lastTouchedVersionOverride: params.lastTouchedVersionOverride }
+      : {},
   );
 }
 
@@ -322,6 +329,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
     vi.clearAllMocks();
     fsMocks.realpath.mockImplementation(async (value: string) => value);
     mocks.resolveGatewayPort.mockReturnValue(18789);
+    mocks.readRuntime.mockResolvedValue({ status: "unknown" });
     mocks.needsNodeRuntimeMigration.mockReturnValue(false);
     mocks.renderSystemNodeWarning.mockReturnValue(undefined);
     mocks.resolveSystemNodeInfo.mockResolvedValue(null);
@@ -937,6 +945,128 @@ describe("maybeRepairGatewayServiceConfig", () => {
         expect(mocks.install).not.toHaveBeenCalled();
       },
     );
+  });
+
+  it("installs running Windows update repairs so Startup-folder fallback installs can migrate", async () => {
+    mockProcessPlatform("win32");
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+    mocks.readCommand.mockResolvedValue({
+      programArguments: gatewayProgramArguments,
+      environment: {
+        OPENCLAW_SERVICE_VERSION: "2026.5.25",
+      },
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: true,
+      issues: [],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: gatewayProgramArguments,
+      workingDirectory: "/tmp",
+      environment: {
+        OPENCLAW_SERVICE_VERSION: "2026.5.26",
+      },
+    });
+    mocks.readRuntime.mockResolvedValue({ status: "running" });
+
+    await runNonInteractiveRepair({ updateInProgress: true });
+
+    expectNoteContaining(
+      "Gateway service version does not match the current CLI.",
+      "Gateway service config",
+    );
+    expect(mocks.stage).not.toHaveBeenCalled();
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists embedded service tokens before Windows update repairs rewrite the task", async () => {
+    mockProcessPlatform("win32");
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+
+    await withEnvAsync(
+      {
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+      },
+      async () => {
+        mocks.readCommand.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          environment: {
+            OPENCLAW_GATEWAY_TOKEN: "stale-token",
+            OPENCLAW_SERVICE_VERSION: "2026.5.25",
+          },
+        });
+        mocks.auditGatewayServiceConfig.mockResolvedValue({
+          ok: true,
+          issues: [],
+        });
+        mocks.buildGatewayInstallPlan.mockResolvedValue({
+          programArguments: gatewayProgramArguments,
+          workingDirectory: "/tmp",
+          environment: {
+            OPENCLAW_SERVICE_VERSION: "2026.5.26",
+          },
+        });
+        mocks.readRuntime.mockResolvedValue({ status: "running" });
+
+        await runNonInteractiveRepair({
+          updateInProgress: true,
+          lastTouchedVersionOverride: "2026.5.14",
+        });
+
+        const replaceOptions = requireRecord(
+          callArg(mocks.replaceConfigFile, 0, "replaceConfigFile call"),
+          "replaceConfigFile options",
+        );
+        expectGatewayAuthToken(replaceOptions.nextConfig, "stale-token");
+        expect(replaceOptions.afterWrite).toEqual({ mode: "auto" });
+        expect(replaceOptions.writeOptions).toEqual({
+          lastTouchedVersionOverride: "2026.5.14",
+        });
+        expectCallConfigGatewayAuthToken(mocks.buildGatewayInstallPlan, "stale-token");
+        expect(mocks.stage).not.toHaveBeenCalled();
+        expect(mocks.install).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
+  it("stages stopped Windows update repairs without activating the gateway", async () => {
+    mockProcessPlatform("win32");
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+    mocks.readCommand.mockResolvedValue({
+      programArguments: gatewayProgramArguments,
+      environment: {
+        OPENCLAW_SERVICE_VERSION: "2026.5.25",
+      },
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: true,
+      issues: [],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: gatewayProgramArguments,
+      workingDirectory: "/tmp",
+      environment: {
+        OPENCLAW_SERVICE_VERSION: "2026.5.26",
+      },
+    });
+    mocks.readRuntime.mockResolvedValue({ status: "stopped" });
+
+    await runNonInteractiveRepair({ updateInProgress: true });
+
+    expect(mocks.install).not.toHaveBeenCalled();
+    expect(mocks.stage).toHaveBeenCalledTimes(1);
   });
 
   it("does not persist EnvironmentFile-backed service tokens into config", async () => {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -32,6 +32,7 @@ import {
   uninstallLegacySystemdUnits,
   type SystemdUnitScope,
 } from "../daemon/systemd.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { VERSION } from "../version.js";
 import { buildGatewayInstallPlan } from "./daemon-install-helpers.js";
@@ -45,6 +46,25 @@ import {
   isServiceRepairExternallyManaged,
   resolveServiceRepairPolicy,
 } from "./doctor-service-repair-policy.js";
+import {
+  UPDATE_IN_PROGRESS_ENV,
+  UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
+} from "./doctor/shared/update-phase.js";
+
+type GatewayServiceConfigRepairOptions = {
+  allowConfigSizeDrop?: boolean;
+  allowExecSecretRefs?: boolean;
+  lastTouchedVersionOverride?: string;
+  preservedLegacyRootKeys?: readonly string[];
+  skipPluginValidation?: boolean;
+};
+
+function shouldSkipLegacyUpdateRepairConfigWrite(env: NodeJS.ProcessEnv): boolean {
+  return (
+    isTruthyEnvValue(env[UPDATE_IN_PROGRESS_ENV]) &&
+    !isTruthyEnvValue(env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV])
+  );
+}
 
 const execFileAsync = promisify(execFile);
 const EXECSTART_REPAIR_CODES = new Set<string>([
@@ -366,16 +386,16 @@ export async function maybeRepairGatewayServiceConfig(
   mode: "local" | "remote",
   runtime: RuntimeEnv,
   prompter: DoctorPrompter,
-  options: { allowExecSecretRefs?: boolean; lastTouchedVersionOverride?: string } = {},
-) {
+  options: GatewayServiceConfigRepairOptions = {},
+): Promise<OpenClawConfig> {
   if (resolveIsNixMode(process.env)) {
     note("Nix mode detected; skip service updates.", "Gateway");
-    return;
+    return cfg;
   }
 
   if (mode === "remote") {
     note("Gateway mode is remote; skipped local service audit.", "Gateway");
-    return;
+    return cfg;
   }
 
   const service = resolveGatewayService();
@@ -386,7 +406,7 @@ export async function maybeRepairGatewayServiceConfig(
     command = null;
   }
   if (!command) {
-    return;
+    return cfg;
   }
   const serviceInstallEnv = buildGatewayServiceRepairEnv(command);
   const serviceWrapperPath = resolveGatewayServiceWrapperPath(command);
@@ -514,7 +534,7 @@ export async function maybeRepairGatewayServiceConfig(
     if (sourceCheckoutWarning !== null && !hasEntrypointMismatch) {
       note(sourceCheckoutWarning, "Gateway service config");
     }
-    return;
+    return cfg;
   }
 
   const serviceRepairPolicy = resolveServiceRepairPolicy();
@@ -546,7 +566,7 @@ export async function maybeRepairGatewayServiceConfig(
 
   if (serviceRepairExternal) {
     note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway service config");
-    return;
+    return cfg;
   }
 
   if (serviceRewriteBlocked) {
@@ -554,7 +574,7 @@ export async function maybeRepairGatewayServiceConfig(
       "Gateway service is running; leaving supervisor metadata unchanged. Stop the service first or use `openclaw gateway install --force` when you want to replace the active launcher.",
       "Gateway service config",
     );
-    return;
+    return cfg;
   }
 
   const updateRepairMode = isDoctorUpdateRepairMode(prompter.repairMode);
@@ -568,7 +588,7 @@ export async function maybeRepairGatewayServiceConfig(
       "Update-mode doctor detected gateway service drift but left the live systemd unit unchanged. Review the service file and run `openclaw gateway install --force` when you want OpenClaw to replace operator-owned systemd directives.",
       "Gateway service config",
     );
-    return;
+    return cfg;
   }
 
   const repairMessage = needsAggressive
@@ -596,7 +616,7 @@ export async function maybeRepairGatewayServiceConfig(
         "Gateway service config",
       );
     }
-    return;
+    return cfg;
   }
   const serviceEmbeddedToken = readEmbeddedGatewayToken(command);
   const gatewayTokenForRepair = expectedGatewayToken ?? serviceEmbeddedToken;
@@ -614,6 +634,16 @@ export async function maybeRepairGatewayServiceConfig(
     !configuredGatewayToken &&
     gatewayTokenForRepair
   ) {
+    if (
+      updateRepairWillRewriteWindowsTask &&
+      shouldSkipLegacyUpdateRepairConfigWrite(process.env)
+    ) {
+      note(
+        "Legacy update parent cannot persist gateway.auth.token before service repair; leaving the existing gateway service unchanged.",
+        "Gateway",
+      );
+      return cfg;
+    }
     const nextCfg: OpenClawConfig = {
       ...cfg,
       gateway: {
@@ -629,13 +659,14 @@ export async function maybeRepairGatewayServiceConfig(
       await replaceConfigFile({
         nextConfig: nextCfg,
         afterWrite: { mode: "auto" },
-        ...(options.lastTouchedVersionOverride
-          ? {
-              writeOptions: {
-                lastTouchedVersionOverride: options.lastTouchedVersionOverride,
-              },
-            }
-          : {}),
+        writeOptions: {
+          allowConfigSizeDrop: options.allowConfigSizeDrop === true || updateRepairMode,
+          skipPluginValidation: options.skipPluginValidation === true || updateRepairMode,
+          preservedLegacyRootKeys: options.preservedLegacyRootKeys,
+          ...(options.lastTouchedVersionOverride
+            ? { lastTouchedVersionOverride: options.lastTouchedVersionOverride }
+            : {}),
+        },
       });
       cfgForServiceInstall = nextCfg;
       note(
@@ -646,7 +677,7 @@ export async function maybeRepairGatewayServiceConfig(
       );
     } catch (err) {
       runtime.error(`Failed to persist gateway.auth.token before service repair: ${String(err)}`);
-      return;
+      return cfg;
     }
   }
 
@@ -681,6 +712,7 @@ export async function maybeRepairGatewayServiceConfig(
   } catch (err) {
     runtime.error(`Gateway service update failed: ${String(err)}`);
   }
+  return cfgForServiceInstall;
 }
 
 export async function maybeScanExtraGatewayServices(

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -33,6 +33,7 @@ import {
   type SystemdUnitScope,
 } from "../daemon/systemd.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { VERSION } from "../version.js";
 import { buildGatewayInstallPlan } from "./daemon-install-helpers.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME, type GatewayDaemonRuntime } from "./daemon-runtime.js";
 import { resolveGatewayAuthTokenForService } from "./doctor-gateway-auth-token.js";
@@ -179,6 +180,17 @@ function shouldDeferUpdateModeSystemdServiceRepair(params: {
     isDoctorUpdateRepairMode(params.repairMode) &&
     !params.shouldForce
   );
+}
+
+async function isWindowsGatewayRunningForUpdateRepair(params: {
+  service: ReturnType<typeof resolveGatewayService>;
+  env: NodeJS.ProcessEnv;
+}): Promise<boolean> {
+  if (process.platform !== "win32") {
+    return false;
+  }
+  const runtime = await params.service.readRuntime(params.env).catch(() => null);
+  return runtime?.status === "running";
 }
 
 async function suppressRunningSystemdExecStartRepairs(params: {
@@ -354,7 +366,7 @@ export async function maybeRepairGatewayServiceConfig(
   mode: "local" | "remote",
   runtime: RuntimeEnv,
   prompter: DoctorPrompter,
-  options: { allowExecSecretRefs?: boolean } = {},
+  options: { allowExecSecretRefs?: boolean; lastTouchedVersionOverride?: string } = {},
 ) {
   if (resolveIsNixMode(process.env)) {
     note("Nix mode detected; skip service updates.", "Gateway");
@@ -426,6 +438,15 @@ export async function maybeRepairGatewayServiceConfig(
       message:
         "Gateway service OPENCLAW_GATEWAY_TOKEN should be unset when gateway.auth.token is SecretRef-managed",
       detail: "service token is stale",
+      level: "recommended",
+    });
+  }
+  const serviceVersion = normalizeOptionalString(command.environment?.OPENCLAW_SERVICE_VERSION);
+  if (serviceVersion && serviceVersion !== VERSION) {
+    audit.issues.push({
+      code: SERVICE_AUDIT_CODES.gatewayVersionMismatch,
+      message: "Gateway service version does not match the current CLI.",
+      detail: `${serviceVersion} -> ${VERSION}`,
       level: "recommended",
     });
   }
@@ -584,8 +605,11 @@ export async function maybeRepairGatewayServiceConfig(
       ? normalizeOptionalString(cfg.gateway.auth.token)
       : undefined;
   let cfgForServiceInstall = cfg;
+  // Windows update repairs rewrite the Scheduled Task immediately, so migrate an
+  // embedded legacy token first; otherwise the restarted gateway loses auth.
+  const updateRepairWillRewriteWindowsTask = updateRepairMode && process.platform === "win32";
   if (
-    !updateRepairMode &&
+    (!updateRepairMode || updateRepairWillRewriteWindowsTask) &&
     !tokenRefConfigured &&
     !configuredGatewayToken &&
     gatewayTokenForRepair
@@ -605,6 +629,13 @@ export async function maybeRepairGatewayServiceConfig(
       await replaceConfigFile({
         nextConfig: nextCfg,
         afterWrite: { mode: "auto" },
+        ...(options.lastTouchedVersionOverride
+          ? {
+              writeOptions: {
+                lastTouchedVersionOverride: options.lastTouchedVersionOverride,
+              },
+            }
+          : {}),
       });
       cfgForServiceInstall = nextCfg;
       note(
@@ -628,8 +659,18 @@ export async function maybeRepairGatewayServiceConfig(
     runtime: needsNodeRuntime && systemNodePath ? "node" : runtimeChoice,
     nodePath: systemNodePath ?? undefined,
   });
+  const updateRepairShouldInstall =
+    updateRepairMode &&
+    (await isWindowsGatewayRunningForUpdateRepair({
+      service,
+      env: serviceInstallEnv,
+    }));
+  // Windows `install` activates the task/login item. In update mode, only take
+  // that path when the gateway was already running; stopped installs stay staged.
+  const repairService =
+    updateRepairMode && !updateRepairShouldInstall ? service.stage : service.install;
   try {
-    await (updateRepairMode ? service.stage : service.install)({
+    await repairService({
       env: serviceInstallEnv,
       stdout: process.stdout,
       programArguments: updatedPlan.programArguments,

--- a/src/commands/doctor-service-audit.test-helpers.ts
+++ b/src/commands/doctor-service-audit.test-helpers.ts
@@ -8,6 +8,7 @@ export const testServiceAuditCodes = {
   gatewayManagedEnvEmbedded: "gateway-managed-env-embedded",
   gatewayPortMismatch: "gateway-port-mismatch",
   gatewayProxyEnvEmbedded: "gateway-proxy-env-embedded",
+  gatewayVersionMismatch: "gateway-version-mismatch",
   gatewayTokenMismatch: "gateway-token-mismatch",
 } as const;
 

--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -1,11 +1,17 @@
 import fs from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import { EXTERNAL_SERVICE_REPAIR_NOTE } from "./doctor-service-repair-policy.js";
 import { maybeOfferUpdateBeforeDoctor } from "./doctor-update.js";
 
 const originalStdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const originalServiceRepairPolicy = process.env.OPENCLAW_SERVICE_REPAIR_POLICY;
 
 const mocks = vi.hoisted(() => ({
   note: vi.fn(),
+  readGatewayServiceState: vi.fn(),
+  restartGatewayService: vi.fn(),
+  resolveGatewayService: vi.fn(),
   runCommandWithTimeout: vi.fn(),
   runGatewayUpdate: vi.fn(),
 }));
@@ -18,6 +24,11 @@ vi.mock("../infra/update-runner.js", () => ({
   runGatewayUpdate: mocks.runGatewayUpdate,
 }));
 
+vi.mock("../daemon/service.js", () => ({
+  readGatewayServiceState: mocks.readGatewayServiceState,
+  resolveGatewayService: mocks.resolveGatewayService,
+}));
+
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: mocks.note,
 }));
@@ -25,10 +36,15 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({
 async function runOffer(params?: {
   root?: string;
   confirm?: (p: { message: string; initialValue: boolean }) => Promise<boolean>;
+  runtime?: RuntimeEnv;
 }): Promise<Awaited<ReturnType<typeof maybeOfferUpdateBeforeDoctor>>> {
   const confirm = params?.confirm ?? vi.fn().mockResolvedValue(false);
   return await maybeOfferUpdateBeforeDoctor({
-    runtime: {} as never,
+    runtime: params?.runtime ?? {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    },
     options: {},
     root: params?.root ?? "/repo/link",
     confirm,
@@ -38,8 +54,19 @@ async function runOffer(params?: {
 
 beforeEach(async () => {
   mocks.note.mockReset();
+  mocks.readGatewayServiceState.mockReset();
+  mocks.restartGatewayService.mockReset();
+  mocks.resolveGatewayService.mockReset();
   mocks.runCommandWithTimeout.mockReset();
   mocks.runGatewayUpdate.mockReset();
+  mocks.resolveGatewayService.mockReturnValue({
+    restart: mocks.restartGatewayService,
+  });
+  mocks.readGatewayServiceState.mockResolvedValue({
+    installed: false,
+    running: false,
+    env: {},
+  });
   Object.defineProperty(process.stdin, "isTTY", {
     configurable: true,
     value: true,
@@ -53,9 +80,27 @@ afterEach(() => {
   } else {
     delete (process.stdin as Partial<typeof process.stdin>).isTTY;
   }
+  if (originalServiceRepairPolicy === undefined) {
+    delete process.env.OPENCLAW_SERVICE_REPAIR_POLICY;
+  } else {
+    process.env.OPENCLAW_SERVICE_REPAIR_POLICY = originalServiceRepairPolicy;
+  }
 });
 
 describe("maybeOfferUpdateBeforeDoctor", () => {
+  function mockGitCheckout() {
+    vi.spyOn(fs, "realpath").mockImplementation(async (candidate) => String(candidate));
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      stdout: "/repo/link\n",
+      stderr: "",
+      code: 0,
+      killed: false,
+      signal: null,
+      termination: "exit",
+      noOutputTimedOut: false,
+    });
+  }
+
   it("treats a linked package root as a git checkout when realpaths match", async () => {
     const confirm = vi.fn().mockResolvedValue(false);
     vi.spyOn(fs, "realpath").mockImplementation(async (candidate) => {
@@ -106,6 +151,88 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("This install is not a git checkout."),
       "Update",
+    );
+  });
+
+  it("restarts a running managed gateway after a successful git update", async () => {
+    mockGitCheckout();
+    mocks.runGatewayUpdate.mockResolvedValue({
+      status: "ok",
+      mode: "git",
+      root: "/repo/link",
+    });
+    mocks.readGatewayServiceState.mockResolvedValue({
+      installed: true,
+      running: true,
+      env: { OPENCLAW_PROFILE: "work" },
+    });
+
+    await expect(runOffer({ confirm: vi.fn().mockResolvedValue(true) })).resolves.toEqual({
+      updated: true,
+      handled: true,
+    });
+
+    expect(mocks.restartGatewayService).toHaveBeenCalledWith({
+      env: { OPENCLAW_PROFILE: "work" },
+      stdout: process.stdout,
+    });
+    expect(mocks.note).toHaveBeenCalledWith(
+      "Restarted the running gateway service after updating OpenClaw.",
+      "Update",
+    );
+  });
+
+  it("leaves a running gateway alone when service repair is externally managed", async () => {
+    mockGitCheckout();
+    process.env.OPENCLAW_SERVICE_REPAIR_POLICY = "external";
+    mocks.runGatewayUpdate.mockResolvedValue({
+      status: "ok",
+      mode: "git",
+      root: "/repo/link",
+    });
+    mocks.readGatewayServiceState.mockResolvedValue({
+      installed: true,
+      running: true,
+      env: { OPENCLAW_PROFILE: "work" },
+    });
+
+    await expect(runOffer({ confirm: vi.fn().mockResolvedValue(true) })).resolves.toEqual({
+      updated: true,
+      handled: true,
+    });
+
+    expect(mocks.resolveGatewayService).not.toHaveBeenCalled();
+    expect(mocks.readGatewayServiceState).not.toHaveBeenCalled();
+    expect(mocks.restartGatewayService).not.toHaveBeenCalled();
+    expect(mocks.note).toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Update");
+  });
+
+  it("stops the parent doctor when the post-update gateway restart fails", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    mockGitCheckout();
+    mocks.runGatewayUpdate.mockResolvedValue({
+      status: "ok",
+      mode: "git",
+      root: "/repo/link",
+    });
+    mocks.readGatewayServiceState.mockResolvedValue({
+      installed: true,
+      running: true,
+      env: { OPENCLAW_PROFILE: "work" },
+    });
+    mocks.restartGatewayService.mockRejectedValue(new Error("schtasks failed"));
+
+    await expect(runOffer({ confirm: vi.fn().mockResolvedValue(true), runtime })).resolves.toEqual({
+      updated: true,
+      handled: true,
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Update completed, but gateway service restart failed: Error: schtasks failed",
     );
   });
 });

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -3,11 +3,16 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { readGatewayServiceState, resolveGatewayService } from "../daemon/service.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { runGatewayUpdate } from "../infra/update-runner.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
+import {
+  EXTERNAL_SERVICE_REPAIR_NOTE,
+  isServiceRepairExternallyManaged,
+} from "./doctor-service-repair-policy.js";
 
 async function resolveComparablePath(target: string): Promise<string> {
   return await fs.realpath(target).catch(() => path.resolve(target));
@@ -32,6 +37,35 @@ async function detectOpenClawGitCheckout(root: string): Promise<"git" | "not-git
   return (await resolveComparablePath(gitRoot)) === (await resolveComparablePath(root))
     ? "git"
     : "not-git";
+}
+
+async function restartRunningGatewayServiceAfterUpdate(runtime: RuntimeEnv): Promise<boolean> {
+  if (isServiceRepairExternallyManaged()) {
+    note(EXTERNAL_SERVICE_REPAIR_NOTE, "Update");
+    return true;
+  }
+  let service: ReturnType<typeof resolveGatewayService>;
+  let state: Awaited<ReturnType<typeof readGatewayServiceState>>;
+  try {
+    service = resolveGatewayService();
+    state = await readGatewayServiceState(service, { env: process.env });
+  } catch {
+    return true;
+  }
+  if (!state.installed || !state.running) {
+    return true;
+  }
+  try {
+    await service.restart({
+      env: state.env,
+      stdout: process.stdout,
+    });
+    note("Restarted the running gateway service after updating OpenClaw.", "Update");
+    return true;
+  } catch (err) {
+    runtime.error(`Update completed, but gateway service restart failed: ${String(err)}`);
+    return false;
+  }
 }
 
 export async function maybeOfferUpdateBeforeDoctor(params: {
@@ -78,6 +112,11 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
       "Update result",
     );
     if (result.status === "ok") {
+      const restarted = await restartRunningGatewayServiceAfterUpdate(params.runtime);
+      if (!restarted) {
+        params.outro("Update completed, but gateway service restart failed.");
+        return { updated: true, handled: true };
+      }
       params.outro("Update completed (doctor already ran as part of the update).");
       return { updated: true, handled: true };
     }

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -85,8 +85,8 @@ function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd")
   );
 }
 
-async function writeStartupFallbackEntry(env: Record<string, string>) {
-  const startupEntryPath = resolveStartupEntryPath(env);
+async function writeStartupFallbackEntry(env: Record<string, string>, extension = "cmd") {
+  const startupEntryPath = resolveStartupEntryPath(env, extension);
   await fs.mkdir(path.dirname(startupEntryPath), { recursive: true });
   await fs.writeFile(startupEntryPath, "@echo off\r\n", "utf8");
   return startupEntryPath;
@@ -332,6 +332,7 @@ describe("Windows startup fallback", () => {
   it("removes an old Startup-folder launcher after migrating to a Scheduled Task", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       const startupEntryPath = await writeStartupFallbackEntry(env);
+      const hiddenStartupEntryPath = await writeStartupFallbackEntry(env, "vbs");
       addStartupFallbackMissingResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -350,6 +351,7 @@ describe("Windows startup fallback", () => {
       await installGatewayScheduledTask(env, stdout);
 
       await expect(fs.access(startupEntryPath)).rejects.toThrow();
+      await expect(fs.access(hiddenStartupEntryPath)).rejects.toThrow();
       expect(printed).toContain("Installed Scheduled Task");
       expect(printed).toContain("Removed Windows login item");
     });
@@ -377,6 +379,7 @@ describe("Windows startup fallback", () => {
   it("removes an old Startup-folder launcher after Scheduled Task restart is proven", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       const startupEntryPath = await writeStartupFallbackEntry(env);
+      const hiddenStartupEntryPath = await writeStartupFallbackEntry(env, "vbs");
       await writeGatewayScript(env);
       schtasksResponses.push(
         { code: 0, stdout: "", stderr: "" },
@@ -392,6 +395,7 @@ describe("Windows startup fallback", () => {
       await restartScheduledTask({ env, stdout: new PassThrough() });
 
       await expect(fs.access(startupEntryPath)).rejects.toThrow();
+      await expect(fs.access(hiddenStartupEntryPath)).rejects.toThrow();
     });
   });
 

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -248,6 +248,15 @@ function notYetRunTaskQueryOutput() {
   ].join("\r\n");
 }
 
+function runningTaskQueryOutput() {
+  return [
+    "Status: Running",
+    "Last Run Time: 4/15/2026 11:42:31 PM",
+    "Last Run Result: 267009",
+    "",
+  ].join("\r\n");
+}
+
 beforeEach(() => {
   resetSchtasksBaseMocks();
   findVerifiedGatewayListenerPidsOnPortSync.mockReset();
@@ -317,6 +326,72 @@ describe("Windows startup fallback", () => {
       expect(startupScript).toContain("gateway.cmd");
       expect(startupScript).toContain(`Run """${result.scriptPath}""", 0, False`);
       expectStartupFallbackSpawn();
+    });
+  });
+
+  it("removes an old Startup-folder launcher after migrating to a Scheduled Task", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      const startupEntryPath = await writeStartupFallbackEntry(env);
+      addStartupFallbackMissingResponses([
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
+      ]);
+
+      const stdout = new PassThrough();
+      let printed = "";
+      stdout.on("data", (chunk) => {
+        printed += String(chunk);
+      });
+
+      await installGatewayScheduledTask(env, stdout);
+
+      await expect(fs.access(startupEntryPath)).rejects.toThrow();
+      expect(printed).toContain("Installed Scheduled Task");
+      expect(printed).toContain("Removed Windows login item");
+    });
+  });
+
+  it("keeps the Startup-folder launcher when task launch evidence is only the old listener", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      const startupEntryPath = await writeStartupFallbackEntry(env);
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      addStartupFallbackMissingResponses([
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: notYetRunTaskQueryOutput(), stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: notYetRunTaskQueryOutput(), stderr: "" },
+      ]);
+
+      await installGatewayScheduledTask(env);
+
+      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+    });
+  });
+
+  it("removes an old Startup-folder launcher after Scheduled Task restart is proven", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      const startupEntryPath = await writeStartupFallbackEntry(env);
+      await writeGatewayScript(env);
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
+      );
+
+      await restartScheduledTask({ env, stdout: new PassThrough() });
+
+      await expect(fs.access(startupEntryPath)).rejects.toThrow();
     });
   });
 

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -211,6 +211,8 @@ describe("Scheduled Task stop/restart cleanup", () => {
         ["/Run", "/TN", "OpenClaw Gateway"],
         ["/Query"],
         ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
       ]);
     });
   });
@@ -235,6 +237,8 @@ describe("Scheduled Task stop/restart cleanup", () => {
         ["/Query", "/TN", "OpenClaw Node"],
         ["/End", "/TN", "OpenClaw Node"],
         ["/Run", "/TN", "OpenClaw Node"],
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Node", "/V", "/FO", "LIST"],
         ["/Query"],
         ["/Query", "/TN", "OpenClaw Node", "/V", "/FO", "LIST"],
       ]);

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -93,7 +93,8 @@ function resolveStartupEntryPath(env: GatewayServiceEnv, extension?: "cmd" | "vb
 function resolveStartupEntryPaths(env: GatewayServiceEnv): string[] {
   const primaryPath = resolveStartupEntryPath(env);
   const legacyCmdPath = resolveStartupEntryPath(env, "cmd");
-  return uniqueStrings([primaryPath, legacyCmdPath]);
+  const legacyVbsPath = resolveStartupEntryPath(env, "vbs");
+  return uniqueStrings([primaryPath, legacyCmdPath, legacyVbsPath]);
 }
 
 // `/TR` is parsed by schtasks itself, while the generated `gateway.cmd` line is parsed by cmd.exe.

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -462,6 +462,27 @@ async function isStartupEntryInstalled(env: GatewayServiceEnv): Promise<boolean>
   return false;
 }
 
+async function removeStartupEntries(
+  env: GatewayServiceEnv,
+  stdout: NodeJS.WritableStream,
+): Promise<void> {
+  for (const startupEntryPath of resolveStartupEntryPaths(env)) {
+    try {
+      await fs.unlink(startupEntryPath);
+      stdout.write(`${formatLine("Removed Windows login item", startupEntryPath)}\n`);
+    } catch {}
+  }
+}
+
+async function hasScheduledTaskRunningEvidence(env: GatewayServiceEnv): Promise<boolean> {
+  const runtime = await readScheduledTaskRuntime(env).catch(() => null);
+  if (runtime?.status !== "running") {
+    return false;
+  }
+  const normalizedResult = normalizeTaskResultCode(runtime.lastRunResult);
+  return normalizedResult !== null && RUNNING_RESULT_CODES.has(normalizedResult);
+}
+
 async function isRegisteredScheduledTask(env: GatewayServiceEnv): Promise<boolean> {
   const taskName = resolveTaskName(env);
   const res = await execSchtasks(["/Query", "/TN", taskName]).catch(() => ({
@@ -1145,14 +1166,14 @@ async function activateScheduledTask(params: {
   scriptPath: string;
   taskLaunchPath: string;
   description?: string;
-}) {
+}): Promise<"scheduled-task" | "startup-fallback"> {
   const taskDescription = params.description ?? "OpenClaw Gateway";
 
   const taskName = resolveTaskName(params.env);
   const quotedLaunchPath = quoteSchtasksArg(params.taskLaunchPath);
 
   if (await updateExistingScheduledTask({ ...params, taskName, quotedLaunchPath })) {
-    return;
+    return "scheduled-task";
   }
 
   const taskUser = resolveTaskUser(params.env);
@@ -1206,7 +1227,7 @@ async function activateScheduledTask(params: {
         ],
         { leadingBlankLine: true },
       );
-      return;
+      return "startup-fallback";
     }
     throw new Error(`schtasks create failed: ${detail}`.trim());
   }
@@ -1225,19 +1246,27 @@ async function activateScheduledTask(params: {
     ],
     { leadingBlankLine: true },
   );
+  return "scheduled-task";
 }
 
 export async function installScheduledTask(
   args: GatewayServiceInstallArgs,
 ): Promise<{ scriptPath: string }> {
   const staged = await writeScheduledTaskScript(args);
-  await activateScheduledTask({
+  const activation = await activateScheduledTask({
     env: args.env,
     stdout: args.stdout,
     scriptPath: staged.scriptPath,
     taskLaunchPath: staged.taskLaunchPath,
     description: staged.taskDescription,
   });
+  if (activation === "scheduled-task") {
+    // A busy gateway port can be the old Startup-folder fallback. Keep that
+    // fallback until Task Scheduler itself reports the task is running.
+    if (await hasScheduledTaskRunningEvidence(args.env)) {
+      await removeStartupEntries(args.env, args.stdout);
+    }
+  }
   return { scriptPath: staged.scriptPath };
 }
 
@@ -1252,12 +1281,7 @@ export async function uninstallScheduledTask({
     await execSchtasks(["/Delete", "/F", "/TN", taskName]);
   }
 
-  for (const startupEntryPath of resolveStartupEntryPaths(env)) {
-    try {
-      await fs.unlink(startupEntryPath);
-      stdout.write(`${formatLine("Removed Windows login item", startupEntryPath)}\n`);
-    } catch {}
-  }
+  await removeStartupEntries(env, stdout);
 
   const scriptPath = resolveTaskScriptPath(env);
   const launcherPath = resolveTaskLauncherScriptPath(env, scriptPath);
@@ -1366,6 +1390,9 @@ export async function restartScheduledTask({
     env: effectiveEnv,
     scriptPath: resolveTaskScriptPath(effectiveEnv),
   });
+  if (await hasScheduledTaskRunningEvidence(effectiveEnv)) {
+    await removeStartupEntries(effectiveEnv, stdout);
+  }
   stdout.write(`${formatLine("Restarted Scheduled Task", taskName)}\n`);
   return { outcome: "completed" };
 }

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -58,6 +58,7 @@ export const SERVICE_AUDIT_CODES = {
   gatewayManagedEnvEmbedded: "gateway-managed-env-embedded",
   gatewayPortMismatch: "gateway-port-mismatch",
   gatewayProxyEnvEmbedded: "gateway-proxy-env-embedded",
+  gatewayVersionMismatch: "gateway-version-mismatch",
   gatewayTokenMismatch: "gateway-token-mismatch",
   gatewayRuntimeBun: "gateway-runtime-bun",
   gatewayRuntimeNodeVersionManager: "gateway-runtime-node-version-manager",

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -31,6 +31,11 @@ const mocks = vi.hoisted(() => ({
   logConfigUpdated: vi.fn(),
   shortenHomePath: vi.fn((p: string) => p),
   formatCliCommand: vi.fn((cmd: string) => cmd),
+  maybeRepairGatewayServiceConfig: vi.fn(async (cfg: unknown) => cfg),
+  maybeScanExtraGatewayServices: vi.fn().mockResolvedValue(undefined),
+  noteMacLaunchAgentOverrides: vi.fn().mockResolvedValue(undefined),
+  noteMacLaunchctlGatewayEnvOverrides: vi.fn().mockResolvedValue(undefined),
+  noteMacStaleOpenClawUpdateLaunchdJobs: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../commands/doctor/shared/release-configured-plugin-installs.js", () => ({
@@ -99,6 +104,17 @@ vi.mock("../cli/command-format.js", () => ({
   formatCliCommand: mocks.formatCliCommand,
 }));
 
+vi.mock("../commands/doctor-gateway-services.js", () => ({
+  maybeRepairGatewayServiceConfig: mocks.maybeRepairGatewayServiceConfig,
+  maybeScanExtraGatewayServices: mocks.maybeScanExtraGatewayServices,
+}));
+
+vi.mock("../commands/doctor-platform-notes.js", () => ({
+  noteMacLaunchAgentOverrides: mocks.noteMacLaunchAgentOverrides,
+  noteMacLaunchctlGatewayEnvOverrides: mocks.noteMacLaunchctlGatewayEnvOverrides,
+  noteMacStaleOpenClawUpdateLaunchdJobs: mocks.noteMacStaleOpenClawUpdateLaunchdJobs,
+}));
+
 function requireDoctorContribution(id: string) {
   const contribution = resolveDoctorHealthContributions().find((entry) => entry.id === id);
   if (!contribution) {
@@ -106,6 +122,10 @@ function requireDoctorContribution(id: string) {
   }
   return contribution;
 }
+
+type DoctorContributionRunContext = Parameters<
+  ReturnType<typeof requireDoctorContribution>["run"]
+>[0];
 
 function buildDoctorPrompter(shouldRepair: boolean): DoctorPrompter {
   return {
@@ -176,6 +196,20 @@ describe("doctor health contributions", () => {
       config: {},
       issues: [],
     });
+    mocks.replaceConfigFile.mockReset();
+    mocks.replaceConfigFile.mockResolvedValue(undefined);
+    mocks.applyWizardMetadata.mockReset();
+    mocks.applyWizardMetadata.mockImplementation((cfg: unknown) => cfg);
+    mocks.maybeRepairGatewayServiceConfig.mockReset();
+    mocks.maybeRepairGatewayServiceConfig.mockImplementation(async (cfg: unknown) => cfg);
+    mocks.maybeScanExtraGatewayServices.mockReset();
+    mocks.maybeScanExtraGatewayServices.mockResolvedValue(undefined);
+    mocks.noteMacLaunchAgentOverrides.mockReset();
+    mocks.noteMacLaunchAgentOverrides.mockResolvedValue(undefined);
+    mocks.noteMacLaunchctlGatewayEnvOverrides.mockReset();
+    mocks.noteMacLaunchctlGatewayEnvOverrides.mockResolvedValue(undefined);
+    mocks.noteMacStaleOpenClawUpdateLaunchdJobs.mockReset();
+    mocks.noteMacStaleOpenClawUpdateLaunchdJobs.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -201,7 +235,7 @@ describe("doctor health contributions", () => {
       sourceConfigValid: true,
       prompter: buildDoctorPrompter(false),
       env: {},
-    } as Parameters<(typeof contribution)["run"]>[0];
+    } as DoctorContributionRunContext;
 
     await contribution.run(ctx);
 
@@ -222,7 +256,7 @@ describe("doctor health contributions", () => {
       sourceConfigValid: true,
       prompter: buildDoctorPrompter(true),
       env: {},
-    } as Parameters<(typeof contribution)["run"]>[0];
+    } as DoctorContributionRunContext;
 
     await contribution.run(ctx);
 
@@ -258,7 +292,7 @@ describe("doctor health contributions", () => {
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
       },
-    } as Parameters<(typeof contribution)["run"]>[0];
+    } as DoctorContributionRunContext;
 
     await contribution.run(ctx);
 
@@ -292,7 +326,7 @@ describe("doctor health contributions", () => {
     const ctx = {
       cfg,
       options: {},
-    } as Parameters<(typeof contribution)["run"]>[0];
+    } as DoctorContributionRunContext;
 
     await contribution.run(ctx);
 
@@ -332,7 +366,7 @@ describe("doctor health contributions", () => {
       cfgForPersistence: {},
       configPath: "/tmp/fake-openclaw.json",
       env: {},
-    } as Parameters<(typeof contribution)["run"]>[0];
+    } as DoctorContributionRunContext;
 
     await contribution.run(ctx);
 
@@ -369,7 +403,7 @@ describe("doctor health contributions", () => {
       cfgForPersistence: {},
       configPath: "/tmp/fake-openclaw.json",
       env: {},
-    } as Parameters<(typeof contribution)["run"]>[0];
+    } as DoctorContributionRunContext;
 
     await contribution.run(ctx);
 
@@ -421,6 +455,59 @@ describe("doctor health contributions", () => {
     ).toBe(false);
   });
 
+  it("preserves gateway service config repairs for later doctor writes", async () => {
+    const gatewayServicesContribution = requireDoctorContribution("doctor:gateway-services");
+    const writeConfigContribution = requireDoctorContribution("doctor:write-config");
+    const originalCfg = { gateway: {} };
+    const repairedCfg = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "recovered-token",
+        },
+      },
+    };
+    mocks.maybeRepairGatewayServiceConfig.mockResolvedValueOnce(repairedCfg);
+
+    const ctx = {
+      cfg: originalCfg,
+      cfgForPersistence: originalCfg,
+      configResult: {
+        cfg: originalCfg,
+        preservedLegacyRootKeys: ["defaultModel"],
+        shouldWriteConfig: true,
+        skipPluginValidationOnWrite: true,
+      },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+
+    await gatewayServicesContribution.run(ctx);
+    await writeConfigContribution.run(ctx);
+
+    expect(ctx.cfg).toBe(repairedCfg);
+    expect(mocks.maybeRepairGatewayServiceConfig).toHaveBeenCalledWith(
+      originalCfg,
+      "local",
+      ctx.runtime,
+      ctx.prompter,
+      expect.objectContaining({
+        allowConfigSizeDrop: true,
+        preservedLegacyRootKeys: ["defaultModel"],
+        skipPluginValidation: true,
+      }),
+    );
+    expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextConfig: repairedCfg,
+      }),
+    );
+  });
+
   describe("config size drops during update", () => {
     beforeEach(() => {
       mocks.replaceConfigFile.mockReset();
@@ -445,7 +532,7 @@ describe("doctor health contributions", () => {
         runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
         options: {},
         env,
-      } as Parameters<(typeof writeConfigContribution)["run"]>[0];
+      } as DoctorContributionRunContext;
     }
 
     const writeConfigContribution = resolveDoctorHealthContributions().find(
@@ -560,7 +647,7 @@ describe("doctor health contributions", () => {
         env: {
           OPENCLAW_UPDATE_IN_PROGRESS: "1",
         },
-      } as Parameters<(typeof contribution)["run"]>[0]);
+      } as DoctorContributionRunContext);
 
       expect(mocks.readConfigFileSnapshot).toHaveBeenCalledWith({
         skipPluginValidation: true,
@@ -580,7 +667,7 @@ describe("doctor health contributions", () => {
         runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
         options: {},
         env: {},
-      } as Parameters<(typeof contribution)["run"]>[0]);
+      } as DoctorContributionRunContext);
 
       expect(mocks.readConfigFileSnapshot).toHaveBeenCalledWith({
         skipPluginValidation: false,

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -520,13 +520,18 @@ async function runGatewayServicesHealth(ctx: DoctorHealthFlowContext): Promise<v
     noteMacStaleOpenClawUpdateLaunchdJobs,
   } = await import("../commands/doctor-platform-notes.js");
   await maybeScanExtraGatewayServices(ctx.options, ctx.runtime, ctx.prompter);
-  await maybeRepairGatewayServiceConfig(
+  const updateDoctorRun = isUpdateDoctorRun(ctx.env ?? process.env);
+  ctx.cfg = await maybeRepairGatewayServiceConfig(
     ctx.cfg,
     resolveDoctorMode(ctx.cfg),
     ctx.runtime,
     ctx.prompter,
     {
       allowExecSecretRefs: ctx.options.allowExec === true,
+      allowConfigSizeDrop: ctx.configResult.shouldWriteConfig === true || updateDoctorRun,
+      skipPluginValidation:
+        ctx.configResult.skipPluginValidationOnWrite === true || updateDoctorRun,
+      preservedLegacyRootKeys: ctx.configResult.preservedLegacyRootKeys,
       ...resolveLegacyParentVersionOverride(ctx),
     },
   );

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -525,7 +525,10 @@ async function runGatewayServicesHealth(ctx: DoctorHealthFlowContext): Promise<v
     resolveDoctorMode(ctx.cfg),
     ctx.runtime,
     ctx.prompter,
-    { allowExecSecretRefs: ctx.options.allowExec === true },
+    {
+      allowExecSecretRefs: ctx.options.allowExec === true,
+      ...resolveLegacyParentVersionOverride(ctx),
+    },
   );
   await noteMacLaunchAgentOverrides();
   await noteMacStaleOpenClawUpdateLaunchdJobs();
@@ -868,11 +871,8 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
       ctx.runtime.log("Skipping doctor config write during legacy update handoff.");
       return;
     }
-    const legacyParentVersionOverride = isLegacyParentWritableUpdateDoctorPass(
-      ctx.env ?? process.env,
-    )
-      ? ctx.configResult.sourceLastTouchedVersion?.trim() || ctx.cfg.meta?.lastTouchedVersion
-      : undefined;
+    const legacyParentVersionOverride =
+      resolveLegacyParentVersionOverride(ctx).lastTouchedVersionOverride;
     await replaceConfigFile({
       nextConfig: ctx.cfg,
       afterWrite: { mode: "auto" },
@@ -902,6 +902,17 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
   if (!ctx.prompter.shouldRepair) {
     ctx.runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
+}
+
+function resolveLegacyParentVersionOverride(ctx: DoctorHealthFlowContext): {
+  lastTouchedVersionOverride?: string;
+} {
+  if (!isLegacyParentWritableUpdateDoctorPass(ctx.env ?? process.env)) {
+    return {};
+  }
+  const version =
+    ctx.configResult.sourceLastTouchedVersion?.trim() || ctx.cfg.meta?.lastTouchedVersion;
+  return version ? { lastTouchedVersionOverride: version } : {};
 }
 
 async function runWorkspaceSuggestionsHealth(ctx: DoctorHealthFlowContext): Promise<void> {


### PR DESCRIPTION
## Summary

- fixes Windows update-mode doctor repair so running managed gateways are activated/restarted, while stopped services stay staged
- audits stale `OPENCLAW_SERVICE_VERSION` values and repairs version drift through the existing gateway service doctor path
- removes legacy Windows Startup-folder fallback launchers (`.cmd` and hidden `.vbs`) only after Task Scheduler reports running evidence
- preserves auth during update-mode task rewrites by migrating a legacy embedded `OPENCLAW_GATEWAY_TOKEN` into `gateway.auth.token` before reinstalling the task
- keeps config writes safe across both modern update parents and legacy update handoffs, so later doctor writes do not drop recovered tokens and older parents are not given unreadable config

Fixes https://github.com/openclaw/openclaw/issues/87156.

## Verification

- `node scripts/run-vitest.mjs src/commands/doctor-gateway-services.test.ts src/flows/doctor-health-contributions.test.ts src/commands/doctor-update.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.stop.test.ts -- --run` - passed after rebase on `11f564ede1ba3acade0a697090e62e21794c8e59` (100 assertions across 5 files)
- `node_modules/.bin/oxfmt --check src/commands/doctor-gateway-services.ts src/commands/doctor-gateway-services.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts` - passed
- `node scripts/run-oxlint.mjs src/commands/doctor-gateway-services.ts src/commands/doctor-gateway-services.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts` - passed
- `git diff --check origin/main...HEAD && git diff --check` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean after addressing accepted findings for token propagation, update-safe write options, and legacy update-parent write guards
- Native Windows Crabbox proof `run_52d49841f33d` on AWS Windows (`cbx_013fda705836`) created both Startup-folder fallback extensions under the real Windows Startup folder and removed both: `windows_startup_dual_extension_cleanup=ok`, `removed_extensions=.cmd,.vbs`
- Native Windows GitHub probe https://github.com/openclaw/openclaw/actions/runs/26690553757 passed on `windows-2025`; WSL was present (`wsl_status_exit=0`, default version 2) but no distro was installed, so this is WSL availability proof, not successful WSL distro execution
- Crabbox changed gate `run_a9b4283c04ab` reached `pnpm check:changed`; conflict markers, changelog attributions, dependency guards, core typecheck, and core test typecheck passed, then the gate failed in an untouched current-main Discord boundary dts check: `extensions/discord/src/monitor/gateway-plugin.ts:165` (`1000 | 1001` compared with `1008`). This branch does not touch `extensions/discord/**`.

## Real behavior proof

Behavior addressed: Windows doctor/update migration now distinguishes running vs stopped managed gateways, detects stale service versions, preserves gateway auth during task rewrites, restarts stale installed/running gateways after update, and removes old Startup-folder fallback launchers only after Task Scheduler running evidence.

Real environment tested: native AWS Windows via Crabbox for Startup-folder dual-extension cleanup; GitHub-hosted Windows Server 2025 probe for native Windows and WSL availability; focused local Vitest shards for daemon startup fallback, daemon stop, doctor update, doctor gateway services, and doctor health config handoff.

Exact steps or command run after this patch: focused Vitest/format/lint/autoreview commands listed above; native Windows cleanup probe `run_52d49841f33d`; remote changed gate `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` (`run_a9b4283c04ab`).

Evidence after fix: focused tests passed after the latest rebase at `11f564ede1ba3acade0a697090e62e21794c8e59`; autoreview is clean; native Windows cleanup proof removed both `.cmd` and `.vbs` Startup-folder fallbacks; remote changed gate passed the touched core typecheck and test typecheck lanes before hitting the unrelated Discord boundary dts failure.

Observed result after fix: the Windows doctor/service migration paths are validated for the touched unit behavior and the native Windows Startup-folder cleanup path. The broad changed gate is blocked by an untouched current-main Discord type issue, not by this patch.

What was not tested: successful WSL2 distro boot/execution inside a Windows runner; direct Blacksmith Testbox proof, because Blacksmith auth is not available in this environment.
