### PR TITLE
fix: expose session status route channels

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -151,6 +151,33 @@ describe("normalizeMessagesForLlmBoundary", () => {
     expect(input[0]).toHaveProperty("details");
   });
 
+  it("preserves session route context in tool content while stripping details", () => {
+    const routeContext =
+      'Route context:\n```json\n{\n  "originChannel": "discord",\n  "activeChannel": "webchat"\n}\n```';
+    const input = [
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "session_status",
+        content: [{ type: "text", text: `OpenClaw\n\n${routeContext}` }],
+        details: {
+          originChannel: "discord",
+          activeChannel: "webchat",
+        },
+        isError: false,
+        timestamp: 1,
+      },
+    ];
+
+    const output = normalizeMessagesForLlmBoundary(
+      input as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    ) as unknown as Array<{ content?: Array<{ text?: string }>; details?: unknown }>;
+
+    expect(output[0]).not.toHaveProperty("details");
+    expect(output[0]?.content?.[0]?.text).toContain('"originChannel": "discord"');
+    expect(output[0]?.content?.[0]?.text).toContain('"activeChannel": "webchat"');
+  });
+
   it("keeps only pre-user current-turn runtime context at the LLM boundary", () => {
     const input = [
       {

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -444,6 +444,16 @@ function getSessionStatusTool(
   return tool;
 }
 
+function resultText(result: { content?: unknown }) {
+  const content = Array.isArray(result.content) ? result.content : [];
+  const first = content[0];
+  if (!first || typeof first !== "object") {
+    return "";
+  }
+  const text = (first as { text?: unknown }).text;
+  return typeof text === "string" ? text : "";
+}
+
 describe("session_status tool", () => {
   beforeEach(() => {
     buildStatusMessageMock.mockClear();
@@ -471,6 +481,7 @@ describe("session_status tool", () => {
     expect(details.statusText).toContain("OpenClaw");
     expect(details.statusText).toContain("🧠 Model:");
     expect(details.statusText).not.toContain("OAuth/token status");
+    expect(resultText(result)).not.toContain("Route context:");
     expect(details.originChannel).toBeUndefined();
     expect(details.activeChannel).toBeUndefined();
   });
@@ -506,6 +517,7 @@ describe("session_status tool", () => {
       sessionKey?: string;
       originChannel?: string;
       activeChannel?: string;
+      statusText?: string;
       origin?: { channel?: string; provider?: string; accountId?: string };
       active?: { channel?: string; to?: string; accountId?: string };
       deliveryContext?: { channel?: string; to?: string; accountId?: string };
@@ -514,6 +526,11 @@ describe("session_status tool", () => {
     expect(details.sessionKey).toBe("agent:main:discord:channel:1489550370136129537");
     expect(details.originChannel).toBe("discord");
     expect(details.activeChannel).toBe("webchat");
+    expect(resultText(result)).toContain("Route context:");
+    expect(resultText(result)).toContain('"originChannel": "discord"');
+    expect(resultText(result)).toContain('"activeChannel": "webchat"');
+    expect(resultText(result)).toContain('"deliveryContext"');
+    expect(details.statusText).toContain('"activeChannel": "webchat"');
     expect(details.origin).toEqual({
       channel: "discord",
       provider: "discord",
@@ -580,6 +597,10 @@ describe("session_status tool", () => {
     expect(details.ok).toBe(true);
     expect(details.originChannel).toBe("discord");
     expect(details.activeChannel).toBe("webchat");
+    expect(resultText(result)).toContain('"originChannel": "discord"');
+    expect(resultText(result)).toContain('"activeChannel": "webchat"');
+    expect(resultText(result)).toContain('"to": "control-ui-conversation"');
+    expect(resultText(result)).toContain('"threadId": "webchat-thread"');
     expect(details.active).toEqual({
       channel: "webchat",
       to: "control-ui-conversation",

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -297,9 +297,11 @@ vi.mock("../tasks/task-owner-access.js", () => ({
 }));
 
 let createSessionStatusTool: typeof import("./tools/session-status-tool.js").createSessionStatusTool;
+let createOpenClawTools: typeof import("./openclaw-tools.js").createOpenClawTools;
 
 beforeAll(async () => {
   ({ createSessionStatusTool } = await import("./tools/session-status-tool.js"));
+  ({ createOpenClawTools } = await import("./openclaw-tools.js"));
 });
 
 function resetSessionStore(store: Record<string, SessionEntry>) {
@@ -421,13 +423,21 @@ function latestMockCallArg(mock: ReturnType<typeof vi.fn>, argIndex = 0) {
 
 function getSessionStatusTool(
   agentSessionKey = "main",
-  options?: { sandboxed?: boolean; activeModelProvider?: string; activeModelId?: string },
+  options?: {
+    sandboxed?: boolean;
+    activeModelProvider?: string;
+    activeModelId?: string;
+    activeDeliveryContext?: NonNullable<
+      Parameters<typeof createSessionStatusTool>[0]
+    >["activeDeliveryContext"];
+  },
 ) {
   const tool = createSessionStatusTool({
     agentSessionKey,
     sandboxed: options?.sandboxed,
     activeModelProvider: options?.activeModelProvider,
     activeModelId: options?.activeModelId,
+    activeDeliveryContext: options?.activeDeliveryContext,
     config: mockConfig as never,
   });
   expect(tool.name).toBe("session_status");
@@ -451,11 +461,137 @@ describe("session_status tool", () => {
     const tool = getSessionStatusTool();
 
     const result = await tool.execute("call1", {});
-    const details = result.details as { ok?: boolean; statusText?: string };
+    const details = result.details as {
+      ok?: boolean;
+      statusText?: string;
+      originChannel?: string;
+      activeChannel?: string;
+    };
     expect(details.ok).toBe(true);
     expect(details.statusText).toContain("OpenClaw");
     expect(details.statusText).toContain("🧠 Model:");
     expect(details.statusText).not.toContain("OAuth/token status");
+    expect(details.originChannel).toBeUndefined();
+    expect(details.activeChannel).toBeUndefined();
+  });
+
+  it("reports origin and active delivery channels separately", async () => {
+    resetSessionStore({
+      "agent:main:discord:channel:1489550370136129537": {
+        sessionId: "s-discord-origin-webchat-active",
+        updatedAt: 10,
+        origin: { provider: "discord", accountId: "bot-primary" },
+        deliveryContext: {
+          channel: "discord",
+          to: "channel:1489550370136129537",
+          accountId: "bot-primary",
+        },
+      },
+    });
+
+    const tool = createSessionStatusTool({
+      agentSessionKey: "agent:main:discord:channel:1489550370136129537",
+      runSessionKey: "agent:main:discord:channel:1489550370136129537",
+      activeDeliveryContext: {
+        channel: "webchat",
+        to: "control-ui",
+        accountId: "browser-session",
+      },
+      config: mockConfig as never,
+    });
+
+    const result = await tool.execute("call-origin-active", {});
+    const details = result.details as {
+      ok?: boolean;
+      sessionKey?: string;
+      originChannel?: string;
+      activeChannel?: string;
+      origin?: { channel?: string; provider?: string; accountId?: string };
+      active?: { channel?: string; to?: string; accountId?: string };
+      deliveryContext?: { channel?: string; to?: string; accountId?: string };
+    };
+    expect(details.ok).toBe(true);
+    expect(details.sessionKey).toBe("agent:main:discord:channel:1489550370136129537");
+    expect(details.originChannel).toBe("discord");
+    expect(details.activeChannel).toBe("webchat");
+    expect(details.origin).toEqual({
+      channel: "discord",
+      provider: "discord",
+      accountId: "bot-primary",
+      threadId: undefined,
+    });
+    expect(details.active).toEqual({
+      channel: "webchat",
+      to: "control-ui",
+      accountId: "browser-session",
+      threadId: undefined,
+    });
+    expect(details.deliveryContext).toEqual({
+      channel: "discord",
+      to: "channel:1489550370136129537",
+      accountId: "bot-primary",
+    });
+  });
+
+  it("wires active delivery context from createOpenClawTools current route fields", async () => {
+    resetSessionStore({
+      "agent:main:discord:channel:1489550370136129537": {
+        sessionId: "s-discord-origin-webchat-active-factory",
+        updatedAt: 10,
+        origin: { provider: "discord", accountId: "bot-primary" },
+        deliveryContext: {
+          channel: "discord",
+          to: "channel:1489550370136129537",
+          accountId: "bot-primary",
+          threadId: "discord-thread",
+        },
+      },
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:discord:channel:1489550370136129537",
+      runSessionKey: "agent:main:discord:channel:1489550370136129537",
+      agentChannel: "webchat",
+      agentAccountId: "browser-session",
+      agentTo: "channel:1489550370136129537",
+      agentThreadId: "discord-thread",
+      currentChannelId: "control-ui-conversation",
+      currentThreadTs: "webchat-thread",
+      config: mockConfig as never,
+      disablePluginTools: true,
+    }).find((candidate) => candidate.name === "session_status");
+    if (!tool) {
+      throw new Error("missing session_status tool");
+    }
+
+    const result = await tool.execute("call-origin-active-factory", {});
+    const details = result.details as {
+      ok?: boolean;
+      originChannel?: string;
+      activeChannel?: string;
+      active?: { channel?: string; to?: string; accountId?: string; threadId?: string | number };
+      deliveryContext?: {
+        channel?: string;
+        to?: string;
+        accountId?: string;
+        threadId?: string | number;
+      };
+    };
+    expect(details.ok).toBe(true);
+    expect(details.originChannel).toBe("discord");
+    expect(details.activeChannel).toBe("webchat");
+    expect(details.active).toEqual({
+      channel: "webchat",
+      to: "control-ui-conversation",
+      accountId: "browser-session",
+      threadId: "webchat-thread",
+    });
+    expect(details.deliveryContext).toEqual({
+      channel: "discord",
+      to: "channel:1489550370136129537",
+      accountId: "bot-primary",
+      threadId: "discord-thread",
+    });
   });
 
   it("enables transcript usage fallback for session_status", async () => {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -511,6 +511,12 @@ export function createOpenClawTools(
       sandboxed: options?.sandboxed,
       activeModelProvider: options?.modelProvider,
       activeModelId: options?.modelId,
+      activeDeliveryContext: normalizeDeliveryContext({
+        channel: options?.agentChannel,
+        to: options?.currentChannelId ?? options?.agentTo,
+        accountId: options?.agentAccountId,
+        threadId: options?.currentThreadTs ?? options?.agentThreadId,
+      }),
     }),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),
   ];

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -25,10 +25,19 @@ import {
 } from "../../routing/session-key.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { normalizeOptionalLowercaseString, readStringValue } from "../../shared/string-coerce.js";
 import { uniqueStrings } from "../../shared/string-normalization.js";
 import type { BuildStatusTextParams } from "../../status/status-text.types.js";
 import { buildTaskStatusSnapshotForRelatedSessionKeyForOwner } from "../../tasks/task-owner-access.js";
 import { formatTaskStatusDetail, formatTaskStatusTitle } from "../../tasks/task-status.js";
+import {
+  normalizeDeliveryContext,
+  type DeliveryContext,
+} from "../../utils/delivery-context.shared.js";
+import {
+  isDeliverableMessageChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import { loadModelCatalog } from "../model-catalog.js";
 import {
   buildModelAliasIndex,
@@ -189,6 +198,92 @@ function listImplicitDefaultDirectFallbackKeys(params: {
 
 type ActiveStatusModelIdentity = { provider?: string; model: string };
 
+type SessionStatusRouteDetails = {
+  originChannel?: string;
+  activeChannel?: string;
+  origin?: {
+    channel?: string;
+    provider?: string;
+    accountId?: string;
+    threadId?: string | number;
+  };
+  active?: {
+    channel?: string;
+    to?: string;
+    accountId?: string;
+    threadId?: string | number;
+  };
+  deliveryContext?: {
+    channel?: string;
+    to?: string;
+    accountId?: string;
+    threadId?: string | number;
+  };
+};
+
+const INTERNAL_SESSION_KEY_PREFIXES = new Set(["main", "cron", "subagent", "acp"]);
+
+function inferSessionKeyChannel(sessionKey: string): string | undefined {
+  const parsed = parseAgentSessionKey(sessionKey);
+  const head = normalizeOptionalLowercaseString(parsed?.rest.split(":")[0]);
+  if (!head || INTERNAL_SESSION_KEY_PREFIXES.has(head)) {
+    return undefined;
+  }
+  const channel = normalizeMessageChannel(head);
+  return channel && isDeliverableMessageChannel(channel) ? channel : undefined;
+}
+
+function buildSessionStatusRouteDetails(params: {
+  entry: SessionEntry;
+  sessionKey: string;
+  activeDeliveryContext?: DeliveryContext;
+  isLiveRunSession?: boolean;
+}): SessionStatusRouteDetails {
+  const originProvider = readStringValue(params.entry.origin?.provider);
+  const originChannel = originProvider ?? inferSessionKeyChannel(params.sessionKey);
+  const originAccountId = readStringValue(params.entry.origin?.accountId);
+  const originThreadId = params.entry.origin?.threadId;
+  const origin =
+    originChannel || originProvider || originAccountId || originThreadId
+      ? {
+          channel: originChannel,
+          provider: originProvider,
+          accountId: originAccountId,
+          threadId: originThreadId,
+        }
+      : undefined;
+
+  const deliveryContext = normalizeDeliveryContext(params.entry.deliveryContext);
+  const activeContext = params.isLiveRunSession
+    ? (normalizeDeliveryContext(params.activeDeliveryContext) ?? deliveryContext)
+    : undefined;
+  const activeChannel = readStringValue(activeContext?.channel);
+  const activeTo = readStringValue(activeContext?.to);
+  const activeAccountId = readStringValue(activeContext?.accountId);
+  const activeThreadId =
+    typeof activeContext?.threadId === "string" ||
+    (typeof activeContext?.threadId === "number" && Number.isFinite(activeContext.threadId))
+      ? activeContext.threadId
+      : undefined;
+  const active =
+    activeChannel || activeTo || activeAccountId || activeThreadId
+      ? {
+          channel: activeChannel,
+          to: activeTo,
+          accountId: activeAccountId,
+          threadId: activeThreadId,
+        }
+      : undefined;
+
+  return {
+    ...(originChannel ? { originChannel } : {}),
+    ...(activeChannel ? { activeChannel } : {}),
+    ...(origin ? { origin } : {}),
+    ...(active ? { active } : {}),
+    ...(deliveryContext ? { deliveryContext } : {}),
+  };
+}
+
 function resolveActiveStatusModelIdentity(params: {
   activeModelId?: string;
   activeModelProvider?: string;
@@ -347,6 +442,7 @@ export function createSessionStatusTool(opts?: {
   sandboxed?: boolean;
   activeModelProvider?: string;
   activeModelId?: string;
+  activeDeliveryContext?: DeliveryContext;
 }): AnyAgentTool {
   return {
     label: "Session Status",
@@ -672,17 +768,18 @@ export function createSessionStatusTool(opts?: {
       const activeModelId = opts?.activeModelId?.trim();
       const activeModelProvider = opts?.activeModelProvider?.trim();
       const isImplicitCurrentRequest = requestedKeyParam === undefined;
+      const liveSessionKeys = [
+        opts?.runSessionKey,
+        storeScopedRequesterKey,
+        effectiveRequesterKey,
+        visibilityRequesterKey,
+      ];
       const activeModelIdentity = resolveActiveStatusModelIdentity({
         activeModelId,
         activeModelProvider,
         isImplicitCurrentRequest,
         isSemanticCurrentRequest,
-        liveSessionKeys: [
-          opts?.runSessionKey,
-          storeScopedRequesterKey,
-          effectiveRequesterKey,
-          visibilityRequesterKey,
-        ],
+        liveSessionKeys,
         modelRaw,
         resolvedKey: resolved.key,
       });
@@ -766,6 +863,16 @@ export function createSessionStatusTool(opts?: {
         taskLine && !statusText.includes(taskLine) ? `${statusText}\n${taskLine}` : statusText;
       const resultOverrideProvider = statusSessionEntry.providerOverride?.trim();
       const resultOverrideModel = statusSessionEntry.modelOverride?.trim();
+      const routeDetails = buildSessionStatusRouteDetails({
+        entry: statusSessionEntry,
+        sessionKey: resolved.key,
+        activeDeliveryContext: opts?.activeDeliveryContext,
+        isLiveRunSession: new Set(
+          liveSessionKeys
+            .map((value) => value?.trim())
+            .filter((value): value is string => Boolean(value)),
+        ).has(resolved.key.trim()),
+      });
       const modelOverrideForResult =
         modelRaw === undefined
           ? undefined
@@ -791,6 +898,7 @@ export function createSessionStatusTool(opts?: {
               }
             : {}),
           statusText: fullStatusText,
+          ...routeDetails,
         },
       };
     },

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -284,6 +284,13 @@ function buildSessionStatusRouteDetails(params: {
   };
 }
 
+function formatSessionStatusRouteContext(details: SessionStatusRouteDetails): string | undefined {
+  if (Object.keys(details).length === 0) {
+    return undefined;
+  }
+  return `Route context:\n\`\`\`json\n${JSON.stringify(details, null, 2)}\n\`\`\``;
+}
+
 function resolveActiveStatusModelIdentity(params: {
   activeModelId?: string;
   activeModelProvider?: string;
@@ -873,6 +880,10 @@ export function createSessionStatusTool(opts?: {
             .filter((value): value is string => Boolean(value)),
         ).has(resolved.key.trim()),
       });
+      const routeContextText = formatSessionStatusRouteContext(routeDetails);
+      const visibleStatusText = routeContextText
+        ? `${fullStatusText}\n\n${routeContextText}`
+        : fullStatusText;
       const modelOverrideForResult =
         modelRaw === undefined
           ? undefined
@@ -883,7 +894,7 @@ export function createSessionStatusTool(opts?: {
             : null;
 
       return {
-        content: [{ type: "text", text: fullStatusText }],
+        content: [{ type: "text", text: visibleStatusText }],
         details: {
           ok: true,
           sessionKey: resolved.key,
@@ -897,7 +908,7 @@ export function createSessionStatusTool(opts?: {
                 modelOverride: modelOverrideForResult,
               }
             : {}),
-          statusText: fullStatusText,
+          statusText: visibleStatusText,
           ...routeDetails,
         },
       };

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -616,6 +616,10 @@ describe("server-channels auto restart", () => {
       () => startAccount.mock.calls.length === 2,
       "expected explicit start to clear manual stop and restart after old task exits",
     );
+    await waitForMicrotaskCondition(() => {
+      const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+      return account?.running === true && account.restartPending === false;
+    }, "expected explicit start restart bookkeeping to settle");
 
     const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
     expect(account?.running).toBe(true);
@@ -923,7 +927,8 @@ describe("server-channels auto restart", () => {
       measure: async <T>(name: string, run: () => T | Promise<T>) =>
         (await measureMock(name, run)) as T,
     };
-    const startAccount = vi.fn(async () => {});
+    const channelTask = createDeferred();
+    const startAccount = vi.fn(() => channelTask.promise);
 
     installTestRegistry(createTestPlugin({ startAccount }));
     const manager = createManager({ startupTrace });
@@ -941,6 +946,9 @@ describe("server-channels auto restart", () => {
     expect(names).toContain("channels.discord.approval-bootstrap");
     expect(names).toContain("channels.discord.start-account-handoff");
     expect(startAccount).toHaveBeenCalledTimes(1);
+
+    channelTask.resolve();
+    await flushMicrotasks();
   });
 
   it("ends startup trace spans before long-lived channel account tasks settle", async () => {

--- a/src/plugin-sdk/test-helpers/node-builtin-mocks.ts
+++ b/src/plugin-sdk/test-helpers/node-builtin-mocks.ts
@@ -1,3 +1,5 @@
+import { vi } from "vitest";
+
 type MockFactory<TModule extends object> =
   | Partial<TModule>
   | ((actual: TModule) => Partial<TModule>);
@@ -5,7 +7,8 @@ type MockFactory<TModule extends object> =
 let childProcessModulePromise: Promise<typeof import("node:child_process")> | null = null;
 
 const loadChildProcessModule = async () => {
-  childProcessModulePromise ??= import("node:child_process");
+  childProcessModulePromise ??=
+    vi.importActual<typeof import("node:child_process")>("node:child_process");
   return await childProcessModulePromise;
 };
 


### PR DESCRIPTION
## Summary

Fixes #84544.

- adds machine-readable `originChannel` and `activeChannel` fields to `session_status` details
- derives active route details from the live run/tool delivery context, preferring `currentChannelId`/`currentThreadTs` over stored/message `agentTo`/`agentThreadId`
- keeps persisted `deliveryContext` separate so external/origin delivery routes remain visible when the active surface is webchat
- adds nested `origin`, `active`, and `deliveryContext` details so agents can distinguish origin route, current active surface, and stored delivery route
- keeps session-key policy unchanged and only infers an origin channel from session-key prefixes that normalize to deliverable message channels; internal prefixes such as `main`, `cron`, `subagent`, and `acp` stay unset

## Real behavior proof

**Behavior or issue addressed:** Agents previously got a `session_status` details payload with only `sessionKey` and `statusText`, so a session like `agent:main:discord:channel:...` could not machine-read that `discord` was the origin/persisted external delivery route while the active run surface was now `webchat`.

**Real environment tested:** Local OpenClaw source checkout on macOS, running the production `createOpenClawTools(...)` factory and production `session_status` tool from this branch with a temporary `sessions.json` store. No unit-test harness or mocks were used for this proof command.

**Exact steps or command run after this patch:** Ran a Node/tsx script from the repository root that created a temporary `sessions.json`, inserted `agent:main:discord:channel:1489550370136129537` with `origin.provider=discord` and persisted `deliveryContext.channel=discord`, constructed production `createOpenClawTools(...)` with live `agentChannel=webchat`, `currentChannelId=control-ui-conversation`, `currentThreadTs=webchat-thread`, plus stored/message `agentTo=channel:1489550370136129537` and `agentThreadId=discord-thread`, selected the factory-created `session_status` tool, called `.execute(...)`, and printed only the route-related `details` fields.

**Evidence after fix:** Terminal output from the production factory-created tool call:

```json
{
  "sessionKey": "agent:main:discord:channel:1489550370136129537",
  "originChannel": "discord",
  "activeChannel": "webchat",
  "active": {
    "channel": "webchat",
    "to": "control-ui-conversation",
    "accountId": "browser-session",
    "threadId": "webchat-thread"
  },
  "deliveryContext": {
    "channel": "discord",
    "to": "channel:1489550370136129537",
    "accountId": "bot-primary",
    "threadId": "discord-thread"
  }
}
```

**Observed result after fix:** The factory-created `session_status` exposes `originChannel: "discord"`, `activeChannel: "webchat"`, `active.to: "control-ui-conversation"`, and `active.threadId: "webchat-thread"` while preserving persisted `deliveryContext.channel: "discord"`, `deliveryContext.to: "channel:1489550370136129537"`, and `deliveryContext.threadId: "discord-thread"`. This proves the runtime factory path uses live current route fields before falling back to stored/message target fields.

**What was not tested:** A live Discord-to-webchat E2E handoff was not run; this PR exercises the production OpenClaw tool factory and production `session_status` tool against the same persisted session-store fields plus the live tool-run route context used by the runtime.

## Tests

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/openclaw-tools.session-status.test.ts -t 'wires active delivery context from createOpenClawTools current route fields'`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/openclaw-tools.session-status.test.ts -t 'reports origin and active delivery channels separately'`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/openclaw-tools.session-status.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/openclaw-tools.ts src/agents/tools/session-status-tool.ts src/agents/openclaw-tools.session-status.test.ts`
- `node scripts/run-oxlint.mjs src/agents/openclaw-tools.ts src/agents/tools/session-status-tool.ts src/agents/openclaw-tools.session-status.test.ts`
- `pnpm check:test-types`

## Review

- Independent review gate caught the initial blocker around naive persisted-route active channel semantics.
- Follow-up patch separated live active context from persisted delivery context.
- Second independent review gate passed after wiring `createOpenClawTools` to prefer `currentChannelId`/`currentThreadTs` and adding factory-level regression coverage.
