### PR TITLE
fix(build): externalize protobufjs from root bundle

### DIFF
--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -223,6 +223,7 @@ describe("tsdown config", () => {
       expect(neverBundle("@slack/web-api")).toBe(true);
       expect(neverBundle("@vitest/expect")).toBe(true);
       expect(neverBundle("matrix-js-sdk/lib/client.js")).toBe(true);
+      expect(neverBundle("protobufjs/ext/descriptor.js")).toBe(true);
       expect(neverBundle("qrcode-terminal/lib/main.js")).toBe(true);
       expect(neverBundle("vitest")).toBe(true);
       expect(neverBundle("not-a-runtime-dependency")).toBe(false);
@@ -236,6 +237,7 @@ describe("tsdown config", () => {
         "@slack/web-api",
         "@vitest/expect",
         "matrix-js-sdk",
+        "protobufjs",
         "qrcode-terminal",
         "vitest",
       ]) {
@@ -246,6 +248,7 @@ describe("tsdown config", () => {
       throw new Error("expected unified graph external predicate");
     }
     const externalize = external;
+    expect(externalize("protobufjs/ext/descriptor.js", undefined, false)).toBe(true);
     expect(externalize("qrcode-terminal/lib/main.js", undefined, false)).toBe(true);
   });
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -200,6 +200,7 @@ const explicitNeverBundleDependencies = [
   "@vitest/expect",
   "matrix-js-sdk",
   "prism-media",
+  "protobufjs",
   "qrcode-terminal",
   "typescript",
   "vitest",


### PR DESCRIPTION
## Summary
- Externalize `protobufjs` from the unified tsdown graph so the diagnostics-otel/OpenTelemetry gRPC path does not force tsdown to resolve `protobufjs/ext/descriptor.js`'s JSON descriptor import.
- Keep `diagnostics-otel` bundled dist artifacts intact for Docker/full release paths such as `OPENCLAW_EXTENSIONS=diagnostics-otel,codex`.
- Add focused tsdown config regression coverage for the descriptor subpath.

Fixes #85537.

Related: #85711 is a docs-only workaround PR for the same symptom. This PR fixes the build graph instead of documenting the failure.

## Verification
- `node scripts/run-vitest.mjs src/infra/tsdown-config.test.ts test/scripts/bundled-plugin-build-entries.test.ts` passed, 31 tests.
- `node scripts/run-oxlint.mjs tsdown.config.ts src/infra/tsdown-config.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, no accepted/actionable findings, overall 0.84.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, no accepted/actionable findings, overall 0.86.
- AWS Crabbox `pnpm check:changed` passed on provider `aws`, lease `cbx_cecce700e3a1`, run `run_eea849eeb661`.
- Exploratory AWS Crabbox repro `run_4395d8d12e8c` reproduced the reported missing `node_modules/protobufjs/google/protobuf/descriptor.json` after a clean remote install.

## Real behavior proof
Behavior addressed: Source checkout builds can hit diagnostics-otel's OpenTelemetry gRPC/protobuf dependency chain while tsdown bundles the root graph; this change keeps that plugin build entry present but externalizes `protobufjs`, including `protobufjs/ext/descriptor.js`, so the bundler no longer resolves the fragile descriptor JSON import.

Real environment tested: Local linked OpenClaw worktree for focused config tests and AWS Crabbox Linux for `pnpm check:changed` plus exploratory clean-install repro.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/tsdown-config.test.ts test/scripts/bundled-plugin-build-entries.test.ts`; `node scripts/run-oxlint.mjs tsdown.config.ts src/infra/tsdown-config.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --provider aws --label wsl-protobuf-85537-check-changed --idle-timeout 45m --ttl 90m --timing-json --stop-after always --shell -- 'pnpm check:changed'`.

Evidence after fix: The focused test now asserts `neverBundle("protobufjs/ext/descriptor.js")`, the explicit never-bundle fallback list, and `externalize("protobufjs/ext/descriptor.js", undefined, false)`; the bundled-plugin build-entry test still keeps diagnostics-otel in the root build output set; AWS Crabbox `check:changed` completed with exit 0.

Observed result after fix: Targeted tests passed, lint passed, branch autoreview found no actionable defects, and remote `pnpm check:changed` passed on AWS Crabbox.

What was not tested: A successful native Azure WSL2 source CLI startup on this branch was not completed; recent Azure WSL2 allocation attempts in this sweep have not produced usable leases. The closest remote proof here is AWS Linux changed-gate coverage plus the clean-install descriptor-missing repro.
