### PR TITLE
fix(pairing): avoid duplicate approve command

### DIFF
--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -54,6 +54,9 @@ describe("buildPairingReply", () => {
       `(?:openclaw|openclaw) --profile isolated pairing approve ${testCase.channel} ${testCase.code}`,
     );
     expect(text).toMatch(commandRe);
+    expect(
+      text.match(new RegExp(`pairing approve ${testCase.channel} ${testCase.code}`, "g")),
+    ).toHaveLength(1);
   }
 
   function expectProfileAwarePairingReply(testCase: (typeof pairingReplyCases)[number]) {

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -18,7 +18,6 @@ export function buildPairingReply(params: {
     "```",
     "",
     "Ask the bot owner to approve with:",
-    formatCliCommand(`openclaw pairing approve ${channel} ${code}`),
     "```",
     approveCommand,
     "```",


### PR DESCRIPTION
## Summary

The native SMS proof on #88476 exposed a pairing-copy bug: buildPairingReply emitted the approve command twice, once as a plain line and again inside the fenced command block. On SMS that rendered as a duplicated/run-together approve command.

This patch removes the duplicate plain command line and adds a regression assertion that each pairing reply includes the approve command exactly once.

## Verification

- git diff --check
- pnpm exec oxfmt --check src/pairing/pairing-messages.ts src/pairing/pairing-messages.test.ts
- pnpm exec vitest run src/pairing/pairing-messages.test.ts src/pairing/pairing-challenge.test.ts src/plugin-sdk/channel-pairing.test.ts

Context: follow-up polish from the redacted native SMS proof on #88476.
