### PR TITLE
fix(gateway): harden MCP loopback tool schemas

### DIFF
--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -9,7 +9,11 @@ import {
   jsonRpcResult,
   type JsonRpcRequest,
 } from "./mcp-http.protocol.js";
-import type { McpLoopbackTool, McpToolSchemaEntry } from "./mcp-http.schema.js";
+import {
+  readMcpLoopbackToolName,
+  type McpLoopbackTool,
+  type McpToolSchemaEntry,
+} from "./mcp-http.schema.js";
 
 type McpTextContent = {
   type: "text";
@@ -62,9 +66,23 @@ export async function handleMcpJsonRpc(params: {
     case "tools/list":
       return jsonRpcResult(id, { tools: params.toolSchema });
     case "tools/call": {
-      const toolName = methodParams?.name as string;
+      const toolName = typeof methodParams?.name === "string" ? methodParams.name.trim() : "";
       const toolArgs = (methodParams?.arguments ?? {}) as Record<string, unknown>;
-      const tool = params.tools.find((candidate) => candidate.name === toolName);
+      if (!toolName) {
+        return jsonRpcResult(id, {
+          content: [{ type: "text", text: "Tool not available: unknown" }],
+          isError: true,
+        });
+      }
+      if (!params.toolSchema.some((tool) => tool.name === toolName)) {
+        return jsonRpcResult(id, {
+          content: [{ type: "text", text: `Tool not available: ${toolName}` }],
+          isError: true,
+        });
+      }
+      const tool = params.tools.find(
+        (candidate) => readMcpLoopbackToolName(candidate) === toolName,
+      );
       if (!tool) {
         return jsonRpcResult(id, {
           content: [{ type: "text", text: `Tool not available: ${toolName}` }],

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { logWarn } from "../logger.js";
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
@@ -10,23 +11,92 @@ export type McpToolSchemaEntry = {
   inputSchema: Record<string, unknown>;
 };
 
+function readLoopbackToolField(tool: McpLoopbackTool, key: "name" | "description" | "parameters") {
+  try {
+    return (tool as unknown as Record<typeof key, unknown>)[key];
+  } catch {
+    return undefined;
+  }
+}
+
+export function readMcpLoopbackToolName(tool: McpLoopbackTool): string | undefined {
+  const value = readLoopbackToolField(tool, "name");
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const name = value.trim();
+  return name || undefined;
+}
+
+function readLoopbackToolDescription(tool: McpLoopbackTool): string | undefined {
+  const value = readLoopbackToolField(tool, "description");
+  return typeof value === "string" ? value : undefined;
+}
+
+function readLoopbackToolParameters(tool: McpLoopbackTool): Record<string, unknown> | undefined {
+  let value;
+  try {
+    value = (tool as unknown as { parameters?: unknown }).parameters;
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    return {};
+  }
+  try {
+    return { ...value };
+  } catch {
+    return undefined;
+  }
+}
+
 function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknown> {
-  const variants = (raw.anyOf ?? raw.oneOf) as Record<string, unknown>[] | undefined;
+  const variants = (raw.anyOf ?? raw.oneOf) as unknown[] | undefined;
   if (!Array.isArray(variants) || variants.length === 0) {
     return raw;
   }
   const mergedProps: Record<string, unknown> = {};
   const requiredSets: Set<string>[] = [];
   for (const variant of variants) {
-    const props = variant.properties as Record<string, unknown> | undefined;
+    if (variant === true) {
+      requiredSets.push(new Set());
+      continue;
+    }
+    if (!isRecord(variant)) {
+      continue;
+    }
+    const props = isRecord(variant.properties) ? variant.properties : undefined;
     if (props) {
       for (const [key, schema] of Object.entries(props)) {
+        if (!isPropertySchema(schema)) {
+          logWarn(`mcp loopback: malformed schema definition for "${key}", ignoring that variant`);
+          continue;
+        }
         if (!(key in mergedProps)) {
           mergedProps[key] = schema;
           continue;
         }
-        const existing = mergedProps[key] as Record<string, unknown>;
-        const incoming = schema as Record<string, unknown>;
+        const existing = mergedProps[key];
+        const incoming = schema;
+        if (existing === true || incoming === true) {
+          mergedProps[key] = true;
+          continue;
+        }
+        if (existing === false) {
+          mergedProps[key] = incoming;
+          continue;
+        }
+        if (incoming === false) {
+          continue;
+        }
+        if (!isRecord(existing) || !isRecord(incoming)) {
+          if (existing !== incoming) {
+            logWarn(
+              `mcp loopback: conflicting schema definitions for "${key}", keeping the first variant`,
+            );
+          }
+          continue;
+        }
         if (Array.isArray(existing.enum) && Array.isArray(incoming.enum)) {
           mergedProps[key] = {
             ...existing,
@@ -54,18 +124,28 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
   }
   const required =
     requiredSets.length > 0
-      ? [...(requiredSets[0] ?? [])].filter((key) => requiredSets.every((set) => set.has(key)))
+      ? [...(requiredSets[0] ?? [])].filter(
+          (key) => key in mergedProps && requiredSets.every((set) => set.has(key)),
+        )
       : [];
   const { anyOf: _anyOf, oneOf: _oneOf, ...rest } = raw;
   return { ...rest, type: "object", properties: mergedProps, required };
 }
 
+function isPropertySchema(value: unknown): value is boolean | Record<string, unknown> {
+  return typeof value === "boolean" || isRecord(value);
+}
+
 export function buildMcpToolSchema(tools: McpLoopbackTool[]): McpToolSchemaEntry[] {
-  return tools.map((tool) => {
-    let raw =
-      tool.parameters && typeof tool.parameters === "object"
-        ? { ...(tool.parameters as Record<string, unknown>) }
-        : {};
+  return tools.flatMap((tool) => {
+    const name = readMcpLoopbackToolName(tool);
+    if (!name) {
+      return [];
+    }
+    let raw = readLoopbackToolParameters(tool);
+    if (!raw) {
+      return [];
+    }
     if (raw.anyOf || raw.oneOf) {
       raw = flattenUnionSchema(raw);
     }
@@ -76,8 +156,8 @@ export function buildMcpToolSchema(tools: McpLoopbackTool[]): McpToolSchemaEntry
       raw.properties = {};
     }
     return {
-      name: tool.name,
-      description: tool.description,
+      name,
+      description: readLoopbackToolDescription(tool),
       inputSchema: raw,
     };
   });

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getFreePortBlockWithPermissionFallback } from "../test-utils/ports.js";
+import { buildMcpToolSchema } from "./mcp-http.schema.js";
 
 type MockGatewayTool = {
   name: string;
@@ -127,6 +128,22 @@ function getBeforeToolCallHookInput(index: number): BeforeToolCallHookInput {
   return call as BeforeToolCallHookInput;
 }
 
+function makeMockTool(overrides: Partial<MockGatewayTool> = {}): MockGatewayTool {
+  return {
+    name: "mockplugin_tool",
+    description: "mock tool",
+    parameters: { type: "object", properties: {} },
+    execute: async () => ({
+      content: [{ type: "text", text: "ok" }],
+    }),
+    ...overrides,
+  };
+}
+
+function buildMockMcpToolSchema(tools: MockGatewayTool[]) {
+  return buildMcpToolSchema(tools as unknown as Parameters<typeof buildMcpToolSchema>[0]);
+}
+
 beforeEach(() => {
   resolveGatewayScopedToolsMock.mockClear();
   runBeforeToolCallHookMock.mockClear();
@@ -154,6 +171,129 @@ beforeEach(() => {
 afterEach(async () => {
   await server?.close();
   server = undefined;
+});
+
+describe("buildMcpToolSchema", () => {
+  it("omits unreadable loopback tool names and parameters while preserving healthy siblings", () => {
+    const unreadableName = makeMockTool({
+      name: "fuzzplugin_unreadable",
+      description: "unreadable name",
+    });
+    Object.defineProperty(unreadableName, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin loopback tool name getter exploded");
+      },
+    });
+    const unreadableDescription = makeMockTool({
+      name: "mockplugin_unreadable_description",
+      description: "optional",
+      parameters: { type: "object", properties: { value: { type: "string" } } },
+    });
+    Object.defineProperty(unreadableDescription, "description", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin loopback description getter exploded");
+      },
+    });
+    const unreadableParameters = makeMockTool({
+      name: "mockplugin_unreadable_parameters",
+      description: "unreadable parameters",
+    });
+    Object.defineProperty(unreadableParameters, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin loopback parameters getter exploded");
+      },
+    });
+
+    expect(
+      buildMockMcpToolSchema([unreadableName, unreadableDescription, unreadableParameters]),
+    ).toEqual([
+      {
+        name: "mockplugin_unreadable_description",
+        description: undefined,
+        inputSchema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+        },
+      },
+    ]);
+  });
+
+  it("flattens usable schemas from malformed and boolean union variants", () => {
+    const cases: Array<{
+      name: string;
+      parameters: Record<string, unknown>;
+      expected: Record<string, unknown>;
+    }> = [
+      {
+        name: "fuzzplugin_move_delta",
+        parameters: {
+          anyOf: [
+            { type: "object", properties: { angle: null }, required: ["angle"] },
+            {
+              type: "object",
+              properties: { angle: { type: "number" } },
+              required: ["angle"],
+            },
+          ],
+        },
+        expected: {
+          type: "object",
+          properties: { angle: { type: "number" } },
+          required: ["angle"],
+        },
+      },
+      {
+        name: "fuzzplugin_optional_delta",
+        parameters: {
+          anyOf: [
+            {
+              type: "object",
+              properties: { angle: { type: "number" } },
+              required: ["angle"],
+            },
+            true,
+          ],
+        },
+        expected: {
+          type: "object",
+          properties: { angle: { type: "number" } },
+          required: [],
+        },
+      },
+      {
+        name: "fuzzplugin_boolean_delta",
+        parameters: {
+          anyOf: [
+            { type: "object", properties: { angle: false } },
+            {
+              type: "object",
+              properties: { angle: { type: "number" } },
+              required: ["angle"],
+            },
+          ],
+        },
+        expected: {
+          type: "object",
+          properties: { angle: { type: "number" } },
+          required: [],
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      expect(
+        buildMockMcpToolSchema([
+          makeMockTool({
+            name: testCase.name,
+            parameters: testCase.parameters,
+          }),
+        ])[0]?.inputSchema,
+      ).toEqual(testCase.expected);
+    }
+  });
 });
 
 describe("mcp loopback server", () => {
@@ -462,6 +602,106 @@ describe("mcp loopback server", () => {
     expect(cronExecute).toHaveBeenCalledTimes(1);
     expect(payload.result?.isError).not.toBe(true);
     expect(payload.result?.content?.[0]?.text).toBe("CRON_EXECUTED");
+  });
+
+  it("calls healthy tools when an earlier loopback tool name is unreadable", async () => {
+    const messageExecute = vi.fn<MockGatewayTool["execute"]>(async () => ({
+      content: [{ type: "text", text: "MESSAGE_EXECUTED" }],
+    }));
+    const unreadableName = makeMockTool({
+      name: "fuzzplugin_unreadable_call",
+      description: "unreadable name",
+    });
+    Object.defineProperty(unreadableName, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin loopback call name getter exploded");
+      },
+    });
+    resolveGatewayScopedToolsMock.mockReturnValue({
+      agentId: "main",
+      tools: [
+        unreadableName,
+        makeMockTool({
+          name: "message",
+          description: "send a message",
+          execute: messageExecute,
+        }),
+      ],
+    });
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: {
+        "content-type": "application/json",
+        "x-session-key": "agent:main:main",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "message", arguments: { body: "hello" } },
+      }),
+    });
+    const payload = (await response.json()) as {
+      result?: { content?: Array<{ text?: string }>; isError?: boolean };
+    };
+
+    expect(response.status).toBe(200);
+    expect(messageExecute).toHaveBeenCalledTimes(1);
+    expect(payload.result?.isError).not.toBe(true);
+    expect(payload.result?.content?.[0]?.text).toBe("MESSAGE_EXECUTED");
+  });
+
+  it("does not execute loopback tools omitted from the advertised schema", async () => {
+    const unreadableExecute = vi.fn<MockGatewayTool["execute"]>(async () => ({
+      content: [{ type: "text", text: "UNREADABLE_EXECUTED" }],
+    }));
+    const unreadableParameters = makeMockTool({
+      name: "mockplugin_unreadable_parameters",
+      description: "unreadable parameters",
+      execute: unreadableExecute,
+    });
+    Object.defineProperty(unreadableParameters, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin loopback call parameters getter exploded");
+      },
+    });
+    resolveGatewayScopedToolsMock.mockReturnValue({
+      agentId: "main",
+      tools: [unreadableParameters],
+    });
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: {
+        "content-type": "application/json",
+        "x-session-key": "agent:main:main",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "mockplugin_unreadable_parameters", arguments: {} },
+      }),
+    });
+    const payload = (await response.json()) as {
+      result?: { content?: Array<{ text?: string }>; isError?: boolean };
+    };
+
+    expect(response.status).toBe(200);
+    expect(unreadableExecute).not.toHaveBeenCalled();
+    expect(payload.result?.isError).toBe(true);
+    expect(payload.result?.content?.[0]?.text).toBe(
+      "Tool not available: mockplugin_unreadable_parameters",
+    );
   });
 
   it("honors before-tool-call hook blocks before loopback tool execution", async () => {


### PR DESCRIPTION
## Summary

- hardens MCP loopback `tools/list` schema projection when tool metadata is unreadable or a union variant carries malformed property schemas
- keeps healthy sibling tools listed when one loopback tool has an unreadable name or parameter schema
- keeps `tools/call` aligned with the advertised schema so omitted unsafe tools are not executed later by name
- preserves existing hook execution, scoped-tool filtering, and healthy tool call behavior
- uses only synthetic `fuzzplugin` / `mockplugin` fixtures in tests and PR notes

## Landing note

This is real gateway hardening, but it is user-visible MCP behavior. Tools omitted from `tools/list` because their schema cannot be safely projected are now also unavailable through `tools/call`. That is the right fail-closed shape, but it should land after the core runtime/doctor schema quarantine train.

## Verification

- rebuilt the PR from current `origin/main` e1a98171417c into head c8f42e75240, reducing the PR from +491/-15 to +353/-15 across the same 3 files
- `node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts`: 1 gateway shard, 24 tests passed
- `node_modules/.bin/oxfmt --check src/gateway/mcp-http.schema.ts src/gateway/mcp-http.handlers.ts src/gateway/mcp-http.test.ts`
- `node scripts/run-oxlint.mjs src/gateway/mcp-http.schema.ts src/gateway/mcp-http.handlers.ts src/gateway/mcp-http.test.ts`
- `git diff --check` plus touched-file scrub for reported fixture names, private local paths, and install-error output: clean
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings after fixing the schema/call-path mismatch it caught
- local sparse-worktree `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json ...` could not run because the sparse checkout lacks `ui/config`; AWS Crabbox covered the changed gate instead
- AWS Crabbox `pnpm check:changed`: passed on run `run_d56f728b3ba7`, lease `cbx_97469db46b01` / `coral-barnacle` (provider=aws, command 3m11s, total 5m39s)
- live GitHub PR checks on `c8f42e75240`: 114 success, 0 pending/failed, 25 skipped, 1 neutral

## Real behavior proof

Behavior addressed: malformed MCP loopback tool schema metadata no longer crashes schema projection or leaves unsafe omitted tools executable through `tools/call`.

Real environment tested: linked OpenClaw `gwt` worktree based on current `origin/main` e1a98171417c, plus AWS Crabbox Linux proof for the changed gate on head c8f42e75240.

Exact steps or command run after this patch: rebuilt the PR as a reduced single commit, ran focused MCP loopback gateway tests, formatter check, targeted lint check, diff check, touched-file scrub, autoreview, and AWS Crabbox `pnpm check:changed`.

Evidence after fix: tests cover unreadable loopback tool names, unreadable descriptions, unreadable parameter schemas, malformed union property schemas, boolean union variants, healthy sibling calls after unreadable tools, and failure to execute tools omitted from the advertised schema. The remote changed gate covered core and coreTests lanes.

Observed result after fix: loopback `tools/list` still returns healthy tools, and `tools/call` only executes tools that were safely advertised.

What was not tested: no live third-party MCP client session; this PR uses focused loopback server regressions plus the remote changed gate.



## Refresh 2026-05-31T10:47Z

Rebased onto current `origin/main` by cherry-picking the existing single commit and pushed head `80a2a989b8b`. Verification: `node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts` passed 1 shard / 24 tests in 6.64s; `node_modules/.bin/oxfmt --check ...` passed; `node scripts/run-oxlint.mjs ...` passed; `git diff --check` and added-line scrub for reported fixture names/private paths/secrets passed.


## Refresh 2026-05-31T11:41Z

Pre-land autoreview on head `80a2a989b8b8` exited clean with no accepted/actionable findings, `overall: patch is correct (0.86)`.

Live GitHub state after the refresh: mergeable, `mergeStateStatus=CLEAN`, active checks 0, actionable failed checks 0. The current planned stack on `origin/main` `823c38a1f99` still merges cleanly after #88491 and #88368.
