### PR TITLE
fix(heartbeat): advance stale scheduler deferrals

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -363,6 +363,65 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("advances cadence after non-retryable disabled skips", async () => {
+    useFakeHeartbeatTime();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const runSpy = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" } as const);
+
+    const intervalMs = 10 * 60_000;
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig([{ id: "main", heartbeat: { every: "10m" } }]),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+    const firstDueMs = resolveDueFromNow(0, intervalMs, "main");
+
+    await vi.advanceTimersByTimeAsync(firstDueMs + 1);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    const delays = timeoutSpy.mock.calls
+      .map((call) => call[1])
+      .filter((delay): delay is number => typeof delay === "number");
+    expect(delays[delays.length - 1]).toBeGreaterThan(5_000);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    timeoutSpy.mockRestore();
+    runner.stop();
+  });
+
+  it("advances cadence after flood deferrals without wake-layer retry", async () => {
+    useFakeHeartbeatTime();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 } as const);
+
+    const intervalMs = 1_000;
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig([{ id: "main", heartbeat: { every: "1s" } }]),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+    const firstDueMs = resolveDueFromNow(0, intervalMs, "main");
+
+    await vi.advanceTimersByTimeAsync(firstDueMs + 1);
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(intervalMs);
+    }
+    expect(runSpy).toHaveBeenCalledTimes(5);
+
+    await vi.advanceTimersByTimeAsync(intervalMs);
+    expect(runSpy).toHaveBeenCalledTimes(5);
+
+    const delays = timeoutSpy.mock.calls
+      .map((call) => call[1])
+      .filter((delay): delay is number => typeof delay === "number");
+    expect(delays[delays.length - 1]).toBeGreaterThan(0);
+
+    timeoutSpy.mockRestore();
+    runner.stop();
+  });
+
   it("does not push nextDueMs forward on repeated requests-in-flight skips", async () => {
     useFakeHeartbeatTime();
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -2171,6 +2171,20 @@ export function startHeartbeatRunner(opts: {
     agent.nextDueMs = seekActiveSlotForAgent(agent, rawDueMs);
   };
 
+  const advanceStaleScheduleAfterDeferral = (
+    agent: HeartbeatAgentState,
+    now: number,
+    reason?: string,
+    decision?: DeferDecision,
+  ) => {
+    if (!decision?.defer || decision.reason === "not-due" || agent.nextDueMs > now) {
+      return;
+    }
+    // Deferrals that do not have wake-layer retry ownership still need to move
+    // the due slot forward; otherwise scheduleNext() will keep rearming at 0ms.
+    advanceAgentSchedule(agent, now, reason);
+  };
+
   // Centralized cooldown gate. Both targeted and broadcast dispatch branches
   // call this before invoking `runOnce`. Manual wakes are never deferred.
   // Everything else respects `nextDueMs`, the min-spacing floor, and the flood
@@ -2366,6 +2380,7 @@ export function startHeartbeatRunner(opts: {
         }
         const deferral = evaluateWakeDeferral(targetAgent, now, reason, intent);
         if (deferral.defer) {
+          advanceStaleScheduleAfterDeferral(targetAgent, now, reason, deferral);
           return { status: "skipped", reason: deferral.reason };
         }
         try {
@@ -2395,11 +2410,10 @@ export function startHeartbeatRunner(opts: {
             return res;
           }
           // Non-retryable outcome (ran, disabled, failed-but-not-busy). Record
-          // bookkeeping so subsequent wakes within the cooldown window defer.
+          // bookkeeping and move the due slot so scheduleNext() cannot hot-loop
+          // on a stale past-due agent.
           recordRunBookkeeping(targetAgent, now);
-          if (res.status !== "skipped" || res.reason !== "disabled") {
-            advanceAgentSchedule(targetAgent, now, reason);
-          }
+          advanceAgentSchedule(targetAgent, now, reason);
           return res.status === "ran" ? { status: "ran", durationMs: Date.now() - startedAt } : res;
         } catch (err) {
           const errMsg = formatErrorMessage(err);
@@ -2428,6 +2442,7 @@ export function startHeartbeatRunner(opts: {
       const runOneAgent = async (agent: HeartbeatAgentState): Promise<AgentWakeOutcome> => {
         const deferral = evaluateWakeDeferral(agent, now, reason, intent);
         if (deferral.defer) {
+          advanceStaleScheduleAfterDeferral(agent, now, reason, deferral);
           return { ran: false };
         }
 
@@ -2462,9 +2477,7 @@ export function startHeartbeatRunner(opts: {
         }
         // Non-retryable outcome — record bookkeeping for cooldown gates.
         recordRunBookkeeping(agent, now);
-        if (res.status !== "skipped" || res.reason !== "disabled") {
-          advanceAgentSchedule(agent, now, reason);
-        }
+        advanceAgentSchedule(agent, now, reason);
         let agentRan = res.status === "ran";
 
         const defaultSessionKey = resolveHeartbeatSession(


### PR DESCRIPTION
## Summary

Fixes #79380.
Supersedes #79418 with the semantic scheduler-state fix instead of a timer-floor mitigation.

This keeps retryable busy skips owned by the wake-layer retry path, but advances stale heartbeat due slots after terminal skips and non-retry deferrals. That makes `scheduleNext()` see a future due time instead of rearming an immediate timer against the same past-due agent.

## Verification

- `pnpm test src/infra/heartbeat-runner.scheduler.test.ts -- --reporter=verbose`
- `pnpm check:changed` (Testbox `tbx_01ksxfavykc7qyve4ysnxg3smh`)
- `pnpm test:changed` (failed in unrelated `src/auto-reply/reply/commands-status.thinking-default.test.ts` hook timeout; reran that exact file and reproduced the same unrelated timeout)
- `autoreview --mode branch --base origin/main --parallel-tests "pnpm test src/infra/heartbeat-runner.scheduler.test.ts -- --reporter=verbose"` -> clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: Gateway heartbeat scheduler can hot-loop when every due agent either returns a terminal skip without advancing `nextDueMs` or is deferred by a non-retry cooldown/flood gate while `nextDueMs` is already stale.

Real environment tested: Local macOS source checkout for focused scheduler behavior; Blacksmith Testbox for changed check gate.

Exact steps or command run after this patch: `pnpm test src/infra/heartbeat-runner.scheduler.test.ts -- --reporter=verbose` and `pnpm check:changed`.

Evidence after fix: Scheduler regression tests pass and cover both stale terminal `disabled` skips and flood deferrals without wake-layer retry; changed check passed in Testbox `tbx_01ksxfavykc7qyve4ysnxg3smh`.

Observed result after fix: Non-retryable terminal skips now record bookkeeping and advance the agent due slot; stale non-retry deferrals advance the due slot before returning, so the scheduler does not keep rearming at 0ms. Retryable busy skips still avoid schedule advancement and continue to use the wake-layer retry path.

What was not tested: Physical Raspberry Pi 4 ARM64 Docker soak on this exact branch. The original report/PR discussion already includes physical Pi before/after proof for the same scheduler symptom; this PR changes the fix shape to repair the stale schedule state directly.
