### PR TITLE
ci: keep harness changes on fast checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,10 +834,10 @@ jobs:
               ;;
             contracts-plugins-ci-routing)
               pnpm test:contracts:plugins
-              pnpm test src/commands/status.scan-result.test.ts src/scripts/ci-changed-scope.test.ts test/scripts/test-projects.test.ts
+              pnpm test src/commands/status.scan-result.test.ts src/scripts/ci-changed-scope.test.ts test/scripts/changed-lanes.test.ts test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts
               ;;
             ci-routing)
-              pnpm test src/commands/status.scan-result.test.ts src/scripts/ci-changed-scope.test.ts test/scripts/test-projects.test.ts
+              pnpm test src/commands/status.scan-result.test.ts src/scripts/ci-changed-scope.test.ts test/scripts/changed-lanes.test.ts test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts
               ;;
             bun-launcher)
               OPENCLAW_TEST_BUN_LAUNCHER=1 pnpm test test/openclaw-launcher.e2e.test.ts

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -33,7 +33,8 @@ const SHRINKWRAP_POLICY_PATH_RE =
 const CORE_OXLINT_TS_CONFIG = "config/tsconfig/oxlint.core.json";
 const TARGETED_CORE_LINT_PATH_LIMIT = 8;
 const LINTABLE_CORE_PATH_RE = /^(?:src|ui|packages)\/.+\.[cm]?[jt]sx?$/u;
-const CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE = /^(?:scripts|test\/scripts)\//u;
+const CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
+  /^(?:scripts|test\/scripts)\/|^\.github\/workflows\/ci\.yml$/u;
 let corepackPnpmShimDir;
 
 export function createChangedCheckChildEnv(baseEnv = process.env) {

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -52,9 +52,9 @@ const FULL_INSTALL_SMOKE_SCOPE_RE =
 const FAST_INSTALL_SMOKE_RUNTIME_SCOPE_RE =
   /^(?:src\/(?:channels|gateway|plugin-sdk|plugins)\/|packages\/gateway-(?:client|protocol)\/src\/)/;
 const NODE_FAST_PLUGIN_CONTRACT_SCOPE_RE =
-  /^(src\/plugins\/contracts\/(?:inventory\/bundled-capability-metadata|registry|tts-contract-suites)\.ts$|scripts\/test-projects(?:\.test-support)?\.mjs$|test\/scripts\/test-projects\.test\.ts$)/;
+  /^src\/plugins\/contracts\/(?:inventory\/bundled-capability-metadata|registry|tts-contract-suites)\.ts$/;
 const NODE_FAST_CI_ROUTING_SCOPE_RE =
-  /^(scripts\/ci-changed-scope\.mjs$|src\/commands\/status\.scan-result\.test\.ts$|src\/scripts\/ci-changed-scope\.test\.ts$|\.github\/workflows\/ci\.yml$)/;
+  /^(scripts\/(?:ci-changed-scope|check-changed|run-vitest|test-projects(?:\.test-support)?)\.mjs$|scripts\/test-projects\.test-support\.d\.mts$|src\/commands\/status\.scan-result\.test\.ts$|src\/scripts\/ci-changed-scope\.test\.ts$|test\/scripts\/(?:changed-lanes|run-vitest|test-projects)\.test\.ts$|\.github\/workflows\/ci\.yml$)/;
 const NODE_FAST_SCOPE_RE = new RegExp(
   `${NODE_FAST_PLUGIN_CONTRACT_SCOPE_RE.source}|${NODE_FAST_CI_ROUTING_SCOPE_RE.source}`,
 );

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -590,7 +590,7 @@ describe("detectChangedScope", () => {
     ).toEqual({
       runFastOnly: true,
       runPluginContracts: true,
-      runCiRouting: false,
+      runCiRouting: true,
     });
   });
 
@@ -598,9 +598,15 @@ describe("detectChangedScope", () => {
     expect(
       detectNodeFastScope([
         ".github/workflows/ci.yml",
+        "scripts/check-changed.mjs",
         "scripts/ci-changed-scope.mjs",
+        "scripts/run-vitest.mjs",
+        "scripts/test-projects.test-support.d.mts",
         "src/commands/status.scan-result.test.ts",
         "src/scripts/ci-changed-scope.test.ts",
+        "test/scripts/changed-lanes.test.ts",
+        "test/scripts/run-vitest.test.ts",
+        "test/scripts/test-projects.test.ts",
         "docs/ci.md",
       ]),
     ).toEqual({

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -344,6 +344,7 @@ describe("scripts/changed-lanes", () => {
     expect(
       createTargetedCoreLintCommand(
         [
+          ".github/workflows/ci.yml",
           "scripts/check-changed.mjs",
           "src/agents/auth-profiles/usage.ts",
           "test/scripts/changed-lanes.test.ts",


### PR DESCRIPTION
Summary
- Route changed-check and Vitest harness edits through the fast CI-routing path instead of the full Node shard graph.
- Keep the fast CI-routing workflow task aligned with the owner tests for changed-lanes, run-vitest, test-projects, and CI scope routing.
- Preserve full core lint fallback for deleted, broad, or lint-config-impacting core diffs while allowing workflow-only mixed diffs to use targeted core lint.

Verification
- node scripts/run-vitest.mjs src/scripts/ci-changed-scope.test.ts test/scripts/changed-lanes.test.ts test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts
- pnpm check:changed --timed (Testbox tbx_01ksx540yn3rvgj196e9t03g14, command 2m07s, total 2m12s)
- autoreview --mode local --base origin/main
- git diff --check
