### PR TITLE
fix(infra): bridge WSL clipboard through shell

### DIFF
--- a/src/infra/clipboard.test.ts
+++ b/src/infra/clipboard.test.ts
@@ -52,7 +52,7 @@ describe("copyToClipboard", () => {
     await expect(copyToClipboard(tokenUrl)).resolves.toBe(true);
 
     expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
-      ["/bin/sh", "-c", "cat | /mnt/c/Windows/System32/clip.exe"],
+      ["/bin/sh", "-c", "exec /mnt/c/Windows/System32/clip.exe"],
       {
         timeoutMs: 3000,
         input: tokenUrl,

--- a/src/infra/clipboard.test.ts
+++ b/src/infra/clipboard.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
+const isWSL2SyncMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
+}));
+
+vi.mock("./wsl.js", () => ({
+  isWSL2Sync: isWSL2SyncMock,
 }));
 
 const { copyToClipboard } = await import("./clipboard.js");
@@ -11,6 +16,7 @@ const { copyToClipboard } = await import("./clipboard.js");
 describe("copyToClipboard", () => {
   beforeEach(() => {
     runCommandWithTimeoutMock.mockReset();
+    isWSL2SyncMock.mockReturnValue(false);
   });
 
   it("returns true on the first successful clipboard command", async () => {
@@ -35,6 +41,40 @@ describe("copyToClipboard", () => {
       ["pbcopy"],
       ["xclip", "-selection", "clipboard"],
       ["wl-copy"],
+    ]);
+  });
+
+  it("uses a startup-free WSL2 shell bridge for clip.exe without putting the value in argv", async () => {
+    isWSL2SyncMock.mockReturnValue(true);
+    runCommandWithTimeoutMock.mockResolvedValueOnce({ code: 0, killed: false });
+
+    const tokenUrl = "http://127.0.0.1:18789/#token=secret-token";
+    await expect(copyToClipboard(tokenUrl)).resolves.toBe(true);
+
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+      ["/bin/sh", "-c", "cat | /mnt/c/Windows/System32/clip.exe"],
+      {
+        timeoutMs: 3000,
+        input: tokenUrl,
+      },
+    );
+    expect(runCommandWithTimeoutMock.mock.calls[0]?.[0]).not.toContain("secret-token");
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not prepend the WSL2 bridge outside WSL2", async () => {
+    runCommandWithTimeoutMock
+      .mockRejectedValueOnce(new Error("missing pbcopy"))
+      .mockResolvedValueOnce({ code: 0, killed: true })
+      .mockRejectedValueOnce(new Error("missing wl-copy"))
+      .mockResolvedValueOnce({ code: 0, killed: false });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(runCommandWithTimeoutMock.mock.calls.map((call) => call[0])).toEqual([
+      ["pbcopy"],
+      ["xclip", "-selection", "clipboard"],
+      ["wl-copy"],
+      ["clip.exe"],
     ]);
   });
 

--- a/src/infra/clipboard.test.ts
+++ b/src/infra/clipboard.test.ts
@@ -58,7 +58,8 @@ describe("copyToClipboard", () => {
         input: tokenUrl,
       },
     );
-    expect(runCommandWithTimeoutMock.mock.calls[0]?.[0]).not.toContain("secret-token");
+    const invokedArgv = runCommandWithTimeoutMock.mock.calls[0]?.[0] as string[];
+    expect(invokedArgv.join("\0")).not.toContain("secret-token");
     expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/infra/clipboard.ts
+++ b/src/infra/clipboard.ts
@@ -1,9 +1,9 @@
 import { runCommandWithTimeout } from "../process/exec.js";
 import { isWSL2Sync } from "./wsl.js";
 
-// WSL interop needs a shell to launch Windows PE binaries; use sh without
-// login/profile startup so tokenized dashboard URLs stay only on stdin.
-const WSL_CLIPBOARD_ARGV = ["/bin/sh", "-c", "cat | /mnt/c/Windows/System32/clip.exe"];
+// WSL interop needs a shell to launch Windows PE binaries; exec keeps the
+// clipboard process as the timeout-owned child while values stay on stdin.
+const WSL_CLIPBOARD_ARGV = ["/bin/sh", "-c", "exec /mnt/c/Windows/System32/clip.exe"];
 
 export async function copyToClipboard(value: string): Promise<boolean> {
   const attempts: Array<{ argv: string[] }> = [

--- a/src/infra/clipboard.ts
+++ b/src/infra/clipboard.ts
@@ -1,11 +1,17 @@
 import { runCommandWithTimeout } from "../process/exec.js";
+import { isWSL2Sync } from "./wsl.js";
+
+// WSL interop needs a shell to launch Windows PE binaries; use sh without
+// login/profile startup so tokenized dashboard URLs stay only on stdin.
+const WSL_CLIPBOARD_ARGV = ["/bin/sh", "-c", "cat | /mnt/c/Windows/System32/clip.exe"];
 
 export async function copyToClipboard(value: string): Promise<boolean> {
   const attempts: Array<{ argv: string[] }> = [
+    ...(isWSL2Sync() ? [{ argv: WSL_CLIPBOARD_ARGV }] : []),
     { argv: ["pbcopy"] },
     { argv: ["xclip", "-selection", "clipboard"] },
     { argv: ["wl-copy"] },
-    { argv: ["clip.exe"] }, // WSL / Windows
+    { argv: ["clip.exe"] },
     { argv: ["powershell", "-NoProfile", "-Command", "Set-Clipboard"] },
   ];
   for (const attempt of attempts) {


### PR DESCRIPTION
## Summary

- route WSL2 clipboard copies through a static `/bin/sh -c` bridge to `/mnt/c/Windows/System32/clip.exe`
- use `exec` so the clipboard process remains the timeout-owned child while dashboard/token URLs stay on stdin instead of shell argv
- avoid Bash login/profile startup and preserve the existing macOS, Linux, native Windows, PowerShell, and non-WSL2 fallback order
- tighten the regression test so token substrings cannot hide inside argv elements

Fixes #88080.

## Verification

- `node scripts/run-vitest.mjs src/infra/clipboard.test.ts src/infra/wsl.test.ts src/commands/dashboard.links.test.ts src/commands/dashboard.test.ts` - passed on final head, 34 focused tests
- `node_modules/.bin/oxfmt --check src/infra/clipboard.ts src/infra/clipboard.test.ts` - passed
- `node_modules/.bin/oxlint src/infra/clipboard.ts src/infra/clipboard.test.ts` - passed
- `git diff --check origin/main...HEAD` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean on final head, no accepted/actionable findings
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --label wsl-clipboard-88365-check-changed-final --idle-timeout 45m --ttl 90m --timing-json --stop-after always --shell -- 'pnpm check:changed'` - passed on AWS Crabbox, provider `aws`, lease `cbx_78e26498569a`, run `run_0941fd6bfbce`
- `crabbox run --provider aws --target windows --windows-mode wsl2 --no-hydrate --no-sync --label wsl-clipboard-88365-exec-readback --idle-timeout 30m --ttl 60m --timing-json --stop-after always --script-stdin` - passed on AWS Windows/WSL2 Crabbox, provider `aws`, lease `cbx_8a49bbda915d`, run `run_5500c97a427e`; generated probe wrote through `/bin/sh -c 'exec /mnt/c/Windows/System32/clip.exe'` and matched `Get-Clipboard`
- `crabbox run --provider aws --target windows --windows-mode normal --no-hydrate --no-sync --label native-windows-clipboard-88365-final-head --idle-timeout 30m --ttl 60m --timing-json --stop-after always --script-stdin` - passed on AWS native Windows Crabbox, provider `aws`, lease `cbx_0c8c10e18c7f`, run `run_47278979324e`; generated probe wrote through direct `%SystemRoot%\System32\clip.exe` and matched `Get-Clipboard`

## Real behavior proof

Behavior addressed: WSL2 dashboard clipboard copies no longer rely on direct non-shell `clip.exe` argv execution or a Bash login shell. The WSL2 path uses `/bin/sh -c 'exec /mnt/c/Windows/System32/clip.exe'` and passes the copied dashboard URL through stdin, keeping the token out of argv while keeping timeout ownership on the clipboard process.

Real environment tested: AWS Crabbox Windows/WSL2 host for shell-bridge clipboard write/readback; AWS Crabbox native Windows host for direct Windows clipboard write/readback; AWS Crabbox Linux for `pnpm check:changed`; focused local Vitest/format/lint/diff-check; branch autoreview.

Exact steps or command run after this patch: focused Vitest, oxfmt, touched-file oxlint, diff-check, branch autoreview, AWS Linux `pnpm check:changed`, AWS Windows/WSL2 clipboard readback, and AWS native Windows clipboard readback commands listed above.

Evidence after fix: the Windows/WSL2 run wrote a generated probe string through `/bin/sh -c 'exec /mnt/c/Windows/System32/clip.exe'` and read it back with Windows PowerShell `Get-Clipboard`; expected and actual values matched exactly. The native Windows run wrote a generated probe through direct `%SystemRoot%\System32\clip.exe` and read it back with `Get-Clipboard`; expected and actual values matched. The WSL2 regression test asserts copied values stay on stdin rather than argv, and the non-WSL fallback-order test keeps the existing `pbcopy`, `xclip`, `wl-copy`, `clip.exe`, and PowerShell order.

Observed result after fix: Windows/WSL2 clipboard readback passed on commit `0720cb12084c9916d22dbe4868c7e124c6186cf1`; native Windows clipboard readback passed; AWS `pnpm check:changed` passed; focused tests, touched-file format/lint, diff-check, and autoreview passed.

What was not tested: `openclaw dashboard --no-open` end-to-end with a real token URL on a user workstation. The runner proof directly exercised the WSL2 clipboard bridge that dashboard calls, using non-secret generated probe values.
