### PR TITLE
fix(plugins): fail closed on trusted policy errors

### DIFF
--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -16,6 +16,7 @@ import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import { createCanonicalFixtureSkill } from "../skills/test-support/test-helpers.js";
 import {
+  getBeforeToolCallPolicyDiagnosticState,
   runBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
@@ -1166,6 +1167,63 @@ describe("before_tool_call requireApproval handling", () => {
       }),
     ).resolves.toEqual({ blocked: false, params });
     expect(hookRunner.runBeforeToolCall).not.toHaveBeenCalled();
+  });
+
+  it("reports trusted policy diagnostics through guarded readers", () => {
+    hookRunner.hasHooks.mockReturnValue(false);
+    const registry = createEmptyPluginRegistry();
+    const unreadableIdPolicy: Record<string, unknown> = {
+      description: "synthetic trusted policy",
+      evaluate: () => undefined,
+    };
+    Object.defineProperty(unreadableIdPolicy, "id", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin trusted policy id is unreadable");
+      },
+    });
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "fuzzplugin",
+        pluginName: "Fuzz Plugin",
+        source: "test",
+        policy: unreadableIdPolicy as never,
+      },
+      {
+        pluginId: "mockplugin",
+        pluginName: "Mock Plugin",
+        source: "test",
+        policy: {
+          id: "mockpolicy",
+          description: "mock policy",
+          evaluate: () => undefined,
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    let state: ReturnType<typeof getBeforeToolCallPolicyDiagnosticState> | undefined;
+    try {
+      state = getBeforeToolCallPolicyDiagnosticState();
+    } finally {
+      setActivePluginRegistry(createEmptyPluginRegistry());
+    }
+
+    expect(state).toEqual({
+      hasBeforeToolCallHook: false,
+      trustedToolPolicies: [
+        {
+          id: "fuzzplugin",
+          pluginId: "fuzzplugin",
+          pluginName: "Fuzz Plugin",
+        },
+        {
+          id: "mockpolicy",
+          pluginId: "mockplugin",
+          pluginName: "Mock Plugin",
+        },
+      ],
+    });
   });
 
   it("recomputes host-derived paths after trusted policy param rewrites", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -25,9 +25,12 @@ import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { deriveToolParams } from "../plugins/host-tool-param-parsers.js";
-import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { copyPluginToolMeta, getPluginToolMeta } from "../plugins/tools.js";
-import { hasTrustedToolPolicies, runTrustedToolPolicies } from "../plugins/trusted-tool-policy.js";
+import {
+  getTrustedToolPolicyDiagnosticEntries,
+  hasTrustedToolPolicies,
+  runTrustedToolPolicies,
+} from "../plugins/trusted-tool-policy.js";
 import {
   PluginApprovalResolutions,
   type PluginApprovalResolution,
@@ -160,21 +163,9 @@ export type BeforeToolCallPolicyDiagnosticState = {
 };
 
 export function getBeforeToolCallPolicyDiagnosticState(): BeforeToolCallPolicyDiagnosticState {
-  const trustedToolPolicies = (getActivePluginRegistry()?.trustedToolPolicies ?? []).map(
-    (entry) => {
-      const policy = {
-        id: entry.policy.id,
-        pluginId: entry.pluginId,
-      } as BeforeToolCallPolicyDiagnosticState["trustedToolPolicies"][number];
-      if (entry.pluginName) {
-        policy.pluginName = entry.pluginName;
-      }
-      return policy;
-    },
-  );
   return {
     hasBeforeToolCallHook: getGlobalHookRunner()?.hasHooks("before_tool_call") === true,
-    trustedToolPolicies,
+    trustedToolPolicies: getTrustedToolPolicyDiagnosticEntries(),
   };
 }
 

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -338,6 +338,114 @@ describe("host-hook fixture plugin contract", () => {
     });
   });
 
