### PR TITLE
docs: clarify auth profile provider field after openai-codex OAuth login

### DIFF
--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -122,6 +122,13 @@ Flow shape:
 
 OpenAI Codex OAuth is explicitly supported for use outside the Codex CLI, including OpenClaw workflows.
 
+<Warning>
+When you sign in with `--provider openai-codex`, the resulting auth profile
+stores `"provider": "openai"`. The `openai-codex` value is the login flow
+identifier, not the provider ID. Do not set `"provider": "openai-codex"` in
+auth profiles — it causes a runtime error. See [OpenAI provider docs](/providers/openai) for details.
+</Warning>
+
 Flow shape (PKCE):
 
 1. generate PKCE verifier/challenge + random `state`

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -110,6 +110,10 @@ openclaw models auth paste-token --provider openrouter
 
 OpenClaw expects the canonical `version` + `profiles` shape at runtime. If an older install still has a flat file such as `{ "openrouter": { "apiKey": "..." } }`, run `openclaw doctor --fix` to rewrite it as an `openrouter:default` API-key profile; doctor keeps a `.legacy-flat.*.bak` copy beside the original. Endpoint details such as `baseUrl`, `api`, model ids, headers, and timeouts belong under `models.providers.<id>` in `openclaw.json` or `models.json`, not in `auth-profiles.json`.
 
+<Warning>
+**The `provider` field in auth profiles must match a registered provider ID, not a login flow identifier.** For example, after `openclaw models auth login --provider openai-codex`, the stored profile has `"provider": "openai"` — `openai-codex` is the Codex OAuth login flow name, not a provider ID. Setting `"provider": "openai-codex"` manually causes a runtime error: *"No available auth profile for openai-codex (all in cooldown or unavailable)"*. Run `openclaw doctor --fix` to repair mismatched provider fields in existing profiles.
+</Warning>
+
 External auth routes such as Bedrock `auth: "aws-sdk"` are also not credentials. If you want a named Bedrock route, put `auth.profiles.<id>.mode: "aws-sdk"` in `openclaw.json`; do not write `type: "aws-sdk"` into `auth-profiles.json`. `openclaw doctor --fix` moves legacy AWS SDK markers from the credential store into config metadata.
 
 Auth profile refs are also supported for static credentials:

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -49,6 +49,7 @@ The names are similar but not interchangeable:
 | Name you see                            | Layer             | Meaning                                                                                           |
 | --------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------- |
 | `openai`                                | Provider prefix   | Canonical OpenAI model route; agent turns use the Codex runtime.                                  |
+| `openai-codex`                          | Login flow        | Identifier for the Codex OAuth login flow (`--provider openai-codex`). The resulting auth profile stores `"provider": "openai"` — `openai-codex` is **not** a valid provider ID in auth profiles or config. |
 | legacy OpenAI Codex prefix              | Legacy prefix     | Older model/profile namespace. `openclaw doctor --fix` migrates it to `openai`.                   |
 | `codex` plugin                          | Plugin            | Bundled OpenClaw plugin that provides native Codex app-server runtime and `/codex` chat controls. |
 | provider/model `agentRuntime.id: codex` | Agent runtime     | Force the native Codex app-server harness for matching embedded turns.                            |
@@ -60,6 +61,22 @@ profiles point at either API-key or ChatGPT/Codex OAuth credentials. Use
 `auth.order.openai` for config; `openclaw doctor --fix` rewrites legacy
 legacy Codex model refs, legacy Codex auth profile ids, and
 legacy Codex auth order to the canonical OpenAI route.
+
+<Warning>
+**Auth profile `provider` field after `openai-codex` login.** When you run
+`openclaw models auth login --provider openai-codex`, the resulting auth profile
+in `auth-profiles.json` contains `"provider": "openai"` — **not**
+`"openai-codex"`. The `openai-codex` value identifies the Codex OAuth login
+flow, but the stored provider ID is `openai`. If you manually set or preserve
+`"provider": "openai-codex"` in an auth profile, OpenClaw cannot match it to a
+registered provider at runtime and all OpenAI model requests fail with a cryptic
+error: *"No available auth profile for openai-codex (all in cooldown or
+unavailable)"* — even though the profile exists and the token is valid.
+
+Fix: ensure the `provider` field in your auth profiles is `"openai"`. Run
+`openclaw doctor --fix` to repair legacy `openai-codex` profile entries
+automatically.
+</Warning>
 
 <Note>
 GPT-5.5 is available through both direct OpenAI Platform API-key access and

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -46,15 +46,15 @@ changing config.
 
 The names are similar but not interchangeable:
 
-| Name you see                            | Layer             | Meaning                                                                                           |
-| --------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------- |
-| `openai`                                | Provider prefix   | Canonical OpenAI model route; agent turns use the Codex runtime.                                  |
+| Name you see                            | Layer             | Meaning                                                                                                                                                                                                     |
+| --------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `openai`                                | Provider prefix   | Canonical OpenAI model route; agent turns use the Codex runtime.                                                                                                                                            |
 | `openai-codex`                          | Login flow        | Identifier for the Codex OAuth login flow (`--provider openai-codex`). The resulting auth profile stores `"provider": "openai"` — `openai-codex` is **not** a valid provider ID in auth profiles or config. |
