### PR TITLE
fix(codex-supervisor): disable app-server websocket compression

### DIFF
--- a/extensions/codex-supervisor/src/json-rpc-client.ts
+++ b/extensions/codex-supervisor/src/json-rpc-client.ts
@@ -275,12 +275,17 @@ class WebSocketCodexJsonRpcConnection extends BaseCodexJsonRpcConnection {
         headers.authorization = `Bearer ${token}`;
       }
     }
+    const options: WebSocket.ClientOptions = {
+      headers,
+      // Codex app-server's Unix transport closes upgrade handshakes that offer compression.
+      perMessageDeflate: false,
+    };
     this.ws = endpoint.url.startsWith("unix://")
       ? new WebSocket("ws://localhost/", {
-          headers,
+          ...options,
           createConnection: () => connectCodexSupervisorUnixSocket(endpoint.url),
         })
-      : new WebSocket(endpoint.url, { headers });
+      : new WebSocket(endpoint.url, options);
     this.openPromise = new Promise((resolve, reject) => {
       this.ws.once("open", resolve);
       this.ws.once("error", reject);

--- a/extensions/codex-supervisor/src/supervisor.test.ts
+++ b/extensions/codex-supervisor/src/supervisor.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -797,6 +798,34 @@ async function waitForFile(filePath: string): Promise<string> {
 }
 
 describe("connectCodexAppServerEndpoint", () => {
+  it("does not offer websocket compression to Unix socket app-server endpoints", async () => {
+    const socketDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-uds-"));
+    const socketPath = path.join(socketDir, "app-server.sock");
+    let requestText = "";
+    const server = net.createServer((socket) => {
+      socket.once("data", (chunk) => {
+        requestText = chunk.toString("utf8");
+        socket.end("HTTP/1.1 400 Bad Request\r\n\r\n");
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+    try {
+      await expect(
+        connectCodexAppServerEndpoint({
+          id: "local",
+          transport: "websocket",
+          url: `unix://${socketPath}`,
+        }),
+      ).rejects.toThrow();
+      expect(requestText.toLowerCase()).toContain("upgrade: websocket");
+      expect(requestText.toLowerCase()).not.toContain("sec-websocket-extensions");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await fs.rm(socketDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects pending websocket requests when the supervisor closes intentionally", async () => {
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     const port = await new Promise<number>((resolve) => {


### PR DESCRIPTION
## Summary

- disable `permessage-deflate` on Codex Supervisor app-server WebSocket clients
- add a Unix socket handshake regression test that verifies the client does not offer WebSocket compression

## Verification

- `node scripts/run-vitest.mjs extensions/codex-supervisor/src/supervisor.test.ts`
- `pnpm build`
- `autoreview --mode commit --commit HEAD` via `.agents/skills/autoreview/scripts/autoreview`

## Real behavior proof

Behavior addressed: the default local `unix://` Codex Supervisor endpoint could fail health probes because the Node `ws` client offered `permessage-deflate` during the Unix socket WebSocket upgrade and Codex closed that handshake.
Real environment tested: local Codex CLI 0.135.0 app-server daemon with the default Unix control socket.
Exact steps or command run after this patch: used the patched `connectCodexAppServerEndpoint({ id: "local", transport: "websocket", url: "unix://" })`, then requested `thread/loaded/list` with `{ limit: 1 }`.
Evidence after fix: the patched source returned `{"ok":true,"result":{"data":[],"nextCursor":null}}`.
Observed result after fix: the default `unix://` endpoint initializes and answers `thread/loaded/list`.
What was not tested: full CI and cross-platform Codex daemon behavior.
