### PR TITLE
fix(agents): skip auth gate for CLI-owned transport

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -1760,6 +1760,81 @@ describe("CLI attempt execution", () => {
     expect(firstRunCliAgentArg().authProfileId).toBeUndefined();
   });
 
+  it("does not pass auth-order profiles to configured CLI runtimes that do not stage them", async () => {
+    const sessionKey = "agent:main:direct:anthropic-claude-runtime-auth-order";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-anthropic-claude-runtime-auth-order",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "anthropic:work": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "test-key",
+          },
+        },
+      },
+      tmpDir,
+      { filterExternalAuthProfiles: false, syncExternalCli: false },
+    );
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("configured claude cli"));
+
+    await runAgentAttempt({
+      providerOverride: "anthropic",
+      originalProvider: "anthropic",
+      modelOverride: "claude-opus-4-7",
+      cfg: {
+        auth: {
+          order: {
+            anthropic: ["anthropic:work"],
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "use ambient cli auth",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-configured-claude-auth-order",
+      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: undefined,
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "anthropic",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(runCliAgentMock, {
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+    });
+    expect(firstRunCliAgentArg().authProfileId).toBeUndefined();
+  });
+
   it("forwards runtime toolsAllow into CLI attempts so the CLI harness can fail closed", async () => {
     const sessionKey = "agent:main:direct:claude-tools-allow";
     const sessionEntry: SessionEntry = {

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -739,6 +739,58 @@ describe("CLI attempt execution", () => {
     expect(firstRunCliAgentArg().authProfileId).toBe("openai:work");
   });
 
+  it("skips auto auth-profile resolution for CLI-owned transport", async () => {
+    const sessionKey = "agent:main:direct:codex-cli-owned-transport";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-codex-owned",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          agentRuntime: { id: "codex" },
+        },
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+    await fs.writeFile(path.join(tmpDir, "auth-profiles.json"), "{", "utf-8");
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("codex cli response"));
+
+    await runAgentAttempt({
+      providerOverride: "codex-cli",
+      originalProvider: "codex-cli",
+      modelOverride: "gpt-5.4",
+      cfg,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "continue",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-codex-cli-owned-transport-auth-skip",
+      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: undefined,
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "openai-codex",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(firstRunCliAgentArg().authProfileId).toBeUndefined();
+  });
+
   it("selects a google-gemini-cli auth profile for canonical Google models routed through Gemini CLI", async () => {
     const sessionKey = "agent:main:direct:gemini-cli-auth-bridge";
     const sessionEntry: SessionEntry = {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -181,6 +181,10 @@ function resolveHarnessAuthProfileSelection(params: {
     };
   }
 
+  if (!params.allowHarnessAuthProfileForwarding) {
+    return { authProfileProvider: params.authProfileProvider };
+  }
+
   const runtimeAuthPlan = buildAgentRuntimeAuthPlan({
     provider: params.provider,
     authProfileProvider: params.authProfileProvider,

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1100,6 +1100,54 @@ describe("runWithModelFallback", () => {
     expect(result.attempts).toStrictEqual([]);
   });
 
+  it("lets direct CLI providers bypass stale provider auth cooldowns", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          model: {
+            primary: "claude-cli/opus",
+          },
+        },
+      },
+    });
+    const tempDir = await makeAuthTempDir();
+    setAuthRuntimeStore(tempDir, {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "claude-cli:default": {
+          type: "api_key",
+          provider: "claude-cli",
+          key: "test-key",
+        },
+        "openai:default": { type: "api_key", provider: "openai", key: "test-key" },
+      },
+      usageStats: {
+        "claude-cli:default": {
+          disabledUntil: Date.now() + 60_000,
+          disabledReason: "billing",
+          failureCounts: { rate_limit: 4 },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce("direct cli ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "claude-cli",
+      model: "opus",
+      agentDir: tempDir,
+      run,
+    });
+
+    expect(result.result).toBe("direct cli ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0]).toEqual(["claude-cli", "opus"]);
+    expect(result.attempts).toStrictEqual([]);
+  });
+
   it("does not treat command-lane watchdog timeouts as model fallback failures", async () => {
     const cfg = makeCfg();
     const timeoutError = new CommandLaneTaskTimeoutError("cron-nested", 330_000);

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1056,7 +1056,7 @@ describe("runWithModelFallback", () => {
     expect(result.attempts).toStrictEqual([]);
   });
 
-  it("lets configured CLI runtimes reach the run callback", async () => {
+  it("lets configured CLI runtimes bypass stale provider auth cooldowns", async () => {
     const cfg = makeCfg({
       agents: {
         defaults: {
@@ -1069,18 +1069,35 @@ describe("runWithModelFallback", () => {
         },
       },
     });
+    const tempDir = await makeAuthTempDir();
+    setAuthRuntimeStore(tempDir, {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "anthropic:default": { type: "api_key", provider: "anthropic", key: "test-key" },
+        "openai:default": { type: "api_key", provider: "openai", key: "test-key" },
+      },
+      usageStats: {
+        "anthropic:default": {
+          disabledUntil: Date.now() + 60_000,
+          disabledReason: "billing",
+          failureCounts: { rate_limit: 4 },
+        },
+      },
+    });
     const run = vi.fn().mockResolvedValueOnce("cli ok");
 
     const result = await runWithModelFallback({
       cfg,
       provider: "anthropic",
       model: "claude-sonnet-4-6",
+      agentDir: tempDir,
       run,
     });
 
     expect(result.result).toBe("cli ok");
     expect(run).toHaveBeenCalledTimes(1);
     expect(run.mock.calls[0]).toEqual(["anthropic", "claude-sonnet-4-6"]);
+    expect(result.attempts).toStrictEqual([]);
   });
 
   it("does not treat command-lane watchdog timeouts as model fallback failures", async () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -520,7 +520,7 @@ async function resolveModelFallbackCandidateHarnessAuthPrecheck(
     params.model,
   );
   if (isCliProvider(params.provider, params.cfg)) {
-    return { skipsProviderAuthCooldown: false };
+    return { skipsProviderAuthCooldown: true };
   }
   const agentRuntimeOverride = normalizeOptionalAgentRuntimeId(agentHarnessRuntimeOverride);
   const harnessPolicy = resolveAgentHarnessPolicy({

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -539,7 +539,9 @@ async function resolveModelFallbackCandidateHarnessAuthPrecheck(
       ? "model"
       : harnessPolicy.runtimeSource;
   if (isCliAgentRuntime(agentRuntime, params.cfg)) {
-    return { skipsProviderAuthCooldown: false };
+    // CLI runtimes own their transport/auth, so stale OpenClaw provider
+    // profile state must not block the candidate before the CLI starts.
+    return { skipsProviderAuthCooldown: true };
   }
   if (agentRuntime === "openclaw") {
     return { skipsProviderAuthCooldown: false };


### PR DESCRIPTION
### Summary
- Skip the model-fallback auth cooldown gate for explicitly configured CLI agent runtimes such as `anthropic/*` with `agentRuntime.id: "claude-cli"`.
- Keep the attempt-level auth-profile selection guard so CLI-owned transports preserve only `authProfileProvider` when auth-profile forwarding is disabled.

### What changed after review
- Rebased onto current `main`.
- Added the fallback-boundary fix requested by review: CLI runtime candidates now set `skipsProviderAuthCooldown: true` before the fallback loop evaluates stale OpenClaw provider auth state.
- Added production-path coverage through `runWithModelFallback` with `anthropic/*`, `claude-cli`, and stale provider auth state.
- Kept the direct `runAgentAttempt` coverage showing `authProfileId` stays unset while the CLI-owned route still runs.

### Real behavior proof
Behavior or issue addressed: A configured CLI-owned runtime such as `anthropic/claude-sonnet-4-6` with `agentRuntime.id: "claude-cli"` should be allowed to run even when OpenClaw has stale provider auth cooldown state for `anthropic:default`. The downstream CLI attempt must also avoid auto-filling `authProfileId` when auth-profile forwarding is disabled.

Real environment tested: Live PR branch checkout at `78ddcb5bdc61030285dc9baed100e74c184aa949`, local path `/private/tmp/openclaw-88551-clone`, macOS shell, Node `v22.22.2`, corepack pnpm `11.2.2`.

Exact steps or command run after this patch: I ran the copied live terminal commands below on the PR branch checkout after this patch:

```text
git rev-parse --short HEAD
node scripts/run-vitest.mjs run src/agents/model-fallback.test.ts -t 'lets configured CLI runtimes bypass stale provider auth cooldowns' --reporter verbose
node scripts/run-vitest.mjs run src/agents/command/attempt-execution.cli.test.ts -t 'skips auto auth-profile resolution for CLI-owned transport' --reporter verbose
./node_modules/.bin/oxfmt --check --threads=1 src/agents/model-fallback.ts src/agents/model-fallback.test.ts src/agents/command/attempt-execution.ts src/agents/command/attempt-execution.cli.test.ts src/agents/fallback-skip-cache.ts packages/terminal-core/src/ansi.ts
```

Evidence after fix: Copied terminal transcript / live output from the PR branch checkout:

```text
$ git rev-parse --short HEAD
78ddcb5b
$ node --version
v22.22.2
$ corepack pnpm --version
11.2.2
$ node scripts/run-vitest.mjs run src/agents/model-fallback.test.ts -t 'lets configured CLI runtimes bypass stale provider auth cooldowns' --reporter verbose
RUN  v4.1.7 /private/tmp/openclaw-88551-clone
✓ |agents-core| ../../src/agents/model-fallback.test.ts > runWithModelFallback > lets configured CLI runtimes bypass stale provider auth cooldowns 12ms
✓ |agents-support| ../../src/agents/model-fallback.test.ts > runWithModelFallback > lets configured CLI runtimes bypass stale provider auth cooldowns 11ms

Test Files  2 passed (2)
Tests  2 passed | 152 skipped (154)

$ node scripts/run-vitest.mjs run src/agents/command/attempt-execution.cli.test.ts -t 'skips auto auth-profile resolution for CLI-owned transport' --reporter verbose
RUN  v4.1.7 /private/tmp/openclaw-88551-clone
✓ |agents-core| ../../src/agents/command/attempt-execution.cli.test.ts > CLI attempt execution > skips auto auth-profile resolution for CLI-owned transport 5ms
✓ |agents-support| ../../src/agents/command/attempt-execution.cli.test.ts > CLI attempt execution > skips auto auth-profile resolution for CLI-owned transport 6ms

Test Files  2 passed (2)
Tests  2 passed | 70 skipped (72)

$ ./node_modules/.bin/oxfmt --check --threads=1 src/agents/model-fallback.ts src/agents/model-fallback.test.ts src/agents/command/attempt-execution.ts src/agents/command/attempt-execution.cli.test.ts src/agents/fallback-skip-cache.ts packages/terminal-core/src/ansi.ts
Checking formatting...
All matched files use the correct format.
Finished in 44ms on 6 files using 1 threads.
```

Observed result after fix: The model fallback path reaches the configured `claude-cli` runtime even with stale Anthropic provider auth cooldown state, and the CLI-owned attempt path still runs with `authProfileId` unset when auth-profile forwarding is disabled.

What was not tested: No additional gaps for the reviewed fallback/auth-profile behavior. I did not run a real Claude CLI network turn against Anthropic; the after-fix proof covers the OpenClaw fallback and CLI attempt routing behavior changed in this PR.

### Verification
- `node scripts/run-vitest.mjs run src/agents/model-fallback.test.ts -t 'lets configured CLI runtimes bypass stale provider auth cooldowns' --reporter verbose`
- `node scripts/run-vitest.mjs run src/agents/command/attempt-execution.cli.test.ts -t 'skips auto auth-profile resolution for CLI-owned transport' --reporter verbose`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/model-fallback.ts src/agents/model-fallback.test.ts src/agents/command/attempt-execution.ts src/agents/command/attempt-execution.cli.test.ts src/agents/fallback-skip-cache.ts packages/terminal-core/src/ansi.ts`
