### PR TITLE
Store restart recovery delivery routes in SQLite

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -2,6 +2,11 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { SessionEntry } from "../config/sessions.js";
 import { INTERNAL_RUNTIME_CONTEXT_BEGIN, INTERNAL_RUNTIME_CONTEXT_END } from "./internal-events.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
+import {
+  claimRestartRecoveryDeliveryContext,
+  clearRestartRecoveryDeliveryContextsForTest,
+  readRestartRecoveryDeliveryContext,
+} from "./restart-recovery-delivery-state.js";
 
 const state = vi.hoisted(() => ({
   defaultRuntimeConfig: {
@@ -212,6 +217,7 @@ vi.mock("../config/runtime-snapshot.js", () => ({
 }));
 
 vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: () => state.sessionStoreMock ?? {},
   resolveAgentIdFromSessionKey: () => "default",
   mergeSessionEntry: (a: unknown, b: unknown) => ({ ...(a as object), ...(b as object) }),
   updateSessionStore: vi.fn(
@@ -947,6 +953,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   afterEach(() => {
+    clearRestartRecoveryDeliveryContextsForTest();
     vi.restoreAllMocks();
   });
 
@@ -1155,7 +1162,21 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.sessionEntryMock = sessionEntry;
     state.sessionStoreMock = { "agent:main:main": sessionEntry };
     state.storePathMock = "/tmp/openclaw-sessions.json";
-    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      expect(
+        readRestartRecoveryDeliveryContext({
+          sessionId: "session-1",
+          sessionKey: "agent:main:main",
+          storePath: "/tmp/openclaw-sessions.json",
+        })?.context,
+      ).toEqual({
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        threadId: "reply-1",
+      });
+      return { deliverySucceeded: true };
+    });
 
     await agentCommand({
       message: "hello",
@@ -1166,18 +1187,13 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       deliver: true,
     });
 
-    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
-      const params = call[0] as { entry?: SessionEntry };
-      return params.entry?.restartRecoveryDeliveryContext;
-    });
-    expect(persistedContexts).toContainEqual({
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      threadId: "reply-1",
-    });
-    const stored = (state.sessionStoreMock as Record<string, SessionEntry>)["agent:main:main"];
-    expect(stored?.restartRecoveryDeliveryContext).toBeUndefined();
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/openclaw-sessions.json",
+      }),
+    ).toBeUndefined();
   });
 
   it("preserves parsed explicit target threads for restart recovery", async () => {
@@ -1190,7 +1206,21 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.sessionEntryMock = sessionEntry;
     state.sessionStoreMock = { "agent:main:main": sessionEntry };
     state.storePathMock = "/tmp/openclaw-sessions.json";
-    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      expect(
+        readRestartRecoveryDeliveryContext({
+          sessionId: "session-1",
+          sessionKey: "agent:main:main",
+          storePath: "/tmp/openclaw-sessions.json",
+        })?.context,
+      ).toEqual({
+        channel: "discord",
+        to: "discord:channel:general",
+        accountId: "main",
+        threadId: "thread-1",
+      });
+      return { deliverySucceeded: true };
+    });
     state.resolveAgentDeliveryPlanMock.mockReturnValueOnce({
       baseDelivery: {
         mode: "explicit",
@@ -1211,17 +1241,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       accountId: "main",
       deliver: true,
     });
-
-    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
-      const params = call[0] as { entry?: SessionEntry };
-      return params.entry?.restartRecoveryDeliveryContext;
-    });
-    expect(persistedContexts).toContainEqual({
-      channel: "discord",
-      to: "discord:channel:general",
-      accountId: "main",
-      threadId: "thread-1",
-    });
   });
 
   it("does not inherit a stale thread when restart recovery uses an explicit target", async () => {
@@ -1235,7 +1254,20 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.sessionEntryMock = sessionEntry;
     state.sessionStoreMock = { "agent:main:main": sessionEntry };
     state.storePathMock = "/tmp/openclaw-sessions.json";
-    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      expect(
+        readRestartRecoveryDeliveryContext({
+          sessionId: "session-1",
+          sessionKey: "agent:main:main",
+          storePath: "/tmp/openclaw-sessions.json",
+        })?.context,
+      ).toEqual({
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+      });
+      return { deliverySucceeded: true };
+    });
 
     await agentCommand({
       message: "hello",
@@ -1243,16 +1275,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       to: "discord:dm:123",
       accountId: "main",
       deliver: true,
-    });
-
-    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
-      const params = call[0] as { entry?: SessionEntry };
-      return params.entry?.restartRecoveryDeliveryContext;
-    });
-    expect(persistedContexts).toContainEqual({
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
     });
   });
 
@@ -1272,7 +1294,21 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.sessionEntryMock = sessionEntry;
     state.sessionStoreMock = { "agent:main:main": sessionEntry };
     state.storePathMock = "/tmp/openclaw-sessions.json";
-    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      expect(
+        readRestartRecoveryDeliveryContext({
+          sessionId: "session-1",
+          sessionKey: "agent:main:main",
+          storePath: "/tmp/openclaw-sessions.json",
+        })?.context,
+      ).toEqual({
+        channel: "discord",
+        to: "discord:channel:general",
+        accountId: "main",
+        threadId: "thread-1",
+      });
+      return { deliverySucceeded: true };
+    });
 
     await agentCommand({
       message: "hello",
@@ -1280,16 +1316,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       deliver: true,
     });
 
-    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
-      const params = call[0] as { entry?: SessionEntry };
-      return params.entry?.restartRecoveryDeliveryContext;
-    });
-    expect(persistedContexts).toContainEqual({
-      channel: "discord",
-      to: "discord:channel:general",
-      accountId: "main",
-      threadId: "thread-1",
-    });
     expect(state.resolveAgentDeliveryPlanMock).toHaveBeenCalledWith(
       expect.objectContaining({
         explicitTo: undefined,
@@ -1312,7 +1338,19 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.sessionEntryMock = sessionEntry;
     state.sessionStoreMock = { "agent:main:main": sessionEntry };
     state.storePathMock = "/tmp/openclaw-sessions.json";
-    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      expect(
+        readRestartRecoveryDeliveryContext({
+          sessionId: "session-1",
+          sessionKey: "agent:main:main",
+          storePath: "/tmp/openclaw-sessions.json",
+        })?.context,
+      ).toEqual({
+        channel: "discord",
+        to: "discord:channel:default",
+      });
+      return { deliverySucceeded: true };
+    });
     state.resolveMessageChannelSelectionMock.mockResolvedValue({
       channel: "discord",
       configured: ["discord"],
@@ -1330,14 +1368,22 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       deliver: true,
     });
 
-    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
-      const params = call[0] as { entry?: SessionEntry };
-      return params.entry?.restartRecoveryDeliveryContext;
-    });
-    expect(persistedContexts).toContainEqual({
-      channel: "discord",
-      to: "discord:channel:default",
-    });
+    const stored = (state.sessionStoreMock as Record<string, SessionEntry> | undefined)?.[
+      "agent:main:main"
+    ];
+    expect(
+      (stored as Record<string, unknown> | undefined)?.restartRecoveryDeliveryContext,
+    ).toBeUndefined();
+    expect(
+      (stored as Record<string, unknown> | undefined)?.restartRecoveryDeliveryRunId,
+    ).toBeUndefined();
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/openclaw-sessions.json",
+      }),
+    ).toBeUndefined();
   });
 
   it("does not overwrite another active run's restart recovery context", async () => {
@@ -1350,13 +1396,18 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     const laterRunEntry: SessionEntry = {
       sessionId: "session-1",
       updatedAt: 2,
-      restartRecoveryDeliveryContext: {
+    };
+    claimRestartRecoveryDeliveryContext({
+      context: {
         channel: "discord",
         to: "discord:dm:456",
         accountId: "main",
       },
-      restartRecoveryDeliveryRunId: "later-run",
-    };
+      runId: "later-run",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+    });
     const sessionStore: Record<string, SessionEntry> = {
       "agent:main:main": laterRunEntry,
     };
@@ -1374,10 +1425,16 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       runId: "stale-run",
     });
 
-    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryContext).toEqual(
-      laterRunEntry.restartRecoveryDeliveryContext,
-    );
-    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryRunId).toBe("later-run");
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/openclaw-sessions.json",
+      }),
+    ).toMatchObject({
+      runId: "later-run",
+      context: { channel: "discord", to: "discord:dm:456", accountId: "main" },
+    });
   });
 
   it("does not clear another active run's restart recovery context", async () => {
@@ -1390,13 +1447,18 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     const laterRunEntry: SessionEntry = {
       sessionId: "session-1",
       updatedAt: 2,
-      restartRecoveryDeliveryContext: {
+    };
+    claimRestartRecoveryDeliveryContext({
+      context: {
         channel: "discord",
         to: "discord:dm:456",
         accountId: "main",
       },
-      restartRecoveryDeliveryRunId: "later-run",
-    };
+      runId: "later-run",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+    });
     const sessionStore: Record<string, SessionEntry> = {
       "agent:main:main": laterRunEntry,
     };
@@ -1411,10 +1473,16 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       runId: "stale-run",
     });
 
