### PR TITLE
fix(imessage): skip idle approval discovery scans

### DIFF
--- a/extensions/imessage/src/approval-reaction-poller.test.ts
+++ b/extensions/imessage/src/approval-reaction-poller.test.ts
@@ -1,6 +1,9 @@
 // Imessage tests cover approval reaction poller plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { pollPendingIMessageApprovalReactions } from "./approval-reaction-poller.js";
+import {
+  clearIMessageApprovalReactionPollerStateForTest,
+  pollPendingIMessageApprovalReactions,
+} from "./approval-reaction-poller.js";
 import {
   clearIMessageApprovalReactionTargetsForTest,
   registerIMessageApprovalReactionTarget,
@@ -24,6 +27,7 @@ function createClient(request: ReturnType<typeof vi.fn>): IMessageRpcClient {
 describe("iMessage approval reaction poller", () => {
   beforeEach(() => {
     clearIMessageApprovalReactionTargetsForTest();
+    clearIMessageApprovalReactionPollerStateForTest();
     resolverMocks.resolveIMessageApproval.mockReset();
     resolverMocks.resolveIMessageApproval.mockResolvedValue(undefined);
     resolverMocks.isApprovalNotFoundError.mockReset();
@@ -114,6 +118,101 @@ describe("iMessage approval reaction poller", () => {
       senderId: "+15551230000",
       gatewayUrl: undefined,
     });
+  });
+
+  it("bounds no-target recent-chat discovery to one pass per account", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 42 }] };
+      }
+      if (method === "messages.history") {
+        return { messages: [] };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const pollParams = {
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+      allowRecentChatDiscovery: true,
+    };
+
+    await pollPendingIMessageApprovalReactions(pollParams);
+    await pollPendingIMessageApprovalReactions(pollParams);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenCalledWith("chats.list", { limit: 50 }, { timeoutMs: 10_000 });
+    expect(request).toHaveBeenCalledWith(
+      "messages.history",
+      { chat_id: 42, limit: 30 },
+      { timeoutMs: 10_000 },
+    );
+  });
+
+  it("retries no-target recent-chat discovery after the first chat list fails", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chats.list") {
+        const chatListCalls = request.mock.calls.filter(
+          ([calledMethod]) => calledMethod === "chats.list",
+        );
+        if (chatListCalls.length === 1) {
+          throw new Error("temporary imsg failure");
+        }
+        return { chats: [{ id: 42 }] };
+      }
+      if (method === "messages.history") {
+        return { messages: [] };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const pollParams = {
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+      allowRecentChatDiscovery: true,
+    };
+
+    await expect(pollPendingIMessageApprovalReactions(pollParams)).rejects.toThrow(
+      "temporary imsg failure",
+    );
+    await pollPendingIMessageApprovalReactions(pollParams);
+
+    expect(request.mock.calls.filter(([method]) => method === "chats.list")).toHaveLength(2);
+    expect(request.mock.calls.filter(([method]) => method === "messages.history")).toHaveLength(1);
+  });
+
+  it("retries no-target recent-chat discovery after the first history fetch fails", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 42 }] };
+      }
+      if (method === "messages.history") {
+        const historyCalls = request.mock.calls.filter(
+          ([calledMethod]) => calledMethod === "messages.history",
+        );
+        if (historyCalls.length === 1) {
+          throw new Error("temporary history failure");
+        }
+        return { messages: [] };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const pollParams = {
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+      allowRecentChatDiscovery: true,
+    };
+
+    await pollPendingIMessageApprovalReactions(pollParams);
+    await pollPendingIMessageApprovalReactions(pollParams);
+    await pollPendingIMessageApprovalReactions(pollParams);
+
+    expect(request.mock.calls.filter(([method]) => method === "chats.list")).toHaveLength(2);
+    expect(request.mock.calls.filter(([method]) => method === "messages.history")).toHaveLength(2);
   });
 
   it("does not bind observed approval prompts when the process clock is invalid", async () => {

--- a/extensions/imessage/src/approval-reaction-poller.test.ts
+++ b/extensions/imessage/src/approval-reaction-poller.test.ts
@@ -150,6 +150,126 @@ describe("iMessage approval reaction poller", () => {
     );
   });
 
+  it("bounds no-target discovery after resolving an observed reaction", async () => {
+    const request = vi.fn(async (method: string, payload?: { chat_id?: number }) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 42 }, { id: 99 }] };
+      }
+      if (method === "messages.history" && payload?.chat_id === 42) {
+        return {
+          messages: [
+            {
+              guid: "msg-1",
+              chat_id: 42,
+              chat_guid: "SMS;-;+15551230000",
+              chat_identifier: "+15551230000",
+              is_from_me: true,
+              sender: "+15551230000",
+              text: [
+                "Exec approval required",
+                "ID: exec-1",
+                "",
+                "Reply with: /approve exec-1 allow-once|deny",
+              ].join("\n"),
+              reactions: [
+                {
+                  id: 7,
+                  sender: "+15551230000",
+                  is_from_me: true,
+                  type: "like",
+                  emoji: "👍",
+                  created_at: "2026-05-27T21:00:00.000Z",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (method === "messages.history" && payload?.chat_id === 99) {
+        return { messages: [] };
+      }
+      throw new Error(`unexpected request ${method} ${JSON.stringify(payload)}`);
+    });
+
+    const pollParams = {
+      client: createClient(request),
+      cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+      accountId: "default",
+      allowRecentChatDiscovery: true,
+    };
+
+    await pollPendingIMessageApprovalReactions(pollParams);
+    await pollPendingIMessageApprovalReactions(pollParams);
+
+    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(1);
+    expect(request.mock.calls.filter(([method]) => method === "chats.list")).toHaveLength(1);
+    expect(request.mock.calls.filter(([method]) => method === "messages.history")).toHaveLength(2);
+    expect(request).toHaveBeenCalledWith(
+      "messages.history",
+      { chat_id: 99, limit: 30 },
+      { timeoutMs: 10_000 },
+    );
+  });
+
+  it("retries no-target discovery after resolver failures expire observed targets", async () => {
+    resolverMocks.resolveIMessageApproval.mockRejectedValue(new Error("gateway down"));
+    const request = vi.fn(async (method: string) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 42 }] };
+      }
+      if (method === "messages.history") {
+        return {
+          messages: [
+            {
+              guid: "msg-1",
+              chat_id: 42,
+              chat_guid: "SMS;-;+15551230000",
+              chat_identifier: "+15551230000",
+              is_from_me: true,
+              sender: "+15551230000",
+              text: [
+                "Exec approval required",
+                "ID: exec-1",
+                "",
+                "Reply with: /approve exec-1 allow-once|deny",
+              ].join("\n"),
+              reactions: [
+                {
+                  id: 7,
+                  sender: "+15551230000",
+                  is_from_me: true,
+                  type: "like",
+                  emoji: "👍",
+                  created_at: "2026-05-27T21:00:00.000Z",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+
+    try {
+      const pollParams = {
+        client: createClient(request),
+        cfg: { channels: { imessage: { allowFrom: ["+15551230000"] } } },
+        accountId: "default",
+        allowRecentChatDiscovery: true,
+      };
+
+      await pollPendingIMessageApprovalReactions(pollParams);
+      dateNow.mockReturnValue(1_800_000_301_000);
+      await pollPendingIMessageApprovalReactions(pollParams);
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(resolverMocks.resolveIMessageApproval).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls.filter(([method]) => method === "chats.list")).toHaveLength(2);
+  });
+
   it("retries no-target recent-chat discovery after the first chat list fails", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "chats.list") {

--- a/extensions/imessage/src/approval-reaction-poller.ts
+++ b/extensions/imessage/src/approval-reaction-poller.ts
@@ -19,6 +19,12 @@ const RECENT_CHAT_LIMIT = 50;
 const PER_CHAT_HISTORY_LIMIT = 30;
 const OBSERVED_APPROVAL_PROMPT_TARGET_TTL_MS = 5 * 60 * 1000;
 
+const accountIdsWithCompletedNoTargetDiscovery = new Set<string>();
+
+export function clearIMessageApprovalReactionPollerStateForTest(): void {
+  accountIdsWithCompletedNoTargetDiscovery.clear();
+}
+
 type ChatListEntry = {
   id?: number | null;
 };
@@ -228,10 +234,13 @@ export async function pollPendingIMessageApprovalReactions(params: {
   const targets = listPendingIMessageApprovalReactionPollTargets({
     accountId: params.accountId,
   });
-  if (targets.length === 0 && params.allowRecentChatDiscovery !== true) {
+  const shouldAttemptNoTargetDiscovery =
+    targets.length === 0 &&
+    params.allowRecentChatDiscovery === true &&
+    !accountIdsWithCompletedNoTargetDiscovery.has(params.accountId);
+  if (targets.length === 0 && !shouldAttemptNoTargetDiscovery) {
     return;
   }
-
   const pendingByMessageId = buildPendingTargetsByMessageId(targets);
   const explicitChatIds = listTargetChatIds(targets);
   const shouldDiscoverRecentChats =
@@ -241,13 +250,18 @@ export async function pollPendingIMessageApprovalReactions(params: {
     ? uniqueChatIds([...explicitChatIds, ...(await listRecentChatIds(params.client))])
     : explicitChatIds;
   if (chatIds.length === 0) {
+    if (shouldAttemptNoTargetDiscovery) {
+      accountIdsWithCompletedNoTargetDiscovery.add(params.accountId);
+    }
     return;
   }
+  let hadHistoryFetchError = false;
   for (const chatId of chatIds) {
     let messages: HistoryMessage[];
     try {
       messages = await fetchRecentHistory({ client: params.client, chatId });
     } catch (err) {
+      hadHistoryFetchError = true;
       params.logVerboseMessage?.(
         `imessage: approval reaction poll skipped chat_id=${chatId}: ${String(err)}`,
       );
@@ -286,5 +300,8 @@ export async function pollPendingIMessageApprovalReactions(params: {
         }
       }
     }
+  }
+  if (shouldAttemptNoTargetDiscovery && !hadHistoryFetchError) {
+    accountIdsWithCompletedNoTargetDiscovery.add(params.accountId);
   }
 }

--- a/extensions/imessage/src/approval-reaction-poller.ts
+++ b/extensions/imessage/src/approval-reaction-poller.ts
@@ -296,6 +296,9 @@ export async function pollPendingIMessageApprovalReactions(params: {
           logVerboseMessage: params.logVerboseMessage,
         });
         if (handled.stopPolling) {
+          if (shouldAttemptNoTargetDiscovery && handled.stopPollingReason !== "resolver-error") {
+            break;
+          }
           return;
         }
       }

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -32,7 +32,12 @@ type IMessageApprovalReactionResolution = {
 };
 export type IMessageApprovalReactionHandleResult =
   | { handled: false; stopPolling: false }
-  | { handled: true; stopPolling: boolean };
+  | { handled: true; stopPolling: false }
+  | {
+      handled: true;
+      stopPolling: true;
+      stopPollingReason: "resolved" | "not-found" | "resolver-error";
+    };
 
 type IMessageApprovalReactionTarget = ApprovalReactionTargetRecord;
 
@@ -585,7 +590,7 @@ export async function handleIMessageApprovalReaction(params: {
     params.logVerboseMessage?.(
       `imessage: approval reaction resolved id=${target.approvalId} sender=${event.actorHandle} decision=${target.decision} via messageId=${matchedMessageId ?? event.messageId}`,
     );
-    return { handled: true, stopPolling: true };
+    return { handled: true, stopPolling: true, stopPollingReason: "resolved" };
   } catch (error) {
     if (isApprovalNotFoundError(error)) {
       for (const candidate of event.messageIdCandidates) {
@@ -598,7 +603,7 @@ export async function handleIMessageApprovalReaction(params: {
       params.logVerboseMessage?.(
         `imessage: approval reaction ignored for expired approval id=${target.approvalId} sender=${event.actorHandle}`,
       );
-      return { handled: true, stopPolling: true };
+      return { handled: true, stopPolling: true, stopPollingReason: "not-found" };
     }
     // Surface non-NotFound errors at warn level so a gateway 5xx / network
     // outage / auth failure is visible without OPENCLAW_LOG_LEVEL=debug.
@@ -616,7 +621,7 @@ export async function handleIMessageApprovalReaction(params: {
     params.logVerboseMessage?.(
       `imessage: approval reaction failed id=${target.approvalId} sender=${event.actorHandle}: ${String(error)}`,
     );
-    return { handled: true, stopPolling: true };
+    return { handled: true, stopPolling: true, stopPollingReason: "resolver-error" };
   }
 }
 


### PR DESCRIPTION
## Summary
- bound no-target iMessage approval recent-chat discovery to one pass per account
- preserve restart recovery for observed approval prompts found in recent Messages history
- keep recurring fast polling idle when no approval targets exist, avoiding repeated broad chat/history scans

## Why
The iMessage approval discovery timer can run with `allowRecentChatDiscovery: true` even when OpenClaw has no pending iMessage approval targets. The old behavior repeatedly listed recent chats and fetched history every discovery interval. On large Messages databases this can make `imsg` spend CPU in `messages.history`/reaction lookup work despite having no actionable in-memory target.

The fix keeps the useful no-target discovery path for process startup/restart recovery, but records that the no-target discovery pass has already run for the account. Subsequent no-target discovery ticks return before calling `chats.list`.

## Real behavior proof
Behavior or issue addressed: iMessage approval discovery no longer produces recurring idle `imsg` CPU spikes when no approval targets are pending, while the gateway remains running.

Real environment tested: real OpenClaw gateway on macOS using `/Users/colm/clawdbot/dist/index.js gateway --port 18789` and real `imsg rpc --json --db /Users/colm/Library/Messages/chat.db` against the local Messages database.

Exact steps or command run after this patch: deployed the local no-target idle guard, restarted the gateway, watched the process through the morning, checked the live gateway/imsg process state, and checked the Messages database for new self-DM approval prompt echoes since the restart window.

Evidence after fix: copied live output from the real setup after the fix had been running overnight:

```text
$ ps -axo pid,ppid,%cpu,lstart,command | rg '(/Users/colm/clawdbot/dist/index.js gateway|imsg)'
37893     1   7.3 Sat May 30 22:39:08 2026     /opt/homebrew/opt/node/bin/node /Users/colm/clawdbot/dist/index.js gateway --port 18789
37942 37893   0.0 Sat May 30 22:39:16 2026     /opt/homebrew/Cellar/imsg/0.8.1/libexec/imsg rpc --json --db /Users/colm/Library/Messages/chat.db

$ sqlite3 ~/Library/Messages/chat.db "select count(*) from message where date/1000000000 + 978307200 > strftime('%s','2026-05-31 05:39:08') and is_from_me=1 and text like '%Exec approval required%';"
0
```

Observed result after fix: no new self-DM echo texts and no recurring `imsg` spike during the morning watch window after restart; spot check showed the live `imsg rpc` child at 0.0% CPU.

What was not tested: I did not restart the live gateway onto this exact cleaned commit because the cleaned commit intentionally preserves one startup no-target discovery pass; the deployed local guard tested the same recurring idle no-target path that this PR bounds after that first pass.

## Tests
- `pnpm test -- extensions/imessage/src/approval-reaction-poller.test.ts`
  - 1 file passed, 9 tests passed
- `pnpm oxlint extensions/imessage/src/approval-reaction-poller.ts extensions/imessage/src/approval-reaction-poller.test.ts`
- `git diff --check -- extensions/imessage/src/approval-reaction-poller.ts extensions/imessage/src/approval-reaction-poller.test.ts`
