### PR TITLE
Classify release dependency ownership metadata

### DIFF
--- a/scripts/lib/dependency-ownership.json
+++ b/scripts/lib/dependency-ownership.json
@@ -6,6 +6,16 @@
       "class": "core-runtime",
       "risk": ["protocol-client"]
     },
+    "@anthropic-ai/sdk": {
+      "owner": "provider:anthropic",
+      "class": "default-runtime-initially",
+      "risk": ["provider-sdk", "network"]
+    },
+    "@clack/core": {
+      "owner": "core:cli",
+      "class": "core-runtime",
+      "risk": ["interactive-cli"]
+    },
     "@clack/prompts": {
       "owner": "core:cli",
       "class": "core-runtime",
@@ -21,6 +31,26 @@
       "class": "tui-runtime",
       "risk": ["tui-runtime"]
     },
+    "@google/genai": {
+      "owner": "provider:google",
+      "class": "default-runtime-initially",
+      "risk": ["provider-sdk", "network", "realtime"]
+    },
+    "@grammyjs/runner": {
+      "owner": "plugin:telegram",
+      "class": "plugin-runtime",
+      "risk": ["telegram-bot-api", "polling"]
+    },
+    "@grammyjs/transformer-throttler": {
+      "owner": "plugin:telegram",
+      "class": "plugin-runtime",
+      "risk": ["telegram-bot-api", "rate-limiting"]
+    },
+    "@homebridge/ciao": {
+      "owner": "plugin:bonjour",
+      "class": "plugin-runtime",
+      "risk": ["mdns", "network"]
+    },
     "@modelcontextprotocol/sdk": {
       "owner": "core:mcp",
       "class": "core-runtime",
@@ -31,6 +61,16 @@
       "class": "plugin-runtime",
       "activation": ["tools.web.fetch.readability", "plugins.entries.web-readability.enabled"],
       "risk": ["parser", "untrusted-html"]
+    },
+    "@mistralai/mistralai": {
+      "owner": "provider:mistral",
+      "class": "default-runtime-initially",
+      "risk": ["provider-sdk", "network"]
+    },
+    "@openclaw/fs-safe": {
+      "owner": "core:filesystem-safety",
+      "class": "core-runtime",
+      "risk": ["filesystem", "path-safety"]
     },
     "chalk": {
       "owner": "core:cli",
@@ -47,10 +87,20 @@
       "class": "core-runtime",
       "risk": ["cli-parser"]
     },
+    "cross-spawn": {
+      "owner": "core:child-process",
+      "class": "core-runtime",
+      "risk": ["process-spawn"]
+    },
     "croner": {
       "owner": "core:scheduler",
       "class": "core-runtime",
       "risk": ["scheduler"]
+    },
+    "diff": {
+      "owner": "core:agent-editing",
+      "class": "core-runtime",
+      "risk": ["diff"]
     },
     "dotenv": {
       "owner": "core:config",
@@ -66,6 +116,31 @@
       "owner": "core:media-admission",
       "class": "core-runtime",
       "risk": ["file-sniffing", "untrusted-files"]
+    },
+    "glob": {
+      "owner": "core:package-manager",
+      "class": "core-runtime",
+      "risk": ["filesystem-glob"]
+    },
+    "grammy": {
+      "owner": "plugin:telegram",
+      "class": "plugin-runtime",
+      "risk": ["telegram-bot-api", "network"]
+    },
+    "highlight.js": {
+      "owner": "core:syntax-highlighting",
+      "class": "core-runtime",
+      "risk": ["syntax-highlighting"]
+    },
+    "hosted-git-info": {
+      "owner": "core:git-utils",
+      "class": "core-runtime",
+      "risk": ["git-metadata-parser"]
+    },
+    "ignore": {
+      "owner": "core:gitignore-matching",
+      "class": "core-runtime",
+      "risk": ["pattern-matching"]
     },
     "@openclaw/proxyline": {
       "owner": "core:proxy",
@@ -103,15 +178,40 @@
       "class": "core-runtime",
       "risk": ["parser", "markdown"]
     },
+    "minimatch": {
+      "owner": "core:pattern-matching",
+      "class": "core-runtime",
+      "risk": ["pattern-matching"]
+    },
+    "node-edge-tts": {
+      "owner": "plugin:microsoft",
+      "class": "plugin-runtime",
+      "risk": ["tts", "network"]
+    },
     "openai": {
       "owner": "provider:openai",
       "class": "default-runtime-initially",
       "risk": ["provider-sdk", "network"]
     },