-| legacy OpenAI Codex prefix              | Legacy prefix     | Older model/profile namespace. `openclaw doctor --fix` migrates it to `openai`.                   |
-| `codex` plugin                          | Plugin            | Bundled OpenClaw plugin that provides native Codex app-server runtime and `/codex` chat controls. |
-| provider/model `agentRuntime.id: codex` | Agent runtime     | Force the native Codex app-server harness for matching embedded turns.                            |
-| `/codex ...`                            | Chat command set  | Bind/control Codex app-server threads from a conversation.                                        |
-| `runtime: "acp", agentId: "codex"`      | ACP session route | Explicit fallback path that runs Codex through ACP/acpx.                                          |
+| legacy OpenAI Codex prefix              | Legacy prefix     | Older model/profile namespace. `openclaw doctor --fix` migrates it to `openai`.                                                                                                                             |
+| `codex` plugin                          | Plugin            | Bundled OpenClaw plugin that provides native Codex app-server runtime and `/codex` chat controls.                                                                                                           |
+| provider/model `agentRuntime.id: codex` | Agent runtime     | Force the native Codex app-server harness for matching embedded turns.                                                                                                                                      |
+| `/codex ...`                            | Chat command set  | Bind/control Codex app-server threads from a conversation.                                                                                                                                                  |
+| `runtime: "acp", agentId: "codex"`      | ACP session route | Explicit fallback path that runs Codex through ACP/acpx.                                                                                                                                                    |
 
 This means a config can intentionally contain `openai/*` model refs while auth
 profiles point at either API-key or ChatGPT/Codex OAuth credentials. Use


### PR DESCRIPTION
## Summary

After `openclaw models auth login --provider openai-codex`, the generated auth profile contains `"provider": "openai"` (not `"openai-codex"`). The `openai-codex` value is a **login flow identifier**, not a provider ID. If `"provider": "openai-codex"` is set manually in an auth profile, all OpenAI model requests fail with a cryptic error:

> No available auth profile for openai-codex (all in cooldown or unavailable)

This was confusing because `openclaw models auth list` shows the profile as valid and `openclaw models list --provider openai` shows models as available — the failure only happens at actual request time.

Closes #88125

## Changes

- **docs/providers/openai.md**: Added `openai-codex` row to the naming map explaining it is a login flow identifier, not a provider ID. Added a `<Warning>` block about the auth profile `provider` field after `openai-codex` OAuth login, the error it causes when wrong, and the `openclaw doctor --fix` repair path.
- **docs/gateway/authentication.md**: Added a `<Warning>` block in the auth-profiles.json section clarifying that the `provider` field must match a registered provider ID, not a login flow name, with the `openai-codex` example.
- **docs/concepts/oauth.md**: Added a `<Warning>` in the OpenAI Codex OAuth section noting that `--provider openai-codex` stores `"provider": "openai"` in the resulting auth profile.

## Real behavior proof

- **Behavior or issue addressed**: After `openclaw models auth login --provider openai-codex`, the stored auth profile has `"provider": "openai"`. Users who manually set `"provider": "openai-codex"` get a cryptic runtime error even though `openclaw models auth list` shows the profile as valid. The docs did not explain this naming distinction.

- **Real environment tested**: macOS arm64, OpenClaw installed via Homebrew, local `~/.openclaw/agents/main/agent/auth-profiles.json`.

- **Exact steps or command run after this patch**: 1. Created an auth-profiles.json with `"provider": "openai-codex"` to reproduce the confusing state. 2. Ran `openclaw models auth list` — it shows the profile as valid with no warning. 3. Corrected the provider field to `"openai"` in the auth profile. 4. Ran `openclaw doctor --fix` — it rewrites legacy `openai-codex` provider fields to `openai` (source: `src/commands/doctor-auth-flat-profiles.ts:563`). 5. Verified docs render correctly with `pnpm check:docs`.

- **Evidence after fix**: Terminal output showing `openclaw models auth list` accepts a profile with the wrong `provider: "openai-codex"` without warning — this is the source of user confusion the docs now address:

```
$ cat ~/.openclaw/agents/main/agent/auth-profiles.json
{
  "version": 1,
  "profiles": {
    "openai-codex:default": {
      "type": "api_key",
      "provider": "openai-codex",
      "key": "sk-REDACTED"
    }
  }
}

$ openclaw models auth list
Agent: main
Auth state file: ~/.openclaw/agents/main/agent/auth-state.json
Profiles:
- openai-codex:default [openai-codex/api_key]
```

The profile appears valid but will fail at runtime with: `No available auth profile for openai-codex (all in cooldown or unavailable)` (error string in `src/agents/embedded-agent-runner/run/auth-controller.ts:328`).

After applying the documentation, `pnpm check:docs` passes:

```
$ pnpm check:docs
$ pnpm format:docs:check && pnpm lint:docs && pnpm docs:check-mdx && pnpm docs:check-i18n-glossary && pnpm docs:check-links
Docs formatting clean (655 files).
markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
Summary: 0 error(s)
Docs MDX check passed (670 files, 2024ms).
checked_internal_links=4520
broken_links=0
```

- **Observed result after fix**: The three docs files now include `<Warning>` blocks that explicitly warn users: (1) `openai-codex` is a login flow identifier, not a provider ID; (2) the `provider` field in auth profiles must use `"openai"`, not `"openai-codex"`; (3) `openclaw doctor --fix` repairs mismatched entries. The naming map table in `openai.md` now has an `openai-codex` row. All doc checks pass.

- **What was not tested**: Actual OpenAI model request with a real Codex OAuth token (no OpenAI account available). The runtime error string and doctor repair behavior are confirmed via source code references cited by ClawSweeper review.