### PR TITLE
fix(daemon): clean stale Windows startup fallback

### DIFF
--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -358,7 +358,7 @@ describe("findExtraGatewayServices (win32)", () => {
     execSchtasksMock.mockResolvedValueOnce({
       code: 0,
       stdout: [
-        "TaskName: OpenClaw Gateway",
+        "TaskName: \\OpenClaw Gateway",
         "Task To Run: C:\\Program Files\\OpenClaw\\openclaw.exe gateway run",
         "",
         "TaskName: Clawdbot Legacy",

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -195,7 +195,7 @@ function isOpenClawGatewaySystemdService(name: string, contents: string): boolea
 }
 
 function isOpenClawGatewayTaskName(name: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(name);
+  const normalized = normalizeLowercaseStringOrEmpty(name).replace(/^\\+/, "");
   if (!normalized) {
     return false;
   }

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -248,6 +248,15 @@ function notYetRunTaskQueryOutput() {
   ].join("\r\n");
 }
 
+function runningTaskQueryOutput() {
+  return [
+    "Status: Running",
+    "Last Run Time: 11/30/1999 12:00:00 AM",
+    "Last Run Result: 267009",
+    "",
+  ].join("\r\n");
+}
+
 beforeEach(() => {
   resetSchtasksBaseMocks();
   findVerifiedGatewayListenerPidsOnPortSync.mockReset();
@@ -320,6 +329,34 @@ describe("Windows startup fallback", () => {
     });
   });
 
+  it("removes a stale Startup-folder launcher after Scheduled Task install succeeds", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 1, stdout: "", stderr: "not found" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
+      );
+      const startupEntryPath = await writeStartupFallbackEntry(env);
+      const hiddenStartupEntryPath = resolveStartupEntryPath(env, "vbs");
+      await fs.writeFile(hiddenStartupEntryPath, "' stale hidden launcher\r\n", "utf8");
+      const stdout = new PassThrough();
+      let printed = "";
+      stdout.on("data", (chunk) => {
+        printed += String(chunk);
+      });
+
+      await installGatewayScheduledTask(env, stdout);
+
+      await expect(fs.access(startupEntryPath)).rejects.toThrow();
+      await expect(fs.access(hiddenStartupEntryPath)).rejects.toThrow();
+      expect(printed).toContain("Removed Windows login item");
+      expect(printed).toContain("Installed Scheduled Task");
+    });
+  });
+
   it("falls back to a Startup-folder launcher when schtasks create returns Spanish access denied", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       addStartupFallbackMissingResponses([
@@ -376,10 +413,12 @@ describe("Windows startup fallback", () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       fastForwardTaskStartWait();
       addAcceptedRunNeverStartsResponses();
+      const startupEntryPath = await writeStartupFallbackEntry(env);
 
       await installGatewayScheduledTask(env);
 
       expectStartupFallbackSpawn();
+      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
     });
   });
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -92,8 +92,9 @@ function resolveStartupEntryPath(env: GatewayServiceEnv, extension?: "cmd" | "vb
 
 function resolveStartupEntryPaths(env: GatewayServiceEnv): string[] {
   const primaryPath = resolveStartupEntryPath(env);
-  const legacyCmdPath = resolveStartupEntryPath(env, "cmd");
-  return uniqueStrings([primaryPath, legacyCmdPath]);
+  const cmdPath = resolveStartupEntryPath(env, "cmd");
+  const hiddenPath = resolveStartupEntryPath(env, "vbs");
+  return uniqueStrings([primaryPath, cmdPath, hiddenPath]);
 }
 
 // `/TR` is parsed by schtasks itself, while the generated `gateway.cmd` line is parsed by cmd.exe.
@@ -460,6 +461,18 @@ async function isStartupEntryInstalled(env: GatewayServiceEnv): Promise<boolean>
     } catch {}
   }
   return false;
