### PR TITLE
fix: expose Discord reply metadata to before_dispatch hook context

### DIFF
--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -59,6 +59,9 @@ export type CanonicalInboundMessageHookContext = {
   isGroup: boolean;
   groupId?: string;
   topicName?: string;
+  replyToId?: string;
+  replyToBody?: string;
+  replyToSender?: string;
   trace?: DiagnosticTraceContext;
   callDepth?: number;
 };
@@ -158,6 +161,9 @@ export function deriveInboundMessageHookContext(
     isGroup,
     groupId: isGroup ? conversationId : undefined,
     topicName: ctx.TopicName,
+    replyToId: ctx.ReplyToId,
+    replyToBody: ctx.ReplyToBody,
+    replyToSender: ctx.ReplyToSender,
   };
 }
 


### PR DESCRIPTION
## Summary

Discord reply metadata (, , ) was already being derived and stored in the finalized  via , but  was not including these fields in the  it returns. This meant the  plugin hook could not access reply-to information for Discord replied messages.

## Fix

Added , , and  to the  type and populates them from the finalized context (, , ).

## Changes

- :
  - Added , ,  to 
  - Updated  to map these fields from , , 

Fixes #88360