### PR TITLE
fix(agents): preserve runtime tools in lean mode

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -371,6 +371,81 @@ describe("createOpenClawCodingTools", () => {
     expect(toolNameList(tools)).toContain("message");
   });
 
+  it("preserves runtime-allowed message through local model lean filtering", () => {
+    const tools = createOpenClawCodingTools({
+      config: {
+        agents: {
+          defaults: {
+            experimental: {
+              localModelLean: true,
+            },
+          },
+        },
+        tools: { profile: "minimal" },
+      },
+      runtimeToolAllowlist: ["message"],
+      toolConstructionPlan: {
+        includeBaseCodingTools: false,
+        includeShellTools: false,
+        includeChannelTools: false,
+        includeOpenClawTools: true,
+        includePluginTools: false,
+      },
+    });
+
+    expect(toolNameList(tools)).toContain("message");
+  });
+
+  it("preserves forced message through local model lean filtering without runtime allowlist", () => {
+    const tools = createOpenClawCodingTools({
+      config: {
+        agents: {
+          defaults: {
+            experimental: {
+              localModelLean: true,
+            },
+          },
+        },
+        tools: { profile: "minimal" },
+      },
+      forceMessageTool: true,
+      toolConstructionPlan: {
+        includeBaseCodingTools: false,
+        includeShellTools: false,
+        includeChannelTools: false,
+        includeOpenClawTools: true,
+        includePluginTools: false,
+      },
+    });
+
+    expect(toolNameList(tools)).toContain("message");
+  });
+
+  it("preserves message-tool-only replies through local model lean filtering without runtime allowlist", () => {
+    const tools = createOpenClawCodingTools({
+      config: {
+        agents: {
+          defaults: {
+            experimental: {
+              localModelLean: true,
+            },
+          },
+        },
+        tools: { profile: "minimal" },
+      },
+      sourceReplyDeliveryMode: "message_tool_only",
+      toolConstructionPlan: {
+        includeBaseCodingTools: false,
+        includeShellTools: false,
+        includeChannelTools: false,
+        includeOpenClawTools: true,
+        includePluginTools: false,
+      },
+    });
+
+    expect(toolNameList(tools)).toContain("message");
+  });
+
   it("preserves runtime allowlist groups containing message through restrictive profiles", () => {
     for (const runtimeToolAllowlist of [["group:messaging"], ["group:openclaw"], ["*"]]) {
       const tools = createOpenClawCodingTools({

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -63,7 +63,10 @@ import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
-import { filterLocalModelLeanTools } from "./local-model-lean.js";
+import {
+  filterLocalModelLeanTools,
+  resolveLocalModelLeanPreserveToolNames,
+} from "./local-model-lean.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
@@ -245,6 +248,8 @@ function applyModelProviderToolPolicy(
     agentDir?: string;
     modelCompat?: ModelCompatConfig;
     suppressManagedWebSearch?: boolean;
+    runtimeToolAllowlist?: string[];
+    localModelLeanPreserveToolNames?: string[];
   },
 ): AnyAgentTool[] {
   let tools = toolsInput;
@@ -253,6 +258,7 @@ function applyModelProviderToolPolicy(
     config: params?.config,
     agentId: params?.agentId,
     sessionKey: params?.sessionKey,
+    preserveToolNames: params?.localModelLeanPreserveToolNames ?? params?.runtimeToolAllowlist,
   });
 
   if (
@@ -592,6 +598,11 @@ export function createOpenClawCodingTools(options?: {
   ).some((toolName) => {
     const normalized = normalizeToolName(toolName);
     return normalized === "*" || normalized === "message";
+  });
+  const localModelLeanPreserveToolNames = resolveLocalModelLeanPreserveToolNames({
+    toolNames: options?.runtimeToolAllowlist,
+    forceMessageTool: options?.forceMessageTool,
+    sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
   });
   const runtimeProfileAlsoAllow = [
     ...(options?.forceMessageTool || options?.sourceReplyDeliveryMode === "message_tool_only"
@@ -1064,6 +1075,8 @@ export function createOpenClawCodingTools(options?: {
     agentDir: options?.agentDir,
     modelCompat: options?.modelCompat,
     suppressManagedWebSearch: options?.suppressManagedWebSearch,
+    runtimeToolAllowlist: options?.runtimeToolAllowlist,
+    localModelLeanPreserveToolNames,
   });
   options?.recordToolPrepStage?.("model-provider-policy");
   // Sender identity is carried for command/channel-action auth; tool visibility

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -150,7 +150,11 @@ import { isTimeoutError } from "../../failover-error.js";
 import { runAgentEndSideEffects } from "../../harness/agent-end-side-effects.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
-import { filterLocalModelLeanTools, isLocalModelLeanEnabled } from "../../local-model-lean.js";
+import {
+  filterLocalModelLeanTools,
+  isLocalModelLeanEnabled,
+  resolveLocalModelLeanPreserveToolNames,
+} from "../../local-model-lean.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
 import { supportsModelTools } from "../../model-tool-support.js";
@@ -1122,6 +1126,11 @@ export async function runEmbeddedAttempt(
             ]),
           ]
         : toolsAllowWithForcedRuntimeTools;
+    const localModelLeanPreserveToolNames = resolveLocalModelLeanPreserveToolNames({
+      toolNames: effectiveToolsAllow,
+      forceMessageTool: params.forceMessageTool,
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+    });
     const shouldConstructTools =
       toolConstructionPlan.constructTools ||
       toolSearchControlsEnabledForRun ||
@@ -1215,6 +1224,7 @@ export async function runEmbeddedAttempt(
             forceMessageTool: params.forceMessageTool,
             enableHeartbeatTool: params.enableHeartbeatTool,
             forceHeartbeatTool: params.forceHeartbeatTool,
+            runtimeToolAllowlist: effectiveToolsAllow,
             authProfileStore: params.authProfileStore,
             recordToolPrepStage: (name) => corePluginToolStages.mark(name),
             onToolOutcome: params.onToolOutcome,
@@ -1482,6 +1492,7 @@ export async function runEmbeddedAttempt(
       tools: [...tools, ...normalizedBundledTools],
       config: params.config,
       agentId: sessionAgentId,
+      preserveToolNames: localModelLeanPreserveToolNames,
     });
     const uncompactedToolSchemaProjection = filterRuntimeCompatibleTools(
       projectedUncompactedEffectiveTools,
@@ -1553,6 +1564,7 @@ export async function runEmbeddedAttempt(
       tools: toolSearch.tools,
       config: params.config,
       agentId: sessionAgentId,
+      preserveToolNames: localModelLeanPreserveToolNames,
     });
     const toolSearchSchemaProjection = filterRuntimeCompatibleTools(projectedToolSearchTools);
     logRuntimeToolSchemaQuarantine({

--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
-import { filterLocalModelLeanTools, isLocalModelLeanEnabled } from "./local-model-lean.js";
+import {
+  filterLocalModelLeanTools,
+  isLocalModelLeanEnabled,
+  resolveLocalModelLeanPreserveToolNames,
+} from "./local-model-lean.js";
 
 function tools(names: string[]): AnyAgentTool[] {
   return names.map((name) => ({ name })) as AnyAgentTool[];
@@ -28,6 +32,65 @@ describe("local model lean tool filtering", () => {
         tools: tools(["read", "browser", "cron", "message", "exec"]),
         config: cfg,
         agentId: "gemma",
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "exec"]);
+  });
+
+  it("keeps explicitly preserved tools when lean mode is enabled", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      },
+    };
+
+    expect(
+      filterLocalModelLeanTools({
+        tools: tools(["read", "browser", "cron", "message", "exec"]),
+        config: cfg,
+        preserveToolNames: ["browser", "cron", "group:messaging"],
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "browser", "cron", "message", "exec"]);
+  });
+
+  it("adds reply-required message tools to lean preservation", () => {
+    expect(
+      resolveLocalModelLeanPreserveToolNames({
+        forceMessageTool: true,
+      }),
+    ).toEqual(["message"]);
+    expect(
+      resolveLocalModelLeanPreserveToolNames({
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    ).toEqual(["message"]);
+    expect(
+      resolveLocalModelLeanPreserveToolNames({
+        toolNames: ["group:messaging"],
+        forceMessageTool: true,
+      }),
+    ).toEqual(["group:messaging", "message"]);
+  });
+
+  it("does not treat wildcard preservation as disabling lean mode", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      },
+    };
+
+    expect(
+      filterLocalModelLeanTools({
+        tools: tools(["read", "browser", "cron", "message", "exec"]),
+        config: cfg,
+        preserveToolNames: ["*"],
       }).map((tool) => tool.name),
     ).toEqual(["read", "exec"]);
   });

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -2,8 +2,32 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope-config.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import { expandToolGroups, normalizeToolName } from "./tool-policy.js";
 
 const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = new Set(["browser", "cron", "message"]);
+
+function resolvePreservedLocalModelLeanToolNames(names?: Iterable<string>): Set<string> {
+  if (!names) {
+    return new Set();
+  }
+  return new Set(
+    expandToolGroups([...names])
+      .map(normalizeToolName)
+      .filter((name) => name && name !== "*"),
+  );
+}
+
+export function resolveLocalModelLeanPreserveToolNames(params?: {
+  toolNames?: Iterable<string>;
+  forceMessageTool?: boolean;
+  sourceReplyDeliveryMode?: string;
+}): string[] {
+  const names = [...(params?.toolNames ?? [])];
+  if (params?.forceMessageTool || params?.sourceReplyDeliveryMode === "message_tool_only") {
+    names.push("message");
+  }
+  return [...new Set(names)];
+}
 
 function resolveLocalModelLeanAgentId(params: {
   config?: OpenClawConfig;
@@ -43,9 +67,17 @@ export function filterLocalModelLeanTools(params: {
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  preserveToolNames?: Iterable<string>;
 }): AnyAgentTool[] {
   if (!isLocalModelLeanEnabled(params)) {
     return params.tools;
   }
-  return params.tools.filter((tool) => !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(tool.name));
+  const preservedToolNames = resolvePreservedLocalModelLeanToolNames(params.preserveToolNames);
+  return params.tools.filter((tool) => {
+    const normalizedName = normalizeToolName(tool.name);
+    return (
+      preservedToolNames.has(normalizedName) ||
+      !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(normalizedName)
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- keeps `localModelLean` from stripping runtime-required tools when replies must go through the `message` tool
- preserves explicit runtime allowlists plus `forceMessageTool` and `sourceReplyDeliveryMode: "message_tool_only"` through both tool construction and embedded-run schema projection
- adds focused coverage for forced message tools, message-tool-only replies, grouping, and wildcard preservation without disabling lean filtering

## Verification

- `node scripts/run-vitest.mjs src/agents/local-model-lean.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts --reporter=dot` passed, 190 tests
- `git diff --check origin/main...HEAD` passed
- AWS Crabbox `pnpm check:changed` passed: provider `aws`, lease `cbx_05e9c25d9687`, slug `crimson-hermit`, run `run_e0161fcff3cd`, machine `c7a.8xlarge`, exit 0, leaseStopped=true

## What was not tested

- Live Ollama/provider run. Local Ollama API was unavailable on this machine, so this is covered by focused runtime-tool tests plus the remote changed gate.