-    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryContext).toEqual(
-      laterRunEntry.restartRecoveryDeliveryContext,
-    );
-    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryRunId).toBe("later-run");
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/openclaw-sessions.json",
+      }),
+    ).toMatchObject({
+      runId: "later-run",
+      context: { channel: "discord", to: "discord:dm:456", accountId: "main" },
+    });
   });
 
   it("keeps current run delivery context when restart marker wins the cleanup race", async () => {
@@ -1428,12 +1496,37 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.sessionEntryMock = sessionEntry;
     state.sessionStoreMock = sessionStore;
     state.storePathMock = "/tmp/openclaw-sessions.json";
-    state.deliverAgentCommandResultMock.mockImplementation(async () => {
-      const current = sessionStore["agent:main:main"];
-      if (current) {
-        current.abortedLastRun = true;
+    let restartMarkerWon = false;
+    state.persistSessionEntryMock.mockImplementation(async (...args: unknown[]) => {
+      const params = args[0] as {
+        sessionStore?: Record<string, SessionEntry>;
+        sessionKey?: string;
+        entry?: SessionEntry;
+        shouldPersist?: (entry: SessionEntry | undefined) => boolean;
+      };
+      const current =
+        params.sessionStore && params.sessionKey
+          ? params.sessionStore[params.sessionKey]
+          : undefined;
+      if (params.shouldPersist && !params.shouldPersist(current)) {
+        return current;
       }
-      return { deliverySucceeded: false };
+      if (params.sessionStore && params.sessionKey && params.entry) {
+        params.sessionStore[params.sessionKey] = {
+          ...params.entry,
+          ...(restartMarkerWon ? { abortedLastRun: true } : {}),
+        };
+        return params.sessionStore[params.sessionKey];
+      }
+      return current;
+    });
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      restartMarkerWon = true;
+      sessionStore["agent:main:main"] = {
+        ...(sessionStore["agent:main:main"] ?? sessionEntry),
+        abortedLastRun: true,
+      };
+      return { deliverySucceeded: true };
     });
 
     await agentCommand({
@@ -1445,18 +1538,20 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
 
     expect(sessionStore["agent:main:main"]?.abortedLastRun).toBe(true);
-    expect(state.persistSessionEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        entry: expect.objectContaining({
-          restartRecoveryDeliveryContext: {
-            channel: "discord",
-            to: "discord:dm:123",
-            accountId: "main",
-          },
-          restartRecoveryDeliveryRunId: "session-1",
-        }),
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: "/tmp/openclaw-sessions.json",
       }),
-    );
+    ).toMatchObject({
+      runId: "session-1",
+      context: {
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+      },
+    });
   });
 
   it("does not recreate a deleted session entry during restart recovery cleanup", async () => {
@@ -1496,11 +1591,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     const rotatedEntry: SessionEntry = {
       sessionId: "session-2",
       updatedAt: 2,
-      restartRecoveryDeliveryContext: {
-        channel: "discord",
-        to: "discord:dm:456",
-        accountId: "main",
-      },
     };
     const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
     state.sessionEntryMock = sessionEntry;
@@ -1532,13 +1622,18 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     const laterRunEntry: SessionEntry = {
       sessionId: "session-1",
       updatedAt: 2,
-      restartRecoveryDeliveryContext: {
+    };
+    claimRestartRecoveryDeliveryContext({
+      context: {
         channel: "discord",
         to: "discord:dm:456",
         accountId: "main",
       },
-      restartRecoveryDeliveryRunId: "later-run",
-    };
+      runId: "later-run",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+    });
     const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
     state.sessionEntryMock = sessionEntry;
     state.sessionStoreMock = sessionStore;

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -12,6 +12,7 @@ import {
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { getRuntimeConfig } from "../config/io.js";
+import { loadSessionStore } from "../config/sessions.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withLocalGatewayRequestScope } from "../gateway/local-request-context.js";
@@ -115,6 +116,10 @@ import {
 } from "./model-visibility-policy.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-codex-routing.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import {
+  claimRestartRecoveryDeliveryContext,
+  clearRestartRecoveryDeliveryContext,
+} from "./restart-recovery-delivery-state.js";
 import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 import { ensureAgentWorkspace } from "./workspace.js";
@@ -382,30 +387,51 @@ function shouldPersistCurrentRunSessionCleanup(
 function shouldPersistRestartRecoveryContextClaim(
   current: SessionEntry | undefined,
   sessionId: string,
-  runId: string,
   allowCreate: boolean,
 ): boolean {
   if (!current) {
     return allowCreate;
   }
-  if (!shouldPersistCurrentRunSessionCleanup(current, sessionId)) {
-    return false;
-  }
-  return (
-    current.restartRecoveryDeliveryRunId === undefined ||
-    current.restartRecoveryDeliveryRunId === runId
-  );
+  return shouldPersistCurrentRunSessionCleanup(current, sessionId);
 }
 
-function shouldPersistRestartRecoveryCleanup(
-  current: SessionEntry | undefined,
-  sessionId: string,
-  runId: string,
-): boolean {
-  return (
-    shouldPersistCurrentRunSessionCleanup(current, sessionId) &&
-    current?.restartRecoveryDeliveryRunId === runId
-  );
+function readDurableRestartRecoveryCleanupEntry(
+  storePath: string,
+  sessionKey: string,
+): SessionEntry | undefined {
+  try {
+    return loadSessionStore(storePath, {
+      hydrateSkillPromptRefs: false,
+      skipCache: true,
+    })[sessionKey];
+  } catch (error) {
+    log.warn(
+      `failed to read durable restart recovery cleanup entry for ${sessionKey}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return undefined;
+  }
+}
+
+function claimRestartRecoveryDeliveryContextBestEffort(params: {
+  context: DeliveryContext;
+  runId: string;
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+  updatedAtMs?: number;
+}): boolean {
+  try {
+    return claimRestartRecoveryDeliveryContext(params);
+  } catch (error) {
+    log.warn(
+      `failed to persist restart recovery delivery context for ${params.sessionKey}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
 }
 
 function containsControlCharacters(value: string): boolean {
@@ -771,26 +797,33 @@ async function agentCommandInternal(
         ...entry,
         sessionId,
         updatedAt: now,
-        restartRecoveryDeliveryContext: currentRunDeliveryContext,
-        restartRecoveryDeliveryRunId: currentRunDeliveryContext ? runId : undefined,
       };
+      let shouldClaimRestartRecoveryContext = false;
       const persisted = await persistSessionEntry({
         sessionStore,
         sessionKey,
         storePath,
         entry: next,
-        shouldPersist: (current) =>
-          shouldPersistRestartRecoveryContextClaim(
+        shouldPersist: (current) => {
+          shouldClaimRestartRecoveryContext = shouldPersistRestartRecoveryContextClaim(
             current,
             sessionId,
-            runId,
             allowCreateRestartRecoveryEntry,
-          ),
+          );
+          return shouldClaimRestartRecoveryContext;
+        },
       });
       sessionEntry = persisted ?? sessionEntry;
-      trackedRestartRecoveryDeliveryContext =
-        Boolean(persisted?.restartRecoveryDeliveryContext) &&
-        persisted?.restartRecoveryDeliveryRunId === runId;
+      if (shouldClaimRestartRecoveryContext && persisted && currentRunDeliveryContext) {
+        trackedRestartRecoveryDeliveryContext = claimRestartRecoveryDeliveryContextBestEffort({
+          context: currentRunDeliveryContext,
+          runId,
+          sessionId,
+          sessionKey,
+          storePath,
+          updatedAtMs: now,
+        });
+      }
     }
 
     if (!isRawModelRun && acpResolution?.kind === "ready" && sessionKey) {
@@ -1984,23 +2017,14 @@ async function agentCommandInternal(
   } finally {
     if (trackedRestartRecoveryDeliveryContext && sessionStore && sessionKey) {
       try {
-        const entry = sessionStore[sessionKey] ?? sessionEntry;
-        if (entry?.restartRecoveryDeliveryContext && entry.restartRecoveryDeliveryRunId === runId) {
-          const next: SessionEntry = {
-            ...entry,
-            restartRecoveryDeliveryContext: undefined,
-            restartRecoveryDeliveryRunId: undefined,
-            updatedAt: Date.now(),
-          };
-          const persisted = await persistSessionEntry({
-            sessionStore,
+        const entry = readDurableRestartRecoveryCleanupEntry(storePath, sessionKey);
+        if (shouldPersistCurrentRunSessionCleanup(entry, sessionId)) {
+          clearRestartRecoveryDeliveryContext({
+            runId,
+            sessionId,
             sessionKey,
             storePath,
-            entry: next,
-            shouldPersist: (current) =>
-              shouldPersistRestartRecoveryCleanup(current, sessionId, runId),
           });
-          sessionEntry = persisted ?? sessionEntry;
         }
       } catch (error) {
         log.warn(

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadSessionStore, type SessionEntry } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
@@ -13,6 +14,10 @@ import {
   markRestartAbortedMainSessionsFromLocks,
   recoverRestartAbortedMainSessions,
 } from "./main-session-restart-recovery.js";
+import {
+  claimRestartRecoveryDeliveryContext,
+  readRestartRecoveryDeliveryContext,
+} from "./restart-recovery-delivery-state.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
 
 vi.mock("../gateway/call.js", () => ({
@@ -27,6 +32,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -428,13 +434,19 @@ describe("main-session-restart-recovery", () => {
           to: "discord:dm:stale",
           accountId: "old",
         },
-        restartRecoveryDeliveryContext: {
-          channel: "discord",
-          to: "discord:dm:123",
-          accountId: "main",
-          threadId: 123,
-        },
       },
+    });
+    claimRestartRecoveryDeliveryContext({
+      context: {
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        threadId: 123,
+      },
+      runId: "run-interrupted",
+      sessionId: "main-session",
+      sessionKey: "agent:main:discord:direct:123",
+      storePath: path.join(sessionsDir, "sessions.json"),
     });
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "run the tool" },
@@ -483,6 +495,13 @@ describe("main-session-restart-recovery", () => {
 
     expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
     expect(firstGatewayParams().deliver).toBe(false);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "main-session",
+        sessionKey: "agent:main:discord:direct:123",
+        storePath: path.join(sessionsDir, "sessions.json"),
+      }),
+    ).toBeUndefined();
   });
 
   it("does not deliver restart recovery when session send policy denies sends", async () => {
@@ -493,12 +512,18 @@ describe("main-session-restart-recovery", () => {
         updatedAt: Date.now() - 10_000,
         status: "running",
         abortedLastRun: true,
-        restartRecoveryDeliveryContext: {
-          channel: "discord",
-          to: "discord:dm:123",
-          accountId: "main",
-        },
       },
+    });
+    claimRestartRecoveryDeliveryContext({
+      context: {
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+      },
+      runId: "run-interrupted",
+      sessionId: "main-session",
+      sessionKey: "agent:main:discord:direct:123",
+      storePath: path.join(sessionsDir, "sessions.json"),
     });
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "run the tool" },
@@ -525,6 +550,17 @@ describe("main-session-restart-recovery", () => {
         abortedLastRun: true,
       },
     });
+    claimRestartRecoveryDeliveryContext({
+      context: {
+        channel: "discord",
+        to: "discord:dm:interrupted",
+        accountId: "main",
+      },
+      runId: "run-interrupted",
+      sessionId: "main-session",
+      sessionKey: "agent:main:main",
+      storePath: path.join(sessionsDir, "sessions.json"),
+    });
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "run a command that needs approval" },
       { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
@@ -540,13 +576,23 @@ describe("main-session-restart-recovery", () => {
       },
     ]);
 
-    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+    const result = await recoverRestartAbortedMainSessions({
+      cfg: { session: { sendPolicy: { default: "deny" } } },
+      stateDir: tmpDir,
+    });
 
     expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
     expect(callGateway).not.toHaveBeenCalled();
     const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
     expect(store["agent:main:main"]?.status).toBe("failed");
     expect(store["agent:main:main"]?.abortedLastRun).toBe(true);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "main-session",
+        sessionKey: "agent:main:main",
+        storePath: path.join(sessionsDir, "sessions.json"),
+      }),
+    ).toBeUndefined();
   });
 
   it("resumes marked sessions with a durable pending final delivery payload (Phase 2)", async () => {
@@ -566,11 +612,6 @@ describe("main-session-restart-recovery", () => {
           accountId: "main",
         },
         pendingFinalDeliveryCreatedAt: Date.now() - 5_000,
-        restartRecoveryDeliveryContext: {
-          channel: "discord",
-          to: "discord:dm:stale",
-          accountId: "old",
-        },
       },
     });
     await writeTranscript(sessionsDir, "main-session", [

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -30,6 +30,10 @@ import {
   type DeliveryContext,
 } from "../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
+import {
+  clearRestartRecoveryDeliveryContext,
+  readRestartRecoveryDeliveryContext,
+} from "./restart-recovery-delivery-state.js";
 import { resolveAgentSessionDirs } from "./session-dirs.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
 
@@ -41,6 +45,46 @@ const RETRY_BACKOFF_MULTIPLIER = 2;
 const UNRESUMABLE_SESSION_NOTICE =
   "I was interrupted by a gateway restart and couldn't safely resume the previous turn. " +
   "Please send that last request again and I'll pick it up cleanly.";
+
+type ResolvedRestartRecoveryDeliveryContext = {
+  context?: DeliveryContext;
+  runId?: string;
+};
+
+function readRestartRecoveryDeliveryContextBestEffort(params: {
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+}): { context: DeliveryContext; runId: string } | undefined {
+  try {
+    const record = readRestartRecoveryDeliveryContext(params);
+    return record ? { context: record.context, runId: record.runId } : undefined;
+  } catch (error) {
+    log.warn(
+      `failed to read restart recovery delivery context for ${params.sessionKey}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return undefined;
+  }
+}
+
+function clearRestartRecoveryDeliveryContextBestEffort(params: {
+  runId?: string;
+  sessionId?: string;
+  sessionKey: string;
+  storePath: string;
+}): void {
+  try {
+    clearRestartRecoveryDeliveryContext(params);
+  } catch (error) {
+    log.warn(
+      `failed to clear restart recovery delivery context for ${params.sessionKey}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
 
 function shouldSkipMainRecovery(entry: SessionEntry, sessionKey: string): boolean {
   if (typeof entry.spawnDepth === "number" && entry.spawnDepth > 0) {
@@ -259,7 +303,10 @@ async function markSessionFailed(params: {
   storePath: string;
   sessionKey: string;
   reason: string;
+  restartRecoveryDeliveryRunId?: string;
 }): Promise<void> {
+  let failedSessionId: string | undefined;
+  let failedRestartRecoveryDeliveryRunId: string | undefined;
   await updateSessionStore(
     params.storePath,
     (store) => {
@@ -268,6 +315,8 @@ async function markSessionFailed(params: {
         return;
       }
       entry.status = "failed";
+      failedSessionId = entry.sessionId;
+      failedRestartRecoveryDeliveryRunId = params.restartRecoveryDeliveryRunId;
       entry.abortedLastRun = true;
       entry.endedAt = Date.now();
       entry.updatedAt = entry.endedAt;
@@ -278,12 +327,18 @@ async function markSessionFailed(params: {
       entry.pendingFinalDeliveryAttemptCount = undefined;
       entry.pendingFinalDeliveryLastError = undefined;
       entry.pendingFinalDeliveryContext = undefined;
-      entry.restartRecoveryDeliveryContext = undefined;
-      entry.restartRecoveryDeliveryRunId = undefined;
       store[params.sessionKey] = entry;
     },
     { skipMaintenance: true },
   );
+  if (failedSessionId && failedRestartRecoveryDeliveryRunId) {
+    clearRestartRecoveryDeliveryContextBestEffort({
+      runId: failedRestartRecoveryDeliveryRunId,
+      sessionId: failedSessionId,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+    });
+  }
   log.warn(`marked interrupted main session failed: ${params.sessionKey} (${params.reason})`);
 }
 
@@ -292,16 +347,19 @@ async function sendUnresumableSessionNotice(params: {
   entry: SessionEntry;
   reason: string;
   sessionKey: string;
+  storePath: string;
 }): Promise<boolean> {
-  const deliveryContext = resolveRestartRecoveryDeliveryContext({
+  const resolvedDeliveryContext = resolveRestartRecoveryDeliveryContext({
     cfg: params.cfg,
     entry: params.entry,
     includeSessionDeliveryFallback: true,
     sessionKey: params.sessionKey,
+    storePath: params.storePath,
   });
-  if (!deliveryContext) {
+  if (!resolvedDeliveryContext?.context) {
     return false;
   }
+  const deliveryContext = resolvedDeliveryContext.context;
 
   const messageParams: Record<string, unknown> = {
     to: deliveryContext.to,
@@ -347,15 +405,22 @@ function resolveRestartRecoveryDeliveryContext(params: {
   entry: SessionEntry;
   includeSessionDeliveryFallback?: boolean;
   sessionKey: string;
-}): DeliveryContext | undefined {
+  storePath: string;
+}): ResolvedRestartRecoveryDeliveryContext | undefined {
+  const storedDeliveryContext = readRestartRecoveryDeliveryContextBestEffort({
+    sessionId: params.entry.sessionId,
+    sessionKey: params.sessionKey,
+    storePath: params.storePath,
+  });
   const deliveryContext =
     normalizeDeliveryContext(params.entry.pendingFinalDeliveryContext) ??
-    normalizeDeliveryContext(params.entry.restartRecoveryDeliveryContext) ??
+    storedDeliveryContext?.context ??
     (params.includeSessionDeliveryFallback ? deliveryContextFromSession(params.entry) : undefined);
   const channel = normalizeOptionalString(deliveryContext?.channel);
   const to = normalizeOptionalString(deliveryContext?.to);
+  const runId = storedDeliveryContext?.runId;
   if (!channel || !to || !isDeliverableMessageChannel(channel)) {
-    return undefined;
+    return runId ? { runId } : undefined;
   }
   if (
     params.cfg &&
@@ -367,12 +432,15 @@ function resolveRestartRecoveryDeliveryContext(params: {
       chatType: params.entry.chatType,
     }) === "deny"
   ) {
-    return undefined;
+    return runId ? { runId } : undefined;
   }
   return {
-    ...deliveryContext,
-    channel,
-    to,
+    context: {
+      ...deliveryContext,
+      channel,
+      to,
+    },
+    runId,
   };
 }
 
@@ -387,11 +455,13 @@ async function resumeMainSession(params: {
     typeof params.pendingFinalDeliveryText === "string"
       ? sanitizePendingFinalDeliveryText(params.pendingFinalDeliveryText)
       : "";
-  const deliveryContext = resolveRestartRecoveryDeliveryContext({
+  const resolvedDeliveryContext = resolveRestartRecoveryDeliveryContext({
     cfg: params.cfg,
     entry: params.entry,
     sessionKey: params.sessionKey,
+    storePath: params.storePath,
   });
+  const deliveryContext = resolvedDeliveryContext?.context;
   try {
     const agentParams: Record<string, unknown> = {
       message: buildResumeMessage(sanitizedPendingText),
@@ -447,6 +517,14 @@ async function resumeMainSession(params: {
       },
       { skipMaintenance: true },
     );
+    if (resolvedDeliveryContext?.runId) {
+      clearRestartRecoveryDeliveryContextBestEffort({
+        runId: resolvedDeliveryContext.runId,
+        sessionId: params.entry.sessionId,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+      });
+    }
     log.info(
       `resumed interrupted main session: ${params.sessionKey}${
         sanitizedPendingText ? " (with pending payload)" : ""
@@ -554,16 +632,25 @@ async function recoverStore(params: {
 
     const resumeBlockReason = resolveMainSessionResumeBlockReason(messages);
     if (resumeBlockReason) {
+      const resolvedDeliveryContext = resolveRestartRecoveryDeliveryContext({
+        cfg: params.cfg,
+        entry,
+        includeSessionDeliveryFallback: true,
+        sessionKey,
+        storePath: params.storePath,
+      });
       await sendUnresumableSessionNotice({
         cfg: params.cfg,
         entry,
         sessionKey,
+        storePath: params.storePath,
         reason: resumeBlockReason,
       });
       await markSessionFailed({
         storePath: params.storePath,
         sessionKey,
         reason: resumeBlockReason,
+        restartRecoveryDeliveryRunId: resolvedDeliveryContext?.runId,
       });
       result.failed++;
       continue;

--- a/src/agents/restart-recovery-delivery-state.test.ts
+++ b/src/agents/restart-recovery-delivery-state.test.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  claimRestartRecoveryDeliveryContext,
+  clearRestartRecoveryDeliveryContext,
+  clearRestartRecoveryDeliveryContextsForTest,
+  readRestartRecoveryDeliveryContext,
+} from "./restart-recovery-delivery-state.js";
+
+afterEach(() => {
+  clearRestartRecoveryDeliveryContextsForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("restart recovery delivery state", () => {
+  it("claims, reads, updates, and clears delivery contexts by run ownership", () => {
+    const base = {
+      runId: "run-1",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: "relative-sessions.json",
+      updatedAtMs: 100,
+    };
+
+    expect(
+      claimRestartRecoveryDeliveryContext({
+        ...base,
+        context: {
+          channel: "discord",
+          to: "discord:dm:123",
+          accountId: "main",
+          threadId: 123,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: "relative-sessions.json",
+      }),
+    ).toMatchObject({
+      context: {
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        threadId: 123,
+      },
+      runId: "run-1",
+      sessionId: "session-1",
+      updatedAtMs: 100,
+    });
+
+    expect(
+      claimRestartRecoveryDeliveryContext({
+        ...base,
+        runId: "run-2",
+        context: {
+          channel: "discord",
+          to: "discord:dm:456",
+        },
+      }),
+    ).toBe(false);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionKey: "agent:main:main",
+        storePath: "relative-sessions.json",
+      }),
+    ).toMatchObject({ runId: "run-1", context: { to: "discord:dm:123" } });
+
+    expect(
+      claimRestartRecoveryDeliveryContext({
+        ...base,
+        runId: "run-2",
+        replaceExisting: true,
+        context: {
+          channel: "discord",
+          to: "discord:dm:456",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionKey: "agent:main:main",
+        storePath: "relative-sessions.json",
+      }),
+    ).toMatchObject({ runId: "run-2", context: { to: "discord:dm:456" } });
+
+    expect(
+      claimRestartRecoveryDeliveryContext({
+        ...base,
+        runId: "run-3",
+        sessionId: "session-2",
+        updatedAtMs: 150,
+        context: {
+          channel: "discord",
+          to: "discord:dm:456",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionKey: "agent:main:main",
+        storePath: "relative-sessions.json",
+      }),
+    ).toMatchObject({ runId: "run-3", sessionId: "session-2" });
+    expect(
+      clearRestartRecoveryDeliveryContext({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        storePath: "relative-sessions.json",
+      }),
+    ).toBe(false);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionKey: "agent:main:main",
+        storePath: "relative-sessions.json",
+      }),
+    ).toMatchObject({ runId: "run-3", sessionId: "session-2" });
+
+    expect(
+      claimRestartRecoveryDeliveryContext({
+        ...base,
+        runId: "run-3",
+        sessionId: "session-2",
+        updatedAtMs: 200,
+        context: {
+          channel: "discord",
+          to: "discord:dm:789",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      clearRestartRecoveryDeliveryContext({
+        ...base,
+        runId: "run-2",
+      }),
+    ).toBe(false);
+    expect(
+      clearRestartRecoveryDeliveryContext({
+        ...base,
+        runId: "run-3",
+        sessionId: "session-2",
+      }),
+    ).toBe(true);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionKey: "agent:main:main",
+        storePath: "relative-sessions.json",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("uses the real session store path as the SQLite key", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-restart-state-"));
+    const realSessionsDir = path.join(tmpDir, "state", "agents", "main", "sessions");
+    const aliasDir = path.join(tmpDir, "alias-sessions");
+    fs.mkdirSync(realSessionsDir, { recursive: true });
+    const realStorePath = path.join(realSessionsDir, "sessions.json");
+    fs.writeFileSync(realStorePath, "{}");
+    fs.symlinkSync(realSessionsDir, aliasDir);
+    const aliasStorePath = path.join(aliasDir, "sessions.json");
+    try {
+      expect(
+        claimRestartRecoveryDeliveryContext({
+          context: {
+            channel: "discord",
+            to: "discord:dm:123",
+          },
+          runId: "run-1",
+          sessionId: "session-1",
+          sessionKey: "agent:main:main",
+          storePath: aliasStorePath,
+        }),
+      ).toBe(true);
+      expect(
+        readRestartRecoveryDeliveryContext({
+          sessionId: "session-1",
+          sessionKey: "agent:main:main",
+          storePath: realStorePath,
+        }),
+      ).toMatchObject({
+        runId: "run-1",
+        context: { to: "discord:dm:123" },
+      });
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/restart-recovery-delivery-state.ts
+++ b/src/agents/restart-recovery-delivery-state.ts
@@ -1,0 +1,242 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import {
+  normalizeDeliveryContext,
+  type DeliveryContext,
+} from "../utils/delivery-context.shared.js";
+
+export type RestartRecoveryDeliveryContextRecord = {
+  context: DeliveryContext;
+  runId: string;
+  sessionId: string;
+  updatedAtMs: number;
+};
+
+function normalizeStorePath(storePath: string): string {
+  const resolved = path.resolve(storePath);
+  try {
+    return fs.realpathSync.native(resolved);
+  } catch {
+    try {
+      return path.join(fs.realpathSync.native(path.dirname(resolved)), path.basename(resolved));
+    } catch {
+      return resolved;
+    }
+  }
+}
+
+function resolveStateDatabaseOptionsForStorePath(
+  storePath: string,
+  stateDir?: string,
+): OpenClawStateDatabaseOptions {
+  if (stateDir) {
+    return {
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+      },
+    };
+  }
+  const normalized = normalizeStorePath(storePath);
+  if (path.basename(normalized) !== "sessions.json") {
+    return {};
+  }
+  const sessionsDir = path.dirname(normalized);
+  if (path.basename(sessionsDir) !== "sessions") {
+    return {};
+  }
+  const agentDir = path.dirname(sessionsDir);
+  const agentsDir = path.dirname(agentDir);
+  if (path.basename(agentsDir) !== "agents") {
+    return {};
+  }
+  return {
+    env: {
+      ...process.env,
+      OPENCLAW_STATE_DIR: path.dirname(agentsDir),
+    },
+  };
+}
+
+function normalizeRowContext(value: string): DeliveryContext | undefined {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const candidate = parsed as Partial<DeliveryContext>;
+    return normalizeDeliveryContext({
+      channel: candidate.channel,
+      to: candidate.to,
+      accountId: candidate.accountId,
+      threadId: candidate.threadId,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+export function claimRestartRecoveryDeliveryContext(params: {
+  context: DeliveryContext;
+  runId: string;
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+  replaceExisting?: boolean;
+  stateDir?: string;
+  updatedAtMs?: number;
+}): boolean {
+  const context = normalizeDeliveryContext(params.context);
+  if (!context?.channel || !context.to) {
+    return false;
+  }
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const storePath = normalizeStorePath(params.storePath);
+      const existing = db
+        .prepare(
+          `SELECT run_id AS runId, session_id AS sessionId
+           FROM restart_recovery_delivery_contexts
+          WHERE store_path = ? AND session_key = ?`,
+        )
+        .get(storePath, params.sessionKey) as { runId?: unknown; sessionId?: unknown } | undefined;
+      if (
+        existing?.sessionId === params.sessionId &&
+        existing.runId !== params.runId &&
+        !params.replaceExisting
+      ) {
+        return false;
+      }
+      db.prepare(
+        `INSERT INTO restart_recovery_delivery_contexts (
+         store_path,
+         session_key,
+         session_id,
+         run_id,
+         context_json,
+         updated_at_ms
+       )
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(store_path, session_key) DO UPDATE SET
+         session_id = excluded.session_id,
+         run_id = excluded.run_id,
+         context_json = excluded.context_json,
+         updated_at_ms = excluded.updated_at_ms`,
+      ).run(
+        storePath,
+        params.sessionKey,
+        params.sessionId,
+        params.runId,
+        JSON.stringify(context),
+        params.updatedAtMs ?? Date.now(),
+      );
+      return true;
+    },
+    resolveStateDatabaseOptionsForStorePath(params.storePath, params.stateDir),
+  );
+}
+
+export function readRestartRecoveryDeliveryContext(params: {
+  sessionId?: string;
+  sessionKey: string;
+  stateDir?: string;
+  storePath: string;
+}): RestartRecoveryDeliveryContextRecord | undefined {
+  const { db } = openOpenClawStateDatabase(
+    resolveStateDatabaseOptionsForStorePath(params.storePath, params.stateDir),
+  );
+  const row = db
+    .prepare(
+      `SELECT session_id AS sessionId,
+                run_id AS runId,
+                context_json AS contextJson,
+                updated_at_ms AS updatedAtMs
+           FROM restart_recovery_delivery_contexts
+          WHERE store_path = ? AND session_key = ?`,
+    )
+    .get(normalizeStorePath(params.storePath), params.sessionKey) as
+    | {
+        contextJson?: unknown;
+        runId?: unknown;
+        sessionId?: unknown;
+        updatedAtMs?: unknown;
+      }
+    | undefined;
+  if (!row || (params.sessionId && row.sessionId !== params.sessionId)) {
+    return undefined;
+  }
+  if (
+    typeof row.contextJson !== "string" ||
+    typeof row.runId !== "string" ||
+    typeof row.sessionId !== "string" ||
+    typeof row.updatedAtMs !== "number"
+  ) {
+    return undefined;
+  }
+  const context = normalizeRowContext(row.contextJson);
+  if (!context?.channel || !context.to) {
+    return undefined;
+  }
+  return {
+    context,
+    runId: row.runId,
+    sessionId: row.sessionId,
+    updatedAtMs: row.updatedAtMs,
+  };
+}
+
+export function clearRestartRecoveryDeliveryContext(params: {
+  runId?: string;
+  sessionId?: string;
+  sessionKey: string;
+  stateDir?: string;
+  storePath: string;
+}): boolean {
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const storePath = normalizeStorePath(params.storePath);
+      const result =
+        params.runId && params.sessionId
+          ? db
+              .prepare(
+                `DELETE FROM restart_recovery_delivery_contexts
+              WHERE store_path = ?
+                AND session_key = ?
+                AND session_id = ?
+                AND run_id = ?`,
+              )
+              .run(storePath, params.sessionKey, params.sessionId, params.runId)
+          : params.sessionId
+            ? db
+                .prepare(
+                  `DELETE FROM restart_recovery_delivery_contexts
+                WHERE store_path = ?
+                  AND session_key = ?
+                  AND session_id = ?`,
+                )
+                .run(storePath, params.sessionKey, params.sessionId)
+            : db
+                .prepare(
+                  `DELETE FROM restart_recovery_delivery_contexts
+                WHERE store_path = ? AND session_key = ?`,
+                )
+                .run(storePath, params.sessionKey);
+      return Number(result.changes ?? 0) > 0;
+    },
+    resolveStateDatabaseOptionsForStorePath(params.storePath, params.stateDir),
+  );
+}
+
+export function clearRestartRecoveryDeliveryContextsForTest(): void {
+  if (!process.env.VITEST) {
+    throw new Error("clearRestartRecoveryDeliveryContextsForTest is test-only.");
+  }
+  runOpenClawStateWriteTransaction(({ db }) => {
+    db.prepare("DELETE FROM restart_recovery_delivery_contexts").run();
+  });
+}

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { readRestartRecoveryDeliveryContext } from "../../agents/restart-recovery-delivery-state.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import type { TemplateContext } from "../templating.js";
@@ -514,14 +515,18 @@ describe("runReplyAgent pending final delivery capture", () => {
     const sessionStore = { main: sessionEntry };
     const storePath = await createSessionStoreFile(sessionEntry);
     state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
-      const storedDuringRun = await readStoredMainSession(storePath);
-      expect(storedDuringRun.restartRecoveryDeliveryContext).toEqual({
+      const storedDuringRun = readRestartRecoveryDeliveryContext({
+        sessionId: "session",
+        sessionKey: "main",
+        storePath,
+      });
+      expect(storedDuringRun?.context).toEqual({
         channel: "discord",
         to: "channel:24680",
         accountId: "work",
         threadId: "1503645939964055592",
       });
-      expect(typeof storedDuringRun.restartRecoveryDeliveryRunId).toBe("string");
+      expect(typeof storedDuringRun?.runId).toBe("string");
       return {
         payloads: [{ text: "visible final" }],
         meta: {},
@@ -555,8 +560,9 @@ describe("runReplyAgent pending final delivery capture", () => {
       accountId: "work",
       threadId: "1503645939964055592",
     });
-    expect(stored.restartRecoveryDeliveryContext).toBeUndefined();
-    expect(stored.restartRecoveryDeliveryRunId).toBeUndefined();
+    expect(
+      readRestartRecoveryDeliveryContext({ sessionId: "session", sessionKey: "main", storePath }),
+    ).toBeUndefined();
   });
 
   it("keeps heartbeat replies with real content in pending final delivery", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -14,6 +14,10 @@ import {
 } from "../../agents/embedded-agent-runner/runs.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
+import {
+  claimRestartRecoveryDeliveryContext,
+  clearRestartRecoveryDeliveryContext as clearStoredRestartRecoveryDeliveryContext,
+} from "../../agents/restart-recovery-delivery-state.js";
 import { deriveContextPromptTokens, hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
 import { enqueueCommitmentExtraction } from "../../commitments/runtime.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -37,6 +41,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -104,6 +109,8 @@ import {
 } from "./queue.js";
 import { createReplyMediaContext } from "./reply-media-paths.js";
 import { replyRunRegistry, type ReplyOperation } from "./reply-run-registry.js";
+
+const log = createSubsystemLogger("auto-reply/agent-runner");
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { admitReplyTurn, resolveReplyTurnKind } from "./reply-turn-admission.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
@@ -1404,51 +1411,73 @@ export async function runReplyAgent(params: {
       return;
     }
     const updatedAt = Date.now();
-    const patch: Partial<SessionEntry> = {
-      restartRecoveryDeliveryContext: deliveryContext,
-      restartRecoveryDeliveryRunId,
-      updatedAt,
-    };
+    let shouldClaimRestartRecoveryContext = false;
     const persisted = await updateSessionStoreEntry({
       storePath,
       sessionKey,
-      update: async (current) =>
-        current.sessionId === replyOperation.sessionId && current.abortedLastRun !== true
-          ? patch
-          : null,
+      update: async (current) => {
+        shouldClaimRestartRecoveryContext =
+          current.sessionId === replyOperation.sessionId && current.abortedLastRun !== true;
+        return shouldClaimRestartRecoveryContext ? { updatedAt } : null;
+      },
     });
-    if (persisted) {
+    if (persisted && shouldClaimRestartRecoveryContext) {
       activeSessionEntry = persisted;
       if (activeSessionStore) {
         activeSessionStore[sessionKey] = persisted;
       }
-      trackedRestartRecoveryDeliveryContext =
-        persisted.restartRecoveryDeliveryRunId === restartRecoveryDeliveryRunId;
+      try {
+        trackedRestartRecoveryDeliveryContext = claimRestartRecoveryDeliveryContext({
+          context: deliveryContext,
+          runId: restartRecoveryDeliveryRunId,
+          sessionId: replyOperation.sessionId,
+          sessionKey,
+          storePath,
+          replaceExisting: true,
+          updatedAtMs: updatedAt,
+        });
+      } catch (error) {
+        log.warn(
+          `failed to persist restart recovery delivery context for ${sessionKey}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        trackedRestartRecoveryDeliveryContext = false;
+      }
     }
   };
   const clearRestartRecoveryDeliveryContext = async (): Promise<void> => {
     if (!trackedRestartRecoveryDeliveryContext || !sessionKey || !storePath) {
       return;
     }
-    const patch: Partial<SessionEntry> = {
-      restartRecoveryDeliveryContext: undefined,
-      restartRecoveryDeliveryRunId: undefined,
-      updatedAt: Date.now(),
-    };
-    const persisted = await updateSessionStoreEntry({
-      storePath,
-      sessionKey,
-      update: async (current) =>
-        current.sessionId === replyOperation.sessionId &&
-        current.abortedLastRun !== true &&
-        current.restartRecoveryDeliveryRunId === restartRecoveryDeliveryRunId
-          ? patch
-          : null,
-    });
-    if (persisted) {
-      activeSessionEntry = persisted;
-      if (activeSessionStore) {
-        activeSessionStore[sessionKey] = persisted;
+    let entry: SessionEntry | undefined;
+    try {
+      entry = loadSessionStore(storePath, {
+        hydrateSkillPromptRefs: false,
+        skipCache: true,
+      })[sessionKey];
+    } catch (error) {
+      log.warn(
+        `failed to read durable restart recovery cleanup entry for ${sessionKey}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return;
+    }
+    if (entry?.sessionId === replyOperation.sessionId && entry.abortedLastRun !== true) {
+      try {
+        clearStoredRestartRecoveryDeliveryContext({
+          runId: restartRecoveryDeliveryRunId,
+          sessionId: replyOperation.sessionId,
+          sessionKey,
+          storePath,
+        });
+      } catch (error) {
+        log.warn(
+          `failed to clear restart recovery delivery context for ${sessionKey}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
       }
     }
   };

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -201,6 +201,11 @@ function createLegacyStateMigrationDetectionResult(params?: {
       hasLegacy: params?.hasLegacySessions ?? false,
       legacyKeys: [],
     },
+    restartRecoveryDeliveryContexts: {
+      hasLegacy: false,
+      count: 0,
+      storePaths: [],
+    },
     agentDir: {
       legacyDir: "/tmp/state/agent",
       targetDir: "/tmp/state/agents/main/agent",

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -433,8 +433,12 @@ describe("session store writer queue", () => {
     expect(bad?.pendingFinalDeliveryLastError).toBeUndefined();
     expect(bad?.pendingFinalDeliveryContext).toBeUndefined();
     expect(bad?.pendingFinalDeliveryIntentId).toBeUndefined();
-    expect(bad?.restartRecoveryDeliveryContext).toBeUndefined();
-    expect(bad?.restartRecoveryDeliveryRunId).toBeUndefined();
+    expect(
+      (bad as Record<string, unknown> | undefined)?.restartRecoveryDeliveryContext,
+    ).toBeUndefined();
+    expect(
+      (bad as Record<string, unknown> | undefined)?.restartRecoveryDeliveryRunId,
+    ).toBeUndefined();
 
     expect(good).toMatchObject({
       pendingFinalDelivery: true,
@@ -450,14 +454,13 @@ describe("session store writer queue", () => {
         threadId: 42,
       },
       pendingFinalDeliveryIntentId: "intent-1",
-      restartRecoveryDeliveryContext: {
-        channel: "discord",
-        to: "discord:dm:123",
-        accountId: "main",
-        threadId: "reply-1",
-      },
-      restartRecoveryDeliveryRunId: "run-1",
     });
+    expect(
+      (good as Record<string, unknown> | undefined)?.restartRecoveryDeliveryContext,
+    ).toBeUndefined();
+    expect(
+      (good as Record<string, unknown> | undefined)?.restartRecoveryDeliveryRunId,
+    ).toBeUndefined();
   });
 
   it("strips malformed plugin extension state on load", async () => {

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -72,10 +72,6 @@ function normalizeOptionalStringOrNull(value: unknown): string | null | undefine
   return undefined;
 }
 
-function normalizeOptionalString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
-
 function normalizeRecordKey(value: string): string | undefined {
   const key = value.trim();
   return key.length > 0 ? key : undefined;
@@ -156,18 +152,21 @@ function normalizePendingFinalDeliveryFields(entry: SessionEntry): SessionEntry 
     "pendingFinalDeliveryIntentId",
     normalizeOptionalStringOrNull(entry.pendingFinalDeliveryIntentId),
   );
-  const restartRecoveryDeliveryContext = normalizeOptionalDeliveryContext(
-    entry.restartRecoveryDeliveryContext,
-  );
-  if (!sameDeliveryContext(entry.restartRecoveryDeliveryContext, restartRecoveryDeliveryContext)) {
-    assign("restartRecoveryDeliveryContext", restartRecoveryDeliveryContext);
-  }
-  assign(
-    "restartRecoveryDeliveryRunId",
-    normalizeOptionalString(entry.restartRecoveryDeliveryRunId),
-  );
-
   return next;
+}
+
+function stripLegacyRestartRecoveryDeliveryFields(entry: SessionEntry): SessionEntry {
+  const record = entry as unknown as Record<string, unknown>;
+  if (
+    !("restartRecoveryDeliveryContext" in record) &&
+    !("restartRecoveryDeliveryRunId" in record)
+  ) {
+    return entry;
+  }
+  const next = { ...entry } as unknown as Record<string, unknown>;
+  delete next.restartRecoveryDeliveryContext;
+  delete next.restartRecoveryDeliveryRunId;
+  return next as unknown as SessionEntry;
 }
 
 function normalizePluginExtensions(entry: SessionEntry): SessionEntry {
@@ -353,10 +352,12 @@ export function normalizeSessionStore(store: Record<string, SessionEntry>): bool
       continue;
     }
     const normalized = stripPersistedSkillsCache(
-      normalizePluginExtensionSlotKeys(
-        normalizePluginExtensions(
-          normalizePendingFinalDeliveryFields(
-            normalizeSessionEntryDelivery(normalizeSessionRuntimeModelFields(shaped)),
+      stripLegacyRestartRecoveryDeliveryFields(
+        normalizePluginExtensionSlotKeys(
+          normalizePluginExtensions(
+            normalizePendingFinalDeliveryFields(
+              normalizeSessionEntryDelivery(normalizeSessionRuntimeModelFields(shaped)),
+            ),
           ),
         ),
       ),

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -371,10 +371,6 @@ export type SessionEntry = {
   pendingFinalDeliveryContext?: DeliveryContext;
   /** Durable send intent backing pending final delivery, when already created. */
   pendingFinalDeliveryIntentId?: string | null;
-  /** Current visible run delivery context used only for restart recovery. */
-  restartRecoveryDeliveryContext?: DeliveryContext;
-  /** Active run id that owns restartRecoveryDeliveryContext cleanup. */
-  restartRecoveryDeliveryRunId?: string;
   /**
    * Whether totalTokens reflects a fresh context snapshot for the latest run.
    * Undefined means legacy/unknown freshness; false forces consumers to treat

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -2,8 +2,10 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readRestartRecoveryDeliveryContext } from "../agents/restart-recovery-delivery-state.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveChannelAllowFromPath } from "../pairing/pairing-store.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import { detectLegacyStateMigrations, runLegacyStateMigrations } from "./state-migrations.js";
 
@@ -170,6 +172,7 @@ async function createLegacyStateFixture(params?: { includePreKey?: boolean }) {
 }
 
 afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
   await tempDirs.cleanup();
 });
 
@@ -270,5 +273,219 @@ describe("state migrations", () => {
     ).resolves.toBe('["123","456"]\n');
     await expectMissingPath(resolveChannelAllowFromPath("chatapp", env, "default"));
     await expectMissingPath(resolveChannelAllowFromPath("chatapp", env, "beta"));
+  });
+
+  it("migrates legacy restart recovery delivery fields into SQLite", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg = createConfig();
+    const storePath = path.join(stateDir, "agents", "worker-1", "sessions", "sessions.json");
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      `${JSON.stringify(
+        {
+          "agent:worker-1:desk": {
+            sessionId: "session-1",
+            updatedAt: 123,
+            restartRecoveryDeliveryContext: {
+              channel: "Discord",
+              to: " discord:dm:123 ",
+              accountId: "Main",
+              threadId: 42.5,
+            },
+            restartRecoveryDeliveryRunId: "run-1",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+      homedir: () => root,
+    });
+    expect(detected.restartRecoveryDeliveryContexts).toMatchObject({
+      hasLegacy: true,
+      count: 1,
+    });
+    expect(detected.preview).toEqual([
+      "- Restart recovery delivery contexts: migrate 1 session JSON route → shared SQLite state",
+    ]);
+
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated 1 restart recovery delivery context → shared SQLite state",
+    ]);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "session-1",
+        sessionKey: "agent:worker-1:desk",
+        storePath,
+      }),
+    ).toMatchObject({
+      runId: "run-1",
+      sessionId: "session-1",
+      context: {
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        threadId: 42,
+      },
+      updatedAtMs: 123,
+    });
+    const migratedStore = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(migratedStore["agent:worker-1:desk"]?.restartRecoveryDeliveryContext).toBeUndefined();
+    expect(migratedStore["agent:worker-1:desk"]?.restartRecoveryDeliveryRunId).toBeUndefined();
+  });
+
+  it("migrates restart recovery delivery fields while merging legacy sessions", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg = createConfig();
+    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
+    const targetStorePath = path.join(stateDir, "agents", "worker-1", "sessions", "sessions.json");
+    await fs.mkdir(path.dirname(legacyStorePath), { recursive: true });
+    await fs.writeFile(
+      legacyStorePath,
+      `${JSON.stringify(
+        {
+          legacyDirect: {
+            sessionId: "legacy-session",
+            updatedAt: 456,
+            restartRecoveryDeliveryContext: {
+              channel: "discord",
+              to: "discord:dm:456",
+            },
+            restartRecoveryDeliveryRunId: "legacy-run",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+      homedir: () => root,
+    });
+
+    expect(detected.sessions.hasLegacy).toBe(true);
+    expect(detected.restartRecoveryDeliveryContexts.count).toBe(1);
+    const result = await runLegacyStateMigrations({
+      detected,
+      now: () => 1234,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated latest direct-chat session → agent:worker-1:desk",
+      "Migrated 2 restart recovery delivery contexts → shared SQLite state",
+      `Merged sessions store → ${targetStorePath}`,
+    ]);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "legacy-session",
+        sessionKey: "agent:worker-1:desk",
+        storePath: targetStorePath,
+      }),
+    ).toMatchObject({
+      runId: "legacy-run",
+      context: {
+        channel: "discord",
+        to: "discord:dm:456",
+      },
+      updatedAtMs: 456,
+    });
+    const migratedStore = JSON.parse(await fs.readFile(targetStorePath, "utf8")) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(migratedStore["agent:worker-1:desk"]?.restartRecoveryDeliveryContext).toBeUndefined();
+    expect(migratedStore["agent:worker-1:desk"]?.restartRecoveryDeliveryRunId).toBeUndefined();
+    await expectMissingPath(legacyStorePath);
+  });
+
+  it("migrates restart recovery delivery fields from discovered agent stores", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg = createConfig();
+    const storePath = path.join(stateDir, "agents", "sidekick", "sessions", "sessions.json");
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      `${JSON.stringify(
+        {
+          "agent:sidekick:main": {
+            sessionId: "side-session",
+            updatedAt: 789,
+            restartRecoveryDeliveryContext: {
+              channel: "discord",
+              to: "discord:dm:789",
+            },
+            restartRecoveryDeliveryRunId: "side-run",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+      homedir: () => root,
+    });
+
+    expect(detected.restartRecoveryDeliveryContexts).toMatchObject({
+      hasLegacy: true,
+      count: 1,
+    });
+    expect(
+      detected.restartRecoveryDeliveryContexts.storePaths.some((candidate) =>
+        candidate.endsWith(path.join("agents", "sidekick", "sessions", "sessions.json")),
+      ),
+    ).toBe(true);
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated 1 restart recovery delivery context → shared SQLite state",
+    ]);
+    expect(
+      readRestartRecoveryDeliveryContext({
+        sessionId: "side-session",
+        sessionKey: "agent:sidekick:main",
+        stateDir,
+        storePath,
+      }),
+    ).toMatchObject({
+      runId: "side-run",
+      context: {
+        channel: "discord",
+        to: "discord:dm:789",
+      },
+      updatedAtMs: 789,
+    });
+    const migratedStore = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(migratedStore["agent:sidekick:main"]?.restartRecoveryDeliveryContext).toBeUndefined();
+    expect(migratedStore["agent:sidekick:main"]?.restartRecoveryDeliveryRunId).toBeUndefined();
   });
 });

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { claimRestartRecoveryDeliveryContext } from "../agents/restart-recovery-delivery-state.js";
 import {
   listBundledChannelLegacySessionSurfaces,
   listBundledChannelLegacyStateMigrationDetectors,
@@ -15,7 +16,7 @@ import {
   resolveStateDir,
 } from "../config/paths.js";
 import type { SessionEntry } from "../config/sessions.js";
-import { saveSessionStore } from "../config/sessions.js";
+import { resolveAllAgentSessionStoreTargetsSync, saveSessionStore } from "../config/sessions.js";
 import { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
 import type { SessionScope } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -37,6 +38,10 @@ import { normalizeSessionKeyPreservingOpaquePeerIds } from "../sessions/session-
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import {
+  normalizeDeliveryContext,
+  type DeliveryContext,
+} from "../utils/delivery-context.shared.js";
 import { expandHomePrefix } from "./home-dir.js";
 import {
   executeSqliteQuerySync,
@@ -68,6 +73,11 @@ export type LegacyStateDetection = {
     targetStorePath: string;
     hasLegacy: boolean;
     legacyKeys: string[];
+  };
+  restartRecoveryDeliveryContexts: {
+    hasLegacy: boolean;
+    count: number;
+    storePaths: string[];
   };
   agentDir: {
     legacyDir: string;
@@ -1219,6 +1229,81 @@ function normalizeSessionEntry(entry: SessionEntryLike): SessionEntry | null {
   return normalized;
 }
 
+type LegacyRestartRecoveryDeliveryContextCandidate = {
+  context: DeliveryContext;
+  runId: string;
+  sessionId: string;
+  updatedAtMs: number;
+};
+
+function hasLegacyRestartRecoveryDeliveryFields(entry: SessionEntryLike): boolean {
+  const record = entry as Record<string, unknown>;
+  return "restartRecoveryDeliveryContext" in record || "restartRecoveryDeliveryRunId" in record;
+}
+
+function readLegacyRestartRecoveryDeliveryContextCandidate(
+  entry: SessionEntryLike,
+): LegacyRestartRecoveryDeliveryContextCandidate | undefined {
+  const record = entry as Record<string, unknown>;
+  const sessionId = typeof record.sessionId === "string" ? record.sessionId : "";
+  const rawContext = record.restartRecoveryDeliveryContext;
+  if (!sessionId || !rawContext || typeof rawContext !== "object" || Array.isArray(rawContext)) {
+    return undefined;
+  }
+  const contextRecord = rawContext as Record<string, unknown>;
+  const context = normalizeDeliveryContext({
+    channel: typeof contextRecord.channel === "string" ? contextRecord.channel : undefined,
+    to: typeof contextRecord.to === "string" ? contextRecord.to : undefined,
+    accountId: typeof contextRecord.accountId === "string" ? contextRecord.accountId : undefined,
+    threadId:
+      typeof contextRecord.threadId === "string" || typeof contextRecord.threadId === "number"
+        ? contextRecord.threadId
+        : undefined,
+  });
+  if (!context?.channel || !context.to) {
+    return undefined;
+  }
+  const rawRunId = record.restartRecoveryDeliveryRunId;
+  const updatedAt = record.updatedAt;
+  return {
+    context,
+    runId: typeof rawRunId === "string" && rawRunId.trim() ? rawRunId : sessionId,
+    sessionId,
+    updatedAtMs:
+      typeof updatedAt === "number" && Number.isFinite(updatedAt) ? updatedAt : Date.now(),
+  };
+}
+
+function countLegacyRestartRecoveryDeliveryContexts(storePath: string): number {
+  if (!fileExists(storePath)) {
+    return 0;
+  }
+  const parsed = readSessionStoreJson5(storePath);
+  if (!parsed.ok) {
+    return 0;
+  }
+  let count = 0;
+  for (const entry of Object.values(parsed.store)) {
+    if (entry && typeof entry === "object" && hasLegacyRestartRecoveryDeliveryFields(entry)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function normalizeSessionStorePathForMigration(storePath: string): string {
+  const resolved = path.resolve(storePath);
+  try {
+    return fs.realpathSync.native(resolved);
+  } catch {
+    try {
+      return path.join(fs.realpathSync.native(path.dirname(resolved)), path.basename(resolved));
+    } catch {
+      return resolved;
+    }
+  }
+}
+
 function resolveUpdatedAt(entry: SessionEntryLike): number {
   return typeof entry.updatedAt === "number" && Number.isFinite(entry.updatedAt)
     ? entry.updatedAt
@@ -1242,6 +1327,92 @@ function mergeSessionEntry(params: {
     return params.existing;
   }
   return params.preferIncomingOnTie ? params.incoming : params.existing;
+}
+
+type RestartRecoveryDeliveryMigrationResult = {
+  normalized: Record<string, SessionEntry>;
+  changed: boolean;
+  migrated: number;
+  dropped: number;
+  warnings: string[];
+};
+
+function migrateLegacyRestartRecoveryDeliveryContextEntries(params: {
+  stateDir: string;
+  store: Record<string, SessionEntryLike>;
+  storePath: string;
+}): RestartRecoveryDeliveryMigrationResult {
+  let changed = false;
+  let migrated = 0;
+  let dropped = 0;
+  const warnings: string[] = [];
+  const normalized: Record<string, SessionEntry> = {};
+  for (const [sessionKey, entry] of Object.entries(params.store)) {
+    const normalizedEntry = normalizeSessionEntry(entry);
+    if (!normalizedEntry) {
+      continue;
+    }
+    let shouldStripLegacyFields = false;
+    const candidate = hasLegacyRestartRecoveryDeliveryFields(entry)
+      ? readLegacyRestartRecoveryDeliveryContextCandidate(entry)
+      : undefined;
+    if (candidate) {
+      try {
+        const claimed = claimRestartRecoveryDeliveryContext({
+          context: candidate.context,
+          runId: candidate.runId,
+          sessionId: candidate.sessionId,
+          sessionKey,
+          stateDir: params.stateDir,
+          storePath: params.storePath,
+          replaceExisting: true,
+          updatedAtMs: candidate.updatedAtMs,
+        });
+        if (claimed) {
+          migrated++;
+          shouldStripLegacyFields = true;
+        } else {
+          warnings.push(
+            `Skipped migrating restart recovery delivery context for ${sessionKey}: shared SQLite row is owned by another run`,
+          );
+        }
+      } catch (err) {
+        warnings.push(
+          `Failed migrating restart recovery delivery context for ${sessionKey}: ${String(err)}`,
+        );
+      }
+    } else if (hasLegacyRestartRecoveryDeliveryFields(entry)) {
+      dropped++;
+      shouldStripLegacyFields = true;
+    }
+
+    if (shouldStripLegacyFields) {
+      const record = normalizedEntry as unknown as Record<string, unknown>;
+      delete record.restartRecoveryDeliveryContext;
+      delete record.restartRecoveryDeliveryRunId;
+      changed = true;
+    }
+    normalized[sessionKey] = normalizedEntry;
+  }
+  return { normalized, changed, migrated, dropped, warnings };
+}
+
+function appendRestartRecoveryDeliveryMigrationResult(
+  result: Pick<RestartRecoveryDeliveryMigrationResult, "migrated" | "dropped" | "warnings">,
+  changes: string[],
+  warnings: string[],
+): void {
+  if (result.migrated > 0) {
+    changes.push(
+      `Migrated ${result.migrated} restart recovery delivery ${result.migrated === 1 ? "context" : "contexts"} → shared SQLite state`,
+    );
+  }
+  if (result.dropped > 0) {
+    warnings.push(
+      `Dropped ${result.dropped} invalid restart recovery delivery ${result.dropped === 1 ? "context" : "contexts"} from sessions store`,
+    );
+  }
+  warnings.push(...result.warnings);
 }
 
 function canonicalizeSessionStore(params: {
@@ -1903,6 +2074,21 @@ export async function detectLegacyStateMigrations(params: {
         scope: targetScope,
       })
     : [];
+  const restartRecoveryDeliveryContextStorePaths = [
+    ...new Set(
+      [
+        sessionsLegacyStorePath,
+        sessionsTargetStorePath,
+        ...resolveAllAgentSessionStoreTargetsSync(params.cfg, { env }).map(
+          (target) => target.storePath,
+        ),
+      ].map(normalizeSessionStorePathForMigration),
+    ),
+  ];
+  const restartRecoveryDeliveryContextCount = restartRecoveryDeliveryContextStorePaths.reduce(
+    (count, storePath) => count + countLegacyRestartRecoveryDeliveryContexts(storePath),
+    0,
+  );
 
   const legacyAgentDir = path.join(stateDir, "agent");
   const targetAgentDir = path.join(stateDir, "agents", targetAgentId, "agent");
@@ -1925,6 +2111,11 @@ export async function detectLegacyStateMigrations(params: {
   }
   if (legacyKeys.length > 0) {
     preview.push(`- Sessions: canonicalize legacy keys in ${sessionsTargetStorePath}`);
+  }
+  if (restartRecoveryDeliveryContextCount > 0) {
+    preview.push(
+      `- Restart recovery delivery contexts: migrate ${restartRecoveryDeliveryContextCount} session JSON ${restartRecoveryDeliveryContextCount === 1 ? "route" : "routes"} → shared SQLite state`,
+    );
   }
   if (hasLegacyAgentDir) {
     preview.push(`- Agent dir: ${legacyAgentDir} → ${targetAgentDir}`);
@@ -1955,6 +2146,11 @@ export async function detectLegacyStateMigrations(params: {
       targetStorePath: sessionsTargetStorePath,
       hasLegacy: hasLegacySessions || legacyKeys.length > 0,
       legacyKeys,
+    },
+    restartRecoveryDeliveryContexts: {
+      hasLegacy: restartRecoveryDeliveryContextCount > 0,
+      count: restartRecoveryDeliveryContextCount,
+      storePaths: restartRecoveryDeliveryContextStorePaths,
     },
     agentDir: {
       legacyDir: legacyAgentDir,
@@ -2043,17 +2239,23 @@ async function migrateLegacySessions(
     (legacyParsed.ok || targetParsed.ok) &&
     (Object.keys(legacyStore).length > 0 || Object.keys(targetStore).length > 0)
   ) {
-    const normalized: Record<string, SessionEntry> = {};
-    for (const [key, entry] of Object.entries(merged)) {
-      const normalizedEntry = normalizeSessionEntry(entry);
-      if (!normalizedEntry) {
-        continue;
-      }
-      normalized[key] = normalizedEntry;
-    }
-    await saveSessionStore(detected.sessions.targetStorePath, normalized, {
-      skipMaintenance: true,
+    const restartRecoveryDeliveryContexts = migrateLegacyRestartRecoveryDeliveryContextEntries({
+      stateDir: detected.stateDir,
+      store: merged,
+      storePath: detected.sessions.targetStorePath,
     });
+    await saveSessionStore(
+      detected.sessions.targetStorePath,
+      restartRecoveryDeliveryContexts.normalized,
+      {
+        skipMaintenance: true,
+      },
+    );
+    appendRestartRecoveryDeliveryMigrationResult(
+      restartRecoveryDeliveryContexts,
+      changes,
+      warnings,
+    );
     changes.push(`Merged sessions store → ${detected.sessions.targetStorePath}`);
     if (canonicalizedTarget.legacyKeys.length > 0) {
       changes.push(`Canonicalized ${canonicalizedTarget.legacyKeys.length} legacy session key(s)`);
@@ -2103,6 +2305,37 @@ async function migrateLegacySessions(
     }
   }
 
+  return { changes, warnings };
+}
+
+async function migrateLegacyRestartRecoveryDeliveryContexts(
+  detected: LegacyStateDetection,
+): Promise<{ changes: string[]; warnings: string[] }> {
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  for (const storePath of detected.restartRecoveryDeliveryContexts.storePaths) {
+    if (!fileExists(storePath)) {
+      continue;
+    }
+    const parsed = readSessionStoreJson5(storePath);
+    if (!parsed.ok) {
+      warnings.push(
+        `Could not migrate restart recovery delivery contexts because sessions store is unreadable: ${storePath}`,
+      );
+      continue;
+    }
+    const result = migrateLegacyRestartRecoveryDeliveryContextEntries({
+      stateDir: detected.stateDir,
+      store: parsed.store,
+      storePath,
+    });
+    if (result.changed) {
+      await saveSessionStore(storePath, result.normalized, {
+        skipMaintenance: true,
+      });
+    }
+    appendRestartRecoveryDeliveryMigrationResult(result, changes, warnings);
+  }
   return { changes, warnings };
 }
 
@@ -2168,6 +2401,8 @@ export async function runLegacyStateMigrations(params: {
     detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
   );
   const sessions = await migrateLegacySessions(detected, now);
+  const restartRecoveryDeliveryContexts =
+    await migrateLegacyRestartRecoveryDeliveryContexts(detected);
   const agentDir = await migrateLegacyAgentDir(detected, now);
   const channelPlans = await runLegacyMigrationPlans(
     detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
@@ -2178,6 +2413,7 @@ export async function runLegacyStateMigrations(params: {
       ...taskStateSidecars.changes,
       ...preSessionChannelPlans.changes,
       ...sessions.changes,
+      ...restartRecoveryDeliveryContexts.changes,
       ...agentDir.changes,
       ...channelPlans.changes,
     ],
@@ -2186,6 +2422,7 @@ export async function runLegacyStateMigrations(params: {
       ...taskStateSidecars.warnings,
       ...preSessionChannelPlans.warnings,
       ...sessions.warnings,
+      ...restartRecoveryDeliveryContexts.warnings,
       ...agentDir.warnings,
       ...channelPlans.warnings,
     ],
@@ -2426,12 +2663,15 @@ export async function autoMigrateLegacyState(params: {
     const preSessionChannelPlans = await runLegacyMigrationPlans(
       detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
     );
+    const restartRecoveryDeliveryContexts =
+      await migrateLegacyRestartRecoveryDeliveryContexts(detected);
     const changes = [
       ...stateDirResult.changes,
       ...orphanKeys.changes,
       ...pluginStateSidecar.changes,
       ...taskStateSidecars.changes,
       ...preSessionChannelPlans.changes,
+      ...restartRecoveryDeliveryContexts.changes,
     ];
     const warnings = [
       ...stateDirResult.warnings,
@@ -2439,6 +2679,7 @@ export async function autoMigrateLegacyState(params: {
       ...pluginStateSidecar.warnings,
       ...taskStateSidecars.warnings,
       ...preSessionChannelPlans.warnings,
+      ...restartRecoveryDeliveryContexts.warnings,
     ];
     logMigrationResults(changes, warnings);
     return {
@@ -2447,7 +2688,8 @@ export async function autoMigrateLegacyState(params: {
         orphanKeys.changes.length > 0 ||
         pluginStateSidecar.changes.length > 0 ||
         taskStateSidecars.changes.length > 0 ||
-        preSessionChannelPlans.changes.length > 0,
+        preSessionChannelPlans.changes.length > 0 ||
+        restartRecoveryDeliveryContexts.changes.length > 0,
       skipped: true,
       changes,
       warnings,
@@ -2458,7 +2700,8 @@ export async function autoMigrateLegacyState(params: {
     !detected.agentDir.hasLegacy &&
     !detected.channelPlans.hasLegacy &&
     !detected.pluginStateSidecar.hasLegacy &&
-    !detected.taskStateSidecars.hasLegacy
+    !detected.taskStateSidecars.hasLegacy &&
+    !detected.restartRecoveryDeliveryContexts.hasLegacy
   ) {
     const changes = [...stateDirResult.changes, ...orphanKeys.changes];
     const warnings = [...stateDirResult.warnings, ...orphanKeys.warnings];
@@ -2482,6 +2725,8 @@ export async function autoMigrateLegacyState(params: {
     detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
   );
   const sessions = await migrateLegacySessions(detected, now);
+  const restartRecoveryDeliveryContexts =
+    await migrateLegacyRestartRecoveryDeliveryContexts(detected);
   const agentDir = await migrateLegacyAgentDir(detected, now);
   const channelPlans = await runLegacyMigrationPlans(
     detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
@@ -2493,6 +2738,7 @@ export async function autoMigrateLegacyState(params: {
     ...taskStateSidecars.changes,
     ...preSessionChannelPlans.changes,
     ...sessions.changes,
+    ...restartRecoveryDeliveryContexts.changes,
     ...agentDir.changes,
     ...channelPlans.changes,
   ];
@@ -2503,6 +2749,7 @@ export async function autoMigrateLegacyState(params: {
     ...taskStateSidecars.warnings,
     ...preSessionChannelPlans.warnings,
     ...sessions.warnings,
+    ...restartRecoveryDeliveryContexts.warnings,
     ...agentDir.warnings,
     ...channelPlans.warnings,
   ];

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -82,8 +82,6 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "pendingFinalDeliveryText",
   "pendingFinalDeliveryContext",
   "pendingFinalDeliveryIntentId",
-  "restartRecoveryDeliveryContext",
-  "restartRecoveryDeliveryRunId",
   "totalTokensFresh",
   "estimatedCostUsd",
   "cacheRead",

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -684,6 +684,15 @@ export interface PluginStateEntries {
   value_json: string;
 }
 
+export interface RestartRecoveryDeliveryContexts {
+  context_json: string;
+  run_id: string;
+  session_id: string;
+  session_key: string;
+  store_path: string;
+  updated_at_ms: number;
+}
+
 export interface SandboxRegistryEntries {
   backend_id: string | null;
   cdp_port: number | null;
@@ -947,6 +956,7 @@ export interface DB {
   plugin_binding_approvals: PluginBindingApprovals;
   plugin_blob_entries: PluginBlobEntries;
   plugin_state_entries: PluginStateEntries;
+  restart_recovery_delivery_contexts: RestartRecoveryDeliveryContexts;
   sandbox_registry_entries: SandboxRegistryEntries;
   schema_meta: SchemaMeta;
   skill_uploads: SkillUploads;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -56,6 +56,22 @@ CREATE INDEX IF NOT EXISTS idx_state_leases_expiry
 CREATE INDEX IF NOT EXISTS idx_state_leases_owner
   ON state_leases(owner, updated_at DESC);
 
+CREATE TABLE IF NOT EXISTS restart_recovery_delivery_contexts (
+  store_path TEXT NOT NULL,
+  session_key TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  context_json TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (store_path, session_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_restart_recovery_delivery_contexts_run
+  ON restart_recovery_delivery_contexts(run_id, updated_at_ms DESC);
+
+CREATE INDEX IF NOT EXISTS idx_restart_recovery_delivery_contexts_session
+  ON restart_recovery_delivery_contexts(session_id, updated_at_ms DESC);
+
 CREATE TABLE IF NOT EXISTS exec_approvals_config (
   config_key TEXT NOT NULL PRIMARY KEY,
   raw_json TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -51,6 +51,22 @@ CREATE INDEX IF NOT EXISTS idx_state_leases_expiry
 CREATE INDEX IF NOT EXISTS idx_state_leases_owner
   ON state_leases(owner, updated_at DESC);
 
+CREATE TABLE IF NOT EXISTS restart_recovery_delivery_contexts (
+  store_path TEXT NOT NULL,
+  session_key TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  context_json TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (store_path, session_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_restart_recovery_delivery_contexts_run
+  ON restart_recovery_delivery_contexts(run_id, updated_at_ms DESC);
+
+CREATE INDEX IF NOT EXISTS idx_restart_recovery_delivery_contexts_session
+  ON restart_recovery_delivery_contexts(session_id, updated_at_ms DESC);
+
 CREATE TABLE IF NOT EXISTS exec_approvals_config (
   config_key TEXT NOT NULL PRIMARY KEY,
   raw_json TEXT NOT NULL,


### PR DESCRIPTION
## Summary

- Move restart-recovery delivery route metadata into `openclaw-state` SQLite, keyed by session store path/session key with run + session ownership.
- Keep runtime recovery SQLite-only; old `sessions.json` restart recovery fields are stripped from normal session loads.
- Add doctor legacy migration that converts old JSON route fields from root, configured, and discovered agent session stores before normalization removes them.

## Verification

- `pnpm check:test-types`
- `node scripts/run-vitest.mjs src/infra/state-migrations.test.ts src/agents/restart-recovery-delivery-state.test.ts`
- `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts --hookTimeout=240000 --testTimeout=180000`
- `OPENCLAW_TEST_FAST=1 fnm exec --using=24 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "persists auto-reply delivery context for restart recovery" --reporter=verbose --testTimeout=180000`
- `node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts src/config/sessions/sessions.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean

## Real behavior proof

Behavior addressed: restart recovery delivery metadata no longer lives in session JSON; runtime reads the SQLite route only, and doctor migrates old JSON routes.
Real environment tested: local OpenClaw checkout on Node 24 for the auto-reply e2e lane and repo test wrappers for focused unit/regression coverage.
Exact steps or command run after this patch: the verification commands listed above were run after the final code changes.
Evidence after fix: agent-command tests prove SQLite route claim/clear/aborted-race behavior; auto-reply e2e observes the SQLite row during a live reply run and confirms cleanup; state migration tests convert target, legacy root, and discovered-agent session stores.
Observed result after fix: all listed checks passed, and autoreview reported no accepted/actionable findings.
What was not tested: no full `pnpm check` or Crabbox lane; coverage stayed focused on the affected recovery/session/doctor surfaces.
