### PR TITLE
perf(cli): reduce room-event Claude cache churn

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -457,6 +457,53 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("uses compact current-turn context when a room event resumes a CLI session", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    appendTranscriptEntry(sessionFile, {
+      id: "msg-1",
+      parentId: null,
+      timestamp: new Date(1).toISOString(),
+      message: {
+        role: "user",
+        content: "prior room event",
+        timestamp: 1,
+      },
+    });
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:test",
+        agentId: "main",
+        trigger: "user",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "[OpenClaw room event]",
+        currentInboundEventKind: "room_event",
+        currentInboundContext: {
+          text: "Room context:\nAlice: lunch?\n\nCurrent event:\nBob: yes",
+          resumableText: "Current event:\nBob: yes",
+        },
+        cliSessionBinding: {
+          sessionId: "cli-session",
+        },
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-resumable-context",
+        config: createCliBackendConfig({
+          reseedFromRawTranscriptWhenUncompacted: true,
+        }),
+      });
+
+      expect(context.reusableCliSession).toEqual({ sessionId: "cli-session" });
+      expect(context.params.prompt).toBe("Current event:\nBob: yes\n\n[OpenClaw room event]");
+      expect(context.openClawHistoryPrompt).toContain("Room context:\nAlice: lunch?");
+      expect(context.openClawHistoryPrompt).toContain("Current event:\nBob: yes");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("marks inter-session prompts after CLI prompt-build hook context is applied", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -516,11 +516,21 @@ export async function prepareCliRunContext(
   } catch (error) {
     cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);
   }
-  preparedPrompt = buildCurrentInboundPrompt({
+  const fullCurrentInboundPrompt = buildCurrentInboundPrompt({
     context: params.currentInboundContext,
     prompt: preparedPrompt,
   });
-  preparedPrompt = annotateInterSessionPromptText(preparedPrompt, params.inputProvenance);
+  const runCurrentInboundPrompt = buildCurrentInboundPrompt({
+    context: params.currentInboundContext,
+    prompt: preparedPrompt,
+    preferResumableText:
+      params.currentInboundEventKind === "room_event" && Boolean(reusableCliSession.sessionId),
+  });
+  const historyPromptCurrentTurn = annotateInterSessionPromptText(
+    fullCurrentInboundPrompt,
+    params.inputProvenance,
+  );
+  preparedPrompt = annotateInterSessionPromptText(runCurrentInboundPrompt, params.inputProvenance);
   const allowRawTranscriptReseed =
     backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true;
   const rawTranscriptReseedReason = reusableCliSession.sessionId
@@ -539,7 +549,7 @@ export async function prepareCliRunContext(
           allowRawTranscriptReseed,
           rawTranscriptReseedReason,
         }),
-        prompt: preparedPrompt,
+        prompt: historyPromptCurrentTurn,
         maxHistoryChars: autoReseedHistoryChars,
       })
     : undefined;

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -33,6 +33,7 @@ export type EmbeddedRunTrigger = "cron" | "heartbeat" | "manual" | "memory" | "o
 
 export type CurrentInboundPromptContext = {
   text: string;
+  resumableText?: string;
   promptJoiner?: "\n\n" | "\n" | " ";
 };
 

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -279,6 +279,18 @@ describe("runtime context prompt submission", () => {
     ).toBe("Conversation info (untrusted metadata):\n```json\n{}\n```");
   });
 
