### PR TITLE
fix(file-lock): detect PID recycling so container locks don't outlive their owner

### DIFF
--- a/src/infra/stale-lock-file.test.ts
+++ b/src/infra/stale-lock-file.test.ts
@@ -1,30 +1,84 @@
 import { describe, expect, it } from "vitest";
 import { shouldRemoveDeadOwnerOrExpiredLock } from "./stale-lock-file.js";
 
-describe("stale lock file ownership", () => {
-  it("treats permission-denied process probes as not definitely dead", () => {
+describe("shouldRemoveDeadOwnerOrExpiredLock", () => {
+  it("removes an expired lock without owner metadata", () => {
+    const past = new Date(Date.now() - 10_000).toISOString();
     expect(
       shouldRemoveDeadOwnerOrExpiredLock({
-        payload: {
-          pid: 123,
-          createdAt: new Date(Date.now() - 60_000).toISOString(),
-        },
-        staleMs: 10,
+        payload: { createdAt: past },
+        staleMs: 1_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a fresh lock without owner metadata", () => {
+    const nowIso = new Date().toISOString();
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { createdAt: nowIso },
+        staleMs: 1_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("removes a lock whose owner pid is definitely dead", () => {
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { pid: 4242, createdAt: new Date().toISOString() },
+        staleMs: 1_000,
+        isPidDefinitelyDead: () => true,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a lock whose owner pid is alive even when older than staleMs (legacy, no startTime)", () => {
+    // Preserves the pre-existing semantics: a live PID's lock is never stolen
+    // when the lock predates the startTime field.
+    const old = new Date(Date.now() - 60_000).toISOString();
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { pid: process.pid, createdAt: old },
+        staleMs: 1_000,
         isPidDefinitelyDead: () => false,
       }),
     ).toBe(false);
   });
 
-  it("only removes pid-owned locks when the owner is definitely dead", () => {
+  it("removes a lock when the owner pid is alive but its start time was recycled", () => {
+    // Container case: PID 2 is alive after a restart, but it is a new process
+    // (different start time) than the one that wrote the lock.
     expect(
       shouldRemoveDeadOwnerOrExpiredLock({
-        payload: {
-          pid: 123,
-          createdAt: new Date(Date.now() - 60_000).toISOString(),
-        },
-        staleMs: 10,
-        isPidDefinitelyDead: () => true,
+        payload: { pid: 2, createdAt: new Date().toISOString(), startTime: 111 },
+        staleMs: 5 * 60_000,
+        isPidDefinitelyDead: () => false,
+        getProcessStartTime: () => 999,
       }),
     ).toBe(true);
+  });
+
+  it("keeps a lock when the owner pid is alive and its start time still matches", () => {
+    // A genuinely long-running holder (e.g. a slow snapshot dump) must not have
+    // its lock reclaimed out from under it.
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { pid: 2, createdAt: new Date(Date.now() - 60_000).toISOString(), startTime: 555 },
+        staleMs: 1_000,
+        isPidDefinitelyDead: () => false,
+        getProcessStartTime: () => 555,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps a lock when the owner start time cannot be read (non-Linux / unreadable)", () => {
+    expect(
+      shouldRemoveDeadOwnerOrExpiredLock({
+        payload: { pid: 2, createdAt: new Date().toISOString(), startTime: 555 },
+        staleMs: 1_000,
+        isPidDefinitelyDead: () => false,
+        getProcessStartTime: () => null,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/infra/stale-lock-file.ts
+++ b/src/infra/stale-lock-file.ts
@@ -1,8 +1,12 @@
-import { isPidDefinitelyDead as defaultIsPidDefinitelyDead } from "../shared/pid-alive.js";
+import {
+  getProcessStartTime as defaultGetProcessStartTime,
+  isPidDefinitelyDead as defaultIsPidDefinitelyDead,
+} from "../shared/pid-alive.js";
 
 export type LockFileOwnerPayload = {
   pid?: number;
   createdAt?: string;
+  startTime?: number;
 };
 
 export function readLockFileOwnerPayload(
@@ -14,7 +18,20 @@ export function readLockFileOwnerPayload(
   return {
     pid: typeof payload.pid === "number" ? payload.pid : undefined,
     createdAt: typeof payload.createdAt === "string" ? payload.createdAt : undefined,
+    startTime: typeof payload.startTime === "number" ? payload.startTime : undefined,
   };
+}
+
+function isLockExpired(
+  createdAt: string | undefined,
+  staleMs: number,
+  nowMs: number | undefined,
+): boolean {
+  if (!createdAt) {
+    return false;
+  }
+  const createdAtMs = Date.parse(createdAt);
+  return !Number.isFinite(createdAtMs) || (nowMs ?? Date.now()) - createdAtMs > staleMs;
 }
 
 export function shouldRemoveDeadOwnerOrExpiredLock(params: {
@@ -22,14 +39,30 @@ export function shouldRemoveDeadOwnerOrExpiredLock(params: {
   staleMs: number;
   nowMs?: number;
   isPidDefinitelyDead?: (pid: number) => boolean;
+  getProcessStartTime?: (pid: number) => number | null;
 }): boolean {
   const payload = readLockFileOwnerPayload(params.payload);
   if (payload?.pid) {
-    return (params.isPidDefinitelyDead ?? defaultIsPidDefinitelyDead)(payload.pid);
+    const isPidDefinitelyDead = params.isPidDefinitelyDead ?? defaultIsPidDefinitelyDead;
+    if (isPidDefinitelyDead(payload.pid)) {
+      return true;
+    }
+    // The owner PID is alive, but a live PID alone does not prove the original
+    // lock owner is still running. Container inits reuse low PIDs across
+    // restarts — an exec-style entrypoint makes the app PID 2 on every boot —
+    // so a lock written by a previous process records a PID that a new,
+    // unrelated process now holds, and a pure liveness check keeps the lock
+    // forever (the OlmMachine never re-initializes; the bot syncs but cannot
+    // decrypt). When the owner's process start time was recorded, a mismatch
+    // proves the PID was recycled, so the lock is stale and reclaimable.
+    // Without a recorded start time (locks written before this field existed),
+    // preserve the original behavior of never stealing a live PID's lock.
+    if (payload.startTime != null) {
+      const getProcessStartTime = params.getProcessStartTime ?? defaultGetProcessStartTime;
+      const currentStartTime = getProcessStartTime(payload.pid);
+      return currentStartTime != null && currentStartTime !== payload.startTime;
+    }
+    return false;
   }
-  if (payload?.createdAt) {
-    const createdAt = Date.parse(payload.createdAt);
-    return !Number.isFinite(createdAt) || (params.nowMs ?? Date.now()) - createdAt > params.staleMs;
-  }
-  return false;
+  return isLockExpired(payload?.createdAt, params.staleMs, params.nowMs);
 }

--- a/src/plugin-sdk/file-lock.ts
+++ b/src/plugin-sdk/file-lock.ts
@@ -5,6 +5,7 @@ import {
   resetFileLockManagerForTest,
 } from "@openclaw/fs-safe/file-lock";
 import { shouldRemoveDeadOwnerOrExpiredLock } from "../infra/stale-lock-file.js";
+import { getProcessStartTime } from "../shared/pid-alive.js";
 
 export type FileLockOptions = {
   retries: {
@@ -86,7 +87,14 @@ export async function acquireFileLock(
       retry: options.retries,
       staleRecovery: "remove-if-unchanged",
       allowReentrant: true,
-      payload: () => ({ pid: process.pid, createdAt: new Date().toISOString() }),
+      // Record the owner's process start time so the staleness check can
+      // detect PID recycling (e.g. the app is always PID 2 in a container, so
+      // a live PID does not prove the original owner survived a restart).
+      payload: () => ({
+        pid: process.pid,
+        createdAt: new Date().toISOString(),
+        startTime: getProcessStartTime(process.pid) ?? undefined,
+      }),
       shouldReclaim: shouldReclaimPluginLock,
       shouldRemoveStaleLock: (snapshot) =>
         shouldRemoveDeadOwnerOrExpiredLock({


### PR DESCRIPTION
## Summary

The advisory file-lock staleness check (`shouldRemoveDeadOwnerOrExpiredLock` in
`src/infra/stale-lock-file.ts`) returns early on PID liveness whenever the lock
payload carries a `pid`, and never falls through to the `createdAt` expiry
backstop:

```ts
if (payload?.pid) {
  return (params.isPidDefinitelyDead ?? defaultIsPidDefinitelyDead)(payload.pid); // always returns here
}
if (payload?.createdAt) { // unreachable when a pid is present
  ...staleMs expiry...
}
```

In a container the owning process is reused at a low, stable PID across
restarts — an `exec`-style entrypoint makes the app **PID 2 on every boot** — so
a lock orphaned by an unclean shutdown records a PID that a new, unrelated
process now legitimately holds. The liveness check then sees "PID 2 is alive",
considers the lock valid, and **no number of restarts can ever break it**. The
`createdAt` expiry that exists precisely for cases where PID liveness can't be
trusted is dead code whenever a `pid` is present.

### Impact (how it surfaced)

Observed on the Matrix plugin's crypto IndexedDB snapshot lock
(`crypto-idb-snapshot.json.lock`, payload `{"pid":2}`) running in a rootless
podman cage. After an unclean shutdown left the lock behind, the OlmMachine
never re-initialized on the next start: the bot kept `/sync`ing and returning
`200`s, but could no longer decrypt incoming events, never emitted
`m.room_key_request` / `/keys/claim`, and never persisted its snapshot. It
looked online but silently stopped responding to messages — and a
`systemctl restart` did nothing because the relaunched process is PID 2 again.

## Fix

Record the owner's process **start time** (`/proc/<pid>/stat` field 22, via the
existing `getProcessStartTime` helper) in the lock payload, and treat a live PID
as stale when its recorded start time differs from the current one — which
proves the PID was recycled by a different process.

- Genuine long-running holders (same PID **and** same start time) are still
  protected — a slow snapshot dump won't have its lock stolen.
- Locks written before this field existed (no `startTime`) keep the previous
  conservative behavior: a live PID's lock is never reclaimed.
- Start time unreadable (non-Linux, or `/proc` unavailable) also preserves the
  lock, so the change is a no-op off Linux.

Files:
- `src/infra/stale-lock-file.ts` — start-time-aware staleness; `createdAt`
  expiry extracted to a helper and still applied for payloads without a `pid`.
- `src/plugin-sdk/file-lock.ts` — write `startTime` into the lock payload.
- `src/infra/stale-lock-file.test.ts` — coverage for recycled-PID,
  matching-start-time, unreadable-start-time, and legacy-no-start-time cases.

## Verification

**Behavior addressed:** A stale advisory lock whose recorded owner PID has been
recycled (same number, different process) is now reclaimed instead of being
treated as live forever; long-running same-process holders and legacy
no-start-time locks are unchanged.

**Real environment tested:** Local source checkout, Linux, Node 26, pnpm 11.1.0
(`pnpm install` clean). The originating production symptom was reproduced and
resolved out-of-band on a rootless-podman OpenClaw cage by clearing the orphaned
`crypto-idb-snapshot.json.lock`; this PR is the upstream fix so it can't recur.

**Exact steps or command run after this patch:**
```
node scripts/run-vitest.mjs src/infra/stale-lock-file.test.ts src/plugin-sdk/file-lock.test.ts
npx oxfmt --list-different src/infra/stale-lock-file.ts src/plugin-sdk/file-lock.ts src/infra/stale-lock-file.test.ts
node scripts/run-oxlint.mjs src/infra/stale-lock-file.ts src/plugin-sdk/file-lock.ts src/infra/stale-lock-file.test.ts
```

**Evidence after fix:**
```
Test Files  2 passed (2)
     Tests  12 passed (12)
```
oxfmt: no files different (rc=0). oxlint: 0 warnings, 0 errors across the 3 files.
New tests include "removes a lock when the owner pid is alive but its start
time was recycled" → reclaim, and "keeps a lock when the owner pid is alive and
its start time still matches" → keep.

**Observed result after fix:** With a recycled PID the lock is reclaimed; with a
matching start time it is preserved; the pre-existing `file-lock.test.ts`
live-pid / dead-pid cases still pass (no regression).

**What was not tested:** Full `pnpm check` / `tsgo` lanes and CI on Linux Node 24
were not run locally (only the changed-surface vitest + oxfmt + oxlint). No
non-Linux run (the start-time path is Linux-gated and falls back to
lock-preserving). CHANGELOG intentionally untouched per contributor guidance.

Opened as a draft for maintainer review — this touches the `src/plugin-sdk`
boundary (`file-lock.ts` payload shape), so it likely needs an owner decision.
