### PR TITLE
build(OpenClawKit): make ElevenLabsKit (talk/TTS) an optional package trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1972,6 +1972,21 @@ jobs:
           done
           exit 1
 
+      - name: OpenClawKit Talk-trait opt-out (no ElevenLabsKit when default traits disabled)
+        run: |
+          set -euo pipefail
+          # Guard: chat-only consumers build OpenClawKit with the Talk trait
+          # disabled and must NOT link ElevenLabsKit. Assert that future sources
+          # under OpenClawKit cannot silently reintroduce an unconditional
+          # ElevenLabsKit dependency while the manifest still looks correct.
+          deps="$(swift package --package-path apps/shared/OpenClawKit show-dependencies --disable-default-traits)"
+          echo "$deps"
+          if grep -qi 'elevenlabs' <<<"$deps"; then
+            echo "::error::ElevenLabsKit resolved with the Talk trait disabled; keep it gated behind the Talk trait."
+            exit 1
+          fi
+          swift build --package-path apps/shared/OpenClawKit --target OpenClawKit --disable-default-traits
+
       - name: Swift test
         run: |
           set -euo pipefail

--- a/apps/shared/OpenClawKit/Package.swift
+++ b/apps/shared/OpenClawKit/Package.swift
@@ -13,6 +13,10 @@ let package = Package(
         .library(name: "OpenClawKit", targets: ["OpenClawKit"]),
         .library(name: "OpenClawChatUI", targets: ["OpenClawChatUI"]),
     ],
