### PR TITLE
fix(config): compare size-drop guard against canonical config

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -466,6 +466,7 @@ function resolveConfigStatMetadata(
 function resolveConfigWriteSuspiciousReasons(params: {
   existsBefore: boolean;
   previousBytes: number | null;
+  previousCanonicalBytes: number | null;
   nextBytes: number | null;
   hasMetaBefore: boolean;
   gatewayModeBefore: string | null;
@@ -475,13 +476,14 @@ function resolveConfigWriteSuspiciousReasons(params: {
   if (!params.existsBefore) {
     return reasons;
   }
+  const sizeBaselineBytes = params.previousCanonicalBytes ?? params.previousBytes;
   if (
-    typeof params.previousBytes === "number" &&
+    typeof sizeBaselineBytes === "number" &&
     typeof params.nextBytes === "number" &&
-    params.previousBytes >= 512 &&
-    params.nextBytes < Math.floor(params.previousBytes * 0.5)
+    sizeBaselineBytes >= 512 &&
+    params.nextBytes < Math.floor(sizeBaselineBytes * 0.5)
   ) {
-    reasons.push(`size-drop:${params.previousBytes}->${params.nextBytes}`);
+    reasons.push(`size-drop:${sizeBaselineBytes}->${params.nextBytes}`);
   }
   if (!params.hasMetaBefore) {
     reasons.push("missing-meta-before-write");
@@ -575,6 +577,21 @@ function setConfigHealthEntry(
       [configPath]: entry,
     },
   };
+}
+
+function resolvePreviousCanonicalConfigBytes(
+  snapshot: ConfigFileSnapshot,
+  options: Pick<ConfigWriteOptions, "lastTouchedVersionOverride">,
+): number | null {
+  if (!snapshot.exists || !snapshot.valid) {
+    return null;
+  }
+  const stamped = stampConfigVersion(
+    coerceConfig(snapshot.parsed),
+    options.lastTouchedVersionOverride,
+  );
+  const json = JSON.stringify(stamped, null, 2).trimEnd().concat("\n");
+  return Buffer.byteLength(json, "utf-8");
 }
 
 function isUpdateChannelOnlyRoot(value: unknown): boolean {
@@ -2288,6 +2305,9 @@ export function createConfigIO(
     const changedPathCount = changedPaths?.size;
     const previousBytes =
       typeof snapshot.raw === "string" ? Buffer.byteLength(snapshot.raw, "utf-8") : null;
+    // Size-drop protection is semantic, not an editor-format detector. Compare
+    // against canonical previous config so BOM/verbose JSON writers stay safe.
+    const previousCanonicalBytes = resolvePreviousCanonicalConfigBytes(snapshot, options);
     const nextBytes = Buffer.byteLength(json, "utf-8");
     const previousStat = snapshot.exists
       ? await deps.fs.promises.stat(configPath).catch(() => null)
@@ -2299,6 +2319,7 @@ export function createConfigIO(
     const suspiciousReasons = resolveConfigWriteSuspiciousReasons({
       existsBefore: snapshot.exists,
       previousBytes,
+      previousCanonicalBytes,
       nextBytes,
       hasMetaBefore,
       gatewayModeBefore,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -769,9 +769,7 @@ describe("config io write", () => {
         gateway: { mode: "local", port: 18790 },
       });
 
-      expect(warn.mock.calls).toContainEqual([
-        expect.stringContaining("Config write anomaly:"),
-      ]);
+      expect(warn.mock.calls).toContainEqual([expect.stringContaining("Config write anomaly:")]);
       expect(warn.mock.calls).toContainEqual([
         expect.stringContaining("missing-meta-before-write"),
       ]);
@@ -1028,6 +1026,139 @@ describe("config io write", () => {
 
       expect(preflightCalls).toBe(0);
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("accepts canonical config writes after PowerShell-style verbose JSON formatting", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.4.23" },
+        gateway: { mode: "local" },
+        channels: {
+          telegram: {
+            enabled: true,
+            allowFrom: Array.from({ length: 60 }, (_, index) => `telegram:${index}`),
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const powerShellRaw = `\uFEFF${JSON.stringify(original, null, 12)}\n`;
+      const canonicalOriginalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      expect(Buffer.byteLength(powerShellRaw, "utf-8")).toBeGreaterThan(
+        Buffer.byteLength(canonicalOriginalRaw, "utf-8") * 2,
+      );
+      await fs.writeFile(configPath, powerShellRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: powerShellRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await io.writeConfigFile(
+        {
+          ...original,
+          gateway: { mode: "local", port: 18789 },
+        },
+        { baseSnapshot },
+      );
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+      expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
+    });
+  });
+
+  it("still rejects destructive writes after PowerShell-style verbose JSON formatting", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.4.23" },
+        gateway: { mode: "local" },
+        channels: {
+          telegram: {
+            enabled: true,
+            allowFrom: Array.from({ length: 80 }, (_, index) => `telegram:${index}`),
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const powerShellRaw = `\uFEFF${JSON.stringify(original, null, 12)}\n`;
+      const canonicalOriginalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      expect(Buffer.byteLength(powerShellRaw, "utf-8")).toBeGreaterThan(
+        Buffer.byteLength(canonicalOriginalRaw, "utf-8") * 2,
+      );
+      await fs.writeFile(configPath, powerShellRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: powerShellRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expectConfigWriteRejected(
+        io.writeConfigFile({ meta: original.meta, gateway: { mode: "local" } }, { baseSnapshot }),
+      );
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(powerShellRaw);
+    });
+  });
+
+  it("uses raw bytes for size-drop protection when the existing config is invalid", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const invalidRaw = `not-json\n${"x".repeat(2048)}\n`;
+      await fs.writeFile(configPath, invalidRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: invalidRaw,
+        parsed: {},
+        sourceConfig: {},
+        resolved: {},
+        valid: false,
+        runtimeConfig: {},
+        config: {},
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expectConfigWriteRejected(
+        io.writeConfigFile({ gateway: { mode: "local" } }, { baseSnapshot }),
+      );
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(invalidRaw);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #71865.

- compare config size-drop protection against the canonical previous source config for valid existing files, instead of raw editor-format bytes
- keep the raw-byte fallback for invalid existing configs so malformed/clobbered files remain protected
- add regressions for PowerShell-style BOM/verbose JSON writes, destructive shrink rejection, and invalid-config fallback

## Verification

Behavior addressed: PowerShell/BOM/verbose `openclaw.json` formatting no longer makes a normal config mutation look like destructive data loss.

Real environment tested: local source checkout on macOS with repo Vitest wrapper; remote Testbox/Crabbox proof was attempted but blocked before command execution.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs src/config/io.write-config.test.ts src/commands/models/auth.test.ts src/commands/models/shared.test.ts src/commands/models/set.test.ts`
- `./node_modules/.bin/oxfmt --check src/config/io.ts src/config/io.write-config.test.ts`
- `./node_modules/.bin/oxlint src/config/io.ts src/config/io.write-config.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Evidence after fix: config writer regression suite passes with 41 tests, including the new verbose/BOM acceptance case, destructive shrink rejection, and invalid-config fallback.

Observed result after fix: targeted Vitest shards passed; formatter/lint/whitespace checks passed; autoreview reported no accepted/actionable findings.

What was not tested: native Windows/WSL live proof and `pnpm check:changed` were not completed. Azure Crabbox run `run_cba6c8dbed64` waited 5m for a lease and was cancelled with no lease left behind; Blacksmith Testbox was blocked by `blacksmith auth login`; direct `pnpm testbox` in the linked worktree attempted dependency reconciliation and was stopped.
