### PR TITLE
fix #76284: [Bug]: openclaw agents add blocked — cannot add Jon/Atlas as separate agents

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -257,7 +257,8 @@ jobs:
             return -1;
           }
 
-          for (let start = input.indexOf("["); start !== -1; start = input.indexOf("[", start + 1)) {
+          for (const match of input.matchAll(/\[/g)) {
+            const start = match.index;
             const end = arrayEndFrom(start);
             if (end === -1) {
               continue;

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -12,6 +12,12 @@ const writeConfigFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined
 const replaceConfigFileMock = vi.hoisted(() =>
   vi.fn(async (params: { nextConfig: unknown }) => await writeConfigFileMock(params.nextConfig)),
 );
+const commitConfigWithPendingPluginInstallsMock = vi.hoisted(() =>
+  vi.fn(async (params: { nextConfig: Record<string, unknown> }) => {
+    await writeConfigFileMock(params.nextConfig);
+    return { config: params.nextConfig };
+  }),
+);
 const transformConfigWithPendingPluginInstallsMock = vi.hoisted(() =>
   vi.fn(
     async (params: {
@@ -56,6 +62,16 @@ const transformConfigWithPendingPluginInstallsMock = vi.hoisted(() =>
 const wizardMocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
 }));
+const authChoiceMocks = vi.hoisted(() => ({
+  applyAuthChoice: vi.fn(),
+  warnIfModelConfigLooksOff: vi.fn(async () => {}),
+}));
+const onboardChannelsMocks = vi.hoisted(() => ({
+  setupChannels: vi.fn(async (config: Record<string, unknown>) => config),
+}));
+const onboardHelpersMocks = vi.hoisted(() => ({
+  ensureWorkspaceAndSessions: vi.fn(async () => {}),
+}));
 
 vi.mock("../config/config.js", async () => ({
   ...(await vi.importActual<typeof import("../config/config.js")>("../config/config.js")),
@@ -68,11 +84,25 @@ vi.mock("../cli/plugins-install-record-commit.js", async () => ({
   ...(await vi.importActual<typeof import("../cli/plugins-install-record-commit.js")>(
     "../cli/plugins-install-record-commit.js",
   )),
+  commitConfigWithPendingPluginInstalls: commitConfigWithPendingPluginInstallsMock,
   transformConfigWithPendingPluginInstalls: transformConfigWithPendingPluginInstallsMock,
 }));
 
 vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: wizardMocks.createClackPrompter,
+}));
+
+vi.mock("./auth-choice.js", () => ({
+  applyAuthChoice: authChoiceMocks.applyAuthChoice,
+  warnIfModelConfigLooksOff: authChoiceMocks.warnIfModelConfigLooksOff,
+}));
+
+vi.mock("./onboard-channels.js", () => ({
+  setupChannels: onboardChannelsMocks.setupChannels,
+}));
+
+vi.mock("./onboard-helpers.js", () => ({
+  ensureWorkspaceAndSessions: onboardHelpersMocks.ensureWorkspaceAndSessions,
 }));
 
 import { WizardCancelledError } from "../wizard/prompts.js";
@@ -85,8 +115,13 @@ describe("agents add command", () => {
     readConfigFileSnapshotMock.mockClear();
     writeConfigFileMock.mockClear();
     replaceConfigFileMock.mockClear();
+    commitConfigWithPendingPluginInstallsMock.mockClear();
     transformConfigWithPendingPluginInstallsMock.mockClear();
     wizardMocks.createClackPrompter.mockClear();
+    authChoiceMocks.applyAuthChoice.mockClear();
+    authChoiceMocks.warnIfModelConfigLooksOff.mockClear();
+    onboardChannelsMocks.setupChannels.mockClear();
+    onboardHelpersMocks.ensureWorkspaceAndSessions.mockClear();
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
@@ -134,6 +169,33 @@ describe("agents add command", () => {
 
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
+  it("skips catalog validation when checking the interactive wizard model config", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: { agents: { list: [] } },
+      sourceConfig: { agents: { list: [] } },
+    });
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn(),
+      text: vi.fn().mockResolvedValueOnce("Jon").mockResolvedValueOnce("/tmp/openclaw-jon"),
+      confirm: vi.fn().mockResolvedValue(false),
+      note: vi.fn(),
+      outro: vi.fn(),
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(authChoiceMocks.warnIfModelConfigLooksOff).toHaveBeenCalledOnce();
+    expect(authChoiceMocks.warnIfModelConfigLooksOff).toHaveBeenCalledWith(
+      expect.objectContaining({ agents: expect.any(Object) }),
+      expect.any(Object),
+      expect.objectContaining({
+        agentId: "jon",
+        validateCatalog: false,
+      }),
+    );
   });
 
   it("copies only portable auth profiles when seeding a new agent store", async () => {

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -415,6 +415,7 @@ export async function agentsAddCommand(
     await warnIfModelConfigLooksOff(nextConfig, prompter, {
       agentId,
       agentDir,
+      validateCatalog: false,
     });
 
     let selection: ChannelChoice[] = [];

--- a/ui/index.html
+++ b/ui/index.html
@@ -57,7 +57,7 @@
           document.documentElement.setAttribute("data-theme", resolved);
           document.documentElement.setAttribute(
             "data-theme-mode",
-            resolved.indexOf("light") !== -1 ? "light" : "dark",
+            resolved.includes("light") ? "light" : "dark",
           );
         } catch (e) {}
       })();


### PR DESCRIPTION
## Summary

- Skip live model catalog validation during the interactive `openclaw agents add` model warning step.
- Add regression coverage that the agents add wizard passes `validateCatalog: false`, matching the setup wizard behavior.
- Rebase the PR onto the latest `origin/main` so the current head has no merge conflicts or main drift.
- Keep the small lint cleanups needed by the current PR diff.

Fixes openclaw/openclaw#76284.

## Real behavior proof

- **Behavior or issue addressed:** The interactive `openclaw agents add` wizard can create a secondary agent without entering the live model catalog validation path that previously blocked the flow.
- **Real environment tested:** Local OpenClaw source checkout on Linux at rebased PR head `02909bb20e3e4cc106ebe7cbca50211488489241`, with isolated `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and an empty bundled plugin directory.
- **Exact steps or command run after this patch:** Ran `pnpm -s openclaw agents add` in a real pseudo-terminal, entered `Jon`, accepted the isolated workspace path, selected No for model/auth setup, selected No for chat channel setup, then ran `pnpm -s openclaw agents list --json` in the same isolated environment.
- **Evidence after fix:** The wizard completed and printed `Agent "jon" ready.`. The follow-up `agents list --json` command exited 0 and included:

```json
{
  "id": "jon",
  "name": "Jon",
  "agentDir": ".../state/agents/jon/agent",
  "bindings": 0,
  "isDefault": false
}
```

- **Observed result after fix:** The secondary agent was persisted to `openclaw.json` and appeared in `openclaw agents list --json`; the command did not hang or fail during the model warning step.
- **What was not tested:** A macOS npm-installed build was not run from this Linux source checkout. Channel setup was skipped so the proof stayed focused on the reported `agents add` agent-creation path.

## Regression Test Plan

- **Target test file:** `src/commands/agents.add.test.ts`

- `pnpm check:changed`
  - Result: passed on the rebased PR head; evidence: `rebased-pnpm-check-changed.log`.
- CI-equivalent gateway shard rerun for the previously failing check:
  - Command: `pnpm exec node scripts/test-projects.mjs test/vitest/vitest.gateway-server.config.ts` with the `agentic-control-plane-runtime` include file and CI-like Vitest env.
  - Result: 32 files passed, 309 tests passed; evidence: `rebased-gateway-shard-ci-equivalent.log`.
- `pnpm exec node scripts/test-projects.mjs src/commands/agents.add.test.ts`
  - Result: 1 file passed, 11 tests passed; evidence: `rebased-agents-add-test.log`.
- Real CLI proof above with `pnpm -s openclaw agents add` followed by `pnpm -s openclaw agents list --json`; evidence: `openclaw-real-behavior-proof-rebased.md`, `real-agents-add-cli-rebased.log`, and `real-agents-list-cli-rebased.log`.

## Root Cause

- **Root cause:** `openclaw agents add` reused the model-warning helper with catalog validation enabled during the interactive wizard. That made agent creation depend on live catalog validation even when the user was only adding a local secondary agent. The setup wizard already avoids that dependency; this change applies the same `validateCatalog: false` behavior to the agents add wizard.
