### PR TITLE
[codex] Fix Telegram DM topic session routing

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -553,19 +553,24 @@ function resolveTelegramOutboundSessionRoute(params: {
   if (isGroup) {
     return baseRoute;
   }
+  const outboundSessionThreadId =
+    resolvedThreadId !== undefined ? `${chatId}:${resolvedThreadId}` : undefined;
   const route = buildThreadAwareOutboundSessionRoute({
     route: baseRoute,
-    threadId: resolvedThreadId,
+    threadId: outboundSessionThreadId,
     currentSessionKey: params.currentSessionKey,
     precedence: ["threadId", "currentSession"],
     canRecoverCurrentThread: ({ route }) =>
       route.chatType !== "direct" || (params.cfg.session?.dmScope ?? "main") !== "main",
   });
+  const deliveryThreadId =
+    resolvedThreadId ?? parseTelegramThreadId(route.threadId) ?? route.threadId;
   return {
     ...route,
+    ...(deliveryThreadId !== undefined ? { threadId: deliveryThreadId } : {}),
     from:
-      route.threadId !== undefined
-        ? `telegram:${chatId}:topic:${route.threadId}`
+      deliveryThreadId !== undefined
+        ? `telegram:${chatId}:topic:${deliveryThreadId}`
         : `telegram:${chatId}`,
   };
 }

--- a/extensions/telegram/src/session-route.test.ts
+++ b/extensions/telegram/src/session-route.test.ts
@@ -2,16 +2,32 @@ import { describe, expect, it } from "vitest";
 import { telegramPlugin } from "./channel.js";
 
 describe("telegram session route", () => {
-  it("keeps direct topic thread ids in a thread session suffix", async () => {
+  it("scopes direct topic session suffixes by chat id", async () => {
     const route = await telegramPlugin.messaging?.resolveOutboundSessionRoute?.({
       cfg: {},
       agentId: "main",
       target: "12345:topic:99",
     });
 
-    expect(route?.sessionKey).toBe("agent:main:main:thread:99");
+    expect(route?.sessionKey).toBe("agent:main:main:thread:12345:99");
     expect(route?.baseSessionKey).toBe("agent:main:main");
     expect(route?.threadId).toBe(99);
+  });
+
+  it("aligns isolated direct topic sessions with inbound reply routing", async () => {
+    const route = await telegramPlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: { session: { dmScope: "per-account-channel-peer" } },
+      agentId: "finance",
+      accountId: "finance",
+      target: "104506878:topic:174872",
+    });
+
+    expect(route?.sessionKey).toBe(
+      "agent:finance:telegram:finance:direct:104506878:thread:104506878:174872",
+    );
+    expect(route?.baseSessionKey).toBe("agent:finance:telegram:finance:direct:104506878");
+    expect(route?.threadId).toBe(174872);
+    expect(route?.from).toBe("telegram:104506878:topic:174872");
   });
 
   it("recovers direct topic thread routes from currentSessionKey when the DM scope is isolated", async () => {
@@ -24,7 +40,8 @@ describe("telegram session route", () => {
 
     expect(route?.sessionKey).toBe("agent:main:telegram:direct:12345:thread:12345:99");
     expect(route?.baseSessionKey).toBe("agent:main:telegram:direct:12345");
-    expect(route?.threadId).toBe("12345:99");
+    expect(route?.threadId).toBe(99);
+    expect(route?.from).toBe("telegram:12345:topic:99");
   });
 
   it('does not recover currentSessionKey threads for shared dmScope "main" DMs', async () => {


### PR DESCRIPTION
## Summary

This PR fixes Telegram proactive DM-topic session continuity for #80212.

- Aligns outbound Telegram direct-topic session keys with inbound DM-topic reply routing by using the `chatId:threadId` thread suffix.
- Preserves Telegram delivery metadata as the numeric topic id, so outbound delivery still uses `174872` rather than the scoped session token.
- Keeps the change scoped to Telegram outbound session routing and focused regression coverage.
- Intentionally does not add cron session-key overrides, aliases, or broad shared outbound routing changes.

## Linked context

Closes #80212

Related #82164, #82200, #18974, #18993

Requested by maintainer coordination for `issue-80212`.

## Real behavior proof

- Behavior or issue addressed: Proactive Telegram DM-topic sends under isolated DM scope now create/use the same scoped session key shape that inbound topic replies use, while Telegram delivery still receives the numeric topic id.
- Real environment tested: Live OpenClaw `2026.5.27 (27ae826)` on the user's VPS `polymarket-mc`, using `Ant_clawd_bot` and a real private Telegram DM topic. Chat/user ids are redacted as `<chatId>`. A temporary PR-equivalent bundle patch was applied for the proof and restored afterward.
- Exact steps or command run after this patch:
  1. User created a private Telegram DM topic and sent `oc-88421 proof start`.
  2. Applied the PR-equivalent outbound route patch to the installed VPS bundle and restarted the OpenClaw gateway.
  3. Verified the patched route shape before sending.
  4. Sent a proactive Telegram message with `openclaw message send --channel telegram --target <chatId> --thread-id 40931 --message "oc-88421 proof proactive send from patched OpenClaw route..." --json`.
  5. User replied in the same topic with `oc-88421 proof reply`.
  6. Restored the installed bundle from backup and verified the gateway was ready.
- Evidence after fix: Redacted live route output, CLI send output, and runtime log excerpts from the VPS:

```json
{
  "sessionKeyShape": "agent:main:telegram:direct:<chatId>:thread:<chatId>:40931",
  "baseSessionKeyShape": "agent:main:telegram:direct:<chatId>",
  "threadId": 40931,
  "fromShape": "telegram:<chatId>:topic:40931",
  "toShape": "telegram:<chatId>",
  "chatType": "direct"
}
```

```json
{
  "action": "send",
  "channel": "telegram",
  "dryRun": false,
  "handledBy": "plugin",
  "messageId": "9465",
  "payload": { "ok": true, "messageId": "9465" }
}
```

```text
[telegram] outbound send ok accountId=default chatId=<chatId> messageId=9465 operation=sendMessage deliveryKind=text threadId=40931 chunkCount=1
[telegram] Inbound message telegram:<chatId> -> @Ant_clawd_bot (direct, 22 chars)
[plugins] active-memory: agent=main session=agent:main:telegram:direct:<chatId>:thread:<chatId>:40931 activeProvider=codex activeModel=gpt-5.5 start timeoutMs=5000 queryChars=22 searchQueryChars=22
Request timed out before a response was generated. Please try again, or increase `agents.defaults.timeoutSeconds` in your config.
[telegram] outbound send ok accountId=default chatId=<chatId> messageId=9467 operation=sendMessage deliveryKind=text threadId=40931 chunkCount=1
```

Full proof comment: https://github.com/openclaw/openclaw/pull/88421#issuecomment-4584982117
- Observed result after fix: The proactive send created the scoped session key `agent:main:telegram:direct:<chatId>:thread:<chatId>:40931`; the user reply was processed in that same scoped session; both the proactive message and the visible timeout response delivered with numeric `threadId=40931`, not the scoped `chatId:threadId` token.
- What was not tested: Group-topic routing, cron delivery, and Crabbox/Mantis credentialed Telegram proof were not rerun. The live bot response timed out because of the user's prod agent timeout, but the routing and numeric-topic delivery proof completed.

### Source-runtime proof

Local OpenClaw source runtime at `C:\oc-work\oc-80212` also invoked the production Telegram plugin resolver directly with Node/tsx.

```bash
node --import tsx -e "const { telegramPlugin } = await import('./extensions/telegram/src/channel.ts'); const route = await telegramPlugin.messaging?.resolveOutboundSessionRoute?.({ cfg: { session: { dmScope: 'per-account-channel-peer' } }, agentId: 'finance', accountId: 'finance', target: '104506878:topic:174872' }); console.log(JSON.stringify({ sessionKey: route?.sessionKey, baseSessionKey: route?.baseSessionKey, threadId: route?.threadId, from: route?.from, to: route?.to }, null, 2));"
```

Output:

```json
{
  "sessionKey": "agent:finance:telegram:finance:direct:104506878:thread:104506878:174872",
  "baseSessionKey": "agent:finance:telegram:finance:direct:104506878",
  "threadId": 174872,
  "from": "telegram:104506878:topic:174872",
  "to": "telegram:104506878"
}
```

## Tests and validation

Which commands did you run?

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/telegram/src/session-route.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/session-route.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts src/infra/outbound/outbound-session.test.ts`
- `git diff --check`
- `$env:PYTHONIOENCODING='utf-8'; python .agents\skills\autoreview\scripts\autoreview --mode local`

What regression coverage was added or updated?

- Added an isolated per-account Telegram DM-topic outbound regression for the reported `finance` account/session shape.
- Updated the existing direct-topic regression so outbound direct-topic session suffixes include the chat id, matching inbound DM topic replies.
- Updated recovered current-session coverage so delivery metadata remains numeric even when the session suffix is scoped.

What failed before this fix, if known?

- The new isolated DM-topic assertion would have produced `agent:finance:telegram:finance:direct:104506878:thread:174872` before this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Telegram proactive DM-topic sessions now align with inbound replies.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Telegram direct-topic route metadata, especially separating session suffixes from numeric delivery topic ids.

How is that risk mitigated?

The source-runtime proof, live Telegram proof, and regression tests assert both the aligned session key and the preserved numeric delivery thread id.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Live Telegram proof has now been supplied in the PR body and proof comment. Awaiting maintainer/automation review and CI.

Which bot or reviewer comments were addressed?

Focused autoreview initially caught recovered current-session delivery metadata using scoped tokens; this patch was updated and the final autoreview was clean.