### PR TITLE
fix(agents): quarantine invalid runtime tool schemas

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -143,6 +143,15 @@ function createMockToolDefinitions(tools: unknown[] = []) {
   });
 }
 export const createOpenClawCodingToolsMock = vi.fn(() => []);
+export const createBundleMcpToolRuntimeMock = vi.fn(async () => ({
+  tools: [],
+  dispose: vi.fn(async () => {}),
+}));
+export const createBundleLspToolRuntimeMock = vi.fn(async () => ({
+  tools: [],
+  sessions: [],
+  dispose: vi.fn(async () => {}),
+}));
 export const guardSessionManagerMock = vi.fn(() => ({
   flushPendingToolResults: vi.fn(),
 }));
@@ -403,6 +412,17 @@ export function resetCompactHooksHarnessMocks(): void {
   resetCompactSessionStateMocks();
   createOpenClawCodingToolsMock.mockReset();
   createOpenClawCodingToolsMock.mockReturnValue([]);
+  createBundleMcpToolRuntimeMock.mockReset();
+  createBundleMcpToolRuntimeMock.mockResolvedValue({
+    tools: [],
+    dispose: vi.fn(async () => {}),
+  });
+  createBundleLspToolRuntimeMock.mockReset();
+  createBundleLspToolRuntimeMock.mockResolvedValue({
+    tools: [],
+    sessions: [],
+    dispose: vi.fn(async () => {}),
+  });
   guardSessionManagerMock.mockReset();
   guardSessionManagerMock.mockReturnValue({
     flushPendingToolResults: vi.fn(),
@@ -601,20 +621,13 @@ export async function loadCompactHooksHarness(): Promise<{
     resolveBootstrapContextForRun: vi.fn(async () => ({ contextFiles: [] })),
   }));
 
-  vi.doMock("../bundle-mcp-tools.js", () => ({
+  vi.doMock("../agent-bundle-mcp-tools.js", () => ({
     retireSessionMcpRuntime: vi.fn(async () => true),
-    createBundleMcpToolRuntime: vi.fn(async () => ({
-      tools: [],
-      dispose: vi.fn(async () => {}),
-    })),
+    createBundleMcpToolRuntime: createBundleMcpToolRuntimeMock,
   }));
 
-  vi.doMock("../bundle-lsp-runtime.js", () => ({
-    createBundleLspToolRuntime: vi.fn(async () => ({
-      tools: [],
-      sessions: [],
-      dispose: vi.fn(async () => {}),
-    })),
+  vi.doMock("../agent-bundle-lsp-runtime.js", () => ({
+    createBundleLspToolRuntime: createBundleLspToolRuntimeMock,
   }));
 
   vi.doMock("../docs-path.js", () => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -174,6 +174,11 @@ export const rotateTranscriptAfterCompactionMock: Mock<
   rotated: false,
 }));
 export const enqueueCommandInLaneMock = vi.fn((_lane: unknown, task: () => unknown) => task());
+export const runtimePlanToolsNormalizeMock: Mock<
+  (tools: unknown[], params?: unknown) => unknown[]
+> = vi.fn((tools) => tools);
+const runtimePlanToolsNormalize: AgentRuntimePlan["tools"]["normalize"] = (tools, params) =>
+  runtimePlanToolsNormalizeMock(tools, params) as typeof tools;
 
 function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
@@ -215,7 +220,7 @@ function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): Age
       preparedPlanning: {
         loadMetadataSnapshot: () => ({}),
       },
-      normalize: vi.fn((tools) => tools),
+      normalize: runtimePlanToolsNormalize,
       logDiagnostics: vi.fn(),
     },
     transcript: {
@@ -336,6 +341,8 @@ export function resetCompactSessionStateMocks(): void {
   rotateTranscriptAfterCompactionMock.mockResolvedValue({ rotated: false });
   enqueueCommandInLaneMock.mockReset();
   enqueueCommandInLaneMock.mockImplementation((_lane: unknown, task: () => unknown) => task());
+  runtimePlanToolsNormalizeMock.mockReset();
+  runtimePlanToolsNormalizeMock.mockImplementation((tools) => tools);
   listRegisteredPluginAgentPromptGuidanceMock.mockReset();
   listRegisteredPluginAgentPromptGuidanceMock.mockImplementation((params?: { surface?: string }) =>
     params?.surface === "subagent"

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -5,6 +5,8 @@ import {
   applyAgentCompactionSettingsFromConfigMock,
   buildEmbeddedSystemPromptMock,
   contextEngineCompactMock,
+  createBundleLspToolRuntimeMock,
+  createBundleMcpToolRuntimeMock,
   createAgentSessionMock,
   createPreparedEmbeddedAgentSettingsManagerMock,
   createOpenClawCodingToolsMock,
@@ -510,6 +512,14 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
 
     const sessionOptions = expectRecordFields(mockCallArg(createAgentSessionMock), {});
+    const bundleMcpOptions = expectRecordFields(mockCallArg(createBundleMcpToolRuntimeMock), {});
+    expect(bundleMcpOptions.reservedToolNames).toEqual(
+      expect.arrayContaining(["mockplugin_lookup", "fuzzplugin_move_delta"]),
+    );
+    const bundleLspOptions = expectRecordFields(mockCallArg(createBundleLspToolRuntimeMock), {});
+    expect(bundleLspOptions.reservedToolNames).toEqual(
+      expect.arrayContaining(["mockplugin_lookup", "fuzzplugin_move_delta"]),
+    );
     expect(
       (sessionOptions.customTools as Array<{ name: string }>).map((tool) => tool.name),
     ).toEqual(["mockplugin_lookup"]);

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -30,6 +30,7 @@ import {
   rotateTranscriptAfterCompactionMock,
   resetCompactHooksHarnessMocks,
   resetCompactSessionStateMocks,
+  runtimePlanToolsNormalizeMock,
   sessionAbortCompactionMock,
   sessionMessages,
   sessionCompactImpl,
@@ -464,14 +465,33 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       authStorage: { setRuntimeApiKey: vi.fn() },
       modelRegistry: {},
     });
+    runtimePlanToolsNormalizeMock.mockImplementation((tools) => {
+      for (const tool of tools as Array<{ parameters?: unknown }>) {
+        void tool.parameters;
+      }
+      return tools;
+    });
+    const unreadableSchemaTool: Record<string, unknown> = {
+      name: "fuzzplugin_move_delta",
+      label: "Fuzz Plugin Move Delta",
+      description: "Synthetic malformed tool.",
+      execute: async () => ({ text: "bad" }),
+    };
+    Object.defineProperty(unreadableSchemaTool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin tool schema is unreadable");
+      },
+    });
     createOpenClawCodingToolsMock.mockReturnValueOnce([
       {
-        name: "healthy_lookup",
+        name: "mockplugin_lookup",
         label: "Healthy Lookup",
         description: "Look up safe data.",
         parameters: { type: "object", properties: {} },
         execute: async () => ({ text: "ok" }),
       },
+      unreadableSchemaTool,
       {
         name: "fuzzplugin_move_angles",
         label: "FuzzPlugin Move Angles",
@@ -492,8 +512,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     const sessionOptions = expectRecordFields(mockCallArg(createAgentSessionMock), {});
     expect(
       (sessionOptions.customTools as Array<{ name: string }>).map((tool) => tool.name),
-    ).toEqual(["healthy_lookup"]);
-    expect(sessionOptions.tools).toEqual(["healthy_lookup"]);
+    ).toEqual(["mockplugin_lookup"]);
+    expect(sessionOptions.tools).toEqual(["mockplugin_lookup"]);
   });
 
   it("clamps the caller context token budget to the compaction model", async () => {

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -113,8 +113,10 @@ import { createAgentSession, estimateTokens, SessionManager } from "../sessions/
 import { detectRuntimeShell } from "../shell-utils.js";
 import { filterRuntimeCompatibleTools } from "../tool-schema-projection.js";
 import {
+  collectReadableQuarantinedRuntimeToolNames,
   filterProviderNormalizableRuntimeTools,
   filterRuntimeToolsWithReadableNames,
+  inspectProviderNormalizableRuntimeTools,
   logRuntimeToolSchemaQuarantine,
 } from "../tool-schema-quarantine.js";
 import {
@@ -831,21 +833,31 @@ async function compactEmbeddedAgentSessionDirectOnce(
       model,
     };
     const activeToolsRaw = toolsEnabled ? toolsRaw : [];
-    const providerNormalizableTools =
-      activeToolsRaw.length > 0
-        ? filterProviderNormalizableRuntimeTools({
-            tools: activeToolsRaw,
-            runId,
-            sessionKey: params.sessionKey,
-            sessionId: params.sessionId,
-          })
-        : activeToolsRaw;
+    let providerNormalizableTools = activeToolsRaw;
+    let preNormalizationQuarantinedToolNames: string[] = [];
+    if (activeToolsRaw.length > 0) {
+      const providerNormalizableProjection = inspectProviderNormalizableRuntimeTools({
+        tools: activeToolsRaw,
+        runId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+      });
+      providerNormalizableTools = [...providerNormalizableProjection.tools];
+      preNormalizationQuarantinedToolNames = collectReadableQuarantinedRuntimeToolNames({
+        tools: activeToolsRaw,
+        diagnostics: providerNormalizableProjection.diagnostics,
+      });
+    }
     const tools = runtimePlan.tools.normalize(providerNormalizableTools, runtimePlanModelContext);
+    const activeReservedToolNames = [
+      ...tools.map((tool) => tool.name),
+      ...preNormalizationQuarantinedToolNames,
+    ];
     const bundleMcpRuntime = toolsEnabled
       ? await createBundleMcpToolRuntime({
           workspaceDir: effectiveWorkspace,
           cfg: params.config,
-          reservedToolNames: tools.map((tool) => tool.name),
+          reservedToolNames: activeReservedToolNames,
         })
       : undefined;
     const bundleLspRuntime = toolsEnabled
@@ -853,7 +865,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
           workspaceDir: effectiveWorkspace,
           cfg: params.config,
           reservedToolNames: [
-            ...tools.map((tool) => tool.name),
+            ...activeReservedToolNames,
             ...filterRuntimeToolsWithReadableNames(bundleMcpRuntime?.tools ?? []).map(
               (tool) => tool.name,
             ),

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -111,12 +111,12 @@ import {
 } from "../session-write-lock.js";
 import { createAgentSession, estimateTokens, SessionManager } from "../sessions/index.js";
 import { detectRuntimeShell } from "../shell-utils.js";
+import { filterRuntimeCompatibleTools } from "../tool-schema-projection.js";
 import {
-  filterProviderNormalizableTools,
-  filterRuntimeCompatibleTools,
-} from "../tool-schema-projection.js";
-import { logRuntimeToolSchemaQuarantine } from "../tool-schema-quarantine.js";
-import type { AnyAgentTool } from "../tools/common.js";
+  filterProviderNormalizableRuntimeTools,
+  filterRuntimeToolsWithReadableNames,
+  logRuntimeToolSchemaQuarantine,
+} from "../tool-schema-quarantine.js";
 import {
   classifyCompactionReason,
   formatUnknownCompactionReasonDetail,
@@ -248,44 +248,6 @@ function prepareCompactionSessionAgent(params: {
     undefined,
     preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : undefined,
   );
-}
-
-function filterProviderNormalizableCompactionTools(params: {
-  tools: readonly AnyAgentTool[];
-  runId: string;
-  sessionKey?: string;
-  sessionId?: string;
-}): AnyAgentTool[] {
-  const projection = filterProviderNormalizableTools(params.tools);
-  logRuntimeToolSchemaQuarantine({
-    diagnostics: projection.diagnostics,
-    tools: params.tools,
-    runId: params.runId,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionId,
-  });
-  return [...projection.tools];
-}
-
-function filterReadableCompactionToolNames(tools: readonly AnyAgentTool[]): AnyAgentTool[] {
-  let length = 0;
-  try {
-    length = tools.length;
-  } catch {
-    return [];
-  }
-  const readableTools: AnyAgentTool[] = [];
-  for (let index = 0; index < length; index += 1) {
-    try {
-      const tool = tools[index];
-      if (typeof tool.name === "string") {
-        readableTools.push(tool);
-      }
-    } catch {
-      // Unreadable bundled names cannot participate in allowlists/reserved names.
-    }
-  }
-  return readableTools;
 }
 
 function resolveCompactionProviderStream(params: {
@@ -871,7 +833,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
     const activeToolsRaw = toolsEnabled ? toolsRaw : [];
     const providerNormalizableTools =
       activeToolsRaw.length > 0
-        ? filterProviderNormalizableCompactionTools({
+        ? filterProviderNormalizableRuntimeTools({
             tools: activeToolsRaw,
             runId,
             sessionKey: params.sessionKey,
@@ -892,15 +854,15 @@ async function compactEmbeddedAgentSessionDirectOnce(
           cfg: params.config,
           reservedToolNames: [
             ...tools.map((tool) => tool.name),
-            ...filterReadableCompactionToolNames(bundleMcpRuntime?.tools ?? []).map(
+            ...filterRuntimeToolsWithReadableNames(bundleMcpRuntime?.tools ?? []).map(
               (tool) => tool.name,
             ),
           ],
         })
       : undefined;
     const readableBundledToolCandidates = [
-      ...filterReadableCompactionToolNames(bundleMcpRuntime?.tools ?? []),
-      ...filterReadableCompactionToolNames(bundleLspRuntime?.tools ?? []),
+      ...filterRuntimeToolsWithReadableNames(bundleMcpRuntime?.tools ?? []),
+      ...filterRuntimeToolsWithReadableNames(bundleLspRuntime?.tools ?? []),
     ];
     const filteredBundledTools = applyFinalEffectiveToolPolicy({
       bundledTools: readableBundledToolCandidates,
@@ -929,7 +891,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
     });
     const providerNormalizableBundledTools =
       filteredBundledTools.length > 0
-        ? filterProviderNormalizableCompactionTools({
+        ? filterProviderNormalizableRuntimeTools({
             tools: filteredBundledTools,
             runId,
             sessionKey: params.sessionKey,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -111,8 +111,12 @@ import {
 } from "../session-write-lock.js";
 import { createAgentSession, estimateTokens, SessionManager } from "../sessions/index.js";
 import { detectRuntimeShell } from "../shell-utils.js";
-import { filterRuntimeCompatibleTools } from "../tool-schema-projection.js";
+import {
+  filterProviderNormalizableTools,
+  filterRuntimeCompatibleTools,
+} from "../tool-schema-projection.js";
 import { logRuntimeToolSchemaQuarantine } from "../tool-schema-quarantine.js";
+import type { AnyAgentTool } from "../tools/common.js";
 import {
   classifyCompactionReason,
   formatUnknownCompactionReasonDetail,
@@ -244,6 +248,44 @@ function prepareCompactionSessionAgent(params: {
     undefined,
     preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : undefined,
   );
+}
+
+function filterProviderNormalizableCompactionTools(params: {
+  tools: readonly AnyAgentTool[];
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+}): AnyAgentTool[] {
+  const projection = filterProviderNormalizableTools(params.tools);
+  logRuntimeToolSchemaQuarantine({
+    diagnostics: projection.diagnostics,
+    tools: params.tools,
+    runId: params.runId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+  });
+  return [...projection.tools];
+}
+
+function filterReadableCompactionToolNames(tools: readonly AnyAgentTool[]): AnyAgentTool[] {
+  let length = 0;
+  try {
+    length = tools.length;
+  } catch {
+    return [];
+  }
+  const readableTools: AnyAgentTool[] = [];
+  for (let index = 0; index < length; index += 1) {
+    try {
+      const tool = tools[index];
+      if (typeof tool.name === "string") {
+        readableTools.push(tool);
+      }
+    } catch {
+      // Unreadable bundled names cannot participate in allowlists/reserved names.
+    }
+  }
+  return readableTools;
 }
 
 function resolveCompactionProviderStream(params: {
@@ -826,10 +868,17 @@ async function compactEmbeddedAgentSessionDirectOnce(
       modelApi: model.api,
       model,
     };
-    const tools = runtimePlan.tools.normalize(
-      toolsEnabled ? toolsRaw : [],
-      runtimePlanModelContext,
-    );
+    const activeToolsRaw = toolsEnabled ? toolsRaw : [];
+    const providerNormalizableTools =
+      activeToolsRaw.length > 0
+        ? filterProviderNormalizableCompactionTools({
+            tools: activeToolsRaw,
+            runId,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+          })
+        : activeToolsRaw;
+    const tools = runtimePlan.tools.normalize(providerNormalizableTools, runtimePlanModelContext);
     const bundleMcpRuntime = toolsEnabled
       ? await createBundleMcpToolRuntime({
           workspaceDir: effectiveWorkspace,
@@ -843,12 +892,18 @@ async function compactEmbeddedAgentSessionDirectOnce(
           cfg: params.config,
           reservedToolNames: [
             ...tools.map((tool) => tool.name),
-            ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
+            ...filterReadableCompactionToolNames(bundleMcpRuntime?.tools ?? []).map(
+              (tool) => tool.name,
+            ),
           ],
         })
       : undefined;
+    const readableBundledToolCandidates = [
+      ...filterReadableCompactionToolNames(bundleMcpRuntime?.tools ?? []),
+      ...filterReadableCompactionToolNames(bundleLspRuntime?.tools ?? []),
+    ];
     const filteredBundledTools = applyFinalEffectiveToolPolicy({
-      bundledTools: [...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
+      bundledTools: readableBundledToolCandidates,
       config: params.config,
       sandboxToolPolicy: sandbox?.tools,
       sessionKey: sandboxSessionKey,
@@ -872,10 +927,19 @@ async function compactEmbeddedAgentSessionDirectOnce(
       senderE164: params.senderE164,
       warn: (message) => log.warn(message),
     });
-    const normalizedBundledTools =
+    const providerNormalizableBundledTools =
       filteredBundledTools.length > 0
-        ? runtimePlan.tools.normalize(filteredBundledTools, runtimePlanModelContext)
+        ? filterProviderNormalizableCompactionTools({
+            tools: filteredBundledTools,
+            runId,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+          })
         : filteredBundledTools;
+    const normalizedBundledTools =
+      providerNormalizableBundledTools.length > 0
+        ? runtimePlan.tools.normalize(providerNormalizableBundledTools, runtimePlanModelContext)
+        : providerNormalizableBundledTools;
     const projectedEffectiveTools = [...tools, ...normalizedBundledTools];
     const toolSchemaProjection = filterRuntimeCompatibleTools(projectedEffectiveTools);
     logRuntimeToolSchemaQuarantine({

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -353,6 +353,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         throw new Error("fuzz tool parameters are unreadable");
       },
     });
+    hoisted.getOrCreateSessionMcpRuntimeMock.mockResolvedValue({ runtime: "bundle-mcp" });
     hoisted.createOpenClawCodingToolsMock.mockReturnValue([
       {
         name: "healthy_lookup",
@@ -392,6 +393,17 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       0,
       "createAgentSession options",
     );
+    expect(
+      mockParams(
+        hoisted.materializeBundleMcpToolsForRunMock,
+        0,
+        "materializeBundleMcpToolsForRun options",
+      ).reservedToolNames,
+    ).toEqual(expect.arrayContaining(["healthy_lookup", "fuzzplugin_move_angles"]));
+    expect(
+      mockParams(hoisted.createBundleLspToolRuntimeMock, 0, "createBundleLspToolRuntime options")
+        .reservedToolNames,
+    ).toEqual(expect.arrayContaining(["healthy_lookup", "fuzzplugin_move_angles"]));
     const customTools = requireRecords(sessionOptions.customTools, "customTools");
     expect(customTools.map((tool) => tool.name)).toEqual(["healthy_lookup"]);
     expect(activeToolNames).toEqual([["healthy_lookup"]]);

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -340,6 +340,174 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(activeToolNames).toEqual([["healthy_lookup"]]);
   });
 
+  it("quarantines unreadable tool schemas before provider normalization", async () => {
+    const unreadableTool: Record<string, unknown> = {
+      name: "fuzzplugin_move_angles",
+      label: "FuzzPlugin Move Angles",
+      description: "Move synthetic joints.",
+      execute: async () => ({ text: "bad" }),
+    };
+    Object.defineProperty(unreadableTool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzz tool parameters are unreadable");
+      },
+    });
+    hoisted.createOpenClawCodingToolsMock.mockReturnValue([
+      {
+        name: "healthy_lookup",
+        label: "Healthy Lookup",
+        description: "Look up safe data.",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({ text: "ok" }),
+      },
+      unreadableTool,
+    ]);
+
+    const activeToolNames: string[][] = [];
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+        config: {
+          tools: {
+            codeMode: { enabled: false },
+            toolSearch: false,
+          },
+        } as OpenClawConfig,
+      },
+      createSession: () => {
+        const session = createDefaultEmbeddedSession();
+        session.setActiveToolsByName = (toolNames) => {
+          activeToolNames.push([...toolNames]);
+        };
+        return session;
+      },
+    });
+
+    const sessionOptions = mockParams(
+      hoisted.createAgentSessionMock,
+      0,
+      "createAgentSession options",
+    );
+    const customTools = requireRecords(sessionOptions.customTools, "customTools");
+    expect(customTools.map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+    expect(activeToolNames).toEqual([["healthy_lookup"]]);
+  });
+
+  it("does not crash explicit tool allowlists on unreadable tool rows", async () => {
+    const healthyTool = {
+      name: "healthy_lookup",
+      label: "Healthy Lookup",
+      description: "Look up safe data.",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ text: "ok" }),
+    };
+    const tools = [undefined, healthyTool] as unknown[];
+    Object.defineProperty(tools, "0", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzz tool row is unreadable");
+      },
+    });
+    hoisted.createOpenClawCodingToolsMock.mockReturnValue(tools as never);
+
+    const activeToolNames: string[][] = [];
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+        config: {
+          tools: {
+            allow: ["healthy_lookup"],
+            codeMode: { enabled: false },
+            toolSearch: false,
+          },
+        } as OpenClawConfig,
+      },
+      createSession: () => {
+        const session = createDefaultEmbeddedSession();
+        session.setActiveToolsByName = (toolNames) => {
+          activeToolNames.push([...toolNames]);
+        };
+        return session;
+      },
+    });
+
+    const sessionOptions = mockParams(
+      hoisted.createAgentSessionMock,
+      0,
+      "createAgentSession options",
+    );
+    const customTools = requireRecords(sessionOptions.customTools, "customTools");
+    expect(customTools.map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+    expect(activeToolNames).toEqual([["healthy_lookup"]]);
+  });
+
+  it("does not crash bundle MCP allowlists on unreadable bundled tool names", async () => {
+    const healthyBundledTool = {
+      name: "fuzzplugin__healthy_lookup",
+      label: "Healthy Lookup",
+      description: "Look up safe bundled data.",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ text: "ok" }),
+    };
+    const unreadableBundledTool: Record<string, unknown> = {
+      label: "Fuzz Move Delta",
+      description: "Move synthetic joints.",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ text: "bad" }),
+    };
+    Object.defineProperty(unreadableBundledTool, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzz bundled tool name is unreadable");
+      },
+    });
+    hoisted.getOrCreateSessionMcpRuntimeMock.mockResolvedValue({ runtime: "bundle-mcp" });
+    hoisted.materializeBundleMcpToolsForRunMock.mockResolvedValue({
+      tools: [unreadableBundledTool, healthyBundledTool],
+      dispose: async () => {},
+    });
+
+    const activeToolNames: string[][] = [];
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+        config: {
+          tools: {
+            allow: ["fuzzplugin__healthy_lookup"],
+            codeMode: { enabled: false },
+            toolSearch: false,
+          },
+        } as OpenClawConfig,
+      },
+      createSession: () => {
+        const session = createDefaultEmbeddedSession();
+        session.setActiveToolsByName = (toolNames) => {
+          activeToolNames.push([...toolNames]);
+        };
+        return session;
+      },
+    });
+
+    const sessionOptions = mockParams(
+      hoisted.createAgentSessionMock,
+      0,
+      "createAgentSession options",
+    );
+    const customTools = requireRecords(sessionOptions.customTools, "customTools");
+    expect(customTools.map((tool) => tool.name)).toEqual(["fuzzplugin__healthy_lookup"]);
+    expect(activeToolNames).toEqual([["fuzzplugin__healthy_lookup"]]);
+  });
+
   it("keeps the embedded system prompt after active tool selection", async () => {
     let seenSystemPrompt: string | undefined;
 

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -68,6 +68,9 @@ type AttemptSpawnWorkspaceHoisted = {
   ensureGlobalUndiciStreamTimeoutsMock: UnknownMock;
   buildEmbeddedMessageActionDiscoveryInputMock: UnknownMock;
   createOpenClawCodingToolsMock: UnknownMock;
+  getOrCreateSessionMcpRuntimeMock: AsyncUnknownMock;
+  materializeBundleMcpToolsForRunMock: AsyncUnknownMock;
+  createBundleLspToolRuntimeMock: AsyncUnknownMock;
   subscribeEmbeddedAgentSessionMock: Mock<SubscribeEmbeddedAgentSessionFn>;
   acquireSessionWriteLockMock: Mock<AcquireSessionWriteLockFn>;
   installToolResultContextGuardMock: UnknownMock;
@@ -140,6 +143,9 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const ensureGlobalUndiciStreamTimeoutsMock = vi.fn();
   const buildEmbeddedMessageActionDiscoveryInputMock = vi.fn((params: unknown) => params);
   const createOpenClawCodingToolsMock = vi.fn(() => []);
+  const getOrCreateSessionMcpRuntimeMock = vi.fn(async () => undefined);
+  const materializeBundleMcpToolsForRunMock = vi.fn(async () => undefined);
+  const createBundleLspToolRuntimeMock = vi.fn(async () => undefined);
   const installToolResultContextGuardMock = vi.fn(() => () => {});
   const installContextEngineLoopHookMock = vi.fn(() => () => {});
   const flushPendingToolResultsAfterIdleMock = vi.fn(async () => {});
@@ -210,6 +216,9 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     ensureGlobalUndiciStreamTimeoutsMock,
     buildEmbeddedMessageActionDiscoveryInputMock,
     createOpenClawCodingToolsMock,
+    getOrCreateSessionMcpRuntimeMock,
+    materializeBundleMcpToolsForRunMock,
+    createBundleLspToolRuntimeMock,
     subscribeEmbeddedAgentSessionMock,
     acquireSessionWriteLockMock,
     installToolResultContextGuardMock,
@@ -593,13 +602,16 @@ vi.mock("../../agent-tools.js", () => ({
 
 vi.mock("../../agent-bundle-mcp-tools.js", () => ({
   createBundleMcpToolRuntime: async () => undefined,
-  getOrCreateSessionMcpRuntime: async () => undefined,
-  materializeBundleMcpToolsForRun: async () => undefined,
+  getOrCreateSessionMcpRuntime: (...args: unknown[]) =>
+    hoisted.getOrCreateSessionMcpRuntimeMock(...args),
+  materializeBundleMcpToolsForRun: (...args: unknown[]) =>
+    hoisted.materializeBundleMcpToolsForRunMock(...args),
   retireSessionMcpRuntime: async () => true,
 }));
 
 vi.mock("../../agent-bundle-lsp-runtime.js", () => ({
-  createBundleLspToolRuntime: async () => undefined,
+  createBundleLspToolRuntime: (...args: unknown[]) =>
+    hoisted.createBundleLspToolRuntimeMock(...args),
 }));
 
 vi.mock("../../../image-generation/runtime.js", () => ({
@@ -967,6 +979,9 @@ export function resetEmbeddedAttemptHarness(
       },
     ];
   });
+  hoisted.getOrCreateSessionMcpRuntimeMock.mockReset().mockResolvedValue(undefined);
+  hoisted.materializeBundleMcpToolsForRunMock.mockReset().mockResolvedValue(undefined);
+  hoisted.createBundleLspToolRuntimeMock.mockReset().mockResolvedValue(undefined);
   hoisted.subscribeEmbeddedAgentSessionMock
     .mockReset()
     .mockImplementation(() => createSubscriptionMock());

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -202,9 +202,11 @@ import {
 } from "../../tool-allowlist-guard.js";
 import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
 import {
+  collectReadableQuarantinedRuntimeToolNames,
   filterProviderNormalizableRuntimeTools,
   filterRuntimeToolsWithReadableNames,
   hasReadableRuntimeToolName,
+  inspectProviderNormalizableRuntimeTools,
   logRuntimeToolSchemaQuarantine,
 } from "../../tool-schema-quarantine.js";
 import {
@@ -1413,15 +1415,21 @@ export async function runEmbeddedAttempt(
       model: params.model,
     };
     const activeToolsRaw = toolsEnabled ? toolsRaw : [];
-    const providerNormalizableTools =
-      activeToolsRaw.length > 0
-        ? filterProviderNormalizableRuntimeTools({
-            tools: activeToolsRaw,
-            runId: params.runId,
-            sessionKey: params.sessionKey,
-            sessionId: params.sessionId,
-          })
-        : activeToolsRaw;
+    let providerNormalizableTools = activeToolsRaw;
+    let preNormalizationQuarantinedToolNames: string[] = [];
+    if (activeToolsRaw.length > 0) {
+      const providerNormalizableProjection = inspectProviderNormalizableRuntimeTools({
+        tools: activeToolsRaw,
+        runId: params.runId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+      });
+      providerNormalizableTools = [...providerNormalizableProjection.tools];
+      preNormalizationQuarantinedToolNames = collectReadableQuarantinedRuntimeToolNames({
+        tools: activeToolsRaw,
+        diagnostics: providerNormalizableProjection.diagnostics,
+      });
+    }
     const tools = normalizeAgentRuntimeTools({
       runtimePlan: params.runtimePlan,
       tools: providerNormalizableTools,
@@ -1434,6 +1442,10 @@ export async function runEmbeddedAttempt(
       model: params.model,
       runtimeHandle: getProviderRuntimeHandle(),
     });
+    const activeReservedToolNames = [
+      ...tools.map((tool) => tool.name),
+      ...preNormalizationQuarantinedToolNames,
+    ];
     const clientTools = toolsEnabled && !isRawModelRun ? params.clientTools : undefined;
     const bundleMcpEnabled = shouldCreateBundleMcpRuntimeForAttempt({
       toolsEnabled,
@@ -1452,7 +1464,7 @@ export async function runEmbeddedAttempt(
       ? await materializeBundleMcpToolsForRun({
           runtime: bundleMcpSessionRuntime,
           reservedToolNames: [
-            ...tools.map((tool) => tool.name),
+            ...activeReservedToolNames,
             ...(clientTools?.map((tool) => tool.function.name) ?? []),
           ],
         })
@@ -1467,7 +1479,7 @@ export async function runEmbeddedAttempt(
           workspaceDir: effectiveWorkspace,
           cfg: params.config,
           reservedToolNames: [
-            ...tools.map((tool) => tool.name),
+            ...activeReservedToolNames,
             ...(clientTools?.map((tool) => tool.function.name) ?? []),
             ...filterRuntimeToolsWithReadableNames(bundleMcpRuntime?.tools ?? []).map(
               (tool) => tool.name,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -200,11 +200,13 @@ import {
   buildEmptyExplicitToolAllowlistError,
   collectExplicitToolAllowlistSources,
 } from "../../tool-allowlist-guard.js";
+import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
 import {
-  filterProviderNormalizableTools,
-  filterRuntimeCompatibleTools,
-} from "../../tool-schema-projection.js";
-import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
+  filterProviderNormalizableRuntimeTools,
+  filterRuntimeToolsWithReadableNames,
+  hasReadableRuntimeToolName,
+  logRuntimeToolSchemaQuarantine,
+} from "../../tool-schema-quarantine.js";
 import {
   addClientToolsToToolSearchCatalog,
   applyToolSearchCatalog,
@@ -216,7 +218,6 @@ import {
   type ToolSearchCatalogToolExecutor,
   type ToolSearchTargetTranscriptProjection,
 } from "../../tool-search.js";
-import type { AnyAgentTool } from "../../tools/common.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME, type WorkspaceBootstrapFile } from "../../workspace.js";
@@ -513,65 +514,8 @@ function pluginMetadataSnapshotCoversProvider(
   });
 }
 
-function filterProviderNormalizableAttemptTools(params: {
-  tools: readonly AnyAgentTool[];
-  runId: string;
-  sessionKey?: string;
-  sessionId?: string;
-}): AnyAgentTool[] {
-  const projection = filterProviderNormalizableTools(params.tools);
-  logRuntimeToolSchemaQuarantine({
-    diagnostics: projection.diagnostics,
-    tools: params.tools,
-    runId: params.runId,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionId,
-  });
-  return [...projection.tools];
-}
-
 function allowlistNeedsReadableToolNames(toolsAllow: readonly string[] | undefined): boolean {
   return Boolean(toolsAllow?.length && !toolsAllow.some((entry) => entry.trim() === "*"));
-}
-
-function filterReadableAttemptToolNames(tools: readonly AnyAgentTool[]): AnyAgentTool[] {
-  let length = 0;
-  try {
-    length = tools.length;
-  } catch {
-    return [];
-  }
-  const readableTools: AnyAgentTool[] = [];
-  for (let index = 0; index < length; index += 1) {
-    try {
-      const tool = tools[index];
-      if (typeof tool.name === "string") {
-        readableTools.push(tool);
-      }
-    } catch {
-      continue;
-    }
-  }
-  return readableTools;
-}
-
-function hasReadableAttemptToolName(tools: readonly AnyAgentTool[], name: string): boolean {
-  let length = 0;
-  try {
-    length = tools.length;
-  } catch {
-    return false;
-  }
-  for (let index = 0; index < length; index += 1) {
-    try {
-      if (tools[index].name === name) {
-        return true;
-      }
-    } catch {
-      continue;
-    }
-  }
-  return false;
 }
 
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
@@ -1305,7 +1249,7 @@ export async function runEmbeddedAttempt(
           });
           corePluginToolStages.mark("attempt:create-openclaw-coding-tools");
           const allowlistCandidateTools = allowlistNeedsReadableToolNames(effectiveToolsAllow)
-            ? filterReadableAttemptToolNames(allTools)
+            ? filterRuntimeToolsWithReadableNames(allTools)
             : allTools;
           const filteredTools = applyEmbeddedAttemptToolsAllow(
             allowlistCandidateTools,
@@ -1319,7 +1263,7 @@ export async function runEmbeddedAttempt(
         })();
     prepStages.mark("core-plugin-tools");
     emitCorePluginToolStageSummary("core-plugin-tools", corePluginToolStages.snapshot());
-    const bootstrapHasFileAccess = toolsEnabled && hasReadableAttemptToolName(toolsRaw, "read");
+    const bootstrapHasFileAccess = toolsEnabled && hasReadableRuntimeToolName(toolsRaw, "read");
     const bootstrapWarn = makeBootstrapWarn({
       sessionLabel,
       workspaceDir: resolvedWorkspace,
@@ -1471,7 +1415,7 @@ export async function runEmbeddedAttempt(
     const activeToolsRaw = toolsEnabled ? toolsRaw : [];
     const providerNormalizableTools =
       activeToolsRaw.length > 0
-        ? filterProviderNormalizableAttemptTools({
+        ? filterProviderNormalizableRuntimeTools({
             tools: activeToolsRaw,
             runId: params.runId,
             sessionKey: params.sessionKey,
@@ -1525,7 +1469,7 @@ export async function runEmbeddedAttempt(
           reservedToolNames: [
             ...tools.map((tool) => tool.name),
             ...(clientTools?.map((tool) => tool.function.name) ?? []),
-            ...filterReadableAttemptToolNames(bundleMcpRuntime?.tools ?? []).map(
+            ...filterRuntimeToolsWithReadableNames(bundleMcpRuntime?.tools ?? []).map(
               (tool) => tool.name,
             ),
           ],
@@ -1535,7 +1479,8 @@ export async function runEmbeddedAttempt(
       ...(bundleMcpRuntime?.tools ?? []),
       ...(bundleLspRuntime?.tools ?? []),
     ];
-    const readableBundledToolCandidates = filterReadableAttemptToolNames(bundledToolCandidates);
+    const readableBundledToolCandidates =
+      filterRuntimeToolsWithReadableNames(bundledToolCandidates);
     const allowedBundledTools = applyEmbeddedAttemptToolsAllow(
       readableBundledToolCandidates,
       effectiveToolsAllow,
@@ -1565,7 +1510,7 @@ export async function runEmbeddedAttempt(
     });
     const providerNormalizableBundledTools =
       filteredBundledTools.length > 0
-        ? filterProviderNormalizableAttemptTools({
+        ? filterProviderNormalizableRuntimeTools({
             tools: filteredBundledTools,
             runId: params.runId,
             sessionKey: params.sessionKey,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -200,7 +200,10 @@ import {
   buildEmptyExplicitToolAllowlistError,
   collectExplicitToolAllowlistSources,
 } from "../../tool-allowlist-guard.js";
-import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
+import {
+  filterProviderNormalizableTools,
+  filterRuntimeCompatibleTools,
+} from "../../tool-schema-projection.js";
 import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
 import {
   addClientToolsToToolSearchCatalog,
@@ -213,6 +216,7 @@ import {
   type ToolSearchCatalogToolExecutor,
   type ToolSearchTargetTranscriptProjection,
 } from "../../tool-search.js";
+import type { AnyAgentTool } from "../../tools/common.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME, type WorkspaceBootstrapFile } from "../../workspace.js";
@@ -507,6 +511,67 @@ function pluginMetadataSnapshotCoversProvider(
       (providerId) => normalizeProviderId(providerId) === normalizedProvider,
     );
   });
+}
+
+function filterProviderNormalizableAttemptTools(params: {
+  tools: readonly AnyAgentTool[];
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+}): AnyAgentTool[] {
+  const projection = filterProviderNormalizableTools(params.tools);
+  logRuntimeToolSchemaQuarantine({
+    diagnostics: projection.diagnostics,
+    tools: params.tools,
+    runId: params.runId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+  });
+  return [...projection.tools];
+}
+
+function allowlistNeedsReadableToolNames(toolsAllow: readonly string[] | undefined): boolean {
+  return Boolean(toolsAllow?.length && !toolsAllow.some((entry) => entry.trim() === "*"));
+}
+
+function filterReadableAttemptToolNames(tools: readonly AnyAgentTool[]): AnyAgentTool[] {
+  let length = 0;
+  try {
+    length = tools.length;
+  } catch {
+    return [];
+  }
+  const readableTools: AnyAgentTool[] = [];
+  for (let index = 0; index < length; index += 1) {
+    try {
+      const tool = tools[index];
+      if (typeof tool.name === "string") {
+        readableTools.push(tool);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return readableTools;
+}
+
+function hasReadableAttemptToolName(tools: readonly AnyAgentTool[], name: string): boolean {
+  let length = 0;
+  try {
+    length = tools.length;
+  } catch {
+    return false;
+  }
+  for (let index = 0; index < length; index += 1) {
+    try {
+      if (tools[index].name === name) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
 }
 
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
@@ -1239,15 +1304,22 @@ export async function runEmbeddedAttempt(
             },
           });
           corePluginToolStages.mark("attempt:create-openclaw-coding-tools");
-          const filteredTools = applyEmbeddedAttemptToolsAllow(allTools, effectiveToolsAllow, {
-            toolMeta: (tool) => getPluginToolMeta(tool),
-          });
+          const allowlistCandidateTools = allowlistNeedsReadableToolNames(effectiveToolsAllow)
+            ? filterReadableAttemptToolNames(allTools)
+            : allTools;
+          const filteredTools = applyEmbeddedAttemptToolsAllow(
+            allowlistCandidateTools,
+            effectiveToolsAllow,
+            {
+              toolMeta: (tool) => getPluginToolMeta(tool),
+            },
+          );
           corePluginToolStages.mark("attempt:tools-allow");
           return filteredTools;
         })();
     prepStages.mark("core-plugin-tools");
     emitCorePluginToolStageSummary("core-plugin-tools", corePluginToolStages.snapshot());
-    const bootstrapHasFileAccess = toolsEnabled && toolsRaw.some((tool) => tool.name === "read");
+    const bootstrapHasFileAccess = toolsEnabled && hasReadableAttemptToolName(toolsRaw, "read");
     const bootstrapWarn = makeBootstrapWarn({
       sessionLabel,
       workspaceDir: resolvedWorkspace,
@@ -1396,9 +1468,19 @@ export async function runEmbeddedAttempt(
       modelApi: params.model.api,
       model: params.model,
     };
+    const activeToolsRaw = toolsEnabled ? toolsRaw : [];
+    const providerNormalizableTools =
+      activeToolsRaw.length > 0
+        ? filterProviderNormalizableAttemptTools({
+            tools: activeToolsRaw,
+            runId: params.runId,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+          })
+        : activeToolsRaw;
     const tools = normalizeAgentRuntimeTools({
       runtimePlan: params.runtimePlan,
-      tools: toolsEnabled ? toolsRaw : [],
+      tools: providerNormalizableTools,
       provider: params.provider,
       config: params.config,
       workspaceDir: effectiveWorkspace,
@@ -1443,12 +1525,19 @@ export async function runEmbeddedAttempt(
           reservedToolNames: [
             ...tools.map((tool) => tool.name),
             ...(clientTools?.map((tool) => tool.function.name) ?? []),
-            ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
+            ...filterReadableAttemptToolNames(bundleMcpRuntime?.tools ?? []).map(
+              (tool) => tool.name,
+            ),
           ],
         })
       : undefined;
+    const bundledToolCandidates = [
+      ...(bundleMcpRuntime?.tools ?? []),
+      ...(bundleLspRuntime?.tools ?? []),
+    ];
+    const readableBundledToolCandidates = filterReadableAttemptToolNames(bundledToolCandidates);
     const allowedBundledTools = applyEmbeddedAttemptToolsAllow(
-      [...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
+      readableBundledToolCandidates,
       effectiveToolsAllow,
       {
         toolMeta: (tool) => getPluginToolMeta(tool),
@@ -1474,11 +1563,20 @@ export async function runEmbeddedAttempt(
       senderE164: params.senderE164,
       warn: (message) => log.warn(message),
     });
-    const normalizedBundledTools =
+    const providerNormalizableBundledTools =
       filteredBundledTools.length > 0
+        ? filterProviderNormalizableAttemptTools({
+            tools: filteredBundledTools,
+            runId: params.runId,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+          })
+        : filteredBundledTools;
+    const normalizedBundledTools =
+      providerNormalizableBundledTools.length > 0
         ? normalizeAgentRuntimeTools({
             runtimePlan: params.runtimePlan,
-            tools: filteredBundledTools,
+            tools: providerNormalizableBundledTools,
             provider: params.provider,
             config: params.config,
             workspaceDir: effectiveWorkspace,
@@ -1488,7 +1586,7 @@ export async function runEmbeddedAttempt(
             model: params.model,
             runtimeHandle: getProviderRuntimeHandle(),
           })
-        : filteredBundledTools;
+        : providerNormalizableBundledTools;
     const projectedUncompactedEffectiveTools = filterLocalModelLeanTools({
       tools: [...tools, ...normalizedBundledTools],
       config: params.config,

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  filterProviderNormalizableTools,
   filterRuntimeCompatibleTools,
   inspectRuntimeToolInputSchemas,
   projectRuntimeToolInputSchema,
@@ -97,6 +98,107 @@ describe("runtime tool input schema projection", () => {
           toolName: "fuzzplugin_move_angles",
           toolIndex: 1,
           violations: ['fuzzplugin_move_angles.parameters.type must be "object"'],
+        },
+      ],
+    });
+  });
+
+  it("keeps provider-repairable schemas before provider normalization", () => {
+    const missingParameters = {
+      name: "missing_parameters",
+      parameters: undefined,
+    };
+    const nonObjectSchema = {
+      name: "fuzzplugin_move_angles",
+      parameters: { type: "array", items: { type: "number" } },
+    };
+    const circularSchema = {
+      name: "circular_schema",
+      parameters: {} as { self?: unknown },
+    };
+    circularSchema.parameters.self = circularSchema.parameters;
+
+    expect(
+      filterProviderNormalizableTools([
+        missingParameters,
+        nonObjectSchema,
+        circularSchema,
+      ] as never),
+    ).toEqual({
+      tools: [missingParameters, nonObjectSchema],
+      diagnostics: [
+        {
+          toolName: "circular_schema",
+          toolIndex: 2,
+          violations: ["circular_schema.parameters is not JSON-serializable"],
+        },
+      ],
+    });
+  });
+
+  it("filters tools with unreadable descriptors without dropping healthy tools", () => {
+    const unreadableName: Record<string, unknown> = {
+      parameters: { type: "object", properties: {} },
+    };
+    Object.defineProperty(unreadableName, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin name is unreadable");
+      },
+    });
+    const unreadableParameters: Record<string, unknown> = {
+      name: "fuzzplugin_move_angles",
+    };
+    Object.defineProperty(unreadableParameters, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin parameters are unreadable");
+      },
+    });
+    const healthy = {
+      name: "healthy",
+      parameters: { type: "object", properties: {} },
+    };
+
+    expect(
+      filterRuntimeCompatibleTools([unreadableName, unreadableParameters, healthy] as never),
+    ).toEqual({
+      tools: [healthy],
+      diagnostics: [
+        {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["tool[0].name is unreadable"],
+        },
+        {
+          toolName: "fuzzplugin_move_angles",
+          toolIndex: 1,
+          violations: ["fuzzplugin_move_angles.parameters is unreadable"],
+        },
+      ],
+    });
+  });
+
+  it("filters unreadable tool rows without dropping healthy tools", () => {
+    const healthy = {
+      name: "healthy",
+      parameters: { type: "object", properties: {} },
+    };
+    const tools = [undefined, healthy] as unknown[];
+    Object.defineProperty(tools, "0", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin tool row is unreadable");
+      },
+    });
+
+    expect(filterRuntimeCompatibleTools(tools as never)).toEqual({
+      tools: [healthy],
+      diagnostics: [
+        {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["tool[0] is unreadable"],
         },
       ],
     });

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -24,6 +24,66 @@ export type RuntimeToolSchemaInspection<TTool extends Pick<AnyAgentTool, "name" 
   readonly diagnostics: readonly RuntimeToolSchemaDiagnostic[];
 };
 
+type RuntimeToolEntryRead<TTool extends Pick<AnyAgentTool, "name" | "parameters">> =
+  | {
+      readonly ok: true;
+      readonly tool: TTool;
+      readonly toolIndex: number;
+    }
+  | {
+      readonly ok: false;
+      readonly diagnostic: RuntimeToolSchemaDiagnostic;
+    };
+type ToolSchemaInspectionMode = "runtime" | "provider-normalizable";
+
+function unreadableRuntimeToolEntry(
+  toolIndex: number,
+): RuntimeToolEntryRead<Pick<AnyAgentTool, "name" | "parameters">> {
+  return {
+    ok: false,
+    diagnostic: {
+      toolName: `tool[${toolIndex}]`,
+      toolIndex,
+      violations: [`tool[${toolIndex}] is unreadable`],
+    },
+  };
+}
+
+function readRuntimeToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
+  tools: readonly TTool[],
+): RuntimeToolEntryRead<TTool>[] {
+  let length = 0;
+  try {
+    length = tools.length;
+  } catch {
+    return [unreadableRuntimeToolEntry(0) as RuntimeToolEntryRead<TTool>];
+  }
+  const entries: RuntimeToolEntryRead<TTool>[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    try {
+      entries.push({ ok: true, tool: tools[toolIndex], toolIndex });
+    } catch {
+      entries.push(unreadableRuntimeToolEntry(toolIndex) as RuntimeToolEntryRead<TTool>);
+    }
+  }
+  return entries;
+}
+
+function readToolProjectionField<TField extends "name" | "parameters">(
+  tool: Pick<AnyAgentTool, "name" | "parameters">,
+  field: TField,
+):
+  | { readable: true; value: Pick<AnyAgentTool, "name" | "parameters">[TField] }
+  | {
+      readable: false;
+    } {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
 function isJsonValue(value: unknown): value is RuntimeToolInputSchemaJson {
   if (value === null) {
     return true;
@@ -140,29 +200,75 @@ export function projectRuntimeToolInputSchema(
   };
 }
 
+function inspectToolSchema(
+  tool: Pick<AnyAgentTool, "name" | "parameters">,
+  toolIndex: number,
+  mode: ToolSchemaInspectionMode,
+): RuntimeToolSchemaDiagnostic | undefined {
+  const nameRead = readToolProjectionField(tool, "name");
+  const toolName =
+    nameRead.readable && typeof nameRead.value === "string" && nameRead.value
+      ? nameRead.value
+      : `tool[${toolIndex}]`;
+  const descriptorViolations = nameRead.readable ? [] : [`${toolName}.name is unreadable`];
+  const parametersRead = readToolProjectionField(tool, "parameters");
+  if (!parametersRead.readable) {
+    return {
+      toolName,
+      toolIndex,
+      violations: [...descriptorViolations, `${toolName}.parameters is unreadable`],
+    };
+  }
+  const schemaPath = `${toolName}.parameters`;
+  const projectionViolations =
+    mode === "runtime"
+      ? projectRuntimeToolInputSchema(parametersRead.value, schemaPath).violations
+      : parametersRead.value !== null && typeof parametersRead.value === "object"
+        ? projectRuntimeToolInputSchema(parametersRead.value, schemaPath).violations.filter(
+            (violation) =>
+              violation === `${schemaPath} is not JSON-serializable` ||
+              violation === `${schemaPath} is not a JSON value`,
+          )
+        : [];
+  const violations = [...descriptorViolations, ...projectionViolations];
+  return violations.length > 0 ? { toolName, toolIndex, violations } : undefined;
+}
+
+function inspectToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
+  entries: readonly RuntimeToolEntryRead<TTool>[],
+  mode: ToolSchemaInspectionMode,
+): RuntimeToolSchemaInspection<TTool> {
+  const diagnostics: RuntimeToolSchemaDiagnostic[] = [];
+  const compatibleTools: TTool[] = [];
+  for (const entry of entries) {
+    if (!entry.ok) {
+      diagnostics.push(entry.diagnostic);
+      continue;
+    }
+    const diagnostic = inspectToolSchema(entry.tool, entry.toolIndex, mode);
+    if (diagnostic) {
+      diagnostics.push(diagnostic);
+      continue;
+    }
+    compatibleTools.push(entry.tool);
+  }
+  return { tools: compatibleTools, diagnostics };
+}
+
 export function inspectRuntimeToolInputSchemas(
   tools: readonly Pick<AnyAgentTool, "name" | "parameters">[],
-): RuntimeToolSchemaDiagnostic[] {
-  return tools.flatMap((tool, toolIndex) => {
-    const toolName = tool.name || `tool[${toolIndex}]`;
-    const projection = projectRuntimeToolInputSchema(tool.parameters, `${toolName}.parameters`);
-    if (projection.violations.length === 0) {
-      return [];
-    }
-    return [{ toolName, toolIndex, violations: projection.violations }];
-  });
+): readonly RuntimeToolSchemaDiagnostic[] {
+  return inspectToolEntries(readRuntimeToolEntries(tools), "runtime").diagnostics;
 }
 
 export function filterRuntimeCompatibleTools<
   TTool extends Pick<AnyAgentTool, "name" | "parameters">,
 >(tools: readonly TTool[]): RuntimeToolSchemaInspection<TTool> {
-  const diagnostics = inspectRuntimeToolInputSchemas(tools);
-  if (diagnostics.length === 0) {
-    return { tools, diagnostics };
-  }
-  const blockedIndexes = new Set(diagnostics.map((diagnostic) => diagnostic.toolIndex));
-  return {
-    tools: tools.filter((_tool, index) => !blockedIndexes.has(index)),
-    diagnostics,
-  };
+  return inspectToolEntries(readRuntimeToolEntries(tools), "runtime");
+}
+
+export function filterProviderNormalizableTools<
+  TTool extends Pick<AnyAgentTool, "name" | "parameters">,
+>(tools: readonly TTool[]): RuntimeToolSchemaInspection<TTool> {
+  return inspectToolEntries(readRuntimeToolEntries(tools), "provider-normalizable");
 }

--- a/src/agents/tool-schema-quarantine.test.ts
+++ b/src/agents/tool-schema-quarantine.test.ts
@@ -22,7 +22,10 @@ vi.mock("../plugins/tools.js", () => ({
     tool.name === "mockplugin_lookup" ? { pluginId: "mockplugin" } : undefined,
 }));
 
-import { logRuntimeToolSchemaQuarantine } from "./tool-schema-quarantine.js";
+import {
+  collectReadableQuarantinedRuntimeToolNames,
+  logRuntimeToolSchemaQuarantine,
+} from "./tool-schema-quarantine.js";
 
 describe("logRuntimeToolSchemaQuarantine", () => {
   beforeEach(() => {
@@ -82,5 +85,41 @@ describe("logRuntimeToolSchemaQuarantine", () => {
       }),
     );
     expect(String(warnMock.mock.calls[0]?.[0])).toContain("tool[0]: tool[0] is unreadable");
+  });
+});
+
+describe("collectReadableQuarantinedRuntimeToolNames", () => {
+  it("keeps readable quarantined names and ignores unreadable fallback names", () => {
+    const unreadableName: Record<string, unknown> = {
+      parameters: { type: "object", properties: {} },
+    };
+    Object.defineProperty(unreadableName, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin name is unreadable");
+      },
+    });
+    const badParameters = {
+      name: "fuzzplugin_move_angles",
+      parameters: {},
+    };
+
+    expect(
+      collectReadableQuarantinedRuntimeToolNames({
+        tools: [unreadableName, badParameters] as never,
+        diagnostics: [
+          {
+            toolName: "tool[0]",
+            toolIndex: 0,
+            violations: ["tool[0].name is unreadable"],
+          },
+          {
+            toolName: "fuzzplugin_move_angles",
+            toolIndex: 1,
+            violations: ["fuzzplugin_move_angles.parameters is not JSON-serializable"],
+          },
+        ],
+      }),
+    ).toEqual(["fuzzplugin_move_angles"]);
   });
 });

--- a/src/agents/tool-schema-quarantine.test.ts
+++ b/src/agents/tool-schema-quarantine.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeToolSchemaDiagnostic } from "./tool-schema-projection.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+const { emitTrustedDiagnosticEventMock, warnMock } = vi.hoisted(() => ({
+  emitTrustedDiagnosticEventMock: vi.fn(),
+  warnMock: vi.fn(),
+}));
+
+vi.mock("../infra/diagnostic-events.js", () => ({
+  emitTrustedDiagnosticEvent: emitTrustedDiagnosticEventMock,
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    warn: warnMock,
+  }),
+}));
+
+vi.mock("../plugins/tools.js", () => ({
+  getPluginToolMeta: (tool: { name?: string }) =>
+    tool.name === "mockplugin_lookup" ? { pluginId: "mockplugin" } : undefined,
+}));
+
+import { logRuntimeToolSchemaQuarantine } from "./tool-schema-quarantine.js";
+
+describe("logRuntimeToolSchemaQuarantine", () => {
+  beforeEach(() => {
+    emitTrustedDiagnosticEventMock.mockClear();
+    warnMock.mockClear();
+  });
+
+  it("logs unreadable tool rows without re-reading them", () => {
+    const healthy = {
+      name: "mockplugin_lookup",
+      parameters: { type: "object", properties: {} },
+    } as unknown as AnyAgentTool;
+    const tools = [undefined, healthy] as unknown[];
+    Object.defineProperty(tools, "0", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin tool row is unreadable");
+      },
+    });
+    const diagnostics: RuntimeToolSchemaDiagnostic[] = [
+      {
+        toolName: "tool[0]",
+        toolIndex: 0,
+        violations: ["tool[0] is unreadable"],
+      },
+      {
+        toolName: "mockplugin_lookup",
+        toolIndex: 1,
+        violations: ['mockplugin_lookup.parameters.type must be "object"'],
+      },
+    ];
+
+    expect(() =>
+      logRuntimeToolSchemaQuarantine({
+        diagnostics,
+        tools: tools as unknown as AnyAgentTool[],
+        runId: "run-fuzzplugin-quarantine",
+        sessionKey: "session-fuzzplugin",
+      }),
+    ).not.toThrow();
+
+    expect(emitTrustedDiagnosticEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "tool.execution.blocked",
+        runId: "run-fuzzplugin-quarantine",
+        sessionKey: "session-fuzzplugin",
+        toolName: "tool[0]",
+        toolSource: "core",
+      }),
+    );
+    expect(emitTrustedDiagnosticEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "tool.execution.blocked",
+        toolName: "mockplugin_lookup",
+        toolSource: "plugin",
+        toolOwner: "mockplugin",
+      }),
+    );
+    expect(String(warnMock.mock.calls[0]?.[0])).toContain("tool[0]: tool[0] is unreadable");
+  });
+});

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -4,6 +4,7 @@ import { getPluginToolMeta } from "../plugins/tools.js";
 import {
   filterProviderNormalizableTools,
   type RuntimeToolSchemaDiagnostic,
+  type RuntimeToolSchemaInspection,
 } from "./tool-schema-projection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -73,12 +74,31 @@ export function hasReadableRuntimeToolName(tools: readonly AnyAgentTool[], name:
   return false;
 }
 
-export function filterProviderNormalizableRuntimeTools(params: {
+export function collectReadableQuarantinedRuntimeToolNames(params: {
+  tools: readonly AnyAgentTool[];
+  diagnostics: readonly RuntimeToolSchemaDiagnostic[];
+}): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const diagnostic of params.diagnostics) {
+    if (
+      seen.has(diagnostic.toolName) ||
+      !hasReadableRuntimeToolName(params.tools, diagnostic.toolName)
+    ) {
+      continue;
+    }
+    seen.add(diagnostic.toolName);
+    names.push(diagnostic.toolName);
+  }
+  return names;
+}
+
+export function inspectProviderNormalizableRuntimeTools(params: {
   tools: readonly AnyAgentTool[];
   runId: string;
   sessionKey?: string;
   sessionId?: string;
-}): AnyAgentTool[] {
+}): RuntimeToolSchemaInspection<AnyAgentTool> {
   const projection = filterProviderNormalizableTools(params.tools);
   logRuntimeToolSchemaQuarantine({
     diagnostics: projection.diagnostics,
@@ -87,7 +107,16 @@ export function filterProviderNormalizableRuntimeTools(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
   });
-  return [...projection.tools];
+  return { tools: [...projection.tools], diagnostics: projection.diagnostics };
+}
+
+export function filterProviderNormalizableRuntimeTools(params: {
+  tools: readonly AnyAgentTool[];
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+}): AnyAgentTool[] {
+  return [...inspectProviderNormalizableRuntimeTools(params).tools];
 }
 
 export function logRuntimeToolSchemaQuarantine(params: {

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -1,7 +1,10 @@
 import { emitTrustedDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import type { RuntimeToolSchemaDiagnostic } from "./tool-schema-projection.js";
+import {
+  filterProviderNormalizableTools,
+  type RuntimeToolSchemaDiagnostic,
+} from "./tool-schema-projection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 const log = createSubsystemLogger("agents/tools");
@@ -26,6 +29,65 @@ function readToolPluginId(tool: AnyAgentTool | undefined): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+export function filterRuntimeToolsWithReadableNames(
+  tools: readonly AnyAgentTool[],
+): AnyAgentTool[] {
+  let length = 0;
+  try {
+    length = tools.length;
+  } catch {
+    return [];
+  }
+  const readableTools: AnyAgentTool[] = [];
+  for (let index = 0; index < length; index += 1) {
+    try {
+      const tool = tools[index];
+      if (typeof tool.name === "string") {
+        readableTools.push(tool);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return readableTools;
+}
+
+export function hasReadableRuntimeToolName(tools: readonly AnyAgentTool[], name: string): boolean {
+  let length = 0;
+  try {
+    length = tools.length;
+  } catch {
+    return false;
+  }
+  for (let index = 0; index < length; index += 1) {
+    try {
+      if (tools[index].name === name) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+export function filterProviderNormalizableRuntimeTools(params: {
+  tools: readonly AnyAgentTool[];
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+}): AnyAgentTool[] {
+  const projection = filterProviderNormalizableTools(params.tools);
+  logRuntimeToolSchemaQuarantine({
+    diagnostics: projection.diagnostics,
+    tools: params.tools,
+    runId: params.runId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+  });
+  return [...projection.tools];
 }
 
 export function logRuntimeToolSchemaQuarantine(params: {

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -6,6 +6,28 @@ import type { AnyAgentTool } from "./tools/common.js";
 
 const log = createSubsystemLogger("agents/tools");
 
+function readToolAtIndex(
+  tools: readonly AnyAgentTool[],
+  toolIndex: number,
+): AnyAgentTool | undefined {
+  try {
+    return tools[toolIndex];
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolPluginId(tool: AnyAgentTool | undefined): string | undefined {
+  if (!tool) {
+    return undefined;
+  }
+  try {
+    return getPluginToolMeta(tool)?.pluginId;
+  } catch {
+    return undefined;
+  }
+}
+
 export function logRuntimeToolSchemaQuarantine(params: {
   diagnostics: readonly RuntimeToolSchemaDiagnostic[];
   tools: readonly AnyAgentTool[];
@@ -18,8 +40,7 @@ export function logRuntimeToolSchemaQuarantine(params: {
   }
   const summary = params.diagnostics
     .map((diagnostic) => {
-      const tool = params.tools[diagnostic.toolIndex];
-      const pluginId = tool ? getPluginToolMeta(tool)?.pluginId : undefined;
+      const pluginId = readToolPluginId(readToolAtIndex(params.tools, diagnostic.toolIndex));
       const owner = pluginId ? ` plugin=${pluginId}` : "";
       emitTrustedDiagnosticEvent({
         type: "tool.execution.blocked",

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -341,6 +341,43 @@ describe("doctor runtime tool schema checks", () => {
     expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
   });
 
+  it("reports unreadable active tool rows without failing while building doctor findings", async () => {
+    const tools: AnyAgentTool[] = new Proxy(
+      [tool("fuzzplugin_move_angles", { type: "object", properties: {} })],
+      {
+        get(target, property, receiver) {
+          if (property === "0") {
+            throw new Error("fuzz tool row is unreadable");
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      },
+    );
+    mocks.createOpenClawCodingTools.mockReturnValueOnce(tools);
+    mocks.normalizeProviderToolSchemasWithPlugin.mockImplementationOnce(({ context }) => {
+      for (const toolEntry of context.tools) {
+        void toolEntry.parameters;
+      }
+      return context.tools;
+    });
+
+    await expect(collectRuntimeToolSchemaFindings({})).resolves.toContainEqual({
+      checkId: "core/doctor/runtime-tool-schemas",
+      severity: "error",
+      message: "Agent main tool tool[0] has an unsupported input schema for runtime projection.",
+      path: "tools.tool[0]",
+      target: "tool[0]",
+      requirement: "tool[0] is unreadable",
+      fixHint:
+        "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.",
+    });
+    expect(mocks.normalizeProviderToolSchemasWithPlugin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ tools: [] }),
+      }),
+    );
+  });
+
   it("skips ACP-only agents because they do not use embedded tool projection", async () => {
     mocks.createOpenClawCodingTools.mockImplementation((options) =>
       options?.agentId === "acp-worker"

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -25,6 +25,7 @@ import { supportsModelTools } from "../agents/model-tool-support.js";
 import { normalizeAgentRuntimeTools } from "../agents/runtime-plan/tools.js";
 import { collectExplicitAllowlist, normalizeToolName } from "../agents/tool-policy.js";
 import {
+  filterProviderNormalizableTools,
   inspectRuntimeToolInputSchemas,
   type RuntimeToolSchemaDiagnostic,
 } from "../agents/tool-schema-projection.js";
@@ -547,8 +548,13 @@ function toolSchemaDiagnosticToFinding(params: {
   tools: readonly AnyAgentTool[];
   diagnostic: RuntimeToolSchemaDiagnostic;
 }): HealthFinding {
-  const tool = params.tools[params.diagnostic.toolIndex];
-  const pluginId = tool ? getPluginToolMeta(tool)?.pluginId : undefined;
+  let pluginId: string | undefined;
+  try {
+    const tool = params.tools[params.diagnostic.toolIndex];
+    pluginId = tool ? getPluginToolMeta(tool)?.pluginId : undefined;
+  } catch {
+    pluginId = undefined;
+  }
   const owner = pluginId ? ` from plugin ${pluginId}` : "";
   const agent = `Agent ${params.agentId} `;
   const path =
@@ -585,6 +591,23 @@ function collectToolSchemaFindings(params: {
   );
 }
 
+function inspectProviderNormalizableTools(params: {
+  agentId: string;
+  tools: readonly AnyAgentTool[];
+}): { findings: HealthFinding[]; tools: readonly AnyAgentTool[] } {
+  const projection = filterProviderNormalizableTools(params.tools);
+  return {
+    findings: projection.diagnostics.map((diagnostic) =>
+      toolSchemaDiagnosticToFinding({
+        agentId: params.agentId,
+        tools: params.tools,
+        diagnostic,
+      }),
+    ),
+    tools: projection.tools,
+  };
+}
+
 function collectBundleMcpRuntimeToolSchemaFindings(params: {
   bundleRuntime: BundleMcpToolRuntime;
   cfg: OpenClawConfig;
@@ -601,8 +624,12 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
     modelId: params.modelRef.model,
     warn: () => {},
   });
-  const normalizedTools = normalizeAgentRuntimeTools({
+  const activeToolProjection = inspectProviderNormalizableTools({
+    agentId: params.agentId,
     tools: activeBundleTools,
+  });
+  const normalizedTools = normalizeAgentRuntimeTools({
+    tools: [...activeToolProjection.tools],
     provider: params.modelRef.provider,
     config: params.cfg,
     workspaceDir: params.workspaceDir,
@@ -611,10 +638,13 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
     modelApi: params.model.api,
     model: params.model,
   });
-  return collectToolSchemaFindings({
-    agentId: params.agentId,
-    tools: normalizedTools,
-  });
+  return [
+    ...activeToolProjection.findings,
+    ...collectToolSchemaFindings({
+      agentId: params.agentId,
+      tools: normalizedTools,
+    }),
+  ];
 }
 
 function bundleMcpRuntimeLoadFailureFinding(error: unknown): HealthFinding {
@@ -797,8 +827,12 @@ export async function collectRuntimeToolSchemaFindings(
         allowGatewaySubagentBinding: true,
         emitBeforeToolCallDiagnostics: false,
       });
-      const normalizedTools = normalizeAgentRuntimeTools({
+      const activeToolProjection = inspectProviderNormalizableTools({
+        agentId,
         tools,
+      });
+      const normalizedTools = normalizeAgentRuntimeTools({
+        tools: [...activeToolProjection.tools],
         provider: modelRef.provider,
         config: cfg,
         workspaceDir,
@@ -808,6 +842,7 @@ export async function collectRuntimeToolSchemaFindings(
         model,
       });
       findings.push(
+        ...activeToolProjection.findings,
         ...collectToolSchemaFindings({
           agentId,
           tools: normalizedTools,


### PR DESCRIPTION
## Summary
- quarantine runtime tools whose input schemas cannot be projected before model session creation
- apply the same quarantine path to embedded attempts, compaction, and doctor runtime checks
- share runtime quarantine helpers so unreadable tool rows/descriptors do not crash the turn before content

## Stack
- Base PR: #88649 (`test-neutral-tool-schema-fixtures-refresh-20260531`) at `c41dae87105`
- This PR head: `2dae8979791`
- After #88649 lands, retarget this PR back to `main` and rerun the focused proof.

## Verification
- `node scripts/run-vitest.mjs src/agents/tool-schema-projection.test.ts src/agents/tool-schema-quarantine.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts src/flows/doctor-core-checks.runtime.test.ts --reporter=verbose`
- `./node_modules/.bin/oxfmt --check $(cat /tmp/runtime-quarantine-files-current.txt)`
- `node scripts/run-oxlint.mjs $(cat /tmp/runtime-quarantine-files-current.txt)`
- `git diff --check @{u}...HEAD`
- `rg -n "dofbot|doftbot" $(cat /tmp/runtime-quarantine-files-current.txt) || true`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base @{u}`
- `node scripts/crabbox-wrapper.mjs run --provider aws --label runtime-quarantine-check-changed-rebased --shell -- "pnpm check:changed"` (`run_fd4a5a4583a2`, AWS lease `cbx_f87d69efa9b8`, slug `silver-prawn`)

## Real behavior proof
Behavior addressed: unsupported or unreadable active runtime tool schemas are quarantined before embedded attempt or compaction model projection, while doctor reports the active blocker instead of crashing.
Real environment tested: local Codex gwt worktree stacked on #88649 plus AWS Crabbox Linux `c7a.8xlarge` remote changed gate.
Exact steps or command run after this patch: targeted Vitest, oxfmt, oxlint, diff whitespace check, private-name scrub, autoreview, and AWS Crabbox `pnpm check:changed` listed above.
Evidence after fix: targeted tests passed 3 routed Vitest shards / 125 tests; formatting, lint, diff, scrub, and autoreview passed; AWS Crabbox `run_fd4a5a4583a2` passed `pnpm check:changed` and cleaned up its lease.
Observed result after fix: bad runtime tool schemas are filtered/quarantined before provider/model projection, healthy tools remain available, and doctor can surface the offending active tool/plugin path.
What was not tested: no live Telegram turn in this slice; that belongs to a later end-to-end proof after the runtime and doctor PRs are landed/retargeted.
