### PR TITLE
fix(auto-reply): redact secrets in config show output

### DIFF
--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -9,6 +9,7 @@ import {
   setConfigOverride,
   unsetConfigOverride,
 } from "../../config/runtime-overrides.js";
+import { maskApiKey } from "../../utils/mask-api-key.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { resolveChannelAccountId } from "./channel-context.js";
 import {
@@ -26,6 +27,77 @@ import {
 } from "./config-mutations.js";
 import { resolveConfigWriteDeniedText } from "./config-write-authorization.js";
 import { parseDebugCommand } from "./debug-commands.js";
+
+const SECRET_CONFIG_SHOW_KEYS = new Set([
+  "apikey",
+  "key",
+  "token",
+  "password",
+  "secret",
+  "clientsecret",
+  "bottoken",
+  "webhooksecret",
+  "credential",
+  "credentials",
+  "privatekey",
+]);
+
+const SECRET_REF_VISIBLE_KEYS = new Set(["source", "provider", "id"]);
+
+function normalizeConfigShowKey(key: string): string {
+  return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function isSecretShapedConfigShowKey(key: string | undefined): boolean {
+  if (!key) {
+    return false;
+  }
+  const normalized = normalizeConfigShowKey(key);
+  return (
+    SECRET_CONFIG_SHOW_KEYS.has(normalized) ||
+    normalized.endsWith("apikey") ||
+    normalized.endsWith("token") ||
+    normalized.includes("password") ||
+    normalized.endsWith("secret") ||
+    normalized.endsWith("privatekey") ||
+    normalized.endsWith("credential") ||
+    normalized.endsWith("credentials")
+  );
+}
+
+function isSecretRefDisplayObject(
+  value: Record<string, unknown>,
+): value is Record<string, unknown> & { source: string; id: string } {
+  return typeof value.source === "string" && typeof value.id === "string";
+}
+
+function redactConfigShowValue(
+  value: unknown,
+  path: readonly string[] = [],
+  parentKeyIsSecret = false,
+): unknown {
+  const keyIsSecret = parentKeyIsSecret || isSecretShapedConfigShowKey(path[path.length - 1]);
+  if (typeof value === "string") {
+    return keyIsSecret ? maskApiKey(value) : value;
+  }
+  if (value === null || value === undefined || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactConfigShowValue(item, path, keyIsSecret));
+  }
+  const record = value as Record<string, unknown>;
+  const isSecretRef = isSecretRefDisplayObject(record);
+  const result: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(record)) {
+    if (isSecretRef && SECRET_REF_VISIBLE_KEYS.has(key)) {
+      result[key] = child;
+      continue;
+    }
+    result[key] = redactConfigShowValue(child, [...path, key], keyIsSecret);
+  }
+  return result;
+}
 
 export const handleConfigCommand: CommandHandler = async (params, allowTextCommands) => {
   if (!allowTextCommands) {
@@ -122,7 +194,8 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
         };
       }
       const value = getConfigValueAtPath(parsedBase, parsedPath.path);
-      const rendered = JSON.stringify(value ?? null, null, 2);
+      const displayValue = redactConfigShowValue(value ?? null, parsedPath.path);
+      const rendered = JSON.stringify(displayValue, null, 2);
       return {
         shouldContinue: false,
         reply: {
@@ -130,7 +203,7 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
         },
       };
     }
