### PR TITLE
[codex] Route denied exec approval followups to sessions

### DIFF
--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -162,11 +162,16 @@ Approval-backed interpreter/runtime runs are intentionally conservative:
 When approvals are required, the exec tool returns immediately with an approval id. Use that id to
 correlate later approved-run system events (`Exec finished`, and `Exec running` when configured).
 If no decision arrives before the timeout, the request is treated as an approval timeout and
-surfaced as a terminal denial rather than an agent-waking system event.
+surfaced as a terminal host-command denial. For main-agent async approvals with an originating
+session, OpenClaw also resumes that session with an internal followup so the agent observes that
+the command did not run instead of later repairing a missing result.
 
 ### Followup delivery behavior
 
 After an approved async exec finishes, OpenClaw sends a followup `agent` turn to the same session.
+Denied async approvals use the same main-session followup path for the denial status, but they do
+not register elevated runtime handoffs and they do not run the command. Denials without a resumable
+main session are either suppressed or reported through a safe direct route when one exists.
 
 - If a valid external delivery target exists (deliverable channel plus target `to`), followup delivery uses that channel.
 - In webchat-only or internal-session flows with no external target, followup delivery stays session-only (`deliver: false`).

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -443,9 +443,13 @@ Exec lifecycle is surfaced as system messages:
 - `Exec finished`.
 
 These are posted to the agent's session after the node reports the event.
-Denied exec approvals are terminal: OpenClaw can report the denial to the
-operator or direct chat route, but it does not post `Exec denied` back into the
-agent session or wake agent work.
+Denied exec approvals are terminal for the host command itself: the command
+does not run. For main-agent async approvals with an originating session,
+OpenClaw posts the denial back into that session as an internal followup so the
+agent can stop waiting on the async command and avoid a missing-result repair.
+If there is no session or the session cannot be resumed, OpenClaw can still
+report a concise denial to the operator or direct chat route. Denials for
+subagent sessions are not posted back into the subagent.
 Gateway-host exec approvals emit the same lifecycle events when the
 command finishes (and optionally when running longer than the threshold).
 Approval-gated execs reuse the approval id as the `runId` in these
@@ -453,11 +457,12 @@ messages for easy correlation.
 
 ## Denied approval behavior
 
