### PR TITLE
fix(codex): restore historyMessages to before_prompt_build hook in app-server

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1703,7 +1703,8 @@ describe("runCodexAppServerAttempt", () => {
       { runId?: string; sessionId?: string },
     ];
     expect(hookInput.prompt).toBe("hello");
-    expect(hookInput.messages).toEqual([]);
+    expect(hookInput.messages).toHaveLength(1);
+    expect(hookInput.messages?.[0]?.role).toBe("assistant");
     expect(hookContext.runId).toBe("run-1");
     expect(hookContext.sessionId).toBe("session-1");
     const threadStart = harness.requests.find((request) => request.method === "thread/start");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -772,7 +772,7 @@ export async function runCodexAppServerAttempt(
     resolveAgentHarnessBeforePromptBuildResult({
       prompt: prependCurrentInboundContext(promptText, params.currentInboundContext),
       developerInstructions,
-      messages: codexModelInputHistoryMessages,
+      messages: historyMessages,
       ctx: hookContext,
     });
   let promptBuild = await buildPromptFromCurrentInputs();


### PR DESCRIPTION
Fixes #88353

## Summary

PR #88262 changed `resolveAgentHarnessBeforePromptBuildResult` to receive `codexModelInputHistoryMessages` — which is always an empty array for Codex app-server runs — instead of `historyMessages`. This broke the public `before_prompt_build` hook contract: plugins reading `event.messages` for session history (e.g. `active-memory`, `memory-lancedb`) received an empty array even after the session transcript was successfully loaded.

The intent of #88262 was to prevent mirrored session history from being forwarded to Codex model input — that goal is achieved by keeping `codexModelInputHistoryMessages` as an empty array and passing it to the Codex thread. The hook's read-only view of session history is a separate surface and should not share the same empty array.

This PR restores `historyMessages` as the `messages` argument to the hook builder so consumers see the actual loaded session history, while `codexModelInputHistoryMessages` continues to control what is forwarded to the Codex model.

## Real behavior proof

**Behavior addressed:** `before_prompt_build` hook received `messages: []` even when session history was loaded. After fix, it receives the actual session history (e.g. one assistant message from a prior turn).

**Real environment tested:** Linux x86_64, Node.js v22.22.0, HEAD `81b1458815abf9a6ddbb2857315957abd6e6a6f4` based on `origin/main` `6399b6a4455d0a5373329dc8c71ff4b1da6f50c9`.

**Exact steps or command run after this patch:**

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.extension-codex.config.ts \
  extensions/codex/src/app-server/run-attempt.test.ts \
  -t "applies before_prompt_build" \
  --reporter=verbose --testTimeout=60000

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.extension-codex.config.ts \
  extensions/codex/src/app-server/run-attempt.test.ts \
  --reporter=dot --testTimeout=60000
```

**Evidence after fix:**

```
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.extension-codex.config.ts \
  extensions/codex/src/app-server/run-attempt.test.ts \
  -t "applies before_prompt_build" \
  --reporter=verbose --testTimeout=60000

 RUN  v4.1.7 /media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-88353

 ✓ |extension-codex| extensions/codex/src/app-server/run-attempt.test.ts > runCodexAppServerAttempt > applies before_prompt_build to Codex developer instructions and turn input 661ms

 Test Files  1 passed (1)
      Tests  1 passed | 79 skipped (80)
   Start at  03:11:27
   Duration  16.19s (transform 8.54s, setup 385ms, import 14.87s, tests 661ms, environment 0ms)

$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.extension-codex.config.ts \
  extensions/codex/src/app-server/run-attempt.test.ts \
  --reporter=dot --testTimeout=60000

 RUN  v4.1.7 /media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-88353

················································································

 Test Files  1 passed (1)
      Tests  80 passed (80)
   Start at  03:09:57
   Duration  36.86s (transform 9.32s, setup 364ms, import 15.39s, tests 20.85s, environment 0ms)
```

The test `applies before_prompt_build to Codex developer instructions and turn input` asserts `hookInput.messages` has length 1 with `role: "assistant"` (matching the session message appended before the run), replacing the previous `toEqual([])` assertion that locked in the broken behaviour.

**Observed result after fix:** `before_prompt_build` receives the loaded session history messages. Plugins that read `event.messages` for prior session context get the correct data.

**What was not tested:** End-to-end Codex app-server run with a live active-memory or memory-lancedb plugin consuming the hook. The hook dispatch and message pass-through are exercised by the unit test using real session file I/O.