-    const json = JSON.stringify(parsedBase, null, 2);
+    const json = JSON.stringify(redactConfigShowValue(parsedBase), null, 2);
     return {
       shouldContinue: false,
       reply: { text: `⚙️ Config (raw):\n\`\`\`json\n${json}\n\`\`\`` },

--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -3,13 +3,14 @@ import { resolveConfigWriteTargetFromPath } from "../../channels/plugins/config-
 import { normalizeChannelId } from "../../channels/registry.js";
 import { getConfigValueAtPath, parseConfigPath } from "../../config/config-paths.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
+import { redactConfigSnapshot } from "../../config/redact-snapshot.js";
 import {
   getConfigOverrides,
   resetConfigOverrides,
   setConfigOverride,
   unsetConfigOverride,
 } from "../../config/runtime-overrides.js";
-import { maskApiKey } from "../../utils/mask-api-key.js";
+import { loadGatewayRuntimeConfigSchema } from "../../config/runtime-schema.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { resolveChannelAccountId } from "./channel-context.js";
 import {
@@ -27,77 +28,6 @@ import {
 } from "./config-mutations.js";
 import { resolveConfigWriteDeniedText } from "./config-write-authorization.js";
 import { parseDebugCommand } from "./debug-commands.js";
-
-const SECRET_CONFIG_SHOW_KEYS = new Set([
-  "apikey",
-  "key",
-  "token",
-  "password",
-  "secret",
-  "clientsecret",
-  "bottoken",
-  "webhooksecret",
-  "credential",
-  "credentials",
-  "privatekey",
-]);
-
-const SECRET_REF_VISIBLE_KEYS = new Set(["source", "provider", "id"]);
-
-function normalizeConfigShowKey(key: string): string {
-  return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
-}
-
-function isSecretShapedConfigShowKey(key: string | undefined): boolean {
-  if (!key) {
-    return false;
-  }
-  const normalized = normalizeConfigShowKey(key);
-  return (
-    SECRET_CONFIG_SHOW_KEYS.has(normalized) ||
-    normalized.endsWith("apikey") ||
-    normalized.endsWith("token") ||
-    normalized.includes("password") ||
-    normalized.endsWith("secret") ||
-    normalized.endsWith("privatekey") ||
-    normalized.endsWith("credential") ||
-    normalized.endsWith("credentials")
-  );
-}
-
-function isSecretRefDisplayObject(
-  value: Record<string, unknown>,
-): value is Record<string, unknown> & { source: string; id: string } {
-  return typeof value.source === "string" && typeof value.id === "string";
-}
-
-function redactConfigShowValue(
-  value: unknown,
-  path: readonly string[] = [],
-  parentKeyIsSecret = false,
-): unknown {
-  const keyIsSecret = parentKeyIsSecret || isSecretShapedConfigShowKey(path[path.length - 1]);
-  if (typeof value === "string") {
-    return keyIsSecret ? maskApiKey(value) : value;
-  }
-  if (value === null || value === undefined || typeof value !== "object") {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => redactConfigShowValue(item, path, keyIsSecret));
-  }
-  const record = value as Record<string, unknown>;
-  const isSecretRef = isSecretRefDisplayObject(record);
-  const result: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(record)) {
-    if (isSecretRef && SECRET_REF_VISIBLE_KEYS.has(key)) {
-      result[key] = child;
-      continue;
-    }
-    result[key] = redactConfigShowValue(child, [...path, key], keyIsSecret);
-  }
-  return result;
-}
 
 export const handleConfigCommand: CommandHandler = async (params, allowTextCommands) => {
   if (!allowTextCommands) {
@@ -181,7 +111,9 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
       },
     };
   }
-  const parsedBase = structuredClone(snapshot.parsed as Record<string, unknown>);
+  const schema = loadGatewayRuntimeConfigSchema();
+  const redactedSnapshot = redactConfigSnapshot(snapshot, schema.uiHints);
+  const parsedBase = structuredClone(redactedSnapshot.parsed as Record<string, unknown>);
 
   if (configCommand.action === "show") {
     const pathRaw = normalizeOptionalString(configCommand.path);
@@ -194,8 +126,7 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
         };
       }
       const value = getConfigValueAtPath(parsedBase, parsedPath.path);
-      const displayValue = redactConfigShowValue(value ?? null, parsedPath.path);
-      const rendered = JSON.stringify(displayValue, null, 2);
+      const rendered = JSON.stringify(value ?? null, null, 2);
       return {
         shouldContinue: false,
         reply: {
@@ -203,7 +134,7 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
         },
       };
     }
-    const json = JSON.stringify(redactConfigShowValue(parsedBase), null, 2);
+    const json = JSON.stringify(parsedBase, null, 2);
     return {
       shouldContinue: false,
       reply: { text: `⚙️ Config (raw):\n\`\`\`json\n${json}\n\`\`\`` },

--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -1,9 +1,13 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveConfigWriteTargetFromPath } from "../../channels/plugins/config-writes.js";
 import { normalizeChannelId } from "../../channels/registry.js";
