### PR TITLE
fix(agents): skip below-target CLI compaction failures

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -187,6 +187,84 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(updatedEntry?.claudeCliSessionId).toBeUndefined();
   });
 
+  it("treats below-target CLI transcript compaction as a no-op", async () => {
+    const sessionKey = "agent:main:cli-under-target";
+    const sessionId = "session-cli-under-target";
+    const sessionFile = path.join(tmpDir, "session-under-target.jsonl");
+    const storePath = path.join(tmpDir, "sessions-under-target.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "claude-session" },
+      },
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    const recordCliCompactionInStore = vi.fn();
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => ({
+        ...buildContextEngine({ compactCalls }),
+        async compact(compactParams) {
+          compactCalls.push(compactParams);
+          return {
+            ok: true,
+            compacted: false,
+            reason: "already under target",
+          };
+        },
+      }),
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: maintenance,
+      recordCliCompactionInStore,
+    });
+
+    const updatedEntry = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    expect(compactCalls).toHaveLength(1);
+    expect(maintenance).not.toHaveBeenCalled();
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(updatedEntry).toBe(sessionEntry);
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+      "claude-session",
+    );
+  });
+
   it("routes OpenAI Codex harness CLI compaction through native harness compaction", async () => {
     const sessionKey = "agent:main:codex";
     const sessionId = "session-codex";
@@ -303,6 +381,74 @@ describe("runCliTurnCompactionLifecycle", () => {
       }),
     );
     expect(updatedEntry?.compactionCount).toBe(1);
+  });
+
+  it("treats below-target Codex native CLI compaction as a no-op", async () => {
+    const sessionKey = "agent:main:codex-under-target";
+    const sessionId = "session-codex-under-target";
+    const sessionFile = path.join(tmpDir, "session-codex-under-target.jsonl");
+    const storePath = path.join(tmpDir, "sessions-codex-under-target.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const compactAgentHarnessSession = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "already under target",
+    }));
+    const recordCliCompactionInStore = vi.fn();
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+      ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+      maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      recordCliCompactionInStore,
+    });
+
+    const updatedEntry = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "codex",
+      model: "gpt-5.5",
+    });
+
+    expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
+    expect(compactCalls).toHaveLength(0);
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(updatedEntry).toBe(sessionEntry);
   });
 
   it("ignores stale native harness ids when the active provider no longer matches", async () => {

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -1003,6 +1003,100 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(updatedEntry?.compactionCount).toBe(1);
   });
 
