### PR TITLE
fix(gateway): load auto-enabled channel plugins at startup

### DIFF
--- a/src/channels/config-presence.test.ts
+++ b/src/channels/config-presence.test.ts
@@ -74,6 +74,19 @@ describe("config presence", () => {
     });
   });
 
+  it("treats enabled-only channel config as an explicit presence signal", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const cfg = { channels: { matrix: { enabled: true } } };
+
+    expectPotentialConfiguredChannelCase({
+      cfg,
+      env,
+      expectedIds: ["matrix"],
+      expectedConfigured: true,
+      options: { includePersistedAuthState: false },
+    });
+  });
+
   it("lists explicitly disabled channel ids case-insensitively", () => {
     const cfg = {
       channels: {

--- a/src/channels/config-presence.ts
+++ b/src/channels/config-presence.ts
@@ -43,6 +43,10 @@ export function hasMeaningfulChannelConfig(value: unknown): boolean {
   return Object.keys(value).some((key) => key !== "enabled");
 }
 
+function hasExplicitChannelPresenceConfig(value: unknown): boolean {
+  return isRecord(value) && (value.enabled === true || hasMeaningfulChannelConfig(value));
+}
+
 export function listExplicitlyDisabledChannelIdsForConfig(cfg: OpenClawConfig): string[] {
   const channels = isRecord(cfg.channels) ? cfg.channels : null;
   if (!channels) {
@@ -138,7 +142,7 @@ export function listPotentialConfiguredChannelPresenceSignals(
       if (IGNORED_CHANNEL_CONFIG_KEYS.has(key)) {
         continue;
       }
-      if (hasMeaningfulChannelConfig(value)) {
+      if (hasExplicitChannelPresenceConfig(value)) {
         configuredChannelIds.add(key);
         addSignal(key, "config");
       }
@@ -203,7 +207,7 @@ export function hasPotentialConfiguredChannels(
       if (IGNORED_CHANNEL_CONFIG_KEYS.has(key)) {
         continue;
       }
-      if (hasMeaningfulChannelConfig(value)) {
+      if (hasExplicitChannelPresenceConfig(value)) {
         return true;
       }
     }

--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -181,6 +181,32 @@ describe("applyPluginAutoEnable channels", () => {
       expect(result.changes.join("\n")).toContain("apn configured, enabled automatically.");
     });
 
+    it("auto-enables a third-party channel plugin from enabled-only channel config", () => {
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: {
+            "openclaw-weixin": { enabled: true },
+          },
+        },
+        env: makeIsolatedEnv(),
+        manifestRegistry: makeRegistry([
+          {
+            id: "openclaw-weixin",
+            channels: ["openclaw-weixin"],
+            channelConfigs: {
+              "openclaw-weixin": {
+                schema: { type: "object" },
+                label: "Weixin",
+              },
+            },
+          },
+        ]),
+      });
+
+      expect(result.config.plugins?.entries?.["openclaw-weixin"]?.enabled).toBe(true);
+      expect(result.changes.join("\n")).toContain("Weixin configured, enabled automatically.");
+    });
+
     it("does not double-enable when plugin is already enabled under its plugin id", () => {
       const result = applyWithApnChannelConfig({
         plugins: { entries: { "apn-channel": { enabled: true } } },

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -1428,6 +1428,38 @@ describe("resolveGatewayStartupPluginIds", () => {
     ).toEqual(["workspace-demo-channel-plugin"]);
   });
 
+  it("includes auto-enabled deferred channel owners in full startup scope", () => {
+    const registry = createManifestRegistryFixtureWithWorkspaceDemoChannel();
+    const rawConfig = {
+      channels: {
+        "demo-channel": {
+          enabled: true,
+        },
+      },
+    } as OpenClawConfig;
+    const effectiveConfig = {
+      ...rawConfig,
+      plugins: {
+        entries: {
+          "workspace-demo-channel-plugin": {
+            enabled: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const plan = resolveGatewayStartupPluginPlanFromRegistry({
+      config: effectiveConfig,
+      activationSourceConfig: rawConfig,
+      env: createPluginPlanningTestEnv(),
+      index: createInstalledPluginIndexFixture(registry),
+      manifestRegistry: registry,
+    });
+
+    expect(plan.configuredDeferredChannelPluginIds).toEqual(["workspace-demo-channel-plugin"]);
+    expect(plan.pluginIds).toContain("workspace-demo-channel-plugin");
+  });
+
   it("preserves explicit bundled channel config under restrictive allowlists", () => {
     expectStartupPluginIdsCase({
       config: {

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -1040,16 +1040,17 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
     plugins: activationSourcePlugins,
     rootConfig: activationSourceConfig,
   };
+  const configuredChannelActivationSource = {
+    plugins: pluginsConfig,
+    rootConfig: params.config,
+  };
   const manifestLookup = createManifestRegistryLookup(params.manifestRegistry);
   const configuredDeferredChannelPluginIds = resolveConfiguredDeferredChannelPluginIdsFromPrepared({
     config: params.config,
     index: params.index,
     configuredChannelIds,
     pluginsConfig,
-    activationSource: {
-      plugins: pluginsConfig,
-      rootConfig: params.config,
-    },
+    activationSource: configuredChannelActivationSource,
     manifestLookup,
     platform: params.platform,
   });
@@ -1094,7 +1095,7 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
           plugin,
           config: params.config,
           pluginsConfig,
-          activationSource,
+          activationSource: configuredChannelActivationSource,
           manifestLookup,
           platform: params.platform,
         });


### PR DESCRIPTION
Summary
- Treat channels.<id>.enabled=true as explicit channel presence for startup discovery.
- Keep deferred configured channel plugins in the post-bind full runtime startup scope after auto-enable.
- Add regressions for enabled-only external channel config and deferred startup planning.

Fixes #86314

Verification
- node scripts/run-vitest.mjs src/channels/config-presence.test.ts src/config/plugin-auto-enable.channels.test.ts src/plugins/channel-plugin-ids.test.ts
- node scripts/run-vitest.mjs src/channels/config-presence.test.ts src/config/plugin-auto-enable.channels.test.ts src/plugins/channel-plugin-ids.test.ts -t "enabled-only channel config|third-party channel plugins|auto-enabled deferred"
- node scripts/run-oxlint.mjs src/channels/config-presence.ts src/channels/config-presence.test.ts src/config/plugin-auto-enable.channels.test.ts src/plugins/gateway-startup-plugin-ids.ts src/plugins/channel-plugin-ids.test.ts
- git diff --check
- .agents/skills/autoreview/scripts/autoreview --mode local
- Crabbox AWS run run_370b3f29b7c0: pnpm check:changed, exit 0, lease cbx_ebd827974ecb stopped

Behavior addressed
Gateway startup now treats an installed external channel plugin configured only by channels.openclaw-weixin.enabled=true as startup intent, and keeps the auto-enabled plugin in the full post-bind runtime load.

Real environment tested
Crabbox AWS Linux changed-gate runner for the rebased commit; native Windows and WSL2 Crabbox preflights were attempted separately.

Exact steps or command run after this patch
pnpm check:changed through Crabbox AWS run run_370b3f29b7c0, plus focused Vitest and oxlint commands listed above.

Evidence after fix
A direct startup-planner probe on the patched tree auto-enabled openclaw-weixin and produced configuredDeferredChannelPluginIds=[openclaw-weixin] and pluginIds=[openclaw-weixin].

Observed result after fix
The gateway startup plan includes the auto-enabled external channel plugin in the full runtime load path instead of leaving the channel registry setup-only or empty.

What was not tested
Native Windows project execution did not run because AWS Windows raw workspace lacked node and pnpm before project code. WSL2 project execution did not run because AWS WSL2 Actions hydration exited before writing its marker.
