### PR TITLE
fix(plugins): start configured external channel plugins

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -240,11 +240,27 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
         cliBackends: [],
       },
       {
+        id: "workspace-configured-channel-plugin",
+        channels: ["workspace-configured-channel"],
+        origin: "workspace",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+      },
+      {
         id: "global-activation-channel-plugin",
         channels: [],
         activation: {
           onChannels: ["global-activation-channel"],
         },
+        origin: "global",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+      },
+      {
+        id: "external-configured-channel-plugin",
+        channels: ["external-configured-channel"],
         origin: "global",
         enabledByDefault: undefined,
         providers: [],
@@ -1975,6 +1991,18 @@ describe("resolveConfiguredChannelPluginIds", () => {
     ).toStrictEqual([]);
   });
 
+  it("keeps external manifest channel owners trusted by explicit channel config", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: createStartupConfig({
+          channelIds: ["external-configured-channel"],
+        }),
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual(["external-configured-channel-plugin"]);
+  });
+
   it("includes trusted external channel owners configured only by manifest env vars", () => {
     expect(
       resolveConfiguredChannelPluginIds({
@@ -2010,6 +2038,76 @@ describe("resolveConfiguredChannelPluginIds", () => {
         env: process.env,
       }),
     ).toStrictEqual([]);
+  });
+});
+
+describe("resolveGatewayStartupPluginIds with effective channel activation", () => {
+  beforeEach(() => {
+    listPotentialConfiguredChannelIds.mockReset().mockImplementation((config: OpenClawConfig) => {
+      if (Object.prototype.hasOwnProperty.call(config, "channels")) {
+        return Object.keys(config.channels ?? {});
+      }
+      return [];
+    });
+    listPotentialConfiguredChannelPresenceSignals
+      .mockReset()
+      .mockImplementation((config: OpenClawConfig) => {
+        return listPotentialConfiguredChannelIds(config).map((channelId: string) => ({
+          channelId,
+          source: "config",
+        }));
+      });
+    hasPotentialConfiguredChannels.mockReset().mockImplementation((config: OpenClawConfig) => {
+      if (Object.prototype.hasOwnProperty.call(config, "channels")) {
+        return Object.keys(config.channels ?? {}).length > 0;
+      }
+      return false;
+    });
+    useManifestRegistryFixture();
+  });
+
+  it("starts external channel plugins auto-enabled from explicit channel config", () => {
+    const rawConfig = createStartupConfig({
+      channelIds: ["external-configured-channel"],
+    });
+    const effectiveConfig = {
+      ...rawConfig,
+      plugins: {
+        entries: {
+          "external-configured-channel-plugin": {
+            enabled: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expectStartupPluginIdsCase({
+      config: effectiveConfig,
+      activationSourceConfig: rawConfig,
+      expected: ["browser", "external-configured-channel-plugin", "memory-core"],
+    });
+  });
+
+  it("keeps workspace channel plugins behind explicit activation", () => {
+    const rawConfig = createStartupConfig({
+      channelIds: ["workspace-configured-channel"],
+    });
+    const effectiveConfig = {
+      ...rawConfig,
+      plugins: {
+        entries: {
+          "workspace-configured-channel-plugin": {
+            enabled: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expectStartupPluginIdsCase({
+      config: effectiveConfig,
+      activationSourceConfig: rawConfig,
+      expected: ["browser", "memory-core"],
+    });
   });
 });
 

--- a/src/plugins/channel-presence-policy.ts
+++ b/src/plugins/channel-presence-policy.ts
@@ -114,6 +114,20 @@ function recordDeclaresChannel(record: PluginManifestRecord, channelId: string):
   );
 }
 
+function hasExplicitOwnedChannelConfig(params: {
+  plugin: PluginManifestRecord;
+  rootConfig: OpenClawConfig;
+  channelId: string;
+}): boolean {
+  return (
+    recordDeclaresChannel(params.plugin, params.channelId) &&
+    hasExplicitChannelConfig({
+      config: params.rootConfig,
+      channelId: params.channelId,
+    })
+  );
+}
+
 function listManifestEnvConfiguredChannelSignals(params: {
   records: readonly PluginManifestRecord[];
   activationSourceConfig?: OpenClawConfig;
@@ -201,11 +215,21 @@ function isChannelPluginEligibleForScopedOwnership(params: {
   if (isBundledManifestOwner(params.plugin)) {
     return true;
   }
-  if (params.plugin.origin === "global" || params.plugin.origin === "config") {
-    return hasExplicitManifestOwnerTrust({
+  const explicitOwnedChannelConfig =
+    params.channelId !== undefined &&
+    hasExplicitOwnedChannelConfig({
       plugin: params.plugin,
-      normalizedConfig: params.normalizedConfig,
+      rootConfig: params.rootConfig,
+      channelId: params.channelId,
     });
+  if (params.plugin.origin === "global" || params.plugin.origin === "config") {
+    return (
+      explicitOwnedChannelConfig ||
+      hasExplicitManifestOwnerTrust({
+        plugin: params.plugin,
+        normalizedConfig: params.normalizedConfig,
+      })
+    );
   }
   return isActivatedManifestOwner({
     plugin: params.plugin,
@@ -241,11 +265,18 @@ function evaluateEffectiveChannelPlugin(params: {
   }
 
   if (!isBundledManifestOwner(params.plugin)) {
+    const explicitOwnedChannelConfig = hasExplicitOwnedChannelConfig({
+      plugin: params.plugin,
+      rootConfig: params.activationSource.rootConfig ?? params.config,
+      channelId: params.channelId,
+    });
     if (params.plugin.origin === "global" || params.plugin.origin === "config") {
-      const trusted = hasExplicitManifestOwnerTrust({
-        plugin: params.plugin,
-        normalizedConfig: params.normalizedConfig,
-      });
+      const trusted =
+        explicitOwnedChannelConfig ||
+        hasExplicitManifestOwnerTrust({
+          plugin: params.plugin,
+          normalizedConfig: params.normalizedConfig,
+        });
       return trusted
         ? { effective: true, pluginId: params.plugin.id }
         : {

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -178,6 +178,19 @@ function hasConfiguredStartupChannel(params: {
   );
 }
 
+function hasExplicitConfiguredStartupChannel(params: {
+  plugin: InstalledPluginIndexRecord;
+  config: OpenClawConfig;
+  manifestLookup: ManifestRegistryLookup;
+}): boolean {
+  return listManifestChannelIds(params.manifestLookup, params.plugin.pluginId).some((channelId) =>
+    hasExplicitChannelConfig({
+      config: params.config,
+      channelId,
+    }),
+  );
+}
+
 type ManifestRegistryLookup = ReadonlyMap<string, PluginManifestRecord>;
 
 function createManifestRegistryLookup(
@@ -894,14 +907,13 @@ function canStartConfiguredChannelPlugin(params: {
   if (params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false) {
     return false;
   }
+  const explicitConfiguredChannel = hasExplicitConfiguredStartupChannel({
+    plugin: params.plugin,
+    config: params.activationSource.rootConfig ?? params.config,
+    manifestLookup: params.manifestLookup,
+  });
   const explicitBundledChannelConfig =
-    params.plugin.origin === "bundled" &&
-    listManifestChannelIds(params.manifestLookup, params.plugin.pluginId).some((channelId) =>
-      hasExplicitChannelConfig({
-        config: params.activationSource.rootConfig ?? params.config,
-        channelId,
-      }),
-    );
+    params.plugin.origin === "bundled" && explicitConfiguredChannel;
   if (
     params.pluginsConfig.allow.length > 0 &&
     !params.pluginsConfig.allow.includes(params.plugin.pluginId) &&
@@ -920,7 +932,10 @@ function canStartConfiguredChannelPlugin(params: {
     enabledByDefault: isPluginEnabledByDefaultForPlatform(params.plugin, params.platform),
     activationSource: params.activationSource,
   });
-  return activationState.enabled && activationState.explicitlyEnabled;
+  const trustedByChannelConfig =
+    (params.plugin.origin === "global" || params.plugin.origin === "config") &&
+    explicitConfiguredChannel;
+  return activationState.enabled && (activationState.explicitlyEnabled || trustedByChannelConfig);
 }
 
 export function resolveChannelPluginIds(params: {


### PR DESCRIPTION
## Summary
- Treat explicit channel config as startup trust for external manifest-owned channel plugins.
- Keep workspace-origin channel plugins behind explicit plugin activation.
- Cover the WSL2 Weixin failure shape where `channels.openclaw-weixin.enabled=true` auto-enables the external plugin but raw activation config does not contain `plugins.entries.openclaw-weixin.enabled=true`.

Fixes #86314

## Verification
- `node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts`
- `node scripts/run-vitest.mjs src/channels/plugins/read-only.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-plugins.test.ts src/gateway/server-startup-plugins.test.ts`
- `./node_modules/.bin/oxfmt --check src/plugins/gateway-startup-plugin-ids.ts src/plugins/channel-presence-policy.ts src/plugins/channel-plugin-ids.test.ts`
- `./node_modules/.bin/oxlint src/plugins/gateway-startup-plugin-ids.ts src/plugins/channel-presence-policy.ts src/plugins/channel-plugin-ids.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean

## Real behavior proof
Behavior addressed: configured external channel plugins are included in gateway startup planning when their manifest owns the configured channel.
Real environment tested: local linked OpenClaw worktree on Node/Vitest, plus a WSL2 Crabbox allocation attempt.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts` after rebasing onto current `origin/main`.
Evidence after fix: the regression test `starts external channel plugins auto-enabled from explicit channel config` now includes the external channel plugin in startup IDs while `keeps workspace channel plugins behind explicit activation` proves workspace plugins are not widened.
Observed result after fix: focused channel startup tests passed: 109 tests in `src/plugins/channel-plugin-ids.test.ts`.
What was not tested: live WSL2 gateway startup with the real Weixin plugin. `crabbox run --provider azure --target windows --windows-mode wsl2 --slug wsl-weixin-startup --shell -- "node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts"` recorded `run_4829fef34bde` but remained waiting for an Azure WSL2 lease through 2m30s; I canceled the current-turn command and confirmed no new Azure WSL2 lease remained.