-import { getConfigValueAtPath, parseConfigPath } from "../../config/config-paths.js";
+import {
+  getConfigValueAtPath,
+  parseConfigPath,
+  setConfigValueAtPath,
+} from "../../config/config-paths.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
-import { redactConfigSnapshot } from "../../config/redact-snapshot.js";
+import { redactConfigObject, redactConfigSnapshot } from "../../config/redact-snapshot.js";
 import {
   getConfigOverrides,
   resetConfigOverrides,
@@ -28,6 +32,20 @@ import {
 } from "./config-mutations.js";
 import { resolveConfigWriteDeniedText } from "./config-write-authorization.js";
 import { parseDebugCommand } from "./debug-commands.js";
+
+function formatConfigSetValueLabel(params: {
+  path: string[];
+  value: unknown;
+  uiHints: ReturnType<typeof loadGatewayRuntimeConfigSchema>["uiHints"];
+}): string {
+  const previewRoot: Record<string, unknown> = {};
+  setConfigValueAtPath(previewRoot, params.path, params.value);
+  const redactedRoot = redactConfigObject(previewRoot, params.uiHints);
+  const redactedValue = getConfigValueAtPath(redactedRoot, params.path);
+  return typeof redactedValue === "string"
+    ? `"${redactedValue}"`
+    : (JSON.stringify(redactedValue) ?? "null");
+}
 
 export const handleConfigCommand: CommandHandler = async (params, allowTextCommands) => {
   if (!allowTextCommands) {
@@ -175,10 +193,11 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
       }
       throw error;
     }
-    const valueLabel =
-      typeof configCommand.value === "string"
-        ? `"${configCommand.value}"`
-        : JSON.stringify(configCommand.value);
+    const valueLabel = formatConfigSetValueLabel({
+      path,
+      value: configCommand.value,
+      uiHints: schema.uiHints,
+    });
     return {
       shouldContinue: false,
       reply: {

--- a/src/auto-reply/reply/commands-gating.test.ts
+++ b/src/auto-reply/reply/commands-gating.test.ts
@@ -504,6 +504,28 @@ describe("command gating", () => {
     expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_CDP_API_KEY_65623");
   });
 
+  it("redacts secret-shaped values from /config set acknowledgements", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      valid: true,
+      parsed: { gateway: { auth: { mode: "token" } } },
+    });
+    const params = buildParams(
+      '/config set gateway.auth.token="OPENCLAW_CONFIG_SET_CANARY_TOKEN_65623"',
+      {
+        commands: { config: true, text: true },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig,
+    );
+    params.command.senderIsOwner = true;
+
+    const result = await handleConfigCommand(params, true);
+    const output = result?.reply?.text ?? "";
+
+    expect(output).toContain("Config updated: gateway.auth.token=");
+    expect(output).toContain(REDACTED_SENTINEL);
+    expect(output).not.toContain("OPENCLAW_CONFIG_SET_CANARY_TOKEN_65623");
+  });
+
   it("returns explicit unauthorized replies for native privileged commands", async () => {
     const configParams = buildParams("/config show", {
       commands: { config: true, text: true },

--- a/src/auto-reply/reply/commands-gating.test.ts
+++ b/src/auto-reply/reply/commands-gating.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { isCommandFlagEnabled } from "../../config/commands.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { REDACTED_SENTINEL } from "../../config/redact-snapshot.js";
 import type { MsgContext } from "../templating.js";
 import { handleBashChatCommand } from "./bash-command.js";
 import { requireGatewayClientScope } from "./command-gates.js";
@@ -128,6 +129,14 @@ vi.mock("../../config/runtime-overrides.js", () => ({
   setConfigOverride: vi.fn(() => ({ ok: true })),
   unsetConfigOverride: vi.fn(() => ({ ok: true, removed: true })),
 }));
+
+vi.mock("../../config/runtime-schema.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../config/schema.js")>("../../config/schema.js");
+  return {
+    loadGatewayRuntimeConfigSchema: () => actual.buildConfigSchema(),
+  };
+});
 
 vi.mock("../../utils/message-channel.js", () => ({
   isInternalMessageChannel: isInternalMessageChannelMock,
@@ -367,11 +376,35 @@ describe("command gating", () => {
           bind: "127.0.0.1",
           port: 3210,
         },
-        providers: {
-          openai: {
-            apiKey: "OPENCLAW_CONFIG_SHOW_CANARY_API_KEY_65623",
-            baseUrl: "https://api.example.test",
-            model: "gpt-test",
+        models: {
+          providers: {
+            openai: {
+              apiKey: "OPENCLAW_CONFIG_SHOW_CANARY_API_KEY_65623",
+              baseUrl: "https://api.example.test",
+              models: [{ id: "gpt-test", name: "gpt-test" }],
+            },
+          },
+        },
+        browser: {
+          cdpUrl:
+            "wss://chrome.example.test/devtools?token=OPENCLAW_CONFIG_SHOW_CANARY_CDP_TOKEN_65623&apiKey=OPENCLAW_CONFIG_SHOW_CANARY_CDP_API_KEY_65623",
+          profiles: {
+            local: {
+              cdpUrl: "ws://localhost:9222",
+            },
+            remote: {
+              cdpUrl:
+                "wss://chrome.remote.example.test/devtools?apiKey=OPENCLAW_CONFIG_SHOW_CANARY_CDP_PROFILE_API_KEY_65623",
+            },
+          },
+        },
+        talk: {
+          providers: {
+            openai: {
+              apiKey: "OPENCLAW_CONFIG_SHOW_CANARY_API_KEY_65623",
+              baseUrl: "https://api.example.test",
+              model: "gpt-test",
+            },
           },
         },
         channels: {
@@ -402,19 +435,22 @@ describe("command gating", () => {
     expect(output).toContain("token");
     expect(output).toContain("password");
     expect(output).toContain("apiKey");
-    expect(output).toContain("OPENCLAW...EN_65623");
-    expect(output).toContain("OPENCLAW...RD_65623");
-    expect(output).toContain("OPENCLAW...EY_65623");
-    expect(output).toContain("SLACK_BOT_TOKEN");
+    expect(output).toContain("browser");
+    expect(output).toContain("cdpUrl");
+    expect(output).toContain(REDACTED_SENTINEL);
     expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_TOKEN_65623");
     expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_PASSWORD_65623");
     expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_API_KEY_65623");
+    expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_CDP_TOKEN_65623");
+    expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_CDP_API_KEY_65623");
+    expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_CDP_PROFILE_API_KEY_65623");
     expect(output).toContain('"mode": "token"');
     expect(output).toContain('"bind": "127.0.0.1"');
     expect(output).toContain('"port": 3210');
     expect(output).toContain('"enabled": true');
     expect(output).toContain('"model": "gpt-test"');
     expect(output).toContain('"baseUrl": "https://api.example.test"');
+    expect(output).toContain('"cdpUrl": "ws://localhost:9222"');
   });
 
   it("redacts secret-shaped values from path-specific /config show replies", async () => {
@@ -439,8 +475,33 @@ describe("command gating", () => {
     const output = result?.reply?.text ?? "";
 
     expect(output).toContain("Config gateway.auth.token");
-    expect(output).toContain("OPENCLAW...EN_65623");
+    expect(output).toContain(REDACTED_SENTINEL);
     expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_TOKEN_65623");
+  });
+
+  it("redacts browser cdpUrl query secrets from path-specific /config show replies", async () => {
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: {
+        browser: {
+          cdpUrl:
+            "wss://chrome.example.test/devtools?token=OPENCLAW_CONFIG_SHOW_CANARY_CDP_TOKEN_65623&apiKey=OPENCLAW_CONFIG_SHOW_CANARY_CDP_API_KEY_65623",
+        },
+      },
+    });
+    const params = buildParams("/config show browser.cdpUrl", {
+      commands: { config: true, text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.command.senderIsOwner = true;
+
+    const result = await handleConfigCommand(params, true);
+    const output = result?.reply?.text ?? "";
+
+    expect(output).toContain("Config browser.cdpUrl");
+    expect(output).toContain(REDACTED_SENTINEL);
+    expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_CDP_TOKEN_65623");
+    expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_CDP_API_KEY_65623");
   });
 
   it("returns explicit unauthorized replies for native privileged commands", async () => {

--- a/src/auto-reply/reply/commands-gating.test.ts
+++ b/src/auto-reply/reply/commands-gating.test.ts
@@ -354,6 +354,95 @@ describe("command gating", () => {
     expect(debugResult?.reply?.text).toContain("Debug overrides");
   });
 
+  it("redacts secret-shaped fields from full /config show replies", async () => {
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: {
+        gateway: {
+          auth: {
+            mode: "token",
+            token: "OPENCLAW_CONFIG_SHOW_CANARY_TOKEN_65623",
+            password: "OPENCLAW_CONFIG_SHOW_CANARY_PASSWORD_65623",
+          },
+          bind: "127.0.0.1",
+          port: 3210,
+        },
+        providers: {
+          openai: {
+            apiKey: "OPENCLAW_CONFIG_SHOW_CANARY_API_KEY_65623",
+            baseUrl: "https://api.example.test",
+            model: "gpt-test",
+          },
+        },
+        channels: {
+          telegram: {
+            botToken: "1234567890TELEGRAM_BOT_TOKEN",
+            enabled: true,
+          },
+          slack: {
+            token: {
+              source: "env",
+              provider: "default",
+              id: "SLACK_BOT_TOKEN",
+            },
+          },
+        },
+      },
+    });
+    const params = buildParams("/config show", {
+      commands: { config: true, text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.command.senderIsOwner = true;
+
+    const result = await handleConfigCommand(params, true);
+    const output = result?.reply?.text ?? "";
+
+    expect(output).toContain("gateway");
+    expect(output).toContain("token");
+    expect(output).toContain("password");
+    expect(output).toContain("apiKey");
+    expect(output).toContain("OPENCLAW...EN_65623");
+    expect(output).toContain("OPENCLAW...RD_65623");
+    expect(output).toContain("OPENCLAW...EY_65623");
+    expect(output).toContain("SLACK_BOT_TOKEN");
+    expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_TOKEN_65623");
+    expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_PASSWORD_65623");
+    expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_API_KEY_65623");
+    expect(output).toContain('"mode": "token"');
+    expect(output).toContain('"bind": "127.0.0.1"');
+    expect(output).toContain('"port": 3210');
+    expect(output).toContain('"enabled": true');
+    expect(output).toContain('"model": "gpt-test"');
+    expect(output).toContain('"baseUrl": "https://api.example.test"');
+  });
+
+  it("redacts secret-shaped values from path-specific /config show replies", async () => {
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: {
+        gateway: {
+          auth: {
+            mode: "token",
+            token: "OPENCLAW_CONFIG_SHOW_CANARY_TOKEN_65623",
+          },
+        },
+      },
+    });
+    const params = buildParams("/config show gateway.auth.token", {
+      commands: { config: true, text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.command.senderIsOwner = true;
+
+    const result = await handleConfigCommand(params, true);
+    const output = result?.reply?.text ?? "";
+
+    expect(output).toContain("Config gateway.auth.token");
+    expect(output).toContain("OPENCLAW...EN_65623");
+    expect(output).not.toContain("OPENCLAW_CONFIG_SHOW_CANARY_TOKEN_65623");
+  });
+
   it("returns explicit unauthorized replies for native privileged commands", async () => {
     const configParams = buildParams("/config show", {
       commands: { config: true, text: true },


### PR DESCRIPTION
## Summary
- Redact `/config show` chat output through the shared schema-aware config redaction path.
- Apply the same redacted snapshot to both full-config and path-specific `/config show` rendering.
- Add regression coverage for fake token/password/apiKey canaries and `browser.cdpUrl` URLs carrying token/apiKey query secrets.

## Review update
Addressed ClawSweeper feedback by replacing the local key-name-only redactor with `redactConfigSnapshot(snapshot, loadGatewayRuntimeConfigSchema().uiHints)`, matching the gateway config redaction contract.

## Behavior addressed
`/config show` previously rendered plaintext secret values from config into chat-visible command output.

## Before fix
A focused local regression test seeded config with fake canaries:

- `OPENCLAW_CONFIG_SHOW_CANARY_TOKEN_65623`
- `OPENCLAW_CONFIG_SHOW_CANARY_PASSWORD_65623`
- `OPENCLAW_CONFIG_SHOW_CANARY_API_KEY_65623`
- `OPENCLAW_CONFIG_SHOW_CANARY_CDP_TOKEN_65623`
- `OPENCLAW_CONFIG_SHOW_CANARY_CDP_API_KEY_65623`

The unpatched command-output path included raw canary values in rendered `/config show` responses.

## After fix
The command redacts the parsed config snapshot with the shared schema-aware redaction contract before rendering chat-visible text. Full `/config show` and `/config show <path>` now both see the redacted snapshot.

## Real behavior proof
- **Behavior addressed**: `/config show` should not return plaintext config secrets, including sensitive URL query credentials, in chat-visible command output.
- **Real environment tested**: Local OpenClaw checkout at HEAD `b06ad3c59c1291153e49dc7b0e23667dcf7c6f15`, Node `v24.15.0`, temp config file supplied through `OPENCLAW_CONFIG_PATH` and read by the real `readConfigFileSnapshot()` path.
- **Exact steps or command run after fix**: Seeded `/tmp/openclaw-pr65623-live-*/openclaw.json` with fake canary values under `gateway.auth.token`, `gateway.auth.password`, `models.providers.openai.apiKey`, and `browser.cdpUrl` query parameters, then ran `OPENCLAW_CONFIG_PATH="$config" node --import tsx -` to invoke the real `/config show` command handler with an owner text-command context.
- **Evidence after fix**: Terminal output from the local OpenClaw command-runtime smoke:

````text
--- /config show ---
⚙️ Config (raw):
```json
{
  "gateway": {
    "auth": {
      "mode": "token",
      "token": "__OPENCLAW_REDACTED__",
      "password": "__OPENCLAW_REDACTED__"
    },
    "bind": "loopback",
    "port": 3210
  },
  "models": {
    "providers": {
      "openai": {
        "apiKey": "__OPENCLAW_REDACTED__",
        "baseUrl": "https://api.example.test"
      }
    }
  },
  "browser": {
    "cdpUrl": "__OPENCLAW_REDACTED__"
  }
}
```
raw token present: false
raw password present: false
raw api key present: false
raw cdp token present: false
raw cdp api key present: false
--- /config show browser.cdpUrl ---
⚙️ Config browser.cdpUrl:
```json
"__OPENCLAW_REDACTED__"
```
raw cdp token present: false
raw cdp api key present: false
````

- **Observed result after fix**: Full `/config show` and `/config show browser.cdpUrl` both returned chat-formatted config text with the seeded secret values replaced by `__OPENCLAW_REDACTED__`; no raw canary strings appeared.
- **What was not tested**: No external WhatsApp/Slack/Discord delivery was sent; this proof exercises the real OpenClaw config-read and command-rendering path locally before transport delivery.

## Validation
HEAD: `b06ad3c59c1291153e49dc7b0e23667dcf7c6f15`

- `pnpm test src/auto-reply/reply/commands-gating.test.ts` pass: 1 file, 18 tests
- `pnpm test src/auto-reply/reply/commands-parse.test.ts src/auto-reply/reply/commands-slash-parse.test.ts src/auto-reply/command-control.test.ts` pass: 3 files, 58 tests across 2 shards
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/commands-config.ts src/auto-reply/reply/commands-gating.test.ts` pass
- `git diff --check` pass

Proof log: `/tmp/openclaw-pr65623-proof.log`
Validation log: `/tmp/openclaw-pr65623-validation.log`

## Reviewer note
This patch intentionally redacts only the user-visible `/config show` command output. It does not alter config storage, config loading, `SecretRef` resolution, or internal diagnostic state.

Fixes #65623
