### PR TITLE
Fix iMessage startup watch replay

### DIFF
--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -245,6 +245,34 @@ describe("iMessage monitor last-route updates", () => {
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
   });
 
+  it("uses the default local chat.db path for the startup watermark", async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-default-home-"));
+    tempDirs.push(homeDir);
+    vi.stubEnv("HOME", homeDir);
+    await createMessagesDbWithMaxRowid(4000, path.join(homeDir, "Library", "Messages", "chat.db"));
+    const client = {
+      request: vi.fn(async () => ({ subscription: 1 })),
+      waitForClose: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async () => client as never);
+
+    await monitorIMessageProvider({
+      config: {
+        channels: { imessage: { dmPolicy: "allowlist", allowFrom: ["+15550001111"] } },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "watch.subscribe",
+      { attachments: false, include_reactions: true, since_rowid: 4000 },
+      { timeoutMs: 10_000 },
+    );
+  });
+
   it("accepts live watch notifications after startup when catchup is disabled", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-30T05:23:18.000Z"));

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -350,6 +350,40 @@ describe("iMessage monitor last-route updates", () => {
     );
   });
 
+  it("subscribes without a startup watermark when node sqlite is unavailable", async () => {
+    vi.doMock("node:sqlite", () => {
+      throw new Error("node:sqlite unavailable");
+    });
+    vi.resetModules();
+    try {
+      const { monitorIMessageProvider: monitorWithoutSqlite } = await import("./monitor.js");
+      const client = {
+        request: vi.fn(async () => ({ subscription: 1 })),
+        waitForClose: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      };
+      createIMessageRpcClientMock.mockImplementation(async () => client as never);
+
+      await monitorWithoutSqlite({
+        config: {
+          channels: { imessage: { dmPolicy: "allowlist", allowFrom: ["+15550001111"] } },
+          messages: { inbound: { debounceMs: 0 } },
+          session: { mainKey: "main" },
+        } as never,
+        runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+      });
+
+      expect(client.request).toHaveBeenCalledWith(
+        "watch.subscribe",
+        { attachments: false, include_reactions: true },
+        { timeoutMs: 10_000 },
+      );
+    } finally {
+      vi.doUnmock("node:sqlite");
+      vi.resetModules();
+    }
+  });
+
   it("advances the catchup cursor after startup catchup succeeds and a live row is handled", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-live-cursor-"));
     tempDirs.push(stateDir);

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -87,6 +87,25 @@ vi.mock("./monitor/abort-handler.js", () => ({
 describe("iMessage monitor last-route updates", () => {
   const tempDirs: string[] = [];
 
+  async function createMessagesDbWithMaxRowid(maxRowid: number, dbPath?: string): Promise<string> {
+    let resolvedDbPath = dbPath;
+    if (!resolvedDbPath) {
+      const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-watch-watermark-"));
+      tempDirs.push(stateDir);
+      resolvedDbPath = path.join(stateDir, "chat.db");
+    }
+    fs.mkdirSync(path.dirname(resolvedDbPath), { recursive: true });
+    const { DatabaseSync } = await import("node:sqlite");
+    const database = new DatabaseSync(resolvedDbPath);
+    try {
+      database.exec("CREATE TABLE message (text TEXT);");
+      database.prepare("INSERT INTO message(rowid, text) VALUES (?, ?)").run(maxRowid, "watermark");
+    } finally {
+      database.close();
+    }
+    return resolvedDbPath;
+  }
+
   beforeEach(() => {
     waitForTransportReadyMock.mockReset().mockResolvedValue(undefined);
     createIMessageRpcClientMock.mockReset();
@@ -120,7 +139,7 @@ describe("iMessage monitor last-route updates", () => {
               is_from_me: false,
               text: "hello from imessage",
               is_group: false,
-              date: 1_714_000_000_000,
+              created_at: new Date().toISOString(),
             },
           },
         });
@@ -170,6 +189,112 @@ describe("iMessage monitor last-route updates", () => {
     expect(recordParams?.updateLastRoute?.channel).toBe("imessage");
     expect(recordParams?.updateLastRoute?.to).toBe("imessage:+15550001111");
     expect(recordParams?.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+
+  it("drops historical watch notifications on startup when catchup is disabled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-30T05:23:18.000Z"));
+    const dbPath = await createMessagesDbWithMaxRowid(3000);
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async () => ({ subscription: 1 })),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 2023,
+              guid: "OLD-GUID-2023",
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "old row from another account",
+              is_group: false,
+              created_at: "2023-08-09T03:45:59.000Z",
+            },
+          },
+        });
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: { imessage: { dbPath, dmPolicy: "allowlist", allowFrom: ["+15550001111"] } },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "watch.subscribe",
+      { attachments: false, include_reactions: true, since_rowid: 3000 },
+      { timeoutMs: 10_000 },
+    );
+    expect(recordInboundSessionMock).not.toHaveBeenCalled();
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts live watch notifications after startup when catchup is disabled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-30T05:23:18.000Z"));
+    const dbPath = await createMessagesDbWithMaxRowid(3000);
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async () => ({ subscription: 1 })),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 3001,
+              guid: "LIVE-GUID-2026",
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "current row",
+              is_group: false,
+              created_at: "2023-08-09T03:45:59.000Z",
+            },
+          },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: { imessage: { dbPath, dmPolicy: "allowlist", allowFrom: ["+15550001111"] } },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(recordInboundSessionMock).toHaveBeenCalledTimes(1);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("advances the catchup cursor after startup catchup succeeds and a live row is handled", async () => {

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -297,6 +297,31 @@ describe("iMessage monitor last-route updates", () => {
     });
   });
 
