### PR TITLE
fix(ui): keep transient chat errors out of page headers

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -59,6 +59,7 @@ export type ChatHost = ChatInputHistoryState & {
   chatRunId: string | null;
   chatSending: boolean;
   lastError?: string | null;
+  chatError?: string | null;
   basePath: string;
   settings?: { token?: string | null };
   password?: string | null;
@@ -85,6 +86,11 @@ export type ChatHost = ChatInputHistoryState & {
   /** Callback for slash-command side effects that need app-level access. */
   onSlashAction?: (action: string) => void | Promise<void>;
 };
+
+function setChatError(host: ChatHost, error: string | null) {
+  host.lastError = error;
+  host.chatError = error;
+}
 
 export type ChatSendOptions = {
   confirmReset?: boolean;
@@ -580,7 +586,7 @@ async function sendQueuedChatMessage(
   host.chatSending = true;
   const isVisibleSession = () => visibleSessionMatches(host, sessionKey, prepared.agentId);
   if (isVisibleSession()) {
-    host.lastError = null;
+    setChatError(host, null);
     reconcileChatRunLifecycle(host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
       clearRunStatus: true,
     });
@@ -649,7 +655,7 @@ async function sendQueuedChatMessage(
         sendState: "waiting-reconnect",
       }));
       if (isVisibleSession()) {
-        host.lastError = "Message will send when the Gateway reconnects.";
+        setChatError(host, "Message will send when the Gateway reconnects.");
       }
       return "pending";
     }
@@ -659,7 +665,7 @@ async function sendQueuedChatMessage(
       sendState: "failed",
     }));
     if (isVisibleSession()) {
-      host.lastError = error;
+      setChatError(host, error);
       restoreComposerAfterFailedSend(host, opts ?? {});
     }
     return "failed";
