### PR TITLE
fix(ui): keep chat model selected after session switch

### DIFF
--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -109,6 +109,17 @@ export async function startControlUiE2eServer(): Promise<ControlUiE2eServer> {
     publicDir: path.join(uiRoot, "public"),
     resolve: {
       alias: {
+        "@openclaw/net-policy/ip": path.join(repoRoot, "packages/net-policy/src/ip.ts"),
+        "@openclaw/net-policy/ipv4": path.join(repoRoot, "packages/net-policy/src/ipv4.ts"),
+        "@openclaw/net-policy/redact-sensitive-url": path.join(
+          repoRoot,
+          "packages/net-policy/src/redact-sensitive-url.ts",
+        ),
+        "@openclaw/net-policy/url-userinfo": path.join(
+          repoRoot,
+          "packages/net-policy/src/url-userinfo.ts",
+        ),
+        "@openclaw/net-policy": path.join(repoRoot, "packages/net-policy/src/index.ts"),
         json5: json5EsmPath,
       },
     },

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import { live } from "lit/directives/live.js";
 import { repeat } from "lit/directives/repeat.js";
 import { t } from "../../i18n/index.ts";
 import { createChatSessionsLoadOverrides } from "../app-chat.ts";
@@ -810,6 +811,7 @@ function renderChatModelSelect(state: AppViewState) {
         data-chat-model-select="true"
         aria-label=${t("chat.selectors.model")}
         title=${selectedLabel}
+        .value=${live(currentOverride)}
         ?disabled=${disabled}
         @change=${async (e: Event) => {
           const next = (e.target as HTMLSelectElement).value.trim();

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -46,6 +46,33 @@ async function waitForRequests(
   throw new Error(`Timed out waiting for ${count} ${method} requests`);
 }
 
+function chatSessionListResponse() {
+  return {
+    count: 2,
+    defaults: {
+      contextTokens: null,
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    },
+    path: "",
+    sessions: [
+      {
+        key: "agent:main:session-a",
+        kind: "direct",
+        label: "Session A",
+        updatedAt: 2,
+      },
+      {
+        key: "agent:main:session-b",
+        kind: "direct",
+        label: "Session B",
+        updatedAt: 1,
+      },
+    ],
+    ts: Date.now(),
+  };
+}
+
 describeControlUiE2e("Control UI mocked Gateway E2E", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -196,6 +223,63 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       expect(secondParams.idempotencyKey).toBe(runId);
       expect(secondParams.message).toBe(prompt);
       await page.locator(".chat-queue").waitFor({ state: "detached", timeout: 10_000 });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps a session model override selected after switching away and back", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": chatSessionListResponse(),
+      },
+      models: [
+        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+        { id: "claude-opus-4.5", name: "Claude Opus 4.5", provider: "bedrock" },
+      ],
+      sessionKey: "agent:main:session-a",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const main = page.getByRole("main");
+      const modelSelect = main.locator('select[data-chat-model-select="true"]');
+      await modelSelect.waitFor({ state: "visible", timeout: 10_000 });
+      expect(await modelSelect.inputValue()).toBe("");
+
+      await modelSelect.selectOption("bedrock/claude-opus-4.5");
+      const patchRequest = await gateway.waitForRequest("sessions.patch");
+      expect(requireRecord(patchRequest.params)).toMatchObject({
+        key: "agent:main:session-a",
+        model: "bedrock/claude-opus-4.5",
+      });
+      expect(await modelSelect.inputValue()).toBe("bedrock/claude-opus-4.5");
+
+      await main.getByRole("button", { name: "Chat session" }).click();
+      await page
+        .locator('button[data-chat-session-picker-option="true"][data-session-key="agent:main:session-b"]')
+        .click();
+      await main.getByRole("button", { name: "Chat session" }).getByText("Session B").waitFor({
+        timeout: 10_000,
+      });
+      expect(await modelSelect.inputValue()).toBe("");
+
+      await main.getByRole("button", { name: "Chat session" }).click();
+      await page
+        .locator('button[data-chat-session-picker-option="true"][data-session-key="agent:main:session-a"]')
+        .click();
+      await main.getByRole("button", { name: "Chat session" }).getByText("Session A").waitFor({
+        timeout: 10_000,
+      });
+
+      expect(await modelSelect.inputValue()).toBe("bedrock/claude-opus-4.5");
     } finally {
       await context.close();
     }

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2340,6 +2340,81 @@ describe("chat session controls", () => {
     expect(rerendered.value).toBe("openai/gpt-5-mini");
   });
 
+  it("keeps the selected model visible after switching away and back to a session", async () => {
+    const sessionA = "agent:main:session-a";
+    const sessionB = "agent:main:session-b";
+    const catalog = createModelCatalog(...DEFAULT_CHAT_MODEL_CATALOG, {
+      id: "claude-opus-4.5",
+      name: "Claude Opus 4.5",
+      provider: "bedrock",
+    });
+    const { state } = createChatHeaderState({ models: catalog });
+    let rows: GatewaySessionRow[] = [
+      { key: sessionA, kind: "direct", label: "Session A", updatedAt: 2 },
+      { key: sessionB, kind: "direct", label: "Session B", updatedAt: 1 },
+    ];
+    const request = vi.fn(async (method: string, params: Record<string, unknown> = {}) => {
+      if (method === "sessions.patch") {
+        const key = typeof params.key === "string" ? params.key : "";
+        const nextModel = typeof params.model === "string" ? params.model.trim() : "";
+        rows = rows.map((row) => {
+          if (row.key !== key) {
+            return row;
+          }
+          const nextRow: GatewaySessionRow = { ...row };
+          if (!nextModel) {
+            delete nextRow.model;
+            delete nextRow.modelProvider;
+            return nextRow;
+          }
+          const slashIndex = nextModel.indexOf("/");
+          if (slashIndex > 0) {
+            nextRow.modelProvider = nextModel.slice(0, slashIndex);
+          } else {
+            delete nextRow.modelProvider;
+          }
+          nextRow.model = slashIndex > 0 ? nextModel.slice(slashIndex + 1) : nextModel;
+          return nextRow;
+        });
+        return { ok: true, key };
+      }
+      if (method === "sessions.list") {
+        return createSessionsResultFromRows(rows);
+      }
+      if (method === "chat.history") {
+        return { messages: [] };
+      }
+      if (method === "tools.effective") {
+        return { agentId: "main", profile: "coding", groups: [] };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    state.client = { request } as unknown as GatewayBrowserClient;
+    state.sessionKey = sessionA;
+    state.settings.sessionKey = sessionA;
+    state.sessionsResult = createSessionsResultFromRows(rows);
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = getChatModelSelect(container);
+    expect(modelSelect.value).toBe("");
+
+    modelSelect.value = "bedrock/claude-opus-4.5";
+    modelSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+
+    state.sessionKey = sessionB;
+    state.settings.sessionKey = sessionB;
+    render(renderChatSessionSelect(state), container);
+    expect(getChatModelSelect(container).value).toBe("");
+
+    state.sessionKey = sessionA;
+    state.settings.sessionKey = sessionA;
+    render(renderChatSessionSelect(state), container);
+
+    expect(getChatModelSelect(container).value).toBe("bedrock/claude-opus-4.5");
+  });
+
   it("uses default thinking options when the active session is absent", () => {
     const { state } = createChatHeaderState({ omitSessionFromList: true });
     state.sessionsResult = createSessionsListResult({


### PR DESCRIPTION
﻿## Summary

- Fixes the WebChat model picker display after switching away from a session and back.
- Binds the model `<select>` value to the resolved session override so the DOM cannot keep showing the default option while state still points at the persisted override.
- Adds a focused component regression and a Chromium Control UI E2E regression for the A -> B -> A session switch path.
- Adds source aliases for private workspace packages in the Control UI E2E harness so the browser app can resolve `@openclaw/net-policy/*` from source during local Vite E2E runs.

Closes #86597

## Real behavior proof

Behavior or issue addressed: WebChat model picker display-only regression from #86597. After selecting `bedrock/claude-opus-4.5` in session A, switching to session B, then switching back to session A, the picker should visibly show the selected override instead of `Default (GPT-5.5)`.

Real environment tested: Local Windows checkout of this PR branch (`b134fd5533`) running the real Control UI source in Chromium through the repo's Vite Control UI E2E harness. This exercises the browser-rendered chat header, session picker, model picker, WebSocket request path, and actual DOM selected value. No live provider credentials are required because this bug is Control UI display state only.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "keeps a session model override selected after switching away and back" --reporter=dot --pool=forks --no-file-parallelism`

Evidence after fix: Rerun after rebasing onto current `main`:

```text
RUN  v4.1.7 C:/oc-work/oc86597-prepr

----·-

Test Files  1 passed (1)
Tests  1 passed | 5 skipped (6)
Duration  3.95s
```

The browser E2E asserts the visible `select[data-chat-model-select="true"]` value through the user flow:

```text
initial session A select value: ""
after selecting override in session A: "bedrock/claude-opus-4.5"
after switching to session B: ""
after switching back to session A: "bedrock/claude-opus-4.5"
```

Observed result after fix: The picker remains visibly selected as `bedrock/claude-opus-4.5` after switching away from session A and back. Before the fix, the resolved UI state still had `currentOverride="bedrock/claude-opus-4.5"`, but the actual DOM select value stayed `""` and displayed the default option.

What was not tested: A live provider call or real Gateway persistence roundtrip was not used, because the issue is limited to Control UI display binding and the browser proof exercises the rendered UI with deterministic Gateway responses. Provider routing, model execution, and Gateway session persistence are intentionally unchanged.

## Validation

Latest focused validation after rebasing onto current `main`:

- `node scripts/run-vitest.mjs run ui/src/ui/views/chat.test.ts -t "keeps the selected model visible after switching away and back to a session" --reporter=dot --pool=forks --no-file-parallelism` -> passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "keeps a session model override selected after switching away and back" --reporter=dot --pool=forks --no-file-parallelism` -> passed.
- `git diff --check origin/main...HEAD` -> passed.

Broader validation run before the latest upstream-main churn:

- `node scripts/run-vitest.mjs run ui/src/ui/views/chat.test.ts ui/src/ui/chat-model-select-state.test.ts --reporter=dot --pool=forks --no-file-parallelism` -> 2 files passed, 72 tests passed.
- `node scripts/run-vitest.mjs run ui/src/ui/app-chat.test.ts --reporter=dot --pool=forks --no-file-parallelism` -> 1 file passed, 58 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts --reporter=dot --pool=forks --no-file-parallelism` -> 1 file passed, 6 tests passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/test-helpers/control-ui-e2e.ts ui/src/ui/chat/session-controls.ts ui/src/ui/e2e/chat-flow.e2e.test.ts ui/src/ui/views/chat.test.ts --type-aware --report-unused-disable-directives-severity error --threads=1` -> passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` -> passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` -> passed.
- `codex review --uncommitted` -> no actionable regressions found.

Current CI note: the branch was rebased onto current `main`. The previously red upstream-main type/build failures pass locally on this branch (`test/tsconfig/tsconfig.extensions.test.json` and `tsconfig.plugin-sdk.dts.json`). Current main still has an unrelated runtime-config failure in `src/config/sessions.cache.test.ts` (`falls back to full projection when untouched entries need prompt blob repair`), which reproduces locally and is outside this PR's four-file WebChat/UI diff. GitHub CI is rerunning on the refreshed head.

## Risk

Low. The runtime change is limited to binding the existing resolved model override into the DOM select value. The E2E harness alias only affects local Control UI browser tests and resolves private workspace packages from source for Vite.



