### PR TITLE
fix(skills): preserve compact prompt descriptions

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -579,9 +579,12 @@ prompt. The cost is deterministic and scales linearly per skill:
 - At ~4 chars/token, 97 chars ≈ 24 tokens per skill before field lengths.
 
 If the rendered block would exceed the configured prompt budget
-(`skills.limits.maxSkillsPromptChars`), OpenClaw first drops descriptions
-(compact format: name + location only), then truncates the skill list and adds
-a note pointing at `openclaw skills check`.
+(`skills.limits.maxSkillsPromptChars`), OpenClaw first preserves as many skill
+identities (name, location, and version) as the description-free compact format
+can fit. It then uses any remaining budget for shortened descriptions. If no
+description budget remains, descriptions are omitted. The prompt includes a
+note pointing at `openclaw skills check` whenever compact formatting or list
+truncation is required.
 
 Keep descriptions short and descriptive to minimize prompt overhead.
 

--- a/src/skills/loading/compact-format.test.ts
+++ b/src/skills/loading/compact-format.test.ts
@@ -64,6 +64,11 @@ function requireIncludedCounts(prompt: string): [included: number, total: number
   return [Number(match[1]), Number(match[2])];
 }
 
+const COMPACT_OMITTED_NOTICE =
+  "⚠️ Skills catalog using compact format (descriptions omitted). Run `openclaw skills check` to audit.";
+const COMPACT_SHORTENED_NOTICE =
+  "⚠️ Skills catalog using compact format (descriptions shortened). Run `openclaw skills check` to audit.";
+
 describe("formatSkillsCompact", () => {
   it("keeps the full-format XML output aligned with the upstream formatter for visible skills", () => {
     const skills = [
@@ -84,15 +89,31 @@ describe("formatSkillsCompact", () => {
     expect(formatSkillsCompact([])).toBe("");
   });
 
-  it("omits description, keeps name and location", () => {
+  it("keeps compact descriptions with name, location, and version", () => {
     const out = formatSkillsCompact([
       { ...makeSkill("weather", "Get weather data"), promptVersion: "sha256:abc123" },
     ]);
     expect(out).toContain("<name>weather</name>");
+    expect(out).toContain("<description>Get weather data</description>");
     expect(out).toContain("<location>/skills/weather/SKILL.md</location>");
     expect(out).toContain("<version>sha256:abc123</version>");
-    expect(out).not.toContain("Get weather data");
+  });
+
+  it("omits descriptions when their compact budget is zero", () => {
+    const out = formatSkillsCompact([makeSkill("weather", "Get weather data")], {
+      descriptionMaxChars: 0,
+    });
+    expect(out).toContain("<name>weather</name>");
     expect(out).not.toContain("<description>");
+  });
+
+  it("truncates descriptions without splitting emoji surrogate pairs", () => {
+    const out = formatSkillsCompact([makeSkill("emoji", `${"A".repeat(16)}😀 trailing`)], {
+      descriptionMaxChars: 20,
+    });
+
+    expect(out).toContain(`<description>${"A".repeat(16)}...</description>`);
+    expect(out).not.toMatch(/[\uD800-\uDFFF]/u);
   });
 
   it("renders all passed skills without reapplying visibility policy", () => {
@@ -108,11 +129,9 @@ describe("formatSkillsCompact", () => {
   });
 
   it("is significantly smaller than full format", () => {
-    const skills = Array.from({ length: 50 }, (_, i) =>
-      makeSkill(`skill-${i}`, "A moderately long description that takes up space in the prompt"),
-    );
+    const skills = Array.from({ length: 50 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(800)));
     const compact = formatSkillsCompact(skills);
-    expect(compact.length).toBeLessThan(6000);
+    expect(compact.length).toBeLessThan(formatSkillsForPrompt(skills).length / 2);
   });
 });
 
@@ -157,17 +176,15 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
   });
 
   it("tier 2: compact when full exceeds budget but compact fits", () => {
-    const skills = Array.from({ length: 20 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
+    const skills = Array.from({ length: 20 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(800)));
     const fullLen = formatSkillsForPrompt(skills).length;
     const compactLen = formatSkillsCompact(skills).length;
-    const budget = Math.floor((fullLen + compactLen) / 2);
-    // Verify preconditions: full exceeds budget, compact fits within overhead-adjusted budget
+    const budget = `${COMPACT_SHORTENED_NOTICE}\n${formatSkillsCompact(skills)}`.length;
     expect(fullLen).toBeGreaterThan(budget);
-    expect(compactLen + 150).toBeLessThan(budget);
+    expect(compactLen).toBeLessThan(budget);
     const prompt = buildPrompt(skills, { maxChars: budget });
-    expect(prompt).not.toContain("<description>");
-    // All skills preserved — distinct message, no "included X of Y"
-    expect(prompt).toContain("compact format (descriptions omitted)");
+    expect(prompt).toContain("<description>");
+    expect(prompt).toContain("compact format (descriptions shortened)");
     expect(prompt).not.toContain("included");
     expect(prompt).toContain("skill-0");
     expect(prompt).toContain("skill-19");
@@ -176,8 +193,7 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
   it("tier 3: compact + binary search when compact also exceeds budget", () => {
     const skills = Array.from({ length: 100 }, (_, i) => makeSkill(`skill-${i}`, "description"));
     const prompt = buildPrompt(skills, { maxChars: 2000 });
-    expect(prompt).toContain("compact format, descriptions omitted");
-    expect(prompt).not.toContain("<description>");
+    expect(prompt).toContain("compact format");
     expect(prompt).toContain("skill-0");
     const [included, total] = requireIncludedCounts(prompt);
     expect(included).toBeLessThan(total);
@@ -185,34 +201,51 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     expect(prompt.match(/<skill>/g)?.length ?? 0).toBe(included);
   });
 
-  it("compact preserves all skills where full format would drop some", () => {
-    const skills = Array.from({ length: 50 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
-    const compactLen = formatSkillsCompact(skills).length;
-    const budget = compactLen + 250;
-    // Verify precondition: full format must not fit so tier 2 is actually exercised
+  it("preserves every identity before allocating description budget", () => {
+    const skills = Array.from({ length: 50 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(800)));
+    const identityCatalog = formatSkillsCompact(skills, { descriptionMaxChars: 0 });
+    const budget = `${COMPACT_OMITTED_NOTICE}\n${identityCatalog}`.length;
     expect(formatSkillsForPrompt(skills).length).toBeGreaterThan(budget);
+
     const prompt = buildPrompt(skills, { maxChars: budget });
-    // All 50 fit in compact — no truncation, just compact notice
-    expect(prompt).toContain("compact format");
+
+    expect(prompt.length).toBeLessThanOrEqual(budget);
+    expect(prompt).toContain(COMPACT_OMITTED_NOTICE);
+    expect(prompt).not.toContain("<description>");
     expect(prompt).not.toContain("included");
     expect(prompt).toContain("skill-0");
     expect(prompt).toContain("skill-49");
   });
 
+  it("uses leftover compact budget for descriptions without dropping identities", () => {
+    const skills = Array.from({ length: 8 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(800)));
+    const identityCatalog = formatSkillsCompact(skills, { descriptionMaxChars: 0 });
+    const budget = `${COMPACT_OMITTED_NOTICE}\n${identityCatalog}`.length + 500;
+
+    const prompt = buildPrompt(skills, { maxChars: budget });
+
+    expect(prompt.length).toBeLessThanOrEqual(budget);
+    expect(prompt).toContain(COMPACT_SHORTENED_NOTICE);
+    expect(prompt).toContain("<description>");
+    expect(prompt).not.toContain("included");
+    expect(prompt.match(/<skill>/g)).toHaveLength(skills.length);
+  });
+
   it("count truncation + compact: shows included X of Y with compact note", () => {
     // 30 skills but maxCount=10, and full format of 10 exceeds budget
-    const skills = Array.from({ length: 30 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
+    const skills = Array.from({ length: 30 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(800)));
     const tenSkills = skills.slice(0, 10);
     const fullLen = formatSkillsForPrompt(tenSkills).length;
-    const compactLen = formatSkillsCompact(tenSkills).length;
-    const budget = compactLen + 200;
+    const truncatedNotice =
+      "⚠️ Skills truncated: included 10 of 30 (compact format, descriptions shortened). Run `openclaw skills check` to audit.";
+    const budget = `${truncatedNotice}\n${formatSkillsCompact(tenSkills)}`.length;
     // Verify precondition: full format of 10 skills exceeds budget
     expect(fullLen).toBeGreaterThan(budget);
     const prompt = buildPrompt(skills, { maxChars: budget, maxCount: 10 });
     // Count-truncated (30→10) AND compact (full format of 10 exceeds budget)
     expect(prompt).toContain("included 10 of 30");
-    expect(prompt).toContain("compact format, descriptions omitted");
-    expect(prompt).not.toContain("<description>");
+    expect(prompt).toContain("compact format, descriptions shortened");
+    expect(prompt).toContain("<description>");
   });
 
   it("extreme budget: even a single compact skill overflows", () => {
@@ -254,20 +287,6 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     expect(prompt).toContain("<description>");
   });
 
-  it("compact budget reserves space for the warning line", () => {
-    // Build skills whose compact output exactly equals the char budget.
-    // Without overhead reservation the compact block would fit, but the
-    // warning line prepended by the caller would push the total over budget.
-    const skills = Array.from({ length: 50 }, (_, i) => makeSkill(`s-${i}`, "A".repeat(200)));
-    const compactLen = formatSkillsCompact(skills).length;
-    // Set budget = compactLen + 50 — less than the 150-char overhead reserve.
-    // The function should NOT choose compact-only because the warning wouldn't fit.
-    const prompt = buildPrompt(skills, { maxChars: compactLen + 50 });
-    // Should fall through to compact + binary search (some skills dropped)
-    expect(prompt).toContain("included");
-    expect(prompt).not.toContain("<description>");
-  });
-
   it("budget check uses compacted home-dir paths, not canonical paths", () => {
     // Skills with home-dir prefix get compacted (e.g. /home/user/... → ~/...).
     // Budget check must use the compacted length, not the longer canonical path.
@@ -277,7 +296,7 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     const skills = Array.from({ length: 30 }, (_, i) =>
       makeSkill(
         `skill-${i}`,
-        "A".repeat(200),
+        "A".repeat(800),
         `${home}/.openclaw/workspace/skills/skill-${i}/SKILL.md`,
       ),
     );
@@ -286,13 +305,18 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
       ...s,
       filePath: s.filePath.replace(home, "~"),
     }));
-    const compactedCompactLen = formatSkillsCompact(compactedSkills).length;
-    const canonicalCompactLen = formatSkillsCompact(skills).length;
+    const compactedCompactLen = formatSkillsCompact(compactedSkills, {
+      descriptionMaxChars: 0,
+    }).length;
+    const canonicalCompactLen = formatSkillsCompact(skills, { descriptionMaxChars: 0 }).length;
     // Sanity: canonical paths are longer than compacted paths
     expect(canonicalCompactLen).toBeGreaterThan(compactedCompactLen);
     // Set budget between compacted and canonical lengths — only fits if
     // budget check uses compacted paths (correct) not canonical (wrong).
-    const budget = Math.floor((compactedCompactLen + canonicalCompactLen) / 2) + 150;
+    const budget =
+      Math.floor((compactedCompactLen + canonicalCompactLen) / 2) +
+      COMPACT_OMITTED_NOTICE.length +
+      1;
     const prompt = buildPrompt(skills, { maxChars: budget });
     // All 30 skills should be preserved in compact form (tier 2, no dropping)
     expect(prompt).toContain("skill-0");

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -7,6 +7,7 @@ import {
   normalizeTrimmedStringList,
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSandboxPath } from "../../agents/sandbox-paths.js";
 import { canonicalizePath } from "../../agents/utils/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -1299,18 +1300,40 @@ function escapeXml(str: string): string {
     .replace(/'/g, "&apos;");
 }
 
+const COMPACT_DESCRIPTION_MAX_CHARS = 220;
+const COMPACT_DESCRIPTION_MIN_CHARS = 4;
+
+function truncateSkillDescription(description: string, maxChars: number): string {
+  const normalized = description.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  if (maxChars <= 3) {
+    return truncateUtf16Safe(normalized, maxChars);
+  }
+  return `${truncateUtf16Safe(normalized, maxChars - 3).trimEnd()}...`;
+}
+
 /**
- * Compact skill catalog: name + location only (no description).
- * Used as a fallback when the full format exceeds the char budget,
- * preserving awareness of all skills before resorting to dropping.
+ * Compact skill catalog with descriptions bounded independently from identities.
+ * A zero description budget preserves the previous name/location-only format.
  */
-export function formatSkillsCompact(skills: Skill[]): string {
+export function formatSkillsCompact(
+  skills: Skill[],
+  opts?: { descriptionMaxChars?: number },
+): string {
   if (skills.length === 0) {
     return "";
   }
+  const descriptionMaxChars = Math.max(
+    0,
+    Math.floor(opts?.descriptionMaxChars ?? COMPACT_DESCRIPTION_MAX_CHARS),
+  );
   const lines = [
     "\n\nThe following skills provide specialized instructions for specific tasks.",
-    "Use the read tool to load a skill's file when the task matches its name.",
+    descriptionMaxChars > 0
+      ? "Use the read tool to load a skill's file when the task matches its name or description."
+      : "Use the read tool to load a skill's file when the task matches its name.",
     "If a skill's <version> differs from a previous turn, re-read its SKILL.md before using it.",
     "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
     "",
@@ -1319,6 +1342,12 @@ export function formatSkillsCompact(skills: Skill[]): string {
   for (const skill of skills) {
     lines.push("  <skill>");
     lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+    if (descriptionMaxChars > 0) {
+      const description = truncateSkillDescription(skill.description, descriptionMaxChars);
+      if (description) {
+        lines.push(`    <description>${escapeXml(description)}</description>`);
+      }
+    }
     lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
     if (skill.promptVersion) {
       lines.push(`    <version>${escapeXml(skill.promptVersion)}</version>`);
@@ -1329,17 +1358,25 @@ export function formatSkillsCompact(skills: Skill[]): string {
   return lines.join("\n");
 }
 
+type SkillsPromptFormat = { kind: "full" } | { kind: "compact"; descriptionMaxChars: number };
+
 function buildSkillsLimitNote(params: {
   truncated: boolean;
-  compact: boolean;
+  format: SkillsPromptFormat;
   included: number;
   total: number;
 }): string {
   if (params.truncated) {
-    return `⚠️ Skills truncated: included ${params.included} of ${params.total}${params.compact ? " (compact format, descriptions omitted)" : ""}. Run \`openclaw skills check\` to audit.`;
+    const compactDetails =
+      params.format.kind === "compact"
+        ? ` (compact format, ${params.format.descriptionMaxChars > 0 ? "descriptions shortened" : "descriptions omitted"})`
+        : "";
+    return `⚠️ Skills truncated: included ${params.included} of ${params.total}${compactDetails}. Run \`openclaw skills check\` to audit.`;
   }
-  if (params.compact) {
-    return `⚠️ Skills catalog using compact format (descriptions omitted). Run \`openclaw skills check\` to audit.`;
+  if (params.format.kind === "compact") {
+    const compactDetails =
+      params.format.descriptionMaxChars > 0 ? "descriptions shortened" : "descriptions omitted";
+    return `⚠️ Skills catalog using compact format (${compactDetails}). Run \`openclaw skills check\` to audit.`;
   }
   return "";
 }
@@ -1348,18 +1385,21 @@ function buildRenderedSkillsPrompt(params: {
   remoteNote?: string;
   skills: Skill[];
   total: number;
-  compact: boolean;
+  format: SkillsPromptFormat;
 }): string {
   const truncated = params.skills.length < params.total;
   const limitNote = buildSkillsLimitNote({
     truncated,
-    compact: params.compact,
+    format: params.format,
     included: params.skills.length,
     total: params.total,
   });
-  const catalog = params.compact
-    ? formatSkillsCompact(params.skills)
-    : formatSkillsForPrompt(params.skills);
+  const catalog =
+    params.format.kind === "compact"
+      ? formatSkillsCompact(params.skills, {
+          descriptionMaxChars: params.format.descriptionMaxChars,
+        })
+      : formatSkillsForPrompt(params.skills);
   return [params.remoteNote, limitNote, catalog].filter(Boolean).join("\n");
 }
 
@@ -1370,44 +1410,40 @@ function applySkillsPromptLimits(params: {
   remoteNote?: string;
 }): {
   skillsForPrompt: Skill[];
-  compact: boolean;
+  format: SkillsPromptFormat;
 } {
   const limits = resolveSkillsLimits(params.config, params.agentId);
   const total = params.skills.length;
   const byCount = params.skills.slice(0, Math.max(0, limits.maxSkillsInPrompt));
 
   let skillsForPrompt = byCount;
-  let compact = false;
 
   const fitsFull = (skills: Skill[]): boolean =>
     buildRenderedSkillsPrompt({
       remoteNote: params.remoteNote,
       skills,
       total,
-      compact: false,
+      format: { kind: "full" },
     }).length <= limits.maxSkillsPromptChars;
 
-  const fitsCompact = (skills: Skill[]): boolean =>
+  const fitsCompact = (skills: Skill[], descriptionMaxChars: number): boolean =>
     buildRenderedSkillsPrompt({
       remoteNote: params.remoteNote,
       skills,
       total,
-      compact: true,
+      format: { kind: "compact", descriptionMaxChars },
     }).length <= limits.maxSkillsPromptChars;
 
   if (!fitsFull(skillsForPrompt)) {
-    // Full format exceeds budget. Try compact (name + location, no description)
-    // to preserve awareness of all skills before dropping any.
-    if (fitsCompact(skillsForPrompt)) {
-      compact = true;
-    } else {
-      // Compact still too large — binary search the largest prefix that fits.
-      compact = true;
+    // Identity coverage takes priority over descriptions. Find the same largest
+    // name/location/version prefix as the previous compact format before using
+    // any leftover budget for trigger guidance.
+    if (!fitsCompact(skillsForPrompt, 0)) {
       let lo = 0;
       let hi = skillsForPrompt.length;
       while (lo < hi) {
         const mid = Math.ceil((lo + hi) / 2);
-        if (fitsCompact(skillsForPrompt.slice(0, mid))) {
+        if (fitsCompact(skillsForPrompt.slice(0, mid), 0)) {
           lo = mid;
         } else {
           hi = mid - 1;
@@ -1415,9 +1451,25 @@ function applySkillsPromptLimits(params: {
       }
       skillsForPrompt = skillsForPrompt.slice(0, lo);
     }
+
+    let descriptionMaxChars = 0;
+    if (skillsForPrompt.length > 0 && fitsCompact(skillsForPrompt, COMPACT_DESCRIPTION_MIN_CHARS)) {
+      let lo = COMPACT_DESCRIPTION_MIN_CHARS;
+      let hi = COMPACT_DESCRIPTION_MAX_CHARS;
+      while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (fitsCompact(skillsForPrompt, mid)) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      descriptionMaxChars = lo;
+    }
+    return { skillsForPrompt, format: { kind: "compact", descriptionMaxChars } };
   }
 
-  return { skillsForPrompt, compact };
+  return { skillsForPrompt, format: { kind: "full" } };
 }
 
 export function buildWorkspaceSkillSnapshot(
@@ -1505,7 +1557,7 @@ function resolveWorkspaceSkillPromptState(
   const promptSkills = compactSkillPaths(resolvedSkills).toSorted((a, b) =>
     a.name.localeCompare(b.name, "en"),
   );
-  const { skillsForPrompt, compact } = applySkillsPromptLimits({
+  const { skillsForPrompt, format } = applySkillsPromptLimits({
     skills: promptSkills,
     config: opts?.config,
     agentId: opts?.agentId,
@@ -1515,7 +1567,7 @@ function resolveWorkspaceSkillPromptState(
     remoteNote,
     skills: skillsForPrompt,
     total: resolvedSkills.length,
-    compact,
+    format,
   });
   return { eligible, prompt, resolvedSkills };
 }

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -110,7 +110,7 @@ export type SkillEligibilityContext = {
   };
 };
 
-export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 1;
+export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 2;
 
 export type SkillSnapshot = {
   prompt: string;


### PR DESCRIPTION
Related: #50677

## What Problem This Solves

When a skills catalog exceeded `maxSkillsPromptChars`, OpenClaw's compact fallback removed every description. Opaque skill names then lost the semantic trigger guidance the model needs to choose the right skill.

## Why This Change Was Made

The compact formatter now preserves the existing name/location/version identity set first, then spends only the remaining prompt budget on bounded descriptions. Description truncation reuses the shared UTF-16-safe helper so a limit cannot split a surrogate pair, and the prompt-format version advances so persisted sessions rebuild the changed catalog shape.

This is a current-`main` rewrite of the original contribution: it keeps the newer version-marker/session-refresh behavior, accounts for the complete rendered notice when enforcing the cap, and avoids trading an identity for description text.

## User Impact

Large skills installations retain useful matching descriptions whenever budget remains. At the exact identity-only budget, behavior remains the previous compact contract: all identities fit, descriptions are omitted, and the prompt explains that state. Documentation now describes both compact modes.

## Evidence

- Exact reviewed head: `3bf7b9967330af23b8db52c175192442da3cf178`.
- Sanitized AWS Crabbox focused run `run_3ff6ad25c73e`: 2 files, 31 tests passed (`compact-format` and session snapshot coverage).
- Sanitized AWS Crabbox changed-surface run `run_1eeb815a2313`: core/core-tests/docs lanes passed, including core and core-test tsgo, changed-file lint, import-cycle and repository guards.
- Sanitized AWS Crabbox live run `run_b4518917d9ec`: two real `openclaw agent --local` turns through the repository mock `/v1/responses` endpoint. At 18,000 chars, 29 discovered identities/versions and all 12 long fixture descriptions survived with UTF-16-safe truncation. At the exact 6,107-char identity budget, the same 29 identities/versions remained byte-for-byte after description-line removal, with zero descriptions.
- Local fallback: focused tests passed (31/31), touched files formatted, and `git diff --check` passed.
- Fresh autoreview on the final source diff: clean; no accepted or actionable findings.

AI-assisted maintainer takeover: an OpenClaw maintainer agent rebased and rewrote the contributor patch against current `main`, added regression/live proof, and preserved contributor credit in the commit.
