### PR TITLE
fix #88216: [Bug]: Feishu p2p DM dispatch crashes with TypeError: Cannot read properties of undefined (reading 'run') on 2026.5.27 (regression since 2026.5.22)

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -500,6 +500,35 @@ describe("handleFeishuMessage ACP routing", () => {
     expect(mockEnsureConfiguredBindingRouteReady).toHaveBeenCalledTimes(1);
   });
 
+  it("dispatches Feishu DMs when the runtime lacks an injected inbound runner", async () => {
+    mockResolveAgentRoute.mockReturnValue({
+      ...buildDefaultResolveRoute(),
+      sessionKey: "agent:main:main",
+    });
+    const runtimeWithoutInbound = createFeishuBotRuntime();
+    delete (runtimeWithoutInbound.channel as { inbound?: unknown }).inbound;
+    setFeishuRuntime(runtimeWithoutInbound);
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-runtime-inbound-missing",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledTimes(1);
+  });
+
   it("surfaces configured ACP initialization failures to the Feishu conversation", async () => {
     mockResolveConfiguredBindingRoute.mockReturnValue(createConfiguredFeishuRoute());
     mockEnsureConfiguredBindingRouteReady.mockResolvedValue(

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1,6 +1,7 @@
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-writes";
 import {
   buildChannelInboundEventContext,
+  runChannelInboundEvent,
   toInboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveAgentOutboundIdentity } from "openclaw/plugin-sdk/channel-outbound";
@@ -701,6 +702,7 @@ export async function handleFeishuMessage(params: {
 
   try {
     const core = getFeishuRuntime();
+    const runInboundEvent = core.channel.inbound?.run ?? runChannelInboundEvent;
     const pairing = createChannelPairingController({
       core,
       channel: "feishu",
@@ -1493,7 +1495,7 @@ export async function handleFeishuMessage(params: {
           log(
             `feishu[${account.accountId}]: broadcast active dispatch agent=${agentId} (session=${agentSessionKey})`,
           );
-          await core.channel.inbound.run({
+          await runInboundEvent({
             channel: "feishu",
             accountId: route.accountId,
             raw: ctx,
@@ -1552,7 +1554,7 @@ export async function handleFeishuMessage(params: {
           log(
             `feishu[${account.accountId}]: broadcast observer dispatch agent=${agentId} (session=${agentSessionKey})`,
           );
-          await core.channel.inbound.run({
+          await runInboundEvent({
             channel: "feishu",
             accountId: route.accountId,
             raw: ctx,
@@ -1656,7 +1658,7 @@ export async function handleFeishuMessage(params: {
       });
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
-      const turnResult = await core.channel.inbound.run({
+      const turnResult = await runInboundEvent({
         channel: "feishu",
         accountId: route.accountId,
         raw: ctx,


### PR DESCRIPTION
## Summary

- Fixes Feishu p2p DM dispatch when the stored plugin runtime lacks `channel.inbound.run` by falling back to the public channel inbound runner.
- Covers the `session=agent:main:main` route with a regression test that removes the injected inbound runner before dispatch.

Fixes #88216

## Real behavior proof

- **Behavior or issue addressed:** Feishu p2p direct-message dispatch no longer crashes before the agent run when the Feishu runtime object lacks `channel.inbound.run`.
- **Real environment tested:** Local OpenClaw task worktree with workspace dependencies installed via `pnpm install --frozen-lockfile`; no Feishu workspace credentials were available.
- **Exact steps or command run after this patch:** `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH="$EVIDENCE_DIR/vitest-cache" pnpm exec vitest run extensions/feishu/src/bot.test.ts`
- **Evidence after fix:** `/media/vdc/code/ai/aispace/openclaw-issue-88216-evidence/feishu-bot-vitest.log`
- **Observed result after fix:** `extensions/feishu/src/bot.test.ts` passed with 72 tests, including the regression case that deletes `runtime.channel.inbound` and dispatches a p2p Feishu DM routed to `agent:main:main`.
- **What was not tested:** A live Feishu websocket/API round trip was not tested because this environment does not provide Feishu app credentials or a paired Feishu workspace.
- **Target test file:** `extensions/feishu/src/bot.test.ts`

## Regression Test Plan

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH="$EVIDENCE_DIR/vitest-cache" pnpm exec vitest run extensions/feishu/src/bot.test.ts`
- `git diff --check`

## Root Cause

- **Root cause:** Feishu dispatch assumed the injected plugin runtime always exposed `core.channel.inbound.run`. In the reported shipped runtime path that nested helper was missing, so p2p DM dispatch failed while reading `run` before the agent could execute. The Feishu handler now keeps using the injected runner when present and otherwise uses the public SDK inbound runner already available to bundled channel plugins.
