### PR TITLE
fix(discord): strip internal tool traces from tool replies

### DIFF
--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -157,7 +157,7 @@ describe("deliverDiscordReply", () => {
     ).rejects.toThrow("discord final reply produced no delivered message for channel:101");
   });
 
-  it("preserves explicit tool progress payloads at the tool delivery boundary", async () => {
+  it("drops raw internal tool trace payloads at the tool delivery boundary", async () => {
     await deliverDiscordReply({
       replies: [{ text: "🛠️ Exec: `echo visible`" }],
       target: "channel:101",
@@ -169,19 +169,35 @@ describe("deliverDiscordReply", () => {
       kind: "tool",
     });
 
+    expect(sendDurableMessageBatchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves non-internal tool progress text at the tool delivery boundary", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: "Working on the fix now." }],
+      target: "channel:101",
+      token: "token",
+      accountId: "default",
+      runtime,
+      cfg,
+      textLimit: 2000,
+      kind: "tool",
+    });
+
     expect(sendDurableMessageBatchMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        payloads: [{ text: "🛠️ Exec: `echo visible`" }],
+        payloads: [{ text: "Working on the fix now." }],
       }),
     );
   });
 
-  it("strips internal execution trace lines at the final Discord send boundary", async () => {
+  it("strips internal execution trace lines at the Discord send boundary", async () => {
     await deliverDiscordReply({
       replies: [
         {
           text: [
             "📊 Session Status: current",
+            "🧾 Session History: session current, limit 20",
             "🛠️ run git status",
             "🛠️ `gh pr view`",
             "🛠️ `docker compose up`",

--- a/extensions/discord/src/monitor/reply-safety.ts
+++ b/extensions/discord/src/monitor/reply-safety.ts
@@ -4,7 +4,7 @@ import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking"
 import { stripPlainTextToolCallBlocks } from "openclaw/plugin-sdk/tool-payload";
 
 const DISCORD_INTERNAL_TRACE_LINE_RE =
-  /^(?:>\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️)\s*(?:Session Status|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
+  /^(?:>\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️|🧾)\s*(?:Session Status|Session History|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
 const DISCORD_INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE =
   /^(?:>\s*)?🛠️\s*(?:(?:(?:elevated|pty)\b\s*(?:·|,)\s*)+)?(?:`{1,2}\s*\S|(?:run|check|fetch|pull|push|view|show|list|switch|create|merge|rebase|stage|restore|reset|stash|search|find|print|copy|move|remove|install|start|cd|git|pnpm|npm|yarn|bun|node|python|python3|bash|sh)\b)/i;
 const DISCORD_INTERNAL_CHANNEL_LINE_RE =
@@ -76,14 +76,12 @@ export function sanitizeDiscordFrontChannelReplyPayloads(
   payloads: readonly ReplyPayload[],
   options: { kind?: "tool" | "block" | "final" } = {},
 ): ReplyPayload[] {
-  const preserveVerboseToolProgress = options.kind === "tool";
+  void options;
   const safePayloads: ReplyPayload[] = [];
   for (const payload of payloads) {
     const safeText =
       typeof payload.text === "string"
-        ? preserveVerboseToolProgress
-          ? collapseExcessBlankLines(sanitizeAssistantVisibleText(payload.text)).trim()
-          : sanitizeDiscordFrontChannelText(payload.text)
+        ? sanitizeDiscordFrontChannelText(payload.text)
         : payload.text;
     const nextPayload =
       safeText === payload.text


### PR DESCRIPTION
## Summary
- strip Discord front-channel tool replies with the same reply-safety sanitizer used for block/final delivery
- extend the internal-trace matcher to catch leaked `🧾 Session History:` lines alongside existing raw tool trace shapes
- add regression coverage proving raw internal tool traces are dropped while normal user-facing tool text still survives

## Testing
- pnpm vitest run extensions/discord/src/monitor/reply-delivery.test.ts extensions/discord/src/send.webhook-activity.test.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts

## Issue
- closes #88341
