### PR TITLE
fix(agents): unblock fallback classification tests

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -119,6 +119,7 @@ vi.mock("../../agents/embedded-agent-helpers.js", () => ({
   isOverloadedErrorMessage: (message: string) => /overloaded|capacity/i.test(message),
   isRateLimitErrorMessage: (message: string) =>
     /rate.limit|too many requests|429|usage limit/i.test(message),
+  classifyFailoverReason: () => undefined,
   isTransientHttpError: () => false,
   sanitizeUserFacingText: (text?: string) => text ?? "",
 }));


### PR DESCRIPTION
### Summary
- Add the missing `classifyFailoverReason` export to the auto-reply test mock used by embedded agent runner fallback tests.
- Keep the production dynamic model/provider normalization path unchanged.

### What changed after review
- Removed the earlier `src/agents/live-model-dynamic-candidates.ts` change so provider-owned normalization and transport hooks remain intact.
- Rebased onto current `main`; the PR diff is now intentionally limited to the test mock export.

### Real behavior proof
Behavior or issue addressed: The embedded agent runner fallback regression tests need the auto-reply mock to expose `classifyFailoverReason`, matching the production helper surface. Before this patch, the fallback classification cases could not exercise the GPT-5 plan-only, terminal-empty, or rejected fallback-selection behavior because the mocked module was missing that export.

Real environment tested: Local OpenClaw checkout on macOS, Node `v25.9.0`, pnpm `11.2.2`, running from `/Users/stellarfish/.codex/worktrees/5db8/openclaw-work` with the PR branch contents for this change.

Exact steps or command run after this patch: I ran the copied live terminal commands below after applying the patch:

```text
node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner-execution.test.ts -t 'classifies GPT-5 plan-only|classifies final GPT-5 terminal-empty|rolls back persisted fallback selection' --reporter verbose
pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-execution.test.ts
```

Evidence after fix: Copied terminal transcript / live output from the local OpenClaw checkout:

```text
$ node --version
v25.9.0
$ pnpm --version
11.2.2
$ node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner-execution.test.ts -t 'classifies GPT-5 plan-only|classifies final GPT-5 terminal-empty|rolls back persisted fallback selection' --reporter verbose
RUN  v4.1.7 /Users/stellarfish/.codex/worktrees/5db8/openclaw-work
✓ |auto-reply| ../../src/auto-reply/reply/agent-runner-execution.test.ts > runAgentTurnWithFallback > classifies GPT-5 plan-only terminal results as fallback-eligible 136ms
✓ |auto-reply| ../../src/auto-reply/reply/agent-runner-execution.test.ts > runAgentTurnWithFallback > classifies final GPT-5 terminal-empty results instead of silently succeeding 1ms
✓ |auto-reply| ../../src/auto-reply/reply/agent-runner-execution.test.ts > runAgentTurnWithFallback > rolls back persisted fallback selection when result classification rejects a candidate 1ms

Test Files  1 passed (1)
Tests  3 passed | 143 skipped (146)

$ pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-execution.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 12ms on 1 files using 1 threads.
```

Observed result after fix: The fallback classification cases now run to completion instead of failing on a missing mock export. The observed output shows the three targeted after-fix behaviors passing: GPT-5 plan-only terminal results are classified as fallback-eligible, final GPT-5 terminal-empty results are classified instead of silently succeeding, and persisted fallback selection is rolled back when result classification rejects a candidate.

What was not tested: No additional gaps for this test-mock-only fix; a full production Matrix/Discord agent run was not part of this patch because the changed file only repairs the test mock export surface.

### Verification
- `node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner-execution.test.ts -t 'classifies GPT-5 plan-only|classifies final GPT-5 terminal-empty|rolls back persisted fallback selection' --reporter verbose`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-execution.test.ts`
