### PR TITLE
fix(agents): strip malformed arg-value suffixes

### DIFF
--- a/src/agents/agent-tools.params.test.ts
+++ b/src/agents/agent-tools.params.test.ts
@@ -3,6 +3,7 @@ import {
   assertRequiredParams,
   REQUIRED_PARAM_GROUPS,
   getToolParamsRecord,
+  stripMalformedXmlArgValueSuffix,
   wrapToolParamValidation,
 } from "./agent-tools.params.js";
 
@@ -10,6 +11,86 @@ describe("assertRequiredParams", () => {
   it("returns object params unchanged", () => {
     const params = { path: "test.txt" };
     expect(getToolParamsRecord(params)).toBe(params);
+  });
+
+  it("strips only the malformed terminal XML arg-value suffix", () => {
+    expect(stripMalformedXmlArgValueSuffix("echo test</arg_value>>")).toBe("echo test");
+    expect(stripMalformedXmlArgValueSuffix("echo test</arg_value>>>>>")).toBe("echo test");
+    expect(stripMalformedXmlArgValueSuffix("echo </arg_value>> test")).toBe(
+      "echo </arg_value>> test",
+    );
+  });
+
+  it("strips malformed path suffixes without touching payload text", async () => {
+    const execute = vi.fn(async (_id, args) => args);
+    const tool = wrapToolParamValidation(
+      {
+        name: "write",
+        label: "write",
+        description: "write a file",
+        parameters: {},
+        execute,
+      },
+      REQUIRED_PARAM_GROUPS.write,
+    );
+
+    await tool.execute("id", {
+      path: "notes.txt</arg_value>>",
+      content: "keep literal payload</arg_value>>",
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      "id",
+      {
+        path: "notes.txt",
+        content: "keep literal payload</arg_value>>",
+      },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("rejects paths that become empty after malformed XML arg-value suffix stripping", async () => {
+    const execute = vi.fn();
+    const tool = wrapToolParamValidation(
+      {
+        name: "write",
+        label: "write",
+        description: "write a file",
+        parameters: {},
+        execute,
+      },
+      REQUIRED_PARAM_GROUPS.write,
+    );
+
+    await expect(tool.execute("id", { path: "</arg_value>>", content: "x" })).rejects.toThrow(
+      /Missing required parameter: path/,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("preserves edit replacement payloads while cleaning the path", async () => {
+    const execute = vi.fn(async (_id, args) => args);
+    const tool = wrapToolParamValidation(
+      {
+        name: "edit",
+        label: "edit",
+        description: "edit a file",
+        parameters: {},
+        execute,
+      },
+      REQUIRED_PARAM_GROUPS.edit,
+    );
+
+    const edits = [
+      {
+        oldText: "literal old</arg_value>>",
+        newText: "literal new</arg_value>>",
+      },
+    ];
+    await tool.execute("id", { path: "notes.txt</arg_value>>>", edits });
+
+    expect(execute).toHaveBeenCalledWith("id", { path: "notes.txt", edits }, undefined, undefined);
   });
 
   it("includes received keys in error when some params are present but content is missing", () => {

--- a/src/agents/agent-tools.params.test.ts
+++ b/src/agents/agent-tools.params.test.ts
@@ -16,6 +16,7 @@ describe("assertRequiredParams", () => {
   it("strips only the malformed terminal XML arg-value suffix", () => {
     expect(stripMalformedXmlArgValueSuffix("echo test</arg_value>>")).toBe("echo test");
     expect(stripMalformedXmlArgValueSuffix("echo test</arg_value>>>>>")).toBe("echo test");
+    expect(stripMalformedXmlArgValueSuffix("echo test</arg_value>")).toBe("echo test</arg_value>");
     expect(stripMalformedXmlArgValueSuffix("echo </arg_value>> test")).toBe(
       "echo </arg_value>> test",
     );

--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -8,6 +8,8 @@ export type RequiredParamGroup = {
 };
 
 const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
+const XML_ARG_VALUE_SUFFIX_RE = /<\/arg_value>>*$/;
+const XML_ARG_VALUE_PATH_PARAM_KEYS = new Set(["path"]);
 
 function parameterValidationError(message: string): Error {
   return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
@@ -94,6 +96,43 @@ export function getToolParamsRecord(params: unknown): Record<string, unknown> | 
   return params && typeof params === "object" ? (params as Record<string, unknown>) : undefined;
 }
 
+export function stripMalformedXmlArgValueSuffix(value: string): string {
+  return value.includes("</arg_value>") ? value.replace(XML_ARG_VALUE_SUFFIX_RE, "") : value;
+}
+
+export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string, unknown>>(
+  record: T,
+  keys: readonly string[],
+): T {
+  let normalized: T | undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const stripped = stripMalformedXmlArgValueSuffix(value);
+    if (stripped !== value) {
+      normalized ??= { ...record };
+      normalized[key as keyof T] = stripped as T[keyof T];
+    }
+  }
+  return normalized ?? record;
+}
+
+function resolveMalformedXmlArgValuePathKeys(
+  groups: readonly RequiredParamGroup[] | undefined,
+): string[] {
+  const keys = new Set<string>();
+  for (const group of groups ?? []) {
+    for (const key of group.keys) {
+      if (XML_ARG_VALUE_PATH_PARAM_KEYS.has(key)) {
+        keys.add(key);
+      }
+    }
+  }
+  return [...keys];
+}
+
 export function assertRequiredParams(
   record: Record<string, unknown> | undefined,
   groups: readonly RequiredParamGroup[],
@@ -143,10 +182,15 @@ export function wrapToolParamValidation(
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
       const record = getToolParamsRecord(params);
+      const pathKeys = resolveMalformedXmlArgValuePathKeys(requiredParamGroups);
+      const normalizedParams =
+        record && pathKeys.length > 0
+          ? stripMalformedXmlArgValueSuffixFromKeys(record, pathKeys)
+          : params;
       if (requiredParamGroups?.length) {
-        assertRequiredParams(record, requiredParamGroups, tool.name);
+        assertRequiredParams(getToolParamsRecord(normalizedParams), requiredParamGroups, tool.name);
       }
-      return tool.execute(toolCallId, params, signal, onUpdate);
+      return tool.execute(toolCallId, normalizedParams, signal, onUpdate);
     },
   };
 }

--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -8,7 +8,7 @@ export type RequiredParamGroup = {
 };
 
 const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
-const XML_ARG_VALUE_SUFFIX_RE = /<\/arg_value>>*$/;
+const XML_ARG_VALUE_SUFFIX_RE = /<\/arg_value>>+$/;
 const XML_ARG_VALUE_PATH_PARAM_KEYS = new Set(["path"]);
 
 function parameterValidationError(message: string): Error {

--- a/src/agents/agent-tools.read.arg-value-suffix.test.ts
+++ b/src/agents/agent-tools.read.arg-value-suffix.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOpenClawReadTool } from "./agent-tools.read.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+
+describe("createOpenClawReadTool malformed XML arg-value suffix handling", () => {
+  it("strips the suffix from read paths before invoking the base tool", async () => {
+    const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "ok" }] }));
+    const base = {
+      name: "read",
+      label: "read",
+      description: "read a file",
+      parameters: {},
+      execute,
+    } as unknown as AnyAgentTool;
+    const tool = createOpenClawReadTool(base);
+
+    await tool.execute("read-1", { path: "notes.txt</arg_value>>" });
+
+    expect(execute).toHaveBeenCalledWith(
+      "read-1",
+      {
+        path: "notes.txt",
+        offset: 1,
+      },
+      undefined,
+    );
+  });
+
+  it("rejects read paths that become empty after suffix stripping", async () => {
+    const execute = vi.fn();
+    const base = {
+      name: "read",
+      label: "read",
+      description: "read a file",
+      parameters: {},
+      execute,
+    } as unknown as AnyAgentTool;
+    const tool = createOpenClawReadTool(base);
+
+    await expect(tool.execute("read-1", { path: "</arg_value>>" })).rejects.toThrow(
+      /Missing required parameter: path/,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -15,6 +15,8 @@ import {
   REQUIRED_PARAM_GROUPS,
   assertRequiredParams,
   getToolParamsRecord,
+  stripMalformedXmlArgValueSuffix,
+  stripMalformedXmlArgValueSuffixFromKeys,
   wrapToolParamValidation,
 } from "./agent-tools.params.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
@@ -78,6 +80,10 @@ function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number 
     contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * ADAPTIVE_READ_CONTEXT_SHARE,
   );
   return clamp(fromContext, DEFAULT_READ_PAGE_MAX_BYTES, MAX_ADAPTIVE_READ_MAX_BYTES);
+}
+
+function malformedXmlArgValuePathError(key: string): Error {
+  return new Error(`Malformed path parameter: ${key}. Supply correct parameters before retrying.`);
 }
 
 function formatBytes(bytes: number): string {
@@ -631,9 +637,14 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
     description: `${tool.description} During memory flush, this tool may only append to ${options.relativePath}.`,
     execute: async (toolCallId, args, signal, onUpdate) => {
       const record = getToolParamsRecord(args);
-      assertRequiredParams(record, REQUIRED_PARAM_GROUPS.write, tool.name);
+      const normalizedRecord = record
+        ? stripMalformedXmlArgValueSuffixFromKeys(record, ["path"])
+        : undefined;
+      assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.write, tool.name);
       const filePath =
-        typeof record?.path === "string" && record.path.trim() ? record.path : undefined;
+        typeof normalizedRecord?.path === "string" && normalizedRecord.path.trim()
+          ? normalizedRecord.path
+          : undefined;
       const content = typeof record?.content === "string" ? record.content : undefined;
       if (!filePath || content === undefined) {
         return tool.execute(toolCallId, args, signal, onUpdate);
@@ -737,9 +748,17 @@ export function wrapToolWorkspaceRootGuardWithOptions(
       const record = getToolParamsRecord(args);
       let normalizedRecord: Record<string, unknown> | undefined;
       for (const key of pathParamKeys) {
-        const filePath = record?.[key];
-        if (typeof filePath !== "string" || !filePath.trim()) {
+        const rawFilePath = record?.[key];
+        if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
           continue;
+        }
+        const filePath = stripMalformedXmlArgValueSuffix(rawFilePath);
+        if (!filePath.trim()) {
+          throw malformedXmlArgValuePathError(key);
+        }
+        if (filePath !== rawFilePath && record) {
+          normalizedRecord ??= { ...record };
+          normalizedRecord[key] = filePath;
         }
         let guardedRoot = root;
         const workspaceMapping = mapContainerPathToRoot({
@@ -836,15 +855,19 @@ export function createOpenClawReadTool(
     ...base,
     execute: async (toolCallId, params, signal) => {
       const record = getToolParamsRecord(params);
-      assertRequiredParams(record, REQUIRED_PARAM_GROUPS.read, base.name);
+      const normalizedRecord = record
+        ? stripMalformedXmlArgValueSuffixFromKeys(record, ["path"])
+        : undefined;
+      assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.read, base.name);
       const result = await executeReadWithAdaptivePaging({
         base,
         toolCallId,
-        args: record ?? {},
+        args: normalizedRecord ?? {},
         signal,
         maxBytes: resolveAdaptiveReadMaxBytes(options),
       });
-      const filePath = typeof record?.path === "string" ? record.path : "<unknown>";
+      const filePath =
+        typeof normalizedRecord?.path === "string" ? normalizedRecord.path : "<unknown>";
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
       const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
       return sanitizeToolResultImages(

--- a/src/agents/agent-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/agent-tools.read.workspace-root-guard.test.ts
@@ -66,6 +66,25 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
     });
   });
 
+  it("strips malformed XML arg-value suffixes before guarding path params", async () => {
+    const { execute, tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root);
+
+    await wrapped.execute("tc-suffix", { path: "docs/readme.md</arg_value>>" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: "docs/readme.md",
+      cwd: root,
+      root,
+    });
+    expect(execute).toHaveBeenCalledWith(
+      "tc-suffix",
+      { path: "docs/readme.md" },
+      undefined,
+      undefined,
+    );
+  });
+
   it("maps file:// container workspace paths to host workspace root", async () => {
     const { tool } = createToolHarness();
     const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
@@ -256,5 +275,21 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
       undefined,
       undefined,
     );
+  });
+
+  it("rejects custom path params that become empty after suffix stripping", async () => {
+    const { execute, tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/workspace",
+      pathParamKeys: ["outPath"],
+      normalizeGuardedPathParams: true,
+    });
+
+    await expect(
+      wrapped.execute("tc-outpath-empty-suffix", { outPath: "</arg_value>>" }),
+    ).rejects.toThrow(/Malformed path parameter: outPath/);
+
+    expect(mocks.assertSandboxPath).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/agent-tools.workspace-only-false.test.ts
+++ b/src/agents/agent-tools.workspace-only-false.test.ts
@@ -270,4 +270,49 @@ describe("FS tools with workspaceOnly=false", () => {
     });
     await expect(fs.readFile(allowedAbsolutePath, "utf-8")).resolves.toBe("seed\nnew note");
   });
+
+  it("accepts memory-triggered append-only writes with malformed XML arg-value path suffixes", async () => {
+    const allowedRelativePath = "memory/2026-03-08.md";
+    const allowedAbsolutePath = path.join(workspaceDir, allowedRelativePath);
+
+    const writeTool = wrapToolMemoryFlushAppendOnlyWrite(
+      createHostWorkspaceWriteTool(workspaceDir),
+      {
+        root: workspaceDir,
+        relativePath: allowedRelativePath,
+      },
+    );
+
+    const result = await writeTool.execute("test-call-memory-suffix", {
+      path: `${allowedRelativePath}</arg_value>>`,
+      content: "new note",
+    });
+
+    expect(hasToolError(result)).toBe(false);
+    expect(result).toStrictEqual({
+      content: [{ type: "text", text: "Appended content to memory/2026-03-08.md." }],
+      details: {
+        path: "memory/2026-03-08.md",
+        appendOnly: true,
+      },
+    });
+    await expect(fs.readFile(allowedAbsolutePath, "utf-8")).resolves.toBe("new note");
+  });
+
+  it("rejects memory-triggered append-only paths that become empty after suffix stripping", async () => {
+    const writeTool = wrapToolMemoryFlushAppendOnlyWrite(
+      createHostWorkspaceWriteTool(workspaceDir),
+      {
+        root: workspaceDir,
+        relativePath: "memory/2026-03-09.md",
+      },
+    );
+
+    await expect(
+      writeTool.execute("test-call-memory-empty-suffix", {
+        path: "</arg_value>>",
+        content: "new note",
+      }),
+    ).rejects.toThrow(/Missing required parameter: path/);
+  });
 });

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -148,6 +148,27 @@ describe("exec PATH login shell merge", () => {
     envSnapshot.restore();
   });
 
+  it("strips malformed XML arg-value suffixes from exec command and routing options", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-xml-"));
+    try {
+      const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+      const result = await tool.execute("call-xml-suffix", {
+        command: "echo ok</arg_value>>",
+        workdir: `${tempDir}</arg_value>>`,
+        host: "gateway</arg_value>>",
+        security: "full</arg_value>>",
+        ask: "off</arg_value>>",
+        node: "ignored-node</arg_value>>",
+        yieldMs: FOREGROUND_TEST_YIELD_MS,
+      });
+      const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+      expect(value).toBe("ok");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("merges login-shell PATH for host=gateway", async () => {
     if (isWin) {
       return;

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -152,7 +152,7 @@ describe("exec PATH login shell merge", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-xml-"));
     try {
       const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
-      const result = await tool.execute("call-xml-suffix", {
+      const malformedArgs = {
         command: "echo ok</arg_value>>",
         workdir: `${tempDir}</arg_value>>`,
         host: "gateway</arg_value>>",
@@ -160,7 +160,8 @@ describe("exec PATH login shell merge", () => {
         ask: "off</arg_value>>",
         node: "ignored-node</arg_value>>",
         yieldMs: FOREGROUND_TEST_YIELD_MS,
-      });
+      } as unknown as Parameters<typeof tool.execute>[1];
+      const result = await tool.execute("call-xml-suffix", malformedArgs);
       const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
 
       expect(value).toBe("ok");

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExecApprovalsResolved } from "../infra/exec-approvals.js";
 import { captureEnv } from "../test-utils/env.js";
 import { sanitizeBinaryOutput } from "./shell-utils.js";
@@ -134,6 +134,13 @@ describe("exec PATH login shell merge", () => {
 
   beforeAll(async () => {
     ({ createExecTool } = await import("./bash-tools.exec.js"));
+  });
+
+  afterAll(async () => {
+    vi.doUnmock("../infra/shell-env.js");
+    vi.doUnmock("../infra/exec-approvals.js");
+    vi.doUnmock("../process/supervisor/index.js");
+    await vi.resetModules();
   });
 
   beforeEach(() => {

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -136,11 +136,11 @@ describe("exec PATH login shell merge", () => {
     ({ createExecTool } = await import("./bash-tools.exec.js"));
   });
 
-  afterAll(async () => {
+  afterAll(() => {
     vi.doUnmock("../infra/shell-env.js");
     vi.doUnmock("../infra/exec-approvals.js");
     vi.doUnmock("../process/supervisor/index.js");
-    await vi.resetModules();
+    vi.resetModules();
   });
 
   beforeEach(() => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -35,6 +35,7 @@ import {
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
+import { stripMalformedXmlArgValueSuffixFromKeys } from "./agent-tools.params.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { describeExecTool } from "./bash-tools.descriptions.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
@@ -75,6 +76,30 @@ export type {
   ExecToolDefaults,
   ExecToolDetails,
 } from "./bash-tools.exec-types.js";
+
+type ExecToolArgs = Record<string, unknown> & {
+  command: string;
+  workdir?: string;
+  env?: Record<string, string>;
+  yieldMs?: number;
+  background?: boolean;
+  timeout?: number;
+  pty?: boolean;
+  elevated?: boolean;
+  host?: string;
+  security?: string;
+  ask?: string;
+  node?: string;
+};
+
+const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
+  "command",
+  "workdir",
+  "host",
+  "security",
+  "ask",
+  "node",
+] as const;
 
 function buildExecForegroundResult(params: {
   outcome: ExecProcessOutcome;
@@ -1306,20 +1331,10 @@ export function createExecTool(
     },
     parameters: execSchema,
     execute: async (_toolCallId, args, signal, onUpdate) => {
-      const params = args as {
-        command: string;
-        workdir?: string;
-        env?: Record<string, string>;
-        yieldMs?: number;
-        background?: boolean;
-        timeout?: number;
-        pty?: boolean;
-        elevated?: boolean;
-        host?: string;
-        security?: string;
-        ask?: string;
-        node?: string;
-      };
+      const params = stripMalformedXmlArgValueSuffixFromKeys(
+        args as ExecToolArgs,
+        XML_ARG_VALUE_EXEC_PARAM_KEYS,
+      );
 
       if (!params.command) {
         throw new Error("Provide a command to start.");


### PR DESCRIPTION
## Summary
- Strip the malformed terminal `</arg_value>>` marker from active read/write/edit path args and exec routing args before validation/guard checks.
- Preserve payload text fields (`content`, edit replacements, env values) so legitimate XML-like content is not rewritten.
- Reject explicit guarded path-like args that strip down to empty, including optional `outPath`, before they can fall back to default output behavior.
- Cover the memory-flush append-only wrapper, workspace-root guard, read adaptive wrapper, optional guarded path params, and active exec tool path.

Fixes https://github.com/openclaw/openclaw/issues/48780.
Replaces the closed contributor PR https://github.com/openclaw/openclaw/pull/48792; credit to @zerone0x for the original direction and to @koden588-blip for the report.

## Verification
- `node scripts/run-vitest.mjs src/agents/agent-tools.params.test.ts src/agents/agent-tools.read.arg-value-suffix.test.ts src/agents/agent-tools.read.workspace-root-guard.test.ts src/agents/agent-tools.workspace-only-false.test.ts src/agents/bash-tools.exec.path.test.ts`
- `node_modules/.bin/oxfmt --check src/agents/agent-tools.params.ts src/agents/agent-tools.params.test.ts src/agents/agent-tools.read.ts src/agents/agent-tools.read.arg-value-suffix.test.ts src/agents/agent-tools.read.workspace-root-guard.test.ts src/agents/agent-tools.workspace-only-false.test.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.exec.path.test.ts`
- `node_modules/.bin/oxlint src/agents/agent-tools.params.ts src/agents/agent-tools.params.test.ts src/agents/agent-tools.read.ts src/agents/agent-tools.read.arg-value-suffix.test.ts src/agents/agent-tools.read.workspace-root-guard.test.ts src/agents/agent-tools.workspace-only-false.test.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.exec.path.test.ts`
- `git diff --check origin/main...HEAD && git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean after the empty guarded-path finding was fixed.
- GitHub quick checks on `8f2aff4dbebad2feef14e9f48313a7bb51d02ba5`: `Real behavior proof`, `Workflow Sanity / no-tabs`, and `Workflow Sanity / actionlint` passed.
- Windows/WSL probe on `8f2aff4dbebad2feef14e9f48313a7bb51d02ba5`: https://github.com/openclaw/openclaw/actions/runs/26689711746
  - Native Windows probe: passed on a Blacksmith Windows Server 2025 runner (`Microsoft Windows NT 10.0.26100.0`, `cmd.exe` version `10.0.26100.4946`, PowerShell `7.4.11`, Git `2.51.0.windows.1`).
  - WSL2 probe: `wsl.exe` existed and WSL/VMP features could be enabled, but importing/running the Ubuntu WSL2 distro failed because the runner cannot create a WSL2 VM. The enforced WSL2 gate failed with `OPENCLAW_WSL2_PROBE_OK=false`.
- Azure Crabbox native Windows attempt `run_52edb6cd3581` / slug `coral-barnacle`: no coordinator lease after 6m30s, canceled as provider capacity/unavailability rather than a code result.

## Real behavior proof

**Behavior addressed:** Windows/native and WSL agent tool calls whose `read`, write/edit path, optional guarded path, or `exec` routing args arrive with a terminal malformed `</arg_value>>` marker no longer forward that marker into path, command, or routing fields. Explicit path-like args that strip down to empty now fail before workspace guard or optional output fallback behavior can reinterpret them.

**Real environment tested:** Local focused Node/Vitest proof on the active tool wrappers at `8f2aff4dbebad2feef14e9f48313a7bb51d02ba5`; GitHub native Windows probe on a Blacksmith Windows Server 2025 runner; WSL2 capability probe on that same Windows runner.

**Exact steps or command run after this patch:**
```sh
node scripts/run-vitest.mjs src/agents/agent-tools.params.test.ts src/agents/agent-tools.read.arg-value-suffix.test.ts src/agents/agent-tools.read.workspace-root-guard.test.ts src/agents/agent-tools.workspace-only-false.test.ts src/agents/bash-tools.exec.path.test.ts
node_modules/.bin/oxfmt --check src/agents/agent-tools.params.ts src/agents/agent-tools.params.test.ts src/agents/agent-tools.read.ts src/agents/agent-tools.read.arg-value-suffix.test.ts src/agents/agent-tools.read.workspace-root-guard.test.ts src/agents/agent-tools.workspace-only-false.test.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.exec.path.test.ts
node_modules/.bin/oxlint src/agents/agent-tools.params.ts src/agents/agent-tools.params.test.ts src/agents/agent-tools.read.ts src/agents/agent-tools.read.arg-value-suffix.test.ts src/agents/agent-tools.read.workspace-root-guard.test.ts src/agents/agent-tools.workspace-only-false.test.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.exec.path.test.ts
git diff --check origin/main...HEAD && git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
ghx workflow run windows-testbox-probe.yml --ref main -f target_ref=8f2aff4dbebad2feef14e9f48313a7bb51d02ba5 -f runner_label=blacksmith-16vcpu-windows-2025 -f keepalive_minutes=0 -f require_wsl2=true -f import_ubuntu_wsl2=true -f enable_wsl2_features=true
```

**Evidence after fix:** 5 focused Vitest files passed with 85 tests. Formatting, lint, whitespace checks passed. Autoreview reported no accepted/actionable findings after the optional guarded-path fix. GitHub quick checks passed on the pushed head. The native Windows probe passed on the exact pushed SHA. The WSL2 probe reached `wsl.exe` and enabled Windows features, then failed only at distro VM creation because the runner cannot provide the WSL2 VM capability.

**Observed result after fix:** malformed suffixes are stripped only from terminal path/exec routing fields before validation and guard checks; suffix-only path-like args are rejected; payload text remains unchanged.

**What was not tested:** WSL2 execution inside a real Linux distro remains blocked because the available Blacksmith Windows runner cannot create a WSL2 VM, and the Azure Crabbox native Windows coordinator did not provide a lease for the fresh attempt.
