### PR TITLE
refactor(matrix): move ephemeral state to plugin sqlite

### DIFF
--- a/extensions/matrix/src/matrix/client/storage.test.ts
+++ b/extensions/matrix/src/matrix/client/storage.test.ts
@@ -7,9 +7,11 @@ import { installMatrixTestRuntime } from "../../test-runtime.js";
 import {
   claimCurrentTokenStorageState,
   maybeMigrateLegacyStorage,
+  recordCurrentStorageMetaDeviceId,
   repairCurrentTokenStorageMetaDeviceId,
   resolveMatrixStateFilePath,
   resolveMatrixStoragePaths,
+  writeStorageMeta,
 } from "./storage.js";
 
 const createBackupArchiveMock = vi.hoisted(() =>
@@ -257,6 +259,35 @@ describe("matrix client storage paths", () => {
   function writeJson(rootDir: string, filename: string, value: Record<string, unknown>) {
     fs.writeFileSync(path.join(rootDir, filename), JSON.stringify(value, null, 2));
   }
+
+  it("records a learned deviceId in storage metadata without startup JSON", () => {
+    const stateDir = setupStateDir();
+    const storagePaths = resolveMatrixStoragePaths({
+      ...defaultStorageAuth,
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    expect(
+      writeStorageMeta({
+        storagePaths,
+        homeserver: defaultStorageAuth.homeserver,
+        userId: defaultStorageAuth.userId,
+        deviceId: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      recordCurrentStorageMetaDeviceId({
+        rootDir: storagePaths.rootDir,
+        deviceId: "DEVICE123",
+      }),
+    ).toBe(true);
+
+    const meta = JSON.parse(fs.readFileSync(storagePaths.metaPath, "utf8")) as {
+      deviceId?: string | null;
+    };
+    expect(meta.deviceId).toBe("DEVICE123");
+    expect(fs.existsSync(path.join(storagePaths.rootDir, "startup-verification.json"))).toBe(false);
+  });
 
   function seedExistingStorageRoot(params: {
     accessToken: string;

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -22,7 +22,6 @@ const THREAD_BINDINGS_FILENAME = "thread-bindings.json";
 const LEGACY_CRYPTO_MIGRATION_FILENAME = "legacy-crypto-migration.json";
 const RECOVERY_KEY_FILENAME = "recovery-key.json";
 const IDB_SNAPSHOT_FILENAME = "crypto-idb-snapshot.json";
-const STARTUP_VERIFICATION_FILENAME = "startup-verification.json";
 
 type LegacyMoveRecord = {
   sourcePath: string;
@@ -131,17 +130,6 @@ function readStoredRootMetadata(rootDir: string): StoredRootMetadata {
     if (typeof parsed.createdAt === "string" && parsed.createdAt.trim()) {
       metadata.createdAt = parsed.createdAt.trim();
     }
-  }
-
-  const verification = loadJsonFile<{ deviceId?: unknown }>(
-    path.join(rootDir, STARTUP_VERIFICATION_FILENAME),
-  );
-  if (
-    !metadata.deviceId &&
-    typeof verification?.deviceId === "string" &&
-    verification.deviceId.trim()
-  ) {
-    metadata.deviceId = verification.deviceId.trim();
   }
 
   return metadata;
@@ -512,6 +500,29 @@ export function claimCurrentTokenStorageState(params: { rootDir: string }): bool
     accessTokenHash: metadata.accessTokenHash,
     deviceId: metadata.deviceId ?? null,
     currentTokenStateClaimed: true,
+    createdAt: metadata.createdAt ?? new Date().toISOString(),
+  });
+}
+
+export function recordCurrentStorageMetaDeviceId(params: {
+  rootDir: string;
+  deviceId: string;
+}): boolean {
+  const deviceId = params.deviceId.trim();
+  if (!deviceId) {
+    return false;
+  }
+  const metadata = readStoredRootMetadata(params.rootDir);
+  if (!metadata.accessTokenHash?.trim()) {
+    return false;
+  }
+  return writeStoredRootMetadata(path.join(params.rootDir, STORAGE_META_FILENAME), {
+    homeserver: metadata.homeserver,
+    userId: metadata.userId,
+    accountId: metadata.accountId ?? DEFAULT_ACCOUNT_KEY,
+    accessTokenHash: metadata.accessTokenHash,
+    deviceId,
+    currentTokenStateClaimed: metadata.currentTokenStateClaimed === true,
     createdAt: metadata.createdAt ?? new Date().toISOString(),
   });
 }

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe.test.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe.test.ts
@@ -1,15 +1,33 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginRuntime } from "../../runtime-api.js";
+import { setMatrixRuntime } from "../../runtime.js";
+import { LogService } from "../sdk/logger.js";
 import { createMatrixInboundEventDeduper } from "./inbound-dedupe.js";
 
 describe("Matrix inbound event dedupe", () => {
   const tempDirs: string[] = [];
 
+  beforeEach(() => {
+    setMatrixRuntime({
+      state: {
+        openKeyedStore: (options: OpenKeyedStoreOptions) =>
+          createPluginStateKeyedStoreForTests("matrix", options),
+      },
+    } as unknown as PluginRuntime);
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+    resetPluginStateStoreForTests();
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -125,22 +143,73 @@ describe("Matrix inbound event dedupe", () => {
     expect(second.claimEvent({ roomId: "!room:example.org", eventId: "$backlog" })).toBe(false);
   });
 
-  it("treats stop persistence failures as best-effort cleanup", async () => {
-    const blockingPath = createStoragePath();
-    fs.writeFileSync(blockingPath, "blocking file", "utf8");
+  it("imports legacy JSON entries into plugin state", async () => {
+    const storagePath = createStoragePath();
+    fs.writeFileSync(
+      storagePath,
+      JSON.stringify({
+        version: 1,
+        entries: [{ key: "!room:example.org|$legacy", ts: 90 }],
+      }),
+      "utf8",
+    );
+
+    const first = await createMatrixInboundEventDeduper({
+      auth: auth as never,
+      storagePath,
+      ttlMs: 20,
+      nowMs: () => 100,
+    });
+    expect(first.claimEvent({ roomId: "!room:example.org", eventId: "$legacy" })).toBe(false);
+
+    fs.rmSync(storagePath, { force: true });
+    resetPluginStateStoreForTests();
+    const second = await createMatrixInboundEventDeduper({
+      auth: auth as never,
+      storagePath,
+      ttlMs: 20,
+      nowMs: () => 100,
+    });
+    expect(second.claimEvent({ roomId: "!room:example.org", eventId: "$legacy" })).toBe(false);
+  });
+
+  it("keeps committed events in memory when plugin-state persistence fails", async () => {
+    const storagePath = createStoragePath();
+    const warnSpy = vi.spyOn(LogService, "warn").mockImplementation(() => {});
+    setMatrixRuntime({
+      state: {
+        openKeyedStore: () => ({
+          entries: async () => [],
+          register: async () => {
+            throw new Error("sqlite unavailable");
+          },
+          registerIfAbsent: async () => false,
+          lookup: async () => undefined,
+          consume: async () => undefined,
+          delete: async () => false,
+          clear: async () => {},
+        }),
+      },
+    } as unknown as PluginRuntime);
     const deduper = await createMatrixInboundEventDeduper({
       auth: auth as never,
-      storagePath: path.join(blockingPath, "nested", "inbound-dedupe.json"),
+      storagePath,
     });
 
-    expect(deduper.claimEvent({ roomId: "!room:example.org", eventId: "$persist-fail" })).toBe(
-      true,
+    expect(deduper.claimEvent({ roomId: "!room:example.org", eventId: "$best-effort" })).toBe(true);
+    await expect(
+      deduper.commitEvent({
+        roomId: "!room:example.org",
+        eventId: "$best-effort",
+      }),
+    ).resolves.toBeUndefined();
+    expect(deduper.claimEvent({ roomId: "!room:example.org", eventId: "$best-effort" })).toBe(
+      false,
     );
-    await deduper.commitEvent({
-      roomId: "!room:example.org",
-      eventId: "$persist-fail",
-    });
-
-    await expect(deduper.stop()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "MatrixInboundDedupe",
+      "Failed persisting Matrix inbound dedupe entry:",
+      expect.any(Error),
+    );
   });
 });

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe.ts
@@ -1,23 +1,38 @@
-import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
-import { createAsyncLock } from "../async-lock.js";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { readJsonFileWithFallback } from "openclaw/plugin-sdk/json-store";
+import { getMatrixRuntime } from "../../runtime.js";
 import { resolveMatrixStateFilePath } from "../client/storage.js";
 import type { MatrixAuth } from "../client/types.js";
 import { LogService } from "../sdk/logger.js";
+import { resolveMatrixSqliteStateEnv } from "../sqlite-state.js";
 
 const INBOUND_DEDUPE_FILENAME = "inbound-dedupe.json";
+const INBOUND_DEDUPE_NAMESPACE = "inbound-dedupe";
+const INBOUND_DEDUPE_MIGRATIONS_NAMESPACE = "inbound-dedupe-migrations";
 const STORE_VERSION = 1;
 const DEFAULT_MAX_ENTRIES = 20_000;
 const DEFAULT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-const PERSIST_DEBOUNCE_MS = 250;
 
 type StoredMatrixInboundDedupeEntry = {
+  roomId: string;
+  eventId: string;
+  ts: number;
+};
+
+type LegacyMatrixInboundDedupeEntry = {
   key: string;
   ts: number;
 };
 
-type StoredMatrixInboundDedupeState = {
+type LegacyMatrixInboundDedupeState = {
   version: number;
-  entries: StoredMatrixInboundDedupeEntry[];
+  entries: LegacyMatrixInboundDedupeEntry[];
+};
+
+type MatrixInboundDedupeMigrationMarker = {
+  importedAt: number;
 };
 
 export type MatrixInboundEventDeduper = {
@@ -32,10 +47,21 @@ function normalizeEventPart(value: string): string {
   return value.trim();
 }
 
-function buildEventKey(params: { roomId: string; eventId: string }): string {
+function buildEventKey(params: { auth: MatrixAuth; roomId: string; eventId: string }): string {
+  const accountId = normalizeEventPart(params.auth.accountId) || "default";
   const roomId = normalizeEventPart(params.roomId);
   const eventId = normalizeEventPart(params.eventId);
-  return roomId && eventId ? `${roomId}|${eventId}` : "";
+  if (!roomId || !eventId) {
+    return "";
+  }
+  const digest = createHash("sha256")
+    .update(accountId)
+    .update("\0")
+    .update(roomId)
+    .update("\0")
+    .update(eventId)
+    .digest("hex");
+  return `${accountId}:${digest}`;
 }
 
 function resolveInboundDedupeStatePath(params: {
@@ -79,7 +105,9 @@ function pruneSeenEvents(params: {
     return;
   }
   while (seen.size > max) {
-    const oldestKey = seen.keys().next().value;
+    const oldestKey = [...seen.entries()].toSorted(
+      (a, b) => a[1] - b[1] || a[0].localeCompare(b[0]),
+    )[0]?.[0];
     if (typeof oldestKey !== "string") {
       break;
     }
@@ -87,30 +115,58 @@ function pruneSeenEvents(params: {
   }
 }
 
-function toStoredState(params: {
-  seen: Map<string, number>;
-  ttlMs: number;
-  maxEntries: number;
-  nowMs: number;
-}): StoredMatrixInboundDedupeState {
-  pruneSeenEvents(params);
-  return {
-    version: STORE_VERSION,
-    entries: Array.from(params.seen.entries()).map(([key, ts]) => ({ key, ts })),
-  };
+function createInboundDedupeStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {
+  return getMatrixRuntime().state.openKeyedStore<StoredMatrixInboundDedupeEntry>({
+    namespace: INBOUND_DEDUPE_NAMESPACE,
+    maxEntries: DEFAULT_MAX_ENTRIES,
+    env: resolveMatrixSqliteStateEnv(params),
+  });
 }
 
-async function readStoredState(
-  storagePath: string,
-): Promise<StoredMatrixInboundDedupeState | null> {
-  const { value } = await readJsonFileWithFallback<StoredMatrixInboundDedupeState | null>(
+function createInboundDedupeMigrationStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {
+  return getMatrixRuntime().state.openKeyedStore<MatrixInboundDedupeMigrationMarker>({
+    namespace: INBOUND_DEDUPE_MIGRATIONS_NAMESPACE,
+    maxEntries: 1_000,
+    env: resolveMatrixSqliteStateEnv(params),
+  });
+}
+
+function buildLegacyImportKey(params: { auth: MatrixAuth; storagePath: string }): string {
+  const accountId = normalizeEventPart(params.auth.accountId) || "default";
+  const digest = createHash("sha256")
+    .update(accountId)
+    .update("\0")
+    .update(params.storagePath)
+    .digest("hex");
+  return `${accountId}:${digest}`;
+}
+
+async function loadLegacyEntries(storagePath: string): Promise<StoredMatrixInboundDedupeEntry[]> {
+  const { value } = await readJsonFileWithFallback<LegacyMatrixInboundDedupeState | null>(
     storagePath,
     null,
   );
   if (value?.version !== STORE_VERSION || !Array.isArray(value.entries)) {
-    return null;
+    return [];
   }
-  return value;
+  const entries: StoredMatrixInboundDedupeEntry[] = [];
+  for (const entry of value.entries) {
+    if (!entry || typeof entry.key !== "string") {
+      continue;
+    }
+    const separatorIndex = entry.key.indexOf("|");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+    const roomId = entry.key.slice(0, separatorIndex).trim();
+    const eventId = entry.key.slice(separatorIndex + 1).trim();
+    const ts = normalizeTimestamp(entry.ts);
+    if (!roomId || !eventId || ts === null) {
+      continue;
+    }
+    entries.push({ roomId, eventId, ts });
+  }
+  return entries;
 }
 
 export async function createMatrixInboundEventDeduper(params: {
@@ -138,90 +194,63 @@ export async function createMatrixInboundEventDeduper(params: {
       env: params.env,
       stateDir: params.stateDir,
     });
+  const stateDir = params.stateDir ?? path.dirname(storagePath);
+  const store = createInboundDedupeStore({ env: params.env, stateDir });
+  const migrationStore = createInboundDedupeMigrationStore({ env: params.env, stateDir });
 
   const seen = new Map<string, number>();
   const pending = new Set<string>();
-  const persistLock = createAsyncLock();
 
   try {
-    const stored = await readStoredState(storagePath);
-    for (const entry of stored?.entries ?? []) {
-      if (!entry || typeof entry.key !== "string") {
-        continue;
+    for (const entry of await store.entries()) {
+      const value = entry.value;
+      const roomId = typeof value?.roomId === "string" ? value.roomId.trim() : "";
+      const eventId = typeof value?.eventId === "string" ? value.eventId.trim() : "";
+      const ts = normalizeTimestamp(value?.ts);
+      const expectedKey = buildEventKey({ auth: params.auth, roomId, eventId });
+      if (expectedKey && expectedKey === entry.key && ts !== null) {
+        seen.set(entry.key, ts);
       }
-      const key = entry.key.trim();
-      const ts = normalizeTimestamp(entry.ts);
-      if (!key || ts === null) {
-        continue;
+    }
+    const legacyImportKey = buildLegacyImportKey({ auth: params.auth, storagePath });
+    const legacyAlreadyImported = await migrationStore.lookup(legacyImportKey);
+    if (!legacyAlreadyImported) {
+      const legacyEntries = await loadLegacyEntries(storagePath);
+      let migratedLegacyEntries = 0;
+      for (const entry of legacyEntries) {
+        const key = buildEventKey({
+          auth: params.auth,
+          roomId: entry.roomId,
+          eventId: entry.eventId,
+        });
+        if (!key) {
+          continue;
+        }
+        if (seen.has(key)) {
+          migratedLegacyEntries += 1;
+          continue;
+        }
+        seen.set(key, entry.ts);
+        await store
+          .register(key, entry, ttlMs > 0 ? { ttlMs } : undefined)
+          .then(() => {
+            migratedLegacyEntries += 1;
+          })
+          .catch(() => {});
       }
-      seen.set(key, ts);
+      if (legacyEntries.length > 0 && migratedLegacyEntries === legacyEntries.length) {
+        await migrationStore.register(legacyImportKey, { importedAt: nowMs() });
+        await fs.rm(storagePath, { force: true }).catch(() => {});
+      }
     }
     pruneSeenEvents({ seen, ttlMs, maxEntries, nowMs: nowMs() });
   } catch (err) {
     LogService.warn("MatrixInboundDedupe", "Failed loading Matrix inbound dedupe store:", err);
   }
 
-  let dirty = false;
-  let persistTimer: NodeJS.Timeout | null = null;
-  let persistPromise: Promise<void> | null = null;
-
-  const persist = async () => {
-    dirty = false;
-    const payload = toStoredState({
-      seen,
-      ttlMs,
-      maxEntries,
-      nowMs: nowMs(),
-    });
-    try {
-      await persistLock(async () => {
-        await writeJsonFileAtomically(storagePath, payload);
-      });
-    } catch (err) {
-      dirty = true;
-      throw err;
-    }
-  };
-
-  const flush = async (): Promise<void> => {
-    if (persistTimer) {
-      clearTimeout(persistTimer);
-      persistTimer = null;
-    }
-    for (;;) {
-      if (!dirty && !persistPromise) {
-        break;
-      }
-      if (dirty && !persistPromise) {
-        persistPromise = persist().finally(() => {
-          persistPromise = null;
-        });
-      }
-      await persistPromise;
-    }
-  };
-
-  const schedulePersist = () => {
-    dirty = true;
-    if (persistTimer) {
-      return;
-    }
-    persistTimer = setTimeout(() => {
-      persistTimer = null;
-      void flush().catch((err) => {
-        LogService.warn(
-          "MatrixInboundDedupe",
-          "Failed persisting Matrix inbound dedupe store:",
-          err,
-        );
-      });
-    }, PERSIST_DEBOUNCE_MS);
-    persistTimer.unref?.();
-  };
-
   return {
     claimEvent: ({ roomId, eventId }) => {
-      const key = buildEventKey({ roomId, eventId });
+      const key = buildEventKey({ auth: params.auth, roomId, eventId });
       if (!key) {
         return true;
       }
@@ -233,7 +262,7 @@ export async function createMatrixInboundEventDeduper(params: {
       return true;
     },
     commitEvent: async ({ roomId, eventId }) => {
-      const key = buildEventKey({ roomId, eventId });
+      const key = buildEventKey({ auth: params.auth, roomId, eventId });
       if (!key) {
         return;
       }
@@ -242,26 +271,32 @@ export async function createMatrixInboundEventDeduper(params: {
       seen.delete(key);
       seen.set(key, ts);
       pruneSeenEvents({ seen, ttlMs, maxEntries, nowMs: nowMs() });
-      schedulePersist();
+      await store
+        .register(
+          key,
+          {
+            roomId: normalizeEventPart(roomId),
+            eventId: normalizeEventPart(eventId),
+            ts,
+          },
+          ttlMs > 0 ? { ttlMs } : undefined,
+        )
+        .catch((err) => {
+          LogService.warn(
+            "MatrixInboundDedupe",
+            "Failed persisting Matrix inbound dedupe entry:",
+            err,
+          );
+        });
     },
     releaseEvent: ({ roomId, eventId }) => {
-      const key = buildEventKey({ roomId, eventId });
+      const key = buildEventKey({ auth: params.auth, roomId, eventId });
       if (!key) {
         return;
       }
       pending.delete(key);
     },
-    flush,
-    stop: async () => {
-      try {
-        await flush();
-      } catch (err) {
-        LogService.warn(
-          "MatrixInboundDedupe",
-          "Failed to flush Matrix inbound dedupe store during stop():",
-          err,
-        );
-      }
-    },
+    flush: async () => {},
+    stop: async () => {},
   };
 }

--- a/extensions/matrix/src/matrix/monitor/startup-verification.test.ts
+++ b/extensions/matrix/src/matrix/monitor/startup-verification.test.ts
@@ -1,7 +1,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginRuntime } from "../../runtime-api.js";
+import { setMatrixRuntime } from "../../runtime.js";
 import { ensureMatrixStartupVerification } from "./startup-verification.js";
 
 function createTempStateDir(): string {
@@ -10,6 +17,18 @@ function createTempStateDir(): string {
 
 function createStateFilePath(rootDir: string): string {
   return path.join(rootDir, "startup-verification.json");
+}
+
+async function readPersistedStartupState(rootDir: string) {
+  const store = createPluginStateKeyedStoreForTests<{
+    attemptedAt?: string;
+    outcome?: string;
+  }>("matrix", {
+    namespace: "startup-verification",
+    maxEntries: 1_000,
+    env: { ...process.env, OPENCLAW_STATE_DIR: rootDir },
+  });
+  return await store.lookup("default");
 }
 
 function createAuth(accountId = "default") {
@@ -80,8 +99,18 @@ function createHarness(params?: {
 }
 
 describe("ensureMatrixStartupVerification", () => {
+  beforeEach(() => {
+    setMatrixRuntime({
+      state: {
+        openKeyedStore: (options: OpenKeyedStoreOptions) =>
+          createPluginStateKeyedStoreForTests("matrix", options),
+      },
+    } as unknown as PluginRuntime);
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
+    resetPluginStateStoreForTests();
   });
 
   it("skips automatic requests when the device is already verified", async () => {
@@ -204,7 +233,11 @@ describe("ensureMatrixStartupVerification", () => {
     expect(result.kind).toBe("requested");
     expect(harness.client.crypto.requestVerification).toHaveBeenCalledWith({ ownUser: true });
 
-    expect(fs.existsSync(createStateFilePath(tempHome))).toBe(true);
+    await expect(readPersistedStartupState(tempHome)).resolves.toMatchObject({
+      attemptedAt: "2026-03-08T12:00:00.000Z",
+      outcome: "requested",
+    });
+    expect(fs.existsSync(createStateFilePath(tempHome))).toBe(false);
   });
 
   it("falls back when startup verification nowMs is outside Date range", async () => {
@@ -222,10 +255,9 @@ describe("ensureMatrixStartupVerification", () => {
     });
 
     expect(result.kind).toBe("requested");
-    const state = JSON.parse(fs.readFileSync(stateFilePath, "utf-8")) as {
-      attemptedAt?: string;
-    };
-    expect(state.attemptedAt).toBe("2026-05-30T12:00:00.000Z");
+    await expect(readPersistedStartupState(tempHome)).resolves.toMatchObject({
+      attemptedAt: "2026-05-30T12:00:00.000Z",
+    });
   });
 
   it("keeps startup verification failures non-fatal", async () => {
@@ -303,7 +335,7 @@ describe("ensureMatrixStartupVerification", () => {
       nowMs: Date.parse("2026-03-08T12:00:00.000Z"),
     });
 
-    expect(fs.existsSync(stateFilePath)).toBe(true);
+    await expect(readPersistedStartupState(tempHome)).resolves.toBeDefined();
 
     const verified = createHarness({ verified: true });
     const result = await ensureMatrixStartupVerification({
@@ -315,5 +347,6 @@ describe("ensureMatrixStartupVerification", () => {
 
     expect(result.kind).toBe("verified");
     expect(fs.existsSync(stateFilePath)).toBe(false);
+    await expect(readPersistedStartupState(tempHome)).resolves.toBeUndefined();
   });
 });

--- a/extensions/matrix/src/matrix/monitor/startup-verification.ts
+++ b/extensions/matrix/src/matrix/monitor/startup-verification.ts
@@ -1,14 +1,20 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
+import { readJsonFileWithFallback } from "openclaw/plugin-sdk/json-store";
 import { timestampMsToIsoString } from "openclaw/plugin-sdk/number-runtime";
+import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixConfig } from "../../types.js";
-import { resolveMatrixStoragePaths } from "../client/storage.js";
+import { recordCurrentStorageMetaDeviceId, resolveMatrixStoragePaths } from "../client/storage.js";
 import type { MatrixAuth } from "../client/types.js";
 import { formatMatrixErrorMessage } from "../errors.js";
 import type { MatrixClient, MatrixOwnDeviceVerificationStatus } from "../sdk.js";
+import { resolveMatrixSqliteStateEnv } from "../sqlite-state.js";
 
 const STARTUP_VERIFICATION_STATE_FILENAME = "startup-verification.json";
+const STARTUP_VERIFICATION_NAMESPACE = "startup-verification";
+const STARTUP_VERIFICATION_MIGRATIONS_NAMESPACE = "startup-verification-migrations";
+const STARTUP_VERIFICATION_MAX_ENTRIES = 1_000;
 const DEFAULT_STARTUP_VERIFICATION_MODE = "if-unverified" as const;
 const DEFAULT_STARTUP_VERIFICATION_COOLDOWN_HOURS = 24;
 const DEFAULT_STARTUP_VERIFICATION_FAILURE_COOLDOWN_MS = 60 * 60 * 1000;
@@ -21,6 +27,10 @@ type MatrixStartupVerificationState = {
   requestId?: string;
   transactionId?: string;
   error?: string;
+};
+
+type MatrixStartupVerificationMigrationMarker = {
+  importedAt: number;
 };
 
 export type MatrixStartupVerificationOutcome =
@@ -47,6 +57,7 @@ function normalizeCooldownHours(value: number | undefined): number {
 function resolveStartupVerificationStatePath(params: {
   auth: MatrixAuth;
   env?: NodeJS.ProcessEnv;
+  stateDir?: string;
 }): string {
   const storagePaths = resolveMatrixStoragePaths({
     homeserver: params.auth.homeserver,
@@ -55,11 +66,48 @@ function resolveStartupVerificationStatePath(params: {
     accountId: params.auth.accountId,
     deviceId: params.auth.deviceId,
     env: params.env,
+    stateDir: params.stateDir,
   });
   return path.join(storagePaths.rootDir, STARTUP_VERIFICATION_STATE_FILENAME);
 }
 
-async function readStartupVerificationState(
+function buildStartupVerificationKey(auth: MatrixAuth): string {
+  return auth.accountId.trim() || "default";
+}
+
+function createStartupVerificationStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {
+  return getMatrixRuntime().state.openKeyedStore<MatrixStartupVerificationState>({
+    namespace: STARTUP_VERIFICATION_NAMESPACE,
+    maxEntries: STARTUP_VERIFICATION_MAX_ENTRIES,
+    env: resolveMatrixSqliteStateEnv(params),
+  });
+}
+
+function createStartupVerificationMigrationStore(params: {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+}) {
+  return getMatrixRuntime().state.openKeyedStore<MatrixStartupVerificationMigrationMarker>({
+    namespace: STARTUP_VERIFICATION_MIGRATIONS_NAMESPACE,
+    maxEntries: STARTUP_VERIFICATION_MAX_ENTRIES,
+    env: resolveMatrixSqliteStateEnv(params),
+  });
+}
+
+function buildStartupVerificationImportKey(params: {
+  auth: MatrixAuth;
+  legacyFilePath: string;
+}): string {
+  const accountId = params.auth.accountId.trim() || "default";
+  const digest = createHash("sha256")
+    .update(accountId)
+    .update("\0")
+    .update(params.legacyFilePath)
+    .digest("hex");
+  return `${accountId}:${digest}`;
+}
+
+async function readLegacyStartupVerificationState(
   filePath: string,
 ): Promise<MatrixStartupVerificationState | null> {
   const { value } = await readJsonFileWithFallback<MatrixStartupVerificationState | null>(
@@ -69,8 +117,93 @@ async function readStartupVerificationState(
   return value && typeof value === "object" ? value : null;
 }
 
-async function clearStartupVerificationState(filePath: string): Promise<void> {
-  await fs.rm(filePath, { force: true }).catch(() => {});
+async function readStartupVerificationState(params: {
+  auth: MatrixAuth;
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  legacyFilePath: string;
+}): Promise<MatrixStartupVerificationState | null> {
+  const store = createStartupVerificationStore(params);
+  const key = buildStartupVerificationKey(params.auth);
+  const value = await store.lookup(key);
+  if (value && typeof value === "object") {
+    return value;
+  }
+  const migrationStore = createStartupVerificationMigrationStore(params);
+  const legacyImportKey = buildStartupVerificationImportKey({
+    auth: params.auth,
+    legacyFilePath: params.legacyFilePath,
+  });
+  if (await migrationStore.lookup(legacyImportKey)) {
+    return null;
+  }
+  const legacy = await readLegacyStartupVerificationState(params.legacyFilePath);
+  if (legacy) {
+    await store
+      .register(key, legacy)
+      .then(async () => {
+        if (typeof legacy.deviceId === "string" && legacy.deviceId.trim()) {
+          recordCurrentStorageMetaDeviceId({
+            rootDir: path.dirname(params.legacyFilePath),
+            deviceId: legacy.deviceId,
+          });
+        }
+        await migrationStore.register(legacyImportKey, { importedAt: Date.now() });
+        await fs.rm(params.legacyFilePath, { force: true }).catch(() => {});
+      })
+      .catch(() => {});
+  }
+  return legacy;
+}
+
+async function writeStartupVerificationState(params: {
+  auth: MatrixAuth;
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  legacyFilePath: string;
+  state: MatrixStartupVerificationState;
+}): Promise<void> {
+  await createStartupVerificationStore(params).register(
+    buildStartupVerificationKey(params.auth),
+    params.state,
+  );
+  await createStartupVerificationMigrationStore(params)
+    .register(
+      buildStartupVerificationImportKey({
+        auth: params.auth,
+        legacyFilePath: params.legacyFilePath,
+      }),
+      { importedAt: Date.now() },
+    )
+    .catch(() => {});
+  if (typeof params.state.deviceId === "string" && params.state.deviceId.trim()) {
+    recordCurrentStorageMetaDeviceId({
+      rootDir: path.dirname(params.legacyFilePath),
+      deviceId: params.state.deviceId,
+    });
+  }
+  await fs.rm(params.legacyFilePath, { force: true }).catch(() => {});
+}
+
+async function clearStartupVerificationState(params: {
+  auth: MatrixAuth;
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  legacyFilePath: string;
+}): Promise<void> {
+  await createStartupVerificationStore(params)
+    .delete(buildStartupVerificationKey(params.auth))
+    .catch(() => {});
+  await createStartupVerificationMigrationStore(params)
+    .register(
+      buildStartupVerificationImportKey({
+        auth: params.auth,
+        legacyFilePath: params.legacyFilePath,
+      }),
+      { importedAt: Date.now() },
+    )
+    .catch(() => {});
+  await fs.rm(params.legacyFilePath, { force: true }).catch(() => {});
 }
 
 function resolveStateCooldownMs(
@@ -154,6 +287,7 @@ export async function ensureMatrixStartupVerification(params: {
   accountConfig: Pick<MatrixConfig, "startupVerification" | "startupVerificationCooldownHours">;
   env?: NodeJS.ProcessEnv;
   nowMs?: number;
+  stateDir?: string;
   stateFilePath?: string;
 }): Promise<MatrixStartupVerificationOutcome> {
   if (params.auth.encryption !== true || !params.client.crypto) {
@@ -166,10 +300,17 @@ export async function ensureMatrixStartupVerification(params: {
     resolveStartupVerificationStatePath({
       auth: params.auth,
       env: params.env,
+      stateDir: params.stateDir,
     });
+  const stateDir = params.stateDir ?? path.dirname(statePath);
 
   if (verification.verified) {
-    await clearStartupVerificationState(statePath);
+    await clearStartupVerificationState({
+      auth: params.auth,
+      env: params.env,
+      stateDir,
+      legacyFilePath: statePath,
+    });
     return {
       kind: "verified",
       verification,
@@ -178,7 +319,12 @@ export async function ensureMatrixStartupVerification(params: {
 
   const mode = params.accountConfig.startupVerification ?? DEFAULT_STARTUP_VERIFICATION_MODE;
   if (mode === "off") {
-    await clearStartupVerificationState(statePath);
+    await clearStartupVerificationState({
+      auth: params.auth,
+      env: params.env,
+      stateDir,
+      legacyFilePath: statePath,
+    });
     return {
       kind: "disabled",
       verification,
@@ -199,7 +345,12 @@ export async function ensureMatrixStartupVerification(params: {
   const cooldownMs = cooldownHours * 60 * 60 * 1000;
   const nowMs = params.nowMs ?? Date.now();
   const attemptedAt = resolveStartupVerificationTimestamp(nowMs);
-  const state = await readStartupVerificationState(statePath);
+  const state = await readStartupVerificationState({
+    auth: params.auth,
+    env: params.env,
+    stateDir,
+    legacyFilePath: statePath,
+  });
   const stateCooldownMs = resolveStateCooldownMs(state, cooldownMs);
   if (shouldHonorCooldown({ state, verification, stateCooldownMs, nowMs })) {
     return {
@@ -215,14 +366,20 @@ export async function ensureMatrixStartupVerification(params: {
 
   try {
     const request = await params.client.crypto.requestVerification({ ownUser: true });
-    await writeJsonFileAtomically(statePath, {
-      userId: verification.userId,
-      deviceId: verification.deviceId,
-      attemptedAt,
-      outcome: "requested",
-      requestId: request.id,
-      transactionId: request.transactionId,
-    } satisfies MatrixStartupVerificationState);
+    await writeStartupVerificationState({
+      auth: params.auth,
+      env: params.env,
+      stateDir,
+      legacyFilePath: statePath,
+      state: {
+        userId: verification.userId,
+        deviceId: verification.deviceId,
+        attemptedAt,
+        outcome: "requested",
+        requestId: request.id,
+        transactionId: request.transactionId,
+      },
+    });
     return {
       kind: "requested",
       verification,
@@ -231,13 +388,19 @@ export async function ensureMatrixStartupVerification(params: {
     };
   } catch (err) {
     const error = formatMatrixErrorMessage(err);
-    await writeJsonFileAtomically(statePath, {
-      userId: verification.userId,
-      deviceId: verification.deviceId,
-      attemptedAt,
-      outcome: "failed",
-      error,
-    } satisfies MatrixStartupVerificationState).catch(() => {});
+    await writeStartupVerificationState({
+      auth: params.auth,
+      env: params.env,
+      stateDir,
+      legacyFilePath: statePath,
+      state: {
+        userId: verification.userId,
+        deviceId: verification.deviceId,
+        attemptedAt,
+        outcome: "failed",
+        error,
+      },
+    }).catch(() => {});
     return {
       kind: "request-failed",
       verification,

--- a/extensions/matrix/src/matrix/sqlite-state.ts
+++ b/extensions/matrix/src/matrix/sqlite-state.ts
@@ -1,0 +1,40 @@
+import os from "node:os";
+import { getMatrixRuntime } from "../runtime.js";
+
+export type MatrixSqliteStateOptions = {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  stateRootDir?: string;
+};
+
+function resolveStateDirOverride(
+  options: MatrixSqliteStateOptions | undefined,
+): string | undefined {
+  if (!options) {
+    return undefined;
+  }
+  if (options.stateDir) {
+    return options.stateDir;
+  }
+  if (options.stateRootDir) {
+    return options.stateRootDir;
+  }
+  return getMatrixRuntime().state.resolveStateDir(options.env ?? process.env, os.homedir);
+}
+
+export function resolveMatrixSqliteStateKey(options: MatrixSqliteStateOptions | undefined): string {
+  return resolveStateDirOverride(options) ?? "";
+}
+
+export function resolveMatrixSqliteStateEnv(
+  options: MatrixSqliteStateOptions | undefined,
+): NodeJS.ProcessEnv | undefined {
+  const stateDir = resolveStateDirOverride(options);
+  if (!stateDir) {
+    return options?.env;
+  }
+  return {
+    ...(options?.env ?? process.env),
+    OPENCLAW_STATE_DIR: stateDir,
+  };
+}

--- a/extensions/matrix/src/matrix/thread-bindings-shared.ts
+++ b/extensions/matrix/src/matrix/thread-bindings-shared.ts
@@ -45,7 +45,7 @@ export type MatrixThreadBindingManager = {
 };
 
 type MatrixThreadBindingManagerCacheEntry = {
-  filePath: string;
+  storageKey: string;
   manager: MatrixThreadBindingManager;
 };
 

--- a/extensions/matrix/src/matrix/thread-bindings.test.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.test.ts
@@ -2,8 +2,13 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { getSessionBindingService, testing } from "openclaw/plugin-sdk/session-binding-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime } from "../../runtime-api.js";
 import { setMatrixRuntime } from "../runtime.js";
 import {
@@ -25,9 +30,6 @@ const sendMessageMatrixMock = vi.hoisted(() =>
     roomId: "!room:example",
   })),
 );
-const actualRename = fs.rename.bind(fs);
-const renameMock = vi.spyOn(fs, "rename");
-
 vi.mock("./send.js", () => {
   return {
     sendMessageMatrix: sendMessageMatrixMock,
@@ -128,22 +130,34 @@ describe("matrix thread bindings", () => {
   }
 
   async function readPersistedLastActivityAt(bindingsPath: string) {
-    const raw = await fs.readFile(bindingsPath, "utf-8");
-    const parsed = JSON.parse(raw) as {
-      bindings?: Array<{ lastActivityAt?: number }>;
-    };
+    const parsed = await readPersistedBindings(bindingsPath);
     return parsed.bindings?.[0]?.lastActivityAt;
   }
 
   async function readPersistedBindings(bindingsPath: string) {
-    const raw = await fs.readFile(bindingsPath, "utf-8");
-    return JSON.parse(raw) as {
-      version?: number;
-      bindings?: Array<{
+    const store = createPluginStateKeyedStoreForTests<{
+      accountId?: string;
+      conversationId?: string;
+      parentConversationId?: string;
+      targetSessionKey?: string;
+      lastActivityAt?: number;
+      boundAt?: number;
+    }>("matrix", {
+      namespace: "thread-bindings",
+      maxEntries: 10_000,
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.dirname(bindingsPath) },
+    });
+    return {
+      version: 1,
+      bindings: (await store.entries())
+        .map((entry) => entry.value)
+        .filter((entry) => entry.accountId === accountId)
+        .toSorted((a, b) => (a.boundAt ?? 0) - (b.boundAt ?? 0)) as Array<{
         conversationId?: string;
         parentConversationId?: string;
         targetSessionKey?: string;
-      }>;
+        lastActivityAt?: number;
+      }>,
     };
   }
 
@@ -176,14 +190,22 @@ describe("matrix thread bindings", () => {
   beforeEach(() => {
     stateDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "matrix-thread-bindings-"));
     resetThreadBindingAdapters();
+    resetPluginStateStoreForTests();
     sendMessageMatrixMock.mockClear();
-    renameMock.mockReset();
-    renameMock.mockImplementation(actualRename);
     setMatrixRuntime({
       state: {
+        openKeyedStore: (options: OpenKeyedStoreOptions) =>
+          createPluginStateKeyedStoreForTests("matrix", options),
         resolveStateDir: () => stateDir,
       },
     } as PluginRuntime);
+  });
+
+  afterEach(() => {
+    resetThreadBindingAdapters();
+    resetPluginStateStoreForTests();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("creates child Matrix thread bindings from a top-level room context", async () => {
@@ -350,69 +372,6 @@ describe("matrix thread bindings", () => {
         },
         { interval: 10, timeout: 1_000 },
       );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("logs and survives sweeper persistence failures", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-08T12:00:00.000Z"));
-    const logVerboseMessage = vi.fn();
-    try {
-      await createMatrixThreadBindingManager({
-        cfg: {},
-        accountId: "ops",
-        auth,
-        client: {} as never,
-        idleTimeoutMs: 1_000,
-        maxAgeMs: 0,
-        logVerboseMessage,
-      });
-
-      await getSessionBindingService().bind({
-        targetSessionKey: "agent:ops:subagent:child",
-        targetKind: "subagent",
-        conversation: {
-          channel: "matrix",
-          accountId: "ops",
-          conversationId: "$thread",
-          parentConversationId: "!room:example",
-        },
-        placement: "current",
-      });
-
-      renameMock.mockRejectedValueOnce(new Error("disk full"));
-      await vi.advanceTimersByTimeAsync(61_000);
-
-      await vi.waitFor(
-        () => {
-          expect(
-            logVerboseMessage.mock.calls.some(
-              ([message]) =>
-                typeof message === "string" &&
-                message.includes("failed auto-unbinding expired bindings"),
-            ),
-          ).toBe(true);
-          expect(
-            logVerboseMessage.mock.calls.some(
-              ([message]) =>
-                typeof message === "string" &&
-                message.includes("matrix: auto-unbinding $thread due to idle-expired"),
-            ),
-          );
-        },
-        { interval: 1, timeout: 100 },
-      );
-
-      expect(
-        getSessionBindingService().resolveByConversation({
-          channel: "matrix",
-          accountId: "ops",
-          conversationId: "$thread",
-          parentConversationId: "!room:example",
-        }),
-      ).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/matrix/src/matrix/thread-bindings.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.ts
@@ -1,6 +1,8 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
+import { readJsonFileWithFallback } from "openclaw/plugin-sdk/json-store";
 import { resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/session-key-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -9,10 +11,12 @@ import {
   type SessionBindingAdapter,
   unregisterSessionBindingAdapter,
 } from "openclaw/plugin-sdk/thread-bindings-session-runtime";
+import { getMatrixRuntime } from "../runtime.js";
 import { claimCurrentTokenStorageState, resolveMatrixStateFilePath } from "./client/storage.js";
 import type { MatrixAuth } from "./client/types.js";
 import type { MatrixClient } from "./sdk.js";
 import { sendMessageMatrix } from "./send.js";
+import { resolveMatrixSqliteStateEnv, resolveMatrixSqliteStateKey } from "./sqlite-state.js";
 import {
   deleteMatrixThreadBindingManagerEntry,
   getMatrixThreadBindingManager,
@@ -33,12 +37,19 @@ import {
 } from "./thread-bindings-shared.js";
 
 const STORE_VERSION = 1;
+const THREAD_BINDINGS_NAMESPACE = "thread-bindings";
+const THREAD_BINDINGS_MIGRATIONS_NAMESPACE = "thread-bindings-migrations";
+const THREAD_BINDINGS_MAX_ENTRIES = 10_000;
 const THREAD_BINDINGS_SWEEP_INTERVAL_MS = 60_000;
 const TOUCH_PERSIST_DELAY_MS = 30_000;
 
 type StoredMatrixThreadBindingState = {
   version: number;
   bindings: MatrixThreadBindingRecord[];
+};
+
+type MatrixThreadBindingMigrationMarker = {
+  importedAt: number;
 };
 
 function resolveBindingsPath(params: {
@@ -56,7 +67,97 @@ function resolveBindingsPath(params: {
   });
 }
 
-async function loadBindingsFromDisk(filePath: string, accountId: string) {
+function createThreadBindingStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {
+  return getMatrixRuntime().state.openKeyedStore<MatrixThreadBindingRecord>({
+    namespace: THREAD_BINDINGS_NAMESPACE,
+    maxEntries: THREAD_BINDINGS_MAX_ENTRIES,
+    env: resolveMatrixSqliteStateEnv(params),
+  });
+}
+
+function createThreadBindingMigrationStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {
+  return getMatrixRuntime().state.openKeyedStore<MatrixThreadBindingMigrationMarker>({
+    namespace: THREAD_BINDINGS_MIGRATIONS_NAMESPACE,
+    maxEntries: 1_000,
+    env: resolveMatrixSqliteStateEnv(params),
+  });
+}
+
+function buildThreadBindingStoreKey(record: {
+  accountId: string;
+  conversationId: string;
+  parentConversationId?: string;
+}): string {
+  const digest = createHash("sha256")
+    .update(record.accountId)
+    .update("\0")
+    .update(record.parentConversationId ?? "")
+    .update("\0")
+    .update(record.conversationId)
+    .digest("hex");
+  return `${record.accountId}:${digest}`;
+}
+
+function buildLegacyThreadBindingsImportKey(params: {
+  accountId: string;
+  legacyFilePath: string;
+}): string {
+  const digest = createHash("sha256")
+    .update(params.accountId)
+    .update("\0")
+    .update(params.legacyFilePath)
+    .digest("hex");
+  return `${params.accountId}:${digest}`;
+}
+
+function normalizeBindingRecord(
+  entry: unknown,
+  accountId: string,
+): MatrixThreadBindingRecord | null {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return null;
+  }
+  const record = entry as Partial<MatrixThreadBindingRecord>;
+  if (record.accountId && record.accountId !== accountId) {
+    return null;
+  }
+  const conversationId = normalizeOptionalString(record.conversationId);
+  const parentConversationId = normalizeOptionalString(record.parentConversationId);
+  const targetSessionKey = normalizeOptionalString(record.targetSessionKey) ?? "";
+  if (!conversationId || !targetSessionKey) {
+    return null;
+  }
+  const boundAt =
+    typeof record.boundAt === "number" && Number.isFinite(record.boundAt)
+      ? Math.floor(record.boundAt)
+      : Date.now();
+  const lastActivityAt =
+    typeof record.lastActivityAt === "number" && Number.isFinite(record.lastActivityAt)
+      ? Math.floor(record.lastActivityAt)
+      : boundAt;
+  return {
+    accountId,
+    conversationId,
+    ...(parentConversationId ? { parentConversationId } : {}),
+    targetKind: record.targetKind === "subagent" ? "subagent" : "acp",
+    targetSessionKey,
+    agentId: normalizeOptionalString(record.agentId) || undefined,
+    label: normalizeOptionalString(record.label) || undefined,
+    boundBy: normalizeOptionalString(record.boundBy) || undefined,
+    boundAt,
+    lastActivityAt: Math.max(lastActivityAt, boundAt),
+    idleTimeoutMs:
+      typeof record.idleTimeoutMs === "number" && Number.isFinite(record.idleTimeoutMs)
+        ? Math.max(0, Math.floor(record.idleTimeoutMs))
+        : undefined,
+    maxAgeMs:
+      typeof record.maxAgeMs === "number" && Number.isFinite(record.maxAgeMs)
+        ? Math.max(0, Math.floor(record.maxAgeMs))
+        : undefined,
+  };
+}
+
+async function loadBindingsFromLegacyDisk(filePath: string, accountId: string) {
   const { value } = await readJsonFileWithFallback<StoredMatrixThreadBindingState | null>(
     filePath,
     null,
@@ -66,61 +167,51 @@ async function loadBindingsFromDisk(filePath: string, accountId: string) {
   }
   const loaded: MatrixThreadBindingRecord[] = [];
   for (const entry of value.bindings) {
-    const conversationId = normalizeOptionalString(entry?.conversationId);
-    const parentConversationId = normalizeOptionalString(entry?.parentConversationId);
-    const targetSessionKey = normalizeOptionalString(entry?.targetSessionKey) ?? "";
-    if (!conversationId || !targetSessionKey) {
-      continue;
+    const record = normalizeBindingRecord(entry, accountId);
+    if (record) {
+      loaded.push(record);
     }
-    const boundAt =
-      typeof entry?.boundAt === "number" && Number.isFinite(entry.boundAt)
-        ? Math.floor(entry.boundAt)
-        : Date.now();
-    const lastActivityAt =
-      typeof entry?.lastActivityAt === "number" && Number.isFinite(entry.lastActivityAt)
-        ? Math.floor(entry.lastActivityAt)
-        : boundAt;
-    loaded.push({
-      accountId,
-      conversationId,
-      ...(parentConversationId ? { parentConversationId } : {}),
-      targetKind: entry?.targetKind === "subagent" ? "subagent" : "acp",
-      targetSessionKey,
-      agentId: normalizeOptionalString(entry?.agentId) || undefined,
-      label: normalizeOptionalString(entry?.label) || undefined,
-      boundBy: normalizeOptionalString(entry?.boundBy) || undefined,
-      boundAt,
-      lastActivityAt: Math.max(lastActivityAt, boundAt),
-      idleTimeoutMs:
-        typeof entry?.idleTimeoutMs === "number" && Number.isFinite(entry.idleTimeoutMs)
-          ? Math.max(0, Math.floor(entry.idleTimeoutMs))
-          : undefined,
-      maxAgeMs:
-        typeof entry?.maxAgeMs === "number" && Number.isFinite(entry.maxAgeMs)
-          ? Math.max(0, Math.floor(entry.maxAgeMs))
-          : undefined,
-    });
   }
   return loaded;
 }
 
-function toStoredBindingsState(
-  bindings: MatrixThreadBindingRecord[],
-): StoredMatrixThreadBindingState {
-  return {
-    version: STORE_VERSION,
-    bindings: [...bindings].toSorted((a, b) => a.boundAt - b.boundAt),
-  };
+async function loadBindingsFromPluginState(params: {
+  accountId: string;
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+}): Promise<MatrixThreadBindingRecord[]> {
+  const store = createThreadBindingStore(params);
+  const loaded: MatrixThreadBindingRecord[] = [];
+  for (const entry of await store.entries()) {
+    const record = normalizeBindingRecord(entry.value, params.accountId);
+    if (record) {
+      loaded.push(record);
+    }
+  }
+  return loaded;
 }
 
-async function persistBindingsSnapshot(
-  filePath: string,
-  bindings: MatrixThreadBindingRecord[],
-): Promise<void> {
-  await writeJsonFileAtomically(filePath, toStoredBindingsState(bindings));
-  claimCurrentTokenStorageState({
-    rootDir: path.dirname(filePath),
-  });
+function toPluginJsonValue<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+async function persistBindingsSnapshot(params: {
+  accountId: string;
+  bindings: MatrixThreadBindingRecord[];
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+}): Promise<void> {
+  const store = createThreadBindingStore(params);
+  const liveKeys = new Set(params.bindings.map((record) => buildThreadBindingStoreKey(record)));
+  for (const entry of await store.entries()) {
+    const record = normalizeBindingRecord(entry.value, params.accountId);
+    if (record && !liveKeys.has(entry.key)) {
+      await store.delete(entry.key);
+    }
+  }
+  for (const record of params.bindings) {
+    await store.register(buildThreadBindingStoreKey(record), toPluginJsonValue(record));
+  }
 }
 
 function buildMatrixBindingIntroText(params: {
@@ -212,20 +303,47 @@ export async function createMatrixThreadBindingManager(params: {
       `Matrix thread binding account mismatch: requested ${params.accountId}, auth resolved ${params.auth.accountId}`,
     );
   }
-  const filePath = resolveBindingsPath({
+  const legacyFilePath = resolveBindingsPath({
     auth: params.auth,
     accountId: params.accountId,
     env: params.env,
     stateDir: params.stateDir,
   });
+  const sqliteStateDir = path.dirname(legacyFilePath);
+  const storageKey = resolveMatrixSqliteStateKey({ env: params.env, stateDir: sqliteStateDir });
   const existingEntry = getMatrixThreadBindingManagerEntry(params.accountId);
   if (existingEntry) {
-    if (existingEntry.filePath === filePath) {
+    if (existingEntry.storageKey === storageKey) {
       return existingEntry.manager;
     }
     existingEntry.manager.stop();
   }
-  const loaded = await loadBindingsFromDisk(filePath, params.accountId);
+  const pluginLoaded = await loadBindingsFromPluginState({
+    accountId: params.accountId,
+    env: params.env,
+    stateDir: sqliteStateDir,
+  });
+  const migrationStore = createThreadBindingMigrationStore({
+    env: params.env,
+    stateDir: sqliteStateDir,
+  });
+  const legacyImportKey = buildLegacyThreadBindingsImportKey({
+    accountId: params.accountId,
+    legacyFilePath,
+  });
+  const pluginLoadedKeys = new Set(
+    pluginLoaded.map((record) => buildThreadBindingStoreKey(record)),
+  );
+  let legacyHadRows = false;
+  let legacyLoaded: MatrixThreadBindingRecord[] = [];
+  if (!(await migrationStore.lookup(legacyImportKey))) {
+    const legacyCandidates = await loadBindingsFromLegacyDisk(legacyFilePath, params.accountId);
+    legacyHadRows = legacyCandidates.length > 0;
+    legacyLoaded = legacyCandidates.filter(
+      (record) => !pluginLoadedKeys.has(buildThreadBindingStoreKey(record)),
+    );
+  }
+  const loaded = [...pluginLoaded, ...legacyLoaded];
   for (const record of loaded) {
     setBindingRecord(record);
   }
@@ -236,7 +354,13 @@ export async function createMatrixThreadBindingManager(params: {
     const next = persistQueue
       .catch(() => {})
       .then(async () => {
-        await persistBindingsSnapshot(filePath, snapshot);
+        await persistBindingsSnapshot({
+          accountId: params.accountId,
+          bindings: snapshot,
+          env: params.env,
+          stateDir: sqliteStateDir,
+        });
+        claimCurrentTokenStorageState({ rootDir: sqliteStateDir });
       });
     persistQueue = next;
     return next;
@@ -253,6 +377,17 @@ export async function createMatrixThreadBindingManager(params: {
     idleTimeoutMs: params.idleTimeoutMs,
     maxAgeMs: params.maxAgeMs,
   };
+  if (legacyHadRows) {
+    if (legacyLoaded.length > 0) {
+      await persist();
+    }
+    await migrationStore.register(legacyImportKey, { importedAt: Date.now() });
+    await fs.rm(legacyFilePath, { force: true }).catch((err) => {
+      params.logVerboseMessage?.(
+        `matrix: failed removing migrated legacy thread bindings account=${params.accountId}: ${String(err)}`,
+      );
+    });
+  }
   let persistTimer: NodeJS.Timeout | null = null;
   const schedulePersist = (delayMs: number) => {
     if (persistTimer) {
@@ -567,7 +702,7 @@ export async function createMatrixThreadBindingManager(params: {
   }
 
   setMatrixThreadBindingManagerEntry(params.accountId, {
-    filePath,
+    storageKey,
     manager,
   });
   return manager;

--- a/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
+++ b/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
@@ -8,6 +8,11 @@ import {
   type SessionBindingRecord,
 } from "../../../../infra/outbound/session-binding-service.js";
 import { resolvePreferredOpenClawTmpDir } from "../../../../infra/tmp-openclaw-dir.js";
+import type { OpenKeyedStoreOptions } from "../../../../plugin-sdk/plugin-state-runtime.js";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "../../../../plugin-sdk/plugin-state-test-runtime.js";
 import { setActivePluginRegistry } from "../../../../plugins/runtime.js";
 import { createTestRegistry } from "../../../../test-utils/channel-plugins.js";
 import { createChannelConversationBindingManager } from "../../conversation-bindings.js";
@@ -95,6 +100,7 @@ function expectClearedSessionBinding(params: {
 }
 
 function resetMatrixSessionBindingStateDir() {
+  resetPluginStateStoreForTests();
   fs.rmSync(matrixSessionBindingStateDir, { recursive: true, force: true });
   fs.mkdirSync(matrixSessionBindingStateDir, { recursive: true });
 }
@@ -105,6 +111,8 @@ async function createContractMatrixThreadBindingManager() {
     await getContractApi<MatrixContractApi>("matrix");
   setMatrixRuntime({
     state: {
+      openKeyedStore: (options: OpenKeyedStoreOptions) =>
+        createPluginStateKeyedStoreForTests("matrix", options),
       resolveStateDir: () => matrixSessionBindingStateDir,
     },
   } as never);


### PR DESCRIPTION
## Summary

- move Matrix inbound dedupe, startup verification, and thread bindings from plugin-local JSON files into Matrix plugin-state SQLite namespaces
- import legacy JSON once with migration markers, remove stale fallback reads/writes, and preserve account/storage-root isolation
- keep Matrix crypto, recovery key, and IDB sync storage on existing disk files
- update the channel session-binding contract helper so bundled Matrix contract tests provide the same plugin-state runtime seam

## Verification

- `pnpm test extensions/matrix/src/matrix/client/storage.test.ts extensions/matrix/src/matrix/monitor/inbound-dedupe.test.ts extensions/matrix/src/matrix/monitor/startup-verification.test.ts extensions/matrix/src/matrix/thread-bindings.test.ts -- --reporter=verbose`
- `pnpm test:contracts:channels -- src/channels/plugins/contracts/session-binding.registry-backed.contract.test.ts --reporter=verbose`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --prompt 'Final review after removing storage root legacy startup JSON deviceId fallback. Confirm startup verification no longer relies on legacy JSON for deviceId fallback, thread binding SQLite writes still claim current storage root, all legacy JSON imports are one-shot with markers, no fresh legacy JSON writes, inbound persistence remains best-effort, and account/state-dir isolation is preserved.'`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --prompt 'Review the incremental fix after CI channel contract failure. Confirm Matrix contract test runtime now exposes plugin-state openKeyedStore through the SDK test helper, no production fallback/shim was added, and the Matrix SQLite state behavior remains intact.'`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01kswxxmpby4963btjwtm0aqf8`, GitHub Actions run `26689939748`

## Real behavior proof

Behavior addressed: Matrix plugin-local ephemeral state now persists in plugin-state SQLite for inbound dedupe, startup verification, and thread bindings, with one-shot import from legacy JSON and no movement of crypto/recovery/IDB stores.

Real environment tested: local macOS checkout plus delegated Blacksmith Testbox Linux environment.

Exact steps or command run after this patch: focused Matrix Vitest command above, channel session-binding contract command above, structured autoreview commands above, and `pnpm check:changed` in Testbox `tbx_01kswxxmpby4963btjwtm0aqf8`.

Evidence after fix: focused Matrix tests passed 1 Vitest shard with 43 tests; session-binding contract passed 4 Vitest shards with 20 tests; both autoreview runs returned `autoreview clean: no accepted/actionable findings reported`; Testbox changed gate exited 0.

Observed result after fix: Matrix SQLite state migration and persistence tests pass; bundled channel contract runtime covers Matrix plugin-state access; changed typecheck, lint, import-cycle, dependency, and guard checks pass.

What was not tested: live Matrix homeserver traffic.
