### PR TITLE
fix: release abandoned provider streams

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -110,6 +110,22 @@ function buildRawSseResponse(sse: string): Response {
   });
 }
 
+function buildOpenRawSseResponse(params: { sse: string; onCancel: () => void }): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(params.sse));
+    },
+    cancel() {
+      params.onCancel();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
 function buildDelayedSecondSseResponse(params: {
   first: unknown;
   second: unknown;
@@ -581,6 +597,37 @@ describe("google transport stream", () => {
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("Google SSE stream returned malformed JSON");
+  });
+
+  it("cancels open Gemini SSE bodies when parsing fails", async () => {
+    let cancelCalled = false;
+    guardedFetchMock.mockResolvedValueOnce(
+      buildOpenRawSseResponse({
+        sse: "data: {not json\n\n",
+        onCancel: () => {
+          cancelCalled = true;
+        },
+      }),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as unknown as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gemini-api-key",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("Google SSE stream returned malformed JSON");
+    expect(cancelCalled).toBe(true);
   });
 
   it("retries Gemini 3 requests with lean thinking when the first attempt has no first response", async () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -1098,6 +1098,7 @@ async function* parseGoogleSseChunks(
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let completed = false;
   const abortHandler = () => {
     void reader.cancel().catch(() => undefined);
   };
@@ -1109,6 +1110,7 @@ async function* parseGoogleSseChunks(
       }
       const { done, value } = await reader.read();
       if (done) {
+        completed = true;
         break;
       }
       buffer += decoder.decode(value, { stream: true }).replace(/\r/g, "");
@@ -1134,6 +1136,10 @@ async function* parseGoogleSseChunks(
     }
   } finally {
     signal?.removeEventListener("abort", abortHandler);
+    if (!completed) {
+      await reader.cancel(signal?.reason).catch(() => undefined);
+    }
+    reader.releaseLock();
   }
 }
 

--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -48,6 +48,7 @@ export const KNIP_OPTIONAL_UNUSED_FILE_ALLOWLIST = [
   "src/plugins/contracts/tts-contract-suites.ts",
   "src/plugins/runtime-sidecar-paths-baseline.ts",
   "src/tasks/task-registry-control.runtime.ts",
+  "ui/src/ui/browser-redact.ts",
   "extensions/qa-lab/src/auth-profile.fixture.ts",
   "extensions/qa-lab/src/codex-plugin.fixture.ts",
 ];

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -55,6 +55,25 @@ function createRawSseResponse(body: string): Response {
   });
 }
 
+function createOpenRawSseResponse(params: {
+  body: string;
+  onCancel: (reason: unknown) => void;
+}): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(params.body));
+    },
+    cancel(reason) {
+      params.onCancel(reason);
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
 function delay<T>(ms: number, value: T): Promise<T> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(value), ms);
