### PR TITLE
fix: resolve google provider default API to google-generative-ai

### DIFF
--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -88,6 +88,16 @@ describe("google generative ai helpers", () => {
   it("normalizes transport baseUrls only for Google Generative AI", () => {
     expect(
       resolveGoogleGenerativeAiTransport({
+        provider: "google",
+        api: undefined,
+        baseUrl: "https://generativelanguage.googleapis.com",
+      }),
+    ).toEqual({
+      api: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    });
+    expect(
+      resolveGoogleGenerativeAiTransport({
         api: "google-generative-ai",
         baseUrl: "https://generativelanguage.googleapis.com",
       }),

--- a/extensions/google/provider-policy.ts
+++ b/extensions/google/provider-policy.ts
@@ -82,12 +82,16 @@ export function normalizeGoogleGenerativeAiBaseUrl(baseUrl?: string): string | u
 }
 
 export function resolveGoogleGenerativeAiTransport<TApi extends string | null | undefined>(params: {
+  provider?: string;
   api: TApi;
   baseUrl?: string;
-}): { api: TApi; baseUrl?: string } {
+}): { api: TApi | "google-generative-ai"; baseUrl?: string } {
+  const api =
+    params.api ??
+    (params.provider === "google" && params.baseUrl ? "google-generative-ai" : params.api);
   return {
-    api: params.api,
-    baseUrl: isGoogleGenerativeAiApi(params.api)
+    api,
+    baseUrl: isGoogleGenerativeAiApi(api)
       ? normalizeGoogleGenerativeAiBaseUrl(params.baseUrl)
       : params.baseUrl,
   };

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -44,7 +44,8 @@ export function buildGoogleProvider(): ProviderPlugin {
         },
       }),
     ],
-    normalizeTransport: ({ api, baseUrl }) => resolveGoogleGenerativeAiTransport({ api, baseUrl }),
+    normalizeTransport: ({ provider, api, baseUrl }) =>
+      resolveGoogleGenerativeAiTransport({ provider, api, baseUrl }),
     normalizeConfig: ({ provider, providerConfig }) =>
       normalizeGoogleProviderConfig(provider, providerConfig),
     staticCatalog: {

--- a/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
@@ -172,6 +172,16 @@ function normalizeTransport(params: {
       baseUrl: GOOGLE_GENERATIVE_AI_BASE_URL,
     };
   }
+  if (
+    params.provider === "google" &&
+    params.context.api == null &&
+    params.context.baseUrl === "https://generativelanguage.googleapis.com"
+  ) {
+    return {
+      api: "google-generative-ai",
+      baseUrl: GOOGLE_GENERATIVE_AI_BASE_URL,
+    };
+  }
   if (isNativeOpenAiTransport) {
     return {
       api: "openai-responses",

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -989,6 +989,27 @@ describe("resolveModel", () => {
     expect(model.api).toBe("openai-completions");
   });
 
+  it("defaults baseUrl-only Google fallback models to native Gemini transport", () => {
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            baseUrl: "https://generativelanguage.googleapis.com",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("google", "gemini-2.5-flash-lite", "/tmp/agent", cfg);
+    const model = expectResolvedModel(result);
+
+    expect(model.provider).toBe("google");
+    expect(model.id).toBe("gemini-2.5-flash-lite");
+    expect(model.api).toBe("google-generative-ai");
+    expect(model.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta");
+  });
+
   it("uses bundled static metadata for configured provider fallback token limits", () => {
     resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
       provider: "xiaomi-token-plan",

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -338,14 +338,30 @@ function resolveProviderTransport(params: {
   };
 }
 
-function resolveConfiguredProviderDefaultApi(
-  providerConfig: InlineProviderConfig | undefined,
-): Api | undefined {
+function resolveConfiguredProviderDefaultApi(params: {
+  provider: string;
+  providerConfig: InlineProviderConfig | undefined;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  runtimeHooks?: ProviderRuntimeHooks;
+}): Api | undefined {
+  const { providerConfig } = params;
   const explicit = normalizeResolvedTransportApi(providerConfig?.api);
   if (explicit) {
     return explicit;
   }
-  return providerConfig?.baseUrl ? "openai-completions" : undefined;
+  if (!providerConfig?.baseUrl) {
+    return undefined;
+  }
+  const normalized = resolveProviderTransport({
+    provider: params.provider,
+    api: undefined,
+    baseUrl: providerConfig.baseUrl,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
+    runtimeHooks: params.runtimeHooks,
+  });
+  return normalized.api ?? "openai-completions";
 }
 
 function resolveProviderRequestTimeoutMs(timeoutSeconds: unknown): number | undefined {
@@ -660,7 +676,13 @@ function applyConfiguredProviderOverrides(params: {
     input: metadataOverrideModel?.input,
     fallbackInput: discoveredModel.input,
   });
-  const providerDefaultApi = resolveConfiguredProviderDefaultApi(providerConfig);
+  const providerDefaultApi = resolveConfiguredProviderDefaultApi({
+    provider: params.provider,
+    providerConfig,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
+    runtimeHooks: params.runtimeHooks,
+  });
   const resolvedTransportApi =
     metadataOverrideModel?.api ??
     (params.preferDiscoveredTransport
@@ -697,7 +719,7 @@ function applyConfiguredProviderOverrides(params: {
     api:
       resolvedTransport.api ??
       normalizeResolvedTransportApi(discoveredModel.api) ??
-      resolveConfiguredProviderDefaultApi(providerConfig) ??
+      providerDefaultApi ??
       "openai-responses",
     baseUrl: resolvedTransport.baseUrl ?? discoveredModel.baseUrl,
     discoveredHeaders,
@@ -1040,7 +1062,13 @@ function resolveConfiguredFallbackModel(params: {
     provider,
     api:
       normalizeResolvedTransportApi(configuredModel?.api) ??
-      resolveConfiguredProviderDefaultApi(providerConfig) ??
+      resolveConfiguredProviderDefaultApi({
+        provider,
+        providerConfig,
+        cfg,
+        workspaceDir,
+        runtimeHooks,
+      }) ??
       normalizeResolvedTransportApi(staticCatalogModel?.api) ??
       "openai-responses",
     baseUrl: configuredModel?.baseUrl ?? providerConfig?.baseUrl ?? staticCatalogModel?.baseUrl,


### PR DESCRIPTION
Fixes #88480

## Summary
- Keeps the generic baseUrl-only fallback for non-Google providers on `openai-completions`.
- Lets provider transport hooks claim omitted provider defaults before the generic fallback is applied.
- Makes the Google provider hook resolve baseUrl-only `models.providers.google` configs to `google-generative-ai`, while explicit `api: openai-completions` stays unchanged.

## Verification
- `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/pr88512-model-vitest-cache2 fnm exec --using=24.15.0 node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/model.test.ts extensions/google/api.test.ts`
- `fnm exec --using=24.15.0 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile /tmp/pr88512-test-src2.tsbuildinfo`
- `fnm exec --using=24.15.0 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile /tmp/pr88512-extensions-test.tsbuildinfo`
- `git diff --check`

## Real behavior proof
Behavior addressed: Google provider configs with `models.providers.google.baseUrl` and omitted `api` now resolve to the native Gemini `google-generative-ai` transport instead of the OpenAI-compatible transport.

Real environment tested: Local OpenClaw checkout at `5a15bd1c79740f7538d31c7cbde2483c4887b0a3`, Node 24.15.0, Google Gemini API key read from 1Password item `AI API Key - Google Gemini - GEMINI_API_KEY - steipete-m5`; key value was not printed.

Exact steps or command run after this patch: Resolved the Google provider transport for provider `google`, omitted `api`, and baseUrl `https://generativelanguage.googleapis.com`, then used the same 1Password Gemini key for a live `generateContent` request to `gemini-2.0-flash`.

Evidence after fix: Copied live output from the redacted terminal capture:
```text
head=5a15bd1c79740f7538d31c7cbde2483c4887b0a3
provider=google
configuredApi=omitted
configuredBaseUrl=https://generativelanguage.googleapis.com
resolvedTransport={"api":"google-generative-ai","baseUrl":"https://generativelanguage.googleapis.com/v1beta"}
secretPrefix=AIza
secretSource=1password:AI API Key - Google Gemini - GEMINI_API_KEY - steipete-m5
googleGenerateContent={"status":200,"ok":true,"textLen":3,"containsOk":true}
```

Observed result after fix: The omitted-api Google config selected the native Gemini transport, and the live Google endpoint accepted the configured key with HTTP 200.

What was not tested: A full packaged gateway chat loop was not run; the focused resolver path, Google provider hook, and live Gemini endpoint were verified directly.
