### PR TITLE
fix(gateway): skip gateway restart for auth.cooldowns config changes (#88443)

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -110,6 +110,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
 ];
 
 const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
+  { prefix: "auth.cooldowns", kind: "none" },
   { prefix: "meta", kind: "none" },
   { prefix: "identity", kind: "none" },
   { prefix: "wizard", kind: "none" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -423,6 +423,18 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartReasons).toContain("gateway.auth.mode");
   });
 
+  it("skips restart for auth.cooldowns changes", () => {
+    const plan = buildGatewayReloadPlan(["auth.cooldowns"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("auth.cooldowns");
+  });
+
+  it("skips restart for auth.cooldowns sub-path changes", () => {
+    const plan = buildGatewayReloadPlan(["auth.cooldowns.billingBackoffHours"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("auth.cooldowns.billingBackoffHours");
+  });
+
   it("defaults unknown paths to restart", () => {
     const plan = buildGatewayReloadPlan(["unknownField"]);
     expect(plan.restartGateway).toBe(true);


### PR DESCRIPTION
## Problem

When the gateway writes a new `auth.cooldowns` entry (typically after an Anthropic billing 400 or rate-limit response), the config-reload classifier classifies the change as restart-required because the `auth` prefix has no matching rule in `BASE_RELOAD_RULES_TAIL`.

This triggers a full gateway restart, dropping in-flight CLI runs with `FailoverError` and silently discarding user-trigger messages.

Fixes #88443.

## Root cause

The `matchRule` function in `config-reload-plan.ts` falls through to `null` for `auth.cooldowns` → defaults to `"restart"`.
All cooldown parameters (billing backoff, rate-limit rotations, overload backoff) are runtime-only values that can be applied without a gateway restart.

## Fix

Add explicit `auth.cooldowns` noop rule to `BASE_RELOAD_RULES_TAIL` so cooldown changes are hot-reloaded.
Other auth paths (`auth.profiles`, etc.) continue to require restart as before — only the cooldowns subtree is affected.

## Changes

- `src/gateway/config-reload-plan.ts`: add `{ prefix: "auth.cooldowns", kind: "none" }` rule
- `src/gateway/config-reload.test.ts`: add 2 test cases for auth.cooldowns paths

## Verification

- `auth.cooldowns` → noop (no restart)
- `auth.cooldowns.billingBackoffHours` → noop (prefix match)
- `gateway.auth.token` → restart (unchanged, covered by existing `gateway` prefix rule)