+    "partial-json": {
+      "owner": "core:llm-json-parsing",
+      "class": "core-runtime",
+      "risk": ["streaming-json-parser"]
+    },
     "playwright-core": {
       "owner": "core:browser",
       "class": "core-runtime",
       "risk": ["browser-automation", "cdp"]
+    },
+    "proper-lockfile": {
+      "owner": "core:session-storage",
+      "class": "core-runtime",
+      "risk": ["filesystem-locking"]
+    },
+    "quickjs-wasi": {
+      "owner": "core:code-mode",
+      "class": "core-runtime",
+      "risk": ["wasm", "sandboxed-js"]
     },
     "clawpdf": {
       "owner": "plugin:document-extract",
@@ -139,10 +239,20 @@
       "class": "core-runtime",
       "risk": ["archive-parser", "untrusted-files"]
     },
+    "tree-sitter-bash": {
+      "owner": "core:command-explainer",
+      "class": "core-runtime",
+      "risk": ["wasm", "parser", "untrusted-shell"]
+    },
     "tslog": {
       "owner": "core:logging",
       "class": "core-runtime",
       "risk": ["logging"]
+    },
+    "typescript": {
+      "owner": "core:typescript-analysis",
+      "class": "core-runtime",
+      "risk": ["compiler-api"]
     },
     "typebox": {
       "owner": "core:json-schema-contracts",
@@ -158,6 +268,11 @@
       "owner": "core:web-push",
       "class": "core-runtime",
       "risk": ["network", "push-notifications", "crypto"]
+    },
+    "web-tree-sitter": {
+      "owner": "core:command-explainer",
+      "class": "core-runtime",
+      "risk": ["wasm", "parser", "untrusted-shell"]
     },
     "ws": {
       "owner": "core:gateway-websocket",

--- a/scripts/root-dependency-ownership-audit.mjs
+++ b/scripts/root-dependency-ownership-audit.mjs
@@ -19,6 +19,9 @@ const DYNAMIC_CONSTANT_IMPORT_PATTERNS = [
   /\brequire\s*\(\s*([_$A-Za-z][\w$]*)\s*\)/g,
   /\b(?:require|[_$A-Za-z][\w$]*require[\w$]*)\.resolve\s*\(\s*([_$A-Za-z][\w$]*)\s*\)/gi,
 ];
+const PACKAGE_FILE_LOOKUP_PATTERNS = [
+  /\bresolvePackageFileForCommandExplanation\s*\(\s*["']([^"']+)["']/g,
+];
 const ROOT_OWNED_EXTENSION_RUNTIME_DEPENDENCIES = new Map([
   [
     "@homebridge/ciao",
@@ -79,6 +82,13 @@ function sectionFor(relativePath) {
 export function collectModuleSpecifiers(source) {
   const specifiers = new Set();
   for (const pattern of IMPORT_PATTERNS) {
+    for (const match of source.matchAll(pattern)) {
+      if (match[1]) {
+        specifiers.add(match[1]);
+      }
+    }
+  }
+  for (const pattern of PACKAGE_FILE_LOOKUP_PATTERNS) {
     for (const match of source.matchAll(pattern)) {
       if (match[1]) {
         specifiers.add(match[1]);

--- a/test/scripts/root-dependency-ownership-audit.test.ts
+++ b/test/scripts/root-dependency-ownership-audit.test.ts
@@ -37,8 +37,9 @@ describe("collectModuleSpecifiers", () => {
         const runtimeRequire = createRequire(runtimePackagePath);
         require.resolve("gaxios");
         runtimeRequire.resolve("openshell/package.json");
+        resolvePackageFileForCommandExplanation("tree-sitter-bash", "tree-sitter-bash.wasm");
       `),
-    ]).toEqual(["gaxios", "openshell/package.json"]);
+    ]).toEqual(["gaxios", "openshell/package.json", "tree-sitter-bash"]);
   });
 
   it("resolves simple string constants used by lazy runtime imports", () => {


### PR DESCRIPTION
## Summary
- add owner/class/risk metadata for the current root dependency ownership gaps surfaced by release evidence
- classify provider SDKs, Telegram/Bonjour/Microsoft plugin runtimes, command explainer parser packages, code-mode/runtime tooling, and core agent/session utilities
- teach the root dependency ownership audit to recognize command-explainer package-file lookups so `tree-sitter-bash` is no longer treated as unreferenced

## Verification
- `jq empty scripts/lib/dependency-ownership.json`
- `node scripts/dependency-ownership-surface-report.mjs --check`
- `node scripts/root-dependency-ownership-audit.mjs --check`
- `node scripts/dependency-ownership-surface-report.mjs --json | jq '{summary, ownershipGaps, staleOwnershipRecords, ownershipWarnings}'` -> `ownershipGaps: []`, `staleOwnershipRecords: []`
- `pnpm test test/scripts/root-dependency-ownership-audit.test.ts test/scripts/dependency-ownership-surface-report.test.ts -- --reporter=verbose`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

Notes: `pnpm check:changed` is running in Blacksmith Testbox as `tbx_01ksx97ewbacdjnwvfb37nyfgh` / https://github.com/openclaw/openclaw/actions/runs/26694154988.
