### PR TITLE
docs(codex): clarify report-mode plugin approval ownership

### DIFF
--- a/docs/plugins/plugin-permission-requests.md
+++ b/docs/plugins/plugin-permission-requests.md
@@ -157,6 +157,11 @@ Codex native permission prompts can also travel through plugin approvals, but
 they have different ownership than plugin-authored hooks.
 
 - Codex app-server approval requests route through OpenClaw after Codex review.
+- Plugin hook `before_tool_call.requireApproval` is not the same thing as a
+  Codex `PermissionRequest`. In Codex app-server report-mode `PreToolUse`
+  relays, hook-level approval requirements do not open an interactive OpenClaw
+  plugin approval prompt on their own; they stay tied to the matching
+  Codex-owned approval flow.
 - The native hook `permission_request` relay can ask through
   `plugin.approval.request` when that relay is enabled.
 - MCP tool approval elicitations route through plugin approvals when Codex marks

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -172,7 +172,12 @@ Quick `/acp` flow from chat:
     For Codex-native tool events, OpenClaw injects a per-turn native
     hook relay so plugin hooks can block `before_tool_call`, observe
     `after_tool_call`, and route Codex `PermissionRequest` events
-    through OpenClaw approvals. Codex `Stop` hooks are relayed to
+    through OpenClaw approvals. Hook-level
+    `before_tool_call.requireApproval` is a separate path: in app-server
+    report-mode `PreToolUse` relays it does not open an interactive
+    OpenClaw plugin approval prompt, and the native call stays blocked
+    until the matching Codex-owned approval flow decides it. Codex
+    `Stop` hooks are relayed to
     OpenClaw `before_agent_finalize`, where plugins can request one more
     model pass before Codex finalizes its answer. The relay remains
     deliberately conservative: it does not mutate Codex-native tool


### PR DESCRIPTION
Closes #86777

## Summary

Clarify the operator-facing Codex documentation boundary between:

- Codex-owned native `PermissionRequest` approvals, and
- plugin hook `before_tool_call.requireApproval`

This patch adds that distinction in two entry-point docs that operators and plugin authors are likely to read first:

- `docs/tools/acp-agents.md`
- `docs/plugins/plugin-permission-requests.md`

The new wording makes two points explicit:

1. `before_tool_call.requireApproval` is not the same approval path as a Codex native `PermissionRequest`.
2. In Codex app-server report-mode `PreToolUse` relays, hook-level approval requirements do not open a standalone interactive OpenClaw plugin approval prompt on their own; they stay tied to the matching Codex-owned approval flow.

## Real behavior proof

**Behavior addressed:** the current docs can lead operators and plugin authors to treat Codex `PermissionRequest` approvals and plugin hook `before_tool_call.requireApproval` as the same path, even though report-mode native `PreToolUse` relays handle them differently.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, commit `88329836fd8201a5bec29b948833f29e717b5eb1`

**Exact steps or command run after this patch:**

```bash
git diff --check
node scripts/check-docs-mdx.mjs docs/tools/acp-agents.md docs/plugins/plugin-permission-requests.md
pnpm docs:list
nl -ba docs/tools/acp-agents.md | sed -n '168,182p'
nl -ba docs/plugins/plugin-permission-requests.md | sed -n '156,168p'
```

**Evidence after fix:**

Targeted docs checks:

```text
Docs MDX check passed (2 files, 182ms).
```

Updated operator-facing wording in `docs/tools/acp-agents.md`:

```text
174    `after_tool_call`, and route Codex `PermissionRequest` events
175    through OpenClaw approvals. Hook-level
176    `before_tool_call.requireApproval` is a separate path: in app-server
177    report-mode `PreToolUse` relays it does not open an interactive
178    OpenClaw plugin approval prompt, and the native call stays blocked
179    until the matching Codex-owned approval flow decides it.
```

Updated ownership distinction in `docs/plugins/plugin-permission-requests.md`:

```text
159 - Codex app-server approval requests route through OpenClaw after Codex review.
160 - Plugin hook `before_tool_call.requireApproval` is not the same thing as a
161   Codex `PermissionRequest`. In Codex app-server report-mode `PreToolUse`
162   relays, hook-level approval requirements do not open an interactive OpenClaw
163   plugin approval prompt on their own; they stay tied to the matching
164   Codex-owned approval flow.
```

**Observed result after fix:** the docs now distinguish Codex-owned native approvals from plugin-authored approval hooks at the ACP/Codex operator entry point and in the plugin approval guide, reducing the chance that plugin authors expect a standalone OpenClaw approval prompt on report-mode native tool relays.

**What was not tested:** no live Gateway or Codex runtime session was started for this docs-only clarification. The change only updates documentation for an already source-backed runtime boundary.
