### PR TITLE
fix(acp): assemble prompts with context engine

### DIFF
--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -95,6 +95,11 @@ const transcriptMocks = vi.hoisted(() => ({
   persistAcpDispatchTranscript: vi.fn(async (_params: unknown) => undefined),
 }));
 
+const contextEngineMocks = vi.hoisted(() => ({
+  resolveContextEngine: vi.fn(),
+  assemble: vi.fn(),
+}));
+
 const bindingServiceMocks = vi.hoisted(() => ({
   listBySession: vi.fn<(sessionKey: string) => SessionBindingRecord[]>(() => []),
   unbind: vi.fn<(input: unknown) => Promise<SessionBindingRecord[]>>(async () => []),
@@ -198,6 +203,11 @@ vi.mock("../../logging/diagnostic.js", () => ({
 vi.mock("./dispatch-acp-transcript.runtime.js", () => ({
   persistAcpDispatchTranscript: (params: unknown) =>
     transcriptMocks.persistAcpDispatchTranscript(params),
+}));
+
+vi.mock("../../context-engine/registry.js", () => ({
+  resolveContextEngine: (cfg: OpenClawConfig, options: unknown) =>
+    contextEngineMocks.resolveContextEngine(cfg, options),
 }));
 
 const sessionKey = "agent:codex-acp:session-1";
@@ -455,6 +465,18 @@ describe("tryDispatchAcpReply", () => {
     sessionMetaMocks.readAcpSessionEntry.mockReset();
     sessionMetaMocks.readAcpSessionEntry.mockReturnValue(null);
     transcriptMocks.persistAcpDispatchTranscript.mockClear();
+    contextEngineMocks.assemble.mockReset();
+    contextEngineMocks.assemble.mockImplementation(async (params: { messages: unknown[] }) => ({
+      messages: params.messages,
+      estimatedTokens: 0,
+    }));
+    contextEngineMocks.resolveContextEngine.mockReset();
+    contextEngineMocks.resolveContextEngine.mockResolvedValue({
+      info: { id: "test-context-engine", name: "Test Context Engine" },
+      assemble: (params: unknown) => contextEngineMocks.assemble(params),
+      ingest: vi.fn(async () => ({ ingested: false })),
+      compact: vi.fn(async () => ({ ok: false, compacted: false })),
+    });
     bindingServiceMocks.listBySession.mockReset();
     bindingServiceMocks.listBySession.mockReturnValue([]);
     bindingServiceMocks.unbind.mockReset();
@@ -500,6 +522,52 @@ describe("tryDispatchAcpReply", () => {
     expect(transcript.promptText).toBe("reply");
     expect(transcript.finalText).toBe("hello");
     expect(routeCall().mirror).toBe(false);
+  });
+
+  it("assembles ACP prompts through the active context engine before runTurn", async () => {
+    setReadyAcpResolution();
+    mockRoutedTextTurn("hello");
+    contextEngineMocks.assemble.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "user",
+          content: "<openviking-context>\nremembered fact\n</openviking-context>\n\nreply",
+          timestamp: 0,
+        },
+      ],
+      estimatedTokens: 12,
+    });
+
+    await runDispatch({
+      bodyForAgent: "reply",
+      shouldRouteToOriginating: true,
+    });
+
+    expect(contextEngineMocks.resolveContextEngine).toHaveBeenCalledTimes(1);
+    const assembleParams = requireRecord(
+      mockArg(contextEngineMocks.assemble, 0, 0, "context engine assemble call"),
+      "context engine assemble call",
+    );
+    expect(assembleParams.sessionKey).toBe(sessionKey);
+    expect(assembleParams.prompt).toBe("reply");
+    expect(runTurnCall().text).toContain("<openviking-context>");
+    expect(runTurnCall().text).toContain("remembered fact");
+
+    const transcript = requireRecord(
+      mockArg(transcriptMocks.persistAcpDispatchTranscript, 0, 0, "transcript call"),
+      "transcript call",
+    );
+    expect(transcript.promptText).toBe("reply");
+  });
+
+  it("continues ACP dispatch with the original prompt when context engine assemble fails", async () => {
+    setReadyAcpResolution();
+    contextEngineMocks.assemble.mockRejectedValueOnce(new Error("assemble failed"));
+
+    await runDispatch({ bodyForAgent: "reply" });
+
+    expect(managerMocks.runTurn).toHaveBeenCalledTimes(1);
+    expect(runTurnCall().text).toBe("reply");
   });
 
   it("adds source delivery guidance to tool-only ACP turns", async () => {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -7,8 +7,10 @@ import {
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
+import { resolveContextEngine } from "../../context-engine/registry.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
@@ -119,6 +121,64 @@ function resolveAcpTurnText(params: {
     ].join(" "),
   );
   return params.promptText ? `${guidance}\n\n${params.promptText}` : guidance;
+}
+
+function extractUserMessageText(message: AgentMessage | undefined): string | undefined {
+  if (!message || message.role !== "user") {
+    return undefined;
+  }
+
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+
+  const text = message.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n\n")
+    .trim();
+  return text || undefined;
+}
+
+async function assembleAcpTurnPromptText(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId: string;
+  promptText: string;
+}): Promise<string> {
+  try {
+    const agentDir = resolveAgentDir(params.cfg, params.agentId);
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    const contextEngine = await resolveContextEngine(params.cfg, {
+      agentDir,
+      workspaceDir,
+    });
+    const inputMessages: AgentMessage[] = [
+      { role: "user", content: params.promptText, timestamp: Date.now() },
+    ];
+    const assembleParams = {
+      sessionId: params.sessionKey,
+      sessionKey: params.sessionKey,
+      messages: inputMessages,
+      prompt: params.promptText,
+      runtimeContext: {
+        agentId: params.agentId,
+        agentDir,
+        workspaceDir,
+        runtime: "acp",
+      },
+    } as Parameters<typeof contextEngine.assemble>[0] & {
+      runtimeContext: Record<string, unknown>;
+    };
+    const assembled = await contextEngine.assemble(assembleParams);
+    const assembledPromptText = extractUserMessageText(assembled.messages.at(-1));
+    return assembledPromptText ?? params.promptText;
+  } catch (error) {
+    logVerbose(
+      `dispatch-acp: context engine assemble failed, using original prompt: ${formatErrorMessage(error)}`,
+    );
+    return params.promptText;
+  }
 }
 
 async function hasBoundConversationForSession(params: {
@@ -564,6 +624,12 @@ export async function tryDispatchAcpReply(params: {
       params.markIdle("message_completed");
       return { queuedFinal: false, counts };
     }
+    const assembledTurnPromptText = await assembleAcpTurnPromptText({
+      cfg: params.cfg,
+      sessionKey: canonicalSessionKey,
+      agentId: acpAgentId,
+      promptText: turnPromptText,
+    });
 
     try {
       await delivery.startReplyLifecycle();
@@ -575,7 +641,7 @@ export async function tryDispatchAcpReply(params: {
       cfg: params.cfg,
       sessionKey: canonicalSessionKey,
       text: resolveAcpTurnText({
-        promptText: turnPromptText,
+        promptText: assembledTurnPromptText,
         sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
       }),
       attachments: attachments.length > 0 ? attachments : undefined,


### PR DESCRIPTION
## Summary
- run ACP dispatch prompts through the active context engine before `acpManager.runTurn`
- keep ACP transcript persistence on the original prompt text so injected context is not written into user history
- add regression coverage for context-engine injection and fallback when assemble fails

## Tests
- `node scripts/test-projects.mjs src/auto-reply/reply/dispatch-acp.test.ts`
- `pnpm exec oxlint src/auto-reply/reply/dispatch-acp.ts src/auto-reply/reply/dispatch-acp.test.ts`
- `pnpm exec oxfmt --check src/auto-reply/reply/dispatch-acp.ts src/auto-reply/reply/dispatch-acp.test.ts`

## Notes
This fixes the ACP external-agent path bypassing context-engine `assemble()`, which prevented context-engine plugins from injecting pre-prompt context for bound ACP sessions.