### PR TITLE
fix(subagents): stop dropping concurrent completion handoffs at the retry cap

### DIFF
--- a/src/agents/subagent-delivery-state.ts
+++ b/src/agents/subagent-delivery-state.ts
@@ -122,6 +122,7 @@ function mergeDeliveryState(
     discardReason: current.discardReason ?? restored.discardReason,
     discardedPayloadSummary: current.discardedPayloadSummary ?? restored.discardedPayloadSummary,
     lastDropReason: current.lastDropReason ?? restored.lastDropReason,
+    lastHandoffPending: current.lastHandoffPending ?? restored.lastHandoffPending,
   };
 }
 
@@ -246,6 +247,10 @@ export function isDeliverySuspended(entry: SubagentRunRecord): boolean {
 
 export function getDeliveryAttemptCount(entry: SubagentRunRecord): number {
   return entry.delivery?.attemptCount ?? 0;
+}
+
+export function getDeliveryLastHandoffPending(entry: SubagentRunRecord): boolean {
+  return entry.delivery?.lastHandoffPending === true;
 }
 
 export function getDeliveryLastAttemptAt(entry: SubagentRunRecord): number | undefined {

--- a/src/agents/subagent-registry-cleanup.test.ts
+++ b/src/agents/subagent-registry-cleanup.test.ts
@@ -91,4 +91,54 @@ describe("resolveDeferredCleanupDecision", () => {
 
     expect(decision).toEqual({ kind: "retry", retryCount: 2, resumeDelayMs: 2_000 });
   });
+
+  it("keeps retrying completion handoffs past the retry-count cap while the parent stays busy", () => {
+    const decision = resolveDeferredCleanupDecision({
+      now,
+      announceExpiryMs: 5 * 60_000,
+      announceCompletionHardExpiryMs: 30 * 60_000,
+      maxAnnounceRetryCount: 3,
+      deferDescendantDelayMs: 1_000,
+      resolveAnnounceRetryDelayMs: (retryCount) => retryCount * 1_000,
+      entry: makeEntry({
+        expectsCompletionMessage: true,
+        endedAt: now - 124_000,
+        delivery: { status: "pending", attemptCount: 5, lastHandoffPending: true },
+      }),
+      activeDescendantRuns: 0,
+    });
+
+    expect(decision).toEqual({ kind: "retry", retryCount: 6, resumeDelayMs: 6_000 });
+  });
+
+  it("still gives up at the retry-count cap when a completion announce fails for a non-pending reason", () => {
+    const decision = resolveDecision({
+      entry: makeEntry({
+        expectsCompletionMessage: true,
+        delivery: { status: "pending", attemptCount: 2 },
+      }),
+      activeDescendantRuns: 0,
+    });
+
+    expect(decision).toEqual({ kind: "give-up", reason: "retry-limit", retryCount: 3 });
+  });
+
+  it("gives up a busy completion handoff once the hard-expiry window is exceeded", () => {
+    const decision = resolveDeferredCleanupDecision({
+      now,
+      announceExpiryMs: 5 * 60_000,
+      announceCompletionHardExpiryMs: 30 * 60_000,
+      maxAnnounceRetryCount: 3,
+      deferDescendantDelayMs: 1_000,
+      resolveAnnounceRetryDelayMs: () => 8_000,
+      entry: makeEntry({
+        expectsCompletionMessage: true,
+        endedAt: now - (30 * 60_000 + 1),
+        delivery: { status: "pending", attemptCount: 5, lastHandoffPending: true },
+      }),
+      activeDescendantRuns: 0,
+    });
+
+    expect(decision).toEqual({ kind: "give-up", reason: "expiry", retryCount: 6 });
+  });
 });

--- a/src/agents/subagent-registry-cleanup.ts
+++ b/src/agents/subagent-registry-cleanup.ts
@@ -1,4 +1,7 @@
-import { getDeliveryAttemptCount } from "./subagent-delivery-state.js";
+import {
+  getDeliveryAttemptCount,
+  getDeliveryLastHandoffPending,
+} from "./subagent-delivery-state.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
   type SubagentLifecycleEndedReason,
