### PR TITLE
fix(shared): restore number coercion module export

### DIFF
--- a/src/shared/number-coercion.ts
+++ b/src/shared/number-coercion.ts
@@ -1,0 +1,10 @@
+export {
+  addTimerTimeoutGraceMs,
+  clampNumberOption,
+  clampPositiveTimerTimeoutMs,
+  MAX_TIMER_TIMEOUT_MS,
+  resolveIntegerOption,
+  resolvePositiveIntegerOption,
+  resolvePositiveTimerTimeoutMs,
+  resolveTimerTimeoutMs,
+} from "@openclaw/normalization-core/number-coercion";


### PR DESCRIPTION
## Summary
- restore the missing `src/shared/number-coercion.ts` module as a thin re-export from `@openclaw/normalization-core/number-coercion`
- unblock current `origin/main` imports from `src/utils.ts` and sibling runtime files that import `../shared/number-coercion.js`

## Verification
- `node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts` -> 22/22 passed on current `origin/main` plus this patch
- `git diff --check`

## Real behavior proof
- Behavior addressed: current `origin/main` failed before loading focused tests because `src/utils.ts` imports `./shared/number-coercion.js` while `src/shared/number-coercion.ts` was missing.
- Real environment tested: local source checkout on macOS.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts`.
- Evidence after fix: the test file loaded successfully and passed 22/22 tests.
- Observed result after fix: the missing-module import error is gone.
- What was not tested: full CI; this is a one-file module restore intended to unblock the broad CI failure already visible on #87904.
