### PR TITLE
fix(auth): bound inherited oauth expiry

### DIFF
--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -1,3 +1,8 @@
+import {
+  addTimerTimeoutGraceMs,
+  clampPositiveTimerTimeoutMs,
+  resolveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
 import type {
   BrowserActionOk,
   BrowserActionPathResult,
@@ -26,9 +31,7 @@ type BrowserActResponse = {
 const BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS = 5_000;
 
 function normalizePositiveTimeoutMs(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : undefined;
+  return clampPositiveTimerTimeoutMs(value);
 }
 
 function resolveBrowserActRequestTimeoutMs(req: BrowserActRequest): number {
@@ -36,11 +39,13 @@ function resolveBrowserActRequestTimeoutMs(req: BrowserActRequest): number {
   const candidateTimeouts =
     explicitTimeout === undefined
       ? [DEFAULT_BROWSER_ACTION_TIMEOUT_MS]
-      : [explicitTimeout + BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS];
+      : [addTimerTimeoutGraceMs(explicitTimeout, BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS) ?? 1];
   if (req.kind === "wait") {
     const waitDuration = normalizePositiveTimeoutMs(req.timeMs);
     if (waitDuration !== undefined) {
-      candidateTimeouts.push(waitDuration + BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS);
+      candidateTimeouts.push(
+        addTimerTimeoutGraceMs(waitDuration, BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS) ?? 1,
+      );
     }
   }
   return Math.max(...candidateTimeouts);
@@ -127,10 +132,7 @@ export async function browserAct(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(req),
-    timeoutMs:
-      typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
-        ? Math.max(1, Math.floor(opts.timeoutMs))
-        : resolveBrowserActRequestTimeoutMs(req),
+    timeoutMs: resolveTimerTimeoutMs(opts?.timeoutMs, resolveBrowserActRequestTimeoutMs(req)),
   });
 }
 
@@ -148,10 +150,7 @@ export async function browserScreenshotAction(
   },
 ): Promise<BrowserActionPathResult> {
   const q = buildProfileQuery(opts.profile);
-  const timeoutMs =
-    typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
-      ? Math.max(1, Math.floor(opts.timeoutMs))
-      : undefined;
+  const timeoutMs = clampPositiveTimerTimeoutMs(opts.timeoutMs);
   const effectiveTimeoutMs = timeoutMs ?? DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS;
   return await fetchBrowserJson<BrowserActionPathResult>(withBaseUrl(baseUrl, `/screenshot${q}`), {
     method: "POST",

--- a/extensions/browser/src/browser/client.test.ts
+++ b/extensions/browser/src/browser/client.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   browserAct,
@@ -125,6 +126,19 @@ describe("browser client", () => {
     expect(snapshotCall).toBeTruthy();
     const parsed = new URL(snapshotCall as string);
     expect(parsed.searchParams.get("timeoutMs")).toBe("4321");
+  });
+
+  it("clamps oversized snapshot timeoutMs before forwarding", async () => {
+    const calls: string[] = [];
+    stubSnapshotFetch(calls);
+
+    await browserSnapshot("http://127.0.0.1:18791", {
+      format: "ai",
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    const parsed = new URL(requireSnapshotCall(calls));
+    expect(parsed.searchParams.get("timeoutMs")).toBe(String(MAX_TIMER_TIMEOUT_MS));
   });
 
   it("falls back to the default snapshot timeout when none is supplied", async () => {
@@ -415,5 +429,36 @@ describe("browser client", () => {
     });
 
     expect(calls.map((call) => call.init?.timeoutMs)).toEqual([60_000, 75_000, 50_000]);
+  });
+
+  it("clamps oversized browser action timeouts before forwarding", async () => {
+    const calls: Array<{ url: string; init?: RequestInit & { timeoutMs?: number } }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit & { timeoutMs?: number }) => {
+        calls.push({ url, init });
+        return {
+          ok: true,
+          json: async () => ({ ok: true, targetId: "t1", path: "/tmp/a.png" }),
+        } as unknown as Response;
+      }),
+    );
+
+    await browserAct("http://127.0.0.1:18791", {
+      kind: "wait",
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+    await browserScreenshotAction("http://127.0.0.1:18791", {
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    const act = calls.find((call) => call.url.endsWith("/act"));
+    expect(act?.init?.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    const screenshot = calls.find((call) => call.url.endsWith("/screenshot"));
+    expect(screenshot?.init?.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    const screenshotBody = JSON.parse(
+      typeof screenshot?.init?.body === "string" ? screenshot.init.body : "{}",
+    ) as { timeoutMs?: unknown };
+    expect(screenshotBody.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 });

--- a/extensions/browser/src/browser/client.ts
+++ b/extensions/browser/src/browser/client.ts
@@ -1,3 +1,7 @@
+import {
+  clampPositiveTimerTimeoutMs,
+  resolveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
 import { buildProfileQuery, withBaseUrl } from "./client-actions-url.js";
 import { fetchBrowserJson } from "./client-fetch.js";
 import type {
@@ -29,9 +33,7 @@ function resolveBrowserClientTimeoutMs(
   opts: BrowserClientTimeoutOptions | undefined,
   fallbackMs: number,
 ): number {
-  return typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
-    ? Math.max(1, Math.floor(opts.timeoutMs))
-    : fallbackMs;
+  return resolveTimerTimeoutMs(opts?.timeoutMs, fallbackMs);
 }
 
 function withProfilePath(baseUrl: string | undefined, path: string, profile?: string): string {
@@ -373,9 +375,7 @@ export async function browserSnapshot(
     q.set("profile", opts.profile);
   }
   const resolvedTimeoutMs =
-    typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0
-      ? Math.floor(opts.timeoutMs)
-      : DEFAULT_BROWSER_SNAPSHOT_TIMEOUT_MS;
+    clampPositiveTimerTimeoutMs(opts.timeoutMs) ?? DEFAULT_BROWSER_SNAPSHOT_TIMEOUT_MS;
   q.set("timeoutMs", String(resolvedTimeoutMs));
   return await fetchBrowserJson<SnapshotResult>(withBaseUrl(baseUrl, `/snapshot?${q.toString()}`), {
     timeoutMs: resolvedTimeoutMs,

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it } from "vitest";
 import type { BrowserConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
@@ -149,6 +150,19 @@ describe("browser config", () => {
       maxTabsPerSession: 0,
       sweepMinutes: 15,
     });
+  });
+
+  it("caps browser tab cleanup timer minutes before converting to milliseconds", () => {
+    const maxTimerMinutes = Math.floor(MAX_TIMER_TIMEOUT_MS / 60_000);
+    const resolved = resolveBrowserConfig({
+      tabCleanup: {
+        idleMinutes: Number.MAX_SAFE_INTEGER,
+        sweepMinutes: Number.MAX_SAFE_INTEGER,
+      },
+    });
+
+    expect(resolved.tabCleanup.idleMinutes).toBe(maxTimerMinutes);
+    expect(resolved.tabCleanup.sweepMinutes).toBe(maxTimerMinutes);
   });
 
   it("expands tilde-prefixed executablePath with the OS home directory", () => {

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import {
   normalizeOptionalString,
   normalizeOptionalTrimmedStringList,
@@ -166,6 +167,16 @@ function normalizePositiveInteger(raw: number | undefined, fallback: number): nu
   return value <= 0 ? fallback : value;
 }
 
+const MAX_BROWSER_TIMER_MINUTES = Math.floor(MAX_TIMER_TIMEOUT_MS / 60_000);
+
+function normalizeNonNegativeTimerMinutes(raw: number | undefined, fallback: number): number {
+  return Math.min(normalizeNonNegativeInteger(raw, fallback), MAX_BROWSER_TIMER_MINUTES);
+}
+
+function normalizePositiveTimerMinutes(raw: number | undefined, fallback: number): number {
+  return Math.min(normalizePositiveInteger(raw, fallback), MAX_BROWSER_TIMER_MINUTES);
+}
+
 function normalizeExecutablePath(raw: string | undefined): string | undefined {
   const value = normalizeOptionalString(raw);
   if (!value) {
@@ -222,7 +233,7 @@ function resolveBrowserTabCleanupConfig(
   const raw = cfg?.tabCleanup;
   return {
     enabled: raw?.enabled ?? true,
-    idleMinutes: normalizeNonNegativeInteger(
+    idleMinutes: normalizeNonNegativeTimerMinutes(
       raw?.idleMinutes,
       DEFAULT_BROWSER_TAB_CLEANUP_IDLE_MINUTES,
     ),
@@ -230,7 +241,7 @@ function resolveBrowserTabCleanupConfig(
       raw?.maxTabsPerSession,
       DEFAULT_BROWSER_TAB_CLEANUP_MAX_TABS_PER_SESSION,
     ),
-    sweepMinutes: normalizePositiveInteger(
+    sweepMinutes: normalizePositiveTimerMinutes(
       raw?.sweepMinutes,
       DEFAULT_BROWSER_TAB_CLEANUP_SWEEP_MINUTES,
     ),

--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -157,4 +157,26 @@ describe("ClickClack account resolution", () => {
       workspace: "wsp_1",
     });
   });
+
+  it("normalizes reconnect intervals to the public config bounds", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          token: "ccb_global",
+          workspace: "wsp_1",
+          reconnectMs: 1,
+          accounts: {
+            slow: {
+              reconnectMs: 1_000_000,
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(resolveClickClackAccount({ cfg }).reconnectMs).toBe(100);
+    expect(resolveClickClackAccount({ cfg, accountId: "slow" }).reconnectMs).toBe(60_000);
+  });
 });

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -4,6 +4,7 @@ import {
 } from "openclaw/plugin-sdk/account-helpers";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { resolveMergedAccountConfig } from "openclaw/plugin-sdk/account-resolution";
+import { resolveIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/provider-auth";
 import {
   normalizeSecretInputString,
@@ -14,6 +15,8 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import type { ClickClackAccountConfig, CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
 const DEFAULT_RECONNECT_MS = 1_500;
+const MIN_RECONNECT_MS = 100;
+const MAX_RECONNECT_MS = 60_000;
 
 const {
   listAccountIds: listClickClackAccountIds,
@@ -128,7 +131,10 @@ export function resolveClickClackAccount(params: {
     toolsAllow: merged.toolsAllow,
     defaultTo: merged.defaultTo?.trim() || "channel:general",
     allowFrom: merged.allowFrom ?? ["*"],
-    reconnectMs: merged.reconnectMs ?? DEFAULT_RECONNECT_MS,
+    reconnectMs: resolveIntegerOption(merged.reconnectMs, DEFAULT_RECONNECT_MS, {
+      min: MIN_RECONNECT_MS,
+      max: MAX_RECONNECT_MS,
+    }),
     config: {
       ...merged,
       allowFrom: merged.allowFrom ?? ["*"],

--- a/extensions/codex/media-understanding-provider.test.ts
+++ b/extensions/codex/media-understanding-provider.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { buildCodexMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import type { CodexAppServerClient } from "./src/app-server/client.js";
@@ -227,6 +228,33 @@ describe("codex media understanding provider", () => {
       model: "gpt-5.4",
       effort: "low",
     });
+  });
+
+  it("clamps oversized image understanding turn timeouts", async () => {
+    vi.useFakeTimers();
+    try {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const { client } = createFakeClient();
+      const provider = buildCodexMediaUnderstandingProvider({
+        clientFactory: async () => client,
+      });
+
+      const result = await provider.describeImage?.({
+        buffer: Buffer.from("image-bytes"),
+        fileName: "image.png",
+        mime: "image/png",
+        provider: "codex",
+        model: "gpt-5.4",
+        timeoutMs: MAX_TIMER_TIMEOUT_MS + 1,
+        cfg: {},
+        agentDir: "/tmp/openclaw-agent",
+      });
+
+      expect(result?.text).toBe("A red square.");
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("declines approval requests during image understanding", async () => {

--- a/extensions/codex/media-understanding-provider.ts
+++ b/extensions/codex/media-understanding-provider.ts
@@ -9,6 +9,7 @@ import {
   type StructuredExtractionRequest,
   type StructuredExtractionResult,
 } from "openclaw/plugin-sdk/media-understanding";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { CODEX_PROVIDER_ID, FALLBACK_CODEX_MODELS } from "./provider-catalog.js";
 import { type CodexAppServerClientFactory } from "./src/app-server/client-factory.js";
 import type { CodexAppServerClient } from "./src/app-server/client.js";
@@ -124,7 +125,7 @@ async function runBoundedCodexVisionTurn(params: BoundedCodexVisionTurnParams): 
   const appServer = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.options.pluginConfig,
   });
-  const timeoutMs = Math.max(100, params.timeoutMs);
+  const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 100, 100);
   const ownsClient = !params.options.clientFactory;
   const client = params.options.clientFactory
     ? await params.options.clientFactory(appServer.start, params.profile)

--- a/extensions/codex/src/app-server/attempt-turn-watches.test.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCodexAttemptTurnWatchController } from "./attempt-turn-watches.js";
 
@@ -88,6 +89,26 @@ describe("Codex app-server attempt turn watches", () => {
       },
     ]);
     expect(harness.abortController.signal.reason).toBe("turn_completion_idle_timeout");
+  });
+
+  it("clamps oversized completion idle timeouts before scheduling", () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const harness = createController({
+      turnCompletionIdleTimeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    harness.controller.touchActivity("turn:start", { arm: true });
+
+    expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("clamps oversized completion idle override timeouts before scheduling", () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const harness = createController();
+
+    harness.controller.armCompletionIdleWatch({ timeoutMs: Number.MAX_SAFE_INTEGER });
+
+    expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
 
   it("does not fire completion idle timeout after terminal notification is queued", () => {

--- a/extensions/codex/src/app-server/attempt-turn-watches.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.ts
@@ -1,4 +1,5 @@
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 
 type Timer = ReturnType<typeof setTimeout>;
 
@@ -58,6 +59,15 @@ export function createCodexAttemptTurnWatchController(params: {
   let attemptLastProgressAt = Date.now();
   let attemptLastProgressReason = "startup";
   let attemptLastProgressDetails: Record<string, unknown> | undefined;
+  const turnCompletionIdleTimeoutMs = resolveTimerTimeoutMs(params.turnCompletionIdleTimeoutMs, 1);
+  const turnAssistantCompletionIdleTimeoutMs = resolveTimerTimeoutMs(
+    params.turnAssistantCompletionIdleTimeoutMs,
+    1,
+  );
+  const turnAttemptIdleTimeoutMs = resolveTimerTimeoutMs(params.turnAttemptIdleTimeoutMs, 1);
+  const turnTerminalIdleTimeoutMs = resolveTimerTimeoutMs(params.turnTerminalIdleTimeoutMs, 1);
+  const interruptTimeoutMs = resolveTimerTimeoutMs(params.interruptTimeoutMs, 1);
+  const resolveWatchTimeoutMs = (timeoutMs: number) => resolveTimerTimeoutMs(timeoutMs, 1);
 
   const clearCompletionIdleTimer = () => {
     if (completionIdleTimer) {
@@ -105,7 +115,7 @@ export function createCodexAttemptTurnWatchController(params: {
       return;
     }
     const elapsedMs = Math.max(0, Date.now() - completionLastActivityAt);
-    const timeoutMs = completionIdleTimeoutOverrideMs ?? params.turnCompletionIdleTimeoutMs;
+    const timeoutMs = completionIdleTimeoutOverrideMs ?? turnCompletionIdleTimeoutMs;
     const delayMs = Math.max(1, timeoutMs - elapsedMs);
     completionIdleTimer = setTimeout(fireCompletionIdleTimeout, delayMs);
     completionIdleTimer.unref?.();
@@ -117,7 +127,7 @@ export function createCodexAttemptTurnWatchController(params: {
       return;
     }
     const elapsedMs = Math.max(0, Date.now() - assistantCompletionLastActivityAt);
-    const delayMs = Math.max(1, params.turnAssistantCompletionIdleTimeoutMs - elapsedMs);
+    const delayMs = Math.max(1, turnAssistantCompletionIdleTimeoutMs - elapsedMs);
     assistantCompletionIdleTimer = setTimeout(fireAssistantCompletionIdleRelease, delayMs);
     assistantCompletionIdleTimer.unref?.();
   }
@@ -128,7 +138,7 @@ export function createCodexAttemptTurnWatchController(params: {
       return;
     }
     const elapsedMs = Math.max(0, Date.now() - attemptLastProgressAt);
-    const timeoutMs = attemptIdleTimeoutOverrideMs ?? params.turnAttemptIdleTimeoutMs;
+    const timeoutMs = attemptIdleTimeoutOverrideMs ?? turnAttemptIdleTimeoutMs;
     const delayMs = Math.max(1, timeoutMs - elapsedMs);
     attemptIdleTimer = setTimeout(fireAttemptIdleTimeout, delayMs);
     attemptIdleTimer.unref?.();
@@ -145,7 +155,7 @@ export function createCodexAttemptTurnWatchController(params: {
       return;
     }
     const elapsedMs = Math.max(0, Date.now() - completionLastActivityAt);
-    const delayMs = Math.max(1, params.turnTerminalIdleTimeoutMs - elapsedMs);
+    const delayMs = Math.max(1, turnTerminalIdleTimeoutMs - elapsedMs);
     terminalIdleTimer = setTimeout(fireTerminalIdleTimeout, delayMs);
     terminalIdleTimer.unref?.();
   }
@@ -162,7 +172,7 @@ export function createCodexAttemptTurnWatchController(params: {
   ) {
     attemptIdleTimeoutOverrideMs =
       options?.attemptTimeoutMs !== undefined
-        ? Math.max(1, Math.floor(options.attemptTimeoutMs))
+        ? resolveWatchTimeoutMs(options.attemptTimeoutMs)
         : undefined;
     attemptLastProgressAt = completionLastActivityAt;
     attemptLastProgressReason = reason;
@@ -180,7 +190,7 @@ export function createCodexAttemptTurnWatchController(params: {
       return;
     }
     const idleMs = Math.max(0, Date.now() - assistantCompletionLastActivityAt);
-    if (idleMs < params.turnAssistantCompletionIdleTimeoutMs) {
+    if (idleMs < turnAssistantCompletionIdleTimeoutMs) {
       scheduleAssistantCompletionIdleWatch();
       return;
     }
@@ -192,7 +202,7 @@ export function createCodexAttemptTurnWatchController(params: {
       threadId: params.threadId,
       turnId,
       idleMs,
-      timeoutMs: params.turnAssistantCompletionIdleTimeoutMs,
+      timeoutMs: turnAssistantCompletionIdleTimeoutMs,
       ...assistantCompletionLastActivityDetails,
     });
     embeddedAgentLog.warn(
@@ -201,7 +211,7 @@ export function createCodexAttemptTurnWatchController(params: {
         threadId: params.threadId,
         turnId,
         idleMs,
-        timeoutMs: params.turnAssistantCompletionIdleTimeoutMs,
+        timeoutMs: turnAssistantCompletionIdleTimeoutMs,
         ...assistantCompletionLastActivityDetails,
       },
     );
@@ -209,7 +219,7 @@ export function createCodexAttemptTurnWatchController(params: {
       params.onInterruptTurn({
         threadId: params.threadId,
         turnId,
-        timeoutMs: params.interruptTimeoutMs,
+        timeoutMs: interruptTimeoutMs,
       });
     }
     params.onCompleted();
@@ -221,7 +231,7 @@ export function createCodexAttemptTurnWatchController(params: {
       return;
     }
     const idleMs = Math.max(0, Date.now() - attemptLastProgressAt);
-    const timeoutMs = attemptIdleTimeoutOverrideMs ?? params.turnAttemptIdleTimeoutMs;
+    const timeoutMs = attemptIdleTimeoutOverrideMs ?? turnAttemptIdleTimeoutMs;
     if (idleMs < timeoutMs) {
       scheduleAttemptIdleWatch();
       return;
@@ -264,7 +274,7 @@ export function createCodexAttemptTurnWatchController(params: {
     ) {
       return;
     }
-    const timeoutMs = completionIdleTimeoutOverrideMs ?? params.turnCompletionIdleTimeoutMs;
+    const timeoutMs = completionIdleTimeoutOverrideMs ?? turnCompletionIdleTimeoutMs;
     const idleMs = Math.max(0, Date.now() - completionLastActivityAt);
     if (idleMs < timeoutMs) {
       scheduleCompletionIdleWatch();
@@ -309,14 +319,14 @@ export function createCodexAttemptTurnWatchController(params: {
       return;
     }
     const idleMs = Math.max(0, Date.now() - completionLastActivityAt);
-    if (idleMs < params.turnTerminalIdleTimeoutMs) {
+    if (idleMs < turnTerminalIdleTimeoutMs) {
       scheduleTerminalIdleWatch();
       return;
     }
     const timeout = {
       kind: "terminal" as const,
       idleMs,
-      timeoutMs: params.turnTerminalIdleTimeoutMs,
+      timeoutMs: turnTerminalIdleTimeoutMs,
       lastActivityReason: completionLastActivityReason,
       details: completionLastActivityDetails,
     };
@@ -357,7 +367,7 @@ export function createCodexAttemptTurnWatchController(params: {
       completionIdleWatchArmed = true;
       completionIdleWatchPinnedByTerminalError = options?.pinnedByTerminalError === true;
       completionIdleTimeoutOverrideMs =
-        options?.timeoutMs !== undefined ? Math.max(1, Math.floor(options.timeoutMs)) : undefined;
+        options?.timeoutMs !== undefined ? resolveWatchTimeoutMs(options.timeoutMs) : undefined;
       scheduleCompletionIdleWatch();
     },
     disarmCompletionIdleWatch: () => {
@@ -418,7 +428,7 @@ export function createCodexAttemptTurnWatchController(params: {
       }
     },
     extendAttemptIdleWatch: (timeoutMs: number) => {
-      attemptIdleTimeoutOverrideMs = Math.max(1, Math.floor(timeoutMs));
+      attemptIdleTimeoutOverrideMs = resolveWatchTimeoutMs(timeoutMs);
       scheduleAttemptIdleWatch();
     },
     scheduleProgressWatches,

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
 import {
   CODEX_APP_SERVER_CONFIG_KEYS,
@@ -117,6 +118,40 @@ describe("Codex app-server config", () => {
       transport: "websocket",
       url: "ws://127.0.0.1:39175",
       headers: { "X-Test": "yes" },
+    });
+  });
+
+  it("clamps oversized app-server timer config", () => {
+    const runtime = resolveRuntimeForTest({
+      pluginConfig: {
+        appServer: {
+          requestTimeoutMs: Number.MAX_SAFE_INTEGER,
+          turnCompletionIdleTimeoutMs: Number.MAX_SAFE_INTEGER,
+          postToolRawAssistantCompletionIdleTimeoutMs: Number.MAX_SAFE_INTEGER,
+        },
+      },
+    });
+
+    expectFields(runtime, "runtime", {
+      requestTimeoutMs: MAX_TIMER_TIMEOUT_MS,
+      turnCompletionIdleTimeoutMs: MAX_TIMER_TIMEOUT_MS,
+      postToolRawAssistantCompletionIdleTimeoutMs: MAX_TIMER_TIMEOUT_MS,
+    });
+  });
+
+  it("falls back for non-positive app-server timer config", () => {
+    const runtime = resolveRuntimeForTest({
+      pluginConfig: {
+        appServer: {
+          requestTimeoutMs: 0,
+          turnCompletionIdleTimeoutMs: -1,
+        },
+      },
+    });
+
+    expectFields(runtime, "runtime", {
+      requestTimeoutMs: 60_000,
+      turnCompletionIdleTimeoutMs: 60_000,
     });
   });
 

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -5,6 +5,7 @@ import {
   resolveExecApprovalsFromFile,
   type ExecApprovalsFile,
 } from "openclaw/plugin-sdk/exec-approvals-runtime";
+import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { detectWindowsSpawnCommandInlineArgs } from "openclaw/plugin-sdk/windows-spawn";
@@ -1384,7 +1385,7 @@ export function isCodexFastServiceTier(value: unknown): boolean {
 }
 
 function normalizePositiveNumber(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+  return resolvePositiveTimerTimeoutMs(value, fallback);
 }
 
 function normalizeHeaders(value: unknown): Record<string, string> {

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2124,6 +2124,44 @@ describe("CodexAppServerEventProjector", () => {
     expect(context.toolCallId).toBe("cmd-observed");
   });
 
+  it("omits after_tool_call startedAt when native duration is out of range", async () => {
+    const afterToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: afterToolCall }]),
+    );
+    const projector = await createProjector(await createParams());
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-huge-duration",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "ok",
+          exitCode: 0,
+          durationMs: Number.MAX_SAFE_INTEGER,
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+    const event = requireRecord(
+      mockCallArg(afterToolCall, 0, 0, "after_tool_call event"),
+      "after_tool_call event",
+    );
+    expect(event.result).toEqual({
+      status: "completed",
+      exitCode: 0,
+      durationMs: Number.MAX_SAFE_INTEGER,
+    });
+    expect(event).not.toHaveProperty("durationMs");
+  });
+
   it("does not duplicate native items already covered by PostToolUse relay", async () => {
     const afterToolCall = vi.fn();
     initializeGlobalHookRunner(

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -23,6 +23,7 @@ import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runti
 import { generatedImageAssetFromBase64 } from "openclaw/plugin-sdk/image-generation";
 import type { AssistantMessage, Usage } from "openclaw/plugin-sdk/llm";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
+import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import {
   readCodexNotificationThreadId,
@@ -1200,8 +1201,7 @@ export class CodexAppServerEventProjector {
     this.afterToolCallObservedItemIds.add(item.id);
     const result = itemToolResult(item).result;
     const error = itemToolError(item, status, this.toolResultOutputTextByItem);
-    const startedAt =
-      typeof item.durationMs === "number" ? Date.now() - Math.max(0, item.durationMs) : undefined;
+    const startedAt = resolveStartedAtFromDurationMs(item.durationMs);
     const hookParams = {
       toolName: name,
       toolCallId: item.id,
@@ -1729,6 +1729,13 @@ function readNullableString(record: JsonObject, key: string): string | null | un
 function readNumber(record: JsonObject, key: string): number | undefined {
   const value = record[key];
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function resolveStartedAtFromDurationMs(durationMs: unknown): number | undefined {
+  if (typeof durationMs !== "number" || !Number.isFinite(durationMs)) {
+    return undefined;
+  }
+  return asDateTimestampMs(Date.now() - Math.max(0, durationMs));
 }
 
 function readNonNegativeInteger(record: JsonObject, key: string): number | undefined {

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -1,8 +1,10 @@
 import type { NativeHookRelayRegistrationHandle } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it } from "vitest";
 import {
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayDisabledConfig,
+  resolveCodexNativeHookRelayUnregisterGraceMs,
 } from "./native-hook-relay.js";
 
 describe("Codex native hook relay config", () => {
@@ -250,6 +252,12 @@ describe("Codex native hook relay config", () => {
       "hooks.PermissionRequest": [],
       "hooks.Stop": [],
     });
+  });
+
+  it("caps oversized native hook cleanup grace before scheduling", () => {
+    expect(resolveCodexNativeHookRelayUnregisterGraceMs(Number.MAX_SAFE_INTEGER)).toBe(
+      MAX_TIMER_TIMEOUT_MS,
+    );
   });
 });
 

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -5,6 +5,10 @@ import {
   type NativeHookRelayEvent,
   type NativeHookRelayRegistrationHandle,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  addTimerTimeoutGraceMs,
+  finiteSecondsToTimerSafeMilliseconds,
+} from "openclaw/plugin-sdk/number-runtime";
 import type { CodexAppServerRuntimeOptions } from "./config.js";
 import type { JsonObject, JsonValue } from "./protocol.js";
 
@@ -61,11 +65,11 @@ export function resolveCodexNativeHookRelayUnregisterGraceMs(
 ): number {
   const hookTimeoutMs =
     typeof hookTimeoutSec === "number" && Number.isFinite(hookTimeoutSec) && hookTimeoutSec > 0
-      ? Math.ceil(hookTimeoutSec) * 1000
+      ? (finiteSecondsToTimerSafeMilliseconds(Math.ceil(hookTimeoutSec)) ?? 0)
       : 0;
   return Math.max(
     CODEX_NATIVE_HOOK_RELAY_UNREGISTER_GRACE_MS,
-    hookTimeoutMs + CODEX_NATIVE_HOOK_RELAY_UNREGISTER_EXTRA_GRACE_MS,
+    addTimerTimeoutGraceMs(hookTimeoutMs, CODEX_NATIVE_HOOK_RELAY_UNREGISTER_EXTRA_GRACE_MS) ?? 0,
   );
 }
 

--- a/extensions/codex/src/conversation-turn-collector.test.ts
+++ b/extensions/codex/src/conversation-turn-collector.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { createCodexConversationTurnCollector } from "./conversation-turn-collector.js";
 
@@ -184,6 +185,26 @@ describe("codex conversation turn collector", () => {
       const assertion = expect(completion).rejects.toThrow("codex app-server bound turn timed out");
       await vi.advanceTimersByTimeAsync(100);
       await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps oversized turn wait timers", async () => {
+    vi.useFakeTimers();
+    try {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const collector = createCodexConversationTurnCollector("thread-1");
+      collector.setTurnId("turn-1");
+      const completion = collector.wait({ timeoutMs: MAX_TIMER_TIMEOUT_MS + 1 });
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      collector.handleNotification({
+        method: "turn/completed",
+        params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [] } },
+      });
+
+      await expect(completion).resolves.toEqual({ replyText: "" });
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/codex/src/conversation-turn-collector.ts
+++ b/extensions/codex/src/conversation-turn-collector.ts
@@ -1,3 +1,4 @@
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { asOptionalRecord as readRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   readCodexNotificationThreadId,
@@ -143,7 +144,7 @@ export function createCodexConversationTurnCollector(threadId: string) {
             reject(new Error("codex app-server bound turn timed out"));
             clearWaitState();
           },
-          Math.max(100, params.timeoutMs),
+          resolveTimerTimeoutMs(params.timeoutMs, 100, 100),
         );
         timeout.unref?.();
       });

--- a/extensions/diffs/src/tool.test.ts
+++ b/extensions/diffs/src/tool.test.ts
@@ -219,6 +219,29 @@ describe("diffs tool", () => {
     }
   });
 
+  it("caps artifact-only ttlSeconds that bypass schema validation", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-02-27T16:00:00Z");
+    vi.setSystemTime(now);
+    try {
+      const screenshotter = createPngScreenshotter();
+      const tool = createToolWithScreenshotter(store, screenshotter);
+
+      const result = await tool.execute?.("tool-2c-ttl-cap", {
+        before: "one\n",
+        after: "two\n",
+        mode: "file",
+        ttlSeconds: Number.MAX_SAFE_INTEGER,
+      });
+
+      expect(Date.parse(requireString(readDetails(result).expiresAt, "expiresAt"))).toBe(
+        now.getTime() + 21_600_000,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses default ttlSeconds when tool input omits ttlSeconds", async () => {
     vi.useFakeTimers();
     const now = new Date("2026-02-27T16:00:00Z");

--- a/extensions/diffs/src/tool.ts
+++ b/extensions/diffs/src/tool.ts
@@ -36,6 +36,7 @@ const MAX_PATCH_BYTES = 2 * 1024 * 1024;
 const MAX_TITLE_BYTES = 1_024;
 const MAX_PATH_BYTES = 2_048;
 const MAX_LANG_BYTES = 128;
+const MAX_DIFF_ARTIFACT_TTL_SECONDS = 21_600;
 
 const DiffsToolSchema = Type.Object(
   {
@@ -127,7 +128,7 @@ const DiffsToolSchema = Type.Object(
     ttlSeconds: optionalFiniteNumberSchema({
       description: "Artifact lifetime in seconds. Default: 1800. Maximum: 21600.",
       minimum: 1,
-      maximum: 21_600,
+      maximum: MAX_DIFF_ARTIFACT_TTL_SECONDS,
     }),
     baseUrl: Type.Optional(
       Type.String({
@@ -539,7 +540,7 @@ function normalizeTtlMs(ttlSeconds?: number): number | undefined {
   if (!Number.isFinite(ttlSeconds) || ttlSeconds === undefined) {
     return undefined;
   }
-  return Math.floor(ttlSeconds * 1000);
+  return Math.floor(Math.min(Math.max(ttlSeconds, 1), MAX_DIFF_ARTIFACT_TTL_SECONDS) * 1000);
 }
 
 class PluginToolInputError extends Error {

--- a/extensions/discord/src/internal/client.test.ts
+++ b/extensions/discord/src/internal/client.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { ApplicationCommandType, ComponentType, Routes } from "discord-api-types/v10";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Client, ComponentRegistry, type AnyListener } from "./client.js";
 import { BaseCommand } from "./commands.js";
@@ -101,6 +102,19 @@ describe("ComponentRegistry", () => {
     expect(registry.resolve("encoded:payload=two", { componentType: ComponentType.Button })).toBe(
       button,
     );
+  });
+
+  it("caps oversized one-off component wait timers", () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const registry = new ComponentRegistry<Button>();
+
+    void registry.waitForMessageComponent(
+      { id: "message-1", channelId: "channel-1" } as never,
+      Number.MAX_SAFE_INTEGER,
+    );
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
 });
 

--- a/extensions/discord/src/internal/client.ts
+++ b/extensions/discord/src/internal/client.ts
@@ -1,4 +1,5 @@
 import type { APIApplicationCommand, APIInteraction } from "discord-api-types/v10";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { DiscordCommandDeployer, type DeployCommandOptions } from "./command-deploy.js";
 import type { BaseCommand } from "./commands.js";
 import { BaseMessageInteractiveComponent, parseCustomId, type Modal } from "./components.js";
@@ -113,7 +114,7 @@ export class ComponentRegistry<
           this.oneOffComponents.delete(key);
           resolve({ success: false, message, reason: "timed out" });
         },
-        Math.max(0, timeoutMs),
+        resolveTimerTimeoutMs(timeoutMs, 0, 0),
       );
       timer.unref?.();
       this.oneOffComponents.set(key, {

--- a/extensions/discord/src/internal/gateway-identify-limiter.ts
+++ b/extensions/discord/src/internal/gateway-identify-limiter.ts
@@ -2,21 +2,36 @@ import { parseFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
 
 const IDENTIFY_WINDOW_MS = 5_000;
 
+type IdentifyRateState = {
+  lastObservedAt: number;
+  nextAllowedAt: number;
+};
+
 function normalizeMaxConcurrency(value: number | undefined): number {
   const parsed = parseFiniteNumber(value);
   return parsed === undefined ? 1 : Math.max(1, Math.floor(parsed));
 }
 
 class GatewayIdentifyLimiter {
-  private nextAllowedAtByKey = new Map<number, number>();
+  private stateByKey = new Map<number, IdentifyRateState>();
 
   async wait(params: { shardId?: number; maxConcurrency?: number }): Promise<void> {
     const maxConcurrency = normalizeMaxConcurrency(params.maxConcurrency);
     const rateKey = (params.shardId ?? 0) % maxConcurrency;
     const now = Date.now();
-    const nextAllowedAt = this.nextAllowedAtByKey.get(rateKey) ?? now;
+    const state = this.stateByKey.get(rateKey);
+    const clockMovedBackward = state !== undefined && now < state.lastObservedAt;
+    const nextAllowedAt =
+      state === undefined
+        ? now
+        : clockMovedBackward
+          ? now + IDENTIFY_WINDOW_MS
+          : state.nextAllowedAt;
     const waitMs = Math.max(0, nextAllowedAt - now);
-    this.nextAllowedAtByKey.set(rateKey, Math.max(now, nextAllowedAt) + IDENTIFY_WINDOW_MS);
+    this.stateByKey.set(rateKey, {
+      lastObservedAt: now,
+      nextAllowedAt: Math.max(now, nextAllowedAt) + IDENTIFY_WINDOW_MS,
+    });
     if (waitMs > 0) {
       await new Promise<void>((resolve) => {
         const timer = setTimeout(resolve, waitMs);
@@ -26,7 +41,7 @@ class GatewayIdentifyLimiter {
   }
 
   reset(): void {
-    this.nextAllowedAtByKey.clear();
+    this.stateByKey.clear();
   }
 }
 

--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -257,6 +257,50 @@ describe("GatewayPlugin", () => {
     expect(secondResolved).toBe(true);
   });
 
+  it("bounds identify waits after a backward clock jump", async () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      vi.setSystemTime(1_000_000_000_000);
+      await sharedGatewayIdentifyLimiter.wait({ shardId: 0, maxConcurrency: 1 });
+
+      vi.setSystemTime(0);
+      const second = sharedGatewayIdentifyLimiter.wait({ shardId: 0, maxConcurrency: 1 });
+
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5_000);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(second).resolves.toBeUndefined();
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  it("preserves queued identify spacing in the same bucket", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    await sharedGatewayIdentifyLimiter.wait({ shardId: 0, maxConcurrency: 1 });
+    let secondResolved = false;
+    let thirdResolved = false;
+
+    const second = sharedGatewayIdentifyLimiter.wait({ shardId: 0, maxConcurrency: 1 }).then(() => {
+      secondResolved = true;
+    });
+    const third = sharedGatewayIdentifyLimiter.wait({ shardId: 0, maxConcurrency: 1 }).then(() => {
+      thirdResolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await second;
+    expect(secondResolved).toBe(true);
+    expect(thirdResolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await third;
+    expect(thirdResolved).toBe(true);
+  });
+
   it("preserves MESSAGE_CREATE author payloads for inbound dispatch", async () => {
     const gateway = new GatewayPlugin({ autoInteractions: false });
     const dispatchGatewayEvent = vi.fn(async (eventValue: string, dataValue: unknown) => {});

--- a/extensions/discord/src/internal/rest-scheduler.test.ts
+++ b/extensions/discord/src/internal/rest-scheduler.test.ts
@@ -1,4 +1,4 @@
-import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
+import { MAX_DATE_TIMESTAMP_MS, MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { RateLimitError } from "./rest-errors.js";
 import { RestScheduler, type RestSchedulerOptions } from "./rest-scheduler.js";
@@ -16,6 +16,20 @@ function createOptions(overrides: Partial<RestSchedulerOptions> = {}): RestSched
     maxRateLimitRetries: 1,
     ...overrides,
   };
+}
+
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
 }
 
 describe("RestScheduler", () => {
@@ -132,4 +146,56 @@ describe("RestScheduler", () => {
       vi.useRealTimers();
     }
   });
+
+  it("caps oversized route rate-limit drain waits before scheduling", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const first = createDeferred<unknown>();
+      const executor = vi.fn(async () => await first.promise);
+      const scheduler = new RestScheduler(createOptions({ maxConcurrency: 1 }), executor);
+
+      const active = scheduler.enqueue({
+        method: "POST",
+        path: "/channels/c1/messages",
+        priority: "standard",
+      });
+      await vi.waitFor(() => expect(executor).toHaveBeenCalledTimes(1));
+      scheduler.recordResponse(
+        "POST /channels/c1/messages",
+        "/channels/c1/messages",
+        createJsonResponse(
+          { message: "Rate limited", retry_after: 0, global: false },
+          {
+            status: 429,
+            headers: {
+              "X-RateLimit-Bucket": "bucket-1",
+              "X-RateLimit-Remaining": "0",
+              "X-RateLimit-Reset-After": String((MAX_TIMER_TIMEOUT_MS + 1_000_000) / 1000),
+            },
+          },
+        ),
+        { message: "Rate limited", retry_after: 0, global: false },
+      );
+
+      const queued = scheduler.enqueue({
+        method: "POST",
+        path: "/channels/c1/messages",
+        priority: "standard",
+      });
+      first.resolve({ ok: true });
+      await expect(active).resolves.toEqual({ ok: true });
+
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      queued.catch(() => undefined);
+    } finally {
+      schedulerCleanup(timeoutSpy);
+      vi.useRealTimers();
+    }
+  });
 });
+
+function schedulerCleanup(timeoutSpy: ReturnType<typeof vi.spyOn>): void {
+  timeoutSpy.mockRestore();
+}

--- a/extensions/discord/src/internal/rest-scheduler.ts
+++ b/extensions/discord/src/internal/rest-scheduler.ts
@@ -1,4 +1,4 @@
-import { resolveIntegerOption } from "openclaw/plugin-sdk/number-runtime";
+import { resolveIntegerOption, resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { RateLimitError, readRetryAfter } from "./rest-errors.js";
 import {
   createBucketKey,
@@ -390,7 +390,7 @@ export class RestScheduler<TData> {
         this.drainTimer = undefined;
         this.drainQueues();
       },
-      Math.max(0, delayMs),
+      resolveTimerTimeoutMs(delayMs, 0, 0),
     );
     this.drainTimer.unref?.();
   }

--- a/extensions/discord/src/internal/rest.test.ts
+++ b/extensions/discord/src/internal/rest.test.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server } from "node:http";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { fetch as undiciFetch } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { serializeRequestBody } from "./rest-body.js";
@@ -96,6 +97,21 @@ describe("RequestClient", () => {
 
     await expect(client.get("/guilds/g1/roles")).resolves.toEqual({ ok: true });
     expect(client.getSchedulerMetrics().maxConcurrentWorkers).toBe(4);
+  });
+
+  it("caps oversized REST client request timeouts before scheduling aborts", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const fetchSpy = vi.fn(async () => createJsonResponse({ ok: true }));
+    const client = new RequestClient("test-token", {
+      fetch: fetchSpy,
+      queueRequests: false,
+      timeout: Number.MAX_SAFE_INTEGER,
+    });
+
+    await expect(client.get("/guilds/g1/roles")).resolves.toEqual({ ok: true });
+
+    expect(client.options.timeout).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
 
   it("uses the default background stale timeout for non-finite lane overrides", async () => {

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -1,6 +1,10 @@
 import { randomBytes } from "node:crypto";
 import { inspect } from "node:util";
-import { parseFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
+import {
+  clampTimerTimeoutMs,
+  parseFiniteNumber,
+  resolveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
 import { serializeRequestBody } from "./rest-body.js";
 import {
   DiscordError,
@@ -310,7 +314,8 @@ function normalizeRequestClientOptions(
   return {
     ...merged,
     apiVersion: normalizeIntegerOption(merged.apiVersion, defaultOptions.apiVersion, { min: 1 }),
-    timeout: normalizeIntegerOption(merged.timeout, defaultOptions.timeout, { min: 1 }),
+    timeout:
+      clampTimerTimeoutMs(merged.timeout, 1) ?? resolveTimerTimeoutMs(defaultOptions.timeout, 1),
     maxQueueSize: normalizeIntegerOption(merged.maxQueueSize, defaultOptions.maxQueueSize, {
       min: 1,
     }),

--- a/extensions/discord/src/monitor/provider.acp.ts
+++ b/extensions/discord/src/monitor/provider.acp.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { raceWithTimeout } from "./timeouts.js";
 
@@ -36,6 +37,23 @@ function classifyAcpStatusProbeError(params: {
     : { status: "uncertain", reason: "status-error" };
 }
 
+function resolveRunningActivityAgeMs(params: {
+  storedState?: "idle" | "running" | "error";
+  lastActivityAt?: number;
+}): number {
+  if (params.storedState !== "running") {
+    return 0;
+  }
+  const nowMs = asDateTimestampMs(Date.now());
+  if (nowMs === undefined) {
+    return 0;
+  }
+  const activityAtMs = asDateTimestampMs(params.lastActivityAt);
+  const boundedActivityAtMs =
+    activityAtMs === undefined ? 0 : Math.max(0, Math.floor(activityAtMs));
+  return Math.max(0, nowMs - boundedActivityAtMs);
+}
+
 export async function probeDiscordAcpBindingHealth(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -63,10 +81,7 @@ export async function probeDiscordAcpBindingHealth(params: {
   if (result.kind === "timeout") {
     statusProbeAbortController.abort();
   }
-  const runningForMs =
-    params.storedState === "running" && Number.isFinite(params.lastActivityAt)
-      ? Date.now() - Math.max(0, Math.floor(params.lastActivityAt ?? 0))
-      : 0;
+  const runningForMs = resolveRunningActivityAgeMs(params);
   const isStaleRunning =
     params.storedState === "running" && runningForMs >= DISCORD_ACP_STALE_RUNNING_ACTIVITY_MS;
 

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -337,6 +337,14 @@ describe("runDiscordGatewayLifecycle", () => {
     emitter.emit(DISCORD_GATEWAY_TRANSPORT_ACTIVITY_EVENT, { at: 100_000 });
     emitter.emit(DISCORD_GATEWAY_TRANSPORT_ACTIVITY_EVENT, { at: 101_000 });
     emitter.emit(DISCORD_GATEWAY_TRANSPORT_ACTIVITY_EVENT, { at: 131_000 });
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(200_000);
+    try {
+      emitter.emit(DISCORD_GATEWAY_TRANSPORT_ACTIVITY_EVENT, {
+        at: Number.MAX_SAFE_INTEGER,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
 
     const transportPatches = statusSink.mock.calls
       .slice(baselinePatchCount)
@@ -345,6 +353,7 @@ describe("runDiscordGatewayLifecycle", () => {
     expect(transportPatches).toEqual([
       { lastTransportActivityAt: 100_000 },
       { lastTransportActivityAt: 131_000 },
+      { lastTransportActivityAt: 200_000 },
     ]);
     expect(
       transportPatches.every(

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -2,7 +2,7 @@ import {
   createConnectedChannelStatusPatch,
   createTransportActivityStatusPatch,
 } from "openclaw/plugin-sdk/gateway-runtime";
-import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import { asDateTimestampMs, parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
@@ -184,7 +184,8 @@ function parseGatewayCloseCode(message: string): number | undefined {
 
 function resolveTransportActivityAt(event: unknown): number {
   const at = (event as { at?: unknown } | undefined)?.at;
-  return typeof at === "number" && Number.isFinite(at) && at >= 0 ? at : Date.now();
+  const timestampMs = asDateTimestampMs(at);
+  return timestampMs !== undefined && timestampMs >= 0 ? timestampMs : Date.now();
 }
 
 function createGatewayStatusObserver(params: {

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -713,6 +713,45 @@ describe("monitorDiscordProvider", () => {
     }
   });
 
+  it("treats out-of-range running ACP activity timestamps as stale on probe timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(10 * 60 * 1000);
+      getAcpSessionStatusMock.mockImplementation(
+        ({ signal }: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+          }),
+      );
+
+      await monitorDiscordProvider({
+        config: baseConfig(),
+        runtime: baseRuntime(),
+      });
+
+      const probePromise = getHealthProbe()({
+        cfg: baseConfig(),
+        accountId: "default",
+        sessionKey: "agent:codex:acp:timeout-invalid-activity",
+        binding: {} as never,
+        session: {
+          acp: {
+            state: "running",
+            lastActivityAt: Number.MAX_SAFE_INTEGER,
+          },
+        } as never,
+      });
+
+      await vi.advanceTimersByTimeAsync(8_100);
+      await expect(probePromise).resolves.toEqual({
+        status: "stale",
+        reason: "status-timeout-running-stale",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("falls back to legacy missing-session message classification", async () => {
     getAcpSessionStatusMock.mockRejectedValue(new Error("ACP session metadata missing"));
 

--- a/extensions/feishu/src/async.test.ts
+++ b/extensions/feishu/src/async.test.ts
@@ -49,4 +49,19 @@ describe("waitForAbortableDelay", () => {
 
     await expect(delay).resolves.toBe(true);
   });
+
+  it("normalizes oversized delays before arming the timer", async () => {
+    const timeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((callback: () => void) => {
+        queueMicrotask(callback);
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      });
+    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+
+    const delay = waitForAbortableDelay(Number.MAX_SAFE_INTEGER);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    await expect(delay).resolves.toBe(true);
+  });
 });

--- a/extensions/feishu/src/async.ts
+++ b/extensions/feishu/src/async.ts
@@ -101,7 +101,7 @@ export function waitForAbortableDelay(
       return;
     }
 
-    timer = setTimeout(() => finish(true), delayMs);
+    timer = setTimeout(() => finish(true), resolveTimerTimeoutMs(delayMs, 1));
     timer.unref?.();
   });
 }

--- a/extensions/feishu/src/sequential-queue.test.ts
+++ b/extensions/feishu/src/sequential-queue.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSequentialQueue } from "./sequential-queue.js";
 
@@ -130,6 +131,25 @@ describe("createSequentialQueue", () => {
     // Drain the leaked stuck task so it doesn't trip the unhandled-rejection guard.
     stuckGate.resolve();
     await stuck;
+  });
+
+  it("clamps oversized task timeouts before scheduling", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const enqueue = createSequentialQueue({
+      taskTimeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+    const gate = createDeferred();
+
+    const first = enqueue("feishu:default:chat-large-timeout", async () => {
+      await gate.promise;
+    });
+
+    await Promise.resolve();
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+
+    gate.resolve();
+    await first;
   });
 
   it("disables the timeout cap when taskTimeoutMs is 0 (legacy behavior)", async () => {

--- a/extensions/feishu/src/sequential-queue.ts
+++ b/extensions/feishu/src/sequential-queue.ts
@@ -1,3 +1,5 @@
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+
 /**
  * Per-key serial task queue for Feishu inbound message handling.
  *
@@ -65,16 +67,17 @@ async function boundedRun(
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return task();
   }
+  const resolvedTimeoutMs = resolveTimerTimeoutMs(timeoutMs, DEFAULT_TASK_TIMEOUT_MS);
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<void>((resolve) => {
     timeoutHandle = setTimeout(() => {
       try {
-        onTaskTimeout?.(key, timeoutMs);
+        onTaskTimeout?.(key, resolvedTimeoutMs);
       } catch {
         // Swallow logging errors so they cannot poison the queue chain.
       }
       resolve();
-    }, timeoutMs);
+    }, resolvedTimeoutMs);
   });
   try {
     await Promise.race([task(), timeoutPromise]);

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -5,7 +5,7 @@ import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
 } from "openclaw/plugin-sdk/agent-runtime";
-import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
+import { MAX_DATE_TIMESTAMP_MS, MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import type {
   OpenClawConfig,
   OpenClawPluginApi,
@@ -458,6 +458,55 @@ describe("github-copilot plugin", () => {
     }
     expect(showCode).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds oversized GitHub device polling intervals before waiting", async () => {
+    vi.useFakeTimers();
+    try {
+      const release = vi.fn(async () => {});
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      let accessTokenPolls = 0;
+      setGitHubCopilotDeviceFlowFetchGuardForTesting(async (params) => {
+        if (params.url === "https://github.com/login/device/code") {
+          return {
+            response: new Response(
+              '{"device_code":"device-code-stub","user_code":"ABCD-1234","verification_uri":"https://github.com/login/device","expires_in":3000010,"interval":3000000}',
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+            finalUrl: params.url,
+            release,
+          };
+        }
+        accessTokenPolls += 1;
+        return {
+          response: new Response(
+            JSON.stringify(
+              accessTokenPolls === 1
+                ? { error: "authorization_pending" }
+                : { access_token: "refreshed-token", token_type: "bearer" },
+            ),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+          finalUrl: params.url,
+          release,
+        };
+      });
+
+      const flow = runGitHubCopilotDeviceFlow({ showCode: vi.fn(async () => {}) });
+      await vi.waitFor(() =>
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS),
+      );
+      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+      expect(accessTokenPolls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(3_000_000_000 - MAX_TIMER_TIMEOUT_MS);
+      await expect(flow).resolves.toEqual({
+        status: "authorized",
+        accessToken: "refreshed-token",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("stores GitHub Copilot token from non-interactive onboarding", async () => {

--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -5,6 +5,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
   nonNegativeSecondsToSafeMilliseconds,
   positiveSecondsToSafeMilliseconds,
+  resolveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import {
   applyAuthProfileConfig,
@@ -189,11 +190,11 @@ async function pollForAccessToken(params: {
 
     const err = "error" in json ? json.error : "unknown";
     if (err === "authorization_pending") {
-      await new Promise((r) => setTimeout(r, params.intervalMs));
+      await sleepGitHubDevicePollDelay(params.intervalMs, params.expiresAt);
       continue;
     }
     if (err === "slow_down") {
-      await new Promise((r) => setTimeout(r, params.intervalMs + 2000));
+      await sleepGitHubDevicePollDelay(params.intervalMs + 2000, params.expiresAt);
       continue;
     }
     if (err === "expired_token") {
@@ -212,6 +213,16 @@ async function pollForAccessToken(params: {
     GITHUB_DEVICE_EXPIRED,
     "GitHub device code expired; run login again",
   );
+}
+
+async function sleepGitHubDevicePollDelay(delayMs: number, expiresAt: number): Promise<void> {
+  const requestedDelayMs = Math.max(1, Math.floor(delayMs));
+  const targetAt = Math.min(Date.now() + requestedDelayMs, expiresAt);
+  while (Date.now() < targetAt) {
+    const remainingMs = Math.max(1, targetAt - Date.now());
+    const safeDelayMs = resolveTimerTimeoutMs(remainingMs, 1);
+    await new Promise((resolve) => setTimeout(resolve, Math.min(safeDelayMs, remainingMs)));
+  }
 }
 
 function normalizeGitHubDeviceVerificationUrl(raw: string): string {

--- a/extensions/google-meet/src/config.test.ts
+++ b/extensions/google-meet/src/config.test.ts
@@ -3,6 +3,28 @@ import { describe, expect, it } from "vitest";
 import { resolveGoogleMeetConfig, resolveGoogleMeetGatewayOperationTimeoutMs } from "./config.js";
 
 describe("google meet gateway operation timeout", () => {
+  it("caps timer config fields before runtime polling uses them", () => {
+    const config = resolveGoogleMeetConfig({
+      chrome: {
+        joinTimeoutMs: Number.MAX_VALUE,
+        waitForInCallMs: Number.MAX_VALUE,
+        bargeInCooldownMs: Number.MAX_VALUE,
+      },
+      voiceCall: {
+        requestTimeoutMs: Number.MAX_VALUE,
+        dtmfDelayMs: Number.MAX_VALUE,
+        postDtmfSpeechDelayMs: Number.MAX_VALUE,
+      },
+    });
+
+    expect(config.chrome.joinTimeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(config.chrome.waitForInCallMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(config.chrome.bargeInCooldownMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(config.voiceCall.requestTimeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(config.voiceCall.dtmfDelayMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(config.voiceCall.postDtmfSpeechDelayMs).toBe(MAX_TIMER_TIMEOUT_MS);
+  });
+
   it("adds operation grace to normal transport timeouts", () => {
     expect(resolveGoogleMeetGatewayOperationTimeoutMs(resolveGoogleMeetConfig({}))).toBe(60_000);
     expect(

--- a/extensions/google-meet/src/config.ts
+++ b/extensions/google-meet/src/config.ts
@@ -1,4 +1,7 @@
-import { addTimerTimeoutGraceMs } from "openclaw/plugin-sdk/number-runtime";
+import {
+  addTimerTimeoutGraceMs,
+  resolvePositiveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   resolveRealtimeVoiceAgentConsultToolPolicy,
@@ -280,6 +283,10 @@ function resolveNumber(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
+function resolveTimerConfigMs(value: unknown, fallback: number): number {
+  return resolvePositiveTimerTimeoutMs(resolveNumber(value, fallback), fallback);
+}
+
 function resolveOptionalNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
@@ -481,11 +488,11 @@ export function resolveGoogleMeetConfigWithEnv(
         DEFAULT_GOOGLE_MEET_CONFIG.chrome.reuseExistingTab,
       ),
       autoJoin: resolveBoolean(chrome.autoJoin, DEFAULT_GOOGLE_MEET_CONFIG.chrome.autoJoin),
-      joinTimeoutMs: resolveNumber(
+      joinTimeoutMs: resolveTimerConfigMs(
         chrome.joinTimeoutMs,
         DEFAULT_GOOGLE_MEET_CONFIG.chrome.joinTimeoutMs,
       ),
-      waitForInCallMs: resolveNumber(
+      waitForInCallMs: resolveTimerConfigMs(
         chrome.waitForInCallMs,
         DEFAULT_GOOGLE_MEET_CONFIG.chrome.waitForInCallMs,
       ),
@@ -502,7 +509,7 @@ export function resolveGoogleMeetConfigWithEnv(
         chrome.bargeInPeakThreshold,
         DEFAULT_GOOGLE_MEET_CONFIG.chrome.bargeInPeakThreshold,
       ),
-      bargeInCooldownMs: resolveNumber(
+      bargeInCooldownMs: resolveTimerConfigMs(
         chrome.bargeInCooldownMs,
         DEFAULT_GOOGLE_MEET_CONFIG.chrome.bargeInCooldownMs,
       ),
@@ -521,15 +528,15 @@ export function resolveGoogleMeetConfigWithEnv(
       enabled: resolveBoolean(voiceCall.enabled, DEFAULT_GOOGLE_MEET_CONFIG.voiceCall.enabled),
       gatewayUrl: normalizeOptionalString(voiceCall.gatewayUrl),
       token: normalizeOptionalString(voiceCall.token),
-      requestTimeoutMs: resolveNumber(
+      requestTimeoutMs: resolveTimerConfigMs(
         voiceCall.requestTimeoutMs,
         DEFAULT_GOOGLE_MEET_CONFIG.voiceCall.requestTimeoutMs,
       ),
-      dtmfDelayMs: resolveNumber(
+      dtmfDelayMs: resolveTimerConfigMs(
         voiceCall.dtmfDelayMs,
         DEFAULT_GOOGLE_MEET_CONFIG.voiceCall.dtmfDelayMs,
       ),
-      postDtmfSpeechDelayMs: resolveNumber(
+      postDtmfSpeechDelayMs: resolveTimerConfigMs(
         voiceCall.postDtmfSpeechDelayMs,
         DEFAULT_GOOGLE_MEET_CONFIG.voiceCall.postDtmfSpeechDelayMs,
       ),

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -284,7 +284,7 @@ export async function runGeminiEmbeddingBatches(
       maxRequests: GEMINI_BATCH_MAX_REQUESTS,
       debugLabel: "memory embeddings: gemini batch submit",
     }),
-    runGroup: async ({ group, groupIndex, groups, byCustomId }) => {
+    runGroup: async ({ group, groupIndex, groups, byCustomId, pollIntervalMs, timeoutMs }) => {
       const batchInfo = await submitGeminiBatch({
         gemini: params.gemini,
         requests: group,
@@ -326,8 +326,8 @@ export async function runGeminiEmbeddingBatches(
               gemini: params.gemini,
               batchName,
               wait: params.wait,
-              pollIntervalMs: params.pollIntervalMs,
-              timeoutMs: params.timeoutMs,
+              pollIntervalMs,
+              timeoutMs,
               debug: params.debug,
               initial: batchInfo,
             });

--- a/extensions/mattermost/src/mattermost/probe.test.ts
+++ b/extensions/mattermost/src/mattermost/probe.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { probeMattermost } from "./probe.js";
 
@@ -85,6 +86,24 @@ describe("probeMattermost", () => {
 
     const fetchCall = requireFirstFetchCall();
     expect(fetchCall?.policy).toStrictEqual({ allowPrivateNetwork: true });
+  });
+
+  it("clamps oversized probe timeouts before scheduling", async () => {
+    mockFetchGuard.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ id: "bot-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release: mockRelease,
+    });
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      await probeMattermost("https://mm.example.com", "bot-token", Number.MAX_SAFE_INTEGER);
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   it("returns API error details from JSON response", async () => {

--- a/extensions/mattermost/src/mattermost/probe.ts
+++ b/extensions/mattermost/src/mattermost/probe.ts
@@ -1,4 +1,5 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromPrivateNetworkOptIn,
@@ -24,10 +25,11 @@ export async function probeMattermost(
   }
   const url = `${normalized}/api/v4/users/me`;
   const start = Date.now();
-  const controller = timeoutMs > 0 ? new AbortController() : undefined;
+  const resolvedTimeoutMs = timeoutMs > 0 ? resolveTimerTimeoutMs(timeoutMs, 2500) : 0;
+  const controller = resolvedTimeoutMs > 0 ? new AbortController() : undefined;
   let timer: NodeJS.Timeout | null = null;
   if (controller) {
-    timer = setTimeout(() => controller.abort(), timeoutMs);
+    timer = setTimeout(() => controller.abort(), resolvedTimeoutMs);
   }
   try {
     const { response: res, release } = await fetchWithSsrFGuard({

--- a/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
@@ -1,0 +1,95 @@
+import type { DatabaseSync } from "node:sqlite";
+import type {
+  OpenClawConfig,
+  ResolvedMemorySearchConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
+
+type MemoryIndexEntry = {
+  path: string;
+  absPath: string;
+  mtimeMs: number;
+  size: number;
+  hash: string;
+  content?: string;
+};
+
+class IntervalSyncHarness extends MemoryManagerSyncOps {
+  protected readonly cfg = {} as OpenClawConfig;
+  protected readonly agentId = "main";
+  protected readonly workspaceDir = "/tmp/openclaw-memory-interval-test";
+  protected readonly settings: ResolvedMemorySearchConfig;
+  protected readonly batch = {
+    enabled: false,
+    wait: false,
+    concurrency: 1,
+    pollIntervalMs: 0,
+    timeoutMs: 0,
+  };
+  protected readonly vector = { enabled: false, available: false };
+  protected readonly cache = { enabled: false };
+  protected providerUnavailableReason?: string;
+  protected providerLifecycle = { mode: "active" as const, providerId: "test" };
+  protected db = {} as DatabaseSync;
+
+  constructor(intervalMinutes: number) {
+    super();
+    this.settings = {
+      sync: { intervalMinutes },
+    } as ResolvedMemorySearchConfig;
+  }
+
+  arm(): void {
+    this.ensureIntervalSync();
+  }
+
+  stop(): void {
+    if (this.intervalTimer) {
+      clearInterval(this.intervalTimer);
+      this.intervalTimer = null;
+    }
+  }
+
+  protected computeProviderKey(): string {
+    return "test";
+  }
+
+  protected async sync(): Promise<void> {}
+
+  protected async withTimeout<T>(promise: Promise<T>): Promise<T> {
+    return await promise;
+  }
+
+  protected getIndexConcurrency(): number {
+    return 1;
+  }
+
+  protected pruneEmbeddingCacheIfNeeded(): void {}
+
+  protected resetProviderInitializationForRetry(): void {}
+
+  protected async indexFile(
+    _entry: MemoryIndexEntry,
+    _options: { source: MemorySource; content?: string },
+  ): Promise<void> {}
+}
+
+describe("MemoryManagerSyncOps interval sync", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clamps oversized interval sync timers", () => {
+    vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const harness = new IntervalSyncHarness(Number.MAX_SAFE_INTEGER);
+
+    harness.arm();
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    harness.stop();
+  });
+});

--- a/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
@@ -35,10 +35,16 @@ class IntervalSyncHarness extends MemoryManagerSyncOps {
   protected providerLifecycle = { mode: "active" as const, providerId: "test" };
   protected db = {} as DatabaseSync;
 
-  constructor(intervalMinutes: number) {
+  constructor(params: { intervalMinutes?: number; batchTimeoutMinutes?: number }) {
     super();
     this.settings = {
-      sync: { intervalMinutes },
+      sync: { intervalMinutes: params.intervalMinutes ?? 0 },
+      remote: {
+        batch: {
+          enabled: true,
+          timeoutMinutes: params.batchTimeoutMinutes,
+        },
+      },
     } as ResolvedMemorySearchConfig;
   }
 
@@ -51,6 +57,10 @@ class IntervalSyncHarness extends MemoryManagerSyncOps {
       clearInterval(this.intervalTimer);
       this.intervalTimer = null;
     }
+  }
+
+  batchConfig(): ReturnType<MemoryManagerSyncOps["resolveBatchConfig"]> {
+    return this.resolveBatchConfig();
   }
 
   protected computeProviderKey(): string {
@@ -85,11 +95,19 @@ describe("MemoryManagerSyncOps interval sync", () => {
   it("clamps oversized interval sync timers", () => {
     vi.useFakeTimers();
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
-    const harness = new IntervalSyncHarness(Number.MAX_SAFE_INTEGER);
+    const harness = new IntervalSyncHarness({ intervalMinutes: Number.MAX_SAFE_INTEGER });
 
     harness.arm();
 
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     harness.stop();
+  });
+
+  it("clamps oversized batch timeout minutes", () => {
+    const harness = new IntervalSyncHarness({
+      batchTimeoutMinutes: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(harness.batchConfig().timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 });

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1568,7 +1568,7 @@ export abstract class MemoryManagerSyncOps {
       wait: batch?.wait ?? true,
       concurrency: Math.max(1, batch?.concurrency ?? 2),
       pollIntervalMs: batch?.pollIntervalMs ?? 2000,
-      timeoutMs: (batch?.timeoutMinutes ?? 60) * 60 * 1000,
+      timeoutMs: resolveTimerTimeoutMs((batch?.timeoutMinutes ?? 60) * 60 * 1000, 60 * 60_000),
     };
   }
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -33,6 +33,7 @@ import {
   type MemorySource,
   type MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createEmbeddingProvider,
@@ -1061,7 +1062,10 @@ export abstract class MemoryManagerSyncOps {
     if (!minutes || minutes <= 0 || this.intervalTimer) {
       return;
     }
-    const ms = minutes * 60 * 1000;
+    const ms = resolveTimerTimeoutMs(minutes * 60 * 1000, 0, 0);
+    if (ms <= 0) {
+      return;
+    }
     this.intervalTimer = setInterval(() => {
       runDetachedMemorySync(() => this.sync({ reason: "interval" }), "interval");
     }, ms);

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -19,6 +19,7 @@ import {
   registerMemoryCapability,
   type MemoryPluginCapability,
 } from "openclaw/plugin-sdk/memory-host-core";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, test, expect, vi } from "vitest";
 import memoryPlugin, {
   detectCategory,
@@ -27,6 +28,7 @@ import memoryPlugin, {
   normalizeEmbeddingVector,
   normalizeRecallQuery,
   shouldCapture,
+  testing,
 } from "./index.js";
 import { createLanceDbRuntimeLoader } from "./lancedb-runtime.js";
 import { installTmpDirHarness } from "./test-helpers.js";
@@ -1061,6 +1063,40 @@ describe("memory plugin e2e", () => {
           await vi.advanceTimersByTimeAsync(15_000);
         },
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("clamps oversized auto-recall timeout timers", async () => {
+    vi.useFakeTimers();
+    try {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      await expect(
+        testing.runWithTimeout({
+          timeoutMs: Number.MAX_SAFE_INTEGER,
+          task: async () => "ok",
+        }),
+      ).resolves.toEqual({ status: "ok", value: "ok" });
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("falls back for invalid auto-recall timeout timers", async () => {
+    vi.useFakeTimers();
+    try {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      await expect(
+        testing.runWithTimeout({
+          timeoutMs: Number.NaN,
+          task: async () => "ok",
+        }),
+      ).resolves.toEqual({ status: "ok", value: "ok" });
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -15,7 +15,10 @@ import {
 } from "openclaw/plugin-sdk/channel-actions";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MemoryEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import {
+  parseStrictPositiveInteger,
+  resolveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
 import { readFiniteNumberParam, readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
@@ -451,7 +454,7 @@ async function runWithTimeout<T>(params: {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const TIMEOUT = Symbol("timeout");
   const timeoutPromise = new Promise<typeof TIMEOUT>((resolve) => {
-    timeout = setTimeout(() => resolve(TIMEOUT), params.timeoutMs);
+    timeout = setTimeout(() => resolve(TIMEOUT), resolveTimerTimeoutMs(params.timeoutMs, 1));
     timeout.unref?.();
   });
   const taskPromise = params.task();
@@ -469,6 +472,10 @@ async function runWithTimeout<T>(params: {
     }
   }
 }
+
+export const testing = {
+  runWithTimeout,
+} as const;
 
 function createEmbeddings(api: OpenClawPluginApi, cfg: MemoryConfig): Embeddings {
   const { provider, model, dimensions, apiKey, baseUrl } = cfg.embedding;

--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -1,7 +1,10 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loginMiniMaxPortalOAuth, normalizeOAuthExpires } from "./oauth.js";
 
 afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -53,5 +56,153 @@ describe("loginMiniMaxPortalOAuth", () => {
       }),
     ).rejects.toThrow("invalid expired_in");
     expect(note).not.toHaveBeenCalled();
+  });
+
+  it("caps oversized authorization poll intervals before scheduling", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    let callCount = 0;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      callCount += 1;
+      const body =
+        init?.body instanceof URLSearchParams
+          ? init.body
+          : new URLSearchParams(typeof init?.body === "string" ? init.body : "");
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            user_code: "CODE",
+            verification_uri: "https://example.com/device",
+            expired_in: Date.now() + MAX_TIMER_TIMEOUT_MS + 10_000,
+            interval: Number.MAX_SAFE_INTEGER,
+            state: body.get("state"),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify(
+          callCount === 2
+            ? { status: "pending" }
+            : {
+                status: "success",
+                access_token: "access",
+                refresh_token: "refresh",
+                expired_in: 3600,
+              },
+        ),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = loginMiniMaxPortalOAuth({
+      openUrl: vi.fn(async () => undefined),
+      note: vi.fn(async () => undefined),
+      progress: { update: vi.fn(), stop: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    });
+
+    await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+    await expect(result).resolves.toMatchObject({ access: "access", refresh: "refresh" });
+  });
+
+  it("does not sleep past the authorization expiry deadline", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    let callCount = 0;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      callCount += 1;
+      const body =
+        init?.body instanceof URLSearchParams
+          ? init.body
+          : new URLSearchParams(typeof init?.body === "string" ? init.body : "");
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            user_code: "CODE",
+            verification_uri: "https://example.com/device",
+            expired_in: Date.now() + 10_000,
+            interval: Number.MAX_SAFE_INTEGER,
+            state: body.get("state"),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ status: "pending" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = loginMiniMaxPortalOAuth({
+      openUrl: vi.fn(async () => undefined),
+      note: vi.fn(async () => undefined),
+      progress: { update: vi.fn(), stop: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10_000);
+    });
+
+    const rejection = expect(result).rejects.toThrow("timed out");
+    await vi.advanceTimersByTimeAsync(10_000);
+    await rejection;
+  });
+
+  it("keeps the default poll delay for zero authorization intervals", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    let callCount = 0;
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      callCount += 1;
+      const body =
+        init?.body instanceof URLSearchParams
+          ? init.body
+          : new URLSearchParams(typeof init?.body === "string" ? init.body : "");
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            user_code: "CODE",
+            verification_uri: "https://example.com/device",
+            expired_in: Date.now() + 10_000,
+            interval: 0,
+            state: body.get("state"),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify(
+          callCount === 2
+            ? { status: "pending" }
+            : {
+                status: "success",
+                access_token: "access",
+                refresh_token: "refresh",
+                expired_in: 3600,
+              },
+        ),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = loginMiniMaxPortalOAuth({
+      openUrl: vi.fn(async () => undefined),
+      note: vi.fn(async () => undefined),
+      progress: { update: vi.fn(), stop: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2_000);
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(result).resolves.toMatchObject({ access: "access", refresh: "refresh" });
   });
 });

--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -3,6 +3,7 @@ import {
   MAX_DATE_TIMESTAMP_MS,
   asSafeIntegerInRange,
   resolveExpiresAtMsFromDurationOrEpoch,
+  resolvePositiveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
@@ -259,7 +260,7 @@ export async function loginMiniMaxPortalOAuth(params: {
     // Fall back to manual copy/paste if browser open fails.
   }
 
-  let pollIntervalMs = oauth.interval ? oauth.interval : 2000;
+  let pollIntervalMs = resolvePositiveTimerTimeoutMs(oauth.interval, 2000);
   // The authorization endpoint returns an absolute millisecond deadline.
   const expireTimeMs = oauth.expired_in;
 
@@ -279,7 +280,11 @@ export async function loginMiniMaxPortalOAuth(params: {
       throw new Error(result.message);
     }
 
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    const remainingMs = Math.max(0, expireTimeMs - Date.now());
+    if (remainingMs <= 0) {
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, Math.min(pollIntervalMs, remainingMs)));
     pollIntervalMs = Math.max(pollIntervalMs, 2000);
   }
 

--- a/extensions/nostr/src/nostr-bus.integration.test.ts
+++ b/extensions/nostr/src/nostr-bus.integration.test.ts
@@ -167,6 +167,19 @@ describe("SeenTracker", () => {
 
       tracker.stop();
     });
+
+    it("keeps non-positive capacities usable", () => {
+      const tracker = createTracker({ maxEntries: 0 });
+
+      tracker.add("id1");
+      tracker.add("id2");
+
+      expect(tracker.size()).toBe(1);
+      expect(tracker.peek("id1")).toBe(false);
+      expect(tracker.peek("id2")).toBe(true);
+
+      tracker.stop();
+    });
   });
 
   describe("TTL expiration", () => {

--- a/extensions/nostr/src/seen-tracker.ts
+++ b/extensions/nostr/src/seen-tracker.ts
@@ -3,6 +3,8 @@
  * Prevents unbounded memory growth under high load or abuse.
  */
 
+import { resolveIntegerOption } from "openclaw/plugin-sdk/number-runtime";
+
 interface SeenTrackerOptions {
   /** Maximum number of entries to track (default: 100,000) */
   maxEntries?: number;
@@ -42,7 +44,7 @@ interface Entry {
  * Create a new seen tracker with LRU eviction and TTL expiration.
  */
 export function createSeenTracker(options?: SeenTrackerOptions): SeenTracker {
-  const maxEntries = options?.maxEntries ?? 100_000;
+  const maxEntries = resolveIntegerOption(options?.maxEntries, 100_000, { min: 1 });
   const ttlMs = options?.ttlMs ?? 60 * 60 * 1000; // 1 hour
   const pruneIntervalMs = options?.pruneIntervalMs ?? 10 * 60 * 1000; // 10 minutes
 

--- a/extensions/openai/embedding-batch.ts
+++ b/extensions/openai/embedding-batch.ts
@@ -211,7 +211,7 @@ export async function runOpenAiEmbeddingBatches(
       maxRequests: OPENAI_BATCH_MAX_REQUESTS,
       debugLabel: "memory embeddings: openai batch submit",
     }),
-    runGroup: async ({ group, groupIndex, groups, byCustomId }) => {
+    runGroup: async ({ group, groupIndex, groups, byCustomId, pollIntervalMs, timeoutMs }) => {
       const batchInfo = await submitOpenAiBatch({
         openAi: params.openAi,
         requests: group,
@@ -239,8 +239,8 @@ export async function runOpenAiEmbeddingBatches(
             openAi: params.openAi,
             batchId,
             wait: params.wait,
-            pollIntervalMs: params.pollIntervalMs,
-            timeoutMs: params.timeoutMs,
+            pollIntervalMs,
+            timeoutMs,
             debug: params.debug,
             initial: batchInfo,
           }),

--- a/extensions/openai/realtime-provider-shared.ts
+++ b/extensions/openai/realtime-provider-shared.ts
@@ -1,3 +1,4 @@
+import { resolveExpiresAtMsFromEpochSeconds } from "openclaw/plugin-sdk/number-runtime";
 import {
   createProviderHttpError,
   resolveProviderRequestHeaders,
@@ -125,9 +126,10 @@ async function createOpenAIRealtimeSecret(
     payload && typeof payload === "object"
       ? (payload as Record<string, unknown>).expires_at
       : undefined;
+  const expiresAtMs = resolveExpiresAtMsFromEpochSeconds(expiresAt);
   return {
     value: clientSecret,
-    ...(typeof expiresAt === "number" ? { expiresAt } : {}),
+    ...(expiresAtMs === undefined ? {} : { expiresAt: expiresAtMs }),
   };
 }
 

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -495,6 +495,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       clientSecret: "client-secret-123",
       offerUrl: "https://api.openai.com/v1/realtime/calls",
       model: "gpt-realtime-2",
+      expiresAt: 1_765_000_000_000,
     });
     // originator, version, and User-Agent are server-side attribution headers; they
     // must not be forwarded to the browser so that the browser's direct SDP POST to

--- a/extensions/qa-lab/src/browser-runtime.test.ts
+++ b/extensions/qa-lab/src/browser-runtime.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
 import {
   callQaBrowserRequest,
@@ -134,6 +135,28 @@ describe("browser-runtime", () => {
         timeoutMs: 9_000,
       },
       { timeoutMs: 9_000 },
+    );
+  });
+
+  it("caps oversized browser request timeouts", async () => {
+    const env = createEnv();
+
+    await callQaBrowserRequest(env, {
+      method: "GET",
+      path: "/snapshot",
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(env.gateway.call).toHaveBeenCalledWith(
+      "browser.request",
+      {
+        method: "GET",
+        path: "/snapshot",
+        query: undefined,
+        body: undefined,
+        timeoutMs: MAX_TIMER_TIMEOUT_MS,
+      },
+      { timeoutMs: MAX_TIMER_TIMEOUT_MS },
     );
   });
 

--- a/extensions/qa-lab/src/browser-runtime.ts
+++ b/extensions/qa-lab/src/browser-runtime.ts
@@ -1,3 +1,4 @@
+import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 
 type QaBrowserGateway = {
@@ -102,10 +103,7 @@ function normalizeBrowserQuery(
 }
 
 function resolveBrowserTimeoutMs(timeoutMs: number | undefined, fallbackMs: number) {
-  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
-    return fallbackMs;
-  }
-  return Math.max(1, Math.floor(timeoutMs));
+  return resolvePositiveTimerTimeoutMs(timeoutMs, fallbackMs);
 }
 
 export async function callQaBrowserRequest<T = unknown>(

--- a/extensions/qa-lab/src/bus-state.test.ts
+++ b/extensions/qa-lab/src/bus-state.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 
 describe("qa-bus state", () => {
@@ -89,6 +90,29 @@ describe("qa-bus state", () => {
         timeoutMs: 20,
       }),
     ).rejects.toThrow("qa-bus wait timeout");
+  });
+
+  it("caps oversized wait timers", async () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const state = createQaBusState();
+      const pendingMessage = state.waitFor({
+        kind: "message-text",
+        textIncludes: "missing",
+        timeoutMs: Number.MAX_SAFE_INTEGER,
+      });
+      const pendingCursor = state.waitForCursorAdvance(0, Number.MAX_SAFE_INTEGER);
+
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      expect(timeoutSpy).toHaveBeenCalledTimes(2);
+
+      pendingMessage.catch(() => undefined);
+      pendingCursor.catch(() => undefined);
+    } finally {
+      timeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("keeps account-scoped cursor waits blocked on unrelated account traffic", async () => {

--- a/extensions/qa-lab/src/bus-waiters.ts
+++ b/extensions/qa-lab/src/bus-waiters.ts
@@ -1,3 +1,4 @@
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import type {
   QaBusEvent,
   QaBusMessage,
@@ -95,7 +96,7 @@ export function createQaBusWaiterStore(getSnapshot: () => QaBusStateSnapshot) {
         return immediate;
       }
       return await new Promise<QaBusWaitMatch>((resolve, reject) => {
-        const timeoutMs = input.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS;
+        const timeoutMs = resolveTimerTimeoutMs(input.timeoutMs, DEFAULT_WAIT_TIMEOUT_MS, 0);
         const waiter: Waiter = {
           resolve,
           reject,
@@ -118,6 +119,7 @@ export function createQaBusWaiterStore(getSnapshot: () => QaBusStateSnapshot) {
         return;
       }
       return await new Promise<void>((resolve, reject) => {
+        const resolvedTimeoutMs = resolveTimerTimeoutMs(timeoutMs, DEFAULT_WAIT_TIMEOUT_MS, 0);
         const waiter: CursorWaiter = {
           resolve,
           reject,
@@ -125,8 +127,8 @@ export function createQaBusWaiterStore(getSnapshot: () => QaBusStateSnapshot) {
           shouldResolve,
           timer: setTimeout(() => {
             cursorWaiters.delete(waiter);
-            reject(new Error(`qa-bus wait timeout after ${timeoutMs}ms`));
-          }, timeoutMs),
+            reject(new Error(`qa-bus wait timeout after ${resolvedTimeoutMs}ms`));
+          }, resolvedTimeoutMs),
         };
         cursorWaiters.add(waiter);
       });

--- a/extensions/qa-lab/src/cron-run-wait.test.ts
+++ b/extensions/qa-lab/src/cron-run-wait.test.ts
@@ -1,5 +1,6 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { waitForCronRunCompletion } from "./cron-run-wait.js";
+import { resolveCronRunPollIntervalMs, waitForCronRunCompletion } from "./cron-run-wait.js";
 
 describe("waitForCronRunCompletion", () => {
   it("ignores older entries and returns the newly finished run", async () => {
@@ -47,6 +48,30 @@ describe("waitForCronRunCompletion", () => {
         afterTs: 150,
         timeoutMs: 5,
         intervalMs: 0,
+      }),
+    ).rejects.toThrow(/timed out waiting for cron run completion/);
+  });
+
+  it("clamps oversized poll intervals before sleeping", () => {
+    expect(resolveCronRunPollIntervalMs(Number.MAX_SAFE_INTEGER)).toBe(MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("keeps oversized poll intervals within the overall timeout", async () => {
+    const callGateway = vi
+      .fn<
+        (method: string, rpcParams?: unknown, opts?: { timeoutMs?: number }) => Promise<unknown>
+      >()
+      .mockResolvedValue({
+        entries: [{ ts: 100, status: "ok", summary: "older run" }],
+      });
+
+    await expect(
+      waitForCronRunCompletion({
+        callGateway,
+        jobId: "dreaming-job",
+        afterTs: 150,
+        timeoutMs: 5,
+        intervalMs: Number.MAX_SAFE_INTEGER,
       }),
     ).rejects.toThrow(/timed out waiting for cron run completion/);
   });

--- a/extensions/qa-lab/src/cron-run-wait.ts
+++ b/extensions/qa-lab/src/cron-run-wait.ts
@@ -1,5 +1,6 @@
 import { setTimeout as sleep } from "node:timers/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 
 type QaCronRunLogEntry = {
   ts?: number;
@@ -13,6 +14,10 @@ type QaCronRunsPage = {
   entries?: QaCronRunLogEntry[];
 };
 
+export function resolveCronRunPollIntervalMs(intervalMs: number | undefined): number {
+  return resolveTimerTimeoutMs(intervalMs ?? 1_000, 1_000, 0);
+}
+
 export async function waitForCronRunCompletion(params: {
   callGateway: (
     method: string,
@@ -25,7 +30,7 @@ export async function waitForCronRunCompletion(params: {
   intervalMs?: number;
 }) {
   const timeoutMs = params.timeoutMs ?? 90_000;
-  const intervalMs = params.intervalMs ?? 1_000;
+  const intervalMs = resolveCronRunPollIntervalMs(params.intervalMs);
   const startedAt = Date.now();
   let lastEntries: QaCronRunLogEntry[] = [];
   while (Date.now() - startedAt < timeoutMs) {
@@ -49,7 +54,11 @@ export async function waitForCronRunCompletion(params: {
     if (completed) {
       return completed;
     }
-    await sleep(intervalMs);
+    const remainingMs = timeoutMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      break;
+    }
+    await sleep(Math.min(intervalMs, remainingMs));
   }
   throw new Error(
     `timed out waiting for cron run completion for ${params.jobId}: ${formatErrorMessage(lastEntries)}`,

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -434,6 +434,17 @@ describe("buildQaRuntimeEnv", () => {
     ).rejects.toThrow("qa gateway child did not reach restart boundary");
   });
 
+  it("keeps oversized restart-boundary poll intervals within the timeout", async () => {
+    await expect(
+      testing.waitForQaGatewayRestartBoundary({
+        logs: () => "signal SIGUSR1 received\n",
+        offset: 0,
+        pollMs: Number.MAX_SAFE_INTEGER,
+        timeoutMs: 5,
+      }),
+    ).rejects.toThrow("qa gateway child did not reach restart boundary");
+  });
+
   it("stages a live Anthropic setup-token profile for isolated QA workers", async () => {
     const stateDir = await mkdtemp(path.join(os.tmpdir(), "qa-setup-token-state-"));
     cleanups.push(async () => {

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -306,13 +307,17 @@ async function waitForQaGatewayRestartBoundary(params: {
   timeoutMs?: number;
 }) {
   const timeoutMs = params.timeoutMs ?? QA_GATEWAY_CHILD_RESTART_BOUNDARY_TIMEOUT_MS;
-  const pollMs = params.pollMs ?? 100;
+  const pollMs = resolveTimerTimeoutMs(params.pollMs ?? 100, 100, 0);
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
     if (params.logs().slice(params.offset).includes("restart mode:")) {
       return;
     }
-    await sleep(pollMs);
+    const remainingMs = timeoutMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      break;
+    }
+    await sleep(Math.min(pollMs, remainingMs));
   }
   throw new Error(`qa gateway child did not reach restart boundary within ${timeoutMs}ms`);
 }

--- a/extensions/qa-lab/src/qa-channel-transport.test.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.test.ts
@@ -153,4 +153,12 @@ describe("qa channel transport", () => {
       "ok",
     );
   });
+
+  it("keeps oversized wait helper intervals within the timeout", async () => {
+    const transport = createQaChannelTransport(createQaBusState());
+
+    await expect(
+      transport.capabilities.waitForCondition(async () => undefined, 5, Number.MAX_SAFE_INTEGER),
+    ).rejects.toThrow("timed out after 5ms");
+  });
 });

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -1,5 +1,6 @@
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import type { QaProviderMode } from "./model-selection.js";
 import { extractQaFailureReplyText } from "./reply-failure.js";
 import type {
@@ -85,13 +86,18 @@ export async function waitForQaTransportCondition<T>(
   timeoutMs = 15_000,
   intervalMs = 100,
 ): Promise<T> {
+  const pollIntervalMs = resolveTimerTimeoutMs(intervalMs, 100, 0);
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
     const value = await check();
     if (value !== null && value !== undefined) {
       return value;
     }
-    await sleep(intervalMs);
+    const remainingMs = timeoutMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      break;
+    }
+    await sleep(Math.min(pollIntervalMs, remainingMs));
   }
   throw new Error(`timed out after ${timeoutMs}ms`);
 }

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -115,6 +115,37 @@ describe("qa suite runtime agent process helpers", () => {
     expect((spawnCall?.[2] as { env?: unknown } | undefined)?.env).toEqual({ PATH: "/usr/bin" });
   });
 
+  it("caps oversized qa cli timeout timers", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const child = createSpawnedProcess();
+      spawnMock.mockReturnValue(child);
+
+      const pending = runQaCli(
+        {
+          repoRoot: "/repo",
+          gateway: {
+            tempRoot: "/tmp/runtime",
+            runtimeEnv: { PATH: "/usr/bin" },
+          },
+          primaryModel: "openai/gpt-5.5",
+          alternateModel: "openai/gpt-5.5-mini",
+          providerMode: "mock-openai",
+        } as never,
+        ["qa", "suite"],
+        { timeoutMs: Number.MAX_SAFE_INTEGER },
+      );
+
+      await waitForSpawnCount(1);
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      child.stdout.emit("data", Buffer.from("ok\n"));
+      child.emit("exit", 0);
+      await expect(pending).resolves.toBe("ok");
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
   it("merges isolated env overrides into qa cli runs", async () => {
     const child = createSpawnedProcess();
     spawnMock.mockReturnValue(child);

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   appendQaChildOutput,
   appendQaChildOutputTail,
@@ -98,10 +99,11 @@ async function runQaCli(
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
+    const timeoutMs = resolveTimerTimeoutMs(opts?.timeoutMs, 60_000);
     const timeout = setTimeout(() => {
       child.kill("SIGKILL");
       reject(new Error(`qa cli timed out: openclaw ${args.join(" ")}`));
-    }, opts?.timeoutMs ?? 60_000);
+    }, timeoutMs);
     child.stdout.on("data", (chunk) => appendQaChildOutput(stdout, chunk));
     child.stderr.on("data", (chunk) => appendQaChildOutputTail(stderr, chunk));
     child.once("error", (error) => {

--- a/extensions/qa-lab/src/web-runtime.test.ts
+++ b/extensions/qa-lab/src/web-runtime.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -143,5 +144,41 @@ describe("qa web runtime", () => {
     const snapshot = await qaWebSnapshot({ pageId: second.pageId });
     expect(snapshot.text).toBe("hello from body");
     await closeAllQaWebSessions();
+  });
+
+  it("caps oversized web runtime timeouts", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    try {
+      const opened = await qaWebOpenPage({
+        url: "http://127.0.0.1:3000/chat",
+        timeoutMs: Number.MAX_SAFE_INTEGER,
+      });
+
+      await qaWebWait({
+        pageId: opened.pageId,
+        selector: "textarea",
+        timeoutMs: Number.MAX_SAFE_INTEGER,
+      });
+      await qaWebEvaluate({
+        pageId: opened.pageId,
+        expression: "'ok'",
+        timeoutMs: Number.MAX_SAFE_INTEGER,
+      });
+      await closeAllQaWebSessions();
+
+      expect(goto).toHaveBeenCalledWith("http://127.0.0.1:3000/chat", {
+        waitUntil: "domcontentloaded",
+        timeout: MAX_TIMER_TIMEOUT_MS,
+      });
+      expect(pageWaitForSelector).toHaveBeenCalledWith("textarea", {
+        timeout: MAX_TIMER_TIMEOUT_MS,
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    } finally {
+      clearTimeoutSpy.mockRestore();
+      timeoutSpy.mockRestore();
+    }
   });
 });

--- a/extensions/qa-lab/src/web-runtime.ts
+++ b/extensions/qa-lab/src/web-runtime.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright-core";
 
 type QaWebSession = {
@@ -64,10 +65,7 @@ function appendDiagnostic(diagnostics: QaWebDiagnosticEntry[], entry: QaWebDiagn
 }
 
 function resolveTimeoutMs(timeoutMs: number | undefined, fallbackMs = DEFAULT_WEB_TIMEOUT_MS) {
-  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
-    return fallbackMs;
-  }
-  return Math.max(1, Math.floor(timeoutMs));
+  return resolvePositiveTimerTimeoutMs(timeoutMs, fallbackMs);
 }
 
 function resolveSession(pageId: string): QaWebSession {
@@ -172,14 +170,24 @@ export async function qaWebSnapshot(params: QaWebSnapshotParams) {
 export async function qaWebEvaluate<T = unknown>(params: QaWebEvaluateParams): Promise<T> {
   const session = resolveSession(params.pageId);
   const timeoutMs = resolveTimeoutMs(params.timeoutMs);
-  return (await Promise.race([
-    session.page.evaluate(({ expression }) => (0, eval)(expression) as unknown, {
-      expression: params.expression,
-    }),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`web evaluate timed out after ${timeoutMs}ms`)), timeoutMs),
-    ),
-  ])) as T;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return (await Promise.race([
+      session.page.evaluate(({ expression }) => (0, eval)(expression) as unknown, {
+        expression: params.expression,
+      }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`web evaluate timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ])) as T;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 export async function closeQaWebSessions(pageIds?: Iterable<string>): Promise<void> {

--- a/extensions/synology-chat/src/core.test.ts
+++ b/extensions/synology-chat/src/core.test.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import {
   createPluginSetupWizardConfigure,
   createTestWizardPrompter,
@@ -445,5 +446,24 @@ describe("synology-chat security helpers", () => {
     expect(capped.check("user3")).toBe(true);
     expect(capped.check("user4")).toBe(true);
     expect(capped.size()).toBeLessThanOrEqual(3);
+  });
+
+  it("caps oversized rate limit windows before constructing the limiter", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const limiter = new RateLimiter(1, Number.MAX_SAFE_INTEGER);
+
+      expect(limiter.check("user1")).toBe(true);
+      expect(limiter.check("user1")).toBe(false);
+
+      vi.setSystemTime(MAX_TIMER_TIMEOUT_MS - 1);
+      expect(limiter.check("user1")).toBe(false);
+
+      vi.setSystemTime(MAX_TIMER_TIMEOUT_MS);
+      expect(limiter.check("user1")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/synology-chat/src/security.ts
+++ b/extensions/synology-chat/src/security.ts
@@ -3,6 +3,7 @@
  */
 
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
+import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import {
   createFixedWindowRateLimiter,
@@ -78,8 +79,9 @@ export class RateLimiter {
 
   constructor(limit = 30, windowSeconds = 60, maxTrackedUsers = 5_000) {
     this.limit = limit;
+    const windowMs = finiteSecondsToTimerSafeMilliseconds(windowSeconds) ?? 1;
     this.limiter = createFixedWindowRateLimiter({
-      windowMs: Math.max(1, Math.floor(windowSeconds * 1000)),
+      windowMs,
       maxRequests: Math.max(1, Math.floor(limit)),
       maxTrackedKeys: Math.max(1, Math.floor(maxTrackedUsers)),
     });

--- a/extensions/tlon/src/urbit/sse-client.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { urbitFetch } from "./fetch.js";
 import { UrbitSSEClient } from "./sse-client.js";
@@ -135,6 +136,16 @@ describe("UrbitSSEClient", () => {
         onReconnect,
       });
       expect(client.onReconnect).toBe(onReconnect);
+    });
+
+    it("clamps oversized reconnect delays", () => {
+      const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123", {
+        reconnectDelay: Number.MAX_SAFE_INTEGER,
+        maxReconnectDelay: Number.MAX_SAFE_INTEGER,
+      });
+
+      expect(client.reconnectDelay).toBe(MAX_TIMER_TIMEOUT_MS);
+      expect(client.maxReconnectDelay).toBe(MAX_TIMER_TIMEOUT_MS);
     });
 
     it("resets reconnect attempts on successful connect", async () => {

--- a/extensions/tlon/src/urbit/sse-client.ts
+++ b/extensions/tlon/src/urbit/sse-client.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { Readable } from "node:stream";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import type { LookupFn, SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { ensureUrbitChannelOpen, pokeUrbitChannel, scryUrbitPath } from "./channel-ops.js";
 import { getUrbitContext, normalizeUrbitCookie } from "./context.js";
@@ -87,8 +88,8 @@ export class UrbitSSEClient {
     this.onReconnect = options.onReconnect ?? null;
     this.autoReconnect = options.autoReconnect !== false;
     this.maxReconnectAttempts = options.maxReconnectAttempts ?? 10;
-    this.reconnectDelay = options.reconnectDelay ?? 1000;
-    this.maxReconnectDelay = options.maxReconnectDelay ?? 30000;
+    this.reconnectDelay = resolveTimerTimeoutMs(options.reconnectDelay, 1000);
+    this.maxReconnectDelay = resolveTimerTimeoutMs(options.maxReconnectDelay, 30000);
     this.logger = options.logger ?? {};
     this.ssrfPolicy = options.ssrfPolicy;
     this.lookupFn = options.lookupFn;

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -70,4 +70,11 @@ describe("voice-call CLI timeout helpers", () => {
       10_000 + MAX_TIMER_TIMEOUT_MS,
     );
   });
+
+  it("caps gateway continue poll timeouts from async operation payloads", () => {
+    expect(
+      testing.readGatewayPollTimeoutMs({ pollTimeoutMs: Number.MAX_SAFE_INTEGER }, 45_000),
+    ).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(testing.readGatewayPollTimeoutMs({ pollTimeoutMs: Number.NaN }, 45_000)).toBe(45_000);
+  });
 });

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -74,6 +74,7 @@ export const testing = {
   parseVoiceCallIntOption,
   resolveGatewayContinueTimeoutMs,
   resolveGatewayOperationTimeoutMs,
+  readGatewayPollTimeoutMs,
   resolveVoiceCallDeadlineMs,
 };
 
@@ -170,7 +171,7 @@ function readGatewayOperationId(payload: unknown): string {
 
 function readGatewayPollTimeoutMs(payload: unknown, fallbackTimeoutMs: number): number {
   if (isRecord(payload) && typeof payload.pollTimeoutMs === "number") {
-    return Math.max(1, Math.ceil(payload.pollTimeoutMs));
+    return clampTimerTimeoutMs(payload.pollTimeoutMs) ?? fallbackTimeoutMs;
   }
   return fallbackTimeoutMs;
 }

--- a/extensions/voice-call/src/gateway-continue-operation.test.ts
+++ b/extensions/voice-call/src/gateway-continue-operation.test.ts
@@ -1,0 +1,28 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import { describe, expect, it } from "vitest";
+import { createVoiceCallContinueOperationStore } from "./gateway-continue-operation.js";
+
+describe("voice-call gateway continue operation store", () => {
+  it("caps async continue poll timeouts from voice and tts config", () => {
+    const store = createVoiceCallContinueOperationStore({
+      config: {
+        transcriptTimeoutMs: Number.MAX_SAFE_INTEGER,
+        tts: { timeoutMs: Number.MAX_SAFE_INTEGER },
+      } as never,
+      coreConfig: { messages: {} } as never,
+    });
+
+    const started = store.start({
+      callId: "call-1",
+      message: "hello",
+      rt: {
+        config: {},
+        manager: {
+          continueCall: async () => new Promise(() => {}),
+        },
+      } as never,
+    });
+
+    expect(started.pollTimeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
+  });
+});

--- a/extensions/voice-call/src/gateway-continue-operation.ts
+++ b/extensions/voice-call/src/gateway-continue-operation.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import type { VoiceCallConfig } from "./config.js";
 import type { CoreConfig } from "./core-bridge.js";
 import type { VoiceCallRuntime } from "./runtime.js";
@@ -76,10 +77,11 @@ export function createVoiceCallContinueOperationStore(params: {
       params.config.tts?.timeoutMs ??
       params.coreConfig.messages?.tts?.timeoutMs ??
       TELEPHONY_DEFAULT_TTS_TIMEOUT_MS;
-    return (
+    return resolveTimerTimeoutMs(
       (rt.config.transcriptTimeoutMs ?? params.config.transcriptTimeoutMs) +
-      ttsTimeoutMs +
-      VOICE_CALL_CONTINUE_OPERATION_BUFFER_MS
+        ttsTimeoutMs +
+        VOICE_CALL_CONTINUE_OPERATION_BUFFER_MS,
+      VOICE_CALL_CONTINUE_OPERATION_BUFFER_MS,
     );
   };
 

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from "node:http";
 import net from "node:net";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import type {
   RealtimeTranscriptionProviderPlugin,
   RealtimeTranscriptionSession,
@@ -432,6 +433,30 @@ describe("MediaStreamHandler security hardening", () => {
       expect(shouldAcceptStreamCalls).toStrictEqual([]);
     } finally {
       await server.close();
+    }
+  });
+
+  it("clamps oversized pre-start connection timeouts", () => {
+    vi.useFakeTimers();
+    try {
+      const handler = new MediaStreamHandler({
+        transcriptionProvider: createStubSttProvider(),
+        providerConfig: {},
+        preStartTimeoutMs: Number.MAX_SAFE_INTEGER,
+      });
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const ws = { close: vi.fn() } as unknown as WebSocket;
+
+      const registered = (
+        handler as unknown as {
+          registerPendingConnection(ws: WebSocket, ip: string): boolean;
+        }
+      ).registerPendingConnection(ws, "203.0.113.10");
+
+      expect(registered).toBe(true);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      vi.useRealTimers();
     }
   });
 

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -10,6 +10,7 @@
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import type {
   RealtimeTranscriptionProviderConfig,
   RealtimeTranscriptionProviderPlugin,
@@ -155,7 +156,10 @@ export class MediaStreamHandler {
 
   constructor(config: MediaStreamConfig) {
     this.config = config;
-    this.preStartTimeoutMs = config.preStartTimeoutMs ?? DEFAULT_PRE_START_TIMEOUT_MS;
+    this.preStartTimeoutMs = resolveTimerTimeoutMs(
+      config.preStartTimeoutMs,
+      DEFAULT_PRE_START_TIMEOUT_MS,
+    );
     this.maxPendingConnections = config.maxPendingConnections ?? DEFAULT_MAX_PENDING_CONNECTIONS;
     this.maxPendingConnectionsPerIp =
       config.maxPendingConnectionsPerIp ?? DEFAULT_MAX_PENDING_CONNECTIONS_PER_IP;

--- a/extensions/voice-call/src/telephony-tts.test.ts
+++ b/extensions/voice-call/src/telephony-tts.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { VoiceCallTtsConfig } from "./config.js";
 import type { CoreConfig } from "./core-bridge.js";
@@ -177,6 +178,23 @@ describe("createTelephonyTtsProvider deepMerge hardening", () => {
     });
 
     expect(provider.synthesisTimeoutMs).toBe(15000);
+  });
+
+  it("clamps oversized configured timeoutMs", () => {
+    const provider = createTelephonyTtsProvider({
+      coreConfig: {
+        messages: { tts: { provider: "openai", timeoutMs: Number.MAX_SAFE_INTEGER } },
+      },
+      runtime: {
+        textToSpeechTelephony: async () => ({
+          success: true,
+          audioBuffer: Buffer.alloc(2),
+          sampleRate: 8000,
+        }),
+      },
+    });
+
+    expect(provider.synthesisTimeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 
   it("keeps the telephony timeout default when timeoutMs is not configured", () => {

--- a/extensions/voice-call/src/telephony-tts.ts
+++ b/extensions/voice-call/src/telephony-tts.ts
@@ -1,3 +1,4 @@
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   parseTtsDirectives,
   type SpeechModelOverridePolicy,
@@ -60,8 +61,10 @@ export function createTelephonyTtsProvider(params: {
   );
   const providerConfigs = collectTelephonyProviderConfigs(ttsConfig);
   const activeProvider = normalizeProviderId(ttsConfig?.provider);
-  const synthesisTimeoutMs =
-    mergedConfig.messages?.tts?.timeoutMs ?? TELEPHONY_DEFAULT_TTS_TIMEOUT_MS;
+  const synthesisTimeoutMs = resolveTimerTimeoutMs(
+    mergedConfig.messages?.tts?.timeoutMs,
+    TELEPHONY_DEFAULT_TTS_TIMEOUT_MS,
+  );
 
   return {
     synthesisTimeoutMs,

--- a/extensions/voyage/embedding-batch.ts
+++ b/extensions/voyage/embedding-batch.ts
@@ -228,7 +228,7 @@ export async function runVoyageEmbeddingBatches(
       maxRequests: VOYAGE_BATCH_MAX_REQUESTS,
       debugLabel: "memory embeddings: voyage batch submit",
     }),
-    runGroup: async ({ group, groupIndex, groups, byCustomId }) => {
+    runGroup: async ({ group, groupIndex, groups, byCustomId, pollIntervalMs, timeoutMs }) => {
       const batchInfo = await submitVoyageBatch({
         client: params.client,
         requests: group,
@@ -257,8 +257,8 @@ export async function runVoyageEmbeddingBatches(
             client: params.client,
             batchId,
             wait: params.wait,
-            pollIntervalMs: params.pollIntervalMs,
-            timeoutMs: params.timeoutMs,
+            pollIntervalMs,
+            timeoutMs,
             debug: params.debug,
             initial: batchInfo,
             deps,

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import {
+  asDateTimestampMs,
   asFiniteNumberInRange,
   isFutureDateTimestampMs,
   parseStrictFiniteNumber,
@@ -270,6 +271,7 @@ function normalizeMessageContent(content: unknown): string {
 }
 
 function resolveInboundTimestamp(rawTs: unknown): number {
+  const fallbackTimestamp = () => asDateTimestampMs(Date.now()) ?? 0;
   const parsed =
     typeof rawTs === "number"
       ? rawTs
@@ -282,15 +284,15 @@ function resolveInboundTimestamp(rawTs: unknown): number {
     max: Number.MAX_SAFE_INTEGER,
   });
   if (timestamp === undefined) {
-    return Date.now();
+    return fallbackTimestamp();
   }
   if (timestamp > ZALO_TIMESTAMP_MS_THRESHOLD) {
-    return Math.trunc(timestamp);
+    return asDateTimestampMs(Math.trunc(timestamp)) ?? fallbackTimestamp();
   }
   if (timestamp > MAX_SAFE_ZALO_TIMESTAMP_SECONDS) {
-    return Date.now();
+    return fallbackTimestamp();
   }
-  return Math.trunc(timestamp * 1000);
+  return asDateTimestampMs(Math.trunc(timestamp * 1000)) ?? fallbackTimestamp();
 }
 
 function extractMentionIds(rawMentions: unknown): string[] {

--- a/extensions/zalouser/src/zalo-quote-metadata.test.ts
+++ b/extensions/zalouser/src/zalo-quote-metadata.test.ts
@@ -73,6 +73,7 @@ describe("Zalo inbound timestamp normalization", () => {
 
     expect(inboundTimestamp("1764000000abc")).toBe(1_700_000_000_000);
     expect(inboundTimestamp("9007199254740993")).toBe(1_700_000_000_000);
+    expect(inboundTimestamp(8_640_000_000_000_001)).toBe(1_700_000_000_000);
   });
 });
 

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -1389,7 +1389,7 @@ export class GatewayClient {
       typeof rawMinInterval === "number" && Number.isFinite(rawMinInterval)
         ? Math.max(1, Math.min(30_000, rawMinInterval))
         : 1000;
-    const interval = Math.max(this.tickIntervalMs, minInterval);
+    const interval = resolveSafeTimeoutDelayMs(Math.max(this.tickIntervalMs, minInterval));
     this.tickTimer = setInterval(() => {
       if (this.closed) {
         return;

--- a/packages/gateway-client/src/client.watchdog.test.ts
+++ b/packages/gateway-client/src/client.watchdog.test.ts
@@ -253,6 +253,39 @@ describe("GatewayClient", () => {
     }
   });
 
+  test("clamps oversized tick watchdog intervals before scheduling", () => {
+    vi.useFakeTimers();
+    try {
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+      const client = new GatewayClient({
+        tickWatchMinIntervalMs: 5,
+      });
+      Object.assign(
+        client as unknown as { ws: unknown; tickIntervalMs: number; lastTick: number },
+        {
+          ws: {
+            readyState: WebSocket.OPEN,
+            send: vi.fn(),
+            close: vi.fn(),
+          },
+          tickIntervalMs: Number.MAX_SAFE_INTEGER,
+          lastTick: Date.now(),
+        },
+      );
+
+      (
+        client as unknown as {
+          startTickWatch: () => void;
+        }
+      ).startTickWatch();
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_SAFE_TIMEOUT_DELAY_MS);
+      client.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("times out unresolved requests and clears pending state", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/gateway-client/src/event-loop-ready.test.ts
+++ b/packages/gateway-client/src/event-loop-ready.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { waitForEventLoopReady } from "./event-loop-ready.js";
+import { MAX_SAFE_TIMEOUT_DELAY_MS } from "./timeouts.js";
 
 describe("waitForEventLoopReady", () => {
   afterEach(() => {
@@ -23,6 +24,28 @@ describe("waitForEventLoopReady", () => {
     await expect(readiness).resolves.toMatchObject({
       ready: true,
       checks: 2,
+    });
+  });
+
+  it("clamps oversized readiness intervals before scheduling", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const readiness = waitForEventLoopReady({
+      maxWaitMs: Number.MAX_SAFE_INTEGER,
+      intervalMs: Number.MAX_SAFE_INTEGER,
+      consecutiveReadyChecks: 1,
+    });
+
+    expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), MAX_SAFE_TIMEOUT_DELAY_MS);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(MAX_SAFE_TIMEOUT_DELAY_MS - 1);
+    await expect(readiness).resolves.toMatchObject({
+      ready: true,
+      checks: 1,
     });
   });
 });

--- a/packages/gateway-client/src/event-loop-ready.ts
+++ b/packages/gateway-client/src/event-loop-ready.ts
@@ -31,7 +31,7 @@ export async function waitForEventLoopReady(
   const maxWaitMs = resolveFiniteTimeoutDelayMs(options.maxWaitMs, DEFAULT_MAX_WAIT_MS, {
     minMs: 0,
   });
-  const intervalMs = resolvePositiveInteger(options.intervalMs, DEFAULT_INTERVAL_MS);
+  const intervalMs = resolveFiniteTimeoutDelayMs(options.intervalMs, DEFAULT_INTERVAL_MS);
   const driftThresholdMs = resolvePositiveInteger(
     options.driftThresholdMs,
     DEFAULT_DRIFT_THRESHOLD_MS,

--- a/packages/memory-host-sdk/src/host/batch-runner.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-runner.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { MAX_SAFE_TIMEOUT_DELAY_MS } from "../../../gateway-client/src/timeouts.js";
+import { buildEmbeddingBatchGroupOptions, runEmbeddingBatchGroups } from "./batch-runner.js";
+
+describe("buildEmbeddingBatchGroupOptions", () => {
+  it("clamps oversized embedding batch poll intervals to the timeout budget", () => {
+    const options = buildEmbeddingBatchGroupOptions(
+      {
+        requests: ["request-1"],
+        wait: true,
+        pollIntervalMs: Number.MAX_SAFE_INTEGER,
+        timeoutMs: 60_000,
+        concurrency: 1,
+      },
+      {
+        maxRequests: 100,
+        debugLabel: "embedding batch submit",
+      },
+    );
+
+    expect(options.pollIntervalMs).toBe(60_000);
+  });
+
+  it("passes clamped poll intervals into batch group runners", async () => {
+    const runGroup = vi.fn(async () => {});
+
+    await runEmbeddingBatchGroups({
+      requests: ["request-1"],
+      maxRequests: 100,
+      wait: true,
+      pollIntervalMs: Number.MAX_SAFE_INTEGER,
+      timeoutMs: 60_000,
+      concurrency: 1,
+      debugLabel: "embedding batch submit",
+      runGroup,
+    });
+
+    expect(runGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pollIntervalMs: 60_000,
+        timeoutMs: 60_000,
+      }),
+    );
+  });
+
+  it("keeps timeout-safe oversized embedding batch poll intervals bounded", () => {
+    const options = buildEmbeddingBatchGroupOptions(
+      {
+        requests: ["request-1"],
+        wait: true,
+        pollIntervalMs: Number.MAX_SAFE_INTEGER,
+        timeoutMs: Number.MAX_SAFE_INTEGER,
+        concurrency: 1,
+      },
+      {
+        maxRequests: 100,
+        debugLabel: "embedding batch submit",
+      },
+    );
+
+    expect(options.pollIntervalMs).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
+  });
+});

--- a/packages/memory-host-sdk/src/host/batch-runner.ts
+++ b/packages/memory-host-sdk/src/host/batch-runner.ts
@@ -1,3 +1,4 @@
+import { resolveSafeTimeoutDelayMs } from "../../../gateway-client/src/timeouts.js";
 import { splitBatchRequests } from "./batch-utils.js";
 import { runWithConcurrency } from "./internal.js";
 
@@ -8,6 +9,20 @@ export type EmbeddingBatchExecutionParams = {
   concurrency: number;
   debug?: (message: string, data?: Record<string, unknown>) => void;
 };
+
+function resolveEmbeddingBatchPollIntervalMs(params: {
+  pollIntervalMs: number;
+  timeoutMs: number;
+}): number {
+  const safePollIntervalMs = resolveSafeTimeoutDelayMs(params.pollIntervalMs);
+  const safeTimeoutMs =
+    typeof params.timeoutMs === "number" &&
+    Number.isFinite(params.timeoutMs) &&
+    params.timeoutMs > 0
+      ? resolveSafeTimeoutDelayMs(params.timeoutMs)
+      : safePollIntervalMs;
+  return Math.min(safePollIntervalMs, safeTimeoutMs);
+}
 
 export async function runEmbeddingBatchGroups<TRequest>(params: {
   requests: TRequest[];
@@ -23,6 +38,8 @@ export async function runEmbeddingBatchGroups<TRequest>(params: {
     groupIndex: number;
     groups: number;
     byCustomId: Map<string, number[]>;
+    pollIntervalMs: number;
+    timeoutMs: number;
   }) => Promise<void>;
 }): Promise<Map<string, number[]>> {
   if (params.requests.length === 0) {
@@ -30,8 +47,16 @@ export async function runEmbeddingBatchGroups<TRequest>(params: {
   }
   const groups = splitBatchRequests(params.requests, params.maxRequests);
   const byCustomId = new Map<string, number[]>();
+  const pollIntervalMs = resolveEmbeddingBatchPollIntervalMs(params);
   const tasks = groups.map((group, groupIndex) => async () => {
-    await params.runGroup({ group, groupIndex, groups: groups.length, byCustomId });
+    await params.runGroup({
+      group,
+      groupIndex,
+      groups: groups.length,
+      byCustomId,
+      pollIntervalMs,
+      timeoutMs: params.timeoutMs,
+    });
   });
 
   params.debug?.(params.debugLabel, {
@@ -39,7 +64,7 @@ export async function runEmbeddingBatchGroups<TRequest>(params: {
     groups: groups.length,
     wait: params.wait,
     concurrency: params.concurrency,
-    pollIntervalMs: params.pollIntervalMs,
+    pollIntervalMs,
     timeoutMs: params.timeoutMs,
   });
 
@@ -51,11 +76,12 @@ export function buildEmbeddingBatchGroupOptions<TRequest>(
   params: { requests: TRequest[] } & EmbeddingBatchExecutionParams,
   options: { maxRequests: number; debugLabel: string },
 ) {
+  const pollIntervalMs = resolveEmbeddingBatchPollIntervalMs(params);
   return {
     requests: params.requests,
     maxRequests: options.maxRequests,
     wait: params.wait,
-    pollIntervalMs: params.pollIntervalMs,
+    pollIntervalMs,
     timeoutMs: params.timeoutMs,
     concurrency: params.concurrency,
     debug: params.debug,

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -295,4 +295,22 @@ describe("buildSessionEntry", () => {
     expect(entry.content).toBe("Assistant: User-facing summary.\nUser: Actual user follow-up.");
     expect(entry.lineMap).toStrictEqual([2, 3]);
   });
+
+  it("drops Date-invalid numeric message timestamps", async () => {
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "Hello",
+          timestamp: 8_640_000_000_000_001,
+        },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "invalid-timestamp-session.jsonl");
+    fsSync.writeFileSync(filePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(filePath));
+    expect(entry.messageTimestampsMs).toStrictEqual([0]);
+  });
 });

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -28,6 +28,7 @@ const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
 // This limit applies to content only; the role label adds up to 11 chars.
 const SESSION_EXPORT_CONTENT_WRAP_CHARS = 800;
 const SESSION_ENTRY_PARSE_YIELD_LINES = 250;
+const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
 const DIRECT_CRON_PROMPT_RE = /^\[cron:[^\]]+\]\s*/;
 
 export type SessionFileEntry = {
@@ -509,7 +510,7 @@ function parseSessionTimestampMs(
   for (const value of candidates) {
     if (typeof value === "number" && Number.isFinite(value)) {
       const ms = value > 0 && value < 1e11 ? value * 1000 : value;
-      if (Number.isFinite(ms) && ms > 0) {
+      if (Number.isFinite(ms) && ms > 0 && ms <= MAX_DATE_TIMESTAMP_MS) {
         return ms;
       }
     }

--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -2,6 +2,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveOAuthDir } from "../config/paths.js";
+import { MAX_DATE_TIMESTAMP_MS } from "../shared/number-coercion.js";
+import { legacyOAuthSidecarTestUtils } from "./auth-profiles/legacy-oauth-sidecar.js";
 import { resolveAuthStatePath, resolveAuthStorePath } from "./auth-profiles/paths.js";
 import { getRuntimeAuthProfileStoreSnapshot } from "./auth-profiles/runtime-snapshots.js";
 import {
@@ -1162,6 +1165,63 @@ describe("saveAuthProfileStore", () => {
         type: "oauth",
         access: "main-refreshed-access-token",
         refresh: "main-refreshed-refresh-token",
+      });
+    } finally {
+      clearRuntimeAuthProfileStoreSnapshots();
+      vi.unstubAllEnvs();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not persist inherited OAuth with an out-of-range local expiry", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-save-invalid-local-"));
+    const stateDir = path.join(root, ".openclaw");
+    const childAgentDir = path.join(stateDir, "agents", "worker", "agent");
+    const childAuthPath = resolveAuthStorePath(childAgentDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("OPENCLAW_AGENT_DIR", "");
+    try {
+      saveAuthProfileStore({
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "main-access-token",
+            refresh: "main-refresh-token",
+            expires: Date.now() + 120_000,
+            accountId: "acct-shared",
+          },
+        },
+      });
+
+      const localUpdateStore = ensureAuthProfileStoreForLocalUpdate(childAgentDir);
+      localUpdateStore.profiles["openai-codex:default"] = {
+        type: "oauth",
+        provider: "openai-codex",
+        access: "main-access-token",
+        refresh: "main-refresh-token",
+        expires: MAX_DATE_TIMESTAMP_MS + 1,
+        accountId: "acct-shared",
+      };
+      localUpdateStore.profiles["openai:default"] = {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-child-local",
+      };
+
+      saveAuthProfileStore(localUpdateStore, childAgentDir, {
+        filterExternalAuthProfiles: false,
+      });
+
+      const child = JSON.parse(await fs.readFile(childAuthPath, "utf8")) as {
+        profiles: Record<string, unknown>;
+      };
+      expect(child.profiles["openai-codex:default"]).toBeUndefined();
+      expectProfileFields(ensureAuthProfileStore(childAgentDir).profiles["openai-codex:default"], {
+        type: "oauth",
+        access: "main-access-token",
+        refresh: "main-refresh-token",
       });
     } finally {
       clearRuntimeAuthProfileStoreSnapshots();

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { testing as externalAuthTesting } from "./external-auth.js";
 import {
@@ -387,6 +388,71 @@ describe("createOAuthManager", () => {
     expect(result.apiKey).toBe("rotated-main-access");
     expect(result.credential.access).toBe("rotated-main-access");
     expect(result.credential.refresh).toBe("rotated-main-refresh");
+  });
+
+  it("adopts main-store OAuth when the local expiry is out of range", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-invalid-local-"));
+    tempDirs.push(tempRoot);
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    const mainAgentDir = path.join(tempRoot, "agents", "main", "agent");
+    const agentDir = path.join(tempRoot, "agents", "sub", "agent");
+    process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(mainAgentDir, { recursive: true });
+
+    const profileId = "openai-codex:default";
+    const localCredential = createCredential({
+      access: "poisoned-local-access",
+      refresh: "local-refresh",
+      expires: MAX_DATE_TIMESTAMP_MS + 1,
+    });
+    const mainCredential = createCredential({
+      access: "main-access",
+      refresh: "main-refresh",
+      expires: Date.now() + 10 * 60_000,
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: mainCredential,
+        },
+      },
+      mainAgentDir,
+      { filterExternalAuthProfiles: false },
+    );
+
+    const refreshCredential = vi.fn(async () => {
+      throw new Error("should not refresh poisoned local credential");
+    });
+    const manager = createOAuthManager({
+      buildApiKey: async (_provider, credential) => credential.access,
+      refreshCredential,
+      readBootstrapCredential: () => null,
+      isRefreshTokenReusedError: () => false,
+    });
+
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: localCredential,
+      },
+    };
+    const result = await manager.resolveOAuthAccess({
+      store,
+      profileId,
+      credential: localCredential,
+      agentDir,
+    });
+
+    expect(refreshCredential).not.toHaveBeenCalled();
+    expect(result?.apiKey).toBe("main-access");
+    expect(result?.credential.access).toBe("main-access");
+    expect(store.profiles[profileId]).toMatchObject({
+      type: "oauth",
+      access: "main-access",
+      refresh: "main-refresh",
+    });
   });
 
   it("refreshes with the adopted external oauth credential", async () => {

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -3,6 +3,7 @@ import { normalizeSecretInputString } from "../../config/types.secrets.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { redactSensitiveText } from "../../logging/redact.js";
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import {
   AUTH_STORE_LOCK_OPTIONS,
   OAUTH_REFRESH_CALL_TIMEOUT_MS,
@@ -325,13 +326,14 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         allowKeychainPrompt: false,
       });
       const mainCred = mainStore.profiles[params.profileId];
+      const mainExpires = asDateTimestampMs(mainCred?.expires);
+      const localExpires = asDateTimestampMs(params.credential.expires);
       if (
         mainCred?.type === "oauth" &&
         mainCred.provider === params.credential.provider &&
         hasUsableOAuthCredential(mainCred) &&
-        Number.isFinite(mainCred.expires) &&
-        (!Number.isFinite(params.credential.expires) ||
-          mainCred.expires > params.credential.expires) &&
+        mainExpires !== undefined &&
+        (localExpires === undefined || mainExpires > localExpires) &&
         isSafeToAdoptMainStoreOAuthIdentity(params.credential, mainCred)
       ) {
         params.store.profiles[params.profileId] = { ...mainCred };

--- a/src/agents/auth-profiles/oauth-shared.test.ts
+++ b/src/agents/auth-profiles/oauth-shared.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { overlayRuntimeExternalOAuthProfiles } from "./oauth-shared.js";
-import type { AuthProfileStore } from "./types.js";
+import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
+import {
+  overlayRuntimeExternalOAuthProfiles,
+  shouldReplaceStoredOAuthCredential,
+} from "./oauth-shared.js";
+import type { AuthProfileStore, OAuthCredential } from "./types.js";
 
 describe("overlayRuntimeExternalOAuthProfiles", () => {
   it("isolates runtime OAuth overlays without structuredClone", () => {
@@ -115,5 +119,24 @@ describe("overlayRuntimeExternalOAuthProfiles", () => {
 
     expect(overlaid.runtimeExternalProfileIds).toEqual(["minimax:minimax-cli"]);
     expect(overlaid.runtimeExternalProfileIdsAuthoritative).toBe(true);
+  });
+
+  it("replaces an existing OAuth credential with an out-of-range expiry", () => {
+    const existing: OAuthCredential = {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "poisoned-access",
+      refresh: "poisoned-refresh",
+      expires: MAX_DATE_TIMESTAMP_MS + 1,
+    };
+    const incoming: OAuthCredential = {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "valid-access",
+      refresh: "valid-refresh",
+      expires: Date.now() + 60_000,
+    };
+
+    expect(shouldReplaceStoredOAuthCredential(existing, incoming)).toBe(true);
   });
 });

--- a/src/agents/auth-profiles/oauth-shared.ts
+++ b/src/agents/auth-profiles/oauth-shared.ts
@@ -1,3 +1,4 @@
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import { hasUsableOAuthCredential as hasUsableStoredOAuthCredential } from "./credential-state.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
@@ -32,11 +33,13 @@ function hasNewerStoredOAuthCredential(
   existing: OAuthCredential | undefined,
   incoming: OAuthCredential,
 ): boolean {
+  const existingExpires = asDateTimestampMs(existing?.expires);
+  const incomingExpires = asDateTimestampMs(incoming.expires);
   return Boolean(
     existing &&
     existing.provider === incoming.provider &&
-    Number.isFinite(existing.expires) &&
-    (!Number.isFinite(incoming.expires) || existing.expires > incoming.expires),
+    existingExpires !== undefined &&
+    (incomingExpires === undefined || existingExpires > incomingExpires),
   );
 }
 

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -4,6 +4,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { loadJsonFile, repairJsonFilePermissions, saveJsonFile } from "../../infra/json-file.js";
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import { isRecord } from "../../utils.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION, log } from "./constants.js";
@@ -186,10 +187,12 @@ function shouldUseMainOwnerForLocalOAuthCredential(params: {
   if (isDeepStrictEqual(params.local, params.main)) {
     return true;
   }
-  return (
-    Number.isFinite(params.main.expires) &&
-    (!Number.isFinite(params.local.expires) || params.main.expires >= params.local.expires)
-  );
+  const mainExpires = asDateTimestampMs(params.main.expires);
+  if (mainExpires === undefined) {
+    return false;
+  }
+  const localExpires = asDateTimestampMs(params.local.expires);
+  return localExpires === undefined || mainExpires >= localExpires;
 }
 
 function resolveRuntimeAuthProfileStore(

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 
 export function isAuthCooldownBypassedForProvider(provider: string | undefined): boolean {
@@ -10,8 +11,8 @@ export function resolveProfileUnusableUntil(
   stats: Pick<ProfileUsageStats, "blockedUntil" | "cooldownUntil" | "disabledUntil">,
 ): number | null {
   const values = [stats.blockedUntil, stats.cooldownUntil, stats.disabledUntil]
-    .filter((value): value is number => typeof value === "number")
-    .filter((value) => Number.isFinite(value) && value > 0);
+    .map((value) => asDateTimestampMs(value))
+    .filter((value): value is number => value !== undefined && value > 0);
   if (values.length === 0) {
     return null;
   }
@@ -19,7 +20,8 @@ export function resolveProfileUnusableUntil(
 }
 
 export function isActiveUnusableWindow(until: number | undefined, now: number): boolean {
-  return typeof until === "number" && Number.isFinite(until) && until > 0 && now < until;
+  const timestamp = asDateTimestampMs(until);
+  return timestamp !== undefined && timestamp > 0 && now < timestamp;
 }
 
 function shouldBypassModelScopedCooldown(

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import {
@@ -657,6 +658,7 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
     store: ReturnType<typeof makeStore>;
     now: number;
     reason: "rate_limit" | "billing" | "auth_permanent";
+    cfg?: OpenClawConfig;
   }): Promise<void> {
     vi.useFakeTimers();
     vi.setSystemTime(params.now);
@@ -665,6 +667,7 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
         store: params.store,
         profileId: "anthropic:default",
         reason: params.reason,
+        cfg: params.cfg,
       });
     } finally {
       vi.useRealTimers();
@@ -792,6 +795,50 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
       expect(testCase.readUntil(stats)).toBe(testCase.expectedUntil(now));
     });
   }
+
+  it.each([
+    {
+      label: "cooldownUntil",
+      reason: "rate_limit" as const,
+      readUntil: (stats: WindowStats | undefined) => stats?.cooldownUntil,
+    },
+    {
+      label: "disabledUntil",
+      reason: "billing" as const,
+      readUntil: (stats: WindowStats | undefined) => stats?.disabledUntil,
+    },
+  ])("keeps recomputed $label inside the valid Date range", async (testCase) => {
+    const store = makeStore({});
+
+    await markFailureAt({
+      store,
+      now: MAX_DATE_TIMESTAMP_MS,
+      reason: testCase.reason,
+    });
+
+    const stats = store.usageStats?.["anthropic:default"];
+    expect(testCase.readUntil(stats)).toBe(MAX_DATE_TIMESTAMP_MS);
+  });
+
+  it("preserves fractional disabled cooldown config durations", async () => {
+    const now = 1_000_000;
+    const store = makeStore({});
+
+    await markFailureAt({
+      store,
+      now,
+      reason: "billing",
+      cfg: {
+        auth: {
+          cooldowns: {
+            billingBackoffHours: 0.0166667,
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBe(now + 60_000);
+  });
 });
 
 describe("markAuthProfileBlockedUntil", () => {
@@ -1021,6 +1068,15 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     await markCodexFailureAt({ store, now, reason: "unknown" });
 
     expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBe(now + 30_000);
+  });
+
+  it("keeps fallback WHAM cooldowns inside the valid Date range", async () => {
+    const store = makeStore({});
+    fetchMock.mockRejectedValueOnce(new Error("network unavailable"));
+
+    await markCodexFailureAt({ store, now: MAX_DATE_TIMESTAMP_MS, reason: "unknown" });
+
+    expect(store.usageStats?.["openai-codex:default"]?.cooldownUntil).toBe(MAX_DATE_TIMESTAMP_MS);
   });
 
   it.each([

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import {
   testing as authProfileUsageTesting,
@@ -71,6 +72,7 @@ describe("resolveProfileUnusableUntil", () => {
   it("returns null when all values are missing or invalid", () => {
     expect(resolveProfileUnusableUntil({})).toBeNull();
     expect(resolveProfileUnusableUntil({ cooldownUntil: 0, disabledUntil: Number.NaN })).toBeNull();
+    expect(resolveProfileUnusableUntil({ blockedUntil: MAX_DATE_TIMESTAMP_MS + 1 })).toBeNull();
   });
 
   it("returns the latest active timestamp", () => {
@@ -134,6 +136,13 @@ describe("isProfileInCooldown", () => {
   it("returns false when cooldownUntil has passed", () => {
     const store = makeStore({
       "anthropic:default": { cooldownUntil: Date.now() - 1_000 },
+    });
+    expect(isProfileInCooldown(store, "anthropic:default")).toBe(false);
+  });
+
+  it("returns false when cooldownUntil is out of range", () => {
+    const store = makeStore({
+      "anthropic:default": { cooldownUntil: MAX_DATE_TIMESTAMP_MS + 1 },
     });
     expect(isProfileInCooldown(store, "anthropic:default")).toBe(false);
   });

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -3,6 +3,7 @@ import {
   asDateTimestampMs,
   isFutureDateTimestampMs,
   positiveSecondsToSafeMilliseconds,
+  resolveExpiresAtMsFromDurationMs,
   resolveExpiresAtMsFromEpochSeconds,
 } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -127,6 +128,15 @@ function resolveActiveWindowUntil(value: unknown, now: number): number {
   return timestampMs !== undefined && timestampMs > now ? timestampMs : 0;
 }
 
+function resolveUsageWindowUntil(now: number, durationMs: number): number {
+  if (!Number.isFinite(durationMs) || durationMs <= 0) {
+    return now;
+  }
+  return (
+    resolveExpiresAtMsFromDurationMs(Math.max(1, Math.floor(durationMs)), { nowMs: now }) ?? now
+  );
+}
+
 function resolveWhamResetMs(window: WhamUsageWindow | undefined, now: number): number | null {
   if (!window) {
     return null;
@@ -192,7 +202,10 @@ function applyWhamCooldownResult(params: {
   }
   return {
     ...params.computed,
-    cooldownUntil: Math.max(existingActiveCooldownUntil, params.now + params.whamResult.cooldownMs),
+    cooldownUntil: Math.max(
+      existingActiveCooldownUntil,
+      resolveUsageWindowUntil(params.now, params.whamResult.cooldownMs),
+    ),
   };
 }
 
@@ -263,7 +276,7 @@ async function probeWhamForCooldown(
       }
       return {
         cooldownMs: WHAM_BURST_COOLDOWN_MS,
-        blockedUntil: now + primaryResetMs,
+        blockedUntil: resolveUsageWindowUntil(now, primaryResetMs),
         blockedSource: "wham",
         reason: "wham_personal_rolling",
       };
@@ -275,7 +288,7 @@ async function probeWhamForCooldown(
       }
       return {
         cooldownMs: WHAM_BURST_COOLDOWN_MS,
-        blockedUntil: now + secondaryResetMs,
+        blockedUntil: resolveUsageWindowUntil(now, secondaryResetMs),
         blockedSource: "wham",
         reason: "wham_team_weekly",
       };
@@ -287,7 +300,7 @@ async function probeWhamForCooldown(
       }
       return {
         cooldownMs: WHAM_BURST_COOLDOWN_MS,
-        blockedUntil: now + primaryResetMs,
+        blockedUntil: resolveUsageWindowUntil(now, primaryResetMs),
         blockedSource: "wham",
         reason: "wham_team_rolling",
       };
@@ -615,7 +628,7 @@ function computeNextProfileUsageStats(params: {
     updatedStats.disabledUntil = keepActiveWindowOrRecompute({
       existingUntil: params.existing.disabledUntil,
       now: params.now,
-      recomputedUntil: params.now + backoffMs,
+      recomputedUntil: resolveUsageWindowUntil(params.now, backoffMs),
     });
     updatedStats.disabledReason = disabledFailureReason;
   } else {
@@ -625,7 +638,7 @@ function computeNextProfileUsageStats(params: {
     updatedStats.cooldownUntil = keepActiveWindowOrRecompute({
       existingUntil: params.existing.cooldownUntil,
       now: params.now,
-      recomputedUntil: params.now + backoffMs,
+      recomputedUntil: resolveUsageWindowUntil(params.now, backoffMs),
     });
     // Update cooldown metadata based on whether the window is still active
     // and whether the same or a different model is failing.

--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { compactionPlanningWorkerTesting } from "./compaction-planning-worker.js";
 import { runCompactionPlanningWorkerInput } from "./compaction-planning.worker.js";
 import type { AgentMessage } from "./runtime/index.js";
@@ -48,6 +49,21 @@ describe("compaction planning worker", () => {
     }
     expect(value.chunks.flat().map((message) => message.timestamp)).toEqual([1, 2, 3]);
     expect(value.chunks.length).toBeGreaterThan(1);
+  });
+
+  it("clamps oversized worker timeouts before scheduling", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    await compactionPlanningWorkerTesting.runCompactionPlanningWorker({
+      input: {
+        kind: "summaryChunks",
+        messages: [makeMessage(1), makeMessage(2), makeMessage(3)],
+        maxChunkTokens: 1200,
+      },
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
 
   it("classifies missing worker runtime as unavailable", async () => {

--- a/src/agents/compaction-planning-worker.ts
+++ b/src/agents/compaction-planning-worker.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import {
   buildHistoryPrunePlan,
   buildOversizedFallbackPlan,
@@ -78,15 +79,18 @@ function runCompactionPlanningWorker(params: {
 
   return new Promise<CompactionPlanningWorkerValue>((resolve, reject) => {
     let settled = false;
-    const timeout = setTimeout(() => {
-      settle(
-        () =>
-          reject(
-            new CompactionPlanningWorkerError("compaction planning worker timed out", "timeout"),
-          ),
-        true,
-      );
-    }, params.timeoutMs ?? COMPACTION_PLANNING_WORKER_TIMEOUT_MS);
+    const timeout = setTimeout(
+      () => {
+        settle(
+          () =>
+            reject(
+              new CompactionPlanningWorkerError("compaction planning worker timed out", "timeout"),
+            ),
+          true,
+        );
+      },
+      resolveTimerTimeoutMs(params.timeoutMs, COMPACTION_PLANNING_WORKER_TIMEOUT_MS),
+    );
 
     const abort = () => {
       settle(() => reject(params.signal?.reason ?? new Error("compaction planning aborted")), true);

--- a/src/agents/embedded-agent-runner.guard.waitforidle-before-flush.test.ts
+++ b/src/agents/embedded-agent-runner.guard.waitforidle-before-flush.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { flushPendingToolResultsAfterIdle } from "./embedded-agent-runner/wait-for-idle-before-flush.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 
@@ -142,6 +143,26 @@ describe("flushPendingToolResultsAfterIdle", () => {
       timeoutMs: 30_000,
     });
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clamps oversized idle wait timeouts before scheduling", async () => {
+    const sm = guardSessionManager(SessionManager.inMemory());
+    const idle = deferred<void>();
+    const agent = { waitForIdle: () => idle.promise };
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const flushPromise = flushPendingToolResultsAfterIdle({
+        agent,
+        sessionManager: sm,
+        timeoutMs: Number.MAX_SAFE_INTEGER,
+      });
+      idle.resolve();
+      await flushPromise;
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   it("immediately flushes pending tool results without waiting when timeoutMs is 0 or less", async () => {

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -393,6 +393,28 @@ describe("embedded-agent runner run registry", () => {
     }
   });
 
+  it("clamps oversized active-run drain poll intervals", async () => {
+    vi.useFakeTimers();
+    try {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const handle = createRunHandle();
+      setActiveEmbeddedRun("session-a", handle);
+
+      const waitPromise = waitForActiveEmbeddedRuns(undefined, {
+        pollMs: Number.MAX_SAFE_INTEGER,
+      });
+      await Promise.resolve();
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      clearActiveEmbeddedRun("session-a", handle);
+      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+      await expect(waitPromise).resolves.toEqual({ drained: true });
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
   it("shares active run state across distinct module instances", async () => {
     const runsA = await importFreshModule<typeof import("./runs.js")>(
       import.meta.url,

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -13,6 +13,7 @@ import {
   resetDiagnosticSessionStateForTest,
 } from "../../logging/diagnostic-session-state.js";
 import { diagnosticLogger } from "../../logging/diagnostic.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
 import {
   testing,
   abortAndDrainEmbeddedAgentRun,
@@ -35,6 +36,7 @@ import {
   updateActiveEmbeddedRunSnapshot,
   updateActiveEmbeddedRunSessionFile,
   waitForActiveEmbeddedRuns,
+  waitForEmbeddedAgentRunEnd,
 } from "./runs.js";
 
 type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
@@ -332,6 +334,24 @@ describe("embedded-agent runner run registry", () => {
       expect(abortRun).toHaveBeenCalledTimes(1);
       expect(isEmbeddedAgentRunHandleActive("session-stuck")).toBe(false);
       expect(resolveActiveEmbeddedRunHandleSessionId("agent:main")).toBeUndefined();
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps oversized embedded run wait timers", async () => {
+    vi.useFakeTimers();
+    try {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const handle = createRunHandle();
+      setActiveEmbeddedRun("session-running", handle);
+
+      const waitPromise = waitForEmbeddedAgentRunEnd("session-running", MAX_TIMER_TIMEOUT_MS + 1);
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      clearActiveEmbeddedRun("session-running", handle);
+      await expect(waitPromise).resolves.toBe(true);
     } finally {
       await vi.runOnlyPendingTimersAsync();
       vi.useRealTimers();

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -617,7 +617,7 @@ export async function waitForActiveEmbeddedRuns(
   opts?: { pollMs?: number },
 ): Promise<{ drained: boolean }> {
   const pollMsRaw = opts?.pollMs ?? 250;
-  const pollMs = Math.max(10, Math.floor(pollMsRaw));
+  const pollMs = resolveTimerTimeoutMs(pollMsRaw, 250, 10);
   if (timeoutMs !== undefined && timeoutMs <= 0) {
     return { drained: getActiveEmbeddedRunCount() === 0 };
   }

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -19,6 +19,7 @@ import {
   logSessionStateChange,
   updateDiagnosticSessionFile,
 } from "../../logging/diagnostic.js";
+import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
 import {
   ACTIVE_EMBEDDED_RUNS,
   ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE,
@@ -665,7 +666,7 @@ export function waitForEmbeddedAgentRunEnd(
           diag.warn(`wait timeout: sessionId=${sessionId} timeoutMs=${timeoutMs}`);
           resolve(false);
         },
-        Math.max(100, timeoutMs),
+        resolveTimerTimeoutMs(timeoutMs, 100, 100),
       ),
     };
     waiters.add(waiter);

--- a/src/agents/embedded-agent-runner/wait-for-idle-before-flush.ts
+++ b/src/agents/embedded-agent-runner/wait-for-idle-before-flush.ts
@@ -1,3 +1,5 @@
+import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
+
 type IdleAwareAgent = {
   waitForIdle?: (() => Promise<void>) | undefined;
 };
@@ -17,6 +19,7 @@ async function waitForAgentIdleBestEffort(
   if (typeof waitForIdle !== "function") {
     return false;
   }
+  const resolvedTimeoutMs = resolveTimerTimeoutMs(timeoutMs, DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS);
 
   const idleResolved = Symbol("idle");
   const idleTimedOut = Symbol("timeout");
@@ -25,7 +28,7 @@ async function waitForAgentIdleBestEffort(
     const outcome = await Promise.race([
       waitForIdle.call(agent).then(() => idleResolved),
       new Promise<symbol>((resolve) => {
-        timeoutHandle = setTimeout(() => resolve(idleTimedOut), timeoutMs);
+        timeoutHandle = setTimeout(() => resolve(idleTimedOut), resolvedTimeoutMs);
         timeoutHandle.unref?.();
       }),
     ]);

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -4,6 +4,7 @@ import {
   clearMemoryEmbeddingProviders,
   registerMemoryEmbeddingProvider,
 } from "../plugins/memory-embedding-providers.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { resolveMemorySearchConfig, resolveMemorySearchSyncConfig } from "./memory-search.js";
 
 const asConfig = (cfg: OpenClawConfig): OpenClawConfig => cfg;
@@ -527,6 +528,50 @@ describe("memory search config", () => {
     const cfg = configWithDefaultProvider("openai");
     const resolved = resolveMemorySearchConfig(cfg, "main");
     expectDefaultRemoteBatch(resolved);
+  });
+
+  it("normalizes remote batch timer config once before provider adapters receive it", () => {
+    const cfg = asConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "openai",
+            remote: {
+              batch: {
+                pollIntervalMs: Number.MAX_SAFE_INTEGER,
+                timeoutMinutes: Number.MAX_SAFE_INTEGER,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const resolved = resolveMemorySearchConfig(cfg, "main");
+
+    expect(resolved?.remote?.batch?.pollIntervalMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(resolved?.remote?.batch?.timeoutMinutes).toBe(Math.floor(MAX_TIMER_TIMEOUT_MS / 60_000));
+  });
+
+  it("keeps the default remote batch poll delay for zero intervals", () => {
+    const cfg = asConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "openai",
+            remote: {
+              batch: {
+                pollIntervalMs: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const resolved = resolveMemorySearchConfig(cfg, "main");
+
+    expect(resolved?.remote?.batch?.pollIntervalMs).toBe(2000);
   });
 
   it("keeps remote unset for local provider without overrides", () => {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -5,6 +5,10 @@ import {
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
 import {
+  MAX_TIMER_TIMEOUT_MS,
+  resolvePositiveTimerTimeoutMs,
+} from "@openclaw/normalization-core/number-coercion";
+import {
   normalizeStringEntries,
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
@@ -126,6 +130,29 @@ const DEFAULT_TEMPORAL_DECAY_HALF_LIFE_DAYS = 30;
 const DEFAULT_CACHE_ENABLED = true;
 const DEFAULT_SOURCES: Array<"memory" | "sessions"> = ["memory"];
 const DEFAULT_MEMORY_EMBEDDING_PROVIDER = "openai";
+const DEFAULT_REMOTE_BATCH_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_REMOTE_BATCH_TIMEOUT_MINUTES = 60;
+const MAX_REMOTE_BATCH_TIMEOUT_MINUTES = Math.floor(MAX_TIMER_TIMEOUT_MS / 60_000);
+
+function resolveRemoteBatchPollIntervalMs(
+  overrideValue: number | undefined,
+  defaultValue: number | undefined,
+): number {
+  return resolvePositiveTimerTimeoutMs(
+    overrideValue ?? defaultValue,
+    DEFAULT_REMOTE_BATCH_POLL_INTERVAL_MS,
+  );
+}
+
+function resolveRemoteBatchTimeoutMinutes(
+  overrideValue: number | undefined,
+  defaultValue: number | undefined,
+): number {
+  const value = overrideValue ?? defaultValue;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? clampInt(value, 1, MAX_REMOTE_BATCH_TIMEOUT_MINUTES)
+    : DEFAULT_REMOTE_BATCH_TIMEOUT_MINUTES;
+}
 
 function normalizeSources(
   sources: Array<"memory" | "sessions"> | undefined,
@@ -221,10 +248,14 @@ function mergeConfig(
       1,
       overrideRemote?.batch?.concurrency ?? defaultRemote?.batch?.concurrency ?? 2,
     ),
-    pollIntervalMs:
-      overrideRemote?.batch?.pollIntervalMs ?? defaultRemote?.batch?.pollIntervalMs ?? 2000,
-    timeoutMinutes:
-      overrideRemote?.batch?.timeoutMinutes ?? defaultRemote?.batch?.timeoutMinutes ?? 60,
+    pollIntervalMs: resolveRemoteBatchPollIntervalMs(
+      overrideRemote?.batch?.pollIntervalMs,
+      defaultRemote?.batch?.pollIntervalMs,
+    ),
+    timeoutMinutes: resolveRemoteBatchTimeoutMinutes(
+      overrideRemote?.batch?.timeoutMinutes,
+      defaultRemote?.batch?.timeoutMinutes,
+    ),
   };
   const remote = includeRemote
     ? {

--- a/src/agents/model-catalog-browse.test.ts
+++ b/src/agents/model-catalog-browse.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { loadModelCatalogForBrowse } from "./model-catalog-browse.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 
@@ -105,5 +106,27 @@ describe("loadModelCatalogForBrowse", () => {
 
     await expect(resultPromise).resolves.toBe(readOnlyCatalog);
     expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("caps oversized browse timeouts before scheduling the fallback timer", async () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const loadCatalog = vi.fn(
+      () =>
+        new Promise<ModelCatalogEntry[]>((resolve) => {
+          setTimeout(() => resolve(readOnlyCatalog), 5);
+        }),
+    );
+
+    const resultPromise = loadModelCatalogForBrowse({
+      cfg: config(),
+      loadCatalog,
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(5);
+
+    await expect(resultPromise).resolves.toBe(readOnlyCatalog);
   });
 });

--- a/src/agents/model-catalog-browse.ts
+++ b/src/agents/model-catalog-browse.ts
@@ -1,4 +1,7 @@
-import { parseFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import {
+  clampTimerTimeoutMs,
+  resolveTimerTimeoutMs,
+} from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { parseConfiguredModelVisibilityEntries } from "./model-selection-shared.js";
@@ -8,9 +11,9 @@ export const DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS = 750;
 export type ModelCatalogBrowseView = "default" | "configured" | "all";
 
 function resolveModelCatalogBrowseTimeoutMs(value: number | undefined): number {
-  return Math.max(
-    1,
-    Math.floor(parseFiniteNumber(value) ?? DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS),
+  return (
+    clampTimerTimeoutMs(value, 1) ??
+    resolveTimerTimeoutMs(DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS, 1)
   );
 }
 

--- a/src/agents/model-scan.test.ts
+++ b/src/agents/model-scan.test.ts
@@ -72,6 +72,28 @@ describe("scanOpenRouterModels", () => {
     expect(byPricing.image.skipped).toBe(true);
   });
 
+  it("drops out-of-range OpenRouter created_at timestamps", async () => {
+    const fetchImpl = createFetchFixture({
+      data: [
+        {
+          id: "acme/free-invalid-created:free",
+          name: "Free Invalid Created",
+          context_length: 16_384,
+          supported_parameters: [],
+          modality: "text",
+          created_at: 8_640_000_000_000_001,
+        },
+      ],
+    });
+
+    const [result] = await scanOpenRouterModels({
+      fetchImpl,
+      probe: false,
+    });
+
+    expect(result?.createdAtMs).toBeNull();
+  });
+
   it("requires an API key when probing", async () => {
     const fetchImpl = createFetchFixture({ data: [] });
     await withEnvAsync({ OPENROUTER_API_KEY: undefined }, async () => {

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -1,5 +1,8 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import {
+  asDateTimestampMs,
+  resolveTimerTimeoutMs,
+} from "@openclaw/normalization-core/number-coercion";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -98,10 +101,8 @@ function normalizeCreatedAtMs(value: unknown): number | null {
   if (value <= 0) {
     return null;
   }
-  if (value > 1e12) {
-    return Math.round(value);
-  }
-  return Math.round(value * 1000);
+  const timestampMs = value > 1e12 ? Math.round(value) : Math.round(value * 1000);
+  return asDateTimestampMs(timestampMs) ?? null;
 }
 
 function parseModality(modality: string | null): Array<"text" | "image"> {

--- a/src/agents/sandbox/fs-bridge-stat-parse.ts
+++ b/src/agents/sandbox/fs-bridge-stat-parse.ts
@@ -1,4 +1,5 @@
 import { parseStrictNonNegativeInteger } from "../../infra/parse-finite-number.js";
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
 
 export function parseSandboxStatSize(value: string | undefined): number {
   const raw = value ?? "0";
@@ -13,8 +14,8 @@ export function parseSandboxStatMtimeMs(value: string | undefined): number {
   const raw = value ?? "0";
   if (/^\d+(?:\.\d+)?$/.test(raw)) {
     const mtimeMs = Number(raw) * 1000;
-    return Number.isFinite(mtimeMs) ? mtimeMs : 0;
+    return asDateTimestampMs(mtimeMs) ?? 0;
   }
   const parsed = Date.parse(raw);
-  return Number.isFinite(parsed) ? parsed : 0;
+  return asDateTimestampMs(parsed) ?? 0;
 }

--- a/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
+++ b/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
@@ -228,7 +228,7 @@ describe("sandbox fs bridge anchored ops", () => {
           return dockerExecResult(`${getDockerArg(args, 1)}\n`);
         }
         if (script.includes('stat -c "%F|%s|%y"')) {
-          return dockerExecResult("regular file|9007199254740992|not-a-date\n");
+          return dockerExecResult("regular file|9007199254740992|8640000000001\n");
         }
         return dockerExecResult("");
       });

--- a/src/agents/sandbox/prune.test.ts
+++ b/src/agents/sandbox/prune.test.ts
@@ -146,4 +146,23 @@ describe("maybePruneSandboxes", () => {
       "Sandbox prune failed to remove sandbox-1: docker rm failed",
     );
   });
+
+  it("prunes entries with out-of-range registry timestamps", async () => {
+    registryMocks.readRegistry.mockResolvedValueOnce({
+      entries: [
+        {
+          containerName: "sandbox-out-of-range",
+          backendId: "docker",
+          createdAtMs: Date.now(),
+          lastUsedAtMs: Number.MAX_SAFE_INTEGER,
+          image: "openclaw-sandbox:bookworm-slim",
+        },
+      ],
+    });
+
+    await maybePruneSandboxes(buildPruneConfig());
+
+    expect(backendMocks.removeRuntime).toHaveBeenCalledTimes(1);
+    expect(registryMocks.removeRegistryEntry).toHaveBeenCalledWith("sandbox-out-of-range");
+  });
 });

--- a/src/agents/sandbox/prune.ts
+++ b/src/agents/sandbox/prune.ts
@@ -1,6 +1,7 @@
 import { getRuntimeConfig } from "../../config/config.js";
 import { stopBrowserBridgeServer } from "../../plugin-sdk/browser-bridge.js";
 import { defaultRuntime } from "../../runtime.js";
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import { getSandboxBackendManager } from "./backend.js";
 import { BROWSER_BRIDGES } from "./browser-bridges.js";
 import { dockerSandboxBackendManager } from "./docker-backend.js";
@@ -27,8 +28,11 @@ function shouldPruneSandboxEntry(cfg: SandboxConfig, now: number, entry: Pruneab
   if (idleHours === 0 && maxAgeDays === 0) {
     return false;
   }
-  const idleMs = now - entry.lastUsedAtMs;
-  const ageMs = now - entry.createdAtMs;
+  const nowMs = asDateTimestampMs(now) ?? 0;
+  const lastUsedAtMs = asDateTimestampMs(entry.lastUsedAtMs) ?? 0;
+  const createdAtMs = asDateTimestampMs(entry.createdAtMs) ?? 0;
+  const idleMs = nowMs - lastUsedAtMs;
+  const ageMs = nowMs - createdAtMs;
   return (
     (idleHours > 0 && idleMs > idleHours * 60 * 60 * 1000) ||
     (maxAgeDays > 0 && ageMs > maxAgeDays * 24 * 60 * 60 * 1000)

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -209,7 +209,7 @@ describe("remote sandbox fs bridge", () => {
           }
           if (command.script.includes('stat -c "%F|%s|%y"')) {
             return {
-              stdout: Buffer.from("regular file|9007199254740992|not-a-date\n"),
+              stdout: Buffer.from("regular file|9007199254740992|8640000000001\n"),
               stderr: Buffer.alloc(0),
               code: 0,
             };

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../config/cron-limits.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { CommandLane } from "../process/lanes.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 
 const sessionStoreMocks = vi.hoisted(() => ({
   applySessionStoreEntryPatch: vi.fn(),
@@ -100,6 +101,20 @@ describe("session suspension", () => {
       CommandLane.Cron,
       1,
     );
+  });
+
+  it("clamps oversized suspension TTLs for timers and persisted resume time", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    await suspendLane(Number.MAX_SAFE_INTEGER, {} as OpenClawConfig, CommandLane.Main);
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    const patch = sessionStoreMocks.applySessionStoreEntryPatch.mock.calls[0]?.[0].patch as {
+      quotaSuspension?: { expectedResumeBy?: number };
+    };
+    expect(patch.quotaSuspension?.expectedResumeBy).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
   });
 
   it("maps failover reasons to persisted suspension reasons", async () => {

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -5,6 +5,10 @@ import { applySessionStoreEntryPatch } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
+import {
+  resolveExpiresAtMsFromDurationMs,
+  resolveTimerTimeoutMs,
+} from "../shared/number-coercion.js";
 import { resolveStoredSessionKeyForSessionId } from "./command/session.js";
 import type { FailoverReason } from "./embedded-agent-helpers/types.js";
 
@@ -94,8 +98,9 @@ export async function suspendSession(params: {
     return;
   }
 
-  const ttlMs = params.ttlMs ?? DEFAULT_QUOTA_SUSPENSION_RESUME_MS;
+  const ttlMs = resolveTimerTimeoutMs(params.ttlMs, DEFAULT_QUOTA_SUSPENSION_RESUME_MS, 0);
   const now = Date.now();
+  const expectedResumeBy = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: now }) ?? now;
 
   try {
     await applySessionStoreEntryPatch({
@@ -112,7 +117,7 @@ export async function suspendSession(params: {
           failedModel: params.failedModel,
           summary: params.summary,
           laneId: params.laneId,
-          expectedResumeBy: now + ttlMs,
+          expectedResumeBy,
           state: "suspended",
         },
       },

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -53,6 +53,7 @@ import {
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import type { PendingFinalDeliveryPayload, SubagentRunRecord } from "./subagent-registry.types.js";
+import { resolveSubagentRunDeadlineMs } from "./subagent-run-timeout.js";
 import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
 
 type CaptureSubagentCompletionReply =
@@ -73,27 +74,6 @@ async function loadCleanupBrowserSessionsForLifecycleEnd(): Promise<
   BrowserCleanupModule["cleanupBrowserSessionsForLifecycleEnd"]
 > {
   return (await browserCleanupLoader.load()).cleanupBrowserSessionsForLifecycleEnd;
-}
-
-function resolveSubagentRunDeadlineMs(
-  entry: SubagentRunRecord,
-  observedStartedAt?: number,
-): number | undefined {
-  const timeoutSeconds = entry.runTimeoutSeconds;
-  if (
-    typeof timeoutSeconds !== "number" ||
-    !Number.isFinite(timeoutSeconds) ||
-    timeoutSeconds <= 0
-  ) {
-    return undefined;
-  }
-  const startedAt =
-    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
-      ? observedStartedAt
-      : typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
-        ? entry.startedAt
-        : entry.createdAt;
-  return Number.isFinite(startedAt) ? startedAt + Math.floor(timeoutSeconds * 1000) : undefined;
 }
 
 function shouldPreservePublishedExplicitRunTimeout(params: { entry: SubagentRunRecord }): boolean {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -35,6 +35,7 @@ import {
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import { resolveSubagentRunDeadlineMs } from "./subagent-run-timeout.js";
 import type { SubagentSessionCompletion } from "./subagent-session-reconciliation.js";
 
 const log = createSubsystemLogger("agents/subagent-registry");
@@ -43,30 +44,6 @@ const WAIT_TIMEOUT_DEADLINE_SKEW_MS = 250;
 
 function shouldDeleteAttachments(entry: SubagentRunRecord) {
   return entry.cleanup === "delete" || !entry.retainAttachmentsOnKeep;
-}
-
-function resolveSubagentRunDeadlineMs(
-  entry: SubagentRunRecord,
-  observedStartedAt?: number,
-): number | undefined {
-  const timeoutSeconds = entry.runTimeoutSeconds;
-  if (
-    typeof timeoutSeconds !== "number" ||
-    !Number.isFinite(timeoutSeconds) ||
-    timeoutSeconds <= 0
-  ) {
-    return undefined;
-  }
-  const startedAt =
-    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
-      ? observedStartedAt
-      : typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
-        ? entry.startedAt
-        : entry.createdAt;
-  if (!Number.isFinite(startedAt)) {
-    return undefined;
-  }
-  return startedAt + Math.floor(timeoutSeconds * 1000);
 }
 
 function resolveHardRunTimeoutEndedAt(

--- a/src/agents/subagent-run-liveness.ts
+++ b/src/agents/subagent-run-liveness.ts
@@ -1,4 +1,5 @@
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import { resolveSubagentRunDurationMs } from "./subagent-run-timeout.js";
 import { getSubagentSessionStartedAt } from "./subagent-session-metrics.js";
 
 export const STALE_UNENDED_SUBAGENT_RUN_MS = 2 * 60 * 60 * 1_000;
@@ -13,12 +14,9 @@ export function hasSubagentRunEnded<T extends Pick<SubagentRunRecord, "endedAt">
 }
 
 function resolveStaleCutoffMs(entry: Pick<SubagentRunRecord, "runTimeoutSeconds">): number {
-  const timeoutSeconds = entry.runTimeoutSeconds;
-  if (typeof timeoutSeconds === "number" && Number.isFinite(timeoutSeconds) && timeoutSeconds > 0) {
-    return Math.max(
-      STALE_UNENDED_SUBAGENT_RUN_MS,
-      Math.floor(timeoutSeconds) * 1_000 + EXPLICIT_TIMEOUT_STALE_GRACE_MS,
-    );
+  const durationMs = resolveSubagentRunDurationMs(entry.runTimeoutSeconds);
+  if (durationMs !== undefined) {
+    return Math.max(STALE_UNENDED_SUBAGENT_RUN_MS, durationMs + EXPLICIT_TIMEOUT_STALE_GRACE_MS);
   }
   return STALE_UNENDED_SUBAGENT_RUN_MS;
 }

--- a/src/agents/subagent-run-timeout.test.ts
+++ b/src/agents/subagent-run-timeout.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
+import {
+  resolveSubagentRunDeadlineMs,
+  resolveSubagentRunDurationMs,
+  resolveSubagentRunTimerDelayMs,
+} from "./subagent-run-timeout.js";
+
+describe("subagent run timeout helpers", () => {
+  it("preserves semantic deadlines longer than the timer cap", () => {
+    const thirtyDaysSeconds = 30 * 24 * 60 * 60;
+
+    expect(resolveSubagentRunDurationMs(thirtyDaysSeconds)).toBe(2_592_000_000);
+    expect(
+      resolveSubagentRunDeadlineMs({
+        createdAt: 1_000,
+        runTimeoutSeconds: thirtyDaysSeconds,
+      }),
+    ).toBe(2_592_001_000);
+  });
+
+  it("caps actual timer delays without shortening semantic durations", () => {
+    const thirtyDaysSeconds = 30 * 24 * 60 * 60;
+
+    expect(resolveSubagentRunTimerDelayMs(thirtyDaysSeconds)).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(resolveSubagentRunDurationMs(thirtyDaysSeconds)).toBeGreaterThan(MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("ignores invalid timeout seconds and invalid start timestamps", () => {
+    expect(resolveSubagentRunDurationMs(Number.NaN)).toBeUndefined();
+    expect(resolveSubagentRunDurationMs(0)).toBeUndefined();
+    expect(
+      resolveSubagentRunDeadlineMs({
+        createdAt: Number.POSITIVE_INFINITY,
+        runTimeoutSeconds: 60,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/subagent-run-timeout.ts
+++ b/src/agents/subagent-run-timeout.ts
@@ -1,0 +1,45 @@
+import {
+  asDateTimestampMs,
+  finiteSecondsToTimerSafeMilliseconds,
+} from "../shared/number-coercion.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+export function resolveSubagentRunTimerDelayMs(timeoutSeconds: unknown): number | undefined {
+  return finiteSecondsToTimerSafeMilliseconds(timeoutSeconds, { floorSeconds: true });
+}
+
+export function resolveSubagentRunDurationMs(timeoutSeconds: unknown): number | undefined {
+  if (
+    typeof timeoutSeconds !== "number" ||
+    !Number.isFinite(timeoutSeconds) ||
+    timeoutSeconds <= 0
+  ) {
+    return undefined;
+  }
+  const durationMs = Math.floor(timeoutSeconds) * 1000;
+  return Number.isSafeInteger(durationMs) && durationMs > 0 ? durationMs : undefined;
+}
+
+export function resolveSubagentRunDeadlineMs(
+  entry: Pick<SubagentRunRecord, "createdAt" | "startedAt" | "runTimeoutSeconds">,
+  observedStartedAt?: number,
+): number | undefined {
+  const durationMs = resolveSubagentRunDurationMs(entry.runTimeoutSeconds);
+  if (durationMs === undefined) {
+    return undefined;
+  }
+  const startedAt =
+    typeof observedStartedAt === "number" && Number.isFinite(observedStartedAt)
+      ? observedStartedAt
+      : typeof entry.startedAt === "number" && Number.isFinite(entry.startedAt)
+        ? entry.startedAt
+        : entry.createdAt;
+  const safeStartedAt = asDateTimestampMs(startedAt);
+  if (safeStartedAt === undefined) {
+    return undefined;
+  }
+  const deadlineMs = safeStartedAt + durationMs;
+  return Number.isSafeInteger(deadlineMs) && asDateTimestampMs(deadlineMs) !== undefined
+    ? deadlineMs
+    : undefined;
+}

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -54,6 +54,7 @@ import { resolveSubagentCapabilities } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
+import { resolveSubagentRunTimerDelayMs } from "./subagent-run-timeout.js";
 import { resolveSubagentSpawnAcceptedNote } from "./subagent-spawn-accepted-note.js";
 import { resolveSubagentSpawnOwnership } from "./subagent-spawn-ownership.js";
 import { resolveSubagentTargetPolicy } from "./subagent-target-policy.js";
@@ -261,10 +262,7 @@ function buildResolvedSubagentModelMetadata(
 }
 
 function resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds: number): number {
-  const runTimeoutMs =
-    Number.isFinite(runTimeoutSeconds) && runTimeoutSeconds > 0
-      ? Math.floor(runTimeoutSeconds * 1000)
-      : 0;
+  const runTimeoutMs = resolveSubagentRunTimerDelayMs(runTimeoutSeconds) ?? 0;
   if (runTimeoutMs <= 0) {
     return DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS;
   }

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -1,9 +1,13 @@
-import { MAX_TIMER_TIMEOUT_SECONDS } from "@openclaw/normalization-core/number-coercion";
+import {
+  MAX_TIMER_TIMEOUT_MS,
+  MAX_TIMER_TIMEOUT_SECONDS,
+} from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   readCache,
   resolvePositiveTimeoutSeconds,
   resolveTimeoutSeconds,
+  withTimeout,
   writeCache,
   type CacheEntry,
 } from "./web-shared.js";
@@ -62,5 +66,19 @@ describe("web shared timeout seconds", () => {
     expect(cache.size).toBe(100);
     expect(cache.get("key-0")?.value).toBe("value-0");
     expect(cache.has("invalid")).toBe(false);
+  });
+});
+
+describe("web shared withTimeout", () => {
+  it("clamps oversized timeoutMs before scheduling", () => {
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
+    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+
+    const signal = withTimeout(undefined, Number.MAX_SAFE_INTEGER);
+    signal.dispatchEvent(new Event("abort"));
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
 });

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -2,6 +2,7 @@ import {
   asDateTimestampMs,
   MAX_TIMER_TIMEOUT_SECONDS,
   resolveExpiresAtMsFromDurationMs,
+  resolveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
@@ -84,7 +85,7 @@ export function withTimeout(signal: AbortSignal | undefined, timeoutMs: number):
     return signal ?? new AbortController().signal;
   }
   const controller = new AbortController();
-  const timer = setTimeout(controller.abort.bind(controller), timeoutMs);
+  const timer = setTimeout(controller.abort.bind(controller), resolveTimerTimeoutMs(timeoutMs, 1));
   if (signal) {
     signal.addEventListener(
       "abort",

--- a/src/agents/utils/sleep.test.ts
+++ b/src/agents/utils/sleep.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
+import { sleep } from "./sleep.js";
+
+describe("agents sleep", () => {
+  it("clamps oversized delays before scheduling", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const sleeper = sleep(Number.MAX_SAFE_INTEGER);
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+
+      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+      await expect(sleeper).resolves.toBeUndefined();
+    } finally {
+      setTimeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("removes abort listeners after normal resolution", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const removeListenerSpy = vi.spyOn(controller.signal, "removeEventListener");
+    try {
+      const sleeper = sleep(5, controller.signal);
+
+      await vi.advanceTimersByTimeAsync(5);
+      await expect(sleeper).resolves.toBeUndefined();
+
+      expect(removeListenerSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+    } finally {
+      removeListenerSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/agents/utils/sleep.ts
+++ b/src/agents/utils/sleep.ts
@@ -1,6 +1,8 @@
 /**
  * Sleep helper that respects abort signal.
  */
+import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
+
 export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
@@ -8,11 +10,18 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       return;
     }
 
-    const timeout = setTimeout(resolve, ms);
-
-    signal?.addEventListener("abort", () => {
+    const onAbort = () => {
       clearTimeout(timeout);
       reject(new Error("Aborted"));
-    });
+    };
+    const timeout = setTimeout(
+      () => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      },
+      resolveTimerTimeoutMs(ms, 0, 0),
+    );
+
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }

--- a/src/auto-reply/reply/commands-session-lifecycle.test.ts
+++ b/src/auto-reply/reply/commands-session-lifecycle.test.ts
@@ -570,7 +570,7 @@ describe("/session idle and /session max-age", () => {
     expect(result?.reply?.text).toContain("2026-02-20T02:00:00.000Z");
   });
 
-  it("falls back when active idle timeout expiry is Date-invalid", async () => {
+  it("falls back to bind time when idle activity timestamp is out of range", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-20T00:00:00.000Z"));
 
@@ -586,7 +586,26 @@ describe("/session idle and /session max-age", () => {
     );
 
     const result = await handleSessionCommand(createThreadCommandParams("/session idle"), true);
-    expect(result?.reply?.text).toBe("ℹ️ Idle timeout active (2h, next auto-unfocus at n/a).");
+    expect(result?.reply?.text).toContain("Idle timeout active (2h");
+    expect(result?.reply?.text).toContain("2026-02-20T02:00:00.000Z");
+  });
+
+  it("treats overflowed idle timeout metadata as disabled", async () => {
+    hoisted.sessionBindingResolveByConversationMock.mockReturnValue(
+      createThreadBinding({
+        metadata: {
+          boundBy: "user-1",
+          lastActivityAt: Date.now(),
+          idleTimeoutMs: Number.MAX_SAFE_INTEGER,
+          maxAgeMs: 0,
+        },
+      }),
+    );
+
+    const result = await handleSessionCommand(createThreadCommandParams("/session idle"), true);
+    expect(result?.reply?.text).toBe(
+      "ℹ️ Idle timeout is currently disabled for this focused session.",
+    );
   });
 
   it("sets max age for the focused thread-chat session", async () => {

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -27,6 +27,10 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart, triggerOpenClawRestart } from "../../infra/restart.js";
 import { loadCostUsageSummary, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
+import {
+  asDateTimestampMs,
+  resolveExpiresAtMsFromDurationMs,
+} from "../../shared/number-coercion.js";
 import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 import { parseActivationCommand } from "../group-activation.js";
 import { parseSendPolicyCommand } from "../send-policy.js";
@@ -104,11 +108,17 @@ function resolveSessionBindingDurationMs(
 }
 
 function resolveSessionBindingLastActivityAt(binding: SessionBindingRecord): number {
-  const raw = binding.metadata?.lastActivityAt;
-  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+  const raw = asDateTimestampMs(binding.metadata?.lastActivityAt);
+  if (raw === undefined) {
     return binding.boundAt;
   }
   return Math.max(Math.floor(raw), binding.boundAt);
+}
+
+function resolveSessionBindingExpiryAt(baseMs: number, durationMs: number): number | undefined {
+  return durationMs > 0
+    ? resolveExpiresAtMsFromDurationMs(durationMs, { nowMs: baseMs })
+    : undefined;
 }
 
 function resolveSessionBindingBoundBy(binding: SessionBindingRecord): string {
@@ -177,7 +187,10 @@ function resolveUpdatedBindingExpiry(params: {
         if (idleTimeoutMs <= 0) {
           return undefined;
         }
-        return Math.max(binding.lastActivityAt, binding.boundAt) + idleTimeoutMs;
+        return resolveSessionBindingExpiryAt(
+          Math.max(binding.lastActivityAt, binding.boundAt),
+          idleTimeoutMs,
+        );
       }
 
       const maxAgeMs =
@@ -187,7 +200,7 @@ function resolveUpdatedBindingExpiry(params: {
       if (maxAgeMs <= 0) {
         return undefined;
       }
-      return binding.boundAt + maxAgeMs;
+      return resolveSessionBindingExpiryAt(binding.boundAt, maxAgeMs);
     })
     .filter((expiresAt): expiresAt is number => typeof expiresAt === "number");
 
@@ -537,12 +550,12 @@ export const handleSessionCommand: CommandHandler = async (params, allowTextComm
     "idleTimeoutMs",
     24 * 60 * 60 * 1000,
   );
-  const idleExpiresAt =
-    idleTimeoutMs > 0
-      ? resolveSessionBindingLastActivityAt(activeBinding) + idleTimeoutMs
-      : undefined;
+  const idleExpiresAt = resolveSessionBindingExpiryAt(
+    resolveSessionBindingLastActivityAt(activeBinding),
+    idleTimeoutMs,
+  );
   const maxAgeMs = resolveSessionBindingDurationMs(activeBinding, "maxAgeMs", 0);
-  const maxAgeExpiresAt = maxAgeMs > 0 ? activeBinding.boundAt + maxAgeMs : undefined;
+  const maxAgeExpiresAt = resolveSessionBindingExpiryAt(activeBinding.boundAt, maxAgeMs);
 
   const durationArgRaw = tokens.slice(1).join("");
   if (!durationArgRaw) {

--- a/src/auto-reply/reply/directive-handling.auth.test.ts
+++ b/src/auto-reply/reply/directive-handling.auth.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
 
 let mockStore: AuthProfileStore;
 let mockOrder: string[];
@@ -141,6 +142,23 @@ describe("resolveAuthLabel ref-aware labels", () => {
 
     expect(result.label).toContain("github-copilot:default=token:ref");
     expect(result.label).not.toContain("token:missing");
+  });
+
+  it("omits out-of-range token expiry labels", async () => {
+    const result = await resolveRefOnlyAuthLabel({
+      provider: "github-copilot",
+      profileId: "github-copilot:default",
+      profile: {
+        type: "token",
+        provider: "github-copilot",
+        token: "gho-test",
+        expires: MAX_DATE_TIMESTAMP_MS + 1,
+      },
+      mode: "compact",
+    });
+
+    expect(result.label).toBe("github-copilot:default token gh...st");
+    expect(result.label).not.toContain(" exp ");
   });
 
   it("labels config-only aws-sdk profiles as valid in compact mode", async () => {

--- a/src/auto-reply/reply/directive-handling.auth.ts
+++ b/src/auto-reply/reply/directive-handling.auth.ts
@@ -16,6 +16,7 @@ import {
 import { findNormalizedProviderValue, normalizeProviderId } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import { shortenHomePath } from "../../utils.js";
 import { maskApiKey } from "../../utils/mask-api-key.js";
 
@@ -42,10 +43,11 @@ function formatExpirationLabel(
   formatUntil: (timestampMs: number) => string,
   compactExpiredPrefix = " expired",
 ) {
-  if (typeof expires !== "number" || !Number.isFinite(expires) || expires <= 0) {
+  const timestampMs = asDateTimestampMs(expires);
+  if (timestampMs === undefined || timestampMs <= 0) {
     return "";
   }
-  return expires <= now ? compactExpiredPrefix : ` exp ${formatUntil(expires)}`;
+  return timestampMs <= now ? compactExpiredPrefix : ` exp ${formatUntil(timestampMs)}`;
 }
 
 function formatFlagsSuffix(flags: string[]) {

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -3,6 +3,7 @@ import {
   getDiagnosticSessionActivitySnapshot,
   resetDiagnosticRunActivityForTest,
 } from "../../logging/diagnostic-run-activity.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
 import {
   testing,
   abortActiveReplyRuns,
@@ -147,6 +148,30 @@ describe("reply run registry", () => {
       expect(forceClearReplyRunBySessionId("session-running", new Error("stuck"))).toBe(true);
 
       expect(isReplyRunActiveForSessionId("session-running")).toBe(false);
+      await expect(waitPromise).resolves.toBe(true);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps oversized wait timers instead of resolving idle waits immediately", async () => {
+    vi.useFakeTimers();
+    try {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const operation = createReplyOperation({
+        sessionKey: "agent:main:main",
+        sessionId: "session-running",
+        resetTriggered: false,
+      });
+
+      const waitPromise = waitForReplyRunEndBySessionId(
+        "session-running",
+        MAX_TIMER_TIMEOUT_MS + 1,
+      );
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      operation.complete();
       await expect(waitPromise).resolves.toBe(true);
     } finally {
       await vi.runOnlyPendingTimersAsync();

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -4,6 +4,7 @@ import {
   markDiagnosticEmbeddedRunStarted,
 } from "../../logging/diagnostic-run-activity.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
 
 export type ReplyRunKey = string;
 
@@ -473,7 +474,10 @@ export const replyRunRegistry: ReplyRunRegistry = {
         },
       };
       if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs)) {
-        waiter.timer = setTimeout(() => waiter.finish(false), Math.max(100, timeoutMs));
+        waiter.timer = setTimeout(
+          () => waiter.finish(false),
+          resolveTimerTimeoutMs(timeoutMs, 100, 100),
+        );
       }
       if (opts?.signal) {
         abortHandler = () => waiter.finish(false);

--- a/src/auto-reply/reply/typing-persistence.test.ts
+++ b/src/auto-reply/reply/typing-persistence.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
 import { createTypingController } from "./typing.js";
 
 describe("typing persistence bug fix", () => {
@@ -117,5 +118,23 @@ describe("typing persistence bug fix", () => {
 
     expect(inert.isActive()).toBe(false);
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clamps oversized typing interval and TTL timers", async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const boundedController = createTypingController({
+      onReplyStart: onReplyStartSpy,
+      onCleanup: onCleanupSpy,
+      typingIntervalSeconds: Number.MAX_SAFE_INTEGER,
+      typingTtlMs: Number.MAX_SAFE_INTEGER,
+      log: vi.fn(),
+    });
+
+    await boundedController.startTypingLoop();
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    boundedController.cleanup();
   });
 });

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -1,7 +1,24 @@
+import {
+  finiteSecondsToTimerSafeMilliseconds,
+  resolveTimerTimeoutMs,
+} from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { createTypingKeepaliveLoop } from "../../channels/typing-lifecycle.js";
 import { createTypingStartGuard } from "../../channels/typing-start-guard.js";
 import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+
+const DEFAULT_TYPING_INTERVAL_SECONDS = 6;
+const DEFAULT_TYPING_TTL_MS = 2 * 60_000;
+
+function resolveTypingIntervalMs(seconds: number | undefined): number {
+  if (Number.isFinite(seconds) && (seconds ?? 0) <= 0) {
+    return 0;
+  }
+  return (
+    finiteSecondsToTimerSafeMilliseconds(seconds ?? DEFAULT_TYPING_INTERVAL_SECONDS) ??
+    DEFAULT_TYPING_INTERVAL_SECONDS * 1000
+  );
+}
 
 export type TypingController = {
   onReplyStart: () => Promise<void>;
@@ -22,14 +39,7 @@ export function createTypingController(params: {
   silentToken?: string;
   log?: (message: string) => void;
 }): TypingController {
-  const {
-    onReplyStart,
-    onCleanup,
-    typingIntervalSeconds = 6,
-    typingTtlMs = 2 * 60_000,
-    silentToken = SILENT_REPLY_TOKEN,
-    log,
-  } = params;
+  const { onReplyStart, onCleanup, silentToken = SILENT_REPLY_TOKEN, log } = params;
   if (!onReplyStart && !onCleanup) {
     return {
       onReplyStart: async () => {},
@@ -52,7 +62,8 @@ export function createTypingController(params: {
   // Once we stop typing, we "seal" the controller so late events can't restart typing forever.
   let sealed = false;
   let typingTtlTimer: NodeJS.Timeout | undefined;
-  const typingIntervalMs = typingIntervalSeconds * 1000;
+  const typingIntervalMs = resolveTypingIntervalMs(params.typingIntervalSeconds);
+  const typingTtlMs = resolveTimerTimeoutMs(params.typingTtlMs, DEFAULT_TYPING_TTL_MS, 0);
 
   const formatTypingTtl = (ms: number) => {
     if (ms % 60_000 === 0) {

--- a/src/channels/draft-stream-loop.test.ts
+++ b/src/channels/draft-stream-loop.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createDraftStreamLoop } from "./draft-stream-loop.js";
 
 const flushMicrotasks = async () => {
@@ -89,6 +90,26 @@ describe("createDraftStreamLoop", () => {
           await vi.advanceTimersByTimeAsync(0);
         },
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps oversized throttle timers", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const loop = createDraftStreamLoop({
+        throttleMs: Number.MAX_SAFE_INTEGER,
+        isStopped: () => false,
+        sendOrEditStreamMessage: vi.fn(async () => true),
+      });
+
+      loop.update("hello");
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      loop.stop();
     } finally {
       vi.useRealTimers();
     }

--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -1,3 +1,5 @@
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
+
 export type DraftStreamLoop = {
   update: (text: string) => void;
   flush: () => Promise<void>;
@@ -13,6 +15,7 @@ export function createDraftStreamLoop(params: {
   sendOrEditStreamMessage: (text: string) => Promise<void | boolean>;
   onBackgroundFlushError?: (err: unknown) => void;
 }): DraftStreamLoop {
+  const throttleMs = resolveTimerTimeoutMs(params.throttleMs, 0, 0);
   let lastSentAt = 0;
   let pendingText = "";
   let inFlightPromise: Promise<void | boolean> | undefined;
@@ -78,7 +81,7 @@ export function createDraftStreamLoop(params: {
     if (timer) {
       return;
     }
-    const delay = Math.max(0, params.throttleMs - (Date.now() - lastSentAt));
+    const delay = Math.max(0, throttleMs - (Date.now() - lastSentAt));
     timer = setTimeout(() => {
       startBackgroundFlush();
     }, delay);
@@ -94,7 +97,7 @@ export function createDraftStreamLoop(params: {
         schedule();
         return;
       }
-      if (!timer && Date.now() - lastSentAt >= params.throttleMs) {
+      if (!timer && Date.now() - lastSentAt >= throttleMs) {
         startBackgroundFlush();
         return;
       }

--- a/src/channels/thread-bindings-policy.test.ts
+++ b/src/channels/thread-bindings-policy.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { MAX_DATE_TIMESTAMP_MS } from "../shared/number-coercion.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
   requiresNativeThreadContextForThreadHere,
+  resolveThreadBindingIdleTimeoutMs,
+  resolveThreadBindingMaxAgeMs,
   resolveThreadBindingPlacementForCurrentContext,
   resolveThreadBindingSpawnPolicy,
   supportsAutomaticThreadBindingSpawn,
@@ -78,6 +81,21 @@ describe("thread binding spawn policy helpers", () => {
     expect(policy.enabled).toBe(true);
     expect(policy.spawnEnabled).toBe(true);
     expect(policy.defaultSpawnContext).toBe("fork");
+  });
+
+  it("preserves long lifecycle hour values while capping unsafe conversions", () => {
+    expect(
+      resolveThreadBindingIdleTimeoutMs({
+        channelIdleHoursRaw: 720,
+        sessionIdleHoursRaw: undefined,
+      }),
+    ).toBe(2_592_000_000);
+    expect(
+      resolveThreadBindingMaxAgeMs({
+        channelMaxAgeHoursRaw: undefined,
+        sessionMaxAgeHoursRaw: Number.MAX_SAFE_INTEGER,
+      }),
+    ).toBe(MAX_DATE_TIMESTAMP_MS);
   });
 
   it("uses spawnSessions for both subagent and ACP spawn policy", () => {

--- a/src/channels/thread-bindings-policy.ts
+++ b/src/channels/thread-bindings-policy.ts
@@ -1,3 +1,4 @@
+import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAccountId } from "../routing/session-key.js";
@@ -94,26 +95,34 @@ function normalizeThreadBindingHours(raw: unknown): number | undefined {
   return raw;
 }
 
+function resolveThreadBindingHoursMs(raw: unknown, fallbackHours: number): number {
+  const hours = normalizeThreadBindingHours(raw) ?? fallbackHours;
+  const durationMs = Math.floor(hours * 60 * 60 * 1000);
+  if (!Number.isFinite(durationMs) || durationMs < 0) {
+    return 0;
+  }
+  return Math.min(durationMs, MAX_DATE_TIMESTAMP_MS);
+}
+
 export function resolveThreadBindingIdleTimeoutMs(params: {
   channelIdleHoursRaw: unknown;
   sessionIdleHoursRaw: unknown;
 }): number {
-  const idleHours =
-    normalizeThreadBindingHours(params.channelIdleHoursRaw) ??
-    normalizeThreadBindingHours(params.sessionIdleHoursRaw) ??
-    DEFAULT_THREAD_BINDING_IDLE_HOURS;
-  return Math.floor(idleHours * 60 * 60 * 1000);
+  return resolveThreadBindingHoursMs(
+    params.channelIdleHoursRaw,
+    normalizeThreadBindingHours(params.sessionIdleHoursRaw) ?? DEFAULT_THREAD_BINDING_IDLE_HOURS,
+  );
 }
 
 export function resolveThreadBindingMaxAgeMs(params: {
   channelMaxAgeHoursRaw: unknown;
   sessionMaxAgeHoursRaw: unknown;
 }): number {
-  const maxAgeHours =
-    normalizeThreadBindingHours(params.channelMaxAgeHoursRaw) ??
+  return resolveThreadBindingHoursMs(
+    params.channelMaxAgeHoursRaw,
     normalizeThreadBindingHours(params.sessionMaxAgeHoursRaw) ??
-    DEFAULT_THREAD_BINDING_MAX_AGE_HOURS;
-  return Math.floor(maxAgeHours * 60 * 60 * 1000);
+      DEFAULT_THREAD_BINDING_MAX_AGE_HOURS,
+  );
 }
 
 export function resolveThreadBindingEffectiveExpiresAt(params: {

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createTypingCallbacks } from "./typing.js";
 
 type TypingCallbackOverrides = Partial<Parameters<typeof createTypingCallbacks>[0]>;
@@ -186,6 +187,21 @@ describe("createTypingCallbacks", () => {
     });
   });
 
+  it("clamps oversized keepalive intervals before arming timers", async () => {
+    await withFakeTimers(async () => {
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+      const { callbacks } = createTypingHarness({
+        keepaliveIntervalMs: Number.MAX_SAFE_INTEGER,
+      });
+
+      await callbacks.onReplyStart();
+      await flushMicrotasks();
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      callbacks.onCleanup?.();
+    });
+  });
+
   it("does not restart keepalive when breaker trips on initial start", async () => {
     await withFakeTimers(async () => {
       const { start, onStartError, callbacks } = createTypingHarness({
@@ -344,6 +360,21 @@ describe("createTypingCallbacks", () => {
         // Should not auto-stop even after long time
         await vi.advanceTimersByTimeAsync(300_000);
         expect(stop).not.toHaveBeenCalled();
+      });
+    });
+
+    it("clamps oversized TTLs before arming timers", async () => {
+      await withFakeTimers(async () => {
+        const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+        const { callbacks } = createTypingHarness({
+          maxDurationMs: Number.MAX_SAFE_INTEGER,
+        });
+
+        await callbacks.onReplyStart();
+        await flushMicrotasks();
+
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+        callbacks.onCleanup?.();
       });
     });
 

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -1,4 +1,7 @@
-import { parseFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import {
+  parseFiniteNumber,
+  resolveTimerTimeoutMs,
+} from "@openclaw/normalization-core/number-coercion";
 import { createTypingKeepaliveLoop } from "./typing-lifecycle.js";
 import { createTypingStartGuard } from "./typing-start-guard.js";
 
@@ -27,13 +30,11 @@ function resolvePositiveIntegerOption(value: number | undefined, fallback: numbe
 }
 
 function resolveKeepaliveIntervalMs(value: number | undefined): number {
-  const parsed = parseFiniteNumber(value);
-  return parsed === undefined ? 3_000 : Math.floor(parsed);
+  return resolveTimerTimeoutMs(value, 3_000, 0);
 }
 
 function resolveDurationMsOption(value: number | undefined, fallback: number): number {
-  const parsed = parseFiniteNumber(value);
-  return parsed === undefined ? fallback : Math.floor(parsed);
+  return resolveTimerTimeoutMs(value, fallback, 0);
 }
 
 export function createTypingCallbacks(params: CreateTypingCallbacksParams): TypingCallbacks {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -354,6 +354,48 @@ describe("cron cli", () => {
     expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.run")).toBe(false);
   });
 
+  it("bounds oversized cron run wait poll intervals by the wait timeout", async () => {
+    vi.useFakeTimers();
+    resetGatewayMock();
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "cron.status") {
+          return { enabled: true };
+        }
+        if (method === "cron.run") {
+          return { ok: true, enqueued: true, runId: "manual:job-1:123:0", params };
+        }
+        if (method === "cron.runs") {
+          return { entries: [] };
+        }
+        return { ok: true, params };
+      },
+    );
+    const program = buildProgram();
+    const run = program.parseAsync(
+      [
+        "cron",
+        "run",
+        "job-1",
+        "--wait",
+        "--wait-timeout",
+        "10ms",
+        "--poll-interval",
+        "999999999999999ms",
+      ],
+      { from: "user" },
+    );
+
+    await vi.waitFor(() => {
+      expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.runs")).toBe(true);
+    });
+
+    const rejection = expect(run).rejects.toThrow("__exit__:1");
+    await vi.advanceTimersByTimeAsync(10);
+    await rejection;
+    expectRuntimeErrorContaining("timed out waiting for cron run");
+  });
+
   it("trims model and thinking on cron add", { timeout: CRON_CLI_TEST_TIMEOUT_MS }, async () => {
     await runCronCommand([
       "cron",

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -1,3 +1,7 @@
+import {
+  resolvePositiveTimerTimeoutMs,
+  resolveTimerTimeoutMs,
+} from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import type { CronDeliveryPreview, CronJob } from "../../cron/types.js";
@@ -44,7 +48,7 @@ function parseCronRunWaitDuration(raw: unknown, label: string): number {
   if (!Number.isFinite(durationMs) || durationMs < 0) {
     throw new Error(`invalid ${label}`);
   }
-  return durationMs;
+  return resolveTimerTimeoutMs(durationMs, 0, 0);
 }
 
 function parseCronRunPollInterval(raw: unknown): number {
@@ -52,7 +56,7 @@ function parseCronRunPollInterval(raw: unknown): number {
   if (durationMs <= 0) {
     throw new Error("invalid --poll-interval");
   }
-  return durationMs;
+  return resolvePositiveTimerTimeoutMs(durationMs, 2_000);
 }
 
 async function waitForCronRunCompletion(params: {
@@ -73,10 +77,11 @@ async function waitForCronRunCompletion(params: {
     if (entry?.status === "ok" || entry?.status === "error" || entry?.status === "skipped") {
       return entry;
     }
-    if (Date.now() - startedAt >= params.timeoutMs) {
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs >= params.timeoutMs) {
       throw new Error(`timed out waiting for cron run ${params.runId}`);
     }
-    await sleep(params.pollIntervalMs);
+    await sleep(Math.min(params.pollIntervalMs, params.timeoutMs - elapsedMs));
   }
 }
 

--- a/src/cli/ports.test.ts
+++ b/src/cli/ports.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import net from "node:net";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Hoist the factory so vi.mock can access it.
 const mockCreateServer = vi.hoisted(() => vi.fn());
@@ -11,6 +11,10 @@ vi.mock("node:net", async () => {
 });
 
 import { probePortFree, waitForPortBindable } from "./ports.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 /** Build a minimal fake net.Server that emits a given error code on listen(). */
 function makeErrServer(code: string): net.Server {
@@ -128,5 +132,17 @@ describe("waitForPortBindable", () => {
     await expectRejectCode(waitForPortBindable(80, { timeoutMs: 5000, intervalMs: 50 }), "EACCES");
     // Only one probe should have been attempted — no spinning through the retry loop.
     expect(mockCreateServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds oversized bindability intervals by the remaining timeout", async () => {
+    mockCreateServer.mockReturnValue(makeErrServer("EADDRINUSE"));
+
+    await expect(
+      waitForPortBindable(9999, {
+        timeoutMs: 1,
+        intervalMs: Number.MAX_SAFE_INTEGER,
+        host: "127.0.0.1",
+      }),
+    ).rejects.toThrow(/still not bindable after 1ms/);
   });
 });

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:net";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveLsofCommandSync } from "../infra/ports-lsof.js";
 import { tryListenOnPort } from "../infra/ports-probe.js";
+import { resolvePositiveTimerTimeoutMs, resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { sleep } from "../utils.js";
 
 export type PortProcess = { pid: number; command?: string };
@@ -259,9 +260,12 @@ export async function forceFreePortAndWait(
     sigtermTimeoutMs?: number;
   } = {},
 ): Promise<ForceFreePortResult> {
-  const timeoutMs = Math.max(opts.timeoutMs ?? 1500, 0);
-  const intervalMs = Math.max(opts.intervalMs ?? 100, 1);
-  const sigtermTimeoutMs = Math.min(Math.max(opts.sigtermTimeoutMs ?? 600, 0), timeoutMs);
+  const timeoutMs = resolveTimerTimeoutMs(opts.timeoutMs, 1500, 0);
+  const intervalMs = resolvePositiveTimerTimeoutMs(opts.intervalMs, 100);
+  const sigtermTimeoutMs = Math.min(
+    resolveTimerTimeoutMs(opts.sigtermTimeoutMs, 600, 0),
+    timeoutMs,
+  );
 
   let killed: PortProcess[] = [];
   let useFuserFallback = false;
@@ -292,13 +296,13 @@ export async function forceFreePortAndWait(
   }
 
   let waitedMs = 0;
-  const triesSigterm = intervalMs > 0 ? Math.ceil(sigtermTimeoutMs / intervalMs) : 0;
-  for (let i = 0; i < triesSigterm; i++) {
+  while (waitedMs < sigtermTimeoutMs) {
     if (!(await checkBusy())) {
       return { killed, waitedMs, escalatedToSigkill: false };
     }
-    await sleep(intervalMs);
-    waitedMs += intervalMs;
+    const sleepMs = Math.min(intervalMs, sigtermTimeoutMs - waitedMs);
+    await sleep(sleepMs);
+    waitedMs += sleepMs;
   }
 
   if (!(await checkBusy())) {
@@ -312,14 +316,13 @@ export async function forceFreePortAndWait(
     killPids(remaining, "SIGKILL");
   }
 
-  const remainingBudget = Math.max(timeoutMs - waitedMs, 0);
-  const triesSigkill = intervalMs > 0 ? Math.ceil(remainingBudget / intervalMs) : 0;
-  for (let i = 0; i < triesSigkill; i++) {
+  while (waitedMs < timeoutMs) {
     if (!(await checkBusy())) {
       return { killed, waitedMs, escalatedToSigkill: true };
     }
-    await sleep(intervalMs);
-    waitedMs += intervalMs;
+    const sleepMs = Math.min(intervalMs, timeoutMs - waitedMs);
+    await sleep(sleepMs);
+    waitedMs += sleepMs;
   }
 
   if (!(await checkBusy())) {
@@ -377,16 +380,17 @@ export async function waitForPortBindable(
   port: number,
   opts: { timeoutMs?: number; intervalMs?: number; host?: string } = {},
 ): Promise<number> {
-  const timeoutMs = Math.max(opts.timeoutMs ?? 3000, 0);
-  const intervalMs = Math.max(opts.intervalMs ?? 150, 1);
+  const timeoutMs = resolveTimerTimeoutMs(opts.timeoutMs, 3000, 0);
+  const intervalMs = resolvePositiveTimerTimeoutMs(opts.intervalMs, 150);
   const host = opts.host;
   let waited = 0;
   while (waited < timeoutMs) {
     if (await probePortFree(port, host)) {
       return waited;
     }
-    await sleep(intervalMs);
-    waited += intervalMs;
+    const sleepMs = Math.min(intervalMs, timeoutMs - waited);
+    await sleep(sleepMs);
+    waited += sleepMs;
   }
   // Final attempt
   if (await probePortFree(port, host)) {

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -171,6 +171,23 @@ describe("gateway --force helpers", () => {
     vi.useRealTimers();
   });
 
+  it("bounds oversized force-free intervals by the remaining timeout", async () => {
+    (execFileSync as unknown as Mock).mockReturnValue(["p42", "cnode", ""].join("\n"));
+    const killMock = vi.fn();
+    process.kill = killMock;
+
+    await expect(
+      forceFreePortAndWait(18789, {
+        timeoutMs: 2,
+        intervalMs: Number.MAX_SAFE_INTEGER,
+        sigtermTimeoutMs: 1,
+      }),
+    ).rejects.toThrow(/still has listeners/);
+
+    expect(killMock).toHaveBeenCalledWith(42, "SIGTERM");
+    expect(killMock).toHaveBeenCalledWith(42, "SIGKILL");
+  });
+
   it("falls back to fuser when lsof is permission denied", async () => {
     (execFileSync as unknown as Mock).mockImplementation((cmd: string) => {
       if (cmd.includes("lsof")) {

--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createCliProgress, shouldUseInteractiveProgressSpinner } from "./progress.js";
 
 function withStdinIsRaw<T>(isRaw: boolean, run: () => T): T {
@@ -129,5 +130,26 @@ describe("cli progress", () => {
     next.done();
 
     expect(firstWrites).toStrictEqual([]);
+  });
+
+  it("clamps oversized delayed progress timers", () => {
+    const stream = {
+      isTTY: true,
+      write: vi.fn(),
+    } as unknown as NodeJS.WriteStream;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const progress = createCliProgress({
+        label: "Delayed",
+        stream,
+        fallback: "line",
+        delayMs: Number.MAX_SAFE_INTEGER,
+      });
+      progress.done();
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 });

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -9,6 +9,7 @@ import {
   unregisterActiveProgressLine,
 } from "../../packages/terminal-core/src/progress-line.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 
 const DEFAULT_DELAY_MS = 0;
 let activeProgress = 0;
@@ -67,7 +68,7 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
     return noopReporter;
   }
 
-  const delayMs = typeof options.delayMs === "number" ? options.delayMs : DEFAULT_DELAY_MS;
+  const delayMs = resolveTimerTimeoutMs(options.delayMs, DEFAULT_DELAY_MS, 0);
   const canOsc = isTty && supportsOscProgress(process.env, isTty);
   const stdinIsRaw = process.stdin.isRaw;
   const allowSpinner = shouldUseInteractiveProgressSpinner({

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { loggingState } from "../logging/state.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { agentCliCommand, agentViaGatewayTesting } from "./agent-via-gateway.js";
 import type { agentCommand as AgentCommand } from "./agent.js";
 
@@ -243,6 +244,12 @@ describe("agentCliCommand", () => {
       const request = requireFirstCallArg(callGateway, "gateway") as { timeoutMs?: number };
       expect(request.timeoutMs).toBe(2_147_000_000);
     });
+  });
+
+  it("clamps oversized gateway timeout seconds", () => {
+    expect(agentViaGatewayTesting.resolveGatewayAgentTimeoutMs(Number.MAX_SAFE_INTEGER)).toBe(
+      MAX_TIMER_TIMEOUT_MS,
+    );
   });
 
   it("rejects partial gateway timeout values", async () => {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import {
@@ -129,6 +130,7 @@ export const agentViaGatewayTesting = {
     agentSessionModulePromise = undefined;
     agentSessionModuleLoader = loader;
   },
+  resolveGatewayAgentTimeoutMs,
 };
 
 function protectJsonStdout(opts: Pick<AgentCliOpts, "json">): void {
@@ -148,6 +150,13 @@ function parseTimeoutSeconds(opts: { cfg: OpenClawConfig; timeout?: string }) {
     );
   }
   return raw;
+}
+
+function resolveGatewayAgentTimeoutMs(timeoutSeconds: number): number {
+  if (timeoutSeconds === 0) {
+    return NO_GATEWAY_TIMEOUT_MS;
+  }
+  return resolveTimerTimeoutMs((timeoutSeconds + 30) * 1000, 10_000, 10_000);
 }
 
 function getGatewayDispatchConfig(): OpenClawConfig {
@@ -580,10 +589,7 @@ async function agentViaGatewayCommand(
     }
   }
   const timeoutSeconds = parseTimeoutSeconds({ cfg, timeout: opts.timeout });
-  const gatewayTimeoutMs =
-    timeoutSeconds === 0
-      ? NO_GATEWAY_TIMEOUT_MS // no timeout (timer-safe max)
-      : Math.max(10_000, (timeoutSeconds + 30) * 1000);
+  const gatewayTimeoutMs = resolveGatewayAgentTimeoutMs(timeoutSeconds);
 
   const sessionKey =
     classifySessionKeyShape(explicitSessionKey) === "agent"

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { createPluginRecord } from "../plugins/status.test-helpers.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import type { HealthSummary } from "./health.js";
 
 let testConfig: Record<string, unknown> = {};
@@ -472,6 +473,23 @@ describe("getHealthSnapshot", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
+  });
+
+  it("clamps oversized probe timeouts", async () => {
+    testConfig = {
+      session: { store: "/tmp/x" },
+      channels: { telegram: { botToken: "123:test" } },
+    };
+    testStore = {};
+    const timeouts: number[] = [];
+    probeTelegramAccountForTestOverride = async (_account, timeoutMs) => {
+      timeouts.push(timeoutMs);
+      return { ok: true };
+    };
+
+    await getHealthSnapshot({ timeoutMs: Number.MAX_SAFE_INTEGER });
+
+    expect(timeouts).toEqual([MAX_TIMER_TIMEOUT_MS]);
   });
 
   it("includes active plugin load errors in the health snapshot", async () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1,3 +1,4 @@
+import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { styleHealthChannelLine } from "../../packages/terminal-core/src/health-style.js";
 import { isRich } from "../../packages/terminal-core/src/theme.js";
@@ -428,7 +429,7 @@ export async function getHealthSnapshot(params?: {
     (await buildSessionSummary(resolveStorePath(cfg.session?.store, { agentId: defaultAgentId })));
 
   const start = Date.now();
-  const cappedTimeout = timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : Math.max(50, timeoutMs);
+  const cappedTimeout = resolveTimerTimeoutMs(timeoutMs, DEFAULT_TIMEOUT_MS, 50);
   const doProbe = params?.probe !== false;
   const includeSensitive = params?.includeSensitive !== false;
   const channels: Record<string, ChannelHealthSummary> = {};

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -16,6 +16,7 @@ import {
   resolveControlUiLinks,
   summarizeExistingConfig,
   validateGatewayPasswordInput,
+  waitForGatewayReachable,
 } from "./onboard-helpers.js";
 
 const mocks = vi.hoisted(() => ({
@@ -304,6 +305,31 @@ describe("probeGatewayReachable", () => {
       ok: false,
       detail: "connect failed: timeout",
     });
+  });
+});
+
+describe("waitForGatewayReachable", () => {
+  it("keeps oversized poll intervals within the overall deadline", async () => {
+    mocks.probeGateway.mockResolvedValue({
+      ok: false,
+      url: "ws://127.0.0.1:18789",
+      connectLatencyMs: null,
+      error: "connect failed: timeout",
+      close: null,
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+
+    const result = await waitForGatewayReachable({
+      url: "ws://127.0.0.1:18789",
+      deadlineMs: 5,
+      pollMs: Number.MAX_SAFE_INTEGER,
+      probeTimeoutMs: 1,
+    });
+
+    expect(result).toEqual({ ok: false, detail: "connect failed: timeout" });
   });
 });
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { inspect } from "node:util";
 import { cancel, isCancel } from "@clack/prompts";
+import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
@@ -339,7 +340,7 @@ export async function waitForGatewayReachable(params: {
   pollMs?: number;
 }): Promise<{ ok: boolean; detail?: string }> {
   const deadlineMs = params.deadlineMs ?? 15_000;
-  const pollMs = params.pollMs ?? 400;
+  const pollMs = resolveTimerTimeoutMs(params.pollMs ?? 400, 400, 0);
   const probeTimeoutMs = params.probeTimeoutMs ?? 1500;
   const startedAt = Date.now();
   let lastDetail: string | undefined;
@@ -355,7 +356,11 @@ export async function waitForGatewayReachable(params: {
       return probe;
     }
     lastDetail = probe.detail;
-    await sleep(pollMs);
+    const remainingMs = deadlineMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      break;
+    }
+    await sleep(Math.min(pollMs, remainingMs));
   }
 
   return { ok: false, detail: lastDetail };

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
@@ -12,7 +13,8 @@ type SessionLifecycleEntry = Pick<
 >;
 
 function resolveTimestamp(value: number | undefined): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+  const timestampMs = asDateTimestampMs(value);
+  return timestampMs !== undefined && timestampMs >= 0 ? timestampMs : undefined;
 }
 
 function parseTimestampMs(value: unknown): number | undefined {
@@ -23,7 +25,7 @@ function parseTimestampMs(value: unknown): number | undefined {
     return undefined;
   }
   const parsed = Date.parse(value);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+  return resolveTimestamp(parsed);
 }
 
 function readFirstLine(filePath: string): string | undefined {

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -301,6 +301,42 @@ describe("session lifecycle timestamps", () => {
       await fsPromises.rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("ignores out-of-range lifecycle timestamps before header fallback", async () => {
+    const dir = await fsPromises.mkdtemp("/tmp/openclaw-lifecycle-test-");
+    try {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionFile = path.join(dir, "legacy-session.jsonl");
+      const headerTimestamp = "2026-04-20T04:30:00.000Z";
+      await fsPromises.writeFile(
+        sessionFile,
+        `${JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "legacy-session",
+          timestamp: headerTimestamp,
+          cwd: dir,
+        })}\n`,
+        "utf8",
+      );
+
+      const timestamps = resolveSessionLifecycleTimestamps({
+        storePath,
+        entry: {
+          sessionId: "legacy-session",
+          sessionFile,
+          sessionStartedAt: Number.MAX_SAFE_INTEGER,
+          lastInteractionAt: Number.MAX_SAFE_INTEGER,
+          updatedAt: Date.parse("2026-04-25T08:00:00.000Z"),
+        },
+      });
+
+      expect(timestamps.sessionStartedAt).toBe(Date.parse(headerTimestamp));
+      expect(timestamps.lastInteractionAt).toBeUndefined();
+    } finally {
+      await fsPromises.rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("session store writer queue", () => {

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -108,6 +108,23 @@ describe("auth rate limiter", () => {
     }
   });
 
+  it("clamps oversized lockout durations", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({
+        maxAttempts: 1,
+        windowMs: 60_000,
+        lockoutMs: Number.MAX_SAFE_INTEGER,
+      });
+
+      limiter.recordFailure("10.0.0.34");
+
+      expect(limiter.check("10.0.0.34").retryAfterMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // ---------- sliding window expiry ----------
 
   it("expires old failures outside the window", () => {

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
   AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH,
@@ -233,6 +234,19 @@ describe("auth rate limiter", () => {
       vi.advanceTimersByTime(6_000);
       limiter.prune();
       expect(limiter.size()).toBe(1); // Still locked-out, not pruned.
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps oversized positive auto-prune intervals", () => {
+    vi.useFakeTimers();
+    try {
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+      limiter = createAuthRateLimiter({ pruneIntervalMs: Number.MAX_SAFE_INTEGER });
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     } finally {
       vi.useRealTimers();
     }

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -16,6 +16,7 @@
  *   {@link createAuthRateLimiter} and pass it where needed.
  */
 
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { isLoopbackAddress, resolveClientIp } from "./net.js";
 
 // ---------------------------------------------------------------------------
@@ -96,12 +97,22 @@ export function normalizeRateLimitClientIp(ip: string | undefined): string {
   return resolveClientIp({ remoteAddr: ip }) ?? "unknown";
 }
 
+function resolvePruneIntervalMs(value: number | undefined): number {
+  if (value === undefined) {
+    return PRUNE_INTERVAL_MS;
+  }
+  if (Number.isFinite(value) && value <= 0) {
+    return 0;
+  }
+  return resolveTimerTimeoutMs(value, PRUNE_INTERVAL_MS);
+}
+
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
   const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
   const windowMs = config?.windowMs ?? DEFAULT_WINDOW_MS;
   const lockoutMs = config?.lockoutMs ?? DEFAULT_LOCKOUT_MS;
   const exemptLoopback = config?.exemptLoopback ?? true;
-  const pruneIntervalMs = config?.pruneIntervalMs ?? PRUNE_INTERVAL_MS;
+  const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);
 
   const entries = new Map<string, RateLimitEntry>();
 

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -109,8 +109,8 @@ function resolvePruneIntervalMs(value: number | undefined): number {
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
   const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
-  const windowMs = config?.windowMs ?? DEFAULT_WINDOW_MS;
-  const lockoutMs = config?.lockoutMs ?? DEFAULT_LOCKOUT_MS;
+  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS, 0);
+  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 0);
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);
 

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import type { ChannelManager, ChannelRuntimeSnapshot } from "./server-channels.js";
 
@@ -167,6 +168,16 @@ describe("channel-health-monitor", () => {
 
     expect(addEventListener).toHaveBeenCalledWith("abort", expect.any(Function), { once: true });
     expect(removeEventListener).toHaveBeenCalledWith("abort", addEventListener.mock.calls[0]?.[1]);
+  });
+
+  it("normalizes oversized check intervals before arming timers", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const monitor = startDefaultMonitor(createMockChannelManager(), {
+      checkIntervalMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    monitor.stop();
   });
 
   it("does not run before the grace period", async () => {

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -1,5 +1,6 @@
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
@@ -76,11 +77,11 @@ function resolveTimingPolicy(
 export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): ChannelHealthMonitor {
   const {
     channelManager,
-    checkIntervalMs = DEFAULT_CHECK_INTERVAL_MS,
     cooldownCycles = DEFAULT_COOLDOWN_CYCLES,
     maxRestartsPerHour = DEFAULT_MAX_RESTARTS_PER_HOUR,
     abortSignal,
   } = deps;
+  const checkIntervalMs = resolveTimerTimeoutMs(deps.checkIntervalMs, DEFAULT_CHECK_INTERVAL_MS);
   const timing = resolveTimingPolicy(deps);
 
   const cooldownMs = cooldownCycles * checkIntervalMs;

--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 
 type TimeoutCallback = Parameters<typeof setTimeout>[0];
@@ -57,6 +58,22 @@ describe("ExecApprovalManager", () => {
 
     const cleanupTimer = timers.find((timer) => timer.delay === 15_000);
     expect(cleanupTimer?.handle.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps oversized approval timers instead of letting Node fire them immediately", () => {
+    const timers = installTimerMocks();
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const manager = new ExecApprovalManager();
+    const record = manager.create(
+      { command: "echo ok" },
+      MAX_TIMER_TIMEOUT_MS + 1,
+      "approval-long",
+    );
+
+    void manager.register(record, MAX_TIMER_TIMEOUT_MS + 1);
+
+    expect(record.expiresAtMs).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
+    expect(timers[0]?.delay).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 
   it("rejects approval records when expiry would exceed the Date range", () => {

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -5,6 +5,7 @@ import type {
   ExecApprovalDecision,
   ExecApprovalRequestPayload as InfraExecApprovalRequestPayload,
 } from "../infra/exec-approvals.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 
 // Grace period to keep resolved entries for late awaitDecision calls
 const RESOLVED_ENTRY_GRACE_MS = 15_000;
@@ -19,6 +20,10 @@ function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
 function scheduleResolvedEntryCleanup(cleanup: () => void): void {
   const timer = setTimeout(cleanup, RESOLVED_ENTRY_GRACE_MS);
   unrefTimer(timer);
+}
+
+function resolveApprovalTimeoutMs(timeoutMs: number): number {
+  return resolveTimerTimeoutMs(timeoutMs, 1);
 }
 
 type ExecApprovalRequestPayload = InfraExecApprovalRequestPayload;
@@ -57,7 +62,8 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
 
   create(request: TPayload, timeoutMs: number, id?: string | null): ExecApprovalRecord<TPayload> {
     const now = Date.now();
-    const expiresAtMs = resolveExpiresAtMsFromDurationMs(timeoutMs, { nowMs: now });
+    const resolvedTimeoutMs = resolveApprovalTimeoutMs(timeoutMs);
+    const expiresAtMs = resolveExpiresAtMsFromDurationMs(resolvedTimeoutMs, { nowMs: now });
     if (expiresAtMs === undefined) {
       throw new Error("approval expiry is unavailable");
     }
@@ -103,9 +109,10 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       timer: null as unknown as ReturnType<typeof setTimeout>,
       promise,
     };
+    const timerDelayMs = resolveApprovalTimeoutMs(timeoutMs);
     entry.timer = setTimeout(() => {
       this.expire(record.id);
-    }, timeoutMs);
+    }, timerDelayMs);
     this.pending.set(record.id, entry);
     return promise;
   }

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
+import {
+  MAX_PLUGIN_APPROVAL_TIMEOUT_MS,
+  type PluginApprovalRequestPayload,
+} from "../infra/plugin-approvals.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import type { OpenClawPluginNodeInvokePolicyContext } from "../plugins/types.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
@@ -253,6 +256,70 @@ describe("applyPluginNodeInvokePolicy", () => {
     await expect(resultPromise).resolves.toStrictEqual({
       ok: true,
       payload: { id: record?.id, decision: "allow-once" },
+    });
+  });
+
+  it("caps plugin policy approval timeouts through the shared approval policy", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    registryState.current = {
+      nodeHostCommands: [
+        {
+          pluginId: "demo",
+          command: {
+            command: "demo.read",
+            dangerous: true,
+            handle: async () => "{}",
+          },
+          source: "test",
+        },
+      ],
+      nodeInvokePolicies: [
+        {
+          pluginId: "demo",
+          policy: {
+            commands: ["demo.read"],
+            handle: async (ctx: OpenClawPluginNodeInvokePolicyContext) => {
+              const approval = await ctx.approvals?.request({
+                title: "Sensitive action",
+                description: "Needs approval",
+                timeoutMs: Number.MAX_SAFE_INTEGER,
+              });
+              return { ok: true, payload: approval ?? null };
+            },
+          },
+          pluginConfig: { enabled: true },
+          source: "test",
+        },
+      ],
+    } as unknown as PluginRegistry;
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds: createApprovalClientLookup([
+        createApprovalClient({
+          connId: "conn-owner-approval",
+          clientId: "client-owner",
+          deviceId: "device-owner",
+        }),
+      ]),
+    });
+    const resultPromise = applyPluginNodeInvokePolicy({
+      context,
+      client: createOperatorClient(),
+      nodeSession: createNodeSession(),
+      command: "demo.read",
+      params: { path: "/tmp/x" },
+    });
+
+    await vi.waitFor(() => {
+      expect(manager.listPendingRecords()).toHaveLength(1);
+    });
+    const [record] = manager.listPendingRecords();
+    expect(record.expiresAtMs - record.createdAtMs).toBe(MAX_PLUGIN_APPROVAL_TIMEOUT_MS);
+
+    expect(manager.resolve(record.id, "allow-once")).toBe(true);
+    await expect(resultPromise).resolves.toStrictEqual({
+      ok: true,
+      payload: { id: record.id, decision: "allow-once" },
     });
   });
 

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
-import { DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS } from "../infra/plugin-approvals.js";
+import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import type {
@@ -54,10 +54,7 @@ function createApprovalRuntime(params: {
   }
   return {
     async request(input) {
-      const timeoutMs =
-        typeof input.timeoutMs === "number" && Number.isFinite(input.timeoutMs)
-          ? input.timeoutMs
-          : DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS;
+      const timeoutMs = resolvePluginApprovalTimeoutMs(input.timeoutMs);
       const request: PluginApprovalRequestPayload = {
         pluginId: params.pluginId,
         title: input.title.slice(0, 80),

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthHealthSummary } from "../../agents/auth-health.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
@@ -911,5 +912,19 @@ describe("aggregateOAuthStatus", () => {
     );
     expect(result.expiresAt).toBe(earlier);
     expect(result.remainingMs).toBe(1_000);
+  });
+
+  it("ignores out-of-range OAuth expiry timestamps", () => {
+    const valid = NOW + 5_000;
+    const result = aggregateOAuthStatus(
+      {
+        provider: "openai-codex",
+        status: "ok",
+        profiles: [oauth("ok", MAX_DATE_TIMESTAMP_MS + 1), oauth("ok", valid)],
+      },
+      NOW,
+    );
+    expect(result.expiresAt).toBe(valid);
+    expect(result.remainingMs).toBe(5_000);
   });
 });

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -29,6 +29,7 @@ import { PROVIDER_LABELS, resolveUsageProviderId } from "../../infra/provider-us
 import type { UsageProviderId, UsageWindow } from "../../infra/provider-usage.types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { refreshActiveSecretsRuntimeSnapshot } from "../../secrets/runtime.js";
+import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import { abortChatRunsForProvider, type ChatAbortOps } from "../chat-abort.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
@@ -153,11 +154,7 @@ function buildExpiry(
   remainingMs: number | undefined,
   expiresAt: number | undefined,
 ): ModelAuthExpiry | undefined {
-  if (
-    typeof expiresAt !== "number" ||
-    !Number.isFinite(expiresAt) ||
-    typeof remainingMs !== "number"
-  ) {
+  if (asDateTimestampMs(expiresAt) === undefined || typeof remainingMs !== "number") {
     return undefined;
   }
   return { at: expiresAt, remainingMs, label: formatRemainingShort(remainingMs) };
@@ -227,7 +224,7 @@ export function aggregateOAuthStatus(
   }
   const expirable = oauth
     .map((p) => p.expiresAt)
-    .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+    .filter((v): v is number => asDateTimestampMs(v) !== undefined);
   const expiresAt = expirable.length > 0 ? Math.min(...expirable) : undefined;
   const remainingMs = expiresAt !== undefined ? expiresAt - now : undefined;
   return { status, expiresAt, remainingMs };

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -10,9 +10,8 @@ import {
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import type { PluginApprovalRequestPayload } from "../../infra/plugin-approvals.js";
 import {
-  DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS,
-  MAX_PLUGIN_APPROVAL_TIMEOUT_MS,
   resolvePluginApprovalRequestAllowedDecisions,
+  resolvePluginApprovalTimeoutMs,
 } from "../../infra/plugin-approvals.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import {
@@ -67,10 +66,7 @@ export function createPluginApprovalHandlers(
         twoPhase?: boolean;
       };
       const twoPhase = p.twoPhase === true;
-      const timeoutMs = Math.min(
-        typeof p.timeoutMs === "number" ? p.timeoutMs : DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS,
-        MAX_PLUGIN_APPROVAL_TIMEOUT_MS,
-      );
+      const timeoutMs = resolvePluginApprovalTimeoutMs(p.timeoutMs);
 
       const normalizeTrimmedString = (value?: string | null): string | null =>
         normalizeOptionalString(value) || null;

--- a/src/hooks/fire-and-forget.test.ts
+++ b/src/hooks/fire-and-forget.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { fireAndForgetBoundedHook, fireAndForgetHook } from "./fire-and-forget.js";
 
 function requireFirstLog(logger: ReturnType<typeof vi.fn>): string {
@@ -80,5 +81,23 @@ describe("fireAndForgetBoundedHook", () => {
     await vi.waitFor(() => {
       expect(starts).toEqual(["first", "second"]);
     });
+  });
+
+  it("caps oversized hook timeout timers", async () => {
+    vi.useFakeTimers();
+    try {
+      const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const logger = vi.fn();
+
+      fireAndForgetBoundedHook(async () => new Promise(() => {}), "hook failed", logger, {
+        timeoutMs: Number.MAX_SAFE_INTEGER,
+      });
+
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+      expect(logger).toHaveBeenCalledWith(`hook failed: timed out after ${MAX_TIMER_TIMEOUT_MS}ms`);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/hooks/fire-and-forget.ts
+++ b/src/hooks/fire-and-forget.ts
@@ -1,6 +1,7 @@
 import { logVerbose } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 
 const DEFAULT_MAX_CONCURRENT_FIRE_AND_FORGET_HOOKS = 16;
 const DEFAULT_MAX_QUEUED_FIRE_AND_FORGET_HOOKS = 256;
@@ -36,6 +37,13 @@ const getFireAndForgetHookState = () =>
 
 function positiveIntegerOrDefault(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function resolveFireAndForgetHookTimeoutMs(value: number | undefined): number {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return resolveTimerTimeoutMs(value, DEFAULT_FIRE_AND_FORGET_HOOK_TIMEOUT_MS);
+  }
+  return resolveTimerTimeoutMs(DEFAULT_FIRE_AND_FORGET_HOOK_TIMEOUT_MS, 1);
 }
 
 function replaceLogControlCharacters(value: string): string {
@@ -133,10 +141,7 @@ export function fireAndForgetBoundedHook(
     options.maxQueue,
     DEFAULT_MAX_QUEUED_FIRE_AND_FORGET_HOOKS,
   );
-  const timeoutMs = positiveIntegerOrDefault(
-    options.timeoutMs,
-    DEFAULT_FIRE_AND_FORGET_HOOK_TIMEOUT_MS,
-  );
+  const timeoutMs = resolveFireAndForgetHookTimeoutMs(options.timeoutMs);
 
   if (state.active >= maxConcurrency && state.queue.length >= maxQueue) {
     logger(`${label}: queue full; dropping hook`);

--- a/src/infra/backoff.test.ts
+++ b/src/infra/backoff.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "./backoff.js";
 
 async function expectAbortedSleep(promise: Promise<void>): Promise<Error> {
@@ -64,6 +65,22 @@ describe("backoff helpers", () => {
       await vi.advanceTimersByTimeAsync(1);
       await expect(sleeper).resolves.toBeUndefined();
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps oversized sleep durations before scheduling", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const sleeper = sleepWithAbort(Number.MAX_SAFE_INTEGER);
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+
+      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+      await expect(sleeper).resolves.toBeUndefined();
+    } finally {
+      setTimeoutSpy.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/src/infra/backoff.ts
+++ b/src/infra/backoff.ts
@@ -1,3 +1,5 @@
+import { clampPositiveTimerTimeoutMs } from "../shared/number-coercion.js";
+
 export type BackoffPolicy = {
   initialMs: number;
   maxMs: number;
@@ -12,7 +14,8 @@ export function computeBackoff(policy: BackoffPolicy, attempt: number) {
 }
 
 export async function sleepWithAbort(ms: number, abortSignal?: AbortSignal) {
-  if (ms <= 0) {
+  const delayMs = clampPositiveTimerTimeoutMs(ms);
+  if (delayMs === undefined) {
     return;
   }
   await new Promise<void>((resolve, reject) => {
@@ -48,7 +51,7 @@ export async function sleepWithAbort(ms: number, abortSignal?: AbortSignal) {
       }
       timer = null;
       resolve();
-    }, ms);
+    }, delayMs);
 
     if (abortSignal) {
       if (abortSignal.aborted) {

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -293,6 +293,33 @@ describe("gateway lock", () => {
     }
   });
 
+  it("bounds oversized lock polling intervals by the acquire timeout", async () => {
+    const env = await makeEnv();
+    await writeRecentLockFile(env);
+    const sleepDelays: number[] = [];
+    let now = 0;
+
+    await expect(
+      acquireGatewayLock({
+        env,
+        allowInTests: true,
+        timeoutMs: 5,
+        pollIntervalMs: Number.MAX_SAFE_INTEGER,
+        staleMs: 10_000,
+        platform: "darwin",
+        now: () => now,
+        sleep: async (ms) => {
+          sleepDelays.push(ms);
+          now = 10;
+        },
+        lockDir: resolveTestLockDir(),
+        readProcessCmdline: () => ["/usr/local/bin/openclaw", "gateway", "run"],
+      }),
+    ).rejects.toBeInstanceOf(GatewayLockError);
+
+    expect(sleepDelays).toEqual([5]);
+  });
+
   it("returns null when multi-gateway override is enabled", async () => {
     const env = await makeEnv();
     const lock = await acquireGatewayLock({

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -4,7 +4,11 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
-import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import {
+  resolvePositiveTimerTimeoutMs,
+  resolveTimerTimeoutMs,
+  resolveTimestampMsToIsoString,
+} from "@openclaw/normalization-core/number-coercion";
 import { z } from "zod";
 import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
 import { isPidAlive } from "../shared/pid-alive.js";
@@ -256,9 +260,12 @@ export async function acquireGatewayLock(
     return null;
   }
 
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-  const staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
+  const timeoutMs = resolveTimerTimeoutMs(opts.timeoutMs, DEFAULT_TIMEOUT_MS, 0);
+  const pollIntervalMs = resolvePositiveTimerTimeoutMs(
+    opts.pollIntervalMs,
+    DEFAULT_POLL_INTERVAL_MS,
+  );
+  const staleMs = resolveTimerTimeoutMs(opts.staleMs, DEFAULT_STALE_MS, 0);
   const platform = opts.platform ?? process.platform;
   const port = opts.port;
   const now = opts.now ?? Date.now;
@@ -336,7 +343,11 @@ export async function acquireGatewayLock(
         }
       }
 
-      await sleep(pollIntervalMs);
+      const remainingMs = timeoutMs - (now() - startedAt);
+      if (remainingMs <= 0) {
+        break;
+      }
+      await sleep(Math.min(pollIntervalMs, remainingMs));
     }
   }
 

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -217,6 +217,17 @@ describe("heartbeat-wake", () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
+  it("clamps oversized coalesce delays instead of firing immediately", async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeat(wake("slow", { coalesceMs: Number.MAX_SAFE_INTEGER }));
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it("does not downgrade a higher-priority pending reason", async () => {
     vi.useFakeTimers();
     const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { normalizeHeartbeatWakeReason } from "./heartbeat-reason.js";
 
 export type HeartbeatRunResult =
@@ -184,7 +185,7 @@ function queuePendingWakeReason(params: {
 }
 
 function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
-  const delay = Number.isFinite(coalesceMs) ? Math.max(0, coalesceMs) : DEFAULT_COALESCE_MS;
+  const delay = resolveTimerTimeoutMs(coalesceMs, DEFAULT_COALESCE_MS, 0);
   const dueAt = Date.now() + delay;
   if (timer) {
     // Keep retry cooldown as a hard minimum delay. This prevents the

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -41,8 +41,6 @@ import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citati
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import {
-  GATEWAY_CLIENT_MODES,
-  GATEWAY_CLIENT_NAMES,
   INTERNAL_MESSAGE_CHANNEL,
   type GatewayClientMode,
   type GatewayClientName,
@@ -73,6 +71,7 @@ import {
   resolveAndApplyOutboundThreadId,
 } from "./message-action-threading.js";
 import { maybeApplyTtsToMessageActionSendPayload } from "./message-action-tts.js";
+import { resolveOutboundMessageGatewayOptions } from "./message-gateway-options.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import {
   applyCrossContextDecoration,
@@ -187,22 +186,7 @@ export function getToolResult(
 }
 
 function resolveGatewayActionOptions(gateway?: MessageActionRunnerGateway) {
-  const url =
-    gateway?.mode === GATEWAY_CLIENT_MODES.BACKEND ||
-    gateway?.clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT
-      ? undefined
-      : gateway?.url;
-  return {
-    url,
-    token: gateway?.token,
-    timeoutMs:
-      typeof gateway?.timeoutMs === "number" && Number.isFinite(gateway.timeoutMs)
-        ? Math.max(1, Math.floor(gateway.timeoutMs))
-        : 10_000,
-    clientName: gateway?.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
-    clientDisplayName: gateway?.clientDisplayName,
-    mode: gateway?.mode ?? GATEWAY_CLIENT_MODES.CLI,
-  };
+  return resolveOutboundMessageGatewayOptions(gateway);
 }
 
 async function callGatewayMessageAction<T>(params: {

--- a/src/infra/outbound/message-gateway-options.test.ts
+++ b/src/infra/outbound/message-gateway-options.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
+import { resolveOutboundMessageGatewayOptions } from "./message-gateway-options.js";
+
+describe("resolveOutboundMessageGatewayOptions", () => {
+  it("clamps oversized gateway timeouts", () => {
+    expect(
+      resolveOutboundMessageGatewayOptions({ timeoutMs: Number.MAX_SAFE_INTEGER }).timeoutMs,
+    ).toBe(MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("drops caller-provided urls for backend gateway callers", () => {
+    expect(
+      resolveOutboundMessageGatewayOptions({
+        url: "http://attacker.invalid",
+        clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      }).url,
+    ).toBeUndefined();
+  });
+});

--- a/src/infra/outbound/message-gateway-options.ts
+++ b/src/infra/outbound/message-gateway-options.ts
@@ -1,0 +1,33 @@
+import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+  type GatewayClientMode,
+  type GatewayClientName,
+} from "../../utils/message-channel.js";
+
+export type OutboundMessageGatewayOptionsInput = {
+  url?: string;
+  token?: string;
+  timeoutMs?: number;
+  clientName?: GatewayClientName;
+  clientDisplayName?: string;
+  mode?: GatewayClientMode;
+};
+
+export function resolveOutboundMessageGatewayOptions(gateway?: OutboundMessageGatewayOptionsInput) {
+  const clientName = gateway?.clientName ?? GATEWAY_CLIENT_NAMES.CLI;
+  const mode = gateway?.mode ?? GATEWAY_CLIENT_MODES.CLI;
+  const url =
+    mode === GATEWAY_CLIENT_MODES.BACKEND || clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT
+      ? undefined
+      : gateway?.url;
+  return {
+    url,
+    token: gateway?.token,
+    timeoutMs: resolveTimerTimeoutMs(gateway?.timeoutMs, 10_000),
+    clientName,
+    clientDisplayName: gateway?.clientDisplayName,
+    mode,
+  };
+}

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -5,12 +5,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
-import {
-  GATEWAY_CLIENT_MODES,
-  GATEWAY_CLIENT_NAMES,
-  type GatewayClientMode,
-  type GatewayClientName,
-} from "../../utils/message-channel.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
 import {
@@ -20,6 +14,10 @@ import {
   type OutboundDeliveryQueuePolicy,
   type OutboundSendDeps,
 } from "./deliver.js";
+import {
+  resolveOutboundMessageGatewayOptions,
+  type OutboundMessageGatewayOptionsInput,
+} from "./message-gateway-options.js";
 import type { OutboundMirror } from "./mirror.js";
 import {
   createOutboundPayloadPlan,
@@ -44,14 +42,7 @@ function loadMessageGatewayRuntime() {
   return messageGatewayRuntimePromise;
 }
 
-export type MessageGatewayOptions = {
-  url?: string;
-  token?: string;
-  timeoutMs?: number;
-  clientName?: GatewayClientName;
-  clientDisplayName?: string;
-  mode?: GatewayClientMode;
-};
+export type MessageGatewayOptions = OutboundMessageGatewayOptionsInput;
 
 type MessageSendParams = {
   to: string;
@@ -261,24 +252,7 @@ async function assertRequiredMessageSendDurability(params: {
 }
 
 function resolveGatewayOptions(opts?: MessageGatewayOptions) {
-  // Security: backend callers (tools/agents) must not accept user-controlled gateway URLs.
-  // Use config-derived gateway target only.
-  const url =
-    opts?.mode === GATEWAY_CLIENT_MODES.BACKEND ||
-    opts?.clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT
-      ? undefined
-      : opts?.url;
-  return {
-    url,
-    token: opts?.token,
-    timeoutMs:
-      typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
-        ? Math.max(1, Math.floor(opts.timeoutMs))
-        : 10_000,
-    clientName: opts?.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
-    clientDisplayName: opts?.clientDisplayName,
-    mode: opts?.mode ?? GATEWAY_CLIENT_MODES.CLI,
-  };
+  return resolveOutboundMessageGatewayOptions(opts);
 }
 
 async function callMessageGateway<T>(params: {

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -50,6 +50,14 @@ export const DEFAULT_PLUGIN_APPROVAL_DECISIONS = [
   "deny",
 ] as const satisfies readonly ExecApprovalDecision[];
 
+export function resolvePluginApprovalTimeoutMs(value: unknown): number {
+  const candidate =
+    typeof value === "number" && Number.isFinite(value)
+      ? value
+      : DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS;
+  return Math.min(MAX_PLUGIN_APPROVAL_TIMEOUT_MS, Math.max(1, Math.floor(candidate)));
+}
+
 export function approvalDecisionLabel(decision: ExecApprovalDecision): string {
   if (decision === "allow-once") {
     return "allowed once";

--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -194,6 +194,21 @@ describe("fetchMinimaxUsage", () => {
       },
     },
     {
+      name: "drops Date-invalid reset timestamps",
+      payload: {
+        data: {
+          plan_name: "Overflow Plan",
+          reset_at: 8_640_000_000_000_001,
+          current_interval_total_count: 100,
+          current_interval_usage_count: 25,
+        },
+      },
+      expected: {
+        plan: "Overflow Plan",
+        windows: [{ label: "5h", usedPercent: 75, resetAt: undefined }],
+      },
+    },
+    {
       name: "prefers chat model entries from model_remains and derives window labels from timestamps",
       payload: {
         data: {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -1,3 +1,4 @@
+import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isRecord } from "../utils.js";
 import {
@@ -192,16 +193,12 @@ function pickString(record: Record<string, unknown>, keys: readonly string[]): s
 
 function parseEpoch(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) {
-    if (value < 1e12) {
-      return Math.floor(value * 1000);
-    }
-    return Math.floor(value);
+    const timestampMs = value < 1e12 ? Math.floor(value * 1000) : Math.floor(value);
+    return asDateTimestampMs(timestampMs);
   }
   if (typeof value === "string" && value.trim()) {
     const parsed = Date.parse(value);
-    if (Number.isFinite(parsed)) {
-      return parsed;
-    }
+    return asDateTimestampMs(parsed);
   }
   return undefined;
 }

--- a/src/infra/provider-usage.shared.test.ts
+++ b/src/infra/provider-usage.shared.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { clampPercent, resolveUsageProviderId, withTimeout } from "./provider-usage.shared.js";
 
 describe("provider-usage.shared", () => {
@@ -62,6 +63,18 @@ describe("provider-usage.shared", () => {
     const late = new Promise<string>((resolve) => setTimeout(() => resolve("late"), 50));
     const result = withTimeout(late, 1, "fallback");
     await vi.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toBe("fallback");
+  });
+
+  it("clamps oversized timeout delays before scheduling", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const result = withTimeout(new Promise<string>(() => {}), Number.MAX_SAFE_INTEGER, "fallback");
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+
+    await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
     await expect(result).resolves.toBe("fallback");
   });
 

--- a/src/infra/provider-usage.shared.ts
+++ b/src/infra/provider-usage.shared.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import type { UsageProviderId } from "./provider-usage.types.js";
 
 export const DEFAULT_TIMEOUT_MS = 5000;
@@ -71,11 +72,12 @@ export const clampPercent = (value: number) =>
 
 export const withTimeout = async <T>(work: Promise<T>, ms: number, fallback: T): Promise<T> => {
   let timeout: NodeJS.Timeout | undefined;
+  const timeoutMs = resolveTimerTimeoutMs(ms, 1);
   try {
     return await Promise.race([
       work,
       new Promise<T>((resolve) => {
-        timeout = setTimeout(() => resolve(fallback), ms);
+        timeout = setTimeout(() => resolve(fallback), timeoutMs);
       }),
     ]);
   } finally {

--- a/src/infra/restart.deferral-timeout.test.ts
+++ b/src/infra/restart.deferral-timeout.test.ts
@@ -66,6 +66,23 @@ describe("deferGatewayRestartUntilIdle timeout", () => {
     expect(hooks.onTimeout).toHaveBeenCalledOnce();
   });
 
+  it("clamps oversized poll intervals instead of polling immediately", () => {
+    const hooks: RestartDeferralHooks = {
+      onReady: vi.fn(),
+    };
+    let pending = 1;
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => pending,
+      pollMs: Number.MAX_SAFE_INTEGER,
+      hooks,
+    });
+
+    pending = 0;
+    vi.advanceTimersByTime(1);
+    expect(hooks.onReady).not.toHaveBeenCalled();
+  });
+
   it("carries timeout restart intent when the deferral budget is exhausted", () => {
     const hooks: RestartDeferralHooks = {
       onTimeout: vi.fn(),

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -9,6 +9,7 @@ import {
   resolveGatewaySystemdServiceName,
 } from "../daemon/constants.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { replaceFileAtomicSync } from "./replace-file.js";
 import { cleanStaleGatewayProcessesSync, findGatewayPidsOnPortSync } from "./restart-stale-pids.js";
 import type { RestartAttempt } from "./restart.types.js";
@@ -494,8 +495,7 @@ export function deferGatewayRestartUntilIdle(opts: {
   reason?: string;
   timeoutIntent?: GatewayRestartIntent;
 }): void {
-  const pollMsRaw = opts.pollMs ?? DEFAULT_DEFERRAL_POLL_MS;
-  const pollMs = Math.max(10, Math.floor(pollMsRaw));
+  const pollMs = resolveTimerTimeoutMs(opts.pollMs, DEFAULT_DEFERRAL_POLL_MS, 10);
   const maxWaitMs =
     typeof opts.maxWaitMs === "number" && Number.isFinite(opts.maxWaitMs) && opts.maxWaitMs > 0
       ? Math.max(pollMs, Math.floor(opts.maxWaitMs))

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import {
   DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES,
   configureSqliteWalMaintenance,
@@ -44,6 +45,19 @@ describe("sqlite WAL maintenance", () => {
 
     vi.advanceTimersByTime(200);
     expect(db.exec).toHaveBeenCalledTimes(4);
+  });
+
+  it("clamps oversized checkpoint intervals before arming timers", () => {
+    vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const db = createMockDb();
+
+    const maintenance = configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    maintenance.close();
   });
 
   it("reports checkpoint errors without throwing from background maintenance", () => {

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 
 export const DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const DEFAULT_SQLITE_WAL_TRUNCATE_INTERVAL_MS = 30 * 60 * 1000;
@@ -42,6 +43,7 @@ export function configureSqliteWalMaintenance(
     options.checkpointIntervalMs ?? DEFAULT_SQLITE_WAL_TRUNCATE_INTERVAL_MS,
     "checkpointIntervalMs",
   );
+  const timerIntervalMs = Math.min(checkpointIntervalMs, MAX_TIMER_TIMEOUT_MS);
   const checkpointMode = options.checkpointMode ?? "TRUNCATE";
   db.exec("PRAGMA journal_mode = WAL;");
   db.exec(`PRAGMA wal_autocheckpoint = ${autoCheckpointPages};`);
@@ -57,8 +59,8 @@ export function configureSqliteWalMaintenance(
   };
 
   let timer: IntervalHandle | null = null;
-  if (checkpointIntervalMs > 0) {
-    timer = setInterval(checkpoint, checkpointIntervalMs) as IntervalHandle;
+  if (timerIntervalMs > 0) {
+    timer = setInterval(checkpoint, timerIntervalMs) as IntervalHandle;
     timer.unref?.();
   }
 

--- a/src/media-understanding/shared.test.ts
+++ b/src/media-understanding/shared.test.ts
@@ -163,6 +163,20 @@ describe("provider operation deadlines", () => {
     await expect(wait).resolves.toBeUndefined();
   });
 
+  it("caps oversized provider poll waits without an operation deadline", async () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const wait = waitProviderOperationPollInterval({
+      deadline: createProviderOperationDeadline({ label: "video generation" }),
+      pollIntervalMs: MAX_TIMER_TIMEOUT_MS + 1_000_000,
+    });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
+    await expect(wait).resolves.toBeUndefined();
+  });
+
   it("polls provider status JSON until a payload is complete", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -148,16 +148,17 @@ export async function waitProviderOperationPollInterval(params: {
   deadline: ProviderOperationDeadline;
   pollIntervalMs: number;
 }): Promise<void> {
+  const pollIntervalMs = resolveTimerTimeoutMs(params.pollIntervalMs, 1);
   const deadlineAtMs = params.deadline.deadlineAtMs;
   if (typeof deadlineAtMs !== "number") {
-    await new Promise((resolve) => setTimeout(resolve, params.pollIntervalMs));
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
     return;
   }
   const remainingMs = deadlineAtMs - Date.now();
   if (remainingMs <= 0) {
     throw new Error(`${params.deadline.label} timed out after ${params.deadline.timeoutMs}ms`);
   }
-  await new Promise((resolve) => setTimeout(resolve, Math.min(params.pollIntervalMs, remainingMs)));
+  await new Promise((resolve) => setTimeout(resolve, Math.min(pollIntervalMs, remainingMs)));
 }
 
 export async function pollProviderOperationJson<TPayload>(

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -633,6 +634,32 @@ describe("readRemoteMediaBuffer", () => {
     expect(saved.path).toMatch(/[a-f0-9-]{36}\.png$/);
     expect(saved.path).not.toMatch(/photo---/);
     await expect(fs.readFile(saved.path)).resolves.toStrictEqual(Buffer.from([1, 2, 3, 4]));
+  });
+
+  it("clamps oversized saved-response idle timeout timers", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+            status: 200,
+            headers: { "content-type": "application/octet-stream" },
+          }),
+      );
+
+      const saved = await saveRemoteMedia({
+        url: "https://example.com/download",
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 8,
+        readIdleTimeoutMs: MAX_TIMER_TIMEOUT_MS + 1,
+      });
+
+      await expect(fs.readFile(saved.path)).resolves.toStrictEqual(Buffer.from([1, 2, 3]));
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   it("cancels ignored content-length overflow bodies for saved responses", async () => {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -8,6 +8,7 @@ import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/
 import { retryAsync, type RetryOptions } from "../infra/retry.js";
 import { isAbortError, isTransientNetworkError } from "../infra/unhandled-rejections.js";
 import { redactSensitiveText } from "../logging/redact.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { MAX_DOCUMENT_BYTES } from "./constants.js";
 import { parseMediaContentLength } from "./content-length.js";
 import { basenameFromAnyPath, extnameFromAnyPath } from "./file-name.js";
@@ -390,12 +391,13 @@ async function readChunkWithIdleTimeout(
         timeoutId = undefined;
       }
     };
+    const resolvedChunkTimeoutMs = resolveTimerTimeoutMs(chunkTimeoutMs, 1);
     timeoutId = setTimeout(() => {
       timedOut = true;
       clear();
       void reader.cancel().catch(() => undefined);
-      reject(new Error(`Media download stalled: no data received for ${chunkTimeoutMs}ms`));
-    }, chunkTimeoutMs);
+      reject(new Error(`Media download stalled: no data received for ${resolvedChunkTimeoutMs}ms`));
+    }, resolvedChunkTimeoutMs);
     void reader.read().then(
       (result) => {
         clear();

--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { readResponseTextSnippet, readResponseWithLimit } from "./read-response-with-limit.js";
 
 function makeStream(chunks: Uint8Array[], delayMs?: number) {
@@ -156,6 +157,23 @@ describe("readResponseWithLimit", () => {
       expect(buf).toEqual(expected);
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("clamps oversized idle timeout timers while reading chunks", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const body = makeStream([new Uint8Array([1]), new Uint8Array([2])]);
+      const res = new Response(body);
+
+      const buf = await readResponseWithLimit(res, 100, {
+        chunkTimeoutMs: MAX_TIMER_TIMEOUT_MS + 1,
+      });
+
+      expect(buf).toEqual(Buffer.from([1, 2]));
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
     }
   });
 

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -1,3 +1,5 @@
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
+
 async function readChunkWithIdleTimeout(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   chunkTimeoutMs: number,
@@ -14,15 +16,16 @@ async function readChunkWithIdleTimeout(
       }
     };
 
+    const resolvedChunkTimeoutMs = resolveTimerTimeoutMs(chunkTimeoutMs, 1);
     timeoutId = setTimeout(() => {
       timedOut = true;
       const error =
-        onIdleTimeout?.({ chunkTimeoutMs }) ??
-        new Error(`Media download stalled: no data received for ${chunkTimeoutMs}ms`);
+        onIdleTimeout?.({ chunkTimeoutMs: resolvedChunkTimeoutMs }) ??
+        new Error(`Media download stalled: no data received for ${resolvedChunkTimeoutMs}ms`);
       clear();
       void reader.cancel(error).catch(() => undefined);
       reject(error);
-    }, chunkTimeoutMs);
+    }, resolvedChunkTimeoutMs);
 
     void reader.read().then(
       (result) => {

--- a/src/plugin-sdk/provider-auth-runtime.test.ts
+++ b/src/plugin-sdk/provider-auth-runtime.test.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:net";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import * as providerAuthRuntime from "./provider-auth-runtime.js";
 
 async function getFreePort(): Promise<number> {
@@ -149,6 +150,35 @@ describe("plugin-sdk provider-auth-runtime", () => {
     const response = await fetch(`http://127.0.0.1:${port}/callback?code=code-1&state=state-1`);
     expect(response.status).toBe(200);
     await expect(callback).resolves.toEqual({ code: "code-1", state: "state-1" });
+  });
+
+  it("clamps oversized OAuth callback timeouts before scheduling", async () => {
+    const port = await getFreePort();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      let callback!: Promise<providerAuthRuntime.OAuthCallbackResult>;
+      const listening = new Promise<void>((resolve) => {
+        callback = providerAuthRuntime.waitForLocalOAuthCallback({
+          expectedState: "state-1",
+          timeoutMs: Number.MAX_SAFE_INTEGER,
+          port,
+          callbackPath: "/callback",
+          redirectUri: `http://127.0.0.1:${port}/callback`,
+          hostname: "127.0.0.1",
+          successTitle: "OAuth complete",
+          onProgress: () => resolve(),
+        });
+      });
+      await listening;
+
+      const response = await fetch(`http://127.0.0.1:${port}/callback?code=code-1&state=state-1`);
+
+      expect(response.status).toBe(200);
+      await expect(callback).resolves.toEqual({ code: "code-1", state: "state-1" });
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 });
 

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -6,6 +6,7 @@ import { createServer } from "node:http";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveApiKeyForProvider as resolveModelApiKeyForProvider } from "../agents/model-auth.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 
 export { resolveEnvApiKey } from "../agents/model-auth-env.js";
 export {
@@ -107,6 +108,7 @@ export async function waitForLocalOAuthCallback(params: {
   corsOriginAllowlist?: readonly string[];
 }): Promise<OAuthCallbackResult> {
   const hostname = params.hostname ?? "localhost";
+  const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
   const escapedSuccessTitle = escapeHtmlText(params.successTitle);
   const resolveOAuthCallbackOrigin = buildOAuthCallbackOriginResolver(params.corsOriginAllowlist);
   const hasCorsOriginAllowlist =
@@ -216,7 +218,7 @@ export async function waitForLocalOAuthCallback(params: {
 
     timeout = setTimeout(() => {
       finish(new Error("OAuth callback timeout"));
-    }, params.timeoutMs);
+    }, timeoutMs);
   });
 }
 

--- a/src/plugins/hooks.correlation.test.ts
+++ b/src/plugins/hooks.correlation.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createHookRunner } from "./hooks.js";
 import { addTestHook, TEST_PLUGIN_AGENT_CTX } from "./hooks.test-helpers.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
@@ -171,6 +172,27 @@ describe("hook correlation fields", () => {
       expect(logger.error).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("clamps oversized hook timeouts before scheduling", async () => {
+    const handler = vi.fn(async () => {});
+    addTestHook({
+      registry,
+      pluginId: "plugin-a",
+      hookName: "agent_end",
+      handler: handler as PluginHookRegistration["handler"],
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const runner = createHookRunner(registry);
+
+      await runner.runAgentEnd({ messages: [], success: true }, TEST_PLUGIN_AGENT_CTX);
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
     }
   });
 });

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -8,6 +8,7 @@
 import { copyReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-payload.js";
 import { formatHookErrorForLog } from "../hooks/fire-and-forget.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { clampPositiveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { concatOptionalTextSegments } from "../shared/text/join-segments.js";
 import {
   type GateHookResult,
@@ -535,10 +536,7 @@ export function createHookRunner(
   };
 
   const normalizePositiveTimeoutMs = (timeoutMs: number | undefined): number | undefined => {
-    if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-      return undefined;
-    }
-    return Math.floor(timeoutMs);
+    return clampPositiveTimerTimeoutMs(timeoutMs);
   };
 
   const getVoidHookTimeoutMs = (

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { INVALID_EXEC_SECRET_REF_IDS } from "../test-utils/secret-ref-test-vectors.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 import {
@@ -54,6 +55,8 @@ describe("secret ref resolver", () => {
     allowSymlinkCommand?: boolean;
     trustedDirs?: string[];
     args?: string[];
+    timeoutMs?: number;
+    noOutputTimeoutMs?: number;
   };
   type FileProviderConfig = {
     source: "file";
@@ -203,6 +206,18 @@ describe("secret ref resolver", () => {
   itPosix("resolves exec refs with protocolVersion 1 response", async () => {
     const value = await resolveExecSecret(execProtocolV1ScriptPath);
     expect(value).toBe("value:openai/api-key");
+  });
+
+  itPosix("clamps oversized exec provider timeouts", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const value = await resolveExecSecret(execProtocolV1ScriptPath, {
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+      noOutputTimeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(value).toBe("value:openai/api-key");
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
 
   itPosix("uses timeoutMs as the default no-output timeout for exec providers", async () => {

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -34,7 +34,12 @@ import {
   secretRefKey,
 } from "./ref-contract.js";
 import type { SecretRefResolveCache } from "./resolve-types.js";
-import { isNonEmptyString, isRecord, normalizePositiveInt } from "./shared.js";
+import {
+  isNonEmptyString,
+  isRecord,
+  normalizePositiveInt,
+  normalizePositiveTimerMs,
+} from "./shared.js";
 
 const DEFAULT_PROVIDER_CONCURRENCY = 4;
 const DEFAULT_MAX_REFS_PER_PROVIDER = 512;
@@ -329,7 +334,7 @@ async function readFileProviderPayload(params: {
 
   const filePath = resolveUserPath(params.providerConfig.path);
   const readPromise = (async () => {
-    const timeoutMs = normalizePositiveInt(
+    const timeoutMs = normalizePositiveTimerMs(
       params.providerConfig.timeoutMs,
       DEFAULT_FILE_TIMEOUT_MS,
     );
@@ -734,8 +739,11 @@ async function resolveExecRefs(params: {
     childEnv[key] = value;
   }
 
-  const timeoutMs = normalizePositiveInt(params.providerConfig.timeoutMs, DEFAULT_EXEC_TIMEOUT_MS);
-  const noOutputTimeoutMs = normalizePositiveInt(
+  const timeoutMs = normalizePositiveTimerMs(
+    params.providerConfig.timeoutMs,
+    DEFAULT_EXEC_TIMEOUT_MS,
+  );
+  const noOutputTimeoutMs = normalizePositiveTimerMs(
     params.providerConfig.noOutputTimeoutMs,
     timeoutMs,
   );

--- a/src/secrets/shared.ts
+++ b/src/secrets/shared.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { privateFileStoreSync } from "../infra/private-file-store.js";
 import { replaceFileAtomicSync } from "../infra/replace-file.js";
+import { resolvePositiveTimerTimeoutMs } from "../shared/number-coercion.js";
 export { isRecord } from "../utils.js";
 
 export function isNonEmptyString(value: unknown): value is string {
@@ -24,6 +25,10 @@ export function normalizePositiveInt(value: unknown, fallback: number): number {
     return Math.max(1, Math.floor(value));
   }
   return Math.max(1, Math.floor(fallback));
+}
+
+export function normalizePositiveTimerMs(value: unknown, fallback: number): number {
+  return resolvePositiveTimerTimeoutMs(value, fallback);
 }
 
 export function parseDotPath(pathname: string): string[] {

--- a/src/talk/forced-consult-coordinator.test.ts
+++ b/src/talk/forced-consult-coordinator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createRealtimeVoiceForcedConsultCoordinator } from "./forced-consult-coordinator.js";
 
 describe("realtime voice forced consult coordinator", () => {
@@ -155,6 +156,21 @@ describe("realtime voice forced consult coordinator", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("caps oversized forced consult schedule delays", () => {
+    const scheduledDelays: number[] = [];
+    const coordinator = createRealtimeVoiceForcedConsultCoordinator({
+      setTimer: (_fn, ms) => {
+        scheduledDelays.push(ms);
+        return { clear: vi.fn() };
+      },
+    });
+    const pending = coordinator.prepare("check status", { id: "forced-1" });
+
+    coordinator.schedule(pending!, Number.MAX_SAFE_INTEGER, vi.fn());
+
+    expect(scheduledDelays).toEqual([MAX_TIMER_TIMEOUT_MS]);
   });
 
   it("reports cancelled handles until the dedupe window expires", () => {

--- a/src/talk/forced-consult-coordinator.ts
+++ b/src/talk/forced-consult-coordinator.ts
@@ -1,3 +1,4 @@
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import {
   matchRealtimeVoiceConsultQuestions,
   readRealtimeVoiceConsultQuestion,
@@ -231,12 +232,15 @@ export function createRealtimeVoiceForcedConsultCoordinator<TContext = unknown>(
       if (!stored || !stored.pending || stored.timer) {
         return;
       }
-      stored.timer = setTimer(() => {
-        stored.timer = undefined;
-        if (state.get(handle.id) === stored && stored.pending && !stored.cancelled) {
-          run(handle);
-        }
-      }, delayMs);
+      stored.timer = setTimer(
+        () => {
+          stored.timer = undefined;
+          if (state.get(handle.id) === stored && stored.pending && !stored.cancelled) {
+            run(handle);
+          }
+        },
+        resolveTimerTimeoutMs(delayMs, 0, 0),
+      );
     },
     clearPending() {
       for (const stored of state.values()) {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
+import { summarizeText } from "./tts-core.js";
+import type { ResolvedTtsConfig } from "./tts-types.js";
+
+describe("TTS core", () => {
+  it("clamps oversized summarization timeout timers", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const model = { provider: { id: "test-provider" } };
+      const config = {
+        summarizeModel: { primary: "test-provider/test-model" },
+      } as ResolvedTtsConfig;
+
+      const result = await summarizeText(
+        {
+          text: "Long text that should be summarized for speech.",
+          targetLength: 120,
+          cfg: {},
+          config,
+          timeoutMs: MAX_TIMER_TIMEOUT_MS + 1,
+        },
+        {
+          completeSimple: vi.fn(async () => ({
+            content: [{ type: "text", text: "Short summary." }],
+            stopReason: "stop",
+            usage: {},
+          })),
+          getApiKeyForModel: vi.fn(async () => "key"),
+          prepareModelForSimpleCompletion: vi.fn(() => model as never),
+          requireApiKey: vi.fn(() => "key"),
+          resolveModelAsync: vi.fn(async () => ({ model })),
+        },
+      );
+
+      expect(result.summary).toBe("Short summary.");
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+});

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -11,6 +11,7 @@ import { prepareModelForSimpleCompletion } from "../agents/simple-completion-tra
 import type { OpenClawConfig } from "../config/types.js";
 import { completeSimple } from "../llm/stream.js";
 import type { TextContent } from "../llm/types.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import type { ResolvedTtsConfig } from "./tts-types.js";
 export {
   normalizeApplyTextNormalization,
@@ -105,7 +106,8 @@ export async function summarizeText(
 
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const resolvedTimeoutMs = resolveTimerTimeoutMs(timeoutMs, 1);
+    const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
 
     try {
       const res = await deps.completeSimple(

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "./shared/number-coercion.js";
 import { withTempDir } from "./test-helpers/temp-dir.js";
 import {
   ensureDir,
@@ -30,6 +31,22 @@ describe("sleep", () => {
       vi.advanceTimersByTime(1000);
       await expect(promise).resolves.toBeUndefined();
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps oversized sleep delays before scheduling", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const promise = sleep(Number.MAX_SAFE_INTEGER);
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+
+      vi.advanceTimersByTime(MAX_TIMER_TIMEOUT_MS);
+      await expect(promise).resolves.toBeUndefined();
+    } finally {
+      setTimeoutSpy.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
   resolveRequiredHomeDir,
 } from "./infra/home-dir.js";
 import { isPlainObject } from "./infra/plain-object.js";
+import { resolveTimerTimeoutMs } from "./shared/number-coercion.js";
 export { escapeRegExp } from "./shared/regexp.js";
 
 export async function ensureDir(dir: string) {
@@ -57,7 +58,7 @@ export function normalizeE164(number: string): string {
 }
 
 export function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, resolveTimerTimeoutMs(ms, 0, 0)));
 }
 
 function isHighSurrogate(codeUnit: number): boolean {


### PR DESCRIPTION
## Summary

- Treat inherited OAuth expiry comparisons as valid date timestamps, not just finite numbers.
- Prevent child-agent auth stores from persisting inherited OAuth profiles whose local expiry is outside the supported JavaScript date range.
- Add a regression covering valid main OAuth winning over an out-of-range local inherited expiry.

## Verification

- `fnm exec --using 24.15.0 node scripts/run-vitest.mjs src/agents/auth-profiles.store.save.test.ts`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled OPENCLAW_OXLINT_SKIP_PREPARE=1 fnm exec --using 24.15.0 node scripts/run-oxlint.mjs src/agents/auth-profiles/store.ts src/agents/auth-profiles.store.save.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: child-agent auth store inheritance no longer treats an out-of-range OAuth expiry as fresher than a valid main-agent OAuth credential.
Real environment tested: local macOS checkout with Node 24.15.0 via repo test wrapper.
Exact steps or command run after this patch: focused Vitest file, touched-file oxlint, `git diff --check`, and local autoreview.
Evidence after fix: auth profile store save suite passed 23 tests; lint and diff check were clean; autoreview reported no accepted/actionable findings.
Observed result after fix: the regression leaves the poisoned child OAuth profile out of the persisted child auth store and resolves the inherited valid main OAuth profile at runtime.
What was not tested: full repo check and remote CI were not run locally.
