### PR TITLE
[AI-assisted] fix(gateway): avoid restarts for auth cooldown reloads

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -97,6 +97,9 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-heartbeat"],
   },
+  // Auth cooldown readers resolve values from the active config for each auth
+  // failure decision, so cooldown tuning does not need a gateway restart.
+  { prefix: "auth.cooldowns", kind: "none" },
   {
     prefix: "agents.list",
     kind: "hot",

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -97,9 +97,10 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-heartbeat"],
   },
-  // Auth cooldown readers resolve values from the active config for each auth
-  // failure decision, so cooldown tuning does not need a gateway restart.
-  { prefix: "auth.cooldowns", kind: "none" },
+  // Auth cooldown readers resolve values from the active runtime config for each
+  // auth failure decision, so cooldown tuning needs a snapshot refresh but not
+  // a gateway restart.
+  { prefix: "auth.cooldowns", kind: "hot" },
   {
     prefix: "agents.list",
     kind: "hot",

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -411,7 +411,7 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toStrictEqual([]);
   });
 
-  it("treats auth cooldown changes as no-op for gateway restart planning", () => {
+  it("hot-reloads auth cooldown changes without a gateway restart", () => {
     const changedPaths = [
       "auth.cooldowns.billingBackoffHours",
       "auth.cooldowns.billingBackoffHoursByProvider.anthropic",
@@ -420,9 +420,9 @@ describe("buildGatewayReloadPlan", () => {
 
     expect(plan.restartGateway).toBe(false);
     expect(plan.restartReasons).toStrictEqual([]);
-    expect(plan.hotReasons).toStrictEqual([]);
-    expect(plan.noopPaths).toEqual(changedPaths);
-    expect(resolveConfigReloadMetadata("auth.cooldowns.billingBackoffHours").kind).toBe("none");
+    expect(plan.hotReasons).toStrictEqual(changedPaths);
+    expect(plan.noopPaths).toStrictEqual([]);
+    expect(resolveConfigReloadMetadata("auth.cooldowns.billingBackoffHours").kind).toBe("hot");
   });
 
   it("restarts for gateway.auth.token changes", () => {
@@ -481,7 +481,7 @@ describe("buildGatewayReloadPlan", () => {
     {
       path: "auth.cooldowns.billingBackoffHours",
       expectRestartGateway: false,
-      expectNoopPath: "auth.cooldowns.billingBackoffHours",
+      expectHotPath: "auth.cooldowns.billingBackoffHours",
     },
     {
       path: "gateway.auth.token",
@@ -1348,6 +1348,57 @@ describe("startGatewayConfigReloader", () => {
     expect(plan.restartGateway).toBe(false);
     expect(plan.reloadPlugins).toBe(true);
     expect(plan.hotReasons).toEqual(["plugins.entries.telegram.enabled"]);
+    expect(hotConfig).toBe(nextConfig);
+
+    await harness.reloader.stop();
+  });
+
+  it("keeps external auth cooldown writes on the hot reload path", async () => {
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      auth: {
+        cooldowns: {
+          billingBackoffHours: 1,
+          billingBackoffHoursByProvider: { anthropic: 2 },
+        },
+      },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      auth: {
+        cooldowns: {
+          billingBackoffHours: 3,
+          billingBackoffHoursByProvider: { anthropic: 4 },
+        },
+      },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "external-auth-cooldowns-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, {
+      initialCompareConfig: previousConfig,
+    });
+
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    const [plan, hotConfig] = getOnlyHotReloadCall(harness);
+    expect(plan.changedPaths).toEqual([
+      "auth.cooldowns.billingBackoffHours",
+      "auth.cooldowns.billingBackoffHoursByProvider.anthropic",
+    ]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.hotReasons).toEqual([
+      "auth.cooldowns.billingBackoffHours",
+      "auth.cooldowns.billingBackoffHoursByProvider.anthropic",
+    ]);
+    expect(plan.noopPaths).toStrictEqual([]);
     expect(hotConfig).toBe(nextConfig);
 
     await harness.reloader.stop();

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -411,6 +411,20 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toStrictEqual([]);
   });
 
+  it("treats auth cooldown changes as no-op for gateway restart planning", () => {
+    const changedPaths = [
+      "auth.cooldowns.billingBackoffHours",
+      "auth.cooldowns.billingBackoffHoursByProvider.anthropic",
+    ];
+    const plan = buildGatewayReloadPlan(changedPaths);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartReasons).toStrictEqual([]);
+    expect(plan.hotReasons).toStrictEqual([]);
+    expect(plan.noopPaths).toEqual(changedPaths);
+    expect(resolveConfigReloadMetadata("auth.cooldowns.billingBackoffHours").kind).toBe("none");
+  });
+
   it("restarts for gateway.auth.token changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.auth.token"]);
     expect(plan.restartGateway).toBe(true);
@@ -463,6 +477,11 @@ describe("buildGatewayReloadPlan", () => {
       path: "gateway.remote.url",
       expectRestartGateway: false,
       expectNoopPath: "gateway.remote.url",
+    },
+    {
+      path: "auth.cooldowns.billingBackoffHours",
+      expectRestartGateway: false,
+      expectNoopPath: "auth.cooldowns.billingBackoffHours",
     },
     {
       path: "gateway.auth.token",


### PR DESCRIPTION
## Summary

- Fixes cooldown-only config reloads under `auth.cooldowns.*` so they no longer schedule a full gateway restart.
- Changes the reload classification from restart-required to hot reload, not no-op, so the active runtime config snapshot is refreshed without bouncing the gateway.
- Adds planner and reloader-level regression coverage for cooldown leaf paths while preserving restart behavior for `gateway.auth.*` credential paths.
- Out of scope: no dependency, lockfile, generated dist, config shape, migration, provider, channel, auth token, secret-handling, or API behavior changes.

## Linked context

Closes #88443

Related context: ClawSweeper identified the safe fix shape as refreshing active runtime config for `auth.cooldowns.*` without a gateway restart.

Maintainer request: no direct maintainer request; this follows the linked P1 issue and ClawSweeper review guidance.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: external edits to existing `auth.cooldowns.*` leaf values no longer require a gateway restart, and the edited cooldown values are refreshed into active runtime config instead of staying stale.
- Real environment tested: disposable Linux OpenClaw checkout from PR head `618ab9afecedb93bca1e627253bc95cc9225b536`, Node `v24.15.0`, pnpm `11.2.2`, built `dist` gateway process, no real provider/channel secrets.
- Exact steps or command run after this patch:

```text
pnpm install --frozen-lockfile --prefer-offline
git diff --check
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts
node dist/index.js gateway --port <loopback-port> --bind loopback --allow-unconfigured
node dist/index.js gateway status --url ws://127.0.0.1:<loopback-port> --token <redacted> --require-rpc --timeout 30000
# external config edit: auth.cooldowns.billingBackoffHours 1 -> 3
# external config edit: auth.cooldowns.billingBackoffHoursByProvider.anthropic 2 -> 4
node dist/index.js gateway status --url ws://127.0.0.1:<loopback-port> --token <redacted> --require-rpc --timeout 30000
```

- Evidence after fix (terminal capture from disposable managed-gateway proof):

```text
GATEWAY_STATUS_BEFORE=ok
PID_BEFORE=15369
GATEWAY_STATUS_AFTER=ok
PID_AFTER=15369
PID_SAME=true
RELOAD_LOG_LINE=2026-05-31T00:47:39.318+00:00 [reload] config change detected; evaluating reload (auth.cooldowns.billingBackoffHours, auth.cooldowns.billingBackoffHoursByProvider.anthropic)
HOT_RELOAD_LOG_LINE=2026-05-31T00:47:39.430+00:00 [reload] config hot reload applied (auth.cooldowns.billingBackoffHours, auth.cooldowns.billingBackoffHoursByProvider.anthropic)
RESTART_LOG_LINES=0
AUTH_COOLDOWN_MANAGED_GATEWAY_LEAF_PROOF_PASS
```

Additional active-value runtime proof from the earlier disposable runtime-snapshot proof:

```text
AUTH_COOLDOWN_RUNTIME_REFRESH_PROOF_PASS
RESTART_CALLED=false
HOT_RELOAD_CALLED=true
ACTIVE_BILLING_BACKOFF_HOURS=3
ACTIVE_ANTHROPIC_BACKOFF_HOURS=4
```

- Observed result after fix: a built OpenClaw gateway stayed on the same process ID, RPC status remained healthy before and after the external cooldown leaf edit, the reload log showed managed hot reload for both cooldown paths, no restart-required log line appeared, and the active-value proof showed the updated cooldown values became visible in the runtime config snapshot.
- What was not tested: full systemd service-manager behavior, live Telegram account delivery, real provider billing-failure message-loss E2E, real secrets, or Docker E2E on this test host.
- Proof limitations or environment constraints: this is stronger than a unit-only proof because it starts the real built gateway process and mutates the real config file, but it is still not a systemd-supervised service run or live user-account E2E.
- Before evidence: current main without this PR classifies `auth.cooldowns.*` as restart-required; the linked issue includes gateway/systemd logs for the restart cascade.

## Tests and validation

Which commands did you run?

```text
pnpm install --frozen-lockfile --prefer-offline
git diff --check
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts
node dist/index.js gateway --port <loopback-port> --bind loopback --allow-unconfigured
node dist/index.js gateway status --url ws://127.0.0.1:<loopback-port> --token <redacted> --require-rpc --timeout 30000
```

What regression coverage was added or updated?

- Updated `src/gateway/config-reload.test.ts` so `auth.cooldowns.billingBackoffHours` and `auth.cooldowns.billingBackoffHoursByProvider.anthropic` are hot reload paths, not restart or no-op paths.
- Added reloader-level coverage proving an external cooldown-only config change calls `onHotReload`, does not call restart, and passes the new config through the hot reload path.
- Kept adjacent assertions that `gateway.auth.token` remains restart-required.

What failed before this fix, if known?

- Initial PR version used `kind: "none"`, which avoided restart but skipped `onHotReload` and could leave active cooldown values stale.
- Current main has no `auth.cooldowns` reload rule, so cooldown-only edits fall through to full gateway restart.

If no test was added, why not?

N/A.

Validation result on PR head `618ab9afecedb93bca1e627253bc95cc9225b536`:

```text
git diff --check
PASS

src/gateway/config-reload.test.ts
1 file / 78 tests passed

managed built-gateway cooldown leaf smoke
GATEWAY_STATUS_BEFORE=ok
GATEWAY_STATUS_AFTER=ok
PID_SAME=true
RESTART_LOG_LINES=0
AUTH_COOLDOWN_MANAGED_GATEWAY_LEAF_PROOF_PASS
```

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Cooldown-only config edits no longer restart the gateway; they hot-refresh runtime config instead.

Did config, environment, or migration behavior change? (`Yes/No`)

No config shape, environment, or migration behavior changes.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No new security, secrets, network, or tool execution behavior. Auth cooldown reload classification changes, but credential paths such as `gateway.auth.*` remain restart-required.

What is the highest-risk area?

Reload classification for auth cooldown config, because stale runtime cooldown values would be a functional regression.

How is that risk mitigated?

The fix uses hot reload instead of no-op, so the managed hot-reload path can refresh the active runtime config snapshot. Tests cover both planner classification and reloader-level active config refresh behavior, while the managed gateway smoke proves existing cooldown leaf edits keep the gateway process alive and apply hot reload without restart. Credential paths such as `gateway.auth.token` remain restart-required.

## Current review state

What is the next action?

Wait for GitHub CI and ClawSweeper re-review on the updated proof.

What is still waiting on author, maintainer, CI, or external proof?

GitHub CI and ClawSweeper have not completed on the latest PR body update; full systemd-managed gateway proof and live provider/channel delivery proof were not run.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's runtime-refresh finding and real-behavior proof request for `auth.cooldowns.*` reloads.