### PR TITLE
fix(discord): ping mention-bearing final replies under live preview (#88360)

### DIFF
--- a/extensions/discord/src/mentions.test.ts
+++ b/extensions/discord/src/mentions.test.ts
@@ -3,7 +3,12 @@ import {
   resetDiscordDirectoryCacheForTest,
   rememberDiscordDirectoryUser,
 } from "./directory-cache.js";
-import { formatMention, rewriteDiscordKnownMentions } from "./mentions.js";
+import {
+  discordTextHasBroadcastMention,
+  discordTextHasTargetedMention,
+  formatMention,
+  rewriteDiscordKnownMentions,
+} from "./mentions.js";
 
 describe("formatMention", () => {
   it("formats user mentions from ids", () => {
@@ -107,5 +112,31 @@ describe("rewriteDiscordKnownMentions", () => {
     const opsRewrite = rewriteDiscordKnownMentions("@alice", { accountId: "ops" });
     expect(defaultRewrite).toBe("@alice");
     expect(opsRewrite).toBe("<@999888777>");
+  });
+});
+
+describe("discordTextHasTargetedMention", () => {
+  it("detects user and role mentions", () => {
+    expect(discordTextHasTargetedMention("ping <@123>")).toBe(true);
+    expect(discordTextHasTargetedMention("ping <@!123>")).toBe(true);
+    expect(discordTextHasTargetedMention("ping <@&456>")).toBe(true);
+  });
+
+  it("ignores plain text, channels, and broadcasts", () => {
+    expect(discordTextHasTargetedMention("ping @alice")).toBe(false);
+    expect(discordTextHasTargetedMention("see <#789>")).toBe(false);
+    expect(discordTextHasTargetedMention("heads up @everyone @here")).toBe(false);
+  });
+});
+
+describe("discordTextHasBroadcastMention", () => {
+  it("detects @everyone and @here", () => {
+    expect(discordTextHasBroadcastMention("heads up @everyone")).toBe(true);
+    expect(discordTextHasBroadcastMention("@here please")).toBe(true);
+  });
+
+  it("ignores targeted mentions and lookalikes", () => {
+    expect(discordTextHasBroadcastMention("ping <@123>")).toBe(false);
+    expect(discordTextHasBroadcastMention("mail me at a@everyones")).toBe(false);
   });
 });

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -11,6 +11,8 @@ const MARKDOWN_CODE_SEGMENT_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
 const MENTION_CANDIDATE_PATTERN = /(^|[\s([{"'.,;:!?])@([a-z0-9_.-]{2,32}(?:#[0-9]{4})?)/gi;
 const DISCORD_RESERVED_MENTIONS = new Set(["everyone", "here"]);
 const DISCORD_DISCRIMINATOR_SUFFIX = /#\d{4}$/;
+const DISCORD_TARGETED_MENTION_PATTERN = /<@!?\d+>|<@&\d+>/;
+const DISCORD_BROADCAST_MENTION_PATTERN = /@(everyone|here)\b/;
 
 function normalizeSnowflake(value: string | number | bigint): string | null {
   const text = normalizeOptionalStringifiedId(value) ?? "";
@@ -144,4 +146,14 @@ export function rewriteDiscordKnownMentions(
   }
   rewritten += rewritePlainTextMentions(text.slice(offset), params);
   return rewritten;
+}
+
+/** Whether text carries a Discord user/role mention (`<@id>`, `<@!id>`, `<@&id>`) that pings when sent fresh. */
+export function discordTextHasTargetedMention(text: string): boolean {
+  return DISCORD_TARGETED_MENTION_PATTERN.test(text);
+}
+
+/** Whether text carries an `@everyone`/`@here` broadcast mention. */
+export function discordTextHasBroadcastMention(text: string): boolean {
+  return DISCORD_BROADCAST_MENTION_PATTERN.test(text);
 }

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1952,6 +1952,95 @@ describe("processDiscordMessage draft streaming", () => {
     expectSinglePreviewEdit();
   });
 
+  it("delivers a fresh message instead of a preview edit when the final reply resolves a mention alias", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "On it @Sentinel" });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+      cfg: {
+        channels: { discord: { mentionAliases: { Sentinel: "1485891428809707651" } } },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    // Discord only fires mention notifications on create, never on edits, so the
+    // streamed preview must be abandoned and the mention delivered fresh.
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers a fresh message instead of a preview edit for a literal user mention in the final reply", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "On it <@1485891428809707651>" });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("still finalizes via preview edit when an unaliased handle stays plain text", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "On it @Sentinel" });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(editMessageDiscord).toHaveBeenCalledTimes(1);
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
+  it("still finalizes via preview edit for broadcast mentions like @everyone", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "heads up @everyone" });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(editMessageDiscord).toHaveBeenCalledTimes(1);
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
+  it("still finalizes via preview edit when a targeted mention is mixed with @everyone", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "heads up @Sentinel @everyone" });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+      cfg: {
+        channels: { discord: { mentionAliases: { Sentinel: "1485891428809707651" } } },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    // Mixed targeted + broadcast must not escalate into a create that pings @everyone.
+    expect(editMessageDiscord).toHaveBeenCalledTimes(1);
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
   it("accepts streaming=true alias for partial preview mode", async () => {
     await runSingleChunkFinalScenario({ streaming: true, maxLinesPerMessage: 5 });
     expectSinglePreviewEdit();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -48,9 +48,14 @@ import {
   resolveSessionStoreEntry,
   resolveStorePath,
 } from "openclaw/plugin-sdk/session-store-runtime";
-import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
+import { resolveDiscordAccount, resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { createDiscordRestClient } from "../client.js";
 import { beginDiscordInboundEventDeliveryCorrelation } from "../inbound-event-delivery.js";
+import {
+  discordTextHasBroadcastMention,
+  discordTextHasTargetedMention,
+  rewriteDiscordKnownMentions,
+} from "../mentions.js";
 import { removeReactionDiscord } from "../send.js";
 import { editMessageDiscord } from "../send.messages.js";
 import { resolveDiscordTargetChannelId } from "../send.shared.js";
@@ -710,6 +715,17 @@ async function processDiscordMessageInner(
               typeof previewFinalText !== "string" ||
               hasExplicitReplyDirective ||
               payload.isError
+            ) {
+              return undefined;
+            }
+            // Discord pings only on create, not edits: send a targeted mention fresh, but keep mixed @everyone/@here in place so the create cannot escalate a broadcast.
+            const rewrittenFinal = rewriteDiscordKnownMentions(previewFinalText, {
+              accountId,
+              mentionAliases: resolveDiscordAccount({ cfg, accountId }).config.mentionAliases,
+            });
+            if (
+              discordTextHasTargetedMention(rewrittenFinal) &&
+              !discordTextHasBroadcastMention(rewrittenFinal)
             ) {
               return undefined;
             }


### PR DESCRIPTION
### Summary

- **Problem**: Issue #88360 reports that on Discord, `channels.discord.mentionAliases` (`@handle` → `<@userId>`) only fires when a reply is sent through the `message` tool. When an agent puts the mention in its natural-language final answer (e.g. `Done. @Vladislava please review.`), the literal `@handle` reaches Discord as plain text and the target is never pinged. This breaks the multi-agent scenario the feature was introduced for (#67587), where most cross-agent mentions originate in natural assistant text rather than explicit `message` tool calls.
- **Root Cause**: With live preview streaming active (the default for non-block modes), the agent's final answer is delivered by finalizing the already-streamed preview message *in place* via a Discord **edit** (`buildFinalEdit` → `editMessageDiscord` in `extensions/discord/src/monitor/message-handler.process.ts`, through the core `deliverWithFinalizableLivePreviewAdapter` in `src/channels/message/live.ts`). Discord fires mention notifications only on message **create**, never on **edit** — so finalizing in place can never ping, no matter how the mention is expressed. This affects every targeted mention in a streamed final answer: a configured alias (`@handle`), a directory-resolved handle, and a literal `<@userId>` / `<@&roleId>` the model emits directly (the plugin's `messageToolHints` actually instruct the model to use that canonical form). The non-streaming path was never affected — it delivers through `deliverDiscordReply` → `sendMessageDiscord`, which rewrites and creates a fresh message that pings. The reporter's claim that `sendMessageDiscord` does not rewrite is inaccurate on current `main` (it has rewritten since at least v2026.5.12); the real gap is the live-preview finalize path.
- **Fix**: Add one guard to the Discord live-preview `buildFinalEdit` in `extensions/discord/src/monitor/message-handler.process.ts`. Run the resolved final text through `rewriteDiscordKnownMentions` (using the account's `mentionAliases` via `resolveDiscordAccount`); if the result contains a targeted user/role mention (`<@id>` / `<@!id>` / `<@&id>`), return `undefined`, which routes delivery to the existing normal path (`deliverNormally` → `deliverDiscordReply` → `sendMessageDiscord`). That path discards the streamed preview and creates a fresh message with the rewrite applied and Discord's default mention parsing, so the mention actually notifies. This covers both aliases/handles and literal `<@id>` / `<@&id>`. When the final text has no targeted mention, the efficient in-place preview edit is kept unchanged.
- **What changed**:
  - `extensions/discord/src/mentions.ts` — two small predicates next to the existing rewriter: `discordTextHasTargetedMention` (`<@id>` / `<@!id>` / `<@&id>`) and `discordTextHasBroadcastMention` (`@everyone` / `@here`), so the mention-format knowledge stays in one place.
  - `extensions/discord/src/monitor/message-handler.process.ts` — `buildFinalEdit` returns `undefined` (routing to the normal create-based delivery) when the rewritten final text has a targeted mention and no broadcast. Reuses the existing `rewriteDiscordKnownMentions` rewriter, `resolveDiscordAccount` resolver, and the new predicates — the same rewrite the `message`-tool/create path already uses.
  - `extensions/discord/src/mentions.test.ts` — unit coverage for the two predicates (user/role vs. channel/plain/broadcast).
  - `extensions/discord/src/monitor/message-handler.process.test.ts` — five integration cases pinning the delivery path: an alias-resolved final and a literal `<@id>` final are each delivered via fresh create (not an edit); an unaliased plain handle, an `@everyone` broadcast, and a mixed targeted-plus-`@everyone` final each still finalize in place via the preview edit.
- **What did NOT change (scope boundary)**:
  - `extensions/discord/src/draft-stream.ts` — streamed intermediate preview frames still suppress mentions (`allowed_mentions: { parse: [] }`) exactly as before; untouched.
  - Replies with no targeted mention — still finalize in place via the preview edit (no extra message, same UX).
  - `@everyone` / `@here` — left as-is and not rerouted. The reroute is also skipped when a targeted mention is mixed with `@everyone` / `@here` (e.g. `@Sentinel @everyone`), so a broadcast mention is never escalated into a fresh-create ping; that reply finalizes in place as before.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config` edits).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/api.ts` / `runtime-api.ts`, registry, or loader edits).
  - Dependencies unchanged.

### Reproduction

1. Configure two Discord bot accounts in a shared guild/channel, with `channels.discord.mentionAliases` mapping a handle to a user ID (e.g. `{ "Sentinel": "1485891428809707651" }`).
2. Have an agent emit the mention in its natural final answer (not via the `message` tool) — either as the alias `On it @Sentinel` or as the canonical `On it <@1485891428809707651>`.
3. **Before this PR**: the preview is finalized via an edit, so there is no ping, no notification, and no `message.mentions` entry — for both the alias form and the literal `<@id>` form.
4. **After this PR**: the final answer is delivered as a fresh message with the mention intact (`@Sentinel` rewritten to `<@1485891428809707651>`, or the literal `<@1485891428809707651>` preserved), which pings.

### Real behavior proof

**Behavior addressed (#88360)**: a targeted mention (alias, directory handle, or literal `<@id>` / `<@&id>`) in a Discord final answer under live preview streaming is delivered as a fresh message create (which rewrites and pings) instead of an in-place edit (which Discord never notifies on); plain text and `@everyone` / `@here` still finalize in place unchanged.

**Real environment tested (Linux, Node 22, production Discord handler `processDiscordMessageInner` driven against a mocked Discord REST transport)**: the test exercises the real outbound-finalize decision — in-place `editMessageDiscord` vs. fresh-create `deliverDiscordReply` — with a real `channels.discord.mentionAliases` config resolved through the production `resolveDiscordAccount`.

**Exact steps or command run after this patch**:

1. `pnpm test extensions/discord/src/monitor/message-handler.process.test.ts`
2. Before/after isolation: restore the production file to `origin/main` (no guard), run the alias and literal cases, then restore the patched file.
3. `pnpm exec oxfmt --check --threads=1 extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts`

**Evidence before fix (verbatim vitest output, production file reverted to `origin/main` — reproduces the bug)**:

```text
 ❯ extensions/discord/src/monitor/message-handler.process.test.ts (90 tests | 2 failed | 88 skipped)
     × delivers a fresh message instead of a preview edit when the final reply resolves a mention alias
     × delivers a fresh message instead of a preview edit for a literal user mention in the final reply
      Tests  2 failed | 88 skipped (90)
```

Both forms reproduce: the alias `On it @Sentinel` and the literal `On it <@1485891428809707651>` are each finalized via an edit (`editMessageDiscord` is called) instead of a fresh create.

**Evidence after fix (verbatim vitest output for the four delivery-path cases)**:

```text
 RUN  v4.1.7

 Test Files  1 passed (1)
      Tests  4 passed | 86 skipped (90)
```

**Observed result after fix**:

- An alias final (`On it @Sentinel` with `mentionAliases: { Sentinel: "1485891428809707651" }`) and a literal final (`On it <@1485891428809707651>`) no longer call `editMessageDiscord`; both route to `deliverDiscordReply` (a fresh create that pings).
- An unaliased plain handle (`On it @Sentinel`, no alias configured) and an `@everyone` broadcast still finalize in place via the preview edit — no escalation.
- Full file: `Tests 90 passed (90)`.

**What was not tested**:

- A live Discord guild round-trip — no bot instance was available in this environment, so the after-fix evidence drives the production handler against a mocked Discord transport rather than a live gateway. The decisive ping/no-ping fact is documented Discord platform behavior (mention notifications fire on message create, not on edit), which is why rewriting the edited content alone is insufficient and the fix reroutes to a create. A live two-bot round-trip (alias and literal `<@id>`) is the recommended maintainer-side confirmation.

**Regression tests**:

- `message-handler.process.test.ts` → `delivers a fresh message instead of a preview edit when the final reply resolves a mention alias` and `delivers a fresh message instead of a preview edit for a literal user mention in the final reply` (both fail before the fix; see Evidence before fix), plus the controls `still finalizes via preview edit when an unaliased handle stays plain text`, `still finalizes via preview edit for broadcast mentions like @everyone`, and `still finalizes via preview edit when a targeted mention is mixed with @everyone` (this last one fails if the broadcast exclusion is dropped, locking the no-escalation guarantee).

### Risk / Mitigation

- **Risk**: the in-place-vs-create decision could over-trigger, or escalate a broadcast ping. **Mitigation**: it triggers only when the rewritten final text contains a targeted user/role mention (`<@id>` / `<@&id>`) and contains no `@everyone` / `@here`; plain text, broadcast-only, and mixed targeted-plus-broadcast replies all stay on the unchanged in-place edit (dedicated tests lock the `@everyone` and mixed cases, so the create path can never newly ping everyone).
- **Risk**: a final answer containing a targeted mention is now delivered as a fresh message rather than finalizing the streamed preview in place. **Mitigation**: the streamed preview is discarded by the existing normal-delivery fallback — the same path already used for media/error/explicit-reply finals — so no duplicate message is produced.
- **Risk**: rewriting lengthens text (`@name` → `<@id>`), which could affect chunking. **Mitigation**: the create path is the same one the `message` tool uses and applies the existing chunking, so over-length handling is unchanged.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Channels / messaging (Discord)

### Linked Issue/PR

Fixes #88360

Related #67587