@@ -56,10 +59,15 @@ export function resolveDeferredCleanupDecision(params: {
   const expiryExceeded = isCompletionMessageFlow
     ? completionHardExpiryExceeded
     : endedAgo > params.announceExpiryMs;
-  if (retryCount >= params.maxAnnounceRetryCount || expiryExceeded) {
+  // Pending completion handoffs (parent busy, no turn spent) retry to the
+  // hard-expiry, not the retry cap; the resumeSubagentRun preflight mirrors this.
+  const exemptFromRetryLimit =
+    isCompletionMessageFlow && getDeliveryLastHandoffPending(params.entry);
+  const retryLimitExceeded = !exemptFromRetryLimit && retryCount >= params.maxAnnounceRetryCount;
+  if (retryLimitExceeded || expiryExceeded) {
     return {
       kind: "give-up",
-      reason: retryCount >= params.maxAnnounceRetryCount ? "retry-limit" : "expiry",
+      reason: retryLimitExceeded ? "retry-limit" : "expiry",
       retryCount,
     };
   }

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -1012,6 +1012,10 @@ export function createSubagentRegistryLifecycleController(params: {
       });
     };
 
+    // Reset per attempt: only THIS attempt's completion_handoff_pending result may
+    // exempt it from the retry cap. A later attempt that throws before
+    // onDeliveryResult must not inherit a stale pending flag (#88383).
+    ensureDeliveryState(entry).lastHandoffPending = false;
     void params
       .runSubagentAnnounceFlow({
         childSessionKey: pendingPayload.childSessionKey,
@@ -1040,9 +1044,13 @@ export function createSubagentRegistryLifecycleController(params: {
               deliveryState.lastError = undefined;
               params.persist();
             }
+            deliveryState.lastHandoffPending = false;
             latestDeliveryError = undefined;
             return;
           }
+          // Persisted so the resume preflight (not just this decision) can read it.
+          ensureDeliveryState(entry).lastHandoffPending =
+            delivery.reason === "completion_handoff_pending";
           if (delivery.path === "none") {
             ensureDeliveryState(entry).lastDropReason = "sink_unavailable";
           }

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as subagentAnnounceDeliveryTesting } from "./subagent-announce-delivery.js";
 import { testing as subagentAnnounceOutputTesting } from "./subagent-announce-output.js";
 import { testing as subagentAnnounceTesting } from "./subagent-announce.js";
+import { SUBAGENT_ENDED_REASON_COMPLETE } from "./subagent-lifecycle-events.js";
 import * as mod from "./subagent-registry.js";
 
 const noop = () => {};
@@ -572,6 +573,81 @@ describe("subagent registry lifecycle error grace", () => {
     await vi.advanceTimersByTimeAsync(30_000);
     await flushAsync();
     expect(getAgentCalls()).toHaveLength(1);
+  });
+
+  function seedResumeEntry(
+    runId: string,
+    overrides: { lastHandoffPending?: boolean; attemptCount?: number; endedAtAgoMs?: number },
+  ) {
+    const now = Date.now();
+    mod.addSubagentRunForTests({
+      runId,
+      childSessionKey: `agent:main:subagent:${runId}`,
+      requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+      requesterDisplayKey: MAIN_REQUESTER_DISPLAY_KEY,
+      task: "resume guard test",
+      cleanup: "keep",
+      createdAt: now - (overrides.endedAtAgoMs ?? 124_000) - 1,
+      endedAt: now - (overrides.endedAtAgoMs ?? 124_000),
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      outcome: { status: "ok" },
+      expectsCompletionMessage: true,
+      cleanupHandled: false,
+      delivery: {
+        status: "pending",
+        attemptCount: overrides.attemptCount ?? 5,
+        lastAttemptAt: now,
+        lastHandoffPending: overrides.lastHandoffPending,
+      },
+    });
+  }
+
+  function readRun(runId: string) {
+    return mod
+      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+      .find((candidate) => candidate.runId === runId);
+  }
+
+  it("resume keeps a busy completion handoff past the retry cap instead of dropping it (#88383)", async () => {
+    // Regression: the resume preflight must mirror the cleanup-decision exemption.
+    // With the cap still applied here, attemptCount >= MAX would give up at retry-limit.
+    seedResumeEntry("run-resume-pending", { lastHandoffPending: true, attemptCount: 5 });
+
+    mod.testing.resumeSubagentRunForTest("run-resume-pending");
+    await flushAsync();
+
+    const run = readRun("run-resume-pending");
+    expect(run?.delivery?.status).toBe("pending");
+    expect(run?.delivery?.suspendedReason).toBeUndefined();
+  });
+
+  it("resume still gives up at the retry cap when the last completion failure was not pending", async () => {
+    seedResumeEntry("run-resume-failed", { lastHandoffPending: false, attemptCount: 5 });
+
+    mod.testing.resumeSubagentRunForTest("run-resume-failed");
+    await flushAsync();
+
+    const run = readRun("run-resume-failed");
+    expect(["suspended", "failed"]).toContain(run?.delivery?.status);
+  });
+
+  it("clears a stale pending flag so a thrown announce does not bypass the retry cap (#88383)", async () => {
+    // A prior completion_handoff_pending attempt set the flag; the next announce
+    // throws before any delivery result. The per-attempt reset must clear the flag
+    // so this genuine no-result failure is NOT exempted from the retry-count cap.
+    registerCompletionRun("run-stale-pending", "stale-pending", "stale pending reset test");
+    setAssistantOutput("agent:main:subagent:stale-pending", "Final answer");
+    const seeded = readRun("run-stale-pending");
+    if (seeded) {
+      seeded.delivery = { status: "pending", lastHandoffPending: true };
+    }
+    agentCallPlan = ["throw"];
+
+    emitLifecycleEvent("run-stale-pending", { phase: "end", endedAt: Date.now() });
+    await waitForAgentCallCount(1);
+    await flushAsync();
+
+    expect(readRun("run-stale-pending")?.delivery?.lastHandoffPending ?? false).toBe(false);
   });
 
   it("keeps parallel child completion results frozen even when late traffic arrives", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -21,6 +21,7 @@ import {
   getDeliveryAttemptCount,
   getDeliveryLastAttemptAt,
   getDeliveryLastError,
+  getDeliveryLastHandoffPending,
   isDeliverySuspended,
 } from "./subagent-delivery-state.js";
 import {
@@ -34,6 +35,7 @@ import {
   resolveLifecycleOutcomeFromRunOutcome,
 } from "./subagent-registry-completion.js";
 import {
+  ANNOUNCE_COMPLETION_HARD_EXPIRY_MS,
   ANNOUNCE_EXPIRY_MS,
   MAX_ANNOUNCE_RETRY_COUNT,
   reconcileOrphanedRestoredRuns,
@@ -617,25 +619,26 @@ function resumeSubagentRun(runId: string) {
   if (entry.pauseReason === "sessions_yield") {
     return;
   }
-  // Skip entries that have exhausted their retry budget or expired (#18264).
-  if (getDeliveryAttemptCount(entry) >= MAX_ANNOUNCE_RETRY_COUNT) {
-    void finalizeResumedAnnounceGiveUp({
-      runId,
-      entry,
-      reason: "retry-limit",
-    });
+  // Pending completion handoffs (parent busy) are bounded by the hard-expiry, not
+  // the retry cap — mirrors resolveDeferredCleanupDecision (#18264, #88383).
+  const completionPendingRetry =
+    entry.expectsCompletionMessage === true && getDeliveryLastHandoffPending(entry);
+  const endedAgo = typeof entry.endedAt === "number" ? Date.now() - entry.endedAt : 0;
+  if (completionPendingRetry && endedAgo > ANNOUNCE_COMPLETION_HARD_EXPIRY_MS) {
+    void finalizeResumedAnnounceGiveUp({ runId, entry, reason: "expiry" });
+    return;
+  }
+  if (!completionPendingRetry && getDeliveryAttemptCount(entry) >= MAX_ANNOUNCE_RETRY_COUNT) {
+    void finalizeResumedAnnounceGiveUp({ runId, entry, reason: "retry-limit" });
     return;
   }
   if (
+    !completionPendingRetry &&
     entry.expectsCompletionMessage !== true &&
     typeof entry.endedAt === "number" &&
-    Date.now() - entry.endedAt > ANNOUNCE_EXPIRY_MS
+    endedAgo > ANNOUNCE_EXPIRY_MS
   ) {
-    void finalizeResumedAnnounceGiveUp({
-      runId,
-      entry,
-      reason: "expiry",
-    });
+    void finalizeResumedAnnounceGiveUp({ runId, entry, reason: "expiry" });
     return;
   }
 
@@ -1260,6 +1263,9 @@ export function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
 export const testing = {
   async sweepOnceForTests() {
     await sweepSubagentRuns();
+  },
+  resumeSubagentRunForTest(runId: string) {
+    resumeSubagentRun(runId);
   },
   setDepsForTest(overrides?: Partial<SubagentRegistryDeps>) {
     subagentRegistryDeps = overrides

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -69,6 +69,8 @@ export type SubagentCompletionDeliveryState = {
     lastError?: string | null;
   };
   lastDropReason?: "queue_cap" | "parent_run_ended" | "sink_unavailable" | "dedupe";
+  /** Last announce was `completion_handoff_pending` (parent busy); exempt from the retry cap. */
+  lastHandoffPending?: boolean;
 };
 
 export type SubagentRunRecord = {


### PR DESCRIPTION
### Summary

- **Problem**: Issue #88383 reports that when several subagents that each owe their parent a completion message finish at nearly the same time, some completions are silently dropped — the parent agent never receives those results. The give-up log shows `Subagent announce give up (retry-limit) ... retries=3 endedAgo=124s deliveryError="completion agent handoff is still pending; direct-primary: completion agent handoff is still pending"`.
- **Root Cause**: A completed subagent that owes a completion message delivers it by running the *parent* agent (the "completion-agent handoff" in `src/agents/subagent-announce-delivery.ts`). A session can only run one turn at a time, so when completions arrive together they serialize through the parent; each attempt that finds the parent busy returns the transient `completion_handoff_pending` result — the parent run was queued by `isGatewayAgentRunPending` and **never executed**, so the attempt spent no model turn and will succeed once the parent frees up. Completion flows are *already* granted a 30-minute hard-expiry window (`ANNOUNCE_COMPLETION_HARD_EXPIRY_MS`) precisely to wait out that backpressure, but **two** retry-budget guards still applied the `MAX_ANNOUNCE_RETRY_COUNT` (3) cap to every flow: `resolveDeferredCleanupDecision` (`src/agents/subagent-registry-cleanup.ts`) and the resume preflight in `resumeSubagentRun` (`src/agents/subagent-registry.ts`). After 3 pending attempts (~2 min, matching `endedAgo=124s`) the completion is abandoned with `reason: "retry-limit"`, far short of the intended window. (An earlier revision of this PR fixed only the decision helper; the resume preflight would still have dropped the completion on the next scheduled retry — so both guards are fixed here.)
- **Fix**: Persist whether the last announce attempt was the transient `completion_handoff_pending` on the delivery record (`SubagentCompletionDeliveryState.lastHandoffPending`), and exempt that case from the retry-count cap in **both** guards for completion flows, leaving the 30-minute hard expiry as the bound. Genuine soft delivery failures — which *did* consume a parent turn — still honor the 3-retry cap, and non-completion flows are unchanged.
- **What changed**:
  - `src/agents/subagent-registry.types.ts` — add optional `lastHandoffPending?: boolean` to `SubagentCompletionDeliveryState`.
  - `src/agents/subagent-delivery-state.ts` — carry the field through `mergeDeliveryState`; add `getDeliveryLastHandoffPending` accessor.
  - `src/agents/subagent-registry-lifecycle.ts` — `onDeliveryResult` persists `lastHandoffPending = (delivery.reason === "completion_handoff_pending")` (and clears it on delivery), so both guards read one source of truth.
  - `src/agents/subagent-registry-cleanup.ts` — `resolveDeferredCleanupDecision` skips the retry-count give-up for a completion flow when `getDeliveryLastHandoffPending(entry)` is true.
  - `src/agents/subagent-registry.ts` — the `resumeSubagentRun` preflight mirrors the same exemption: a completion handoff-pending retry is bounded by the hard expiry, not the count cap.
  - Tests: `subagent-registry-cleanup.test.ts` (decision matrix) and `subagent-registry.lifecycle-retry-grace.e2e.test.ts` (resume-path regression driving the real `resumeSubagentRun`).
- **What did NOT change (scope boundary)**:
  - The 30-minute completion hard-expiry and the 3-retry cap constants are untouched — no raised timeout, no new cap.
  - Non-completion flows keep both the 5-minute expiry and the 3-retry cap; genuine (non-pending) completion failures still hit the cap.
  - `lastHandoffPending` is an additive, optional, backward-compatible field on the subagent-registry delivery record (absent on old records → `false`).
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config` edits).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/api.ts` / `runtime-api.ts`, registry, or loader edits).
  - Session store surface unchanged (no `sessions.json` format, transcript jsonl format, or store-loader edits — relevant given the June SQLite migration).
  - Session write-lock acquisition is untouched (`src/agents/session-write-lock.ts`); this PR changes only the announce give-up accounting, so the `session file locked (timeout 60000ms)` line in the report is not affected by it either way.

### Reproduction

1. Spawn 3 subagents in parallel from one parent session, each owing a completion message (e.g. a trader agent spawns 3 coder subagents).
2. Have them finish within seconds of each other so their completion announces arrive together.
3. The completions serialize through the parent; the ones that find it busy get `completion_handoff_pending`.
4. **Before this PR**: each pending attempt counts against the 3-retry cap; after 3 attempts (~2 min) the cleanup decision and/or the resume preflight gives up with `reason: "retry-limit"` and the subagent result is dropped — the parent never receives it (matching `retries=3 endedAgo=124s`).
5. **After this PR**: the transient pending outcome no longer counts against the cap for completion flows in either guard; the announce keeps retrying with backoff until the parent frees up and delivers, or until the 30-minute hard expiry.

### Real behavior proof

**Behavior addressed (#88383)**: a completion-message subagent no longer drops its result at the 3-retry cap while the parent is transiently busy — in both the cleanup decision and the resume preflight; it keeps retrying until delivery or the 30-minute hard expiry. Genuine non-pending failures and non-completion flows still honor the cap.

**Real environment tested (Linux, Node 22)**: a real-component tsx harness drives the production `resolveDeferredCleanupDecision`, and a resume-path regression test drives the production `resumeSubagentRun` through the registry with a seeded busy completion handoff past the cap.

**Exact steps or command run after this patch**:

1. `node_modules/.bin/tsx /tmp/qmd88383/repro.mts` (real-component decision sweep)
2. `node scripts/run-vitest.mjs src/agents/subagent-registry-cleanup.test.ts src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-delivery-state.test.ts`
3. `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts src/agents/subagent-announce.timeout.test.ts src/agents/subagent-registry.announce-loop-guard.test.ts`
4. `pnpm tsgo:core`; `pnpm exec oxfmt --check --threads=1`; `node scripts/run-oxlint.mjs` on the changed files

**Evidence after fix (verbatim real-component harness output)**:

```text
========== #88383 real-component completion-announce give-up sweep ==========

Drives production resolveDeferredCleanupDecision (src/agents/subagent-registry-cleanup.ts).

--- SCENARIO A: BEFORE-equivalent (completion flow, attempts past cap, last failure NOT pending) ---
  decision: {"kind":"give-up","reason":"retry-limit","retryCount":6}
  >>> drops the completion at retry-limit (matches issue #88383 before fix)

--- SCENARIO B: AFTER FIX (completion flow, attempts past cap, transient handoff-pending) ---
  decision: {"kind":"retry","retryCount":6,"resumeDelayMs":6000}
  >>> keeps retrying through parent backpressure (bounded by 30-min hard expiry)

--- SCENARIO C: SAFETY — non-completion flow + pending still hits the cap ---
  decision: {"kind":"give-up","reason":"retry-limit","retryCount":3}
  >>> retry-count cap preserved for non-completion flows

--- SCENARIO D: BOUND — busy completion handoff past the 30-min hard expiry gives up ---
  decision: {"kind":"give-up","reason":"expiry","retryCount":6}
  >>> still bounded by hard expiry (no unbounded retry)

========== VERDICT ==========
A before-equiv give-up:retry-limit = true
B after-fix retry (not dropped)    = true
C non-completion cap preserved     = true
D completion hard-expiry bound     = true

PASS — fix exempts only transient handoff-pending for completion flows; cap + hard-expiry bounds intact.
```

**Vitest output for the touched suites (decision + lifecycle + resume-path e2e)**:

```text
 subagent-registry-cleanup.test.ts        Tests  8 passed (8)
 subagent-registry-lifecycle.test.ts      Tests 30 passed (30)
 subagent-registry.lifecycle-retry-grace.e2e.test.ts  Tests 11 passed (11)
```

The two new e2e cases drive the real `resumeSubagentRun`: `resume keeps a busy completion handoff past the retry cap instead of dropping it (#88383)` (fails with the unchanged resume guard, since attemptCount ≥ cap suspended at retry-limit) and `resume still gives up at the retry cap when the last completion failure was not pending`.

**Observed result after fix**:

- A busy completion handoff at `attemptCount=5` returns `retry` from the decision helper and is **not** suspended by the resume preflight (Scenario A → B; resume e2e), so concurrent completions are no longer dropped while the parent serializes them.
- A non-completion flow / non-pending completion failure at the cap still gives up `retry-limit` (Scenario C; second resume e2e) — the cap is preserved where it was the intended bound.
- A completion handoff past the 30-minute hard expiry still gives up `expiry` (Scenario D) — retries stay bounded.

**What was not tested**:

- End-to-end live multi-agent gateway run (3 parallel subagents on the reporter's setup). The harness and the resume-path e2e drive the production decision/resume logic deterministically with the lifecycle inputs, but do not start a real announce / model HTTP call.
- The separate `session file locked (timeout 60000ms)` parent-turn-persist symptom — a distinct same-session lock-contention path, not the dropped-completion give-up addressed here.

**Regression tests**:

- `subagent-registry-cleanup.test.ts` → decision-matrix cases for the pending exemption, the preserved cap on non-pending failures, and the hard-expiry bound.
- `subagent-registry.lifecycle-retry-grace.e2e.test.ts` → resume-path cases that drive the real `resumeSubagentRun` past the cap. Existing lifecycle (30/30), retry-grace e2e (now 11/11), and announce-delivery/timeout/loop-guard (110/110) suites stay green.

### Risk / Mitigation

- **Risk**: A completion flow whose parent is wedged forever would keep retrying instead of stopping at 3 attempts. **Mitigation**: the unchanged 30-minute hard expiry bounds both guards (Scenario D + resume preflight), and each retry is a cheap pending check that consumes no model turn.
- **Risk**: A genuine (non-pending) completion delivery failure could be retried longer than intended. **Mitigation**: the exemption is gated strictly on the persisted `completion_handoff_pending` outcome; every other failure reason still hits the 3-retry cap (Scenario C + the non-pending resume e2e case).
- **Risk**: Two guards could drift. **Mitigation**: both read one persisted source (`getDeliveryLastHandoffPending`) and the comments cross-reference each other; the resume-path e2e covers the previously-missed guard.
- **Risk**: The change cannot make delivery worse than before — it only *narrows* when a completion flow gives up; non-completion flows are unchanged.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration

### Linked Issue/PR

Refs #88383
