### PR TITLE
Fix gateway status sandbox diagnostics

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -452,6 +452,32 @@ describe("gatherDaemonStatus", () => {
     expect((status.service.runtime as { detail?: string }).detail).toBe("19001");
   });
 
+  it("suppresses busy-port hints when all listeners belong to the running gateway pid", async () => {
+    serviceReadRuntime.mockResolvedValueOnce({ status: "running", pid: 73614 });
+    inspectPortUsage.mockResolvedValueOnce({
+      port: 19001,
+      status: "busy",
+      listeners: [
+        { pid: 73614, command: "node", address: "127.0.0.1:19001" },
+        { pid: 73614, command: "node", address: "[::1]:19001" },
+      ],
+      hints: [
+        "Another process is listening on this port.",
+        "Multiple listeners detected; ensure only one gateway/tunnel per port unless intentionally running isolated profiles.",
+      ],
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: false,
+      deep: false,
+    });
+
+    expect(status.port?.status).toBe("busy");
+    expect(status.port?.listeners).toHaveLength(2);
+    expect(status.port?.hints).toEqual([]);
+  });
+
   it("surfaces recent service restart handoffs only during deep status", async () => {
     readGatewayRestartHandoffSync.mockReturnValueOnce({
       kind: "gateway-supervisor-restart-handoff",

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -24,6 +24,7 @@ import {
   resolveBestEffortGatewayBindHostForDisplay,
 } from "../../infra/network-discovery-display.js";
 import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
+import { isExpectedGatewayListenersForPid } from "../../infra/ports-format.js";
 import {
   formatPortDiagnostics,
   inspectPortConnections,
@@ -453,6 +454,22 @@ function toPortStatusSummary(
   };
 }
 
+function suppressKnownGatewayPortHints(
+  status: PortStatusSummary | undefined,
+  runtime: GatewayServiceRuntime | undefined,
+): PortStatusSummary | undefined {
+  if (status?.status !== "busy" || status.hints.length === 0 || runtime?.status !== "running") {
+    return status;
+  }
+  if (!isExpectedGatewayListenersForPid(status.listeners, status.port, runtime.pid)) {
+    return status;
+  }
+  return {
+    ...status,
+    hints: [],
+  };
+}
+
 async function inspectDaemonPortStatuses(params: {
   daemonPort: number;
   cliPort: number;
@@ -538,6 +555,7 @@ export async function gatherDaemonStatus(
     daemonPort,
     cliPort,
   });
+  const daemonPortStatus = suppressKnownGatewayPortHints(portStatus, runtime);
   const establishedClients = await inspectEstablishedGatewayClients({
     daemonPort,
     deep: opts.deep,
@@ -632,7 +650,12 @@ export async function gatherDaemonStatus(
     : undefined;
 
   let lastError: string | undefined;
-  if (loaded && runtime?.status === "running" && portStatus && portStatus.status !== "busy") {
+  if (
+    loaded &&
+    runtime?.status === "running" &&
+    daemonPortStatus &&
+    daemonPortStatus.status !== "busy"
+  ) {
     lastError = (await readLastGatewayErrorLine(mergedDaemonEnv as NodeJS.ProcessEnv)) ?? undefined;
   }
 
@@ -663,7 +686,7 @@ export async function gatherDaemonStatus(
           }
         : {}),
     },
-    port: portStatus,
+    port: daemonPortStatus,
     ...(portCliStatus ? { portCli: portCliStatus } : {}),
     ...(establishedClients ? { connections: establishedClients } : {}),
     lastError,

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,3 +1,4 @@
+import net from "node:net";
 import os from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeNetworkInterfacesSnapshot } from "../test-helpers/network-interfaces.js";
@@ -21,6 +22,26 @@ import {
 } from "./net.js";
 
 const flyMachineEnvKeys = ["FLY_MACHINE_ID", "FLY_APP_NAME"] as const;
+
+function mockCanBindToHost(bindable: boolean) {
+  vi.spyOn(net, "createServer").mockImplementation(() => {
+    const handlers = new Map<string, () => void>();
+    const server = {
+      once: vi.fn((event: string, handler: () => void) => {
+        handlers.set(event, handler);
+        return server;
+      }),
+      listen: vi.fn(() => {
+        queueMicrotask(() => {
+          handlers.get(bindable ? "listening" : "error")?.();
+        });
+        return server;
+      }),
+      close: vi.fn(),
+    };
+    return server as unknown as net.Server;
+  });
+}
 
 function clearFlyMachineEnvForTest(): () => void {
   const previousEnv = new Map<(typeof flyMachineEnvKeys)[number], string | undefined>();
@@ -673,8 +694,11 @@ describe("resolveGatewayBindHost", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns 127.0.0.1 for loopback mode", async () => {
+  it("returns 127.0.0.1 for loopback mode without probing bind fallback", async () => {
+    const createServer = vi.spyOn(net, "createServer");
+
     expect(await resolveGatewayBindHost("loopback")).toBe("127.0.0.1");
+    expect(createServer).not.toHaveBeenCalled();
   });
 
   it("returns 0.0.0.0 for lan mode", async () => {
@@ -687,6 +711,7 @@ describe("resolveGatewayBindHost", () => {
       throw new Error("ENOENT");
     });
     vi.spyOn(fs, "readFileSync").mockReturnValue("12:memory:/user.slice\n");
+    mockCanBindToHost(true);
     expect(await resolveGatewayBindHost("auto")).toBe("127.0.0.1");
   });
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -251,7 +251,7 @@ export {
  * Resolves gateway bind host with fallback strategy.
  *
  * Modes:
- * - loopback: 127.0.0.1 (rarely fails, but handled gracefully)
+ * - loopback: 127.0.0.1
  * - lan: always 0.0.0.0 (no fallback)
  * - tailnet: Tailnet IPv4 if available, else loopback
  * - auto: 0.0.0.0 inside containers (Docker/Podman/K8s); loopback otherwise
@@ -266,11 +266,7 @@ export async function resolveGatewayBindHost(
   const mode = bind ?? "loopback";
 
   if (mode === "loopback") {
-    // 127.0.0.1 rarely fails, but handle gracefully
-    if (await canBindToHost("127.0.0.1")) {
-      return "127.0.0.1";
-    }
-    return "0.0.0.0"; // extreme fallback
+    return "127.0.0.1";
   }
 
   if (mode === "tailnet") {

--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -7,6 +7,7 @@ import {
   formatPortListener,
   isDualStackLoopbackGatewayListeners,
   isExpectedGatewayListeners,
+  isExpectedGatewayListenersForPid,
   isSingleExpectedGatewayListener,
 } from "./ports-format.js";
 
@@ -51,6 +52,17 @@ describe("ports-format", () => {
     expect(isDualStackLoopbackGatewayListeners(listeners, 18789)).toBe(true);
     expect(isExpectedGatewayListeners(listeners, 18789)).toBe(true);
     expect(buildPortHints(listeners, 18789)).toEqual([]);
+  });
+
+  it("recognizes expected loopback listeners owned by a known gateway service pid", () => {
+    const listeners = [
+      { pid: 73614, command: "node", address: "127.0.0.1:18789" },
+      { pid: 73614, command: "node", address: "[::1]:18789" },
+    ];
+
+    expect(isExpectedGatewayListeners(listeners, 18789)).toBe(false);
+    expect(isExpectedGatewayListenersForPid(listeners, 18789, 73614)).toBe(true);
+    expect(isExpectedGatewayListenersForPid(listeners, 18789, 12345)).toBe(false);
   });
 
   it.each([

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -134,6 +134,30 @@ export function isExpectedGatewayListeners(listeners: PortListener[], port: numb
   );
 }
 
+export function isExpectedGatewayListenersForPid(
+  listeners: PortListener[],
+  port: number,
+  pid: number | undefined,
+): boolean {
+  if (!listeners.length || typeof pid !== "number" || !Number.isFinite(pid)) {
+    return false;
+  }
+  for (const listener of listeners) {
+    if (listener.pid !== pid || typeof listener.address !== "string") {
+      return false;
+    }
+    const parsedAddress = parseListenerAddress(listener.address);
+    if (
+      !parsedAddress ||
+      parsedAddress.port !== port ||
+      !isExpectedGatewayBindAddress(parsedAddress.host)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function buildPortHints(listeners: PortListener[], port: number): string[] {
   if (listeners.length === 0) {
     return [];


### PR DESCRIPTION
## Summary
- keep `gateway.bind=loopback` status/security diagnostics on `127.0.0.1` instead of falling back to `0.0.0.0` when sandbox bind probes fail
- suppress busy-port conflict hints when the running gateway service PID owns the expected listener addresses but process inspection can only report `node`

## Verification
- `node scripts/run-vitest.mjs src/commands/doctor-security.test.ts src/cli/daemon-cli/status.gather.test.ts src/gateway/net.test.ts src/infra/ports-format.test.ts`
- `pnpm build`
- `OPENCLAW_STATE_DIR=/private/tmp/openclaw-status-test node openclaw.mjs gateway status --json` showed `bindHost: "127.0.0.1"` and same-PID loopback listeners with empty `hints`