### PR TITLE
fix(ui): satisfy vite config includes lint

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -119,10 +119,7 @@ function resolveTsconfigPathAlias(key: string, target: string): ControlUiViteAli
     };
   }
 
-  if (
-    key.indexOf("*", keyWildcardIndex + 1) !== -1 ||
-    target.indexOf("*", targetWildcardIndex + 1) !== -1
-  ) {
+  if (key.includes("*", keyWildcardIndex + 1) || target.includes("*", targetWildcardIndex + 1)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Replace the second-position `indexOf("*") !== -1` checks in the Control UI Vite alias resolver with `includes("*", fromIndex)`.
- Keeps behavior identical while satisfying `typescript(prefer-includes)` on current `main`.

Related https://github.com/openclaw/openclaw/pull/88181.

## Verification

- `node scripts/run-oxlint.mjs ui/vite.config.ts`
- `node_modules/.bin/oxfmt --write --threads=1 ui/vite.config.ts`
- `git diff --check origin/main...HEAD`
- `node_modules/.bin/oxfmt --check --threads=1 ui/vite.config.ts`

## Real behavior proof

Behavior addressed: current `main` no longer trips the one-file `typescript(prefer-includes)` lint hit in `ui/vite.config.ts`.

Real environment tested: local linked OpenClaw worktree with targeted lint and formatter checks.

Exact steps or command run after this patch: `node scripts/run-oxlint.mjs ui/vite.config.ts`; `node_modules/.bin/oxfmt --check --threads=1 ui/vite.config.ts`; `git diff --check origin/main...HEAD`.

Evidence after fix: targeted oxlint exited 0; formatter check exited 0; whitespace check exited 0.

Observed result after fix: the wildcard alias guard still rejects second wildcards, now using `String.prototype.includes` with the same starting position.

What was not tested: no full UI build or broad changed gate; this is a lint-only cleanup for a current-main blocker.
