### PR TITLE
Retry stale CLI sessions inside runner lifecycle

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -129,7 +129,11 @@ function buildPreparedContext(params?: {
   runId?: string;
   lane?: string;
   openClawHistoryPrompt?: string;
+  provider?: string;
+  model?: string;
 }): PreparedCliRunContext {
+  const provider = params?.provider ?? "codex-cli";
+  const model = params?.model ?? "gpt-5.4";
   const backend = {
     command: "codex",
     args: ["exec", "--json"],
@@ -146,8 +150,8 @@ function buildPreparedContext(params?: {
       sessionFile: "/tmp/session.jsonl",
       workspaceDir: "/tmp",
       prompt: "hi",
-      provider: "codex-cli",
-      model: "gpt-5.4",
+      provider,
+      model,
       thinkLevel: "low",
       timeoutMs: 1_000,
       runId: params?.runId ?? "run-2",
@@ -156,10 +160,10 @@ function buildPreparedContext(params?: {
     started: Date.now(),
     workspaceDir: "/tmp",
     backendResolved: {
-      id: "codex-cli",
+      id: provider,
       config: backend,
       bundleMcp: false,
-      pluginId: "openai",
+      pluginId: provider === "claude-cli" ? "anthropic" : "openai",
     },
     preparedBackend: {
       backend,
@@ -168,8 +172,8 @@ function buildPreparedContext(params?: {
     reusableCliSession: params?.cliSessionId ? { sessionId: params.cliSessionId } : {},
     hadSessionFile: false,
     contextEngineConfig: {},
-    modelId: "gpt-5.4",
-    normalizedModel: "gpt-5.4",
+    modelId: model,
+    normalizedModel: model,
     contextWindowInfo: {
       tokens: 150_000,
       referenceTokens: 200_000,
@@ -252,6 +256,9 @@ function readTranscriptMessages(sessionFile: string): unknown[] {
     .map((entry) => entry.message)
     .filter(Boolean);
 }
+
+const CLI_RESEED_PROMPT =
+  "Continue this conversation using the OpenClaw transcript below as prior session history.\n\n<conversation_history>\nUser: earlier context\n</conversation_history>\n\n<next_user_message>\nhi\n</next_user_message>";
 
 describe("runCliAgent reliability", () => {
   afterEach(() => {
@@ -370,6 +377,420 @@ describe("runCliAgent reliability", () => {
     ).rejects.toThrow("exceeded timeout");
   });
 
+  it("does not retry recoverable failover when no reusable CLI session was used", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "no-output-timeout",
+        exitCode: null,
+        exitSignal: "SIGKILL",
+        durationMs: 200,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+        noOutputTimedOut: true,
+      }),
+    );
+
+    await expect(
+      runPreparedCliAgent(
+        buildPreparedContext({
+          sessionKey: "agent:main:fresh",
+          runId: "run-fresh-timeout",
+          provider: "claude-cli",
+          model: "opus",
+        }),
+      ),
+    ).rejects.toThrow("produced no output");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a resumed CLI session after the hard overall timeout", async () => {
+    supervisorSpawnMock.mockClear();
+    const clearBeforeRetry = vi.fn(async () => undefined);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "overall-timeout",
+        exitCode: null,
+        exitSignal: "SIGKILL",
+        durationMs: 200,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+        noOutputTimedOut: false,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:overall-timeout",
+      runId: "run-overall-timeout",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    await expect(
+      runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      }),
+    ).rejects.toThrow("exceeded timeout");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    expect(clearBeforeRetry).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a resumed recoverable failover without a reseed prompt", async () => {
+    supervisorSpawnMock.mockClear();
+    const clearBeforeRetry = vi.fn(async () => undefined);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "no-output-timeout",
+        exitCode: null,
+        exitSignal: "SIGKILL",
+        durationMs: 200,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+        noOutputTimedOut: true,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:no-reseed",
+      runId: "run-no-reseed",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    await expect(
+      runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      }),
+    ).rejects.toThrow("produced no output");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    expect(clearBeforeRetry).not.toHaveBeenCalled();
+  });
+
+  it("preserves fresh retry for direct CLI callers without a pre-clear hook", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 150,
+        stdout: "",
+        stderr: "session expired",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from fresh cli",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:direct",
+      runId: "run-direct-retry",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+
+    const result = await runPreparedCliAgent(context);
+
+    expect(result.payloads).toEqual([{ text: "hello from fresh cli" }]);
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry an unclassified CLI failure with diagnostic output", async () => {
+    supervisorSpawnMock.mockClear();
+    const clearBeforeRetry = vi.fn(async () => true);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 150,
+        stdout: "",
+        stderr: "worker crashed without details",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:unknown-output",
+      runId: "run-unknown-output",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+
+    await expect(
+      runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      }),
+    ).rejects.toThrow("worker crashed without details");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    expect(clearBeforeRetry).not.toHaveBeenCalled();
+  });
+
+  it("does not fresh retry when the run timeout budget is exhausted", async () => {
+    supervisorSpawnMock.mockClear();
+    const clearBeforeRetry = vi.fn(async () => true);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "no-output-timeout",
+        exitCode: null,
+        exitSignal: "SIGKILL",
+        durationMs: 1_000,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+        noOutputTimedOut: true,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:expired-budget",
+      runId: "run-expired-budget",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    const expiredBudgetContext = {
+      ...context,
+      started: Date.now() - context.params.timeoutMs - 1,
+    };
+
+    await expect(
+      runPreparedCliAgent({
+        ...expiredBudgetContext,
+        params: {
+          ...expiredBudgetContext.params,
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      }),
+    ).rejects.toThrow("produced no output");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    expect(clearBeforeRetry).not.toHaveBeenCalled();
+  });
+
+  it("does not fresh retry a no-output timeout after CLI diagnostic output", async () => {
+    supervisorSpawnMock.mockClear();
+    enqueueSystemEventMock.mockClear();
+    const clearBeforeRetry = vi.fn(async () => true);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "no-output-timeout",
+        exitCode: null,
+        exitSignal: "SIGKILL",
+        durationMs: 500,
+        stdout: "partial progress before the stall",
+        stderr: "",
+        timedOut: true,
+        noOutputTimedOut: true,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:timeout-after-output",
+      runId: "run-timeout-after-output",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+
+    await expect(
+      runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      }),
+    ).rejects.toThrow("produced no output");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    expect(clearBeforeRetry).not.toHaveBeenCalled();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fresh retry an empty supervisor cancellation", async () => {
+    supervisorSpawnMock.mockClear();
+    const clearBeforeRetry = vi.fn(async () => true);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "manual-cancel",
+        exitCode: null,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:manual-cancel",
+      runId: "run-manual-cancel",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+
+    await expect(
+      runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      }),
+    ).rejects.toThrow("CLI failed");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    expect(clearBeforeRetry).not.toHaveBeenCalled();
+  });
+
+  it.each(["timeout", "unknown"] as const)(
+    "retries a fresh CLI session after recoverable %s failover without a failed agent_end",
+    async (reason) => {
+      const hookRunner = {
+        hasHooks: vi.fn((hookName: string) =>
+          ["llm_input", "llm_output", "agent_end"].includes(hookName),
+        ),
+        runLlmInput: vi.fn(async () => undefined),
+        runLlmOutput: vi.fn(async () => undefined),
+        runAgentEnd: vi.fn(async () => undefined),
+      };
+      setHookRunnerForTest(hookRunner);
+      supervisorSpawnMock.mockClear();
+      enqueueSystemEventMock.mockClear();
+      requestHeartbeatMock.mockClear();
+      const events: string[] = [];
+      let spawnCount = 0;
+      supervisorSpawnMock.mockImplementation(async () => {
+        spawnCount += 1;
+        events.push(`spawn-${spawnCount}`);
+        if (spawnCount === 1 && reason === "timeout") {
+          return createManagedRun({
+            reason: "no-output-timeout",
+            exitCode: null,
+            exitSignal: "SIGKILL",
+            durationMs: 200,
+            stdout: "",
+            stderr: "",
+            timedOut: true,
+            noOutputTimedOut: true,
+          });
+        }
+        if (spawnCount === 1) {
+          return createManagedRun({
+            reason: "exit",
+            exitCode: 1,
+            exitSignal: null,
+            durationMs: 150,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            noOutputTimedOut: false,
+          });
+        }
+        return createManagedRun({
+          reason: "exit",
+          exitCode: 0,
+          exitSignal: null,
+          durationMs: 50,
+          stdout: "hello from fresh cli",
+          stderr: "",
+          timedOut: false,
+          noOutputTimedOut: false,
+        });
+      });
+      const { dir, sessionFile } = createSessionFile({
+        history: [{ role: "user", content: "earlier context" }],
+      });
+      const clearBeforeRetry = vi.fn(async () => {
+        events.push(`clear-${reason}`);
+        return true;
+      });
+
+      try {
+        const context = buildPreparedContext({
+          sessionKey: "agent:main:subagent:retry",
+          runId: `run-retry-${reason}`,
+          cliSessionId: "stale-cli-session",
+          provider: "claude-cli",
+          model: "opus",
+          openClawHistoryPrompt: CLI_RESEED_PROMPT,
+        });
+        const result = await runPreparedCliAgent({
+          ...context,
+          params: {
+            ...context.params,
+            agentId: "main",
+            sessionFile,
+            workspaceDir: dir,
+            onBeforeFreshCliSessionRetry: clearBeforeRetry,
+          },
+        });
+
+        expect(result.payloads).toEqual([{ text: "hello from fresh cli" }]);
+        expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
+        expect(events).toEqual(["spawn-1", `clear-${reason}`, "spawn-2"]);
+        if (reason === "timeout") {
+          expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+          expect(requestHeartbeatMock).not.toHaveBeenCalled();
+        }
+        expect(clearBeforeRetry).toHaveBeenCalledWith({
+          provider: "claude-cli",
+          reason,
+          sessionId: "stale-cli-session",
+        });
+        await vi.waitFor(() => {
+          expect(hookRunner.runLlmInput).toHaveBeenCalledTimes(1);
+          expect(hookRunner.runLlmOutput).toHaveBeenCalledTimes(1);
+          expect(hookRunner.runAgentEnd).toHaveBeenCalledTimes(1);
+        });
+        const agentEndEvent = requireRecord(
+          callArg(hookRunner.runAgentEnd, 0, 0, "agent_end event"),
+          "agent_end event",
+        );
+        expect(agentEndEvent.success).toBe(true);
+        expect(agentEndEvent.error).toBeUndefined();
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("rethrows the retry failure when session-expired recovery retry also fails", async () => {
     const hookRunner = {
       hasHooks: vi.fn((hookName: string) => ["llm_input", "agent_end"].includes(hookName)),
@@ -406,24 +827,24 @@ describe("runCliAgent reliability", () => {
     const { dir, sessionFile } = createSessionFile({
       history: [{ role: "user", content: "earlier context" }],
     });
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:subagent:retry",
+      runId: "run-retry-failure",
+      cliSessionId: "thread-123",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    const clearBeforeRetry = vi.fn(async () => true);
 
     try {
       await expect(
         runPreparedCliAgent({
-          ...buildPreparedContext({
-            sessionKey: "agent:main:subagent:retry",
-            runId: "run-retry-failure",
-            cliSessionId: "thread-123",
-          }),
+          ...context,
           params: {
-            ...buildPreparedContext({
-              sessionKey: "agent:main:subagent:retry",
-              runId: "run-retry-failure",
-              cliSessionId: "thread-123",
-            }).params,
+            ...context.params,
             agentId: "main",
             sessionFile,
             workspaceDir: dir,
+            onBeforeFreshCliSessionRetry: clearBeforeRetry,
           },
         }),
       ).rejects.toThrow("rate limit exceeded");
@@ -1388,24 +1809,22 @@ describe("runCliAgent reliability", () => {
       }),
     );
 
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:main",
+      runId: "run-retry-success",
+      cliSessionId: "thread-123",
+      openClawHistoryPrompt:
+        "Continue this conversation using the OpenClaw transcript below.\n\nUser: recovered history\n\n<next_user_message>\nhi\n</next_user_message>",
+    });
+    const clearBeforeRetry = vi.fn(async () => true);
+
     try {
       const result = await runPreparedCliAgent({
-        ...buildPreparedContext({
-          sessionKey: "agent:main:main",
-          runId: "run-retry-success",
-          cliSessionId: "thread-123",
-          openClawHistoryPrompt:
-            "Continue this conversation using the OpenClaw transcript below.\n\nUser: recovered history\n\n<next_user_message>\nhi\n</next_user_message>",
-        }),
+        ...context,
         params: {
-          ...buildPreparedContext({
-            sessionKey: "agent:main:main",
-            runId: "run-retry-success",
-            cliSessionId: "thread-123",
-            openClawHistoryPrompt:
-              "Continue this conversation using the OpenClaw transcript below.\n\nUser: recovered history\n\n<next_user_message>\nhi\n</next_user_message>",
-          }).params,
+          ...context.params,
           agentId: "main",
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
           sessionFile,
           workspaceDir: dir,
         },
@@ -1413,6 +1832,11 @@ describe("runCliAgent reliability", () => {
 
       expect(result.payloads).toEqual([{ text: "recovered output" }]);
       expect(result.meta.finalPromptText).toContain("User: recovered history");
+      expect(clearBeforeRetry).toHaveBeenCalledWith({
+        provider: "codex-cli",
+        reason: "session_expired",
+        sessionId: "thread-123",
+      });
 
       await vi.waitFor(() => {
         expect(hookRunner.runLlmInput).toHaveBeenCalledTimes(1);

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -408,7 +408,7 @@ describe("runCliAgent reliability", () => {
 
   it("does not retry a resumed CLI session after the hard overall timeout", async () => {
     supervisorSpawnMock.mockClear();
-    const clearBeforeRetry = vi.fn(async () => undefined);
+    const clearBeforeRetry = vi.fn(async () => false);
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({
         reason: "overall-timeout",
@@ -445,7 +445,7 @@ describe("runCliAgent reliability", () => {
 
   it("does not retry a resumed recoverable failover without a reseed prompt", async () => {
     supervisorSpawnMock.mockClear();
-    const clearBeforeRetry = vi.fn(async () => undefined);
+    const clearBeforeRetry = vi.fn(async () => false);
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({
         reason: "no-output-timeout",

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -61,16 +61,19 @@ function shouldRetryFreshCliSessionAfterFailover(params: {
   error: FailoverError;
   hasHistoryPrompt: boolean;
 }): boolean {
-  // These reasons can mean only the resumed CLI session is bad. Auth, billing,
-  // rate-limit, and provider/config errors should clear stale state but surface.
   if (!params.hasHistoryPrompt) {
     return false;
   }
-  return (
-    params.error.reason === "session_expired" ||
-    (params.error.reason === "unknown" && params.error.code === "cli_unknown_empty_failure") ||
-    (params.error.reason === "timeout" && params.error.code === "cli_no_output_timeout")
-  );
+  switch (params.error.reason) {
+    case "session_expired":
+      return true;
+    case "unknown":
+      return params.error.code === "cli_unknown_empty_failure";
+    case "timeout":
+      return params.error.code === "cli_no_output_timeout";
+    default:
+      return false;
+  }
 }
 
 export async function isCliBindingFlushed(
@@ -666,7 +669,6 @@ export async function runPreparedCliAgent(
     };
   };
 
-  // Try with the provided CLI session ID first
   try {
     await bootstrapHarnessContextEngine({
       hadSessionFile: context.hadSessionFile,
@@ -686,6 +688,35 @@ export async function runPreparedCliAgent(
           config: params.config,
         })
       : [];
+    const finishCliAttempt = async (
+      result: Awaited<ReturnType<typeof executeCliAttempt>>,
+      fallbackCliSessionId?: string,
+    ) => {
+      const { output, lastAssistant } = result;
+      const assistantText = output.text.trim();
+      const effectiveCliSessionId = output.sessionId ?? fallbackCliSessionId;
+      await finalizeCliContextEngineTurn({
+        context,
+        historyMessages: context.contextEngine ? contextEngineHistoryMessages : historyMessages,
+        assistantText,
+        output,
+      });
+      const bindingFlushOk = await isCliBindingFlushed(
+        effectiveCliSessionId,
+        params.provider,
+        context.cwd ?? context.workspaceDir,
+      );
+      await runCliAgentEndHook(params, {
+        event: {
+          messages: buildAgentEndMessages(lastAssistant),
+          success: true,
+          durationMs: Date.now() - context.started,
+        },
+        ctx: hookContext,
+        hookRunner,
+      });
+      return buildCliRunResult({ output, effectiveCliSessionId, bindingFlushOk });
+    };
 
     if (hasBeforeAgentRunHooks && hookRunner) {
       let beforeRunResult:
@@ -747,32 +778,10 @@ export async function runPreparedCliAgent(
       hookRunner,
     });
     try {
-      const { output, lastAssistant } = await executeCliAttempt(
+      return await finishCliAttempt(
+        await executeCliAttempt(context.reusableCliSession.sessionId),
         context.reusableCliSession.sessionId,
       );
-      const assistantText = output.text.trim();
-      const effectiveCliSessionId = output.sessionId ?? context.reusableCliSession.sessionId;
-      await finalizeCliContextEngineTurn({
-        context,
-        historyMessages: context.contextEngine ? contextEngineHistoryMessages : historyMessages,
-        assistantText,
-        output,
-      });
-      const bindingFlushOk = await isCliBindingFlushed(
-        effectiveCliSessionId,
-        params.provider,
-        context.cwd ?? context.workspaceDir,
-      );
-      await runCliAgentEndHook(params, {
-        event: {
-          messages: buildAgentEndMessages(lastAssistant),
-          success: true,
-          durationMs: Date.now() - context.started,
-        },
-        ctx: hookContext,
-        hookRunner,
-      });
-      return buildCliRunResult({ output, effectiveCliSessionId, bindingFlushOk });
     } catch (err) {
       if (isFailoverError(err)) {
         const retryableSessionId = context.reusableCliSession.sessionId;
@@ -802,32 +811,7 @@ export async function runPreparedCliAgent(
             cliBackendLog.warn(
               `cli session recovery retry: provider=${params.provider} reason=${err.reason} sessionKey=${params.sessionKey}`,
             );
-            const { output, lastAssistant } = await executeCliAttempt(undefined, retryTimeoutMs);
-            const assistantText = output.text.trim();
-            const effectiveCliSessionId = output.sessionId;
-            await finalizeCliContextEngineTurn({
-              context,
-              historyMessages: context.contextEngine
-                ? contextEngineHistoryMessages
-                : historyMessages,
-              assistantText,
-              output,
-            });
-            const bindingFlushOk = await isCliBindingFlushed(
-              effectiveCliSessionId,
-              params.provider,
-              context.cwd ?? context.workspaceDir,
-            );
-            await runCliAgentEndHook(params, {
-              event: {
-                messages: buildAgentEndMessages(lastAssistant),
-                success: true,
-                durationMs: Date.now() - context.started,
-              },
-              ctx: hookContext,
-              hookRunner,
-            });
-            return buildCliRunResult({ output, effectiveCliSessionId, bindingFlushOk });
+            return await finishCliAttempt(await executeCliAttempt(undefined, retryTimeoutMs));
           } catch (retryErr) {
             const retryMessage = formatErrorMessage(retryErr);
             await runCliAgentEndHook(params, {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -57,6 +57,22 @@ function isClaudeCliProvider(provider: string): boolean {
   return provider.trim().toLowerCase() === "claude-cli";
 }
 
+function shouldRetryFreshCliSessionAfterFailover(params: {
+  error: FailoverError;
+  hasHistoryPrompt: boolean;
+}): boolean {
+  // These reasons can mean only the resumed CLI session is bad. Auth, billing,
+  // rate-limit, and provider/config errors should clear stale state but surface.
+  if (!params.hasHistoryPrompt) {
+    return false;
+  }
+  return (
+    params.error.reason === "session_expired" ||
+    (params.error.reason === "unknown" && params.error.code === "cli_unknown_empty_failure") ||
+    (params.error.reason === "timeout" && params.error.code === "cli_no_output_timeout")
+  );
+}
+
 export async function isCliBindingFlushed(
   sessionId: string | undefined,
   provider: string | undefined,
@@ -498,8 +514,18 @@ export async function runPreparedCliAgent(
     throw error;
   };
 
-  const executeCliAttempt = async (cliSessionIdToUse?: string) => {
-    const output = await executePreparedCliRun(context, cliSessionIdToUse);
+  const executeCliAttempt = async (cliSessionIdToUse?: string, timeoutMs = params.timeoutMs) => {
+    const attemptContext =
+      timeoutMs === params.timeoutMs
+        ? context
+        : {
+            ...context,
+            params: {
+              ...context.params,
+              timeoutMs,
+            },
+          };
+    const output = await executePreparedCliRun(attemptContext, cliSessionIdToUse);
     const assistantText = output.text.trim();
     if (!assistantText) {
       throw new FailoverError("CLI backend returned an empty response.", {
@@ -749,16 +775,34 @@ export async function runPreparedCliAgent(
       return buildCliRunResult({ output, effectiveCliSessionId, bindingFlushOk });
     } catch (err) {
       if (isFailoverError(err)) {
-        const retryableSessionId = context.reusableCliSession.sessionId ?? params.cliSessionId;
-        // Check if this is a session expired error and we have a session to clear
-        if (err.reason === "session_expired" && retryableSessionId && params.sessionKey) {
-          // Clear the expired session ID from the session entry
-          // This requires access to the session store, which we don't have here
-          // We'll need to modify the caller to handle this case
-
-          // For now, retry without the session ID to create a new session
+        const retryableSessionId = context.reusableCliSession.sessionId;
+        if (
+          shouldRetryFreshCliSessionAfterFailover({
+            error: err,
+            hasHistoryPrompt: Boolean(context.openClawHistoryPrompt),
+          }) &&
+          retryableSessionId &&
+          params.sessionKey
+        ) {
           try {
-            const { output, lastAssistant } = await executeCliAttempt(undefined);
+            const retryTimeoutMs = params.timeoutMs - (Date.now() - context.started);
+            if (retryTimeoutMs <= 0) {
+              throw err;
+            }
+            if (params.onBeforeFreshCliSessionRetry) {
+              const clearedStaleBinding = await params.onBeforeFreshCliSessionRetry({
+                provider: params.provider,
+                reason: err.reason,
+                sessionId: retryableSessionId,
+              });
+              if (clearedStaleBinding !== true) {
+                throw err;
+              }
+            }
+            cliBackendLog.warn(
+              `cli session recovery retry: provider=${params.provider} reason=${err.reason} sessionKey=${params.sessionKey}`,
+            );
+            const { output, lastAssistant } = await executeCliAttempt(undefined, retryTimeoutMs);
             const assistantText = output.text.trim();
             const effectiveCliSessionId = output.sessionId;
             await finalizeCliContextEngineTurn({

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -795,7 +795,7 @@ export async function runPreparedCliAgent(
                 reason: err.reason,
                 sessionId: retryableSessionId,
               });
-              if (clearedStaleBinding !== true) {
+              if (!clearedStaleBinding) {
                 throw err;
               }
             }

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -456,12 +456,17 @@ function scheduleIdleClose(session: ClaudeLiveSession): void {
   }, CLAUDE_LIVE_IDLE_TIMEOUT_MS);
 }
 
-function createTimeoutError(session: ClaudeLiveSession, message: string): FailoverError {
+function createTimeoutError(
+  session: ClaudeLiveSession,
+  message: string,
+  code?: string,
+): FailoverError {
   return new FailoverError(message, {
     reason: "timeout",
     provider: session.providerId,
     model: session.modelId,
     status: resolveFailoverStatus("timeout"),
+    code,
   });
 }
 
@@ -1146,6 +1151,7 @@ function createTurn(params: {
       createTimeoutError(
         params.session,
         `CLI produced no output for ${Math.round(params.noOutputTimeoutMs / 1000)}s and was terminated.`,
+        "cli_no_output_timeout",
       ),
     );
   }, params.noOutputTimeoutMs);

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -449,11 +449,13 @@ export async function executePreparedCliRun(
         });
         const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
         const hasJsonlOutput = outputMode === "jsonl";
+        let observedCliActivity = false;
         const emitCliToolUseStart = (event: {
           toolCallId: string;
           name: string;
           args: Record<string, unknown>;
         }) => {
+          observedCliActivity = true;
           emitAgentEvent({
             runId: params.runId,
             stream: "tool",
@@ -471,6 +473,7 @@ export async function executePreparedCliRun(
           isError: boolean;
           result?: unknown;
         }) => {
+          observedCliActivity = true;
           emitAgentEvent({
             runId: params.runId,
             stream: "tool",
@@ -505,6 +508,9 @@ export async function executePreparedCliRun(
             noOutputTimeoutMs,
             getProcessSupervisor: executeDeps.getProcessSupervisor,
             onAssistantDelta: ({ text, delta }) => {
+              if (text || delta) {
+                observedCliActivity = true;
+              }
               emitAgentEvent({
                 runId: params.runId,
                 stream: "assistant",
@@ -546,6 +552,9 @@ export async function executePreparedCliRun(
               backend,
               providerId: context.backendResolved.id,
               onAssistantDelta: ({ text, delta }) => {
+                if (text || delta) {
+                  observedCliActivity = true;
+                }
                 emitAgentEvent({
                   runId: params.runId,
                   stream: "assistant",
@@ -677,7 +686,18 @@ export async function executePreparedCliRun(
             cliBackendLog.warn(
               `cli watchdog timeout: provider=${params.provider} model=${context.modelId} session=${resolvedSessionId ?? params.sessionId} noOutputTimeoutMs=${noOutputTimeoutMs} pid=${managedRun.pid ?? "unknown"}`,
             );
-            if (params.sessionKey) {
+            const retryableNoOutputTimeout =
+              !observedCliActivity &&
+              stdoutDiagnostic.length === 0 &&
+              stderrDiagnostic.length === 0;
+            const deferWatchdogNoticeForFreshRetry =
+              retryableNoOutputTimeout &&
+              Boolean(cliSessionIdToUse) &&
+              Boolean(resolvedSessionId) &&
+              Boolean(context.openClawHistoryPrompt) &&
+              Boolean(params.sessionKey) &&
+              params.timeoutMs - (Date.now() - context.started) > 0;
+            if (params.sessionKey && !deferWatchdogNoticeForFreshRetry) {
               const stallNotice = [
                 `CLI agent (${params.provider}) produced no output for ${Math.round(noOutputTimeoutMs / 1000)}s and was terminated.`,
                 "It may have been waiting for interactive input or an approval prompt.",
@@ -711,6 +731,7 @@ export async function executePreparedCliRun(
               sessionId: params.sessionId,
               lane: params.lane,
               status: resolveFailoverStatus("timeout"),
+              code: retryableNoOutputTimeout ? "cli_no_output_timeout" : undefined,
             });
           }
           if (result.reason === "overall-timeout") {
@@ -722,6 +743,7 @@ export async function executePreparedCliRun(
               sessionId: params.sessionId,
               lane: params.lane,
               status: resolveFailoverStatus("timeout"),
+              code: "cli_overall_timeout",
             });
           }
           const errorCandidates = [stderr, stdout, stderrDiagnostic, stdoutDiagnostic].filter(
@@ -746,6 +768,13 @@ export async function executePreparedCliRun(
           const err = structuredError || classifiedErrorText || errorCandidates[0] || "CLI failed.";
           reason = reason ?? "unknown";
           const status = resolveFailoverStatus(reason);
+          const retryCode =
+            reason === "unknown" &&
+            result.reason === "exit" &&
+            errorCandidates.length === 0 &&
+            !observedCliActivity
+              ? "cli_unknown_empty_failure"
+              : undefined;
           throw new FailoverError(err, {
             reason,
             provider: params.provider,
@@ -753,6 +782,7 @@ export async function executePreparedCliRun(
             sessionId: params.sessionId,
             lane: params.lane,
             status,
+            code: retryCode,
           });
         }
 

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -18,6 +18,7 @@ import type { SkillSnapshot } from "../../skills/types.js";
 import type { BootstrapContextMode } from "../bootstrap-files.js";
 import type { ResolvedCliBackend } from "../cli-backends.js";
 import type { ContextWindowInfo } from "../context-window-guard.js";
+import type { FailoverReason } from "../embedded-agent-helpers.js";
 import type { EmbeddedAgentExecutionPhase } from "../embedded-agent-runner/execution-phase.js";
 import type {
   CurrentInboundPromptContext,
@@ -61,6 +62,11 @@ export type RunCliAgentParams = {
   cliSessionId?: string;
   cliSessionBinding?: CliSessionBinding;
   authProfileId?: string;
+  onBeforeFreshCliSessionRetry?: (params: {
+    provider: string;
+    reason: FailoverReason;
+    sessionId: string;
+  }) => boolean | Promise<boolean>;
   bootstrapPromptWarningSignaturesSeen?: string[];
   bootstrapPromptWarningSignature?: string;
   bootstrapContextMode?: BootstrapContextMode;

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -252,7 +252,7 @@ describe("CLI attempt execution", () => {
     };
   }
 
-  it("clears stale Claude CLI session IDs before retrying after session expiration", async () => {
+  it("clears stale Claude CLI session IDs before a fresh retry after session expiration", async () => {
     const sessionKey = "agent:main:subagent:cli-expired";
     const homeDir = path.join(tmpDir, "home");
     const projectsDir = resolveClaudeCliProjectDirForWorkspace({
@@ -278,16 +278,24 @@ describe("CLI attempt execution", () => {
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
 
-    runCliAgentMock
-      .mockRejectedValueOnce(
-        new FailoverError("session expired", {
-          reason: "session_expired",
-          provider: "claude-cli",
-          model: "opus",
-          status: 410,
-        }),
-      )
-      .mockResolvedValueOnce(makeCliResult("hello from cli"));
+    runCliAgentMock.mockImplementationOnce(async (args: unknown) => {
+      const retry = requireRecord(args, "run CLI agent argument").onBeforeFreshCliSessionRetry;
+      expect(retry).toBeTypeOf("function");
+      await (
+        retry as (params: {
+          provider: string;
+          reason: "session_expired";
+          sessionId: string;
+        }) => Promise<boolean>
+      )({
+        provider: "claude-cli",
+        reason: "session_expired",
+        sessionId: "stale-cli-session",
+      });
+      expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+      return makeCliResult("hello from cli");
+    });
 
     await runAgentAttempt({
       providerOverride: "claude-cli",
@@ -319,9 +327,8 @@ describe("CLI attempt execution", () => {
       sessionHasHistory: false,
     });
 
-    expect(runCliAgentMock).toHaveBeenCalledTimes(2);
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
     expect(firstRunCliAgentArg().cliSessionId).toBe("stale-cli-session");
-    expect(firstRunCliAgentArg(1).cliSessionId).toBeUndefined();
     expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
     expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
 
@@ -368,30 +375,40 @@ describe("CLI attempt execution", () => {
     expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
   });
 
-  it("clears reused Claude CLI session IDs after non-expired failover without retrying", async () => {
+  it("clears reused Claude CLI session IDs before a fresh retry after timeout failover", async () => {
     const sessionKey = "agent:main:direct:cli-timeout";
     const cliSessionId = "timeout-poisoned-session";
     await writeClaudeCliAssistantTranscript(cliSessionId);
     const sessionEntry = makeClaudeCliSessionEntry("session-cli-timeout", cliSessionId);
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
-    runCliAgentMock.mockRejectedValueOnce(
-      new FailoverError("CLI produced no output for 60s", {
-        reason: "timeout",
+    runCliAgentMock.mockImplementationOnce(async (args: unknown) => {
+      const retry = requireRecord(args, "run CLI agent argument").onBeforeFreshCliSessionRetry;
+      expect(retry).toBeTypeOf("function");
+      await (
+        retry as (params: {
+          provider: string;
+          reason: "timeout";
+          sessionId: string;
+        }) => Promise<boolean>
+      )({
         provider: "claude-cli",
-        model: "opus",
-      }),
-    );
+        reason: "timeout",
+        sessionId: cliSessionId,
+      });
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+      return makeCliResult("hello after timeout");
+    });
 
-    await expect(
-      runClaudeCliAttempt({
-        sessionKey,
-        sessionEntry,
-        sessionStore,
-        body: "resume after timeout",
-        runId: "run-cli-timeout",
-      }),
-    ).rejects.toMatchObject({ name: "FailoverError", reason: "timeout" });
+    await runClaudeCliAttempt({
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      body: "resume after timeout",
+      runId: "run-cli-timeout",
+    });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
     expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
@@ -399,6 +416,81 @@ describe("CLI attempt execution", () => {
     expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
     expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
   });
+
+  it("does not install a stale-session clearing hook for storeless CLI attempts", async () => {
+    const sessionKey = "agent:main:internal-storeless";
+    const cliSessionId = "storeless-stale-session";
+    await writeClaudeCliAssistantTranscript(cliSessionId);
+    const sessionEntry = makeClaudeCliSessionEntry("session-storeless", cliSessionId);
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("storeless ok"));
+
+    await runAgentAttempt({
+      providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
+      modelOverride: "opus",
+      cfg: {} as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "storeless retry path",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-storeless-cli",
+      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: undefined,
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "claude-cli",
+      sessionHasHistory: false,
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
+    expect(firstRunCliAgentArg().onBeforeFreshCliSessionRetry).toBeUndefined();
+  });
+
+  it.each(["auth", "billing", "rate_limit"] as const)(
+    "clears reused Claude CLI session IDs after %s failover without retrying",
+    async (reason) => {
+      const sessionKey = `agent:main:direct:cli-${reason}`;
+      const cliSessionId = `${reason}-poisoned-session`;
+      await writeClaudeCliAssistantTranscript(cliSessionId);
+      const sessionEntry = makeClaudeCliSessionEntry(`session-cli-${reason}`, cliSessionId);
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+      runCliAgentMock.mockRejectedValueOnce(
+        new FailoverError(`${reason} failed`, {
+          reason,
+          provider: "claude-cli",
+          model: "opus",
+        }),
+      );
+
+      await expect(
+        runClaudeCliAttempt({
+          sessionKey,
+          sessionEntry,
+          sessionStore,
+          body: `resume after ${reason}`,
+          runId: `run-cli-${reason}`,
+        }),
+      ).rejects.toMatchObject({ name: "FailoverError", reason });
+
+      expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+      expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    },
+  );
 
   it("does not pass --resume when the stored Claude CLI transcript is missing", async () => {
     const sessionKey = "agent:main:direct:claude-missing-transcript";

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -27,7 +27,7 @@ import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
 import { ensureAuthProfileStore } from "../auth-profiles/store.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { runCliAgent } from "../cli-runner.js";
-import { getCliSessionBinding, setCliSessionBinding } from "../cli-session.js";
+import { getCliSessionBinding } from "../cli-session.js";
 import { runEmbeddedAgent, type EmbeddedAgentRunResult } from "../embedded-agent.js";
 import { FailoverError } from "../failover-error.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../harness/hook-helpers.js";
@@ -44,7 +44,6 @@ import {
   claudeCliSessionTranscriptHasContent,
   resolveFallbackRetryPrompt,
 } from "./attempt-execution.helpers.js";
-import { persistSessionEntry } from "./attempt-execution.shared.js";
 import { resolveAgentRunContext } from "./run-context.js";
 import { clearCliSessionInStore } from "./session-store.js";
 import type { AgentCommandOpts } from "./types.js";
@@ -60,7 +59,7 @@ function shouldClearReusedCliSessionAfterError(err: unknown): boolean {
   if (readErrorName(err) === "AbortError") {
     return true;
   }
-  return err instanceof FailoverError && err.reason !== "session_expired";
+  return err instanceof FailoverError;
 }
 
 function resolveClearedCliSessionReason(err: unknown): string {
@@ -538,6 +537,9 @@ export function runAgentAttempt(params: {
 
       return undefined;
     };
+    const canClearCliSessionBeforeRetry = Boolean(
+      params.sessionKey && params.sessionStore && params.storePath,
+    );
     const runCliWithSession = (
       nextCliSessionId: string | undefined,
       activeCliSessionBinding = cliSessionBinding,
@@ -579,59 +581,38 @@ export function runAgentAttempt(params: {
         toolsAllow: params.opts.toolsAllow,
         cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
         cleanupCliLiveSessionOnRunEnd: params.opts.cleanupCliLiveSessionOnRunEnd,
+        ...(canClearCliSessionBeforeRetry
+          ? {
+              onBeforeFreshCliSessionRetry: async (retry) => {
+                if (
+                  retry.sessionId !== activeCliSessionBinding?.sessionId ||
+                  !params.sessionKey ||
+                  !params.sessionStore ||
+                  !params.storePath
+                ) {
+                  return false;
+                }
+
+                log.warn(
+                  `CLI session failed, clearing before fresh retry: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${params.sessionKey} reason=${sanitizeForLog(retry.reason)}`,
+                );
+
+                params.sessionEntry =
+                  (await clearCliSessionInStore({
+                    provider: cliExecutionProvider,
+                    sessionKey: params.sessionKey,
+                    sessionStore: params.sessionStore,
+                    storePath: params.storePath,
+                  })) ?? params.sessionEntry;
+                return true;
+              },
+            }
+          : {}),
       });
     return resolveReusableCliSessionBinding().then(async (activeCliSessionBinding) => {
       try {
         return await runCliWithSession(activeCliSessionBinding?.sessionId, activeCliSessionBinding);
       } catch (err) {
-        if (
-          err instanceof FailoverError &&
-          err.reason === "session_expired" &&
-          activeCliSessionBinding?.sessionId &&
-          params.sessionKey &&
-          params.sessionStore &&
-          params.storePath
-        ) {
-          log.warn(
-            `CLI session expired, clearing from session store: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${params.sessionKey}`,
-          );
-
-          params.sessionEntry =
-            (await clearCliSessionInStore({
-              provider: cliExecutionProvider,
-              sessionKey: params.sessionKey,
-              sessionStore: params.sessionStore,
-              storePath: params.storePath,
-            })) ?? params.sessionEntry;
-
-          return await runCliWithSession(undefined).then(async (result) => {
-            if (
-              result.meta.agentMeta?.cliSessionBinding?.sessionId &&
-              params.sessionKey &&
-              params.sessionStore &&
-              params.storePath
-            ) {
-              const entry = params.sessionStore[params.sessionKey];
-              if (entry) {
-                const updatedEntry = { ...entry };
-                setCliSessionBinding(
-                  updatedEntry,
-                  cliExecutionProvider,
-                  result.meta.agentMeta.cliSessionBinding,
-                );
-                updatedEntry.updatedAt = Date.now();
-
-                await persistSessionEntry({
-                  sessionStore: params.sessionStore,
-                  sessionKey: params.sessionKey,
-                  storePath: params.storePath,
-                  entry: updatedEntry,
-                });
-              }
-            }
-            return result;
-          });
-        }
         if (
           isClaudeCliProvider(cliExecutionProvider) &&
           shouldClearReusedCliSessionAfterError(err) &&

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -509,6 +509,14 @@ export function runAgentAttempt(params: {
   if (!isRawModelRun && isCliProvider(cliExecutionProvider, params.cfg)) {
     const cliSessionBinding = getCliSessionBinding(params.sessionEntry, cliExecutionProvider);
     const cliProcessCwd = params.cwd ? resolveUserPath(params.cwd) : params.workspaceDir;
+    const mutableCliSessionStore =
+      params.sessionKey && params.sessionStore && params.storePath
+        ? {
+            sessionKey: params.sessionKey,
+            sessionStore: params.sessionStore,
+            storePath: params.storePath,
+          }
+        : undefined;
     const resolveReusableCliSessionBinding = async () => {
       if (
         !isClaudeCliProvider(cliExecutionProvider) ||
@@ -525,21 +533,16 @@ export function runAgentAttempt(params: {
         `cli session reset: provider=${sanitizeForLog(cliExecutionProvider)} reason=transcript-missing sessionKey=${params.sessionKey ?? params.sessionId}`,
       );
 
-      if (params.sessionKey && params.sessionStore && params.storePath) {
+      if (mutableCliSessionStore) {
         params.sessionEntry =
           (await clearCliSessionInStore({
             provider: cliExecutionProvider,
-            sessionKey: params.sessionKey,
-            sessionStore: params.sessionStore,
-            storePath: params.storePath,
+            ...mutableCliSessionStore,
           })) ?? params.sessionEntry;
       }
 
       return undefined;
     };
-    const canClearCliSessionBeforeRetry = Boolean(
-      params.sessionKey && params.sessionStore && params.storePath,
-    );
     const runCliWithSession = (
       nextCliSessionId: string | undefined,
       activeCliSessionBinding = cliSessionBinding,
@@ -581,28 +584,21 @@ export function runAgentAttempt(params: {
         toolsAllow: params.opts.toolsAllow,
         cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
         cleanupCliLiveSessionOnRunEnd: params.opts.cleanupCliLiveSessionOnRunEnd,
-        ...(canClearCliSessionBeforeRetry
+        ...(mutableCliSessionStore
           ? {
               onBeforeFreshCliSessionRetry: async (retry) => {
-                if (
-                  retry.sessionId !== activeCliSessionBinding?.sessionId ||
-                  !params.sessionKey ||
-                  !params.sessionStore ||
-                  !params.storePath
-                ) {
+                if (retry.sessionId !== activeCliSessionBinding?.sessionId) {
                   return false;
                 }
 
                 log.warn(
-                  `CLI session failed, clearing before fresh retry: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${params.sessionKey} reason=${sanitizeForLog(retry.reason)}`,
+                  `CLI session failed, clearing before fresh retry: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${mutableCliSessionStore.sessionKey} reason=${sanitizeForLog(retry.reason)}`,
                 );
 
                 params.sessionEntry =
                   (await clearCliSessionInStore({
                     provider: cliExecutionProvider,
-                    sessionKey: params.sessionKey,
-                    sessionStore: params.sessionStore,
-                    storePath: params.storePath,
+                    ...mutableCliSessionStore,
                   })) ?? params.sessionEntry;
                 return true;
               },
@@ -617,20 +613,16 @@ export function runAgentAttempt(params: {
           isClaudeCliProvider(cliExecutionProvider) &&
           shouldClearReusedCliSessionAfterError(err) &&
           activeCliSessionBinding?.sessionId &&
-          params.sessionKey &&
-          params.sessionStore &&
-          params.storePath
+          mutableCliSessionStore
         ) {
           log.warn(
-            `CLI session cleared after failed reused turn: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${params.sessionKey} reason=${sanitizeForLog(resolveClearedCliSessionReason(err))}`,
+            `CLI session cleared after failed reused turn: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${mutableCliSessionStore.sessionKey} reason=${sanitizeForLog(resolveClearedCliSessionReason(err))}`,
           );
 
           params.sessionEntry =
             (await clearCliSessionInStore({
               provider: cliExecutionProvider,
-              sessionKey: params.sessionKey,
-              sessionStore: params.sessionStore,
-              storePath: params.storePath,
+              ...mutableCliSessionStore,
             })) ?? params.sessionEntry;
         }
         throw err;

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -108,6 +108,7 @@ function collectProductionLintSuppressionsFromGit(): SuppressionEntry[] | null {
     "git",
     [
       "grep",
+      "--cached",
       "-n",
       "-E",
       String.raw`(oxlint|eslint)-disable(-next-line)?[[:space:]]+[@/[:alnum:]_-]+`,

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -108,7 +108,6 @@ function collectProductionLintSuppressionsFromGit(): SuppressionEntry[] | null {
     "git",
     [
       "grep",
-      "--cached",
       "-n",
       "-E",
       String.raw`(oxlint|eslint)-disable(-next-line)?[[:space:]]+[@/[:alnum:]_-]+`,


### PR DESCRIPTION
## Summary

- Recovers stale resumed CLI sessions inside the CLI runner lifecycle so hooks observe only the final command outcome.
- Retries fresh only for bounded, recoverable resumed-session failures with reseed context: `session_expired`, empty no-output timeout, and empty unclassified CLI exit.
- Clears the stored stale CLI binding before command-path fresh retry when a mutable session store is available, while preserving storeless/direct runner behavior.
- Keeps auth, billing, rate-limit, hard overall timeout, cancellation, diagnostic-output failures, acted/stalled turns, and no-reseed paths as no-retry paths.

## Linked context

Fixes #77089.

Related context: this follows the issue evidence and ClawSweeper guidance to recover stale CLI sessions without broadening retry behavior into auth/provider failure paths.

Maintainer/owner request: no direct maintainer request; this is an issue-driven fix prepared for maintainer review.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Recoverable stale resumed CLI-session failures now clear the stale stored binding and retry once with a fresh CLI session inside the runner lifecycle, while auth, billing, rate-limit, hard-timeout, cancellation, diagnostic-output, acted/stalled, and no-reseed paths remain no-retry paths.
- **Real environment tested:** Local Windows OpenClaw source worktree at `C:\oc-work\oc-77089` on branch `issue-77089`, using isolated `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`, plus a local CLI backend executable exercised through the real `openclaw agent --local --json` command path. No live channel auth, production config, Telegram, Discord, or VPS state was used.
- **Exact steps or command run after this patch:** Ran `powershell -NoProfile -ExecutionPolicy Bypass -File .\.artifacts\issue-77089-proof-tools\run-real-behavior-proof.ps1`. After rebasing onto current `main`, reran `node scripts/run-vitest.mjs run src/agents/command/attempt-execution.cli.test.ts src/agents/cli-runner.reliability.test.ts`, `node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts test/scripts/lint-suppressions.test.ts`, `pnpm check:test-types`, `node scripts/run-oxlint-shards.mjs --threads=8`, and `git diff --check upstream/main...HEAD`.
- **Evidence after fix:** Terminal capture from `.artifacts\issue-77089-real-proof\terminal-retry.log` and backend sidecar capture from `.artifacts\issue-77089-real-proof\backend-events.jsonl` showed the stale resume, binding clear, fresh retry, fresh success, and persisted binding replacement:

  ```text
  [agent/cli-backend] cli exec: provider=proof-cli model=model promptChars=55 trigger=user useResume=true session=present resumeSession=a8fc01f726ed reuse=reusable historyPrompt=present
  [agent/cli-backend] cli argv: node C:\oc-work\oc-77089\.artifacts\issue-77089-proof-tools\proof-cli.mjs --mode resume --resume stale-session-77089
  [agents/agent-command] CLI session failed, clearing before fresh retry: provider=proof-cli sessionKey=agent:main:issue-77089-real-proof reason=unknown
  [agent/cli-backend] cli session recovery retry: provider=proof-cli reason=unknown sessionKey=agent:main:issue-77089-real-proof
  [agent/cli-backend] cli exec: provider=proof-cli model=model promptChars=440 trigger=user useResume=false session=none resumeSession=none reuse=reusable historyPrompt=present
  [agent/cli-backend] cli argv: node C:\oc-work\oc-77089\.artifacts\issue-77089-proof-tools\proof-cli.mjs --mode fresh --session-id b8204865-3410-41e6-9a3b-93060eb0acff
  REAL_BEHAVIOR_PROOF_OK fresh session=b8204865-3410-41e6-9a3b-93060eb0acff
  ```

  ```text
  invoke mode=resume argv=[...,"--resume","stale-session-77089"]
  stale_resume_empty_unknown_exit resumeSessionId=stale-session-77089 stdoutBytes=0 stderrBytes=0 exitCode=77
  invoke mode=fresh argv=[...,"--session-id","b8204865-3410-41e6-9a3b-93060eb0acff"] stdinChars=440 stdinHasReseedPrompt=true
  fresh_success sessionId=b8204865-3410-41e6-9a3b-93060eb0acff
  final_binding=b8204865-3410-41e6-9a3b-93060eb0acff
  ```

  Local Crabbox/Docker proof also passed in provider/id `local-container`, `cbx_ab78f1b74b26` with image `openclaw-77089-crabbox-node-rsync:latest`; timing JSON reported `exitCode=0`, install `30.351s`, test `82.284s`, and diff-check `127ms`.
- **Observed result after fix:** The seeded store started with `cliSessionBindings.proof-cli.sessionId = stale-session-77089` and `forceReuse=true`; after the real command-path run, the persisted binding was replaced by fresh session id `b8204865-3410-41e6-9a3b-93060eb0acff`. Focused behavior coverage also confirms no retry for auth, billing, rate limit, hard overall timeout, missing reseed prompt, no reusable session, diagnostic unknown output, no-output after CLI activity, exhausted timeout budget, and supervisor cancellation.
- **What was not tested:** Live channel auth, live Telegram/Discord delivery, and live VPS production OpenClaw state were not tested. Normal Crabbox `local-container` sync on this Windows host is blocked before command execution by its rsync/SSH bridge passing an identity path like `/tmp/crabbox-wsl-<id>` to MSYS rsync while the private key is not present at the MSYS-visible `/tmp` path, so the local-container proof copied the checkout separately before running inside the lease.
- **Before evidence:** Issue #77089 includes the original incident timeline showing a stale CLI session binding surviving timeout/unknown failures until a later gateway restart created a fresh session.

## Tests and validation

Commands run locally after the latest rebase onto `main`:

- `node scripts/run-vitest.mjs run src/agents/command/attempt-execution.cli.test.ts src/agents/cli-runner.reliability.test.ts` - 71 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts test/scripts/lint-suppressions.test.ts` - reproduces the previously red CI shard locally; 3 tests passed after the rebase.
- `pnpm check:test-types` - passed.
- `node scripts/run-oxlint-shards.mjs --threads=8` - passed.
- `git diff --check upstream/main...HEAD` - passed.

Regression coverage added/updated:

- Added focused CLI runner reliability coverage for stale resumed-session retry, timeout/unknown retry gates, timeout-budget handling, cancellation, no-output-after-activity, missing reseed, no reusable session, and diagnostic-output no-retry paths.
- Updated command-path CLI execution coverage for clearing stale persisted bindings before runner-owned fresh retry and preserving no-retry behavior where intended.

Known pre-fix failure mode:

- A stale resumed CLI session could fail with timeout or unknown/no-output, skip same-turn fresh retry, keep or only later clear the stale binding, and fall through to API fallback until an external restart or later turn recovered the session.

## Risk checklist

Did user-visible behavior change? `Yes`.

Did config, environment, or migration behavior change? `No`.

Did security, auth, secrets, network, or tool execution behavior change? `Yes`, in a bounded CLI tool-execution/session-state path. Auth, billing, rate-limit, cancellation, hard-timeout, and diagnostic-output failures deliberately remain no-retry paths.

Highest-risk area: stale CLI session-state recovery and retry/no-retry classification for provider failures.

Risk mitigation: retry is limited to resumed sessions with reusable session context and remaining timeout budget; command execution clears only the matching persisted binding before retry; focused tests cover both retry and explicit no-retry boundaries.

## Current review state

Next action: wait for the fresh GitHub CI run from the rebased branch and maintainer review.

Still waiting on: CI after the latest force-push and maintainer acceptance of the bounded retry/no-retry boundary called out by ClawSweeper.

Bot/reviewer comments addressed: PR body now follows the current repository template, preserves the required `Real behavior proof` fields, includes after-fix evidence, and the branch was rebased onto current `main`. The prior `build-artifacts` failure was narrowed to `test/scripts/lint-suppressions.test.ts` reading suppression state from the mutable working tree during the broad shard; the guard now reads from the git index so CI validates the committed PR tree instead of order-dependent file mutations from sibling tooling tests.

