### PR TITLE
fix(control-ui): respect chat history max chars config

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1317,6 +1317,43 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history without RPC maxChars uses gateway webchat history cap", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await writeGatewayConfig({
+        gateway: {
+          webchat: {
+            chatHistoryMaxChars: 64_000,
+          },
+        },
+      });
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      const longText = Array.from(
+        { length: 500 },
+        (_, index) => `SENTINEL-${String(index + 1).padStart(3, "0")} ${"x".repeat(80)}`,
+      ).join("\n");
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: longText }],
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const configBackedMessages = await fetchHistoryMessages(ws);
+      const configBackedSerialized = JSON.stringify(configBackedMessages);
+      expect(configBackedSerialized).toContain("SENTINEL-500");
+      expect(configBackedSerialized).not.toContain("...(truncated)...");
+
+      const explicitRpcMessages = await fetchHistoryMessages(ws, { maxChars: 4_000 });
+      const explicitRpcSerialized = JSON.stringify(explicitRpcMessages);
+      expect(explicitRpcSerialized).toContain("SENTINEL-001");
+      expect(explicitRpcSerialized).not.toContain("SENTINEL-050");
+      expect(explicitRpcSerialized).toContain("...(truncated)...");
+    });
+  });
+
   test("chat.history prefers RPC maxChars over config", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await writeGatewayConfig({

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -226,7 +226,6 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
       limit: 100,
-      maxChars: 4000,
     });
     expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
     const sessionsListPayload = findRequestPayload(
@@ -264,7 +263,6 @@ describe("refreshChat", () => {
       sessionKey: "global",
       agentId: "work",
       limit: 100,
-      maxChars: 4000,
     });
     const sessionsListPayload = findRequestPayload(
       request as unknown as MockCallSource,
@@ -291,7 +289,6 @@ describe("refreshChat", () => {
       sessionKey: "agent:work:main",
       agentId: "work",
       limit: 100,
-      maxChars: 4000,
     });
     const sessionsListPayload = findRequestPayload(
       request as unknown as MockCallSource,
@@ -323,7 +320,6 @@ describe("refreshChat", () => {
       sessionKey: "global",
       agentId: "ops",
       limit: 100,
-      maxChars: 4000,
     });
     const sessionsListPayload = findRequestPayload(
       request as unknown as MockCallSource,
@@ -1645,7 +1641,6 @@ describe("handleSendChat", () => {
       sessionKey: "global",
       agentId: "work",
       limit: 100,
-      maxChars: 4000,
     });
     expect(host.chatMessages).toStrictEqual([]);
   });

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1612,7 +1612,6 @@ describe("loadChatHistory retry handling", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
       limit: 100,
-      maxChars: 4000,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "visible answer" }] },

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -28,7 +28,6 @@ const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 const CHAT_HISTORY_REQUEST_LIMIT = 100;
-const CHAT_HISTORY_REQUEST_MAX_CHARS = 4_000;
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
@@ -421,7 +420,6 @@ export async function loadChatHistory(state: ChatState) {
           sessionKey,
           ...(requestAgentId ? { agentId: requestAgentId } : {}),
           limit: CHAT_HISTORY_REQUEST_LIMIT,
-          maxChars: CHAT_HISTORY_REQUEST_MAX_CHARS,
         });
         break;
       } catch (err) {


### PR DESCRIPTION
## Summary

This is the intentionally small fix for the Control UI/WebChat truncation bug tracked in #87897.

Control UI was sending every `chat.history` request with an explicit `maxChars: 4000`. The gateway correctly gives an RPC `maxChars` parameter precedence over `gateway.webchat.chatHistoryMaxChars`, so the documented/user-configured setting was ignored whenever history was loaded through Control UI.

This removes the hardcoded Control UI `maxChars` override so `chat.history` can fall back to the gateway's configured/default limit.

Fixes #87897.

## Notes

This is deliberately not the larger full-message-reader work from #84651/#84670. That UI can still be useful later, but it should not block the minimal config-precedence fix: if a user explicitly sets `gateway.webchat.chatHistoryMaxChars`, Control UI should respect it.

## Real behavior proof

- **Behavior or issue addressed**: Control UI/WebChat history reload should respect `gateway.webchat.chatHistoryMaxChars` instead of always forcing a 4,000-character `chat.history` cap from the client.
- **Real environment tested**: Local OpenClaw gateway from this PR branch (`toruviel/fix-control-ui-chat-history-maxchars`) on macOS arm64, started with `OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr-proof/config.json`, `OPENCLAW_STATE_DIR=/tmp/openclaw-pr-proof/state`, `OPENCLAW_SKIP_CHANNELS=1`, and `OPENCLAW_GATEWAY_PORT=19031`. Config set `gateway.webchat.chatHistoryMaxChars = 64000`; auth was disabled only in this throwaway local proof profile and Control UI device auth was disabled only to allow a scripted local Control UI WebSocket proof client.
- **Exact steps or command run after this patch**: Started the local gateway from the PR checkout, seeded the main session transcript with one assistant message containing 500 sentinel lines (~47k chars), then used a small Control UI WebSocket proof client to call `chat.history` twice: once as Control UI now does after this PR (`{ sessionKey, limit: 100 }`, no client `maxChars`) and once with the old explicit `{ maxChars: 4000 }` override for comparison.
- **Evidence after fix**: Terminal output from the live local gateway/proof client:

```text
sessionKey=agent:main:main
config_chatHistoryMaxChars=64000
noRpcMaxChars_len=47733
noRpcMaxChars_has_SENTINEL_001=true
noRpcMaxChars_has_SENTINEL_050=true
noRpcMaxChars_has_SENTINEL_400=true
noRpcMaxChars_has_SENTINEL_500=true
noRpcMaxChars_has_truncated=false
rpcMax4000_len=4296
rpcMax4000_has_SENTINEL_001=true
rpcMax4000_has_SENTINEL_050=false
rpcMax4000_has_SENTINEL_400=false
rpcMax4000_has_SENTINEL_500=false
rpcMax4000_has_truncated=true
```

- **Observed result after fix**: With no RPC `maxChars`, the live gateway returned the full seeded long history under the configured 64k cap and included sentinel lines through `SENTINEL-500` with no truncation marker. With the old explicit `maxChars: 4000` override, the same live gateway response was truncated around 4.3k JSON chars and only included the early sentinel lines. This confirms the PR restores the documented config/default path.
- **What was not tested**: A screenshot/recording of the browser-rendered bubble was not captured because the proof focuses on the exact Control UI request/projection boundary that caused the bug. Unit/UI tests and build were run separately.

## Testing

- `../node_modules/.bin/vitest run --config vitest.config.ts src/ui/controllers/chat.test.ts src/ui/app-chat.test.ts` from `ui/`
- `../node_modules/.bin/vite build` from `ui/`
- `git diff --check`
