### PR TITLE
fix(sandbox): include message tool in default sandbox allowlist

### DIFF
--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -18,6 +18,7 @@ export const DEFAULT_TOOL_ALLOW = [
   "edit",
   "apply_patch",
   "image",
+  "message",
   "sessions_list",
   "sessions_history",
   "sessions_send",

--- a/src/agents/sandbox/tool-policy.test.ts
+++ b/src/agents/sandbox/tool-policy.test.ts
@@ -38,6 +38,28 @@ describe("sandbox/tool-policy", () => {
     });
   });
 
+  it("includes message tool in the default sandbox allowlist", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+      },
+    };
+
+    const resolved = resolveSandboxToolPolicyForAgent(cfg, "main");
+    expect(resolved.allow).toContain("message");
+    expect(
+      isToolAllowed(
+        {
+          allow: resolved.allow,
+          deny: resolved.deny,
+        },
+        "message",
+      ),
+    ).toBe(true);
+  });
+
   it("lets explicit sandbox allow remove entries from the default sandbox denylist", () => {
     const cfg: OpenClawConfig = {
       agents: {


### PR DESCRIPTION
Fixes #88253

## Summary

A sandboxed channel-bound agent had no way to deliver replies to the originating channel. `message` was absent from `DEFAULT_TOOL_ALLOW`, so the only available messaging tool was `sessions_send` — which routes internally via the webchat lane and is never delivered to a real channel.

Adding `message` to the default allowlist restores expected behaviour: a sandboxed agent can use the `message` tool to reply to Telegram/Discord/etc. without requiring an explicit `tools.sandbox.tools.alsoAllow: [\"message\"]` override in every agent config. Explicit `deny` entries still take precedence per the existing policy.

## Real behavior proof

**Behavior addressed:** `DEFAULT_TOOL_ALLOW` lacked `\"message\"`, so the gateway log showed `tool policy removed … message …` for sandboxed agents. Sandboxed Telegram agents replied to the internal webchat lane instead of the inbound channel, producing silent no-delivery.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, HEAD `24c41971676474f4ad8e7c5364c6920caebc5e47` based on `origin/main` `6399b6a4455d0a5373329dc8c71ff4b1da6f50c9`.

**Exact steps or command run after this patch:**

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.unit-fast.config.ts \
  src/agents/sandbox/tool-policy.test.ts \
  --reporter=verbose --testTimeout=10000
```

**Evidence after fix:**

```
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.unit-fast.config.ts \
  src/agents/sandbox/tool-policy.test.ts \
  --reporter=verbose --testTimeout=10000

 RUN  v4.1.7 /media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-88253

 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > merges sandbox alsoAllow into the default sandbox allowlist 6ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > includes message tool in the default sandbox allowlist 1ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > lets explicit sandbox allow remove entries from the default sandbox denylist 1ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > preserves allow-all semantics for allow: [] plus alsoAllow 1ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > keeps canonical sandbox config and runtime status aligned with the effective resolver 4ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > treats channel direct sessions as sandboxed in non-main mode 1ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > keeps the agent main session sandboxed in all mode 1ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > keeps explicit sandbox deny precedence over allow and alsoAllow 1ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > uses the effective sandbox policy when formatting blocked-tool guidance 2ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > keeps blocked-tool guidance glob-aware and shell-safe 1ms
 ✓ |unit-fast| src/agents/sandbox/tool-policy.test.ts > sandbox/tool-policy > avoids terminal injection for control-character session keys 1ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  03:20:10
   Duration  869ms (transform 330ms, setup 0ms, import 628ms, tests 22ms, environment 0ms)
```

The test `includes message tool in the default sandbox allowlist` directly verifies the fix: `DEFAULT_TOOL_ALLOW` now contains `"message"` and `isToolAllowed` returns `true` for a sandboxed agent with no explicit deny. The test `keeps explicit sandbox deny precedence over allow and alsoAllow` confirms existing deny semantics are unchanged.

**Observed result after fix:** `DEFAULT_TOOL_ALLOW` includes `\"message\"`. A sandboxed agent's resolved allow list contains `\"message\"` without any `alsoAllow` override.

**What was not tested:** End-to-end sandboxed Telegram → message tool → real channel delivery in a live gateway. The policy-resolution logic is exercised by unit tests against real config structs.