-When an async exec approval is denied, OpenClaw treats the request as terminal.
-It can show a concise denial to the operator or direct chat route, but it does
-not send denial guidance back through the agent session. That keeps a denied
-command from becoming another model turn and prevents the agent from reusing
-output from an earlier run of the same command.
+When an async exec approval is denied, OpenClaw treats the host command as
+terminal and fail-closed. For main-agent sessions, the denial is delivered as an
+internal session followup that tells the agent the async command did not run.
+That preserves transcript continuity without exposing stale command output. If
+session delivery is unavailable, OpenClaw falls back to a concise operator or
+direct-chat denial when a safe route exists.
 
 ## Implications
 

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -113,17 +113,26 @@ describe("exec approval followup", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("suppresses denied followups for normal sessions", async () => {
-    await expect(
-      sendExecApprovalFollowup({
-        approvalId: "req-denied-main",
-        sessionKey: "agent:main:main",
-        turnSourceChannel: "webchat",
-        resultText: "Exec denied (gateway id=req-denied-main, user-denied): uname -a",
-      }),
-    ).resolves.toBe(false);
+  it("routes denied followups through the originating main session", async () => {
+    await sendExecApprovalFollowup({
+      approvalId: "req-denied-main",
+      sessionKey: "agent:main:main",
+      turnSourceChannel: "webchat",
+      resultText: "Exec denied (gateway id=req-denied-main, user-denied): uname -a",
+    });
 
-    expect(callGatewayTool).not.toHaveBeenCalled();
+    const agentArgs = expectGatewayAgentFollowup({
+      sessionKey: "agent:main:main",
+      deliver: false,
+      channel: "webchat",
+      idempotencyKey: "exec-approval-followup:req-denied-main",
+    });
+    expect(agentArgs.message).toContain("An async command did not run.");
+    expect(agentArgs.message).toContain(
+      "Exec denied (gateway id=req-denied-main, user-denied): uname -a",
+    );
+    expect(agentArgs.message).not.toContain("missing tool result");
+    expect(agentArgs.message).not.toContain("transcript repair");
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
@@ -287,7 +296,9 @@ describe("exec approval followup", () => {
     });
   });
 
-  it("uses safe direct denied copy without resuming the session", async () => {
+  it("falls back to safe direct denied copy when session resume fails", async () => {
+    vi.mocked(callGatewayTool).mockRejectedValueOnce(new Error("session missing"));
+
     await sendExecApprovalFollowup({
       approvalId: "req-denied-resume-failed",
       sessionKey: "agent:main:telegram:-100123",
@@ -302,10 +313,12 @@ describe("exec approval followup", () => {
       content: "Command did not run: approval timed out.",
       idempotencyKey: "exec-approval-followup:req-denied-resume-failed",
     });
-    expect(callGatewayTool).not.toHaveBeenCalled();
+    expect(callGatewayTool).toHaveBeenCalledTimes(1);
   });
 
-  it("uses safe direct denied copy for nested-parentheses denial metadata without resuming the session", async () => {
+  it("falls back to safe direct denied copy for nested-parentheses denial metadata", async () => {
+    vi.mocked(callGatewayTool).mockRejectedValueOnce(new Error("session missing"));
+
     await sendExecApprovalFollowup({
       approvalId: "req-denied-resume-failed-nested",
       sessionKey: "agent:main:telegram:-100123",
@@ -321,7 +334,7 @@ describe("exec approval followup", () => {
       content: "Command did not run: approval timed out.",
       idempotencyKey: "exec-approval-followup:req-denied-resume-failed-nested",
     });
-    expect(callGatewayTool).not.toHaveBeenCalled();
+    expect(callGatewayTool).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses denied followups for subagent sessions", async () => {

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -292,20 +292,11 @@ export async function sendExecApprovalFollowup(
       ? normalizedTurnSourceChannel
       : undefined;
 
-  if (isDenied) {
-    if (!sessionKey || shouldSuppressExecDeniedFollowup(sessionKey)) {
-      return false;
-    }
-    return await sendDirectFollowupFallback({
-      approvalId: params.approvalId,
-      deliveryTarget,
-      resultText,
-      sessionError: null,
-      allowDenied: true,
-    });
-  }
-
   let sessionError: unknown = null;
+
+  if (isDenied && (!sessionKey || shouldSuppressExecDeniedFollowup(sessionKey))) {
+    return false;
+  }
 
   if (sessionKey && params.direct !== true) {
     try {
@@ -340,6 +331,24 @@ export async function sendExecApprovalFollowup(
     } catch (err) {
       sessionError = err;
     }
+  }
+
+  if (isDenied) {
+    if (
+      await sendDirectFollowupFallback({
+        approvalId: params.approvalId,
+        deliveryTarget,
+        resultText,
+        sessionError,
+        allowDenied: true,
+      })
+    ) {
+      return true;
+    }
+    if (sessionError) {
+      throw new Error(`Session followup failed: ${formatUnknownError(sessionError)}`);
+    }
+    return false;
   }
 
   if (

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -332,6 +332,7 @@ describe("processGatewayAllowlist", () => {
     askFallback: "full" | "allowlist";
     approvedByAsk: boolean;
   }) {
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
     resolveExecHostApprovalContextMock.mockReturnValue({
       approvals: { allowlist: [], file: { version: 1, agents: {} } },
       hostSecurity: params.security,
@@ -355,6 +356,7 @@ describe("processGatewayAllowlist", () => {
       security: params.security,
       ask: "always",
       strictInlineEval: true,
+      sessionKey: "agent:main:main",
     });
   }
 
@@ -1117,7 +1119,12 @@ EOF`,
     expect(result.pendingResult?.details.status).toBe("approval-pending");
     await vi.waitFor(() => {
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
-        null,
+        expect.objectContaining({
+          approvalId: "req-1",
+          sessionKey: "agent:main:main",
+          turnSourceChannel: undefined,
+          direct: false,
+        }),
         "Exec denied (gateway id=req-1, approval-timeout): python3 -c 'print(1)'",
       );
     });
@@ -1135,7 +1142,12 @@ EOF`,
     expect(result.pendingResult?.details.status).toBe("approval-pending");
     await vi.waitFor(() => {
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
-        null,
+        expect.objectContaining({
+          approvalId: "req-1",
+          sessionKey: "agent:main:main",
+          turnSourceChannel: undefined,
+          direct: false,
+        }),
         "Exec denied (gateway id=req-1, approval-timeout): python3 -c 'print(1)'",
       );
     });

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -168,7 +168,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   buildDefaultExecApprovalRequestArgs: vi.fn(() => ({})),
   createAndRegisterDefaultExecApprovalRequest: createAndRegisterDefaultExecApprovalRequestMock,
   shouldResolveExecApprovalUnavailableInline: vi.fn(() => false),
-  buildExecApprovalFollowupTarget: vi.fn(() => ({ approvalId: "approval-1" })),
+  buildExecApprovalFollowupTarget: vi.fn((value) => value),
   resolveApprovalDecisionOrUndefined: resolveApprovalDecisionOrUndefinedMock,
   createExecApprovalDecisionState: createExecApprovalDecisionStateMock,
   enforceStrictInlineEvalApprovalBoundary: enforceStrictInlineEvalApprovalBoundaryMock,
@@ -1365,7 +1365,10 @@ describe("executeNodeHostCommand", () => {
     expect(autoReviewer).not.toHaveBeenCalled();
     await vi.waitFor(() => {
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
-        { approvalId: "approval-1" },
+        expect.objectContaining({
+          approvalId: "approval-1",
+          sessionKey: "requested-session",
+        }),
         "Exec denied (node=node-1 id=approval-1, approval-timeout): bun ./script.ts",
       );
     });
@@ -1638,7 +1641,10 @@ describe("executeNodeHostCommand", () => {
     expect(autoReviewer).not.toHaveBeenCalled();
     await vi.waitFor(() => {
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
-        { approvalId: "approval-1" },
+        expect.objectContaining({
+          approvalId: "approval-1",
+          sessionKey: "requested-session",
+        }),
         "Exec denied (node=node-1 id=approval-1, approval-timeout): echo 'unterminated",
       );
     });
@@ -1693,7 +1699,10 @@ describe("executeNodeHostCommand", () => {
     expect(result.details?.status).toBe("approval-pending");
     await vi.waitFor(() => {
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
-        { approvalId: "approval-1" },
+        expect.objectContaining({
+          approvalId: "approval-1",
+          sessionKey: "requested-session",
+        }),
         "Exec denied (node=node-1 id=approval-1, approval-timeout): bun ./script.ts",
       );
     });
@@ -2057,7 +2066,10 @@ describe("executeNodeHostCommand", () => {
     expect(result.details?.status).toBe("approval-pending");
     await vi.waitFor(() => {
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
-        { approvalId: "approval-1" },
+        expect.objectContaining({
+          approvalId: "approval-1",
+          sessionKey: "requested-session",
+        }),
         "Exec denied (node=node-1 id=approval-1, approval-timeout): python3 -c 'print(1)'",
       );
     });

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -1141,7 +1141,7 @@ describe("exec approvals", () => {
     expect(agentCalls[0]?.message).toContain("webchat-ok");
   });
 
-  it("does not spawn a gateway followup agent when approval is denied", async () => {
+  it("routes denied approval status through the originating session", async () => {
     const agentCalls: Array<Record<string, unknown>> = [];
 
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
@@ -1172,8 +1172,19 @@ describe("exec approvals", () => {
     });
 
     expect(result.details.status).toBe("approval-pending");
-    await new Promise((resolve) => setTimeout(resolve, 25));
-    expect(agentCalls).toHaveLength(0);
+    const approvalId = (result.details as { approvalId?: string }).approvalId;
+    expect(typeof approvalId).toBe("string");
+    await expect.poll(() => agentCalls.length, { timeout: 3000, interval: 1 }).toBe(1);
+    expectRecordFields(agentCalls[0], {
+      sessionKey: "agent:main:main",
+      deliver: false,
+      idempotencyKey: `exec-approval-followup:${approvalId}`,
+    });
+    expect(agentCalls[0]?.message).toContain("An async command did not run.");
+    expect(agentCalls[0]?.message).toContain(
+      `Exec denied (gateway id=${approvalId}, user-denied): echo ok`,
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("requires a separate approval for each elevated command after allow-once", async () => {


### PR DESCRIPTION
﻿## Summary

- Routes async `Exec denied (...)` approval followups through the originating main agent session before using direct external fallback.
- Keeps strict inline-eval fail-closed behavior: timeout denials still do not run the command.
- Preserves denied-followup suppression for subagent, cron, and no-session cases.
- Adds regression coverage for the gateway non-inline/followup strict inline-eval timeout path so the denial carries the originating `sessionKey` instead of disappearing behind generic transcript repair.

Out of scope: no live channel auth, no Telegram/Discord/VPS validation, no change to approval semantics for successful async exec completions.

## Linked context

Closes #88167

Related #88168 reports a similar placeholder symptom from a different parallel-tool-call path; this PR does not change that path.

Requested in maintainer workflow as `issue-88167`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Strict inline-eval approval-timeout denials on the Gateway async followup path now reach the originating main session as an explicit `Exec denied (...)` followup instead of falling through to generic missing-tool-result transcript repair.
- Real environment tested: Local Windows source worktree at `C:\oc-work\oc-88167`, Node `v24.13.0`, loopback OpenClaw Gateway started from this branch with temporary `HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH` under `%TEMP%`. Channel/provider sidecars were disabled, the model endpoint was a loopback OpenAI Responses-compatible HTTP endpoint, and no VPS, Telegram, Discord, live channel auth, real provider key, or secret was used.
- Exact steps or command run after this patch: Started the local Gateway on `127.0.0.1` with temp state/config, configured `tools.exec.host=gateway`, `security=full`, `ask=off`, and `strictInlineEval=true`, targeted `sessionKey=agent:main:main`, then invoked the real `exec` tool with `node -e "console.log('should-not-run-oc88167')"`. With no interactive approval client available, Gateway approval resolved through the same null/timeout denial path and the async followup resumed the originating session.
- Evidence after fix: Terminal transcript from the local runtime proof:

```text
[proof] worktree: C:\oc-work\oc-88167
[proof] temp state root: C:\Users\marti\AppData\Local\Temp\oc88167-real-EvN9X2
[proof] gateway: ws://127.0.0.1:55559 (loopback token redacted)
[proof] local Responses endpoint: http://127.0.0.1:55560/v1 (loopback stub)
[proof] channels/providers sidecars: disabled; no external provider credentials or calls
[proof] sessionKey: agent:main:main
[proof] command: node -e "console.log('should-not-run-oc88167')"
[proof] exec tool status: approval-unavailable
[proof] local Responses calls during followup: 1
[proof] same-session evidence file: .openclaw\agents\main\sessions\24b50a79-eeae-46fd-a1b5-a160d329ec9a.trajectory.jsonl
[proof] explicit denial line: Exec denied (gateway id=1b4dd26d-5e48-4edb-95e5-a32fe1abf50a, approval-timeout): node -e \"console.log('should-not-run-oc88167')\"
[proof] missing-tool-result repair placeholder present: no
```

- Observed result after fix: The command did not run, the same local `agent:main:main` session artifact contained the explicit `Exec denied (gateway id=..., approval-timeout): node -e "console.log('should-not-run-oc88167')"` signal, and the proof scan found no `missing tool result` repair placeholder.
- What was not tested: No live Telegram/Discord/VPS/channel auth or real provider API key was used. I did not wait the default 30-minute approval timer; this local no-route setup resolves the approval to the same null/timeout denial decision immediately.
- Before evidence (optional but encouraged): Existing regression expectations covered the lost-routing shape: the async strict inline-eval timeout denial had no originating followup target, matching the session-state/message-loss symptom reported in #88167.

## Tests and validation

Commands run:

```powershell
node scripts/run-vitest.mjs src/agents/bash-tools.exec-approval-followup.test.ts src/agents/bash-tools.exec-host-gateway.test.ts
node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts
node scripts/run-vitest.mjs src/agents/session-transcript-repair.test.ts src/agents/session-tool-result-guard.test.ts
git diff --check
python .agents\skills\autoreview\scripts\autoreview --mode local
```

Regression coverage added/updated:

- `src/agents/bash-tools.exec-approval-followup.test.ts` now covers denied main-session followups, session-resume failure fallback, and suppression for subagent/no-session cases.
- `src/agents/bash-tools.exec-host-gateway.test.ts` now pins gateway async strict inline-eval timeout denial to a same-session followup target.

What failed before this fix: The main-session denied followup test would have failed because denied followups returned `false` without calling the agent session path; the gateway strict-inline timeout regression previously expected a `null` followup target.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `Yes`

Highest-risk area: Exec approval denial routing.

Mitigation: The denial still fail-closes and never executes the command; subagent/cron/no-session denied followups remain suppressed; direct external denied copy is retained only as a fallback when session resume fails.

## Current review state

Next action: Maintainer review and CI.

Still waiting on: Optional maintainer live/local Gateway proof if required; no live auth was used in this fix.

Bot/reviewer comments addressed: none.

