### PR TITLE
fix(agents): guard vanished workspaces

### DIFF
--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -41,6 +41,8 @@ If a file is missing, OpenClaw injects a single "missing file" marker line (and 
 
 `BOOTSTRAP.md` is only created for a **brand new workspace** (no other bootstrap files present). While it is pending, OpenClaw keeps it in Project Context and adds system-prompt bootstrap guidance for the initial ritual instead of copying it into the user message. If you delete it after completing the ritual, it should not be recreated on later restarts.
 
+After a workspace has been observed, OpenClaw also keeps a sibling attestation marker next to the workspace path. If a recently attested workspace disappears or is wiped, startup refuses to silently re-seed `BOOTSTRAP.md`; restore the workspace or use a full onboard reset so the workspace and marker are cleared together.
+
 To disable bootstrap file creation entirely (for pre-seeded workspaces), set:
 
 ```json5

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -41,7 +41,7 @@ If a file is missing, OpenClaw injects a single "missing file" marker line (and 
 
 `BOOTSTRAP.md` is only created for a **brand new workspace** (no other bootstrap files present). While it is pending, OpenClaw keeps it in Project Context and adds system-prompt bootstrap guidance for the initial ritual instead of copying it into the user message. If you delete it after completing the ritual, it should not be recreated on later restarts.
 
-After a workspace has been observed, OpenClaw also keeps a sibling attestation marker next to the workspace path. If a recently attested workspace disappears or is wiped, startup refuses to silently re-seed `BOOTSTRAP.md`; restore the workspace or use a full onboard reset so the workspace and marker are cleared together.
+After a workspace has been observed, OpenClaw also keeps a state-dir attestation marker for the workspace path. If a recently attested workspace disappears or is wiped, startup refuses to silently re-seed `BOOTSTRAP.md`; restore the workspace or use a full onboard reset so the workspace and marker are cleared together.
 
 To disable bootstrap file creation entirely (for pre-seeded workspaces), set:
 

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -231,18 +231,6 @@ describe("ensureAgentWorkspace", () => {
     ).resolves.toMatchObject({ dir: tempDir });
   });
 
-  it("keeps ISO-only attestation markers from the previous branch format effective", async () => {
-    const tempDir = await makeTempWorkspace("openclaw-workspace-");
-    const legacyAttestationPath = `${tempDir}.attested`;
-    await fs.writeFile(legacyAttestationPath, `${new Date().toISOString()}\n`);
-    await fs.rm(tempDir, { recursive: true, force: true });
-
-    await expectWorkspaceVanished(
-      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
-      { attestationPath: legacyAttestationPath },
-    );
-  });
-
   it("allows a brand new workspace when the only attestation marker is stale", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
   DEFAULT_AGENTS_FILENAME,
@@ -19,9 +19,25 @@ import {
   reconcileWorkspaceBootstrapCompletion,
   resolveWorkspaceBootstrapStatus,
   resolveDefaultAgentWorkspaceDir,
+  resolveWorkspaceAttestationPath,
   WORKSPACE_VANISHED_ERROR_CODE,
   type WorkspaceBootstrapFile,
 } from "./workspace.js";
+
+let testStateDir: string | undefined;
+
+beforeEach(async () => {
+  testStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-state-"));
+  vi.stubEnv("OPENCLAW_STATE_DIR", testStateDir);
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  if (testStateDir) {
+    await fs.rm(testStateDir, { recursive: true, force: true });
+    testStateDir = undefined;
+  }
+});
 
 describe("resolveDefaultAgentWorkspaceDir", () => {
   it("uses OPENCLAW_HOME for default workspace resolution", () => {
@@ -69,10 +85,14 @@ async function expectPathMissing(filePath: string): Promise<void> {
   await expect(fs.access(filePath)).rejects.toHaveProperty("code", "ENOENT");
 }
 
-async function expectWorkspaceVanished(action: Promise<unknown>): Promise<void> {
+async function expectWorkspaceVanished(
+  action: Promise<unknown>,
+  expected?: { attestationPath?: string },
+): Promise<void> {
   await expect(action).rejects.toMatchObject({
     code: WORKSPACE_VANISHED_ERROR_CODE,
     name: "WorkspaceVanishedError",
+    ...expected,
   });
 }
 
@@ -106,7 +126,7 @@ describe("ensureAgentWorkspace", () => {
   it("refuses to re-seed a recently attested workspace after the directory disappears", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
-    await expect(fs.access(`${tempDir}.attested`)).resolves.toBeUndefined();
+    await expect(fs.access(resolveWorkspaceAttestationPath(tempDir))).resolves.toBeUndefined();
 
     await fs.rm(tempDir, { recursive: true, force: true });
 
@@ -132,11 +152,13 @@ describe("ensureAgentWorkspace", () => {
 
   it("keeps ISO-only attestation markers from the previous branch format effective", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
-    await fs.writeFile(`${tempDir}.attested`, `${new Date().toISOString()}\n`);
+    const legacyAttestationPath = `${tempDir}.attested`;
+    await fs.writeFile(legacyAttestationPath, `${new Date().toISOString()}\n`);
     await fs.rm(tempDir, { recursive: true, force: true });
 
     await expectWorkspaceVanished(
       ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+      { attestationPath: legacyAttestationPath },
     );
   });
 
@@ -145,7 +167,7 @@ describe("ensureAgentWorkspace", () => {
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
     await fs.rm(tempDir, { recursive: true, force: true });
     const staleDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
-    await fs.utimes(`${tempDir}.attested`, staleDate, staleDate);
+    await fs.utimes(resolveWorkspaceAttestationPath(tempDir), staleDate, staleDate);
 
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
 
@@ -177,12 +199,51 @@ describe("ensureAgentWorkspace", () => {
   });
 
   it.skipIf(process.platform === "win32")(
+    "refuses to re-seed when a recent owned marker becomes unreadable",
+    async () => {
+      const tempDir = await makeTempWorkspace("openclaw-workspace-");
+      const attestationPath = resolveWorkspaceAttestationPath(tempDir);
+      await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+      await fs.chmod(attestationPath, 0o000);
+      await fs.rm(tempDir, { recursive: true, force: true });
+
+      try {
+        await expectWorkspaceVanished(
+          ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+        );
+      } finally {
+        await fs.chmod(attestationPath, 0o600);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "refuses to re-seed when the state marker directory is unreadable",
+    async () => {
+      const tempDir = await makeTempWorkspace("openclaw-workspace-");
+      const attestationDir = path.dirname(resolveWorkspaceAttestationPath(tempDir));
+      await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+      await fs.chmod(attestationDir, 0o000);
+      await fs.rm(tempDir, { recursive: true, force: true });
+
+      try {
+        await expectWorkspaceVanished(
+          ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+        );
+      } finally {
+        await fs.chmod(attestationDir, 0o700);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
     "ignores symlinked attestation markers without overwriting the target",
     async () => {
       const tempDir = await makeTempWorkspace("openclaw-workspace-");
-      const attestationPath = `${tempDir}.attested`;
-      const symlinkTargetPath = `${tempDir}.attested-target`;
+      const attestationPath = resolveWorkspaceAttestationPath(tempDir);
+      const symlinkTargetPath = `${attestationPath}-target`;
       const targetContent = "outside-marker\n";
+      await fs.mkdir(path.dirname(attestationPath), { recursive: true });
       await fs.writeFile(symlinkTargetPath, targetContent);
       await fs.symlink(symlinkTargetPath, attestationPath);
 

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -130,15 +130,50 @@ describe("ensureAgentWorkspace", () => {
     await expectPathMissing(path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS));
   });
 
+  it("keeps ISO-only attestation markers from the previous branch format effective", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await fs.writeFile(`${tempDir}.attested`, `${new Date().toISOString()}\n`);
+    await fs.rm(tempDir, { recursive: true, force: true });
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    );
+  });
+
   it("allows a brand new workspace when the only attestation marker is stale", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await fs.rm(tempDir, { recursive: true, force: true });
     const staleDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
-    await fs.writeFile(`${tempDir}.attested`, staleDate.toISOString());
     await fs.utimes(`${tempDir}.attested`, staleDate, staleDate);
 
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
 
     await expectBootstrapSeeded(tempDir);
+  });
+
+  it("does not overwrite a sibling file that is not an OpenClaw attestation marker", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const attestationPath = `${tempDir}.attested`;
+    const siblingContent = "external attestation data\n";
+    await fs.writeFile(attestationPath, siblingContent);
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expectBootstrapSeeded(tempDir);
+    expect(await fs.readFile(attestationPath, "utf-8")).toBe(siblingContent);
+  });
+
+  it("does not read or overwrite a large sibling file at the marker path", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const attestationPath = `${tempDir}.attested`;
+    const siblingContent = "x".repeat(1024);
+    await fs.writeFile(attestationPath, siblingContent);
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expectBootstrapSeeded(tempDir);
+    expect(await fs.readFile(attestationPath, "utf-8")).toBe(siblingContent);
   });
 
   it.skipIf(process.platform === "win32")(

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -194,6 +194,20 @@ describe("ensureAgentWorkspace", () => {
     expect((await readWorkspaceState(tempDir)).setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
   });
 
+  it("refuses a recently attested workspace when only non-skill skills leftovers survive", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.mkdir(path.join(tempDir, "skills"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "skills", ".DS_Store"), "");
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    );
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+  });
+
   it("refuses to recreate a skip-bootstrap workspace after the directory disappears", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await fs.writeFile(path.join(tempDir, "seed.txt"), "preseeded\n");

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -173,6 +174,28 @@ describe("ensureAgentWorkspace", () => {
     await fs.rm(tempDir, { recursive: true, force: true });
     await fs.mkdir(path.join(tempDir, ".git"), { recursive: true });
     await fs.mkdir(path.join(tempDir, ".openclaw"), { recursive: true });
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    );
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+  });
+
+  it("refuses to accept old generated bootstrap files recorded by the attestation marker", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const oldGeneratedAgents = "old generated agents\n";
+    await fs.writeFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), oldGeneratedAgents);
+    const attestationPath = resolveWorkspaceAttestationPath(tempDir);
+    await fs.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fs.writeFile(
+      attestationPath,
+      [
+        "openclaw-workspace-attestation:v1",
+        new Date().toISOString(),
+        `generated:${DEFAULT_AGENTS_FILENAME}:${createHash("sha256").update(oldGeneratedAgents).digest("hex")}`,
+        "",
+      ].join("\n"),
+    );
 
     await expectWorkspaceVanished(
       ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -166,6 +166,20 @@ describe("ensureAgentWorkspace", () => {
     await expectPathMissing(path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS));
   });
 
+  it("refuses to re-seed a recently attested workspace after only generated git metadata survives", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.mkdir(path.join(tempDir, ".git"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, ".openclaw"), { recursive: true });
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    );
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+  });
+
   it("accepts a recently attested workspace when customized AGENTS.md survives", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -150,6 +150,58 @@ describe("ensureAgentWorkspace", () => {
     await expectPathMissing(path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS));
   });
 
+  it("refuses to recreate a skip-bootstrap workspace after the directory disappears", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await fs.writeFile(path.join(tempDir, "seed.txt"), "preseeded\n");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: false });
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: false }),
+    );
+    await expectPathMissing(tempDir);
+  });
+
+  it("refuses to accept an empty skip-bootstrap workspace after contents are wiped", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await fs.writeFile(path.join(tempDir, "seed.txt"), "preseeded\n");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: false });
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.mkdir(tempDir, { recursive: true });
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: false }),
+    );
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+  });
+
+  it("refuses to accept a wiped skip-bootstrap workspace with only metadata leftovers", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await fs.writeFile(path.join(tempDir, "seed.txt"), "preseeded\n");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: false });
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.mkdir(path.join(tempDir, ".openclaw"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, "skills"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, ".DS_Store"), "");
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: false }),
+    );
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+  });
+
+  it("allows repeated skip-bootstrap setup for an intentionally empty workspace", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: false });
+    await expect(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: false }),
+    ).resolves.toMatchObject({ dir: tempDir });
+  });
+
   it("keeps ISO-only attestation markers from the previous branch format effective", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const legacyAttestationPath = `${tempDir}.attested`;

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -179,6 +179,21 @@ describe("ensureAgentWorkspace", () => {
     await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
   });
 
+  it("accepts a recently attested workspace when only custom skills survive", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.mkdir(path.join(tempDir, "skills", "local-skill"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "skills", "local-skill", "SKILL.md"), "---\n");
+
+    await expect(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    ).resolves.toMatchObject({ dir: tempDir });
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+    expect((await readWorkspaceState(tempDir)).setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
   it("refuses to recreate a skip-bootstrap workspace after the directory disappears", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await fs.writeFile(path.join(tempDir, "seed.txt"), "preseeded\n");

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -150,6 +150,35 @@ describe("ensureAgentWorkspace", () => {
     await expectPathMissing(path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS));
   });
 
+  it("refuses to re-seed a recently attested workspace after only generated remnants survive", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    const generatedAgents = await fs.readFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), "utf-8");
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), generatedAgents);
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    );
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+    await expectPathMissing(path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS));
+  });
+
+  it("accepts a recently attested workspace when customized AGENTS.md survives", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await fs.writeFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), "custom instructions\n");
+    await fs.rm(path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS), { force: true });
+    await fs.rm(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME), { force: true });
+
+    await expect(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    ).resolves.toMatchObject({ dir: tempDir });
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+  });
+
   it("refuses to recreate a skip-bootstrap workspace after the directory disappears", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await fs.writeFile(path.join(tempDir, "seed.txt"), "preseeded\n");

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -19,6 +19,7 @@ import {
   reconcileWorkspaceBootstrapCompletion,
   resolveWorkspaceBootstrapStatus,
   resolveDefaultAgentWorkspaceDir,
+  WORKSPACE_VANISHED_ERROR_CODE,
   type WorkspaceBootstrapFile,
 } from "./workspace.js";
 
@@ -68,6 +69,13 @@ async function expectPathMissing(filePath: string): Promise<void> {
   await expect(fs.access(filePath)).rejects.toHaveProperty("code", "ENOENT");
 }
 
+async function expectWorkspaceVanished(action: Promise<unknown>): Promise<void> {
+  await expect(action).rejects.toMatchObject({
+    code: WORKSPACE_VANISHED_ERROR_CODE,
+    name: "WorkspaceVanishedError",
+  });
+}
+
 async function expectCompletedWithoutBootstrap(dir: string) {
   await expect(fs.access(path.join(dir, DEFAULT_IDENTITY_FILENAME))).resolves.toBeUndefined();
   await expectPathMissing(path.join(dir, DEFAULT_BOOTSTRAP_FILENAME));
@@ -94,6 +102,62 @@ describe("ensureAgentWorkspace", () => {
     await expectBootstrapSeeded(tempDir);
     expect((await readWorkspaceState(tempDir)).setupCompletedAt).toBeUndefined();
   });
+
+  it("refuses to re-seed a recently attested workspace after the directory disappears", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await expect(fs.access(`${tempDir}.attested`)).resolves.toBeUndefined();
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    );
+    await expectPathMissing(tempDir);
+  });
+
+  it("refuses to re-seed a recently attested workspace after its contents are wiped", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.mkdir(tempDir, { recursive: true });
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    );
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+    await expectPathMissing(path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS));
+  });
+
+  it("allows a brand new workspace when the only attestation marker is stale", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const staleDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    await fs.writeFile(`${tempDir}.attested`, staleDate.toISOString());
+    await fs.utimes(`${tempDir}.attested`, staleDate, staleDate);
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expectBootstrapSeeded(tempDir);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "ignores symlinked attestation markers without overwriting the target",
+    async () => {
+      const tempDir = await makeTempWorkspace("openclaw-workspace-");
+      const attestationPath = `${tempDir}.attested`;
+      const symlinkTargetPath = `${tempDir}.attested-target`;
+      const targetContent = "outside-marker\n";
+      await fs.writeFile(symlinkTargetPath, targetContent);
+      await fs.symlink(symlinkTargetPath, attestationPath);
+
+      await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+      await expectBootstrapSeeded(tempDir);
+      expect(await fs.readFile(symlinkTargetPath, "utf-8")).toBe(targetContent);
+      expect((await fs.lstat(attestationPath)).isSymbolicLink()).toBe(true);
+    },
+  );
 
   it("recovers partial initialization by creating BOOTSTRAP.md when marker is missing", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -203,6 +203,23 @@ describe("ensureAgentWorkspace", () => {
     await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
   });
 
+  it("refuses a recently attested workspace when generated state and only one generated file survive", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    const generatedAgents = await fs.readFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), "utf-8");
+    const state = await fs.readFile(path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS), "utf-8");
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.mkdir(path.join(tempDir, WORKSPACE_STATE_PATH_SEGMENTS[0]), { recursive: true });
+    await fs.writeFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), generatedAgents);
+    await fs.writeFile(path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS), state);
+
+    await expectWorkspaceVanished(
+      ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+    );
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+  });
+
   it("accepts a recently attested workspace when customized AGENTS.md survives", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -32,6 +32,8 @@ export const DEFAULT_MEMORY_FILENAME = CANONICAL_ROOT_MEMORY_FILENAME;
 const WORKSPACE_STATE_DIRNAME = ".openclaw";
 const WORKSPACE_STATE_FILENAME = "workspace-state.json";
 const WORKSPACE_STATE_VERSION = 1;
+const WORKSPACE_ATTESTATION_SUFFIX = ".attested";
+const WORKSPACE_ATTESTATION_RECENT_MS = 24 * 60 * 60 * 1000;
 const WORKSPACE_ONBOARDING_PROFILE_FILENAMES = [
   DEFAULT_SOUL_FILENAME,
   DEFAULT_IDENTITY_FILENAME,
@@ -196,6 +198,25 @@ const OPTIONAL_BOOTSTRAP_FILENAMES: ReadonlySet<string> = new Set([
   DEFAULT_HEARTBEAT_FILENAME,
 ]);
 
+export const WORKSPACE_VANISHED_ERROR_CODE = "WORKSPACE_VANISHED";
+
+export class WorkspaceVanishedError extends Error {
+  readonly code = WORKSPACE_VANISHED_ERROR_CODE;
+  readonly workspaceDir: string;
+  readonly attestationPath: string;
+
+  constructor(params: { workspaceDir: string; attestationPath: string }) {
+    super(
+      `OpenClaw workspace appears to have disappeared after a recent initialization: ${params.workspaceDir}. ` +
+        `Refusing to reseed BOOTSTRAP.md over a recently attested workspace. ` +
+        `Restore the workspace or remove ${params.attestationPath} if this reset was intentional.`,
+    );
+    this.name = "WorkspaceVanishedError";
+    this.workspaceDir = params.workspaceDir;
+    this.attestationPath = params.attestationPath;
+  }
+}
+
 async function writeFileIfMissing(filePath: string, content: string): Promise<boolean> {
   try {
     await fs.writeFile(filePath, content, {
@@ -324,6 +345,63 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
 
 function resolveWorkspaceStatePath(dir: string): string {
   return path.join(dir, WORKSPACE_STATE_DIRNAME, WORKSPACE_STATE_FILENAME);
+}
+
+export function resolveWorkspaceAttestationPath(dir: string): string {
+  return `${dir}${WORKSPACE_ATTESTATION_SUFFIX}`;
+}
+
+async function hasRecentWorkspaceAttestation(attestationPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(attestationPath);
+    if (!stat.isFile()) {
+      return false;
+    }
+    return Date.now() - stat.mtimeMs <= WORKSPACE_ATTESTATION_RECENT_MS;
+  } catch (err) {
+    const anyErr = err as { code?: string };
+    if (anyErr.code !== "ENOENT") {
+      throw err;
+    }
+    return false;
+  }
+}
+
+async function writeWorkspaceAttestation(attestationPath: string): Promise<void> {
+  await fs.mkdir(path.dirname(attestationPath), { recursive: true });
+  try {
+    const stat = await fs.lstat(attestationPath);
+    if (!stat.isFile()) {
+      return;
+    }
+  } catch (err) {
+    const anyErr = err as { code?: string };
+    if (anyErr.code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  const noFollowFlag =
+    typeof syncFs.constants.O_NOFOLLOW === "number" ? syncFs.constants.O_NOFOLLOW : 0;
+  const handle = await fs.open(
+    attestationPath,
+    syncFs.constants.O_WRONLY | syncFs.constants.O_CREAT | syncFs.constants.O_TRUNC | noFollowFlag,
+    0o600,
+  );
+  try {
+    await handle.writeFile(`${new Date().toISOString()}\n`, "utf-8");
+  } finally {
+    await handle.close();
+  }
+}
+
+async function maybeWriteWorkspaceAttestation(attestationPath: string): Promise<void> {
+  try {
+    await writeWorkspaceAttestation(attestationPath);
+  } catch {
+    // The marker is a lifecycle guard; setup should not fail solely because it
+    // could not refresh auxiliary disappearance evidence.
+  }
 }
 
 function parseWorkspaceSetupState(raw: string): WorkspaceSetupState | null {
@@ -499,6 +577,16 @@ export async function ensureAgentWorkspace(params?: {
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
   const dir = resolveUserPath(rawDir);
+  const attestationPath = resolveWorkspaceAttestationPath(dir);
+
+  if (
+    params?.ensureBootstrapFiles &&
+    !(await pathExists(dir)) &&
+    (await hasRecentWorkspaceAttestation(attestationPath))
+  ) {
+    throw new WorkspaceVanishedError({ workspaceDir: dir, attestationPath });
+  }
+
   await fs.mkdir(dir, { recursive: true });
 
   if (!params?.ensureBootstrapFiles) {
@@ -531,6 +619,10 @@ export async function ensureAgentWorkspace(params?: {
     const hasCanonicalRootMemory = await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME);
     return existing.every((v) => !v) && !hasCanonicalRootMemory;
   })();
+
+  if (isBrandNewWorkspace && (await hasRecentWorkspaceAttestation(attestationPath))) {
+    throw new WorkspaceVanishedError({ workspaceDir: dir, attestationPath });
+  }
 
   const agentsTemplate = await loadTemplate(DEFAULT_AGENTS_FILENAME);
   const soulTemplate = await loadTemplate(DEFAULT_SOUL_FILENAME);
@@ -616,6 +708,7 @@ export async function ensureAgentWorkspace(params?: {
     await writeWorkspaceSetupState(statePath, state);
   }
   await ensureGitRepo(dir, isBrandNewWorkspace);
+  await maybeWriteWorkspaceAttestation(attestationPath);
 
   return {
     dir,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -38,7 +38,7 @@ const WORKSPACE_ATTESTATION_SUFFIX = ".attested";
 const WORKSPACE_ATTESTATION_DIRNAME = "workspace-attestations";
 const WORKSPACE_ATTESTATION_RECENT_MS = 24 * 60 * 60 * 1000;
 const WORKSPACE_ATTESTATION_HEADER = "openclaw-workspace-attestation:v1";
-const WORKSPACE_ATTESTATION_MAX_BYTES = 256;
+const WORKSPACE_ATTESTATION_MAX_BYTES = 2048;
 const WORKSPACE_ONBOARDING_PROFILE_FILENAMES = [
   DEFAULT_SOUL_FILENAME,
   DEFAULT_IDENTITY_FILENAME,
@@ -336,8 +336,30 @@ async function workspaceProfileLooksConfigured(params: {
   );
 }
 
-async function workspaceRequiredBootstrapLooksCustomized(dir: string): Promise<boolean> {
+async function workspaceRequiredBootstrapLooksCustomized(
+  dir: string,
+  opts?: { attestationPath?: string },
+): Promise<boolean> {
   const fileNames = [DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME, DEFAULT_HEARTBEAT_FILENAME];
+  const generatedHashes = opts?.attestationPath
+    ? await readWorkspaceAttestationGeneratedHashes(opts.attestationPath)
+    : undefined;
+  if (generatedHashes) {
+    for (const fileName of fileNames) {
+      const filePath = path.join(dir, fileName);
+      const generatedHash = generatedHashes.get(fileName);
+      try {
+        const content = await fs.readFile(filePath, "utf-8");
+        const contentHash = createHash("sha256").update(content).digest("hex");
+        if (!generatedHash || contentHash !== generatedHash) {
+          return true;
+        }
+      } catch {
+        // Missing generated files are not customization evidence.
+      }
+    }
+    return false;
+  }
   const fileDiffs = await Promise.all(
     fileNames.map(async (fileName) =>
       fileContentDiffersFromTemplate(path.join(dir, fileName), await loadTemplate(fileName)),
@@ -502,12 +524,71 @@ async function readWorkspaceAttestationMarkerStatus(
   }
 }
 
-async function writeWorkspaceAttestation(attestationPath: string): Promise<void> {
+async function readWorkspaceAttestationGeneratedHashes(
+  attestationPath: string,
+): Promise<Map<string, string> | undefined> {
+  try {
+    const stat = await fs.lstat(attestationPath);
+    if (!stat.isFile() || stat.size > WORKSPACE_ATTESTATION_MAX_BYTES) {
+      return undefined;
+    }
+    const raw = await fs.readFile(attestationPath, "utf-8");
+    if (!raw.startsWith(`${WORKSPACE_ATTESTATION_HEADER}\n`)) {
+      return undefined;
+    }
+    const hashes = new Map<string, string>();
+    for (const line of raw.split(/\r?\n/)) {
+      const match = /^generated:([^:]+):([a-f0-9]{64})$/.exec(line);
+      if (match?.[1] && match[2]) {
+        hashes.set(match[1], match[2]);
+      }
+    }
+    return hashes.size > 0 ? hashes : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function collectGeneratedBootstrapHashes(dir: string): Promise<Map<string, string>> {
+  const hashes = new Map<string, string>();
+  const fileNames = [
+    DEFAULT_AGENTS_FILENAME,
+    DEFAULT_SOUL_FILENAME,
+    DEFAULT_TOOLS_FILENAME,
+    DEFAULT_IDENTITY_FILENAME,
+    DEFAULT_USER_FILENAME,
+    DEFAULT_HEARTBEAT_FILENAME,
+  ];
+  for (const fileName of fileNames) {
+    try {
+      const content = await fs.readFile(path.join(dir, fileName), "utf-8");
+      if (content === (await loadTemplate(fileName))) {
+        hashes.set(fileName, createHash("sha256").update(content).digest("hex"));
+      }
+    } catch {
+      // Missing or unreadable files are not attested as generated.
+    }
+  }
+  return hashes;
+}
+
+async function buildWorkspaceAttestationContent(dir: string, now: Date): Promise<string> {
+  const hashes = await collectGeneratedBootstrapHashes(dir);
+  const lines = [`${WORKSPACE_ATTESTATION_HEADER}`, now.toISOString()];
+  for (const [fileName, hash] of [...hashes.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    lines.push(`generated:${fileName}:${hash}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function writeWorkspaceAttestation(attestationPath: string, dir: string): Promise<void> {
   await fs.mkdir(path.dirname(attestationPath), { recursive: true });
   const now = new Date();
+  const content = await buildWorkspaceAttestationContent(dir, now);
   try {
     const status = await readWorkspaceAttestationMarkerStatus(attestationPath);
     if (status === "marker") {
+      await fs.writeFile(attestationPath, content, "utf-8");
       await fs.utimes(attestationPath, now, now);
       return;
     }
@@ -526,15 +607,15 @@ async function writeWorkspaceAttestation(attestationPath: string): Promise<void>
     0o600,
   );
   try {
-    await handle.writeFile(`${WORKSPACE_ATTESTATION_HEADER}\n${now.toISOString()}\n`, "utf-8");
+    await handle.writeFile(content, "utf-8");
   } finally {
     await handle.close();
   }
 }
 
-async function maybeWriteWorkspaceAttestation(attestationPath: string): Promise<void> {
+async function maybeWriteWorkspaceAttestation(attestationPath: string, dir: string): Promise<void> {
   try {
-    await writeWorkspaceAttestation(attestationPath);
+    await writeWorkspaceAttestation(attestationPath, dir);
   } catch {
     // The marker is a lifecycle guard; setup should not fail solely because it
     // could not refresh auxiliary disappearance evidence.
@@ -736,7 +817,7 @@ export async function ensureAgentWorkspace(params?: {
       });
     }
     if (hasContentEvidence) {
-      await maybeWriteWorkspaceAttestation(attestationPath);
+      await maybeWriteWorkspaceAttestation(attestationPath, dir);
     }
     return { dir };
   }
@@ -784,7 +865,9 @@ export async function ensureAgentWorkspace(params?: {
     const hasWorkspaceEvidence =
       hasSetupState ||
       bootstrapExists ||
-      (await workspaceRequiredBootstrapLooksCustomized(dir)) ||
+      (await workspaceRequiredBootstrapLooksCustomized(dir, {
+        attestationPath: recentAttestationPath,
+      })) ||
       (await workspaceProfileLooksConfigured({
         dir,
       }));
@@ -856,7 +939,10 @@ export async function ensureAgentWorkspace(params?: {
     // indicators exist, treat setup as complete and avoid recreating BOOTSTRAP for
     // already-configured workspaces.
     if (
-      (Boolean(recentAttestationPath) && (await workspaceRequiredBootstrapLooksCustomized(dir))) ||
+      (Boolean(recentAttestationPath) &&
+        (await workspaceRequiredBootstrapLooksCustomized(dir, {
+          attestationPath: recentAttestationPath,
+        }))) ||
       (await workspaceProfileLooksConfigured({
         dir,
         includeGitEvidence: true,
@@ -881,7 +967,7 @@ export async function ensureAgentWorkspace(params?: {
     await writeWorkspaceSetupState(statePath, state);
   }
   await ensureGitRepo(dir, isBrandNewWorkspace);
-  await maybeWriteWorkspaceAttestation(attestationPath);
+  await maybeWriteWorkspaceAttestation(attestationPath, dir);
 
   return {
     dir,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -462,11 +462,7 @@ async function readWorkspaceAttestationMarkerStatus(
     if (raw.startsWith(`${WORKSPACE_ATTESTATION_HEADER}\n`)) {
       return "marker";
     }
-    const trimmed = raw.trim();
-    return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(trimmed) &&
-      !Number.isNaN(Date.parse(trimmed))
-      ? "marker"
-      : "not-marker";
+    return "not-marker";
   } catch (err) {
     const anyErr = err as { code?: string };
     return anyErr.code === "ENOENT" ? "missing" : "unknown";

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -368,6 +368,28 @@ async function workspaceRequiredBootstrapLooksCustomized(
   return fileDiffs.some(Boolean);
 }
 
+async function workspaceAttestedGeneratedFilesIntact(
+  dir: string,
+  attestationPath: string,
+): Promise<boolean> {
+  const generatedHashes = await readWorkspaceAttestationGeneratedHashes(attestationPath);
+  if (!generatedHashes) {
+    return false;
+  }
+  for (const [fileName, generatedHash] of generatedHashes) {
+    try {
+      const content = await fs.readFile(path.join(dir, fileName), "utf-8");
+      const contentHash = createHash("sha256").update(content).digest("hex");
+      if (contentHash !== generatedHash) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
 async function workspaceHasBootstrapCompletionEvidence(params: { dir: string }): Promise<boolean> {
   return await workspaceProfileLooksConfigured(params);
 }
@@ -862,15 +884,17 @@ export async function ensureAgentWorkspace(params?: {
       persistLegacyMigration: true,
     });
     const hasSetupState = Boolean(state.bootstrapSeededAt || state.setupCompletedAt);
+    const hasCustomizedRequiredBootstrap = await workspaceRequiredBootstrapLooksCustomized(dir, {
+      attestationPath: recentAttestationPath,
+    });
+    const hasConfiguredProfile = await workspaceProfileLooksConfigured({
+      dir,
+    });
     const hasWorkspaceEvidence =
-      hasSetupState ||
       bootstrapExists ||
-      (await workspaceRequiredBootstrapLooksCustomized(dir, {
-        attestationPath: recentAttestationPath,
-      })) ||
-      (await workspaceProfileLooksConfigured({
-        dir,
-      }));
+      hasCustomizedRequiredBootstrap ||
+      hasConfiguredProfile ||
+      (hasSetupState && (await workspaceAttestedGeneratedFilesIntact(dir, recentAttestationPath)));
     if (!hasWorkspaceEvidence) {
       throw new WorkspaceVanishedError({
         workspaceDir: dir,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -596,8 +596,8 @@ async function collectGeneratedBootstrapHashes(dir: string): Promise<Map<string,
 
 async function buildWorkspaceAttestationContent(dir: string, now: Date): Promise<string> {
   const hashes = await collectGeneratedBootstrapHashes(dir);
-  const lines = [`${WORKSPACE_ATTESTATION_HEADER}`, now.toISOString()];
-  for (const [fileName, hash] of [...hashes.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+  const lines = [WORKSPACE_ATTESTATION_HEADER, now.toISOString()];
+  for (const [fileName, hash] of [...hashes.entries()].toSorted(([a], [b]) => a.localeCompare(b))) {
     lines.push(`generated:${fileName}:${hash}`);
   }
   return `${lines.join("\n")}\n`;
@@ -962,11 +962,13 @@ export async function ensureAgentWorkspace(params?: {
     // Legacy migration path: if USER/IDENTITY diverged from templates, or if user-content
     // indicators exist, treat setup as complete and avoid recreating BOOTSTRAP for
     // already-configured workspaces.
-    if (
-      (Boolean(recentAttestationPath) &&
-        (await workspaceRequiredBootstrapLooksCustomized(dir, {
+    const hasRecentAttestedCustomization = recentAttestationPath
+      ? await workspaceRequiredBootstrapLooksCustomized(dir, {
           attestationPath: recentAttestationPath,
-        }))) ||
+        })
+      : false;
+    if (
+      hasRecentAttestedCustomization ||
       (await workspaceProfileLooksConfigured({
         dir,
         includeGitEvidence: true,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -273,11 +273,27 @@ async function hasWorkspaceUserContentEvidence(
   if (await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME)) {
     return true;
   }
+  return await hasWorkspaceSkillEvidence(dir);
+}
+
+async function hasWorkspaceSkillEvidence(dir: string): Promise<boolean> {
   try {
-    return (await fs.readdir(path.join(dir, "skills"))).length > 0;
+    const skillEntries = await fs.readdir(path.join(dir, "skills"), { withFileTypes: true });
+    for (const entry of skillEntries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      try {
+        await fs.access(path.join(dir, "skills", entry.name, "SKILL.md"));
+        return true;
+      } catch {
+        // continue
+      }
+    }
   } catch {
-    return false;
+    // no workspace skills
   }
+  return false;
 }
 
 async function hasSkipBootstrapWorkspaceContentEvidence(dir: string): Promise<boolean> {
@@ -288,11 +304,7 @@ async function hasSkipBootstrapWorkspaceContentEvidence(dir: string): Promise<bo
         continue;
       }
       if (entry.name === "skills" && entry.isDirectory()) {
-        try {
-          if ((await fs.readdir(path.join(dir, entry.name))).length === 0) {
-            continue;
-          }
-        } catch {
+        if (!(await hasWorkspaceSkillEvidence(dir))) {
           continue;
         }
       }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -1,7 +1,9 @@
+import { createHash } from "node:crypto";
 import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import { resolveLegacyStateDirs, resolveStateDir } from "../config/paths.js";
 import { openRootFile } from "../infra/boundary-file-read.js";
 import { pathExists } from "../infra/fs-safe.js";
 import { replaceFileAtomic } from "../infra/replace-file.js";
@@ -33,6 +35,7 @@ const WORKSPACE_STATE_DIRNAME = ".openclaw";
 const WORKSPACE_STATE_FILENAME = "workspace-state.json";
 const WORKSPACE_STATE_VERSION = 1;
 const WORKSPACE_ATTESTATION_SUFFIX = ".attested";
+const WORKSPACE_ATTESTATION_DIRNAME = "workspace-attestations";
 const WORKSPACE_ATTESTATION_RECENT_MS = 24 * 60 * 60 * 1000;
 const WORKSPACE_ATTESTATION_HEADER = "openclaw-workspace-attestation:v1";
 const WORKSPACE_ATTESTATION_MAX_BYTES = 256;
@@ -180,6 +183,7 @@ type WorkspaceSetupState = {
   bootstrapSeededAt?: string;
   setupCompletedAt?: string;
 };
+type WorkspaceAttestationMarkerStatus = "marker" | "not-marker" | "missing" | "unknown";
 
 /** Set of recognized bootstrap filenames for runtime validation */
 const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
@@ -350,49 +354,85 @@ function resolveWorkspaceStatePath(dir: string): string {
 }
 
 export function resolveWorkspaceAttestationPath(dir: string): string {
+  return resolveWorkspaceAttestationPathInStateDir(dir, resolveStateDir());
+}
+
+function resolveWorkspaceAttestationPathInStateDir(dir: string, stateDir: string): string {
+  const key = createHash("sha256").update(path.resolve(dir)).digest("hex");
+  return path.join(stateDir, WORKSPACE_ATTESTATION_DIRNAME, `${key}.attested`);
+}
+
+function resolveLegacyWorkspaceAttestationPath(dir: string): string {
   return `${dir}${WORKSPACE_ATTESTATION_SUFFIX}`;
 }
 
-async function hasRecentWorkspaceAttestation(attestationPath: string): Promise<boolean> {
+export function resolveWorkspaceAttestationPaths(dir: string): string[] {
+  const stateAttestationPaths = [resolveStateDir(), ...resolveLegacyStateDirs()].map((stateDir) =>
+    resolveWorkspaceAttestationPathInStateDir(dir, stateDir),
+  );
+  const legacy = resolveLegacyWorkspaceAttestationPath(dir);
+  return [...new Set([...stateAttestationPaths, legacy])];
+}
+
+async function findRecentWorkspaceAttestationPath(
+  attestationPaths: string[],
+): Promise<string | null> {
+  for (const [index, attestationPath] of attestationPaths.entries()) {
+    if (await hasRecentWorkspaceAttestation(attestationPath, { trustUnknown: index === 0 })) {
+      return attestationPath;
+    }
+  }
+  return null;
+}
+
+export async function hasRecentWorkspaceAttestation(
+  attestationPath: string,
+  opts?: { trustUnknown?: boolean },
+): Promise<boolean> {
   try {
     const stat = await fs.lstat(attestationPath);
-    if (!stat.isFile()) {
+    if (
+      !stat.isFile() ||
+      stat.size > WORKSPACE_ATTESTATION_MAX_BYTES ||
+      Date.now() - stat.mtimeMs > WORKSPACE_ATTESTATION_RECENT_MS
+    ) {
       return false;
     }
-    if (!(await isWorkspaceAttestationMarker(attestationPath))) {
-      return false;
-    }
-    return Date.now() - stat.mtimeMs <= WORKSPACE_ATTESTATION_RECENT_MS;
+    const status = await readWorkspaceAttestationMarkerStatus(attestationPath);
+    return status === "marker" || (opts?.trustUnknown === true && status === "unknown");
   } catch (err) {
     const anyErr = err as { code?: string };
     if (anyErr.code !== "ENOENT") {
-      throw err;
+      return opts?.trustUnknown === true;
     }
     return false;
   }
 }
 
 export async function isWorkspaceAttestationMarker(attestationPath: string): Promise<boolean> {
+  return (await readWorkspaceAttestationMarkerStatus(attestationPath)) === "marker";
+}
+
+async function readWorkspaceAttestationMarkerStatus(
+  attestationPath: string,
+): Promise<WorkspaceAttestationMarkerStatus> {
   try {
     const stat = await fs.lstat(attestationPath);
     if (!stat.isFile() || stat.size > WORKSPACE_ATTESTATION_MAX_BYTES) {
-      return false;
+      return "not-marker";
     }
     const raw = await fs.readFile(attestationPath, "utf-8");
     if (raw.startsWith(`${WORKSPACE_ATTESTATION_HEADER}\n`)) {
-      return true;
+      return "marker";
     }
     const trimmed = raw.trim();
-    return (
-      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(trimmed) &&
+    return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(trimmed) &&
       !Number.isNaN(Date.parse(trimmed))
-    );
+      ? "marker"
+      : "not-marker";
   } catch (err) {
     const anyErr = err as { code?: string };
-    if (anyErr.code !== "ENOENT") {
-      throw err;
-    }
-    return false;
+    return anyErr.code === "ENOENT" ? "missing" : "unknown";
   }
 }
 
@@ -400,20 +440,16 @@ async function writeWorkspaceAttestation(attestationPath: string): Promise<void>
   await fs.mkdir(path.dirname(attestationPath), { recursive: true });
   const now = new Date();
   try {
-    const stat = await fs.lstat(attestationPath);
-    if (!stat.isFile()) {
+    const status = await readWorkspaceAttestationMarkerStatus(attestationPath);
+    if (status === "marker") {
+      await fs.utimes(attestationPath, now, now);
       return;
     }
-    if (!(await isWorkspaceAttestationMarker(attestationPath))) {
+    if (status !== "missing") {
       return;
     }
-    await fs.utimes(attestationPath, now, now);
+  } catch {
     return;
-  } catch (err) {
-    const anyErr = err as { code?: string };
-    if (anyErr.code !== "ENOENT") {
-      throw err;
-    }
   }
 
   const noFollowFlag =
@@ -612,14 +648,17 @@ export async function ensureAgentWorkspace(params?: {
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
   const dir = resolveUserPath(rawDir);
-  const attestationPath = resolveWorkspaceAttestationPath(dir);
+  const [attestationPath, ...legacyAttestationPaths] = resolveWorkspaceAttestationPaths(dir);
+  const attestationPaths = [attestationPath, ...legacyAttestationPaths];
 
-  if (
-    params?.ensureBootstrapFiles &&
-    !(await pathExists(dir)) &&
-    (await hasRecentWorkspaceAttestation(attestationPath))
-  ) {
-    throw new WorkspaceVanishedError({ workspaceDir: dir, attestationPath });
+  if (params?.ensureBootstrapFiles && !(await pathExists(dir))) {
+    const recentAttestationPath = await findRecentWorkspaceAttestationPath(attestationPaths);
+    if (recentAttestationPath) {
+      throw new WorkspaceVanishedError({
+        workspaceDir: dir,
+        attestationPath: recentAttestationPath,
+      });
+    }
   }
 
   await fs.mkdir(dir, { recursive: true });
@@ -655,8 +694,14 @@ export async function ensureAgentWorkspace(params?: {
     return existing.every((v) => !v) && !hasCanonicalRootMemory;
   })();
 
-  if (isBrandNewWorkspace && (await hasRecentWorkspaceAttestation(attestationPath))) {
-    throw new WorkspaceVanishedError({ workspaceDir: dir, attestationPath });
+  if (isBrandNewWorkspace) {
+    const recentAttestationPath = await findRecentWorkspaceAttestationPath(attestationPaths);
+    if (recentAttestationPath) {
+      throw new WorkspaceVanishedError({
+        workspaceDir: dir,
+        attestationPath: recentAttestationPath,
+      });
+    }
   }
 
   const agentsTemplate = await loadTemplate(DEFAULT_AGENTS_FILENAME);

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -372,7 +372,7 @@ async function hasRecentWorkspaceAttestation(attestationPath: string): Promise<b
   }
 }
 
-async function isWorkspaceAttestationMarker(attestationPath: string): Promise<boolean> {
+export async function isWorkspaceAttestationMarker(attestationPath: string): Promise<boolean> {
   try {
     const stat = await fs.lstat(attestationPath);
     if (!stat.isFile() || stat.size > WORKSPACE_ATTESTATION_MAX_BYTES) {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -34,6 +34,8 @@ const WORKSPACE_STATE_FILENAME = "workspace-state.json";
 const WORKSPACE_STATE_VERSION = 1;
 const WORKSPACE_ATTESTATION_SUFFIX = ".attested";
 const WORKSPACE_ATTESTATION_RECENT_MS = 24 * 60 * 60 * 1000;
+const WORKSPACE_ATTESTATION_HEADER = "openclaw-workspace-attestation:v1";
+const WORKSPACE_ATTESTATION_MAX_BYTES = 256;
 const WORKSPACE_ONBOARDING_PROFILE_FILENAMES = [
   DEFAULT_SOUL_FILENAME,
   DEFAULT_IDENTITY_FILENAME,
@@ -357,7 +359,34 @@ async function hasRecentWorkspaceAttestation(attestationPath: string): Promise<b
     if (!stat.isFile()) {
       return false;
     }
+    if (!(await isWorkspaceAttestationMarker(attestationPath))) {
+      return false;
+    }
     return Date.now() - stat.mtimeMs <= WORKSPACE_ATTESTATION_RECENT_MS;
+  } catch (err) {
+    const anyErr = err as { code?: string };
+    if (anyErr.code !== "ENOENT") {
+      throw err;
+    }
+    return false;
+  }
+}
+
+async function isWorkspaceAttestationMarker(attestationPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(attestationPath);
+    if (!stat.isFile() || stat.size > WORKSPACE_ATTESTATION_MAX_BYTES) {
+      return false;
+    }
+    const raw = await fs.readFile(attestationPath, "utf-8");
+    if (raw.startsWith(`${WORKSPACE_ATTESTATION_HEADER}\n`)) {
+      return true;
+    }
+    const trimmed = raw.trim();
+    return (
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(trimmed) &&
+      !Number.isNaN(Date.parse(trimmed))
+    );
   } catch (err) {
     const anyErr = err as { code?: string };
     if (anyErr.code !== "ENOENT") {
@@ -369,11 +398,17 @@ async function hasRecentWorkspaceAttestation(attestationPath: string): Promise<b
 
 async function writeWorkspaceAttestation(attestationPath: string): Promise<void> {
   await fs.mkdir(path.dirname(attestationPath), { recursive: true });
+  const now = new Date();
   try {
     const stat = await fs.lstat(attestationPath);
     if (!stat.isFile()) {
       return;
     }
+    if (!(await isWorkspaceAttestationMarker(attestationPath))) {
+      return;
+    }
+    await fs.utimes(attestationPath, now, now);
+    return;
   } catch (err) {
     const anyErr = err as { code?: string };
     if (anyErr.code !== "ENOENT") {
@@ -385,11 +420,11 @@ async function writeWorkspaceAttestation(attestationPath: string): Promise<void>
     typeof syncFs.constants.O_NOFOLLOW === "number" ? syncFs.constants.O_NOFOLLOW : 0;
   const handle = await fs.open(
     attestationPath,
-    syncFs.constants.O_WRONLY | syncFs.constants.O_CREAT | syncFs.constants.O_TRUNC | noFollowFlag,
+    syncFs.constants.O_WRONLY | syncFs.constants.O_CREAT | syncFs.constants.O_EXCL | noFollowFlag,
     0o600,
   );
   try {
-    await handle.writeFile(`${new Date().toISOString()}\n`, "utf-8");
+    await handle.writeFile(`${WORKSPACE_ATTESTATION_HEADER}\n${now.toISOString()}\n`, "utf-8");
   } finally {
     await handle.close();
   }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -317,6 +317,16 @@ async function workspaceProfileLooksConfigured(params: {
   );
 }
 
+async function workspaceRequiredBootstrapLooksCustomized(dir: string): Promise<boolean> {
+  const fileNames = [DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME, DEFAULT_HEARTBEAT_FILENAME];
+  const fileDiffs = await Promise.all(
+    fileNames.map(async (fileName) =>
+      fileContentDiffersFromTemplate(path.join(dir, fileName), await loadTemplate(fileName)),
+    ),
+  );
+  return fileDiffs.some(Boolean);
+}
+
 async function workspaceHasBootstrapCompletionEvidence(params: { dir: string }): Promise<boolean> {
   return await workspaceProfileLooksConfigured(params);
 }
@@ -738,6 +748,28 @@ export async function ensureAgentWorkspace(params?: {
     }
   }
 
+  if (recentAttestationPath && !isBrandNewWorkspace) {
+    const bootstrapExists = await pathExists(bootstrapPath);
+    const state = await readWorkspaceSetupState(statePath, {
+      persistLegacyMigration: true,
+    });
+    const hasSetupState = Boolean(state.bootstrapSeededAt || state.setupCompletedAt);
+    const hasWorkspaceEvidence =
+      hasSetupState ||
+      bootstrapExists ||
+      (await workspaceRequiredBootstrapLooksCustomized(dir)) ||
+      (await workspaceProfileLooksConfigured({
+        dir,
+        includeGitEvidence: true,
+      }));
+    if (!hasWorkspaceEvidence) {
+      throw new WorkspaceVanishedError({
+        workspaceDir: dir,
+        attestationPath: recentAttestationPath,
+      });
+    }
+  }
+
   const agentsTemplate = await loadTemplate(DEFAULT_AGENTS_FILENAME);
   const soulTemplate = await loadTemplate(DEFAULT_SOUL_FILENAME);
   const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
@@ -798,10 +830,11 @@ export async function ensureAgentWorkspace(params?: {
     // indicators exist, treat setup as complete and avoid recreating BOOTSTRAP for
     // already-configured workspaces.
     if (
-      await workspaceProfileLooksConfigured({
+      (Boolean(recentAttestationPath) && (await workspaceRequiredBootstrapLooksCustomized(dir))) ||
+      (await workspaceProfileLooksConfigured({
         dir,
         includeGitEvidence: true,
-      })
+      }))
     ) {
       markState({ setupCompletedAt: nowIso() });
     } else {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -469,6 +469,20 @@ export async function isWorkspaceAttestationMarker(attestationPath: string): Pro
   return (await readWorkspaceAttestationMarkerStatus(attestationPath)) === "marker";
 }
 
+export async function shouldRemoveWorkspaceAttestation(
+  attestationPath: string,
+  opts?: { trustUnknown?: boolean },
+): Promise<boolean> {
+  try {
+    return (
+      (await isWorkspaceAttestationMarker(attestationPath)) ||
+      (await hasRecentWorkspaceAttestation(attestationPath, opts))
+    );
+  } catch {
+    return false;
+  }
+}
+
 async function readWorkspaceAttestationMarkerStatus(
   attestationPath: string,
 ): Promise<WorkspaceAttestationMarkerStatus> {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -273,6 +273,33 @@ async function hasWorkspaceUserContentEvidence(
   return await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME);
 }
 
+async function hasSkipBootstrapWorkspaceContentEvidence(dir: string): Promise<boolean> {
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === ".DS_Store" || entry.name === WORKSPACE_STATE_DIRNAME) {
+        continue;
+      }
+      if (entry.name === "skills" && entry.isDirectory()) {
+        try {
+          if ((await fs.readdir(path.join(dir, entry.name))).length === 0) {
+            continue;
+          }
+        } catch {
+          continue;
+        }
+      }
+      return true;
+    }
+  } catch (err) {
+    const anyErr = err as { code?: string };
+    if (anyErr.code !== "ENOENT") {
+      throw err;
+    }
+  }
+  return false;
+}
+
 async function workspaceProfileLooksConfigured(params: {
   dir: string;
   includeGitEvidence?: boolean;
@@ -650,20 +677,28 @@ export async function ensureAgentWorkspace(params?: {
   const dir = resolveUserPath(rawDir);
   const [attestationPath, ...legacyAttestationPaths] = resolveWorkspaceAttestationPaths(dir);
   const attestationPaths = [attestationPath, ...legacyAttestationPaths];
+  const recentAttestationPath = await findRecentWorkspaceAttestationPath(attestationPaths);
 
-  if (params?.ensureBootstrapFiles && !(await pathExists(dir))) {
-    const recentAttestationPath = await findRecentWorkspaceAttestationPath(attestationPaths);
-    if (recentAttestationPath) {
-      throw new WorkspaceVanishedError({
-        workspaceDir: dir,
-        attestationPath: recentAttestationPath,
-      });
-    }
+  if (!(await pathExists(dir)) && recentAttestationPath) {
+    throw new WorkspaceVanishedError({
+      workspaceDir: dir,
+      attestationPath: recentAttestationPath,
+    });
   }
 
   await fs.mkdir(dir, { recursive: true });
 
   if (!params?.ensureBootstrapFiles) {
+    const hasContentEvidence = await hasSkipBootstrapWorkspaceContentEvidence(dir);
+    if (recentAttestationPath && !hasContentEvidence) {
+      throw new WorkspaceVanishedError({
+        workspaceDir: dir,
+        attestationPath: recentAttestationPath,
+      });
+    }
+    if (hasContentEvidence) {
+      await maybeWriteWorkspaceAttestation(attestationPath);
+    }
     return { dir };
   }
 
@@ -695,7 +730,6 @@ export async function ensureAgentWorkspace(params?: {
   })();
 
   if (isBrandNewWorkspace) {
-    const recentAttestationPath = await findRecentWorkspaceAttestationPath(attestationPaths);
     if (recentAttestationPath) {
       throw new WorkspaceVanishedError({
         workspaceDir: dir,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -270,7 +270,14 @@ async function hasWorkspaceUserContentEvidence(
       // continue
     }
   }
-  return await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME);
+  if (await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME)) {
+    return true;
+  }
+  try {
+    return (await fs.readdir(path.join(dir, "skills"))).length > 0;
+  } catch {
+    return false;
+  }
 }
 
 async function hasSkipBootstrapWorkspaceContentEvidence(dir: string): Promise<boolean> {
@@ -719,8 +726,7 @@ export async function ensureAgentWorkspace(params?: {
 
   const isBrandNewWorkspace = await (async () => {
     const templatePaths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
-    const userContentPaths = [path.join(dir, "memory"), path.join(dir, ".git")];
-    const paths = [...templatePaths, ...userContentPaths];
+    const paths = [...templatePaths, path.join(dir, "memory"), path.join(dir, ".git")];
     const existing = await Promise.all(
       paths.map(async (p) => {
         try {
@@ -731,8 +737,7 @@ export async function ensureAgentWorkspace(params?: {
         }
       }),
     );
-    const hasCanonicalRootMemory = await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME);
-    return existing.every((v) => !v) && !hasCanonicalRootMemory;
+    return existing.every((v) => !v) && !(await hasWorkspaceUserContentEvidence(dir));
   })();
 
   if (isBrandNewWorkspace) {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -752,7 +752,7 @@ export async function ensureAgentWorkspace(params?: {
 
   const isBrandNewWorkspace = await (async () => {
     const templatePaths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
-    const paths = [...templatePaths, path.join(dir, "memory"), path.join(dir, ".git")];
+    const paths = [...templatePaths, path.join(dir, "memory")];
     const existing = await Promise.all(
       paths.map(async (p) => {
         try {
@@ -787,7 +787,6 @@ export async function ensureAgentWorkspace(params?: {
       (await workspaceRequiredBootstrapLooksCustomized(dir)) ||
       (await workspaceProfileLooksConfigured({
         dir,
-        includeGitEvidence: true,
       }));
     if (!hasWorkspaceEvidence) {
       throw new WorkspaceVanishedError({

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,5 +1,9 @@
 import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import {
+  resolveWorkspaceAttestationPaths,
+  shouldRemoveWorkspaceAttestation,
+} from "../agents/workspace.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { replaceConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
@@ -164,6 +168,13 @@ export async function agentsDeleteCommand(
     );
   } else {
     await moveToTrash(workspaceDir, quietRuntime);
+    for (const [index, attestationPath] of resolveWorkspaceAttestationPaths(
+      workspaceDir,
+    ).entries()) {
+      if (await shouldRemoveWorkspaceAttestation(attestationPath, { trustUnknown: index === 0 })) {
+        await moveToTrash(attestationPath, quietRuntime);
+      }
+    }
   }
   await moveToTrash(agentDir, quietRuntime);
   await moveToTrash(sessionsDir, quietRuntime);

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveWorkspaceAttestationPath } from "../agents/workspace.js";
 import { loadSessionStore, resolveStorePath, saveSessionStore } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
@@ -238,6 +239,40 @@ describe("agents delete command", () => {
     });
   });
 
+  it("trashes workspace attestations during local deletion", async () => {
+    await withStateDirEnv("openclaw-agents-delete-attestation-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: path.join(stateDir, "workspace-main") },
+            { id: "ops", workspace: path.join(stateDir, "workspace-ops") },
+          ],
+        },
+      } satisfies OpenClawConfig;
+      await arrangeAgentsDeleteTest({
+        stateDir,
+        cfg,
+        deletedAgentId: "ops",
+        sessions: {},
+      });
+      const attestationPath = resolveWorkspaceAttestationPath(path.join(stateDir, "workspace-ops"));
+      await fs.mkdir(path.dirname(attestationPath), { recursive: true });
+      await fs.writeFile(
+        attestationPath,
+        `openclaw-workspace-attestation:v1\n${new Date().toISOString()}\n`,
+      );
+      const resolvedAttestationPath = path.join(
+        await fs.realpath(path.dirname(attestationPath)),
+        path.basename(attestationPath),
+      );
+
+      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+      const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
+      expect(trashedPaths).toContain(resolvedAttestationPath);
+    });
+  });
+
   it("purges legacy main-alias entries owned by the deleted default agent", async () => {
     await withStateDirEnv("openclaw-agents-delete-main-alias-", async ({ stateDir }) => {
       const now = Date.now();
@@ -310,6 +345,12 @@ describe("agents delete command", () => {
     await withStateDirEnv("openclaw-agents-delete-shared-workspace-", async ({ stateDir }) => {
       const sharedWorkspace = path.join(stateDir, "workspace-shared");
       await fs.mkdir(sharedWorkspace, { recursive: true });
+      const attestationPath = resolveWorkspaceAttestationPath(sharedWorkspace);
+      await fs.mkdir(path.dirname(attestationPath), { recursive: true });
+      await fs.writeFile(
+        attestationPath,
+        `openclaw-workspace-attestation:v1\n${new Date().toISOString()}\n`,
+      );
 
       const now = Date.now();
       const cfg: OpenClawConfig = {
@@ -344,6 +385,7 @@ describe("agents delete command", () => {
       expect(jsonOutput[0]?.workspaceSharedWith).toEqual(["main"]);
       const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
       expect(trashedPaths).not.toContain(sharedWorkspace);
+      expect(trashedPaths).not.toContain(attestationPath);
     });
   });
 

--- a/src/commands/cleanup-command.test-support.ts
+++ b/src/commands/cleanup-command.test-support.ts
@@ -7,6 +7,7 @@ const removePath = vi.fn();
 const listAgentSessionDirs = vi.fn();
 export const removeStateAndLinkedPaths = vi.fn();
 const removeWorkspaceDirs = vi.fn();
+export const removeWorkspaceAttestationPaths = vi.fn();
 
 vi.mock("../config/config.js", () => ({
   isNixMode: false,
@@ -20,6 +21,7 @@ vi.mock("./cleanup-utils.js", () => ({
   removePath,
   listAgentSessionDirs,
   removeStateAndLinkedPaths,
+  removeWorkspaceAttestationPaths,
   removeWorkspaceDirs,
 }));
 
@@ -41,6 +43,7 @@ export function resetCleanupCommandMocks() {
   listAgentSessionDirs.mockResolvedValue(["/tmp/.openclaw/agents/main/sessions"]);
   removeStateAndLinkedPaths.mockResolvedValue(undefined);
   removeWorkspaceDirs.mockResolvedValue(undefined);
+  removeWorkspaceAttestationPaths.mockResolvedValue(undefined);
 }
 
 export function silenceCleanupCommandRuntime(runtime: RuntimeEnv) {

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -8,6 +8,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import {
   buildCleanupPlan,
   removeStateAndLinkedPaths,
+  removeWorkspaceAttestationPaths,
   removeWorkspaceDirs,
 } from "./cleanup-utils.js";
 
@@ -192,5 +193,26 @@ describe("cleanup path removals", () => {
       "[dry-run] remove /tmp/openclaw-workspace-1",
       "[dry-run] remove /tmp/openclaw-workspace-2",
     ]);
+  });
+
+  it("removes owned legacy workspace attestations", async () => {
+    const runtime = createRuntimeMock();
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cleanup-attest-"));
+    const workspaceDir = path.join(tmpRoot, "workspace");
+    const legacyAttestationPath = `${workspaceDir}.attested`;
+
+    try {
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(
+        legacyAttestationPath,
+        `openclaw-workspace-attestation:v1\n${new Date().toISOString()}\n`,
+      );
+
+      await removeWorkspaceAttestationPaths([workspaceDir], runtime);
+
+      await expect(fs.stat(legacyAttestationPath)).rejects.toThrow();
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace-default.js";
+import {
+  resolveWorkspaceAttestationPaths,
+  shouldRemoveWorkspaceAttestation,
+} from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPathInside } from "../infra/path-guards.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -105,6 +109,22 @@ export async function removePath(
   } catch (err) {
     runtime.error(`Failed to remove ${displayLabel}: ${String(err)}`);
     return { ok: false };
+  }
+}
+
+export async function removeWorkspaceAttestationPaths(
+  workspaceDirs: readonly string[],
+  runtime: RuntimeEnv,
+  opts?: RemovalOptions,
+): Promise<void> {
+  for (const workspaceDir of workspaceDirs) {
+    for (const [index, attestationPath] of resolveWorkspaceAttestationPaths(
+      workspaceDir,
+    ).entries()) {
+      if (await shouldRemoveWorkspaceAttestation(attestationPath, { trustUnknown: index === 0 })) {
+        await removePath(attestationPath, runtime, opts);
+      }
+    }
   }
 }
 

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -85,6 +85,7 @@ describe("handleReset", () => {
     const profileCredentialsDir = path.join(profileStateDir, "credentials");
     const profileSessionsDir = path.join(profileStateDir, "agents", "main", "sessions");
     const workspaceDir = path.join(profileStateDir, "workspace");
+    const workspaceAttestationPath = `${workspaceDir}.attested`;
     const defaultCredentialsDir = path.join(defaultStateDir, "credentials");
 
     fs.mkdirSync(profileCredentialsDir, { recursive: true });
@@ -92,6 +93,7 @@ describe("handleReset", () => {
     fs.mkdirSync(workspaceDir, { recursive: true });
     fs.mkdirSync(defaultCredentialsDir, { recursive: true });
     fs.writeFileSync(profileConfigPath, "{}\n");
+    fs.writeFileSync(workspaceAttestationPath, new Date().toISOString());
 
     vi.stubEnv("HOME", homeDir);
     vi.stubEnv("OPENCLAW_HOME", homeDir);
@@ -105,6 +107,7 @@ describe("handleReset", () => {
       profileCredentialsDir,
       profileSessionsDir,
       workspaceDir,
+      workspaceAttestationPath,
     ].map(expectedTrashSourcePath);
     const expectedDefaultCredentialsDir = expectedTrashSourcePath(defaultCredentialsDir);
 

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -93,7 +93,10 @@ describe("handleReset", () => {
     fs.mkdirSync(workspaceDir, { recursive: true });
     fs.mkdirSync(defaultCredentialsDir, { recursive: true });
     fs.writeFileSync(profileConfigPath, "{}\n");
-    fs.writeFileSync(workspaceAttestationPath, new Date().toISOString());
+    fs.writeFileSync(
+      workspaceAttestationPath,
+      `openclaw-workspace-attestation:v1\n${new Date().toISOString()}\n`,
+    );
 
     vi.stubEnv("HOME", homeDir);
     vi.stubEnv("OPENCLAW_HOME", homeDir);

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -157,7 +157,7 @@ describe("handleReset", () => {
   });
 
   it.skipIf(process.platform === "win32")(
-    "does not abort full reset for an unreadable sibling attestation path",
+    "does not abort full reset for an unreadable legacy attestation path",
     async () => {
       const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reset-profile-"));
       const profileStateDir = path.join(homeDir, ".openclaw-work");
@@ -181,6 +181,7 @@ describe("handleReset", () => {
       vi.stubEnv("OPENCLAW_CONFIG_PATH", profileConfigPath);
 
       const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+      const unreadableAttestationTrashPath = expectedTrashSourcePath(workspaceAttestationPath);
 
       try {
         await expect(handleReset("full", workspaceDir, runtime)).resolves.toBeUndefined();
@@ -188,6 +189,9 @@ describe("handleReset", () => {
         fs.chmodSync(workspaceAttestationPath, 0o600);
         fs.rmSync(homeDir, { recursive: true, force: true });
       }
+
+      const trashedPaths = mocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
+      expect(trashedPaths).not.toContain(unreadableAttestationTrashPath);
     },
   );
 });

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -121,6 +121,75 @@ describe("handleReset", () => {
     expect(trashedPaths).toEqual(expectedTrashedPaths);
     expect(trashedPaths).not.toContain(expectedDefaultCredentialsDir);
   });
+
+  it("does not trash an unowned sibling attestation path during full reset", async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reset-profile-"));
+    const profileStateDir = path.join(homeDir, ".openclaw-work");
+    const profileConfigPath = path.join(profileStateDir, "openclaw.json");
+    const profileCredentialsDir = path.join(profileStateDir, "credentials");
+    const profileSessionsDir = path.join(profileStateDir, "agents", "main", "sessions");
+    const workspaceDir = path.join(profileStateDir, "workspace");
+    const workspaceAttestationPath = `${workspaceDir}.attested`;
+
+    fs.mkdirSync(profileCredentialsDir, { recursive: true });
+    fs.mkdirSync(profileSessionsDir, { recursive: true });
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(profileConfigPath, "{}\n");
+    fs.writeFileSync(workspaceAttestationPath, "external data\n");
+
+    vi.stubEnv("HOME", homeDir);
+    vi.stubEnv("OPENCLAW_HOME", homeDir);
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
+    vi.stubEnv("OPENCLAW_STATE_DIR", profileStateDir);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", profileConfigPath);
+
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+    const unownedAttestationTrashPath = expectedTrashSourcePath(workspaceAttestationPath);
+
+    try {
+      await handleReset("full", workspaceDir, runtime);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+
+    const trashedPaths = mocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
+    expect(trashedPaths).not.toContain(unownedAttestationTrashPath);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "does not abort full reset for an unreadable sibling attestation path",
+    async () => {
+      const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reset-profile-"));
+      const profileStateDir = path.join(homeDir, ".openclaw-work");
+      const profileConfigPath = path.join(profileStateDir, "openclaw.json");
+      const profileCredentialsDir = path.join(profileStateDir, "credentials");
+      const profileSessionsDir = path.join(profileStateDir, "agents", "main", "sessions");
+      const workspaceDir = path.join(profileStateDir, "workspace");
+      const workspaceAttestationPath = `${workspaceDir}.attested`;
+
+      fs.mkdirSync(profileCredentialsDir, { recursive: true });
+      fs.mkdirSync(profileSessionsDir, { recursive: true });
+      fs.mkdirSync(workspaceDir, { recursive: true });
+      fs.writeFileSync(profileConfigPath, "{}\n");
+      fs.writeFileSync(workspaceAttestationPath, "external data\n", { mode: 0o000 });
+      fs.chmodSync(workspaceAttestationPath, 0o000);
+
+      vi.stubEnv("HOME", homeDir);
+      vi.stubEnv("OPENCLAW_HOME", homeDir);
+      vi.stubEnv("OPENCLAW_PROFILE", "work");
+      vi.stubEnv("OPENCLAW_STATE_DIR", profileStateDir);
+      vi.stubEnv("OPENCLAW_CONFIG_PATH", profileConfigPath);
+
+      const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+      try {
+        await expect(handleReset("full", workspaceDir, runtime)).resolves.toBeUndefined();
+      } finally {
+        fs.chmodSync(workspaceAttestationPath, 0o600);
+        fs.rmSync(homeDir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("moveToTrash", () => {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -11,7 +11,11 @@ import {
   supportsDecorativeEmoji,
 } from "../../packages/terminal-core/src/decorative-emoji.js";
 import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.js";
-import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
+import {
+  DEFAULT_AGENT_WORKSPACE_DIR,
+  ensureAgentWorkspace,
+  resolveWorkspaceAttestationPath,
+} from "../agents/workspace.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveConfigPath } from "../config/paths.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
@@ -301,6 +305,7 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
   await moveToTrash(resolveSessionTranscriptsDirForAgent(), runtime);
   if (scope === "full") {
     await moveToTrash(workspaceDir, runtime);
+    await moveToTrash(resolveWorkspaceAttestationPath(workspaceDir), runtime);
   }
 }
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -14,9 +14,8 @@ import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.
 import {
   DEFAULT_AGENT_WORKSPACE_DIR,
   ensureAgentWorkspace,
-  hasRecentWorkspaceAttestation,
-  isWorkspaceAttestationMarker,
   resolveWorkspaceAttestationPaths,
+  shouldRemoveWorkspaceAttestation,
 } from "../agents/workspace.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveConfigPath } from "../config/paths.js";
@@ -310,24 +309,10 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
     for (const [index, attestationPath] of resolveWorkspaceAttestationPaths(
       workspaceDir,
     ).entries()) {
-      if (await shouldMoveWorkspaceAttestation(attestationPath, { trustUnknown: index === 0 })) {
+      if (await shouldRemoveWorkspaceAttestation(attestationPath, { trustUnknown: index === 0 })) {
         await moveToTrash(attestationPath, runtime);
       }
     }
-  }
-}
-
-async function shouldMoveWorkspaceAttestation(
-  attestationPath: string,
-  opts?: { trustUnknown?: boolean },
-): Promise<boolean> {
-  try {
-    return (
-      (await isWorkspaceAttestationMarker(attestationPath)) ||
-      (await hasRecentWorkspaceAttestation(attestationPath, opts))
-    );
-  } catch {
-    return false;
   }
 }
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -14,8 +14,9 @@ import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.
 import {
   DEFAULT_AGENT_WORKSPACE_DIR,
   ensureAgentWorkspace,
+  hasRecentWorkspaceAttestation,
   isWorkspaceAttestationMarker,
-  resolveWorkspaceAttestationPath,
+  resolveWorkspaceAttestationPaths,
 } from "../agents/workspace.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveConfigPath } from "../config/paths.js";
@@ -306,16 +307,25 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
   await moveToTrash(resolveSessionTranscriptsDirForAgent(), runtime);
   if (scope === "full") {
     await moveToTrash(workspaceDir, runtime);
-    const attestationPath = resolveWorkspaceAttestationPath(workspaceDir);
-    if (await shouldMoveWorkspaceAttestation(attestationPath)) {
-      await moveToTrash(attestationPath, runtime);
+    for (const [index, attestationPath] of resolveWorkspaceAttestationPaths(
+      workspaceDir,
+    ).entries()) {
+      if (await shouldMoveWorkspaceAttestation(attestationPath, { trustUnknown: index === 0 })) {
+        await moveToTrash(attestationPath, runtime);
+      }
     }
   }
 }
 
-async function shouldMoveWorkspaceAttestation(attestationPath: string): Promise<boolean> {
+async function shouldMoveWorkspaceAttestation(
+  attestationPath: string,
+  opts?: { trustUnknown?: boolean },
+): Promise<boolean> {
   try {
-    return await isWorkspaceAttestationMarker(attestationPath);
+    return (
+      (await isWorkspaceAttestationMarker(attestationPath)) ||
+      (await hasRecentWorkspaceAttestation(attestationPath, opts))
+    );
   } catch {
     return false;
   }

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -14,6 +14,7 @@ import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.
 import {
   DEFAULT_AGENT_WORKSPACE_DIR,
   ensureAgentWorkspace,
+  isWorkspaceAttestationMarker,
   resolveWorkspaceAttestationPath,
 } from "../agents/workspace.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
@@ -305,7 +306,18 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
   await moveToTrash(resolveSessionTranscriptsDirForAgent(), runtime);
   if (scope === "full") {
     await moveToTrash(workspaceDir, runtime);
-    await moveToTrash(resolveWorkspaceAttestationPath(workspaceDir), runtime);
+    const attestationPath = resolveWorkspaceAttestationPath(workspaceDir);
+    if (await shouldMoveWorkspaceAttestation(attestationPath)) {
+      await moveToTrash(attestationPath, runtime);
+    }
+  }
+}
+
+async function shouldMoveWorkspaceAttestation(attestationPath: string): Promise<boolean> {
+  try {
+    return await isWorkspaceAttestationMarker(attestationPath);
+  } catch {
+    return false;
   }
 }
 

--- a/src/commands/reset.test.ts
+++ b/src/commands/reset.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   cleanupCommandLogMessages,
   createCleanupCommandRuntime,
+  removeWorkspaceAttestationPaths,
   resetCleanupCommandMocks,
   silenceCleanupCommandRuntime,
 } from "./cleanup-command.test-support.js";
@@ -47,5 +48,20 @@ describe("resetCommand", () => {
         message.includes("openclaw backup create"),
       ),
     ).toBe(false);
+  });
+
+  it("removes workspace attestations during full reset", async () => {
+    await resetCommand(runtime, {
+      scope: "full",
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(removeWorkspaceAttestationPaths).toHaveBeenCalledWith(
+      ["/tmp/.openclaw/workspace"],
+      runtime,
+      { dryRun: true },
+    );
   });
 });

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -13,6 +13,7 @@ import {
   listAgentSessionDirs,
   removePath,
   removeStateAndLinkedPaths,
+  removeWorkspaceAttestationPaths,
   removeWorkspaceDirs,
 } from "./cleanup-utils.js";
 
@@ -148,6 +149,7 @@ export async function resetCommand(runtime: RuntimeEnv, opts: ResetOptions) {
       { dryRun },
     );
     await removeWorkspaceDirs(workspaceDirs, runtime, { dryRun });
+    await removeWorkspaceAttestationPaths(workspaceDirs, runtime, { dryRun });
     runtime.log(`Next: ${formatCliCommand("openclaw onboard --install-daemon")}`);
   }
 }

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupCommandLogMessages,
   createCleanupCommandRuntime,
   removeStateAndLinkedPaths,
+  removeWorkspaceAttestationPaths,
   resetCleanupCommandMocks,
   silenceCleanupCommandRuntime,
 } from "./cleanup-command.test-support.js";
@@ -81,6 +82,21 @@ describe("uninstallCommand", () => {
         dryRun: true,
         preservePaths: [],
       }),
+    );
+  });
+
+  it("removes workspace attestations when workspace removal is selected", async () => {
+    await uninstallCommand(runtime, {
+      workspace: true,
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(removeWorkspaceAttestationPaths).toHaveBeenCalledWith(
+      ["/tmp/.openclaw/workspace"],
+      runtime,
+      { dryRun: true },
     );
   });
 });

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -12,7 +12,12 @@ import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveHomeDir } from "../utils.js";
 import { resolveCleanupPlanFromDisk } from "./cleanup-plan.js";
-import { removePath, removeStateAndLinkedPaths, removeWorkspaceDirs } from "./cleanup-utils.js";
+import {
+  removePath,
+  removeStateAndLinkedPaths,
+  removeWorkspaceAttestationPaths,
+  removeWorkspaceDirs,
+} from "./cleanup-utils.js";
 
 type UninstallScope = "service" | "state" | "workspace" | "app";
 
@@ -199,6 +204,7 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
 
   if (scopes.has("workspace")) {
     await removeWorkspaceDirs(workspaceDirs, runtime, { dryRun });
+    await removeWorkspaceAttestationPaths(workspaceDirs, runtime, { dryRun });
   }
 
   if (scopes.has("app")) {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -20,6 +20,10 @@ const mocks = vi.hoisted(() => ({
     }),
   ),
   isWorkspaceSetupCompleted: vi.fn(async () => false),
+  resolveWorkspaceAttestationPaths: vi.fn((_workspaceDir: string) => [
+    "/state/workspace-attestations/test-agent.attested",
+  ]),
+  shouldRemoveWorkspaceAttestation: vi.fn(async () => true),
   resolveAgentDir: vi.fn((_cfg?: unknown, _agentId?: string) => "/agents/test-agent"),
   resolveAgentWorkspaceDir: vi.fn((_cfg?: unknown, _agentId?: string) => "/workspace/test-agent"),
   resolveSessionTranscriptsDirForAgent: vi.fn((_agentId?: string) => "/transcripts/test-agent"),
@@ -117,6 +121,8 @@ vi.mock("../../agents/workspace.js", async () => {
     ...actual,
     ensureAgentWorkspace: mocks.ensureAgentWorkspace,
     isWorkspaceSetupCompleted: mocks.isWorkspaceSetupCompleted,
+    resolveWorkspaceAttestationPaths: mocks.resolveWorkspaceAttestationPaths,
+    shouldRemoveWorkspaceAttestation: mocks.shouldRemoveWorkspaceAttestation,
   };
 });
 
@@ -210,6 +216,10 @@ beforeEach(() => {
   mocks.resolveAgentWorkspaceDir.mockImplementation((cfg: unknown, agentId?: string) =>
     resolveMockWorkspaceDir(cfg, agentId),
   );
+  mocks.resolveWorkspaceAttestationPaths.mockImplementation((_workspaceDir: string) => [
+    "/state/workspace-attestations/test-agent.attested",
+  ]);
+  mocks.shouldRemoveWorkspaceAttestation.mockResolvedValue(true);
   mocks.rootOpen.mockResolvedValue({
     handle: { close: vi.fn(async () => {}) },
     realPath: "/workspace/test-agent/AGENTS.md",
@@ -1113,6 +1123,39 @@ describe("agents.delete", () => {
     expect(mocks.writeConfigFile).toHaveBeenCalled();
     // moveToTrashBestEffort calls fs.access then movePathToTrash for each dir
     expect(mocks.movePathToTrash).toHaveBeenCalled();
+  });
+
+  it("trashes workspace attestations when deleting the last workspace owner", async () => {
+    const { respond, promise } = makeCall("agents.delete", {
+      agentId: "test-agent",
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.resolveWorkspaceAttestationPaths).toHaveBeenCalledWith("/workspace/test-agent");
+    expect(mocks.shouldRemoveWorkspaceAttestation).toHaveBeenCalledWith(
+      "/state/workspace-attestations/test-agent.attested",
+      { trustUnknown: true },
+    );
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(
+      "/state/workspace-attestations/test-agent.attested",
+    );
+  });
+
+  it("keeps workspace attestations when another agent still owns the workspace", async () => {
+    mocks.pruneAgentConfig.mockReturnValue({
+      config: { agents: { list: [{ id: "other", workspace: "/workspace/test-agent" }] } },
+      removedBindings: 2,
+    });
+
+    const { respond, promise } = makeCall("agents.delete", {
+      agentId: "test-agent",
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.resolveWorkspaceAttestationPaths).not.toHaveBeenCalled();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/workspace/test-agent");
   });
 
   it("skips file deletion when deleteFiles is false", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -32,6 +32,8 @@ import {
   DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
   isWorkspaceSetupCompleted,
+  resolveWorkspaceAttestationPaths,
+  shouldRemoveWorkspaceAttestation,
 } from "../../agents/workspace.js";
 import { applyAgentConfig } from "../../commands/agents.config.js";
 import {
@@ -740,11 +742,20 @@ export const agentsHandlers: GatewayRequestHandlers = {
         deleteResult.workspaceDir,
       );
       const deleteWorkspace = workspaceSharedWith.length === 0;
-      await Promise.all([
-        ...(deleteWorkspace ? [moveToTrashBestEffort(deleteResult.workspaceDir)] : []),
-        moveToTrashBestEffort(deleteResult.agentDir),
-        moveToTrashBestEffort(deleteResult.sessionsDir),
-      ]);
+      const pathsToTrash = [deleteResult.agentDir, deleteResult.sessionsDir];
+      if (deleteWorkspace) {
+        pathsToTrash.unshift(deleteResult.workspaceDir);
+        for (const [index, attestationPath] of resolveWorkspaceAttestationPaths(
+          deleteResult.workspaceDir,
+        ).entries()) {
+          if (
+            await shouldRemoveWorkspaceAttestation(attestationPath, { trustUnknown: index === 0 })
+          ) {
+            pathsToTrash.push(attestationPath);
+          }
+        }
+      }
+      await Promise.all(pathsToTrash.map((pathname) => moveToTrashBestEffort(pathname)));
     }
 
     respond(true, { ok: true, agentId, removedBindings: deleteResult.removedBindings }, undefined);

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -1595,28 +1595,7 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
-      "text": "Auto"
-    },
-    {
-      "count": 2,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
       "text": "close"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Custom"
-    },
-    {
-      "count": 3,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Default"
     },
     {
       "count": 2,
@@ -1658,27 +1637,6 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
-      "text": "Gateway relay"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Google"
-    },
-    {
-      "count": 2,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "High"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
       "text": "instant"
     },
     {
@@ -1694,27 +1652,6 @@
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
       "text": "Loading files..."
-    },
-    {
-      "count": 2,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Low"
-    },
-    {
-      "count": 2,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Medium"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Minimal"
     },
     {
       "count": 1,
@@ -1756,35 +1693,7 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
-      "text": "OpenAI"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
       "text": "Pause before send"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Provider"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Provider WebSocket"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Reasoning"
     },
     {
       "count": 1,
@@ -1799,13 +1708,6 @@
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
       "text": "select"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Sensitivity"
     },
     {
       "count": 2,
@@ -1826,28 +1728,196 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
+      "text": "Workspace"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Alloy"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Ash"
+    },
+    {
+      "count": 2,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Auto"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Ballad"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Cedar"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Coral"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Custom"
+    },
+    {
+      "count": 3,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Default"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Echo"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Gateway relay"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Google"
+    },
+    {
+      "count": 2,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "High"
+    },
+    {
+      "count": 2,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Low"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Marin"
+    },
+    {
+      "count": 2,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Medium"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Minimal"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "OpenAI"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Provider"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Provider WebSocket"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Reasoning"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Sage"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Sensitivity"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Shimmer"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
       "text": "Transport"
     },
     {
       "count": 1,
-      "kind": "html-text",
-      "name": "text",
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Verse"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
       "path": "ui/src/ui/views/chat.ts",
       "text": "Voice"
     },
     {
       "count": 1,
-      "kind": "html-text",
-      "name": "text",
+      "kind": "object-property",
+      "name": "label",
       "path": "ui/src/ui/views/chat.ts",
       "text": "WebRTC"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "Workspace"
     },
     {
       "count": 1,
@@ -3990,6 +4060,13 @@
       "name": "text",
       "path": "ui/src/ui/views/markdown-sidebar.ts",
       "text": "No content available"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/views/markdown-sidebar.ts",
+      "text": "No previewable markdown content."
     },
     {
       "count": 1,


### PR DESCRIPTION
Fixes #88333

## Summary
- add a recent-workspace attestation marker next to the agent workspace path
- refuse to silently re-seed BOOTSTRAP.md/state when a recently attested workspace directory disappears or is wiped
- cover the vanished-directory, wiped-directory, and stale-attestation paths, plus docs and changelog

## Verification
- `pnpm test src/agents/workspace.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/workspace.ts src/agents/workspace.test.ts docs/concepts/agent.md CHANGELOG.md`
- `git diff --check`

## Real behavior proof
- **Behavior or issue addressed:** `ensureAgentWorkspace` no longer silently re-seeds `BOOTSTRAP.md` and `.openclaw/workspace-state.json` over an agent workspace that was previously initialized and then disappeared or was wiped.
- **Real environment tested:** Local OpenClaw checkout at `/Users/andy/openclaw/openclaw-88333` on macOS, using the real `src/agents/workspace.js` entrypoint through the repo tsx loader and a real temporary filesystem workspace under `/tmp`.
- **Exact steps or command run after this patch:** Ran `node --import tsx --eval <script>` where the script called `ensureAgentWorkspace({ ensureBootstrapFiles: true })`, verified the sibling `.attested` marker, removed the workspace directory, called `ensureAgentWorkspace` again, caught the thrown error code, and checked whether `BOOTSTRAP.md` or `.openclaw/workspace-state.json` had been recreated.
- **Evidence after fix:** Terminal output from the live command:

```json
{
  "attestedExists": true,
  "errorCode": "WORKSPACE_VANISHED",
  "bootstrapExists": false,
  "stateExists": false
}
```

- **Observed result after fix:** The second startup refused to re-seed the vanished workspace with `WORKSPACE_VANISHED`; the attestation marker remained the signal, and both `BOOTSTRAP.md` and workspace state stayed absent.
- **What was not tested:** No additional gaps.

## Attribution
If maintainers squash or rework this PR, please preserve author attribution or include `Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`.
