### PR TITLE
fix(imessage): tolerate sub-second self-chat reflection skew

### DIFF
--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -434,7 +434,7 @@ export async function resolveIMessageInboundDecision(params: {
       params.selfChatCache?.remember(selfChatLookup);
     }
     if (isSelfChat) {
-      params.selfChatCache?.remember(selfChatLookup);
+      params.selfChatCache?.remember({ ...selfChatLookup, allowCreatedAtSkew: true });
       const echoScope = buildIMessageEchoScope({
         accountId: params.accountId,
         isGroup,

--- a/extensions/imessage/src/monitor/self-chat-cache.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-cache.test.ts
@@ -32,6 +32,46 @@ describe("createSelfChatCache", () => {
     ).toBe(true);
   });
 
+  it("matches reflected rows whose created_at differs by less than one second", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));
+
+    const cache = createSelfChatCache();
+    cache.remember({
+      ...directLookup,
+      text: "hello",
+      createdAt: 1_774_136_400_000,
+    });
+
+    expect(
+      cache.has({
+        ...directLookup,
+        text: "hello",
+        createdAt: 1_774_136_400_736,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match reflected rows whose created_at differs by one second", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));
+
+    const cache = createSelfChatCache();
+    cache.remember({
+      ...directLookup,
+      text: "hello",
+      createdAt: 1_774_136_400_000,
+    });
+
+    expect(
+      cache.has({
+        ...directLookup,
+        text: "hello",
+        createdAt: 1_774_136_401_000,
+      }),
+    ).toBe(false);
+  });
+
   it("expires entries after the ttl window", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));
@@ -60,6 +100,27 @@ describe("createSelfChatCache", () => {
 
     expect(cache.has({ ...directLookup, text: "message-0", createdAt: 0 })).toBe(false);
     expect(cache.has({ ...directLookup, text: "message-512", createdAt: 512 })).toBe(true);
+  });
+
+  it("trims bursty inserts without requiring per-entry cleanup", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));
+
+    const cache = createSelfChatCache();
+    for (let i = 0; i < 2_000; i += 1) {
+      cache.remember({
+        ...directLookup,
+        text: `burst-${i}`,
+        createdAt: i,
+      });
+    }
+
+    vi.advanceTimersByTime(1_001);
+
+    expect(cache.has({ ...directLookup, text: "burst-0", createdAt: 0 })).toBe(false);
+    expect(cache.has({ ...directLookup, text: "burst-1487", createdAt: 1_487 })).toBe(false);
+    expect(cache.has({ ...directLookup, text: "burst-1488", createdAt: 1_488 })).toBe(true);
+    expect(cache.has({ ...directLookup, text: "burst-1999", createdAt: 1_999 })).toBe(true);
   });
 
   it("does not collide long texts that differ only in the middle", () => {

--- a/extensions/imessage/src/monitor/self-chat-cache.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-cache.test.ts
@@ -41,6 +41,7 @@ describe("createSelfChatCache", () => {
       ...directLookup,
       text: "hello",
       createdAt: 1_774_136_400_000,
+      allowCreatedAtSkew: true,
     });
 
     expect(
@@ -61,6 +62,7 @@ describe("createSelfChatCache", () => {
       ...directLookup,
       text: "hello",
       createdAt: 1_774_136_400_000,
+      allowCreatedAtSkew: true,
     });
 
     expect(
@@ -68,6 +70,26 @@ describe("createSelfChatCache", () => {
         ...directLookup,
         text: "hello",
         createdAt: 1_774_136_401_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps timestamp matching exact unless skew is allowed by the remembered row", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));
+
+    const cache = createSelfChatCache();
+    cache.remember({
+      ...directLookup,
+      text: "hello",
+      createdAt: 1_774_136_400_000,
+    });
+
+    expect(
+      cache.has({
+        ...directLookup,
+        text: "hello",
+        createdAt: 1_774_136_400_239,
       }),
     ).toBe(false);
   });

--- a/extensions/imessage/src/monitor/self-chat-cache.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-cache.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSelfChatCache } from "./self-chat-cache.js";
 
+type SelfChatCacheDebug = {
+  entryCount: number;
+  insertionOrder: unknown[];
+};
+
 describe("createSelfChatCache", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -143,6 +148,24 @@ describe("createSelfChatCache", () => {
     expect(cache.has({ ...directLookup, text: "burst-1487", createdAt: 1_487 })).toBe(false);
     expect(cache.has({ ...directLookup, text: "burst-1488", createdAt: 1_488 })).toBe(true);
     expect(cache.has({ ...directLookup, text: "burst-1999", createdAt: 1_999 })).toBe(true);
+  });
+
+  it("compacts stale insertion order records during ttl-only cleanup", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T00:00:00Z"));
+
+    const cache = createSelfChatCache();
+    for (let i = 0; i < 1_500; i += 1) {
+      cache.remember({
+        ...directLookup,
+        text: `ttl-${i}`,
+        createdAt: i,
+      });
+      vi.advanceTimersByTime(1_001);
+    }
+
+    const debug = cache as unknown as SelfChatCacheDebug;
+    expect(debug.insertionOrder.length).toBeLessThanOrEqual(debug.entryCount + 1_024);
   });
 
   it("does not collide long texts that differ only in the middle", () => {

--- a/extensions/imessage/src/monitor/self-chat-cache.ts
+++ b/extensions/imessage/src/monitor/self-chat-cache.ts
@@ -11,11 +11,13 @@ type SelfChatCacheKeyParts = {
 type SelfChatLookup = SelfChatCacheKeyParts & {
   text?: string;
   createdAt?: number;
+  allowCreatedAtSkew?: boolean;
 };
 
 type SelfChatCacheEntry = {
   id: number;
   createdAt: number;
+  createdAtSkewToleranceMs: number;
   rememberedAt: number;
 };
 
@@ -78,6 +80,7 @@ class DefaultSelfChatCache implements SelfChatCache {
     const entry = {
       id: this.nextEntryId,
       createdAt: lookup.createdAt,
+      createdAtSkewToleranceMs: lookup.allowCreatedAtSkew ? SELF_CHAT_CREATED_AT_TOLERANCE_MS : 0,
       rememberedAt: Date.now(),
     };
     this.nextEntryId += 1;
@@ -100,11 +103,13 @@ class DefaultSelfChatCache implements SelfChatCache {
     }
     const now = Date.now();
     const createdAt = lookup.createdAt;
-    return [...entries.values()].some(
-      (entry) =>
+    return [...entries.values()].some((entry) => {
+      const createdAtDelta = Math.abs(entry.createdAt - createdAt);
+      return (
         now - entry.rememberedAt <= SELF_CHAT_TTL_MS &&
-        Math.abs(entry.createdAt - createdAt) < SELF_CHAT_CREATED_AT_TOLERANCE_MS,
-    );
+        (createdAtDelta === 0 || createdAtDelta < entry.createdAtSkewToleranceMs)
+      );
+    });
   }
 
   private maybeCleanup(): void {

--- a/extensions/imessage/src/monitor/self-chat-cache.ts
+++ b/extensions/imessage/src/monitor/self-chat-cache.ts
@@ -13,12 +13,19 @@ type SelfChatLookup = SelfChatCacheKeyParts & {
   createdAt?: number;
 };
 
+type SelfChatCacheEntry = {
+  id: number;
+  createdAt: number;
+  rememberedAt: number;
+};
+
 export type SelfChatCache = {
   remember: (lookup: SelfChatLookup) => void;
   has: (lookup: SelfChatLookup) => boolean;
 };
 
 const SELF_CHAT_TTL_MS = 10_000;
+const SELF_CHAT_CREATED_AT_TOLERANCE_MS = 1_000;
 const MAX_SELF_CHAT_CACHE_ENTRIES = 512;
 const CLEANUP_MIN_INTERVAL_MS = 1_000;
 
@@ -47,34 +54,57 @@ function buildScope(parts: SelfChatCacheKeyParts): string {
 }
 
 class DefaultSelfChatCache implements SelfChatCache {
-  private cache = new Map<string, number>();
+  private cache = new Map<string, Map<number, SelfChatCacheEntry>>();
+  private insertionOrder: Array<{ key: string; id: number }> = [];
+  private insertionOrderOffset = 0;
+  private entryCount = 0;
   private lastCleanupAt = 0;
+  private nextEntryId = 1;
 
-  private buildKey(lookup: SelfChatLookup): string | null {
+  private buildBucketKey(lookup: SelfChatLookup): string | null {
     const text = normalizeText(lookup.text);
-    if (!text || !isUsableTimestamp(lookup.createdAt)) {
+    if (!text) {
       return null;
     }
-    return `${buildScope(lookup)}:${lookup.createdAt}:${digestText(text)}`;
+    return `${buildScope(lookup)}:${digestText(text)}`;
   }
 
   remember(lookup: SelfChatLookup): void {
-    const key = this.buildKey(lookup);
-    if (!key) {
+    const key = this.buildBucketKey(lookup);
+    if (!key || !isUsableTimestamp(lookup.createdAt)) {
       return;
     }
-    this.cache.set(key, Date.now());
+    const entries = this.cache.get(key) ?? new Map<number, SelfChatCacheEntry>();
+    const entry = {
+      id: this.nextEntryId,
+      createdAt: lookup.createdAt,
+      rememberedAt: Date.now(),
+    };
+    this.nextEntryId += 1;
+    entries.set(entry.id, entry);
+    this.cache.set(key, entries);
+    this.insertionOrder.push({ key, id: entry.id });
+    this.entryCount += 1;
     this.maybeCleanup();
   }
 
   has(lookup: SelfChatLookup): boolean {
     this.maybeCleanup();
-    const key = this.buildKey(lookup);
-    if (!key) {
+    const key = this.buildBucketKey(lookup);
+    if (!key || !isUsableTimestamp(lookup.createdAt)) {
       return false;
     }
-    const timestamp = this.cache.get(key);
-    return typeof timestamp === "number" && Date.now() - timestamp <= SELF_CHAT_TTL_MS;
+    const entries = this.cache.get(key);
+    if (!entries) {
+      return false;
+    }
+    const now = Date.now();
+    const createdAt = lookup.createdAt;
+    return [...entries.values()].some(
+      (entry) =>
+        now - entry.rememberedAt <= SELF_CHAT_TTL_MS &&
+        Math.abs(entry.createdAt - createdAt) < SELF_CHAT_CREATED_AT_TOLERANCE_MS,
+    );
   }
 
   private maybeCleanup(): void {
@@ -83,17 +113,41 @@ class DefaultSelfChatCache implements SelfChatCache {
       return;
     }
     this.lastCleanupAt = now;
-    for (const [key, timestamp] of this.cache.entries()) {
-      if (now - timestamp > SELF_CHAT_TTL_MS) {
+    for (const [key, entries] of this.cache.entries()) {
+      for (const [id, entry] of entries.entries()) {
+        if (now - entry.rememberedAt > SELF_CHAT_TTL_MS) {
+          entries.delete(id);
+          this.entryCount -= 1;
+        }
+      }
+      if (entries.size === 0) {
         this.cache.delete(key);
       }
     }
-    while (this.cache.size > MAX_SELF_CHAT_CACHE_ENTRIES) {
-      const oldestKey = this.cache.keys().next().value;
-      if (typeof oldestKey !== "string") {
-        break;
+    while (
+      this.entryCount > MAX_SELF_CHAT_CACHE_ENTRIES &&
+      this.insertionOrderOffset < this.insertionOrder.length
+    ) {
+      const oldest = this.insertionOrder[this.insertionOrderOffset];
+      this.insertionOrderOffset += 1;
+      const entries = this.cache.get(oldest.key);
+      if (!entries) {
+        continue;
       }
-      this.cache.delete(oldestKey);
+      if (!entries.delete(oldest.id)) {
+        continue;
+      }
+      this.entryCount -= 1;
+      if (entries.size === 0) {
+        this.cache.delete(oldest.key);
+      }
+    }
+    if (
+      this.insertionOrderOffset > 1_024 &&
+      this.insertionOrderOffset * 2 > this.insertionOrder.length
+    ) {
+      this.insertionOrder = this.insertionOrder.slice(this.insertionOrderOffset);
+      this.insertionOrderOffset = 0;
     }
   }
 }

--- a/extensions/imessage/src/monitor/self-chat-cache.ts
+++ b/extensions/imessage/src/monitor/self-chat-cache.ts
@@ -147,13 +147,20 @@ class DefaultSelfChatCache implements SelfChatCache {
         this.cache.delete(oldest.key);
       }
     }
+    this.compactInsertionOrder();
+  }
+
+  private compactInsertionOrder(): void {
     if (
-      this.insertionOrderOffset > 1_024 &&
-      this.insertionOrderOffset * 2 > this.insertionOrder.length
+      this.insertionOrderOffset <= 1_024 &&
+      this.insertionOrder.length <= this.entryCount + 1_024
     ) {
-      this.insertionOrder = this.insertionOrder.slice(this.insertionOrderOffset);
-      this.insertionOrderOffset = 0;
+      return;
     }
+    this.insertionOrder = this.insertionOrder
+      .slice(this.insertionOrderOffset)
+      .filter((entry) => this.cache.get(entry.key)?.has(entry.id));
+    this.insertionOrderOffset = 0;
   }
 }
 

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -608,6 +608,54 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     expect(second).toEqual({ kind: "drop", reason: "self-chat echo" });
   });
 
+  it("drops is_from_me=false self-chat reflection with sub-second created_at skew", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-10T05:34:00Z"));
+
+    const selfChatCache = createSelfChatCache();
+
+    const first = await resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 85160,
+          guid: "p:0/from-me-guid",
+          sender: "+16043519505",
+          chat_identifier: "+16043519505",
+          destination_caller_id: "+16043519505",
+          text: "Aha, neat!",
+          created_at: "2026-05-10T05:34:00.000Z",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "Aha, neat!",
+        bodyText: "Aha, neat!",
+        selfChatCache,
+      }),
+    );
+    expect(first.kind).toBe("dispatch");
+
+    const reflection = await resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 85161,
+          guid: "p:0/reflected-guid",
+          sender: "+16043519505",
+          chat_identifier: "+16043519505",
+          destination_caller_id: null,
+          text: "Aha, neat!",
+          created_at: "2026-05-10T05:34:00.239Z",
+          is_from_me: false,
+          is_group: false,
+        },
+        messageText: "Aha, neat!",
+        bodyText: "Aha, neat!",
+        selfChatCache,
+      }),
+    );
+
+    expect(reflection).toEqual({ kind: "drop", reason: "self-chat echo" });
+  });
+
   it("drops outbound DM when sender matches chat_identifier but destination_caller_id is absent (#63980)", async () => {
     const selfChatCache = createSelfChatCache();
 

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -619,9 +619,9 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
         message: {
           id: 85160,
           guid: "p:0/from-me-guid",
-          sender: "+16043519505",
-          chat_identifier: "+16043519505",
-          destination_caller_id: "+16043519505",
+          sender: "+15555550123",
+          chat_identifier: "+15555550123",
+          destination_caller_id: "+15555550123",
           text: "Aha, neat!",
           created_at: "2026-05-10T05:34:00.000Z",
           is_from_me: true,
@@ -639,8 +639,8 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
         message: {
           id: 85161,
           guid: "p:0/reflected-guid",
-          sender: "+16043519505",
-          chat_identifier: "+16043519505",
+          sender: "+15555550123",
+          chat_identifier: "+15555550123",
           destination_caller_id: null,
           text: "Aha, neat!",
           created_at: "2026-05-10T05:34:00.239Z",
@@ -654,6 +654,54 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     );
 
     expect(reflection).toEqual({ kind: "drop", reason: "self-chat echo" });
+  });
+
+  it("does not apply sub-second skew matching to ambiguous normal DM rows", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-10T05:34:00Z"));
+
+    const selfChatCache = createSelfChatCache();
+
+    const ambiguousOutbound = await resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 85170,
+          guid: "p:0/ambiguous-from-me-guid",
+          sender: "+15555550124",
+          chat_identifier: "+15555550124",
+          destination_caller_id: null,
+          text: "Same text",
+          created_at: "2026-05-10T05:34:00.000Z",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "Same text",
+        bodyText: "Same text",
+        selfChatCache,
+      }),
+    );
+    expect(ambiguousOutbound).toEqual({ kind: "drop", reason: "from me" });
+
+    const inboundReply = await resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 85171,
+          guid: "p:0/real-inbound-guid",
+          sender: "+15555550124",
+          chat_identifier: "+15555550124",
+          destination_caller_id: null,
+          text: "Same text",
+          created_at: "2026-05-10T05:34:00.239Z",
+          is_from_me: false,
+          is_group: false,
+        },
+        messageText: "Same text",
+        bodyText: "Same text",
+        selfChatCache,
+      }),
+    );
+
+    expect(inboundReply.kind).toBe("dispatch");
   });
 
   it("drops outbound DM when sender matches chat_identifier but destination_caller_id is absent (#63980)", async () => {


### PR DESCRIPTION
## Summary
- Tolerate sub-second `created_at` skew when matching reflected iMessage self-chat rows.
- Keep the match scoped to same account/chat/sender plus same normalized text.
- Preserve the existing 10s cache TTL and avoid dropping deliberate repeated same-text messages at 1s+ apart.
- Keep cache cleanup bounded after bursty inserts by tracking entry count and evicting via insertion order instead of repeatedly rescanning all buckets.

## Context
This extends the self-chat echo handling discussed in #41330. That issue was closed as implemented for exact-timestamp and missing-`destination_caller_id` reflected rows, but Apple can also write the paired self-DM rows with different GUIDs and `created_at` skew of a few hundred ms. In that shape, the current exact timestamp cache key misses and the reflected `is_from_me=false` row can be dispatched as inbound.

## Real behavior proof

- Behavior or issue addressed: iMessage self-chat reflection rows with the same normalized text and same self-chat scope can miss echo suppression when Apple writes the reflected row with sub-second `created_at` skew.
- Real environment tested: local OpenClaw checkout on macOS from this PR branch, using the real `extensions/imessage/src/monitor/self-chat-cache.ts` implementation. Phone number and message text are redacted/minimized.
- Exact steps or command run after this patch: replayed the observed row timing shape through the actual self-chat cache with `pnpm tsx -e` after applying this patch.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
reflected row +239ms: drop as self-chat echo
repeated same text +1000ms: dispatch
```

- Observed result after fix: the reflected row with 239 ms skew is treated as a self-chat echo, while the same text at a 1000 ms delta is not matched and remains dispatchable.
- What was not tested: I did not rebuild and restart a live gateway for this PR; the local production gateway still requires explicit operator approval before restart.
- Proof limitations or environment constraints: this proof exercises the real OpenClaw self-chat cache logic in a local checkout rather than a full end-to-end Messages.app watcher run. The PR also includes focused regression coverage for the inbound decision path.
- Before evidence (optional but encouraged): current upstream/main keys `SelfChatCache` by exact `createdAt`, so the same +239 ms reflected row misses the cache bucket before this change.

## Verification
- `pnpm test -- extensions/imessage/src/monitor/self-chat-cache.test.ts extensions/imessage/src/monitor/self-chat-dedupe.test.ts extensions/imessage/src/monitor/inbound-processing.test.ts`
  - 3 files passed, 69 tests passed
- `pnpm oxlint extensions/imessage/src/monitor/self-chat-cache.ts extensions/imessage/src/monitor/self-chat-cache.test.ts extensions/imessage/src/monitor/self-chat-dedupe.test.ts`
- `git diff --check -- extensions/imessage/src/monitor/self-chat-cache.ts extensions/imessage/src/monitor/self-chat-cache.test.ts`
