### PR TITLE
fix(scripts): quiet minimal runtime asset copies

### DIFF
--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -173,6 +173,16 @@ export const BUILD_ALL_PROFILE_STEP_ENV = {
       OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
     },
   },
+  gatewayWatch: {
+    "runtime-postbuild": {
+      OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS: "0",
+    },
+  },
+  cliStartup: {
+    "runtime-postbuild": {
+      OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS: "0",
+    },
+  },
 };
 
 export function buildAllUsage() {

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -453,6 +453,11 @@ export function writeLegacyCliExitCompatChunks(params = {}) {
   }
 }
 
+function shouldCopyStaticExtensionAssets(params) {
+  const env = params.env ?? process.env;
+  return env.OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS !== "0";
+}
+
 export function runRuntimePostBuild(params = {}) {
   const timingsEnabled = params.timings ?? process.env.OPENCLAW_RUNTIME_POSTBUILD_TIMINGS !== "0";
   const runPhase = (label, action) => {
@@ -471,6 +476,9 @@ export function runRuntimePostBuild(params = {}) {
   runPhase("official channel catalog", () => writeOfficialChannelCatalog(params));
   runPhase("bundled plugin runtime overlay", () => stageBundledPluginRuntime(params));
   runPhase("static extension assets", () => {
+    if (!shouldCopyStaticExtensionAssets(params)) {
+      return;
+    }
     const staticAssetParams = {
       rootDir: ROOT,
       ...params,

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -180,9 +180,7 @@ describe("resolveBuildAllSteps", () => {
       help: true,
       profile: "cliStartup",
     });
-    expect(() => parseBuildAllArgs(["cliStartup", "--bogus"])).toThrow(
-      "unknown argument: --bogus",
-    );
+    expect(() => parseBuildAllArgs(["cliStartup", "--bogus"])).toThrow("unknown argument: --bogus");
     expect(() => parseBuildAllArgs(["wat"])).toThrow("Unknown build profile: wat");
   });
 
@@ -277,6 +275,28 @@ describe("resolveBuildAllSteps", () => {
       "write-cli-startup-metadata",
       "write-cli-compat",
     ]);
+  });
+
+  it("skips generated static plugin assets for minimal backend-only profiles", () => {
+    for (const profile of ["gatewayWatch", "cliStartup"]) {
+      const runtimePostbuild = resolveBuildAllSteps(profile).find(
+        (step) => step.label === "runtime-postbuild",
+      );
+      if (!runtimePostbuild) {
+        throw new Error(`Missing ${profile} runtime-postbuild step`);
+      }
+
+      expect(BUILD_ALL_PROFILE_STEP_ENV[profile]["runtime-postbuild"]).toEqual({
+        OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS: "0",
+      });
+      expect(
+        resolveBuildAllStep(runtimePostbuild, {
+          env: { OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS: "1" },
+        }).options.env,
+      ).toMatchObject({
+        OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS: "0",
+      });
+    }
   });
 
   it("writes the runtime postbuild stamp after the build stamp", () => {

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -61,9 +61,7 @@ describe("runtime postbuild static assets", () => {
       "dist/extensions/diffs-language-pack/assets/viewer-runtime.js",
       "dist/extensions/diffs/assets/viewer-runtime.js",
     ]);
-    expect(payload.sources).toContain(
-      "extensions/diffs-language-pack/assets/viewer-runtime.js",
-    );
+    expect(payload.sources).toContain("extensions/diffs-language-pack/assets/viewer-runtime.js");
     expect(payload.sources).toContain("extensions/diffs/assets/viewer-runtime.js");
   });
 
@@ -206,6 +204,45 @@ describe("runtime postbuild static assets", () => {
     });
 
     await expect(fs.readFile(runtimeAsset, "utf8")).resolves.toBe("console.log('viewer');\n");
+  });
+
+  it("can skip static asset copies for minimal runtime builds", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const warn = vi.fn();
+    const output = "assets/viewer-runtime.js";
+
+    await fs.mkdir(path.join(rootDir, "src", "plugin-sdk"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf8",
+    );
+    await fs.mkdir(path.join(rootDir, "extensions", "diffs"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "extensions", "diffs", "package.json"),
+      JSON.stringify({
+        name: "@openclaw/diffs",
+        openclaw: {
+          extensions: ["./index.ts"],
+          build: {
+            staticAssets: [{ source: `./${output}`, output }],
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    runRuntimePostBuild({
+      cwd: rootDir,
+      repoRoot: rootDir,
+      rootDir,
+      env: { OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS: "0" },
+      timings: false,
+      warn,
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+    await expectPathMissing(path.join(rootDir, "dist", "extensions", "diffs", output));
   });
 
   it("skips runtime overlay asset copies when the runtime extension root is absent", async () => {


### PR DESCRIPTION
## Summary

- Stops minimal `cliStartup` and `gatewayWatch` build profiles from trying to copy generated plugin static assets they intentionally do not build.
- Keeps full and CI artifact builds strict: direct `runtime-postbuild` still copies static assets and warns when required sources are missing.
- Adds regression coverage for profile env propagation and the explicit static-asset skip path.

## Linked context

Closes #

Related #

Was this requested by a maintainer or owner?

Maintainer QA/SRE sweep of script surfaces and startup-memory behavior.

## Real behavior proof (required for external PRs)

- Behavior addressed: `pnpm test:startup:memory` emitted repeated `[runtime-postbuild] static asset not found` warnings during the minimal `cliStartup` build profile even though generated plugin assets are intentionally out of scope for that profile.
- Real environment tested: AWS Crabbox Linux runner, provider `aws`, type `c7a.8xlarge`, run `run_fb3052f4574b`, lease `cbx_2251cfa28dde`.
- Exact steps or command run after this patch: `pnpm test:startup:memory` with a post-run grep that failed the command if `[runtime-postbuild] static asset not found` appeared.
- Evidence after fix: Crabbox run `run_fb3052f4574b` completed exit 0; `runtime-postbuild: static extension assets completed in 0ms`; no static asset warning matched.
- Observed result after fix: startup-memory passed with RSS `--help 47.5 MB`, `status --json 336.0 MB`, `gateway status 277.9 MB`; the warning check stayed clean.
- What was not tested: native macOS OpenClaw Node/pnpm proof, because the managed macOS Crabbox host was still `pending` and the prior macOS image had no Node/npm/pnpm installed.
- Proof limitations or environment constraints: direct push to `main` is blocked by required GitHub status `dependency-guard`, so this draft PR exists to let that required check run.
- Before evidence (optional but encouraged): previous startup-memory Crabbox run emitted missing static asset warnings for `extensions/diffs-language-pack/assets/viewer-runtime.js` and `extensions/diffs/assets/viewer-runtime.js` during `cliStartup`.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs test/scripts/build-all.test.ts test/scripts/runtime-postbuild.test.ts`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 180m --timing-json --artifact-glob '.artifacts/startup-memory/*' --shell -- "bash -lc 'set -euo pipefail; export CI=1 COREPACK_ENABLE_DOWNLOAD_PROMPT=0; output=\$(mktemp); pnpm test:startup:memory 2>&1 | tee \"\$output\"; if grep -F \"[runtime-postbuild] static asset not found\" \"\$output\"; then echo \"unexpected runtime-postbuild static asset warning\" >&2; exit 1; fi'"`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 180m --timing-json --shell -- "bash -lc 'set -euo pipefail; export CI=1 COREPACK_ENABLE_DOWNLOAD_PROMPT=0; pnpm check:changed'"`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git diff --check`

What regression coverage was added or updated?

- `test/scripts/build-all.test.ts` covers minimal profile env propagation into `runtime-postbuild`.
- `test/scripts/runtime-postbuild.test.ts` covers explicit static asset copy skipping without suppressing normal missing-asset warnings.

What failed before this fix, if known?

- The startup-memory path passed but emitted misleading missing static asset warnings from an intentionally minimal build profile.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes, build-profile-specific environment for two internal build profiles changed.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Accidentally suppressing static asset copy warnings in full/package builds.

How is that risk mitigated?

The skip is only set by `gatewayWatch` and `cliStartup`; default `runtime-postbuild`, full builds, and CI artifact builds still copy static assets and keep missing-source warnings.

## Current review state

What is the next action?

Wait for required GitHub checks, especially `dependency-guard`, then merge/land if green.

What is still waiting on author, maintainer, CI, or external proof?

GitHub required status checks.

Which bot or reviewer comments were addressed?

Local autoreview reported no accepted/actionable findings.
