### PR TITLE
fix(agents): preserve required replies in lean local mode

### DIFF
--- a/docs/concepts/experimental-features.md
+++ b/docs/concepts/experimental-features.md
@@ -30,11 +30,11 @@ Treat them differently from normal config:
 
 ## Local model lean mode
 
-`agents.defaults.experimental.localModelLean: true` is a pressure-release valve for weaker local-model setups. When it is on, OpenClaw drops three default tools — `browser`, `cron`, and `message` — from the agent's tool surface for every turn. Nothing else changes. Use `agents.list[].experimental.localModelLean` to enable or disable the same behavior for one configured agent.
+`agents.defaults.experimental.localModelLean: true` is a pressure-release valve for weaker local-model setups. When it is on, OpenClaw drops `browser` and `cron` from the agent's tool surface, and it drops `message` unless the current runtime requires source replies to go through the message tool. Nothing else changes. Use `agents.list[].experimental.localModelLean` to enable or disable the same behavior for one configured agent.
 
-### Why these three tools
+### Why these tools
 
-These three tools have the largest descriptions and the most parameter shapes in the default OpenClaw runtime. On a small-context or stricter OpenAI-compatible backend that is the difference between:
+These tools have the largest descriptions and the most parameter shapes in the default OpenClaw runtime. On a small-context or stricter OpenAI-compatible backend that is the difference between:
 
 - Tool schemas fitting cleanly in the prompt vs. crowding out conversation history.
 - The model picking the right tool vs. emitting malformed tool calls because there are too many similar-looking schemas.
@@ -94,7 +94,7 @@ Restart the Gateway after changing the flag, then confirm the trimmed tool list 
 openclaw status --deep
 ```
 
-The deep status output lists the active agent tools; `browser`, `cron`, and `message` should be absent when lean mode is on.
+The deep status output lists the active agent tools; `browser` and `cron` should be absent when lean mode is on. `message` is also absent unless the current runtime requires source replies to be delivered through the message tool.
 
 ## Experimental does not mean hidden
 

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -315,7 +315,7 @@ If the model loads cleanly but full agent turns misbehave, work top-down — con
    openclaw infer model run --gateway --model <provider/model> --prompt "Reply with exactly: pong" --json
    ```
 