@@ -942,7 +948,7 @@ async function flushChatQueue(host: ChatHost) {
       });
     }
   } catch (err) {
-    host.lastError = String(err);
+    setChatError(host, String(err));
   }
   if (!ok && next.localCommandName) {
     host.chatQueue = [next, ...host.chatQueue];
@@ -1204,7 +1210,7 @@ async function dispatchSlashCommand(
       return;
     case "new":
       if (!host.onSlashAction) {
-        host.lastError = "New Chat is unavailable.";
+        setChatError(host, "New Chat is unavailable.");
         return;
       }
       await host.onSlashAction("new-session");
@@ -1228,7 +1234,7 @@ async function dispatchSlashCommand(
   }
 
   if (!host.client || !host.connected) {
-    host.lastError = "Gateway not connected";
+    setChatError(host, "Gateway not connected");
     injectCommandResult(
       host,
       `Cannot run \`/${name}\`: Control UI is not connected to the Gateway.`,
@@ -1246,7 +1252,7 @@ async function dispatchSlashCommand(
       agentId: scopedAgentIdForSession(host, targetSessionKey),
     });
   } catch (err) {
-    host.lastError = String(err);
+    setChatError(host, String(err));
     injectCommandResult(host, `Command \`/${name}\` failed unexpectedly.`);
     scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
     return;
@@ -1306,7 +1312,7 @@ async function clearChatHistory(host: ChatHost) {
     });
     await loadChatHistory(host as unknown as ChatState);
   } catch (err) {
-    host.lastError = String(err);
+    setChatError(host, String(err));
   }
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
 }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -101,6 +101,7 @@ type GatewayHost = {
   hello: GatewayHelloOk | null;
   lastError: string | null;
   lastErrorCode: string | null;
+  chatError?: string | null;
   onboarding?: boolean;
   eventLogBuffer: EventLogEntry[];
   eventLog: EventLogEntry[];
@@ -589,6 +590,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
   clearSessionsChangedReloadTimer(host);
   host.lastError = null;
   host.lastErrorCode = null;
+  host.chatError = null;
   host.hello = null;
   host.connected = false;
   if (reconnectReason === "seq-gap") {
@@ -624,6 +626,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       host.connected = true;
       host.lastError = null;
       host.lastErrorCode = null;
+      host.chatError = null;
       host.hello = hello;
       applySnapshot(host, hello);
       void loadControlUiBootstrapConfig(

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -3,10 +3,14 @@
 import { html, render } from "lit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppViewState } from "./app-view-state.ts";
+import type { ChatProps } from "./views/chat.ts";
 import type { QuickSettingsProps } from "./views/config-quick.ts";
 
 const quickSettingsProps = vi.hoisted(() => ({
   current: null as QuickSettingsProps | null,
+}));
+const chatProps = vi.hoisted(() => ({
+  current: null as ChatProps | null,
 }));
 const localStorageValues = vi.hoisted(() => new Map<string, string>());
 
@@ -27,7 +31,10 @@ vi.mock("./views/config-quick.ts", () => ({
 }));
 
 vi.mock("./views/chat.ts", () => ({
-  renderChat: () => html`<div data-testid="chat"></div>`,
+  renderChat: (props: ChatProps) => {
+    chatProps.current = props;
+    return html`<div data-testid="chat"></div>`;
+  },
 }));
 
 vi.mock("./icons.ts", () => ({
@@ -76,6 +83,7 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
     hello: null,
     lastError: null,
     lastErrorCode: null,
+    chatError: null,
     eventLog: [],
     assistantName: "Nova",
     assistantAvatar: "/avatar/main",
@@ -214,6 +222,7 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
 beforeEach(() => {
   localStorageValues.clear();
   quickSettingsProps.current = null;
+  chatProps.current = null;
 });
 
 describe("renderApp assistant avatar routing", () => {
@@ -251,6 +260,77 @@ describe("renderApp assistant avatar routing", () => {
     const content = container.querySelector<HTMLElement>("main.content");
     expect(content?.classList.contains("content--logs")).toBe(true);
     expect(content?.classList.contains("content--chat")).toBe(false);
+  });
+
+  it("does not render chat errors in non-chat page headers", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "sessions",
+          lastError: "transient tool failure",
+          chatError: "transient tool failure",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".page-meta .pill.danger")?.textContent?.trim()).toBeUndefined();
+  });
+
+  it("keeps non-chat global errors visible in non-chat page headers", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "nodes",
+          lastError: "node list failed",
+          chatError: "previous chat failure",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".page-meta .pill.danger")?.textContent?.trim()).toBe(
+      "node list failed",
+    );
+  });
+
+  it("routes chat errors through the chat view instead of the shared header", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "chat",
+          lastError: "transient tool failure",
+          chatError: "transient tool failure",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".page-meta .pill.danger")?.textContent?.trim()).toBeUndefined();
+    expect(chatProps.current?.error).toBe("transient tool failure");
+  });
+
+  it("routes newer global errors through the chat view ahead of stale chat errors", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "chat",
+          lastError: "gateway disconnected",
+          chatError: "previous chat failure",
+        }),
+      ),
+      container,
+    );
+
+    expect(chatProps.current?.error).toBe("gateway disconnected");
   });
 
   it("passes security quick setting fields to Quick Settings", () => {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -154,6 +154,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.chatStream = null;
   state.chatSideResult = null;
   state.lastError = null;
+  state.chatError = null;
   state.chatAvatarUrl = null;
   state.chatAvatarSource = null;
   state.chatAvatarStatus = null;
@@ -680,6 +681,7 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
 export function dismissChatError(state: AppViewState) {
   state.lastError = null;
   state.lastErrorCode = null;
+  state.chatError = null;
   if (state.realtimeTalkStatus === "error") {
     const talkHost = state as unknown as {
       realtimeTalkSession?: { stop(): void } | null;
@@ -700,14 +702,17 @@ export async function createChatSession(state: AppViewState): Promise<boolean> {
   }
   if (!canSwitchToNewChatSession(state)) {
     state.lastError = NEW_CHAT_ACTIVE_RUN_MESSAGE;
+    state.chatError = state.lastError;
     return false;
   }
   if (state.sessionsLoading) {
     state.lastError = NEW_CHAT_SESSIONS_LOADING_MESSAGE;
+    state.chatError = state.lastError;
     return false;
   }
 
   state.lastError = null;
+  state.chatError = null;
   const previousSessionKey = state.sessionKey;
   const parentSessionKey = state.sessionsResult?.sessions.some(
     (row) => row.key === previousSessionKey,
@@ -739,6 +744,7 @@ export async function createChatSession(state: AppViewState): Promise<boolean> {
         (state.sessionsLoading
           ? NEW_CHAT_SESSIONS_LOADING_MESSAGE
           : NEW_CHAT_CREATE_FAILED_MESSAGE);
+      state.chatError = state.lastError;
     }
     return false;
   }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -983,6 +983,8 @@ export function renderApp(state: AppViewState) {
   const cronNext = state.cronStatus?.nextWakeAtMs ?? null;
   const chatDisabledReason = state.connected ? null : t("chat.disconnected");
   const isChat = state.tab === "chat";
+  const headerError = !isChat && state.lastError !== state.chatError ? state.lastError : null;
+  const chatViewError = state.lastError;
   const chatFocus = isChat && (state.settings.chatFocusMode || state.onboarding);
   const chatHeaderHidden = isChat && (chatFocus || state.chatHeaderControlsHidden);
   const navDrawerOpen = state.navDrawerOpen && !chatFocus && !state.onboarding;
@@ -1999,9 +2001,7 @@ export function renderApp(state: AppViewState) {
                       </div>
                     `
                   : nothing}
-                ${state.lastError
-                  ? html`<div class="pill danger">${state.lastError}</div>`
-                  : nothing}
+                ${headerError ? html`<div class="pill danger">${headerError}</div>` : nothing}
                 ${isChat ? renderChatControls(state) : nothing}
               </div>
             </section>`}
@@ -2924,7 +2924,7 @@ export function renderApp(state: AppViewState) {
                   connected: state.connected,
                   canSend: state.connected,
                   disabledReason: chatDisabledReason,
-                  error: state.lastError,
+                  error: chatViewError,
                   runStatus: state.chatRunStatus,
                   onDismissError: () => dismissChatError(state),
                   sessions: state.sessionsResult,
@@ -3004,6 +3004,7 @@ export function renderApp(state: AppViewState) {
                       await loadChatHistory(state);
                     } catch (err) {
                       state.lastError = String(err);
+                      state.chatError = state.lastError;
                     }
                   },
                   agentsList: state.agentsList,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -74,6 +74,7 @@ export type AppViewState = {
   hello: GatewayHelloOk | null;
   lastError: string | null;
   lastErrorCode: string | null;
+  chatError: string | null;
   eventLog: EventLogEntry[];
   assistantName: string;
   assistantAvatar: string | null;

--- a/ui/src/ui/app.talk.test.ts
+++ b/ui/src/ui/app.talk.test.ts
@@ -115,4 +115,41 @@ describe("OpenClawApp Talk controls", () => {
       { role: "user", text: "Second request", isStreaming: false },
     ]);
   });
+
+  it("routes Talk startup failures through the chat error surface", async () => {
+    startMock.mockRejectedValueOnce(new Error("voice provider missing"));
+    const { OpenClawApp } = await import("./app.ts");
+    const app = Object.create(OpenClawApp.prototype) as {
+      chatError: string | null;
+      client: unknown;
+      connected: boolean;
+      lastError: string | null;
+      realtimeTalkActive: boolean;
+      realtimeTalkConversation: Array<{ role: string; text: string; isStreaming: boolean }>;
+      realtimeTalkDetail: string | null;
+      realtimeTalkStatus: string;
+      realtimeTalkSession: { stop(): void } | null;
+      realtimeTalkTranscript: string | null;
+      sessionKey: string;
+    };
+    Object.defineProperties(app, {
+      chatError: { value: "previous chat failure", writable: true },
+      client: { value: { request: vi.fn() }, writable: true },
+      connected: { value: true, writable: true },
+      lastError: { value: "previous chat failure", writable: true },
+      realtimeTalkActive: { value: false, writable: true },
+      realtimeTalkConversation: { value: [], writable: true },
+      realtimeTalkDetail: { value: null, writable: true },
+      realtimeTalkSession: { value: null, writable: true },
+      realtimeTalkStatus: { value: "idle", writable: true },
+      realtimeTalkTranscript: { value: null, writable: true },
+      sessionKey: { value: "main", writable: true },
+    });
+
+    await OpenClawApp.prototype.toggleRealtimeTalk.call(app as never);
+
+    expect(app.lastError).toBe("voice provider missing");
+    expect(app.chatError).toBe("voice provider missing");
+    expect(stopMock).toHaveBeenCalledOnce();
+  });
 });

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -215,6 +215,7 @@ export class OpenClawApp extends LitElement {
   @state() hello: GatewayHelloOk | null = null;
   @state() lastError: string | null = null;
   @state() lastErrorCode: string | null = null;
+  @state() chatError: string | null = null;
   @state() eventLog: EventLogEntry[] = [];
   eventLogBuffer: EventLogEntry[] = [];
   toolStreamSyncTimer: number | null = null;
@@ -1158,6 +1159,7 @@ export class OpenClawApp extends LitElement {
     }
     if (!this.client || !this.connected) {
       this.lastError = "Gateway not connected";
+      this.chatError = this.lastError;
       return;
     }
     this.realtimeTalkActive = true;
@@ -1174,6 +1176,10 @@ export class OpenClawApp extends LitElement {
           this.realtimeTalkDetail = detail ?? null;
           if (status === "idle" || status === "error") {
             this.realtimeTalkActive = status !== "idle";
+          }
+          if (status === "error" && this.realtimeTalkDetail) {
+            this.lastError = this.realtimeTalkDetail;
+            this.chatError = this.realtimeTalkDetail;
           }
         },
         onTranscript: (entry) => {
@@ -1199,6 +1205,7 @@ export class OpenClawApp extends LitElement {
       this.realtimeTalkStatus = "error";
       this.realtimeTalkDetail = error instanceof Error ? error.message : String(error);
       this.lastError = this.realtimeTalkDetail;
+      this.chatError = this.realtimeTalkDetail;
     }
   }
 

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -54,6 +54,11 @@ const chatSessionPickerSearchControllers = new WeakMap<
   ChatSessionPickerSearchController
 >();
 
+function setChatError(state: AppViewState, error: string | null) {
+  state.lastError = error;
+  state.chatError = error;
+}
+
 export function renderChatSessionSelect(
   state: AppViewState,
   onSwitchSession: ChatSessionSwitchHandler = () => undefined,
@@ -1013,7 +1018,7 @@ async function switchChatModel(state: AppViewState, nextModel: string): Promise<
   }
   const targetSessionKey = state.sessionKey;
   const prevOverride = state.chatModelOverrides[targetSessionKey];
-  state.lastError = null;
+  setChatError(state, null);
   // Write the override cache immediately so the picker stays in sync during the RPC round-trip.
   state.chatModelOverrides = {
     ...state.chatModelOverrides,
@@ -1040,7 +1045,7 @@ async function switchChatModel(state: AppViewState, nextModel: string): Promise<
     } catch (err) {
       // Roll back so the picker reflects the actual server model.
       state.chatModelOverrides = { ...state.chatModelOverrides, [targetSessionKey]: prevOverride };
-      state.lastError = `Failed to set model: ${String(err)}`;
+      setChatError(state, `Failed to set model: ${String(err)}`);
       return false;
     } finally {
       clearPendingSwitch();
@@ -1086,7 +1091,7 @@ async function switchChatThinkingLevel(state: AppViewState, nextThinkingLevel: s
   if ((normalizedPrev ?? "") === (normalizedNext ?? "")) {
     return;
   }
-  state.lastError = null;
+  setChatError(state, null);
   patchSessionThinkingLevel(state, targetSessionKey, normalizedNext);
   state.chatThinkingLevel = normalizedNext ?? null;
   try {
@@ -1098,7 +1103,7 @@ async function switchChatThinkingLevel(state: AppViewState, nextThinkingLevel: s
   } catch (err) {
     patchSessionThinkingLevel(state, targetSessionKey, previousThinkingLevel);
     state.chatThinkingLevel = normalizedPrev ?? null;
-    state.lastError = `Failed to set thinking level: ${String(err)}`;
+    setChatError(state, `Failed to set thinking level: ${String(err)}`);
   }
 }
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -287,6 +287,7 @@ export type ChatState = {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   lastError: string | null;
+  chatError?: string | null;
   resetChatInputHistoryNavigation?: () => void;
   assistantAgentId?: string | null;
   agentsList?: { defaultId?: string | null } | null;
@@ -301,6 +302,11 @@ export type ChatEventPayload = {
   message?: unknown;
   errorMessage?: string;
 };
+
+function setChatError(state: ChatState, error: string | null) {
+  state.lastError = error;
+  state.chatError = error;
+}
 
 function isGlobalSessionKey(sessionKey: string | undefined | null): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
@@ -408,7 +414,7 @@ export async function loadChatHistory(state: ChatState) {
   // Any pending input-history snapshot becomes invalid once we start reloading transcript state.
   state.resetChatInputHistoryNavigation?.();
   state.chatLoading = true;
-  state.lastError = null;
+  setChatError(state, null);
   try {
     let res: { messages?: Array<unknown>; sessionId?: string; thinkingLevel?: string };
     for (;;) {
@@ -461,9 +467,9 @@ export async function loadChatHistory(state: ChatState) {
     if (isMissingOperatorReadScopeError(err)) {
       state.chatMessages = [];
       state.chatThinkingLevel = null;
-      state.lastError = formatMissingOperatorReadScopeMessage("existing chat history");
+      setChatError(state, formatMissingOperatorReadScopeMessage("existing chat history"));
     } else {
-      state.lastError = String(err);
+      setChatError(state, String(err));
     }
   } finally {
     if (isLatestChatHistoryRequest(state, requestVersion)) {
@@ -657,7 +663,7 @@ export async function sendChatMessage(
   appendUserChatMessage(state, msg, attachments, now);
 
   state.chatSending = true;
-  state.lastError = null;
+  setChatError(state, null);
   reconcileChatRunLifecycle(state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
     clearRunStatus: true,
   });
@@ -686,7 +692,7 @@ export async function sendChatMessage(
       clearLocalRun: true,
       clearChatStream: true,
     });
-    state.lastError = error;
+    setChatError(state, error);
     state.chatMessages = [
       ...state.chatMessages,
       {
@@ -776,13 +782,13 @@ async function sendChatMessageWithGeneratedRunId(
   if (!msg && !hasAttachments) {
     return null;
   }
-  state.lastError = null;
+  setChatError(state, null);
   const runId = generateUUID();
   try {
     const ack = await requestChatSend(state, { message: msg, attachments, runId });
     return ack.runId;
   } catch (err) {
-    state.lastError = formatConnectError(err);
+    setChatError(state, formatConnectError(err));
     return null;
   }
 }
@@ -830,7 +836,7 @@ export async function abortChatRun(state: ChatState): Promise<boolean> {
     );
     return true;
   } catch (err) {
-    state.lastError = formatConnectError(err);
+    setChatError(state, formatConnectError(err));
     return false;
   }
 }
@@ -939,7 +945,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       state.chatMessages = [...state.chatMessages, errorMessage];
     }
     reconcileTerminalRun("interrupted", "failed");
-    state.lastError = payload.errorMessage ?? "chat error";
+    setChatError(state, payload.errorMessage ?? "chat error");
   }
   return payload.state;
 }

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -39,6 +39,7 @@ export type ConfigState = {
   pendingUpdateExpectedVersion: string | null;
   updateStatusBanner: { tone: "danger" | "warn" | "info"; text: string } | null;
   lastError: string | null;
+  chatError?: string | null;
 };
 
 const autoAllowlistedPluginIdsByState = new WeakMap<ConfigState, Set<string>>();
@@ -53,6 +54,7 @@ export async function loadConfig(state: ConfigState, options: LoadConfigOptions 
   }
   state.configLoading = true;
   state.lastError = null;
+  state.chatError = null;
   try {
     const res = await state.client.request<ConfigSnapshot>("config.get", {});
     applyConfigSnapshot(state, res, options);
@@ -224,6 +226,7 @@ async function submitConfigChange(
   }
   state[busyKey] = true;
   state.lastError = null;
+  state.chatError = null;
   try {
     const raw = serializeFormForSubmit(state);
     const baseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash;
@@ -272,6 +275,7 @@ export async function runUpdate(state: ConfigState) {
   }
   state.updateRunning = true;
   state.lastError = null;
+  state.chatError = null;
   state.updateStatusBanner = null;
   try {
     const res = await state.client.request<{
@@ -502,6 +506,7 @@ export async function openConfigFile(state: ConfigState): Promise<void> {
     return;
   }
   state.lastError = null;
+  state.chatError = null;
   try {
     const res = await state.client.request<{ ok: boolean; path?: string; error?: string }>(
       "config.openFile",

--- a/ui/src/ui/controllers/exec-approvals.ts
+++ b/ui/src/ui/controllers/exec-approvals.ts
@@ -49,6 +49,7 @@ export type ExecApprovalsState = {
   execApprovalsForm: ExecApprovalsFile | null;
   execApprovalsSelectedAgent: string | null;
   lastError: string | null;
+  chatError?: string | null;
 };
 
 function resolveExecApprovalsRpc(target?: ExecApprovalsTarget | null): {
@@ -91,6 +92,7 @@ export async function loadExecApprovals(
   }
   state.execApprovalsLoading = true;
   state.lastError = null;
+  state.chatError = null;
   try {
     const rpc = resolveExecApprovalsRpc(target);
     if (!rpc) {
@@ -122,6 +124,7 @@ export async function saveExecApprovals(
   }
   state.execApprovalsSaving = true;
   state.lastError = null;
+  state.chatError = null;
   try {
     const baseHash = state.execApprovalsSnapshot?.hash;
     if (!baseHash) {

--- a/ui/src/ui/controllers/nodes.ts
+++ b/ui/src/ui/controllers/nodes.ts
@@ -6,6 +6,7 @@ export type NodesState = {
   nodesLoading: boolean;
   nodes: Array<Record<string, unknown>>;
   lastError: string | null;
+  chatError?: string | null;
 };
 
 export async function loadNodes(state: NodesState, opts?: { quiet?: boolean }) {
@@ -18,6 +19,7 @@ export async function loadNodes(state: NodesState, opts?: { quiet?: boolean }) {
   state.nodesLoading = true;
   if (!opts?.quiet) {
     state.lastError = null;
+    state.chatError = null;
   }
   try {
     const res = await state.client.request<{ nodes?: Record<string, unknown> }>("node.list", {});


### PR DESCRIPTION
## Summary
- Keep the shared Control UI header error path for non-chat/global failures.
- Track chat-originated failures separately with `chatError` so Usage/Sessions and other non-chat headers suppress only stale chat errors.
- Keep chat failures visible through the existing chat view error path, where `renderChat` receives the current `lastError`.

## Context
PR #88248 intentionally made chat failures visible as assistant/chat errors. That intent is still preserved here.

The regression is that the shared non-config page header also rendered the global `state.lastError`, so a transient chat/runtime error could briefly appear as a red header pill on unrelated pages such as Usage or Sessions. The first version of this PR removed that shared header pill too broadly; this update preserves non-chat error visibility while scoping chat-owned transient errors out of unrelated headers.

## Verification
- `pnpm test ui/src/ui/app-render.assistant-avatar.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/app.talk.test.ts -- --reporter=verbose`
- `pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof
Behavior addressed: Transient chat errors no longer leak into non-chat Control UI page headers such as Usage or Sessions, while non-chat/global failures remain visible in non-chat page headers.

Real environment tested: Local jsdom UI render tests and changed-check gates.

Evidence after fix: The focused render test asserts a Sessions render with a chat-owned `lastError` has no `.page-meta .pill.danger`, a Nodes render with a newer non-chat `lastError` still shows the header error, and a Chat render continues to pass the current error to `renderChat`.

Observed result after fix: Chat errors remain visible through the chat view, stale chat errors do not appear in unrelated page headers, and non-chat/global errors still have a visible header surface.

Pre-fix
<img width="2382" height="680" alt="Screenshot 2026-05-30 at 4 57 22 PM" src="https://github.com/user-attachments/assets/9429596d-401b-418f-b4c6-59572aba2d99" />

After fix:
<img width="793" height="121" alt="Screenshot 2026-05-31 at 1 19 39 AM" src="https://github.com/user-attachments/assets/0639eae1-da0e-47cc-a630-f6e153e2fc0c" />

<img width="1727" height="342" alt="Screenshot 2026-05-31 at 1 23 36 AM" src="https://github.com/user-attachments/assets/70b1abe3-cba5-4b6d-bfb1-6b06c8d98998" />

