### PR TITLE
fix(agents): recover DeepSeek DSML tool calls

### DIFF
--- a/src/agents/deepseek-text-filter.test.ts
+++ b/src/agents/deepseek-text-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createDeepSeekTextFilter } from "./deepseek-text-filter.js";
+import { createDeepSeekTextEventFilter, createDeepSeekTextFilter } from "./deepseek-text-filter.js";
 
 function filteredText(chunks: readonly string[]) {
   const filter = createDeepSeekTextFilter();
@@ -64,6 +64,41 @@ describe("createDeepSeekTextFilter", () => {
   it("emits normal short text immediately", () => {
     const filter = createDeepSeekTextFilter();
     expect(filter.push("hello")).toEqual(["hello"]);
+    expect(filter.flush()).toEqual([]);
+  });
+
+  it("emits recoverable events for tool-call wrapper spelling variants", () => {
+    const filter = createDeepSeekTextEventFilter();
+    expect(
+      filter.push(
+        '<|DSML|tool_call><|DSML|invoke name="read">{"path":"/tmp/x"}</|DSML|invoke></|DSML|tool_calls> after',
+      ),
+    ).toEqual([
+      {
+        type: "dsml",
+        kind: "tool_call",
+        body: '<|DSML|invoke name="read">{"path":"/tmp/x"}</|DSML|invoke>',
+      },
+      { type: "text", text: " after" },
+    ]);
+    expect(filter.flush()).toEqual([]);
+  });
+
+  it("strips mismatched DSML wrappers without emitting a recoverable event", () => {
+    const filter = createDeepSeekTextEventFilter();
+    expect(
+      filter.push(
+        '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/x"}</|DSML|invoke></|DSML|tool_use_error> after',
+      ),
+    ).toEqual([{ type: "text", text: " after" }]);
+    expect(filter.flush()).toEqual([]);
+  });
+
+  it("drops oversized DSML bodies without retaining them as events", () => {
+    const filter = createDeepSeekTextEventFilter();
+    expect(filter.push("<|DSML|tool_calls>")).toEqual([]);
+    expect(filter.push("x".repeat(260_000))).toEqual([]);
+    expect(filter.push("</|DSML|tool_calls>tail")).toEqual([{ type: "text", text: "tail" }]);
     expect(filter.flush()).toEqual([]);
   });
 });

--- a/src/agents/deepseek-text-filter.ts
+++ b/src/agents/deepseek-text-filter.ts
@@ -1,14 +1,17 @@
 const DSML_KINDS = ["tool_use_error", "tool_calls", "tool_call", "function_calls"] as const;
 const DSML_BARS = ["|", "｜"] as const;
 
-const DSML_OPEN_TOKENS = DSML_BARS.flatMap((bar) =>
-  DSML_KINDS.map((kind) => `<${bar}DSML${bar}${kind}>`),
+const DSML_TOKEN_PAIRS = DSML_BARS.flatMap((bar) =>
+  DSML_KINDS.map((kind) => ({
+    kind,
+    open: `<${bar}DSML${bar}${kind}>`,
+    close: `</${bar}DSML${bar}${kind}>`,
+  })),
 );
-const DSML_CLOSE_TOKENS = DSML_BARS.flatMap((bar) =>
-  DSML_KINDS.map((kind) => `</${bar}DSML${bar}${kind}>`),
-);
+const DSML_OPEN_TOKENS = DSML_TOKEN_PAIRS.map((token) => token.open);
 const MAX_OPEN_TOKEN_LEN = Math.max(...DSML_OPEN_TOKENS.map((token) => token.length));
-const MAX_CLOSE_TOKEN_LEN = Math.max(...DSML_CLOSE_TOKENS.map((token) => token.length));
+const MAX_CLOSE_TOKEN_LEN = Math.max(...DSML_TOKEN_PAIRS.map((token) => token.close.length));
+const MAX_DSML_BODY_BYTES = 256_000;
 
 export interface DeepSeekTextFilter {
   push(chunk: string): string[];
@@ -16,38 +19,97 @@ export interface DeepSeekTextFilter {
 }
 
 export function createDeepSeekTextFilter(): DeepSeekTextFilter {
-  let buffer = "";
-  let insideDsml = false;
+  const filter = createDeepSeekTextEventFilter();
+  const textParts = (events: DeepSeekTextFilterEvent[]) =>
+    events.flatMap((event) => (event.type === "text" ? [event.text] : []));
 
-  const consume = (final: boolean): string[] => {
-    const output: string[] = [];
+  return {
+    push(chunk: string) {
+      return textParts(filter.push(chunk));
+    },
+    flush() {
+      return textParts(filter.flush());
+    },
+  };
+}
+
+export type DeepSeekDsmlKind = (typeof DSML_KINDS)[number];
+
+export type DeepSeekTextFilterEvent =
+  | { type: "text"; text: string }
+  | { type: "dsml"; kind: DeepSeekDsmlKind; body: string };
+
+export interface DeepSeekTextEventFilter {
+  push(chunk: string): DeepSeekTextFilterEvent[];
+  flush(): DeepSeekTextFilterEvent[];
+}
+
+export function createDeepSeekTextEventFilter(): DeepSeekTextEventFilter {
+  let buffer = "";
+  let insideDsml: {
+    kind: DeepSeekDsmlKind;
+    body: string;
+    bodyBytes: number;
+    truncated: boolean;
+  } | null = null;
+
+  const appendDsmlBody = (text: string) => {
+    if (!insideDsml || insideDsml.truncated || !text) {
+      return;
+    }
+    const nextBytes = Buffer.byteLength(text, "utf8");
+    if (insideDsml.bodyBytes + nextBytes > MAX_DSML_BODY_BYTES) {
+      insideDsml.body = "";
+      insideDsml.bodyBytes = 0;
+      insideDsml.truncated = true;
+      return;
+    }
+    insideDsml.body += text;
+    insideDsml.bodyBytes += nextBytes;
+  };
+
+  const consume = (final: boolean): DeepSeekTextFilterEvent[] => {
+    const output: DeepSeekTextFilterEvent[] = [];
     const emit = (text: string) => {
       if (text) {
-        output.push(text);
+        output.push({ type: "text", text });
       }
     };
 
     while (buffer) {
       if (insideDsml) {
-        const close = findEarliestToken(buffer, DSML_CLOSE_TOKENS);
+        const close = findEarliestCloseTokenPair(buffer, DSML_TOKEN_PAIRS);
         if (close) {
-          buffer = buffer.slice(close.index + close.token.length);
-          insideDsml = false;
+          appendDsmlBody(buffer.slice(0, close.index));
+          if (
+            !insideDsml.truncated &&
+            isCompatibleDsmlCloseKind(insideDsml.kind, close.token.kind)
+          ) {
+            output.push({
+              type: "dsml",
+              kind: insideDsml.kind,
+              body: insideDsml.body,
+            });
+          }
+          buffer = buffer.slice(close.index + close.token.close.length);
+          insideDsml = null;
           continue;
         }
         const keep = final ? 0 : Math.min(buffer.length, MAX_CLOSE_TOKEN_LEN - 1);
-        buffer = buffer.slice(buffer.length - keep);
+        const consumedLength = buffer.length - keep;
+        appendDsmlBody(buffer.slice(0, consumedLength));
+        buffer = buffer.slice(consumedLength);
         if (final) {
-          insideDsml = false;
+          insideDsml = null;
         }
         return output;
       }
 
-      const open = findEarliestToken(buffer, DSML_OPEN_TOKENS);
+      const open = findEarliestTokenPair(buffer, DSML_TOKEN_PAIRS);
       if (open) {
         emit(buffer.slice(0, open.index));
-        buffer = buffer.slice(open.index + open.token.length);
-        insideDsml = true;
+        buffer = buffer.slice(open.index + open.token.open.length);
+        insideDsml = { kind: open.token.kind, body: "", bodyBytes: 0, truncated: false };
         continue;
       }
 
@@ -80,10 +142,44 @@ export function createDeepSeekTextFilter(): DeepSeekTextFilter {
   };
 }
 
-function findEarliestToken(text: string, tokens: readonly string[]) {
-  let best: { index: number; token: string } | null = null;
+function isCompatibleDsmlCloseKind(openKind: DeepSeekDsmlKind, closeKind: DeepSeekDsmlKind) {
+  if (openKind === closeKind) {
+    return true;
+  }
+  return isDsmlToolCallFamilyKind(openKind) && isDsmlToolCallFamilyKind(closeKind);
+}
+
+function isDsmlToolCallFamilyKind(kind: DeepSeekDsmlKind) {
+  return kind === "tool_calls" || kind === "tool_call" || kind === "function_calls";
+}
+
+function findEarliestCloseTokenPair(
+  text: string,
+  tokens: readonly { kind: DeepSeekDsmlKind; close: string }[],
+) {
+  let best: {
+    index: number;
+    token: { kind: DeepSeekDsmlKind; close: string };
+  } | null = null;
   for (const token of tokens) {
-    const index = text.indexOf(token);
+    const index = text.indexOf(token.close);
+    if (index !== -1 && (!best || index < best.index)) {
+      best = { index, token };
+    }
+  }
+  return best;
+}
+
+function findEarliestTokenPair(
+  text: string,
+  tokens: readonly { kind: DeepSeekDsmlKind; open: string }[],
+) {
+  let best: {
+    index: number;
+    token: { kind: DeepSeekDsmlKind; open: string };
+  } | null = null;
+  for (const token of tokens) {
+    const index = text.indexOf(token.open);
     if (index !== -1 && (!best || index < best.index)) {
       best = { index, token };
     }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -61,6 +61,10 @@ function createAssistantOutput(model: Model<"openai-completions">): OpenAIComple
   };
 }
 
+function withDeepSeekDsmlToolNames(...names: string[]) {
+  return { deepSeekDsmlToolNames: new Set(names) };
+}
+
 function createResponsesAssistantOutput(
   model: Model<"azure-openai-responses">,
 ): OpenAIResponsesOutput {
@@ -1649,6 +1653,7 @@ describe("openai transport stream", () => {
       output,
       model,
       { push: (event) => events.push(event as CapturedStreamEvent) },
+      withDeepSeekDsmlToolNames("read"),
     );
 
     expect(output.content).toEqual([
@@ -1662,6 +1667,728 @@ describe("openai transport stream", () => {
       },
     ]);
     expect(JSON.stringify(events)).not.toContain("DSML");
+  });
+
+  it("recovers observed DeepSeek DSML parameter tool calls", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  'before <｜DSML｜tool_calls><｜DSML｜invoke name="session_status"><｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+      withDeepSeekDsmlToolNames("session_status"),
+    );
+
+    expect(output.content).toEqual([
+      { type: "text", text: "before " },
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_0",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+    expect(JSON.stringify(events)).not.toContain("DSML");
+  });
+
+  it("preserves DeepSeek DSML string flag argument semantics", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-parameter-flags",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<|DSML|tool_calls><|DSML|invoke name="write"><|DSML|parameter name="count" string="false">5</|DSML|parameter><|DSML|parameter name="body" string="true">  keep whitespace\n</|DSML|parameter></|DSML|invoke></|DSML|tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("write"),
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_0",
+        name: "write",
+        arguments: { count: 5, body: "  keep whitespace\n" },
+        partialArgs: '{"count":5,"body":"  keep whitespace\\n"}',
+      },
+    ]);
+  });
+
+  it("recovers split DeepSeek DSML JSON tool calls", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-split-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: '<|DSML|tool_calls><|DSML|invoke name="read">',
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-split-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: '{"path":"/tmp/repro.md"}</|DSML|invoke></|DSML|tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("read"),
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_0",
+        name: "read",
+        arguments: { path: "/tmp/repro.md" },
+        partialArgs: '{"path":"/tmp/repro.md"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
+  it("keeps visible text between multiple recovered DeepSeek DSML tool calls", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-tool-text-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/one.md"}</|DSML|invoke></|DSML|tool_calls> between <|DSML|tool_calls><|DSML|invoke name="write">{"path":"/tmp/two.md"}</|DSML|invoke></|DSML|tool_calls> after',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("read", "write"),
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_0",
+        name: "read",
+        arguments: { path: "/tmp/one.md" },
+        partialArgs: '{"path":"/tmp/one.md"}',
+      },
+      { type: "text", text: " between " },
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_1",
+        name: "write",
+        arguments: { path: "/tmp/two.md" },
+        partialArgs: '{"path":"/tmp/two.md"}',
+      },
+      { type: "text", text: " after" },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
+  it("keeps structured thinking after recovered DeepSeek DSML tool calls ordered after the tool", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-tool-thinking",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: [
+                  '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/repro.md"}</|DSML|invoke></|DSML|tool_calls>',
+                  { type: "thinking", text: "considering" },
+                  { type: "text", text: " after" },
+                ],
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("read"),
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_0",
+        name: "read",
+        arguments: { path: "/tmp/repro.md" },
+        partialArgs: '{"path":"/tmp/repro.md"}',
+      },
+      { type: "thinking", thinking: "considering", thinkingSignature: "content" },
+      { type: "text", text: " after" },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
+  it("recovers DeepSeek DSML tool-call wrapper spelling variants", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-tool-call-variant",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<|DSML|tool_call><|DSML|invoke name="read">{"path":"/tmp/repro.md"}</|DSML|invoke></|DSML|tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("read"),
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_0",
+        name: "read",
+        arguments: { path: "/tmp/repro.md" },
+        partialArgs: '{"path":"/tmp/repro.md"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
+  it("does not recover DeepSeek DSML wrappers with noisy non-invoke text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-noisy-wrapper",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  'before <|DSML|tool_calls>noise <|DSML|invoke name="read">{"path":"/tmp/repro.md"}</|DSML|invoke> trailing</|DSML|tool_calls> after',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("read"),
+    );
+
+    expect(output.content).toEqual([{ type: "text", text: "before  after" }]);
+    expect(output.stopReason).toBe("stop");
+  });
+
+  it("strips DeepSeek DSML tool calls without recovery when tools are disabled", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-tool-no-tools",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  'before <|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/repro.md"}</|DSML|invoke></|DSML|tool_calls> after',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([{ type: "text", text: "before  after" }]);
+    expect(output.stopReason).toBe("stop");
+  });
+
+  it("does not recover DeepSeek DSML calls for undeclared tool names", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-unknown-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  'before <|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/repro.md"}</|DSML|invoke></|DSML|tool_calls> after',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("write"),
+    );
+
+    expect(output.content).toEqual([{ type: "text", text: "before  after" }]);
+    expect(output.stopReason).toBe("stop");
+  });
+
+  it("does not recover malformed DeepSeek DSML parameter bodies", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-malformed-parameter",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<|DSML|tool_calls><|DSML|invoke name="write"><|DSML|parameter name="path" string="true">/tmp/repro.md</|DSML|parameter><|DSML|parameter name="content" string="true">unterminated</|DSML|invoke></|DSML|tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("write"),
+    );
+
+    expect(output.content).toEqual([]);
+    expect(output.stopReason).toBe("stop");
+  });
+
+  it("does not recover malformed typed DeepSeek DSML parameters", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-malformed-typed-parameters",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<|DSML|tool_calls><|DSML|invoke name="write"><|DSML|parameter name="dryRun" boolean="true"></|DSML|parameter></|DSML|invoke><|DSML|invoke name="limit"><|DSML|parameter name="count" number="true"> </|DSML|parameter></|DSML|invoke></|DSML|tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("write", "limit"),
+    );
+
+    expect(output.content).toEqual([]);
+    expect(output.stopReason).toBe("stop");
+  });
+
+  it("recovers zero-argument DeepSeek DSML tool calls", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-empty-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<|DSML|tool_calls><|DSML|invoke name="refresh_status"></|DSML|invoke></|DSML|tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("refresh_status"),
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_0",
+        name: "refresh_status",
+        arguments: {},
+        partialArgs: "{}",
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
+  it("does not promote incomplete DeepSeek DSML invokes", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-malformed-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: '<|DSML|tool_calls><|DSML|invoke name="session_status">',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("session_status"),
+    );
+
+    expect(output.content).toEqual([]);
+    expect(output.stopReason).toBe("stop");
+  });
+
+  it("does not duplicate split DeepSeek DSML shadows when native tool calls are present", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-native-split-shadow-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: '<|DSML|tool_calls><|DSML|invoke name="read">',
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-native-split-shadow-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: '{"path":"/tmp/shadow.md"}</|DSML|invoke></|DSML|tool_calls>',
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_native_1",
+                    type: "function",
+                    function: { name: "read", arguments: '{"path":"/tmp/native.md"}' },
+                  },
+                ],
+              },
+              logprobs: null,
+              finish_reason: "tool_calls",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("read"),
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_native_1",
+        name: "read",
+        arguments: { path: "/tmp/native.md" },
+        partialArgs: '{"path":"/tmp/native.md"}',
+      },
+    ]);
+  });
+
+  it("keeps visible text after queued DeepSeek DSML shadows when native tool calls arrive later", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-native-after-shadow-text",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/shadow.md"}</|DSML|invoke></|DSML|tool_calls> visible',
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-native-after-shadow-text",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_native_1",
+                    type: "function",
+                    function: { name: "read", arguments: '{"path":"/tmp/native.md"}' },
+                  },
+                ],
+              },
+              logprobs: null,
+              finish_reason: "tool_calls",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("read"),
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_native_1",
+        name: "read",
+        arguments: { path: "/tmp/native.md" },
+        partialArgs: '{"path":"/tmp/native.md"}',
+      },
+      { type: "text", text: " visible" },
+    ]);
+  });
+
+  it("keeps same-chunk visible text after native tool calls that replace queued DSML shadows", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-native-after-shadow-same-chunk-text",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/shadow.md"}</|DSML|invoke></|DSML|tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-native-after-shadow-same-chunk-text",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: " after",
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_native_1",
+                    type: "function",
+                    function: { name: "read", arguments: '{"path":"/tmp/native.md"}' },
+                  },
+                ],
+              },
+              logprobs: null,
+              finish_reason: "tool_calls",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+      withDeepSeekDsmlToolNames("read"),
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_native_1",
+        name: "read",
+        arguments: { path: "/tmp/native.md" },
+        partialArgs: '{"path":"/tmp/native.md"}',
+      },
+      { type: "text", text: " after" },
+    ]);
   });
 
   it("preserves DeepSeek visible content before same-chunk native tool calls", async () => {
@@ -1712,7 +2439,7 @@ describe("openai transport stream", () => {
     ]);
   });
 
