### PR TITLE
Fix auth profile block expiry type narrowing

### DIFF
--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -836,9 +836,11 @@ export async function markAuthProfileBlockedUntil(params: {
       previousStats = freshStore.usageStats?.[profileId];
       updateTime = now;
       const existingBlockedUntil = previousStats?.blockedUntil;
-      const activeBlockedUntil = isFutureDateTimestampMs(existingBlockedUntil, { nowMs: now })
-        ? existingBlockedUntil
-        : 0;
+      const existingActiveBlockedUntil = asDateTimestampMs(existingBlockedUntil);
+      const activeBlockedUntil =
+        existingActiveBlockedUntil !== undefined && existingActiveBlockedUntil > now
+          ? existingActiveBlockedUntil
+          : 0;
       nextStats = {
         ...previousStats,
         blockedUntil: Math.max(activeBlockedUntil, blockedUntil),
@@ -883,9 +885,11 @@ export async function markAuthProfileBlockedUntil(params: {
   }
   previousStats = store.usageStats?.[profileId];
   const existingBlockedUntil = previousStats?.blockedUntil;
-  const activeBlockedUntil = isFutureDateTimestampMs(existingBlockedUntil, { nowMs: now })
-    ? existingBlockedUntil
-    : 0;
+  const existingActiveBlockedUntil = asDateTimestampMs(existingBlockedUntil);
+  const activeBlockedUntil =
+    existingActiveBlockedUntil !== undefined && existingActiveBlockedUntil > now
+      ? existingActiveBlockedUntil
+      : 0;
   nextStats = {
     ...previousStats,
     blockedUntil: Math.max(activeBlockedUntil, blockedUntil),


### PR DESCRIPTION
## Summary

- Fix auth-profile blocked-until updates so existing expiry timestamps are narrowed to a definite number before `Math.max`.
- Restores the plugin SDK declaration build on current `main`.

## Root Cause

Commit `30e3ca08a5` replaced the explicit numeric guard for `previousStats?.blockedUntil` with `isFutureDateTimestampMs(...)`. That helper returns `boolean`, not a TypeScript type predicate, so `existingBlockedUntil` remains `number | undefined` when passed to `Math.max` during `tsconfig.plugin-sdk.dts.json` declaration generation.

Before behavior proof: `pnpm build` failed in `build:plugin-sdk:dts` with `TS2345` at `src/agents/auth-profiles/usage.ts:844` and `:891`, both reporting `number | undefined` was not assignable to `number`.

## Real behavior proof

Behavior addressed: `pnpm build` failure in `build:plugin-sdk:dts` on current `main`.

Real environment tested: local OpenClaw checkout in a detached worktree based on `origin/main` at `bdb0fde0ea`.

Exact steps or command run after this patch: `pnpm build`

Evidence after fix: `build:plugin-sdk:dts done in 3.96s`; final build summary reported `phase timings: total 101.3s` with exit code 0.

Observed result after fix: the exact failed build phase completed successfully and the full core/UI build finished.

What was not tested: daemon install, health check, and security audit; those are covered by the follow-up `oc-update` run.

## Verification

- `pnpm build`

## What was not tested

- `openclaw daemon install --force`, `openclaw health`, and `openclaw security audit --deep` before opening this PR.
