### PR TITLE
feat(cron): make isolated-agent setup watchdog configurable

### DIFF
--- a/.changeset/configurable-cron-setup-watchdog.md
+++ b/.changeset/configurable-cron-setup-watchdog.md
@@ -1,0 +1,14 @@
+---
+"openclaw": patch
+---
+
+cron: make the isolated-agent setup watchdog configurable via
+`cron.agentSetupWatchdogMs`.
+
+The setup watchdog (previously a hardcoded 60s) aborts an isolated agent cron
+job that does not reach "runner started" in time. When several heavy isolated
+jobs start in the same window, concurrent setup contends on the single gateway
+event loop and a healthy agent can exceed 60s during setup — producing false
+`isolated agent setup timed out before runner start` failures even on idle,
+high-spec hosts. The value now defaults to 60000ms and honours an optional
+override, clamped to a 1000ms minimum so the safety timer cannot be disabled.

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -32,6 +32,20 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
+  /**
+   * Time budget (ms) for an isolated agent cron job to reach "runner started"
+   * before the setup watchdog aborts it with
+   * "isolated agent setup timed out before runner start".
+   *
+   * The watchdog protects the scheduler from genuinely-stuck agents, but the
+   * fixed default can produce false timeouts when several heavy isolated jobs
+   * start in the same window and contend on the single gateway event loop
+   * during setup (runtime init, plugin load, CLI handshake), even on idle,
+   * high-spec hosts.
+   *
+   * Accepts a value >= 1000 (clamped). Default: 60000 (60s).
+   */
+  agentSetupWatchdogMs?: number;
   /** Override default retry policy for one-shot jobs on transient errors. */
   retry?: CronRetryConfig;
   /**

--- a/src/config/zod-schema.cron-setup-watchdog.test.ts
+++ b/src/config/zod-schema.cron-setup-watchdog.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("cron agentSetupWatchdogMs config parsing", () => {
+  it("accepts a positive integer value", () => {
+    const parsed = OpenClawSchema.parse({
+      cron: { agentSetupWatchdogMs: 120000 },
+    });
+    expect(parsed.cron?.agentSetupWatchdogMs).toBe(120000);
+  });
+
+  it("parses cleanly when the key is omitted", () => {
+    const parsed = OpenClawSchema.parse({
+      cron: { maxConcurrentRuns: 2 },
+    });
+    expect(parsed.cron?.agentSetupWatchdogMs).toBeUndefined();
+  });
+
+  it("rejects non-integer values", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        cron: { agentSetupWatchdogMs: 1500.5 },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-positive values", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        cron: { agentSetupWatchdogMs: 0 },
+      }),
+    ).toThrow();
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -751,6 +751,7 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
+        agentSetupWatchdogMs: z.number().int().positive().optional(),
         retry: z
           .object({
             maxAttempts: z.number().int().min(0).max(10).optional(),

--- a/src/cron/service/timer.setup-watchdog.test.ts
+++ b/src/cron/service/timer.setup-watchdog.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { resolveCronAgentSetupWatchdogMs } from "./timer.js";
+
+describe("resolveCronAgentSetupWatchdogMs", () => {
+  it("defaults to 60s when no override is provided", () => {
+    expect(resolveCronAgentSetupWatchdogMs(undefined)).toBe(60_000);
+    expect(resolveCronAgentSetupWatchdogMs({})).toBe(60_000);
+  });
+
+  it("honours a valid override", () => {
+    expect(resolveCronAgentSetupWatchdogMs({ agentSetupWatchdogMs: 120_000 })).toBe(120_000);
+    expect(resolveCronAgentSetupWatchdogMs({ agentSetupWatchdogMs: 90_000 })).toBe(90_000);
+  });
+
+  it("floors fractional overrides", () => {
+    expect(resolveCronAgentSetupWatchdogMs({ agentSetupWatchdogMs: 90_500.9 })).toBe(90_500);
+  });
+
+  it("clamps overrides below the safety minimum (1s) so the watchdog cannot be disabled", () => {
+    expect(resolveCronAgentSetupWatchdogMs({ agentSetupWatchdogMs: 0 })).toBe(1_000);
+    expect(resolveCronAgentSetupWatchdogMs({ agentSetupWatchdogMs: -5_000 })).toBe(1_000);
+    expect(resolveCronAgentSetupWatchdogMs({ agentSetupWatchdogMs: 500 })).toBe(1_000);
+  });
+
+  it("falls back to the default for non-finite values", () => {
+    expect(resolveCronAgentSetupWatchdogMs({ agentSetupWatchdogMs: Number.NaN })).toBe(60_000);
+    expect(
+      resolveCronAgentSetupWatchdogMs({
+        agentSetupWatchdogMs: Number.POSITIVE_INFINITY,
+      }),
+    ).toBe(60_000);
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -71,8 +71,24 @@ export { DEFAULT_JOB_TIMEOUT_MS } from "./timeout-policy.js";
 const MAX_TIMER_DELAY_MS = 60_000;
 const CRON_TIMEOUT_CLEANUP_GUARD_MS = 20_000;
 const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
+const CRON_AGENT_SETUP_MIN_WATCHDOG_MS = 1_000;
 const CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 60_000;
 const CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS = 1_000;
+
+/**
+ * Resolve the isolated-agent setup watchdog budget.
+ *
+ * Defaults to {@link CRON_AGENT_SETUP_WATCHDOG_MS} (60s) and honours an
+ * optional `cron.agentSetupWatchdogMs` override, clamped to a sane minimum so
+ * a misconfiguration cannot disable the safety timer entirely.
+ */
+export function resolveCronAgentSetupWatchdogMs(cronConfig?: CronConfig): number {
+  const raw = cronConfig?.agentSetupWatchdogMs;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return CRON_AGENT_SETUP_WATCHDOG_MS;
+  }
+  return Math.max(CRON_AGENT_SETUP_MIN_WATCHDOG_MS, Math.floor(raw));
+}
 
 /**
  * Minimum gap between consecutive fires of the same cron job.  This is a
@@ -189,6 +205,7 @@ export async function executeJobCoreWithTimeout(
   const watchdog = createCronAgentWatchdog({
     deferUntilRunner: deferTimeoutUntilExecutionStart,
     jobTimeoutMs,
+    setupWatchdogMs: resolveCronAgentSetupWatchdogMs(state.deps.cronConfig),
     triggerTimeout,
   });
   const corePromise = executeJobCore(state, job, runAbortController.signal, {
@@ -227,6 +244,7 @@ export async function executeJobCoreWithTimeout(
 function createCronAgentWatchdog(params: {
   deferUntilRunner: boolean;
   jobTimeoutMs: number;
+  setupWatchdogMs: number;
   triggerTimeout: (reason: string) => void;
 }): CronAgentWatchdog {
   let state: CronAgentWatchdogState = params.deferUntilRunner ? "waiting_for_runner" : "executing";
@@ -303,7 +321,7 @@ function createCronAgentWatchdog(params: {
           if (state === "waiting_for_runner") {
             setTimedOut(setupTimeoutErrorMessage(activeExecution));
           }
-        }, CRON_AGENT_SETUP_WATCHDOG_MS);
+        }, params.setupWatchdogMs);
         return;
       }
       startTimeout();


### PR DESCRIPTION
## Summary

- The cron **setup watchdog** that aborts an isolated agent job which has not reached `runner started` is a hardcoded `60_000` ms (`CRON_AGENT_SETUP_WATCHDOG_MS` in `src/cron/service/timer.ts`). It is not overridable via config.
- When several heavy isolated agent jobs come due in the same window, their setup (runtime init, plugin load, CLI handshake) contends on the single gateway event loop. A healthy agent can then exceed 60s **during setup** and is aborted with `isolated agent setup timed out before runner start` — even on idle, high-spec hosts where nothing is actually stuck.
- This change adds an optional **`cron.agentSetupWatchdogMs`** override (default `60000`), clamped to a `1000` ms minimum so the safety timer can never be disabled. It mirrors the existing `resolveRunConcurrency()` config pattern already in the same module (`state.deps.cronConfig?.maxConcurrentRuns`).

Why now: operators running many isolated cron jobs on capable hardware hit false setup timeouts with no supported way to tune the budget; the only current mitigation is manually spreading job schedules.

Out of scope: the pre-execution watchdog and per-job execution `timeoutSeconds` are unchanged. Default behaviour is unchanged when the new field is unset.

What success looks like: with `cron.agentSetupWatchdogMs` set above 60s, concurrently-starting isolated jobs that previously failed setup now reach the runner; unset config behaves exactly as before.

Reviewers may want to focus on: the clamp/fallback semantics in `resolveCronAgentSetupWatchdogMs` (min 1000 ms; non-finite → default) — the watchdog can never be disabled.

## Real behavior proof

Behavior addressed: `cron.agentSetupWatchdogMs` is accepted by the cron config schema and the cron timer resolver uses the configured setup watchdog budget while preserving the 60s default and 1s safety floor.

Real environment tested: Local OpenClaw contributor checkout on macOS, branch `feat/configurable-cron-setup-watchdog` at `3fb689ac0d`, with repository dependencies already installed.

Exact steps or command run after this patch: `node_modules/.bin/vitest run src/cron/service/timer.setup-watchdog.test.ts --reporter=verbose 2>&1 | grep -E '✓|Tests '` and `node_modules/.bin/vitest run src/cron/service src/config/zod-schema.cron-setup-watchdog.test.ts 2>&1 | tail -8`.

Evidence after fix: Terminal capture from this branch after the patch:

```text
✓ |cron| ../../src/cron/service/timer.setup-watchdog.test.ts > resolveCronAgentSetupWatchdogMs > defaults to 60s when no override is provided 10ms
✓ |cron| ../../src/cron/service/timer.setup-watchdog.test.ts > resolveCronAgentSetupWatchdogMs > honours a valid override 0ms
✓ |cron| ../../src/cron/service/timer.setup-watchdog.test.ts > resolveCronAgentSetupWatchdogMs > floors fractional overrides 0ms
✓ |cron| ../../src/cron/service/timer.setup-watchdog.test.ts > resolveCronAgentSetupWatchdogMs > clamps overrides below the safety minimum (1s) so the watchdog cannot be disabled 0ms
✓ |cron| ../../src/cron/service/timer.setup-watchdog.test.ts > resolveCronAgentSetupWatchdogMs > falls back to the default for non-finite values 0ms
      Tests  5 passed (5)

Test Files  13 passed (13)
      Tests  123 passed (123)
```

Observed result after fix: The resolver proof shows default, valid override, fractional floor, minimum clamp, and non-finite fallback all passing; the broader cron service plus schema run completed with `Test Files  13 passed (13)` and `Tests  123 passed (123)`.

What was not tested: No live production cron jobs were started; this PR only changes local config parsing and timer budget resolution, and the default runtime behaviour remains unchanged when the new option is unset.

## Testing

- New unit test `src/cron/service/timer.setup-watchdog.test.ts` (5 cases: default, valid override, fractional floor, sub-minimum clamp, non-finite fallback) — passing.
- Full `src/cron/service` plus `src/config/zod-schema.cron-setup-watchdog.test.ts` run passes with no regressions.

## Linked context

Closes #

Related #