+    traits: [
+        .trait(name: "Talk", description: "ElevenLabs cloud TTS / talk support"),
+        .default(enabledTraits: ["Talk"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/steipete/ElevenLabsKit", exact: "0.1.1"),
         .package(url: "https://github.com/gonzalezreal/textual", exact: "0.3.1"),
@@ -28,7 +32,7 @@ let package = Package(
             name: "OpenClawKit",
             dependencies: [
                 "OpenClawProtocol",
-                .product(name: "ElevenLabsKit", package: "ElevenLabsKit"),
+                .product(name: "ElevenLabsKit", package: "ElevenLabsKit", condition: .when(traits: ["Talk"])),
             ],
             path: "Sources/OpenClawKit",
             resources: [

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/AudioStreamingProtocols.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/AudioStreamingProtocols.swift
@@ -1,3 +1,4 @@
+#if Talk
 import Foundation
 
 @MainActor
@@ -14,3 +15,4 @@ public protocol PCMStreamingAudioPlaying {
 
 extension StreamingAudioPlayer: StreamingAudioPlaying {}
 extension PCMStreamingAudioPlayer: PCMStreamingAudioPlaying {}
+#endif

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ElevenLabsKitShim.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ElevenLabsKitShim.swift
@@ -1,3 +1,4 @@
+#if Talk
 @_exported import ElevenLabsKit
 
 public typealias ElevenLabsVoice = ElevenLabsKit.ElevenLabsVoice
@@ -7,3 +8,4 @@ public typealias TalkTTSValidation = ElevenLabsKit.TalkTTSValidation
 public typealias StreamingAudioPlayer = ElevenLabsKit.StreamingAudioPlayer
 public typealias PCMStreamingAudioPlayer = ElevenLabsKit.PCMStreamingAudioPlayer
 public typealias StreamingPlaybackResult = ElevenLabsKit.StreamingPlaybackResult
+#endif

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ElevenLabsTTSValidationTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ElevenLabsTTSValidationTests.swift
@@ -1,3 +1,4 @@
+#if Talk
 import XCTest
 @testable import OpenClawKit
 
@@ -17,3 +18,4 @@ final class ElevenLabsTTSValidationTests: XCTestCase {
         XCTAssertNil(ElevenLabsTTSClient.validatedNormalize("maybe"))
     }
 }
+#endif


### PR DESCRIPTION
## Summary

`OpenClawKit` hard-depends on `ElevenLabsKit` (`exact: 0.1.1`), which is used only for talk/TTS. Every consumer of `OpenClawKit` / `OpenClawChatUI` links it transitively — including chat-only embeds that never call TTS.

This adds a default-enabled SwiftPM package trait **`Talk`** that gates the `ElevenLabsKit` target dependency and the kit code that references it. Because the trait is **default-on**, there is **no change** to the resolved dependency graph or behavior for existing consumers or the bundled iOS/macOS apps. Chat-only consumers opt out with `traits: []` and get `OpenClawKit` with `ElevenLabsKit` pruned from the resolved dependency graph.

## Why

Removes a forced cloud-TTS transitive dependency from chat-only third-party embeds. Keeps the core agnostic; the change is additive and opt-in/compat-preserving. (A fully local, on-device path — `TalkSystemSpeechSynthesizer` — already exists in the kit with no `ElevenLabsKit` coupling, so chat-only consumers can still drive TTS without the cloud dependency.)

## Changes

- `Package.swift`: declare a default-enabled `Talk` trait; gate the `ElevenLabsKit` target dependency with `condition: .when(traits: ["Talk"])`. The top-level `.package(url:)` line is intentionally left unconditional — the trait-gated target dependency is what prunes it from resolution.
- `Sources/OpenClawKit/ElevenLabsKitShim.swift`, `Sources/OpenClawKit/AudioStreamingProtocols.swift`: wrapped in `#if Talk`. These are the only kit sources that reference `ElevenLabsKit` symbols; their consumers are app-level talk code (`TalkModeManager`, `RealtimeTalkRelaySession`, `TalkModeRuntime`), which keep `Talk` enabled by default.
- `Tests/OpenClawKitTests/ElevenLabsTTSValidationTests.swift`: wrapped in `#if Talk` so a `--disable-default-traits` test run still compiles.

## Compatibility

Default-enabled trait preserves behavior and the resolved dependency graph for all existing consumers and bundled apps. No app-target changes. Additive; no config/default key changes. Consumers/CI that explicitly disable default traits intentionally drop the talk/TTS public API.

## Real behavior proof

This is a SwiftPM packaging change, so the observable behavior is the resolved dependency graph and the compile graph. Evidence below is copied live console output from a real local build (macOS, Swift 6.2.3); ElevenLabs is not invoked at runtime by this change.

- **Behavior addressed:** `OpenClawKit` no longer forces `ElevenLabsKit` on chat-only consumers; with the `Talk` trait disabled, `ElevenLabsKit` is pruned from the resolved dependency graph and never compiled.
- **Real environment tested:** macOS, Swift 6.2.3 (Xcode toolchain), against the real `apps/shared/OpenClawKit` package.
- **Exact steps or command run after this patch:** `swift package --disable-default-traits show-dependencies`, `swift build --disable-default-traits`, `swift package show-dependencies` (default), `swift build` (default), `swift build --build-tests --disable-default-traits`.
- **Evidence after fix:** copied live console output below.

```
$ swift package --disable-default-traits show-dependencies
.
└── textual<https://github.com/gonzalezreal/textual@0.3.1>
    ├── swift-concurrency-extras<https://github.com/pointfreeco/swift-concurrency-extras@1.4.0>
    └── swiftui-math<https://github.com/gonzalezreal/swiftui-math@0.1.0>
(ElevenLabsKit is absent from the trait-off resolved graph)

$ swift build --disable-default-traits
[362/362] Compiling OpenClawChatUI ChatPayloadDecoding.swift
Build complete! (14.85s)
(ElevenLabsKit was never compiled in the trait-off build)

$ swift package show-dependencies        [default, Talk on]
Computed https://github.com/steipete/ElevenLabsKit at 0.1.1
Working copy of https://github.com/steipete/ElevenLabsKit resolved at 0.1.1

$ swift build                            [default, Talk on]
Build complete! (6.87s)
```

- **Observed result after fix:** trait-off consumers resolve and build with `ElevenLabsKit` pruned from the dependency graph and never compiled; trait-on resolution, build, and test target are unchanged.
- **What was not tested:** live ElevenLabs TTS API call (no API key, out of scope); CI Linux lane; the iOS/macOS *app* xcodebuild (only the SwiftPM package was built locally — apps keep `Talk` on by default, and CI's macOS lane covers `apps/macos`). Note: 2 pre-existing `TalkConfigContractTests.selectionFixtures()` failures exist on `main` (`adf981de89`), reproduced on a clean checkout — unrelated to this change.

---

*Reviewed with Claude (Opus 4.8) and OpenAI Codex (gpt-5, high reasoning): trait syntax, gating completeness, and trait-on/off build + dependency-resolution proof were cross-checked by both before opening.*
