### PR TITLE
fix(gateway): guide dashboard auth after service repair

### DIFF
--- a/src/cli/daemon-cli/start-repair.ts
+++ b/src/cli/daemon-cli/start-repair.ts
@@ -87,7 +87,8 @@ export async function repairLoadedGatewayServiceForStart(params: {
 
   return {
     result: "started",
-    message: "Gateway service definition repaired and started.",
+    message:
+      "Gateway service definition repaired and started. Reopen the Control UI with `openclaw dashboard` or copy a fresh auth URL with `openclaw dashboard --no-open`.",
     warnings: warnings.length ? warnings : undefined,
     loaded,
   };


### PR DESCRIPTION
## Summary

- After gateway service repair, tell users to reopen the Control UI with `openclaw dashboard` or copy a fresh auth URL with `openclaw dashboard --no-open`.

Fixes #88290.

## Verification

- `node scripts/run-vitest.mjs src/commands/dashboard.links.test.ts`
- `git diff --check`
- Isolated macOS LaunchAgent proof with `openclaw --profile issue88290proof gateway start` followed by `openclaw --profile issue88290proof dashboard --no-open`

## Real behavior proof

Behavior addressed: A repaired gateway can leave an old Control UI tab without usable auth state; the repair message now points users at the dashboard command that supplies the current auth URL.

Real environment tested: Local Codex worktree plus an isolated macOS LaunchAgent profile named `issue88290proof`. The profile used separate OpenClaw state/config and was stopped/uninstalled after testing.

Exact steps or command run after this patch: Started the isolated profile through the gateway repair path, then ran `openclaw --profile issue88290proof dashboard --no-open`.

Evidence after fix: The repair output included the new dashboard guidance, and `dashboard --no-open` copied a fresh tokenized URL. The token was redacted from the proof notes.

Observed result after fix: The repaired service started, the dashboard command produced a fresh auth URL, focused dashboard link tests passed, and `git diff --check` passed.

What was not tested: A full upgrade from `2026.5.18` with existing Safari localStorage state.
