### PR TITLE
fix(plugins): batch fix for plugin architecture issues (#80621, #78301, #78622, #84256)

### DIFF
--- a/src/infra/net/runtime-fetch.ts
+++ b/src/infra/net/runtime-fetch.ts
@@ -47,6 +47,27 @@ function normalizeRuntimeFormData(
   return next as unknown as BodyInit;
 }
 
+let contentLengthWarningEmitted = false;
+function warnContentLengthStripped(): void {
+  if (contentLengthWarningEmitted) return;
+  contentLengthWarningEmitted = true;
+  console.warn(
+    "[plugins] dropping plugin-supplied Content-Length header — " +
+      "undici computes this from the request body. " +
+      "Manual Content-Length values risk request-smuggling (UND_ERR_INVALID_ARG).",
+  );
+}
+
+function headerHasKey(
+  headers: HeadersInit | undefined,
+  key: string,
+): boolean {
+  if (!headers) return false;
+  if (headers instanceof Headers) return headers.has(key);
+  if (Array.isArray(headers)) return headers.some(([k]) => k.toLowerCase() === key);
+  return Object.keys(headers).some((k) => k.toLowerCase() === key);
+}
+
 function normalizeRuntimeRequestInit(
   init: DispatcherAwareRequestInit | undefined,
   RuntimeFormData: RuntimeFormDataCtor | undefined,
@@ -62,17 +83,30 @@ function normalizeRuntimeRequestInit(
   }
 
   const body = normalizeRuntimeFormData(init.body, RuntimeFormData);
-  if (body === init.body) {
+  const bodyChanged = body !== init.body;
+
+  // Always strip plugin-supplied Content-Length when a body is present.
+  // Node/undici computes Content-Length from the actual transmitted bytes;
+  // manual values risk request-smuggling and cause UND_ERR_INVALID_ARG.
+  const hasManualContentLength = headerHasKey(normalizedHeaders, "content-length");
+
+  if (!bodyChanged && !hasManualContentLength) {
     return initWithNormalizedHeaders;
+  }
+
+  if (hasManualContentLength) {
+    warnContentLengthStripped();
   }
 
   const headers = new Headers(normalizedHeaders);
   headers.delete("content-length");
-  headers.delete("content-type");
+  if (bodyChanged) {
+    headers.delete("content-type");
+  }
   return {
     ...initWithNormalizedHeaders,
     headers,
-    body,
+    body: bodyChanged ? body : init.body,
   };
 }
 

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -26,6 +26,7 @@ import {
 } from "./sdk-alias.js";
 import {
   findUndeclaredPluginToolNames,
+  isWildcardToolContract,
   normalizePluginToolContractNames,
 } from "./tool-contracts.js";
 import type { OpenClawPluginDefinition, OpenClawPluginModule } from "./types.js";
@@ -504,19 +505,24 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       const declaredToolNames = normalizePluginToolContractNames(record.contracts);
+      const isWildcard = isWildcardToolContract(record.contracts);
       for (const tool of captured.tools) {
-        const undeclared = findUndeclaredPluginToolNames({
-          declaredNames: declaredToolNames,
-          toolNames: [tool.name],
-        });
-        if (undeclared.length > 0) {
-          registry.diagnostics.push({
-            level: "error",
-            pluginId: record.id,
-            source: record.source,
-            message: `plugin must declare contracts.tools for: ${undeclared.join(", ")}`,
+        if (isWildcard) {
+          // Wildcard contract — all tool names are allowed
+        } else {
+          const undeclared = findUndeclaredPluginToolNames({
+            declaredNames: declaredToolNames,
+            toolNames: [tool.name],
           });
-          continue;
+          if (undeclared.length > 0) {
+            registry.diagnostics.push({
+              level: "error",
+              pluginId: record.id,
+              source: record.source,
+              message: `plugin must declare contracts.tools for: ${undeclared.join(", ")}`,
+            });
+            continue;
+          }
         }
         registry.tools.push({
           pluginId: record.id,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3625,7 +3625,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
       registry.diagnostics.some(
         (entry) =>
           entry.pluginId === "undeclared-tool-owner" &&
-          entry.message === "plugin must declare contracts.tools before registering agent tools",
+          entry.message === 'plugin must declare contracts.tools before registering agent tools. Set contracts.tools to true (allow any) or an array of tool names, e.g. ["my_tool"]',
       ),
     ).toBe(true);
   });

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3625,7 +3625,8 @@ module.exports = { id: "throws-after-import", register() {} };`,
       registry.diagnostics.some(
         (entry) =>
           entry.pluginId === "undeclared-tool-owner" &&
-          entry.message === 'plugin must declare contracts.tools before registering agent tools. Set contracts.tools to true (allow any) or an array of tool names, e.g. ["my_tool"]',
+          entry.message ===
+            'plugin must declare contracts.tools before registering agent tools. Set contracts.tools to true (allow any) or an array of tool names, e.g. ["my_tool"]',
       ),
     ).toBe(true);
   });

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -850,7 +850,10 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const webSearchProviders = normalizeTrimmedStringList(value.webSearchProviders);
   const migrationProviders = normalizeTrimmedStringList(value.migrationProviders);
   const gatewayMethodDispatch = normalizeTrimmedStringList(value.gatewayMethodDispatch);
-  const tools = normalizeTrimmedStringList(value.tools);
+  const tools =
+    value.tools === true
+      ? ["*"]
+      : normalizeTrimmedStringList(value.tools);
   const contracts = {
     ...(embeddedExtensionFactories.length > 0 ? { embeddedExtensionFactories } : {}),
     ...(agentToolResultMiddleware.length > 0 ? { agentToolResultMiddleware } : {}),

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -850,10 +850,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const webSearchProviders = normalizeTrimmedStringList(value.webSearchProviders);
   const migrationProviders = normalizeTrimmedStringList(value.migrationProviders);
   const gatewayMethodDispatch = normalizeTrimmedStringList(value.gatewayMethodDispatch);
-  const tools =
-    value.tools === true
-      ? ["*"]
-      : normalizeTrimmedStringList(value.tools);
+  const tools = value.tools === true ? ["*"] : normalizeTrimmedStringList(value.tools);
   const contracts = {
     ...(embeddedExtensionFactories.length > 0 ? { embeddedExtensionFactories } : {}),
     ...(agentToolResultMiddleware.length > 0 ? { agentToolResultMiddleware } : {}),

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -146,6 +146,7 @@ import { normalizeSessionEntrySlotKey } from "./session-entry-slot-keys.js";
 import { defaultSlotIdForKey, hasKind } from "./slots.js";
 import {
   findUndeclaredPluginToolNames,
+  isWildcardToolContract,
   normalizePluginToolContractNames,
   normalizePluginToolNames,
 } from "./tool-contracts.js";
@@ -575,12 +576,14 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       return;
     }
     const declaredNames = normalizePluginToolContractNames(record.contracts);
-    if (declaredNames.length === 0) {
+    const wildcard = isWildcardToolContract(record.contracts);
+    if (declaredNames.length === 0 && !wildcard) {
       pushDiagnostic({
         level: "error",
         pluginId: record.id,
         source: record.source,
-        message: "plugin must declare contracts.tools before registering agent tools",
+        message:
+          'plugin must declare contracts.tools before registering agent tools. Set contracts.tools to true (allow any) or an array of tool names, e.g. ["my_tool"]',
       });
       return;
     }
@@ -594,18 +597,20 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
 
     const normalized = normalizePluginToolNames(names);
-    const undeclared = findUndeclaredPluginToolNames({
-      declaredNames,
-      toolNames: normalized,
-    });
-    if (undeclared.length > 0) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `plugin must declare contracts.tools for: ${undeclared.join(", ")}`,
+    if (!wildcard) {
+      const undeclared = findUndeclaredPluginToolNames({
+        declaredNames,
+        toolNames: normalized,
       });
-      return;
+      if (undeclared.length > 0) {
+        pushDiagnostic({
+          level: "error",
+          pluginId: record.id,
+          source: record.source,
+          message: `plugin must declare contracts.tools for: ${undeclared.join(", ")}`,
+        });
+        return;
+      }
     }
     if (normalized.length > 0) {
       record.toolNames.push(...normalized);
@@ -2015,18 +2020,20 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       return;
     }
     const declaredNames = normalizePluginToolContractNames(record.contracts);
-    const undeclared = findUndeclaredPluginToolNames({
-      declaredNames,
-      toolNames: [toolName],
-    });
-    if (undeclared.length > 0) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `plugin must declare contracts.tools for tool metadata: ${undeclared.join(", ")}`,
+    if (!isWildcardToolContract(record.contracts)) {
+      const undeclared = findUndeclaredPluginToolNames({
+        declaredNames,
+        toolNames: [toolName],
       });
-      return;
+      if (undeclared.length > 0) {
+        pushDiagnostic({
+          level: "error",
+          pluginId: record.id,
+          source: record.source,
+          message: `plugin must declare contracts.tools for tool metadata: ${undeclared.join(", ")}`,
+        });
+        return;
+      }
     }
     // Uniqueness is scoped to (pluginId + toolName): different plugins may each
     // register metadata under the same toolName for their own tools, but a given

--- a/src/plugins/tool-contracts.ts
+++ b/src/plugins/tool-contracts.ts
@@ -6,6 +6,17 @@ export function normalizePluginToolContractNames(
   return normalizePluginToolNames(contracts?.tools);
 }
 
+/**
+ * Returns true when the plugin declared `contracts.tools: true` (wildcard),
+ * meaning any tool name is allowed without explicit enumeration.
+ */
+export function isWildcardToolContract(
+  contracts: Pick<PluginManifestContracts, "tools"> | undefined,
+): boolean {
+  const names = contracts?.tools;
+  return Array.isArray(names) && names.length === 1 && names[0] === "*";
+}
+
 export function normalizePluginToolNames(names: readonly string[] | undefined): string[] {
   const normalized = new Set<string>();
   for (const name of names ?? []) {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -150,6 +150,18 @@ type InstallIntegrityDrift = {
   };
 };
 
+function wouldDowngradeInstalledVersion(params: {
+  currentVersion: string;
+  targetVersion: string;
+}): boolean {
+  const current = parseComparableSemver(params.currentVersion);
+  const target = parseComparableSemver(params.targetVersion);
+  if (!current || !target) {
+    return false;
+  }
+  return compareComparableSemver(target, current) < 0;
+}
+
 function shouldSkipUnchangedNpmInstall(params: {
   currentVersion?: string;
   record: {
@@ -1251,6 +1263,22 @@ export async function updateNpmInstalledPlugins(params: {
             currentVersion,
             nextVersion: metadataResult.metadata.version,
             message: `${pluginId} is up to date (${currentVersion}).`,
+          });
+          continue;
+        }
+        if (
+          metadataResult.metadata.version &&
+          wouldDowngradeInstalledVersion({
+            currentVersion,
+            targetVersion: metadataResult.metadata.version,
+          })
+        ) {
+          outcomes.push({
+            pluginId,
+            status: "unchanged",
+            currentVersion,
+            nextVersion: metadataResult.metadata.version,
+            message: `${pluginId}: installed version ${currentVersion} is newer than update target ${metadataResult.metadata.version}; skipping (use an explicit spec to downgrade).`,
           });
           continue;
         }

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1469,8 +1469,13 @@ export async function updateNpmInstalledPlugins(params: {
         record.source === "npm" || usedOfficialNpmFallback
           ? resolveNpmResultVersion(probe)
           : undefined;
+      const clawhubProbeVersion =
+        record.source === "clawhub" && "clawhub" in probe
+          ? (probe as { clawhub?: { version?: string } }).clawhub?.version
+          : undefined;
       const resolvedProbeVersion =
         probe.version ??
+        clawhubProbeVersion ??
         npmProbeVersion ??
         (record.source === "npm" || usedOfficialNpmFallback
           ? resolveExactNpmSpecVersion(probeSpec)


### PR DESCRIPTION
## Summary

Fixes 4 open plugin architecture issues in a single batch:

### #80621 — \contracts.tools: true\ not treated as wildcard
- \isWildcardToolContract()\ recognizes \	rue\ as allowing any tool registration
- Applied in both \egistry.ts\ validation and \undled-capability-runtime.ts\ loader

### #78301 — Plugin-supplied Content-Length causes undici crash
- Always strip \Content-Length\ header from plugin fetch requests when body is present
- Prevents \UND_ERR_INVALID_ARG: invalid content-length header\ from undici
- One-time warning emitted via \warnContentLengthStripped()\

### #78622 — \plugins update --dry-run\ shows 'unknown' version for ClawHub plugins
- Extract version from \probe.clawhub.version\ for ClawHub-sourced plugins

### #84256 — \plugins update --all\ downgrades manually-updated plugins
- Added \wouldDowngradeInstalledVersion()\ check using semver comparison
- Skips update when installed version is already newer than the target

Closes #80621, closes #78301, closes #78622, closes #84256