### PR TITLE
refactor(telegram): keep topic thread mapping plugin-local

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -565,7 +565,7 @@ function resolveTelegramOutboundSessionRoute(params: {
     canRecoverCurrentThread: ({ route }) =>
       route.chatType !== "direct" || (params.cfg.session?.dmScope ?? "main") !== "main",
   });
-  const routeThreadId = resolveTelegramNativeTopicThreadId(route.threadId);
+  const routeThreadId = resolveTelegramNativeTopicThreadId(route.threadId, resolvedThreadId);
   return {
     ...route,
     ...(routeThreadId !== undefined ? { threadId: routeThreadId } : {}),
@@ -584,10 +584,27 @@ function buildTelegramCanonicalTopicThreadId(params: { chatId: string; topicId: 
 
 function resolveTelegramNativeTopicThreadId(
   threadId?: string | number,
+  nativeTopicId?: number,
 ): string | number | undefined {
+  if (nativeTopicId !== undefined) {
+    return nativeTopicId;
+  }
   // Keep the chat-scoped canonical id inside OpenClaw state; translate it back
   // only when returning Telegram route metadata used by send/typing paths.
-  return threadId === undefined ? undefined : (parseTelegramThreadId(threadId) ?? threadId);
+  if (threadId === undefined) {
+    return undefined;
+  }
+  const parsedThreadId = parseTelegramThreadId(threadId);
+  if (parsedThreadId !== undefined) {
+    return parsedThreadId;
+  }
+  if (typeof threadId === "string") {
+    const canonicalMatch = /:(\d+)$/.exec(threadId.trim());
+    if (canonicalMatch?.[1]) {
+      return Number(canonicalMatch[1]);
+    }
+  }
+  return threadId;
 }
 
 async function resolveTelegramTargets(params: {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -553,26 +553,41 @@ function resolveTelegramOutboundSessionRoute(params: {
   if (isGroup) {
     return baseRoute;
   }
-  const outboundSessionThreadId =
-    resolvedThreadId !== undefined ? `${chatId}:${resolvedThreadId}` : undefined;
+  const canonicalThreadId =
+    resolvedThreadId !== undefined
+      ? buildTelegramCanonicalTopicThreadId({ chatId, topicId: resolvedThreadId })
+      : undefined;
   const route = buildThreadAwareOutboundSessionRoute({
     route: baseRoute,
-    threadId: outboundSessionThreadId,
+    threadId: canonicalThreadId,
     currentSessionKey: params.currentSessionKey,
     precedence: ["threadId", "currentSession"],
     canRecoverCurrentThread: ({ route }) =>
       route.chatType !== "direct" || (params.cfg.session?.dmScope ?? "main") !== "main",
   });
-  const deliveryThreadId =
-    resolvedThreadId ?? parseTelegramThreadId(route.threadId) ?? route.threadId;
+  const routeThreadId = resolveTelegramNativeTopicThreadId(route.threadId);
   return {
     ...route,
-    ...(deliveryThreadId !== undefined ? { threadId: deliveryThreadId } : {}),
+    ...(routeThreadId !== undefined ? { threadId: routeThreadId } : {}),
     from:
-      deliveryThreadId !== undefined
-        ? `telegram:${chatId}:topic:${deliveryThreadId}`
+      routeThreadId !== undefined
+        ? `telegram:${chatId}:topic:${routeThreadId}`
         : `telegram:${chatId}`,
   };
+}
+
+function buildTelegramCanonicalTopicThreadId(params: { chatId: string; topicId: number }): string {
+  // Core session routing sees one canonical thread id. Telegram topic ids are
+  // chat-scoped, so direct-topic sessions include the chat id to avoid collisions.
+  return `${params.chatId}:${params.topicId}`;
+}
+
+function resolveTelegramNativeTopicThreadId(
+  threadId?: string | number,
+): string | number | undefined {
+  // Keep the chat-scoped canonical id inside OpenClaw state; translate it back
+  // only when returning Telegram route metadata used by send/typing paths.
+  return threadId === undefined ? undefined : (parseTelegramThreadId(threadId) ?? threadId);
 }
 
 async function resolveTelegramTargets(params: {

--- a/extensions/telegram/src/session-route.test.ts
+++ b/extensions/telegram/src/session-route.test.ts
@@ -14,6 +14,24 @@ describe("telegram session route", () => {
     expect(route?.threadId).toBe(99);
   });
 
+  it("keeps same direct topic ids distinct across chats", async () => {
+    const first = await telegramPlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {},
+      agentId: "main",
+      target: "12345:topic:99",
+    });
+    const second = await telegramPlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {},
+      agentId: "main",
+      target: "67890:topic:99",
+    });
+
+    expect(first?.sessionKey).toBe("agent:main:main:thread:12345:99");
+    expect(second?.sessionKey).toBe("agent:main:main:thread:67890:99");
+    expect(first?.threadId).toBe(99);
+    expect(second?.threadId).toBe(99);
+  });
+
   it("aligns isolated direct topic sessions with inbound reply routing", async () => {
     const route = await telegramPlugin.messaging?.resolveOutboundSessionRoute?.({
       cfg: { session: { dmScope: "per-account-channel-peer" } },

--- a/extensions/telegram/src/session-route.test.ts
+++ b/extensions/telegram/src/session-route.test.ts
@@ -32,6 +32,19 @@ describe("telegram session route", () => {
     expect(second?.threadId).toBe(99);
   });
 
+  it("returns native topic ids for username direct topic targets", async () => {
+    const route = await telegramPlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {},
+      agentId: "main",
+      target: "@alice:topic:99",
+    });
+
+    expect(route?.sessionKey).toBe("agent:main:main:thread:@alice:99");
+    expect(route?.baseSessionKey).toBe("agent:main:main");
+    expect(route?.threadId).toBe(99);
+    expect(route?.from).toBe("telegram:@alice:topic:99");
+  });
+
   it("aligns isolated direct topic sessions with inbound reply routing", async () => {
     const route = await telegramPlugin.messaging?.resolveOutboundSessionRoute?.({
       cfg: { session: { dmScope: "per-account-channel-peer" } },
@@ -60,6 +73,20 @@ describe("telegram session route", () => {
     expect(route?.baseSessionKey).toBe("agent:main:telegram:direct:12345");
     expect(route?.threadId).toBe(99);
     expect(route?.from).toBe("telegram:12345:topic:99");
+  });
+
+  it("recovers username direct topic thread routes from currentSessionKey", async () => {
+    const route = await telegramPlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: { session: { dmScope: "per-channel-peer" } },
+      agentId: "main",
+      target: "@alice",
+      currentSessionKey: "agent:main:telegram:direct:@alice:thread:@alice:99",
+    });
+
+    expect(route?.sessionKey).toBe("agent:main:telegram:direct:@alice:thread:@alice:99");
+    expect(route?.baseSessionKey).toBe("agent:main:telegram:direct:@alice");
+    expect(route?.threadId).toBe(99);
+    expect(route?.from).toBe("telegram:@alice:topic:99");
   });
 
   it('does not recover currentSessionKey threads for shared dmScope "main" DMs', async () => {


### PR DESCRIPTION
## Summary

- Keep `buildThreadAwareOutboundSessionRoute(...)` on its existing single canonical `threadId` API; no new plugin SDK thread-id shape.
- Move Telegram topic mapping into Telegram: OpenClaw session state keeps a chat-scoped canonical id, while Telegram route metadata is translated back to the native topic id at the plugin boundary.
- Add inline comments at the mapper boundary explaining why Telegram direct-topic ids are chat-scoped internally.
- Add a regression test proving the same Telegram topic id in different direct chats creates distinct session keys while both routes still expose the native topic id.

## Why

Telegram forum topic ids are only unique within a chat. Core should not learn Telegram's native route metadata shape, and other channels should not have to pass duplicate session/route fields just because Telegram needs scoped identity. This patch keeps core on one canonical thread id and makes Telegram translate at its own boundary:

- canonical OpenClaw thread id: `chatId:topicId`
- Telegram route/native topic id: `topicId`

That keeps the bug class pinned to Telegram-owned code and avoids plugin SDK API churn.

## Compatibility

- No plugin SDK API change.
- Existing `replyToId` / `threadId` helper callers remain unchanged.
- The earlier unmerged `sessionThreadId` / `routeThreadId` SDK shape was removed from this PR branch before merge.

## Verification

- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/channel.ts extensions/telegram/src/session-route.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/session-route.test.ts` (6 tests)
- Testbox `tbx_01ksyg2xhb2wf690ryvxg5zp2q`: `node scripts/run-vitest.mjs extensions/telegram/src/session-route.test.ts` (6 tests)
- Autoreview branch diff against `origin/main`: clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: Telegram direct-topic sessions now keep chat-scoped canonical thread ids in OpenClaw state while returning native Telegram topic ids for route metadata.
Real environment tested: Blacksmith Testbox on Linux via OpenClaw CI workflow.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/session-route.test.ts`.
Evidence after fix: Testbox `tbx_01ksyg2xhb2wf690ryvxg5zp2q` passed the Telegram session-route shard with 6 tests.
Observed result after fix: `12345:topic:99` and `67890:topic:99` produce distinct session keys, while both routes expose `threadId: 99` for Telegram-native route metadata.
What was not tested: live Telegram send/typing delivery against the Telegram API.
