### PR TITLE
docs(openai): clarify legacy openai-codex auth profile provider

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -20,6 +20,8 @@ The normal setup uses canonical OpenAI model refs such as `openai/gpt-5.5`.
 Do not configure `openai-codex/gpt-*` model refs. Put OpenAI agent auth order
 under `auth.order.openai`; older `openai-codex:*` profiles and
 `auth.order.openai-codex` entries remain supported for existing installs.
+Legacy `openai-codex:*` profile IDs are still stored with `provider: "openai"`
+inside `auth-profiles.json`.
 
 When no OpenClaw sandbox is active, OpenClaw starts Codex app-server threads
 with Codex native code mode enabled while leaving code-mode-only off by default.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -49,7 +49,7 @@ The names are similar but not interchangeable:
 | Name you see                            | Layer             | Meaning                                                                                           |
 | --------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------- |
 | `openai`                                | Provider prefix   | Canonical OpenAI model route; agent turns use the Codex runtime.                                  |
-| `openai-codex`                          | Legacy prefix     | Older model/profile namespace. `openclaw doctor --fix` migrates it to `openai`.                   |
+| `openai-codex`                          | Legacy prefix     | Legacy model/profile ID namespace (`openai-codex/*`, `openai-codex:*`). `openclaw doctor --fix` migrates it to `openai`. |
 | `codex` plugin                          | Plugin            | Bundled OpenClaw plugin that provides native Codex app-server runtime and `/codex` chat controls. |
 | provider/model `agentRuntime.id: codex` | Agent runtime     | Force the native Codex app-server harness for matching embedded turns.                            |
 | `/codex ...`                            | Chat command set  | Bind/control Codex app-server threads from a conversation.                                        |
@@ -60,6 +60,13 @@ profiles point at either API-key or ChatGPT/Codex OAuth credentials. Use
 `auth.order.openai` for config; `openclaw doctor --fix` rewrites legacy
 `openai-codex/*` model refs, `openai-codex:*` profile ids, and
 `auth.order.openai-codex` to the canonical OpenAI route.
+
+<Note>
+Legacy Codex OAuth logins often have profile IDs prefixed `openai-codex:`. Those
+profiles are still stored with `provider: "openai"` inside `auth-profiles.json`.
+Keep the profile ID, but keep the stored provider as `openai` and order it under
+`auth.order.openai`.
+</Note>
 
 <Note>
 GPT-5.5 is available through both direct OpenAI Platform API-key access and


### PR DESCRIPTION
Fixes #88125.

- Clarify that legacy `openai-codex:*` profile IDs are still stored with `provider: "openai"` inside `auth-profiles.json`.
- Point readers to keep ordering under `auth.order.openai` when migrating old configs.

Validation: `node scripts/docs-list.js` (the command behind `pnpm docs:list`).