### PR TITLE
fix(agents): guard transport payload sanitizer against non-string input

### DIFF
--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -17,6 +17,14 @@ describe("transport stream shared helpers", () => {
     expect(sanitizeTransportPayloadText("emoji 🙈 ok")).toBe("emoji 🙈 ok");
   });
 
+  it("returns empty string for nullish payloads instead of throwing", () => {
+    expect(sanitizeTransportPayloadText(undefined as unknown as string)).toBe("");
+    expect(sanitizeTransportPayloadText(null as unknown as string)).toBe("");
+    expect(sanitizeNonEmptyTransportPayloadText(undefined as unknown as string)).toBe(
+      "(no output)",
+    );
+  });
+
   it.each([
     ["empty", ""],
     ["whitespace-only", " \n\t "],

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -26,6 +26,9 @@ type TransportOutputShape = {
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
 export function sanitizeTransportPayloadText(text: string): string {
+  if (typeof text !== "string") {
+    return "";
+  }
   return text.replace(
     /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
     "",


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**
`sanitizeTransportPayloadText()` in `src/agents/transport-stream-shared.ts` calls `text.replace(...)` directly. When a caller passes runtime-`undefined` content (an assistant/tool message with missing text during model failover or tool-error handling), it throws `TypeError: Cannot read properties of undefined (reading 'replace')`, aborting the embedded agent run and writing an empty assistant message to the transcript.

**Why does this matter now?**
Actively reported on v2026.4.1–v2026.4.14 (#60113, labeled `impact:crash-loop` / `impact:message-loss`). The empty assistant messages then accumulate with lossless-claw and trigger downstream Anthropic `messages.0 is empty` errors.

**What is the intended outcome?**
Nullish payload text no longer crashes the run; the shared sanitizer returns `""`, which degrades to `(no output)` via `sanitizeNonEmptyTransportPayloadText`.

**What is intentionally out of scope?**
- Enhancing `embedded run agent end` logging to capture `error.stack` (a separate request in the issue).
- Per-call-site audits — this fixes the single shared chokepoint that all ~20 call sites funnel through.

**What does success look like?**
No `TypeError` from the sanitizer for nullish input; existing unpaired-surrogate stripping behavior is unchanged.

**What should reviewers focus on?**
Whether returning `""` (vs throwing) is the right degradation at this shared sanitizer.

## Linked context

Closes #60113
Related #21923 (same error via an earlier `client.baseUrl.replace()` path)
Requested by a maintainer or owner? No — selected from a triaged `P2` crash issue (`clawsweeper:queueable-fix`, `clawsweeper:source-repro`).

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** embedded run / provider transport crash `Cannot read properties of undefined (reading 'replace')` when malformed runtime text payloads reach the shared transport sanitizer.
- **Real environment tested:** local OpenClaw source checkout for this PR (`fix/transport-stream-null-guard`, head `6cfe273b`), Node `v25.8.1`, pnpm `11.2.2`. I do not have the reporter's Bedrock multi-model failover / ~1M-token setup, so I exercised the closest real OpenClaw runtime boundary available without private credentials: the production OpenAI Responses transport payload builder (`buildOpenAIResponsesParams`), which is the path embedded-agent runs use before sending OpenAI-family provider requests.
- **Exact steps or command run after this patch:**
  - `node --import tsx --input-type=module` importing `buildOpenAIResponsesParams` from `src/agents/openai-transport-stream.ts`, with malformed user + assistant text blocks (`{ type: "text" }` with no `text`) to force the real serializer through `sanitizeTransportPayloadText(undefined)`.
  - `pnpm exec vitest run src/agents/transport-stream-shared.test.ts`.
- **Evidence after fix:**
  ```text
  ## Local proof for PR #88388
  repo: https://github.com/openclaw/openclaw.git
  branch: fix/transport-stream-null-guard
  head: 6cfe273b
  node: v25.8.1
  pnpm: 11.2.2

  ### Real OpenClaw transport payload builder path
  OpenClaw transport builder: PASS
  request.input.length: 3
  user text after sanitizer: ""
  assistant text after sanitizer: ""
  pre-fix failure signature: TypeError: Cannot read properties of undefined (reading 'replace')

  ### Focused regression test
  Test Files  2 passed (2)
       Tests  18 passed (18)
  ```
- **Observed result after fix:** the real transport builder completes and serializes the malformed user/assistant text fields as empty strings instead of throwing; existing surrogate stripping and `(no output)` fallback behavior remain covered by the focused test.
- **What was not tested:** the reporter's exact Bedrock timeout chain and lossless-claw downstream accumulation, because those require private provider credentials and a large live session.
- **Proof limitations or environment constraints:** this is not a live Bedrock run, but it is not a standalone regex-only proof either: it uses the production OpenAI Responses payload builder that embedded-agent/provider dispatch uses before a request leaves OpenClaw. On unpatched code this path reaches the same `text.replace(...)` chokepoint with `undefined` and throws the issue's TypeError.

## Tests and validation

- **Commands run:** `pnpm exec vitest run src/agents/transport-stream-shared.test.ts` (18 passed); `oxfmt` + `oxlint` on changed files (clean).
- **Regression coverage:** new test `returns empty string for nullish payloads instead of throwing` — fails before the guard (`undefined.replace` throws), passes after.
- **What failed before this fix:** `sanitizeTransportPayloadText(undefined)` threw `TypeError` (shown in the Node reproduction above).
- **If no test was added, why not:** n/a, test added.

## Risk checklist

- **Did user-visible behavior change?** No — a crash is replaced by the pre-existing `(no output)` degradation.
- **Did config, environment, or migration behavior change?** No.
- **Did security, auth, secrets, network, or tool execution behavior change?** No.
- **Highest-risk area:** a caller that intentionally passed a non-string and relied on the throw — none found; the ~20 call sites pass message/tool text expected to be `string`, and several already guard with `typeof x === "string"`.
- **How is that risk mitigated?** Returning `""` mirrors the existing per-call-site defenses (e.g. `anthropic-transport-stream.ts` already does `typeof contentBlock.text === "string" ? sanitize(...) : ""`).

## Current review state

- **Next action:** maintainer review.
- **Still waiting on:** maintainer.
- **Bot/reviewer comments addressed:** none yet.

Made with [Cursor](https://cursor.com)