+  it("clears stale Codex native binding when context-engine fallback is below target", async () => {
+    const sessionKey = "agent:main:codex-stale-binding-under-target";
+    const sessionId = "session-codex-stale-binding-under-target";
+    const sessionFile = path.join(tmpDir, "session-codex-stale-binding-under-target.jsonl");
+    const storePath = path.join(tmpDir, "sessions-codex-stale-binding-under-target.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+      cliSessionBindings: {
+        codex: { sessionId: "thread-1" },
+      },
+      cliSessionIds: {
+        codex: "thread-1",
+      },
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const compactAgentHarnessSession = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "thread not found: thread-1",
+      failure: {
+        reason: "stale_thread_binding",
+      },
+    }));
+    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    const recordCliCompactionInStore = vi.fn();
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => ({
+        ...buildContextEngine({ compactCalls }),
+        async compact(compactParams) {
+          compactCalls.push(compactParams);
+          return {
+            ok: true,
+            compacted: false,
+            reason: "already under target",
+          };
+        },
+      }),
+      ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+      maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: maintenance,
+      recordCliCompactionInStore,
+    });
+
+    const updatedEntry = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "codex",
+      model: "gpt-5.5",
+    });
+
+    expect(compactAgentHarnessSession).toHaveBeenCalledTimes(1);
+    expect(compactCalls).toHaveLength(1);
+    expect(maintenance).not.toHaveBeenCalled();
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(updatedEntry?.compactionCount).toBeUndefined();
+    expect(updatedEntry?.cliSessionBindings?.codex).toBeUndefined();
+    expect(updatedEntry?.cliSessionIds?.codex).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.codex).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionIds?.codex).toBeUndefined();
+  });
+
   it("falls back to context-engine compaction when Codex native compaction returns a raw missing thread reason", async () => {
     const sessionKey = "agent:main:codex-raw-stale-binding";
     const sessionId = "session-codex-raw-stale-binding";

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -13,6 +13,7 @@ import {
   applyAgentAutoCompactionGuard as applyAgentAutoCompactionGuardImpl,
   resolveEffectiveCompactionMode,
 } from "../agent-settings.js";
+import { classifyCompactionReason } from "../embedded-agent-runner/compact-reasons.js";
 import { buildEmbeddedCompactionRuntimeContext } from "../embedded-agent-runner/compaction-runtime-context.js";
 import {
   compactContextEngineWithSafetyTimeout,
@@ -28,7 +29,10 @@ import { ensureSelectedAgentHarnessPlugin as ensureSelectedAgentHarnessPluginImp
 import { maybeCompactAgentHarnessSession as maybeCompactAgentHarnessSessionImpl } from "../harness/selection.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { SessionManager } from "../sessions/session-manager.js";
-import { recordCliCompactionInStore as recordCliCompactionInStoreImpl } from "./session-store.js";
+import {
+  clearCliSessionInStore as clearCliSessionInStoreImpl,
+  recordCliCompactionInStore as recordCliCompactionInStoreImpl,
+} from "./session-store.js";
 
 const CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON = "codex app-server owns automatic compaction";
 
@@ -64,6 +68,7 @@ type CliCompactionDeps = {
   runContextEngineMaintenance: typeof runContextEngineMaintenanceImpl;
   ensureSelectedAgentHarnessPlugin: typeof ensureSelectedAgentHarnessPluginImpl;
   maybeCompactAgentHarnessSession: typeof maybeCompactAgentHarnessSessionImpl;
+  clearCliSessionInStore: typeof clearCliSessionInStoreImpl;
   recordCliCompactionInStore: typeof recordCliCompactionInStoreImpl;
 };
 
@@ -71,6 +76,7 @@ type NativeHarnessCliCompactionOutcome = {
   compacted: boolean;
   result?: EmbeddedAgentCompactResult;
   fallbackToContextEngine?: boolean;
+  clearCliSessionBinding?: boolean;
   failureReason?: string;
 };
 type CliTranscriptCompactionOutcome = {
@@ -109,6 +115,7 @@ const cliCompactionDeps: CliCompactionDeps = {
   runContextEngineMaintenance: runContextEngineMaintenanceImpl,
   ensureSelectedAgentHarnessPlugin: ensureSelectedAgentHarnessPluginImpl,
   maybeCompactAgentHarnessSession: maybeCompactAgentHarnessSessionImpl,
+  clearCliSessionInStore: clearCliSessionInStoreImpl,
   recordCliCompactionInStore: recordCliCompactionInStoreImpl,
 };
 
@@ -128,6 +135,7 @@ export function resetCliCompactionTestDeps(): void {
     runContextEngineMaintenance: runContextEngineMaintenanceImpl,
     ensureSelectedAgentHarnessPlugin: ensureSelectedAgentHarnessPluginImpl,
     maybeCompactAgentHarnessSession: maybeCompactAgentHarnessSessionImpl,
+    clearCliSessionInStore: clearCliSessionInStoreImpl,
     recordCliCompactionInStore: recordCliCompactionInStoreImpl,
   });
 }
@@ -175,6 +183,10 @@ function isUnsupportedNativeHarnessCompaction(
   result: EmbeddedAgentCompactResult | undefined,
 ): boolean {
   return result?.ok === false && result.failure?.reason === "unsupported_harness_compaction";
+}
+
+function isBelowCompactionTargetReason(reason: string | undefined): boolean {
+  return classifyCompactionReason(reason) === "below_threshold";
 }
 
 function isIntentionalNativeAutoCompactionSkip(
@@ -285,8 +297,15 @@ async function compactCliTranscript(params: {
   }
 
   if (!compactResult.compacted) {
+    const reason = compactResult.reason ?? "nothing to compact";
+    if (isBelowCompactionTargetReason(reason)) {
+      log.info(
+        `CLI transcript compaction skipped for ${params.provider}/${params.model}: ${reason}`,
+      );
+      return { compacted: false };
+    }
     log.warn(
-      `CLI transcript compaction did not reduce context for ${params.provider}/${params.model}: ${compactResult.reason ?? "nothing to compact"}`,
+      `CLI transcript compaction did not reduce context for ${params.provider}/${params.model}: ${reason}`,
     );
     return {
       compacted: false,
@@ -412,6 +431,13 @@ async function compactNativeHarnessCliTranscript(params: {
   }
 
   if (!result?.compacted) {
+    const reason = result?.reason ?? "nothing to compact";
+    if (isBelowCompactionTargetReason(reason)) {
+      log.info(
+        `CLI native harness compaction skipped for ${params.provider}/${params.model}: ${reason}`,
+      );
+      return { compacted: false };
+    }
     if (isIntentionalNativeAutoCompactionSkip(result)) {
       return {
         compacted: false,
@@ -419,15 +445,16 @@ async function compactNativeHarnessCliTranscript(params: {
         failureReason: CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON,
       };
     }
+    const recoverableBindingFailure = isRecoverableNativeHarnessBindingFailure(result);
     const fallbackToContextEngine =
-      isUnsupportedNativeHarnessCompaction(result) ||
-      isRecoverableNativeHarnessBindingFailure(result);
+      isUnsupportedNativeHarnessCompaction(result) || recoverableBindingFailure;
     log.warn(
-      `CLI native harness compaction did not reduce context for ${params.provider}/${params.model}: ${result?.reason ?? "nothing to compact"}`,
+      `CLI native harness compaction did not reduce context for ${params.provider}/${params.model}: ${reason}`,
     );
     return {
       compacted: false,
       fallbackToContextEngine,
+      clearCliSessionBinding: recoverableBindingFailure,
       failureReason: result?.reason ?? "native harness compaction did not reduce context",
     };
   }
@@ -496,6 +523,7 @@ export async function runCliTurnCompactionLifecycle(params: {
   let nativeCompactionResult: EmbeddedAgentCompactResult | undefined;
   let useContextEngineCompaction = true;
   let nativeFallbackToContextEngine = false;
+  let nativeFallbackNeedsBindingClear = false;
   let resolvedContextEngine: ContextEngine | undefined;
   let autoCompactionGuardApplied = false;
   const applyAutoCompactionGuard = async (contextEngine: ContextEngine): Promise<void> => {
@@ -539,14 +567,17 @@ export async function runCliTurnCompactionLifecycle(params: {
       compacted = true;
       nativeCompactionResult = nativeOutcome.result;
       useContextEngineCompaction = false;
-    } else if (!nativeOutcome.fallbackToContextEngine) {
+    } else if (nativeOutcome.fallbackToContextEngine) {
+      nativeFallbackToContextEngine = true;
+      nativeFallbackNeedsBindingClear = nativeOutcome.clearCliSessionBinding === true;
+    } else if (nativeOutcome.failureReason) {
       throw new Error(
         `CLI native harness compaction failed for ${params.provider}/${params.model}: ${
           nativeOutcome.failureReason ?? "compaction did not reduce context"
         }`,
       );
     } else {
-      nativeFallbackToContextEngine = true;
+      useContextEngineCompaction = false;
     }
   }
 
@@ -581,13 +612,24 @@ export async function runCliTurnCompactionLifecycle(params: {
       bestEffortMaintenance: nativeFallbackToContextEngine,
     });
     compacted = contextOutcome.compacted;
-    if (!compacted) {
+    if (!compacted && contextOutcome.failureReason) {
       throw new Error(
         `CLI transcript compaction failed for ${params.provider}/${params.model}: ${
           contextOutcome.failureReason ?? "compaction did not reduce context"
         }`,
       );
     }
+  }
+
+  if (nativeFallbackNeedsBindingClear && !compacted && params.sessionStore && params.storePath) {
+    return (
+      (await cliCompactionDeps.clearCliSessionInStore({
+        provider: params.provider,
+        sessionKey: params.sessionKey,
+        sessionStore: params.sessionStore,
+        storePath: params.storePath,
+      })) ?? params.sessionEntry
+    );
   }
 
   if (!compacted || !params.sessionStore || !params.storePath) {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Prevents retried CLI/Codex agent turns from failing when compaction reports the transcript is already below target.
- Treats `already under target` / below-threshold compaction as a no-op instead of a fatal post-turn compaction error.
- Clears stale Codex native CLI bindings when native compaction reports a missing thread and the context-engine fallback also has nothing to compact.

Why does this matter now?

- Telegram and other webhook retries can re-enter the same agent path after a transient turn failure. A harmless compaction no-op should not become a visible repeated error.

What is the intended outcome?

- CLI-backed Codex turns continue when compaction says there is nothing useful to reduce.
- Real compaction failures, such as timeouts, still fail loudly.

What is intentionally out of scope?

- Durable Telegram webhook dedupe behavior.
- Notification dispatch policy changes.
- Codex app-server compaction algorithm changes.

What does success look like?

- `already under target` compaction results resolve as no-ops.
- Stale Codex thread bindings are dropped after a recoverable missing-thread compaction response, so the next retry starts from a fresh binding instead of looping on the dead one.
- Existing timeout/native harness failure coverage still proves non-benign failures throw.

What should reviewers focus on?

- Whether `below_threshold` is the right existing classifier to reuse for CLI no-op behavior.
- Whether the no-op branch avoids clearing CLI resume state or recording a compaction count.
- Whether stale native binding cleanup should stay limited to recoverable Codex/native binding failures rather than all compaction no-ops.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

- Requested during investigation of repeated Telegram-visible progress errors caused by retried CLI/Codex turns hitting `already under target` compaction.
- Builds on Ayaan Zaidi's (@obviyus) prior maintainer fix, `c0a5f15dc8 fix(agents): clear unflushed cli bindings`, which established the session-store path for clearing stale/unflushed CLI bindings. This PR extends that recovery to the compaction retry path.

## Real behavior proof

- Behavior or issue addressed: CLI/Codex compaction returning `compacted:false` with `reason:"already under target"` was treated as a fatal post-turn compaction failure.
- Real environment tested: Local OpenClaw source checkout on macOS, Node 24.14.0, Codex CLI 0.135.0, Codex app-server 0.134.0.
- Exact steps or command run after this patch: Ran a source-checkout Node/tsx smoke that creates an isolated production Codex app-server client, starts a real Codex thread, and calls `thread/compact/start` on that below-target thread.
- Evidence after fix:

```json
{
  "proof": "PR88319 Codex app-server below-target compact smoke",
  "source": "local OpenClaw source checkout",
  "codexCli": "0.135.0",
  "serverVersion": "0.134.0",
  "threadStarted": true,
  "compactReturned": true,
  "visibleTurnFailure": false,
  "redactions": [
    "thread id",
    "temp path"
  ]
}
```

- Observed result after fix: The real Codex app-server compaction request returned successfully for the tiny below-target thread, and the OpenClaw regression tests prove both CLI transcript and Codex native `already under target` results now return as no-ops without recording a compaction or throwing.
- What was not tested: Live Telegram webhook retry against production bot credentials.
- Proof limitations or environment constraints: The local Codex/OpenAI auth path hit a Cloudflare 403 when trying to run a full OpenClaw agent turn with context-engine fallback, so the real runtime proof is scoped to the production Codex app-server compaction request plus focused OpenClaw regression tests for the exact `already under target` reason.
- Before evidence (optional but encouraged): The pre-fix control flow threw for non-fallback `compacted:false` results; the old tests had no below-target coverage.


## Tests and validation

Which commands did you run?

- `PNPM_CONFIG_FETCH_RETRIES=5 PNPM_CONFIG_FETCH_RETRY_MINTIMEOUT=60000 PNPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=180000 pnpm install --frozen-lockfile`
- `node scripts/test-projects.mjs src/agents/command/cli-compaction.test.ts`
- `node_modules/.bin/tsgo -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo --declaration false --pretty false`
- `node_modules/.bin/tsgo -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo --declaration false --pretty false`
- `git diff --check`
- `pnpm check:changed` (blocked at unrelated lint tooling issue after core typechecks passed)

What regression coverage was added or updated?

- Added context-engine CLI compaction coverage for `{ ok: true, compacted: false, reason: "already under target" }`.
- Added Codex native CLI compaction coverage for `{ ok: true, compacted: false, reason: "already under target" }`.
- Added stale Codex native binding coverage for missing-thread recovery where the context-engine fallback is also below target, proving the stale binding is cleared without recording a compaction.
- Existing nonrecoverable native timeout failure coverage remains unchanged.

What failed before this fix, if known?

- The CLI compaction lifecycle treated non-fallback `compacted:false` as fatal, even when the reason was below-target/no-op.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Harmless below-target compaction no-ops no longer surface as failed CLI/Codex turns.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Accidentally swallowing real compaction failures.

How is that risk mitigated?

- The no-op handling is restricted to the existing `below_threshold` classifier.
- Timeout and unsupported/stale-binding failure paths remain covered separately.

## Current review state

What is the next action?

- Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- CI should confirm full repo gates in a clean environment.
- Optional live webhook verification can be done by a maintainer with Telegram credentials.

Which bot or reviewer comments were addressed?

- None yet.