@@ -1859,6 +1878,28 @@ describe("anthropic transport stream", () => {
     expect(result.stopReason).toBe("aborted");
     expect(result.errorMessage).toBe("pre-aborted stream");
     expect(cancelReason).toBe(abortReason);
+  });
+
+  it("cancels open SSE bodies when Anthropic stream consumers throw", async () => {
+    let cancelCalled = false;
+    guardedFetchMock.mockResolvedValueOnce(
+      createOpenRawSseResponse({
+        body: 'data: {"type":"error","error":{"message":"stream exploded"}}\n\n',
+        onCancel: () => {
+          cancelCalled = true;
+        },
+      }),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("stream exploded");
+    expect(cancelCalled).toBe(true);
   });
 
   it("maps adaptive thinking effort for Claude 4.6 transport runs", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -617,10 +617,12 @@ async function* parseAnthropicSseBody(
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let completed = false;
   try {
     while (true) {
       const { done, value } = await readAnthropicSseChunk(reader, signal);
       if (done) {
+        completed = true;
         break;
       }
       buffer = `${buffer}${decoder.decode(value, { stream: true })}`.replaceAll("\r\n", "\n");
@@ -651,6 +653,9 @@ async function* parseAnthropicSseBody(
       }
     }
   } finally {
+    if (!completed) {
+      await reader.cancel(signal?.reason).catch(() => undefined);
+    }
     reader.releaseLock();
   }
 }

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -144,7 +144,8 @@ describe("exec PATH login shell merge", () => {
   });
 
   beforeEach(() => {
-    envSnapshot = captureEnv(["PATH", "SHELL"]);
+    envSnapshot = captureEnv(["OPENCLAW_EXEC_SHELL_SNAPSHOT", "PATH", "SHELL"]);
+    process.env.OPENCLAW_EXEC_SHELL_SNAPSHOT = "0";
     shellEnvMocks.getShellPathFromLoginShell.mockReset();
     shellEnvMocks.getShellPathFromLoginShell.mockReturnValue("/custom/bin:/opt/bin");
     shellEnvMocks.resolveShellEnvFallbackTimeoutMs.mockReset();
@@ -289,6 +290,17 @@ describe("exec PATH login shell merge", () => {
 });
 
 describe("exec host env validation", () => {
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["OPENCLAW_EXEC_SHELL_SNAPSHOT"]);
+    process.env.OPENCLAW_EXEC_SHELL_SNAPSHOT = "0";
+  });
+
+  afterEach(() => {
+    envSnapshot.restore();
+  });
+
   it("blocks LD_/DYLD_ env vars on host execution", async () => {
     const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -217,8 +217,8 @@ const NOTIFY_POLL_OPTIONS = {
   timeout: NOTIFY_EVENT_TIMEOUT_MS,
   interval: POLL_INTERVAL_MS,
 };
-const SHELL_ENV_KEYS = ["SHELL"] as const;
-const PATH_SHELL_ENV_KEYS = ["PATH", "SHELL"] as const;
+const SHELL_ENV_KEYS = ["OPENCLAW_EXEC_SHELL_SNAPSHOT", "SHELL"] as const;
+const PATH_SHELL_ENV_KEYS = ["OPENCLAW_EXEC_SHELL_SNAPSHOT", "PATH", "SHELL"] as const;
 const PROCESS_STATUS_RUNNING = "running";
 const PROCESS_STATUS_COMPLETED = "completed";
 const PROCESS_STATUS_FAILED = "failed";
@@ -348,6 +348,7 @@ async function pollProcessSession(params: {
   };
 }
 function applyDefaultShellEnv() {
+  process.env.OPENCLAW_EXEC_SHELL_SNAPSHOT = "0";
   if (!isWin && defaultShell) {
     process.env.SHELL = defaultShell;
   }
@@ -771,6 +772,8 @@ describe("exec exit codes", () => {
 });
 
 describe("exec notifyOnExit", () => {
+  useCapturedEnv([...SHELL_ENV_KEYS], applyDefaultShellEnv);
+
   beforeEach(() => {
     resetHeartbeatWakeStateForTests();
   });

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -20,27 +20,58 @@ const {
   resolveProviderRequestPolicyConfigMock,
   shouldUseEnvHttpProxyForUrlMock,
   withTrustedEnvProxyGuardedFetchModeMock,
-} = vi.hoisted(() => ({
-  buildProviderRequestDispatcherPolicyMock: vi.fn<
-    (_request?: unknown) => { mode: "direct" } | undefined
-  >(() => undefined),
-  fetchWithSsrFGuardMock: vi.fn(),
-  ensureModelProviderLocalServiceMock: vi.fn(),
-  mergeModelProviderRequestOverridesMock: vi.fn((current, overrides) => ({
-    ...current,
-    ...overrides,
-  })),
-  resolveProviderRequestPolicyConfigMock: vi.fn<() => ProviderRequestPolicyConfigMockResult>(
-    () => ({
-      allowPrivateNetwork: false,
-    }),
-  ),
-  shouldUseEnvHttpProxyForUrlMock: vi.fn(() => false),
-  withTrustedEnvProxyGuardedFetchModeMock: vi.fn((params: Record<string, unknown>) => ({
-    ...params,
-    mode: "trusted_env_proxy",
-  })),
-}));
+  managedStreamCleanupRegistrations,
+} = vi.hoisted(() => {
+  const managedStreamCleanupRegistrations: Array<{
+    callback: (held: { finalize: () => Promise<void> }) => void;
+    held: { finalize: () => Promise<void> };
+    token: object;
+  }> = [];
+
+  class MockFinalizationRegistry {
+    constructor(private callback: (held: { finalize: () => Promise<void> }) => void) {}
+
+    register(_target: object, held: { finalize: () => Promise<void> }, token?: object) {
+      managedStreamCleanupRegistrations.push({
+        callback: this.callback,
+        held,
+        token: token ?? {},
+      });
+    }
+
+    unregister(token: object) {
+      const index = managedStreamCleanupRegistrations.findIndex((entry) => entry.token === token);
+      if (index >= 0) {
+        managedStreamCleanupRegistrations.splice(index, 1);
+      }
+    }
+  }
+
+  vi.stubGlobal("FinalizationRegistry", MockFinalizationRegistry);
+
+  return {
+    buildProviderRequestDispatcherPolicyMock: vi.fn<
+      (_request?: unknown) => { mode: "direct" } | undefined
+    >(() => undefined),
+    fetchWithSsrFGuardMock: vi.fn(),
+    ensureModelProviderLocalServiceMock: vi.fn(),
+    mergeModelProviderRequestOverridesMock: vi.fn((current, overrides) => ({
+      ...current,
+      ...overrides,
+    })),
+    resolveProviderRequestPolicyConfigMock: vi.fn<() => ProviderRequestPolicyConfigMockResult>(
+      () => ({
+        allowPrivateNetwork: false,
+      }),
+    ),
+    shouldUseEnvHttpProxyForUrlMock: vi.fn(() => false),
+    withTrustedEnvProxyGuardedFetchModeMock: vi.fn((params: Record<string, unknown>) => ({
+      ...params,
+      mode: "trusted_env_proxy",
+    })),
+    managedStreamCleanupRegistrations,
+  };
+});
 
 vi.mock("../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
@@ -82,6 +113,7 @@ function latestTrustedEnvProxyParams(): Record<string, unknown> {
 
 describe("buildGuardedModelFetch", () => {
   beforeEach(() => {
+    managedStreamCleanupRegistrations.length = 0;
     fetchWithSsrFGuardMock.mockReset().mockResolvedValue({
       response: new Response("ok", { status: 200 }),
       finalUrl: "https://api.openai.com/v1/responses",
@@ -149,6 +181,49 @@ describe("buildGuardedModelFetch", () => {
     expect(ensureModelProviderLocalServiceMock).toHaveBeenCalledWith(model, undefined, undefined);
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+  });
+
+  it("releases guarded fetch slots when streamed bodies are abandoned", async () => {
+    const release = vi.fn(async () => undefined);
+    const encoder = new TextEncoder();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode("chunk-1"));
+            controller.enqueue(encoder.encode("chunk-2"));
+          },
+        }),
+        { status: 200 },
+      ),
+      finalUrl: "https://api.anthropic.com/v1/messages",
+      release,
+    });
+    const model = {
+      id: "claude-sonnet-4-6",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+    } as unknown as Model<"anthropic-messages">;
+
+    const fetcher = buildGuardedModelFetch(model, undefined, { sanitizeSse: false });
+    let response = await fetcher("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"stream":true}',
+    });
+    const reader = response.body?.getReader();
+    expect(reader).toBeDefined();
+    const firstChunk = await reader?.read();
+    expect(firstChunk?.done).toBe(false);
+
+    response = undefined as unknown as Response;
+    const registration = managedStreamCleanupRegistrations.at(-1);
+    expect(registration).toBeDefined();
+    await registration?.held.finalize();
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(managedStreamCleanupRegistrations).toHaveLength(0);
   });
 
   it("passes model request headers to local service health probes", async () => {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -433,6 +433,8 @@ function buildManagedResponse(
       }
     },
   });
+  // Stream consumers should cancel deterministically; this catches abandoned
+  // wrapper bodies so guarded dispatchers and local-service leases do not leak.
   managedStreamCleanupRegistry.register(wrappedBody, { finalize }, cleanupRegistrationToken);
   return new Response(wrappedBody, {
     status: response.status,

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -370,6 +370,12 @@ function shouldBypassLongSdkRetry(response: Response): boolean {
   return status === 429;
 }
 
+const managedStreamCleanupRegistry = new FinalizationRegistry<{ finalize: () => Promise<void> }>(
+  (held) => {
+    void held.finalize();
+  },
+);
+
 function buildManagedResponse(
   response: Response,
   release: () => Promise<void>,
@@ -386,12 +392,15 @@ function buildManagedResponse(
   const source = response.body;
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let released = false;
+  const cleanupRegistrationToken = {};
   const finalize = async () => {
     if (released) {
       return;
     }
     released = true;
+    managedStreamCleanupRegistry.unregister(cleanupRegistrationToken);
     try {
+      await reader?.cancel().catch(() => undefined);
       await release().catch(() => undefined);
     } finally {
       finalizeLocalServiceLease();
@@ -424,6 +433,7 @@ function buildManagedResponse(
       }
     },
   });
+  managedStreamCleanupRegistry.register(wrappedBody, { finalize }, cleanupRegistrationToken);
   return new Response(wrappedBody, {
     status: response.status,
     statusText: response.statusText,

--- a/src/gateway/gateway-acp-spawn-defaults.live.test.ts
+++ b/src/gateway/gateway-acp-spawn-defaults.live.test.ts
@@ -180,6 +180,17 @@ function createConfig(params: {
   thinking?: string;
   includePrimaryOnlyAcpAgent?: boolean;
 }): OpenClawConfig {
+  const subagents = params.subagentModel
+    ? {
+        allowAgents: ["*"],
+        maxSpawnDepth: 2,
+        model: params.subagentModel,
+      }
+    : {
+        allowAgents: ["*"],
+        maxSpawnDepth: 2,
+      };
+
   return {
     agents: {
       list: params.includePrimaryOnlyAcpAgent
@@ -198,11 +209,7 @@ function createConfig(params: {
         model: {
           primary: "openai/gpt-5.5",
         },
-        subagents: {
-          allowAgents: ["*"],
-          maxSpawnDepth: 2,
-          ...(params.subagentModel ? { model: params.subagentModel } : {}),
-        },
+        subagents,
         models:
           params.subagentModel && params.thinking
             ? {

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -80,6 +80,7 @@ describe("scripts/test-live-shard", () => {
     expect(selectLiveShardFiles("native-live-src-gateway-core", allFiles)).toEqual([
       "src/crestodian/rescue-channel.live.test.ts",
       "src/gateway/android-node.capabilities.live.test.ts",
+      "src/gateway/gateway-acp-spawn-defaults.live.test.ts",
       "src/gateway/gateway-trajectory-export.live.test.ts",
     ]);
     expect(selectLiveShardFiles("native-live-src-infra", allFiles)).toEqual([


### PR DESCRIPTION
## Summary

Fixes https://github.com/openclaw/openclaw/issues/67461

- Release guarded provider fetch slots when a streamed response body is abandoned before normal completion or cancel.
- Keep the existing completion/cancel release path idempotent, and unregister normal releases from the cleanup registry.
- Add regression coverage for abandoned managed stream cleanup.

## Verification

- `git diff --check` -> passed.
- `node scripts/run-vitest.mjs src/agents/provider-transport-fetch.test.ts` -> passed, 67 tests.
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings.
- Real stream harness after rebase: `node --expose-gc --import tsx --input-type=module` with a local HTTP streaming server, `buildGuardedModelFetch`, first-chunk read, abandoned `Response`/reader, forced GC loop -> `{"requestReceived":true,"firstChunkRead":true,"socketClosed":true,"writes":3}`.

## Real behavior proof

- Behavior addressed: abandoned provider streaming responses now release the guarded fetch slot and close the underlying streamed HTTP socket instead of waiting forever for a body that no caller is reading.
- Real environment tested: local Node 24.14.0 process using the actual `buildGuardedModelFetch` source path, actual `fetch`/`ReadableStream`, and a real local TCP HTTP streaming server on `127.0.0.1`.
- Exact steps or command run after this patch: ran `node --expose-gc --import tsx --input-type=module` with a local streaming HTTP server, called `buildGuardedModelFetch(model, 5000, { sanitizeSse: false })`, read the first response body chunk, dropped the `Response` and body reader, then forced GC until the server observed socket close.
- Evidence after fix: Console output from the real local stream harness:

  ```json
  {"requestReceived":true,"firstChunkRead":true,"socketClosed":true,"writes":3}
  ```

- Observed result after fix: The copied live output shows the server received the model request, the client read the first streamed chunk, and the server observed the socket close after the abandoned managed response was garbage-collected.
- What was not tested: live remote provider credentials, full Gateway agent run, and cross-OS/Testbox proof.

## Performance accounting

No latency, throughput, or speedup claim. This moves abandoned-stream cleanup off a leak path; the runtime change adds one `FinalizationRegistry` registration per managed streamed response and unregisters it on normal release.

## AI-assisted

This PR was prepared with Codex.

