### PR TITLE
fix(doctor): report runtime tool schema validation errors

### DIFF
--- a/src/flows/doctor-core-checks.runtime-errors.test.ts
+++ b/src/flows/doctor-core-checks.runtime-errors.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "../agents/tools/common.js";
+import { setPluginToolMeta } from "../plugins/tools.js";
+
+const mocks = vi.hoisted(() => ({
+  createBundleMcpToolRuntime: vi.fn(),
+  createOpenClawCodingTools: vi.fn(),
+  disposeBundleRuntime: vi.fn(),
+  loadModelCatalog: vi.fn(async (): Promise<Array<Record<string, unknown>>> => []),
+  normalizeProviderToolSchemasWithPlugin: vi.fn(),
+  resolveDefaultModelForAgent: vi.fn(() => ({ provider: "openai", model: "gpt-5.5" })),
+}));
+
+vi.mock("../agents/model-catalog.js", () => ({
+  findModelInCatalog: (
+    catalog: Array<{ provider?: string; id?: string }>,
+    provider: string,
+    modelId: string,
+  ) => catalog.find((entry) => entry.provider === provider && entry.id === modelId),
+  loadModelCatalog: mocks.loadModelCatalog,
+}));
+
+vi.mock("../agents/model-selection.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agents/model-selection.js")>()),
+  resolveDefaultModelForAgent: mocks.resolveDefaultModelForAgent,
+}));
+
+vi.mock("../agents/agent-bundle-mcp-tools.js", () => ({
+  createBundleMcpToolRuntime: mocks.createBundleMcpToolRuntime,
+}));
+
+vi.mock("../agents/agent-tools.js", () => ({
+  createOpenClawCodingTools: mocks.createOpenClawCodingTools,
+}));
+
+vi.mock("../plugins/provider-runtime.js", () => ({
+  inspectProviderToolSchemasWithPlugin: () => [],
+  normalizeProviderToolSchemasWithPlugin: mocks.normalizeProviderToolSchemasWithPlugin,
+}));
+
+const { collectRuntimeToolSchemaFindings } = await import("./doctor-core-checks.runtime.js");
+
+function tool(name: string, parameters: unknown): AnyAgentTool {
+  return {
+    name,
+    label: name,
+    description: name,
+    parameters,
+    execute: async () => ({ text: "ok" }),
+  } as unknown as AnyAgentTool;
+}
+
+function bundleMcpTool(name: string, parameters: unknown): AnyAgentTool {
+  const entry = tool(name, parameters);
+  setPluginToolMeta(entry, { pluginId: "bundle-mcp", optional: false });
+  return entry;
+}
+
+describe("doctor runtime tool schema error handling", () => {
+  beforeEach(() => {
+    mocks.createOpenClawCodingTools.mockReset().mockReturnValue([]);
+    mocks.createBundleMcpToolRuntime.mockReset().mockResolvedValue({
+      tools: [],
+      dispose: mocks.disposeBundleRuntime,
+    });
+    mocks.disposeBundleRuntime.mockReset().mockResolvedValue(undefined);
+    mocks.loadModelCatalog.mockClear();
+    mocks.normalizeProviderToolSchemasWithPlugin
+      .mockReset()
+      .mockImplementation(({ context }) => context.tools);
+    mocks.resolveDefaultModelForAgent.mockClear();
+  });
+
+  it("reports agent runtime tool construction failures without aborting schema checks", async () => {
+    mocks.createOpenClawCodingTools.mockImplementationOnce(() => {
+      throw new Error("fuzzplugin startup failed");
+    });
+
+    await expect(collectRuntimeToolSchemaFindings({})).resolves.toContainEqual({
+      checkId: "core/doctor/runtime-tool-schemas",
+      severity: "error",
+      message: "Agent main runtime tool schema validation could not load the runtime tool set.",
+      path: "agents.main.tools",
+      requirement: "fuzzplugin startup failed",
+      fixHint:
+        "Fix provider/plugin tool loading errors, then rerun doctor before relying on assistant tool startup.",
+    });
+    expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledTimes(1);
+    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports agent runtime tool normalization failures without aborting doctor", async () => {
+    mocks.createOpenClawCodingTools.mockReturnValueOnce([
+      tool("fuzzplugin_move_angles", { type: "object", properties: {} }),
+    ]);
+    mocks.normalizeProviderToolSchemasWithPlugin.mockImplementation(({ context }) => {
+      const tools = context.tools as AnyAgentTool[];
+      if (tools.some((entry) => entry.name === "fuzzplugin_move_angles")) {
+        throw new Error("fuzzplugin schema normalization failed");
+      }
+      return tools;
+    });
+
+    await expect(collectRuntimeToolSchemaFindings({})).resolves.toContainEqual({
+      checkId: "core/doctor/runtime-tool-schemas",
+      severity: "error",
+      message:
+        "Agent main runtime tool schema validation could not normalize the runtime tool set.",
+      path: "agents.main.tools",
+      requirement: "fuzzplugin schema normalization failed",
+      fixHint:
+        "Fix provider/plugin schema normalization errors, then rerun doctor before relying on assistant tool startup.",
+    });
+    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports bundle MCP runtime tool normalization failures without aborting doctor", async () => {
+    mocks.createBundleMcpToolRuntime.mockResolvedValueOnce({
+      tools: [bundleMcpTool("fuzzplugin__move_angles", { type: "object", properties: {} })],
+      dispose: mocks.disposeBundleRuntime,
+    });
+    mocks.normalizeProviderToolSchemasWithPlugin.mockImplementation(({ context }) => {
+      const tools = context.tools as AnyAgentTool[];
+      if (tools.some((entry) => entry.name === "fuzzplugin__move_angles")) {
+        throw new Error("fuzzplugin MCP schema normalization failed");
+      }
+      return tools;
+    });
+
+    await expect(collectRuntimeToolSchemaFindings({})).resolves.toContainEqual({
+      checkId: "core/doctor/runtime-tool-schemas",
+      severity: "error",
+      message: "Configured MCP tool schema validation could not normalize the runtime tool set.",
+      path: "mcp.servers",
+      requirement: "fuzzplugin MCP schema normalization failed",
+      fixHint:
+        "Fix provider/plugin schema normalization errors, then rerun doctor before relying on assistant tool startup.",
+    });
+    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -647,6 +647,36 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
   ];
 }
 
+function agentRuntimeToolLoadFailureFinding(params: {
+  agentId: string;
+  error: unknown;
+}): HealthFinding {
+  return {
+    checkId: "core/doctor/runtime-tool-schemas",
+    severity: "error",
+    message: `Agent ${params.agentId} runtime tool schema validation could not load the runtime tool set.`,
+    path: `agents.${params.agentId}.tools`,
+    requirement: formatErrorMessage(params.error),
+    fixHint:
+      "Fix provider/plugin tool loading errors, then rerun doctor before relying on assistant tool startup.",
+  };
+}
+
+function agentRuntimeToolNormalizationFailureFinding(params: {
+  agentId: string;
+  error: unknown;
+}): HealthFinding {
+  return {
+    checkId: "core/doctor/runtime-tool-schemas",
+    severity: "error",
+    message: `Agent ${params.agentId} runtime tool schema validation could not normalize the runtime tool set.`,
+    path: `agents.${params.agentId}.tools`,
+    requirement: formatErrorMessage(params.error),
+    fixHint:
+      "Fix provider/plugin schema normalization errors, then rerun doctor before relying on assistant tool startup.",
+  };
+}
+
 function bundleMcpRuntimeLoadFailureFinding(error: unknown): HealthFinding {
   return {
     checkId: "core/doctor/runtime-tool-schemas",
@@ -657,6 +687,73 @@ function bundleMcpRuntimeLoadFailureFinding(error: unknown): HealthFinding {
     fixHint:
       "Fix or disable the offending MCP server, then rerun doctor before relying on assistant tool startup.",
   };
+}
+
+function bundleMcpRuntimeNormalizationFailureFinding(error: unknown): HealthFinding {
+  return {
+    checkId: "core/doctor/runtime-tool-schemas",
+    severity: "error",
+    message: "Configured MCP tool schema validation could not normalize the runtime tool set.",
+    path: "mcp.servers",
+    requirement: formatErrorMessage(error),
+    fixHint:
+      "Fix provider/plugin schema normalization errors, then rerun doctor before relying on assistant tool startup.",
+  };
+}
+
+function collectAgentRuntimeToolSchemaFindings(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  workspaceDir: string;
+  modelRef: { provider: string; model: string };
+  model: ProviderRuntimeModel;
+}): readonly HealthFinding[] {
+  let tools: AnyAgentTool[];
+  try {
+    tools = createOpenClawCodingTools({
+      agentId: params.agentId,
+      workspaceDir: params.workspaceDir,
+      config: params.cfg,
+      modelProvider: params.modelRef.provider,
+      modelId: params.modelRef.model,
+      modelApi: params.model.api,
+      modelCompat: params.model.compat,
+      modelContextWindowTokens: params.model.contextWindow,
+      allowGatewaySubagentBinding: true,
+      emitBeforeToolCallDiagnostics: false,
+    });
+  } catch (error) {
+    return [agentRuntimeToolLoadFailureFinding({ agentId: params.agentId, error })];
+  }
+
+  const activeToolProjection = inspectProviderNormalizableTools({
+    agentId: params.agentId,
+    tools,
+  });
+
+  let normalizedTools: AnyAgentTool[];
+  try {
+    normalizedTools = normalizeAgentRuntimeTools({
+      tools: [...activeToolProjection.tools],
+      provider: params.modelRef.provider,
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      env: process.env,
+      modelId: params.modelRef.model,
+      modelApi: params.model.api,
+      model: params.model,
+    });
+  } catch (error) {
+    return [agentRuntimeToolNormalizationFailureFinding({ agentId: params.agentId, error })];
+  }
+
+  return [
+    ...activeToolProjection.findings,
+    ...collectToolSchemaFindings({
+      agentId: params.agentId,
+      tools: normalizedTools,
+    }),
+  ];
 }
 
 function bundleMcpRuntimeDiagnosticFinding(diagnostic: McpToolCatalogDiagnostic): HealthFinding {
@@ -815,37 +912,13 @@ export async function collectRuntimeToolSchemaFindings(
       if (!supportsModelTools(model)) {
         continue;
       }
-      const tools = createOpenClawCodingTools({
-        agentId,
-        workspaceDir,
-        config: cfg,
-        modelProvider: modelRef.provider,
-        modelId: modelRef.model,
-        modelApi: model.api,
-        modelCompat: model.compat,
-        modelContextWindowTokens: model.contextWindow,
-        allowGatewaySubagentBinding: true,
-        emitBeforeToolCallDiagnostics: false,
-      });
-      const activeToolProjection = inspectProviderNormalizableTools({
-        agentId,
-        tools,
-      });
-      const normalizedTools = normalizeAgentRuntimeTools({
-        tools: [...activeToolProjection.tools],
-        provider: modelRef.provider,
-        config: cfg,
-        workspaceDir,
-        env: process.env,
-        modelId: modelRef.model,
-        modelApi: model.api,
-        model,
-      });
       findings.push(
-        ...activeToolProjection.findings,
-        ...collectToolSchemaFindings({
+        ...collectAgentRuntimeToolSchemaFindings({
+          cfg,
           agentId,
-          tools: normalizedTools,
+          workspaceDir,
+          modelRef,
+          model,
         }),
       );
       if (!shouldCreateBundleMcpRuntimeForAttempt({ toolsEnabled: true })) {
@@ -889,16 +962,20 @@ export async function collectRuntimeToolSchemaFindings(
           });
           findings.push(...policyActiveDiagnostics.map(bundleMcpRuntimeDiagnosticFinding));
         }
-        findings.push(
-          ...collectBundleMcpRuntimeToolSchemaFindings({
-            bundleRuntime,
-            cfg,
-            agentId,
-            workspaceDir,
-            modelRef,
-            model,
-          }),
-        );
+        try {
+          findings.push(
+            ...collectBundleMcpRuntimeToolSchemaFindings({
+              bundleRuntime,
+              cfg,
+              agentId,
+              workspaceDir,
+              modelRef,
+              model,
+            }),
+          );
+        } catch (error) {
+          findings.push(bundleMcpRuntimeNormalizationFailureFinding(error));
+        }
       }
     }
   } finally {


### PR DESCRIPTION
## Summary
- make doctor report runtime tool construction failures as actionable schema-check findings instead of aborting
- make doctor report provider/plugin normalization failures for agent and bundled MCP runtime tools
- preserve the #88368 pre-normalization quarantine path while adding doctor diagnostics

## Stack
- Base PR: #88368 (`fuzz-tool-schema-runtime-20260530`) at `2dae8979791`
- This PR head: `7569ddc70d2`
- After #88649 and #88368 land, retarget this PR back to `main` and rerun the focused proof.

## Verification
- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.runtime.test.ts src/flows/doctor-core-checks.runtime-errors.test.ts --reporter=verbose`
- `./node_modules/.bin/oxfmt --check $(cat /tmp/doctor-runtime-errors-files-current.txt)`
- `node scripts/run-oxlint.mjs $(cat /tmp/doctor-runtime-errors-files-current.txt)`
- `git diff --check @{u}...HEAD`
- `rg -n "dofbot|doftbot" $(cat /tmp/doctor-runtime-errors-files-current.txt) || true`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base @{u}`
- `node scripts/crabbox-wrapper.mjs run --provider aws --label doctor-runtime-errors-check-changed --shell -- "pnpm check:changed"` (`run_3621756fcf12`, AWS lease `cbx_09998d224eb3`, slug `tidal-prawn`)

## Real behavior proof
Behavior addressed: doctor now reports runtime tool-set load and normalization failures as `core/doctor/runtime-tool-schemas` findings instead of letting those paths abort schema validation.
Real environment tested: local Codex gwt worktree stacked on #88368 plus AWS Crabbox Linux `c7a.8xlarge` remote changed gate.
Exact steps or command run after this patch: targeted doctor runtime Vitest, oxfmt, oxlint, diff whitespace check, private-name scrub, autoreview, and AWS Crabbox `pnpm check:changed` listed above.
Evidence after fix: targeted tests passed 1 routed Vitest shard / 33 tests; formatting, lint, diff, scrub, and autoreview passed; AWS Crabbox `run_3621756fcf12` passed `pnpm check:changed` and cleaned up its lease.
Observed result after fix: doctor returns clear findings for agent runtime load failures, agent runtime schema normalization failures, and bundled MCP normalization failures while preserving runtime quarantine behavior from #88368.
What was not tested: no live Telegram turn in this slice; live channel proof should come after the runtime and doctor stack is landed/retargeted.
