### PR TITLE
test(core): align changed gate type fixtures

### DIFF
--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveOAuthDir } from "../config/paths.js";
 import { MAX_DATE_TIMESTAMP_MS } from "../shared/number-coercion.js";
 import { resolveAuthStatePath, resolveAuthStorePath } from "./auth-profiles/paths.js";
 import { getRuntimeAuthProfileStoreSnapshot } from "./auth-profiles/runtime-snapshots.js";

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -197,7 +197,7 @@ describe("bundled channel entry shape guards", () => {
   const bundledPluginRoots = listSourceBundledPluginRoots();
   let realBundledSourceTreeProbe: {
     hasAccountInspect: boolean;
-    pluginIds: string[];
+    pluginIds: readonly string[];
   };
 
   beforeAll(async () => {

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -296,7 +296,7 @@ async function expectBuiltArtifactNodeRequireFastPath(
   }
 }
 
-function runCompiledEsmSidecarFastPathProbe(): ReturnType<typeof spawnSync> {
+function runCompiledEsmSidecarFastPathProbe(): SpawnSyncReturns<string> {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
   tempDirs.push(tempRoot);
   const probePath = path.join(tempRoot, "probe.mjs");
@@ -358,7 +358,7 @@ function runCompiledEsmSidecarFastPathProbe(): ReturnType<typeof spawnSync> {
 }
 
 describe("loadBundledEntryExportSync", () => {
-  let compiledEsmSidecarFastPathResult: ReturnType<typeof spawnSync>;
+  let compiledEsmSidecarFastPathResult: SpawnSyncReturns<string>;
 
   beforeAll(() => {
     compiledEsmSidecarFastPathResult = runCompiledEsmSidecarFastPathProbe();
@@ -573,9 +573,9 @@ describe("loadBundledEntryExportSync", () => {
     const result = compiledEsmSidecarFastPathResult;
 
     expect(result.status).toBe(0);
-    expect(String(result.stdout).trim()).toBe("adapter");
-    expect(String(result.stderr)).toMatch(/sourceLoaderCreateMs=0(?:\.0+)?(?:\s|$)/u);
-    expect(String(result.stderr)).toMatch(/sourceLoaderCallMs=0(?:\.0+)?(?:\s|$)/u);
+    expect(result.stdout.trim()).toBe("adapter");
+    expect(result.stderr).toMatch(/sourceLoaderCreateMs=0(?:\.0+)?(?:\s|$)/u);
+    expect(result.stderr).toMatch(/sourceLoaderCallMs=0(?:\.0+)?(?:\s|$)/u);
   });
 
   it("can disable source-tree fallback for dist bundled entry checks", () => {


### PR DESCRIPTION
## Summary

This PR is currently parked as a narrow changed-gate fixture cleanup.

It was useful while the schema-runtime PR was blocked by transient main drift, but newer main now enables stricter unsafe-assertion lint on the full changed test files. Making this PR green would require broad cleanup across large pre-existing test fixtures, which is intentionally out of scope for the schema hardening lane.

Current narrow diff:

- Remove a stale legacy OAuth sidecar import from the auth-profile save tests.
- Accept readonly bundled channel ids in the bundled channel shape guard test.
- Type the encoded `spawnSync` result in the plugin SDK channel-entry contract test and remove redundant string conversions.

## Verification

- `node scripts/run-vitest.mjs src/agents/auth-profiles.store.save.test.ts src/channels/plugins/bundled.shape-guard.test.ts src/plugin-sdk/channel-entry-contract.test.ts` passed on head `5f89cf31202`: 3 shards, 57 tests, 12.51s.
- `node_modules/.bin/oxfmt --check src/agents/auth-profiles.store.save.test.ts src/channels/plugins/bundled.shape-guard.test.ts src/plugin-sdk/channel-entry-contract.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- `node scripts/run-oxlint.mjs src/agents/auth-profiles.store.save.test.ts src/channels/plugins/bundled.shape-guard.test.ts src/plugin-sdk/channel-entry-contract.test.ts` is blocked by newly enabled current-main `typescript(no-unsafe-type-assertion)` findings across pre-existing test assertions in the touched files.
- AWS Crabbox `pnpm check:changed` on `1fd9fe2b33a` was blocked by unrelated current-main extension type drift: run `run_2c976ad4f696`, lease `cbx_d60d77f3e4dd` / `blue-hermit`, provider `aws`. Main later moved to `4d95ae39d43` to repair that extension drift, but the strict test-file lint blocker remains.

## Real behavior proof

Behavior addressed: Current changed-gate core/plugin contract test fixtures are aligned with stricter type surfaces without carrying broad runtime changes.

Real environment tested: Local linked worktree via repo Vitest/format wrappers; remote AWS Crabbox changed gate before the latest lint-rule drift.

Exact steps or command run after this patch: See Verification above.

Evidence after fix: Focused test files pass locally after rebasing onto current main.

Observed result after fix: The branch diff is still 3 test files, +7/-8.

What was not tested: A green current `pnpm check:changed`; making this PR green now requires broad existing test-fixture lint cleanup that should not be mixed into the runtime schema hardening work.
