### PR TITLE
test(agents): use neutral tool schema fixtures

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -1,15 +1,15 @@
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
-import {
-  onInternalDiagnosticEvent,
-  waitForDiagnosticEventsDrained,
-  type DiagnosticEventPayload,
-} from "openclaw/plugin-sdk/diagnostic-runtime";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness";
 import {
   HEARTBEAT_RESPONSE_TOOL_NAME,
   embeddedAgentLog,
   wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  onInternalDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
@@ -309,7 +309,7 @@ describe("createCodexDynamicToolBridge", () => {
         tools: [
           createTool({ name: "message" }),
           createTool({
-            name: "dofbot_move_angles",
+            name: "fuzzplugin_move_angles",
             parameters: { type: "array", items: { type: "number" } },
             execute: badExecute,
           }),
@@ -330,25 +330,23 @@ describe("createCodexDynamicToolBridge", () => {
     expect(bridge.specs.map((tool) => tool.name)).toEqual(["message"]);
     expect(bridge.telemetry.quarantinedTools).toEqual([
       {
-        tool: "dofbot_move_angles",
-        violations: ['dofbot_move_angles.inputSchema.type must be "object"'],
+        tool: "fuzzplugin_move_angles",
+        violations: ['fuzzplugin_move_angles.inputSchema.type must be "object"'],
       },
     ]);
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("dofbot_move_angles"),
+      expect.stringContaining("fuzzplugin_move_angles"),
       expect.objectContaining({
         tools: [
           {
-            tool: "dofbot_move_angles",
-            violations: ['dofbot_move_angles.inputSchema.type must be "object"'],
+            tool: "fuzzplugin_move_angles",
+            violations: ['fuzzplugin_move_angles.inputSchema.type must be "object"'],
           },
         ],
       }),
     );
     const blockedEvents = diagnosticEvents.filter(
-      (
-        event,
-      ): event is Extract<DiagnosticEventPayload, { type: "tool.execution.blocked" }> =>
+      (event): event is Extract<DiagnosticEventPayload, { type: "tool.execution.blocked" }> =>
         event.type === "tool.execution.blocked",
     );
     expect(blockedEvents).toContainEqual(
@@ -357,9 +355,9 @@ describe("createCodexDynamicToolBridge", () => {
         runId: "run-1",
         sessionId: "session-1",
         sessionKey: "agent:main:session-1",
-        toolName: "dofbot_move_angles",
+        toolName: "fuzzplugin_move_angles",
         deniedReason: "unsupported_tool_schema",
-        reason: 'dofbot_move_angles.inputSchema.type must be "object"',
+        reason: 'fuzzplugin_move_angles.inputSchema.type must be "object"',
       }),
     );
 
@@ -368,13 +366,13 @@ describe("createCodexDynamicToolBridge", () => {
       turnId: "turn-1",
       callId: "call-1",
       namespace: null,
-      tool: "dofbot_move_angles",
+      tool: "fuzzplugin_move_angles",
       arguments: {},
     });
 
     expect(result).toEqual({
       success: false,
-      contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: dofbot_move_angles" }],
+      contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: fuzzplugin_move_angles" }],
     });
     expect(badExecute).not.toHaveBeenCalled();
   });

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -34,10 +34,10 @@ describe("ToolsEffectiveResultSchema", () => {
       ...toolsEffectiveResult(),
       notices: [
         {
-          id: "unsupported-tool-schema:dofbot_move_angles",
+          id: "unsupported-tool-schema:fuzzplugin_move_angles",
           severity: "warning",
           message:
-            'Tool "dofbot_move_angles" from plugin "dofbot" has an unsupported runtime input schema and was quarantined before model projection.',
+            'Tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has an unsupported runtime input schema and was quarantined before model projection.',
         },
       ],
     };
@@ -50,7 +50,7 @@ describe("ToolsEffectiveResultSchema", () => {
       ...toolsEffectiveResult(),
       notices: [
         {
-          id: "unsupported-tool-schema:dofbot_move_angles",
+          id: "unsupported-tool-schema:fuzzplugin_move_angles",
           severity: "warning",
           message: "Unsupported schema.",
           extra: true,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -747,7 +747,7 @@ describe("session MCP runtime", () => {
       cfg: {
         mcp: {
           servers: {
-            dofbot: {
+            fuzzplugin: {
               command: process.execPath,
               args: [serverPath],
             },
@@ -761,7 +761,7 @@ describe("session MCP runtime", () => {
 
       expect(catalog.servers).toEqual({});
       expect(catalog.tools).toEqual([]);
-      expect(catalog.diagnostics?.[0]?.serverName).toBe("dofbot");
+      expect(catalog.diagnostics?.[0]?.serverName).toBe("fuzzplugin");
       expect(catalog.diagnostics?.[0]?.message).toContain("Invalid input: expected");
       expect(catalog.diagnostics?.[0]?.message).toContain("object");
     } finally {
@@ -852,7 +852,7 @@ describe("session MCP runtime", () => {
       expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["legacy_tool"]);
       expect(catalog.servers.legacy?.toolCount).toBe(1);
       expect(catalog.servers.legacy?.tools).toBeUndefined();
-      await expect(fs.readFile(logPath, "utf8")).resolves.toContain("recv tools/list");
+      await waitForFileText(logPath, "recv tools/list", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -159,9 +159,9 @@ describe("createBundleMcpToolRuntime", () => {
   it("preserves catalog diagnostics when MCP servers fail tool listing", async () => {
     const diagnostics = [
       {
-        serverName: "dofbot",
-        safeServerName: "dofbot",
-        launchSummary: "node dofbot-mcp.mjs",
+        serverName: "fuzzplugin",
+        safeServerName: "fuzzplugin",
+        launchSummary: "node fuzzplugin-mcp.mjs",
         message: 'tools[0].inputSchema.type expected "object"',
       },
     ];

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -316,8 +316,8 @@ describe("resolveEffectiveToolInventory", () => {
       tools: [
         mockTool({ name: "exec", label: "Exec", description: "Run shell commands" }),
         mockTool({
-          name: "dofbot_move_angles",
-          label: "Dofbot Move Angles",
+          name: "fuzzplugin_move_angles",
+          label: "FuzzPlugin Move Angles",
           description: "Move robot joints",
           parameters: {
             type: "object",
@@ -327,7 +327,7 @@ describe("resolveEffectiveToolInventory", () => {
           },
         }),
       ],
-      pluginMeta: { dofbot_move_angles: { pluginId: "dofbot" } },
+      pluginMeta: { fuzzplugin_move_angles: { pluginId: "fuzzplugin" } },
     });
 
     const result = resolveEffectiveToolInventory({ cfg: {} });
@@ -335,10 +335,10 @@ describe("resolveEffectiveToolInventory", () => {
     expect(result.groups.flatMap((group) => group.tools.map((tool) => tool.id))).toEqual(["exec"]);
     expect(result.notices).toEqual([
       {
-        id: "unsupported-tool-schema:dofbot_move_angles",
+        id: "unsupported-tool-schema:fuzzplugin_move_angles",
         severity: "warning",
         message:
-          'Tool "dofbot_move_angles" from plugin "dofbot" has an unsupported runtime input schema (dofbot_move_angles.parameters.properties.target.$dynamicRef) and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
+          'Tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has an unsupported runtime input schema (fuzzplugin_move_angles.parameters.properties.target.$dynamicRef) and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
       },
     ]);
   });

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -434,16 +434,16 @@ describe("doctor repair sequencing", () => {
 
   it("emits active tool schema projection warnings during doctor repair", async () => {
     mocks.collectActiveToolSchemaProjectionWarnings.mockReturnValueOnce([
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema.',
+      '- agents.main: active tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema.',
     ]);
 
     const result = await runDoctorRepairSequence({
       state: {
         cfg: {
-          tools: { allow: ["dofbot_move_angles"] },
+          tools: { allow: ["fuzzplugin_move_angles"] },
         } as OpenClawConfig,
         candidate: {
-          tools: { allow: ["dofbot_move_angles"] },
+          tools: { allow: ["fuzzplugin_move_angles"] },
         } as OpenClawConfig,
         pendingChanges: false,
         fixHints: [],
@@ -453,11 +453,11 @@ describe("doctor repair sequencing", () => {
 
     expect(result.changeNotes).toStrictEqual([]);
     expect(result.warningNotes).toContain(
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema.',
+      '- agents.main: active tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema.',
     );
     expect(mocks.collectActiveToolSchemaProjectionWarnings).toHaveBeenCalledWith({
       cfg: {
-        tools: { allow: ["dofbot_move_angles"] },
+        tools: { allow: ["fuzzplugin_move_angles"] },
       },
       env: process.env,
     });

--- a/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
@@ -85,29 +85,31 @@ describe("active tool schema doctor warnings", () => {
   it("warns with plugin ownership for active tools blocked by runtime projection", () => {
     toolState.tools = [
       tool("message", { type: "object", properties: {} }),
-      tool("dofbot_move_angles", { type: "array", items: { type: "number" } }),
+      tool("fuzzplugin_move_angles", { type: "array", items: { type: "number" } }),
     ];
-    toolState.pluginIds = { dofbot_move_angles: "dofbot" };
+    toolState.pluginIds = { fuzzplugin_move_angles: "fuzzplugin" };
 
     expect(
       collectActiveToolSchemaProjectionWarnings({
         cfg: {
           plugins: {
             entries: {
-              dofbot: { enabled: true },
+              fuzzplugin: { enabled: true },
             },
           },
         },
         env: { HOME: "/tmp/openclaw-test" },
       }),
     ).toEqual([
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema (dofbot_move_angles.parameters.type must be "object"). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
+      '- agents.main: active tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema (fuzzplugin_move_angles.parameters.type must be "object"). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
     ]);
   });
 
   it("does not validate disabled plugin mode", () => {
-    toolState.tools = [tool("dofbot_move_angles", { type: "array", items: { type: "number" } })];
-    toolState.pluginIds = { dofbot_move_angles: "dofbot" };
+    toolState.tools = [
+      tool("fuzzplugin_move_angles", { type: "array", items: { type: "number" } }),
+    ];
+    toolState.pluginIds = { fuzzplugin_move_angles: "fuzzplugin" };
 
     expect(
       collectActiveToolSchemaProjectionWarnings({
@@ -121,7 +123,7 @@ describe("active tool schema doctor warnings", () => {
 
   it("validates provider-normalized runtime schemas before reporting doctor health", () => {
     const healthyTool = tool("message", { type: "object", properties: {} });
-    const dynamicTool = tool("dofbot_move_angles", { type: "object", properties: {} });
+    const dynamicTool = tool("fuzzplugin_move_angles", { type: "object", properties: {} });
     toolState.runtimeModel = {
       id: "gpt-5.5",
       name: "GPT-5.5",
@@ -131,7 +133,7 @@ describe("active tool schema doctor warnings", () => {
       compat: { unsupportedToolSchemaKeywords: ["$dynamicRef"] },
     };
     toolState.tools = [healthyTool, dynamicTool];
-    toolState.pluginIds = { dofbot_move_angles: "dofbot" };
+    toolState.pluginIds = { fuzzplugin_move_angles: "fuzzplugin" };
     toolState.normalizeTools.mockImplementation(({ tools, modelApi, model }) => {
       if (
         modelApi !== "openai-responses" ||
@@ -141,8 +143,8 @@ describe("active tool schema doctor warnings", () => {
         return tools;
       }
       return tools.map((entry) =>
-        entry.name === "dofbot_move_angles"
-          ? tool("dofbot_move_angles", {
+        entry.name === "fuzzplugin_move_angles"
+          ? tool("fuzzplugin_move_angles", {
               type: "object",
               properties: {
                 target: { $dynamicRef: "#target" },
@@ -162,14 +164,14 @@ describe("active tool schema doctor warnings", () => {
           },
           plugins: {
             entries: {
-              dofbot: { enabled: true },
+              fuzzplugin: { enabled: true },
             },
           },
         },
         env: { HOME: "/tmp/openclaw-test" },
       }),
     ).toEqual([
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema (dofbot_move_angles.parameters.properties.target.$dynamicRef). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
+      '- agents.main: active tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema (fuzzplugin_move_angles.parameters.properties.target.$dynamicRef). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
     ]);
     expect(toolState.createTools).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -223,7 +225,7 @@ describe("active tool schema doctor warnings", () => {
 
     expect(
       collectActiveToolSchemaProjectionWarnings({
-        cfg: { plugins: { entries: { dofbot: { enabled: true } } } },
+        cfg: { plugins: { entries: { fuzzplugin: { enabled: true } } } },
         env: { HOME: "/tmp/openclaw-test" },
       }),
     ).toEqual([

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -388,17 +388,17 @@ describe("doctor preview warnings", () => {
 
   it("includes active tool schema projection warnings", async () => {
     activeToolSchemaState.warnings = [
-      '- agents.main: active tool "dofbot_move_angles" from plugin "dofbot" has unsupported runtime input schema.',
+      '- agents.main: active tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has unsupported runtime input schema.',
     ];
 
     const warnings = await collectDoctorPreviewWarnings({
-      cfg: { tools: { allow: ["dofbot_move_angles"] } },
+      cfg: { tools: { allow: ["fuzzplugin_move_angles"] } },
       doctorFixCommand: "openclaw doctor --fix",
     });
 
-    expect(warnings.some((warning) => warning.includes('active tool "dofbot_move_angles"'))).toBe(
-      true,
-    );
+    expect(
+      warnings.some((warning) => warning.includes('active tool "fuzzplugin_move_angles"')),
+    ).toBe(true);
   });
 
   it("warns but skips auto-removal when plugin discovery has errors", async () => {

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -74,8 +74,8 @@ describe("doctor runtime tool schema checks", () => {
   it("reports active bundle MCP tool schemas that would be quarantined before a model turn", async () => {
     mocks.createBundleMcpToolRuntime.mockResolvedValueOnce({
       tools: [
-        bundleMcpTool("dofbot__healthy", { type: "object", properties: {} }),
-        bundleMcpTool("dofbot__dofbot_move_angles", {
+        bundleMcpTool("fuzzplugin__healthy", { type: "object", properties: {} }),
+        bundleMcpTool("fuzzplugin__fuzzplugin_move_angles", {
           type: "array",
           items: { type: "number" },
         }),
@@ -87,7 +87,7 @@ describe("doctor runtime tool schema checks", () => {
       collectRuntimeToolSchemaFindings({
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -95,10 +95,10 @@ describe("doctor runtime tool schema checks", () => {
       checkId: "core/doctor/runtime-tool-schemas",
       severity: "error",
       message:
-        "Agent main tool dofbot__dofbot_move_angles from plugin bundle-mcp has an unsupported input schema for runtime projection.",
+        "Agent main tool fuzzplugin__fuzzplugin_move_angles from plugin bundle-mcp has an unsupported input schema for runtime projection.",
       path: "mcp.servers",
-      target: "dofbot__dofbot_move_angles",
-      requirement: 'dofbot__dofbot_move_angles.parameters.type must be "object"',
+      target: "fuzzplugin__fuzzplugin_move_angles",
+      requirement: 'fuzzplugin__fuzzplugin_move_angles.parameters.type must be "object"',
       fixHint:
         "Disable or update the offending MCP server/tool so its parameters are a JSON object schema, then rerun doctor.",
     });
@@ -170,9 +170,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -183,7 +183,7 @@ describe("doctor runtime tool schema checks", () => {
       collectRuntimeToolSchemaFindings({
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -191,8 +191,8 @@ describe("doctor runtime tool schema checks", () => {
       checkId: "core/doctor/runtime-tool-schemas",
       severity: "error",
       message:
-        'Configured MCP server "dofbot" could not expose runtime tools for schema validation.',
-      path: "mcp.servers.dofbot",
+        'Configured MCP server "fuzzplugin" could not expose runtime tools for schema validation.',
+      path: "mcp.servers.fuzzplugin",
       requirement: 'tools[0].inputSchema.type: Invalid input: expected "object"',
       fixHint:
         "Fix or disable the offending MCP server, then rerun doctor before relying on assistant tool startup.",
@@ -205,9 +205,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -216,17 +216,17 @@ describe("doctor runtime tool schema checks", () => {
 
     await expect(
       collectRuntimeToolSchemaFindings({
-        tools: { allow: ["dofbot__healthy"] },
+        tools: { allow: ["fuzzplugin__healthy"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
     ).resolves.toContainEqual(
       expect.objectContaining({
         checkId: "core/doctor/runtime-tool-schemas",
-        path: "mcp.servers.dofbot",
+        path: "mcp.servers.fuzzplugin",
       }),
     );
   });
@@ -238,7 +238,7 @@ describe("doctor runtime tool schema checks", () => {
         {
           serverName: "my__server",
           safeServerName: "my__server",
-          launchSummary: "node dofbot-mcp.mjs",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -250,7 +250,7 @@ describe("doctor runtime tool schema checks", () => {
         tools: { allow: ["my__server__healthy"] },
         mcp: {
           servers: {
-            my__server: { command: "node", args: ["dofbot-mcp.mjs"] },
+            my__server: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -267,9 +267,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -281,14 +281,14 @@ describe("doctor runtime tool schema checks", () => {
         tools: { allow: ["*__healthy"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
     ).resolves.toContainEqual(
       expect.objectContaining({
         checkId: "core/doctor/runtime-tool-schemas",
-        path: "mcp.servers.dofbot",
+        path: "mcp.servers.fuzzplugin",
       }),
     );
   });
@@ -296,7 +296,7 @@ describe("doctor runtime tool schema checks", () => {
   it("reports unsupported schemas exposed only to a non-default configured agent", async () => {
     mocks.createOpenClawCodingTools.mockImplementation((options) =>
       options?.agentId === "worker"
-        ? [tool("dofbot_move_angles", { type: "array", items: { type: "number" } })]
+        ? [tool("fuzzplugin_move_angles", { type: "array", items: { type: "number" } })]
         : [tool("healthy", { type: "object", properties: {} })],
     );
 
@@ -313,10 +313,10 @@ describe("doctor runtime tool schema checks", () => {
       checkId: "core/doctor/runtime-tool-schemas",
       severity: "error",
       message:
-        "Agent worker tool dofbot_move_angles has an unsupported input schema for runtime projection.",
-      path: "tools.dofbot_move_angles",
-      target: "dofbot_move_angles",
-      requirement: 'dofbot_move_angles.parameters.type must be "object"',
+        "Agent worker tool fuzzplugin_move_angles has an unsupported input schema for runtime projection.",
+      path: "tools.fuzzplugin_move_angles",
+      target: "fuzzplugin_move_angles",
+      requirement: 'fuzzplugin_move_angles.parameters.type must be "object"',
       fixHint:
         "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.",
     });
@@ -333,13 +333,13 @@ describe("doctor runtime tool schema checks", () => {
   it("skips ACP-only agents because they do not use embedded tool projection", async () => {
     mocks.createOpenClawCodingTools.mockImplementation((options) =>
       options?.agentId === "acp-worker"
-        ? [tool("dofbot_move_angles", { type: "array", items: { type: "number" } })]
+        ? [tool("fuzzplugin_move_angles", { type: "array", items: { type: "number" } })]
         : [tool("healthy", { type: "object", properties: {} })],
     );
     mocks.createBundleMcpToolRuntime.mockImplementation(
       async (options: { workspaceDir: string }) => ({
         tools: options.workspaceDir.includes("acp")
-          ? [bundleMcpTool("dofbot__bad", { type: "array", items: { type: "number" } })]
+          ? [bundleMcpTool("fuzzplugin__bad", { type: "array", items: { type: "number" } })]
           : [],
         dispose: mocks.disposeBundleRuntime,
       }),
@@ -375,7 +375,7 @@ describe("doctor runtime tool schema checks", () => {
       async (options: { workspaceDir: string }) => ({
         tools: options.workspaceDir.includes("worker")
           ? [
-              bundleMcpTool("dofbot__dofbot_move_angles", {
+              bundleMcpTool("fuzzplugin__fuzzplugin_move_angles", {
                 type: "array",
                 items: { type: "number" },
               }),
@@ -398,10 +398,10 @@ describe("doctor runtime tool schema checks", () => {
       checkId: "core/doctor/runtime-tool-schemas",
       severity: "error",
       message:
-        "Agent worker tool dofbot__dofbot_move_angles from plugin bundle-mcp has an unsupported input schema for runtime projection.",
+        "Agent worker tool fuzzplugin__fuzzplugin_move_angles from plugin bundle-mcp has an unsupported input schema for runtime projection.",
       path: "mcp.servers",
-      target: "dofbot__dofbot_move_angles",
-      requirement: 'dofbot__dofbot_move_angles.parameters.type must be "object"',
+      target: "fuzzplugin__fuzzplugin_move_angles",
+      requirement: 'fuzzplugin__fuzzplugin_move_angles.parameters.type must be "object"',
       fixHint:
         "Disable or update the offending MCP server/tool so its parameters are a JSON object schema, then rerun doctor.",
     });
@@ -418,7 +418,7 @@ describe("doctor runtime tool schema checks", () => {
   it("does not report bundle MCP schemas filtered out by the final runtime tool policy", async () => {
     mocks.createBundleMcpToolRuntime.mockResolvedValueOnce({
       tools: [
-        bundleMcpTool("dofbot__dofbot_move_angles", {
+        bundleMcpTool("fuzzplugin__fuzzplugin_move_angles", {
           type: "array",
           items: { type: "number" },
         }),
@@ -431,7 +431,7 @@ describe("doctor runtime tool schema checks", () => {
         tools: { deny: ["bundle-mcp"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -443,9 +443,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -457,7 +457,7 @@ describe("doctor runtime tool schema checks", () => {
         tools: { deny: ["bundle-mcp"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),
@@ -469,9 +469,9 @@ describe("doctor runtime tool schema checks", () => {
       tools: [],
       diagnostics: [
         {
-          serverName: "dofbot",
-          safeServerName: "dofbot",
-          launchSummary: "node dofbot-mcp.mjs",
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
           message: 'tools[0].inputSchema.type: Invalid input: expected "object"',
         },
       ],
@@ -480,10 +480,10 @@ describe("doctor runtime tool schema checks", () => {
 
     await expect(
       collectRuntimeToolSchemaFindings({
-        tools: { deny: ["dofbot__*"] },
+        tools: { deny: ["fuzzplugin__*"] },
         mcp: {
           servers: {
-            dofbot: { command: "node", args: ["dofbot-mcp.mjs"] },
+            fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
           },
         },
       }),

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -638,10 +638,10 @@ describe("registerCoreHealthChecks", () => {
                 checkId: "core/doctor/runtime-tool-schemas",
                 severity: "error",
                 message:
-                  "Tool dofbot_move_angles from plugin dofbot has an unsupported input schema for runtime projection.",
-                path: "plugins.entries.dofbot",
-                target: "dofbot_move_angles",
-                requirement: 'dofbot_move_angles.parameters.type must be "object"',
+                  "Tool fuzzplugin_move_angles from plugin fuzzplugin has an unsupported input schema for runtime projection.",
+                path: "plugins.entries.fuzzplugin",
+                target: "fuzzplugin_move_angles",
+                requirement: 'fuzzplugin_move_angles.parameters.type must be "object"',
               },
             ];
           },
@@ -660,7 +660,7 @@ describe("registerCoreHealthChecks", () => {
       expect.objectContaining({
         checkId: "core/doctor/runtime-tool-schemas",
         severity: "error",
-        target: "dofbot_move_angles",
+        target: "fuzzplugin_move_angles",
       }),
     );
   });

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -350,10 +350,10 @@ describe("doctor health contributions", () => {
           checkId: "core/doctor/runtime-tool-schemas",
           severity: "error",
           message:
-            "Tool dofbot_move_angles from plugin dofbot has an unsupported input schema for runtime projection.",
-          path: "plugins.entries.dofbot",
-          target: "dofbot_move_angles",
-          requirement: 'dofbot_move_angles.parameters.type must be "object"',
+            "Tool fuzzplugin_move_angles from plugin fuzzplugin has an unsupported input schema for runtime projection.",
+          path: "plugins.entries.fuzzplugin",
+          target: "fuzzplugin_move_angles",
+          requirement: 'fuzzplugin_move_angles.parameters.type must be "object"',
           fixHint:
             "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.",
         },
@@ -375,11 +375,11 @@ describe("doctor health contributions", () => {
 
     expect(ctx.healthOk).toBe(false);
     expect(mocks.note).toHaveBeenCalledWith(
-      expect.stringContaining("Tool dofbot_move_angles from plugin dofbot"),
+      expect.stringContaining("Tool fuzzplugin_move_angles from plugin fuzzplugin"),
       "Doctor warnings",
     );
     expect(mocks.note).toHaveBeenCalledWith(
-      expect.stringContaining('issue: dofbot_move_angles.parameters.type must be "object"'),
+      expect.stringContaining('issue: fuzzplugin_move_angles.parameters.type must be "object"'),
       "Doctor warnings",
     );
   });


### PR DESCRIPTION
## Summary

- replaces reported plugin/tool fixture names with neutral synthetic `fuzzplugin` / `mockplugin` names in tests and expected diagnostics
- keeps this PR test-only and deliberately excludes the runtime-quarantine test files now owned by #88368
- stabilizes one MCP runtime test log assertion by waiting for the existing server log helper instead of reading before the async write flushes

## Landing note

This is hygiene, not the runtime fix. It can land before the schema-hardening PRs because it avoids their runtime-quarantine test files, but it should not block the critical behavior fixes if GitHub flakes again.

## Verification

- rebuilt the PR from current `origin/main` e1a98171417c into head f34707507fa, reducing the PR from +123/-127 across 14 files to +114/-118 across 11 files
- synthetic sequential merge proof for #88491 -> #88368 -> #88493 completed without conflicts using `git merge-tree --write-tree`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts packages/gateway-protocol/src/schema/agents-models-skills.test.ts src/agents/agent-bundle-mcp-runtime.test.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts src/agents/tools-effective-inventory.test.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/commands/doctor/shared/preview-warnings.test.ts src/flows/doctor-core-checks.runtime.test.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-health-contributions.test.ts`: 6 routed shards, 197 tests passed
- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts`: 27 tests passed
- `node_modules/.bin/oxfmt --check src/agents/agent-bundle-mcp-runtime.test.ts`
- `node scripts/run-oxlint.mjs src/agents/agent-bundle-mcp-runtime.test.ts`
- `git diff --check` plus touched-file scrub for reported fixture names, private local paths, and install-error output: clean
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings
- AWS Crabbox `pnpm check:changed`: passed on run `run_f749e4297816`, lease `cbx_812307f4af8c` / `silver-lobster` (provider=aws, command 9m50s, total 12m27s)
- GitHub checks on f34707507fa settled with 115 success, 0 failed/pending, 24 skipped, and 1 neutral

## Real behavior proof

Behavior addressed: test fixtures no longer preserve report-specific plugin/tool names in reusable runtime-schema diagnostics.

Real environment tested: linked OpenClaw `gwt` worktree based on current `origin/main` e1a98171417c, plus AWS Crabbox Linux proof for the changed gate on head f34707507fa.

Exact steps or command run after this patch: rebuilt the PR as a reduced single commit, ran targeted fixture tests, formatter check, targeted lint check, diff check, scrub, autoreview, synthetic sequential merge proof, AWS Crabbox `pnpm check:changed`, and watched GitHub CI to green.

Evidence after fix: touched tests and expected diagnostics use neutral synthetic names, and the first-wave PR sequence no longer conflicts on runtime-quarantine test files.

Observed result after fix: the scrub PR stays test-only, avoids the overlapping runtime-quarantine files, and its MCP runtime log assertion no longer races CI log flushing.

What was not tested: no product runtime behavior; this is intentionally tests-only fixture cleanup.


## Refresh 2026-05-31T10:47Z

Rebased onto current `origin/main` and pushed head `12723ee25f2e`. Verification: `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts packages/gateway-protocol/src/schema/agents-models-skills.test.ts src/agents/agent-bundle-mcp-runtime.test.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts src/agents/tools-effective-inventory.test.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/commands/doctor/shared/preview-warnings.test.ts src/flows/doctor-core-checks.runtime.test.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-health-contributions.test.ts` passed 6 shards in 32.35s; `node_modules/.bin/oxfmt --check ...` passed; `git diff --check` and added-line scrub for reported fixture names/private paths/secrets passed.


## Refresh 2026-05-31T11:45Z

Live GitHub state on head `12723ee25f2e`: mergeable, `mergeStateStatus=CLEAN`, active checks 0, actionable failed checks 0.

Current non-mutating stack proof against `origin/main` `fde87f475f7`: this PR merges cleanly first, then #88368, #88410, and #88351 merge cleanly after it. Landing recommendation remains: land this neutral fixture cleanup first.