-3. **Try lean mode.** If both probes pass but real agent turns fail with malformed tool calls or oversized prompts, enable `agents.defaults.experimental.localModelLean: true`. It drops the three heaviest default tools (`browser`, `cron`, `message`) so the prompt shape is smaller and less brittle. See [Experimental Features → Local model lean mode](/concepts/experimental-features#local-model-lean-mode) for the full explanation, when to use it, and how to confirm it is on.
+3. **Try lean mode.** If both probes pass but real agent turns fail with malformed tool calls or oversized prompts, enable `agents.defaults.experimental.localModelLean: true`. It drops the heaviest optional default tools (`browser`, `cron`, and usually `message`) so the prompt shape is smaller and less brittle. `message` stays available when the current runtime requires source replies to use it. See [Experimental Features → Local model lean mode](/concepts/experimental-features#local-model-lean-mode) for the full explanation, when to use it, and how to confirm it is on.
 
 4. **Disable tools entirely as a last resort.** If lean mode is not enough, set `models.providers.<provider>.models[].compat.supportsTools: false` for that model entry. The agent will then operate without tool calls on that model.
 

--- a/src/agents/agent-tools.model-provider-collision.test.ts
+++ b/src/agents/agent-tools.model-provider-collision.test.ts
@@ -196,6 +196,35 @@ describe("applyModelProviderToolPolicy", () => {
     expect(toolNames(filtered)).toEqual(["read", "exec"]);
   });
 
+  it("keeps the message tool in lean local-model mode when source replies require it", () => {
+    const filtered = testing.applyModelProviderToolPolicy(
+      [
+        { name: "read" },
+        { name: "browser" },
+        { name: "cron" },
+        { name: "message" },
+        { name: "exec" },
+      ] as unknown as AnyAgentTool[],
+      {
+        config: {
+          agents: {
+            defaults: {
+              experimental: {
+                localModelLean: true,
+              },
+            },
+          },
+        },
+        modelProvider: "ollama",
+        modelApi: "openai-compatible",
+        modelId: "gemma3:4b",
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    );
+
+    expect(toolNames(filtered)).toEqual(["read", "message", "exec"]);
+  });
+
   it("drops heavyweight tools when lean local-model mode is enabled for the default agent", () => {
     const filtered = testing.applyModelProviderToolPolicy(
       [

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -245,6 +245,8 @@ function applyModelProviderToolPolicy(
     agentDir?: string;
     modelCompat?: ModelCompatConfig;
     suppressManagedWebSearch?: boolean;
+    forceMessageTool?: boolean;
+    sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   },
 ): AnyAgentTool[] {
   tools = filterLocalModelLeanTools({
@@ -252,6 +254,10 @@ function applyModelProviderToolPolicy(
     config: params?.config,
     agentId: params?.agentId,
     sessionKey: params?.sessionKey,
+    preserveToolNames:
+      params?.forceMessageTool === true || params?.sourceReplyDeliveryMode === "message_tool_only"
+        ? ["message"]
+        : undefined,
   });
 
   if (
@@ -1063,6 +1069,8 @@ export function createOpenClawCodingTools(options?: {
     agentDir: options?.agentDir,
     modelCompat: options?.modelCompat,
     suppressManagedWebSearch: options?.suppressManagedWebSearch,
+    forceMessageTool: options?.forceMessageTool,
+    sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
   });
   options?.recordToolPrepStage?.("model-provider-policy");
   // Sender identity is carried for command/channel-action auth; tool visibility

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1438,6 +1438,10 @@ export async function runEmbeddedAttempt(
       tools: [...tools, ...normalizedBundledTools],
       config: params.config,
       agentId: sessionAgentId,
+      preserveToolNames:
+        params.forceMessageTool === true || params.sourceReplyDeliveryMode === "message_tool_only"
+          ? ["message"]
+          : undefined,
     });
     const uncompactedToolSchemaProjection = filterRuntimeCompatibleTools(
       projectedUncompactedEffectiveTools,
@@ -1509,6 +1513,10 @@ export async function runEmbeddedAttempt(
       tools: toolSearch.tools,
       config: params.config,
       agentId: sessionAgentId,
+      preserveToolNames:
+        params.forceMessageTool === true || params.sourceReplyDeliveryMode === "message_tool_only"
+          ? ["message"]
+          : undefined,
     });
     const toolSearchSchemaProjection = filterRuntimeCompatibleTools(projectedToolSearchTools);
     logRuntimeToolSchemaQuarantine({

--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -162,4 +162,24 @@ describe("local model lean tool filtering", () => {
       }).map((tool) => tool.name),
     ).toEqual(["read", "exec"]);
   });
+
+  it("keeps explicitly preserved runtime tools in lean mode", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      },
+    };
+
+    expect(
+      filterLocalModelLeanTools({
+        tools: tools(["read", "browser", "cron", "message", "exec"]),
+        config: cfg,
+        preserveToolNames: ["message"],
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "message", "exec"]);
+  });
 });

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -5,6 +5,17 @@ import type { AnyAgentTool } from "./agent-tools.types.js";
 
 const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = new Set(["browser", "cron", "message"]);
 
+function normalizePreservedLocalModelLeanToolNames(names?: Iterable<string>): Set<string> {
+  const preserved = new Set<string>();
+  for (const name of names ?? []) {
+    const normalized = name.trim();
+    if (normalized) {
+      preserved.add(normalized);
+    }
+  }
+  return preserved;
+}
+
 function resolveLocalModelLeanAgentId(params: {
   config?: OpenClawConfig;
   agentId?: string;
@@ -43,9 +54,13 @@ export function filterLocalModelLeanTools(params: {
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  preserveToolNames?: Iterable<string>;
 }): AnyAgentTool[] {
   if (!isLocalModelLeanEnabled(params)) {
     return params.tools;
   }
-  return params.tools.filter((tool) => !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(tool.name));
+  const preservedToolNames = normalizePreservedLocalModelLeanToolNames(params.preserveToolNames);
+  return params.tools.filter(
+    (tool) => preservedToolNames.has(tool.name) || !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(tool.name),
+  );
 }


### PR DESCRIPTION
## Summary

- keeps lean local-model mode from dropping the `message` tool when the run explicitly requires message-tool source replies
- threads the runtime delivery requirement through model-provider tool policy and embedded-run schema projections so prompt/schema accounting matches the actual tool surface
- updates the local-model docs so lean-mode guidance matches the conditional `message` behavior
- adds focused coverage for direct lean filtering and provider tool policy with `sourceReplyDeliveryMode: "message_tool_only"`

Refs https://github.com/openclaw/openclaw/issues/86599.

## Verification

Behavior addressed: `agents.*.experimental.localModelLean` still removes heavyweight default tools, but no longer breaks visible reply delivery for runs that force the `message` tool.

Real environment tested: focused local Vitest wrapper in a Codex worktree, direct formatter/lint/docs checks, branch autoreview, and AWS Crabbox Linux changed gate.

Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs src/agents/local-model-lean.test.ts src/agents/agent-tools.model-provider-collision.test.ts --reporter=dot
node_modules/.bin/oxfmt --check --threads=1 src/agents/local-model-lean.ts src/agents/local-model-lean.test.ts src/agents/agent-tools.ts src/agents/agent-tools.model-provider-collision.test.ts src/agents/embedded-agent-runner/run/attempt.ts
node_modules/.bin/oxlint src/agents/local-model-lean.ts src/agents/local-model-lean.test.ts src/agents/agent-tools.ts src/agents/agent-tools.model-provider-collision.test.ts src/agents/embedded-agent-runner/run/attempt.ts
git diff --check origin/main...HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
node scripts/docs-list.js
node scripts/format-docs.mjs --check docs/concepts/experimental-features.md docs/gateway/local-models.md
node scripts/check-docs-mdx.mjs docs/concepts/experimental-features.md docs/gateway/local-models.md
node scripts/docs-link-audit.mjs docs/concepts/experimental-features.md docs/gateway/local-models.md
node scripts/check-docs-i18n-glossary.mjs
node_modules/.bin/oxfmt --check --threads=1 docs/concepts/experimental-features.md docs/gateway/local-models.md
git diff --cached --check
node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 45m --ttl 90m --timing-json --shell -- "pnpm check:changed"
```

Evidence after fix: focused local wrapper passed `src/agents/local-model-lean.test.ts` and `src/agents/agent-tools.model-provider-collision.test.ts` with 21/21 tests after the docs update; oxfmt, oxlint, diff checks, MDX, docs links, docs i18n glossary, and docs format checks passed; autoreview reported no accepted/actionable findings with `overall: patch is correct (0.84)`. AWS Crabbox `check:changed` passed on the refreshed branch with provider `aws`, lease `cbx_022675ef6a54`, slug `crimson-barnacle`, run `run_e9b63a18a42a`, machine `c7a.8xlarge`, exit 0, `leaseStopped=true`, lanes `core`, `coreTests`, and `docs`.

Observed result after fix: local-model lean filtering keeps `read`, `message`, and `exec` when message-tool-only source reply delivery is required, while continuing to drop `browser` and `cron`; docs now say `message` is conditional rather than always removed.

What was not tested: a live channel roundtrip was not run for this PR. This is one scoped localModelLean compatibility improvement, not the whole small-model stability program.
