### PR TITLE
Remove channel test isolation hack

### DIFF
--- a/src/channels/draft-stream-loop.test.ts
+++ b/src/channels/draft-stream-loop.test.ts
@@ -34,7 +34,11 @@ describe("createDraftStreamLoop", () => {
   });
 
   afterEach(() => {
+    if (vi.isFakeTimers()) {
+      vi.clearAllTimers();
+    }
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("contains immediate background flush rejections and preserves pending text", async () => {
@@ -99,7 +103,9 @@ describe("createDraftStreamLoop", () => {
         },
       );
     } finally {
+      vi.clearAllTimers();
       vi.useRealTimers();
+      vi.restoreAllMocks();
     }
   });
 
@@ -107,18 +113,23 @@ describe("createDraftStreamLoop", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(0);
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const sendOrEditStreamMessage = vi.fn(async () => true);
       const loop = createDraftStreamLoop({
         throttleMs: Number.MAX_SAFE_INTEGER,
         isStopped: () => false,
-        sendOrEditStreamMessage: vi.fn(async () => true),
+        sendOrEditStreamMessage,
       });
 
       loop.update("hello");
 
-      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      expect(vi.getTimerCount()).toBe(1);
+      vi.advanceTimersByTime(MAX_TIMER_TIMEOUT_MS - 1);
+      expect(sendOrEditStreamMessage).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(sendOrEditStreamMessage).toHaveBeenCalledExactlyOnceWith("hello");
       loop.stop();
     } finally {
+      vi.clearAllTimers();
       vi.useRealTimers();
     }
   });

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -18,6 +18,7 @@ async function withFakeTimers(run: () => Promise<void>) {
   } finally {
     vi.clearAllTimers();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   }
 }
 
@@ -62,8 +63,11 @@ describe("createTypingCallbacks", () => {
   });
 
   afterEach(() => {
-    vi.clearAllTimers();
+    if (vi.isFakeTimers()) {
+      vi.clearAllTimers();
+    }
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("invokes start on reply start", async () => {
@@ -211,15 +215,19 @@ describe("createTypingCallbacks", () => {
 
   it("clamps oversized keepalive intervals before arming timers", async () => {
     await withFakeTimers(async () => {
-      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
-      const { callbacks } = createTypingHarness({
+      const { start, callbacks } = createTypingHarness({
         keepaliveIntervalMs: Number.MAX_SAFE_INTEGER,
+        maxDurationMs: 0,
       });
 
       await callbacks.onReplyStart();
       await flushMicrotasks();
 
-      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      expect(vi.getTimerCount()).toBe(1);
+      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS - 1);
+      expect(start).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(start).toHaveBeenCalledTimes(2);
       callbacks.onCleanup?.();
     });
   });
@@ -387,15 +395,23 @@ describe("createTypingCallbacks", () => {
 
     it("clamps oversized TTLs before arming timers", async () => {
       await withFakeTimers(async () => {
-        const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-        const { callbacks } = createTypingHarness({
+        const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const { stop, callbacks } = createTypingHarness({
+          keepaliveIntervalMs: 0,
           maxDurationMs: Number.MAX_SAFE_INTEGER,
         });
 
         await callbacks.onReplyStart();
         await flushMicrotasks();
 
-        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+        expect(vi.getTimerCount()).toBe(1);
+        await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS - 1);
+        expect(stop).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(stop).toHaveBeenCalledTimes(1);
+        expect(consoleWarn).toHaveBeenCalledWith(
+          `[typing] TTL exceeded (${MAX_TIMER_TIMEOUT_MS}ms), auto-stopping typing indicator`,
+        );
         callbacks.onCleanup?.();
       });
     });

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -452,8 +452,8 @@ describe("scoped vitest configs", () => {
     expect(testConfig.exclude).not.toContain("chat/slash-command-executor.node.test.ts");
   });
 
-  it("defaults channel tests to isolated threads", () => {
-    expectThreadedIsolatedRunner(defaultChannelsConfig);
+  it("defaults channel tests to threads with the non-isolated runner", () => {
+    expectThreadedNonIsolatedRunner(defaultChannelsConfig);
   });
 
   it("keeps the core channel lane limited to non-extension roots", () => {

--- a/test/vitest/vitest.channels.config.ts
+++ b/test/vitest/vitest.channels.config.ts
@@ -12,7 +12,6 @@ export function createChannelsVitestConfig(env?: Record<string, string | undefin
   return createScopedVitestConfig(loadIncludePatternsFromEnv(env) ?? coreChannelTestInclude, {
     env,
     exclude: ["src/gateway/**", "src/channels/plugins/contracts/**"],
-    isolate: true,
     name: "channels",
     passWithNoTests: true,
   });


### PR DESCRIPTION
## Summary
- remove isolate: true from the channel Vitest config so it uses the shared non-isolated runner
- clean up fake timers and mocks in typing and draft stream loop tests
- replace global timer spy assertions with timer-advancement assertions that do not leak fake timer state

## Verification
- node scripts/run-vitest.mjs test/vitest-scoped-config.test.ts src/channels/typing.test.ts src/channels/draft-stream-loop.test.ts
- OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=240000 node scripts/run-vitest.mjs run --config test/vitest/vitest.channels.config.ts
- .agents/skills/autoreview/scripts/autoreview --mode local
- git diff --check

## Real behavior proof
Behavior addressed: Channel tests no longer require Vitest isolate mode to avoid fake-timer and mock leakage.
Real environment tested: Local OpenClaw checkout on macOS, Node 24 via repo test wrapper.
Exact steps or command run after this patch: Ran focused scoped-config plus typing and draft stream tests, then ran the full channels Vitest config without isolate: true.
Evidence after fix: Full channel lane passed with 68 test files and 631 tests.
Observed result after fix: The previous hang after typing.test.ts before draft-stream-loop.test.ts no longer reproduces.
What was not tested: Broader non-channel lanes and remote Crabbox proof were not run because this patch is scoped to channel Vitest config and test cleanup.
