### PR TITLE
feat(workboard): persist orchestration metadata in sqlite

### DIFF
--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -108,6 +108,18 @@ Workboard also exposes optional agent tools for board-aware workflows:
   final summaries, proof, artifacts, created-card manifests, and blocker
   reasons. Created-card manifests must reference cards linked back to the
   completed card, which keeps phantom children out of summaries.
+- `workboard_board_create`, `workboard_board_archive`, and
+  `workboard_board_delete` manage persisted board metadata such as display name,
+  description, archive state, and default workspace.
+- `workboard_runs` returns the persisted run-attempt history stored on a card.
+- `workboard_specify` turns a rough triage or backlog card into a clarified
+  `todo` card and records the specification summary on the card.
+- `workboard_decompose` fans a parent orchestration card into linked children,
+  inherits board and tenant metadata, and can complete the parent with a
+  created-card manifest.
+- `workboard_notify_subscribe`, `workboard_notify_list`, and
+  `workboard_notify_unsubscribe` manage notification subscriptions in plugin
+  state so operators and agents can discover durable notification intent.
 - `workboard_boards`, `workboard_stats`, `workboard_promote`,
   `workboard_reassign`, `workboard_reclaim`, `workboard_comment`,
   `workboard_proof`, `workboard_unblock`, and `workboard_dispatch` let an agent
@@ -119,6 +131,12 @@ Claimed cards reject agent-tool mutations from other agents unless the caller
 has the claim token returned by `workboard_claim`. Dashboard operators still use
 the normal Gateway RPC surface and can recover or reassign cards.
 
+Workboard stores all durable board data through the plugin SQLite key-value
+store. Cards live in `workboard.cards`, board metadata in `workboard.boards`,
+and notification subscriptions in `workboard.notify`. Run history, comments,
+proof, artifacts, diagnostics, dependencies, lifecycle events, and automation
+metadata stay on the card record so a card export remains self-contained.
+
 Workboard diagnostics are computed from local card metadata. The built-in checks
 flag assigned cards that wait too long, running cards without recent heartbeat,
 blocked cards that need attention, repeated failures, done cards without proof,
@@ -126,9 +144,9 @@ and running cards that only have a loose session link.
 
 Dispatch is intentionally Gateway-local. It does not spawn arbitrary operating
 system processes; normal OpenClaw sessions still own execution. A dispatch nudge
-promotes dependency-ready cards, records dispatch metadata on ready cards, and
-blocks expired claims or timed-out runs so operators can recover them from the
-board.
+promotes dependency-ready cards, records dispatch metadata on ready cards,
+blocks expired claims or timed-out runs, and leaves durable notification
+subscriptions for the caller that delivers notifications.
 
 ## Session lifecycle sync
 

--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -1,6 +1,6 @@
 import { definePluginEntry } from "./api.js";
 import { registerWorkboardGatewayMethods } from "./runtime-api.js";
