### PR TITLE
feat(agents): generalized native compaction ownership for CLI backends

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -376,20 +376,16 @@ For CLIs that emit Claude Code stream-json compatible JSONL, set
 
 Some CLI backends run an agent that compacts its **own** transcript, so OpenClaw must
 not run its safeguard summarizer against them - doing so fights the backend's own
-compaction and can hard-fail the turn. **Codex** (its app-server owns automatic
-compaction) and **Claude Code** (`claude-cli`) both work this way, and both **opt out
-of OpenClaw compaction**:
+compaction and can hard-fail the turn.
 
-- **Codex** routes to its native-harness compaction endpoint (matched by the session's
-  `agentHarnessId`).
-- **`claude-cli`** has no harness endpoint - Claude Code compacts internally - so it
-  declares `ownsNativeCompaction: true`, and OpenClaw returns a no-op from the
-  compaction path.
+`claude-cli` has no harness endpoint - Claude Code compacts internally - so it declares
+`ownsNativeCompaction: true`, and OpenClaw returns a no-op from the compaction path.
+Native-harness sessions such as Codex keep routing to their harness compaction endpoint
+instead.
 
-Either way OpenClaw **defers and never compacts these sessions.** Because the backend
-owns compaction, the old stopgap of setting `contextTokens: 1_000_000` purely to keep
-OpenClaw's safeguard from firing on a claude-cli session is **no longer needed** - the
-opt-out replaces it.
+Because the backend owns compaction, the old stopgap of setting
+`contextTokens: 1_000_000` purely to keep OpenClaw's safeguard from firing on a
+claude-cli session is **no longer needed** - the opt-out replaces it.
 
 ```typescript
 api.registerCliBackend({ id: "my-cli", ownsNativeCompaction: true /* ... */ });
@@ -398,8 +394,7 @@ api.registerCliBackend({ id: "my-cli", ownsNativeCompaction: true /* ... */ });
 Only declare `ownsNativeCompaction` for a backend that genuinely owns its compaction: it
 must reliably bound its own transcript as it nears its context window and persist a
 resumable session (e.g. `--resume` / `--session-id`); otherwise a deferred session can
-stay over budget. (A session whose `agentHarnessId` matches the provider still routes to
-the harness endpoint - the no-op applies only when there is no harness endpoint.)
+stay over budget. Matching `agentHarnessId` sessions still route to the harness endpoint.
 
 ## Bundle MCP overlays
 

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -372,6 +372,35 @@ its own control markers and channel delivery.
 For CLIs that emit Claude Code stream-json compatible JSONL, set
 `jsonlDialect: "claude-stream-json"` on that backend's config.
 
+## Native compaction ownership
+
+Some CLI backends run an agent that compacts its **own** transcript, so OpenClaw must
+not run its safeguard summarizer against them - doing so fights the backend's own
+compaction and can hard-fail the turn. **Codex** (its app-server owns automatic
+compaction) and **Claude Code** (`claude-cli`) both work this way, and both **opt out
+of OpenClaw compaction**:
+
+- **Codex** routes to its native-harness compaction endpoint (matched by the session's
+  `agentHarnessId`).
+- **`claude-cli`** has no harness endpoint - Claude Code compacts internally - so it
+  declares `ownsNativeCompaction: true`, and OpenClaw returns a no-op from the
+  compaction path.
+
+Either way OpenClaw **defers and never compacts these sessions.** Because the backend
+owns compaction, the old stopgap of setting `contextTokens: 1_000_000` purely to keep
+OpenClaw's safeguard from firing on a claude-cli session is **no longer needed** - the
+opt-out replaces it.
+
+```typescript
+api.registerCliBackend({ id: "my-cli", ownsNativeCompaction: true /* ... */ });
+```
+
+Only declare `ownsNativeCompaction` for a backend that genuinely owns its compaction: it
+must reliably bound its own transcript as it nears its context window and persist a
+resumable session (e.g. `--resume` / `--session-id`); otherwise a deferred session can
+stay over budget. (A session whose `agentHarnessId` matches the provider still routes to
+the harness endpoint - the no-op applies only when there is no harness endpoint.)
+
 ## Bundle MCP overlays
 
 CLI backends do **not** receive OpenClaw tool calls directly, but a backend can

--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -208,9 +208,29 @@ only for behavior that really belongs to the backend.
 | `authEpochMode`                    | Decide how auth changes invalidate stored CLI sessions |
 | `nativeToolMode`                   | Declare whether the CLI has always-on native tools     |
 | `bundleMcp` / `bundleMcpMode`      | Opt into OpenClaw's loopback MCP tool bridge           |
+| `ownsNativeCompaction`             | Backend owns its own compaction - OpenClaw defers      |
 
 Keep these hooks provider-owned. Do not add CLI-specific branches to core when a
 backend hook can express the behavior.
+
+### `ownsNativeCompaction`: opting out of OpenClaw compaction
+
+If your backend runs an agent that compacts its **own** transcript, set
+`ownsNativeCompaction: true` so OpenClaw's safeguard summarizer never runs against its
+sessions - the CLI compaction lifecycle returns a no-op and the turn proceeds. This is
+the **same opt-out Codex uses** (its app-server owns automatic compaction); `claude-cli`
+declares it because Claude Code compacts internally with no harness endpoint. It also
+removes any need to inflate `contextTokens` just to keep the safeguard from firing.
+
+**Only declare it when all of the following hold**, or a deferred over-budget session can
+stay over budget / go stale (OpenClaw no longer rescues it):
+
+- the backend reliably compacts or bounds its own transcript as it nears its window;
+- it persists a resumable session so the compacted state survives turns
+  (e.g. `--resume` / `--session-id`);
+- it is **not** a native-harness compaction session - a session whose `agentHarnessId`
+  matches the provider routes to the harness endpoint instead; this no-op applies only
+  when there is no harness endpoint.
 
 ## MCP tool bridge
 

--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -217,10 +217,9 @@ backend hook can express the behavior.
 
 If your backend runs an agent that compacts its **own** transcript, set
 `ownsNativeCompaction: true` so OpenClaw's safeguard summarizer never runs against its
-sessions - the CLI compaction lifecycle returns a no-op and the turn proceeds. This is
-the **same opt-out Codex uses** (its app-server owns automatic compaction); `claude-cli`
-declares it because Claude Code compacts internally with no harness endpoint. It also
-removes any need to inflate `contextTokens` just to keep the safeguard from firing.
+sessions - the CLI compaction lifecycle returns a no-op and the turn proceeds. `claude-cli`
+declares it because Claude Code compacts internally with no harness endpoint. Native-harness
+sessions such as Codex keep routing to their harness compaction endpoint instead.
 
 **Only declare it when all of the following hold**, or a deferred over-budget session can
 stay over budget / go stale (OpenClaw no longer rescues it):
@@ -228,9 +227,8 @@ stay over budget / go stale (OpenClaw no longer rescues it):
 - the backend reliably compacts or bounds its own transcript as it nears its window;
 - it persists a resumable session so the compacted state survives turns
   (e.g. `--resume` / `--session-id`);
-- it is **not** a native-harness compaction session - a session whose `agentHarnessId`
-  matches the provider routes to the harness endpoint instead; this no-op applies only
-  when there is no harness endpoint.
+- it is not a native-harness compaction session - matching `agentHarnessId` sessions
+  route to the harness endpoint instead.
 
 ## MCP tool bridge
 

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -29,6 +29,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
     bundleMcp: true,
     bundleMcpMode: "claude-config-file",
     nativeToolMode: "always-on",
+    ownsNativeCompaction: true,
     config: {
       command: "claude",
       args: [

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -31,6 +31,7 @@ function createBackendEntry(params: {
   bundleMcpMode?: CliBundleMcpMode;
   defaultAuthProfileId?: string;
   authEpochMode?: CliBackendAuthEpochMode;
+  ownsNativeCompaction?: boolean;
   prepareExecution?: () => Promise<null>;
   resolveExecutionArgs?: CliBackendResolveExecutionArgs;
   normalizeConfig?: (
@@ -48,6 +49,7 @@ function createBackendEntry(params: {
       ...(params.bundleMcpMode ? { bundleMcpMode: params.bundleMcpMode } : {}),
       ...(params.defaultAuthProfileId ? { defaultAuthProfileId: params.defaultAuthProfileId } : {}),
       ...(params.authEpochMode ? { authEpochMode: params.authEpochMode } : {}),
+      ...(params.ownsNativeCompaction ? { ownsNativeCompaction: params.ownsNativeCompaction } : {}),
       ...(params.prepareExecution ? { prepareExecution: params.prepareExecution } : {}),
       ...(params.resolveExecutionArgs ? { resolveExecutionArgs: params.resolveExecutionArgs } : {}),
       ...(params.normalizeConfig ? { normalizeConfig: params.normalizeConfig } : {}),
@@ -230,6 +232,7 @@ beforeEach(() => {
       id: "claude-cli",
       bundleMcp: true,
       bundleMcpMode: "claude-config-file",
+      ownsNativeCompaction: true,
       config: {
         command: "claude",
         args: [
@@ -544,6 +547,11 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(resolved?.config.resumeArgs).toContain("--permission-mode");
     expect(resolved?.config.resumeArgs).toContain("bypassPermissions");
     expect(resolved?.config.resumeArgs).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("declares ownsNativeCompaction for claude-cli", () => {
+    const resolved = requireCliBackendConfig("claude-cli");
+    expect(resolved?.ownsNativeCompaction).toBe(true);
   });
 
   it("keeps Claude permission mode unset when OpenClaw exec policy is not YOLO", () => {

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -46,6 +46,7 @@ export type ResolvedCliBackend = {
   defaultAuthProfileId?: string;
   authEpochMode?: CliBackendAuthEpochMode;
   contextEngineHostCapabilities?: readonly ContextEngineHostCapability[];
+  ownsNativeCompaction?: boolean;
   prepareExecution?: CliBackendPlugin["prepareExecution"];
   resolveExecutionArgs?: CliBackendPlugin["resolveExecutionArgs"];
   nativeToolMode?: CliBackendNativeToolMode;
@@ -79,6 +80,7 @@ type FallbackCliBackendPolicy = {
   defaultAuthProfileId?: string;
   authEpochMode?: CliBackendAuthEpochMode;
   contextEngineHostCapabilities?: readonly ContextEngineHostCapability[];
+  ownsNativeCompaction?: boolean;
   prepareExecution?: CliBackendPlugin["prepareExecution"];
   resolveExecutionArgs?: CliBackendPlugin["resolveExecutionArgs"];
   nativeToolMode?: CliBackendNativeToolMode;
@@ -119,6 +121,7 @@ function resolveSetupCliBackendPolicy(provider: string): FallbackCliBackendPolic
     defaultAuthProfileId: entry.backend.defaultAuthProfileId,
     authEpochMode: entry.backend.authEpochMode,
     contextEngineHostCapabilities: entry.backend.contextEngineHostCapabilities,
+    ownsNativeCompaction: entry.backend.ownsNativeCompaction,
     prepareExecution: entry.backend.prepareExecution,
     resolveExecutionArgs: entry.backend.resolveExecutionArgs,
     nativeToolMode: entry.backend.nativeToolMode,
@@ -411,6 +414,7 @@ export function resolveCliBackendConfig(
       defaultAuthProfileId: registered.defaultAuthProfileId,
       authEpochMode: registered.authEpochMode,
       contextEngineHostCapabilities: registered.contextEngineHostCapabilities,
+      ownsNativeCompaction: registered.ownsNativeCompaction,
       prepareExecution: registered.prepareExecution,
       resolveExecutionArgs: registered.resolveExecutionArgs,
       nativeToolMode: registered.nativeToolMode,
@@ -443,6 +447,7 @@ export function resolveCliBackendConfig(
       defaultAuthProfileId: fallbackPolicy.defaultAuthProfileId,
       authEpochMode: fallbackPolicy.authEpochMode,
       contextEngineHostCapabilities: fallbackPolicy.contextEngineHostCapabilities,
+      ownsNativeCompaction: fallbackPolicy.ownsNativeCompaction,
       prepareExecution: fallbackPolicy.prepareExecution,
       resolveExecutionArgs: fallbackPolicy.resolveExecutionArgs,
       nativeToolMode: fallbackPolicy.nativeToolMode,
@@ -472,6 +477,7 @@ export function resolveCliBackendConfig(
     defaultAuthProfileId: fallbackPolicy?.defaultAuthProfileId,
     authEpochMode: fallbackPolicy?.authEpochMode,
     contextEngineHostCapabilities: fallbackPolicy?.contextEngineHostCapabilities,
+    ownsNativeCompaction: fallbackPolicy?.ownsNativeCompaction,
     prepareExecution: fallbackPolicy?.prepareExecution,
     resolveExecutionArgs: fallbackPolicy?.resolveExecutionArgs,
     nativeToolMode: fallbackPolicy?.nativeToolMode,

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -76,12 +76,6 @@ describe("runCliTurnCompactionLifecycle", () => {
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-compaction-"));
-    // Default backends to non-owning so the context-engine compaction-path tests
-    // exercise that path. On current main resolveCliBackendConfig("claude-cli")
-    // resolves the (now ownsNativeCompaction) backend even in unit tests, which
-    // would otherwise route every claude-cli compaction test through the #88315
-    // defer no-op. The ownsNativeCompaction-specific tests override this with an
-    // owning backend to exercise the defer.
     setCliCompactionTestDeps({ resolveCliBackendConfig: () => null });
   });
 

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -76,6 +76,13 @@ describe("runCliTurnCompactionLifecycle", () => {
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-compaction-"));
+    // Default backends to non-owning so the context-engine compaction-path tests
+    // exercise that path. On current main resolveCliBackendConfig("claude-cli")
+    // resolves the (now ownsNativeCompaction) backend even in unit tests, which
+    // would otherwise route every claude-cli compaction test through the #88315
+    // defer no-op. The ownsNativeCompaction-specific tests override this with an
+    // owning backend to exercise the defer.
+    setCliCompactionTestDeps({ resolveCliBackendConfig: () => null });
   });
 
   afterEach(async () => {
@@ -1405,5 +1412,213 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
       "claude-session",
     );
+  });
+
+  it("skips compaction when backend declares ownsNativeCompaction and has no harness endpoint", async () => {
+    const sessionKey = "agent:main:claude-owns-compaction";
+    const sessionId = "session-claude-owns";
+    const sessionFile = path.join(tmpDir, "session-claude-owns.jsonl");
+    const storePath = path.join(tmpDir, "sessions-claude-owns.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const compactAgentHarnessSession = vi.fn();
+    const recordCliCompactionInStore = vi.fn();
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+      maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
+      resolveCliBackendConfig: () => ({
+        id: "claude-cli",
+        config: { command: "claude" },
+        bundleMcp: true,
+        ownsNativeCompaction: true,
+      }),
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      recordCliCompactionInStore,
+    });
+
+    const updatedEntry = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    expect(compactAgentHarnessSession).not.toHaveBeenCalled();
+    expect(compactCalls).toHaveLength(0);
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(updatedEntry).toBe(sessionEntry);
+  });
+
+  it("does not skip compaction when backend does not declare ownsNativeCompaction", async () => {
+    const sessionKey = "agent:main:generic-no-ownership";
+    const sessionId = "session-generic";
+    const sessionFile = path.join(tmpDir, "session-generic.jsonl");
+    const storePath = path.join(tmpDir, "sessions-generic.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+      resolveCliBackendConfig: () => ({
+        id: "generic-backend",
+        config: { command: "generic" },
+        bundleMcp: false,
+      }),
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: maintenance,
+    });
+
+    await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "generic-backend",
+      model: "model",
+    });
+
+    expect(compactCalls).toHaveLength(1);
+  });
+
+  it("still uses native harness path when backend declares ownsNativeCompaction and has agentHarnessId", async () => {
+    const sessionKey = "agent:main:codex-with-ownership";
+    const sessionId = "session-codex-ownership";
+    const sessionFile = path.join(tmpDir, "session-codex-ownership.jsonl");
+    const storePath = path.join(tmpDir, "sessions-codex-ownership.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const contextEngine = buildContextEngine({ compactCalls });
+    const compactAgentHarnessSession = vi.fn(async () => ({
+      ok: true,
+      compacted: true,
+      result: { tokensBefore: 950, tokensAfter: 100 },
+    }));
+    const recordCliCompactionInStore = vi.fn(async () => ({
+      ...sessionEntry,
+      compactionCount: 1,
+    }));
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => contextEngine,
+      ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+      maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
+      resolveCliBackendConfig: () => ({
+        id: "codex",
+        config: { command: "codex" },
+        bundleMcp: false,
+        ownsNativeCompaction: true,
+      }),
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      applyAgentAutoCompactionGuard: vi.fn(async () => ({ supported: true, disabled: false })),
+      recordCliCompactionInStore,
+    });
+
+    await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+
+    expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
+    expect(compactCalls).toHaveLength(0);
+    expect(recordCliCompactionInStore).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -13,6 +13,7 @@ import {
   applyAgentAutoCompactionGuard as applyAgentAutoCompactionGuardImpl,
   resolveEffectiveCompactionMode,
 } from "../agent-settings.js";
+import { resolveCliBackendConfig as resolveCliBackendConfigImpl } from "../cli-backends.js";
 import { classifyCompactionReason } from "../embedded-agent-runner/compact-reasons.js";
 import { buildEmbeddedCompactionRuntimeContext } from "../embedded-agent-runner/compaction-runtime-context.js";
 import {
@@ -29,7 +30,6 @@ import { ensureSelectedAgentHarnessPlugin as ensureSelectedAgentHarnessPluginImp
 import { maybeCompactAgentHarnessSession as maybeCompactAgentHarnessSessionImpl } from "../harness/selection.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { SessionManager } from "../sessions/session-manager.js";
-import { resolveCliBackendConfig as resolveCliBackendConfigImpl } from "../cli-backends.js";
 import {
   clearCliSessionInStore as clearCliSessionInStoreImpl,
   recordCliCompactionInStore as recordCliCompactionInStoreImpl,
@@ -529,18 +529,12 @@ export async function runCliTurnCompactionLifecycle(params: {
     return params.sessionEntry;
   }
 
-  // When the backend declares native compaction ownership but has no harness
-  // compaction endpoint (e.g. claude-cli — Claude Code compacts its own
-  // transcript internally), skip both native-harness and context-engine
-  // compaction. The backend will handle it; OpenClaw returns a no-op.
   const resolvedBackend = cliCompactionDeps.resolveCliBackendConfig(params.provider, params.cfg);
   if (
     resolvedBackend?.ownsNativeCompaction &&
     !isNativeHarnessCompactionSession(params.sessionEntry, params.provider)
   ) {
-    log.info(
-      `CLI backend "${params.provider}" owns native compaction — deferring to backend`,
-    );
+    log.info(`CLI backend "${params.provider}" owns native compaction — deferring to backend`);
     return params.sessionEntry;
   }
 

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -29,6 +29,7 @@ import { ensureSelectedAgentHarnessPlugin as ensureSelectedAgentHarnessPluginImp
 import { maybeCompactAgentHarnessSession as maybeCompactAgentHarnessSessionImpl } from "../harness/selection.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { SessionManager } from "../sessions/session-manager.js";
+import { resolveCliBackendConfig as resolveCliBackendConfigImpl } from "../cli-backends.js";
 import {
   clearCliSessionInStore as clearCliSessionInStoreImpl,
   recordCliCompactionInStore as recordCliCompactionInStoreImpl,
@@ -69,6 +70,7 @@ type CliCompactionDeps = {
   ensureSelectedAgentHarnessPlugin: typeof ensureSelectedAgentHarnessPluginImpl;
   maybeCompactAgentHarnessSession: typeof maybeCompactAgentHarnessSessionImpl;
   clearCliSessionInStore: typeof clearCliSessionInStoreImpl;
+  resolveCliBackendConfig: typeof resolveCliBackendConfigImpl;
   recordCliCompactionInStore: typeof recordCliCompactionInStoreImpl;
 };
 
@@ -117,6 +119,7 @@ const cliCompactionDeps: CliCompactionDeps = {
   ensureSelectedAgentHarnessPlugin: ensureSelectedAgentHarnessPluginImpl,
   maybeCompactAgentHarnessSession: maybeCompactAgentHarnessSessionImpl,
   clearCliSessionInStore: clearCliSessionInStoreImpl,
+  resolveCliBackendConfig: resolveCliBackendConfigImpl,
   recordCliCompactionInStore: recordCliCompactionInStoreImpl,
 };
 
@@ -137,6 +140,7 @@ export function resetCliCompactionTestDeps(): void {
     ensureSelectedAgentHarnessPlugin: ensureSelectedAgentHarnessPluginImpl,
     maybeCompactAgentHarnessSession: maybeCompactAgentHarnessSessionImpl,
     clearCliSessionInStore: clearCliSessionInStoreImpl,
+    resolveCliBackendConfig: resolveCliBackendConfigImpl,
     recordCliCompactionInStore: recordCliCompactionInStoreImpl,
   });
 }
@@ -522,6 +526,21 @@ export async function runCliTurnCompactionLifecycle(params: {
     !preemptiveCompaction.shouldCompact &&
     currentTokenCount <= preemptiveCompaction.promptBudgetBeforeReserve
   ) {
+    return params.sessionEntry;
+  }
+
+  // When the backend declares native compaction ownership but has no harness
+  // compaction endpoint (e.g. claude-cli — Claude Code compacts its own
+  // transcript internally), skip both native-harness and context-engine
+  // compaction. The backend will handle it; OpenClaw returns a no-op.
+  const resolvedBackend = cliCompactionDeps.resolveCliBackendConfig(params.provider, params.cfg);
+  if (
+    resolvedBackend?.ownsNativeCompaction &&
+    !isNativeHarnessCompactionSession(params.sessionEntry, params.provider)
+  ) {
+    log.info(
+      `CLI backend "${params.provider}" owns native compaction — deferring to backend`,
+    );
     return params.sessionEntry;
   }
 

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -83,6 +83,13 @@ export type CliBackendPlugin = {
    */
   contextEngineHostCapabilities?: readonly ContextEngineHostCapability[];
   /**
+   * When true, the backend manages its own transcript compaction lifecycle
+   * (e.g. Claude Code's internal auto-compaction). OpenClaw will skip its
+   * safeguard summarizer and return a no-op from the compaction path instead
+   * of fighting the backend's own compaction or hard-failing the turn.
+   */
+  ownsNativeCompaction?: boolean;
+  /**
    * Optional live-smoke metadata owned by the backend plugin.
    *
    * Keep provider-specific test wiring here instead of scattering it across

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -84,9 +84,20 @@ export type CliBackendPlugin = {
   contextEngineHostCapabilities?: readonly ContextEngineHostCapability[];
   /**
    * When true, the backend manages its own transcript compaction lifecycle
-   * (e.g. Claude Code's internal auto-compaction). OpenClaw will skip its
-   * safeguard summarizer and return a no-op from the compaction path instead
-   * of fighting the backend's own compaction or hard-failing the turn.
+   * (e.g. Claude Code's internal auto-compaction). OpenClaw skips its safeguard
+   * summarizer and returns a no-op from the CLI compaction path instead of
+   * fighting the backend's own compaction or hard-failing the turn.
+   *
+   * Safety contract - only declare this when ALL of the following hold, or an
+   * over-budget session can stay over budget / go stale (OpenClaw no longer
+   * rescues it):
+   *  - the backend reliably compacts or bounds its own transcript as it nears
+   *    its context window;
+   *  - it persists a resumable session so the compacted state survives across
+   *    turns (e.g. `--resume` / `--session-id`);
+   *  - it is NOT a native-harness compaction session - a session whose
+   *    `agentHarnessId` matches the provider still routes to the harness
+   *    endpoint, so this no-op applies only when there is no harness endpoint.
    */
   ownsNativeCompaction?: boolean;
   /**

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -83,21 +83,8 @@ export type CliBackendPlugin = {
    */
   contextEngineHostCapabilities?: readonly ContextEngineHostCapability[];
   /**
-   * When true, the backend manages its own transcript compaction lifecycle
-   * (e.g. Claude Code's internal auto-compaction). OpenClaw skips its safeguard
-   * summarizer and returns a no-op from the CLI compaction path instead of
-   * fighting the backend's own compaction or hard-failing the turn.
-   *
-   * Safety contract - only declare this when ALL of the following hold, or an
-   * over-budget session can stay over budget / go stale (OpenClaw no longer
-   * rescues it):
-   *  - the backend reliably compacts or bounds its own transcript as it nears
-   *    its context window;
-   *  - it persists a resumable session so the compacted state survives across
-   *    turns (e.g. `--resume` / `--session-id`);
-   *  - it is NOT a native-harness compaction session - a session whose
-   *    `agentHarnessId` matches the provider still routes to the harness
-   *    endpoint, so this no-op applies only when there is no harness endpoint.
+   * Backend-owned compaction for non-harness CLI sessions.
+   * Set only when the backend bounds its own transcript and persists resumable state.
    */
   ownsNativeCompaction?: boolean;
   /**


### PR DESCRIPTION
## Summary

Generalizes native-compaction ownership for CLI backends via a new `ownsNativeCompaction` capability flag.

When a CLI backend owns transcript compaction and the session has no native-harness compaction endpoint, OpenClaw's CLI compaction lifecycle returns a no-op instead of running its safeguard summarizer. This avoids fighting backend-owned compaction or hard-failing the turn.

- Any CLI backend can declare `ownsNativeCompaction: true`.
- This PR wires it for `claude-cli`: Claude Code compacts internally and exposes no OpenClaw harness compaction endpoint.
- Codex still routes to its native-harness compaction endpoint via the session `agentHarnessId`; the no-op applies only when no harness endpoint exists.

Scope: generalized mechanism plus the `claude-cli` declaration. Opting in other backends is out of scope.

## What changed since review

This PR is purely the opt-out. The earlier `contextTokens` cap-precedence change was removed: once a backend owns compaction, its budget never drives OpenClaw compaction, so capping below the native window solved a problem that no longer exists. `src/agents/context.ts`, `src/agents/context.test.ts`, and generated SDK baseline files are not part of this PR.

## Testing

- `src/agents/command/cli-compaction.test.ts` covers over-budget `ownsNativeCompaction` + no harness endpoint -> no-op defer; native-harness sessions still route to the harness endpoint; non-owning backends still run the safeguard summarizer.
- `src/agents/cli-backends.test.ts` covers capability registration.
- Focused local proof: `node scripts/run-vitest.mjs src/agents/command/cli-compaction.test.ts src/agents/cli-backends.test.ts`.

## Real behavior proof

Behavior addressed: `claude-cli` sessions that own native compaction defer to Claude Code instead of triggering OpenClaw safeguard summarization when over budget and no harness compaction endpoint exists.

Real environment tested: local OpenClaw source checkout with installed Claude CLI `2.1.150 (Claude Code)`.

Exact steps or command run after this patch: one-off Node/tsx smoke registered the bundled Anthropic CLI backend, invoked OpenClaw `runCliAgent` with `provider=claude-cli` and `model=claude-sonnet-4-6`, then invoked `runCliTurnCompactionLifecycle` with a synthetic over-budget session entry for the returned `claude-cli` session.

Evidence after fix:

```
[agent/cli-backend] cli exec: provider=claude-cli model=claude-sonnet-4-6 promptChars=74 trigger=unknown useResume=false session=none resumeSession=none reuse=none historyPrompt=none
[agent/cli-backend] cli argv: claude -p --output-format stream-json --include-partial-messages --verbose --setting-sources user --allowedTools mcp__openclaw__* --permission-mode bypassPermissions --strict-mcp-config --model claude-sonnet-4-6 --session-id <redacted>
[agent/cli-backend] claude live session turn: provider=claude-cli model=claude-sonnet-4-6 durationMs=3402 rawLines=13 outBytes=25 outHash=2be5da4cba0f
[agents/cli-compaction] CLI backend "claude-cli" owns native compaction — deferring to backend
```

Observed result after fix: Claude CLI returned the expected response token, the OpenClaw session had a Claude CLI session id, compaction deferred with `deferred=true`, `compactionCount=0`, and token counts stayed at the synthetic over-budget values.

What was not tested: an organically over-budget live Claude GA session, because current GA models report a 1M-token window; the over-budget condition was forced only for the lifecycle proof.
