### PR TITLE
Suggest closest edit match when oldText is missing

### DIFF
--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -86,6 +86,23 @@ interface MatchedEdit {
   newText: string;
 }
 
+interface ClosestEditMatchHint {
+  startLine: number;
+  endLine: number;
+  similarity: number;
+  snippet: string;
+}
+
+const CLOSEST_MATCH_HINT_LIMIT = 3;
+const CLOSEST_MATCH_MIN_SIMILARITY = 0.65;
+const CLOSEST_MATCH_MAX_CONTENT_CHARS = 500_000;
+const CLOSEST_MATCH_MAX_FILE_LINES = 5_000;
+const CLOSEST_MATCH_MAX_OLD_LINES = 40;
+const CLOSEST_MATCH_MAX_WINDOWS = 5_000;
+const CLOSEST_MATCH_SNIPPET_CHARS = 240;
+const CLOSEST_MATCH_MAX_DIFF_CELLS = 20_000;
+const CLOSEST_MATCH_MAX_TOTAL_DIFF_CELLS = 250_000;
+
 /**
  * Find oldText in content, trying exact match first, then fuzzy match.
  * When fuzzy matching is used, the returned contentForReplacement is the
@@ -145,14 +162,142 @@ function countOccurrences(content: string, oldText: string): number {
   return fuzzyContent.split(fuzzyOldText).length - 1;
 }
 
-function getNotFoundError(path: string, editIndex: number, totalEdits: number): Error {
+function splitHintLines(text: string): string[] {
+  const lines = text.split("\n");
+  if (lines.length > 1 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function compactSimilarityText(text: string): string {
+  return normalizeForFuzzyMatch(text).trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function characterSimilarityAgainstCompactTexts(
+  leftText: string,
+  rightText: string,
+  remainingDiffCells: { value: number },
+): number {
+  if (leftText === rightText) {
+    return 1;
+  }
+  if (!leftText || !rightText) {
+    return 0;
+  }
+  const diffCells = leftText.length * rightText.length;
+  if (diffCells > CLOSEST_MATCH_MAX_DIFF_CELLS || diffCells > remainingDiffCells.value) {
+    return 0;
+  }
+  remainingDiffCells.value -= diffCells;
+
+  const unchangedChars = Diff.diffChars(leftText, rightText).reduce(
+    (total, part) => total + (part.added || part.removed ? 0 : part.value.length),
+    0,
+  );
+  return (2 * unchangedChars) / (leftText.length + rightText.length);
+}
+
+function truncateClosestMatchSnippet(snippet: string): string {
+  const compact = snippet.trim().replace(/\n/g, "\\n");
+  if (compact.length <= CLOSEST_MATCH_SNIPPET_CHARS) {
+    return compact;
+  }
+  return `${compact.slice(0, CLOSEST_MATCH_SNIPPET_CHARS - 15)}... (truncated)`;
+}
+
+function findClosestEditMatchHints(content: string, oldText: string): ClosestEditMatchHint[] {
+  if (content.length > CLOSEST_MATCH_MAX_CONTENT_CHARS) {
+    return [];
+  }
+
+  const contentLines = splitHintLines(content);
+  const oldLines = splitHintLines(oldText);
+  const windowLineCount = Math.max(1, oldLines.length);
+  const windowCount = contentLines.length - windowLineCount + 1;
+  if (
+    contentLines.length > CLOSEST_MATCH_MAX_FILE_LINES ||
+    oldLines.length > CLOSEST_MATCH_MAX_OLD_LINES ||
+    windowCount <= 0 ||
+    windowCount > CLOSEST_MATCH_MAX_WINDOWS
+  ) {
+    return [];
+  }
+
+  const compactOldText = compactSimilarityText(oldText);
+  if (!compactOldText || compactOldText.length > CLOSEST_MATCH_MAX_DIFF_CELLS) {
+    return [];
+  }
+
+  const hints: ClosestEditMatchHint[] = [];
+  const remainingDiffCells = { value: CLOSEST_MATCH_MAX_TOTAL_DIFF_CELLS };
+  for (let index = 0; index < windowCount; index++) {
+    if (remainingDiffCells.value <= 0) {
+      break;
+    }
+    const snippet = contentLines.slice(index, index + windowLineCount).join("\n");
+    const compactSnippet = compactSimilarityText(snippet);
+    const similarity = characterSimilarityAgainstCompactTexts(
+      compactOldText,
+      compactSnippet,
+      remainingDiffCells,
+    );
+    if (similarity < CLOSEST_MATCH_MIN_SIMILARITY) {
+      continue;
+    }
+    hints.push({
+      startLine: index + 1,
+      endLine: index + windowLineCount,
+      similarity,
+      snippet: truncateClosestMatchSnippet(snippet),
+    });
+  }
+  return hints
+    .toSorted((a, b) => b.similarity - a.similarity || a.startLine - b.startLine)
+    .slice(0, CLOSEST_MATCH_HINT_LIMIT);
+}
+
+function formatLineRange(hint: ClosestEditMatchHint): string {
+  return hint.startLine === hint.endLine
+    ? `line ${hint.startLine}`
+    : `lines ${hint.startLine}-${hint.endLine}`;
+}
+
+function formatClosestMatchHints(
+  hints: ClosestEditMatchHint[],
+  editIndex: number | undefined,
+): string {
+  if (hints.length === 0) {
+    return "";
+  }
+
+  const editLabel = editIndex === undefined ? "" : ` for edits[${editIndex}]`;
+  const formatHint = (hint: ClosestEditMatchHint) =>
+    `${formatLineRange(hint)} (${Math.round(hint.similarity * 100)}% similar): ${JSON.stringify(hint.snippet)}`;
+  if (hints.length === 1) {
+    return `\nClosest match${editLabel} at ${formatHint(hints[0])}.`;
+  }
+  return `\nClosest matches${editLabel}:\n${hints.map((hint) => `- ${formatHint(hint)}`).join("\n")}`;
+}
+
+function getNotFoundError(
+  path: string,
+  editIndex: number,
+  totalEdits: number,
+  content: string,
+  oldText: string,
+): Error {
+  const closestMatchHint = formatClosestMatchHints(
+    findClosestEditMatchHints(content, oldText),
+    totalEdits === 1 ? undefined : editIndex,
+  );
   if (totalEdits === 1) {
     return new Error(
-      `Could not find the exact text in ${path}. The old text must match exactly including all whitespace and newlines.`,
+      `Could not find the exact text in ${path}. The old text must match exactly including all whitespace and newlines.${closestMatchHint}`,
     );
   }
   return new Error(
-    `Could not find edits[${editIndex}] in ${path}. The oldText must match exactly including all whitespace and newlines.`,
+    `Could not find edits[${editIndex}] in ${path}. The oldText must match exactly including all whitespace and newlines.${closestMatchHint}`,
   );
 }
 
@@ -224,7 +369,7 @@ export function applyEditsToNormalizedContent(
     const edit = normalizedEdits[i];
     const matchResult = fuzzyFindText(baseContent, edit.oldText);
     if (!matchResult.found) {
-      throw getNotFoundError(path, i, normalizedEdits.length);
+      throw getNotFoundError(path, i, normalizedEdits.length, baseContent, edit.oldText);
     }
 
     const occurrences = countOccurrences(baseContent, edit.oldText);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -30,6 +30,16 @@ describe("edit tool", () => {
     return filePath;
   }
 
+  async function captureEditError(action: Promise<unknown>): Promise<Error> {
+    try {
+      await action;
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      return error as Error;
+    }
+    throw new Error("Expected edit tool to throw");
+  }
+
   it("adds current file contents to exact-match mismatch errors", async () => {
     const filePath = await createTempFile("actual current content");
     const tool = createEditTool(tmpDir);
@@ -41,6 +51,101 @@ describe("edit tool", () => {
         undefined,
       ),
     ).rejects.toThrow(/Current file contents:\nactual current content/);
+  });
+
+  it("adds a closest-match line hint to near exact-match mismatch errors", async () => {
+    const filePath = await createTempFile('alpha\nconst value = "actual";\nomega\n');
+    const tool = createEditTool(tmpDir);
+
+    const error = await captureEditError(
+      tool.execute(
+        "call-1",
+        { path: filePath, edits: [{ oldText: 'const value = "actuel";', newText: "ignored" }] },
+        undefined,
+      ),
+    );
+
+    expect(error.message).toContain("Closest match at line 2");
+    expect(error.message).toMatch(/\(\d+% similar\)/);
+    expect(error.message).toContain('const value = \\"actual\\";');
+  });
+
+  it("does not add a closest-match hint for unrelated missing oldText", async () => {
+    const filePath = await createTempFile("alpha beta gamma\n");
+    const tool = createEditTool(tmpDir);
+
+    const error = await captureEditError(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: "network socket reader", newText: "ignored" }],
+        },
+        undefined,
+      ),
+    );
+
+    expect(error.message).not.toContain("Closest match");
+  });
+
+  it("skips closest-match hints for large files", async () => {
+    const lines = Array.from({ length: 5_001 }, (_, index) =>
+      index === 4_000 ? 'const value = "actual";' : `line ${index} unrelated;`,
+    );
+    const filePath = await createTempFile(`${lines.join("\n")}\n`);
+    const tool = createEditTool(tmpDir);
+
+    const error = await captureEditError(
+      tool.execute(
+        "call-1",
+        { path: filePath, edits: [{ oldText: 'const value = "actuel";', newText: "ignored" }] },
+        undefined,
+      ),
+    );
+
+    expect(error.message).not.toContain("Closest match");
+  });
+
+  it("skips closest-match hints for oversized oldText", async () => {
+    const filePath = await createTempFile('const value = "actual";\n');
+    const tool = createEditTool(tmpDir);
+
+    const error = await captureEditError(
+      tool.execute(
+        "call-1",
+        { path: filePath, edits: [{ oldText: "a".repeat(25_000), newText: "ignored" }] },
+        undefined,
+      ),
+    );
+
+    expect(error.message).not.toContain("Closest match");
+  });
+
+  it("caps closest-match work before scanning every candidate window", async () => {
+    const oldValue = "a".repeat(125);
+    const unrelatedValue = "b".repeat(125);
+    const nearValue = `${"a".repeat(124)}b`;
+    const unrelatedLines = Array.from(
+      { length: 30 },
+      (_, index) => `const value${index} = "${unrelatedValue}";`,
+    );
+    const filePath = await createTempFile(
+      `${unrelatedLines.join("\n")}\nconst value999 = "${nearValue}";\n`,
+    );
+    const tool = createEditTool(tmpDir);
+
+    const error = await captureEditError(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: `const value999 = "${oldValue}";`, newText: "ignored" }],
+        },
+        undefined,
+      ),
+    );
+
+    expect(error.message).not.toContain("Closest match");
   });
 
   it("recovers success after a post-write throw when the edit already applied", async () => {


### PR DESCRIPTION
## Summary
- Add line-numbered closest-match hints when the edit tool cannot find an `oldText` block.
- Reuse the edit diff failure path so execution and preview errors share the same hint wording.
- Keep hint generation bounded for large files, oversized oldText blocks, and expensive character comparisons.

## Verification
- `pnpm build` passed.
- `node scripts/run-vitest.mjs src/agents/sessions/tools/edit.test.ts` passed: 1 file, 9 tests.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` passed with no accepted/actionable findings.
- `node scripts/check-changed.mjs --base upstream/main` did not complete locally because this checkout has no usable `crabbox` binary; the local remote-child fallback reached core test typecheck and failed in unchanged upstream file `ui/src/ui/control-ui-vite-config.node.test.ts`.

## Real behavior proof
Behavior addressed: The edit tool now includes a closest matching line hint when `oldText` is near existing content but not exact.
Real environment tested: Local OpenClaw checkout on `feat/edit-fuzzy-match-hint` at `ca0f52d0818c6913a66a4b4cfd16d6c816c254c9`, Node 22.22.2, invoking the production `createEditTool` against a real temporary file.
Exact steps or command run after this patch: Ran `pnpm exec tsx -e ...` to create a temp file containing `const value = "actual";`, call `createEditTool(dir).execute(...)` with missing `oldText` `const value = "actuel";`, and print the thrown edit-tool error.
Evidence after fix: Console output from that real edit-tool invocation:

```text
REAL_EDIT_TOOL_ERROR_START
Could not find the exact text in /tmp/openclaw-edit-proof-Zl7UYp/sample.ts. The old text must match exactly including all whitespace and newlines.
Closest match at line 2 (96% similar): "const value = \"actual\";".
Current file contents:
alpha
const value = "actual";
omega

REAL_EDIT_TOOL_ERROR_END
```

Observed result after fix: The failed edit reported the closest match at line 2 with similarity and included the real current file contents; no replacement was applied.
What was not tested: Full Vitest suite and remote Testbox proof were not run from this local checkout; broad GitHub CI is running on the pushed PR head.