+}
+
+async function removeStartupEntries(
+  env: GatewayServiceEnv,
+  stdout?: NodeJS.WritableStream,
+): Promise<void> {
+  for (const startupEntryPath of resolveStartupEntryPaths(env)) {
+    try {
+      await fs.unlink(startupEntryPath);
+      stdout?.write(`${formatLine("Removed Windows login item", startupEntryPath)}\n`);
+    } catch {}
+  }
 }
 
 async function isRegisteredScheduledTask(env: GatewayServiceEnv): Promise<boolean> {
@@ -995,11 +1008,14 @@ async function updateExistingScheduledTask(params: {
   } finally {
     await fs.rm(path.dirname(upgradeXmlPath), { recursive: true, force: true }).catch(() => {});
   }
-  await runScheduledTaskOrThrow({
+  const runResult = await runScheduledTaskOrThrow({
     taskName: params.taskName,
     env: params.env,
     scriptPath: params.scriptPath,
   });
+  if (runResult.taskStarted) {
+    await removeStartupEntries(params.env, params.stdout);
+  }
   writeFormattedLines(
     params.stdout,
     [
@@ -1014,15 +1030,21 @@ async function updateExistingScheduledTask(params: {
 async function shouldFallbackScheduledTaskLaunch(params: {
   env: GatewayServiceEnv;
   scriptPath: string;
-}): Promise<boolean> {
+}): Promise<{ shouldLaunchFallback: boolean; taskStarted: boolean }> {
   const readLaunchObservation = async (): Promise<{
-    state: "running" | "not-yet-run" | "other";
+    state: "confirmed-running" | "running" | "not-yet-run" | "other";
     signature: string;
   }> => {
     const runtime = await readScheduledTaskRuntime(params.env).catch(() => null);
     if (runtime?.status === "running") {
+      const normalizedResult = normalizeTaskResultCode(runtime.lastRunResult);
+      const state = normalizedResult
+        ? RUNNING_RESULT_CODES.has(normalizedResult)
+          ? "confirmed-running"
+          : "running"
+        : "running";
       return {
-        state: "running",
+        state,
         signature: [runtime.state, runtime.lastRunTime, runtime.lastRunResult, runtime.detail]
           .filter(Boolean)
           .join("|"),
@@ -1104,39 +1126,54 @@ async function shouldFallbackScheduledTaskLaunch(params: {
   };
 
   const initial = await readLaunchObservation();
+  if (initial.state === "confirmed-running") {
+    return { shouldLaunchFallback: false, taskStarted: true };
+  }
   if (initial.state !== "not-yet-run") {
-    return false;
+    return { shouldLaunchFallback: false, taskStarted: false };
   }
 
   const deadline = Date.now() + SCHEDULED_TASK_FALLBACK_TIMEOUT_MS;
   while (Date.now() < deadline) {
     await sleep(SCHEDULED_TASK_FALLBACK_POLL_MS);
     const current = await readLaunchObservation();
+    if (current.state === "confirmed-running") {
+      return { shouldLaunchFallback: false, taskStarted: true };
+    }
+    if (current.state === "running") {
+      return { shouldLaunchFallback: false, taskStarted: false };
+    }
     if (current.state !== "not-yet-run") {
-      return false;
+      return { shouldLaunchFallback: false, taskStarted: false };
     }
     if (current.signature !== initial.signature) {
-      return false;
+      return { shouldLaunchFallback: false, taskStarted: false };
     }
   }
-  return !(await hasLaunchEvidence());
+  return {
+    shouldLaunchFallback: !(await hasLaunchEvidence()),
+    taskStarted: false,
+  };
 }
 
 async function runScheduledTaskOrThrow(params: {
   taskName: string;
   env: GatewayServiceEnv;
   scriptPath: string;
-}): Promise<void> {
+}): Promise<{ fallbackLaunched: boolean; taskStarted: boolean }> {
   const run = await execSchtasks(["/Run", "/TN", params.taskName]);
   if (run.code !== 0) {
     throw new Error(`schtasks run failed: ${run.stderr || run.stdout}`.trim());
   }
-  if (
-    !(await shouldFallbackScheduledTaskLaunch({ env: params.env, scriptPath: params.scriptPath }))
-  ) {
-    return;
+  const launchResult = await shouldFallbackScheduledTaskLaunch({
+    env: params.env,
+    scriptPath: params.scriptPath,
+  });
+  if (!launchResult.shouldLaunchFallback) {
+    return { fallbackLaunched: false, taskStarted: launchResult.taskStarted };
   }
   await launchFallbackTaskScript(params.env);
+  return { fallbackLaunched: true, taskStarted: false };
 }
 
 async function activateScheduledTask(params: {
@@ -1211,11 +1248,14 @@ async function activateScheduledTask(params: {
     throw new Error(`schtasks create failed: ${detail}`.trim());
   }
 
-  await runScheduledTaskOrThrow({
+  const runResult = await runScheduledTaskOrThrow({
     taskName,
     env: params.env,
     scriptPath: params.scriptPath,
   });
+  if (runResult.taskStarted) {
+    await removeStartupEntries(params.env, params.stdout);
+  }
   // Ensure we don't end up writing to a clack spinner line (wizards show progress without a newline).
   writeFormattedLines(
     params.stdout,
@@ -1252,12 +1292,7 @@ export async function uninstallScheduledTask({
     await execSchtasks(["/Delete", "/F", "/TN", taskName]);
   }
 
-  for (const startupEntryPath of resolveStartupEntryPaths(env)) {
-    try {
-      await fs.unlink(startupEntryPath);
-      stdout.write(`${formatLine("Removed Windows login item", startupEntryPath)}\n`);
-    } catch {}
-  }
+  await removeStartupEntries(env, stdout);
 
   const scriptPath = resolveTaskScriptPath(env);
   const launcherPath = resolveTaskLauncherScriptPath(env, scriptPath);


### PR DESCRIPTION
Summary
- Remove stale Windows Startup-folder fallback launchers after a Scheduled Task install/update is confirmed running.
- Preserve the fallback when Task Scheduler only gets a one-shot fallback launch instead of a real running task.
- Normalize root schtasks names like `\OpenClaw Gateway` so the active task is not reported as another gateway-like service.

Refs #87156. This is the native-Windows daemon cleanup slice; the broader doctor/update migration from existing fallback installs to Scheduled Task is tracked in #88311.

Verification
- `node scripts/run-vitest.mjs src/daemon/schtasks.startup-fallback.test.ts src/daemon/inspect.test.ts`
- `node_modules/.bin/oxfmt --check src/daemon/schtasks.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/inspect.ts src/daemon/inspect.test.ts`
- `node_modules/.bin/oxlint src/daemon/schtasks.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/inspect.ts src/daemon/inspect.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `pnpm check:changed`: `provider=aws`, `lease=cbx_5e61cd2ed565`, `run=run_7f8dc0bf445a`
- AWS Crabbox native Windows SYSTEM schtasks/Startup-folder contract proof: `provider=aws`, `lease=cbx_070e47559279`, `run=run_b633192f400e`
- Native Windows CI `checks-windows-node-test`: https://github.com/openclaw/openclaw/actions/runs/26687401081/job/78657871243

Behavior addressed: Windows fallback installs that later migrate to a healthy Scheduled Task no longer keep stale Startup-folder launchers, and `gateway status --deep` no longer treats `\OpenClaw Gateway` as an extra service.
Real environment tested: focused unit coverage in a Codex worktree, AWS Crabbox native Windows SYSTEM scheduled-task proof, AWS Crabbox changed gate, plus the existing native Windows GitHub Actions runner proof.
Exact steps or command run after this patch: the Verification commands and Crabbox runs above.
Evidence after fix: targeted schtasks fallback tests pass, win32 extra-service parsing test passes, formatter/lint/diff checks pass, autoreview is clean, `pnpm check:changed` passed remotely, and native Windows proof observed `Status: Running` with `Last Result: 267009` before cleanup.
Observed result after fix: cleanup removes both `.cmd` and `.vbs` Startup entries only after Task Scheduler reports a running task result; the fallback is preserved when `schtasks /Run` falls back to direct launch.
What was not tested: live elevated manual install/update on an interactive Windows desktop and Windows WSL; this patch touches native-Windows service metadata/runtime cleanup, not WSL behavior.
