### PR TITLE
fix(gateway): avoid default provider auth startup prewarm

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -942,6 +942,59 @@ describe("startGatewayPostAttachRuntime", () => {
     }
   });
 
+  it("keeps provider auth failure rewarm without default startup prewarm", async () => {
+    vi.useFakeTimers();
+    const onGatewayLifetimeSidecars = vi.fn();
+    const startupCfg = { marker: "startup" } as never;
+    const afterFailureCfg = { marker: "after-failure" } as never;
+    let currentCfg = startupCfg;
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    try {
+      await startGatewayPostAttachRuntime({
+        ...createPostAttachParams(),
+        log,
+        deferSidecars: true,
+        providerAuthPrewarm: {
+          delayMs: 1_000,
+          getConfig: () => currentCfg,
+        },
+        onGatewayLifetimeSidecars,
+      });
+
+      await vi.advanceTimersToNextTimerAsync();
+      await vi.waitFor(() => {
+        expect(onGatewayLifetimeSidecars).toHaveBeenCalledTimes(1);
+      });
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(1);
+      await vi.dynamicImportSettled();
+      await vi.waitFor(() => {
+        expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(hoisted.warmCurrentProviderAuthStateOffMainThread).not.toHaveBeenCalled();
+
+      const hook = hoisted.setAuthProfileFailureHook.mock.calls[0]?.[0] as (() => void) | undefined;
+      if (!hook) {
+        throw new Error("Expected provider auth failure hook to be registered");
+      }
+      currentCfg = afterFailureCfg;
+      hook();
+      expect(hoisted.clearCurrentProviderAuthState).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => {
+        expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledTimes(1);
+      });
+      expect(hoisted.warmCurrentProviderAuthStateOffMainThread.mock.calls[0]?.[0]).toBe(
+        afterFailureCfg,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps provider auth prewarm alive when Gmail post-ready sidecars stop", async () => {
     vi.useFakeTimers();
     const onPostReadySidecars = vi.fn();

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -220,6 +220,7 @@ function scheduleProviderAuthStatePrewarm(params: {
     warn: (msg: string) => void;
   };
   delayMs?: number;
+  startupWarmEnabled?: boolean;
 }): GatewayPostReadySidecarHandle {
   let stopped = false;
   let startupTimer: ReturnType<typeof setTimeout> | undefined;
@@ -285,29 +286,31 @@ function scheduleProviderAuthStatePrewarm(params: {
       clearCurrentProviderAuthState();
       scheduleAuthMapRewarm("auth-profile-failure");
     });
-    startupTimer = setTimeout(
-      () => {
-        void (async () => {
-          if (isStopped()) {
-            return;
-          }
-          const cfg = params.getConfig();
-          const metrics = await measureProviderAuthWarm(() =>
-            warmCurrentProviderAuthStateOffMainThread(cfg, { isCancelled: isStopped }),
-          );
-          if (isStopped()) {
-            return;
-          }
-          params.log.info(
-            `provider auth state pre-warmed ${formatProviderAuthWarmMetrics(metrics)}`,
-          );
-        })().catch((err) => {
-          params.log.warn(`provider auth state pre-warm failed: ${String(err)}`);
-        });
-      },
-      Math.max(0, delayMs),
-    );
-    startupTimer.unref?.();
+    if (params.startupWarmEnabled !== false) {
+      startupTimer = setTimeout(
+        () => {
+          void (async () => {
+            if (isStopped()) {
+              return;
+            }
+            const cfg = params.getConfig();
+            const metrics = await measureProviderAuthWarm(() =>
+              warmCurrentProviderAuthStateOffMainThread(cfg, { isCancelled: isStopped }),
+            );
+            if (isStopped()) {
+              return;
+            }
+            params.log.info(
+              `provider auth state pre-warmed ${formatProviderAuthWarmMetrics(metrics)}`,
+            );
+          })().catch((err) => {
+            params.log.warn(`provider auth state pre-warm failed: ${String(err)}`);
+          });
+        },
+        Math.max(0, delayMs),
+      );
+      startupTimer.unref?.();
+    }
   })().catch((err) => {
     params.log.warn(`provider auth state pre-warm setup failed: ${String(err)}`);
   });
@@ -1255,12 +1258,13 @@ export async function startGatewayPostAttachRuntime(
         }
         const postReadySidecars = [...result.postReadySidecars];
         const gatewayLifetimeSidecars: GatewayPostReadySidecarHandle[] = [];
-        if (params.providerAuthPrewarm?.enabled !== false) {
+        if (params.providerAuthPrewarm && params.providerAuthPrewarm.enabled !== false) {
           gatewayLifetimeSidecars.push(
             scheduleProviderAuthStatePrewarm({
               getConfig: params.providerAuthPrewarm?.getConfig ?? (() => params.cfgAtStart),
               log: params.log,
               delayMs: params.providerAuthPrewarm?.delayMs,
+              startupWarmEnabled: params.providerAuthPrewarm.enabled === true,
             }),
           );
         }


### PR DESCRIPTION
## Summary

This PR stops the gateway from running the provider-auth warm sweep by default during startup. The issue report shows Docker/WSL2 gateway event-loop starvation, local RPC timeouts, and a 284s provider-auth prewarm on 2026.5.22; current main had moved the warm path off-main-thread, but still scheduled the warm sweep automatically after ready.

The intended outcome is narrower: default startup should keep the gateway responsive and avoid unsolicited provider-auth sweep work, while explicit callers can still opt into startup warming and auth-profile failure events still trigger a rewarm.

Out of scope: this does not solve every context-size or runtime-startup latency signal from the issue, and native Windows proof here uses an isolated foreground gateway with no live provider credentials or channel accounts.

Reviewers should focus on the startup contract in `src/gateway/server-startup-post-attach.ts`: default startup no longer schedules provider-auth prewarm, but the failure hook and explicit `enabled: true` path remain covered.

## Linked context

Closes #86752

Related #85999, #86201, #86512, #86073.

Maintainer-requested as part of the Windows / WSL issue sweep from #74163.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: WSL2/Docker-style and native Windows gateway startup should avoid the default provider-auth warm sweep that can starve gateway RPCs and channel timers.
- Real environment tested: AWS Crabbox Windows WSL2 lease `cbx_be71611ba83d` (`harbor-lobster`), Node `v22.22.2`, pnpm `11.2.2`; AWS Crabbox native Windows lease `cbx_8ccfe5ff4900` (`native-win-pr74163-aws`), Node `v24.16.0`, pnpm `11.2.2`, PowerShell `5.1.20348.4294`, Windows `10.0.20348.5139`.
- Exact steps or command run after this patch: started a foreground gateway in WSL2 with token auth, `OPENCLAW_GATEWAY_STARTUP_TRACE=1`, then ran authenticated `gateway status --require-rpc` and direct `gateway call status` against the live gateway. On native Windows, hydrated the PR branch through `hydrate-windows-daemon`, started an isolated foreground gateway with token auth and `OPENCLAW_GATEWAY_STARTUP_TRACE=1`, then ran authenticated `gateway status --require-rpc --json` against the live gateway.
- Evidence after fix: WSL2 Crabbox run `run_76eb41a23a64` reported `rpc.ok: true`, direct `status` RPC returned runtime status, gateway reached `[gateway] ready`, and startup logs did not contain `provider auth state pre-warmed`. Native Windows Crabbox run `run_0b72afe5ff48` reported `rpc.ok: true`, gateway reached `[gateway] ready`, startup trace showed `eventLoopMax=0.0ms`, and startup logs did not contain `provider auth state pre-warmed`.
- Observed result after fix: the gateway became RPC-ready and served status requests while skipping default startup provider-auth prewarm on both WSL2 and native Windows proof lanes.
- What was not tested: live native Windows provider credentials, real channel accounts, and the broader context-size/runtime-startup latency cluster were not exercised by this narrow startup-prewarm change.
- Before evidence: #86752 includes a 2026.5.22 Docker/WSL2 report with about 284s provider-auth prewarm, local node RPC timeouts, delayed Telegram timer firing, and slow Telegram turn latency.

## Tests and validation

Commands run:

- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts src/agents/model-provider-auth.test.ts -- --run`
- `node scripts/run-oxlint.mjs src/gateway/server-startup-post-attach.ts src/gateway/server-startup-post-attach.test.ts src/agents/model-provider-auth.ts src/agents/model-provider-auth.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox WSL2 `run_101b08aeda52`: targeted Vitest and oxlint in WSL2 after hydrating Node/pnpm.
- AWS Crabbox WSL2 `run_76eb41a23a64`: authenticated live gateway RPC proof.
- AWS Crabbox native Windows Actions hydrate `26703936119`: `hydrate-windows-daemon` on branch `fix-wsl-event-loop-starvation-86752`.
- AWS Crabbox native Windows `run_db0c5343dbb9`: `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts -- --run` passed 46 tests.
- AWS Crabbox native Windows `run_0b72afe5ff48`: authenticated foreground gateway RPC proof.
- AWS Crabbox native Windows `run_612f3d317f98`: `pnpm check:changed` passed after deepening the shallow checkout so `origin/main...HEAD` had a merge base.

Regression coverage added:

- Added coverage that startup can register provider-auth failure rewarm without scheduling default startup prewarm.
- Existing explicit `enabled: true` prewarm tests continue to cover the opt-in startup warm path.

What failed before this fix:

- Current main still scheduled provider-auth startup warm by default after ready, matching the issue's remaining implicated path even after earlier worker-thread mitigations.

If no test was added, why not?

- A focused regression test was added for the changed startup scheduling contract.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Gateway startup no longer performs default provider-auth prewarm unless explicitly enabled.

Did config, environment, or migration behavior change? (`Yes/No`)

No config or migration shape changes.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This changes when provider-auth state is warmed, but not the auth decision path itself.

What is the highest-risk area?

A provider account state that previously became available from default startup prewarm may now be computed lazily or after an auth-profile failure event.

How is that risk mitigated?

The explicit `enabled: true` startup warm path remains available and tested, and the auth-profile failure rewarm hook still runs even when default startup prewarm is disabled.

## Current review state

What is the next action?

Maintainer review the behavioral tradeoff: default startup responsiveness versus eager provider-auth state. The earlier native Windows proof gap is now covered by native Windows targeted tests, `check:changed`, and foreground gateway RPC proof.

What is still waiting on author, maintainer, CI, or external proof?

Human maintainer review of the startup behavior tradeoff. The WSL2 proof, native Windows proof, targeted tests, lint, changed gate, diff check, and autoreview are complete.

Which bot or reviewer comments were addressed?

Local autoreview completed cleanly with no accepted/actionable findings. The ClawSweeper native Windows proof caveat has been addressed with the native Windows proof runs listed above.
