### PR TITLE
Fix embedded session fence for queued transcript writes

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -659,6 +659,37 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(3);
   });
 
+  it("allows queued user turn appends while the prompt lock is released", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "[Queued user message that arrived while the previous turn was still active]",
+          },
+        ],
+      },
+    });
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).resolves.toBe("late-write");
+    const cleanupLock = await controller.acquireForCleanup();
+    await cleanupLock.release();
+
+    expect(controller.hasSessionTakeover()).toBe(false);
+    expect(release).toHaveBeenCalledTimes(3);
+  });
+
   it("allows delivery mirror appends that migrate legacy linear transcripts", async () => {
     const sessionFile = await createTempSessionFile();
     await fs.appendFile(
@@ -693,6 +724,49 @@ describe("embedded attempt session lock lifecycle", () => {
     await cleanupLock.release();
 
     await expect(fs.readFile(sessionFile, "utf8")).resolves.toContain('"parentId"');
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
+  it("allows same-length linear transcript rewrites while the prompt lock is released", async () => {
+    const sessionFile = await createTempSessionFile();
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session" }),
+        JSON.stringify({
+          type: "message",
+          id: "legacy-user",
+          message: { role: "user", content: [{ type: "text", text: "hello" }] },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", version: 1 }),
+        JSON.stringify({
+          type: "message",
+          id: "legacy-user",
+          parentId: null,
+          message: { role: "user", content: [{ type: "text", text: "hello" }] },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).resolves.toBe("late-write");
+    const cleanupLock = await controller.acquireForCleanup();
+    await cleanupLock.release();
+
     expect(controller.hasSessionTakeover()).toBe(false);
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -114,6 +114,22 @@ function isTranscriptOnlyOpenClawAssistantLine(line: string): boolean {
   }
 }
 
+function isBenignSessionFenceAppendLine(line: string): boolean {
+  if (isTranscriptOnlyOpenClawAssistantLine(line)) {
+    return true;
+  }
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!isJsonRecord(parsed)) {
+      return false;
+    }
+    const message = parsed.message;
+    return isJsonRecord(message) && message.role === "user";
+  } catch {
+    return false;
+  }
+}
+
 function normalizeTranscriptEntryId(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
@@ -251,7 +267,7 @@ async function sessionFenceAdvanceIsBenign(params: {
     return false;
   }
   const lines = normalizeStringEntries(text.split("\n"));
-  return lines.length > 0 && lines.every(isTranscriptOnlyOpenClawAssistantLine);
+  return lines.length > 0 && lines.every(isBenignSessionFenceAppendLine);
 }
 
 async function sessionFenceRewriteIsBenign(params: {
@@ -278,9 +294,12 @@ async function sessionFenceRewriteIsBenign(params: {
   if (!currentText.endsWith("\n")) {
     return false;
   }
+  if (currentText === params.previous.text) {
+    return true;
+  }
   const previousLines = splitSessionFileLines(params.previous.text);
   const currentLines = splitSessionFileLines(currentText);
-  if (currentLines.length <= previousLines.length) {
+  if (currentLines.length < previousLines.length) {
     return false;
   }
   let expectedParentId: string | null = null;
@@ -295,8 +314,11 @@ async function sessionFenceRewriteIsBenign(params: {
     }
     expectedParentId = lineMatch.nextPreviousId ?? expectedParentId;
   }
+  if (currentLines.length === previousLines.length) {
+    return true;
+  }
   const appendedLines = currentLines.slice(previousLines.length);
-  return appendedLines.every(isTranscriptOnlyOpenClawAssistantLine);
+  return appendedLines.every(isBenignSessionFenceAppendLine);
 }
 
 type OwnedSessionFileWrite = {
@@ -926,15 +948,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
       }
       if (activeWriteLock.getStore()?.active === true) {
-        if (options?.publishOwnedWrite !== true) {
-          return await run();
-        }
-        const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-        try {
-          return await run();
-        } finally {
-          await publishOwnedSessionFileFence(beforeWrite);
-        }
+        return await run();
       }
       const { lock, owned, releaseRetainedUse } = await acquireWriteLock();
       try {


### PR DESCRIPTION
## Summary
- allow queued user transcript appends while the embedded prompt lock is released
- allow same-length linear transcript rewrites and unchanged text refreshes to advance the session fence
- avoid publishing nested writes while an active session write lock is already running

## Why
OpenClaw can append queued user turns or rewrite linear transcript metadata while an embedded prompt is waiting on model I/O. Those OpenClaw-owned updates should not be classified as external session takeover.

## Real behavior proof

Behavior addressed: Embedded agent runs no longer fail with `EmbeddedAttemptSessionTakeoverError` / `session file changed while embedded prompt lock was released` when OpenClaw-owned transcript appends happen while the embedded prompt lock is released.

Real environment tested: Local macOS OpenClaw setup using the installed gateway with the equivalent session-fence fix applied before upstreaming this TypeScript source patch. `openclaw gateway status --deep` reported CLI version `2026.5.28`, Gateway version `2026.5.28`, runtime `running`, connectivity probe `ok`, and admin capability available.

Exact steps or command run after this patch:
```bash
openclaw gateway status --deep
openclaw agent --agent main --message '请用一句中文简短说明你现在可以正常响应。' --timeout 90
tail -n 240 /tmp/openclaw/openclaw-2026-06-04.log | rg -n "EmbeddedAttemptSessionTakeoverError|session file changed while embedded prompt lock was released" || true
```

Evidence after fix:
```text
Runtime: running (pid 32433, state active)
Connectivity probe: ok
Capability: admin-capable

$ openclaw agent --agent main --message '请用一句中文简短说明你现在可以正常响应。' --timeout 90
可以，一切正常。

$ tail -n 240 /tmp/openclaw/openclaw-2026-06-04.log | rg -n "EmbeddedAttemptSessionTakeoverError|session file changed while embedded prompt lock was released" || true
# no matches
```

Observed result after fix: The real local OpenClaw gateway accepted an embedded agent request and returned a normal response; the recent gateway log window did not contain the session-fence takeover error that this patch targets.

What was not tested: I did not run a remote cross-platform package smoke or Telegram/Desktop channel proof for this PR. The focused source regression coverage below exercises the session-fence cases added by this change.

## Tests
- `pnpm exec node scripts/test-projects.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/attempt.session-lock.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
- `git diff --check`
