### PR TITLE
fix(plugins): isolate cached tool runtime siblings

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -2061,6 +2061,39 @@ describe("resolvePluginTools optional tools", () => {
     expect(factory).toHaveBeenCalledTimes(2);
   });
 
+  it("executes cached healthy tools when a runtime sibling is malformed", async () => {
+    const factory = vi.fn(() => [
+      createMalformedTool("fuzz_move_angles"),
+      {
+        ...makeTool("mockplugin_status"),
+        async execute() {
+          return { content: [{ type: "text", text: "mock-status-ok" }] };
+        },
+      },
+    ]);
+    setRegistry([
+      {
+        pluginId: "fuzzplugin",
+        optional: false,
+        source: "/tmp/fuzzplugin.js",
+        names: ["mockplugin_status"],
+        factory,
+      },
+    ]);
+
+    const first = resolvePluginTools(createResolveToolsParams());
+    const second = resolvePluginTools(createResolveToolsParams());
+    const statusTool = second.find((tool) => tool.name === "mockplugin_status");
+
+    expectResolvedToolNames(first, ["mockplugin_status"]);
+    expectResolvedToolNames(second, ["mockplugin_status"]);
+    expect(factory).toHaveBeenCalledTimes(1);
+    await expect(statusTool?.execute("call", {}, undefined)).resolves.toEqual({
+      content: [{ type: "text", text: "mock-status-ok" }],
+    });
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
   it("reuses cached plugin tool descriptors across session identity changes", async () => {
     const factory = vi.fn((rawCtx: unknown) => {
       const ctx = rawCtx as { sessionId?: string };

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -692,10 +692,10 @@ function createCachedDescriptorPluginTool(params: {
         for (const toolRaw of listRaw) {
           const malformedReason = describeMalformedPluginTool(toolRaw);
           if (malformedReason) {
-            throw new Error(`plugin tool is malformed (${pluginId}): ${malformedReason}`);
+            continue;
           }
           const runtimeTool = toolRaw as AnyAgentTool;
-          if (normalizeToolName(runtimeTool.name) === requestedToolName) {
+          if (normalizeToolName(readPluginToolName(runtimeTool)) === requestedToolName) {
             return runtimeTool;
           }
         }


### PR DESCRIPTION
## Summary

- refreshes the cached plugin tool runtime sibling isolation slice onto current `main`
- skips malformed sibling tool entries when executing a cached descriptor so a healthy requested tool can still run
- keeps the regression fixtures neutral with `fuzzplugin` / `mockplugin` names only

## Verification

- `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts --reporter=verbose`: passed 1 shard / 67 tests
- `./node_modules/.bin/oxfmt --check src/plugins/tools.ts src/plugins/tools.optional.test.ts`: passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/plugins/tools.ts src/plugins/tools.optional.test.ts`: passed
- `git diff --check origin/main...HEAD`: passed
- added-line private-name scrub returned no reported private plugin/tool names
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings

## Current CI note

The remaining red checks are baseline failures outside this PR's diff: `check-lint`, `checks-node-agentic-control-plane-agent-chat`, and `checks-node-agentic-gateway-methods`. The baseline fix is #88814, which is now clean on GitHub CI; this PR can stay limited to cached plugin runtime sibling isolation until #88814 lands on `main`.

## Real behavior proof

Behavior addressed: a malformed runtime sibling returned by a cached plugin tool factory no longer prevents execution of the healthy requested cached tool.

Real environment tested: linked OpenClaw gwt worktree `cached-runtime-sibling-isolation-20260601` based on `origin/main` at `72f74b33e12`.

Exact steps or command run after this patch: cherry-picked the existing cached runtime sibling fix onto current `main`, reran the focused optional-tool Vitest file, formatting, targeted lint, diff check, private-name scrub, and structured autoreview.

Evidence after fix: the focused regression resolves `mockplugin_status` from the cached descriptor, skips the malformed `fuzz_move_angles` sibling at runtime, and still executes `mockplugin_status`.

Observed result after fix: cached descriptor execution now matches the non-cached plugin resolver behavior: malformed sibling tools are isolated instead of poisoning healthy sibling tools.

What was not tested: full repository suite, completed `pnpm check:changed`, or a live external plugin process.
