### PR TITLE
fix: mark auth.cooldowns as no-op in config reload plan

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -124,6 +124,7 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "session", kind: "none" },
   { prefix: "talk", kind: "none" },
   { prefix: "skills", kind: "none" },
+  { prefix: "auth.cooldowns", kind: "none" },
   { prefix: "secrets", kind: "none" },
   { prefix: "plugins", kind: "hot", actions: ["reload-plugins", "dispose-mcp-runtimes"] },
   { prefix: "ui", kind: "none" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -423,6 +423,12 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartReasons).toContain("gateway.auth.mode");
   });
 
+  it("no-ops auth.cooldowns changes instead of restarting", () => {
+    const plan = buildGatewayReloadPlan(["auth.cooldowns.billingBackoffHours"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("auth.cooldowns.billingBackoffHours");
+  });
+
   it("defaults unknown paths to restart", () => {
     const plan = buildGatewayReloadPlan(["unknownField"]);
     expect(plan.restartGateway).toBe(true);
@@ -463,6 +469,11 @@ describe("buildGatewayReloadPlan", () => {
       path: "gateway.remote.url",
       expectRestartGateway: false,
       expectNoopPath: "gateway.remote.url",
+    },
+    {
+      path: "auth.cooldowns.billingBackoffHours",
+      expectRestartGateway: false,
+      expectNoopPath: "auth.cooldowns.billingBackoffHours",
     },
     {
       path: "gateway.auth.token",


### PR DESCRIPTION
Fixes #88443

## Problem
auth.cooldowns config changes previously triggered a full gateway restart, dropping in-flight CLI runs and user-triggered messages. This happened because the reload rule table had no entry for auth.cooldowns, causing it to fall through to the restart-required default.

## Fix
Added `{ prefix: "auth.cooldowns", kind: "none" }` to the BASE_RELOAD_RULES_TAIL in config-reload-plan.ts. Cooldown values are read dynamically from runtime config on each auth evaluation (`params.cfg?.auth?.cooldowns`), so a no-op is sufficient — the next cooldown check picks up the new values without a process restart.

## Changes
- `src/gateway/config-reload-plan.ts`: Added no-op rule for auth.cooldowns
- `src/gateway/config-reload.test.ts`: Added test case and table entry for auth.cooldowns no-op classification

## Testing
All 231 config-reload tests pass (3 suites × 77 tests).