### PR TITLE
fix(ui): preserve chat sends across reconnect

### DIFF
--- a/scripts/repro/webchat-reconnect-send-live-proof.mjs
+++ b/scripts/repro/webchat-reconnect-send-live-proof.mjs
@@ -1,0 +1,369 @@
+#!/usr/bin/env node
+/**
+ * Live Control UI + Gateway proof: defer chat.send ACK, drop the WebSocket, verify one replay.
+ *
+ * Run:
+ *   pnpm ui:build
+ *   node scripts/repro/webchat-reconnect-send-live-proof.mjs
+ */
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright-core";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function log(line) {
+  process.stdout.write(`${line}\n`);
+}
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("failed to allocate port"));
+        return;
+      }
+      const { port } = address;
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+function waitForGatewayReady(child, timeoutMs = 120_000) {
+  return new Promise((resolve, reject) => {
+    let buffer = "";
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`gateway did not become ready within ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onData = (chunk) => {
+      buffer += String(chunk);
+      if (buffer.includes("[gateway] ready") || buffer.includes("http server listening")) {
+        cleanup();
+        resolve(buffer);
+      }
+    };
+    const onExit = (code, signal) => {
+      cleanup();
+      reject(new Error(`gateway exited early code=${code ?? "null"} signal=${signal ?? "null"}`));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stdout?.off("data", onData);
+      child.stderr?.off("data", onData);
+      child.off("exit", onExit);
+    };
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    child.on("exit", onExit);
+  });
+}
+
+async function stopGateway(child) {
+  if (!child || child.killed) {
+    return;
+  }
+  child.kill("SIGTERM");
+  await new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve(undefined);
+    }, 5_000);
+    child.on("exit", () => {
+      clearTimeout(timer);
+      resolve(undefined);
+    });
+  });
+}
+
+const WS_SHIM = String.raw`
+(() => {
+  if (window.__openclawWsProofInstalled) {
+    return;
+  }
+  window.__openclawWsProofInstalled = true;
+  const Native = window.WebSocket;
+  const state = {
+    deferNextChatSend: false,
+    deferredResponseId: null,
+    chatSends: [],
+    sockets: [],
+  };
+  window.__openclawWsProof = {
+    deferNextChatSend() {
+      state.deferNextChatSend = true;
+    },
+    closeActive(code = 4001, reason = "live proof ack loss") {
+      const latest = state.sockets.at(-1);
+      latest?.native.close(code, reason);
+    },
+    snapshot() {
+      return {
+        chatSends: state.chatSends.map((entry) => ({
+          id: entry.id,
+          idempotencyKey: entry.params?.idempotencyKey ?? null,
+          message: entry.params?.message ?? null,
+        })),
+        deferredResponseId: state.deferredResponseId,
+        socketCount: state.sockets.length,
+      };
+    },
+  };
+
+  function ProofWebSocket(url, protocols) {
+    const native =
+      protocols === undefined ? new Native(url) : new Native(url, protocols);
+    const listeners = { open: [], message: [], close: [], error: [] };
+    const entry = { native };
+    state.sockets.push(entry);
+
+    native.addEventListener("open", (ev) => {
+      for (const listener of listeners.open) {
+        listener.call(native, ev);
+      }
+    });
+    native.addEventListener("message", (ev) => {
+      const raw = String(ev.data ?? "");
+      try {
+        const frame = JSON.parse(raw);
+        if (frame.type === "res" && frame.id && frame.id === state.deferredResponseId) {
+          return;
+        }
+      } catch {
+        // ignore parse errors
+      }
+      const messageEvent = typeof MessageEvent === "function" ? new MessageEvent("message", { data: raw }) : ev;
+      for (const listener of listeners.message) {
+        listener.call(native, messageEvent);
+      }
+    });
+    native.addEventListener("close", (ev) => {
+      for (const listener of listeners.close) {
+        listener.call(native, ev);
+      }
+    });
+    native.addEventListener("error", (ev) => {
+      for (const listener of listeners.error) {
+        listener.call(native, ev);
+      }
+    });
+
+    const proxy = {
+      get readyState() {
+        return native.readyState;
+      },
+      get url() {
+        return native.url;
+      },
+      get protocol() {
+        return native.protocol;
+      },
+      get extensions() {
+        return native.extensions;
+      },
+      get bufferedAmount() {
+        return native.bufferedAmount;
+      },
+      send(data) {
+        try {
+          const frame = JSON.parse(String(data));
+          if (frame.type === "req" && frame.method === "chat.send") {
+            state.chatSends.push({
+              id: frame.id,
+              params: frame.params ?? {},
+              at: Date.now(),
+            });
+            if (state.deferNextChatSend) {
+              state.deferNextChatSend = false;
+              state.deferredResponseId = frame.id;
+            }
+          }
+        } catch {
+          // ignore parse errors
+        }
+        native.send(data);
+      },
+      close(code, reason) {
+        native.close(code, reason);
+      },
+      addEventListener(type, listener) {
+        listeners[type]?.push(listener);
+      },
+      removeEventListener(type, listener) {
+        const bucket = listeners[type];
+        if (!bucket) {
+          return;
+        }
+        const index = bucket.indexOf(listener);
+        if (index >= 0) {
+          bucket.splice(index, 1);
+        }
+      },
+      dispatchEvent(event) {
+        return native.dispatchEvent(event);
+      },
+    };
+    return proxy;
+  }
+  ProofWebSocket.CONNECTING = Native.CONNECTING;
+  ProofWebSocket.OPEN = Native.OPEN;
+  ProofWebSocket.CLOSING = Native.CLOSING;
+  ProofWebSocket.CLOSED = Native.CLOSED;
+  window.WebSocket = ProofWebSocket;
+})();
+`;
+
+async function waitForProofSnapshot(page, predicate, timeoutMs = 60_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const snapshot = await page.evaluate(() => window.__openclawWsProof.snapshot());
+    if (predicate(snapshot)) {
+      return snapshot;
+    }
+    await page.waitForTimeout(100);
+  }
+  throw new Error(`timed out waiting for websocket proof condition after ${timeoutMs}ms`);
+}
+
+async function main() {
+  const indexPath = path.join(repoRoot, "dist", "control-ui", "index.html");
+  if (!fs.existsSync(indexPath)) {
+    throw new Error("missing dist/control-ui/index.html; run pnpm ui:build first");
+  }
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-reconnect-proof-"));
+  const stateDir = path.join(tmpRoot, "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const configPath = path.join(stateDir, "openclaw.json");
+  fs.writeFileSync(configPath, "{}\n");
+
+  const port = await getFreePort();
+  const chatUrl = `http://127.0.0.1:${port}/chat`;
+  const screenshotPath = path.join(tmpRoot, "live-webchat-reconnect-send.png");
+
+  const gateway = spawn(
+    "pnpm",
+    [
+      "openclaw",
+      "gateway",
+      "run",
+      "--dev",
+      "--allow-unconfigured",
+      "--auth",
+      "none",
+      "--bind",
+      "loopback",
+      "--port",
+      String(port),
+      "--force",
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  let browser;
+  try {
+    await waitForGatewayReady(gateway);
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { width: 1280, height: 900 },
+    });
+    const page = await context.newPage();
+    await page.addInitScript(WS_SHIM);
+    await page.goto(chatUrl, { waitUntil: "domcontentloaded", timeout: 60_000 });
+
+    const composer = page.locator(".agent-chat__composer-combobox textarea");
+    await composer.waitFor({ state: "visible", timeout: 60_000 });
+    await page.waitForFunction(
+      () =>
+        typeof window.__openclawWsProof?.snapshot === "function" &&
+        window.__openclawWsProof.snapshot().socketCount >= 1,
+      undefined,
+      { timeout: 60_000 },
+    );
+
+    const prompt = "live reconnect send queue proof";
+    await page.evaluate(() => window.__openclawWsProof.deferNextChatSend());
+    await composer.fill(prompt);
+    await page.getByRole("button", { name: "Send message" }).click();
+
+    const afterFirstSend = await waitForProofSnapshot(
+      page,
+      (snapshot) => snapshot.chatSends.length >= 1 && snapshot.deferredResponseId != null,
+    );
+
+    await page.evaluate(() => window.__openclawWsProof.closeActive(4001, "live proof ack loss"));
+
+    const afterReplay = await waitForProofSnapshot(
+      page,
+      (snapshot) => snapshot.chatSends.length >= 2,
+      90_000,
+    );
+
+    await page
+      .locator(".chat-queue")
+      .waitFor({ state: "detached", timeout: 60_000 })
+      .catch(async () => {
+        const queueCount = await page.locator(".chat-queue .chat-queue__item").count();
+        if (queueCount !== 0) {
+          throw new Error(`expected empty chat queue, found ${queueCount} items`);
+        }
+      });
+
+    const userBubbleCount = await page
+      .locator(".chat-group.user .chat-text")
+      .filter({ hasText: prompt })
+      .count();
+    if (userBubbleCount !== 1) {
+      throw new Error(`expected exactly one user bubble for prompt, found ${userBubbleCount}`);
+    }
+
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    await context.close();
+
+    const firstKey = afterReplay.chatSends[0]?.idempotencyKey;
+    const secondKey = afterReplay.chatSends[1]?.idempotencyKey;
+    if (!firstKey || firstKey !== secondKey) {
+      throw new Error(
+        `expected replay to reuse idempotency key, got first=${String(firstKey)} second=${String(secondKey)}`,
+      );
+    }
+
+    log("REAL_WEBCHAT_RECONNECT_PROOF");
+    log(`url=${chatUrl}`);
+    log(`prompt=${prompt}`);
+    log(`first.idempotencyKey=${firstKey}`);
+    log(`replay.idempotencyKey=${secondKey}`);
+    log(`chat.send.count=${afterReplay.chatSends.length}`);
+    log(`deferredResponseId=${afterFirstSend.deferredResponseId}`);
+    log(`socketCount=${afterReplay.socketCount}`);
+    log(`userBubbleCount=${userBubbleCount}`);
+    log(`queueCleared=true`);
+    log(`screenshot=${screenshotPath}`);
+    log(`stateDir=${stateDir}`);
+  } finally {
+    if (browser) {
+      await browser.close().catch(() => undefined);
+    }
+    await stopGateway(gateway);
+  }
+}
+
+await main();

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -2,6 +2,7 @@
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatHost } from "./app-chat.ts";
+import { GatewayRequestError } from "./gateway.ts";
 import {
   getChatAttachmentDataUrl,
   getChatAttachmentPreviewUrl,
@@ -1470,6 +1471,154 @@ describe("handleSendChat", () => {
     expect(host.chatQueueBySession?.["agent:a"]).toBeUndefined();
   });
 
+  it("ignores stale in-flight send completion after reconnect replay starts", async () => {
+    const firstSend = createDeferred<unknown>();
+    const replaySend = createDeferred<unknown>();
+    const sends = [firstSend, replaySend];
+    const request = vi.fn((method: string) => {
+      if (method === "chat.send") {
+        const next = sends.shift();
+        if (!next) {
+          throw new Error("Unexpected extra chat.send");
+        }
+        return next.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "retry once",
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+
+    const runId = host.chatQueue[0]?.sendRunId;
+    expect(runId).toEqual(expect.any(String));
+    markQueuedChatSendsWaitingForReconnect(host);
+    host.chatSending = false;
+    const replay = retryReconnectableQueuedChatSends(host);
+    await Promise.resolve();
+    expect(request).toHaveBeenCalledTimes(2);
+
+    firstSend.resolve({ runId, status: "started" });
+    await send;
+
+    expect(host.chatQueue).toHaveLength(1);
+    expect(host.chatQueue[0]).toMatchObject({
+      sendAttempts: 2,
+      sendRunId: runId,
+      sendState: "sending",
+      text: "retry once",
+    });
+    expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatSending).toBe(true);
+
+    replaySend.resolve({ runId, status: "started" });
+    await replay;
+
+    expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatRunId).toBe(runId);
+    expect(host.chatMessages).toHaveLength(1);
+    const userMessage = requireRecord(host.chatMessages[0], "user message");
+    expect(userMessage.role).toBe("user");
+  });
+
+  it("ignores stale in-flight send completion after reconnect replay succeeds", async () => {
+    const firstSend = createDeferred<unknown>();
+    const replaySend = createDeferred<unknown>();
+    const sends = [firstSend, replaySend];
+    const request = vi.fn((method: string) => {
+      if (method === "chat.send") {
+        const next = sends.shift();
+        if (!next) {
+          throw new Error("Unexpected extra chat.send");
+        }
+        return next.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "retry once",
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+
+    const runId = host.chatQueue[0]?.sendRunId;
+    expect(runId).toEqual(expect.any(String));
+    markQueuedChatSendsWaitingForReconnect(host);
+    host.chatSending = false;
+    const replay = retryReconnectableQueuedChatSends(host);
+    await Promise.resolve();
+
+    replaySend.resolve({ runId, status: "started" });
+    await replay;
+    expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatMessages).toHaveLength(1);
+
+    firstSend.resolve({ runId, status: "started" });
+    await send;
+
+    expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatRunId).toBe(runId);
+    expect(host.chatMessages).toHaveLength(1);
+    const userMessage = requireRecord(host.chatMessages[0], "user message");
+    expect(userMessage.role).toBe("user");
+  });
+
+  it("keeps a stopped gateway client error recoverable with the same run id", async () => {
+    const request = vi.fn((method: string) => {
+      if (method === "chat.send") {
+        throw new GatewayRequestError({
+          code: "client_stopped",
+          message: "gateway client stopped",
+          retryable: true,
+        });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "retry after client stop",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatQueue).toHaveLength(1);
+    expect(host.chatQueue[0]).toMatchObject({
+      text: "retry after client stop",
+      sendState: "waiting-reconnect",
+    });
+    expect(host.chatQueue[0]?.sendRunId).toEqual(expect.any(String));
+    expect(host.lastError).toBe("Message will send when the Gateway reconnects.");
+  });
+
+  it("does not replay non-retryable stopped gateway client errors", async () => {
+    const request = vi.fn((method: string) => {
+      if (method === "chat.send") {
+        throw new Error("gateway client stopped");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "do not replay after gateway switch",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatQueue).toHaveLength(1);
+    expect(host.chatQueue[0]).toMatchObject({
+      text: "do not replay after gateway switch",
+      sendState: "failed",
+    });
+    expect(host.lastError).toBe("gateway client stopped");
+  });
+
   it("keeps a pre-ack socket close recoverable with the same run id", async () => {
     const request = vi.fn((method: string) => {
       if (method === "chat.send") {
@@ -1871,6 +2020,25 @@ describe("handleSendChat", () => {
     expect(host.chatQueue).toStrictEqual([]);
     expect(getChatAttachmentDataUrl(attachment)).toBeNull();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:queued");
+  });
+
+  it("does not remove an in-flight send", () => {
+    const host = makeHost({
+      chatQueue: [
+        {
+          id: "sending-1",
+          text: "already sent",
+          createdAt: 1,
+          sendRunId: "run-sending-1",
+          sendState: "sending",
+        },
+      ],
+    });
+
+    removeQueuedMessage(host, "sending-1");
+
+    expect(host.chatQueue).toHaveLength(1);
+    expect(host.chatQueue[0]?.id).toBe("sending-1");
   });
 });
 

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -2,7 +2,6 @@
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatHost } from "./app-chat.ts";
-import { GatewayRequestError } from "./gateway.ts";
 import {
   getChatAttachmentDataUrl,
   getChatAttachmentPreviewUrl,
@@ -11,6 +10,7 @@ import {
   resetChatAttachmentPayloadStoreForTest,
 } from "./chat/attachment-payload-store.ts";
 import type { executeSlashCommand } from "./chat/slash-command-executor.ts";
+import { GatewayRequestError } from "./gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "./types.ts";
 
 type ExecuteSlashCommand = typeof executeSlashCommand;

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -567,10 +567,17 @@ async function sendQueuedChatMessage(
   }
 
   const runId = prepared.sendRunId ?? generateUUID();
+  const sendAttempt = (prepared.sendAttempts ?? 0) + 1;
   const startedAt = Date.now();
+  const readCurrentQueuedSend = () =>
+    readChatQueueForSession(host, sessionKey).find((item) => item.id === id) ?? null;
+  const isCurrentSendAttempt = () => {
+    const current = readCurrentQueuedSend();
+    return current?.sendAttempts === sendAttempt;
+  };
   updateQueuedMessageForSession(host, sessionKey, id, (item) => ({
     ...item,
-    sendAttempts: (item.sendAttempts ?? 0) + 1,
+    sendAttempts: sendAttempt,
     sendError: undefined,
     sendRunId: runId,
     sendState: "sending",
@@ -594,6 +601,9 @@ async function sendQueuedChatMessage(
       sessionKey,
       agentId: prepared.agentId,
     });
+    if (!isCurrentSendAttempt()) {
+      return "pending";
+    }
     removeQueuedMessageWithoutReleasing(host, id, sessionKey);
     if (isVisibleSession()) {
       appendUserChatMessage(
@@ -642,6 +652,9 @@ async function sendQueuedChatMessage(
     return "sent";
   } catch (err) {
     const error = formatConnectError(err);
+    if (!isCurrentSendAttempt()) {
+      return "pending";
+    }
     if (isRecoverableChatSendError(err, error)) {
       updateQueuedMessageForSession(host, sessionKey, id, (item) => ({
         ...item,
@@ -664,7 +677,10 @@ async function sendQueuedChatMessage(
     }
     return "failed";
   } finally {
-    host.chatSending = false;
+    const current = readCurrentQueuedSend();
+    if (!current || current.sendAttempts === sendAttempt || current.sendState !== "sending") {
+      host.chatSending = false;
+    }
   }
 }
 
@@ -953,8 +969,8 @@ async function flushChatQueue(host: ChatHost) {
 }
 
 export function removeQueuedMessage(host: ChatHost, id: string) {
-  const removed = host.chatQueue.filter((item) => item.id === id);
-  host.chatQueue = host.chatQueue.filter((item) => item.id !== id);
+  const removed = host.chatQueue.filter((item) => item.id === id && item.sendState !== "sending");
+  host.chatQueue = host.chatQueue.filter((item) => item.id !== id || item.sendState === "sending");
   for (const item of removed) {
     releaseChatAttachmentPayloads(excludeComposerAttachments(host, item.attachments));
   }

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -120,6 +120,8 @@ type TestGatewayHost = Parameters<typeof connectGateway>[0] & {
   chatMessages: unknown[];
   chatQueue: import("./ui-types.ts").ChatQueueItem[];
   chatQueueBySession: Record<string, import("./ui-types.ts").ChatQueueItem[]>;
+  chatRunId: string | null;
+  chatSending: boolean;
   chatSideResult: unknown;
   chatSideResultTerminalRuns: Set<string>;
   chatStream: string | null;
@@ -519,6 +521,52 @@ describe("connectGateway", () => {
     secondClient.emitClose({ code: 1005 });
     expect(host.lastError).toBe("disconnected (1005): no reason");
     expect(host.lastErrorCode).toBeNull();
+  });
+
+  it("marks old client pending requests retryable when reconnecting to the same gateway", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const firstClient = requireGatewayClient();
+    connectGateway(host);
+
+    expect(firstClient.stop).toHaveBeenCalledWith({ retryablePending: true });
+  });
+
+  it("does not mark old client pending requests retryable after gateway scope changes", async () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const firstClient = requireGatewayClient();
+    host.chatQueue = [
+      {
+        id: "pending-send",
+        text: "send during gateway switch",
+        createdAt: 1,
+        sendRunId: "run-gateway-switch",
+        sendState: "sending",
+        sessionKey: "main",
+      },
+    ];
+    host.chatSending = true;
+    host.settings = {
+      ...host.settings,
+      gatewayUrl: "ws://127.0.0.1:18790",
+    };
+    connectGateway(host);
+    const secondClient = requireGatewayClient(1);
+    secondClient.emitHello();
+    await Promise.resolve();
+
+    expect(firstClient.stop).toHaveBeenCalledWith({ retryablePending: false });
+    expect(secondClient.request).not.toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({ message: "send during gateway switch" }),
+    );
+    expect(host.chatQueue[0]).toMatchObject({
+      sendState: "sending",
+      sendRunId: "run-gateway-switch",
+    });
   });
 
   it("routes exec approval requested events with command spans", () => {
@@ -966,6 +1014,63 @@ describe("connectGateway", () => {
       agentId: "work",
     });
     expect(host.pendingAbort).toBeNull();
+  });
+
+  it("replays in-flight queued chat sends when hello arrives before stale close", async () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const firstClient = requireGatewayClient();
+    firstClient.emitHello();
+    await Promise.resolve();
+
+    host.chatQueue = [
+      {
+        id: "pending-send",
+        text: "send during reconnect",
+        createdAt: 1,
+        sendRunId: "run-fast-reconnect",
+        sendState: "sending",
+        sessionKey: "main",
+      },
+    ];
+    host.chatSending = true;
+
+    connectGateway(host);
+    const secondClient = requireGatewayClient(1);
+    secondClient.request.mockImplementation(async (method: string) => {
+      if (method === "chat.send") {
+        return { runId: "run-fast-reconnect", status: "started" };
+      }
+      if (method === "update.status") {
+        return { sentinel: null };
+      }
+      if (method === "models.authStatus") {
+        return { ts: 0, providers: [] };
+      }
+      if (method === "sessions.list") {
+        return { count: 0, sessions: [] };
+      }
+      return {};
+    });
+
+    secondClient.emitHello();
+
+    await vi.waitFor(() => {
+      expect(secondClient.request).toHaveBeenCalledWith("chat.send", {
+        sessionKey: "main",
+        message: "send during reconnect",
+        deliver: false,
+        idempotencyKey: "run-fast-reconnect",
+        attachments: undefined,
+      });
+    });
+
+    firstClient.emitClose({ code: 1001, reason: "going away" });
+    await Promise.resolve();
+
+    expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatRunId).toBe("run-fast-reconnect");
   });
 
   it("retries reconnectable queued chat sends after reconnect hello", async () => {

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -569,6 +569,40 @@ describe("connectGateway", () => {
     });
   });
 
+  it("does not flush queued follow-up sends after gateway scope changes", async () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const firstClient = requireGatewayClient();
+    host.chatRunId = "old-run";
+    host.chatQueue = [
+      {
+        id: "queued-follow-up",
+        text: "do not send to another gateway",
+        createdAt: 1,
+        sessionKey: "main",
+      },
+    ];
+    host.settings = {
+      ...host.settings,
+      gatewayUrl: "ws://127.0.0.1:18790",
+    };
+    connectGateway(host);
+    const secondClient = requireGatewayClient(1);
+    secondClient.emitHello();
+    await Promise.resolve();
+
+    expect(firstClient.stop).toHaveBeenCalledWith({ retryablePending: false });
+    expect(secondClient.request).not.toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({ message: "do not send to another gateway" }),
+    );
+    expect(host.chatQueue[0]).toMatchObject({
+      id: "queued-follow-up",
+      text: "do not send to another gateway",
+    });
+  });
+
   it("routes exec approval requested events with command spans", () => {
     const { host, client } = connectHostGateway();
 
@@ -1140,6 +1174,59 @@ describe("connectGateway", () => {
       expect(host.chatQueueBySession.main).toBeUndefined();
       expect(host.chatMessages).toStrictEqual([]);
       expect(host.chatRunId).toBeNull();
+    });
+  });
+
+  it("flushes active-session queued follow-up sends after ordinary reconnect hello", async () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const firstClient = requireGatewayClient();
+    firstClient.emitHello();
+    await Promise.resolve();
+
+    host.chatRunId = "old-run";
+    host.chatQueue = [
+      {
+        id: "queued-follow-up",
+        text: "send after interrupted run",
+        createdAt: 1,
+        sessionKey: "main",
+      },
+    ];
+
+    connectGateway(host);
+    const secondClient = requireGatewayClient(1);
+    secondClient.request.mockImplementation(async (method: string) => {
+      if (method === "chat.send") {
+        return { runId: "run-follow-up", status: "started" };
+      }
+      if (method === "update.status") {
+        return { sentinel: null };
+      }
+      if (method === "models.authStatus") {
+        return { ts: 0, providers: [] };
+      }
+      if (method === "sessions.list") {
+        return { count: 0, sessions: [] };
+      }
+      return {};
+    });
+
+    secondClient.emitHello();
+
+    await vi.waitFor(() => {
+      expect(secondClient.request).toHaveBeenCalledWith("chat.send", {
+        sessionKey: "main",
+        message: "send after interrupted run",
+        deliver: false,
+        idempotencyKey: expect.any(String),
+        attachments: undefined,
+      });
+    });
+    await vi.waitFor(() => {
+      expect(host.chatQueue).toStrictEqual([]);
+      expect(host.chatRunId).toBe("run-follow-up");
     });
   });
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -147,6 +147,7 @@ type SessionDefaultsSnapshot = {
 };
 
 type GatewayHostWithShutdownMessage = GatewayHost & {
+  gatewayClientScopeKey?: string;
   pendingShutdownMessage?: string | null;
   resumeChatQueueAfterReconnect?: boolean;
 };
@@ -581,9 +582,16 @@ async function loadAgentsThenRefreshActiveTab(host: GatewayHost) {
   }
 }
 
+function gatewayClientScopeKey(host: GatewayHost): string {
+  return JSON.stringify([host.settings.gatewayUrl, host.settings.token.trim(), host.password]);
+}
+
 export function connectGateway(host: GatewayHost, options?: ConnectGatewayOptions) {
   const shutdownHost = host as GatewayHostWithShutdownMessage;
   const reconnectReason = options?.reason ?? "initial";
+  const previousGatewayClientScopeKey = shutdownHost.gatewayClientScopeKey;
+  const nextGatewayClientScopeKey = gatewayClientScopeKey(host);
+  shutdownHost.gatewayClientScopeKey = nextGatewayClientScopeKey;
   shutdownHost.pendingShutdownMessage = null;
   shutdownHost.resumeChatQueueAfterReconnect = false;
   clearSessionsChangedReloadTimer(host);
@@ -604,6 +612,8 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
   host.execApprovalError = null;
 
   const previousClient = host.client;
+  const canReplayPreviousClientSends =
+    previousClient != null && previousGatewayClientScopeKey === nextGatewayClientScopeKey;
   const clientVersion = resolveControlUiClientVersion({
     gatewayUrl: host.settings.gatewayUrl,
     serverVersion: host.serverVersion,
@@ -676,6 +686,16 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
           clearRunStatus: !hadOrphanedRun,
         },
       );
+      if (canReplayPreviousClientSends) {
+        // Stale client onClose may never run after reconnect; normalize in-flight sends here.
+        markQueuedChatSendsWaitingForReconnect(
+          host as unknown as Parameters<typeof markQueuedChatSendsWaitingForReconnect>[0],
+        );
+        const chatHost = host as unknown as { chatSending?: boolean };
+        if (chatHost.chatSending) {
+          chatHost.chatSending = false;
+        }
+      }
       const hasReconnectableChatSends = hasReconnectableQueuedChatSends(
         host as unknown as Parameters<typeof hasReconnectableQueuedChatSends>[0],
       );
@@ -763,7 +783,9 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
     },
   });
   host.client = client;
-  previousClient?.stop();
+  previousClient?.stop({
+    retryablePending: previousGatewayClientScopeKey === nextGatewayClientScopeKey,
+  });
   client.start();
 }
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -149,7 +149,6 @@ type SessionDefaultsSnapshot = {
 type GatewayHostWithShutdownMessage = GatewayHost & {
   gatewayClientScopeKey?: string;
   pendingShutdownMessage?: string | null;
-  resumeChatQueueAfterReconnect?: boolean;
 };
 
 type GatewayHostWithSideResults = GatewayHost & {
@@ -593,7 +592,6 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
   const nextGatewayClientScopeKey = gatewayClientScopeKey(host);
   shutdownHost.gatewayClientScopeKey = nextGatewayClientScopeKey;
   shutdownHost.pendingShutdownMessage = null;
-  shutdownHost.resumeChatQueueAfterReconnect = false;
   clearSessionsChangedReloadTimer(host);
   host.lastError = null;
   host.lastErrorCode = null;
@@ -605,15 +603,16 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       host as unknown as Parameters<typeof clearPendingQueueItemsForRun>[0],
       host.chatRunId ?? undefined,
     );
-    shutdownHost.resumeChatQueueAfterReconnect = true;
   } else {
     host.execApprovalQueue = pruneExecApprovalQueue(host.execApprovalQueue);
   }
   host.execApprovalError = null;
 
   const previousClient = host.client;
-  const canReplayPreviousClientSends =
-    previousClient != null && previousGatewayClientScopeKey === nextGatewayClientScopeKey;
+  const canReplayQueuedChatWork =
+    previousGatewayClientScopeKey === undefined ||
+    previousGatewayClientScopeKey === nextGatewayClientScopeKey;
+  const canReplayPreviousClientSends = previousClient != null && canReplayQueuedChatWork;
   const clientVersion = resolveControlUiClientVersion({
     gatewayUrl: host.settings.gatewayUrl,
     serverVersion: host.serverVersion,
@@ -696,13 +695,10 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
           chatHost.chatSending = false;
         }
       }
-      const hasReconnectableChatSends = hasReconnectableQueuedChatSends(
-        host as unknown as Parameters<typeof hasReconnectableQueuedChatSends>[0],
-      );
-      if (shutdownHost.resumeChatQueueAfterReconnect || hasReconnectableChatSends) {
-        // The interrupted run will never emit its terminal event now that the
-        // old client is gone, so resume any deferred commands after hello.
-        shutdownHost.resumeChatQueueAfterReconnect = false;
+      if (canReplayQueuedChatWork) {
+        const hasReconnectableChatSends = hasReconnectableQueuedChatSends(
+          host as unknown as Parameters<typeof hasReconnectableQueuedChatSends>[0],
+        );
         if (hasReconnectableChatSends) {
           void retryReconnectableQueuedChatSends(
             host as unknown as Parameters<typeof retryReconnectableQueuedChatSends>[0],

--- a/ui/src/ui/chat/chat-queue.ts
+++ b/ui/src/ui/chat/chat-queue.ts
@@ -84,14 +84,18 @@ export function renderChatQueue(props: ChatQueueProps) {
                       </button>
                     `
                   : nothing}
-                <button
-                  class="btn chat-queue__remove"
-                  type="button"
-                  aria-label="Remove queued message"
-                  @click=${() => props.onQueueRemove(item.id)}
-                >
-                  ${icons.x}
-                </button>
+                ${item.sendState !== "sending"
+                  ? html`
+                      <button
+                        class="btn chat-queue__remove"
+                        type="button"
+                        aria-label="Remove queued message"
+                        @click=${() => props.onQueueRemove(item.id)}
+                      >
+                        ${icons.x}
+                      </button>
+                    `
+                  : nothing}
               </div>
             </div>
           `;

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -458,7 +458,7 @@ export class GatewayBrowserClient {
     this.connect();
   }
 
-  stop() {
+  stop(options: { retryablePending?: boolean } = {}) {
     this.closed = true;
     this.clearConnectTimer();
     this.ws?.close();
@@ -467,7 +467,15 @@ export class GatewayBrowserClient {
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
     this.pendingStartupReconnectDelayMs = null;
-    this.flushPending(new Error("gateway client stopped"));
+    this.flushPending(
+      options.retryablePending
+        ? new GatewayRequestError({
+            code: "client_stopped",
+            message: "gateway client stopped",
+            retryable: true,
+          })
+        : new Error("gateway client stopped"),
+    );
   }
 
   get connected() {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1230,6 +1230,23 @@ describe("chat queue", () => {
 
     expect(onQueueRetry).toHaveBeenCalledWith("failed-1");
   });
+
+  it("does not render remove for in-flight sends", () => {
+    const container = renderQueue({
+      queue: [
+        {
+          id: "sending-1",
+          text: "already sent",
+          createdAt: 1,
+          sendRunId: "run-sending-1",
+          sendState: "sending",
+        },
+      ],
+    });
+
+    expect(container.querySelector(".chat-queue__badge")?.textContent?.trim()).toBe("Sending");
+    expect(container.querySelector(".chat-queue__remove")).toBeNull();
+  });
 });
 
 describe("chat sidebar raw content", () => {


### PR DESCRIPTION
## Summary

- Keep in-flight Webchat sends tied to the current send attempt so stale pre-reconnect completions cannot remove or duplicate replayed queued messages.
- Mark stopped same-scope Gateway requests as retryable, while preventing gateway-scope changes from replaying old in-flight sends.
- Hide and ignore remove actions for messages already being sent.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/views/chat.test.ts --reporter=verbose` (132 tests passed after rebase)
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/ui/app-chat.ts ui/src/ui/app-gateway.ts ui/src/ui/gateway.ts ui/src/ui/chat/chat-queue.ts ui/src/ui/app-chat.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/views/chat.test.ts`
- `node scripts/check-no-raw-window-open.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings
- `git diff --check`

`node --import tsx scripts/control-ui-i18n.ts check` currently fails on latest `upstream/main` due to unrelated raw-copy baseline drift in `ui/src/ui/chat/tool-cards.ts` from upstream commit `1e3542bbe7a986ebd920a827aafe47f076f381d5`; this branch does not touch that file.

## Real behavior proof

Behavior addressed: Webchat queued sends survive same-gateway reconnect races (hello before stale close, ACK loss during in-flight send) without stale old `chat.send` completions removing the replayed send; gateway-scope changes do not mark old pending sends retryable.

Real environment tested: Actual local OpenClaw Gateway from this branch (`pnpm ui:build` + `pnpm openclaw gateway run --dev --allow-unconfigured --auth none --bind loopback`), Playwright Chromium driving the real Control UI over HTTP/WebSocket against that Gateway, plus mocked-Gateway Playwright E2E harness and focused Vitest reconnect regressions on this branch.

Exact steps or command run after this patch:

```text
# Live Gateway + Chromium reconnect timing proof (ACK held, socket dropped, replay verified)
pnpm ui:build
node scripts/repro/webchat-reconnect-send-live-proof.mjs

# Reconnect/replay regressions exercised on this branch
node scripts/run-vitest.mjs ui/src/ui/app-gateway.node.test.ts ui/src/ui/app-chat.test.ts \
  -t "replays in-flight|stopped gateway client|ignores stale in-flight|retryablePending|gateway-scope|pre-ack socket close"
```

Evidence after fix:

Live Gateway + Chromium reconnect timing proof (2026-06-01 local rerun on `44e9052b558`):

```text
pnpm ui:build
node scripts/repro/webchat-reconnect-send-live-proof.mjs

REAL_WEBCHAT_RECONNECT_PROOF
url=http://127.0.0.1:52774/chat
prompt=live reconnect send queue proof
first.idempotencyKey=37ab513d-b150-4070-bfd0-deb957318d38
replay.idempotencyKey=37ab513d-b150-4070-bfd0-deb957318d38
chat.send.count=2
deferredResponseId=646b132e-7f81-45af-90a4-260b8485a654
socketCount=2
userBubbleCount=1
queueCleared=true
```

Proof method: Playwright loads the real Control UI from the live Gateway, installs a WebSocket shim that defers the first `chat.send` response, sends a message, then closes the active socket before the deferred ACK is delivered. After auto-reconnect, the UI issues exactly one replayed `chat.send` with the same `idempotencyKey`, clears the queue, and renders a single user bubble (no duplicate).

Live Gateway + Chrome send smoke (baseline connectivity, prior run on `ef8fad43e38`):

```text
REAL_WEBCHAT_PROOF
url=http://127.0.0.1:19123/chat
send.method=chat.send
send.sessionKey=agent:dev:main
send.deliver=false
send.message=live proof webchat send queue smoke
send.idempotencyKey=f4aae40c-b566-4b26-a3b7-06a2ab3f1189
ack.ok=true
```

Reconnect/replay regressions (2026-05-31 local rerun on `ef8fad43e38`):

```text
node scripts/run-vitest.mjs ui/src/ui/app-gateway.node.test.ts ui/src/ui/app-chat.test.ts \
  -t "replays in-flight|stopped gateway client|ignores stale in-flight|retryablePending|gateway-scope|pre-ack socket close"

Test Files  2 passed (2)
Tests  6 passed | 120 skipped (126)
```

Cases covered by those 6 tests:
- `replays in-flight queued chat sends when hello arrives before stale close` — fast reconnect replay with same `idempotencyKey`
- `keeps a stopped gateway client error recoverable with the same run id` — `retryablePending` stop path
- `ignores stale in-flight send completion after reconnect replay starts/succeeds` — stale completion cannot drop replayed queue item
- `retries reconnectable queued chat sends after reconnect hello` / gateway-scope gating / `pre-ack socket close` recoverable paths

Additional browser-level reconnect proof exists in `ui/src/ui/e2e/chat-flow.e2e.test.ts` (`retries an ACK-lost send after reconnect with the same idempotency key`): Playwright drives the real Control UI against a mocked Gateway WebSocket, defers the first `chat.send` ACK, closes the socket, and asserts a second `chat.send` reuses the same idempotency key and clears the queue.

Observed result after fix: Live Gateway + Chromium timing proof shows deferred-ACK reconnect replays once with the same idempotency key, clears the queue, and leaves a single user bubble. Focused unit regressions and mocked-Gateway browser E2E cover adjacent race paths.

What was not tested: Manual human-timed reconnect in a visible Chrome window (automated Chromium proof above covers the timing-sensitive ACK-loss race). `checks-node-agentic-agents-core` failure on `src/agents/agent-bundle-mcp-runtime.test.ts:853` is unrelated to this UI-only diff (local rerun of that test passes).