+  it("subscribes without a startup watermark when the configured dbPath is not readable", async () => {
+    const dbPath = path.join(os.tmpdir(), `openclaw-missing-chat-${Date.now()}.db`);
+    const client = {
+      request: vi.fn(async () => ({ subscription: 1 })),
+      waitForClose: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async () => client as never);
+
+    await monitorIMessageProvider({
+      config: {
+        channels: { imessage: { dbPath, dmPolicy: "allowlist", allowFrom: ["+15550001111"] } },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "watch.subscribe",
+      { attachments: false, include_reactions: true },
+      { timeoutMs: 10_000 },
+    );
+  });
+
   it("advances the catchup cursor after startup catchup succeeds and a live row is handled", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-live-cursor-"));
     tempDirs.push(stateDir);

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -147,14 +147,19 @@ function resolveIMessageWatchSourceDbPath(params: {
 
 async function resolveIMessageStartupRowidWatermark(dbPath: string): Promise<number | null> {
   const { DatabaseSync } = await import("node:sqlite");
-  const database = new DatabaseSync(resolveLocalMessagesDbPath(dbPath), { readOnly: true });
+  const resolvedDbPath = resolveLocalMessagesDbPath(dbPath);
+  let database: InstanceType<typeof DatabaseSync> | undefined;
   try {
+    database = new DatabaseSync(resolvedDbPath, { readOnly: true });
     const row = database.prepare("SELECT MAX(ROWID) AS maxRowid FROM message").get() as
       | { maxRowid?: unknown }
       | undefined;
     return typeof row?.maxRowid === "number" && Number.isFinite(row.maxRowid) ? row.maxRowid : null;
+  } catch (err) {
+    logVerbose(`imessage: startup rowid watermark unavailable for db=${dbPath}: ${String(err)}`);
+    return null;
   } finally {
-    database.close();
+    database?.close();
   }
 }
 

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
@@ -123,6 +125,36 @@ async function detectRemoteHostFromCliPath(cliPath: string): Promise<string | un
       );
     }
     return undefined;
+  }
+}
+
+function resolveLocalMessagesDbPath(dbPath: string): string {
+  return dbPath.startsWith("~")
+    ? path.join(os.homedir(), dbPath.slice(1).replace(/^\/+/, ""))
+    : dbPath;
+}
+
+function resolveIMessageWatchSourceDbPath(params: {
+  catchupEnabled: boolean;
+  dbPath?: string;
+  remoteHost?: string;
+}): string | undefined {
+  if (params.catchupEnabled || params.remoteHost) {
+    return undefined;
+  }
+  return params.dbPath?.trim() || undefined;
+}
+
+async function resolveIMessageStartupRowidWatermark(dbPath: string): Promise<number | null> {
+  const { DatabaseSync } = await import("node:sqlite");
+  const database = new DatabaseSync(resolveLocalMessagesDbPath(dbPath), { readOnly: true });
+  try {
+    const row = database.prepare("SELECT MAX(ROWID) AS maxRowid FROM message").get() as
+      | { maxRowid?: unknown }
+      | undefined;
+    return typeof row?.maxRowid === "number" && Number.isFinite(row.maxRowid) ? row.maxRowid : null;
+  } finally {
+    database.close();
   }
 }
 
@@ -257,6 +289,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       logVerbose(`imessage: detected remoteHost=${remoteHost} from cliPath`);
     }
   }
