### PR TITLE
Move Workboard to relational SQLite

### DIFF
--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -140,14 +140,19 @@ Claimed cards reject agent-tool mutations from other agents unless the caller
 has the claim token returned by `workboard_claim`. Dashboard operators still use
 the normal Gateway RPC surface and can recover or reassign cards.
 
-Workboard stores all durable board data through the plugin SQLite key-value
-store. Cards live in `workboard.cards`, board metadata in `workboard.boards`,
-notification subscriptions in `workboard.notify`, and attachment blobs in
-`workboard.attachments`. Run history, comments, proof, artifact references,
-attachment indexes, diagnostics, dependencies, lifecycle events, worker logs,
-protocol state, and automation metadata stay on the card record so a card export
-preserves the board narrative without inlining attachment blob contents. Each
-attachment blob must fit one 64 KiB plugin state value after JSON serialization.
+Workboard stores durable board data in a plugin-owned relational SQLite database
+under the OpenClaw state directory. Boards, cards, labels, lifecycle events,
+run attempts, comments, dependency links, proof, artifact references,
+attachment metadata and blobs, diagnostics, notifications, worker logs,
+protocol state, and subscriptions are persisted in Workboard tables instead of
+plugin key-value entries. A card export still preserves the board narrative
+without inlining attachment blob contents.
+
+Installations that used Workboard in the `.28` release can run
+`openclaw doctor --fix` to migrate the shipped legacy plugin-state namespaces
+(`workboard.cards`, `workboard.boards`, and `workboard.notify`) into the
+relational database. If a legacy `workboard.attachments` namespace is present,
+doctor migrates those attachment blobs too.
 
 Workboard diagnostics are computed from local card metadata. The built-in checks
 flag assigned cards that wait too long, running cards without recent heartbeat,