-import { WorkboardStore, type PersistedWorkboardCard } from "./src/store.js";
+import { WorkboardStore } from "./src/store.js";
 import { createWorkboardTools } from "./src/tools.js";
 
 export default definePluginEntry({
@@ -8,9 +8,7 @@ export default definePluginEntry({
   name: "Workboard",
   description: "Dashboard workboard for agent-owned issues and sessions.",
   register(api) {
-    const store = WorkboardStore.open((options) =>
-      api.runtime.state.openKeyedStore<PersistedWorkboardCard>(options),
-    );
+    const store = WorkboardStore.open((options) => api.runtime.state.openKeyedStore(options));
     registerWorkboardGatewayMethods({ api, store });
     api.registerTool((context) => createWorkboardTools({ api, context, store }), {
       names: [
@@ -23,7 +21,16 @@ export default definePluginEntry({
         "workboard_complete",
         "workboard_block",
         "workboard_boards",
+        "workboard_board_create",
+        "workboard_board_archive",
+        "workboard_board_delete",
         "workboard_stats",
+        "workboard_runs",
+        "workboard_specify",
+        "workboard_decompose",
+        "workboard_notify_subscribe",
+        "workboard_notify_list",
+        "workboard_notify_unsubscribe",
         "workboard_promote",
         "workboard_reassign",
         "workboard_reclaim",

--- a/extensions/workboard/openclaw.plugin.json
+++ b/extensions/workboard/openclaw.plugin.json
@@ -17,7 +17,16 @@
       "workboard_complete",
       "workboard_block",
       "workboard_boards",
+      "workboard_board_create",
+      "workboard_board_archive",
+      "workboard_board_delete",
       "workboard_stats",
+      "workboard_runs",
+      "workboard_specify",
+      "workboard_decompose",
+      "workboard_notify_subscribe",
+      "workboard_notify_list",
+      "workboard_notify_unsubscribe",
       "workboard_promote",
       "workboard_reassign",
       "workboard_reclaim",
@@ -56,7 +65,34 @@
     "workboard_boards": {
       "optional": true
     },
+    "workboard_board_create": {
+      "optional": true
+    },
+    "workboard_board_archive": {
+      "optional": true
+    },
+    "workboard_board_delete": {
+      "optional": true
+    },
     "workboard_stats": {
+      "optional": true
+    },
+    "workboard_runs": {
+      "optional": true
+    },
+    "workboard_specify": {
+      "optional": true
+    },
+    "workboard_decompose": {
+      "optional": true
+    },
+    "workboard_notify_subscribe": {
+      "optional": true
+    },
+    "workboard_notify_list": {
+      "optional": true
+    },
+    "workboard_notify_unsubscribe": {
       "optional": true
     },
     "workboard_promote": {

--- a/extensions/workboard/src/gateway.test.ts
+++ b/extensions/workboard/src/gateway.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../api.js";
 import { registerWorkboardGatewayMethods } from "./gateway.js";
-import type { WorkboardKeyedStore } from "./store.js";
+import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./store.js";
 
-function createMemoryStore(): WorkboardKeyedStore {
-  const entries = new Map<string, Awaited<ReturnType<WorkboardKeyedStore["lookup"]>>>();
+function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
+  const entries = new Map<string, T>();
   return {
     async register(key, value) {
       entries.set(key, value);
@@ -68,7 +68,16 @@ describe("workboard gateway methods", () => {
       "workboard.cards.diagnostics.refresh",
       "workboard.cards.dispatch",
       "workboard.boards.list",
+      "workboard.boards.upsert",
+      "workboard.boards.archive",
+      "workboard.boards.delete",
       "workboard.cards.stats",
+      "workboard.cards.runs",
+      "workboard.cards.specify",
+      "workboard.cards.decompose",
+      "workboard.notifications.subscribe",
+      "workboard.notifications.list",
+      "workboard.notifications.delete",
       "workboard.cards.archive",
       "workboard.cards.export",
     ]);
@@ -79,6 +88,11 @@ describe("workboard gateway methods", () => {
     });
     expect(methods.get("workboard.cards.export")?.opts).toEqual({ scope: "operator.read" });
     expect(methods.get("workboard.cards.create")?.opts).toEqual({ scope: "operator.write" });
+    expect(methods.get("workboard.cards.runs")?.opts).toEqual({ scope: "operator.read" });
+    expect(methods.get("workboard.boards.upsert")?.opts).toEqual({ scope: "operator.write" });
+    expect(methods.get("workboard.notifications.list")?.opts).toEqual({
+      scope: "operator.read",
+    });
 
     const createHandler = methods.get("workboard.cards.create")?.handler;
     const listHandler = methods.get("workboard.cards.list")?.handler;

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -1,6 +1,6 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { OpenClawPluginApi } from "../api.js";
-import { WorkboardStore, type PersistedWorkboardCard } from "./store.js";
+import { WorkboardStore } from "./store.js";
 import { WORKBOARD_STATUSES, type WorkboardCard } from "./types.js";
 
 const READ_SCOPE = "operator.read" as const;
@@ -64,10 +64,7 @@ export function registerWorkboardGatewayMethods(params: {
 }) {
   const { api } = params;
   const store =
-    params.store ??
-    WorkboardStore.open((options) =>
-      api.runtime.state.openKeyedStore<PersistedWorkboardCard>(options),
-    );
+    params.store ?? WorkboardStore.open((options) => api.runtime.state.openKeyedStore(options));
 
   api.registerGatewayMethod(
     "workboard.cards.list",
@@ -408,6 +405,44 @@ export function registerWorkboardGatewayMethods(params: {
   );
 
   api.registerGatewayMethod(
+    "workboard.boards.upsert",
+    async ({ params: requestParams, respond }) => {
+      try {
+        respond(true, { board: await store.upsertBoard(requestParams) });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workboard.boards.archive",
+    async ({ params: requestParams, respond }) => {
+      try {
+        respond(true, {
+          board: await store.archiveBoard(requestParams.id, requestParams.archived),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workboard.boards.delete",
+    async ({ params: requestParams, respond }) => {
+      try {
+        respond(true, await store.deleteBoard(requestParams.id));
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
     "workboard.cards.stats",
     async ({ params: requestParams, respond }) => {
       try {
@@ -417,6 +452,85 @@ export function registerWorkboardGatewayMethods(params: {
       }
     },
     { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workboard.cards.runs",
+    async ({ params: requestParams, respond }) => {
+      try {
+        const result = await store.runs(readId(requestParams));
+        respond(true, { ...result, card: redactClaimToken(result.card) });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workboard.cards.specify",
+    async ({ params: requestParams, respond }) => {
+      try {
+        respond(true, {
+          card: redactClaimToken(await store.specify(readId(requestParams), requestParams, null)),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workboard.cards.decompose",
+    async ({ params: requestParams, respond }) => {
+      try {
+        const result = await store.decompose(readId(requestParams), requestParams, null);
+        respond(true, {
+          parent: redactClaimToken(result.parent),
+          children: result.children.map(redactClaimToken),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workboard.notifications.subscribe",
+    async ({ params: requestParams, respond }) => {
+      try {
+        respond(true, { subscription: await store.subscribeNotifications(requestParams) });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workboard.notifications.list",
+    async ({ params: requestParams, respond }) => {
+      try {
+        respond(true, await store.listNotificationSubscriptions(requestParams));
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workboard.notifications.delete",
+    async ({ params: requestParams, respond }) => {
+      try {
+        respond(true, await store.deleteNotificationSubscription(readId(requestParams)));
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
   );
 
   api.registerGatewayMethod(

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
-import { WorkboardStore, type WorkboardKeyedStore } from "./store.js";
+import {
+  WorkboardStore,
+  type PersistedWorkboardBoard,
+  type PersistedWorkboardCard,
+  type PersistedWorkboardNotificationSubscription,
+  type WorkboardKeyedStore,
+} from "./store.js";
 
-function createMemoryStore(options?: {
-  beforeRegister?: (
-    key: string,
-    value: NonNullable<Awaited<ReturnType<WorkboardKeyedStore["lookup"]>>>,
-  ) => Promise<void> | void;
-}): WorkboardKeyedStore {
-  const entries = new Map<string, Awaited<ReturnType<WorkboardKeyedStore["lookup"]>>>();
+function createMemoryStore<T = PersistedWorkboardCard>(options?: {
+  beforeRegister?: (key: string, value: T) => Promise<void> | void;
+}): WorkboardKeyedStore<T> {
+  const entries = new Map<string, T>();
   return {
     async register(key, value) {
       await options?.beforeRegister?.(key, value);
@@ -1479,6 +1482,282 @@ describe("WorkboardStore", () => {
     await expect(store.buildWorkerContext(crossBoardChild.id)).resolves.toContain(
       "Use board-scoped queues.",
     );
+  });
+
+  it("persists board metadata and notification subscriptions in separate stores", async () => {
+    const cards = createMemoryStore();
+    const boards = createMemoryStore<PersistedWorkboardBoard>();
+    const subscriptions = createMemoryStore<PersistedWorkboardNotificationSubscription>();
+    const store = new WorkboardStore(cards, { boards, subscriptions });
+
+    const board = await store.upsertBoard({
+      id: "ops",
+      name: "Ops",
+      description: "Operational work",
+      defaultWorkspace: { kind: "dir", path: "/tmp/openclaw-ops" },
+    });
+    const card = await store.create({ title: "Ops card", boardId: "ops" });
+    const subscription = await store.subscribeNotifications({
+      boardId: "ops",
+      cardId: card.id,
+      target: "session:operator",
+      eventKinds: ["completed", "failed"],
+    });
+
+    await expect(boards.lookup("ops")).resolves.toMatchObject({
+      version: 1,
+      board: { id: "ops", name: "Ops", description: "Operational work" },
+    });
+    await expect(subscriptions.lookup(subscription.id)).resolves.toMatchObject({
+      version: 1,
+      subscription: {
+        id: subscription.id,
+        boardId: "ops",
+        cardId: card.id,
+        target: "session:operator",
+        eventKinds: ["completed", "failed"],
+      },
+    });
+    await expect(cards.lookup("ops")).resolves.toBeUndefined();
+    expect(board.defaultWorkspace).toEqual({ kind: "dir", path: "/tmp/openclaw-ops" });
+    expect((await store.listBoards()).boards.find((item) => item.id === "ops")).toMatchObject({
+      name: "Ops",
+      total: 1,
+      active: 1,
+      byStatus: { todo: 1 },
+    });
+    await expect(store.listNotificationSubscriptions({ boardId: "ops" })).resolves.toMatchObject({
+      subscriptions: [expect.objectContaining({ id: subscription.id, cardId: card.id })],
+    });
+  });
+
+  it("deletes board notification subscriptions with empty board metadata", async () => {
+    const store = new WorkboardStore(createMemoryStore(), {
+      boards: createMemoryStore<PersistedWorkboardBoard>(),
+      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
+    });
+    await store.upsertBoard({ id: "ops", name: "Ops" });
+    await store.subscribeNotifications({
+      boardId: "ops",
+      target: "session:operator",
+      eventKinds: ["completed"],
+    });
+
+    await expect(store.deleteBoard("ops")).resolves.toEqual({ deleted: true });
+    await expect(store.listNotificationSubscriptions({ boardId: "ops" })).resolves.toEqual({
+      subscriptions: [],
+    });
+  });
+
+  it("deletes card notification subscriptions with the card", async () => {
+    const store = new WorkboardStore(createMemoryStore(), {
+      subscriptions: createMemoryStore<PersistedWorkboardNotificationSubscription>(),
+    });
+    const card = await store.create({ title: "Notify me" });
+    await store.subscribeNotifications({
+      cardId: card.id,
+      target: "session:operator",
+      eventKinds: ["completed"],
+    });
+
+    await expect(store.delete(card.id)).resolves.toEqual({ deleted: true });
+    await expect(store.listNotificationSubscriptions({ cardId: card.id })).resolves.toEqual({
+      subscriptions: [],
+    });
+  });
+
+  it("specifies and decomposes rough cards into linked children", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({
+      title: "Rough idea",
+      status: "triage",
+      boardId: "planning",
+      tenant: "qa",
+      idempotencyKey: "planning:rough",
+    });
+
+    const specified = await store.specify(parent.id, {
+      title: "Clarified plan",
+      notes: "Acceptance: two concrete follow-up cards.",
+      summary: "Clarified the outcome and acceptance criteria.",
+      labels: ["planning"],
+    });
+    expect(specified).toMatchObject({
+      title: "Clarified plan",
+      status: "todo",
+      notes: "Acceptance: two concrete follow-up cards.",
+      labels: ["planning"],
+      metadata: {
+        comments: [
+          expect.objectContaining({ body: "Clarified the outcome and acceptance criteria." }),
+        ],
+      },
+    });
+    expect(specified.events?.at(-1)).toMatchObject({ kind: "specified" });
+
+    const result = await store.decompose(specified.id, {
+      summary: "Split into implementation and review.",
+      children: [
+        { title: "Implement SQLite persistence", priority: "high" },
+        { title: "Review Workboard flows", agentId: "reviewer" },
+      ],
+    });
+
+    expect(result.parent.status).toBe("done");
+    expect(result.parent.events?.at(-1)).toMatchObject({ kind: "decomposed" });
+    expect(result.parent.metadata?.automation?.createdCardIds).toEqual(
+      result.children.map((child) => child.id),
+    );
+    expect(result.children).toEqual([
+      expect.objectContaining({
+        title: "Implement SQLite persistence",
+        priority: "high",
+        metadata: {
+          automation: expect.objectContaining({
+            boardId: "planning",
+            tenant: "qa",
+            createdByCardId: parent.id,
+            idempotencyKey: "planning:rough:child:1",
+          }),
+          links: expect.arrayContaining([
+            expect.objectContaining({ type: "parent", targetCardId: parent.id }),
+          ]),
+        },
+      }),
+      expect.objectContaining({
+        title: "Review Workboard flows",
+        agentId: "reviewer",
+      }),
+    ]);
+    await expect(store.runs(parent.id)).resolves.toMatchObject({
+      card: { id: parent.id },
+      attempts: [],
+    });
+  });
+
+  it("keeps specify as a todo-only clarification step", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({ title: "Rough idea", status: "triage" });
+    const blocked = await store.create({ title: "Blocked idea", status: "blocked" });
+
+    await expect(store.specify(card.id, { status: "done" })).rejects.toThrow(/must move to todo/);
+    await expect(store.specify(card.id, { status: "running" })).rejects.toThrow(
+      /must move to todo/,
+    );
+    await expect(store.specify(blocked.id, { title: "Specified" })).rejects.toThrow(
+      /only triage, backlog, or todo/,
+    );
+    await expect(store.specify(card.id, { title: "Specified" })).resolves.toMatchObject({
+      title: "Specified",
+      status: "todo",
+    });
+  });
+
+  it("rolls back newly created children when decomposition fails", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({ title: "Parent", status: "todo" });
+
+    await expect(
+      store.decompose(parent.id, {
+        children: [{ title: "First child" }, { notes: "Missing title" }],
+      }),
+    ).rejects.toThrow(/title is required/);
+
+    await expect(store.list()).resolves.toEqual([expect.objectContaining({ id: parent.id })]);
+    expect((await store.get(parent.id))?.metadata?.links).toBeUndefined();
+  });
+
+  it("rolls back links added to reused idempotent children when decomposition fails", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({ title: "Parent" });
+    const existingChild = await store.create({
+      title: "Existing child",
+      status: "ready",
+      idempotencyKey: "child-key",
+    });
+    await store.addLink(existingChild.id, { type: "relates_to", targetCardId: parent.id });
+
+    await expect(
+      store.decompose(parent.id, {
+        children: [
+          { title: "Existing child", idempotencyKey: "child-key" },
+          { notes: "Missing title" },
+        ],
+      }),
+    ).rejects.toThrow(/title is required/);
+
+    await expect(store.list()).resolves.toHaveLength(2);
+    expect((await store.get(parent.id))?.metadata?.links).toBeUndefined();
+    await expect(store.get(existingChild.id)).resolves.toMatchObject({
+      status: "ready",
+      metadata: {
+        links: [expect.objectContaining({ type: "relates_to", targetCardId: parent.id })],
+      },
+    });
+  });
+
+  it("preserves parent child links when decomposition leaves the parent open", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({ title: "Parent", status: "triage" });
+    await store.addLink(parent.id, { type: "relates_to", url: "https://example.com/context" });
+
+    const result = await store.decompose(parent.id, {
+      completeParent: false,
+      summary: "Split and keep parent open.",
+      children: [{ title: "Child" }],
+    });
+
+    expect(result.parent.status).toBe("todo");
+    expect(result.parent.metadata?.links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "relates_to", url: "https://example.com/context" }),
+        expect.objectContaining({ type: "child", targetCardId: result.children[0]?.id }),
+      ]),
+    );
+    await expect(
+      store.complete(parent.id, {
+        createdCardIds: result.children.map((child) => child.id),
+        summary: "Children recorded.",
+      }),
+    ).resolves.toMatchObject({ status: "done" });
+  });
+
+  it("omits derived child idempotency keys when the parent key is already at the limit", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({
+      title: "Parent",
+      idempotencyKey: "p".repeat(160),
+    });
+
+    const result = await store.decompose(parent.id, {
+      children: [{ title: "Child" }],
+    });
+
+    expect(result.children[0]?.metadata?.automation?.idempotencyKey).toBeUndefined();
+  });
+
+  it("links an idempotent existing child before completing decomposition", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const existingChild = await store.create({
+      title: "Existing child",
+      idempotencyKey: "child-key",
+    });
+    const parent = await store.create({ title: "Parent" });
+
+    const result = await store.decompose(parent.id, {
+      children: [{ title: "Ignored duplicate", idempotencyKey: "child-key" }],
+    });
+
+    expect(result.parent.status).toBe("done");
+    expect(result.children).toEqual([expect.objectContaining({ id: existingChild.id })]);
+    expect(result.parent.metadata?.automation?.createdCardIds).toEqual([existingChild.id]);
+    await expect(store.get(existingChild.id)).resolves.toMatchObject({
+      metadata: {
+        links: expect.arrayContaining([
+          expect.objectContaining({ type: "parent", targetCardId: parent.id }),
+        ]),
+      },
+    });
   });
 
   it("rejects invalid status values", async () => {

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -17,6 +17,7 @@ import {
   type WorkboardArtifact,
   type WorkboardAttemptStatus,
   type WorkboardAutomation,
+  type WorkboardBoardMetadata,
   type WorkboardClaim,
   type WorkboardComment,
   type WorkboardDiagnostic,
@@ -34,6 +35,7 @@ import {
   type WorkboardMetadata,
   type WorkboardNotification,
   type WorkboardNotificationKind,
+  type WorkboardNotificationSubscription,
   type WorkboardPriority,
   type WorkboardProof,
   type WorkboardProofStatus,
@@ -65,11 +67,21 @@ export type PersistedWorkboardCard = {
   card: WorkboardCard;
 };
 
-export type WorkboardKeyedStore = {
-  register(key: string, value: PersistedWorkboardCard): Promise<void>;
-  lookup(key: string): Promise<PersistedWorkboardCard | undefined>;
+export type PersistedWorkboardBoard = {
+  version: 1;
+  board: WorkboardBoardMetadata;
+};
+
+export type PersistedWorkboardNotificationSubscription = {
+  version: 1;
+  subscription: WorkboardNotificationSubscription;
+};
+
+export type WorkboardKeyedStore<T = PersistedWorkboardCard> = {
+  register(key: string, value: T): Promise<void>;
+  lookup(key: string): Promise<T | undefined>;
   delete(key: string): Promise<boolean>;
-  entries(): Promise<Array<{ key: string; value: PersistedWorkboardCard }>>;
+  entries(): Promise<Array<{ key: string; value: T }>>;
 };
 
 export type WorkboardCardInput = {
@@ -164,11 +176,17 @@ export type WorkboardListOptions = {
 };
 export type WorkboardBoardSummary = {
   id: string;
+  name?: string;
+  description?: string;
+  icon?: string;
+  color?: string;
+  defaultWorkspace?: WorkboardWorkspace;
   total: number;
   active: number;
   archived: number;
   byStatus: Partial<Record<WorkboardStatus, number>>;
   updatedAt?: number;
+  archivedAt?: number;
 };
 export type WorkboardStatsResult = WorkboardBoardSummary & {
   byAgent: Record<string, number>;
@@ -187,6 +205,38 @@ export type WorkboardReassignInput = {
 export type WorkboardReclaimInput = {
   status?: unknown;
   reason?: unknown;
+};
+export type WorkboardBoardInput = {
+  id?: unknown;
+  name?: unknown;
+  description?: unknown;
+  icon?: unknown;
+  color?: unknown;
+  defaultWorkspace?: unknown;
+  archived?: unknown;
+};
+export type WorkboardSpecifyInput = WorkboardCardPatch & {
+  summary?: unknown;
+};
+export type WorkboardDecomposeChildInput = WorkboardLinkedCreateInput & {
+  idempotencyKey?: unknown;
+};
+export type WorkboardDecomposeInput = {
+  summary?: unknown;
+  children?: unknown;
+  completeParent?: unknown;
+};
+export type WorkboardNotificationSubscribeInput = {
+  boardId?: unknown;
+  cardId?: unknown;
+  sessionKey?: unknown;
+  runId?: unknown;
+  target?: unknown;
+  eventKinds?: unknown;
+};
+export type WorkboardNotificationListOptions = {
+  boardId?: unknown;
+  cardId?: unknown;
 };
 export type WorkboardMutationScope = {
   ownerId?: unknown;
@@ -217,6 +267,99 @@ function normalizeBoardId(value: unknown, fallback?: string): string | undefined
     );
   }
   return boardId;
+}
+
+function normalizeBoardIdRequired(value: unknown): string {
+  return normalizeBoardId(value) ?? "default";
+}
+
+function normalizeBoardMetadata(
+  input: WorkboardBoardInput,
+  fallback: WorkboardBoardMetadata | undefined,
+  now = Date.now(),
+): WorkboardBoardMetadata {
+  const id = normalizeBoardId(input.id, fallback?.id) ?? "default";
+  const name = normalizeBoundedString(input.name, fallback?.name, 120, "board name");
+  const description = normalizeBoundedString(
+    input.description,
+    fallback?.description,
+    1000,
+    "board description",
+  );
+  const icon = normalizeBoundedString(input.icon, fallback?.icon, 40, "board icon");
+  const color = normalizeBoundedString(input.color, fallback?.color, 40, "board color");
+  const defaultWorkspace = Object.hasOwn(input, "defaultWorkspace")
+    ? normalizeWorkspace(input.defaultWorkspace, fallback?.defaultWorkspace)
+    : fallback?.defaultWorkspace;
+  const archivedAt = Object.hasOwn(input, "archived")
+    ? input.archived === false
+      ? undefined
+      : now
+    : fallback?.archivedAt;
+  return {
+    id,
+    ...(name ? { name } : {}),
+    ...(description ? { description } : {}),
+    ...(icon ? { icon } : {}),
+    ...(color ? { color } : {}),
+    ...(defaultWorkspace ? { defaultWorkspace } : {}),
+    createdAt: fallback?.createdAt ?? now,
+    updatedAt: now,
+    ...(archivedAt ? { archivedAt } : {}),
+  };
+}
+
+function normalizeNotificationKinds(value: unknown): WorkboardNotificationKind[] | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const entries = typeof value === "string" ? value.split(",") : Array.isArray(value) ? value : [];
+  const kinds: WorkboardNotificationKind[] = [];
+  for (const entry of entries) {
+    const kind = typeof entry === "string" ? entry.trim() : "";
+    if (!WORKBOARD_NOTIFICATION_KINDS.includes(kind as WorkboardNotificationKind)) {
+      throw new Error(
+        `notification kind must be one of: ${WORKBOARD_NOTIFICATION_KINDS.join(", ")}.`,
+      );
+    }
+    const notificationKind = kind as WorkboardNotificationKind;
+    if (!kinds.includes(notificationKind)) {
+      kinds.push(notificationKind);
+    }
+  }
+  return kinds.length ? kinds : undefined;
+}
+
+function normalizeNotificationSubscription(
+  input: WorkboardNotificationSubscribeInput,
+  fallback?: WorkboardNotificationSubscription,
+  now = Date.now(),
+): WorkboardNotificationSubscription {
+  const boardId = normalizeBoardId(input.boardId, fallback?.boardId) ?? "default";
+  const cardId = normalizeBoundedString(input.cardId, fallback?.cardId, 120, "card id");
+  const sessionKey = normalizeBoundedString(
+    input.sessionKey,
+    fallback?.sessionKey,
+    240,
+    "session key",
+  );
+  const runId = normalizeBoundedString(input.runId, fallback?.runId, 160, "run id");
+  const target = normalizeBoundedString(input.target, fallback?.target, 240, "notification target");
+  if (!cardId && !sessionKey && !runId && !target) {
+    throw new Error("notification subscription needs cardId, sessionKey, runId, or target.");
+  }
+  const eventKinds = normalizeNotificationKinds(input.eventKinds);
+  return {
+    id: fallback?.id ?? randomUUID(),
+    boardId,
+    ...(cardId ? { cardId } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(runId ? { runId } : {}),
+    ...(target ? { target } : {}),
+    ...(eventKinds ? { eventKinds } : {}),
+    createdAt: fallback?.createdAt ?? now,
+    updatedAt: now,
+  };
 }
 
 function normalizeTitle(value: unknown): string {
@@ -443,6 +586,17 @@ function normalizeAutomation(
     ...(lastDispatchAt ? { lastDispatchAt } : {}),
   });
   return Object.keys(next).length ? next : undefined;
+}
+
+function deriveChildIdempotencyKey(
+  parentKey: string | undefined,
+  index: number,
+): string | undefined {
+  if (!parentKey) {
+    return undefined;
+  }
+  const key = `${parentKey}:child:${index}`;
+  return key.length <= 160 ? key : undefined;
 }
 
 function normalizeExecutionEngine(
@@ -1723,8 +1877,22 @@ function closeRunningAttempts(
 
 export class WorkboardStore {
   private mutationQueue: Promise<unknown> = Promise.resolve();
+  private readonly boardStore: WorkboardKeyedStore<PersistedWorkboardBoard>;
+  private readonly subscriptionStore: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
 
-  constructor(private readonly store: WorkboardKeyedStore) {}
+  constructor(
+    private readonly store: WorkboardKeyedStore,
+    stores: {
+      boards?: WorkboardKeyedStore<PersistedWorkboardBoard>;
+      subscriptions?: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
+    } = {},
+  ) {
+    this.boardStore =
+      stores.boards ?? (store as unknown as WorkboardKeyedStore<PersistedWorkboardBoard>);
+    this.subscriptionStore =
+      stores.subscriptions ??
+      (store as unknown as WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>);
+  }
 
   private async enqueueMutation<T>(run: () => Promise<T>): Promise<T> {
     const result = this.mutationQueue.then(run, run);
@@ -1763,6 +1931,35 @@ export class WorkboardStore {
 
   async listBoards(): Promise<{ boards: WorkboardBoardSummary[] }> {
     const boards = new Map<string, WorkboardBoardSummary>();
+    for (const entry of await this.boardStore.entries()) {
+      if (entry.value?.version !== 1 || !entry.value.board?.id) {
+        continue;
+      }
+      const board = entry.value.board;
+      boards.set(board.id, {
+        id: board.id,
+        ...(board.name ? { name: board.name } : {}),
+        ...(board.description ? { description: board.description } : {}),
+        ...(board.icon ? { icon: board.icon } : {}),
+        ...(board.color ? { color: board.color } : {}),
+        ...(board.defaultWorkspace ? { defaultWorkspace: board.defaultWorkspace } : {}),
+        total: 0,
+        active: 0,
+        archived: 0,
+        byStatus: {},
+        updatedAt: board.updatedAt,
+        ...(board.archivedAt ? { archivedAt: board.archivedAt } : {}),
+      });
+    }
+    if (!boards.has("default")) {
+      boards.set("default", {
+        id: "default",
+        total: 0,
+        active: 0,
+        archived: 0,
+        byStatus: {},
+      });
+    }
     for (const card of await this.list()) {
       const boardId = cardBoardId(card);
       const summary =
@@ -1784,7 +1981,43 @@ export class WorkboardStore {
       summary.updatedAt = Math.max(summary.updatedAt ?? 0, card.updatedAt);
       boards.set(boardId, summary);
     }
-    return { boards: [...boards.values()].toSorted((a, b) => a.id.localeCompare(b.id)) };
+    return {
+      boards: [...boards.values()].toSorted((a, b) =>
+        a.id === "default" ? -1 : b.id === "default" ? 1 : a.id.localeCompare(b.id),
+      ),
+    };
+  }
+
+  async upsertBoard(input: WorkboardBoardInput): Promise<WorkboardBoardMetadata> {
+    return await this.enqueueMutation(async () => {
+      const id = normalizeBoardIdRequired(input.id);
+      const existing = await this.boardStore.lookup(id);
+      const board = normalizeBoardMetadata({ ...input, id }, existing?.board);
+      await this.boardStore.register(id, { version: 1, board });
+      return board;
+    });
+  }
+
+  async archiveBoard(id: unknown, archived: unknown = true): Promise<WorkboardBoardMetadata> {
+    return await this.upsertBoard({ id, archived });
+  }
+
+  async deleteBoard(id: unknown): Promise<{ deleted: boolean }> {
+    return await this.enqueueMutation(async () => {
+      const boardId = normalizeBoardIdRequired(id);
+      if (boardId === "default") {
+        throw new Error("default board cannot be deleted.");
+      }
+      if ((await this.list({ boardId })).length > 0) {
+        throw new Error("board still has cards; archive it or move/delete the cards first.");
+      }
+      for (const entry of await this.subscriptionStore.entries()) {
+        if (entry.value?.version === 1 && entry.value.subscription?.boardId === boardId) {
+          await this.subscriptionStore.delete(entry.key);
+        }
+      }
+      return { deleted: await this.boardStore.delete(boardId) };
+    });
   }
 
   async stats(input: WorkboardListOptions = {}, now = Date.now()): Promise<WorkboardStatsResult> {
@@ -1842,144 +2075,149 @@ export class WorkboardStore {
     input: WorkboardLinkedCreateInput,
     scope?: WorkboardMutationScope,
   ): Promise<WorkboardCard> {
-    return await this.enqueueMutation(async () => {
-      const now = Date.now();
-      const requestedStatus = normalizeStatus(input.status, "todo");
-      const cards = await this.list();
-      const parents = normalizeStringList(input.parents, "parents", 120);
-      const automation = normalizeAutomation({
-        tenant: input.tenant,
-        boardId: input.boardId,
-        createdByCardId: input.createdByCardId,
-        idempotencyKey: input.idempotencyKey,
-        skills: input.skills,
-        workspace: input.workspace,
-        maxRuntimeSeconds: input.maxRuntimeSeconds,
-        maxRetries: input.maxRetries,
-        scheduledAt: input.scheduledAt,
-      });
-      const heldBySchedule =
-        Boolean(automation?.scheduledAt && automation.scheduledAt > now) &&
-        requestedStatus !== "blocked";
-      let status: WorkboardStatus = heldBySchedule ? "scheduled" : requestedStatus;
-      let heldByDependencies = false;
-      if (parents.length > 0 && (status === "running" || status === "review")) {
-        status = "todo";
-        heldByDependencies = true;
-      }
-      if (automation?.idempotencyKey) {
-        const existing = cards.find(
-          (card) =>
-            card.metadata?.automation?.idempotencyKey === automation.idempotencyKey &&
-            card.metadata?.automation?.tenant === automation.tenant &&
-            cardBoardId(card) === (automation.boardId ?? "default"),
-        );
-        if (existing) {
-          return existing;
-        }
-      }
-      const cardsById = new Map(cards.map((card) => [card.id, card]));
-      const parentCards = parents.map((parentId) => {
-        const parent = cardsById.get(parentId);
-        if (!parent) {
-          throw new Error(`card not found: ${parentId}`);
-        }
-        return parent;
-      });
-      const childAutomation = normalizeAutomation(
-        {
-          ...automation,
-          createdByCardId:
-            automation?.createdByCardId ?? (parents.length === 1 ? parents[0] : undefined),
-        },
-        automation,
-      );
-      const normalizedPosition = normalizePosition(input.position, Number.NaN);
-      const position = Number.isFinite(normalizedPosition)
-        ? normalizedPosition
-        : Math.max(
-            0,
-            ...cards.filter((card) => card.status === status).map((card) => card.position),
-          ) + POSITION_STEP;
-      const notes = normalizeNotes(input.notes);
-      const agentId = normalizeOptionalString(input.agentId);
-      const sessionKey = normalizeOptionalString(input.sessionKey);
-      const runId = normalizeOptionalString(input.runId);
-      const taskId = normalizeOptionalString(input.taskId);
-      const sourceUrl = normalizeOptionalString(input.sourceUrl);
-      const normalizedExecution = normalizeExecution(input.execution);
-      const execution =
-        normalizedExecution?.status === "running" && (heldBySchedule || heldByDependencies)
-          ? undefined
-          : normalizedExecution;
-      const startedAt =
-        input.startedAt === undefined
-          ? status === "running"
-            ? now
-            : undefined
-          : normalizeTimestamp(input.startedAt, 0) || undefined;
-      const completedAt =
-        input.completedAt === undefined
-          ? status === "done"
-            ? now
-            : undefined
-          : normalizeTimestamp(input.completedAt, 0) || undefined;
-      const metadata = normalizeMetadata(
-        input.metadata,
-        {
-          templateId: normalizeTemplateId(input.templateId),
-          ...(childAutomation ? { automation: childAutomation } : {}),
-        },
-        { allowDependencyLinks: false },
-      );
-      const syncedMetadata = trimMetadataToBudget(
-        syncExecutionAttemptMetadata(metadata, execution, now),
-      );
-      let card: WorkboardCard = {
-        id: randomUUID(),
-        title: normalizeTitle(input.title),
-        status,
-        priority: normalizePriority(input.priority, "normal"),
-        labels: normalizeLabels(input.labels),
-        position,
-        createdAt: now,
-        updatedAt: now,
-        events: [
-          {
-            id: randomUUID(),
-            kind: "created",
-            at: now,
-            toStatus: status,
-            ...(sessionKey ? { sessionKey } : {}),
-            ...(runId ? { runId } : {}),
-          },
-        ],
-        ...(notes ? { notes } : {}),
-        ...(agentId ? { agentId } : {}),
-        ...(sessionKey ? { sessionKey } : {}),
-        ...(runId ? { runId } : {}),
-        ...(taskId ? { taskId } : {}),
-        ...(sourceUrl ? { sourceUrl } : {}),
-        ...(execution ? { execution } : {}),
-        ...(startedAt ? { startedAt } : {}),
-        ...(completedAt ? { completedAt } : {}),
-        ...(!metadataIsEmpty(syncedMetadata) ? { metadata: syncedMetadata } : {}),
-      };
-      await this.store.register(card.id, { version: 1, card });
-      try {
-        for (const parent of parentCards) {
-          card = await this.linkCardsDirect(parent.id, card.id, now, {
-            allowStatusOnlyActiveChild: true,
-            scope,
-          });
-        }
-      } catch (error) {
-        await this.store.delete(card.id);
-        await this.removeReferencesToCard(card.id);
-        throw error;
-      }
-      return card;
+    return await this.enqueueMutation(async () => await this.createDirect(input, scope));
+  }
+
+  private async createDirect(
+    input: WorkboardLinkedCreateInput,
+    scope?: WorkboardMutationScope,
+  ): Promise<WorkboardCard> {
+    const now = Date.now();
+    const requestedStatus = normalizeStatus(input.status, "todo");
+    const cards = await this.list();
+    const parents = normalizeStringList(input.parents, "parents", 120);
+    const automation = normalizeAutomation({
+      tenant: input.tenant,
+      boardId: input.boardId,
+      createdByCardId: input.createdByCardId,
+      idempotencyKey: input.idempotencyKey,
+      skills: input.skills,
+      workspace: input.workspace,
+      maxRuntimeSeconds: input.maxRuntimeSeconds,
+      maxRetries: input.maxRetries,
+      scheduledAt: input.scheduledAt,
     });
+    const heldBySchedule =
+      Boolean(automation?.scheduledAt && automation.scheduledAt > now) &&
+      requestedStatus !== "blocked";
+    let status: WorkboardStatus = heldBySchedule ? "scheduled" : requestedStatus;
+    let heldByDependencies = false;
+    if (parents.length > 0 && (status === "running" || status === "review")) {
+      status = "todo";
+      heldByDependencies = true;
+    }
+    if (automation?.idempotencyKey) {
+      const existing = cards.find(
+        (card) =>
+          card.metadata?.automation?.idempotencyKey === automation.idempotencyKey &&
+          card.metadata?.automation?.tenant === automation.tenant &&
+          cardBoardId(card) === (automation.boardId ?? "default"),
+      );
+      if (existing) {
+        return existing;
+      }
+    }
+    const cardsById = new Map(cards.map((card) => [card.id, card]));
+    const parentCards = parents.map((parentId) => {
+      const parent = cardsById.get(parentId);
+      if (!parent) {
+        throw new Error(`card not found: ${parentId}`);
+      }
+      return parent;
+    });
+    const childAutomation = normalizeAutomation(
+      {
+        ...automation,
+        createdByCardId:
+          automation?.createdByCardId ?? (parents.length === 1 ? parents[0] : undefined),
+      },
+      automation,
+    );
+    const normalizedPosition = normalizePosition(input.position, Number.NaN);
+    const position = Number.isFinite(normalizedPosition)
+      ? normalizedPosition
+      : Math.max(
+          0,
+          ...cards.filter((card) => card.status === status).map((card) => card.position),
+        ) + POSITION_STEP;
+    const notes = normalizeNotes(input.notes);
+    const agentId = normalizeOptionalString(input.agentId);
+    const sessionKey = normalizeOptionalString(input.sessionKey);
+    const runId = normalizeOptionalString(input.runId);
+    const taskId = normalizeOptionalString(input.taskId);
+    const sourceUrl = normalizeOptionalString(input.sourceUrl);
+    const normalizedExecution = normalizeExecution(input.execution);
+    const execution =
+      normalizedExecution?.status === "running" && (heldBySchedule || heldByDependencies)
+        ? undefined
+        : normalizedExecution;
+    const startedAt =
+      input.startedAt === undefined
+        ? status === "running"
+          ? now
+          : undefined
+        : normalizeTimestamp(input.startedAt, 0) || undefined;
+    const completedAt =
+      input.completedAt === undefined
+        ? status === "done"
+          ? now
+          : undefined
+        : normalizeTimestamp(input.completedAt, 0) || undefined;
+    const metadata = normalizeMetadata(
+      input.metadata,
+      {
+        templateId: normalizeTemplateId(input.templateId),
+        ...(childAutomation ? { automation: childAutomation } : {}),
+      },
+      { allowDependencyLinks: false },
+    );
+    const syncedMetadata = trimMetadataToBudget(
+      syncExecutionAttemptMetadata(metadata, execution, now),
+    );
+    let card: WorkboardCard = {
+      id: randomUUID(),
+      title: normalizeTitle(input.title),
+      status,
+      priority: normalizePriority(input.priority, "normal"),
+      labels: normalizeLabels(input.labels),
+      position,
+      createdAt: now,
+      updatedAt: now,
+      events: [
+        {
+          id: randomUUID(),
+          kind: "created",
+          at: now,
+          toStatus: status,
+          ...(sessionKey ? { sessionKey } : {}),
+          ...(runId ? { runId } : {}),
+        },
+      ],
+      ...(notes ? { notes } : {}),
+      ...(agentId ? { agentId } : {}),
+      ...(sessionKey ? { sessionKey } : {}),
+      ...(runId ? { runId } : {}),
+      ...(taskId ? { taskId } : {}),
+      ...(sourceUrl ? { sourceUrl } : {}),
+      ...(execution ? { execution } : {}),
+      ...(startedAt ? { startedAt } : {}),
+      ...(completedAt ? { completedAt } : {}),
+      ...(!metadataIsEmpty(syncedMetadata) ? { metadata: syncedMetadata } : {}),
+    };
+    await this.store.register(card.id, { version: 1, card });
+    try {
+      for (const parent of parentCards) {
+        card = await this.linkCardsDirect(parent.id, card.id, now, {
+          allowStatusOnlyActiveChild: true,
+          scope,
+        });
+      }
+    } catch (error) {
+      await this.store.delete(card.id);
+      await this.removeReferencesToCard(card.id);
+      throw error;
+    }
+    return card;
   }
 
   async update(id: string, patch: WorkboardCardPatch): Promise<WorkboardCard> {
@@ -2144,15 +2382,22 @@ export class WorkboardStore {
   }
 
   async delete(id: string): Promise<{ deleted: boolean }> {
-    return await this.enqueueMutation(async () => {
-      const cardId = id.trim();
-      const deleted = await this.store.delete(cardId);
-      if (!deleted) {
-        return { deleted: false };
+    return await this.enqueueMutation(async () => await this.deleteDirect(id));
+  }
+
+  private async deleteDirect(id: string): Promise<{ deleted: boolean }> {
+    const cardId = id.trim();
+    const deleted = await this.store.delete(cardId);
+    if (!deleted) {
+      return { deleted: false };
+    }
+    for (const entry of await this.subscriptionStore.entries()) {
+      if (entry.value?.version === 1 && entry.value.subscription?.cardId === cardId) {
+        await this.subscriptionStore.delete(entry.key);
       }
-      await this.removeReferencesToCard(cardId);
-      return { deleted: true };
-    });
+    }
+    await this.removeReferencesToCard(cardId);
+    return { deleted: true };
   }
 
   async addComment(
@@ -2582,89 +2827,93 @@ export class WorkboardStore {
     input: WorkboardCompleteInput = {},
     scope: WorkboardMutationScope | null | undefined = input,
   ): Promise<WorkboardCard> {
-    return await this.enqueueMutation(async () => {
-      const existing = await this.get(id);
-      if (!existing) {
-        throw new Error(`card not found: ${id}`);
+    return await this.enqueueMutation(async () => await this.completeDirect(id, input, scope));
+  }
+
+  private async completeDirect(
+    id: string,
+    input: WorkboardCompleteInput = {},
+    scope: WorkboardMutationScope | null | undefined = input,
+  ): Promise<WorkboardCard> {
+    const existing = await this.get(id);
+    if (!existing) {
+      throw new Error(`card not found: ${id}`);
+    }
+    assertCanMutateClaimedCard(existing, scope === null ? undefined : scope);
+    const now = Date.now();
+    const createdCardIds = normalizeStringList(input.createdCardIds, "created card ids", 120);
+    const childIds = cardChildIds(existing);
+    for (const createdCardId of createdCardIds) {
+      const createdCard = await this.get(createdCardId);
+      if (!createdCard) {
+        throw new Error(`created card not found: ${createdCardId}`);
       }
-      assertCanMutateClaimedCard(existing, scope === null ? undefined : scope);
-      const now = Date.now();
-      const createdCardIds = normalizeStringList(input.createdCardIds, "created card ids", 120);
-      const childIds = cardChildIds(existing);
-      for (const createdCardId of createdCardIds) {
-        const createdCard = await this.get(createdCardId);
-        if (!createdCard) {
-          throw new Error(`created card not found: ${createdCardId}`);
-        }
-        const linkedFromParent =
-          childIds.includes(createdCardId) && cardParentIds(createdCard).includes(existing.id);
-        if (!linkedFromParent) {
-          throw new Error(`created card is not linked to this card: ${createdCardId}`);
-        }
+      const linkedFromParent =
+        childIds.includes(createdCardId) && cardParentIds(createdCard).includes(existing.id);
+      if (!linkedFromParent) {
+        throw new Error(`created card is not linked to this card: ${createdCardId}`);
       }
-      const summary = normalizeBoundedString(input.summary, undefined, 2000, "summary");
-      const proofInput =
-        input.proof && typeof input.proof === "object" && !Array.isArray(input.proof)
-          ? (input.proof as WorkboardProofInput)
-          : undefined;
-      const proof = proofInput ? normalizeProofInput(proofInput, now) : undefined;
-      const artifacts = Array.isArray(input.artifacts)
-        ? input.artifacts
-            .map((artifact) => normalizeArtifact({ ...artifact, createdAt: now }))
-            .filter((artifact): artifact is WorkboardArtifact => artifact !== null)
-            .slice(-MAX_CARD_ARTIFACTS)
-        : [];
-      const metadata = clearDiagnostics(existing.metadata, ["missing_proof"]);
-      const notification: WorkboardNotification = {
-        id: randomUUID(),
-        kind: "completed",
-        createdAt: now,
-        message: capText(summary, 240) ?? "Workboard card completed.",
-        ...(cardSessionKey(existing) ? { sessionKey: cardSessionKey(existing) } : {}),
-        ...(cardRunId(existing) ? { runId: cardRunId(existing) } : {}),
-      };
-      const execution =
-        existing.execution?.status === "running"
-          ? { ...existing.execution, status: "done" as const, updatedAt: now }
-          : existing.execution;
-      return await this.updateCard(
-        id,
-        {
-          status: "done",
-          ...(execution ? { execution } : {}),
-          metadata: {
-            ...metadata,
-            claim: undefined,
-            attempts: closeRunningAttempts(metadata.attempts, now, "succeeded"),
-            failureCount: 0,
-            automation: normalizeAutomation(
-              {
-                ...metadata.automation,
-                summary,
-                createdCardIds,
-              },
-              metadata.automation,
-            ),
-            comments: summary
-              ? [
-                  ...(metadata.comments ?? []),
-                  { id: randomUUID(), body: summary, createdAt: now },
-                ].slice(-MAX_CARD_COMMENTS)
-              : metadata.comments,
-            proof: proof
-              ? [...(metadata.proof ?? []), proof].slice(-MAX_CARD_PROOF)
-              : metadata.proof,
-            artifacts: artifacts.length
-              ? [...(metadata.artifacts ?? []), ...artifacts].slice(-MAX_CARD_ARTIFACTS)
-              : metadata.artifacts,
-            notifications: [...(metadata.notifications ?? []), notification].slice(
-              -MAX_CARD_NOTIFICATIONS,
-            ),
-          },
+    }
+    const summary = normalizeBoundedString(input.summary, undefined, 2000, "summary");
+    const proofInput =
+      input.proof && typeof input.proof === "object" && !Array.isArray(input.proof)
+        ? (input.proof as WorkboardProofInput)
+        : undefined;
+    const proof = proofInput ? normalizeProofInput(proofInput, now) : undefined;
+    const artifacts = Array.isArray(input.artifacts)
+      ? input.artifacts
+          .map((artifact) => normalizeArtifact({ ...artifact, createdAt: now }))
+          .filter((artifact): artifact is WorkboardArtifact => artifact !== null)
+          .slice(-MAX_CARD_ARTIFACTS)
+      : [];
+    const metadata = clearDiagnostics(existing.metadata, ["missing_proof"]);
+    const notification: WorkboardNotification = {
+      id: randomUUID(),
+      kind: "completed",
+      createdAt: now,
+      message: capText(summary, 240) ?? "Workboard card completed.",
+      ...(cardSessionKey(existing) ? { sessionKey: cardSessionKey(existing) } : {}),
+      ...(cardRunId(existing) ? { runId: cardRunId(existing) } : {}),
+    };
+    const execution =
+      existing.execution?.status === "running"
+        ? { ...existing.execution, status: "done" as const, updatedAt: now }
+        : existing.execution;
+    return await this.updateCard(
+      id,
+      {
+        status: "done",
+        ...(execution ? { execution } : {}),
+        metadata: {
+          ...metadata,
+          claim: undefined,
+          attempts: closeRunningAttempts(metadata.attempts, now, "succeeded"),
+          failureCount: 0,
+          automation: normalizeAutomation(
+            {
+              ...metadata.automation,
+              summary,
+              createdCardIds,
+            },
+            metadata.automation,
+          ),
+          comments: summary
+            ? [
+                ...(metadata.comments ?? []),
+                { id: randomUUID(), body: summary, createdAt: now },
+              ].slice(-MAX_CARD_COMMENTS)
+            : metadata.comments,
+          proof: proof ? [...(metadata.proof ?? []), proof].slice(-MAX_CARD_PROOF) : metadata.proof,
+          artifacts: artifacts.length
+            ? [...(metadata.artifacts ?? []), ...artifacts].slice(-MAX_CARD_ARTIFACTS)
+            : metadata.artifacts,
+          notifications: [...(metadata.notifications ?? []), notification].slice(
+            -MAX_CARD_NOTIFICATIONS,
+          ),
         },
-        { enforceStatusHolds: true },
-      );
-    });
+      },
+      { enforceStatusHolds: true },
+    );
   }
 
   async block(
@@ -2837,6 +3086,213 @@ export class WorkboardStore {
       );
       return await this.promoteDependencyReady(reclaimed.id, now);
     });
+  }
+
+  async runs(id: string): Promise<{ card: WorkboardCard; attempts: WorkboardRunAttempt[] }> {
+    const card = await this.get(id);
+    if (!card) {
+      throw new Error(`card not found: ${id}`);
+    }
+    return { card, attempts: card.metadata?.attempts ?? [] };
+  }
+
+  async specify(
+    id: string,
+    input: WorkboardSpecifyInput = {},
+    scope?: WorkboardMutationScope | null,
+  ): Promise<WorkboardCard> {
+    return await this.enqueueMutation(async () => {
+      const existing = await this.get(id);
+      if (!existing) {
+        throw new Error(`card not found: ${id}`);
+      }
+      assertCanMutateClaimedCard(existing, scope === null ? undefined : scope);
+      if (
+        existing.status !== "triage" &&
+        existing.status !== "backlog" &&
+        existing.status !== "todo"
+      ) {
+        throw new Error("only triage, backlog, or todo cards can be specified.");
+      }
+      const requestedStatus = normalizeStatus(input.status, "todo");
+      if (requestedStatus !== "todo") {
+        throw new Error("specified cards must move to todo.");
+      }
+      const now = Date.now();
+      const summary = normalizeBoundedString(input.summary, undefined, 2000, "spec summary");
+      const metadata = {
+        ...existing.metadata,
+        comments: summary
+          ? [
+              ...(existing.metadata?.comments ?? []),
+              { id: randomUUID(), body: summary, createdAt: now },
+            ].slice(-MAX_CARD_COMMENTS)
+          : existing.metadata?.comments,
+        automation: normalizeAutomation(
+          {
+            ...existing.metadata?.automation,
+            summary: summary ?? existing.metadata?.automation?.summary,
+          },
+          existing.metadata?.automation,
+        ),
+      };
+      const { summary: _summary, status: _status, ...cardPatch } = input;
+      const updated = await this.updateCard(
+        id,
+        {
+          ...cardPatch,
+          status: "todo",
+          metadata,
+        },
+        { enforceStatusHolds: true },
+      );
+      const specified = {
+        ...updated,
+        events: appendEvent(updated, { kind: "specified" }, now),
+      };
+      await this.store.register(specified.id, { version: 1, card: specified });
+      return specified;
+    });
+  }
+
+  async decompose(
+    id: string,
+    input: WorkboardDecomposeInput = {},
+    scope?: WorkboardMutationScope | null,
+  ): Promise<{ parent: WorkboardCard; children: WorkboardCard[] }> {
+    return await this.enqueueMutation(async () => {
+      const parent = await this.get(id);
+      if (!parent) {
+        throw new Error(`card not found: ${id}`);
+      }
+      assertCanMutateClaimedCard(parent, scope === null ? undefined : scope);
+      const childrenInput = Array.isArray(input.children) ? input.children : [];
+      if (childrenInput.length === 0) {
+        throw new Error("children are required.");
+      }
+      if (childrenInput.length > 20) {
+        throw new Error("at most 20 children can be created at once.");
+      }
+      const parentAutomation = parent.metadata?.automation;
+      const existingCardIds = new Set((await this.list()).map((card) => card.id));
+      const children: WorkboardCard[] = [];
+      const reusedChildSnapshots = new Map<string, WorkboardCard>();
+      try {
+        for (const rawChild of childrenInput) {
+          if (!rawChild || typeof rawChild !== "object" || Array.isArray(rawChild)) {
+            throw new Error("children must be objects.");
+          }
+          const child = rawChild as WorkboardDecomposeChildInput;
+          const created = await this.createDirect(
+            {
+              ...child,
+              parents: [parent.id],
+              boardId: child.boardId ?? parentAutomation?.boardId,
+              tenant: child.tenant ?? parentAutomation?.tenant,
+              createdByCardId: parent.id,
+              idempotencyKey:
+                child.idempotencyKey ??
+                deriveChildIdempotencyKey(parentAutomation?.idempotencyKey, children.length + 1),
+            },
+            scope === null ? undefined : scope,
+          );
+          const reusedUnlinkedChild =
+            existingCardIds.has(created.id) && !cardParentIds(created).includes(parent.id);
+          if (reusedUnlinkedChild) {
+            reusedChildSnapshots.set(created.id, created);
+          }
+          children.push(
+            cardParentIds(created).includes(parent.id)
+              ? created
+              : await this.linkCardsDirect(parent.id, created.id, Date.now(), {
+                  allowStatusOnlyActiveChild: true,
+                  scope: scope === null ? undefined : scope,
+                }),
+          );
+        }
+        const summary = normalizeBoundedString(input.summary, undefined, 2000, "decompose summary");
+        const completeParent = input.completeParent !== false;
+        const updatedParent = completeParent
+          ? await this.completeDirect(
+              parent.id,
+              { summary, createdCardIds: children.map((child) => child.id) },
+              scope,
+            )
+          : await (async () => {
+              const latestParent = (await this.get(parent.id)) ?? parent;
+              return await this.updateCard(
+                parent.id,
+                {
+                  status:
+                    latestParent.status === "triage" || latestParent.status === "backlog"
+                      ? "todo"
+                      : latestParent.status,
+                  metadata: {
+                    ...latestParent.metadata,
+                    automation: normalizeAutomation(
+                      {
+                        ...latestParent.metadata?.automation,
+                        summary,
+                        createdCardIds: children.map((child) => child.id),
+                      },
+                      latestParent.metadata?.automation,
+                    ),
+                  },
+                },
+                { enforceStatusHolds: true },
+              );
+            })();
+        const decomposedParent = {
+          ...updatedParent,
+          events: appendEvent(updatedParent, { kind: "decomposed" }),
+        };
+        await this.store.register(decomposedParent.id, { version: 1, card: decomposedParent });
+        return { parent: decomposedParent, children };
+      } catch (error) {
+        for (const child of children.toReversed()) {
+          if (!existingCardIds.has(child.id)) {
+            await this.deleteDirect(child.id);
+          }
+        }
+        for (const child of reusedChildSnapshots.values()) {
+          await this.store.register(child.id, { version: 1, card: child });
+        }
+        await this.store.register(parent.id, { version: 1, card: parent });
+        throw error;
+      }
+    });
+  }
+
+  async subscribeNotifications(
+    input: WorkboardNotificationSubscribeInput,
+  ): Promise<WorkboardNotificationSubscription> {
+    return await this.enqueueMutation(async () => {
+      const subscription = normalizeNotificationSubscription(input);
+      await this.subscriptionStore.register(subscription.id, { version: 1, subscription });
+      return subscription;
+    });
+  }
+
+  async listNotificationSubscriptions(
+    input: WorkboardNotificationListOptions = {},
+  ): Promise<{ subscriptions: WorkboardNotificationSubscription[] }> {
+    const boardId = normalizeBoardId(input.boardId);
+    const cardId = normalizeBoundedString(input.cardId, undefined, 120, "card id");
+    const subscriptions = (await this.subscriptionStore.entries())
+      .map((entry) => entry.value)
+      .filter(
+        (entry): entry is PersistedWorkboardNotificationSubscription =>
+          entry?.version === 1 && Boolean(entry.subscription?.id),
+      )
+      .map((entry) => entry.subscription)
+      .filter((subscription) => !boardId || subscription.boardId === boardId)
+      .filter((subscription) => !cardId || subscription.cardId === cardId)
+      .toSorted((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
+    return { subscriptions };
+  }
+
+  async deleteNotificationSubscription(id: string): Promise<{ deleted: boolean }> {
+    return { deleted: await this.subscriptionStore.delete(id.trim()) };
   }
 
   async dispatch(now = Date.now()): Promise<WorkboardDispatchResult> {
@@ -3016,13 +3472,26 @@ export class WorkboardStore {
   }
 
   static open(
-    openKeyedStore: (options: { namespace: string; maxEntries: number }) => WorkboardKeyedStore,
+    openKeyedStore: (options: {
+      namespace: string;
+      maxEntries: number;
+    }) => WorkboardKeyedStore<unknown>,
   ) {
     return new WorkboardStore(
       openKeyedStore({
         namespace: "workboard.cards",
         maxEntries: MAX_CARDS,
-      }),
+      }) as WorkboardKeyedStore,
+      {
+        boards: openKeyedStore({
+          namespace: "workboard.boards",
+          maxEntries: 200,
+        }) as WorkboardKeyedStore<PersistedWorkboardBoard>,
+        subscriptions: openKeyedStore({
+          namespace: "workboard.notify",
+          maxEntries: 2000,
+        }) as WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>,
+      },
     );
   }
 }

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../api.js";
-import { WorkboardStore, type WorkboardKeyedStore } from "./store.js";
+import { WorkboardStore, type PersistedWorkboardCard, type WorkboardKeyedStore } from "./store.js";
 import { createWorkboardTools } from "./tools.js";
 
-function createMemoryStore(): WorkboardKeyedStore {
-  const entries = new Map<string, Awaited<ReturnType<WorkboardKeyedStore["lookup"]>>>();
+function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
+  const entries = new Map<string, T>();
   return {
     async register(key, value) {
       entries.set(key, value);
@@ -329,5 +329,89 @@ describe("workboard tools", () => {
     }>;
     expect(promoted).toEqual([expect.objectContaining({ id: card.id })]);
     expect(promoted[0]?.metadata?.claim?.token).toBe("[redacted]");
+  });
+
+  it("exposes board lifecycle, decomposition, runs, and notification tools", async () => {
+    const keyed = createMemoryStore();
+    const api = {
+      runtime: {
+        state: {
+          openKeyedStore: vi.fn(() => keyed),
+        },
+      },
+    } as unknown as OpenClawPluginApi;
+    const store = new WorkboardStore(keyed);
+    const tools = new Map(
+      createWorkboardTools({
+        api,
+        store,
+        context: { agentId: "main" } as never,
+      }).map((tool) => [tool.name, tool]),
+    );
+
+    const boardPayload = readPayload(
+      await tools.get("workboard_board_create")?.execute("call-board", {
+        id: "planning",
+        name: "Planning",
+      }),
+    );
+    expect(boardPayload.board).toMatchObject({ id: "planning", name: "Planning" });
+
+    const parent = await store.create({
+      title: "Rough",
+      status: "triage",
+      boardId: "planning",
+      idempotencyKey: "planning:rough",
+    });
+    const specified = readPayload(
+      await tools.get("workboard_specify")?.execute("call-specify", {
+        id: parent.id,
+        title: "Specified",
+        summary: "Ready to split.",
+      }),
+    );
+    expect(specified.card).toMatchObject({ title: "Specified", status: "todo" });
+
+    const decomposed = readPayload(
+      await tools.get("workboard_decompose")?.execute("call-decompose", {
+        id: parent.id,
+        summary: "Split.",
+        children: [{ title: "Child A" }, { title: "Child B" }],
+      }),
+    );
+    expect(decomposed.parent).toMatchObject({ status: "done" });
+    expect(decomposed.children).toEqual([
+      expect.objectContaining({ title: "Child A" }),
+      expect.objectContaining({ title: "Child B" }),
+    ]);
+
+    const runs = readPayload(
+      await tools.get("workboard_runs")?.execute("call-runs", { id: parent.id }),
+    );
+    expect(runs.attempts).toEqual([]);
+
+    const subscription = readPayload(
+      await tools.get("workboard_notify_subscribe")?.execute("call-subscribe", {
+        boardId: "planning",
+        cardId: parent.id,
+        target: "session:operator",
+        eventKinds: ["completed"],
+      }),
+    );
+    expect(subscription.subscription).toMatchObject({
+      boardId: "planning",
+      cardId: parent.id,
+      target: "session:operator",
+      eventKinds: ["completed"],
+    });
+
+    const list = readPayload(
+      await tools.get("workboard_notify_list")?.execute("call-notify-list", {
+        boardId: "planning",
+      }),
+    );
+    expect(list.subscriptions).toEqual([
+      expect.objectContaining({ cardId: parent.id, target: "session:operator" }),
+    ]);
   });
 });

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -2,7 +2,7 @@ import { jsonResult, readStringParam } from "openclaw/plugin-sdk/core";
 import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { Type } from "typebox";
-import { WorkboardStore, type PersistedWorkboardCard } from "./store.js";
+import { WorkboardStore } from "./store.js";
 import type { WorkboardCard } from "./types.js";
 
 function contextOwner(ctx: OpenClawPluginToolContext | undefined): string {
@@ -142,9 +142,7 @@ export function createWorkboardTools(params: {
 }): AnyAgentTool[] {
   const store =
     params.store ??
-    WorkboardStore.open((options) =>
-      params.api.runtime.state.openKeyedStore<PersistedWorkboardCard>(options),
-    );
+    WorkboardStore.open((options) => params.api.runtime.state.openKeyedStore(options));
   const ownerId = contextOwner(params.context);
   return [
     {
@@ -540,6 +538,60 @@ export function createWorkboardTools(params: {
       execute: async () => jsonResult(await store.listBoards()),
     },
     {
+      name: "workboard_board_create",
+      label: "Workboard Board Create",
+      description: "Create or update a Workboard board namespace with persisted SQLite metadata.",
+      parameters: Type.Object(
+        {
+          id: Type.String({ description: "Board id." }),
+          name: Type.Optional(Type.String({ description: "Display name." })),
+          description: Type.Optional(Type.String({ description: "Board description." })),
+          icon: Type.Optional(Type.String({ description: "Short icon or label." })),
+          color: Type.Optional(Type.String({ description: "Display color token." })),
+          defaultWorkspace: Type.Optional(
+            Type.Object(
+              {
+                kind: Type.String({ description: "scratch, dir, or worktree." }),
+                path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
+                branch: Type.Optional(Type.String({ description: "Suggested branch." })),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) =>
+        jsonResult({ board: await store.upsertBoard(rawParams as Record<string, unknown>) }),
+    },
+    {
+      name: "workboard_board_archive",
+      label: "Workboard Board Archive",
+      description: "Archive or restore persisted Workboard board metadata.",
+      parameters: Type.Object(
+        {
+          id: Type.String({ description: "Board id." }),
+          archived: Type.Optional(Type.Boolean({ description: "Archive when true." })),
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) => {
+        const record = rawParams as Record<string, unknown>;
+        return jsonResult({ board: await store.archiveBoard(record.id, record.archived) });
+      },
+    },
+    {
+      name: "workboard_board_delete",
+      label: "Workboard Board Delete",
+      description: "Delete an empty non-default Workboard board metadata record.",
+      parameters: Type.Object(
+        { id: Type.String({ description: "Board id." }) },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) =>
+        jsonResult(await store.deleteBoard((rawParams as Record<string, unknown>).id)),
+    },
+    {
       name: "workboard_stats",
       label: "Workboard Stats",
       description: "Summarize Workboard counts by status and assignee for one board or all boards.",
@@ -552,6 +604,171 @@ export function createWorkboardTools(params: {
       execute: async (_toolCallId, rawParams) => {
         const record = rawParams as Record<string, unknown>;
         return jsonResult(await store.stats({ boardId: record.boardId }));
+      },
+    },
+    {
+      name: "workboard_runs",
+      label: "Workboard Runs",
+      description: "List persisted Workboard run attempts for one card.",
+      parameters: CardIdSchema,
+      execute: async (_toolCallId, rawParams) => {
+        const id = readStringParam(rawParams as Record<string, unknown>, "id", { required: true });
+        const result = await store.runs(id);
+        return jsonResult({ ...result, card: redactClaimToken(result.card) });
+      },
+    },
+    {
+      name: "workboard_specify",
+      label: "Workboard Specify",
+      description:
+        "Turn a rough triage/backlog Workboard card into a specified todo card after reasoning through the requirements.",
+      parameters: Type.Object(
+        {
+          id: Type.String({ description: "Workboard card id." }),
+          title: Type.Optional(Type.String({ description: "Clarified title." })),
+          notes: Type.Optional(
+            Type.String({ description: "Clarified notes or acceptance criteria." }),
+          ),
+          agentId: Type.Optional(Type.String({ description: "Assigned agent id." })),
+          priority: Type.Optional(Type.String({ description: "low, normal, high, or urgent." })),
+          labels: Type.Optional(Type.Array(Type.String(), { description: "Card labels." })),
+          boardId: Type.Optional(Type.String({ description: "Board id." })),
+          tenant: Type.Optional(Type.String({ description: "Tenant or routing namespace." })),
+          skills: Type.Optional(Type.Array(Type.String(), { description: "Suggested skills." })),
+          workspace: Type.Optional(
+            Type.Object(
+              {
+                kind: Type.String({ description: "scratch, dir, or worktree." }),
+                path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
+                branch: Type.Optional(Type.String({ description: "Suggested branch." })),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+          maxRuntimeSeconds: Type.Optional(Type.Number({ description: "Runtime budget." })),
+          maxRetries: Type.Optional(Type.Number({ description: "Retry budget." })),
+          summary: Type.Optional(Type.String({ description: "Specification summary comment." })),
+          token: Type.Optional(Type.String({ description: "Claim token for claimed cards." })),
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) => {
+        const record = rawParams as Record<string, unknown>;
+        const id = readStringParam(record, "id", { required: true });
+        await requireScopedCard(store, id, ownerId, record.token as string | undefined);
+        return jsonResult({
+          card: redactClaimToken(await store.specify(id, record, { ownerId, token: record.token })),
+        });
+      },
+    },
+    {
+      name: "workboard_decompose",
+      label: "Workboard Decompose",
+      description:
+        "Fan out a Workboard card into linked child cards and optionally complete the parent orchestration card.",
+      parameters: Type.Object(
+        {
+          id: Type.String({ description: "Parent Workboard card id." }),
+          token: Type.Optional(Type.String({ description: "Claim token for claimed cards." })),
+          summary: Type.Optional(Type.String({ description: "Decomposition summary." })),
+          completeParent: Type.Optional(
+            Type.Boolean({
+              description: "Complete the parent after child creation. Default true.",
+            }),
+          ),
+          children: Type.Array(
+            Type.Object(
+              {
+                title: Type.String({ description: "Child title." }),
+                notes: Type.Optional(Type.String({ description: "Child notes." })),
+                agentId: Type.Optional(Type.String({ description: "Assigned agent id." })),
+                priority: Type.Optional(
+                  Type.String({ description: "low, normal, high, or urgent." }),
+                ),
+                labels: Type.Optional(Type.Array(Type.String())),
+                boardId: Type.Optional(Type.String()),
+                tenant: Type.Optional(Type.String()),
+                skills: Type.Optional(Type.Array(Type.String())),
+                workspace: Type.Optional(
+                  Type.Object(
+                    {
+                      kind: Type.String({ description: "scratch, dir, or worktree." }),
+                      path: Type.Optional(
+                        Type.String({ description: "Absolute dir/worktree path." }),
+                      ),
+                      branch: Type.Optional(Type.String({ description: "Suggested branch." })),
+                    },
+                    { additionalProperties: false },
+                  ),
+                ),
+                maxRuntimeSeconds: Type.Optional(Type.Number()),
+                maxRetries: Type.Optional(Type.Number()),
+                idempotencyKey: Type.Optional(Type.String()),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) => {
+        const record = rawParams as Record<string, unknown>;
+        const id = readStringParam(record, "id", { required: true });
+        await requireScopedCard(store, id, ownerId, record.token as string | undefined);
+        const result = await store.decompose(id, record, { ownerId, token: record.token });
+        return jsonResult({
+          parent: redactClaimToken(result.parent),
+          children: result.children.map(redactClaimToken),
+        });
+      },
+    },
+    {
+      name: "workboard_notify_subscribe",
+      label: "Workboard Notify Subscribe",
+      description: "Persist a Workboard notification subscription in the plugin SQLite store.",
+      parameters: Type.Object(
+        {
+          boardId: Type.Optional(Type.String({ description: "Board id. Default default." })),
+          cardId: Type.Optional(Type.String({ description: "Card id." })),
+          sessionKey: Type.Optional(Type.String({ description: "Session key." })),
+          runId: Type.Optional(Type.String({ description: "Run id." })),
+          target: Type.Optional(Type.String({ description: "Human-readable target." })),
+          eventKinds: Type.Optional(
+            Type.Array(Type.String(), { description: "completed, failed, stale." }),
+          ),
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) =>
+        jsonResult({
+          subscription: await store.subscribeNotifications(rawParams as Record<string, unknown>),
+        }),
+    },
+    {
+      name: "workboard_notify_list",
+      label: "Workboard Notify List",
+      description: "List persisted Workboard notification subscriptions.",
+      parameters: Type.Object(
+        {
+          boardId: Type.Optional(Type.String({ description: "Board id." })),
+          cardId: Type.Optional(Type.String({ description: "Card id." })),
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) =>
+        jsonResult(await store.listNotificationSubscriptions(rawParams as Record<string, unknown>)),
+    },
+    {
+      name: "workboard_notify_unsubscribe",
+      label: "Workboard Notify Unsubscribe",
+      description: "Delete a persisted Workboard notification subscription.",
+      parameters: Type.Object(
+        { id: Type.String({ description: "Subscription id." }) },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) => {
+        const id = readStringParam(rawParams as Record<string, unknown>, "id", { required: true });
+        return jsonResult(await store.deleteNotificationSubscription(id));
       },
     },
     {

--- a/extensions/workboard/src/types.ts
+++ b/extensions/workboard/src/types.ts
@@ -25,6 +25,8 @@ export const WORKBOARD_EVENT_KINDS = [
   "edited",
   "moved",
   "linked",
+  "specified",
+  "decomposed",
   "claimed",
   "heartbeat",
   "execution_updated",
@@ -212,6 +214,30 @@ export type WorkboardAutomation = {
   createdCardIds?: string[];
   dispatchCount?: number;
   lastDispatchAt?: number;
+};
+
+export type WorkboardBoardMetadata = {
+  id: string;
+  name?: string;
+  description?: string;
+  icon?: string;
+  color?: string;
+  defaultWorkspace?: WorkboardWorkspace;
+  createdAt: number;
+  updatedAt: number;
+  archivedAt?: number;
+};
+
+export type WorkboardNotificationSubscription = {
+  id: string;
+  boardId: string;
+  cardId?: string;
+  sessionKey?: string;
+  runId?: string;
+  target?: string;
+  eventKinds?: WorkboardNotificationKind[];
+  createdAt: number;
+  updatedAt: number;
 };
 
 export type WorkboardMetadata = {

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:13.998Z",
+  "generatedAt": "2026-05-30T14:51:07.817Z",
   "locale": "ar",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:12.229Z",
+  "generatedAt": "2026-05-30T14:51:05.009Z",
   "locale": "de",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:12.582Z",
+  "generatedAt": "2026-05-30T14:51:05.574Z",
   "locale": "es",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:17.237Z",
+  "generatedAt": "2026-05-30T14:51:13.851Z",
   "locale": "fa",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:13.644Z",
+  "generatedAt": "2026-05-30T14:51:07.275Z",
   "locale": "fr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:15.407Z",
+  "generatedAt": "2026-05-30T14:51:09.989Z",
   "locale": "id",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:14.349Z",
+  "generatedAt": "2026-05-30T14:51:08.376Z",
   "locale": "it",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:12.935Z",
+  "generatedAt": "2026-05-30T14:51:06.161Z",
   "locale": "ja-JP",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:13.288Z",
+  "generatedAt": "2026-05-30T14:51:06.743Z",
   "locale": "ko",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:16.874Z",
+  "generatedAt": "2026-05-30T14:51:13.050Z",
   "locale": "nl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:15.770Z",
+  "generatedAt": "2026-05-30T14:51:10.622Z",
   "locale": "pl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:11.874Z",
+  "generatedAt": "2026-05-30T14:51:04.436Z",
   "locale": "pt-BR",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:16.159Z",
+  "generatedAt": "2026-05-30T14:51:11.340Z",
   "locale": "th",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:14.704Z",
+  "generatedAt": "2026-05-30T14:51:08.900Z",
   "locale": "tr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:15.053Z",
+  "generatedAt": "2026-05-30T14:51:09.425Z",
   "locale": "uk",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:16.521Z",
+  "generatedAt": "2026-05-30T14:51:12.152Z",
   "locale": "vi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:11.085Z",
+  "generatedAt": "2026-05-30T14:51:03.178Z",
   "locale": "zh-CN",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-30T00:01:11.524Z",
+  "generatedAt": "2026-05-30T14:51:03.847Z",
   "locale": "zh-TW",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "8f9697af4f21650eef01a2449759b1059950ed0f10455b09693cf3d8837ed538",
-  "totalKeys": 1278,
-  "translatedKeys": 1278,
+  "sourceHash": "cf9ec1de1e155dd9ef3eb10e45f3d93c24c2f18aafcbd2317e0265eea027254f",
+  "totalKeys": 1280,
+  "translatedKeys": 1280,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -563,6 +563,8 @@ export const ar: TranslationMap = {
     eventMoved: "تم النقل",
     eventMovedTo: "تم النقل إلى {status}",
     eventLinked: "تم ربط الجلسة",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "تم الحجز",
     eventHeartbeat: "نبضة",
     eventExecutionUpdated: "تم تحديث الوكيل",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -567,6 +567,8 @@ export const de: TranslationMap = {
     eventMoved: "Verschoben",
     eventMovedTo: "Verschoben nach {status}",
     eventLinked: "Sitzung verknüpft",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Beansprucht",
     eventHeartbeat: "Heartbeat",
     eventExecutionUpdated: "Agent aktualisiert",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -562,6 +562,8 @@ export const en: TranslationMap = {
     eventMoved: "Moved",
     eventMovedTo: "Moved to {status}",
     eventLinked: "Linked session",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Claimed",
     eventHeartbeat: "Heartbeat",
     eventExecutionUpdated: "Agent updated",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -564,6 +564,8 @@ export const es: TranslationMap = {
     eventMoved: "Movido",
     eventMovedTo: "Movido a {status}",
     eventLinked: "Sesión vinculada",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Reclamado",
     eventHeartbeat: "Latido",
     eventExecutionUpdated: "Agente actualizado",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -565,6 +565,8 @@ export const fa: TranslationMap = {
     eventMoved: "منتقل شد",
     eventMovedTo: "به {status} منتقل شد",
     eventLinked: "نشست پیوند داده شد",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "ادعا شد",
     eventHeartbeat: "ضربان",
     eventExecutionUpdated: "Agent به‌روزرسانی شد",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -566,6 +566,8 @@ export const fr: TranslationMap = {
     eventMoved: "Déplacé",
     eventMovedTo: "Déplacé vers {status}",
     eventLinked: "Session liée",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Revendiqué",
     eventHeartbeat: "Signal",
     eventExecutionUpdated: "Agent mis à jour",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -564,6 +564,8 @@ export const id: TranslationMap = {
     eventMoved: "Dipindahkan",
     eventMovedTo: "Dipindahkan ke {status}",
     eventLinked: "Sesi ditautkan",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Diklaim",
     eventHeartbeat: "Detak",
     eventExecutionUpdated: "Agen diperbarui",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -566,6 +566,8 @@ export const it: TranslationMap = {
     eventMoved: "Spostato",
     eventMovedTo: "Spostato in {status}",
     eventLinked: "Sessione collegata",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Rivendicato",
     eventHeartbeat: "Heartbeat",
     eventExecutionUpdated: "Agente aggiornato",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -567,6 +567,8 @@ export const ja_JP: TranslationMap = {
     eventMoved: "移動しました",
     eventMovedTo: "{status} に移動しました",
     eventLinked: "セッションをリンクしました",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "要求済み",
     eventHeartbeat: "ハートビート",
     eventExecutionUpdated: "Agent が更新されました",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -563,6 +563,8 @@ export const ko: TranslationMap = {
     eventMoved: "이동됨",
     eventMovedTo: "{status}(으)로 이동됨",
     eventLinked: "연결된 세션",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "할당됨",
     eventHeartbeat: "하트비트",
     eventExecutionUpdated: "Agent 업데이트됨",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -566,6 +566,8 @@ export const nl: TranslationMap = {
     eventMoved: "Verplaatst",
     eventMovedTo: "Verplaatst naar {status}",
     eventLinked: "Gekoppelde sessie",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Geclaimd",
     eventHeartbeat: "Heartbeat",
     eventExecutionUpdated: "Agent bijgewerkt",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -565,6 +565,8 @@ export const pl: TranslationMap = {
     eventMoved: "Przeniesiono",
     eventMovedTo: "Przeniesiono do {status}",
     eventLinked: "Połączona sesja",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Przejęto",
     eventHeartbeat: "Heartbeat",
     eventExecutionUpdated: "Agent zaktualizowany",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -564,6 +564,8 @@ export const pt_BR: TranslationMap = {
     eventMoved: "Movido",
     eventMovedTo: "Movido para {status}",
     eventLinked: "Sessão vinculada",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Reivindicado",
     eventHeartbeat: "Heartbeat",
     eventExecutionUpdated: "Agente atualizado",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -562,6 +562,8 @@ export const th: TranslationMap = {
     eventMoved: "ย้ายแล้ว",
     eventMovedTo: "ย้ายไปยัง {status}",
     eventLinked: "เซสชันที่ลิงก์แล้ว",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "อ้างสิทธิ์แล้ว",
     eventHeartbeat: "ฮาร์ตบีต",
     eventExecutionUpdated: "เอเจนต์อัปเดตแล้ว",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -566,6 +566,8 @@ export const tr: TranslationMap = {
     eventMoved: "Taşındı",
     eventMovedTo: "{status} durumuna taşındı",
     eventLinked: "Oturum bağlandı",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Üstlenildi",
     eventHeartbeat: "Heartbeat",
     eventExecutionUpdated: "Aracı güncellendi",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -565,6 +565,8 @@ export const uk: TranslationMap = {
     eventMoved: "Переміщено",
     eventMovedTo: "Переміщено до {status}",
     eventLinked: "Пов’язаний сеанс",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Призначено",
     eventHeartbeat: "Heartbeat",
     eventExecutionUpdated: "Агент оновлено",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -564,6 +564,8 @@ export const vi: TranslationMap = {
     eventMoved: "Đã di chuyển",
     eventMovedTo: "Đã di chuyển đến {status}",
     eventLinked: "Phiên đã liên kết",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "Đã nhận",
     eventHeartbeat: "Nhịp tim",
     eventExecutionUpdated: "Agent đã cập nhật",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -561,6 +561,8 @@ export const zh_CN: TranslationMap = {
     eventMoved: "已移动",
     eventMovedTo: "已移至 {status}",
     eventLinked: "已关联会话",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "已认领",
     eventHeartbeat: "心跳",
     eventExecutionUpdated: "Agent 已更新",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -561,6 +561,8 @@ export const zh_TW: TranslationMap = {
     eventMoved: "已移動",
     eventMovedTo: "已移動至 {status}",
     eventLinked: "已連結工作階段",
+    eventSpecified: "Specified",
+    eventDecomposed: "Decomposed",
     eventClaimed: "已認領",
     eventHeartbeat: "心跳",
     eventExecutionUpdated: "代理程式已更新",

--- a/ui/src/ui/controllers/workboard.ts
+++ b/ui/src/ui/controllers/workboard.ts
@@ -28,6 +28,8 @@ export const WORKBOARD_EVENT_KINDS = [
   "edited",
   "moved",
   "linked",
+  "specified",
+  "decomposed",
   "claimed",
   "heartbeat",
   "execution_updated",

--- a/ui/src/ui/views/workboard.ts
+++ b/ui/src/ui/views/workboard.ts
@@ -116,6 +116,10 @@ function formatEventLabel(event: WorkboardEvent): string {
         : t("workboard.eventMoved");
     case "linked":
       return t("workboard.eventLinked");
+    case "specified":
+      return t("workboard.eventSpecified");
+    case "decomposed":
+      return t("workboard.eventDecomposed");
     case "claimed":
       return t("workboard.eventClaimed");
     case "heartbeat":


### PR DESCRIPTION
## Summary
- Store Workboard cards, board metadata, and notification subscriptions in plugin SQLite KV namespaces.
- Add Workboard board lifecycle, run history, specify, decompose, and notification subscription tools/RPCs.
- Make decomposition atomic under the Workboard mutation queue, including rollback for new and reused idempotent children, and document the persisted data model.
- Add UI event support and labels for specified/decomposed Workboard events.

## Verification
- `node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts extensions/workboard/src/gateway.test.ts extensions/workboard/src/tools.test.ts ui/src/ui/controllers/workboard.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/workboard`
- `node scripts/run-oxlint.mjs ui/src/ui/controllers/workboard.ts ui/src/ui/views/workboard.ts ui/src/i18n/locales`
- `pnpm format:docs:check docs/plugins/workboard.md`
- `git diff --check`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean

## Real behavior proof
Behavior addressed: Workboard orchestration metadata now persists in plugin SQLite KV state, with board metadata, notification subscriptions, run history, specify/decompose, and board lifecycle exposed through tools and Gateway RPCs.
Real environment tested: Local source checkout on branch `feat/workboard-sqlite-orchestration`; Blacksmith Testbox was also attempted but its delegated checkout failed before repo checks with `origin/main...HEAD: no merge base`.
Exact steps or command run after this patch: The Verification commands above, including local `check:changed` with Testbox delegation disabled.
Evidence after fix: Focused Workboard/UI tests passed; local changed-scope gate passed across core, core tests, extensions, extension tests, docs, lint, and import-cycle guards; autoreview reported no accepted/actionable findings.
Observed result after fix: Workboard board records and notification subscriptions are durable SQLite KV records; card deletion and board deletion clean matching subscription records; decomposition runs as one serialized mutation and rolls back failed child batches without stale links/status drift.
What was not tested: Live Gateway browser workflow and a successful Blacksmith delegated run, because the Testbox checkout had no merge base before checks started.
