### PR TITLE
docs: clarify Discord generated image delivery

### DIFF
--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -39,6 +39,12 @@ Send media:
 }
 ```
 
+Generated-image delivery:
+
+- For images created by an OpenClaw image tool, attach every returned structured attachment when using the message tool.
+- If replying normally and the runtime supports media pickup, put each local media file on its own line as `MEDIA: /absolute/path/to/file.png`.
+- Do not paste local generated-image paths as ordinary chat text and call it done; Discord may show "media failed" because no uploadable attachment was handed to the gateway.
+
 Components v2:
 
 ```json


### PR DESCRIPTION
## Summary
- document how generated images should be delivered through Discord
- call out structured attachments and MEDIA lines so local paths are not mistaken for uploads

## Real behavior proof

- Behavior or issue addressed: Generated image delivery guidance for Discord should tell agents to hand the gateway an uploadable attachment or `MEDIA:` pickup line, rather than replying with plain local-path text.
- Real environment tested: Local OpenClaw checkout on the PR branch, with redacted local OpenClaw Discord/image-generation session logs and a generated image artifact from a real image-generation run.
- Exact steps or command run after this patch: Checked the patched Discord skill guidance, inspected the generated image artifact, and inspected the redacted runtime log excerpt for the OpenClaw image tool delivery contract.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ sed -n 30,52p skills/discord/SKILL.md
Send media:
...
Generated-image delivery:

- For images created by an OpenClaw image tool, attach every returned structured attachment when using the message tool.
- If replying normally and the runtime supports media pickup, put each local media file on its own line as `MEDIA: /absolute/path/to/file.png`.
- Do not paste local generated-image paths as ordinary chat text and call it done; Discord may show "media failed" because no uploadable attachment was handed to the gateway.

$ file "$OPENCLAW_MEDIA_DIR/tool-image-generation/<redacted-generated-image>.png"
PNG image data, 1024 x 1024, 8-bit/color RGB, non-interlaced

$ wc -c < "$OPENCLAW_MEDIA_DIR/tool-image-generation/<redacted-generated-image>.png"
1854268

$ rg -n "generated media attached or MEDIA: paths" "$OPENCLAW_SESSION_LOG"
<redacted-session-log>: image_generate description: "Create/edit images. Session chats: background task; do not call image_generate again for same request; wait completion, then report through the current visible-reply contract with generated media attached or MEDIA: paths."
```

- Observed result after fix: The patched Discord skill now documents the exact attachment/`MEDIA:` handoff used by the OpenClaw image-generation path, and the real generated image artifact inspected from the run was a valid PNG. The documented failure mode is therefore captured as skill guidance instead of relying on agents to infer it from runtime tool metadata.
- What was not tested: I did not run a fresh public Discord upload from this PR branch because the change is skill documentation only and the available live Discord context contains private workspace/user data.
- Proof limitations or environment constraints: The proof is a redacted terminal/log capture rather than a screenshot or public Discord message link, to avoid exposing private chat content, local account paths, channel IDs, or generated prompt details.
- Before evidence (optional but encouraged): Before this docs update, `skills/discord/SKILL.md` showed a generic `media` send example but did not call out generated-image completion handling. In the observed local run, a valid generated image existed locally while a text-only visible reply did not provide the Discord gateway with an uploadable attachment.

## Validation
- `git diff --check HEAD~1 HEAD`