### PR TITLE
fix(memory-core): reclaim orphaned dreaming sessions with surviving transcripts

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1038,6 +1038,83 @@ describe("generateAndAppendDreamNarrative", () => {
     expectLogIncludes(logger.info, "dreaming cleanup scrubbed");
   });
 
+  it("reclaims an aged dreaming row whose transcript still exists (failed deleteSession)", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const stateDir = await createTempWorkspace("openclaw-dreaming-state-");
+    const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const storePath = path.join(sessionsDir, "sessions.json");
+    // Orphan: a completed dreaming row whose deleteSession previously threw, so
+    // BOTH the store row and its transcript still exist (issue #88322).
+    const orphanTranscript = path.join(sessionsDir, "orphan-dreaming.jsonl");
+    // A second dreaming row whose transcript is fresh (a live/just-started run)
+    // must be preserved.
+    const liveTranscript = path.join(sessionsDir, "live-dreaming.jsonl");
+    await fs.writeFile(
+      storePath,
+      `${JSON.stringify({
+        "agent:main:dreaming-narrative-deep-orphan": {
+          sessionId: "orphan-dreaming",
+        },
+        "agent:main:dreaming-narrative-deep-live": {
+          sessionId: "live-dreaming",
+        },
+        "agent:main:kept-session": {
+          sessionId: "still-live",
+        },
+      })}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(orphanTranscript, '{"runId":"dreaming-narrative-deep-orphan"}\n', "utf-8");
+    await fs.writeFile(liveTranscript, '{"runId":"dreaming-narrative-deep-live"}\n', "utf-8");
+    await fs.writeFile(path.join(sessionsDir, "still-live.jsonl"), "{}\n", "utf-8");
+    // Age the orphan transcript past the 5-minute orphan threshold; keep the
+    // live transcript fresh.
+    const aged = new Date(Date.now() - 600_000);
+    await fs.utimes(orphanTranscript, aged, aged);
+
+    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfig").mockReturnValue({
+      session: {},
+    } as never);
+    vi.spyOn(sessionStoreRuntimeModule, "resolveStorePath").mockImplementation(((
+      _store: string | undefined,
+      { agentId }: { agentId: string },
+    ) => {
+      expect(agentId).toBe("main");
+      return storePath;
+    }) as typeof sessionStoreRuntimeModule.resolveStorePath);
+    vi.spyOn(memoryCoreHostRuntimeCoreModule, "resolveStateDir").mockReturnValue(stateDir);
+
+    const subagent = createMockSubagent("A forgotten endpoint hummed in the dark.");
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["memory fragment"] },
+      logger,
+    });
+
+    const updatedStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    // The aged orphan dreaming row is reclaimed even though its transcript existed.
+    expect(updatedStore).not.toHaveProperty("agent:main:dreaming-narrative-deep-orphan");
+    // The fresh dreaming row and the non-dreaming row survive.
+    expect(updatedStore).toHaveProperty("agent:main:dreaming-narrative-deep-live");
+    expect(updatedStore).toHaveProperty("agent:main:kept-session");
+
+    const sessionFiles = await fs.readdir(sessionsDir);
+    // The orphan transcript is archived; the live transcript stays.
+    expect(
+      sessionFiles.filter((file) => file.startsWith("orphan-dreaming.jsonl.deleted.")),
+    ).not.toEqual([]);
+    expect(sessionFiles).not.toContain("orphan-dreaming.jsonl");
+    expect(sessionFiles).toContain("live-dreaming.jsonl");
+    expectLogIncludes(logger.info, "dreaming cleanup scrubbed");
+  });
+
   it("isolates narrative sessions across workspaces even at the same timestamp", async () => {
     const firstWorkspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const secondWorkspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -772,6 +772,28 @@ function isDreamingSessionStoreKey(sessionKey: string): boolean {
   return sessionSegment.startsWith(DREAMING_SESSION_KEY_PREFIX);
 }
 
+// A dreaming store row is reclaimable once its narrative run is finished. The
+// happy path deletes the session in `finally`, but when `deleteSession` throws
+// (e.g. request-scoped subagent runtime) the row is left behind referencing a
+// still-present transcript, so the missing-transcript check alone never reaps
+// it and the session lingers in the sidebar forever (issue #88322). Reclaim a
+// dreaming row when its transcript is missing, or when the transcript has aged
+// past the orphan threshold (a live narrative refreshes its transcript well
+// within that window, so active runs are never reaped).
+async function isReclaimableDreamingStoreEntry(
+  normalizedSessionFile: string | null,
+): Promise<boolean> {
+  if (!normalizedSessionFile || !(await pathExists(normalizedSessionFile))) {
+    return true;
+  }
+  try {
+    const stat = await fs.stat(normalizedSessionFile);
+    return Date.now() - stat.mtimeMs >= DREAMING_ORPHAN_MIN_AGE_MS;
+  } catch {
+    return true;
+  }
+}
+
 async function normalizeSessionEntryPathForComparison(params: {
   sessionsDir: string;
   entry: { sessionFile?: string; sessionId?: string } | undefined;
@@ -837,7 +859,7 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
       if (!isDreamingSessionStoreKey(key)) {
         continue;
       }
-      if (!normalizedSessionFile || !(await pathExists(normalizedSessionFile))) {
+      if (await isReclaimableDreamingStoreEntry(normalizedSessionFile)) {
         needsStoreUpdate = true;
       }
     }
@@ -851,15 +873,21 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
             sessionsDir,
             entry,
           });
-          if (normalizedSessionFile) {
-            referencedSessionFiles.add(normalizedSessionFile);
-          }
           if (!isDreamingSessionStoreKey(key)) {
+            if (normalizedSessionFile) {
+              referencedSessionFiles.add(normalizedSessionFile);
+            }
             continue;
           }
-          if (!normalizedSessionFile || !(await pathExists(normalizedSessionFile))) {
+          if (await isReclaimableDreamingStoreEntry(normalizedSessionFile)) {
+            // Drop the row and leave the transcript unreferenced so the orphan
+            // transcript pass below archives the aged-out (or missing) file.
             delete lockedStore[key];
             prunedForAgent += 1;
+            continue;
+          }
+          if (normalizedSessionFile) {
+            referencedSessionFiles.add(normalizedSessionFile);
           }
         }
         return prunedForAgent;


### PR DESCRIPTION
Fixes #88322

## Real behavior proof

**Behavior addressed:** Dreaming narrative cleanup deletes the subagent session in a `finally` block, but when `subagent.deleteSession()` throws (e.g. `RequestScopedSubagentRuntimeError` under an isolated cron session) the store row is left behind still referencing a present transcript. `scrubDreamingNarrativeArtifacts` only pruned dreaming rows whose transcript was *missing*, so these orphans were never reaped — they lingered in the recent-sessions sidebar with no kind/status/endedAt and accumulated across restarts. This patch reclaims a dreaming row when its transcript is missing OR has aged past the existing orphan threshold (`DREAMING_ORPHAN_MIN_AGE_MS`, 5 min), leaving the transcript unreferenced so the existing orphan-transcript pass archives it. A live narrative refreshes its transcript well within that window, so active runs are never reaped.

**Real environment tested:** Linux x86_64, Node.js v22.x, HEAD `ba196275eca923a5a133cfd11b244b8a877f736f` based on `origin/main` `e6782254e45752eb1ba51df0b0968c5f12d74826`. Real run points `OPENCLAW_STATE_DIR` at a temp dir and drives the production `generateAndAppendDreamNarrative` export (which runs the real scrubber) against a real on-disk `sessions.json` and real `.jsonl` transcripts.

**Exact steps or command run after this patch:** A small harness (repo root, removed after) sets `OPENCLAW_STATE_DIR`, seeds a real session store with an aged orphan dreaming row (transcript present), a fresh dreaming row, and a non-dreaming row, runs the real narrative+cleanup function, then prints the real store and sessions-dir listing:
```bash
node --import tsx proof-88322.mjs
```

**Evidence after fix:** Real `sessions.json` and sessions-dir state after the production scrubber runs — the aged orphan dreaming row is removed and its transcript archived, while the fresh dreaming row, non-dreaming row, and live transcript are preserved:
```
[info] memory-core: dreaming cleanup scrubbed 1 stale session entry and archived 1 orphan transcript.
----- real sessions.json store keys after scrub -----
[ 'agent:main:dreaming-narrative-deep-live', 'agent:main:kept-session' ]
orphan dreaming row still present: false
live dreaming row preserved: true
non-dreaming row preserved: true
----- real sessions dir listing -----
[ 'live-dreaming.jsonl', 'orphan-dreaming.jsonl.deleted.1780214559340', 'sessions.json', 'still-live.jsonl' ]
```
For contrast, the same `node --import tsx` run against current `origin/main` (before this patch) leaves the orphan row and its transcript in place (and emits no "scrubbed" log line):
```
----- real sessions.json store keys after scrub -----
[ 'agent:main:dreaming-narrative-deep-orphan', 'agent:main:dreaming-narrative-deep-live', 'agent:main:kept-session' ]
orphan dreaming row still present: true
----- real sessions dir listing -----
[ 'live-dreaming.jsonl', 'orphan-dreaming.jsonl', 'sessions.json', 'still-live.jsonl' ]
```

**Observed result after fix:** Orphaned dreaming rows left by a failed `deleteSession` are reclaimed on the next dreaming cleanup once aged past the orphan threshold, and their transcripts are archived; fresh/live dreaming sessions and non-dreaming sessions are untouched. Supplemental: `extensions/memory-core/src/dreaming-narrative.test.ts` runs 50/50 including a new regression test for this exact scenario.

**What was not tested:** No live nightly dreaming cron or real gateway session UI was exercised; the proof drives the real scrubber against a real `OPENCLAW_STATE_DIR` session store and real transcript files, which is exactly the local-filesystem state described in the report.
