### PR TITLE
docs: clarify blank Control UI recovery

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -443,6 +443,15 @@ Then point the UI at your Gateway WS URL (e.g. `ws://127.0.0.1:18789`).
 
 If the browser loads a blank dashboard and DevTools shows no useful error, an extension or early content script may have prevented the JavaScript module app from evaluating. The static page includes a plain HTML recovery panel that appears when `<openclaw-app>` is not registered after startup.
 
+First confirm the Gateway itself is reachable:
+
+```bash
+openclaw gateway status
+openclaw dashboard
+```
+
+If the blank page started immediately after an update, the browser may still be running an old service-worker or cached Control UI bundle against the newer Gateway. Reopen the dashboard with `openclaw dashboard`, then hard-refresh the page (`Cmd+Shift+R` on macOS, `Ctrl+Shift+R` on Windows/Linux). If it still fails, clear site data for the dashboard origin or try a private window.
+
 Use the panel's **Try again** action after changing the browser environment, or reload manually after these checks:
 
 - Disable extensions that inject into all pages, especially extensions with `<all_urls>` content scripts.


### PR DESCRIPTION
## Summary
- Tiny docs tweak for the blank Control UI recovery section.
- Adds the obvious first check: make sure the Gateway is actually reachable.
- Spells out the hard-refresh shortcuts so the cache/service-worker advice is easier to act on.
- AI-assisted with Codex.

## Linked context
Which issue does this close? Closes #
Which issues, PRs, or discussions are related? Related #
Was this requested by a maintainer or owner? No.

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: Users seeing a blank Control UI page get clearer recovery steps.
- Real environment tested: Local Windows checkout of openclaw/openclaw.
- Exact steps or command run after this patch: `Select-String -Path docs\web\control-ui.md -Pattern 'Blank Control UI page' -Context 0,17`; `node scripts/check-no-conflict-markers.mjs`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live output from the local checkout shows `docs\web\control-ui.md:446` now says "First confirm the Gateway itself is reachable:"; lines 449-450 show `openclaw gateway status` and `openclaw dashboard`; line 453 says stale service-worker or cached Control UI bundle after update can be fixed by reopening with `openclaw dashboard`, hard-refreshing with `Cmd+Shift+R` on macOS or `Ctrl+Shift+R` on Windows/Linux, clearing site data, or trying a private window.
- Observed result after fix: The documentation now presents Gateway reachability checks before browser-environment checks and includes stale cache/service-worker recovery guidance.
- What was not tested: Full docs lint/build was not run because this fresh clone does not have `node_modules` installed.
- Proof limitations or environment constraints: Docs-only change; no live Gateway behavior changed.
- Before evidence (optional but encouraged): The previous blank-page section jumped directly from the recovery panel description to extension/private-window checks.

## Tests and validation
Which commands did you run? `node scripts/check-no-conflict-markers.mjs`
What regression coverage was added or updated? None; docs-only change.
What failed before this fix, if known? The Real behavior proof check failed until this PR body included the exact evidence field.
If no test was added, why not? The change only updates Markdown troubleshooting guidance.

## Risk checklist
Did user-visible behavior change? No
Did config, environment, or migration behavior change? No
Did security, auth, secrets, network, or tool execution behavior change? No
What is the highest-risk area? Documentation accuracy.
How is that risk mitigated? The added steps reuse existing documented commands and recovery guidance already present elsewhere on the page.

## Current review state
Ready for maintainer review.