+  it("can use compact current-turn context for resumable backends", () => {
+    expect(
+      buildCurrentInboundPromptContextPrefix(
+        {
+          text: "Room context:\nAlice: lunch?\n\nCurrent event:\nBob: yes",
+          resumableText: "Current event:\nBob: yes",
+        },
+        { preferResumableText: true },
+      ),
+    ).toBe("Current event:\nBob: yes");
+  });
+
   it("omits empty current-turn context", () => {
     expect(buildCurrentInboundPromptContextPrefix(undefined)).toBe("");
     expect(buildCurrentInboundPromptContextPrefix({ text: "   " })).toBe("");
@@ -298,6 +310,17 @@ describe("runtime context prompt submission", () => {
         prompt: "visible ask",
       }),
     ).toBe("Conversation context:\n\nvisible ask");
+
+    expect(
+      buildCurrentInboundPrompt({
+        context: {
+          text: "Room context:\nAlice: lunch?\n\nCurrent event:\nBob: yes",
+          resumableText: "Current event:\nBob: yes",
+        },
+        prompt: "[OpenClaw room event]",
+        preferResumableText: true,
+      }),
+    ).toBe("Current event:\nBob: yes\n\n[OpenClaw room event]");
   });
 
   it("builds runtime context as prompt-local custom context before the current user prompt", () => {

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -31,15 +31,23 @@ type EmptyTranscriptMode = "model-prompt" | "runtime-event";
 
 export function buildCurrentInboundPromptContextPrefix(
   context: CurrentInboundPromptContext | undefined,
+  options?: { preferResumableText?: boolean },
 ): string {
-  return context?.text.trim() ?? "";
+  const text =
+    options?.preferResumableText === true
+      ? (context?.resumableText ?? context?.text)
+      : context?.text;
+  return text?.trim() ?? "";
 }
 
 export function buildCurrentInboundPrompt(params: {
   context: CurrentInboundPromptContext | undefined;
   prompt: string;
+  preferResumableText?: boolean;
 }): string {
-  const prefix = buildCurrentInboundPromptContextPrefix(params.context);
+  const prefix = buildCurrentInboundPromptContextPrefix(params.context, {
+    preferResumableText: params.preferResumableText,
+  });
   if (!prefix) {
     return params.prompt;
   }

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
+import { keepCliSessionBindingOnlyWhenReused } from "./agent-runner-cli-dispatch.js";
+
+describe("keepCliSessionBindingOnlyWhenReused", () => {
+  it("keeps the first room-event CLI binding when no binding exists yet", () => {
+    const result = {
+      payloads: [],
+      meta: {
+        durationMs: 1,
+        agentMeta: {
+          sessionId: "new-cli-session",
+          provider: "claude-cli",
+          model: "claude-opus-4-8",
+          cliSessionBinding: {
+            sessionId: "new-cli-session",
+            authProfileId: "profile",
+          },
+        },
+      },
+    } satisfies EmbeddedAgentRunResult;
+
+    expect(keepCliSessionBindingOnlyWhenReused({ result })).toBe(result);
+  });
+
+  it("drops a replacement room-event CLI binding when an existing binding was reused", () => {
+    const onDroppedReplacement = vi.fn();
+    const result = keepCliSessionBindingOnlyWhenReused({
+      existingSessionId: "existing-cli-session",
+      onDroppedReplacement,
+      result: {
+        payloads: [],
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            sessionId: "replacement-cli-session",
+            provider: "claude-cli",
+            model: "claude-opus-4-8",
+            cliSessionBinding: {
+              sessionId: "replacement-cli-session",
+              authProfileId: "profile",
+            },
+          },
+        },
+      } satisfies EmbeddedAgentRunResult,
+    });
+
+    expect(onDroppedReplacement).toHaveBeenCalledOnce();
+    expect(result.meta.agentMeta?.sessionId).toBe("");
+    expect(result.meta.agentMeta?.cliSessionBinding).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -96,7 +96,11 @@ export function keepCliSessionBindingOnlyWhenReused(params: {
   const agentMeta = params.result.meta.agentMeta;
   const returnedSessionId = normalizeOptionalString(agentMeta?.cliSessionBinding?.sessionId);
   const shouldClearStoredSession = agentMeta?.clearCliSessionBinding === true;
-  if (agentMeta === undefined || (existingSessionId && returnedSessionId === existingSessionId)) {
+  if (
+    agentMeta === undefined ||
+    (!shouldClearStoredSession && existingSessionId === undefined) ||
+    returnedSessionId === existingSessionId
+  ) {
     return params.result;
   }
   if (returnedSessionId || shouldClearStoredSession) {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1933,7 +1933,56 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
-  it("keeps new room-event CLI sessions transient when reuse fails", async () => {
+  it("keeps the first CLI session created by a room-event turn", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("codex-cli", "gpt-5.4"),
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ambient" }],
+      meta: {
+        agentMeta: {
+          sessionId: "new-cli-session",
+          cliSessionBinding: {
+            sessionId: "new-cli-session",
+            authProfileId: "profile",
+          },
+        },
+      },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.currentInboundEventKind = "room_event";
+    followupRun.run.provider = "codex-cli";
+    followupRun.run.model = "gpt-5.4";
+    const sessionEntry = {} as unknown as SessionEntry;
+
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      getActiveSessionEntry: () => sessionEntry,
+    });
+
+    expect(result.kind).toBe("success");
+    expectMockCallArgFields(state.runCliAgentMock, 0, "CLI run params", {
+      currentInboundEventKind: "room_event",
+      cliSessionId: undefined,
+      cliSessionBinding: undefined,
+    });
+    if (result.kind !== "success") {
+      throw new Error("expected success");
+    }
+    expect(result.runResult.meta?.agentMeta?.sessionId).toBe("new-cli-session");
+    expect(result.runResult.meta?.agentMeta?.cliSessionBinding).toEqual({
+      sessionId: "new-cli-session",
+      authProfileId: "profile",
+    });
+  });
+
+  it("drops replacement room-event CLI sessions when reuse fails", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       result: await params.run("codex-cli", "gpt-5.4"),

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { DELIVERY_NO_REPLY_RUNTIME_CONTRACT } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { setCliSessionBinding } from "../../agents/cli-session.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import {
@@ -333,6 +334,9 @@ async function persistRunSessionUsageForFollowupTest(
         (params.lastCallUsage?.cacheWrite ?? params.usage?.cacheWrite ?? 0);
     nextEntry.totalTokens = promptTokens > 0 ? promptTokens : undefined;
     nextEntry.totalTokensFresh = promptTokens > 0;
+  }
+  if (params.cliSessionBinding && params.providerUsed && !preserveUserFacingRunState) {
+    setCliSessionBinding(nextEntry, params.providerUsed, params.cliSessionBinding);
   }
   store[sessionKey] = nextEntry;
   if (registeredStore) {
@@ -989,6 +993,77 @@ describe("createFollowupRunner runtime config", () => {
     expect(call.suppressNextUserMessagePersistence).toBe(true);
     expect(call.cliSessionId).toBe("cli-session-1");
     expect(call.cliSessionBinding).toEqual({ sessionId: "cli-session-1" });
+  });
+
+  it("stores queued room-event CLI sessions created from the first ambient run", async () => {
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    const storePath = "/tmp/openclaw-followup-room-event-cli.json";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-cli-room-event",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+    registerFollowupTestSessionStore(storePath, sessionStore);
+    runCliAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        agentMeta: {
+          provider: "claude-cli",
+          model: "claude-opus-4-7",
+          sessionId: "cli-session-1",
+          cliSessionBinding: {
+            sessionId: "cli-session-1",
+            authProfileId: "profile",
+          },
+        },
+      },
+    });
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    await runner(
+      createQueuedRun({
+        currentInboundEventKind: "room_event",
+        currentInboundContext: { text: "[OpenClaw room event]" },
+        run: {
+          config: runtimeConfig,
+          sessionId: "session-cli-room-event",
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          suppressNextUserMessagePersistence: true,
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      }),
+    );
+
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
+    const call = requireLastMockCallArg(runCliAgentMock, "run cli agent");
+    expect(call.currentInboundEventKind).toBe("room_event");
+    expect(call.cliSessionId).toBeUndefined();
+    expect(sessionStore.main.cliSessionBindings?.["claude-cli"]).toEqual({
+      sessionId: "cli-session-1",
+      authProfileId: "profile",
+    });
   });
 
   it("does not replace queued room-event CLI session bindings when reuse fails", async () => {

--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -110,6 +110,24 @@ describe("buildReplyPromptEnvelope", () => {
         "Treat this as observed room activity. Decide whether to act.",
       ].join("\n\n"),
     );
+    expect(envelope.currentInboundContext?.resumableText).toBe(
+      [
+        "[OpenClaw room event]",
+        "inbound_event_kind: room_event",
+        [
+          "Room context:",
+          "Conversation info (untrusted metadata):",
+          "```json",
+          JSON.stringify({ message_id: "35676", inbound_event_kind: "room_event" }, null, 2),
+          "```",
+        ].join("\n"),
+        "Current event:\n#35676 Keśava: No wtf",
+        "Treat this as observed room activity. Decide whether to act.",
+      ].join("\n\n"),
+    );
+    expect(envelope.currentInboundContext?.resumableText).not.toContain(
+      "Conversation context (untrusted, chronological, selected for current message):",
+    );
   });
 
   it("uses the raw current body for room-event current event text", () => {

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -12,6 +12,10 @@ const REPLY_MEDIA_HINT =
   "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Absolute and ~ paths only work when they stay inside your allowed file-read boundary; host file:// URLs are blocked. Keep caption in the text body.";
 const ROOM_EVENT_PROMPT = "[OpenClaw room event]";
 const ROOM_EVENT_SOURCE_REPLY_DELIVERY_MODE = "message_tool_only";
+const RESUMABLE_ROOM_CONTEXT_OMITTED_PREFIXES = [
+  "Conversation context (untrusted, chronological, selected for current message):",
+  "Chat history since last reply (untrusted, for context):",
+];
 
 export function buildReplyPromptBodies(params: {
   ctx: MsgContext;
@@ -131,8 +135,9 @@ function resolveRoomEventBody(params: ReplyPromptEnvelopeBaseParams): string {
   );
 }
 
-function buildRoomEventContext(params: ReplyPromptEnvelopeBaseParams): string {
+function buildRoomEventContext(params: ReplyPromptEnvelopeBaseParams, roomContext: string): string {
   const roomEventBody = resolveRoomEventBody(params);
+  const roomContextBlock = roomContext.trim() ? `Room context:\n${roomContext.trim()}` : "";
   const visibleReplyContract =
     params.sourceReplyDeliveryMode === "message_tool_only"
       ? `visible_reply_contract: ${ROOM_EVENT_SOURCE_REPLY_DELIVERY_MODE}`
@@ -141,11 +146,21 @@ function buildRoomEventContext(params: ReplyPromptEnvelopeBaseParams): string {
     "[OpenClaw room event]",
     "inbound_event_kind: room_event",
     visibleReplyContract,
-    params.inboundUserContext.trim() ? `Room context:\n${params.inboundUserContext.trim()}` : "",
+    roomContextBlock,
     `Current event:\n${formatRoomEventLine(params.sessionCtx, roomEventBody)}`,
     "Treat this as observed room activity. Decide whether to act.",
   ]
     .filter(Boolean)
+    .join("\n\n");
+}
+
+function buildResumableRoomContext(roomContext: string): string {
+  return roomContext
+    .split(/\n{2,}/u)
+    .filter(
+      (block) =>
+        !RESUMABLE_ROOM_CONTEXT_OMITTED_PREFIXES.some((prefix) => block.startsWith(prefix)),
+    )
     .join("\n\n");
 }
 
@@ -154,10 +169,12 @@ export function buildReplyPromptEnvelopeBase(
 ): ReplyPromptEnvelopeBase {
   const softResetTail = params.softResetTail?.trim() ?? "";
   const isRoomEvent = params.inboundEventKind === "room_event";
-  const roomEventContext = buildRoomEventContext(params);
-  const currentInboundContextText = isRoomEvent
-    ? roomEventContext
-    : params.inboundUserContext.trim();
+  const inboundUserContext = params.inboundUserContext.trim();
+  const roomEventContext = buildRoomEventContext(params, inboundUserContext);
+  const resumableRoomEventContext = isRoomEvent
+    ? buildRoomEventContext(params, buildResumableRoomContext(inboundUserContext))
+    : undefined;
+  const currentInboundContextText = isRoomEvent ? roomEventContext : inboundUserContext;
   const resetModelBody = params.isBareSessionReset
     ? [
         params.inboundUserContext,
@@ -188,6 +205,7 @@ export function buildReplyPromptEnvelopeBase(
     !params.isBareSessionReset && currentInboundContextText
       ? {
           text: currentInboundContextText,
+          ...(resumableRoomEventContext ? { resumableText: resumableRoomEventContext } : {}),
           promptJoiner: params.inboundUserContextPromptJoiner,
         }
       : undefined;


### PR DESCRIPTION
Summary
- Persist the first CLI session binding created by an ambient room-event run, so follow-up room events can actually resume it.
- Add compact resumable room-event context for reused CLI sessions while keeping full current room context for raw-history reseed/session-expired recovery.
- Preserve current-event metadata in compact prompts and drop only bulky selected chat-history blocks.

Verification
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts src/auto-reply/reply/prompt-prelude.test.ts src/agents/cli-runner/prepare.test.ts src/auto-reply/reply/agent-runner-cli-dispatch.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/followup-runner.test.ts --testNamePattern 'resumable|current-turn context|room event|room-event CLI|keepCliSessionBindingOnlyWhenReused|first CLI session|replacement room-event|queued room-event CLI|first ambient run|reuses CLI session bindings'`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Behavior addressed: Always-on room events on Claude CLI could fail to reuse a first-created CLI session and could resend bulky room context on every resumed event, burning cache/write tokens.
Real environment tested: local macOS checkout with real `claude` CLI 2.1.149.
Exact steps or command run after this patch: direct `runCliAgent` script with two room-event Claude CLI turns using `claude-sonnet-4-6`, a persisted CLI session binding, and compact `resumableText`.
Evidence after fix: first turn promptChars=1572, cacheWrite=7064; second resumed turn promptChars=181, cacheRead=10571, cacheWrite=105; same Claude session id reused (`56ea3749-0486-4e02-a5b0-09ad69badb23`).
Observed result after fix: resumed room events use the existing Claude CLI session and send only compact current-event context to the live CLI call.
What was not tested: live Telegram end-to-end on HamVerBot in this PR branch.