+  it("fails closed when a trusted policy throws during evaluation", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "fuzzplugin",
+        pluginName: "Fuzz Plugin",
+        source: "test",
+        policy: {
+          id: "fuzzpolicy",
+          description: "synthetic trusted policy",
+          evaluate: () => {
+            throw new Error("fuzzplugin trusted policy failed");
+          },
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      runTrustedToolPolicies({ toolName: "exec", params: {} }, { toolName: "exec" }),
+    ).resolves.toEqual({
+      block: true,
+      blockReason: "blocked by fuzzpolicy: policy evaluation failed",
+    });
+  });
+
+  it("fails closed when a trusted policy registration is unreadable", async () => {
+    const registry = createEmptyPluginRegistry();
+    const unreadableRegistration = {
+      pluginId: "fuzzplugin",
+      pluginName: "Fuzz Plugin",
+      source: "test",
+    };
+    Object.defineProperty(unreadableRegistration, "policy", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin trusted policy is unreadable");
+      },
+    });
+    registry.trustedToolPolicies = [unreadableRegistration as never];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      runTrustedToolPolicies({ toolName: "exec", params: {} }, { toolName: "exec" }),
+    ).resolves.toEqual({
+      block: true,
+      blockReason: "blocked by fuzzplugin: policy is unreadable",
+    });
+  });
+
+  it("fails closed when a trusted policy owner id is unreadable", async () => {
+    const registry = createEmptyPluginRegistry();
+    const unreadableOwnerRegistration = {
+      pluginName: "Fuzz Plugin",
+      source: "test",
+      policy: {
+        id: "fuzzpolicy",
+        description: "synthetic trusted policy",
+        evaluate: () => undefined,
+      },
+    };
+    Object.defineProperty(unreadableOwnerRegistration, "pluginId", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin trusted policy owner is unreadable");
+      },
+    });
+    registry.trustedToolPolicies = [unreadableOwnerRegistration as never];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      runTrustedToolPolicies({ toolName: "exec", params: {} }, { toolName: "exec" }),
+    ).resolves.toEqual({
+      block: true,
+      blockReason: "blocked by fuzzpolicy: policy owner is unreadable",
+    });
+  });
+
+  it("fails closed when a trusted policy decision is unreadable", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "fuzzplugin",
+        pluginName: "Fuzz Plugin",
+        source: "test",
+        policy: {
+          id: "fuzzpolicy",
+          description: "synthetic trusted policy",
+          evaluate: () =>
+            Object.defineProperty({}, "allow", {
+              enumerable: true,
+              get() {
+                throw new Error("fuzzplugin trusted policy allow is unreadable");
+              },
+            }),
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      runTrustedToolPolicies({ toolName: "exec", params: {} }, { toolName: "exec" }),
+    ).resolves.toEqual({
+      block: true,
+      blockReason: "blocked by fuzzpolicy: policy decision is unreadable",
+    });
+  });
+
   it("lets later trusted policy blocks override earlier approval requests", async () => {
     const registry = createEmptyPluginRegistry();
     registry.trustedToolPolicies = [

--- a/src/plugins/trusted-tool-policy.ts
+++ b/src/plugins/trusted-tool-policy.ts
@@ -9,11 +9,136 @@ import type {
   PluginHookToolKind,
 } from "./hook-types.js";
 import { getPluginSessionExtensionStateSync } from "./host-hook-state.js";
-import type { PluginJsonValue } from "./host-hooks.js";
+import type { PluginJsonValue, PluginTrustedToolPolicyRegistration } from "./host-hooks.js";
+import type {
+  PluginRegistry,
+  PluginTrustedToolPolicyRegistryRegistration,
+} from "./registry-types.js";
 import { getActivePluginRegistry } from "./runtime.js";
 
+type TrustedPolicyRegistration = PluginTrustedToolPolicyRegistryRegistration;
+
+export type TrustedToolPolicyDiagnosticEntry = {
+  id: string;
+  pluginId: string;
+  pluginName?: string;
+};
+
 export function hasTrustedToolPolicies(): boolean {
-  return (getActivePluginRegistry()?.trustedToolPolicies?.length ?? 0) > 0;
+  return copyTrustedPolicyRegistrations(getActivePluginRegistry()).length > 0;
+}
+
+function unreadableTrustedPolicyRegistration(): TrustedPolicyRegistration {
+  return {
+    pluginId: "unknown-plugin",
+    source: "runtime",
+    get policy(): PluginTrustedToolPolicyRegistration {
+      throw new Error("trusted policy registration is unreadable");
+    },
+  };
+}
+
+function copyTrustedPolicyRegistrations(
+  registry: PluginRegistry | null | undefined,
+): TrustedPolicyRegistration[] {
+  let policies: unknown;
+  try {
+    policies = registry?.trustedToolPolicies;
+  } catch {
+    return [unreadableTrustedPolicyRegistration()];
+  }
+  if (!policies) {
+    return [];
+  }
+
+  try {
+    if (!Array.isArray(policies)) {
+      return [unreadableTrustedPolicyRegistration()];
+    }
+    return policies.map((policy) => policy);
+  } catch {
+    return [unreadableTrustedPolicyRegistration()];
+  }
+}
+
+function readTrustedPolicyPluginId(registration: TrustedPolicyRegistration): string | undefined {
+  try {
+    const pluginId = registration.pluginId;
+    return typeof pluginId === "string" && pluginId.trim() ? pluginId.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function trustedPolicyDiagnosticPluginId(registration: TrustedPolicyRegistration): string {
+  return readTrustedPolicyPluginId(registration) ?? "unknown-plugin";
+}
+
+function readTrustedPolicyPluginName(registration: TrustedPolicyRegistration): string | undefined {
+  try {
+    const pluginName = registration.pluginName;
+    return typeof pluginName === "string" && pluginName.trim() ? pluginName.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readTrustedPolicy(registration: TrustedPolicyRegistration):
+  | {
+      ok: true;
+      policy: PluginTrustedToolPolicyRegistration;
+    }
+  | {
+      ok: false;
+    } {
+  try {
+    const policy = registration.policy;
+    return policy && typeof policy.evaluate === "function" ? { ok: true, policy } : { ok: false };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readTrustedPolicyId(registration: TrustedPolicyRegistration): string {
+  const fallback = trustedPolicyDiagnosticPluginId(registration);
+  const policy = readTrustedPolicy(registration);
+  if (!policy.ok) {
+    return fallback;
+  }
+  try {
+    const id = policy.policy.id;
+    return typeof id === "string" && id.trim() ? id.trim() : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function trustedPolicyDefaultBlockReason(registration: TrustedPolicyRegistration): string {
+  return `blocked by ${readTrustedPolicyId(registration)}`;
+}
+
+function trustedPolicyFailureResult(
+  registration: TrustedPolicyRegistration,
+  detail: string,
+): PluginHookBeforeToolCallResult {
+  return {
+    block: true,
+    blockReason: `${trustedPolicyDefaultBlockReason(registration)}: ${detail}`,
+  };
+}
+
+export function getTrustedToolPolicyDiagnosticEntries(): TrustedToolPolicyDiagnosticEntry[] {
+  return copyTrustedPolicyRegistrations(getActivePluginRegistry()).map((registration) => {
+    const entry: TrustedToolPolicyDiagnosticEntry = {
+      id: readTrustedPolicyId(registration),
+      pluginId: trustedPolicyDiagnosticPluginId(registration),
+    };
+    const pluginName = readTrustedPolicyPluginName(registration);
+    if (pluginName) {
+      entry.pluginName = pluginName;
+    }
+    return entry;
+  });
 }
 
 function normalizeDerivedEventFields(
@@ -56,7 +181,7 @@ export async function runTrustedToolPolicies(
       | undefined;
   },
 ): Promise<PluginHookBeforeToolCallResult | undefined> {
-  const policies = getActivePluginRegistry()?.trustedToolPolicies ?? [];
+  const policies = copyTrustedPolicyRegistrations(getActivePluginRegistry());
   let adjustedParams = event.params;
   let hasAdjustedParams = false;
   let approval: PluginHookBeforeToolCallResult["requireApproval"];
@@ -91,13 +216,17 @@ export async function runTrustedToolPolicies(
     };
   };
   for (const registration of policies) {
+    const pluginId = readTrustedPolicyPluginId(registration);
+    if (!pluginId) {
+      return trustedPolicyFailureResult(registration, "policy owner is unreadable");
+    }
     const policyCtx: PluginHookToolContext = {
       ...ctxWithoutToolIdentity,
       ...currentContextToolIdentity,
       // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Plugin callers type JSON reads by namespace.
       getSessionExtension: <T extends PluginJsonValue = PluginJsonValue>(namespace: string) => {
         const normalizedNamespace = namespace.trim();
-        const cacheKey = registration.pluginId;
+        const cacheKey = pluginId;
         if (!sessionExtensionStateCache.has(cacheKey)) {
           const config = ctx.sessionKey ? resolveSessionConfig() : undefined;
           sessionExtensionStateCache.set(
@@ -105,7 +234,7 @@ export async function runTrustedToolPolicies(
             config
               ? getPluginSessionExtensionStateSync({
                   cfg: config,
-                  pluginId: registration.pluginId,
+                  pluginId,
                   sessionKey: ctx.sessionKey,
                 })
               : undefined,
@@ -118,52 +247,66 @@ export async function runTrustedToolPolicies(
         return pluginState[normalizedNamespace] as T | undefined;
       },
     };
-    const decision = await registration.policy.evaluate(buildEvent(), policyCtx);
+    const policy = readTrustedPolicy(registration);
+    if (!policy.ok) {
+      return trustedPolicyFailureResult(registration, "policy is unreadable");
+    }
+
+    let decision: Awaited<ReturnType<PluginTrustedToolPolicyRegistration["evaluate"]>>;
+    try {
+      decision = await policy.policy.evaluate(buildEvent(), policyCtx);
+    } catch {
+      return trustedPolicyFailureResult(registration, "policy evaluation failed");
+    }
     if (!decision) {
       continue;
     }
-    if ("allow" in decision && decision.allow === false) {
-      return {
-        block: true,
-        blockReason: decision.reason ?? `blocked by ${registration.policy.id}`,
-      };
-    }
-    // `block: true` is terminal; normalize a missing blockReason to a deterministic
-    // reason so downstream diagnostics match the `{ allow: false }` path above.
-    if ("block" in decision && decision.block === true) {
-      return {
-        ...decision,
-        blockReason: decision.blockReason ?? `blocked by ${registration.policy.id}`,
-      };
-    }
-    // `block: false` is a no-op (matches the regular `before_tool_call` hook
-    // pipeline) — it does NOT short-circuit the policy chain. Params and
-    // approvals are remembered so later trusted policies can still inspect or
-    // block the final call.
-    if ("params" in decision && isPlainObject(decision.params)) {
-      const normalized = options?.normalizeEvent?.(
-        {
-          ...eventWithoutDerivedPaths,
-          params: decision.params,
-          ...currentEventToolIdentity,
-          ...currentDerivedEvent,
-        },
-        policyCtx,
-      );
-      adjustedParams = normalized?.params ?? decision.params;
-      if (normalized?.event) {
-        currentEventToolIdentity = normalizeToolIdentity(normalized.event);
+    try {
+      if ("allow" in decision && decision.allow === false) {
+        return {
+          block: true,
+          blockReason: decision.reason ?? trustedPolicyDefaultBlockReason(registration),
+        };
       }
-      if (normalized?.ctx) {
-        currentContextToolIdentity = normalizeToolIdentity(normalized.ctx);
-      } else if (normalized?.event) {
-        currentContextToolIdentity = normalizeToolIdentity(normalized.event);
+      // `block: true` is terminal; normalize a missing blockReason to a deterministic
+      // reason so downstream diagnostics match the `{ allow: false }` path above.
+      if ("block" in decision && decision.block === true) {
+        return {
+          ...decision,
+          blockReason: decision.blockReason ?? trustedPolicyDefaultBlockReason(registration),
+        };
       }
-      hasAdjustedParams = true;
-      currentDerivedEvent = normalizeDerivedEventFields(options?.deriveEvent?.(adjustedParams));
-    }
-    if ("requireApproval" in decision && decision.requireApproval && !approval) {
-      approval = decision.requireApproval;
+      // `block: false` is a no-op (matches the regular `before_tool_call` hook
+      // pipeline) — it does NOT short-circuit the policy chain. Params and
+      // approvals are remembered so later trusted policies can still inspect or
+      // block the final call.
+      if ("params" in decision && isPlainObject(decision.params)) {
+        const normalized = options?.normalizeEvent?.(
+          {
+            ...eventWithoutDerivedPaths,
+            params: decision.params,
+            ...currentEventToolIdentity,
+            ...currentDerivedEvent,
+          },
+          policyCtx,
+        );
+        adjustedParams = normalized?.params ?? decision.params;
+        if (normalized?.event) {
+          currentEventToolIdentity = normalizeToolIdentity(normalized.event);
+        }
+        if (normalized?.ctx) {
+          currentContextToolIdentity = normalizeToolIdentity(normalized.ctx);
+        } else if (normalized?.event) {
+          currentContextToolIdentity = normalizeToolIdentity(normalized.event);
+        }
+        hasAdjustedParams = true;
+        currentDerivedEvent = normalizeDerivedEventFields(options?.deriveEvent?.(adjustedParams));
+      }
+      if ("requireApproval" in decision && decision.requireApproval && !approval) {
+        approval = decision.requireApproval;
+      }
+    } catch {
+      return trustedPolicyFailureResult(registration, "policy decision is unreadable");
     }
   }
   if (!hasAdjustedParams && !approval) {


### PR DESCRIPTION
## Summary

- fails closed when trusted tool policy registry reads, policy registration reads, policy evaluation, or returned policy decisions are unreadable
- fails closed before evaluation when a trusted policy registration has an unreadable owner plugin id, so session-extension state cannot be read through a synthetic fallback owner
- keeps valid no-op policy behavior compatible (`undefined`, empty decisions, and non-blocking decisions still continue)
- routes before-tool-call diagnostics through the same guarded trusted-policy readers instead of raw registry access
- prunes the previous broad malformed-field policing so this PR stays focused on crash/fail-open prevention
- uses only synthetic `fuzzplugin` / `mockplugin` fixtures in tests and PR notes

## Landing note

This is real hardening, but it is compatibility-sensitive. Trusted-policy failures now block tool calls instead of preserving prior crash/no-op/fail-open behavior. Land only after maintainer agreement that trusted policy failures should fail closed.

## Verification

- rebuilt the PR from current `origin/main` into head `6d086906d33`, keeping the PR to a single focused commit across 4 files; the final rebase includes the upstream lint-suppression baseline fix for `build-artifacts`
- `node scripts/run-vitest.mjs src/plugins/contracts/host-hooks.contract.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts`: 2 routed shards, 103 tests passed in 7.97s on `6d086906d33`
- `node_modules/.bin/oxfmt --check src/plugins/trusted-tool-policy.ts src/agents/agent-tools.before-tool-call.ts src/plugins/contracts/host-hooks.contract.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts` passed
- `node scripts/run-oxlint.mjs src/plugins/trusted-tool-policy.ts src/agents/agent-tools.before-tool-call.ts src/plugins/contracts/host-hooks.contract.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts` passed
- `git diff --check` plus touched-file scrub for reported fixture names, private local paths, and install-error output: clean
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: previously found a real owner-id fail-closed gap; after the fix, clean with no accepted/actionable findings
- Remote changed-gate rerun was previously blocked by runner availability, not by a code failure: AWS Crabbox failed twice with coordinator lease limit `9/8` (`run_663bb3e3517c`, `run_7dd58769dd19`), and Testbox-through-Crabbox failed because local Blacksmith auth is missing (`blacksmith auth login` required)
- Prior AWS Crabbox `pnpm check:changed` passed for the same PR diff before the latest clean rebase: run `run_08ab8caa6a9e`, lease `cbx_d1f292d2227a` / `violet-shrimp` (provider=aws, command 5m39s, total 7m53s)

## Real behavior proof

Behavior addressed: malformed trusted policy state no longer crashes diagnostics or silently falls through before the assistant/tool-call path can handle the failure.

Real environment tested: linked OpenClaw `gwt` worktree based on current `origin/main`, with local focused test/format/lint proof. Remote changed-gate rerun was blocked by AWS lease capacity and missing local Blacksmith auth before the final clean rebase; GitHub CI is rerunning on the refreshed head.

Exact steps or command run after this patch: rebuilt the PR as a single reduced commit, ran focused host-hook and before-tool-call regression tests, formatter check, targeted lint check, diff check, touched-file scrub, and attempted both AWS Crabbox and Testbox-through-Crabbox changed-gate proof.

Evidence after fix: tests cover throwing trusted-policy evaluation, unreadable trusted-policy registrations, unreadable owner plugin ids, unreadable trusted-policy decisions, and guarded diagnostic state emission while preserving healthy policy chains.

Observed result after fix: a malformed trusted policy returns a deterministic block result naming the synthetic policy/plugin instead of crashing or allowing the tool call by accident.

What was not tested: no full live plugin install with a hostile trusted-policy plugin; this PR uses focused synthetic plugin-policy regressions. Current remote changed-gate rerun is pending runner availability/CI.


## Refresh 2026-05-31T10:47Z

Rebased onto current `origin/main` and pushed head `1dd5760b5a34`. Verification: `node scripts/run-vitest.mjs src/plugins/contracts/host-hooks.contract.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts` passed 2 shards / 103 tests in 6.97s; `node_modules/.bin/oxfmt --check ...` passed; `node scripts/run-oxlint.mjs ...` passed; `git diff --check` and added-line scrub for reported fixture names/private paths/secrets passed. Landing note unchanged: hold unless maintainers explicitly accept fail-closed trusted-policy semantics.