--- a/extensions/workboard/doctor-contract-api.test.ts
+++ b/extensions/workboard/doctor-contract-api.test.ts
@@ -1,0 +1,447 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createPluginStateKeyedStoreForTests as createPluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type {
+  OpenKeyedStoreOptions,
+  PluginDoctorStateMigrationContext,
+} from "openclaw/plugin-sdk/runtime-doctor";
+import { describe, expect, it } from "vitest";
+import { stateMigrations } from "./doctor-contract-api.js";
+import { createWorkboardSqliteStores } from "./src/sqlite-store.js";
+import { WorkboardStore, type PersistedWorkboardCard } from "./src/store.js";
+
+function createDoctorContext(env: NodeJS.ProcessEnv): PluginDoctorStateMigrationContext {
+  return {
+    openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
+      return createPluginStateKeyedStore<T>("workboard", {
+        ...options,
+        env: options.env ?? env,
+      });
+    },
+  };
+}
+
+describe("workboard doctor contract", () => {
+  it("migrates shipped .28 plugin-state workboard data into sqlite", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-doctor-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    try {
+      const cardStore = createPluginStateKeyedStore<PersistedWorkboardCard>("workboard", {
+        namespace: "workboard.cards",
+        maxEntries: 2000,
+        env,
+      });
+      const boardStore = createPluginStateKeyedStore("workboard", {
+        namespace: "workboard.boards",
+        maxEntries: 200,
+        env,
+      });
+      const notifyStore = createPluginStateKeyedStore("workboard", {
+        namespace: "workboard.notify",
+        maxEntries: 2000,
+        env,
+      });
+      const attachmentStore = createPluginStateKeyedStore("workboard", {
+        namespace: "workboard.attachments",
+        maxEntries: 42_000,
+        env,
+      });
+      await boardStore.register("planning", {
+        version: 1,
+        board: { id: "planning", name: "Planning", createdAt: 1, updatedAt: 2 },
+      });
+      await cardStore.register("card-1", {
+        version: 1,
+        card: {
+          id: "card-1",
+          title: "Migrate me",
+          status: "todo",
+          priority: "normal",
+          labels: ["sqlite"],
+          position: 1000,
+          createdAt: 1,
+          updatedAt: 2,
+          metadata: {
+            automation: { boardId: "planning" },
+            attachments: [
+              {
+                id: "attachment-1",
+                cardId: "card-1",
+                createdAt: 2,
+                fileName: "proof.txt",
+                byteSize: 2,
+              },
+            ],
+          },
+        },
+      });
+      await notifyStore.register("sub-1", {
+        version: 1,
+        subscription: { id: "sub-1", boardId: "planning", createdAt: 1, updatedAt: 2 },
+      });
+      await attachmentStore.register("attachment-1", {
+        version: 1,
+        attachment: {
+          id: "attachment-1",
+          cardId: "card-1",
+          createdAt: 2,
+          fileName: "proof.txt",
+          byteSize: 2,
+        },
+        contentBase64: Buffer.from("ok").toString("base64"),
+      });
+
+      const migration = stateMigrations[0];
+      await expect(
+        migration.detectLegacyState({
+          config: {},
+          env,
+          stateDir,
+          oauthDir: path.join(stateDir, "oauth"),
+          context: createDoctorContext(env),
+        }),
+      ).resolves.toMatchObject({
+        preview: [expect.stringContaining("4 legacy .28 plugin-state KV entries")],
+      });
+
+      const result = await migration.migrateLegacyState({
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context: createDoctorContext(env),
+      });
+
+      expect(result).toMatchObject({
+        changes: [expect.stringContaining("Migrated 4 Workboard .28 plugin-state KV entries")],
+        warnings: [],
+      });
+      expect(await cardStore.entries()).toEqual([]);
+      expect(await boardStore.entries()).toEqual([]);
+      expect(await notifyStore.entries()).toEqual([]);
+      expect(await attachmentStore.entries()).toEqual([]);
+
+      const sqlite = createWorkboardSqliteStores({ env });
+      const store = new WorkboardStore(sqlite.cards, {
+        boards: sqlite.boards,
+        subscriptions: sqlite.subscriptions,
+        attachments: sqlite.attachments,
+      });
+      expect(await store.get("card-1")).toMatchObject({
+        title: "Migrate me",
+        metadata: {
+          automation: { boardId: "planning" },
+          attachments: [expect.objectContaining({ id: "attachment-1" })],
+        },
+      });
+      expect(await store.getAttachment("attachment-1")).toMatchObject({
+        contentBase64: Buffer.from("ok").toString("base64"),
+      });
+      expect(await store.listBoards()).toMatchObject({
+        boards: [
+          expect.objectContaining({ id: "default" }),
+          expect.objectContaining({ id: "planning" }),
+        ],
+      });
+      expect(await store.listNotificationSubscriptions({ boardId: "planning" })).toMatchObject({
+        subscriptions: [expect.objectContaining({ id: "sub-1" })],
+      });
+      sqlite.close();
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resumes attachment migration when the owning card was already copied", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-doctor-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    try {
+      const attachmentStore = createPluginStateKeyedStore("workboard", {
+        namespace: "workboard.attachments",
+        maxEntries: 42_000,
+        env,
+      });
+      await attachmentStore.register("attachment-1", {
+        version: 1,
+        attachment: {
+          id: "attachment-1",
+          cardId: "card-1",
+          createdAt: 2,
+          fileName: "proof.txt",
+          byteSize: 2,
+        },
+        contentBase64: Buffer.from("ok").toString("base64"),
+      });
+
+      const sqlite = createWorkboardSqliteStores({ env });
+      await sqlite.cards.register("card-1", {
+        version: 1,
+        card: {
+          id: "card-1",
+          title: "Already copied",
+          status: "todo",
+          priority: "normal",
+          labels: [],
+          position: 1000,
+          createdAt: 1,
+          updatedAt: 2,
+          metadata: {
+            attachments: [
+              {
+                id: "attachment-1",
+                cardId: "card-1",
+                createdAt: 2,
+                fileName: "proof.txt",
+                byteSize: 2,
+              },
+            ],
+          },
+        },
+      });
+      sqlite.close();
+
+      const result = await stateMigrations[0].migrateLegacyState({
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context: createDoctorContext(env),
+      });
+
+      expect(result).toMatchObject({
+        changes: [expect.stringContaining("Migrated 1 Workboard .28 plugin-state KV entry")],
+        warnings: [],
+      });
+      expect(await attachmentStore.entries()).toEqual([]);
+
+      const reopenedStores = createWorkboardSqliteStores({ env });
+      expect(await reopenedStores.attachments.lookup("attachment-1")).toMatchObject({
+        contentBase64: Buffer.from("ok").toString("base64"),
+      });
+      reopenedStores.close();
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips malformed legacy attachments without aborting valid attachment migration", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-doctor-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    try {
+      const attachmentStore = createPluginStateKeyedStore<unknown>("workboard", {
+        namespace: "workboard.attachments",
+        maxEntries: 42_000,
+        env,
+      });
+      await attachmentStore.register("broken", { version: 1 });
+      await attachmentStore.register("attachment-1", {
+        version: 1,
+        attachment: {
+          id: "attachment-1",
+          cardId: "card-1",
+          createdAt: 2,
+          fileName: "proof.txt",
+          byteSize: 2,
+        },
+        contentBase64: Buffer.from("ok").toString("base64"),
+      });
+
+      const sqlite = createWorkboardSqliteStores({ env });
+      await sqlite.cards.register("card-1", {
+        version: 1,
+        card: {
+          id: "card-1",
+          title: "Already copied",
+          status: "todo",
+          priority: "normal",
+          labels: [],
+          position: 1000,
+          createdAt: 1,
+          updatedAt: 2,
+          metadata: {
+            attachments: [
+              {
+                id: "attachment-1",
+                cardId: "card-1",
+                createdAt: 2,
+                fileName: "proof.txt",
+                byteSize: 2,
+              },
+            ],
+          },
+        },
+      });
+      sqlite.close();
+
+      const result = await stateMigrations[0].migrateLegacyState({
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context: createDoctorContext(env),
+      });
+
+      expect(result.changes).toEqual([
+        expect.stringContaining("Migrated 1 Workboard .28 plugin-state KV entry"),
+      ]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining("Skipped malformed legacy Workboard attachment entry broken"),
+      ]);
+      expect((await attachmentStore.entries()).map((entry) => entry.key)).toEqual(["broken"]);
+
+      const reopenedStores = createWorkboardSqliteStores({ env });
+      expect(await reopenedStores.attachments.lookup("attachment-1")).toMatchObject({
+        contentBase64: Buffer.from("ok").toString("base64"),
+      });
+      reopenedStores.close();
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps orphan legacy attachments when migrated card metadata does not reference them", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-doctor-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    try {
+      const cardStore = createPluginStateKeyedStore<PersistedWorkboardCard>("workboard", {
+        namespace: "workboard.cards",
+        maxEntries: 2000,
+        env,
+      });
+      const attachmentStore = createPluginStateKeyedStore("workboard", {
+        namespace: "workboard.attachments",
+        maxEntries: 42_000,
+        env,
+      });
+      await cardStore.register("card-1", {
+        version: 1,
+        card: {
+          id: "card-1",
+          title: "Migrated card",
+          status: "todo",
+          priority: "normal",
+          labels: [],
+          position: 1000,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      });
+      await attachmentStore.register("attachment-1", {
+        version: 1,
+        attachment: {
+          id: "attachment-1",
+          cardId: "card-1",
+          createdAt: 2,
+          fileName: "orphan.txt",
+          byteSize: 2,
+        },
+        contentBase64: Buffer.from("ok").toString("base64"),
+      });
+
+      const result = await stateMigrations[0].migrateLegacyState({
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context: createDoctorContext(env),
+      });
+
+      expect(result.changes).toEqual([
+        expect.stringContaining("Migrated 1 Workboard .28 plugin-state KV entry"),
+      ]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining("does not reference the attachment"),
+      ]);
+      expect(await cardStore.entries()).toEqual([]);
+      expect(await attachmentStore.entries()).toHaveLength(1);
+
+      const reopenedStores = createWorkboardSqliteStores({ env });
+      expect(await reopenedStores.attachments.lookup("attachment-1")).toBeUndefined();
+      reopenedStores.close();
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps current sqlite rows when legacy kv ids conflict", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-doctor-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    try {
+      const cardStore = createPluginStateKeyedStore<PersistedWorkboardCard>("workboard", {
+        namespace: "workboard.cards",
+        maxEntries: 2000,
+        env,
+      });
+      const attachmentStore = createPluginStateKeyedStore("workboard", {
+        namespace: "workboard.attachments",
+        maxEntries: 42_000,
+        env,
+      });
+      await cardStore.register("card-1", {
+        version: 1,
+        card: {
+          id: "card-1",
+          title: "Legacy card",
+          status: "todo",
+          priority: "normal",
+          labels: [],
+          position: 1000,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      });
+      await attachmentStore.register("attachment-1", {
+        version: 1,
+        attachment: {
+          id: "attachment-1",
+          cardId: "card-1",
+          createdAt: 1,
+          fileName: "old.txt",
+          byteSize: 2,
+        },
+        contentBase64: Buffer.from("no").toString("base64"),
+      });
+
+      const sqlite = createWorkboardSqliteStores({ env });
+      await sqlite.cards.register("card-1", {
+        version: 1,
+        card: {
+          id: "card-1",
+          title: "Current card",
+          status: "todo",
+          priority: "normal",
+          labels: [],
+          position: 1000,
+          createdAt: 2,
+          updatedAt: 2,
+        },
+      });
+      sqlite.close();
+
+      const result = await stateMigrations[0].migrateLegacyState({
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context: createDoctorContext(env),
+      });
+
+      expect(result.changes).toEqual([]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining("SQLite target already exists"),
+        expect.stringContaining("owning card was not migrated"),
+      ]);
+      expect(await cardStore.entries()).toHaveLength(1);
+      expect(await attachmentStore.entries()).toHaveLength(1);
+
+      const reopenedStores = createWorkboardSqliteStores({ env });
+      const store = new WorkboardStore(reopenedStores.cards);
+      expect(await store.get("card-1")).toMatchObject({ title: "Current card" });
+      expect(await reopenedStores.attachments.lookup("attachment-1")).toBeUndefined();
+      reopenedStores.close();
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/workboard/doctor-contract-api.ts
+++ b/extensions/workboard/doctor-contract-api.ts
@@ -1,0 +1,288 @@
+import {
+  type PluginDoctorStateMigration,
+  type PluginDoctorStateMigrationContext,
+} from "openclaw/plugin-sdk/runtime-doctor";
+import { createWorkboardSqliteStores, resolveWorkboardSqlitePath } from "./src/sqlite-store.js";
+import type {
+  PersistedWorkboardAttachment,
+  PersistedWorkboardBoard,
+  PersistedWorkboardCard,
+  PersistedWorkboardNotificationSubscription,
+  WorkboardKeyedStore,
+} from "./src/store.js";
+
+const MAX_CARDS = 2000;
+
+function migrationEnv(params: { env: NodeJS.ProcessEnv; stateDir: string }): NodeJS.ProcessEnv {
+  return { ...params.env, OPENCLAW_STATE_DIR: params.stateDir };
+}
+
+function openLegacyStore<T>(params: {
+  context: PluginDoctorStateMigrationContext;
+  env: NodeJS.ProcessEnv;
+  namespace: string;
+  maxEntries: number;
+}): WorkboardKeyedStore<T> {
+  return params.context.openPluginStateKeyedStore<T>({
+    namespace: params.namespace,
+    maxEntries: params.maxEntries,
+    env: params.env,
+  });
+}
+
+function isPersistedCard(value: unknown): value is PersistedWorkboardCard {
+  return Boolean(
+    value && typeof value === "object" && (value as PersistedWorkboardCard).version === 1,
+  );
+}
+
+function isPersistedBoard(value: unknown): value is PersistedWorkboardBoard {
+  return Boolean(
+    value && typeof value === "object" && (value as PersistedWorkboardBoard).version === 1,
+  );
+}
+
+function isPersistedSubscription(
+  value: unknown,
+): value is PersistedWorkboardNotificationSubscription {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    (value as PersistedWorkboardNotificationSubscription).version === 1,
+  );
+}
+
+function isPersistedAttachment(value: unknown): value is PersistedWorkboardAttachment {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as {
+    version?: unknown;
+    attachment?: Partial<PersistedWorkboardAttachment["attachment"]>;
+    contentBase64?: unknown;
+  };
+  const attachment = candidate.attachment;
+  return (
+    candidate.version === 1 &&
+    attachment !== undefined &&
+    typeof attachment === "object" &&
+    typeof attachment.id === "string" &&
+    typeof attachment.cardId === "string" &&
+    typeof attachment.fileName === "string" &&
+    typeof attachment.byteSize === "number" &&
+    typeof attachment.createdAt === "number" &&
+    typeof candidate.contentBase64 === "string"
+  );
+}
+
+async function migrateNamespace<T>(params: {
+  label: string;
+  legacy: WorkboardKeyedStore<T>;
+  target: WorkboardKeyedStore<T>;
+  isValid: (value: unknown) => value is T;
+}): Promise<{ imported: number; warnings: string[] }> {
+  const warnings: string[] = [];
+  let imported = 0;
+  for (const entry of await params.legacy.entries()) {
+    if (!params.isValid(entry.value)) {
+      warnings.push(`Skipped malformed legacy Workboard ${params.label} entry ${entry.key}`);
+      continue;
+    }
+    try {
+      const targetEntry = await params.target.lookup(entry.key);
+      if (targetEntry) {
+        if (JSON.stringify(targetEntry) === JSON.stringify(entry.value)) {
+          await params.legacy.delete(entry.key);
+          imported++;
+          continue;
+        }
+        warnings.push(
+          `Skipped legacy Workboard ${params.label} entry ${entry.key} because the SQLite target already exists`,
+        );
+        continue;
+      }
+      await params.target.register(entry.key, entry.value);
+      await params.legacy.delete(entry.key);
+      imported++;
+    } catch (err) {
+      warnings.push(
+        `Failed migrating legacy Workboard ${params.label} entry ${entry.key}: ${String(err)}`,
+      );
+    }
+  }
+  return { imported, warnings };
+}
+
+async function targetCardReferencesAttachment(
+  cards: WorkboardKeyedStore,
+  attachment: PersistedWorkboardAttachment,
+): Promise<boolean> {
+  const card = await cards.lookup(attachment.attachment.cardId);
+  return Boolean(
+    card?.version === 1 &&
+    card.card.metadata?.attachments?.some(
+      (entry) =>
+        entry.id === attachment.attachment.id && entry.cardId === attachment.attachment.cardId,
+    ),
+  );
+}
+
+async function migrateAttachments(params: {
+  legacy: WorkboardKeyedStore<PersistedWorkboardAttachment>;
+  cards: WorkboardKeyedStore;
+  target: WorkboardKeyedStore<PersistedWorkboardAttachment>;
+}): Promise<{ imported: number; warnings: string[] }> {
+  const warnings: string[] = [];
+  let imported = 0;
+  for (const entry of await params.legacy.entries()) {
+    if (!isPersistedAttachment(entry.value)) {
+      warnings.push(`Skipped malformed legacy Workboard attachment entry ${entry.key}`);
+      continue;
+    }
+    if (!(await targetCardReferencesAttachment(params.cards, entry.value))) {
+      warnings.push(
+        `Skipped legacy Workboard attachment entry ${entry.key} because its owning card was not migrated or does not reference the attachment`,
+      );
+      continue;
+    }
+    const targetEntry = await params.target.lookup(entry.key);
+    if (targetEntry) {
+      if (JSON.stringify(targetEntry) === JSON.stringify(entry.value)) {
+        await params.legacy.delete(entry.key);
+        imported++;
+        continue;
+      }
+      warnings.push(
+        `Skipped legacy Workboard attachment entry ${entry.key} because the SQLite target already exists`,
+      );
+      continue;
+    }
+    try {
+      await params.target.register(entry.key, entry.value);
+      await params.legacy.delete(entry.key);
+      imported++;
+    } catch (err) {
+      warnings.push(
+        `Failed migrating legacy Workboard attachment entry ${entry.key}: ${String(err)}`,
+      );
+    }
+  }
+  return { imported, warnings };
+}
+
+export const stateMigrations: PluginDoctorStateMigration[] = [
+  {
+    id: "workboard-28-kv-to-sqlite",
+    label: "Workboard .28 plugin-state KV",
+    async detectLegacyState(params) {
+      const env = migrationEnv(params);
+      const cards = await openLegacyStore<PersistedWorkboardCard>({
+        context: params.context,
+        env,
+        namespace: "workboard.cards",
+        maxEntries: MAX_CARDS,
+      }).entries();
+      const boards = await openLegacyStore<PersistedWorkboardBoard>({
+        context: params.context,
+        env,
+        namespace: "workboard.boards",
+        maxEntries: 200,
+      }).entries();
+      const subscriptions = await openLegacyStore<PersistedWorkboardNotificationSubscription>({
+        context: params.context,
+        env,
+        namespace: "workboard.notify",
+        maxEntries: 2000,
+      }).entries();
+      const attachments = await openLegacyStore<PersistedWorkboardAttachment>({
+        context: params.context,
+        env,
+        namespace: "workboard.attachments",
+        maxEntries: MAX_CARDS * 21,
+      }).entries();
+      const count = cards.length + boards.length + subscriptions.length + attachments.length;
+      if (count === 0) {
+        return null;
+      }
+      return {
+        preview: [
+          `- Workboard: ${count} legacy .28 plugin-state KV ${count === 1 ? "entry" : "entries"} → ${resolveWorkboardSqlitePath(env)}`,
+        ],
+      };
+    },
+    async migrateLegacyState(params) {
+      const env = migrationEnv(params);
+      const cards = openLegacyStore<PersistedWorkboardCard>({
+        context: params.context,
+        env,
+        namespace: "workboard.cards",
+        maxEntries: MAX_CARDS,
+      });
+      const boards = openLegacyStore<PersistedWorkboardBoard>({
+        context: params.context,
+        env,
+        namespace: "workboard.boards",
+        maxEntries: 200,
+      });
+      const subscriptions = openLegacyStore<PersistedWorkboardNotificationSubscription>({
+        context: params.context,
+        env,
+        namespace: "workboard.notify",
+        maxEntries: 2000,
+      });
+      const attachments = openLegacyStore<PersistedWorkboardAttachment>({
+        context: params.context,
+        env,
+        namespace: "workboard.attachments",
+        maxEntries: MAX_CARDS * 21,
+      });
+      const sqlite = createWorkboardSqliteStores({ env });
+      try {
+        const cardResult = await migrateNamespace({
+          label: "card",
+          legacy: cards,
+          target: sqlite.cards,
+          isValid: isPersistedCard,
+        });
+        const boardResult = await migrateNamespace({
+          label: "board",
+          legacy: boards,
+          target: sqlite.boards,
+          isValid: isPersistedBoard,
+        });
+        const subscriptionResult = await migrateNamespace({
+          label: "notification subscription",
+          legacy: subscriptions,
+          target: sqlite.subscriptions,
+          isValid: isPersistedSubscription,
+        });
+        const attachmentResult = await migrateAttachments({
+          legacy: attachments,
+          cards: sqlite.cards,
+          target: sqlite.attachments,
+        });
+        const imported =
+          cardResult.imported +
+          boardResult.imported +
+          subscriptionResult.imported +
+          attachmentResult.imported;
+        return {
+          changes:
+            imported > 0
+              ? [
+                  `Migrated ${imported} Workboard .28 plugin-state KV ${imported === 1 ? "entry" : "entries"} → relational SQLite`,
+                ]
+              : [],
+          warnings: [
+            ...cardResult.warnings,
+            ...boardResult.warnings,
+            ...subscriptionResult.warnings,
+            ...attachmentResult.warnings,
+          ],
+        };
+      } finally {
+        sqlite.close();
+      }
+    },
+  },
+];

--- a/extensions/workboard/doctor-contract-api.ts
+++ b/extensions/workboard/doctor-contract-api.ts
@@ -2,14 +2,14 @@ import {
   type PluginDoctorStateMigration,
   type PluginDoctorStateMigrationContext,
 } from "openclaw/plugin-sdk/runtime-doctor";
-import { createWorkboardSqliteStores, resolveWorkboardSqlitePath } from "./src/sqlite-store.js";
 import type {
   PersistedWorkboardAttachment,
   PersistedWorkboardBoard,
   PersistedWorkboardCard,
   PersistedWorkboardNotificationSubscription,
   WorkboardKeyedStore,
-} from "./src/store.js";
+} from "./src/persistence-types.js";
+import { createWorkboardSqliteStores, resolveWorkboardSqlitePath } from "./src/sqlite-store.js";
 
 const MAX_CARDS = 2000;
 

--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -8,7 +8,7 @@ export default definePluginEntry({
   name: "Workboard",
   description: "Dashboard workboard for agent-owned issues and sessions.",
   register(api) {
-    const store = WorkboardStore.open((options) => api.runtime.state.openKeyedStore(options));
+    const store = WorkboardStore.openSqlite();
     registerWorkboardGatewayMethods({ api, store });
     api.registerTool((context) => createWorkboardTools({ api, context, store }), {
       names: [

--- a/extensions/workboard/src/gateway.test.ts
+++ b/extensions/workboard/src/gateway.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../api.js";
 import { registerWorkboardGatewayMethods } from "./gateway.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./store.js";
+import { WorkboardStore, type PersistedWorkboardCard, type WorkboardKeyedStore } from "./store.js";
 
 function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
   const entries = new Map<string, T>();
@@ -41,7 +41,7 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
 
-    registerWorkboardGatewayMethods({ api });
+    registerWorkboardGatewayMethods({ api, store: new WorkboardStore(createMemoryStore()) });
 
     expect([...methods.keys()]).toEqual([
       "workboard.cards.list",
@@ -157,7 +157,7 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
 
-    registerWorkboardGatewayMethods({ api });
+    registerWorkboardGatewayMethods({ api, store: new WorkboardStore(createMemoryStore()) });
 
     const createRespond = vi.fn();
     await methods.get("workboard.cards.create")?.handler({
@@ -202,7 +202,7 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
 
-    registerWorkboardGatewayMethods({ api });
+    registerWorkboardGatewayMethods({ api, store: new WorkboardStore(createMemoryStore()) });
 
     const createHandler = methods.get("workboard.cards.create")?.handler;
     const respond = vi.fn();
@@ -236,7 +236,7 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
 
-    registerWorkboardGatewayMethods({ api });
+    registerWorkboardGatewayMethods({ api, store: new WorkboardStore(createMemoryStore()) });
 
     const createRespond = vi.fn();
     await methods.get("workboard.cards.create")?.handler({

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -69,8 +69,7 @@ export function registerWorkboardGatewayMethods(params: {
   store?: WorkboardStore;
 }) {
   const { api } = params;
-  const store =
-    params.store ?? WorkboardStore.open((options) => api.runtime.state.openKeyedStore(options));
+  const store = params.store ?? WorkboardStore.openSqlite();
 
   api.registerGatewayMethod(
     "workboard.cards.list",

--- a/extensions/workboard/src/persistence-types.ts
+++ b/extensions/workboard/src/persistence-types.ts
@@ -1,0 +1,34 @@
+import type {
+  WorkboardAttachment,
+  WorkboardBoardMetadata,
+  WorkboardCard,
+  WorkboardNotificationSubscription,
+} from "./types.js";
+
+export type PersistedWorkboardCard = {
+  version: 1;
+  card: WorkboardCard;
+};
+
+export type PersistedWorkboardBoard = {
+  version: 1;
+  board: WorkboardBoardMetadata;
+};
+
+export type PersistedWorkboardNotificationSubscription = {
+  version: 1;
+  subscription: WorkboardNotificationSubscription;
+};
+
+export type PersistedWorkboardAttachment = {
+  version: 1;
+  attachment: WorkboardAttachment;
+  contentBase64: string;
+};
+
+export type WorkboardKeyedStore<T = PersistedWorkboardCard> = {
+  register(key: string, value: T): Promise<void>;
+  lookup(key: string): Promise<T | undefined>;
+  delete(key: string): Promise<boolean>;
+  entries(): Promise<Array<{ key: string; value: T }>>;
+};

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -8,7 +8,7 @@ import type {
   PersistedWorkboardCard,
   PersistedWorkboardNotificationSubscription,
   WorkboardKeyedStore,
-} from "./store.js";
+} from "./persistence-types.js";
 import type {
   WorkboardArtifact,
   WorkboardAttachment,

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -1,0 +1,1385 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+import type {
+  PersistedWorkboardAttachment,
+  PersistedWorkboardBoard,
+  PersistedWorkboardCard,
+  PersistedWorkboardNotificationSubscription,
+  WorkboardKeyedStore,
+} from "./store.js";
+import type {
+  WorkboardArtifact,
+  WorkboardAttachment,
+  WorkboardCard,
+  WorkboardComment,
+  WorkboardDiagnostic,
+  WorkboardEvent,
+  WorkboardExecution,
+  WorkboardLink,
+  WorkboardMetadata,
+  WorkboardNotification,
+  WorkboardProof,
+  WorkboardRunAttempt,
+  WorkboardWorkerLog,
+} from "./types.js";
+
+const WORKBOARD_DB_RELATIVE_PATH = ["plugins", "workboard", "workboard.sqlite"] as const;
+const SCHEMA_VERSION = 1;
+const WORKBOARD_SQLITE_BUSY_TIMEOUT_MS = 5000;
+const WORKBOARD_SQLITE_DIR_MODE = 0o700;
+const WORKBOARD_SQLITE_FILE_MODE = 0o600;
+
+type Row = Record<string, unknown>;
+
+export type WorkboardSqliteStores = {
+  cards: WorkboardKeyedStore;
+  boards: WorkboardKeyedStore<PersistedWorkboardBoard>;
+  subscriptions: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
+  attachments: WorkboardKeyedStore<PersistedWorkboardAttachment>;
+  close: () => void;
+};
+
+export function resolveWorkboardSqlitePath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), ...WORKBOARD_DB_RELATIVE_PATH);
+}
+
+function jsonValue(value: unknown): string | null {
+  return value === undefined ? null : JSON.stringify(value);
+}
+
+function parseJson(value: unknown): unknown {
+  if (typeof value !== "string" || !value) {
+    return undefined;
+  }
+  return JSON.parse(value) as unknown;
+}
+
+function stringValue(row: Row, key: string): string | undefined {
+  const value = row[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(row: Row, key: string): number | undefined {
+  const value = row[key];
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  return undefined;
+}
+
+function requiredString(row: Row, key: string): string {
+  const value = stringValue(row, key);
+  if (!value) {
+    throw new Error(`workboard sqlite row missing ${key}`);
+  }
+  return value;
+}
+
+function requiredNumber(row: Row, key: string): number {
+  const value = numberValue(row, key);
+  if (value === undefined) {
+    throw new Error(`workboard sqlite row missing ${key}`);
+  }
+  return value;
+}
+
+function optional<T extends object>(value: T): T | undefined {
+  return Object.keys(value).length > 0 ? value : undefined;
+}
+
+function asBlobContent(value: string): Uint8Array {
+  return Buffer.from(value, "base64");
+}
+
+function blobToBase64(value: unknown): string {
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString("base64");
+  }
+  if (typeof value === "string") {
+    return Buffer.from(value).toString("base64");
+  }
+  return "";
+}
+
+function runTransaction<T>(db: DatabaseSync, run: () => T): T {
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    const result = run();
+    db.exec("COMMIT");
+    return result;
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+function ensureWorkboardSchema(db: DatabaseSync): void {
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE IF NOT EXISTS workboard_schema_migrations (
+      id TEXT PRIMARY KEY,
+      applied_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_boards (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      description TEXT,
+      icon TEXT,
+      color TEXT,
+      default_workspace_json TEXT,
+      orchestration_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      archived_at INTEGER
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_cards (
+      id TEXT PRIMARY KEY,
+      board_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      notes TEXT,
+      status TEXT NOT NULL,
+      priority TEXT NOT NULL,
+      agent_id TEXT,
+      session_key TEXT,
+      run_id TEXT,
+      task_id TEXT,
+      source_url TEXT,
+      position REAL NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      started_at INTEGER,
+      completed_at INTEGER,
+      execution_id TEXT,
+      execution_kind TEXT,
+      execution_engine TEXT,
+      execution_mode TEXT,
+      execution_status TEXT,
+      execution_model TEXT,
+      execution_session_key TEXT,
+      execution_run_id TEXT,
+      execution_started_at INTEGER,
+      execution_updated_at INTEGER,
+      automation_json TEXT,
+      claim_json TEXT,
+      template_id TEXT,
+      archived_at INTEGER,
+      stale_json TEXT,
+      failure_count INTEGER
+    );
+    CREATE INDEX IF NOT EXISTS workboard_cards_board_status_idx
+      ON workboard_cards(board_id, status, position);
+    CREATE INDEX IF NOT EXISTS workboard_cards_session_idx
+      ON workboard_cards(session_key, run_id);
+
+    CREATE TABLE IF NOT EXISTS workboard_card_labels (
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      label TEXT NOT NULL,
+      PRIMARY KEY(card_id, ordinal)
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_card_events (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      at INTEGER NOT NULL,
+      from_status TEXT,
+      to_status TEXT,
+      session_key TEXT,
+      run_id TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_card_attempts (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      ended_at INTEGER,
+      engine TEXT,
+      mode TEXT,
+      model TEXT,
+      session_key TEXT,
+      run_id TEXT,
+      error TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_card_comments (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      body TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_card_links (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      type TEXT NOT NULL,
+      target_card_id TEXT,
+      title TEXT,
+      url TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_card_proof (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      label TEXT,
+      command TEXT,
+      url TEXT,
+      note TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_card_artifacts (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      label TEXT,
+      url TEXT,
+      path TEXT,
+      mime_type TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_card_diagnostics (
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      title TEXT NOT NULL,
+      detail TEXT NOT NULL,
+      first_seen_at INTEGER NOT NULL,
+      last_seen_at INTEGER NOT NULL,
+      count INTEGER NOT NULL,
+      actions_json TEXT NOT NULL,
+      PRIMARY KEY(card_id, ordinal)
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_card_notifications (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      message TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      sequence INTEGER,
+      session_key TEXT,
+      run_id TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_worker_logs (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      level TEXT NOT NULL,
+      message TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      session_key TEXT,
+      run_id TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_worker_protocol (
+      card_id TEXT PRIMARY KEY REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      state TEXT NOT NULL,
+      updated_at INTEGER NOT NULL,
+      detail TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_card_attachments (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL REFERENCES workboard_cards(id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      file_name TEXT NOT NULL,
+      byte_size INTEGER NOT NULL,
+      mime_type TEXT,
+      note TEXT,
+      created_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS workboard_card_attachments_card_idx
+      ON workboard_card_attachments(card_id, ordinal);
+
+    CREATE TABLE IF NOT EXISTS workboard_attachment_blobs (
+      attachment_id TEXT PRIMARY KEY,
+      content BLOB NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS workboard_notification_subscriptions (
+      id TEXT PRIMARY KEY,
+      board_id TEXT NOT NULL,
+      card_id TEXT,
+      session_key TEXT,
+      run_id TEXT,
+      target TEXT,
+      event_kinds_json TEXT,
+      last_event_at INTEGER,
+      last_event_id TEXT,
+      last_event_sequence INTEGER,
+      delivered_event_ids_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  db.prepare(
+    "INSERT OR IGNORE INTO workboard_schema_migrations (id, applied_at) VALUES (?, ?)",
+  ).run(`schema-${SCHEMA_VERSION}`, Date.now());
+}
+
+function configureWorkboardDatabase(db: DatabaseSync): void {
+  db.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA synchronous = NORMAL;
+    PRAGMA busy_timeout = ${WORKBOARD_SQLITE_BUSY_TIMEOUT_MS};
+    PRAGMA foreign_keys = ON;
+  `);
+}
+
+function chmodIfExists(targetPath: string, mode: number): void {
+  try {
+    fs.chmodSync(targetPath, mode);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+}
+
+function hardenWorkboardDatabaseFiles(dbPath: string): void {
+  fs.chmodSync(path.dirname(dbPath), WORKBOARD_SQLITE_DIR_MODE);
+  chmodIfExists(dbPath, WORKBOARD_SQLITE_FILE_MODE);
+  chmodIfExists(`${dbPath}-wal`, WORKBOARD_SQLITE_FILE_MODE);
+  chmodIfExists(`${dbPath}-shm`, WORKBOARD_SQLITE_FILE_MODE);
+}
+
+function createDatabase(dbPath: string): DatabaseSync {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true, mode: WORKBOARD_SQLITE_DIR_MODE });
+  chmodIfExists(path.dirname(dbPath), WORKBOARD_SQLITE_DIR_MODE);
+  if (!fs.existsSync(dbPath)) {
+    fs.closeSync(fs.openSync(dbPath, "a", WORKBOARD_SQLITE_FILE_MODE));
+  }
+  const db = new DatabaseSync(dbPath);
+  configureWorkboardDatabase(db);
+  ensureWorkboardSchema(db);
+  hardenWorkboardDatabaseFiles(dbPath);
+  return db;
+}
+
+function childRows(db: DatabaseSync, table: string, cardId: string): Row[] {
+  return db
+    .prepare(`SELECT * FROM ${table} WHERE card_id = ? ORDER BY ordinal ASC`)
+    .all(cardId) as Row[];
+}
+
+function readLabels(db: DatabaseSync, cardId: string): string[] {
+  return childRows(db, "workboard_card_labels", cardId).flatMap((row) => {
+    const label = stringValue(row, "label");
+    return label ? [label] : [];
+  });
+}
+
+function readEvents(db: DatabaseSync, cardId: string): WorkboardEvent[] | undefined {
+  const events = childRows(db, "workboard_card_events", cardId).map((row) => {
+    const event: WorkboardEvent = {
+      id: requiredString(row, "id"),
+      kind: requiredString(row, "kind") as WorkboardEvent["kind"],
+      at: requiredNumber(row, "at"),
+    };
+    const fromStatus = stringValue(row, "from_status");
+    const toStatus = stringValue(row, "to_status");
+    const sessionKey = stringValue(row, "session_key");
+    const runId = stringValue(row, "run_id");
+    if (fromStatus) {
+      event.fromStatus = fromStatus as WorkboardEvent["fromStatus"];
+    }
+    if (toStatus) {
+      event.toStatus = toStatus as WorkboardEvent["toStatus"];
+    }
+    if (sessionKey) {
+      event.sessionKey = sessionKey;
+    }
+    if (runId) {
+      event.runId = runId;
+    }
+    return event;
+  });
+  return events.length > 0 ? events : undefined;
+}
+
+function readExecution(row: Row): WorkboardExecution | undefined {
+  const id = stringValue(row, "execution_id");
+  if (!id) {
+    return undefined;
+  }
+  return {
+    id,
+    kind: "agent-session",
+    engine: requiredString(row, "execution_engine") as WorkboardExecution["engine"],
+    mode: requiredString(row, "execution_mode") as WorkboardExecution["mode"],
+    status: requiredString(row, "execution_status") as WorkboardExecution["status"],
+    model: requiredString(row, "execution_model"),
+    ...(stringValue(row, "execution_session_key")
+      ? { sessionKey: stringValue(row, "execution_session_key") }
+      : {}),
+    ...(stringValue(row, "execution_run_id")
+      ? { runId: stringValue(row, "execution_run_id") }
+      : {}),
+    startedAt: requiredNumber(row, "execution_started_at"),
+    updatedAt: requiredNumber(row, "execution_updated_at"),
+  };
+}
+
+function readMetadata(db: DatabaseSync, row: Row): WorkboardMetadata | undefined {
+  const cardId = requiredString(row, "id");
+  const attempts = childRows(db, "workboard_card_attempts", cardId).map((child) => {
+    const entry: WorkboardRunAttempt = {
+      id: requiredString(child, "id"),
+      status: requiredString(child, "status") as WorkboardRunAttempt["status"],
+      startedAt: requiredNumber(child, "started_at"),
+    };
+    const endedAt = numberValue(child, "ended_at");
+    const engine = stringValue(child, "engine");
+    const mode = stringValue(child, "mode");
+    const model = stringValue(child, "model");
+    const sessionKey = stringValue(child, "session_key");
+    const runId = stringValue(child, "run_id");
+    const error = stringValue(child, "error");
+    if (endedAt !== undefined) {
+      entry.endedAt = endedAt;
+    }
+    if (engine) {
+      entry.engine = engine as WorkboardRunAttempt["engine"];
+    }
+    if (mode) {
+      entry.mode = mode as WorkboardRunAttempt["mode"];
+    }
+    if (model) {
+      entry.model = model;
+    }
+    if (sessionKey) {
+      entry.sessionKey = sessionKey;
+    }
+    if (runId) {
+      entry.runId = runId;
+    }
+    if (error) {
+      entry.error = error;
+    }
+    return entry;
+  });
+  const comments = childRows(db, "workboard_card_comments", cardId).map((child) => {
+    const entry: WorkboardComment = {
+      id: requiredString(child, "id"),
+      body: requiredString(child, "body"),
+      createdAt: requiredNumber(child, "created_at"),
+    };
+    const updatedAt = numberValue(child, "updated_at");
+    if (updatedAt !== undefined) {
+      entry.updatedAt = updatedAt;
+    }
+    return entry;
+  });
+  const links = childRows(db, "workboard_card_links", cardId).map((child) => {
+    const entry: WorkboardLink = {
+      id: requiredString(child, "id"),
+      type: requiredString(child, "type") as WorkboardLink["type"],
+      createdAt: requiredNumber(child, "created_at"),
+    };
+    const targetCardId = stringValue(child, "target_card_id");
+    const title = stringValue(child, "title");
+    const url = stringValue(child, "url");
+    if (targetCardId) {
+      entry.targetCardId = targetCardId;
+    }
+    if (title) {
+      entry.title = title;
+    }
+    if (url) {
+      entry.url = url;
+    }
+    return entry;
+  });
+  const proof = childRows(db, "workboard_card_proof", cardId).map((child) => {
+    const entry: WorkboardProof = {
+      id: requiredString(child, "id"),
+      status: requiredString(child, "status") as WorkboardProof["status"],
+      createdAt: requiredNumber(child, "created_at"),
+    };
+    const label = stringValue(child, "label");
+    const command = stringValue(child, "command");
+    const url = stringValue(child, "url");
+    const note = stringValue(child, "note");
+    if (label) {
+      entry.label = label;
+    }
+    if (command) {
+      entry.command = command;
+    }
+    if (url) {
+      entry.url = url;
+    }
+    if (note) {
+      entry.note = note;
+    }
+    return entry;
+  });
+  const artifacts = childRows(db, "workboard_card_artifacts", cardId).map((child) => {
+    const entry: WorkboardArtifact = {
+      id: requiredString(child, "id"),
+      createdAt: requiredNumber(child, "created_at"),
+    };
+    const label = stringValue(child, "label");
+    const url = stringValue(child, "url");
+    const artifactPath = stringValue(child, "path");
+    const mimeType = stringValue(child, "mime_type");
+    if (label) {
+      entry.label = label;
+    }
+    if (url) {
+      entry.url = url;
+    }
+    if (artifactPath) {
+      entry.path = artifactPath;
+    }
+    if (mimeType) {
+      entry.mimeType = mimeType;
+    }
+    return entry;
+  });
+  const attachments = childRows(db, "workboard_card_attachments", cardId).map((child) => {
+    const entry: WorkboardAttachment = {
+      id: requiredString(child, "id"),
+      cardId: requiredString(child, "card_id"),
+      createdAt: requiredNumber(child, "created_at"),
+      fileName: requiredString(child, "file_name"),
+      byteSize: requiredNumber(child, "byte_size"),
+    };
+    const mimeType = stringValue(child, "mime_type");
+    const note = stringValue(child, "note");
+    if (mimeType) {
+      entry.mimeType = mimeType;
+    }
+    if (note) {
+      entry.note = note;
+    }
+    return entry;
+  });
+  const workerLogs = childRows(db, "workboard_worker_logs", cardId).map((child) => {
+    const entry: WorkboardWorkerLog = {
+      id: requiredString(child, "id"),
+      createdAt: requiredNumber(child, "created_at"),
+      level: requiredString(child, "level") as WorkboardWorkerLog["level"],
+      message: requiredString(child, "message"),
+    };
+    const sessionKey = stringValue(child, "session_key");
+    const runId = stringValue(child, "run_id");
+    if (sessionKey) {
+      entry.sessionKey = sessionKey;
+    }
+    if (runId) {
+      entry.runId = runId;
+    }
+    return entry;
+  });
+  const diagnostics = childRows(db, "workboard_card_diagnostics", cardId).map((child) => ({
+    kind: requiredString(child, "kind") as WorkboardDiagnostic["kind"],
+    severity: requiredString(child, "severity") as WorkboardDiagnostic["severity"],
+    title: requiredString(child, "title"),
+    detail: requiredString(child, "detail"),
+    firstSeenAt: requiredNumber(child, "first_seen_at"),
+    lastSeenAt: requiredNumber(child, "last_seen_at"),
+    count: requiredNumber(child, "count"),
+    actions: (parseJson(child.actions_json) as WorkboardDiagnostic["actions"] | undefined) ?? [],
+  }));
+  const notifications = childRows(db, "workboard_card_notifications", cardId).map((child) => {
+    const entry: WorkboardNotification = {
+      id: requiredString(child, "id"),
+      kind: requiredString(child, "kind") as WorkboardNotification["kind"],
+      createdAt: requiredNumber(child, "created_at"),
+      message: requiredString(child, "message"),
+    };
+    const sequence = numberValue(child, "sequence");
+    const sessionKey = stringValue(child, "session_key");
+    const runId = stringValue(child, "run_id");
+    if (sequence !== undefined) {
+      entry.sequence = sequence;
+    }
+    if (sessionKey) {
+      entry.sessionKey = sessionKey;
+    }
+    if (runId) {
+      entry.runId = runId;
+    }
+    return entry;
+  });
+  const protocol = db
+    .prepare("SELECT * FROM workboard_worker_protocol WHERE card_id = ?")
+    .get(cardId) as Row | undefined;
+  const automation = parseJson(row.automation_json) as WorkboardMetadata["automation"] | undefined;
+  const claim = parseJson(row.claim_json) as WorkboardMetadata["claim"] | undefined;
+  const stale = parseJson(row.stale_json) as WorkboardMetadata["stale"] | undefined;
+  return optional({
+    ...(attempts.length > 0 ? { attempts } : {}),
+    ...(comments.length > 0 ? { comments } : {}),
+    ...(links.length > 0 ? { links } : {}),
+    ...(proof.length > 0 ? { proof } : {}),
+    ...(artifacts.length > 0 ? { artifacts } : {}),
+    ...(attachments.length > 0 ? { attachments } : {}),
+    ...(workerLogs.length > 0 ? { workerLogs } : {}),
+    ...(protocol
+      ? {
+          workerProtocol: {
+            state: requiredString(protocol, "state") as NonNullable<
+              WorkboardMetadata["workerProtocol"]
+            >["state"],
+            updatedAt: requiredNumber(protocol, "updated_at"),
+            ...(stringValue(protocol, "detail") ? { detail: stringValue(protocol, "detail") } : {}),
+          },
+        }
+      : {}),
+    ...(automation ? { automation } : {}),
+    ...(claim ? { claim } : {}),
+    ...(diagnostics.length > 0 ? { diagnostics } : {}),
+    ...(notifications.length > 0 ? { notifications } : {}),
+    ...(stringValue(row, "template_id")
+      ? { templateId: stringValue(row, "template_id") as WorkboardMetadata["templateId"] }
+      : {}),
+    ...(numberValue(row, "archived_at") !== undefined
+      ? { archivedAt: numberValue(row, "archived_at") }
+      : {}),
+    ...(stale ? { stale } : {}),
+    ...(numberValue(row, "failure_count") !== undefined
+      ? { failureCount: numberValue(row, "failure_count") }
+      : {}),
+  });
+}
+
+function readCard(db: DatabaseSync, row: Row): WorkboardCard {
+  const card: WorkboardCard = {
+    id: requiredString(row, "id"),
+    title: requiredString(row, "title"),
+    status: requiredString(row, "status") as WorkboardCard["status"],
+    priority: requiredString(row, "priority") as WorkboardCard["priority"],
+    labels: readLabels(db, requiredString(row, "id")),
+    position: requiredNumber(row, "position"),
+    createdAt: requiredNumber(row, "created_at"),
+    updatedAt: requiredNumber(row, "updated_at"),
+  };
+  const metadata = readMetadata(db, row);
+  return {
+    ...card,
+    ...(stringValue(row, "notes") ? { notes: stringValue(row, "notes") } : {}),
+    ...(stringValue(row, "agent_id") ? { agentId: stringValue(row, "agent_id") } : {}),
+    ...(stringValue(row, "session_key") ? { sessionKey: stringValue(row, "session_key") } : {}),
+    ...(stringValue(row, "run_id") ? { runId: stringValue(row, "run_id") } : {}),
+    ...(stringValue(row, "task_id") ? { taskId: stringValue(row, "task_id") } : {}),
+    ...(stringValue(row, "source_url") ? { sourceUrl: stringValue(row, "source_url") } : {}),
+    ...(readExecution(row) ? { execution: readExecution(row) } : {}),
+    ...(numberValue(row, "started_at") !== undefined
+      ? { startedAt: numberValue(row, "started_at") }
+      : {}),
+    ...(numberValue(row, "completed_at") !== undefined
+      ? { completedAt: numberValue(row, "completed_at") }
+      : {}),
+    ...(readEvents(db, card.id) ? { events: readEvents(db, card.id) } : {}),
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function cardBoardId(card: WorkboardCard): string {
+  return card.metadata?.automation?.boardId ?? "default";
+}
+
+function bindNull(value: unknown): SQLInputValue {
+  if (
+    value === undefined ||
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "bigint" ||
+    value instanceof Uint8Array
+  ) {
+    return (value ?? null) as SQLInputValue;
+  }
+  return JSON.stringify(value);
+}
+
+function insertChildren<T>(
+  db: DatabaseSync,
+  table: string,
+  cardId: string,
+  entries: readonly T[] | undefined,
+  insert: (entry: T, ordinal: number) => void,
+): void {
+  db.prepare(`DELETE FROM ${table} WHERE card_id = ?`).run(cardId);
+  entries?.forEach(insert);
+}
+
+function insertCard(db: DatabaseSync, card: WorkboardCard): void {
+  const execution = card.execution;
+  const metadata = card.metadata;
+  db.prepare(
+    `
+      INSERT INTO workboard_cards (
+        id, board_id, title, notes, status, priority, agent_id, session_key, run_id, task_id,
+        source_url, position, created_at, updated_at, started_at, completed_at,
+        execution_id, execution_kind, execution_engine, execution_mode, execution_status,
+        execution_model, execution_session_key, execution_run_id, execution_started_at,
+        execution_updated_at, automation_json, claim_json, template_id, archived_at, stale_json,
+        failure_count
+      ) VALUES (
+        @id, @board_id, @title, @notes, @status, @priority, @agent_id, @session_key, @run_id,
+        @task_id, @source_url, @position, @created_at, @updated_at, @started_at, @completed_at,
+        @execution_id, @execution_kind, @execution_engine, @execution_mode, @execution_status,
+        @execution_model, @execution_session_key, @execution_run_id, @execution_started_at,
+        @execution_updated_at, @automation_json, @claim_json, @template_id, @archived_at,
+        @stale_json, @failure_count
+      )
+      ON CONFLICT(id) DO UPDATE SET
+        board_id = excluded.board_id,
+        title = excluded.title,
+        notes = excluded.notes,
+        status = excluded.status,
+        priority = excluded.priority,
+        agent_id = excluded.agent_id,
+        session_key = excluded.session_key,
+        run_id = excluded.run_id,
+        task_id = excluded.task_id,
+        source_url = excluded.source_url,
+        position = excluded.position,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        started_at = excluded.started_at,
+        completed_at = excluded.completed_at,
+        execution_id = excluded.execution_id,
+        execution_kind = excluded.execution_kind,
+        execution_engine = excluded.execution_engine,
+        execution_mode = excluded.execution_mode,
+        execution_status = excluded.execution_status,
+        execution_model = excluded.execution_model,
+        execution_session_key = excluded.execution_session_key,
+        execution_run_id = excluded.execution_run_id,
+        execution_started_at = excluded.execution_started_at,
+        execution_updated_at = excluded.execution_updated_at,
+        automation_json = excluded.automation_json,
+        claim_json = excluded.claim_json,
+        template_id = excluded.template_id,
+        archived_at = excluded.archived_at,
+        stale_json = excluded.stale_json,
+        failure_count = excluded.failure_count
+    `,
+  ).run({
+    id: card.id,
+    board_id: cardBoardId(card),
+    title: card.title,
+    notes: bindNull(card.notes),
+    status: card.status,
+    priority: card.priority,
+    agent_id: bindNull(card.agentId),
+    session_key: bindNull(card.sessionKey),
+    run_id: bindNull(card.runId),
+    task_id: bindNull(card.taskId),
+    source_url: bindNull(card.sourceUrl),
+    position: card.position,
+    created_at: card.createdAt,
+    updated_at: card.updatedAt,
+    started_at: bindNull(card.startedAt),
+    completed_at: bindNull(card.completedAt),
+    execution_id: bindNull(execution?.id),
+    execution_kind: bindNull(execution?.kind),
+    execution_engine: bindNull(execution?.engine),
+    execution_mode: bindNull(execution?.mode),
+    execution_status: bindNull(execution?.status),
+    execution_model: bindNull(execution?.model),
+    execution_session_key: bindNull(execution?.sessionKey),
+    execution_run_id: bindNull(execution?.runId),
+    execution_started_at: bindNull(execution?.startedAt),
+    execution_updated_at: bindNull(execution?.updatedAt),
+    automation_json: jsonValue(metadata?.automation),
+    claim_json: jsonValue(metadata?.claim),
+    template_id: bindNull(metadata?.templateId),
+    archived_at: bindNull(metadata?.archivedAt),
+    stale_json: jsonValue(metadata?.stale),
+    failure_count: bindNull(metadata?.failureCount),
+  });
+
+  insertChildren(db, "workboard_card_labels", card.id, card.labels, (label, ordinal) => {
+    db.prepare("INSERT INTO workboard_card_labels (card_id, ordinal, label) VALUES (?, ?, ?)").run(
+      card.id,
+      ordinal,
+      label,
+    );
+  });
+  insertChildren(db, "workboard_card_events", card.id, card.events, (event, ordinal) => {
+    db.prepare(
+      `
+        INSERT INTO workboard_card_events
+          (id, card_id, ordinal, kind, at, from_status, to_status, session_key, run_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      event.id,
+      card.id,
+      ordinal,
+      event.kind,
+      event.at,
+      bindNull(event.fromStatus),
+      bindNull(event.toStatus),
+      bindNull(event.sessionKey),
+      bindNull(event.runId),
+    );
+  });
+  insertChildren(db, "workboard_card_attempts", card.id, metadata?.attempts, (entry, ordinal) => {
+    db.prepare(
+      `
+        INSERT INTO workboard_card_attempts
+          (id, card_id, ordinal, status, started_at, ended_at, engine, mode, model, session_key, run_id, error)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      entry.id,
+      card.id,
+      ordinal,
+      entry.status,
+      entry.startedAt,
+      bindNull(entry.endedAt),
+      bindNull(entry.engine),
+      bindNull(entry.mode),
+      bindNull(entry.model),
+      bindNull(entry.sessionKey),
+      bindNull(entry.runId),
+      bindNull(entry.error),
+    );
+  });
+  insertChildren(db, "workboard_card_comments", card.id, metadata?.comments, (entry, ordinal) => {
+    db.prepare(
+      `
+        INSERT INTO workboard_card_comments (id, card_id, ordinal, body, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `,
+    ).run(entry.id, card.id, ordinal, entry.body, entry.createdAt, bindNull(entry.updatedAt));
+  });
+  insertChildren(db, "workboard_card_links", card.id, metadata?.links, (entry, ordinal) => {
+    db.prepare(
+      `
+        INSERT INTO workboard_card_links
+          (id, card_id, ordinal, type, target_card_id, title, url, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      entry.id,
+      card.id,
+      ordinal,
+      entry.type,
+      bindNull(entry.targetCardId),
+      bindNull(entry.title),
+      bindNull(entry.url),
+      entry.createdAt,
+    );
+  });
+  insertChildren(db, "workboard_card_proof", card.id, metadata?.proof, (entry, ordinal) => {
+    db.prepare(
+      `
+        INSERT INTO workboard_card_proof
+          (id, card_id, ordinal, status, label, command, url, note, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      entry.id,
+      card.id,
+      ordinal,
+      entry.status,
+      bindNull(entry.label),
+      bindNull(entry.command),
+      bindNull(entry.url),
+      bindNull(entry.note),
+      entry.createdAt,
+    );
+  });
+  insertChildren(db, "workboard_card_artifacts", card.id, metadata?.artifacts, (entry, ordinal) => {
+    db.prepare(
+      `
+        INSERT INTO workboard_card_artifacts
+          (id, card_id, ordinal, label, url, path, mime_type, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      entry.id,
+      card.id,
+      ordinal,
+      bindNull(entry.label),
+      bindNull(entry.url),
+      bindNull(entry.path),
+      bindNull(entry.mimeType),
+      entry.createdAt,
+    );
+  });
+  insertChildren(
+    db,
+    "workboard_card_attachments",
+    card.id,
+    metadata?.attachments,
+    (entry, ordinal) => {
+      db.prepare(
+        `
+          INSERT INTO workboard_card_attachments
+            (id, card_id, ordinal, file_name, byte_size, mime_type, note, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      ).run(
+        entry.id,
+        entry.cardId,
+        ordinal,
+        entry.fileName,
+        entry.byteSize,
+        bindNull(entry.mimeType),
+        bindNull(entry.note),
+        entry.createdAt,
+      );
+    },
+  );
+  insertChildren(
+    db,
+    "workboard_card_diagnostics",
+    card.id,
+    metadata?.diagnostics,
+    (entry, ordinal) => {
+      db.prepare(
+        `
+          INSERT INTO workboard_card_diagnostics
+            (card_id, ordinal, kind, severity, title, detail, first_seen_at, last_seen_at, count, actions_json)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      ).run(
+        card.id,
+        ordinal,
+        entry.kind,
+        entry.severity,
+        entry.title,
+        entry.detail,
+        entry.firstSeenAt,
+        entry.lastSeenAt,
+        entry.count,
+        JSON.stringify(entry.actions),
+      );
+    },
+  );
+  insertChildren(
+    db,
+    "workboard_card_notifications",
+    card.id,
+    metadata?.notifications,
+    (entry, ordinal) => {
+      db.prepare(
+        `
+          INSERT INTO workboard_card_notifications
+            (id, card_id, ordinal, kind, message, created_at, sequence, session_key, run_id)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      ).run(
+        entry.id,
+        card.id,
+        ordinal,
+        entry.kind,
+        entry.message,
+        entry.createdAt,
+        bindNull(entry.sequence),
+        bindNull(entry.sessionKey),
+        bindNull(entry.runId),
+      );
+    },
+  );
+  insertChildren(db, "workboard_worker_logs", card.id, metadata?.workerLogs, (entry, ordinal) => {
+    db.prepare(
+      `
+        INSERT INTO workboard_worker_logs
+          (id, card_id, ordinal, level, message, created_at, session_key, run_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      entry.id,
+      card.id,
+      ordinal,
+      entry.level,
+      entry.message,
+      entry.createdAt,
+      bindNull(entry.sessionKey),
+      bindNull(entry.runId),
+    );
+  });
+  db.prepare("DELETE FROM workboard_worker_protocol WHERE card_id = ?").run(card.id);
+  if (metadata?.workerProtocol) {
+    db.prepare(
+      `
+        INSERT INTO workboard_worker_protocol (card_id, state, updated_at, detail)
+        VALUES (?, ?, ?, ?)
+      `,
+    ).run(
+      card.id,
+      metadata.workerProtocol.state,
+      metadata.workerProtocol.updatedAt,
+      bindNull(metadata.workerProtocol.detail),
+    );
+  }
+}
+
+class WorkboardSqliteCardStore implements WorkboardKeyedStore {
+  constructor(private readonly db: DatabaseSync) {}
+
+  async register(key: string, value: PersistedWorkboardCard): Promise<void> {
+    if (value.version !== 1 || value.card.id !== key) {
+      throw new Error("invalid workboard card payload");
+    }
+    runTransaction(this.db, () => insertCard(this.db, value.card));
+  }
+
+  async lookup(key: string): Promise<PersistedWorkboardCard | undefined> {
+    const row = this.db.prepare("SELECT * FROM workboard_cards WHERE id = ?").get(key) as
+      | Row
+      | undefined;
+    return row ? { version: 1, card: readCard(this.db, row) } : undefined;
+  }
+
+  async delete(key: string): Promise<boolean> {
+    const result = runTransaction(this.db, () => {
+      this.db
+        .prepare(
+          `
+            DELETE FROM workboard_attachment_blobs
+            WHERE attachment_id IN (
+              SELECT id FROM workboard_card_attachments WHERE card_id = ?
+            )
+          `,
+        )
+        .run(key);
+      return this.db.prepare("DELETE FROM workboard_cards WHERE id = ?").run(key);
+    });
+    return result.changes > 0;
+  }
+
+  async entries(): Promise<Array<{ key: string; value: PersistedWorkboardCard }>> {
+    return (
+      this.db
+        .prepare("SELECT * FROM workboard_cards ORDER BY created_at ASC, id ASC")
+        .all() as Row[]
+    ).map((row) => ({
+      key: requiredString(row, "id"),
+      value: { version: 1, card: readCard(this.db, row) },
+    }));
+  }
+}
+
+class WorkboardSqliteBoardStore implements WorkboardKeyedStore<PersistedWorkboardBoard> {
+  constructor(private readonly db: DatabaseSync) {}
+
+  async register(key: string, value: PersistedWorkboardBoard): Promise<void> {
+    if (value.version !== 1 || value.board.id !== key) {
+      throw new Error("invalid workboard board payload");
+    }
+    const board = value.board;
+    this.db
+      .prepare(
+        `
+          INSERT INTO workboard_boards (
+            id, name, description, icon, color, default_workspace_json, orchestration_json,
+            created_at, updated_at, archived_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            description = excluded.description,
+            icon = excluded.icon,
+            color = excluded.color,
+            default_workspace_json = excluded.default_workspace_json,
+            orchestration_json = excluded.orchestration_json,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
+            archived_at = excluded.archived_at
+        `,
+      )
+      .run(
+        board.id,
+        bindNull(board.name),
+        bindNull(board.description),
+        bindNull(board.icon),
+        bindNull(board.color),
+        jsonValue(board.defaultWorkspace),
+        jsonValue(board.orchestration),
+        board.createdAt,
+        board.updatedAt,
+        bindNull(board.archivedAt),
+      );
+  }
+
+  async lookup(key: string): Promise<PersistedWorkboardBoard | undefined> {
+    const row = this.db.prepare("SELECT * FROM workboard_boards WHERE id = ?").get(key) as
+      | Row
+      | undefined;
+    if (!row) {
+      return undefined;
+    }
+    const defaultWorkspace = parseJson(row.default_workspace_json) as
+      | PersistedWorkboardBoard["board"]["defaultWorkspace"]
+      | undefined;
+    const orchestration = parseJson(row.orchestration_json) as
+      | PersistedWorkboardBoard["board"]["orchestration"]
+      | undefined;
+    return {
+      version: 1,
+      board: {
+        id: requiredString(row, "id"),
+        ...(stringValue(row, "name") ? { name: stringValue(row, "name") } : {}),
+        ...(stringValue(row, "description")
+          ? { description: stringValue(row, "description") }
+          : {}),
+        ...(stringValue(row, "icon") ? { icon: stringValue(row, "icon") } : {}),
+        ...(stringValue(row, "color") ? { color: stringValue(row, "color") } : {}),
+        ...(defaultWorkspace ? { defaultWorkspace } : {}),
+        ...(orchestration ? { orchestration } : {}),
+        createdAt: requiredNumber(row, "created_at"),
+        updatedAt: requiredNumber(row, "updated_at"),
+        ...(numberValue(row, "archived_at") !== undefined
+          ? { archivedAt: numberValue(row, "archived_at") }
+          : {}),
+      },
+    };
+  }
+
+  async delete(key: string): Promise<boolean> {
+    const result = this.db.prepare("DELETE FROM workboard_boards WHERE id = ?").run(key);
+    return result.changes > 0;
+  }
+
+  async entries(): Promise<Array<{ key: string; value: PersistedWorkboardBoard }>> {
+    const rows = this.db.prepare("SELECT id FROM workboard_boards ORDER BY id ASC").all() as Row[];
+    const entries: Array<{ key: string; value: PersistedWorkboardBoard }> = [];
+    for (const row of rows) {
+      const key = requiredString(row, "id");
+      const value = await this.lookup(key);
+      if (value) {
+        entries.push({ key, value });
+      }
+    }
+    return entries;
+  }
+}
+
+class WorkboardSqliteSubscriptionStore implements WorkboardKeyedStore<PersistedWorkboardNotificationSubscription> {
+  constructor(private readonly db: DatabaseSync) {}
+
+  async register(key: string, value: PersistedWorkboardNotificationSubscription): Promise<void> {
+    if (value.version !== 1 || value.subscription.id !== key) {
+      throw new Error("invalid workboard notification subscription payload");
+    }
+    const subscription = value.subscription;
+    this.db
+      .prepare(
+        `
+          INSERT INTO workboard_notification_subscriptions (
+            id, board_id, card_id, session_key, run_id, target, event_kinds_json,
+            last_event_at, last_event_id, last_event_sequence, delivered_event_ids_json,
+            created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            board_id = excluded.board_id,
+            card_id = excluded.card_id,
+            session_key = excluded.session_key,
+            run_id = excluded.run_id,
+            target = excluded.target,
+            event_kinds_json = excluded.event_kinds_json,
+            last_event_at = excluded.last_event_at,
+            last_event_id = excluded.last_event_id,
+            last_event_sequence = excluded.last_event_sequence,
+            delivered_event_ids_json = excluded.delivered_event_ids_json,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at
+        `,
+      )
+      .run(
+        subscription.id,
+        subscription.boardId,
+        bindNull(subscription.cardId),
+        bindNull(subscription.sessionKey),
+        bindNull(subscription.runId),
+        bindNull(subscription.target),
+        jsonValue(subscription.eventKinds),
+        bindNull(subscription.lastEventAt),
+        bindNull(subscription.lastEventId),
+        bindNull(subscription.lastEventSequence),
+        jsonValue(subscription.deliveredEventIds),
+        subscription.createdAt,
+        subscription.updatedAt,
+      );
+  }
+
+  async lookup(key: string): Promise<PersistedWorkboardNotificationSubscription | undefined> {
+    const row = this.db
+      .prepare("SELECT * FROM workboard_notification_subscriptions WHERE id = ?")
+      .get(key) as Row | undefined;
+    if (!row) {
+      return undefined;
+    }
+    const eventKinds = parseJson(row.event_kinds_json) as
+      | PersistedWorkboardNotificationSubscription["subscription"]["eventKinds"]
+      | undefined;
+    const deliveredEventIds = parseJson(row.delivered_event_ids_json) as
+      | PersistedWorkboardNotificationSubscription["subscription"]["deliveredEventIds"]
+      | undefined;
+    return {
+      version: 1,
+      subscription: {
+        id: requiredString(row, "id"),
+        boardId: requiredString(row, "board_id"),
+        ...(stringValue(row, "card_id") ? { cardId: stringValue(row, "card_id") } : {}),
+        ...(stringValue(row, "session_key") ? { sessionKey: stringValue(row, "session_key") } : {}),
+        ...(stringValue(row, "run_id") ? { runId: stringValue(row, "run_id") } : {}),
+        ...(stringValue(row, "target") ? { target: stringValue(row, "target") } : {}),
+        ...(eventKinds ? { eventKinds } : {}),
+        ...(numberValue(row, "last_event_at") !== undefined
+          ? { lastEventAt: numberValue(row, "last_event_at") }
+          : {}),
+        ...(stringValue(row, "last_event_id")
+          ? { lastEventId: stringValue(row, "last_event_id") }
+          : {}),
+        ...(numberValue(row, "last_event_sequence") !== undefined
+          ? { lastEventSequence: numberValue(row, "last_event_sequence") }
+          : {}),
+        ...(deliveredEventIds ? { deliveredEventIds } : {}),
+        createdAt: requiredNumber(row, "created_at"),
+        updatedAt: requiredNumber(row, "updated_at"),
+      },
+    };
+  }
+
+  async delete(key: string): Promise<boolean> {
+    const result = this.db
+      .prepare("DELETE FROM workboard_notification_subscriptions WHERE id = ?")
+      .run(key);
+    return result.changes > 0;
+  }
+
+  async entries(): Promise<
+    Array<{ key: string; value: PersistedWorkboardNotificationSubscription }>
+  > {
+    const rows = this.db
+      .prepare(
+        "SELECT id FROM workboard_notification_subscriptions ORDER BY created_at ASC, id ASC",
+      )
+      .all() as Row[];
+    const entries: Array<{ key: string; value: PersistedWorkboardNotificationSubscription }> = [];
+    for (const row of rows) {
+      const key = requiredString(row, "id");
+      const value = await this.lookup(key);
+      if (value) {
+        entries.push({ key, value });
+      }
+    }
+    return entries;
+  }
+}
+
+class WorkboardSqliteAttachmentStore implements WorkboardKeyedStore<PersistedWorkboardAttachment> {
+  constructor(private readonly db: DatabaseSync) {}
+
+  async register(key: string, value: PersistedWorkboardAttachment): Promise<void> {
+    if (value.version !== 1 || value.attachment.id !== key) {
+      throw new Error("invalid workboard attachment payload");
+    }
+    const attachment = value.attachment;
+    this.db
+      .prepare(
+        `
+          INSERT INTO workboard_attachment_blobs (attachment_id, content)
+          VALUES (?, ?)
+          ON CONFLICT(attachment_id) DO UPDATE SET content = excluded.content
+        `,
+      )
+      .run(attachment.id, asBlobContent(value.contentBase64));
+  }
+
+  async lookup(key: string): Promise<PersistedWorkboardAttachment | undefined> {
+    const row = this.db
+      .prepare(
+        `
+          SELECT a.*, b.content
+          FROM workboard_card_attachments a
+          JOIN workboard_attachment_blobs b ON b.attachment_id = a.id
+          WHERE a.id = ?
+        `,
+      )
+      .get(key) as Row | undefined;
+    if (!row) {
+      return undefined;
+    }
+    return {
+      version: 1,
+      attachment: {
+        id: requiredString(row, "id"),
+        cardId: requiredString(row, "card_id"),
+        createdAt: requiredNumber(row, "created_at"),
+        fileName: requiredString(row, "file_name"),
+        byteSize: requiredNumber(row, "byte_size"),
+        ...(stringValue(row, "mime_type") ? { mimeType: stringValue(row, "mime_type") } : {}),
+        ...(stringValue(row, "note") ? { note: stringValue(row, "note") } : {}),
+      },
+      contentBase64: blobToBase64(row.content),
+    };
+  }
+
+  async delete(key: string): Promise<boolean> {
+    const deleted = runTransaction(this.db, () => {
+      this.db.prepare("DELETE FROM workboard_attachment_blobs WHERE attachment_id = ?").run(key);
+      return this.db.prepare("DELETE FROM workboard_card_attachments WHERE id = ?").run(key);
+    });
+    return deleted.changes > 0;
+  }
+
+  async entries(): Promise<Array<{ key: string; value: PersistedWorkboardAttachment }>> {
+    const rows = this.db
+      .prepare(
+        `
+          SELECT a.id
+          FROM workboard_card_attachments a
+          JOIN workboard_attachment_blobs b ON b.attachment_id = a.id
+          ORDER BY a.created_at ASC, a.id ASC
+        `,
+      )
+      .all() as Row[];
+    const entries: Array<{ key: string; value: PersistedWorkboardAttachment }> = [];
+    for (const row of rows) {
+      const key = requiredString(row, "id");
+      const value = await this.lookup(key);
+      if (value) {
+        entries.push({ key, value });
+      }
+    }
+    return entries;
+  }
+}
+
+export function createWorkboardSqliteStores(
+  options: {
+    dbPath?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): WorkboardSqliteStores {
+  const db = createDatabase(options.dbPath ?? resolveWorkboardSqlitePath(options.env));
+  return {
+    cards: new WorkboardSqliteCardStore(db),
+    boards: new WorkboardSqliteBoardStore(db),
+    subscriptions: new WorkboardSqliteSubscriptionStore(db),
+    attachments: new WorkboardSqliteAttachmentStore(db),
+    close: () => db.close(),
+  };
+}

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1,5 +1,10 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import {
   WorkboardStore,
   type PersistedWorkboardAttachment,
@@ -31,6 +36,109 @@ function createMemoryStore<T = PersistedWorkboardCard>(options?: {
 }
 
 describe("WorkboardStore", () => {
+  it("persists boards, cards, subscriptions, and attachment blobs in sqlite", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-sqlite-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    if (process.platform !== "win32") {
+      fs.chmodSync(dir, 0o755);
+    }
+    try {
+      const stores = createWorkboardSqliteStores({ dbPath });
+      const store = new WorkboardStore(stores.cards, {
+        boards: stores.boards,
+        subscriptions: stores.subscriptions,
+        attachments: stores.attachments,
+      });
+      const board = await store.upsertBoard({ id: "planning", name: "Planning" });
+      const card = await store.create({
+        title: "Persist it",
+        boardId: board.id,
+        labels: ["sqlite", "doctor"],
+        execution: {
+          id: "exec-1",
+          kind: "agent-session",
+          engine: "codex",
+          mode: "autonomous",
+          status: "running",
+          model: "gpt-5.5",
+          sessionKey: "agent:main:test",
+          runId: "run-1",
+          startedAt: 1,
+          updatedAt: 2,
+        },
+      });
+      await store.addComment(card.id, { body: "round trip" });
+      const attached = await store.addAttachment(card.id, {
+        fileName: "proof.txt",
+        contentBase64: Buffer.from("ok").toString("base64"),
+      });
+      expect(attached.events?.at(-1)).toMatchObject({ kind: "attachment_added" });
+      await store.addAttachment(card.id, {
+        fileName: "large-proof.bin",
+        contentBase64: Buffer.alloc(70 * 1024).toString("base64"),
+      });
+      const attachmentId = attached.metadata?.attachments?.[0]?.id;
+      const subscription = await store.subscribeNotifications({
+        boardId: board.id,
+        target: "agent:main:test",
+        eventKinds: ["completed"],
+      });
+      if (process.platform !== "win32") {
+        expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+        expect(fs.statSync(dbPath).mode & 0o777).toBe(0o600);
+        for (const sidecarPath of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+          if (fs.existsSync(sidecarPath)) {
+            expect(fs.statSync(sidecarPath).mode & 0o777).toBe(0o600);
+          }
+        }
+      }
+      stores.close();
+
+      const rawDb = new DatabaseSync(dbPath);
+      expect(rawDb.prepare("PRAGMA journal_mode").get()).toMatchObject({
+        journal_mode: "wal",
+      });
+      rawDb.close();
+
+      const reopenedStores = createWorkboardSqliteStores({ dbPath });
+      const reopened = new WorkboardStore(reopenedStores.cards, {
+        boards: reopenedStores.boards,
+        subscriptions: reopenedStores.subscriptions,
+        attachments: reopenedStores.attachments,
+      });
+
+      expect(await reopened.listBoards()).toMatchObject({
+        boards: [
+          expect.objectContaining({ id: "default" }),
+          expect.objectContaining({ id: board.id, name: "Planning" }),
+        ],
+      });
+      expect(await reopened.get(card.id)).toMatchObject({
+        id: card.id,
+        labels: ["sqlite", "doctor"],
+        metadata: {
+          automation: { boardId: "planning" },
+          comments: [expect.objectContaining({ body: "round trip" })],
+          attachments: expect.arrayContaining([
+            expect.objectContaining({ fileName: "proof.txt" }),
+            expect.objectContaining({ fileName: "large-proof.bin" }),
+          ]),
+        },
+      });
+      expect(await reopened.getAttachment(attachmentId ?? "")).toMatchObject({
+        contentBase64: Buffer.from("ok").toString("base64"),
+      });
+      await reopened.delete(card.id);
+      expect(await reopened.getAttachment(attachmentId ?? "")).toBeUndefined();
+      expect(await reopened.listNotificationSubscriptions({ boardId: board.id })).toMatchObject({
+        subscriptions: [expect.objectContaining({ id: subscription.id })],
+      });
+      reopenedStores.close();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("creates and lists cards by status order and position", async () => {
     const store = new WorkboardStore(createMemoryStore());
 
@@ -427,10 +535,16 @@ describe("WorkboardStore", () => {
     ).rejects.toThrow(/attachment must be/);
     await expect(
       store.addAttachment(card.id, {
-        fileName: "state-limit.bin",
-        contentBase64: Buffer.alloc(49 * 1024).toString("base64"),
+        fileName: "sqlite-sized.bin",
+        contentBase64: Buffer.alloc(70 * 1024).toString("base64"),
       }),
-    ).rejects.toThrow(/plugin state value/);
+    ).resolves.toMatchObject({
+      metadata: {
+        attachments: expect.arrayContaining([
+          expect.objectContaining({ fileName: "sqlite-sized.bin" }),
+        ]),
+      },
+    });
     await expect(
       store.addAttachment(card.id, {
         fileName: "padded.txt",
@@ -442,7 +556,9 @@ describe("WorkboardStore", () => {
     expect(context).toContain("failure.log");
 
     const deleted = await store.deleteAttachment(card.id, attachment.id);
-    expect(deleted.metadata?.attachments).toBeUndefined();
+    expect(deleted.metadata?.attachments).toEqual([
+      expect.objectContaining({ fileName: "sqlite-sized.bin" }),
+    ]);
     expect(deleted.events?.at(-1)).toMatchObject({ kind: "edited" });
     expect(await store.getAttachment(attachment.id)).toBeUndefined();
   });

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -4,6 +4,7 @@ import {
   MAX_DATE_TIMESTAMP_MS,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import {
   WORKBOARD_DIAGNOSTIC_KINDS,
   WORKBOARD_DIAGNOSTIC_SEVERITIES,
@@ -66,7 +67,6 @@ const MAX_CARD_ATTACHMENTS = 20;
 const MAX_ATTACHMENT_ENTRIES = MAX_CARDS * (MAX_CARD_ATTACHMENTS + 1);
 const MAX_CARD_WORKER_LOGS = 40;
 const MAX_ATTACHMENT_BYTES = 256 * 1024;
-const MAX_ATTACHMENT_STATE_VALUE_BYTES = 65_536;
 const MAX_CARD_DIAGNOSTICS = 12;
 const MAX_CARD_NOTIFICATIONS = 20;
 const MAX_CARD_METADATA_BYTES = 24 * 1024;
@@ -75,7 +75,6 @@ const READY_STRANDED_MS = 60 * 60 * 1000;
 const RUNNING_HEARTBEAT_STALE_MS = 20 * 60 * 1000;
 const BLOCKED_TOO_LONG_MS = 24 * 60 * 60 * 1000;
 const CLAIM_RECLAIM_MS = 5 * 60 * 1000;
-const textEncoder = new TextEncoder();
 
 function secondsToDurationMs(seconds: number): number {
   const ms = Math.trunc(seconds) * 1000;
@@ -1086,12 +1085,6 @@ function normalizeAttachmentInput(
     ...(mimeType ? { mimeType } : {}),
     ...(note ? { note } : {}),
   };
-  const valueJson = JSON.stringify({ version: 1, attachment, contentBase64 });
-  if (textEncoder.encode(valueJson).byteLength > MAX_ATTACHMENT_STATE_VALUE_BYTES) {
-    throw new Error(
-      `attachment content plus metadata must fit one plugin state value (${MAX_ATTACHMENT_STATE_VALUE_BYTES} bytes).`,
-    );
-  }
   return { attachment, contentBase64 };
 }
 
@@ -4248,5 +4241,14 @@ export class WorkboardStore {
         }) as WorkboardKeyedStore<PersistedWorkboardAttachment>,
       },
     );
+  }
+
+  static openSqlite() {
+    const stores = createWorkboardSqliteStores();
+    return new WorkboardStore(stores.cards, {
+      boards: stores.boards,
+      subscriptions: stores.subscriptions,
+      attachments: stores.attachments,
+    });
   }
 }

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -4,6 +4,13 @@ import {
   MAX_DATE_TIMESTAMP_MS,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import type {
+  PersistedWorkboardAttachment,
+  PersistedWorkboardBoard,
+  PersistedWorkboardCard,
+  PersistedWorkboardNotificationSubscription,
+  WorkboardKeyedStore,
+} from "./persistence-types.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import {
   WORKBOARD_DIAGNOSTIC_KINDS,
@@ -54,6 +61,13 @@ import {
   type WorkboardWorkerProtocol,
   type WorkboardWorkspace,
 } from "./types.js";
+export type {
+  PersistedWorkboardAttachment,
+  PersistedWorkboardBoard,
+  PersistedWorkboardCard,
+  PersistedWorkboardNotificationSubscription,
+  WorkboardKeyedStore,
+} from "./persistence-types.js";
 
 const POSITION_STEP = 1000;
 const MAX_CARDS = 2000;
@@ -86,34 +100,6 @@ function secondsToDurationMs(seconds: number): number {
 function addWorkboardDurationMs(now: number, durationMs: number): number {
   return resolveExpiresAtMsFromDurationMs(durationMs, { nowMs: now }) ?? MAX_DATE_TIMESTAMP_MS;
 }
-
-export type PersistedWorkboardCard = {
-  version: 1;
-  card: WorkboardCard;
-};
-
-export type PersistedWorkboardBoard = {
-  version: 1;
-  board: WorkboardBoardMetadata;
-};
-
-export type PersistedWorkboardNotificationSubscription = {
-  version: 1;
-  subscription: WorkboardNotificationSubscription;
-};
-
-export type PersistedWorkboardAttachment = {
-  version: 1;
-  attachment: WorkboardAttachment;
-  contentBase64: string;
-};
-
-export type WorkboardKeyedStore<T = PersistedWorkboardCard> = {
-  register(key: string, value: T): Promise<void>;
-  lookup(key: string): Promise<T | undefined>;
-  delete(key: string): Promise<boolean>;
-  entries(): Promise<Array<{ key: string; value: T }>>;
-};
 
 export type WorkboardCardInput = {
   title?: unknown;

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -35,8 +35,10 @@ describe("workboard tools", () => {
         },
       },
     } as unknown as OpenClawPluginApi;
+    const workboardStore = new WorkboardStore(keyed);
     const tools = createWorkboardTools({
       api,
+      store: workboardStore,
       context: { agentId: "main", sessionKey: "session-1" } as never,
     });
     const byName = new Map(tools.map((tool) => [tool.name, tool]));

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -189,9 +189,7 @@ export function createWorkboardTools(params: {
   context?: OpenClawPluginToolContext;
   store?: WorkboardStore;
 }): AnyAgentTool[] {
-  const store =
-    params.store ??
-    WorkboardStore.open((options) => params.api.runtime.state.openKeyedStore(options));
+  const store = params.store ?? WorkboardStore.openSqlite();
   const ownerId = contextOwner(params.context);
   const readScopedCardToolParams = async (rawParams: unknown): Promise<WorkboardToolCardParams> => {
     const input = readCardToolParams(rawParams, ownerId);

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -24,7 +24,13 @@ import {
   countPluginStateLiveEntries,
   createPluginStateKeyedStore,
   MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN,
+  type OpenKeyedStoreOptions,
 } from "../plugin-state/plugin-state-store.js";
+import {
+  listPluginDoctorStateMigrationEntries,
+  type PluginDoctorStateMigrationContext,
+  type PluginDoctorStateMigration,
+} from "../plugins/doctor-contract-registry.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_AGENT_ID,
@@ -78,6 +84,10 @@ export type LegacyStateDetection = {
     hasLegacy: boolean;
     plans: ChannelLegacyStateMigrationPlan[];
   };
+  pluginPlans?: {
+    hasLegacy: boolean;
+    plans: DetectedPluginDoctorStateMigrationPlan[];
+  };
   pluginStateSidecar: {
     sourcePath: string;
     hasLegacy: boolean;
@@ -119,6 +129,12 @@ type LegacyPluginStateSidecarRow = {
 
 type LegacyPluginStateImportDatabase = Pick<OpenClawStateKyselyDatabase, "plugin_state_entries">;
 type SqliteBindRow = Record<string, SQLInputValue>;
+
+type DetectedPluginDoctorStateMigrationPlan = {
+  pluginId: string;
+  migration: PluginDoctorStateMigration;
+  preview: string[];
+};
 
 const PLUGIN_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
 const TASK_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
@@ -1865,6 +1881,49 @@ async function collectChannelLegacyStateMigrationPlans(params: {
   return plans;
 }
 
+async function collectPluginDoctorStateMigrationPlans(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  stateDir: string;
+  oauthDir: string;
+}): Promise<DetectedPluginDoctorStateMigrationPlan[]> {
+  const plans: DetectedPluginDoctorStateMigrationPlan[] = [];
+  for (const entry of listPluginDoctorStateMigrationEntries({
+    config: params.cfg,
+    env: params.env,
+  })) {
+    const detected = await entry.migration.detectLegacyState({
+      config: params.cfg,
+      env: params.env,
+      stateDir: params.stateDir,
+      oauthDir: params.oauthDir,
+      context: createPluginDoctorStateMigrationContext(entry.pluginId, params.env),
+    });
+    if (detected?.preview.length) {
+      plans.push({
+        pluginId: entry.pluginId,
+        migration: entry.migration,
+        preview: detected.preview,
+      });
+    }
+  }
+  return plans;
+}
+
+function createPluginDoctorStateMigrationContext(
+  pluginId: string,
+  env: NodeJS.ProcessEnv,
+): PluginDoctorStateMigrationContext {
+  return {
+    openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
+      return createPluginStateKeyedStore<T>(pluginId, {
+        ...options,
+        env: options.env ?? env,
+      });
+    },
+  };
+}
+
 export async function detectLegacyStateMigrations(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -1918,6 +1977,12 @@ export async function detectLegacyStateMigrations(params: {
     stateDir,
     oauthDir,
   });
+  const pluginPlans = await collectPluginDoctorStateMigrationPlans({
+    cfg: params.cfg,
+    env,
+    stateDir,
+    oauthDir,
+  });
 
   const preview: string[] = [];
   if (hasLegacySessions) {
@@ -1940,6 +2005,9 @@ export async function detectLegacyStateMigrations(params: {
   }
   if (channelPlans.length > 0) {
     preview.push(...channelPlans.map(buildLegacyMigrationPreview));
+  }
+  if (pluginPlans.length > 0) {
+    preview.push(...pluginPlans.flatMap((plan) => plan.preview));
   }
 
   return {
@@ -1964,6 +2032,10 @@ export async function detectLegacyStateMigrations(params: {
     channelPlans: {
       hasLegacy: channelPlans.length > 0,
       plans: channelPlans,
+    },
+    pluginPlans: {
+      hasLegacy: pluginPlans.length > 0,
+      plans: pluginPlans,
     },
     pluginStateSidecar: {
       sourcePath: pluginStateSidecarPath,
@@ -2152,8 +2224,41 @@ export async function migrateLegacyAgentDir(
   return { changes, warnings };
 }
 
+async function runPluginDoctorStateMigrationPlans(params: {
+  detected: LegacyStateDetection;
+  config: OpenClawConfig;
+}): Promise<{ changes: string[]; warnings: string[] }> {
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const refreshedPlans = await collectPluginDoctorStateMigrationPlans({
+    cfg: params.config,
+    env: process.env,
+    stateDir: params.detected.stateDir,
+    oauthDir: params.detected.oauthDir,
+  });
+  const plans =
+    refreshedPlans.length > 0 ? refreshedPlans : (params.detected.pluginPlans?.plans ?? []);
+  for (const plan of plans) {
+    try {
+      const result = await plan.migration.migrateLegacyState({
+        config: params.config,
+        env: process.env,
+        stateDir: params.detected.stateDir,
+        oauthDir: params.detected.oauthDir,
+        context: createPluginDoctorStateMigrationContext(plan.pluginId, process.env),
+      });
+      changes.push(...result.changes);
+      warnings.push(...result.warnings);
+    } catch (err) {
+      warnings.push(`Failed migrating ${plan.migration.label}: ${String(err)}`);
+    }
+  }
+  return { changes, warnings };
+}
+
 export async function runLegacyStateMigrations(params: {
   detected: LegacyStateDetection;
+  config?: OpenClawConfig;
   now?: () => number;
 }): Promise<{ changes: string[]; warnings: string[] }> {
   const now = params.now ?? (() => Date.now());
@@ -2167,6 +2272,10 @@ export async function runLegacyStateMigrations(params: {
   const preSessionChannelPlans = await runLegacyMigrationPlans(
     detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
   );
+  const pluginPlans = await runPluginDoctorStateMigrationPlans({
+    detected,
+    config: params.config ?? ({} as OpenClawConfig),
+  });
   const sessions = await migrateLegacySessions(detected, now);
   const agentDir = await migrateLegacyAgentDir(detected, now);
   const channelPlans = await runLegacyMigrationPlans(
@@ -2177,6 +2286,7 @@ export async function runLegacyStateMigrations(params: {
       ...pluginStateSidecar.changes,
       ...taskStateSidecars.changes,
       ...preSessionChannelPlans.changes,
+      ...pluginPlans.changes,
       ...sessions.changes,
       ...agentDir.changes,
       ...channelPlans.changes,
@@ -2185,6 +2295,7 @@ export async function runLegacyStateMigrations(params: {
       ...pluginStateSidecar.warnings,
       ...taskStateSidecars.warnings,
       ...preSessionChannelPlans.warnings,
+      ...pluginPlans.warnings,
       ...sessions.warnings,
       ...agentDir.warnings,
       ...channelPlans.warnings,
@@ -2426,12 +2537,17 @@ export async function autoMigrateLegacyState(params: {
     const preSessionChannelPlans = await runLegacyMigrationPlans(
       detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
     );
+    const pluginPlans = await runPluginDoctorStateMigrationPlans({
+      detected,
+      config: params.cfg,
+    });
     const changes = [
       ...stateDirResult.changes,
       ...orphanKeys.changes,
       ...pluginStateSidecar.changes,
       ...taskStateSidecars.changes,
       ...preSessionChannelPlans.changes,
+      ...pluginPlans.changes,
     ];
     const warnings = [
       ...stateDirResult.warnings,
@@ -2439,6 +2555,7 @@ export async function autoMigrateLegacyState(params: {
       ...pluginStateSidecar.warnings,
       ...taskStateSidecars.warnings,
       ...preSessionChannelPlans.warnings,
+      ...pluginPlans.warnings,
     ];
     logMigrationResults(changes, warnings);
     return {
@@ -2447,7 +2564,8 @@ export async function autoMigrateLegacyState(params: {
         orphanKeys.changes.length > 0 ||
         pluginStateSidecar.changes.length > 0 ||
         taskStateSidecars.changes.length > 0 ||
-        preSessionChannelPlans.changes.length > 0,
+        preSessionChannelPlans.changes.length > 0 ||
+        pluginPlans.changes.length > 0,
       skipped: true,
       changes,
       warnings,
@@ -2457,6 +2575,7 @@ export async function autoMigrateLegacyState(params: {
     !detected.sessions.hasLegacy &&
     !detected.agentDir.hasLegacy &&
     !detected.channelPlans.hasLegacy &&
+    !detected.pluginPlans?.hasLegacy &&
     !detected.pluginStateSidecar.hasLegacy &&
     !detected.taskStateSidecars.hasLegacy
   ) {
@@ -2481,6 +2600,10 @@ export async function autoMigrateLegacyState(params: {
   const preSessionChannelPlans = await runLegacyMigrationPlans(
     detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
   );
+  const pluginPlans = await runPluginDoctorStateMigrationPlans({
+    detected,
+    config: params.cfg,
+  });
   const sessions = await migrateLegacySessions(detected, now);
   const agentDir = await migrateLegacyAgentDir(detected, now);
   const channelPlans = await runLegacyMigrationPlans(
@@ -2492,6 +2615,7 @@ export async function autoMigrateLegacyState(params: {
     ...pluginStateSidecar.changes,
     ...taskStateSidecars.changes,
     ...preSessionChannelPlans.changes,
+    ...pluginPlans.changes,
     ...sessions.changes,
     ...agentDir.changes,
     ...channelPlans.changes,
@@ -2502,6 +2626,7 @@ export async function autoMigrateLegacyState(params: {
     ...pluginStateSidecar.warnings,
     ...taskStateSidecars.warnings,
     ...preSessionChannelPlans.warnings,
+    ...pluginPlans.warnings,
     ...sessions.warnings,
     ...agentDir.warnings,
     ...channelPlans.warnings,

--- a/src/plugin-sdk/runtime-doctor.ts
+++ b/src/plugin-sdk/runtime-doctor.ts
@@ -16,5 +16,13 @@ export {
   detectPluginInstallPathIssue,
   formatPluginInstallPathIssue,
 } from "../infra/plugin-install-path-warnings.js";
+export type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "../plugin-state/plugin-state-store.js";
 export { removePluginFromConfig } from "../plugins/uninstall.js";
+export type {
+  PluginDoctorStateMigration,
+  PluginDoctorStateMigrationContext,
+} from "../plugins/doctor-contract-registry.js";
 export type { DoctorSessionRouteStateOwner } from "../plugins/doctor-session-route-state-owner-types.js";

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { LegacyConfigRule } from "../config/legacy.shared.js";
 import type { OpenClawConfig } from "../config/types.js";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "../plugin-state/plugin-state-store.js";
 import { asNullableRecord } from "../shared/record-coerce.js";
 import { normalizeTrimmedStringList } from "../shared/string-normalization.js";
 import type { DoctorSessionRouteStateOwner } from "./doctor-session-route-state-owner-types.js";
@@ -25,6 +29,7 @@ type PluginDoctorContractModule = {
   legacyConfigRules?: unknown;
   normalizeCompatibilityConfig?: unknown;
   sessionRouteStateOwners?: unknown;
+  stateMigrations?: unknown;
 };
 
 type PluginDoctorCompatibilityMutation = {
@@ -41,6 +46,44 @@ type PluginDoctorContractEntry = {
   rules: LegacyConfigRule[];
   normalizeCompatibilityConfig?: PluginDoctorCompatibilityNormalizer;
   sessionRouteStateOwners: DoctorSessionRouteStateOwner[];
+  stateMigrations: PluginDoctorStateMigration[];
+};
+
+export type PluginDoctorStateMigrationDetection = {
+  preview: string[];
+};
+
+export type PluginDoctorStateMigrationContext = {
+  openPluginStateKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>;
+};
+
+export type PluginDoctorStateMigration = {
+  id: string;
+  label: string;
+  detectLegacyState: (params: {
+    config: OpenClawConfig;
+    env: NodeJS.ProcessEnv;
+    stateDir: string;
+    oauthDir: string;
+    context: PluginDoctorStateMigrationContext;
+  }) =>
+    | Promise<PluginDoctorStateMigrationDetection | null>
+    | PluginDoctorStateMigrationDetection
+    | null;
+  migrateLegacyState: (params: {
+    config: OpenClawConfig;
+    env: NodeJS.ProcessEnv;
+    stateDir: string;
+    oauthDir: string;
+    context: PluginDoctorStateMigrationContext;
+  }) =>
+    | Promise<{ changes: string[]; warnings: string[] }>
+    | { changes: string[]; warnings: string[] };
+};
+
+export type PluginDoctorStateMigrationEntry = {
+  pluginId: string;
+  migration: PluginDoctorStateMigration;
 };
 
 type PluginManifestRegistryRecord = PluginManifestRegistry["plugins"][number];
@@ -134,6 +177,38 @@ function coerceDoctorSessionRouteStateOwners(value: unknown): DoctorSessionRoute
     runtimeIds: normalizeTrimmedStringList(owner.runtimeIds),
     cliSessionKeys: normalizeTrimmedStringList(owner.cliSessionKeys),
     authProfilePrefixes: normalizeTrimmedStringList(owner.authProfilePrefixes),
+  }));
+}
+
+function isPluginDoctorStateMigration(value: unknown): value is PluginDoctorStateMigration {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as {
+    id?: unknown;
+    label?: unknown;
+    detectLegacyState?: unknown;
+    migrateLegacyState?: unknown;
+  };
+  return (
+    typeof candidate.id === "string" &&
+    candidate.id.trim().length > 0 &&
+    typeof candidate.label === "string" &&
+    candidate.label.trim().length > 0 &&
+    typeof candidate.detectLegacyState === "function" &&
+    typeof candidate.migrateLegacyState === "function"
+  );
+}
+
+function coercePluginDoctorStateMigrations(value: unknown): PluginDoctorStateMigration[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isPluginDoctorStateMigration).map((migration) => ({
+    id: migration.id.trim(),
+    label: migration.label.trim(),
+    detectLegacyState: migration.detectLegacyState,
+    migrateLegacyState: migration.migrateLegacyState,
   }));
 }
 
@@ -238,7 +313,16 @@ function loadPluginDoctorContractEntry(
     mod.sessionRouteStateOwners ??
       (mod as { default?: PluginDoctorContractModule }).default?.sessionRouteStateOwners,
   );
-  if (rules.length === 0 && !normalizeCompatibilityConfig && sessionRouteStateOwners.length === 0) {
+  const stateMigrations = coercePluginDoctorStateMigrations(
+    mod.stateMigrations ??
+      (mod as { default?: PluginDoctorContractModule }).default?.stateMigrations,
+  );
+  if (
+    rules.length === 0 &&
+    !normalizeCompatibilityConfig &&
+    sessionRouteStateOwners.length === 0 &&
+    stateMigrations.length === 0
+  ) {
     return null;
   }
   return {
@@ -246,6 +330,7 @@ function loadPluginDoctorContractEntry(
     rules,
     normalizeCompatibilityConfig,
     sessionRouteStateOwners,
+    stateMigrations,
   };
 }
 
@@ -322,6 +407,29 @@ export function listPluginDoctorSessionRouteStateOwners(params?: {
     }
   }
   return [...owners.values()].toSorted((left, right) => left.id.localeCompare(right.id));
+}
+
+export function listPluginDoctorStateMigrations(params?: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  pluginIds?: readonly string[];
+}): PluginDoctorStateMigration[] {
+  return listPluginDoctorStateMigrationEntries(params).map((entry) => entry.migration);
+}
+
+export function listPluginDoctorStateMigrationEntries(params?: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  pluginIds?: readonly string[];
+}): PluginDoctorStateMigrationEntry[] {
+  return resolvePluginDoctorContracts(params).flatMap((entry) =>
+    entry.stateMigrations.map((migration) => ({
+      pluginId: entry.pluginId,
+      migration,
+    })),
+  );
 }
 
 export function applyPluginDoctorCompatibilityMigrations(


### PR DESCRIPTION
## Summary

- Move Workboard durable data from plugin KV rows into a plugin-owned relational SQLite database.
- Add a Workboard doctor contract that migrates the `.28` shipped KV namespaces through `openclaw doctor --fix`, including resumable attachment migration when legacy attachment rows are present.
- Wire plugin doctor state migrations through a scoped migration context so plugins can only open their own legacy plugin-state namespaces.
- Preserve Workboard attachment lifecycle events, private SQLite/WAL/SHM permissions, WAL/busy-timeout concurrency behavior, and docs for the new storage format.

## Verification

- `pnpm test extensions/workboard/src/store.test.ts extensions/workboard/src/tools.test.ts extensions/workboard/src/gateway.test.ts extensions/workboard/doctor-contract-api.test.ts -- --reporter=verbose`
- `pnpm check:architecture`
- `OPENCLAW_TESTBOX=0 pnpm check:changed`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Workboard cards, boards, subscriptions, notifications, comments, links, proof, diagnostics, worker logs, and attachment blobs now persist in relational SQLite instead of plugin KV rows, with `.28` legacy data migrated by doctor.
Real environment tested: local OpenClaw source checkout on macOS, PR head `2c93eb695aae9aa5112fe6be93f6de3a78e83135`.
Exact steps or command run after this patch: `pnpm test extensions/workboard/src/store.test.ts extensions/workboard/src/tools.test.ts extensions/workboard/src/gateway.test.ts extensions/workboard/doctor-contract-api.test.ts -- --reporter=verbose`; `pnpm check:architecture`; `OPENCLAW_TESTBOX=0 pnpm check:changed`; autoreview commands above.
Evidence after fix: Workboard shard passed 4 files / 86 tests; architecture import-cycle checks passed with 0 cycles; `check:changed` exited 0 across core, coreTests, extensions, extensionTests, docs lanes; autoreview reported no accepted/actionable findings.
Observed result after fix: SQLite persistence round-trips board/card/subscription/attachment data, doctor migrates valid `.28` KV data, skips malformed/orphan/conflicting attachment rows safely, and Workboard attachment additions still emit `attachment_added` events.
What was not tested: live multi-process dashboard/agent contention against a long-running gateway; covered via WAL/busy-timeout configuration and focused SQLite persistence tests rather than a live desktop scenario.
