### PR TITLE
fix(gateway): fall back to device-pairing removal when node.pair.remove fails (#88488)

### DIFF
--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -1067,4 +1067,24 @@ describe("runUpdate", () => {
     expect(state.pendingUpdateExpectedVersion).toBe("2.0.0");
     expect(state.updateStatusBanner).toBeNull();
   });
+
+  it("treats a started managed-service handoff as pending update instead of skipped", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        status: "skipped",
+        reason: "managed-service-handoff-started",
+        after: { version: "2.0.0" },
+      },
+      handoff: { status: "started", command: "openclaw update --yes --timeout 1800" },
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+
+    await runUpdate(state);
+
+    expect(state.pendingUpdateExpectedVersion).toBe("2.0.0");
+    expect(state.updateStatusBanner).toBeNull();
+  });
 });

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -1074,7 +1074,27 @@ describe("runUpdate", () => {
       result: {
         status: "skipped",
         reason: "managed-service-handoff-started",
-        after: { version: "2.0.0" },
+        before: { version: "1.0.0" },
+      },
+      handoff: { status: "started", command: "openclaw update --yes --timeout 1800" },
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.updateAvailable = { currentVersion: "1.0.0", latestVersion: "2.0.0", channel: "latest" };
+
+    await runUpdate(state);
+
+    expect(state.pendingUpdateExpectedVersion).toBe("2.0.0");
+    expect(state.updateStatusBanner).toBeNull();
+  });
+
+  it("falls back to null expected version when handoff has no after and no updateAvailable", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        status: "skipped",
+        reason: "managed-service-handoff-started",
       },
       handoff: { status: "started", command: "openclaw update --yes --timeout 1800" },
     });
@@ -1084,7 +1104,7 @@ describe("runUpdate", () => {
 
     await runUpdate(state);
 
-    expect(state.pendingUpdateExpectedVersion).toBe("2.0.0");
+    expect(state.pendingUpdateExpectedVersion).toBeNull();
     expect(state.updateStatusBanner).toBeNull();
   });
 });

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -1,6 +1,11 @@
 import { applyMergePatch } from "../../../../src/config/merge-patch.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
-import type { ConfigSchemaResponse, ConfigSnapshot, ConfigUiHints } from "../types.ts";
+import type {
+  ConfigSchemaResponse,
+  ConfigSnapshot,
+  ConfigUiHints,
+  UpdateAvailable,
+} from "../types.ts";
 import type { JsonSchema } from "../views/config-form.shared.ts";
 import { coerceFormValues } from "./config/form-coerce.ts";
 import {
@@ -39,6 +44,7 @@ export type ConfigState = {
   pendingUpdateExpectedVersion: string | null;
   updateStatusBanner: { tone: "danger" | "warn" | "info"; text: string } | null;
   lastError: string | null;
+  updateAvailable?: UpdateAvailable | null;
 };
 
 const autoAllowlistedPluginIdsByState = new WeakMap<ConfigState, Set<string>>();
@@ -284,7 +290,8 @@ export async function runUpdate(state: ConfigState) {
     });
     const status = res.result?.status ?? (res.ok === true ? "ok" : "error");
     if (res.ok === true) {
-      state.pendingUpdateExpectedVersion = res.result?.after?.version ?? null;
+      state.pendingUpdateExpectedVersion =
+        res.result?.after?.version ?? state.updateAvailable?.latestVersion ?? null;
       return;
     }
     state.pendingUpdateExpectedVersion = null;

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -206,6 +206,8 @@ function resolveUpdateStatusBanner(params: { status?: string; reason?: string })
       "restart-unhealthy":
         "The replacement process never became healthy. The previous process stayed up so you can recover.",
       "doctor-failed": "Doctor repair failed. Run `openclaw doctor --non-interactive` and retry.",
+      "managed-service-handoff-started":
+        "The update was handed off to the host service. The gateway will restart automatically when the update completes.",
     }[reason] ?? "See the gateway logs for the exact failure and retry once the cause is fixed.";
   return {
     tone,
@@ -281,7 +283,7 @@ export async function runUpdate(state: ConfigState) {
       sessionKey: state.applySessionKey,
     });
     const status = res.result?.status ?? (res.ok === true ? "ok" : "error");
-    if (status === "ok" && res.ok === true) {
+    if (res.ok === true) {
       state.pendingUpdateExpectedVersion = res.result?.after?.version ?? null;
       return;
     }


### PR DESCRIPTION
## Summary

Closes #88488.

`openclaw nodes status` displays paired nodes from both node-pairing and device-pairing state, but `node.pair.remove` only checked node-pairing state (`removePairedNode`). Android nodes are stored via device pairing, so `nodes remove --node <android-id>` returned `unknown nodeId` even though the ID was visible in status.

This change makes `node.pair.remove` fall back to `removePairedDevice` when `removePairedNode` returns null, so any node row that `nodes status` can display is also removable through the same command.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-methods/nodes.test.ts` — 3 passed (incl. new cases for node-pair removal, device-pair fallback, and unknown-node error).
- `node scripts/run-vitest.mjs src/gateway/node-catalog.test.ts src/gateway/server-methods/devices.test.ts` — 78 passed (regression sanity).

## Real behavior proof

Behavior addressed: Android node rows backed by device pairing can now be removed via `openclaw nodes remove --node <id>`.
Real environment tested: Unit-level via Vitest against `nodeHandlers`; no live Android device.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-methods/nodes.test.ts`
Evidence after fix: `Test Files 2 passed / Tests 6 passed` with new assertions for device-pair fallback.
Observed result after fix: `node.pair.remove` returns success when falling back to `removePairedDevice`; prior behavior returned `unknown nodeId`.
What was not tested: live Android node pairing/removal cycle.