### PR TITLE
test(agents): use synthetic tool schema fixtures

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -1,15 +1,15 @@
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
-import {
-  onInternalDiagnosticEvent,
-  waitForDiagnosticEventsDrained,
-  type DiagnosticEventPayload,
-} from "openclaw/plugin-sdk/diagnostic-runtime";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness";
 import {
   HEARTBEAT_RESPONSE_TOOL_NAME,
   embeddedAgentLog,
   wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  onInternalDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
@@ -309,7 +309,7 @@ describe("createCodexDynamicToolBridge", () => {
         tools: [
           createTool({ name: "message" }),
           createTool({
-            name: "dofbot_move_angles",
+            name: "fuzz_move_angles",
             parameters: { type: "array", items: { type: "number" } },
             execute: badExecute,
           }),
@@ -330,25 +330,23 @@ describe("createCodexDynamicToolBridge", () => {
     expect(bridge.specs.map((tool) => tool.name)).toEqual(["message"]);
     expect(bridge.telemetry.quarantinedTools).toEqual([
       {
-        tool: "dofbot_move_angles",
-        violations: ['dofbot_move_angles.inputSchema.type must be "object"'],
+        tool: "fuzz_move_angles",
+        violations: ['fuzz_move_angles.inputSchema.type must be "object"'],
       },
     ]);
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("dofbot_move_angles"),
+      expect.stringContaining("fuzz_move_angles"),
       expect.objectContaining({
         tools: [
           {
-            tool: "dofbot_move_angles",
-            violations: ['dofbot_move_angles.inputSchema.type must be "object"'],
+            tool: "fuzz_move_angles",
+            violations: ['fuzz_move_angles.inputSchema.type must be "object"'],
           },
         ],
       }),
     );
     const blockedEvents = diagnosticEvents.filter(
-      (
-        event,
-      ): event is Extract<DiagnosticEventPayload, { type: "tool.execution.blocked" }> =>
+      (event): event is Extract<DiagnosticEventPayload, { type: "tool.execution.blocked" }> =>
         event.type === "tool.execution.blocked",
     );
     expect(blockedEvents).toContainEqual(
@@ -357,9 +355,9 @@ describe("createCodexDynamicToolBridge", () => {
         runId: "run-1",
         sessionId: "session-1",
         sessionKey: "agent:main:session-1",
-        toolName: "dofbot_move_angles",
+        toolName: "fuzz_move_angles",
         deniedReason: "unsupported_tool_schema",
-        reason: 'dofbot_move_angles.inputSchema.type must be "object"',
+        reason: 'fuzz_move_angles.inputSchema.type must be "object"',
       }),
     );
 
@@ -368,13 +366,13 @@ describe("createCodexDynamicToolBridge", () => {
       turnId: "turn-1",
       callId: "call-1",
       namespace: null,
-      tool: "dofbot_move_angles",
+      tool: "fuzz_move_angles",
       arguments: {},
     });
 
     expect(result).toEqual({
       success: false,
-      contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: dofbot_move_angles" }],
+      contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: fuzz_move_angles" }],
     });
     expect(badExecute).not.toHaveBeenCalled();
   });

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -31,10 +31,10 @@ describe("ToolsEffectiveResultSchema", () => {
       ...toolsEffectiveResult(),
       notices: [
         {
-          id: "unsupported-tool-schema:dofbot_move_angles",
+          id: "unsupported-tool-schema:fuzz_move_angles",
           severity: "warning",
           message:
-            'Tool "dofbot_move_angles" from plugin "dofbot" has an unsupported runtime input schema and was quarantined before model projection.',
+            'Tool "fuzz_move_angles" from plugin "fuzzplugin" has an unsupported runtime input schema and was quarantined before model projection.',
         },
       ],
     };
@@ -47,7 +47,7 @@ describe("ToolsEffectiveResultSchema", () => {
       ...toolsEffectiveResult(),
       notices: [
         {
-          id: "unsupported-tool-schema:dofbot_move_angles",
+          id: "unsupported-tool-schema:fuzz_move_angles",
           severity: "warning",
           message: "Unsupported schema.",
           extra: true,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -675,7 +675,7 @@ describe("session MCP runtime", () => {
       cfg: {
         mcp: {
           servers: {
-            dofbot: {
+            fuzzplugin: {
               command: process.execPath,
               args: [serverPath],
             },
@@ -689,7 +689,7 @@ describe("session MCP runtime", () => {
 
       expect(catalog.servers).toEqual({});
       expect(catalog.tools).toEqual([]);
-      expect(catalog.diagnostics?.[0]?.serverName).toBe("dofbot");
+      expect(catalog.diagnostics?.[0]?.serverName).toBe("fuzzplugin");
       expect(catalog.diagnostics?.[0]?.message).toContain("Invalid input: expected");
       expect(catalog.diagnostics?.[0]?.message).toContain("object");
     } finally {

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -144,9 +144,9 @@ describe("createBundleMcpToolRuntime", () => {
   it("preserves catalog diagnostics when MCP servers fail tool listing", async () => {
     const diagnostics = [
       {
-        serverName: "dofbot",
-        safeServerName: "dofbot",
-        launchSummary: "node dofbot-mcp.mjs",
+        serverName: "fuzzplugin",
+        safeServerName: "fuzzplugin",
+        launchSummary: "node fuzzplugin-mcp.mjs",
         message: 'tools[0].inputSchema.type expected "object"',
       },
     ];

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -473,8 +473,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         execute: async () => ({ text: "ok" }),
       },
       {
-        name: "dofbot_move_angles",
-        label: "Dofbot Move Angles",
+        name: "fuzz_move_angles",
+        label: "Fuzz Move Angles",
         description: "Move robot joints.",
         parameters: { type: "array", items: { type: "number" } },
         execute: async () => ({ text: "bad" }),

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -274,8 +274,8 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         execute: async () => ({ text: "ok" }),
       },
       {
-        name: "dofbot_move_angles",
-        label: "Dofbot Move Angles",
+        name: "fuzz_move_angles",
+        label: "Fuzz Move Angles",
         description: "Move robot joints.",
         parameters: {
           type: "object",

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -29,15 +29,15 @@ describe("runtime tool input schema projection", () => {
     expect(
       inspectRuntimeToolInputSchemas([
         {
-          name: "dofbot_move_angles",
+          name: "fuzz_move_angles",
           parameters: { type: "array", items: { type: "number" } },
         },
       ] as never),
     ).toEqual([
       {
-        toolName: "dofbot_move_angles",
+        toolName: "fuzz_move_angles",
         toolIndex: 0,
-        violations: ['dofbot_move_angles.parameters.type must be "object"'],
+        violations: ['fuzz_move_angles.parameters.type must be "object"'],
       },
     ]);
   });
@@ -86,7 +86,7 @@ describe("runtime tool input schema projection", () => {
       parameters: { type: "object", properties: {} },
     };
     const broken = {
-      name: "dofbot_move_angles",
+      name: "fuzz_move_angles",
       parameters: { type: "array", items: { type: "number" } },
     };
 
@@ -94,9 +94,9 @@ describe("runtime tool input schema projection", () => {
       tools: [healthy],
       diagnostics: [
         {
-          toolName: "dofbot_move_angles",
+          toolName: "fuzz_move_angles",
           toolIndex: 1,
-          violations: ['dofbot_move_angles.parameters.type must be "object"'],
+          violations: ['fuzz_move_angles.parameters.type must be "object"'],
         },
       ],
     });

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -316,8 +316,8 @@ describe("resolveEffectiveToolInventory", () => {
       tools: [
         mockTool({ name: "exec", label: "Exec", description: "Run shell commands" }),
         mockTool({
-          name: "dofbot_move_angles",
-          label: "Dofbot Move Angles",
+          name: "fuzz_move_angles",
+          label: "Fuzz Move Angles",
           description: "Move robot joints",
           parameters: {
             type: "object",
@@ -327,7 +327,7 @@ describe("resolveEffectiveToolInventory", () => {
           },
         }),
       ],
-      pluginMeta: { dofbot_move_angles: { pluginId: "dofbot" } },
+      pluginMeta: { fuzz_move_angles: { pluginId: "fuzzplugin" } },
     });
 
     const result = resolveEffectiveToolInventory({ cfg: {} });
@@ -335,10 +335,10 @@ describe("resolveEffectiveToolInventory", () => {
     expect(result.groups.flatMap((group) => group.tools.map((tool) => tool.id))).toEqual(["exec"]);
     expect(result.notices).toEqual([
       {
-        id: "unsupported-tool-schema:dofbot_move_angles",
+        id: "unsupported-tool-schema:fuzz_move_angles",
         severity: "warning",
         message:
-          'Tool "dofbot_move_angles" from plugin "dofbot" has an unsupported runtime input schema (dofbot_move_angles.parameters.properties.target.$dynamicRef) and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
+          'Tool "fuzz_move_angles" from plugin "fuzzplugin" has an unsupported runtime input schema (fuzz_move_angles.parameters.properties.target.$dynamicRef) and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
       },
     ]);
   });

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -434,16 +434,16 @@ describe("doctor repair sequencing", () => {
 
   it("emits active tool schema projection warnings during doctor repair", async () => {
     mocks.collectActiveToolSchemaProjectionWarnings.mockReturnValueOnce([
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema.',
+      '- agents.main: active tool "fuzz_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema.',
     ]);
 
     const result = await runDoctorRepairSequence({
       state: {
         cfg: {
-          tools: { allow: ["dofbot_move_angles"] },
+          tools: { allow: ["fuzz_move_angles"] },
         } as OpenClawConfig,
         candidate: {
-          tools: { allow: ["dofbot_move_angles"] },
+          tools: { allow: ["fuzz_move_angles"] },
         } as OpenClawConfig,
         pendingChanges: false,
         fixHints: [],
@@ -453,11 +453,11 @@ describe("doctor repair sequencing", () => {
 
     expect(result.changeNotes).toStrictEqual([]);
     expect(result.warningNotes).toContain(
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema.',
+      '- agents.main: active tool "fuzz_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema.',
     );
     expect(mocks.collectActiveToolSchemaProjectionWarnings).toHaveBeenCalledWith({
       cfg: {
-        tools: { allow: ["dofbot_move_angles"] },
+        tools: { allow: ["fuzz_move_angles"] },
       },
       env: process.env,
     });

--- a/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
@@ -85,29 +85,29 @@ describe("active tool schema doctor warnings", () => {
   it("warns with plugin ownership for active tools blocked by runtime projection", () => {
     toolState.tools = [
       tool("message", { type: "object", properties: {} }),
-      tool("dofbot_move_angles", { type: "array", items: { type: "number" } }),
+      tool("fuzz_move_angles", { type: "array", items: { type: "number" } }),
     ];
-    toolState.pluginIds = { dofbot_move_angles: "dofbot" };
+    toolState.pluginIds = { fuzz_move_angles: "fuzzplugin" };
 
     expect(
       collectActiveToolSchemaProjectionWarnings({
         cfg: {
           plugins: {
             entries: {
-              dofbot: { enabled: true },
+              fuzzplugin: { enabled: true },
             },
           },
         },
         env: { HOME: "/tmp/openclaw-test" },
       }),
     ).toEqual([
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema (dofbot_move_angles.parameters.type must be "object"). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
+      '- agents.main: active tool "fuzz_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema (fuzz_move_angles.parameters.type must be "object"). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
     ]);
   });
 
   it("does not validate disabled plugin mode", () => {
-    toolState.tools = [tool("dofbot_move_angles", { type: "array", items: { type: "number" } })];
-    toolState.pluginIds = { dofbot_move_angles: "dofbot" };
+    toolState.tools = [tool("fuzz_move_angles", { type: "array", items: { type: "number" } })];
+    toolState.pluginIds = { fuzz_move_angles: "fuzzplugin" };
 
     expect(
       collectActiveToolSchemaProjectionWarnings({
@@ -121,7 +121,7 @@ describe("active tool schema doctor warnings", () => {
 
   it("validates provider-normalized runtime schemas before reporting doctor health", () => {
     const healthyTool = tool("message", { type: "object", properties: {} });
-    const dynamicTool = tool("dofbot_move_angles", { type: "object", properties: {} });
+    const dynamicTool = tool("fuzz_move_angles", { type: "object", properties: {} });
     toolState.runtimeModel = {
       id: "gpt-5.5",
       name: "GPT-5.5",
@@ -131,7 +131,7 @@ describe("active tool schema doctor warnings", () => {
       compat: { unsupportedToolSchemaKeywords: ["$dynamicRef"] },
     };
     toolState.tools = [healthyTool, dynamicTool];
-    toolState.pluginIds = { dofbot_move_angles: "dofbot" };
+    toolState.pluginIds = { fuzz_move_angles: "fuzzplugin" };
     toolState.normalizeTools.mockImplementation(({ tools, modelApi, model }) => {
       if (
         modelApi !== "openai-responses" ||
@@ -141,8 +141,8 @@ describe("active tool schema doctor warnings", () => {
         return tools;
       }
       return tools.map((entry) =>
-        entry.name === "dofbot_move_angles"
-          ? tool("dofbot_move_angles", {
+        entry.name === "fuzz_move_angles"
+          ? tool("fuzz_move_angles", {
               type: "object",
               properties: {
                 target: { $dynamicRef: "#target" },
@@ -162,14 +162,14 @@ describe("active tool schema doctor warnings", () => {
           },
           plugins: {
             entries: {
-              dofbot: { enabled: true },
+              fuzzplugin: { enabled: true },
             },
           },
         },
         env: { HOME: "/tmp/openclaw-test" },
       }),
     ).toEqual([
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema (dofbot_move_angles.parameters.properties.target.$dynamicRef). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
+      '- agents.main: active tool "fuzz_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema (fuzz_move_angles.parameters.properties.target.$dynamicRef). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
     ]);
     expect(toolState.createTools).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -223,7 +223,7 @@ describe("active tool schema doctor warnings", () => {
 
     expect(
       collectActiveToolSchemaProjectionWarnings({
-        cfg: { plugins: { entries: { dofbot: { enabled: true } } } },
+        cfg: { plugins: { entries: { fuzzplugin: { enabled: true } } } },
         env: { HOME: "/tmp/openclaw-test" },
       }),
     ).toEqual([

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -388,15 +388,15 @@ describe("doctor preview warnings", () => {
 
   it("includes active tool schema projection warnings", async () => {
     activeToolSchemaState.warnings = [
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema.',
+      '- agents.main: active tool "fuzz_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema.',
     ];
 
     const warnings = await collectDoctorPreviewWarnings({
-      cfg: { tools: { allow: ["dofbot_move_angles"] } },
+      cfg: { tools: { allow: ["fuzz_move_angles"] } },
       doctorFixCommand: "openclaw doctor --fix",
     });
 
-    expect(warnings.some((warning) => warning.includes('active tool "dofbot_move_angles"'))).toBe(
+    expect(warnings.some((warning) => warning.includes('active tool "fuzz_move_angles"'))).toBe(
       true,
     );
   });

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -70,8 +70,8 @@ describe("doctor runtime tool schema checks", () => {
   it("reports active bundle MCP tool schemas that would be quarantined before a model turn", async () => {
     mocks.createBundleMcpToolRuntime.mockResolvedValueOnce({
       tools: [
-        bundleMcpTool("dofbot__healthy", { type: "object", properties: {} }),
-        bundleMcpTool("dofbot__dofbot_move_angles", {
+        bundleMcpTool("fuzzplugin__healthy", { type: "object", properties: {} }),
+        bundleMcpTool("fuzzplugin__fuzz_move_angles", {
           type: "array",
           items: { type: "number" },
         }),
@@ -83,7 +83,7 @@ describe("doctor runtime tool schema checks", () => {
       collectRuntimeToolSchemaFindings({
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -91,10 +91,10 @@ describe("doctor runtime tool schema checks", () => {
       checkId: "core/doctor/runtime-tool-schemas",
       severity: "error",
       message:
-        "Agent main tool dofbot__dofbot_move_angles from plugin bundle-mcp has an unsupported input schema for runtime projection.",
+        "Agent main tool fuzzplugin__fuzz_move_angles from plugin bundle-mcp has an unsupported input schema for runtime projection.",
       path: "mcp.servers",
-      target: "dofbot__dofbot_move_angles",
-      requirement: 'dofbot__dofbot_move_angles.parameters.type must be "object"',
+      target: "fuzzplugin__fuzz_move_angles",
+      requirement: 'fuzzplugin__fuzz_move_angles.parameters.type must be "object"',
       fixHint:
         "Disable or update the offending MCP server/tool so its parameters are a JSON object schema, then rerun doctor.",
     });
@@ -106,9 +106,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -119,7 +119,7 @@ describe("doctor runtime tool schema checks", () => {
       collectRuntimeToolSchemaFindings({
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -127,8 +127,8 @@ describe("doctor runtime tool schema checks", () => {
       checkId: "core/doctor/runtime-tool-schemas",
       severity: "error",
       message:
-        'Configured MCP server "dofbot" could not expose runtime tools for schema validation.',
-      path: "mcp.servers.dofbot",
+        'Configured MCP server "fuzzplugin" could not expose runtime tools for schema validation.',
+      path: "mcp.servers.fuzzplugin",
       requirement: 'tools[0].inputSchema.type: Invalid input: expected "object"',
       fixHint:
         "Fix or disable the offending MCP server, then rerun doctor before relying on assistant tool startup.",
@@ -141,9 +141,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -152,17 +152,17 @@ describe("doctor runtime tool schema checks", () => {
 
     await expect(
       collectRuntimeToolSchemaFindings({
-        tools: { allow: ["dofbot__healthy"] },
+        tools: { allow: ["fuzzplugin__healthy"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
     ).resolves.toContainEqual(
       expect.objectContaining({
         checkId: "core/doctor/runtime-tool-schemas",
-        path: "mcp.servers.dofbot",
+        path: "mcp.servers.fuzzplugin",
       }),
     );
   });
@@ -174,7 +174,7 @@ describe("doctor runtime tool schema checks", () => {
         {
           serverName: "my__server",
           safeServerName: "my__server",
-          launchSummary: "node dofbot-mcp.mjs",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -186,7 +186,7 @@ describe("doctor runtime tool schema checks", () => {
         tools: { allow: ["my__server__healthy"] },
         mcp: {
           servers: {
-            my__server: { command: "node", args: ["dofbot-mcp.mjs"] },
+            my__server: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -203,9 +203,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -217,14 +217,14 @@ describe("doctor runtime tool schema checks", () => {
         tools: { allow: ["*__healthy"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
     ).resolves.toContainEqual(
       expect.objectContaining({
         checkId: "core/doctor/runtime-tool-schemas",
-        path: "mcp.servers.dofbot",
+        path: "mcp.servers.fuzzplugin",
       }),
     );
   });
@@ -232,7 +232,7 @@ describe("doctor runtime tool schema checks", () => {
   it("reports unsupported schemas exposed only to a non-default configured agent", async () => {
     mocks.createOpenClawCodingTools.mockImplementation((options) =>
       options?.agentId === "worker"
-        ? [tool("dofbot_move_angles", { type: "array", items: { type: "number" } })]
+        ? [tool("fuzz_move_angles", { type: "array", items: { type: "number" } })]
         : [tool("healthy", { type: "object", properties: {} })],
     );
 
@@ -249,10 +249,10 @@ describe("doctor runtime tool schema checks", () => {
       checkId: "core/doctor/runtime-tool-schemas",
       severity: "error",
       message:
-        "Agent worker tool dofbot_move_angles has an unsupported input schema for runtime projection.",
-      path: "tools.dofbot_move_angles",
-      target: "dofbot_move_angles",
-      requirement: 'dofbot_move_angles.parameters.type must be "object"',
+        "Agent worker tool fuzz_move_angles has an unsupported input schema for runtime projection.",
+      path: "tools.fuzz_move_angles",
+      target: "fuzz_move_angles",
+      requirement: 'fuzz_move_angles.parameters.type must be "object"',
       fixHint:
         "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.",
     });
@@ -269,13 +269,13 @@ describe("doctor runtime tool schema checks", () => {
   it("skips ACP-only agents because they do not use embedded tool projection", async () => {
     mocks.createOpenClawCodingTools.mockImplementation((options) =>
       options?.agentId === "acp-worker"
-        ? [tool("dofbot_move_angles", { type: "array", items: { type: "number" } })]
+        ? [tool("fuzz_move_angles", { type: "array", items: { type: "number" } })]
         : [tool("healthy", { type: "object", properties: {} })],
     );
     mocks.createBundleMcpToolRuntime.mockImplementation(
       async (options: { workspaceDir: string }) => ({
         tools: options.workspaceDir.includes("acp")
-          ? [bundleMcpTool("dofbot__bad", { type: "array", items: { type: "number" } })]
+          ? [bundleMcpTool("fuzzplugin__bad", { type: "array", items: { type: "number" } })]
           : [],
         dispose: mocks.disposeBundleRuntime,
       }),
@@ -311,7 +311,7 @@ describe("doctor runtime tool schema checks", () => {
       async (options: { workspaceDir: string }) => ({
         tools: options.workspaceDir.includes("worker")
           ? [
-              bundleMcpTool("dofbot__dofbot_move_angles", {
+              bundleMcpTool("fuzzplugin__fuzz_move_angles", {
                 type: "array",
                 items: { type: "number" },
               }),
@@ -334,10 +334,10 @@ describe("doctor runtime tool schema checks", () => {
       checkId: "core/doctor/runtime-tool-schemas",
       severity: "error",
       message:
-        "Agent worker tool dofbot__dofbot_move_angles from plugin bundle-mcp has an unsupported input schema for runtime projection.",
+        "Agent worker tool fuzzplugin__fuzz_move_angles from plugin bundle-mcp has an unsupported input schema for runtime projection.",
       path: "mcp.servers",
-      target: "dofbot__dofbot_move_angles",
-      requirement: 'dofbot__dofbot_move_angles.parameters.type must be "object"',
+      target: "fuzzplugin__fuzz_move_angles",
+      requirement: 'fuzzplugin__fuzz_move_angles.parameters.type must be "object"',
       fixHint:
         "Disable or update the offending MCP server/tool so its parameters are a JSON object schema, then rerun doctor.",
     });
@@ -354,7 +354,7 @@ describe("doctor runtime tool schema checks", () => {
   it("does not report bundle MCP schemas filtered out by the final runtime tool policy", async () => {
     mocks.createBundleMcpToolRuntime.mockResolvedValueOnce({
       tools: [
-        bundleMcpTool("dofbot__dofbot_move_angles", {
+        bundleMcpTool("fuzzplugin__fuzz_move_angles", {
           type: "array",
           items: { type: "number" },
         }),
@@ -367,7 +367,7 @@ describe("doctor runtime tool schema checks", () => {
         tools: { deny: ["bundle-mcp"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -379,9 +379,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -393,7 +393,7 @@ describe("doctor runtime tool schema checks", () => {
         tools: { deny: ["bundle-mcp"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -405,9 +405,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -416,10 +416,10 @@ describe("doctor runtime tool schema checks", () => {
 
     await expect(
       collectRuntimeToolSchemaFindings({
-        tools: { deny: ["dofbot__*"] },
+        tools: { deny: ["fuzzplugin__*"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -616,10 +616,10 @@ describe("registerCoreHealthChecks", () => {
                 checkId: "core/doctor/runtime-tool-schemas",
                 severity: "error",
                 message:
-                  "Tool dofbot_move_angles from plugin dofbot has an unsupported input schema for runtime projection.",
-                path: "plugins.entries.dofbot",
-                target: "dofbot_move_angles",
-                requirement: 'dofbot_move_angles.parameters.type must be "object"',
+                  "Tool fuzz_move_angles from plugin fuzzplugin has an unsupported input schema for runtime projection.",
+                path: "plugins.entries.fuzzplugin",
+                target: "fuzz_move_angles",
+                requirement: 'fuzz_move_angles.parameters.type must be "object"',
               },
             ];
           },
@@ -638,7 +638,7 @@ describe("registerCoreHealthChecks", () => {
       expect.objectContaining({
         checkId: "core/doctor/runtime-tool-schemas",
         severity: "error",
-        target: "dofbot_move_angles",
+        target: "fuzz_move_angles",
       }),
     );
   });

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -349,10 +349,10 @@ describe("doctor health contributions", () => {
           checkId: "core/doctor/runtime-tool-schemas",
           severity: "error",
           message:
-            "Tool dofbot_move_angles from plugin dofbot has an unsupported input schema for runtime projection.",
-          path: "plugins.entries.dofbot",
-          target: "dofbot_move_angles",
-          requirement: 'dofbot_move_angles.parameters.type must be "object"',
+            "Tool fuzz_move_angles from plugin fuzzplugin has an unsupported input schema for runtime projection.",
+          path: "plugins.entries.fuzzplugin",
+          target: "fuzz_move_angles",
+          requirement: 'fuzz_move_angles.parameters.type must be "object"',
           fixHint:
             "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.",
         },
@@ -374,11 +374,11 @@ describe("doctor health contributions", () => {
 
     expect(ctx.healthOk).toBe(false);
     expect(mocks.note).toHaveBeenCalledWith(
-      expect.stringContaining("Tool dofbot_move_angles from plugin dofbot"),
+      expect.stringContaining("Tool fuzz_move_angles from plugin fuzzplugin"),
       "Doctor warnings",
     );
     expect(mocks.note).toHaveBeenCalledWith(
-      expect.stringContaining('issue: dofbot_move_angles.parameters.type must be "object"'),
+      expect.stringContaining('issue: fuzz_move_angles.parameters.type must be "object"'),
       "Doctor warnings",
     );
   });


### PR DESCRIPTION
## Status

This draft is not intended to land standalone.

Use it only as a source for folding synthetic fixture-name cleanup into behavior PRs that already touch the relevant tests. The goal is to avoid real reported plugin/tool names in tests and PR/spec text without creating a separate churn-only landing.

## Landing Rule

- Fold relevant hunks into the active hardening PR that owns the behavior.
- Do not land broad fixture renames by themselves.
- Close this PR once the remaining useful hunks are either folded or deliberately dropped.

## Verification

No standalone verification target. Each folded hunk must be covered by the behavior PR's focused tests and changed gate.
