### PR TITLE
refactor(cron): split service timer helpers

### DIFF
--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -1,0 +1,200 @@
+import type {
+  CronAgentExecutionPhase,
+  CronAgentExecutionPhaseUpdate,
+  CronAgentExecutionStarted,
+  CronJob,
+} from "../types.js";
+import {
+  preExecutionTimeoutErrorMessage,
+  setupTimeoutErrorMessage,
+  timeoutErrorMessage,
+} from "./execution-errors.js";
+import type { CronServiceState } from "./state.js";
+
+const CRON_TIMEOUT_CLEANUP_GUARD_MS = 20_000;
+const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
+const CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 60_000;
+const CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS = 1_000;
+
+type CronAgentWatchdogState =
+  | "waiting_for_runner"
+  | "waiting_for_execution"
+  | "executing"
+  | "timed_out"
+  | "disposed";
+
+type CronAgentPhaseWatchdogStage = "pre_execution" | "execution";
+
+const CRON_AGENT_PHASE_WATCHDOG_STAGE = {
+  runner_entered: "pre_execution",
+  workspace: "pre_execution",
+  runtime_plugins: "pre_execution",
+  before_agent_reply: "execution",
+  model_resolution: "pre_execution",
+  auth: "pre_execution",
+  context_engine: "pre_execution",
+  attempt_dispatch: "execution",
+  context_assembled: "execution",
+  turn_accepted: "execution",
+  process_spawned: "execution",
+  tool_execution_started: "execution",
+  assistant_output_started: "execution",
+  model_call_started: "execution",
+} as const satisfies Record<CronAgentExecutionPhase, CronAgentPhaseWatchdogStage>;
+
+export type CronAgentWatchdog = {
+  start: () => void;
+  noteRunnerStarted: (info?: CronAgentExecutionStarted) => void;
+  notePhase: (info: CronAgentExecutionPhaseUpdate) => void;
+  activeExecution: () => CronAgentExecutionStarted | undefined;
+  dispose: () => void;
+};
+
+export function createCronAgentWatchdog(params: {
+  deferUntilRunner: boolean;
+  jobTimeoutMs: number;
+  triggerTimeout: (reason: string) => void;
+}): CronAgentWatchdog {
+  let state: CronAgentWatchdogState = params.deferUntilRunner ? "waiting_for_runner" : "executing";
+  let timeoutId: NodeJS.Timeout | undefined;
+  let setupTimeoutId: NodeJS.Timeout | undefined;
+  let preExecutionTimeoutId: NodeJS.Timeout | undefined;
+  let activeExecution: CronAgentExecutionStarted | undefined;
+
+  const setTimedOut = (reason: string) => {
+    if (state === "timed_out" || state === "disposed") {
+      return;
+    }
+    state = "timed_out";
+    params.triggerTimeout(reason);
+  };
+  const startTimeout = () => {
+    if (timeoutId || state === "disposed") {
+      return;
+    }
+    timeoutId = setTimeout(() => {
+      setTimedOut(timeoutErrorMessage(activeExecution));
+    }, params.jobTimeoutMs);
+  };
+  const clearSetupTimeout = () => {
+    if (!setupTimeoutId) {
+      return;
+    }
+    clearTimeout(setupTimeoutId);
+    setupTimeoutId = undefined;
+  };
+  const clearPreExecutionTimeout = () => {
+    if (!preExecutionTimeoutId) {
+      return;
+    }
+    clearTimeout(preExecutionTimeoutId);
+    preExecutionTimeoutId = undefined;
+  };
+  const startPreExecutionTimeout = () => {
+    if (preExecutionTimeoutId || state !== "waiting_for_execution") {
+      return;
+    }
+    preExecutionTimeoutId = setTimeout(() => {
+      if (state === "waiting_for_execution") {
+        setTimedOut(preExecutionTimeoutErrorMessage(activeExecution));
+      }
+    }, resolveCronAgentPreExecutionWatchdogMs(params.jobTimeoutMs));
+  };
+  const noteExecutionProgress = (info?: CronAgentExecutionStarted) => {
+    if (!info) {
+      return;
+    }
+    const previousPhase = activeExecution?.phase;
+    activeExecution = { ...activeExecution, ...info };
+    const stage = info.phase ? CRON_AGENT_PHASE_WATCHDOG_STAGE[info.phase] : undefined;
+    if (
+      state === "executing" &&
+      previousPhase === "before_agent_reply" &&
+      stage === "pre_execution"
+    ) {
+      state = "waiting_for_execution";
+      startPreExecutionTimeout();
+      return;
+    }
+    if (stage === "execution" || info.firstModelCallStarted) {
+      state = "executing";
+      clearPreExecutionTimeout();
+    }
+  };
+
+  return {
+    start: () => {
+      if (params.deferUntilRunner) {
+        setupTimeoutId = setTimeout(() => {
+          if (state === "waiting_for_runner") {
+            setTimedOut(setupTimeoutErrorMessage(activeExecution));
+          }
+        }, CRON_AGENT_SETUP_WATCHDOG_MS);
+        return;
+      }
+      startTimeout();
+    },
+    noteRunnerStarted: (info?: CronAgentExecutionStarted) => {
+      if (state === "disposed" || state === "timed_out") {
+        return;
+      }
+      clearSetupTimeout();
+      startTimeout();
+      if (state !== "executing") {
+        state = "waiting_for_execution";
+      }
+      noteExecutionProgress(info);
+      startPreExecutionTimeout();
+    },
+    notePhase: (info: CronAgentExecutionPhaseUpdate) => {
+      if (state === "disposed" || state === "timed_out") {
+        return;
+      }
+      noteExecutionProgress(info);
+    },
+    activeExecution: () => activeExecution,
+    dispose: () => {
+      state = "disposed";
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      clearSetupTimeout();
+      clearPreExecutionTimeout();
+    },
+  };
+}
+
+export async function cleanupTimedOutCronAgentRun(
+  state: CronServiceState,
+  job: CronJob,
+  timeoutMs: number,
+  execution?: CronAgentExecutionStarted,
+): Promise<void> {
+  if (!state.deps.cleanupTimedOutAgentRun) {
+    return;
+  }
+  let settleTimer: NodeJS.Timeout | undefined;
+  const cleanupPromise = state.deps.cleanupTimedOutAgentRun({ job, timeoutMs, execution });
+  const settleTimeout = new Promise<void>((resolve) => {
+    settleTimer = setTimeout(resolve, CRON_TIMEOUT_CLEANUP_GUARD_MS);
+  });
+  try {
+    await Promise.race([cleanupPromise, settleTimeout]);
+  } catch (err) {
+    state.deps.log.warn(
+      { jobId: job.id, err: String(err) },
+      "cron: timed-out agent cleanup failed",
+    );
+  } finally {
+    if (settleTimer) {
+      clearTimeout(settleTimer);
+    }
+  }
+}
+
+function resolveCronAgentPreExecutionWatchdogMs(jobTimeoutMs: number): number {
+  return Math.max(
+    CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS,
+    Math.min(CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS, Math.floor(jobTimeoutMs / 2)),
+  );
+}

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -1,0 +1,55 @@
+import { formatEmbeddedAgentExecutionPhase } from "../../agents/embedded-agent-runner/execution-phase.js";
+import type { CronAgentExecutionStarted } from "../types.js";
+
+function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): string | undefined {
+  return formatEmbeddedAgentExecutionPhase(execution?.phase);
+}
+
+export function timeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
+  const phase = formatCronAgentExecutionPhase(execution);
+  if (!phase) {
+    return "cron: job execution timed out";
+  }
+  return `cron: job execution timed out (last phase: ${phase})`;
+}
+
+export function setupTimeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
+  const phase = formatCronAgentExecutionPhase(execution);
+  if (!phase) {
+    return "cron: isolated agent setup timed out before runner start";
+  }
+  return `cron: isolated agent setup timed out before runner start (last phase: ${phase})`;
+}
+
+export function preExecutionTimeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
+  const phase = formatCronAgentExecutionPhase(execution);
+  if (!phase) {
+    return "cron: isolated agent run stalled before execution start";
+  }
+  return `cron: isolated agent run stalled before execution start (last phase: ${phase})`;
+}
+
+export function abortErrorMessage(signal?: AbortSignal): string {
+  const reason = signal?.reason;
+  if (typeof reason === "string" && reason.trim()) {
+    return reason.trim();
+  }
+  return timeoutErrorMessage();
+}
+
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  return err.name === "AbortError" || err.message === timeoutErrorMessage();
+}
+
+export function normalizeCronRunErrorText(err: unknown): string {
+  if (isAbortError(err)) {
+    return timeoutErrorMessage();
+  }
+  if (typeof err === "string") {
+    return err === `Error: ${timeoutErrorMessage()}` ? timeoutErrorMessage() : err;
+  }
+  return String(err);
+}

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -1,0 +1,190 @@
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
+import type { CronFailureNotificationDelivery, CronJob, CronMessageChannel } from "../types.js";
+import type { CronServiceState } from "./state.js";
+
+const DEFAULT_FAILURE_ALERT_AFTER = 2;
+const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 60 * 60_000; // 1 hour
+
+type ResolvedFailureAlert = {
+  after: number;
+  cooldownMs: number;
+  channel: CronMessageChannel;
+  to?: string;
+  mode?: "announce" | "webhook";
+  accountId?: string;
+  includeSkipped: boolean;
+};
+
+export function failureNotificationDeliveryFromJobState(
+  job: CronJob,
+): CronFailureNotificationDelivery | undefined {
+  const status = job.state.lastFailureNotificationDeliveryStatus;
+  if (!status || status === "not-requested") {
+    return undefined;
+  }
+  return {
+    delivered: job.state.lastFailureNotificationDelivered,
+    status,
+    error: job.state.lastFailureNotificationDeliveryError,
+  };
+}
+
+function normalizeCronMessageChannel(input: unknown): CronMessageChannel | undefined {
+  const channel = normalizeOptionalLowercaseString(input);
+  return channel ? (channel as CronMessageChannel) : undefined;
+}
+
+function normalizeTo(input: unknown): string | undefined {
+  if (typeof input !== "string") {
+    return undefined;
+  }
+  const to = input.trim();
+  return to ? to : undefined;
+}
+
+function clampPositiveInt(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  const floored = Math.floor(value);
+  return floored >= 1 ? floored : fallback;
+}
+
+function clampNonNegativeInt(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  const floored = Math.floor(value);
+  return floored >= 0 ? floored : fallback;
+}
+
+export function resolveFailureAlert(
+  state: CronServiceState,
+  job: CronJob,
+): ResolvedFailureAlert | null {
+  const globalConfig = state.deps.cronConfig?.failureAlert;
+  const jobConfig = job.failureAlert === false ? undefined : job.failureAlert;
+
+  if (job.failureAlert === false) {
+    return null;
+  }
+  if (!jobConfig && globalConfig?.enabled !== true) {
+    return null;
+  }
+
+  const mode = jobConfig?.mode ?? globalConfig?.mode;
+  const explicitTo = normalizeTo(jobConfig?.to);
+
+  return {
+    after: clampPositiveInt(jobConfig?.after ?? globalConfig?.after, DEFAULT_FAILURE_ALERT_AFTER),
+    cooldownMs: clampNonNegativeInt(
+      jobConfig?.cooldownMs ?? globalConfig?.cooldownMs,
+      DEFAULT_FAILURE_ALERT_COOLDOWN_MS,
+    ),
+    channel:
+      normalizeCronMessageChannel(jobConfig?.channel) ??
+      normalizeCronMessageChannel(job.delivery?.channel) ??
+      "last",
+    to: mode === "webhook" ? explicitTo : (explicitTo ?? normalizeTo(job.delivery?.to)),
+    mode,
+    accountId: jobConfig?.accountId ?? globalConfig?.accountId,
+    includeSkipped: jobConfig?.includeSkipped ?? globalConfig?.includeSkipped ?? false,
+  };
+}
+
+function emitFailureAlert(
+  state: CronServiceState,
+  params: {
+    job: CronJob;
+    error?: string;
+    consecutiveErrors: number;
+    channel: CronMessageChannel;
+    to?: string;
+    mode?: "announce" | "webhook";
+    accountId?: string;
+    status: "error" | "skipped";
+    provider?: string;
+  },
+) {
+  const safeJobName = params.job.name || params.job.id;
+  const truncatedError = (params.error?.trim() || "unknown reason").slice(0, 200);
+  const errorReason =
+    params.status === "error" && typeof params.error === "string"
+      ? (resolveFailoverReasonFromError(params.error, params.provider) ?? undefined)
+      : undefined;
+  const statusVerb = params.status === "skipped" ? "skipped" : "failed";
+  const detailLabel = params.status === "skipped" ? "Skip reason" : "Last error";
+  const text = [
+    `Cron job "${safeJobName}" ${statusVerb} ${params.consecutiveErrors} times`,
+    ...(errorReason ? [`Cause: ${errorReason}`] : []),
+    `${detailLabel}: ${truncatedError}`,
+  ].join("\n");
+
+  if (state.deps.sendCronFailureAlert) {
+    void state.deps
+      .sendCronFailureAlert({
+        job: params.job,
+        text,
+        channel: params.channel,
+        to: params.to,
+        mode: params.mode,
+        accountId: params.accountId,
+      })
+      .catch((err) => {
+        state.deps.log.warn(
+          { jobId: params.job.id, err: String(err) },
+          "cron: failure alert delivery failed",
+        );
+      });
+    return;
+  }
+
+  state.deps.enqueueSystemEvent(text, { agentId: params.job.agentId });
+  if (params.job.wakeMode === "now") {
+    state.deps.requestHeartbeat({
+      source: "cron",
+      intent: "immediate",
+      reason: `cron:${params.job.id}:failure-alert`,
+    });
+  }
+}
+
+export function maybeEmitFailureAlert(
+  state: CronServiceState,
+  params: {
+    job: CronJob;
+    alertConfig: ResolvedFailureAlert | null;
+    status: "error" | "skipped";
+    error?: string;
+    provider?: string;
+    consecutiveCount: number;
+  },
+) {
+  if (!params.alertConfig || params.consecutiveCount < params.alertConfig.after) {
+    return;
+  }
+  const isBestEffort = params.job.delivery?.bestEffort === true;
+  if (isBestEffort) {
+    return;
+  }
+  const now = state.deps.nowMs();
+  const lastAlert = params.job.state.lastFailureAlertAtMs;
+  const inCooldown =
+    typeof lastAlert === "number" && now - lastAlert < Math.max(0, params.alertConfig.cooldownMs);
+  if (inCooldown) {
+    return;
+  }
+  emitFailureAlert(state, {
+    job: params.job,
+    error: params.error,
+    consecutiveErrors: params.consecutiveCount,
+    channel: params.alertConfig.channel,
+    to: params.alertConfig.to,
+    mode: params.alertConfig.mode,
+    accountId: params.alertConfig.accountId,
+    status: params.status,
+    provider: params.provider,
+  });
+  params.job.state.lastFailureAlertAtMs = now;
+}

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -12,6 +12,8 @@ import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { createCronExecutionId } from "../run-id.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
+import { normalizeCronRunErrorText } from "./execution-errors.js";
+import { failureNotificationDeliveryFromJobState } from "./failure-alerts.js";
 import {
   applyJobPatch,
   assertSupportedJobSpec,
@@ -44,12 +46,10 @@ import {
   armTimer,
   emit,
   executeJobCoreWithTimeout,
-  failureNotificationDeliveryFromJobState,
-  normalizeCronRunErrorText,
   runMissedJobs,
   stopTimer,
-  wake,
 } from "./timer.js";
+import { wake } from "./wake.js";
 
 const STARTUP_INTERRUPTED_ERROR = "cron: job interrupted by gateway restart";
 

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -1,0 +1,129 @@
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import {
+  DEFAULT_AGENT_ID,
+  normalizeAgentId,
+  resolveAgentIdFromSessionKey,
+} from "../../routing/session-key.js";
+import {
+  completeTaskRunByRunId,
+  createRunningTaskRun,
+  failTaskRunByRunId,
+} from "../../tasks/detached-task-runtime.js";
+import { resolveCronAgentSessionKey } from "../isolated-agent/session-key.js";
+import { createCronExecutionId } from "../run-id.js";
+import type { CronJob, CronRunStatus } from "../types.js";
+import { normalizeCronRunErrorText, timeoutErrorMessage } from "./execution-errors.js";
+import type { CronServiceState } from "./state.js";
+import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
+
+export function normalizeCronLaneSegment(value: string | undefined, fallback: string): string {
+  const normalized = normalizeOptionalLowercaseString(value)
+    ?.replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return normalized || fallback;
+}
+
+export function resolveMainSessionCronRunSessionKey(job: CronJob, startedAt: number): string {
+  const explicitAgentId = job.agentId?.trim();
+  const agentId = normalizeAgentId(explicitAgentId || resolveAgentIdFromSessionKey(job.sessionKey));
+  const jobSegment = normalizeCronLaneSegment(job.id, "job");
+  const runSegment = normalizeCronLaneSegment(String(Math.max(0, Math.floor(startedAt))), "run");
+  return `agent:${agentId}:cron:${jobSegment}:run:${runSegment}`;
+}
+
+function resolveCronTaskChildSessionKey(params: {
+  state: CronServiceState;
+  job: CronJob;
+  startedAt: number;
+}): string | undefined {
+  if (params.job.sessionTarget === "main") {
+    return resolveMainSessionCronRunSessionKey(params.job, params.startedAt);
+  }
+  const explicitSessionKey = params.job.sessionKey?.trim();
+  if (explicitSessionKey) {
+    return explicitSessionKey;
+  }
+  if (params.job.sessionTarget !== "isolated") {
+    return undefined;
+  }
+  return resolveCronAgentSessionKey({
+    sessionKey: `cron:${params.job.id}`,
+    agentId: params.job.agentId ?? params.state.deps.defaultAgentId ?? DEFAULT_AGENT_ID,
+  });
+}
+
+export function tryCreateCronTaskRun(params: {
+  state: CronServiceState;
+  job: CronJob;
+  startedAt: number;
+}): string | undefined {
+  const runId = createCronExecutionId(params.job.id, params.startedAt);
+  try {
+    createRunningTaskRun({
+      runtime: "cron",
+      sourceId: params.job.id,
+      ownerKey: "",
+      scopeKind: "system",
+      childSessionKey: resolveCronTaskChildSessionKey(params),
+      agentId: params.job.agentId,
+      runId,
+      label: params.job.name,
+      task: params.job.name || params.job.id,
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: params.startedAt,
+      lastEventAt: params.startedAt,
+      progressSummary: CRON_TASK_RUNNING_PROGRESS_SUMMARY,
+    });
+    return runId;
+  } catch (error) {
+    params.state.deps.log.warn(
+      { jobId: params.job.id, error },
+      "cron: failed to create task ledger record",
+    );
+    return undefined;
+  }
+}
+
+export function tryFinishCronTaskRun(
+  state: CronServiceState,
+  result: {
+    taskRunId?: string;
+    status: CronRunStatus;
+    error?: unknown;
+    endedAt: number;
+    summary?: string;
+  },
+): void {
+  if (!result.taskRunId) {
+    return;
+  }
+  try {
+    if (result.status === "ok" || result.status === "skipped") {
+      completeTaskRunByRunId({
+        runId: result.taskRunId,
+        runtime: "cron",
+        endedAt: result.endedAt,
+        lastEventAt: result.endedAt,
+        terminalSummary: result.summary ?? undefined,
+      });
+      return;
+    }
+    failTaskRunByRunId({
+      runId: result.taskRunId,
+      runtime: "cron",
+      status:
+        normalizeCronRunErrorText(result.error) === timeoutErrorMessage() ? "timed_out" : "failed",
+      endedAt: result.endedAt,
+      lastEventAt: result.endedAt,
+      error: result.status === "error" ? normalizeCronRunErrorText(result.error) : undefined,
+      terminalSummary: result.summary ?? undefined,
+    });
+  } catch (error) {
+    state.deps.log.warn(
+      { runId: result.taskRunId, jobStatus: result.status, error },
+      "cron: failed to update task ledger record",
+    );
+  }
+}

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,5 +1,3 @@
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import { formatEmbeddedAgentExecutionPhase } from "../../agents/embedded-agent-runner/execution-phase.js";
 import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import { readSessionEntry } from "../../config/sessions/store-load.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
@@ -11,42 +9,43 @@ import {
 } from "../../infra/heartbeat-wake.js";
 import {
   DEFAULT_AGENT_ID,
-  isSubagentSessionKey,
   normalizeAgentId,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
-import {
-  completeTaskRunByRunId,
-  createRunningTaskRun,
-  failTaskRunByRunId,
-} from "../../tasks/detached-task-runtime.js";
 import { deliveryContextFromSession } from "../../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
-import { resolveCronAgentSessionKey } from "../isolated-agent/session-key.js";
 import { resolveCronExecutionRetryHint } from "../retry-hint.js";
 import {
   createCronRunDiagnosticsFromError,
   normalizeCronRunDiagnostics,
   summarizeCronRunDiagnostics,
 } from "../run-diagnostics.js";
-import { createCronExecutionId } from "../run-id.js";
 import { computeNextRunAtMs } from "../schedule.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
 import type {
-  CronAgentExecutionPhase,
   CronAgentExecutionPhaseUpdate,
   CronAgentExecutionStarted,
   CronDeliveryStatus,
   CronDeliveryTrace,
   CronFailureNotificationDelivery,
   CronJob,
-  CronMessageChannel,
   CronRunOutcome,
   CronRunStatus,
   CronRunTelemetry,
 } from "../types.js";
+import { cleanupTimedOutCronAgentRun, createCronAgentWatchdog } from "./agent-watchdog.js";
+import {
+  abortErrorMessage,
+  normalizeCronRunErrorText,
+  timeoutErrorMessage,
+} from "./execution-errors.js";
+import {
+  failureNotificationDeliveryFromJobState,
+  maybeEmitFailureAlert,
+  resolveFailureAlert,
+} from "./failure-alerts.js";
 import {
   DEFAULT_ERROR_BACKOFF_SCHEDULE_MS,
   computeJobPreviousRunAtMs,
@@ -63,16 +62,19 @@ import {
 import { locked } from "./locked.js";
 import type { CronEvent, CronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
-import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
+import {
+  resolveMainSessionCronRunSessionKey,
+  tryCreateCronTaskRun,
+  tryFinishCronTaskRun,
+} from "./task-runs.js";
 import { resolveCronJobTimeoutMs } from "./timeout-policy.js";
 
 export { DEFAULT_JOB_TIMEOUT_MS } from "./timeout-policy.js";
+export { normalizeCronRunErrorText } from "./execution-errors.js";
+export { failureNotificationDeliveryFromJobState } from "./failure-alerts.js";
+export { wake } from "./wake.js";
 
 const MAX_TIMER_DELAY_MS = 60_000;
-const CRON_TIMEOUT_CLEANUP_GUARD_MS = 20_000;
-const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
-const CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 60_000;
-const CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS = 1_000;
 
 /**
  * Minimum gap between consecutive fires of the same cron job.  This is a
@@ -86,18 +88,6 @@ const MIN_REFIRE_GAP_MS = 2_000;
 const DEFAULT_MISSED_JOB_STAGGER_MS = 5_000;
 const DEFAULT_MAX_MISSED_JOBS_PER_RESTART = 5;
 const DEFAULT_STARTUP_DEFERRED_MISSED_AGENT_JOB_DELAY_MS = 2 * 60_000;
-const DEFAULT_FAILURE_ALERT_AFTER = 2;
-const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 60 * 60_000; // 1 hour
-
-type ResolvedFailureAlert = {
-  after: number;
-  cooldownMs: number;
-  channel: CronMessageChannel;
-  to?: string;
-  mode?: "announce" | "webhook";
-  accountId?: string;
-  includeSkipped: boolean;
-};
 
 type TimedCronRunOutcome = CronRunOutcome &
   CronRunTelemetry & {
@@ -123,40 +113,6 @@ type StartupDeferredJob = {
 type StartupCatchupPlan = {
   candidates: StartupCatchupCandidate[];
   deferredJobs: StartupDeferredJob[];
-};
-
-type CronAgentWatchdogState =
-  | "waiting_for_runner"
-  | "waiting_for_execution"
-  | "executing"
-  | "timed_out"
-  | "disposed";
-
-type CronAgentPhaseWatchdogStage = "pre_execution" | "execution";
-
-const CRON_AGENT_PHASE_WATCHDOG_STAGE = {
-  runner_entered: "pre_execution",
-  workspace: "pre_execution",
-  runtime_plugins: "pre_execution",
-  before_agent_reply: "execution",
-  model_resolution: "pre_execution",
-  auth: "pre_execution",
-  context_engine: "pre_execution",
-  attempt_dispatch: "execution",
-  context_assembled: "execution",
-  turn_accepted: "execution",
-  process_spawned: "execution",
-  tool_execution_started: "execution",
-  assistant_output_started: "execution",
-  model_call_started: "execution",
-} as const satisfies Record<CronAgentExecutionPhase, CronAgentPhaseWatchdogStage>;
-
-type CronAgentWatchdog = {
-  start: () => void;
-  noteRunnerStarted: (info?: CronAgentExecutionStarted) => void;
-  notePhase: (info: CronAgentExecutionPhaseUpdate) => void;
-  activeExecution: () => CronAgentExecutionStarted | undefined;
-  dispose: () => void;
 };
 
 export async function executeJobCoreWithTimeout(
@@ -224,229 +180,12 @@ export async function executeJobCoreWithTimeout(
   }
 }
 
-function createCronAgentWatchdog(params: {
-  deferUntilRunner: boolean;
-  jobTimeoutMs: number;
-  triggerTimeout: (reason: string) => void;
-}): CronAgentWatchdog {
-  let state: CronAgentWatchdogState = params.deferUntilRunner ? "waiting_for_runner" : "executing";
-  let timeoutId: NodeJS.Timeout | undefined;
-  let setupTimeoutId: NodeJS.Timeout | undefined;
-  let preExecutionTimeoutId: NodeJS.Timeout | undefined;
-  let activeExecution: CronAgentExecutionStarted | undefined;
-
-  const setTimedOut = (reason: string) => {
-    if (state === "timed_out" || state === "disposed") {
-      return;
-    }
-    state = "timed_out";
-    params.triggerTimeout(reason);
-  };
-  const startTimeout = () => {
-    if (timeoutId || state === "disposed") {
-      return;
-    }
-    timeoutId = setTimeout(() => {
-      setTimedOut(timeoutErrorMessage(activeExecution));
-    }, params.jobTimeoutMs);
-  };
-  const clearSetupTimeout = () => {
-    if (!setupTimeoutId) {
-      return;
-    }
-    clearTimeout(setupTimeoutId);
-    setupTimeoutId = undefined;
-  };
-  const clearPreExecutionTimeout = () => {
-    if (!preExecutionTimeoutId) {
-      return;
-    }
-    clearTimeout(preExecutionTimeoutId);
-    preExecutionTimeoutId = undefined;
-  };
-  const startPreExecutionTimeout = () => {
-    if (preExecutionTimeoutId || state !== "waiting_for_execution") {
-      return;
-    }
-    preExecutionTimeoutId = setTimeout(() => {
-      if (state === "waiting_for_execution") {
-        setTimedOut(preExecutionTimeoutErrorMessage(activeExecution));
-      }
-    }, resolveCronAgentPreExecutionWatchdogMs(params.jobTimeoutMs));
-  };
-  const noteExecutionProgress = (info?: CronAgentExecutionStarted) => {
-    if (!info) {
-      return;
-    }
-    const previousPhase = activeExecution?.phase;
-    activeExecution = { ...activeExecution, ...info };
-    const stage = info.phase ? CRON_AGENT_PHASE_WATCHDOG_STAGE[info.phase] : undefined;
-    if (
-      state === "executing" &&
-      previousPhase === "before_agent_reply" &&
-      stage === "pre_execution"
-    ) {
-      state = "waiting_for_execution";
-      startPreExecutionTimeout();
-      return;
-    }
-    if (stage === "execution" || info.firstModelCallStarted) {
-      state = "executing";
-      clearPreExecutionTimeout();
-    }
-  };
-
-  return {
-    start: () => {
-      if (params.deferUntilRunner) {
-        setupTimeoutId = setTimeout(() => {
-          if (state === "waiting_for_runner") {
-            setTimedOut(setupTimeoutErrorMessage(activeExecution));
-          }
-        }, CRON_AGENT_SETUP_WATCHDOG_MS);
-        return;
-      }
-      startTimeout();
-    },
-    noteRunnerStarted: (info?: CronAgentExecutionStarted) => {
-      if (state === "disposed" || state === "timed_out") {
-        return;
-      }
-      clearSetupTimeout();
-      startTimeout();
-      if (state !== "executing") {
-        state = "waiting_for_execution";
-      }
-      noteExecutionProgress(info);
-      startPreExecutionTimeout();
-    },
-    notePhase: (info: CronAgentExecutionPhaseUpdate) => {
-      if (state === "disposed" || state === "timed_out") {
-        return;
-      }
-      noteExecutionProgress(info);
-    },
-    activeExecution: () => activeExecution,
-    dispose: () => {
-      state = "disposed";
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      clearSetupTimeout();
-      clearPreExecutionTimeout();
-    },
-  };
-}
-
-async function cleanupTimedOutCronAgentRun(
-  state: CronServiceState,
-  job: CronJob,
-  timeoutMs: number,
-  execution?: CronAgentExecutionStarted,
-): Promise<void> {
-  if (!state.deps.cleanupTimedOutAgentRun) {
-    return;
-  }
-  let settleTimer: NodeJS.Timeout | undefined;
-  const cleanupPromise = state.deps.cleanupTimedOutAgentRun({ job, timeoutMs, execution });
-  const settleTimeout = new Promise<void>((resolve) => {
-    settleTimer = setTimeout(resolve, CRON_TIMEOUT_CLEANUP_GUARD_MS);
-  });
-  try {
-    await Promise.race([cleanupPromise, settleTimeout]);
-  } catch (err) {
-    state.deps.log.warn(
-      { jobId: job.id, err: String(err) },
-      "cron: timed-out agent cleanup failed",
-    );
-  } finally {
-    if (settleTimer) {
-      clearTimeout(settleTimer);
-    }
-  }
-}
-
 function resolveRunConcurrency(state: CronServiceState): number {
   const raw = state.deps.cronConfig?.maxConcurrentRuns;
   if (typeof raw !== "number" || !Number.isFinite(raw)) {
     return 1;
   }
   return Math.max(1, Math.floor(raw));
-}
-function timeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
-  const phase = formatCronAgentExecutionPhase(execution);
-  if (!phase) {
-    return "cron: job execution timed out";
-  }
-  return `cron: job execution timed out (last phase: ${phase})`;
-}
-
-function setupTimeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
-  const phase = formatCronAgentExecutionPhase(execution);
-  if (!phase) {
-    return "cron: isolated agent setup timed out before runner start";
-  }
-  return `cron: isolated agent setup timed out before runner start (last phase: ${phase})`;
-}
-
-function preExecutionTimeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
-  const phase = formatCronAgentExecutionPhase(execution);
-  if (!phase) {
-    return "cron: isolated agent run stalled before execution start";
-  }
-  return `cron: isolated agent run stalled before execution start (last phase: ${phase})`;
-}
-
-function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): string | undefined {
-  return formatEmbeddedAgentExecutionPhase(execution?.phase);
-}
-
-function resolveCronAgentPreExecutionWatchdogMs(jobTimeoutMs: number): number {
-  return Math.max(
-    CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS,
-    Math.min(CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS, Math.floor(jobTimeoutMs / 2)),
-  );
-}
-
-function abortErrorMessage(signal?: AbortSignal): string {
-  const reason = signal?.reason;
-  if (typeof reason === "string" && reason.trim()) {
-    return reason.trim();
-  }
-  return timeoutErrorMessage();
-}
-
-function isAbortError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-  return err.name === "AbortError" || err.message === timeoutErrorMessage();
-}
-
-export function normalizeCronRunErrorText(err: unknown): string {
-  if (isAbortError(err)) {
-    return timeoutErrorMessage();
-  }
-  if (typeof err === "string") {
-    return err === `Error: ${timeoutErrorMessage()}` ? timeoutErrorMessage() : err;
-  }
-  return String(err);
-}
-
-function normalizeCronLaneSegment(value: string | undefined, fallback: string): string {
-  const normalized = normalizeOptionalLowercaseString(value)
-    ?.replace(/[^a-z0-9_-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 64);
-  return normalized || fallback;
-}
-
-function resolveMainSessionCronRunSessionKey(job: CronJob, startedAt: number): string {
-  const explicitAgentId = job.agentId?.trim();
-  const agentId = normalizeAgentId(explicitAgentId || resolveAgentIdFromSessionKey(job.sessionKey));
-  const jobSegment = normalizeCronLaneSegment(job.id, "job");
-  const runSegment = normalizeCronLaneSegment(String(Math.max(0, Math.floor(startedAt))), "run");
-  return `agent:${agentId}:cron:${jobSegment}:run:${runSegment}`;
 }
 
 function resolveMainSessionCronDeliveryContext(
@@ -473,95 +212,6 @@ function resolveMainSessionCronDeliveryContext(
   }
 }
 
-function resolveCronTaskChildSessionKey(params: {
-  state: CronServiceState;
-  job: CronJob;
-  startedAt: number;
-}): string | undefined {
-  if (params.job.sessionTarget === "main") {
-    return resolveMainSessionCronRunSessionKey(params.job, params.startedAt);
-  }
-  const explicitSessionKey = params.job.sessionKey?.trim();
-  if (explicitSessionKey) {
-    return explicitSessionKey;
-  }
-  if (params.job.sessionTarget !== "isolated") {
-    return undefined;
-  }
-  return resolveCronAgentSessionKey({
-    sessionKey: `cron:${params.job.id}`,
-    agentId: params.job.agentId ?? params.state.deps.defaultAgentId ?? DEFAULT_AGENT_ID,
-  });
-}
-
-function tryCreateCronTaskRun(params: {
-  state: CronServiceState;
-  job: CronJob;
-  startedAt: number;
-}): string | undefined {
-  const runId = createCronExecutionId(params.job.id, params.startedAt);
-  try {
-    createRunningTaskRun({
-      runtime: "cron",
-      sourceId: params.job.id,
-      ownerKey: "",
-      scopeKind: "system",
-      childSessionKey: resolveCronTaskChildSessionKey(params),
-      agentId: params.job.agentId,
-      runId,
-      label: params.job.name,
-      task: params.job.name || params.job.id,
-      deliveryStatus: "not_applicable",
-      notifyPolicy: "silent",
-      startedAt: params.startedAt,
-      lastEventAt: params.startedAt,
-      progressSummary: CRON_TASK_RUNNING_PROGRESS_SUMMARY,
-    });
-    return runId;
-  } catch (error) {
-    params.state.deps.log.warn(
-      { jobId: params.job.id, error },
-      "cron: failed to create task ledger record",
-    );
-    return undefined;
-  }
-}
-
-function tryFinishCronTaskRun(
-  state: CronServiceState,
-  result: Pick<TimedCronRunOutcome, "taskRunId" | "status" | "error" | "endedAt" | "summary">,
-): void {
-  if (!result.taskRunId) {
-    return;
-  }
-  try {
-    if (result.status === "ok" || result.status === "skipped") {
-      completeTaskRunByRunId({
-        runId: result.taskRunId,
-        runtime: "cron",
-        endedAt: result.endedAt,
-        lastEventAt: result.endedAt,
-        terminalSummary: result.summary ?? undefined,
-      });
-      return;
-    }
-    failTaskRunByRunId({
-      runId: result.taskRunId,
-      runtime: "cron",
-      status:
-        normalizeCronRunErrorText(result.error) === timeoutErrorMessage() ? "timed_out" : "failed",
-      endedAt: result.endedAt,
-      lastEventAt: result.endedAt,
-      error: result.status === "error" ? normalizeCronRunErrorText(result.error) : undefined,
-      terminalSummary: result.summary ?? undefined,
-    });
-  } catch (error) {
-    state.deps.log.warn(
-      { runId: result.taskRunId, jobStatus: result.status, error },
-      "cron: failed to update task ledger record",
-    );
-  }
-}
 /** Default max retries for cron jobs on transient errors (#24355). */
 const DEFAULT_MAX_TRANSIENT_RETRIES = 3;
 
@@ -719,176 +369,6 @@ function resolveDeliveryState(params: {
     };
   }
   return { status: "unknown", failureNotification: { status: "not-requested" } };
-}
-
-export function failureNotificationDeliveryFromJobState(
-  job: CronJob,
-): CronFailureNotificationDelivery | undefined {
-  const status = job.state.lastFailureNotificationDeliveryStatus;
-  if (!status || status === "not-requested") {
-    return undefined;
-  }
-  return {
-    delivered: job.state.lastFailureNotificationDelivered,
-    status,
-    error: job.state.lastFailureNotificationDeliveryError,
-  };
-}
-
-function normalizeCronMessageChannel(input: unknown): CronMessageChannel | undefined {
-  const channel = normalizeOptionalLowercaseString(input);
-  return channel ? (channel as CronMessageChannel) : undefined;
-}
-
-function normalizeTo(input: unknown): string | undefined {
-  if (typeof input !== "string") {
-    return undefined;
-  }
-  const to = input.trim();
-  return to ? to : undefined;
-}
-
-function clampPositiveInt(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return fallback;
-  }
-  const floored = Math.floor(value);
-  return floored >= 1 ? floored : fallback;
-}
-
-function clampNonNegativeInt(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return fallback;
-  }
-  const floored = Math.floor(value);
-  return floored >= 0 ? floored : fallback;
-}
-
-function resolveFailureAlert(state: CronServiceState, job: CronJob): ResolvedFailureAlert | null {
-  const globalConfig = state.deps.cronConfig?.failureAlert;
-  const jobConfig = job.failureAlert === false ? undefined : job.failureAlert;
-
-  if (job.failureAlert === false) {
-    return null;
-  }
-  if (!jobConfig && globalConfig?.enabled !== true) {
-    return null;
-  }
-
-  const mode = jobConfig?.mode ?? globalConfig?.mode;
-  const explicitTo = normalizeTo(jobConfig?.to);
-
-  return {
-    after: clampPositiveInt(jobConfig?.after ?? globalConfig?.after, DEFAULT_FAILURE_ALERT_AFTER),
-    cooldownMs: clampNonNegativeInt(
-      jobConfig?.cooldownMs ?? globalConfig?.cooldownMs,
-      DEFAULT_FAILURE_ALERT_COOLDOWN_MS,
-    ),
-    channel:
-      normalizeCronMessageChannel(jobConfig?.channel) ??
-      normalizeCronMessageChannel(job.delivery?.channel) ??
-      "last",
-    to: mode === "webhook" ? explicitTo : (explicitTo ?? normalizeTo(job.delivery?.to)),
-    mode,
-    accountId: jobConfig?.accountId ?? globalConfig?.accountId,
-    includeSkipped: jobConfig?.includeSkipped ?? globalConfig?.includeSkipped ?? false,
-  };
-}
-
-function emitFailureAlert(
-  state: CronServiceState,
-  params: {
-    job: CronJob;
-    error?: string;
-    consecutiveErrors: number;
-    channel: CronMessageChannel;
-    to?: string;
-    mode?: "announce" | "webhook";
-    accountId?: string;
-    status: "error" | "skipped";
-    provider?: string;
-  },
-) {
-  const safeJobName = params.job.name || params.job.id;
-  const truncatedError = (params.error?.trim() || "unknown reason").slice(0, 200);
-  const errorReason =
-    params.status === "error" && typeof params.error === "string"
-      ? (resolveFailoverReasonFromError(params.error, params.provider) ?? undefined)
-      : undefined;
-  const statusVerb = params.status === "skipped" ? "skipped" : "failed";
-  const detailLabel = params.status === "skipped" ? "Skip reason" : "Last error";
-  const text = [
-    `Cron job "${safeJobName}" ${statusVerb} ${params.consecutiveErrors} times`,
-    ...(errorReason ? [`Cause: ${errorReason}`] : []),
-    `${detailLabel}: ${truncatedError}`,
-  ].join("\n");
-
-  if (state.deps.sendCronFailureAlert) {
-    void state.deps
-      .sendCronFailureAlert({
-        job: params.job,
-        text,
-        channel: params.channel,
-        to: params.to,
-        mode: params.mode,
-        accountId: params.accountId,
-      })
-      .catch((err) => {
-        state.deps.log.warn(
-          { jobId: params.job.id, err: String(err) },
-          "cron: failure alert delivery failed",
-        );
-      });
-    return;
-  }
-
-  state.deps.enqueueSystemEvent(text, { agentId: params.job.agentId });
-  if (params.job.wakeMode === "now") {
-    state.deps.requestHeartbeat({
-      source: "cron",
-      intent: "immediate",
-      reason: `cron:${params.job.id}:failure-alert`,
-    });
-  }
-}
-
-function maybeEmitFailureAlert(
-  state: CronServiceState,
-  params: {
-    job: CronJob;
-    alertConfig: ResolvedFailureAlert | null;
-    status: "error" | "skipped";
-    error?: string;
-    provider?: string;
-    consecutiveCount: number;
-  },
-) {
-  if (!params.alertConfig || params.consecutiveCount < params.alertConfig.after) {
-    return;
-  }
-  const isBestEffort = params.job.delivery?.bestEffort === true;
-  if (isBestEffort) {
-    return;
-  }
-  const now = state.deps.nowMs();
-  const lastAlert = params.job.state.lastFailureAlertAtMs;
-  const inCooldown =
-    typeof lastAlert === "number" && now - lastAlert < Math.max(0, params.alertConfig.cooldownMs);
-  if (inCooldown) {
-    return;
-  }
-  emitFailureAlert(state, {
-    job: params.job,
-    error: params.error,
-    consecutiveErrors: params.consecutiveCount,
-    channel: params.alertConfig.channel,
-    to: params.alertConfig.to,
-    mode: params.alertConfig.mode,
-    accountId: params.alertConfig.accountId,
-    status: params.status,
-    provider: params.provider,
-  });
-  params.job.state.lastFailureAlertAtMs = now;
 }
 
 /**
@@ -2160,49 +1640,6 @@ function emitJobFinished(
     provider: result.provider,
     usage: result.usage,
   });
-}
-
-export function wake(
-  state: CronServiceState,
-  opts: { mode: "now" | "next-heartbeat"; text: string; sessionKey?: string },
-) {
-  const text = opts.text.trim();
-  if (!text) {
-    return { ok: false } as const;
-  }
-  const sessionKey = opts.sessionKey?.trim() || undefined;
-  if (sessionKey && isSubagentSessionKey(sessionKey)) {
-    return { ok: false, reason: "unwakeable-session-key" } as const;
-  }
-  state.deps.enqueueSystemEvent(text, sessionKey ? { sessionKey } : undefined);
-  if (opts.mode === "now") {
-    state.deps.requestHeartbeat({
-      source: "manual",
-      intent: "immediate",
-      reason: "wake",
-      ...(sessionKey ? { sessionKey } : {}),
-    });
-  } else if (sessionKey) {
-    // next-heartbeat + sessionKey still needs a targeted immediate wake.
-    // Reasons:
-    //   1. The regularly-scheduled heartbeat fires for the agent's main
-    //      session, not the supplied sessionKey, so it never peeks the queue
-    //      we just enqueued — the event would sit stranded indefinitely.
-    //   2. An `intent: "event"` wake gets deferred by heartbeat-runner as
-    //      not-due and is not retried (only busy-skips are), so it cannot
-    //      stand in for the regular cadence either.
-    // Effectively, --session-key collapses --mode now and --mode next-heartbeat
-    // into the same targeted-immediate behavior — this matches the documented
-    // user intent (target a specific session for relay) better than silently
-    // dropping the event.
-    state.deps.requestHeartbeat({
-      source: "manual",
-      intent: "immediate",
-      reason: "wake",
-      sessionKey,
-    });
-  }
-  return { ok: true } as const;
 }
 
 export function stopTimer(state: CronServiceState) {

--- a/src/cron/service/wake.test.ts
+++ b/src/cron/service/wake.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { wake } from "./timer.js";
+import { wake } from "./wake.js";
 
 function createState() {
   const enqueueSystemEvent = vi.fn();

--- a/src/cron/service/wake.ts
+++ b/src/cron/service/wake.ts
@@ -1,0 +1,45 @@
+import { isSubagentSessionKey } from "../../routing/session-key.js";
+import type { CronServiceState } from "./state.js";
+
+export function wake(
+  state: CronServiceState,
+  opts: { mode: "now" | "next-heartbeat"; text: string; sessionKey?: string },
+) {
+  const text = opts.text.trim();
+  if (!text) {
+    return { ok: false } as const;
+  }
+  const sessionKey = opts.sessionKey?.trim() || undefined;
+  if (sessionKey && isSubagentSessionKey(sessionKey)) {
+    return { ok: false, reason: "unwakeable-session-key" } as const;
+  }
+  state.deps.enqueueSystemEvent(text, sessionKey ? { sessionKey } : undefined);
+  if (opts.mode === "now") {
+    state.deps.requestHeartbeat({
+      source: "manual",
+      intent: "immediate",
+      reason: "wake",
+      ...(sessionKey ? { sessionKey } : {}),
+    });
+  } else if (sessionKey) {
+    // next-heartbeat + sessionKey still needs a targeted immediate wake.
+    // Reasons:
+    //   1. The regularly-scheduled heartbeat fires for the agent's main
+    //      session, not the supplied sessionKey, so it never peeks the queue
+    //      we just enqueued - the event would sit stranded indefinitely.
+    //   2. An `intent: "event"` wake gets deferred by heartbeat-runner as
+    //      not-due and is not retried (only busy-skips are), so it cannot
+    //      stand in for the regular cadence either.
+    // Effectively, --session-key collapses --mode now and --mode next-heartbeat
+    // into the same targeted-immediate behavior - this matches the documented
+    // user intent (target a specific session for relay) better than silently
+    // dropping the event.
+    state.deps.requestHeartbeat({
+      source: "manual",
+      intent: "immediate",
+      reason: "wake",
+      sessionKey,
+    });
+  }
+  return { ok: true } as const;
+}


### PR DESCRIPTION
## Summary

- split cron timer helper concerns into focused service modules for agent watchdog cleanup, execution error text, failure alerts, task-run ledger handling, and manual wake dispatch
- update cron ops and wake tests to import those helpers directly while preserving timer compatibility re-exports
- keep behavior unchanged; this is cleanup following the cron delivery-target fix

## Verification

- `node scripts/run-vitest.mjs src/cron/service/wake.test.ts src/cron/service/timer.test.ts src/cron/service/timer.regression.test.ts src/cron/service/ops.test.ts src/cron/service/ops.regression.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/cron/service/timer.ts src/cron/service/agent-watchdog.ts src/cron/service/ops.ts src/cron/service/wake.test.ts src/cron/service/execution-errors.ts src/cron/service/failure-alerts.ts src/cron/service/task-runs.ts src/cron/service/wake.ts`
- `git diff --check`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01ksxg68x9vwjp5kzefcyvk0tw`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings
