### PR TITLE
Add requester context threading to before_tool_call hook

### DIFF
--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -88,6 +88,8 @@ export type HookContext = {
   runId?: string;
   trace?: DiagnosticTraceContext;
   channelId?: string;
+  senderId?: string;
+  metadata?: Record<string, unknown>;
   loopDetection?: ToolLoopDetectionConfig;
   onToolOutcome?: ToolOutcomeObserver;
   skillsSnapshot?: SkillSnapshot;
@@ -897,6 +899,8 @@ export async function runBeforeToolCallHook(args: {
       ...(args.ctx?.trace && { trace: freezeDiagnosticTraceContext(args.ctx.trace) }),
       ...(args.toolCallId && { toolCallId: args.toolCallId }),
       ...(args.ctx?.channelId && { channelId: args.ctx.channelId }),
+      ...(args.ctx?.senderId && { senderId: args.ctx.senderId }),
+      ...(args.ctx?.metadata && { metadata: args.ctx.metadata }),
     });
     const toolContext = buildToolContext(toolIdentity);
     const trustedPolicyResult = shouldRunTrustedPolicies

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -208,6 +208,96 @@ describe("createOpenClawCodingTools", () => {
     );
   });
 
+  it("passes current channel ids to wrapped tool hooks", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "hook-current-channel-"));
+    await fs.writeFile(path.join(tmpDir, "note.txt"), "hello");
+    const tools = createOpenClawCodingTools({
+      workspaceDir: tmpDir,
+      currentChannelId: "channel-test-id",
+    });
+    const readTool = requireTool(tools, "read");
+    await requireToolExecute(readTool)("tool-hook-current-channel", { path: "note.txt" });
+
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(beforeToolCall.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ channelId: "channel-test-id" }),
+    );
+  });
+
+  it("passes requester sender ids to wrapped tool hooks", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "hook-requester-"));
+    await fs.writeFile(path.join(tmpDir, "note.txt"), "hello");
+    const tools = createOpenClawCodingTools({
+      workspaceDir: tmpDir,
+      currentChannelId: "channel-test-id",
+      senderId: "requester-test-id",
+    });
+    const readTool = requireTool(tools, "read");
+    await requireToolExecute(readTool)("tool-hook-requester", { path: "note.txt" });
+
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(beforeToolCall.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ senderId: "requester-test-id" }),
+    );
+  });
+
+  it("omits requester sender ids for runs without requester context", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "hook-no-requester-"));
+    await fs.writeFile(path.join(tmpDir, "note.txt"), "hello");
+    const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+    const readTool = requireTool(tools, "read");
+    await requireToolExecute(readTool)("tool-hook-no-requester", { path: "note.txt" });
+
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("senderId");
+  });
+
+  it("passes caller metadata to wrapped tool hooks", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "hook-metadata-"));
+    await fs.writeFile(path.join(tmpDir, "note.txt"), "hello");
+    const metadata = { requestId: "request-1", source: "test" };
+    const tools = createOpenClawCodingTools({
+      workspaceDir: tmpDir,
+      metadata,
+    });
+    const readTool = requireTool(tools, "read");
+    await requireToolExecute(readTool)("tool-hook-metadata", { path: "note.txt" });
+
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(beforeToolCall.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ metadata }));
+  });
+
+  it("omits metadata when callers do not provide it", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "hook-no-metadata-"));
+    await fs.writeFile(path.join(tmpDir, "note.txt"), "hello");
+    const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+    const readTool = requireTool(tools, "read");
+    await requireToolExecute(readTool)("tool-hook-no-metadata", { path: "note.txt" });
+
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("metadata");
+  });
+
   it("adds Tool Search control tools when explicitly requested", () => {
     const tools = createOpenClawCodingTools({
       includeToolSearchControls: true,

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -447,6 +447,8 @@ export function createOpenClawCodingTools(options?: {
   currentChannelId?: string;
   /** Normalized conversation id exposed to tool hooks. Defaults to currentChannelId. */
   hookChannelId?: string;
+  /** Additional caller-provided context exposed to tool hooks. */
+  metadata?: Record<string, unknown>;
   /** Current thread timestamp for auto-threading (Slack). */
   currentThreadTs?: string;
   /** Current inbound message id for action fallbacks (e.g. Telegram react). */
@@ -1132,6 +1134,8 @@ export function createOpenClawCodingTools(options?: {
         sessionId: options?.sessionId,
         runId: options?.runId,
         channelId: options?.hookChannelId ?? options?.currentChannelId,
+        ...(options?.senderId ? { senderId: options.senderId } : {}),
+        ...(options?.metadata ? { metadata: options.metadata } : {}),
         ...(options?.trace ? { trace: options.trace } : {}),
         loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
         onToolOutcome: options?.onToolOutcome,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -493,6 +493,7 @@ export type PluginHookToolContext = {
   sessionId?: string;
   runId?: string;
   trace?: DiagnosticTraceContext;
+  senderId?: string;
   toolName: string;
   /** Host-authoritative discriminator for tools that intentionally share names. */
   toolKind?: PluginHookToolKind;
@@ -501,6 +502,7 @@ export type PluginHookToolContext = {
   toolCallId?: string;
   getSessionExtension?: (namespace: string) => PluginJsonValue | undefined;
   channelId?: string;
+  metadata?: Record<string, unknown>;
 };
 
 export type PluginHookBeforeToolCallEvent = {


### PR DESCRIPTION
## Summary
- Adds optional requester, channel, and metadata fields to tool hook context.
- Threads those fields from tool construction into `before_tool_call` handlers when available.
- Keeps existing plugin behavior non-breaking when the new context fields are absent.

## Validation
- `pnpm exec vitest run src/agents/agent-tools.create-openclaw-coding-tools.test.ts --pool=forks --fileParallelism=false`
- Brand-neutrality diff check returned zero matches for internal/product-specific terms.


Made with [Cursor](https://cursor.com)