+  const watchSourceDbPath = resolveIMessageWatchSourceDbPath({
+    catchupEnabled: catchupCfg.enabled,
+    dbPath,
+    remoteHost,
+  });
+  const watchStartupRowidWatermark = watchSourceDbPath
+    ? await resolveIMessageStartupRowidWatermark(watchSourceDbPath)
+    : null;
 
   // When `coalesceSameSenderDms` is enabled and the user has not set an
   // explicit inbound debounce for this channel, widen the window to 2500 ms.
@@ -912,6 +952,17 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       runtime.error?.(`imessage: dropping malformed RPC message payload (keys=${shape})`);
       return;
     }
+    if (
+      watchStartupRowidWatermark !== null &&
+      typeof message.id === "number" &&
+      Number.isFinite(message.id) &&
+      message.id <= watchStartupRowidWatermark
+    ) {
+      logVerbose(
+        `imessage: dropping stale watch notification at or before startup rowid account=${accountInfo.accountId}`,
+      );
+      return;
+    }
     const repairedMessage = await repairMessageConversationAnchor(message);
     if (!repairedMessage) {
       return;
@@ -990,6 +1041,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         {
           attachments: includeAttachments,
           include_reactions: true,
+          ...(watchStartupRowidWatermark !== null
+            ? { since_rowid: watchStartupRowidWatermark }
+            : {}),
         },
         { timeoutMs: probeTimeoutMs },
       );

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -170,10 +170,15 @@ function resolveIMessageWatchSourceDbPath(params: {
 }
 
 async function resolveIMessageStartupRowidWatermark(dbPath: string): Promise<number | null> {
-  const { DatabaseSync } = await import("node:sqlite");
   const resolvedDbPath = resolveLocalMessagesDbPath(dbPath);
-  let database: InstanceType<typeof DatabaseSync> | undefined;
+  let database:
+    | {
+        close: () => void;
+        prepare: (sql: string) => { get: () => unknown };
+      }
+    | undefined;
   try {
+    const { DatabaseSync } = await import("node:sqlite");
     database = new DatabaseSync(resolvedDbPath, { readOnly: true });
     const row = database.prepare("SELECT MAX(ROWID) AS maxRowid FROM message").get() as
       | { maxRowid?: unknown }

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -128,21 +128,45 @@ async function detectRemoteHostFromCliPath(cliPath: string): Promise<string | un
   }
 }
 
+function resolveLocalMessagesHomeDir(): string | undefined {
+  const home = process.env.HOME?.trim();
+  if (home) {
+    return home;
+  }
+  try {
+    return os.homedir().trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveLocalMessagesDbPath(dbPath: string): string {
-  return dbPath.startsWith("~")
-    ? path.join(os.homedir(), dbPath.slice(1).replace(/^\/+/, ""))
-    : dbPath;
+  if (!dbPath.startsWith("~")) {
+    return dbPath;
+  }
+  const home = resolveLocalMessagesHomeDir();
+  return home ? path.join(home, dbPath.slice(1).replace(/^\/+/, "")) : dbPath;
 }
 
 function resolveIMessageWatchSourceDbPath(params: {
   catchupEnabled: boolean;
+  cliPath: string;
   dbPath?: string;
   remoteHost?: string;
 }): string | undefined {
   if (params.catchupEnabled || params.remoteHost) {
     return undefined;
   }
-  return params.dbPath?.trim() || undefined;
+  const configured = params.dbPath?.trim();
+  if (configured) {
+    return configured;
+  }
+  const cliPath = params.cliPath.trim();
+  if (cliPath !== "imsg" && path.basename(cliPath) !== "imsg") {
+    return undefined;
+  }
+  const home = resolveLocalMessagesHomeDir();
+  return home ? path.join(home, "Library", "Messages", "chat.db") : undefined;
 }
 
 async function resolveIMessageStartupRowidWatermark(dbPath: string): Promise<number | null> {
@@ -296,6 +320,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   }
   const watchSourceDbPath = resolveIMessageWatchSourceDbPath({
     catchupEnabled: catchupCfg.enabled,
+    cliPath,
     dbPath,
     remoteHost,
   });


### PR DESCRIPTION
## Summary
- Capture the configured local iMessage `chat.db` max `message.ROWID` before `watch.subscribe` when Gateway can read that DB directly.
- Pass that rowid as `since_rowid` and drop any startup notification at or below it if the bridge still emits one.
- Keep wrapper/user-account iMessage setups alive by subscribing without a startup watermark when the configured `dbPath` is not readable by the Gateway process.

## Verification
- `node scripts/run-vitest.mjs run extensions/imessage/src --reporter=verbose` (51 files, 510 tests)
- `oxlint extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor.last-route.test.ts`
- `$autoreview` clean
