### PR TITLE
fix: clarify generated media reply prompts

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -991,7 +991,9 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("use `message(action=send)` for visible source-channel output");
-    expect(prompt).toContain("Attach media with message-tool attachment fields");
+    expect(prompt).toContain(
+      "Tool/generated media paths are attachments, not prose; send one with `media`, multiple with `attachments: [{media: ...}]`.",
+    );
     expect(prompt).not.toContain("Attach media: `MEDIA:<path-or-url>`");
     expect(prompt).toContain("The target defaults to the current source channel");
     expect(prompt).toContain("do not repeat that visible content in your final answer");
@@ -1001,6 +1003,23 @@ describe("buildAgentSystemPrompt", () => {
       `respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies)`,
     );
     expect(prompt).not.toContain("For `action=send`, include `target` and `message`.");
+  });
+
+  it("tells automatic source delivery to expose generated media as MEDIA directives", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["message"],
+      runtimeInfo: {
+        channel: "telegram",
+      },
+    });
+
+    expect(prompt).toContain(
+      "Attach media in the final visible reply with `MEDIA:<path-or-url>` on its own line.",
+    );
+    expect(prompt).toContain(
+      "Tool/generated media paths are attachments, not prose; emit each as its own `MEDIA:<path-or-url>` line.",
+    );
   });
 
   it("suppresses plain chat approval commands when inline approval UI is available", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -396,7 +396,8 @@ function buildAssistantOutputDirectivesSection(params: {
     return [
       "## Assistant Output Directives",
       "- Visible source-channel output is delivered through `message(action=send)`.",
-      "- Attach media with message-tool attachment fields such as `media`, `mediaUrl`, `path`, or `filePath`; do not write attachment commands in text.",
+      "- Tool/generated media paths are attachments, not prose; send one with `media`, multiple with `attachments: [{media: ...}]`.",
+      "- Do not use legacy `MEDIA:` directives for source-channel delivery.",
       "- Voice-note audio hint: use message-tool `asVoice` when sending audio as a voice note.",
       "- Native quote/reply: use message-tool `replyTo` when an explicit reply target is needed.",
       "",
@@ -405,6 +406,7 @@ function buildAssistantOutputDirectivesSection(params: {
   return [
     "## Assistant Output Directives",
     "- Attach media in the final visible reply with `MEDIA:<path-or-url>` on its own line.",
+    "- Tool/generated media paths are attachments, not prose; emit each as its own `MEDIA:<path-or-url>` line.",
     "  The MEDIA directive must start the line as plain text, outside code fences and without Markdown wrappers. Do not write `**MEDIA:...**`, `` `MEDIA:...` ``, or inline prose like `Here is the file: MEDIA:...`.",
     "- Voice-note audio hint: `[[audio_as_voice]]` when audio is attached.",
     "- Native quote/reply: first token `[[reply_to_current]]`; use `[[reply_to:<id>]]` only with an explicit id.",

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1075,6 +1075,24 @@ describe("message tool explicit target guard", () => {
 });
 
 describe("message tool path passthrough", () => {
+  it("advertises canonical media params without compat aliases", () => {
+    const properties = getToolProperties(createMessageTool());
+    const attachments = properties.attachments as
+      | { items?: { properties?: Record<string, unknown> } }
+      | undefined;
+    const attachmentProperties = attachments?.items?.properties ?? {};
+
+    expect(properties).toHaveProperty("media");
+    expect(properties).not.toHaveProperty("mediaUrl");
+    expect(properties).not.toHaveProperty("path");
+    expect(properties).not.toHaveProperty("filePath");
+    expect(properties).not.toHaveProperty("fileUrl");
+    expect(attachmentProperties).toHaveProperty("media");
+    for (const name of ["mediaUrl", "path", "filePath", "fileUrl", "url"]) {
+      expect(attachmentProperties).not.toHaveProperty(name);
+    }
+  });
+
   it.each([
     { field: "path", value: "~/Downloads/voice.ogg" },
     { field: "filePath", value: "./tmp/note.m4a" },

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1084,6 +1084,7 @@ describe("message tool path passthrough", () => {
 
     expect(properties).toHaveProperty("media");
     expect(properties).not.toHaveProperty("mediaUrl");
+    expect(properties).not.toHaveProperty("mediaUrls");
     expect(properties).not.toHaveProperty("path");
     expect(properties).not.toHaveProperty("filePath");
     expect(properties).not.toHaveProperty("fileUrl");

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -209,24 +209,16 @@ function buildSendSchema(options: {
     contentType: Type.Optional(Type.String()),
     mimeType: Type.Optional(Type.String()),
     caption: Type.Optional(Type.String()),
-    path: Type.Optional(Type.String()),
-    filePath: Type.Optional(Type.String()),
     attachments: Type.Optional(
       Type.Array(
         Type.Object({
           type: Type.Optional(stringEnum(["image", "audio", "video", "file"])),
           media: Type.Optional(Type.String()),
-          mediaUrl: Type.Optional(Type.String()),
-          path: Type.Optional(Type.String()),
-          filePath: Type.Optional(Type.String()),
-          fileUrl: Type.Optional(Type.String()),
-          url: Type.Optional(Type.String()),
           name: Type.Optional(Type.String()),
           mimeType: Type.Optional(Type.String()),
         }),
         {
-          description:
-            "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
+          description: "Structured attachments; each entry uses media.",
         },
       ),
     ),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -190,16 +190,6 @@ function buildSendSchema(options: {
         description: "Media URL/path. data: use buffer.",
       }),
     ),
-    mediaUrl: Type.Optional(
-      Type.String({
-        description: "Alias for media.",
-      }),
-    ),
-    mediaUrls: Type.Optional(
-      Type.Array(Type.String(), {
-        description: "Multiple media URLs/paths.",
-      }),
-    ),
     filename: Type.Optional(Type.String()),
     buffer: Type.Optional(
       Type.String({

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -658,19 +658,10 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
-              "filePath": {
-                "type": "string"
-              },
-              "fileUrl": {
-                "type": "string"
-              },
               "media": {
-                "type": "string"
-              },
-              "mediaUrl": {
                 "type": "string"
               },
               "mimeType": {
@@ -679,14 +670,8 @@
               "name": {
                 "type": "string"
               },
-              "path": {
-                "type": "string"
-              },
               "type": {
                 "enum": ["image", "audio", "video", "file"],
-                "type": "string"
-              },
-              "url": {
                 "type": "string"
               }
             },
@@ -721,9 +706,6 @@
         "filename": {
           "type": "string"
         },
-        "filePath": {
-          "type": "string"
-        },
         "forceDocument": {
           "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
@@ -741,24 +723,10 @@
           "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
-        "mediaUrl": {
-          "description": "Alias for media.",
-          "type": "string"
-        },
-        "mediaUrls": {
-          "description": "Multiple media URLs/paths.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "message": {
           "type": "string"
         },
         "mimeType": {
-          "type": "string"
-        },
-        "path": {
           "type": "string"
         },
         "quoteText": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -658,19 +658,10 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
-              "filePath": {
-                "type": "string"
-              },
-              "fileUrl": {
-                "type": "string"
-              },
               "media": {
-                "type": "string"
-              },
-              "mediaUrl": {
                 "type": "string"
               },
               "mimeType": {
@@ -679,14 +670,8 @@
               "name": {
                 "type": "string"
               },
-              "path": {
-                "type": "string"
-              },
               "type": {
                 "enum": ["image", "audio", "video", "file"],
-                "type": "string"
-              },
-              "url": {
                 "type": "string"
               }
             },
@@ -721,9 +706,6 @@
         "filename": {
           "type": "string"
         },
-        "filePath": {
-          "type": "string"
-        },
         "forceDocument": {
           "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
@@ -741,24 +723,10 @@
           "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
-        "mediaUrl": {
-          "description": "Alias for media.",
-          "type": "string"
-        },
-        "mediaUrls": {
-          "description": "Multiple media URLs/paths.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "message": {
           "type": "string"
         },
         "mimeType": {
-          "type": "string"
-        },
-        "path": {
           "type": "string"
         },
         "quoteText": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -658,19 +658,10 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
-              "filePath": {
-                "type": "string"
-              },
-              "fileUrl": {
-                "type": "string"
-              },
               "media": {
-                "type": "string"
-              },
-              "mediaUrl": {
                 "type": "string"
               },
               "mimeType": {
@@ -679,14 +670,8 @@
               "name": {
                 "type": "string"
               },
-              "path": {
-                "type": "string"
-              },
               "type": {
                 "enum": ["image", "audio", "video", "file"],
-                "type": "string"
-              },
-              "url": {
                 "type": "string"
               }
             },
@@ -721,9 +706,6 @@
         "filename": {
           "type": "string"
         },
-        "filePath": {
-          "type": "string"
-        },
         "forceDocument": {
           "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
@@ -741,24 +723,10 @@
           "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
-        "mediaUrl": {
-          "description": "Alias for media.",
-          "type": "string"
-        },
-        "mediaUrls": {
-          "description": "Multiple media URLs/paths.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "message": {
           "type": "string"
         },
         "mimeType": {
-          "type": "string"
-        },
-        "path": {
           "type": "string"
         },
         "quoteText": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41505,
-    "roughTokens": 10377
+    "chars": 40696,
+    "roughTokens": 10174
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69207,
-    "roughTokens": 17302
+    "chars": 68398,
+    "roughTokens": 17100
   },
   "userInputText": {
     "chars": 1629,
@@ -603,19 +603,10 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
-              "filePath": {
-                "type": "string"
-              },
-              "fileUrl": {
-                "type": "string"
-              },
               "media": {
-                "type": "string"
-              },
-              "mediaUrl": {
                 "type": "string"
               },
               "mimeType": {
@@ -624,14 +615,8 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
               "name": {
                 "type": "string"
               },
-              "path": {
-                "type": "string"
-              },
               "type": {
                 "enum": ["image", "audio", "video", "file"],
-                "type": "string"
-              },
-              "url": {
                 "type": "string"
               }
             },
@@ -666,9 +651,6 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
         "filename": {
           "type": "string"
         },
-        "filePath": {
-          "type": "string"
-        },
         "forceDocument": {
           "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
@@ -686,24 +668,10 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
-        "mediaUrl": {
-          "description": "Alias for media.",
-          "type": "string"
-        },
-        "mediaUrls": {
-          "description": "Multiple media URLs/paths.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "message": {
           "type": "string"
         },
         "mimeType": {
-          "type": "string"
-        },
-        "path": {
           "type": "string"
         },
         "quoteText": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41226,
-    "roughTokens": 10307
+    "chars": 40417,
+    "roughTokens": 10105
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67404,
-    "roughTokens": 16851
+    "chars": 66595,
+    "roughTokens": 16649
   },
   "userInputText": {
     "chars": 1129,
@@ -580,19 +580,10 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
-              "filePath": {
-                "type": "string"
-              },
-              "fileUrl": {
-                "type": "string"
-              },
               "media": {
-                "type": "string"
-              },
-              "mediaUrl": {
                 "type": "string"
               },
               "mimeType": {
@@ -601,14 +592,8 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
               "name": {
                 "type": "string"
               },
-              "path": {
-                "type": "string"
-              },
               "type": {
                 "enum": ["image", "audio", "video", "file"],
-                "type": "string"
-              },
-              "url": {
                 "type": "string"
               }
             },
@@ -643,9 +628,6 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
         "filename": {
           "type": "string"
         },
-        "filePath": {
-          "type": "string"
-        },
         "forceDocument": {
           "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
@@ -663,24 +645,10 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
-        "mediaUrl": {
-          "description": "Alias for media.",
-          "type": "string"
-        },
-        "mediaUrls": {
-          "description": "Multiple media URLs/paths.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "message": {
           "type": "string"
         },
         "mimeType": {
-          "type": "string"
-        },
-        "path": {
           "type": "string"
         },
         "quoteText": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 42321,
-    "roughTokens": 10581
+    "chars": 41512,
+    "roughTokens": 10378
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69442,
-    "roughTokens": 17361
+    "chars": 68633,
+    "roughTokens": 17159
   },
   "userInputText": {
     "chars": 1367,
@@ -591,19 +591,10 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
-              "filePath": {
-                "type": "string"
-              },
-              "fileUrl": {
-                "type": "string"
-              },
               "media": {
-                "type": "string"
-              },
-              "mediaUrl": {
                 "type": "string"
               },
               "mimeType": {
@@ -612,14 +603,8 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
               "name": {
                 "type": "string"
               },
-              "path": {
-                "type": "string"
-              },
               "type": {
                 "enum": ["image", "audio", "video", "file"],
-                "type": "string"
-              },
-              "url": {
                 "type": "string"
               }
             },
@@ -654,9 +639,6 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
         "filename": {
           "type": "string"
         },
-        "filePath": {
-          "type": "string"
-        },
         "forceDocument": {
           "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
@@ -674,24 +656,10 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
-        "mediaUrl": {
-          "description": "Alias for media.",
-          "type": "string"
-        },
-        "mediaUrls": {
-          "description": "Multiple media URLs/paths.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "message": {
           "type": "string"
         },
         "mimeType": {
-          "type": "string"
-        },
-        "path": {
           "type": "string"
         },
         "quoteText": {


### PR DESCRIPTION
## Summary
- move generated-media delivery guidance into the shared system prompt instead of a Discord skill
- tell message-tool-only sessions to pass generated media as message-tool media/attachments
- tell automatic source delivery sessions to emit generated media as own-line MEDIA directives
- keep message media compat aliases accepted at runtime but hide them from the model-facing schema

## Verification
- pnpm test src/agents/system-prompt.test.ts
- pnpm test src/agents/tools/message-tool.test.ts src/agents/system-prompt.test.ts
- git diff --check
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --download ... --shell -- "pnpm prompt:snapshots:gen" (run_2e2d8cbc7e5f)
- CI green at dd6905c844efd2b7b01cb9c1655505a7e62c3088 after rerunning unrelated checks-node-agentic-agents-core timeout flake

## Notes
- Replaces #88436, which was closed because the guidance is shared visible-reply behavior, not Discord-specific skill behavior.
- Local `pnpm prompt:snapshots:gen` was attempted twice but the generator spun at 100% CPU without output for more than three minutes on macOS; the prompt snapshots were regenerated on Linux via Crabbox instead.
