### PR TITLE
fix(sms): guard Twilio egress

### DIFF
--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -82,13 +82,14 @@ describe("Twilio SMS helpers", () => {
   });
 
   it("sends SMS through Twilio's Messages API", async () => {
-    const fetchImpl = vi.fn(
-      async () =>
-        new Response(JSON.stringify({ sid: "SM456" }), {
-          status: 201,
-          headers: { "content-type": "application/json" },
-        }),
-    );
+    const release = vi.fn();
+    const fetchWithGuard = vi.fn(async () => ({
+      response: new Response(JSON.stringify({ sid: "SM456" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      }),
+      release,
+    }));
 
     await expect(
       sendSmsViaTwilio({
@@ -107,17 +108,21 @@ describe("Twilio SMS helpers", () => {
         },
         to: "+15551234567",
         text: "hello",
-        fetchImpl,
+        fetchWithGuard,
       }),
     ).resolves.toEqual({ sid: "SM456", to: "+15551234567" });
 
-    const [url, init] = fetchImpl.mock.calls[0] ?? [];
-    expect(url).toBe("https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json");
-    expect(init?.method).toBe("POST");
-    expect(init?.headers).toMatchObject({
+    const [request] = fetchWithGuard.mock.calls[0] ?? [];
+    expect(request?.url).toBe("https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json");
+    expect(request?.init?.method).toBe("POST");
+    expect(request?.init?.headers).toMatchObject({
       authorization: `Basic ${Buffer.from("AC123:secret").toString("base64")}`,
       "content-type": "application/x-www-form-urlencoded",
     });
-    expect(String(init?.body)).toBe("From=%2B15557654321&To=%2B15551234567&Body=hello");
+    expect(String(request?.init?.body)).toBe("From=%2B15557654321&To=%2B15551234567&Body=hello");
+    expect(request?.policy).toEqual({ allowedHostnames: ["api.twilio.com"] });
+    expect(request?.timeoutMs).toBe(30_000);
+    expect(request?.auditContext).toBe("sms.twilio.api");
+    expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/sms/src/twilio.ts
+++ b/extensions/sms/src/twilio.ts
@@ -1,10 +1,13 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import * as querystring from "node:querystring";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { readRequestBodyWithLimit } from "openclaw/plugin-sdk/webhook-ingress";
 import type { ResolvedSmsAccount, SmsInboundMessage, SmsSendResult } from "./types.js";
 
-const TWILIO_MESSAGES_URL = "https://api.twilio.com/2010-04-01/Accounts";
+const TWILIO_API_HOSTNAME = "api.twilio.com";
+const TWILIO_MESSAGES_URL = `https://${TWILIO_API_HOSTNAME}/2010-04-01/Accounts`;
+const TWILIO_API_TIMEOUT_MS = 30_000;
 const WEBHOOK_BODY_LIMIT_BYTES = 32 * 1024;
 const WEBHOOK_BODY_TIMEOUT_MS = 5_000;
 
@@ -96,9 +99,8 @@ export async function sendSmsViaTwilio(params: {
   account: ResolvedSmsAccount;
   to: string;
   text: string;
-  fetchImpl?: typeof fetch;
+  fetchWithGuard?: typeof fetchWithSsrFGuard;
 }): Promise<SmsSendResult> {
-  const fetcher = params.fetchImpl ?? fetch;
   const body = new URLSearchParams({
     From: params.account.fromNumber,
     To: params.to,
@@ -107,9 +109,10 @@ export async function sendSmsViaTwilio(params: {
   const auth = Buffer.from(`${params.account.accountSid}:${params.account.authToken}`).toString(
     "base64",
   );
-  const response = await fetcher(
-    `${TWILIO_MESSAGES_URL}/${encodeURIComponent(params.account.accountSid)}/Messages.json`,
-    {
+  const guardedFetch = params.fetchWithGuard ?? fetchWithSsrFGuard;
+  const { response, release } = await guardedFetch({
+    url: `${TWILIO_MESSAGES_URL}/${encodeURIComponent(params.account.accountSid)}/Messages.json`,
+    init: {
       method: "POST",
       headers: {
         authorization: `Basic ${auth}`,
@@ -117,13 +120,22 @@ export async function sendSmsViaTwilio(params: {
       },
       body,
     },
-  );
-  const payload = (await response.json().catch(() => ({}))) as { sid?: string; message?: string };
-  if (!response.ok) {
-    throw new Error(`Twilio SMS send failed (${response.status}): ${payload.message ?? "unknown"}`);
+    policy: { allowedHostnames: [TWILIO_API_HOSTNAME] },
+    timeoutMs: TWILIO_API_TIMEOUT_MS,
+    auditContext: "sms.twilio.api",
+  });
+  try {
+    const payload = (await response.json().catch(() => ({}))) as { sid?: string; message?: string };
+    if (!response.ok) {
+      throw new Error(
+        `Twilio SMS send failed (${response.status}): ${payload.message ?? "unknown"}`,
+      );
+    }
+    return {
+      sid: payload.sid ?? `sms-${Date.now()}`,
+      to: params.to,
+    };
+  } finally {
+    await release();
   }
-  return {
-    sid: payload.sid ?? `sms-${Date.now()}`,
-    to: params.to,
-  };
 }


### PR DESCRIPTION
## Summary

- route SMS Twilio Messages API calls through `fetchWithSsrFGuard`
- allowlist `api.twilio.com`, add a 30s timeout, and use `sms.twilio.api` audit context
- release the guarded fetch slot after the response body is handled
- update the focused Twilio SMS helper test to assert guard policy, timeout, audit context, and release handling

## Why

ClawSweeper flagged the new SMS sender for using raw `fetch` while adjacent Twilio code uses the guarded egress path. This keeps SMS network behavior aligned with OpenClaw's existing Twilio security boundary.

This PR targets the `feat/sms-channel` branch from #88476 so it remains a narrow one-commit patch instead of re-submitting the whole SMS channel.

## Test Plan

- `git diff --check -- extensions/sms/src/twilio.ts extensions/sms/src/twilio.test.ts`
- `./node_modules/.bin/oxfmt --check extensions/sms/src/twilio.ts extensions/sms/src/twilio.test.ts`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-sms-branch node scripts/run-vitest.mjs extensions/sms/src/twilio.test.ts --reporter=verbose`

Focused result: `extensions/sms/src/twilio.test.ts` passed 4/4 locally.

Related context: native SMS PR #88476, prior SMS RFC #85857, external plugin reference https://github.com/clawSean/openclaw-twilio-sms.