### PR TITLE
feat(plugins): accept slot owner records

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -355,8 +355,8 @@ restart after changing native plugin config.
   - `memory.qmd.*`
   - `plugins.entries.memory-core.config.dreaming`
 - Enabled Claude bundle plugins can also contribute embedded OpenClaw defaults from `settings.json`; OpenClaw applies those as sanitized agent settings, not as raw OpenClaw config patches.
-- `plugins.slots.memory`: pick the active memory plugin id, or `"none"` to disable memory plugins.
-- `plugins.slots.contextEngine`: pick the active context engine plugin id; defaults to `"legacy"` unless you install and select another engine.
+- `plugins.slots.memory`: pick the active memory plugin id, or `"none"` to disable memory plugins. The value may be a string id or an object with `owner`.
+- `plugins.slots.contextEngine`: pick the active context engine plugin id; defaults to `"legacy"` unless you install and select another engine. The value may be a string id or an object with `owner`.
 
 See [Plugins](/tools/plugin).
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1435,8 +1435,8 @@ See [Configuration reference](/gateway/configuration) for the full `plugins.*` s
 - Native manifests are parsed with JSON5, so comments, trailing commas, and unquoted keys are accepted as long as the final value is still an object.
 - Only documented manifest fields are read by the manifest loader. Avoid custom top-level keys.
 - `channels`, `providers`, `cliBackends`, and `skills` can all be omitted when a plugin does not need them.