-  it("filters DeepSeek DSML text queued after native tool calls", async () => {
+  it("keeps visible text after parseable DeepSeek DSML shadows that follow native tool calls", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);
     const events: CapturedStreamEvent[] = [];
@@ -1751,7 +2478,24 @@ describe("openai transport stream", () => {
             {
               index: 0,
               delta: {
-                content: "<|DSML|tool_calls>shadow</|DSML|tool_calls> visible",
+                content:
+                  '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/shadow.md"}</|DSML|invoke></|DSML|tool_calls> visible',
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-post-tool-dsml",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: " second",
               },
               logprobs: null,
               finish_reason: null,
@@ -1762,6 +2506,7 @@ describe("openai transport stream", () => {
       output,
       model,
       { push: (event) => events.push(event as CapturedStreamEvent) },
+      withDeepSeekDsmlToolNames("read"),
     );
 
     expect(output.content).toEqual([
@@ -1772,9 +2517,10 @@ describe("openai transport stream", () => {
         arguments: { path: "/tmp/native.md" },
         partialArgs: '{"path":"/tmp/native.md"}',
       },
-      { type: "text", text: " visible" },
+      { type: "text", text: " visible second" },
     ]);
     expect(JSON.stringify(events)).not.toContain("DSML");
+    expect(JSON.stringify(events)).not.toContain("shadow.md");
   });
 
   it("keeps DeepSeek DSML state across native tool-call chunks", async () => {
@@ -6364,6 +7110,33 @@ describe("openai transport stream", () => {
 
     expect(params).toHaveProperty("tools");
     expect(params).toHaveProperty("tool_choice", "required");
+  });
+
+  it("narrows DeepSeek DSML recovery to top-level OpenAI-compatible tool_choice names", () => {
+    const tools = [
+      { type: "function", function: { name: "read" } },
+      { type: "function", function: { name: "write" } },
+      { type: "web_search" },
+    ];
+
+    const toolNames = testing.resolveOpenAICompletionsDeepSeekDsmlToolNames({
+      tools,
+      tool_choice: { type: "tool", name: "write" },
+    });
+
+    expect([...(toolNames ?? [])]).toEqual(["write"]);
+    expect(
+      testing.resolveOpenAICompletionsDeepSeekDsmlToolNames({
+        tools,
+        tool_choice: { type: "tool", name: "web_search" },
+      }),
+    ).toBeUndefined();
+    expect(
+      testing.resolveOpenAICompletionsDeepSeekDsmlToolNames({
+        tools,
+        tool_choice: { type: "tool" },
+      }),
+    ).toBeUndefined();
   });
 
   it("omits empty tools and tool_choice for proxy-like openai-completions endpoints when context.tools is []", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -30,7 +30,7 @@ import { isRecord } from "../shared/record-coerce.js";
 import { uniqueStrings } from "../shared/string-normalization.js";
 import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../utils/cjk-chars.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
-import { createDeepSeekTextFilter } from "./deepseek-text-filter.js";
+import { createDeepSeekTextEventFilter, type DeepSeekDsmlKind } from "./deepseek-text-filter.js";
 import { resolveMaxTokensParam } from "./model-max-tokens-params.js";
 import { supportsModelTools } from "./model-tool-support.js";
 import {
@@ -363,6 +363,69 @@ function summarizeResponsesTools(tools: unknown): string {
   const label = maxNames >= names.length ? "names" : "sample";
   const shown = names.slice(0, maxNames).join(",");
   return `count=${tools.length}${shown ? ` ${label}=${shown}` : ""}`;
+}
+
+function resolveOpenAICompletionsDeepSeekDsmlToolNames(
+  params: Record<string, unknown>,
+): ReadonlySet<string> | undefined {
+  if (params.tool_choice === "none") {
+    return undefined;
+  }
+  const toolNames = readOpenAICompletionsToolNames(params.tools);
+  if (toolNames.size === 0) {
+    return undefined;
+  }
+  if (isRecord(params.tool_choice)) {
+    const chosenToolName = readOpenAICompletionsToolChoiceName(params.tool_choice);
+    return chosenToolName && toolNames.has(chosenToolName) ? new Set([chosenToolName]) : undefined;
+  }
+  return toolNames;
+}
+
+function readOpenAICompletionsToolNames(tools: unknown): Set<string> {
+  const names = new Set<string>();
+  if (!Array.isArray(tools)) {
+    return names;
+  }
+  for (const tool of tools) {
+    const name = readOpenAICompletionsToolName(tool);
+    if (name) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+function readOpenAICompletionsToolName(tool: unknown): string | undefined {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+  const fn = tool.function;
+  if (isRecord(fn) && typeof fn.name === "string") {
+    const name = fn.name.trim();
+    return name || undefined;
+  }
+  if (typeof tool.name === "string") {
+    const name = tool.name.trim();
+    return name || undefined;
+  }
+  return undefined;
+}
+
+function readOpenAICompletionsToolChoiceName(toolChoice: unknown): string | undefined {
+  if (!isRecord(toolChoice)) {
+    return undefined;
+  }
+  if (typeof toolChoice.name === "string") {
+    const name = toolChoice.name.trim();
+    return name || undefined;
+  }
+  const fn = toolChoice.function;
+  if (!isRecord(fn) || typeof fn.name !== "string") {
+    return undefined;
+  }
+  const name = fn.name.trim();
+  return name || undefined;
 }
 
 function responsesPayloadToolName(tool: unknown): string | undefined {
@@ -2454,8 +2517,10 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           buildOpenAISdkRequestOptions(model, options?.signal),
         )) as unknown as AsyncIterable<ChatCompletionChunk>;
         stream.push({ type: "start", partial: output as never });
+        const deepSeekDsmlToolNames = resolveOpenAICompletionsDeepSeekDsmlToolNames(params);
         await processOpenAICompletionsStream(responseStream, output, model, stream, {
           signal: options?.signal,
+          deepSeekDsmlToolNames,
         });
         if (options?.signal?.aborted) {
           throw new Error("Request was aborted");
@@ -2477,14 +2542,15 @@ async function processOpenAICompletionsStream(
   output: MutableAssistantOutput,
   model: Model,
   stream: { push(event: unknown): void },
-  options?: { signal?: AbortSignal },
+  options?: { signal?: AbortSignal; deepSeekDsmlToolNames?: ReadonlySet<string> },
 ) {
   const MAX_POST_TOOL_CALL_BUFFER_BYTES = 256_000;
   const MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES = 256_000;
   const compat = getCompat(model as OpenAIModeModel);
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat)
-    ? createDeepSeekTextFilter()
+    ? createDeepSeekTextEventFilter()
     : null;
+  const deepSeekDsmlToolNames = options?.deepSeekDsmlToolNames;
   type ToolCallBlock = {
     type: "toolCall";
     id: string;
@@ -2504,6 +2570,15 @@ async function processOpenAICompletionsStream(
   const toolCallBlocksByIndex = new Map<number, ToolCallBlock>();
   const toolCallBlocksById = new Map<string, ToolCallBlock>();
   const toolCallBlockBytes = new WeakMap<ToolCallBlock, number>();
+  type PendingDeepSeekDsmlItem =
+    | { type: "toolCall"; invocation: DeepSeekDsmlToolInvocation }
+    | { type: "delta"; delta: CompletionsReasoningDelta };
+  let pendingDeepSeekDsmlItems: PendingDeepSeekDsmlItem[] = [];
+  let pendingDeepSeekPostDsmlBytes = 0;
+  let pendingDeepSeekDsmlInsertIndex: number | null = null;
+  let syntheticDeepSeekToolCallIndex = 0;
+  let hasSyntheticDeepSeekToolCall = false;
+  let sawNativeToolCalls = false;
   const blockIndex = () => output.content.length - 1;
   const measureUtf8Bytes = (text: string) => Buffer.byteLength(text, "utf8");
   const finishCurrentBlock = () => {
@@ -2595,6 +2670,153 @@ async function processOpenAICompletionsStream(
     }
     isFlushingPendingPostToolCallDeltas = false;
   };
+  const startToolCallBlock = (params: {
+    id: string;
+    name: string;
+    thoughtSignature?: string;
+    insertIndex?: number;
+  }) => {
+    const switchingToolCall = currentBlock?.type === "toolCall";
+    finishCurrentBlock();
+    if (switchingToolCall) {
+      currentBlock = null;
+      flushPendingPostToolCallDeltas();
+    }
+    const block: ToolCallBlock = {
+      type: "toolCall",
+      id: params.id,
+      name: params.name,
+      arguments: {},
+      partialArgs: "",
+      ...(params.thoughtSignature ? { thoughtSignature: params.thoughtSignature } : {}),
+    };
+    if (params.insertIndex !== undefined && params.insertIndex >= 0) {
+      output.content.splice(Math.min(params.insertIndex, output.content.length), 0, block);
+    } else {
+      output.content.push(block);
+    }
+    currentBlock = block;
+    stream.push({
+      type: "toolcall_start",
+      contentIndex: output.content.indexOf(block),
+      partial: output,
+    });
+    return block;
+  };
+  const appendToolCallArgumentDelta = (block: ToolCallBlock, text: string) => {
+    if (!text) {
+      return;
+    }
+    const nextArgumentBytes = measureUtf8Bytes(text);
+    const currentBlockArgBytes = toolCallBlockBytes.get(block) ?? 0;
+    if (currentBlockArgBytes + nextArgumentBytes > MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES) {
+      throw new Error("Exceeded tool-call argument buffer limit");
+    }
+    toolCallBlockBytes.set(block, currentBlockArgBytes + nextArgumentBytes);
+    block.partialArgs += text;
+    block.arguments = parseStreamingJson(block.partialArgs);
+    stream.push({
+      type: "toolcall_delta",
+      contentIndex: output.content.indexOf(block),
+      delta: text,
+      partial: output,
+    });
+  };
+  const markSyntheticDeepSeekToolCall = () => {
+    hasSyntheticDeepSeekToolCall = true;
+    if (output.stopReason !== "error" && output.stopReason !== "length") {
+      output.stopReason = "toolUse";
+    }
+  };
+  const hasPendingDeepSeekDsmlToolCalls = () =>
+    pendingDeepSeekDsmlItems.some((item) => item.type === "toolCall");
+  const queueDeepSeekDsmlToolCalls = (kind: DeepSeekDsmlKind, body: string) => {
+    if (!deepSeekDsmlToolNames?.size) {
+      return false;
+    }
+    const invocations = parseDeepSeekDsmlToolInvocations(kind, body).filter((invocation) =>
+      deepSeekDsmlToolNames.has(invocation.name),
+    );
+    if (invocations.length > 0 && pendingDeepSeekDsmlInsertIndex === null) {
+      pendingDeepSeekDsmlInsertIndex = output.content.length;
+    }
+    pendingDeepSeekDsmlItems.push(
+      ...invocations.map((invocation) => ({ type: "toolCall" as const, invocation })),
+    );
+    return invocations.length > 0;
+  };
+  const queuePendingDeepSeekPostDsmlDelta = (next: CompletionsReasoningDelta) => {
+    const nextBytes = measureUtf8Bytes(next.text);
+    if (pendingDeepSeekPostDsmlBytes + nextBytes > MAX_POST_TOOL_CALL_BUFFER_BYTES) {
+      throw new Error("Exceeded post-DSML-tool-call delta buffer limit");
+    }
+    pendingDeepSeekPostDsmlBytes += nextBytes;
+    pendingDeepSeekDsmlItems.push({ type: "delta", delta: next });
+  };
+  const appendOrQueueDeepSeekPostDsmlText = (text: string, forceQueue = false) => {
+    if (forceQueue || (hasPendingDeepSeekDsmlToolCalls() && !sawNativeToolCalls)) {
+      queuePendingDeepSeekPostDsmlDelta({ kind: "text", text });
+      return;
+    }
+    appendVisibleTextDelta(text);
+  };
+  const dropPendingDeepSeekDsmlInvocations = (options?: { preserveInsertIndex?: boolean }) => {
+    pendingDeepSeekDsmlItems = pendingDeepSeekDsmlItems.filter((item) => item.type !== "toolCall");
+    if (!options?.preserveInsertIndex) {
+      pendingDeepSeekDsmlInsertIndex = null;
+    }
+  };
+  const takePendingDeepSeekDsmlInsertIndex = (): number | null => {
+    const insertIndex = pendingDeepSeekDsmlInsertIndex;
+    pendingDeepSeekDsmlInsertIndex = null;
+    return insertIndex;
+  };
+  const appendQueuedDeepSeekDsmlToolCalls = () => {
+    const items = pendingDeepSeekDsmlItems;
+    pendingDeepSeekDsmlItems = [];
+    pendingDeepSeekPostDsmlBytes = 0;
+    let insertIndex = takePendingDeepSeekDsmlInsertIndex();
+    for (const item of items) {
+      if (item.type === "delta") {
+        if (item.delta.kind === "text") {
+          appendVisibleTextDelta(item.delta.text);
+        } else if (currentBlock?.type === "toolCall") {
+          queuePostToolCallDelta(item.delta);
+        } else {
+          appendThinkingDelta(item.delta);
+        }
+        insertIndex = null;
+        continue;
+      }
+      const invocation = item.invocation;
+      const block = startToolCallBlock({
+        id: `call_deepseek_dsml_${syntheticDeepSeekToolCallIndex++}`,
+        name: invocation.name,
+        ...(insertIndex !== null ? { insertIndex: insertIndex++ } : {}),
+      });
+      markSyntheticDeepSeekToolCall();
+      appendToolCallArgumentDelta(block, JSON.stringify(invocation.arguments));
+    }
+  };
+  const flushPendingDeepSeekPostDsmlDeltas = () => {
+    const bufferedItems = pendingDeepSeekDsmlItems;
+    pendingDeepSeekDsmlItems = [];
+    pendingDeepSeekPostDsmlBytes = 0;
+    pendingDeepSeekDsmlInsertIndex = null;
+    for (const item of bufferedItems) {
+      if (item.type === "toolCall") {
+        continue;
+      }
+      const delta = item.delta;
+      if (delta.kind === "text") {
+        appendVisibleTextDelta(delta.text);
+      } else if (currentBlock?.type === "toolCall") {
+        queuePostToolCallDelta(delta);
+      } else {
+        appendThinkingDelta(delta);
+      }
+    }
+  };
   const appendThinkingDelta = (reasoningDelta: { signature: string; text: string }) => {
     flushPendingPostToolCallDeltas();
     appendThinkingDeltaInternal(reasoningDelta);
@@ -2613,19 +2835,51 @@ async function processOpenAICompletionsStream(
       appendTextDelta(text);
     }
   };
-  const appendFilteredVisibleTextDelta = (text: string) => {
-    const parts = deepSeekTextFilter?.push(text) ?? [text];
-    for (const part of parts) {
-      appendVisibleTextDelta(part);
+  const appendFilteredVisibleTextDelta = (
+    text: string,
+    options?: { forceDeepSeekPostDsmlQueue?: boolean; suppressDeepSeekDsmlToolCalls?: boolean },
+  ) => {
+    const events = deepSeekTextFilter?.push(text) ?? [{ type: "text" as const, text }];
+    let queuedDsmlToolCallInBatch = false;
+    const suppressDeepSeekDsmlToolCalls =
+      options?.suppressDeepSeekDsmlToolCalls || sawNativeToolCalls;
+    for (const event of events) {
+      if (event.type === "text") {
+        appendOrQueueDeepSeekPostDsmlText(
+          event.text,
+          options?.forceDeepSeekPostDsmlQueue || queuedDsmlToolCallInBatch,
+        );
+        continue;
+      }
+      if (suppressDeepSeekDsmlToolCalls) {
+        if (
+          options?.suppressDeepSeekDsmlToolCalls &&
+          DEEPSEEK_DSML_TOOL_CALL_KINDS.has(event.kind)
+        ) {
+          queuedDsmlToolCallInBatch = true;
+        }
+        continue;
+      }
+      queuedDsmlToolCallInBatch =
+        queueDeepSeekDsmlToolCalls(event.kind, event.body) || queuedDsmlToolCallInBatch;
     }
+    return queuedDsmlToolCallInBatch;
   };
   const flushDeepSeekTextFilterAtEnd = () => {
-    const parts = deepSeekTextFilter?.flush();
-    if (!parts) {
+    const events = deepSeekTextFilter?.flush();
+    if (!events) {
       return;
     }
-    for (const part of parts) {
-      appendVisibleTextDelta(part);
+    let queuedDsmlToolCallInBatch = false;
+    for (const event of events) {
+      if (event.type === "text") {
+        appendOrQueueDeepSeekPostDsmlText(event.text, queuedDsmlToolCallInBatch);
+        continue;
+      }
+      if (!sawNativeToolCalls) {
+        queuedDsmlToolCallInBatch =
+          queueDeepSeekDsmlToolCalls(event.kind, event.body) || queuedDsmlToolCallInBatch;
+      }
     }
   };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
@@ -2663,15 +2917,34 @@ async function processOpenAICompletionsStream(
       await cooperativeScheduler.afterEvent();
       continue;
     }
+    const hasNativeToolCalls = Boolean(choiceDelta.tool_calls && choiceDelta.tool_calls.length > 0);
+    const nativeReplacesPendingDeepSeekDsml =
+      hasNativeToolCalls && hasPendingDeepSeekDsmlToolCalls();
+    if (hasNativeToolCalls) {
+      sawNativeToolCalls = true;
+      dropPendingDeepSeekDsmlInvocations({
+        preserveInsertIndex: nativeReplacesPendingDeepSeekDsml,
+      });
+    }
+    let forceDeepSeekPostDsmlQueueForChunk = nativeReplacesPendingDeepSeekDsml;
     if (choiceDelta.content) {
       // Structured content can contain visible text and thinking blocks in the
       // same delta, so route each extracted block through the normal stream path.
       const contentDeltas = getCompletionsContentDeltas(choiceDelta.content);
       for (const contentDelta of contentDeltas) {
         if (contentDelta.kind === "text") {
-          appendFilteredVisibleTextDelta(contentDelta.text);
+          forceDeepSeekPostDsmlQueueForChunk =
+            appendFilteredVisibleTextDelta(contentDelta.text, {
+              forceDeepSeekPostDsmlQueue: forceDeepSeekPostDsmlQueueForChunk,
+              suppressDeepSeekDsmlToolCalls: hasNativeToolCalls,
+            }) || forceDeepSeekPostDsmlQueueForChunk;
         } else if (currentBlock?.type === "toolCall") {
           queuePostToolCallDelta(contentDelta);
+        } else if (
+          forceDeepSeekPostDsmlQueueForChunk ||
+          (hasPendingDeepSeekDsmlToolCalls() && !sawNativeToolCalls)
+        ) {
+          queuePendingDeepSeekPostDsmlDelta(contentDelta);
         } else {
           appendThinkingDelta(contentDelta);
         }
@@ -2686,14 +2959,23 @@ async function processOpenAICompletionsStream(
         queuePostToolCallDelta({ ...reasoningDelta });
         continue;
       }
+      if (
+        forceDeepSeekPostDsmlQueueForChunk ||
+        (hasPendingDeepSeekDsmlToolCalls() && !sawNativeToolCalls)
+      ) {
+        queuePendingDeepSeekPostDsmlDelta({ ...reasoningDelta });
+        continue;
+      }
       if (reasoningDelta.kind === "text") {
         appendTextDelta(reasoningDelta.text);
       } else {
         appendThinkingDelta(reasoningDelta);
       }
     }
-    if (choiceDelta.tool_calls && choiceDelta.tool_calls.length > 0) {
-      for (const toolCall of choiceDelta.tool_calls) {
+    if (hasNativeToolCalls) {
+      const nativeToolCalls = choiceDelta.tool_calls ?? [];
+      let nativeInsertIndex = takePendingDeepSeekDsmlInsertIndex();
+      for (const toolCall of nativeToolCalls) {
         const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
         let block = streamIndex !== undefined ? toolCallBlocksByIndex.get(streamIndex) : undefined;
         if (!block && toolCall.id) {
@@ -2715,7 +2997,12 @@ async function processOpenAICompletionsStream(
             partialArgs: "",
             ...(initialSig ? { thoughtSignature: initialSig } : {}),
           };
-          output.content.push(block);
+          if (nativeInsertIndex !== null) {
+            output.content.splice(Math.min(nativeInsertIndex, output.content.length), 0, block);
+            nativeInsertIndex += 1;
+          } else {
+            output.content.push(block);
+          }
           stream.push({
             type: "toolcall_start",
             contentIndex: output.content.indexOf(block),
@@ -2754,15 +3041,25 @@ async function processOpenAICompletionsStream(
           });
         }
       }
+      flushPendingDeepSeekPostDsmlDeltas();
     }
     flushPendingPostToolCallDeltas();
     await cooperativeScheduler.afterEvent();
   }
   flushDeepSeekTextFilterAtEnd();
+  if (!sawNativeToolCalls) {
+    appendQueuedDeepSeekDsmlToolCalls();
+  } else {
+    dropPendingDeepSeekDsmlInvocations();
+  }
+  flushPendingDeepSeekPostDsmlDeltas();
   finishAllToolCallBlocks();
   currentBlock = null;
   flushPendingPostToolCallDeltas();
   const hasToolCalls = output.content.some((block) => block.type === "toolCall");
+  if (hasSyntheticDeepSeekToolCall && hasToolCalls && output.stopReason === "stop") {
+    output.stopReason = "toolUse";
+  }
   if (output.stopReason === "toolUse" && !hasToolCalls) {
     output.stopReason = "stop";
   }
@@ -2781,6 +3078,146 @@ type CompletionsReasoningDelta =
 
 function shouldFilterDeepSeekDsmlText(compat: ReturnType<typeof getCompat>) {
   return compat.thinkingFormat === "deepseek";
+}
+
+const DEEPSEEK_DSML_TOOL_CALL_KINDS = new Set<DeepSeekDsmlKind>([
+  "tool_calls",
+  "tool_call",
+  "function_calls",
+]);
+
+type DeepSeekDsmlToolInvocation = {
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
+const DEEPSEEK_DSML_INVALID_PARAMETER = Symbol("deepseek-dsml-invalid-parameter");
+
+function parseDeepSeekDsmlToolInvocations(
+  kind: DeepSeekDsmlKind,
+  body: string,
+): DeepSeekDsmlToolInvocation[] {
+  if (!DEEPSEEK_DSML_TOOL_CALL_KINDS.has(kind)) {
+    return [];
+  }
+  const invocations: DeepSeekDsmlToolInvocation[] = [];
+  let offset = 0;
+  const invokePattern = /<[|｜]DSML[|｜]invoke\b([^>]*)>([\s\S]*?)<\/[|｜]DSML[|｜]invoke>/g;
+  for (const match of body.matchAll(invokePattern)) {
+    const matchIndex = match.index ?? 0;
+    if (body.slice(offset, matchIndex).trim() !== "") {
+      return [];
+    }
+    offset = matchIndex + match[0].length;
+    const attributes = parseDeepSeekDsmlAttributes(match[1] ?? "");
+    const name = attributes.name?.trim();
+    if (!name) {
+      continue;
+    }
+    const args = parseDeepSeekDsmlToolArguments(match[2] ?? "");
+    if (!args) {
+      continue;
+    }
+    invocations.push({ name, arguments: args });
+  }
+  return body.slice(offset).trim() === "" ? invocations : [];
+}
+
+function parseDeepSeekDsmlToolArguments(body: string): Record<string, unknown> | null {
+  const args: Record<string, unknown> = {};
+  let hasParameter = false;
+  let offset = 0;
+  const parameterPattern =
+    /<[|｜]DSML[|｜]parameter\b([^>]*)>([\s\S]*?)<\/[|｜]DSML[|｜]parameter>/g;
+  for (const match of body.matchAll(parameterPattern)) {
+    const matchIndex = match.index ?? 0;
+    if (body.slice(offset, matchIndex).trim() !== "") {
+      return null;
+    }
+    offset = matchIndex + match[0].length;
+    const attributes = parseDeepSeekDsmlAttributes(match[1] ?? "");
+    const name = attributes.name?.trim();
+    if (!name) {
+      return null;
+    }
+    hasParameter = true;
+    const value = parseDeepSeekDsmlParameterValue(attributes, match[2] ?? "");
+    if (value === DEEPSEEK_DSML_INVALID_PARAMETER) {
+      return null;
+    }
+    args[name] = value;
+  }
+  if (hasParameter) {
+    if (body.slice(offset).trim() !== "") {
+      return null;
+    }
+    return args;
+  }
+  const trimmed = decodeDeepSeekDsmlText(body).trim();
+  if (!trimmed) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseDeepSeekDsmlParameterValue(
+  attributes: Record<string, string>,
+  rawValue: string,
+): unknown {
+  const text = decodeDeepSeekDsmlText(rawValue);
+  const trimmed = text.trim();
+  if (attributes.string === "false" || attributes.json === "true") {
+    try {
+      return JSON.parse(trimmed) as unknown;
+    } catch {
+      return DEEPSEEK_DSML_INVALID_PARAMETER;
+    }
+  }
+  if (attributes.boolean === "true") {
+    const lowerText = trimmed.toLowerCase();
+    if (lowerText === "true") {
+      return true;
+    }
+    if (lowerText === "false") {
+      return false;
+    }
+    return DEEPSEEK_DSML_INVALID_PARAMETER;
+  }
+  if (attributes.number === "true") {
+    if (!trimmed) {
+      return DEEPSEEK_DSML_INVALID_PARAMETER;
+    }
+    const value = Number(trimmed);
+    return Number.isFinite(value) ? value : DEEPSEEK_DSML_INVALID_PARAMETER;
+  }
+  return text;
+}
+
+function parseDeepSeekDsmlAttributes(text: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  const attributePattern = /([A-Za-z_][\w:-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+  for (const match of text.matchAll(attributePattern)) {
+    const name = match[1];
+    if (!name) {
+      continue;
+    }
+    attributes[name] = decodeDeepSeekDsmlText(match[2] ?? match[3] ?? "");
+  }
+  return attributes;
+}
+
+function decodeDeepSeekDsmlText(text: string): string {
+  return text
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
 }
 
 function getCompletionsContentDeltas(content: unknown): CompletionsReasoningDelta[] {
@@ -3767,6 +4204,7 @@ export const testing = {
   enforceCodeModeResponsesToolSurface,
   sanitizeOpenAICodexResponsesParams,
   buildOpenAICompletionsClientConfig,
+  resolveOpenAICompletionsDeepSeekDsmlToolNames,
   processOpenAICompletionsStream,
   processResponsesStream,
   formatModelTransportDebugBaseUrl,


### PR DESCRIPTION
Fixes #85918

## Summary

- Recover complete DeepSeek DSML invoke blocks on the OpenAI-compatible completions stream when tools were actually exposed and the invoke name matches a declared tool.
- Preserve existing DSML visible-text stripping behavior, keep native `tool_calls` authoritative, and cap retained DSML bodies.
- Add regression coverage for parameter semantics, split chunks, native-shadow de-dupe/replacement, same-chunk native replacement ordering, trailing text ordering, disabled/unknown tools, malformed DSML, tool-choice narrowing, structured thinking, and oversized DSML bodies.

## Canonicalization note

This PR intentionally supersedes the overlapping DSML recovery shape in #86637:

- #88320 is rebased on current `upstream/main` and includes a packaged/local OpenClaw CLI proof rather than only unit-level proof.
- It keeps native provider `tool_calls` authoritative and covers native-shadow de-duplication/replacement, including delayed native chunks and same-chunk visible-content ordering.
- It includes broader parser/transport coverage for malformed, incomplete, unknown, disabled, split, typed-parameter, zero-argument, and oversized DSML cases.

## Real behavior proof

Behavior or issue addressed: DeepSeek/Foundry completions streams that emit complete DSML tool-call markup as assistant text now become executable OpenClaw tool calls instead of visible/filtered text, while native `tool_calls` remain authoritative.

Real environment tested: Local OpenClaw source checkout on this PR branch, rebased onto current `upstream/main`, executed through the real OpenClaw CLI via `node scripts/run-node.mjs --profile pr88320proof agent --local ... --json`. The model provider was an isolated OpenAI-compatible loopback SSE server configured as `dsml-loopback/deepseek-v4-pro` with DeepSeek compatibility enabled. No live provider credentials were used.

Exact steps or command run after this patch: Built/reran the local OpenClaw CLI from this branch, configured an isolated `pr88320proof` profile to point at `http://127.0.0.1:19191/v1`, started a local OpenAI-compatible SSE server that first returned the reported DSML `session_status` payload as assistant text, then ran:
`node scripts/run-node.mjs --profile pr88320proof agent --local --agent main --session-key agent:main:dsml-proof-<fresh> --model dsml-loopback/deepseek-v4-pro --message 'Call the session_status tool exactly once with sessionKey current and then stop.' --json --timeout 90`

Evidence after fix:

```json
{
  "exitCode": 0,
  "head": "ba24891857",
  "firstProviderRequest": {
    "url": "/v1/chat/completions",
    "model": "deepseek-v4-pro",
    "stream": true,
    "toolChoice": "auto",
    "toolNamesIncludesSessionStatus": true,
    "messages": ["system", "user"]
  },
  "loopbackFirstResponse": "<｜DSML｜tool_calls><｜DSML｜invoke name=\"session_status\"><｜DSML｜parameter name=\"sessionKey\" string=\"true\">current</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>",
  "secondProviderRequest": {
    "url": "/v1/chat/completions",
    "model": "deepseek-v4-pro",
    "stream": true,
    "containsToolRoleMessage": true
  },
  "sawToolResultRequest": true,
  "secondRequestHasToolRole": true,
  "dsmlLeakedToFinalStdout": false,
  "finalContainsProofDone": true
}
```

Observed result after fix: The first provider response returned DSML as assistant text, OpenClaw recovered it into an executable `session_status` tool call, the second provider request contained a `role: tool` message, the final CLI JSON completed successfully, and the DSML wrapper did not leak into final stdout.

What was not tested: A live Microsoft Foundry/DeepSeek provider call with real credentials. The proof uses the packaged/local OpenClaw CLI path from this branch plus a loopback OpenAI-compatible SSE provider that emits the exact reported DSML shape.

## Verification

- `git fetch upstream main && git rebase upstream/main`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/deepseek-text-filter.test.ts src/agents/openai-transport-stream.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/deepseek-text-filter.ts src/agents/deepseek-text-filter.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check`
- `pnpm check:changed --base upstream/main`
- `node /tmp/pr88320-cli-proof-current.mjs`