-- `providerCatalogEntry` must stay lightweight and should not import broad runtime code; use it for static provider catalog metadata or narrow discovery descriptors, not request-time execution.
-- Exclusive plugin kinds are selected through `plugins.slots.*`: `kind: "memory"` via `plugins.slots.memory`, `kind: "context-engine"` via `plugins.slots.contextEngine` (default `legacy`).
+- `providerCatalogEntry` must stay lightweight and should not import broad runtime code; use it for static provider catalog metadata or narrow discovery descriptors, not request-time execution. `providerDiscoveryEntry` is the legacy spelling and still works for existing plugins.
+- Exclusive plugin kinds are selected through `plugins.slots.*`: `kind: "memory"` via `plugins.slots.memory`, `kind: "context-engine"` via `plugins.slots.contextEngine` (default `legacy`). Slot values may be plugin id strings or `{ owner: "<plugin-id>" }` records; plugin authors should read the normalized owner instead of assuming a raw string.
 - Declare exclusive plugin kind in this manifest. Runtime-entry `OpenClawPluginDefinition.kind` is deprecated and remains only as a compatibility fallback for older plugins.
 - Env-var metadata (`setup.providers[].envVars`, deprecated `providerAuthEnvVars`, and `channelEnvVars`) is declarative only. Status, audit, cron delivery validation, and other read-only surfaces still apply plugin trust and effective activation policy before treating an env var as configured.
 - For runtime wizard metadata that requires provider code, see [Provider runtime hooks](/plugins/architecture-internals#provider-runtime-hooks).

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -182,6 +182,10 @@ Key policy rules:
   for that slot by counting as explicit activation; it can load even when it
   would otherwise be opt-in. `plugins.deny` and
   `plugins.entries.<id>.enabled: false` still block it.
+- Slot values can be a plugin id string or an owner record such as
+  `{ owner: "memory-lancedb", claimed_at: "2026-04-23T21:14:00Z" }`.
+  OpenClaw reads both forms as the same selected owner. Current CLI install and
+  repair flows may still write the string form.
 - Bundled opt-in plugins can auto-activate when config names one of their owned
   surfaces, such as a provider/model ref, channel config, CLI backend, or agent
   harness runtime.

--- a/src/agents/provider-auth-aliases.test.ts
+++ b/src/agents/provider-auth-aliases.test.ts
@@ -40,6 +40,7 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
 
 import {
   resetProviderAuthAliasMapCacheForTest,
+  resolveProviderAuthAliasMap,
   resolveProviderIdForAuth,
 } from "./provider-auth-aliases.js";
 
@@ -114,5 +115,31 @@ describe("provider auth aliases", () => {
     expect(pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry).toHaveBeenCalledTimes(
       2,
     );
+  });
+
+  it("trusts workspace context-engine provider aliases selected by object-form slot owner", () => {
+    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-engine",
+          origin: "workspace",
+          providerAuthAliases: { "engine-plan": "engine-provider" },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    expect(
+      resolveProviderAuthAliasMap({
+        config: {
+          plugins: {
+            slots: {
+              contextEngine: { owner: "workspace-engine", claimed_by_version: "0.9.10" },
+            },
+          },
+        },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).toEqual({ "engine-plan": "engine-provider" });
   });
 });

--- a/src/agents/provider-auth-aliases.ts
+++ b/src/agents/provider-auth-aliases.ts
@@ -11,6 +11,7 @@ import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
+import { resolvePluginSlotOwner } from "../plugins/slots.js";
 
 export type ProviderAuthAliasLookupParams = {
   config?: OpenClawConfig;
@@ -73,7 +74,8 @@ function isWorkspacePluginTrustedForAuthAliases(
   return isWorkspacePluginAllowedByConfig({
     config,
     isImplicitlyAllowed: (pluginId) =>
-      normalizePluginConfigId(config?.plugins?.slots?.contextEngine) === pluginId,
+      normalizePluginConfigId(resolvePluginSlotOwner(config?.plugins?.slots?.contextEngine)) ===
+      pluginId,
     plugin,
   });
 }

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -108,14 +108,16 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     return cursor;
   }
 
+  type ResolveManifestContractOwnerPluginId = NonNullable<
+    Parameters<
+      typeof commandSecretGatewayTesting.setDepsForTest
+    >[0]["resolveManifestContractOwnerPluginId"]
+  >;
+
   function setSingleSecretTargetDeps(params: {
     path: string;
     pathSegments: readonly string[];
-    resolveManifestContractOwnerPluginId?: NonNullable<
-      Parameters<
-        typeof commandSecretGatewayTesting.setDepsForTest
-      >[0]["resolveManifestContractOwnerPluginId"]
-    >;
+    resolveManifestContractOwnerPluginId?: ResolveManifestContractOwnerPluginId;
   }): () => void {
     const deps: Parameters<typeof commandSecretGatewayTesting.setDepsForTest>[0] = {
       analyzeCommandSecretAssignmentsFromSnapshot: ({ inactiveRefPaths, resolvedConfig }) => {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -16,6 +16,7 @@ import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { AgentRuntimePolicyConfig } from "../../../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { detectWindowsSpawnCommandInlineArgs } from "../../../plugin-sdk/windows-spawn.js";
+import { resolvePluginSlotOwner } from "../../../plugins/slots.js";
 import { normalizeAgentId } from "../../../routing/session-key.js";
 
 type CodexRouteHit = {
@@ -1989,7 +1990,7 @@ function maybeMigrateLegacyLosslessCompactionConfig(params: {
     entries[LOSSLESS_CONTEXT_ENGINE_ID] = entry;
   }
   const config = ensureMutablePath(entry, ["config"]);
-  if (slots.contextEngine !== LOSSLESS_CONTEXT_ENGINE_ID) {
+  if (resolvePluginSlotOwner(slots.contextEngine) !== LOSSLESS_CONTEXT_ENGINE_ID) {
     slots.contextEngine = LOSSLESS_CONTEXT_ENGINE_ID;
     changes.push(
       `Set plugins.slots.contextEngine to "${LOSSLESS_CONTEXT_ENGINE_ID}" for legacy Lossless compaction config.`,

--- a/src/commands/doctor/shared/context-engine-host-compat.test.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.test.ts
@@ -45,7 +45,7 @@ function registerEngine(requiredCapabilities: ContextEngineHostCapability[]): st
   return id;
 }
 
-function configWithEngine(engineId: string, cfg: OpenClawConfig = {}): OpenClawConfig {
+function configWithEngine(engineId: unknown, cfg: OpenClawConfig = {}): OpenClawConfig {
   return {
     ...cfg,
     plugins: {
@@ -55,7 +55,7 @@ function configWithEngine(engineId: string, cfg: OpenClawConfig = {}): OpenClawC
         contextEngine: engineId,
       },
     },
-  };
+  } as OpenClawConfig;
 }
 
 describe("doctor context-engine host compatibility", () => {
@@ -111,6 +111,31 @@ describe("doctor context-engine host compatibility", () => {
           },
         },
       }),
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(result.config.plugins?.slots?.contextEngine).toBe("legacy");
+    expect(result.changes).toEqual([
+      `Set plugins.slots.contextEngine to "legacy" because context engine "${engineId}" is incompatible with every configured agent-run host.`,
+    ]);
+  });
+
+  it("resolves object-form context engine slot owners before host compatibility checks", async () => {
+    const engineId = registerEngine(["assemble-before-prompt"]);
+    const result = await maybeRepairContextEngineHostCompatibility({
+      cfg: configWithEngine(
+        { owner: engineId, claimed_by_version: "0.9.10" },
+        {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-sonnet-4-6",
+              models: {
+                "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
+              },
+            },
+          },
+        },
+      ),
       doctorFixCommand: "openclaw doctor --fix",
     });
 

--- a/src/commands/doctor/shared/context-engine-host-compat.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.ts
@@ -18,7 +18,7 @@ import { ensureContextEnginesInitialized } from "../../../context-engine/init.js
 import { getContextEngineFactory, resolveContextEngine } from "../../../context-engine/registry.js";
 import type { ContextEngineInfo } from "../../../context-engine/types.js";
 import { ensurePluginRegistryLoaded } from "../../../plugins/runtime/runtime-registry-loader.js";
-import { defaultSlotIdForKey } from "../../../plugins/slots.js";
+import { defaultSlotIdForKey, resolvePluginSlotOwner } from "../../../plugins/slots.js";
 import { isRecord, resolveUserPath } from "../../../utils.js";
 
 export type HostCandidate = {
@@ -233,10 +233,10 @@ export function collectConfiguredContextEngineAgentRunHosts(params: {
 }
 
 function selectedContextEngineSlotId(cfg: OpenClawConfig): string {
-  const slotValue = cfg.plugins?.slots?.contextEngine;
-  return typeof slotValue === "string" && slotValue.trim()
-    ? slotValue.trim()
-    : defaultSlotIdForKey("contextEngine");
+  return (
+    resolvePluginSlotOwner(cfg.plugins?.slots?.contextEngine) ??
+    defaultSlotIdForKey("contextEngine")
+  );
 }
 
 async function resolveSelectedContextEngineInfo(params: {

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -5,7 +5,11 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { normalizePluginId } from "../../../plugins/config-state.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "../../../plugins/installed-plugin-index-records.js";
 import { loadManifestMetadataSnapshot } from "../../../plugins/manifest-contract-eligibility.js";
-import { defaultSlotIdForKey, type PluginSlotKey } from "../../../plugins/slots.js";
+import {
+  defaultSlotIdForKey,
+  resolvePluginSlotOwner,
+  type PluginSlotKey,
+} from "../../../plugins/slots.js";
 import { asObjectRecord } from "./object.js";
 
 const CHANNEL_CONFIG_META_KEYS = new Set(["defaults", "modelByChannel"]);
@@ -160,7 +164,7 @@ function scanStalePluginConfigWithState(
   const slots = asObjectRecord(plugins?.slots);
   if (slots) {
     for (const slotKey of ["memory", "contextEngine"] as const satisfies readonly PluginSlotKey[]) {
-      const rawPluginId = slots[slotKey];
+      const rawPluginId = resolvePluginSlotOwner(slots[slotKey]);
       if (typeof rawPluginId !== "string") {
         continue;
       }

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resolveGatewayProbeSnapshot,
+  resolveMemoryPluginStatus,
   resolveSharedMemoryStatusSnapshot,
 } from "./status.scan.shared.js";
 
@@ -427,6 +428,21 @@ describe("resolveGatewayProbeSnapshot", () => {
 });
 
 describe("resolveSharedMemoryStatusSnapshot", () => {
+  it("normalizes object-form memory slot owners for status", () => {
+    expect(
+      resolveMemoryPluginStatus({
+        plugins: {
+          slots: {
+            memory: {
+              owner: "memory-lancedb-pro",
+              claimed_at: "2026-04-23T21:14:00Z",
+            },
+          },
+        },
+      }),
+    ).toEqual({ enabled: true, slot: "memory-lancedb-pro" });
+  });
+
   it("asks custom memory-slot runtimes for status without requiring built-in memorySearch", async () => {
     const manager = {
       probeVectorStoreAvailability: vi.fn(async () => true),

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -14,7 +14,7 @@ import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
 import { resolveGatewayProbeTarget } from "../gateway/probe-target.js";
 import type { GatewayProbeResult, probeGateway as probeGatewayFn } from "../gateway/probe.js";
 import type { MemoryProviderStatus } from "../memory-host-sdk/engine-storage.js";
-import { defaultSlotIdForKey } from "../plugins/slots.js";
+import { defaultSlotIdForKey, resolvePluginSlotOwner } from "../plugins/slots.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { pickGatewaySelfPresence } from "./gateway-presence.js";
 import { isProbeReachable } from "./gateway-status/helpers.js";
@@ -187,11 +187,11 @@ export function resolveMemoryPluginStatus(cfg: OpenClawConfig): MemoryPluginStat
   if (!pluginsEnabled) {
     return { enabled: false, slot: null, reason: "plugins disabled" };
   }
-  const raw = normalizeOptionalString(cfg.plugins?.slots?.memory) ?? "";
-  if (normalizeOptionalLowercaseString(raw) === "none") {
+  const raw = resolvePluginSlotOwner(cfg.plugins?.slots?.memory);
+  if (raw === null) {
     return { enabled: false, slot: null, reason: 'plugins.slots.memory="none"' };
   }
-  return { enabled: true, slot: raw || defaultSlotIdForKey("memory") };
+  return { enabled: true, slot: raw ?? defaultSlotIdForKey("memory") };
 }
 
 export async function resolveGatewayProbeSnapshot(params: {

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -357,6 +357,38 @@ describe("plugins.slots.contextEngine", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("accepts object-form slot owner records with provenance metadata", () => {
+    const result = OpenClawSchema.safeParse({
+      plugins: {
+        slots: {
+          memory: {
+            owner: "memory-lancedb",
+            claimed_at: "2026-04-23T21:14:00Z",
+            claimed_by_version: "0.9.10",
+          },
+          contextEngine: {
+            owner: "lossless-claw",
+            claimed_by_version: "1.2.3",
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects object-form slot records without an owner", () => {
+    const result = OpenClawSchema.safeParse({
+      plugins: {
+        slots: {
+          memory: {
+            claimed_at: "2026-04-23T21:14:00Z",
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("models.pricing", () => {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -298,6 +298,25 @@ describe("config plugin validation", () => {
     }
   });
 
+  it("reports missing plugin refs selected through object-form slot owners", () => {
+    const res = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        enabled: true,
+        slots: {
+          memory: {
+            owner: "missing-slot",
+            claimed_at: "2026-04-23T21:14:00Z",
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expectPathMessage(res.issues, "plugins.slots.memory", "plugin not found: missing-slot");
+    }
+  });
+
   it("warns instead of failing for stale plugins.deny entries", () => {
     const res = validateInSuite({
       agents: { list: [{ id: "openclaw" }] },

--- a/src/config/types.plugins.ts
+++ b/src/config/types.plugins.ts
@@ -38,11 +38,19 @@ export type PluginEntryConfig = {
   config?: Record<string, unknown>;
 };
 
+export type PluginSlotOwnerRecord = {
+  /** Plugin id that owns the slot. Extra fields may carry provenance metadata. */
+  owner: string;
+  [key: string]: unknown;
+};
+
+export type PluginSlotValue = string | PluginSlotOwnerRecord;
+
 export type PluginSlotsConfig = {
   /** Select which plugin owns the memory slot ("none" disables memory plugins). */
-  memory?: string;
+  memory?: PluginSlotValue;
   /** Select which plugin owns the context-engine slot. */
-  contextEngine?: string;
+  contextEngine?: PluginSlotValue;
 };
 
 export type PluginsLoadConfig = {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -23,7 +23,7 @@ import {
   type PluginMetadataSnapshot,
 } from "../plugins/plugin-metadata-snapshot.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
-import { hasKind } from "../plugins/slots.js";
+import { hasKind, resolvePluginSlotOwner } from "../plugins/slots.js";
 import { resolveWebSearchInstallCatalogEntries } from "../plugins/web-search-install-catalog.js";
 import { collectUnsupportedSecretRefConfigCandidates } from "../secrets/unsupported-surface-policy.js";
 import {
@@ -802,7 +802,8 @@ function collectExplicitPluginReferences(raw: unknown): ExplicitPluginReferences
     }
   }
   if (isRecord(plugins.slots)) {
-    for (const [slotId, pluginId] of Object.entries(plugins.slots)) {
+    for (const [slotId, slotValue] of Object.entries(plugins.slots)) {
+      const pluginId = resolvePluginSlotOwner(slotValue);
       if (typeof pluginId !== "string") {
         continue;
       }

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -272,6 +272,15 @@ const PluginEntrySchema = z
   })
   .strict();
 
+const PluginSlotValueSchema = z.union([
+  z.string(),
+  z
+    .object({
+      owner: z.string(),
+    })
+    .passthrough(),
+]);
+
 const TalkProviderEntrySchema = z
   .object({
     apiKey: SecretInputSchema.optional().register(sensitive),
@@ -1253,8 +1262,8 @@ export const OpenClawSchema = z
           .optional(),
         slots: z
           .object({
-            memory: z.string().optional(),
-            contextEngine: z.string().optional(),
+            memory: PluginSlotValueSchema.optional(),
+            contextEngine: PluginSlotValueSchema.optional(),
           })
           .strict()
           .optional(),

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -72,8 +72,8 @@ function requireCompactRuntimeParams(callIndex: number): Record<string, unknown>
 // ---------------------------------------------------------------------------
 
 /** Build a config object with a contextEngine slot for testing. */
-function configWithSlot(engineId: string): OpenClawConfig {
-  return { plugins: { slots: { contextEngine: engineId } } };
+function configWithSlot(engineId: unknown): OpenClawConfig {
+  return { plugins: { slots: { contextEngine: engineId } } } as OpenClawConfig;
 }
 
 function makeMockMessage(role: "user" | "assistant" = "user", text = "hello"): AgentMessage {
@@ -758,6 +758,13 @@ describe("Default engine selection", () => {
 
   it("resolveContextEngine() with config contextEngine='test-engine' returns the custom engine", async () => {
     const engine = await resolveContextEngine(configWithSlot("test-engine"));
+    expect(engine.info.id).toBe("test-engine");
+  });
+
+  it("resolveContextEngine() accepts object-form slot owners", async () => {
+    const engine = await resolveContextEngine(
+      configWithSlot({ owner: "test-engine", claimed_by_version: "0.9.10" }),
+    );
     expect(engine.info.id).toBe("test-engine");
   });
 });

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -1,6 +1,6 @@
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { defaultSlotIdForKey } from "../plugins/slots.js";
+import { defaultSlotIdForKey, resolvePluginSlotOwner } from "../plugins/slots.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import type {
   AssembleResult,
@@ -882,11 +882,9 @@ export async function resolveContextEngine(
   config?: OpenClawConfig,
   options?: ResolveContextEngineOptions,
 ): Promise<ContextEngine> {
-  const slotValue = config?.plugins?.slots?.contextEngine;
   const engineId =
-    typeof slotValue === "string" && slotValue.trim()
-      ? slotValue.trim()
-      : defaultSlotIdForKey("contextEngine");
+    resolvePluginSlotOwner(config?.plugins?.slots?.contextEngine) ??
+    defaultSlotIdForKey("contextEngine");
 
   const defaultEngineId = defaultSlotIdForKey("contextEngine");
   const isDefaultEngine = engineId === defaultEngineId;

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -11,7 +11,7 @@ import { resolveMainSessionKey } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { isTestDefaultMemorySlotDisabled } from "../plugins/config-state.js";
-import { defaultSlotIdForKey } from "../plugins/slots.js";
+import { defaultSlotIdForKey, resolvePluginSlotOwner } from "../plugins/slots.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { canonicalizeSessionKeyForAgent } from "./session-store-key.js";
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
@@ -68,8 +68,8 @@ function resolveMemoryToolDisableReasons(cfg: OpenClawConfig): string[] {
   }
   const reasons: string[] = [];
   const plugins = cfg.plugins;
-  const slotRaw = plugins?.slots?.memory;
-  const slotDisabled = slotRaw === null || normalizeOptionalLowercaseString(slotRaw) === "none";
+  const slotOwner = resolvePluginSlotOwner(plugins?.slots?.memory);
+  const slotDisabled = slotOwner === null;
   const pluginsDisabled = plugins?.enabled === false;
   const defaultDisabled = isTestDefaultMemorySlotDisabled(cfg);
 
@@ -77,7 +77,7 @@ function resolveMemoryToolDisableReasons(cfg: OpenClawConfig): string[] {
     reasons.push("plugins.enabled=false");
   }
   if (slotDisabled) {
-    reasons.push(slotRaw === null ? "plugins.slots.memory=null" : 'plugins.slots.memory="none"');
+    reasons.push('plugins.slots.memory="none"');
   }
   if (!pluginsDisabled && !slotDisabled && defaultDisabled) {
     reasons.push("memory plugin disabled by test default");

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -242,6 +242,21 @@ describe("memory dreaming host helpers", () => {
     ).toBe("memos-local-openclaw-plugin");
   });
 
+  it("resolves object-form memory-slot owners for dreaming", () => {
+    expect(
+      resolveMemoryDreamingPluginId({
+        plugins: {
+          slots: {
+            memory: {
+              owner: "memos-local-openclaw-plugin",
+              claimed_by_version: "0.9.10",
+            },
+          },
+        },
+      } as OpenClawConfig),
+    ).toBe("memos-local-openclaw-plugin");
+  });
+
   it("reads dreaming config from the configured memory-slot owner", () => {
     expect(
       resolveMemoryDreamingPluginConfig({

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -7,7 +7,10 @@ import {
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolvePluginSlotOwner } from "../plugins/slots.js";
 
 export const DEFAULT_MEMORY_DREAMING_ENABLED = false;
 export const DEFAULT_MEMORY_DREAMING_TIMEZONE = undefined;
@@ -340,7 +343,7 @@ export function resolveMemoryDreamingPluginId(
   const root = asNullableRecord(cfg);
   const plugins = asNullableRecord(root?.plugins);
   const slots = asNullableRecord(plugins?.slots);
-  const configuredSlot = normalizeTrimmedString(slots?.memory);
+  const configuredSlot = resolvePluginSlotOwner(slots?.memory);
   if (configuredSlot && normalizeLowercaseStringOrEmpty(configuredSlot) !== "none") {
     return configuredSlot;
   }

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -5,7 +5,7 @@ import {
 import { normalizeArrayBackedTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { normalizeChatChannelId } from "../channels/ids.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { defaultSlotIdForKey } from "./slots.js";
+import { defaultSlotIdForKey, resolvePluginSlotOwner } from "./slots.js";
 
 export type NormalizedPluginsConfig = {
   enabled: boolean;
@@ -53,17 +53,6 @@ function normalizeList(value: unknown, normalizePluginId: NormalizePluginId): st
   return value
     .map((entry) => (typeof entry === "string" ? normalizePluginId(entry) : ""))
     .filter(Boolean);
-}
-
-function normalizeSlotValue(value: unknown): string | null | undefined {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed) {
-    return undefined;
-  }
-  if (normalizeOptionalLowercaseString(trimmed) === "none") {
-    return null;
-  }
-  return trimmed;
 }
 
 function normalizeHookTimeoutMs(value: unknown): number | undefined {
@@ -224,7 +213,7 @@ export function normalizePluginsConfigWithResolver(
   config?: OpenClawConfig["plugins"],
   normalizePluginId: NormalizePluginId = identityNormalizePluginId,
 ): NormalizedPluginsConfig {
-  const memorySlot = normalizeSlotValue(config?.slots?.memory);
+  const memorySlot = resolvePluginSlotOwner(config?.slots?.memory);
   return {
     enabled: config?.enabled !== false,
     allow: normalizeList(config?.allow, normalizePluginId),
@@ -232,7 +221,7 @@ export function normalizePluginsConfigWithResolver(
     loadPaths: normalizeList(config?.load?.paths, identityNormalizePluginId),
     slots: {
       memory: memorySlot === undefined ? defaultSlotIdForKey("memory") : memorySlot,
-      contextEngine: normalizeSlotValue(config?.slots?.contextEngine),
+      contextEngine: resolvePluginSlotOwner(config?.slots?.contextEngine),
     },
     entries: normalizePluginEntries(config?.entries, normalizePluginId),
   };

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -47,9 +47,15 @@ describe("normalizePluginsConfig", () => {
   it.each([
     [{}, "memory-core"],
     [{ slots: { memory: "custom-memory" } }, "custom-memory"],
+    [
+      { slots: { memory: { owner: "custom-memory", claimed_at: "2026-04-23T21:14:00Z" } } },
+      "custom-memory",
+    ],
     [{ slots: { memory: "none" } }, null],
+    [{ slots: { memory: { owner: "none" } } }, null],
     [{ slots: { memory: "None" } }, null],
     [{ slots: { memory: "  custom-memory  " } }, "custom-memory"],
+    [{ slots: { memory: { owner: "  custom-memory  " } } }, "custom-memory"],
     [{ slots: { memory: "" } }, "memory-core"],
     [{ slots: { memory: "   " } }, "memory-core"],
   ] as const)("normalizes memory slot for %o", (config, expected) => {
@@ -59,8 +65,14 @@ describe("normalizePluginsConfig", () => {
   it.each([
     [{}, undefined],
     [{ slots: { contextEngine: "lossless-claw" } }, "lossless-claw"],
+    [
+      { slots: { contextEngine: { owner: "lossless-claw", claimed_by_version: "1.2.3" } } },
+      "lossless-claw",
+    ],
     [{ slots: { contextEngine: "none" } }, null],
+    [{ slots: { contextEngine: { owner: "none" } } }, null],
     [{ slots: { contextEngine: "  cortex  " } }, "cortex"],
+    [{ slots: { contextEngine: { owner: "  cortex  " } } }, "cortex"],
     [{ slots: { contextEngine: "" } }, undefined],
   ] as const)("preserves contextEngine slot for %o (#64170)", (config, expected) => {
     expect(normalizePluginsConfig(config).slots.contextEngine).toBe(expected);

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -35,6 +35,7 @@ import {
   normalizePluginsConfigWithRegistry,
 } from "./plugin-registry-contributions.js";
 import type { PluginRegistrySnapshot } from "./plugin-registry-snapshot.js";
+import { resolvePluginSlotOwner } from "./slots.js";
 
 export type GatewayStartupPluginPlan = {
   channelPluginIds: readonly string[];
@@ -102,8 +103,8 @@ function resolveMemorySlotStartupPluginId(params: {
   normalizePluginId: (pluginId: string) => string;
 }): string | undefined {
   const { activationSourceConfig, activationSourcePlugins, normalizePluginId } = params;
-  const configuredSlot = activationSourceConfig.plugins?.slots?.memory?.trim();
-  if (configuredSlot?.toLowerCase() === "none") {
+  const configuredSlot = resolvePluginSlotOwner(activationSourceConfig.plugins?.slots?.memory);
+  if (configuredSlot === null) {
     return undefined;
   }
   if (!configuredSlot) {
@@ -128,7 +129,9 @@ function resolveContextEngineSlotStartupPluginId(params: {
   normalizePluginId: (pluginId: string) => string;
 }): string | undefined {
   const { activationSourceConfig, activationSourcePlugins, normalizePluginId } = params;
-  const configuredSlot = activationSourceConfig.plugins?.slots?.contextEngine?.trim();
+  const configuredSlot = resolvePluginSlotOwner(
+    activationSourceConfig.plugins?.slots?.contextEngine,
+  );
   if (!configuredSlot) {
     return undefined;
   }

--- a/src/plugins/provider-auth-choice-helpers.test.ts
+++ b/src/plugins/provider-auth-choice-helpers.test.ts
@@ -1,6 +1,14 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { applyDefaultModel, applyProviderAuthConfigPatch } from "./provider-auth-choice-helpers.js";
+
+vi.mock("./plugin-metadata-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./plugin-metadata-snapshot.js")>();
+  return {
+    ...actual,
+    resolvePluginMetadataSnapshot: vi.fn((params) => actual.loadPluginMetadataSnapshot(params)),
+  };
+});
 
 describe("applyProviderAuthConfigPatch", () => {
   beforeAll(() => {

--- a/src/plugins/slots.test.ts
+++ b/src/plugins/slots.test.ts
@@ -174,6 +174,15 @@ describe("applyExclusiveSlotSelection", () => {
       registry: { plugins: [{ id: "memory", kind: "memory" }] },
     },
     {
+      name: "does nothing when an owner record already matches",
+      config: createMemoryConfig({
+        slots: { memory: { owner: "memory", claimed_by_version: "1.0.0" } },
+      }),
+      selectedId: "memory",
+      selectedKind: "memory",
+      registry: { plugins: [{ id: "memory", kind: "memory" }] },
+    },
+    {
       name: "skips changes when no exclusive slot applies",
       config: {} as OpenClawConfig,
       selectedId: "custom",
@@ -212,6 +221,27 @@ describe("applyExclusiveSlotSelection", () => {
     expect(result.config.plugins?.slots?.contextEngine).toBe("dual-plugin");
     expect(result.config.plugins?.entries?.["memory-core"]?.enabled).toBe(false);
     expect(result.config.plugins?.entries?.legacy?.enabled).toBe(false);
+  });
+
+  it("switches an owner-record slot by its owner id", () => {
+    const result = runMemorySelection(
+      createMemoryConfig({
+        slots: { memory: { owner: "memory-core", claimed_at: "2026-04-23T21:14:00Z" } },
+        entries: { "memory-core": { enabled: true } },
+      }),
+    );
+
+    expectMemorySelectionState(result, {
+      changed: true,
+      selectedId: "memory",
+      disabledCompetingPlugin: false,
+    });
+    expectSelectionWarnings(result.warnings, {
+      expected: [
+        'Exclusive slot "memory" switched from "memory-core" to "memory".',
+        'Disabled other "memory" slot plugins: memory-core.',
+      ],
+    });
   });
 
   it("does not disable a dual-kind plugin that still owns another slot", () => {

--- a/src/plugins/slots.ts
+++ b/src/plugins/slots.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginSlotsConfig } from "../config/types.plugins.js";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 import type { PluginKind } from "./plugin-kind.types.js";
 
 export type PluginSlotKey = keyof PluginSlotsConfig;
@@ -56,6 +60,21 @@ export function defaultSlotIdForKey(slotKey: PluginSlotKey): string {
   return DEFAULT_SLOT_BY_KEY[slotKey];
 }
 
+export function resolvePluginSlotOwner(value: unknown): string | null | undefined {
+  const rawOwner =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as { owner?: unknown }).owner
+      : value;
+  const trimmed = normalizeOptionalString(rawOwner);
+  if (!trimmed) {
+    return undefined;
+  }
+  if (normalizeOptionalLowercaseString(trimmed) === "none") {
+    return null;
+  }
+  return trimmed;
+}
+
 export type SlotSelectionResult = {
   config: OpenClawConfig;
   warnings: string[];
@@ -81,9 +100,13 @@ export function applyExclusiveSlotSelection(params: {
 
   for (const slotKey of slotKeys) {
     const prevSlot = slots[slotKey];
-    slots[slotKey] = params.selectedId;
+    const prevOwner = resolvePluginSlotOwner(prevSlot);
+    if (prevOwner !== params.selectedId) {
+      slots[slotKey] = params.selectedId;
+    }
 
-    const inferredPrevSlot = prevSlot ?? defaultSlotIdForKey(slotKey);
+    const inferredPrevSlot =
+      prevOwner === undefined ? defaultSlotIdForKey(slotKey) : (prevOwner ?? "none");
     if (inferredPrevSlot && inferredPrevSlot !== params.selectedId) {
       warnings.push(
         `Exclusive slot "${slotKey}" switched from "${inferredPrevSlot}" to "${params.selectedId}".`,
@@ -106,7 +129,11 @@ export function applyExclusiveSlotSelection(params: {
         const stillOwnsOtherSlot = (Object.keys(SLOT_BY_KIND) as PluginKind[])
           .map((k) => SLOT_BY_KIND[k])
           .filter((sk) => sk !== slotKey)
-          .some((sk) => (slots[sk] ?? defaultSlotIdForKey(sk)) === plugin.id);
+          .some((sk) => {
+            const owner = resolvePluginSlotOwner(slots[sk]);
+            const effectiveOwner = owner === undefined ? defaultSlotIdForKey(sk) : owner;
+            return effectiveOwner === plugin.id;
+          });
         if (stillOwnsOtherSlot) {
           continue;
         }
@@ -124,7 +151,7 @@ export function applyExclusiveSlotSelection(params: {
       );
     }
 
-    if (prevSlot !== params.selectedId || disabledIds.length > 0) {
+    if (prevOwner !== params.selectedId || disabledIds.length > 0) {
       anyChanged = true;
     }
   }

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -17,7 +17,7 @@ import {
   resolvePluginNpmProjectsDir,
 } from "./install-paths.js";
 import { relinkOpenClawPeerDependenciesInManagedNpmRoot } from "./plugin-peer-link.js";
-import { defaultSlotIdForKey } from "./slots.js";
+import { defaultSlotIdForKey, resolvePluginSlotOwner } from "./slots.js";
 
 export type UninstallActions = {
   entry: boolean;
@@ -446,14 +446,14 @@ export function removePluginFromConfig(
 
   // Reset slots if this plugin was selected.
   let slots = pluginsConfig.slots;
-  if (slots?.memory === pluginId) {
+  if (resolvePluginSlotOwner(slots?.memory) === pluginId) {
     slots = {
       ...slots,
       memory: defaultSlotIdForKey("memory"),
     };
     actions.memorySlot = true;
   }
-  if (slots?.contextEngine === pluginId) {
+  if (resolvePluginSlotOwner(slots?.contextEngine) === pluginId) {
     slots = {
       ...slots,
       contextEngine: defaultSlotIdForKey("contextEngine"),

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1791,6 +1791,56 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it("clears object-form slot owner references when disabling failed updates", async () => {
+    const warn = vi.fn();
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: false,
+      error: "security scan blocked install",
+    });
+    const config = {
+      plugins: {
+        slots: {
+          memory: {
+            owner: "demo",
+            claimed_at: "2026-05-26T00:00:00.000Z",
+            claimed_by_version: "2026.5.26",
+          },
+          contextEngine: {
+            owner: "demo",
+            claimed_at: "2026-05-26T00:00:00.000Z",
+          },
+        },
+        entries: {
+          demo: {
+            enabled: true,
+          },
+        },
+        installs: {
+          demo: {
+            source: "npm" as const,
+            spec: "@acme/demo",
+            installPath: "/tmp/demo",
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await updateNpmInstalledPlugins({
+      config,
+      disableOnFailure: true,
+      logger: { warn },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.entries?.demo).toEqual({
+      enabled: false,
+    });
+    expect(result.config.plugins?.slots).toEqual({
+      memory: "memory-core",
+      contextEngine: "legacy",
+    });
+  });
+
   it("aborts exact pinned npm plugin updates on integrity drift by default", async () => {
     const warn = vi.fn();
     installPluginFromNpmSpecMock.mockImplementation(
@@ -2766,6 +2816,44 @@ describe("updateNpmInstalledPlugins", () => {
       version: "0.0.2",
     });
     expect(result.config.plugins?.installs?.["context-engine"]).toBeUndefined();
+  });
+
+  it("preserves object-form slot metadata when a plugin id changes during update", async () => {
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: true,
+      pluginId: "@openclaw/context-engine",
+      targetDir: "/tmp/openclaw-context-engine",
+      version: "0.0.2",
+      extensions: ["index.ts"],
+    });
+
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          slots: {
+            contextEngine: {
+              owner: "context-engine",
+              claimed_at: "2026-04-23T21:14:00Z",
+              claimed_by_version: "0.0.1",
+            },
+          },
+          installs: {
+            "context-engine": {
+              source: "npm",
+              spec: "@openclaw/context-engine",
+              installPath: "/tmp/context-engine",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      pluginIds: ["context-engine"],
+    });
+
+    expect(result.config.plugins?.slots?.contextEngine).toEqual({
+      owner: "@openclaw/context-engine",
+      claimed_at: "2026-04-23T21:14:00Z",
+      claimed_by_version: "0.0.1",
+    });
   });
 
   it("checks marketplace installs during dry-run updates", async () => {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginInstallRecord } from "../config/types.plugins.js";
+import type { PluginInstallRecord, PluginSlotValue } from "../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
 import type { NpmSpecResolution } from "../infra/install-source-utils.js";
 import { resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
@@ -49,7 +49,7 @@ import {
   resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
 import { linkOpenClawPeerDependencies } from "./plugin-peer-link.js";
-import { defaultSlotIdForKey } from "./slots.js";
+import { defaultSlotIdForKey, resolvePluginSlotOwner } from "./slots.js";
 
 export type PluginUpdateLogger = {
   info?: (message: string) => void;
@@ -766,6 +766,19 @@ function replacePluginIdInList(
   return next;
 }
 
+function replacePluginSlotOwner(
+  value: PluginSlotValue | undefined,
+  fromId: string,
+  toId: string,
+): PluginSlotValue | undefined {
+  if (resolvePluginSlotOwner(value) !== fromId) {
+    return value;
+  }
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? { ...value, owner: toId }
+    : toId;
+}
+
 function migratePluginConfigId(cfg: OpenClawConfig, fromId: string, toId: string): OpenClawConfig {
   if (fromId === toId) {
     return cfg;
@@ -803,8 +816,8 @@ function migratePluginConfigId(cfg: OpenClawConfig, fromId: string, toId: string
   const nextSlots = slots
     ? {
         ...slots,
-        ...(slots.memory === fromId ? { memory: toId } : {}),
-        ...(slots.contextEngine === fromId ? { contextEngine: toId } : {}),
+        memory: replacePluginSlotOwner(slots.memory, fromId, toId),
+        contextEngine: replacePluginSlotOwner(slots.contextEngine, fromId, toId),
       }
     : undefined;
 
@@ -881,13 +894,13 @@ function resetDisabledPluginSlots(
     return slots;
   }
   let next = slots;
-  if (next.memory === pluginId) {
+  if (resolvePluginSlotOwner(next.memory) === pluginId) {
     next = {
       ...next,
       memory: defaultSlotIdForKey("memory"),
     };
   }
-  if (next.contextEngine === pluginId) {
+  if (resolvePluginSlotOwner(next.contextEngine) === pluginId) {
     next = {
       ...next,
       contextEngine: defaultSlotIdForKey("contextEngine"),

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -604,6 +604,37 @@ describe("provider env vars dynamic manifest metadata", () => {
     ).toEqual(["WHISPERX_API_KEY"]);
   });
 
+  it("keeps selected workspace context engine env vars with object-form slot owners", async () => {
+    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-engine",
+          origin: "workspace",
+          kind: "context-engine",
+          providerAuthEnvVars: {
+            whisperx: ["WHISPERX_API_KEY"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const mod = await import("./provider-env-vars.js");
+
+    expect(
+      mod.getProviderEnvVars("whisperx", {
+        config: {
+          plugins: {
+            slots: {
+              contextEngine: { owner: "workspace-engine", claimed_by_version: "0.9.10" },
+            },
+          },
+        },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).toEqual(["WHISPERX_API_KEY"]);
+  });
+
   it("only loads plugin metadata snapshot once when resolving env var candidates, avoiding duplicate snapshot loads", () => {
     pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
       plugins: [

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -15,7 +15,7 @@ import {
   type PluginMetadataSnapshot,
 } from "../plugins/plugin-metadata-snapshot.js";
 import { listSetupProviderIds } from "../plugins/setup-descriptors.js";
-import { hasKind } from "../plugins/slots.js";
+import { hasKind, resolvePluginSlotOwner } from "../plugins/slots.js";
 
 const CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   anthropic: ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
@@ -64,7 +64,8 @@ function isWorkspacePluginTrustedForProviderEnvVars(
     config,
     isImplicitlyAllowed: (pluginId) =>
       hasKind(plugin.kind, "context-engine") &&
-      normalizePluginConfigId(config?.plugins?.slots?.contextEngine) === pluginId,
+      normalizePluginConfigId(resolvePluginSlotOwner(config?.plugins?.slots?.contextEngine)) ===
+        pluginId,
     plugin,
   });
 }


### PR DESCRIPTION
## Summary

This PR implements the read-side normalization layer proposed in #70823: `plugins.slots.memory` and `plugins.slots.contextEngine` can now be read as either a bare plugin id string or an object-form ownership record with an `owner` field.

What problem does this PR solve?

- Today, OpenClaw slot ownership is represented only as a bare string such as `plugins.slots.memory = "memory-core"`.
- That makes ownership checks brittle: every runtime, doctor, validation, install/update, and plugin trust path has to assume the raw slot value is a string.
- It also blocks the next step in #70823: recording slot ownership provenance without breaking existing configs.

What changes?

- Adds `PluginSlotOwnerRecord` and `PluginSlotValue` config types.
- Extends the config schema so `plugins.slots.memory` and `plugins.slots.contextEngine` accept either `"plugin-id"` or `{ "owner": "plugin-id", ...metadata }`.
- Adds `resolvePluginSlotOwner(value)` as the shared read-side helper for slot owner normalization.
- Updates slot consumers across config normalization, validation, stale config scanning, doctor repair paths, startup plugin preloading, active runtime/status paths, context-engine resolution, memory dreaming, provider auth alias/env-var trust, uninstall cleanup, and plugin ID migration.
- Preserves object-form metadata when plugin ID migration changes only the `owner` field.
- Updates docs and focused regression coverage for object-form slot values.

What is intentionally out of scope?

- No write-side canonicalization. OpenClaw does not start writing `{ owner, claimed_at, claimed_by_version }` records in this PR.
- No overwrite invariant or `--force` behavior. Silent overwrite prevention remains a follow-up to #70823.
- No new slot keys. This PR only covers the existing `memory` and `contextEngine` slots.
- No direct implementation of the memory role-slot architecture from #86210.

Intended outcome:

- Existing configs keep working unchanged.
- New object-form slot records are accepted everywhere relevant on read.
- Later PRs can extend this groundwork instead of reimplementing slot-owner parsing in each surface.

## Linked context

Closes #70823.

Directly related work:

- #86210: adds the multi-slot memory role architecture requested by #60572. This PR intentionally lands the smaller owner-record primitive first, or can be rebased after #86210 by extending the same helper/schema pattern across the new memory role slots.
- #83637: adds per-agent compaction/context-pruning overrides. This PR is complementary because it only changes global plugin-slot value shape and keeps context-engine/compaction semantics separate.
- #60572: user demand for composable memory slots. This PR is supporting groundwork for #60572 by creating the owner-normalization primitive that the role-slot architecture can reuse.

Supporting related PRs and issues:

- #57507: prior multi-kind plugin work showed that one plugin may legitimately participate in multiple exclusive plugin categories.
- #64192: context-engine slot normalization precedent.
- #75640: plugin install slot-selection scope precedent.
- #81512 and #81515: stale plugin reference cleanup and doctor/reporting precedent for slot references.
- #82438: memory-slot warning precedent.
- #85060: memory provider parity proof pattern for active memory plugin behavior.
- #86591: current external-PR body/proof structure used as a template for ClawSweeper-friendly real behavior proof.

## Problem / Root Cause

Before this change, slot readers commonly assumed `plugins.slots.<slot>` was a string. That assumption is exactly what #70823 needs to retire.

The problem is not just schema shape. If only the schema accepts object-form records, but runtime paths keep reading raw values directly, then object-form configs fail in subtle places:

- startup preloading may skip the selected plugin;
- doctor and stale-config scans may miss or misreport owners;
- context-engine resolution may fall back to `legacy`;
- memory status/tool-disable paths may misread `none`;
- provider auth alias/env-var trust may ignore a selected workspace context engine;
- plugin update can collapse or lose ownership metadata.

This PR makes the read-side contract real by routing those consumers through one shared helper.

## What Changed

- `src/config/types.plugins.ts`
  - Adds `PluginSlotOwnerRecord`.
  - Adds `PluginSlotValue = string | PluginSlotOwnerRecord`.
  - Applies the value type to `plugins.slots.memory` and `plugins.slots.contextEngine`.

- `src/config/zod-schema.ts`
  - Accepts string slot values and object values with required `owner`.
  - Allows additional object fields so future provenance fields can be carried without another schema turn.

- `src/plugins/slots.ts`
  - Adds `resolvePluginSlotOwner(value)`.
  - Normalizes strings and object-form owners to one scalar owner id.
  - Treats blank values as unset and `none` as the slot-disabled sentinel.
  - Uses the helper in exclusive slot switching so existing object-form ownership is recognized.

- Runtime/config consumers now normalize slot owners before comparison:
  - config normalization
  - config validation
  - stale plugin config detection
  - doctor route and context-engine compatibility checks
  - gateway startup plugin id selection
  - context-engine resolution
  - memory dreaming config resolution
  - memory status and tool-disable logic
  - provider auth alias/env-var workspace trust checks
  - uninstall cleanup
  - plugin update ID migration

- Documentation now states that slot values may be string ids or `{ owner: "<plugin-id>" }` records.

## Merge-Order Compatibility

This PR is deliberately a groundwork PR, not a competing architecture.

If this lands before #86210:

- #86210 should extend `PluginSlotsConfig`/schema with `memory.recall`, `memory.compaction`, `memory.capture`, `memory.dreaming`, and `memory.userModel` using the same `PluginSlotValue` shape.
- #86210 should use `resolvePluginSlotOwner()` at new role-slot read sites instead of adding new local normalization.
- Expected rebase work should be ordinary schema/docs/test conflicts, not a design rewrite.

If #86210 lands before this:

- This branch should rebase by applying the object-form slot value support to the new memory role keys as well as existing `memory` and `contextEngine`.
- The core helper remains valid; it just gets called from more role-slot consumers.

If #83637 lands before or after this:

- The two changes should stay complementary.
- #83637 controls which agent scope supplies compaction/context-pruning settings.
- This PR controls how global plugin-slot owners are represented and normalized on read.
- Later compaction/context-engine work should consume normalized `contextEngine` ownership where it reads that slot, without changing per-agent compaction semantics.

Follow-up intended after this PR:

- Write-side canonicalization to produce object-form owner records.
- Slot overwrite invariants and explicit force/override behavior.
- Plugin-side adoption of the normalized owner abstraction.

## Real behavior proof

- Behavior or issue addressed: object-form `plugins.slots.memory` and `plugins.slots.contextEngine` records should behave the same as bare string slot owners across config parsing, validation, doctor checks, startup planning, runtime memory/context-engine resolution, provider auth trust checks, plugin lifecycle cleanup, and plugin ID migration.
- Current PR head: `b87f4a710c6de665bffcc6c58245d9950a021926` (`feat(plugins): accept slot owner records`), a final single-commit squash on top of fork `main` at `26913e60a42e84dd256a682c5239be57f346e244`.
- Proof note: The detailed proof below was collected before the final rebase/squash at `27585fb987df8d6c68886566a6280e755a507456`. The final squash preserves the intended branch content as one commit, but exact-head proof has not yet been rerun for `b87f4a710c6de665bffcc6c58245d9950a021926`.
- Real environment tested for proof refresh: Dev-01 source checkout at `/home/kklouzal/.openclaw/workspace/repos/openclaw`; branch `feat/plugin-slot-owner-records`; proof head `27585fb987df8d6c68886566a6280e755a507456`; local Node/Vitest/OpenClaw repo toolchain.
- Exact steps or command run for that proof refresh:

```text
npx vitest run src/plugins/config-state.test.ts src/plugins/slots.test.ts src/config/config-misc.test.ts src/config/config.plugin-validation.test.ts src/agents/provider-auth-aliases.test.ts src/commands/doctor/shared/context-engine-host-compat.test.ts src/commands/status.scan.shared.test.ts src/context-engine/context-engine.test.ts src/gateway/tools-invoke-shared.test.ts src/memory-host-sdk/dreaming.test.ts src/secrets/provider-env-vars.dynamic.test.ts
npx vitest run src/plugins/update.test.ts
node --import tsx scripts/generate-config-doc-baseline.ts --check
node --import tsx scripts/generate-base-config-schema.ts --check
npx oxfmt --check <touched files>
git diff --check
node scripts/run-tsgo.mjs -p tsconfig.core.json
```

- Evidence after fix:

```text
Test Files 11 passed (11)
Tests 301 passed (301)

Test Files 1 passed (1)
Tests 80 passed (80)

OK docs/.generated/config-baseline.sha256
[base-config-schema] ok

All matched files use the correct format.
git diff --check passed
tsgo core check exitCode=0
```

- Observed result after fix: object-form slot owners are accepted by schema, normalize to the same owner ids as string slots, preserve `none` behavior, participate in context-engine and memory runtime resolution, validate missing plugin references correctly, trust selected workspace context-engine plugins for provider auth only when the normalized owner matches, reset/update selected slots during uninstall/update, and preserve extra object metadata when plugin ID migration only changes `owner`.
- What was not tested: live production gateway behavior, write-side object canonicalization, overwrite enforcement, or future #86210 memory role slots. Those are out of scope for this read-side normalization PR.
- Proof limitations or environment constraints: this is a config/runtime parsing and normalization groundwork PR, so the proof is focused local deterministic execution rather than a live model/channel proof. No production config, gateway restart, external provider account, or live plugin registry state was mutated.
- Before evidence: #70823 documents the pre-change limitation: slot ownership was only machine-readable through direct string comparison, leaving no durable place for ownership provenance and forcing each consumer/plugin to repeat brittle raw-slot checks.

## Tests and validation

Commands run:

```text
npx vitest run src/plugins/config-state.test.ts src/plugins/slots.test.ts src/config/config-misc.test.ts src/config/config.plugin-validation.test.ts src/agents/provider-auth-aliases.test.ts src/commands/doctor/shared/context-engine-host-compat.test.ts src/commands/status.scan.shared.test.ts src/context-engine/context-engine.test.ts src/gateway/tools-invoke-shared.test.ts src/memory-host-sdk/dreaming.test.ts src/secrets/provider-env-vars.dynamic.test.ts
npx vitest run src/plugins/update.test.ts
node --import tsx scripts/generate-config-doc-baseline.ts --check
node --import tsx scripts/generate-base-config-schema.ts --check
npx oxfmt --check --threads=1 <touched files>
git diff --check
node scripts/run-tsgo.mjs -p tsconfig.core.json
```

Regression coverage added or updated:

- Slot normalization for string owners, object owners, blank values, and `none`.
- Config schema acceptance for object-form `memory` and `contextEngine`.
- Config validation diagnostics for missing plugin references inside object-form slot owners.
- Exclusive slot selection when the previous owner is object-form.
- Context-engine resolution for object-form `contextEngine`.
- Doctor host compatibility and route-warning paths with object-form context-engine owners.
- Memory status/tool-disable/dreaming paths with object-form `memory`.
- Provider auth alias/env-var trust checks for selected workspace context engines represented as owner records.
- Plugin update migration preserving object-form metadata while changing the `owner`.

## Compatibility and Risk

Backward compatibility:

- Existing string slot configs remain valid.
- Existing `"none"` memory-slot behavior remains valid.
- Existing default behavior remains unchanged: memory defaults to `memory-core`; context engine defaults to `legacy`.
- Existing write paths that still write strings remain valid.

Compatibility changes reviewers should inspect:

- Config schema now accepts object records for existing slot values.
- Consumers that previously compared raw slot strings now compare normalized owners.
- Plugin update migration now preserves object-form slot metadata where possible.

Primary risks:

- A direct raw-slot read could remain somewhere outside the audited surfaces.
- A future #86210 rebase could add new role-slot read sites that need the same helper.
- Accepting passthrough metadata on slot records is intentionally forward-compatible, but reviewers may want to confirm the object shape is the right minimum for #70823.

Risk mitigation:

- The branch adds one shared resolver rather than multiple ad hoc conversions.
- Focused tests cover schema, normalization, runtime consumers, doctor paths, provider auth trust, status/tool behavior, and lifecycle migration.
- This PR avoids write-side canonicalization/enforcement, keeping the blast radius to read compatibility.

## Current Branch State

- Base branch: `main`
- Current PR head: `b87f4a710c6de665bffcc6c58245d9950a021926`
- Commit: `feat(plugins): accept slot owner records`
- Branch shape: one squashed commit over fork `main` at `26913e60a42e84dd256a682c5239be57f346e244`.
- Local final-shape checks before PR creation:
  - `git diff --stat origin/main...fork/feat/plugin-slot-owner-records`: 33 files changed, 450 insertions, 75 deletions.
  - `git rev-list --left-right --count origin/main...fork/feat/plugin-slot-owner-records`: `1 1` because the branch is based on the pinned green fork-main commit one commit behind upstream.
  - Branch verified as one squashed commit over `fork/main`.
  - Anchored conflict-marker scan clean.
  - `git diff --check origin/main...fork/feat/plugin-slot-owner-records`: passed.