### PR TITLE
fix(gateway): enforce OpenAI tool_choice required/function contracts

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -236,7 +236,7 @@ The endpoint returns `400 invalid_request_error` for unsupported tool variants, 
 - `tool_choice` variants such as `allowed_tools` and `custom`
 - `tool_choice.function.name` values that do not match provided `tools`
 
-For `tool_choice: "required"` and function-pinned `tool_choice`, the endpoint narrows the exposed client tool set, instructs the runtime to call tools before responding, and returns an error if the agent response does not include a matching structured tool call.
+For `tool_choice: "required"` and function-pinned `tool_choice`, the endpoint narrows the exposed client function-tool set, instructs the runtime to call a client tool before responding, and returns an error if the agent response does not include a matching structured client-tool call. This contract applies to the caller-supplied HTTP `tools` list, not every internal OpenClaw agent tool.
 
 ### Non-streaming tool response shape
 

--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -212,7 +212,7 @@ Set `stream: true` to receive Server-Sent Events (SSE):
 ### Supported request fields
 
 - `tools`: array of `{ "type": "function", "function": { ... } }`
-- `tool_choice`: `"auto"`, `"none"`
+- `tool_choice`: `"auto"`, `"none"`, `"required"`, or `{ "type": "function", "function": { "name": "..." } }`
 - `messages[*].role: "tool"` follow-up turns
 - `messages[*].tool_call_id` for binding tool results back to a prior tool call
 - `max_completion_tokens`: number; per-call cap for total completion tokens (reasoning tokens included). Current OpenAI Chat Completions field name; preferred when both `max_completion_tokens` and `max_tokens` are sent.
@@ -234,9 +234,9 @@ The endpoint returns `400 invalid_request_error` for unsupported tool variants, 
 - non-function tool entries
 - missing `tool.function.name`
 - `tool_choice` variants such as `allowed_tools` and `custom`
-- `tool_choice: "required"` (not yet enforced at runtime; will be supported once hard enforcement is implemented)
-- `tool_choice: { "type": "function", "function": { "name": "..." } }` (same rationale as `required`)
 - `tool_choice.function.name` values that do not match provided `tools`
+
+For `tool_choice: "required"` and function-pinned `tool_choice`, the endpoint narrows the exposed client tool set, instructs the runtime to call tools before responding, and returns an error if the agent response does not include a matching structured tool call.
 
 ### Non-streaming tool response shape
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -119,12 +119,12 @@ Accepted for schema compatibility but ignored when building the prompt.
 
 ## Tools (client-side function tools)
 
-Provide tools with `tools: [{ type: "function", function: { name, description?, parameters? } }]`.
+Provide tools with `tools: [{ type: "function", name, description?, parameters? }]`.
 
 If the agent decides to call a tool, the response returns a `function_call` output item.
 You then send a follow-up request with `function_call_output` to continue the turn.
 
-For `tool_choice: "required"` and function-pinned `tool_choice`, the endpoint narrows the exposed client tools, instructs the runtime to call a tool before responding, and rejects the turn if it does not include a matching structured tool call. Non-streaming requests return `502` with an `api_error`; streaming requests emit a `response.failed` event. This matches the `/v1/chat/completions` contract.
+For `tool_choice: "required"` and function-pinned `tool_choice`, the endpoint narrows the exposed client function-tool set, instructs the runtime to call a client tool before responding, and rejects the turn if it does not include a matching structured client-tool call. This contract applies to the caller-supplied HTTP `tools` list, not every internal OpenClaw agent tool. Non-streaming requests return `502` with an `api_error`; streaming requests emit a `response.failed` event. This matches the `/v1/chat/completions` contract.
 
 ## Images (`input_image`)
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -72,7 +72,7 @@ The request follows the OpenResponses API with item-based input. Current support
 - `input`: string or array of item objects.
 - `instructions`: merged into the system prompt.
 - `tools`: client tool definitions (function tools).
-- `tool_choice`: filter or require client tools.
+- `tool_choice`: `"auto"`, `"none"`, `"required"`, or `{ "type": "function", "name": "..." }` to filter or require client tools.
 - `stream`: enables SSE streaming.
 - `max_output_tokens`: best-effort output limit (provider dependent).
 - `temperature`: best-effort sampling temperature forwarded to the provider. Ignored by the ChatGPT-based Codex Responses backend, which uses fixed server-side sampling.
@@ -123,6 +123,8 @@ Provide tools with `tools: [{ type: "function", function: { name, description?, 
 
 If the agent decides to call a tool, the response returns a `function_call` output item.
 You then send a follow-up request with `function_call_output` to continue the turn.
+
+For `tool_choice: "required"` and function-pinned `tool_choice`, the endpoint narrows the exposed client tools, instructs the runtime to call a tool before responding, and rejects the turn if it does not include a matching structured tool call. Non-streaming requests return `502` with an `api_error`; streaming requests emit a `response.failed` event. This matches the `/v1/chat/completions` contract.
 
 ## Images (`input_image`)
 

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -184,10 +184,18 @@ export const ToolChoiceSchema = z.union([
   z.literal("auto"),
   z.literal("none"),
   z.literal("required"),
-  z.object({
-    type: z.literal("function"),
-    function: z.object({ name: z.string() }),
-  }),
+  z
+    .object({
+      type: z.literal("function"),
+      name: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("function"),
+      function: z.object({ name: z.string().min(1) }),
+    })
+    .strict(),
 ]);
 
 export const CreateResponseBodySchema = z

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -835,6 +835,44 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
 
       {
         agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "Calling a different tool." }],
+          meta: {
+            stopReason: "tool_calls",
+            pendingToolCalls: [{ id: "call_1", name: "get_time", arguments: "{}" }],
+          },
+        } as never);
+        const res = await postChatCompletions(port, {
+          model: "openclaw",
+          tool_choice: { type: "function", function: { name: "get_weather" } },
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "Get current weather",
+                parameters: { type: "object", properties: {} },
+              },
+            },
+            {
+              type: "function",
+              function: {
+                name: "get_time",
+                description: "Get current time",
+                parameters: { type: "object", properties: {} },
+              },
+            },
+          ],
+          messages: [{ role: "user", content: "weather?" }],
+        });
+        expect(res.status).toBe(502);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("api_error");
+        expect(json.error?.message ?? "").toContain("tool_choice required a get_weather tool call");
+      }
+
+      {
+        agentCommand.mockClear();
         const res = await postChatCompletions(port, {
           model: "openclaw",
           tool_choice: "required",

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -714,6 +714,19 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
 
       {
         agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "tool choice function" }],
+          meta: {
+            stopReason: "tool_calls",
+            pendingToolCalls: [
+              {
+                id: "call_1",
+                name: "get_weather",
+                arguments: '{"city":"Taipei"}',
+              },
+            ],
+          },
+        } as never);
         const res = await postChatCompletions(port, {
           model: "openclaw",
           tool_choice: { type: "function", function: { name: "get_weather" } },
@@ -741,11 +754,83 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           ],
           messages: [{ role: "user", content: "weather?" }],
         });
-        expect(res.status).toBe(400);
+        expect(res.status).toBe(200);
+        const firstCall = getFirstAgentCall();
+        const clientTools = firstCall?.clientTools ?? [];
+        expect(clientTools).toHaveLength(1);
+        expect(clientTools[0]?.function?.name).toBe("get_weather");
+        expect(firstCall?.extraSystemPrompt ?? "").toContain("You must call the get_weather tool");
+        const json = (await res.json()) as { choices?: Array<{ finish_reason?: string | null }> };
+        expect(json.choices?.[0]?.finish_reason).toBe("tool_calls");
+      }
+
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "tool choice required" }],
+          meta: {
+            stopReason: "tool_calls",
+            pendingToolCalls: [
+              {
+                id: "call_1",
+                name: "get_weather",
+                arguments: '{"city":"Taipei"}',
+              },
+            ],
+          },
+        } as never);
+        const res = await postChatCompletions(port, {
+          model: "openclaw",
+          tool_choice: "required",
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "Get current weather",
+                parameters: {
+                  type: "object",
+                  properties: { city: { type: "string" } },
+                  required: ["city"],
+                },
+              },
+            },
+          ],
+          messages: [{ role: "user", content: "weather?" }],
+        });
+        expect(res.status).toBe(200);
+        const firstCall = getFirstAgentCall();
+        const clientTools = firstCall?.clientTools ?? [];
+        expect(clientTools).toHaveLength(1);
+        expect(clientTools[0]?.function?.name).toBe("get_weather");
+        expect(firstCall?.extraSystemPrompt ?? "").toContain(
+          "You must call one of the available tools",
+        );
+        const json = (await res.json()) as { choices?: Array<{ finish_reason?: string | null }> };
+        expect(json.choices?.[0]?.finish_reason).toBe("tool_calls");
+      }
+
+      {
+        mockAgentOnce([{ text: "plain text despite required" }]);
+        const res = await postChatCompletions(port, {
+          model: "openclaw",
+          tool_choice: "required",
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "Get current weather",
+                parameters: { type: "object", properties: {} },
+              },
+            },
+          ],
+          messages: [{ role: "user", content: "weather?" }],
+        });
+        expect(res.status).toBe(502);
         const json = (await res.json()) as { error?: { type?: string; message?: string } };
-        expect(json.error?.type).toBe("invalid_request_error");
-        expect(json.error?.message ?? "").toContain("not supported");
-        expect(agentCommand).toHaveBeenCalledTimes(0);
+        expect(json.error?.type).toBe("api_error");
+        expect(json.error?.message ?? "").toContain("tool_choice=required was not satisfied");
       }
 
       {
@@ -758,7 +843,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(res.status).toBe(400);
         const json = (await res.json()) as { error?: { type?: string; message?: string } };
         expect(json.error?.type).toBe("invalid_request_error");
-        expect(json.error?.message ?? "").toContain("tool_choice=required");
+        expect(json.error?.message ?? "").toContain("no tools were provided");
         expect(agentCommand).toHaveBeenCalledTimes(0);
       }
 
@@ -782,7 +867,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(res.status).toBe(400);
         const json = (await res.json()) as { error?: { type?: string; message?: string } };
         expect(json.error?.type).toBe("invalid_request_error");
-        expect(json.error?.message ?? "").toContain("not supported");
+        expect(json.error?.message ?? "").toContain("unknown tool");
         expect(agentCommand).toHaveBeenCalledTimes(0);
       }
 
@@ -1737,6 +1822,39 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         const fallbackText = await fallbackRes.text();
         expect(fallbackText).toContain("[DONE]");
         expect(fallbackText).toContain("hello");
+      }
+
+      {
+        agentCommand.mockClear();
+        agentCommand.mockImplementationOnce((async (opts: unknown) =>
+          buildAssistantDeltaResult({
+            opts,
+            emit: emitAgentEvent,
+            deltas: ["plain text despite required"],
+            text: "plain text despite required",
+          })) as never);
+
+        const requiredFailureRes = await postChatCompletions(port, {
+          stream: true,
+          model: "openclaw",
+          tool_choice: "required",
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "Get weather",
+                parameters: { type: "object", properties: {} },
+              },
+            },
+          ],
+          messages: [{ role: "user", content: "weather?" }],
+        });
+        expect(requiredFailureRes.status).toBe(200);
+        const requiredFailureText = await requiredFailureRes.text();
+        expect(requiredFailureText).toContain("[DONE]");
+        expect(requiredFailureText).toContain("tool_choice=required was not satisfied");
+        expect(requiredFailureText).not.toContain("plain text despite required");
       }
 
       {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1060,6 +1060,9 @@ export async function handleOpenAiHttpRequest(
       const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
+      // `tool_choice` is an HTTP client-tool contract. The provider may still
+      // ignore the prompt, so enforce after the run using structured pending
+      // client tool calls instead of accepting prose that only says it called.
       if (
         toolChoiceConstraint &&
         !isToolChoiceConstraintSatisfied({
@@ -1200,6 +1203,9 @@ export async function handleOpenAiHttpRequest(
         return;
       }
 
+      // Hold prose until the run proves the requested client-tool call exists.
+      // If the provider ignores `tool_choice`, no partial text should leak
+      // before the stream fails with an OpenAI-compatible error payload.
       if (toolChoiceConstraint) {
         bufferedAssistantContent += content;
         return;
@@ -1249,6 +1255,9 @@ export async function handleOpenAiHttpRequest(
       const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
+      // Streaming enforces the same post-run client-tool contract as the
+      // non-streaming path; buffered assistant prose is only flushed when the
+      // matching structured call is present.
       if (
         toolChoiceConstraint &&
         !isToolChoiceConstraintSatisfied({

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -49,6 +49,12 @@ import {
 } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 import { resolveOpenAiCompatError, validateOpenAiSamplingParams } from "./openai-compat-errors.js";
+import {
+  isToolChoiceConstraintSatisfied,
+  resolveUnsatisfiedToolChoiceMessage,
+  toolChoiceConstraintPrompt,
+  type ToolChoiceConstraint,
+} from "./openai-tool-choice.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -67,10 +73,6 @@ type OpenAiChatMessage = {
   tool_calls?: unknown;
   stopReason?: unknown;
 };
-
-type ChatToolChoiceConstraint =
-  | { type: "required" }
-  | { type: "function"; name: string };
 
 type OpenAiChatCompletionRequest = {
   model?: unknown;
@@ -212,7 +214,7 @@ function extractClientToolsFromChatRequest(tools: unknown): ClientToolDefinition
 function applyChatToolChoice(params: { tools: ClientToolDefinition[]; toolChoice: unknown }): {
   tools: ClientToolDefinition[];
   extraSystemPrompt?: string;
-  constraint?: ChatToolChoiceConstraint;
+  constraint?: ToolChoiceConstraint;
 } {
   const { tools, toolChoice } = params;
   if (toolChoice == null || toolChoice === "auto") {
@@ -225,11 +227,8 @@ function applyChatToolChoice(params: { tools: ClientToolDefinition[]; toolChoice
     if (tools.length === 0) {
       throw new Error("tool_choice=required but no tools were provided");
     }
-    return {
-      tools,
-      extraSystemPrompt: "You must call one of the available tools before responding.",
-      constraint: { type: "required" },
-    };
+    const constraint: ToolChoiceConstraint = { type: "required" };
+    return { tools, extraSystemPrompt: toolChoiceConstraintPrompt(constraint), constraint };
   }
   if (typeof toolChoice !== "object" || Array.isArray(toolChoice)) {
     throw new Error("tool_choice must be a string or object");
@@ -246,41 +245,17 @@ function applyChatToolChoice(params: { tools: ClientToolDefinition[]; toolChoice
     if (matched.length === 0) {
       throw new Error(`tool_choice requested unknown tool: ${targetName}`);
     }
+    const constraint: ToolChoiceConstraint = { type: "function", name: targetName };
     return {
       tools: matched,
-      extraSystemPrompt: `You must call the ${targetName} tool before responding.`,
-      constraint: { type: "function", name: targetName },
+      extraSystemPrompt: toolChoiceConstraintPrompt(constraint),
+      constraint,
     };
   }
   if (typeof choiceType !== "string") {
     throw new Error("unsupported tool_choice type");
   }
   throw new Error(`tool_choice ${choiceType} is not supported`);
-}
-
-function isChatToolChoiceConstraintSatisfied(params: {
-  constraint: ChatToolChoiceConstraint | undefined;
-  pendingToolCalls: Array<{ name: string }> | undefined;
-}): boolean {
-  const { constraint, pendingToolCalls } = params;
-  if (!constraint) {
-    return true;
-  }
-  if (!pendingToolCalls || pendingToolCalls.length === 0) {
-    return false;
-  }
-  if (constraint.type === "required") {
-    return true;
-  }
-  return pendingToolCalls.some((call) => call.name === constraint.name);
-}
-
-function resolveUnsatisfiedChatToolChoiceMessage(
-  constraint: ChatToolChoiceConstraint,
-): string {
-  return constraint.type === "function"
-    ? `tool_choice required a ${constraint.name} tool call, but the agent did not produce one`
-    : "tool_choice=required was not satisfied by the agent response";
 }
 
 function writeAssistantRoleChunk(res: ServerResponse, params: { runId: string; model: string }) {
@@ -1008,7 +983,7 @@ export async function handleOpenAiHttpRequest(
   const prompt = buildAgentPrompt(payload.messages, activeTurnContext.activeUserMessageIndex);
   let resolvedClientTools: ClientToolDefinition[] = [];
   let toolChoicePrompt: string | undefined;
-  let toolChoiceConstraint: ChatToolChoiceConstraint | undefined;
+  let toolChoiceConstraint: ToolChoiceConstraint | undefined;
   try {
     const parsedClientTools = extractClientToolsFromChatRequest(payload.tools);
     const toolChoiceResult = applyChatToolChoice({
@@ -1087,14 +1062,14 @@ export async function handleOpenAiHttpRequest(
 
       if (
         toolChoiceConstraint &&
-        !isChatToolChoiceConstraintSatisfied({
+        !isToolChoiceConstraintSatisfied({
           constraint: toolChoiceConstraint,
           pendingToolCalls,
         })
       ) {
         sendJson(res, 502, {
           error: {
-            message: resolveUnsatisfiedChatToolChoiceMessage(toolChoiceConstraint),
+            message: resolveUnsatisfiedToolChoiceMessage(toolChoiceConstraint),
             type: "api_error",
           },
         });
@@ -1276,7 +1251,7 @@ export async function handleOpenAiHttpRequest(
 
       if (
         toolChoiceConstraint &&
-        !isChatToolChoiceConstraintSatisfied({
+        !isToolChoiceConstraintSatisfied({
           constraint: toolChoiceConstraint,
           pendingToolCalls,
         })
@@ -1286,7 +1261,7 @@ export async function handleOpenAiHttpRequest(
         unsubscribe();
         writeSse(res, {
           error: {
-            message: resolveUnsatisfiedChatToolChoiceMessage(toolChoiceConstraint),
+            message: resolveUnsatisfiedToolChoiceMessage(toolChoiceConstraint),
             type: "api_error",
           },
         });

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -68,6 +68,10 @@ type OpenAiChatMessage = {
   stopReason?: unknown;
 };
 
+type ChatToolChoiceConstraint =
+  | { type: "required" }
+  | { type: "function"; name: string };
+
 type OpenAiChatCompletionRequest = {
   model?: unknown;
   stream?: unknown;
@@ -208,6 +212,7 @@ function extractClientToolsFromChatRequest(tools: unknown): ClientToolDefinition
 function applyChatToolChoice(params: { tools: ClientToolDefinition[]; toolChoice: unknown }): {
   tools: ClientToolDefinition[];
   extraSystemPrompt?: string;
+  constraint?: ChatToolChoiceConstraint;
 } {
   const { tools, toolChoice } = params;
   if (toolChoice == null || toolChoice === "auto") {
@@ -217,16 +222,65 @@ function applyChatToolChoice(params: { tools: ClientToolDefinition[]; toolChoice
     return { tools: [] };
   }
   if (toolChoice === "required") {
-    throw new Error("tool_choice=required is not supported");
+    if (tools.length === 0) {
+      throw new Error("tool_choice=required but no tools were provided");
+    }
+    return {
+      tools,
+      extraSystemPrompt: "You must call one of the available tools before responding.",
+      constraint: { type: "required" },
+    };
   }
   if (typeof toolChoice !== "object" || Array.isArray(toolChoice)) {
     throw new Error("tool_choice must be a string or object");
   }
   const choiceType = (toolChoice as { type?: unknown }).type;
+  if (choiceType === "function") {
+    const targetName = normalizeOptionalString(
+      (toolChoice as { function?: { name?: unknown } }).function?.name,
+    );
+    if (!targetName) {
+      throw new Error("tool_choice.function.name is required");
+    }
+    const matched = tools.filter((tool) => tool.function?.name === targetName);
+    if (matched.length === 0) {
+      throw new Error(`tool_choice requested unknown tool: ${targetName}`);
+    }
+    return {
+      tools: matched,
+      extraSystemPrompt: `You must call the ${targetName} tool before responding.`,
+      constraint: { type: "function", name: targetName },
+    };
+  }
   if (typeof choiceType !== "string") {
     throw new Error("unsupported tool_choice type");
   }
   throw new Error(`tool_choice ${choiceType} is not supported`);
+}
+
+function isChatToolChoiceConstraintSatisfied(params: {
+  constraint: ChatToolChoiceConstraint | undefined;
+  pendingToolCalls: Array<{ name: string }> | undefined;
+}): boolean {
+  const { constraint, pendingToolCalls } = params;
+  if (!constraint) {
+    return true;
+  }
+  if (!pendingToolCalls || pendingToolCalls.length === 0) {
+    return false;
+  }
+  if (constraint.type === "required") {
+    return true;
+  }
+  return pendingToolCalls.some((call) => call.name === constraint.name);
+}
+
+function resolveUnsatisfiedChatToolChoiceMessage(
+  constraint: ChatToolChoiceConstraint,
+): string {
+  return constraint.type === "function"
+    ? `tool_choice required a ${constraint.name} tool call, but the agent did not produce one`
+    : "tool_choice=required was not satisfied by the agent response";
 }
 
 function writeAssistantRoleChunk(res: ServerResponse, params: { runId: string; model: string }) {
@@ -954,6 +1008,7 @@ export async function handleOpenAiHttpRequest(
   const prompt = buildAgentPrompt(payload.messages, activeTurnContext.activeUserMessageIndex);
   let resolvedClientTools: ClientToolDefinition[] = [];
   let toolChoicePrompt: string | undefined;
+  let toolChoiceConstraint: ChatToolChoiceConstraint | undefined;
   try {
     const parsedClientTools = extractClientToolsFromChatRequest(payload.tools);
     const toolChoiceResult = applyChatToolChoice({
@@ -962,6 +1017,7 @@ export async function handleOpenAiHttpRequest(
     });
     resolvedClientTools = toolChoiceResult.tools;
     toolChoicePrompt = toolChoiceResult.extraSystemPrompt;
+    toolChoiceConstraint = toolChoiceResult.constraint;
   } catch (err) {
     sendJson(res, 400, {
       error: {
@@ -1028,6 +1084,22 @@ export async function handleOpenAiHttpRequest(
       const usage = resolveChatCompletionUsage(result);
       const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
+
+      if (
+        toolChoiceConstraint &&
+        !isChatToolChoiceConstraintSatisfied({
+          constraint: toolChoiceConstraint,
+          pendingToolCalls,
+        })
+      ) {
+        sendJson(res, 502, {
+          error: {
+            message: resolveUnsatisfiedChatToolChoiceMessage(toolChoiceConstraint),
+            type: "api_error",
+          },
+        });
+        return true;
+      }
 
       if (stopReason === "tool_calls" && pendingToolCalls && pendingToolCalls.length > 0) {
         const commentary = resolveAgentResponseCommentary(result);
@@ -1101,6 +1173,7 @@ export async function handleOpenAiHttpRequest(
   let wroteRole = false;
   let wroteStopChunk = false;
   let sawAssistantDelta = false;
+  let bufferedAssistantContent = "";
   let finalUsage: OpenAiChatCompletionsUsage | undefined;
   let finalizeRequested = false;
   let finalizeFinishReason: "stop" | "tool_calls" = "stop";
@@ -1152,6 +1225,11 @@ export async function handleOpenAiHttpRequest(
         return;
       }
 
+      if (toolChoiceConstraint) {
+        bufferedAssistantContent += content;
+        return;
+      }
+
       if (!wroteRole) {
         wroteRole = true;
         writeAssistantRoleChunk(res, { runId, model });
@@ -1196,13 +1274,34 @@ export async function handleOpenAiHttpRequest(
       const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
+      if (
+        toolChoiceConstraint &&
+        !isChatToolChoiceConstraintSatisfied({
+          constraint: toolChoiceConstraint,
+          pendingToolCalls,
+        })
+      ) {
+        closed = true;
+        stopWatchingDisconnect();
+        unsubscribe();
+        writeSse(res, {
+          error: {
+            message: resolveUnsatisfiedChatToolChoiceMessage(toolChoiceConstraint),
+            type: "api_error",
+          },
+        });
+        writeDone(res);
+        res.end();
+        return;
+      }
+
       if (stopReason === "tool_calls" && pendingToolCalls && pendingToolCalls.length > 0) {
         if (!wroteRole) {
           wroteRole = true;
           writeAssistantRoleChunk(res, { runId, model });
         }
         if (!sawAssistantDelta) {
-          const commentary = resolveAgentResponseCommentary(result);
+          const commentary = bufferedAssistantContent || resolveAgentResponseCommentary(result);
           if (commentary) {
             sawAssistantDelta = true;
             writeAssistantContentChunk(res, {

--- a/src/gateway/openai-tool-choice.ts
+++ b/src/gateway/openai-tool-choice.ts
@@ -1,9 +1,9 @@
 // Shared OpenAI-compatible `tool_choice` contract for the Chat Completions
 // (`/v1/chat/completions`) and Responses (`/v1/responses`) HTTP endpoints. Both
-// accept `required` and pinned-function choices, narrow the exposed client
-// tools, nudge the model with a system prompt, and must reject a turn that omits
-// the demanded structured tool call. Keeping the constraint shape, prompt
-// wording, and satisfaction check here keeps the two endpoints from drifting.
+// accept `required` and pinned-function choices for caller-supplied client tools.
+// The agent runtime cannot force every upstream provider, so the HTTP boundary
+// narrows exposed tools, nudges the model, then rejects turns without a matching
+// structured client-tool call. Keeping this here keeps the endpoints aligned.
 
 export type ToolChoiceConstraint = { type: "required" } | { type: "function"; name: string };
 

--- a/src/gateway/openai-tool-choice.ts
+++ b/src/gateway/openai-tool-choice.ts
@@ -1,0 +1,40 @@
+// Shared OpenAI-compatible `tool_choice` contract for the Chat Completions
+// (`/v1/chat/completions`) and Responses (`/v1/responses`) HTTP endpoints. Both
+// accept `required` and pinned-function choices, narrow the exposed client
+// tools, nudge the model with a system prompt, and must reject a turn that omits
+// the demanded structured tool call. Keeping the constraint shape, prompt
+// wording, and satisfaction check here keeps the two endpoints from drifting.
+
+export type ToolChoiceConstraint = { type: "required" } | { type: "function"; name: string };
+
+export function toolChoiceConstraintPrompt(constraint: ToolChoiceConstraint): string {
+  return constraint.type === "function"
+    ? `You must call the ${constraint.name} tool before responding.`
+    : "You must call one of the available tools before responding.";
+}
+
+// True when no constraint is active, or the agent produced a structured tool
+// call that honors it: any call for `required`, a name match for a pinned
+// function. Callers reject the turn when this returns false.
+export function isToolChoiceConstraintSatisfied(params: {
+  constraint: ToolChoiceConstraint | undefined;
+  pendingToolCalls: ReadonlyArray<{ name: string }> | undefined;
+}): boolean {
+  const { constraint, pendingToolCalls } = params;
+  if (!constraint) {
+    return true;
+  }
+  if (!pendingToolCalls || pendingToolCalls.length === 0) {
+    return false;
+  }
+  if (constraint.type === "required") {
+    return true;
+  }
+  return pendingToolCalls.some((call) => call.name === constraint.name);
+}
+
+export function resolveUnsatisfiedToolChoiceMessage(constraint: ToolChoiceConstraint): string {
+  return constraint.type === "function"
+    ? `tool_choice required a ${constraint.name} tool call, but the agent did not produce one`
+    : "tool_choice=required was not satisfied by the agent response";
+}

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -642,6 +642,42 @@ describe("OpenResponses HTTP API (e2e)", () => {
       expect(clientTools[0]?.function?.strict).toBe(true);
       await ensureResponseConsumed(resToolChoice);
 
+      mockAgentOnce([{ text: "ok" }], {
+        stopReason: "tool_calls",
+        pendingToolCalls: [{ id: "call_1", name: "get_time", arguments: "{}" }],
+      });
+      const resWrappedToolChoice = await postResponses(port, {
+        model: "openclaw",
+        input: "hi",
+        tools: [
+          {
+            type: "function",
+            name: "get_weather",
+            description: "Get weather",
+          },
+          {
+            type: "function",
+            name: "get_time",
+            description: "Get time",
+            strict: true,
+          },
+        ],
+        tool_choice: { type: "function", function: { name: "get_time" } },
+      });
+      expect(resWrappedToolChoice.status).toBe(200);
+      const wrappedClientTools =
+        (
+          firstAgentOpts() as
+            | {
+                clientTools?: Array<{ function?: { name?: string; strict?: boolean } }>;
+              }
+            | undefined
+        )?.clientTools ?? [];
+      expect(wrappedClientTools).toHaveLength(1);
+      expect(wrappedClientTools[0]?.function?.name).toBe("get_time");
+      expect(wrappedClientTools[0]?.function?.strict).toBe(true);
+      await ensureResponseConsumed(resWrappedToolChoice);
+
       const resUnknownTool = await postResponses(port, {
         model: "openclaw",
         input: "hi",
@@ -1070,6 +1106,47 @@ describe("OpenResponses HTTP API (e2e)", () => {
       model: "openclaw",
       input: "check the weather",
       tools: WEATHER_TOOL,
+      tool_choice: { type: "function", name: "get_weather" },
+    });
+
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as {
+      status?: string;
+      error?: { code?: string; message?: string };
+    };
+    expect(json.status).toBe("failed");
+    expect(json.error?.code).toBe("api_error");
+    expect(json.error?.message ?? "").toContain("tool_choice required a get_weather tool call");
+    await ensureResponseConsumed(res);
+  });
+
+  it("rejects a non-streaming function tool_choice when the agent calls a different tool", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "Calling another tool." }],
+      meta: {
+        stopReason: "tool_calls",
+        pendingToolCalls: [{ id: "call_1", name: "get_time", arguments: "{}" }],
+      },
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: false,
+      model: "openclaw",
+      input: "check the weather",
+      tools: [
+        {
+          type: "function",
+          name: "get_weather",
+          description: "Get weather",
+        },
+        {
+          type: "function",
+          name: "get_time",
+          description: "Get time",
+        },
+      ],
       tool_choice: { type: "function", name: "get_weather" },
     });
 

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -603,7 +603,12 @@ describe("OpenResponses HTTP API (e2e)", () => {
       ).toBeUndefined();
       await ensureResponseConsumed(resToolNone);
 
-      mockAgentOnce([{ text: "ok" }]);
+      // A pinned `tool_choice` now enforces the response contract, so the agent
+      // must produce the matching tool call for a 200; text-only would 502.
+      mockAgentOnce([{ text: "ok" }], {
+        stopReason: "tool_calls",
+        pendingToolCalls: [{ id: "call_1", name: "get_time", arguments: "{}" }],
+      });
       const resToolChoice = await postResponses(port, {
         model: "openclaw",
         input: "hi",
@@ -620,7 +625,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
             strict: true,
           },
         ],
-        tool_choice: { type: "function", function: { name: "get_time" } },
+        tool_choice: { type: "function", name: "get_time" },
       });
       expect(resToolChoice.status).toBe(200);
       const optsToolChoice = firstAgentOpts();
@@ -641,7 +646,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         model: "openclaw",
         input: "hi",
         tools: WEATHER_TOOL,
-        tool_choice: { type: "function", function: { name: "unknown_tool" } },
+        tool_choice: { type: "function", name: "unknown_tool" },
       });
       expect(resUnknownTool.status).toBe(400);
       await ensureResponseConsumed(resUnknownTool);
@@ -991,6 +996,218 @@ describe("OpenResponses HTTP API (e2e)", () => {
     ).toBe("Let me check that.");
     expect(json.output?.[1]?.name).toBe("get_weather");
     await ensureResponseConsumed(res);
+  });
+
+  it("rejects an unsatisfied required tool_choice on the non-streaming path", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "plain text despite required" }],
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: false,
+      model: "openclaw",
+      input: "check the weather",
+      tools: WEATHER_TOOL,
+      tool_choice: "required",
+    });
+
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as {
+      status?: string;
+      error?: { code?: string; message?: string };
+    };
+    expect(json.status).toBe("failed");
+    expect(json.error?.code).toBe("api_error");
+    expect(json.error?.message ?? "").toContain("tool_choice=required was not satisfied");
+    await ensureResponseConsumed(res);
+  });
+
+  it("returns the tool call when a required tool_choice is satisfied (non-streaming)", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "Calling the tool." }],
+      meta: {
+        stopReason: "tool_calls",
+        pendingToolCalls: [{ id: "call_1", name: "get_weather", arguments: '{"city":"Taipei"}' }],
+      },
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: false,
+      model: "openclaw",
+      input: "check the weather",
+      tools: WEATHER_TOOL,
+      tool_choice: "required",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      status?: string;
+      output?: Array<Record<string, unknown>>;
+    };
+    expect(json.status).toBe("incomplete");
+    expect(json.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
+    expect(json.output?.[1]?.name).toBe("get_weather");
+    const opts = firstAgentOpts();
+    expect((opts as { extraSystemPrompt?: string }).extraSystemPrompt ?? "").toContain(
+      "You must call one of the available tools",
+    );
+    await ensureResponseConsumed(res);
+  });
+
+  it("rejects an unsatisfied function tool_choice on the non-streaming path", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "I can answer without the weather tool." }],
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: false,
+      model: "openclaw",
+      input: "check the weather",
+      tools: WEATHER_TOOL,
+      tool_choice: { type: "function", name: "get_weather" },
+    });
+
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as {
+      status?: string;
+      error?: { code?: string; message?: string };
+    };
+    expect(json.status).toBe("failed");
+    expect(json.error?.code).toBe("api_error");
+    expect(json.error?.message ?? "").toContain("tool_choice required a get_weather tool call");
+    await ensureResponseConsumed(res);
+  });
+
+  it("rejects an unsatisfied required tool_choice on the streaming path without leaking text", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) =>
+      buildAssistantDeltaResult({
+        opts,
+        emit: emitAgentEvent,
+        deltas: ["plain text despite required"],
+        text: "plain text despite required",
+      })) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "check the weather",
+      tools: WEATHER_TOOL,
+      tool_choice: "required",
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const events = parseSseEvents(text);
+    const failed = findSseEvent(events, "response.failed");
+    const failedResponse = (
+      parseSseData(failed) as {
+        response?: { status?: string; error?: { code?: string; message?: string } };
+      }
+    ).response;
+    expect(failedResponse?.status).toBe("failed");
+    expect(failedResponse?.error?.code).toBe("api_error");
+    expect(failedResponse?.error?.message ?? "").toContain(
+      "tool_choice=required was not satisfied",
+    );
+    expect(text).toContain("[DONE]");
+    // Buffered prose must never reach the client when the contract fails.
+    expect(text).not.toContain("plain text despite required");
+    expect(collectSseEventTypes(events)).not.toContain("response.output_text.delta");
+  });
+
+  it("rejects a streaming function tool_choice when the agent calls a different tool", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "Calling another tool." }],
+      meta: {
+        stopReason: "tool_calls",
+        pendingToolCalls: [{ id: "call_1", name: "get_time", arguments: "{}" }],
+      },
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "check the weather",
+      tools: [
+        {
+          type: "function",
+          name: "get_weather",
+          description: "Get weather",
+        },
+        {
+          type: "function",
+          name: "get_time",
+          description: "Get time",
+        },
+      ],
+      tool_choice: { type: "function", name: "get_weather" },
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const events = parseSseEvents(text);
+    const failed = findSseEvent(events, "response.failed");
+    const failedResponse = (
+      parseSseData(failed) as {
+        response?: { status?: string; error?: { code?: string; message?: string } };
+      }
+    ).response;
+    expect(failedResponse?.status).toBe("failed");
+    expect(failedResponse?.error?.code).toBe("api_error");
+    expect(failedResponse?.error?.message ?? "").toContain(
+      "tool_choice required a get_weather tool call",
+    );
+    expect(collectSseEventTypes(events)).not.toContain("response.completed");
+    expect(text).toContain("[DONE]");
+  });
+
+  it("emits the tool call when a streaming required tool_choice is satisfied", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "Calling " } });
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "the tool." } });
+      return {
+        payloads: [{ text: "Calling the tool." }],
+        meta: {
+          stopReason: "tool_calls",
+          pendingToolCalls: [{ id: "call_1", name: "get_weather", arguments: '{"city":"Taipei"}' }],
+        },
+      };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "check the weather",
+      tools: WEATHER_TOOL,
+      tool_choice: "required",
+    });
+
+    expect(res.status).toBe(200);
+    const events = parseSseEvents(await res.text());
+    const delta = findSseEvent(events, "response.output_text.delta");
+    expect((parseSseData(delta) as { delta?: string }).delta).toBe("Calling the tool.");
+    const completed = findSseEvent(events, "response.completed");
+    const response = (
+      parseSseData(completed) as {
+        response?: { status?: string; output?: Array<Record<string, unknown>> };
+      }
+    ).response;
+    expect(response?.status).toBe("incomplete");
+    expect(response?.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
+    expect(response?.output?.[1]?.name).toBe("get_weather");
   });
 
   it("falls back to payload text for streamed function_call responses", async () => {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -56,6 +56,12 @@ import {
   type Usage,
 } from "./open-responses.schema.js";
 import { resolveOpenAiCompatError } from "./openai-compat-errors.js";
+import {
+  isToolChoiceConstraintSatisfied,
+  resolveUnsatisfiedToolChoiceMessage,
+  toolChoiceConstraintPrompt,
+  type ToolChoiceConstraint,
+} from "./openai-tool-choice.js";
 import { wrapUntrustedFileContent } from "./openresponses-file-content.js";
 import { buildAgentPrompt } from "./openresponses-prompt.js";
 import { createAssistantOutputItem, createFunctionCallOutputItem } from "./openresponses-shape.js";
@@ -276,7 +282,11 @@ function extractClientTools(body: CreateResponseBody): ClientToolDefinition[] {
 function applyToolChoice(params: {
   tools: ClientToolDefinition[];
   toolChoice: CreateResponseBody["tool_choice"];
-}): { tools: ClientToolDefinition[]; extraSystemPrompt?: string } {
+}): {
+  tools: ClientToolDefinition[];
+  extraSystemPrompt?: string;
+  constraint?: ToolChoiceConstraint;
+} {
   const { tools, toolChoice } = params;
   if (!toolChoice) {
     return { tools };
@@ -290,24 +300,24 @@ function applyToolChoice(params: {
     if (tools.length === 0) {
       throw new Error("tool_choice=required but no tools were provided");
     }
-    return {
-      tools,
-      extraSystemPrompt: "You must call one of the available tools before responding.",
-    };
+    const constraint: ToolChoiceConstraint = { type: "required" };
+    return { tools, extraSystemPrompt: toolChoiceConstraintPrompt(constraint), constraint };
   }
 
   if (typeof toolChoice === "object" && toolChoice.type === "function") {
-    const targetName = toolChoice.function?.name?.trim();
+    const targetName = ("name" in toolChoice ? toolChoice.name : toolChoice.function.name).trim();
     if (!targetName) {
-      throw new Error("tool_choice.function.name is required");
+      throw new Error("tool_choice.name is required");
     }
     const matched = tools.filter((tool) => tool.function?.name === targetName);
     if (matched.length === 0) {
       throw new Error(`tool_choice requested unknown tool: ${targetName}`);
     }
+    const constraint: ToolChoiceConstraint = { type: "function", name: targetName };
     return {
       tools: matched,
-      extraSystemPrompt: `You must call the ${targetName} tool before responding.`,
+      extraSystemPrompt: toolChoiceConstraintPrompt(constraint),
+      constraint,
     };
   }
 
@@ -597,6 +607,7 @@ export async function handleOpenResponsesHttpRequest(
 
   const clientTools = extractClientTools(payload);
   let toolChoicePrompt: string | undefined;
+  let toolChoiceConstraint: ToolChoiceConstraint | undefined;
   let resolvedClientTools = clientTools;
   try {
     const toolChoiceResult = applyToolChoice({
@@ -605,6 +616,7 @@ export async function handleOpenResponsesHttpRequest(
     });
     resolvedClientTools = toolChoiceResult.tools;
     toolChoicePrompt = toolChoiceResult.extraSystemPrompt;
+    toolChoiceConstraint = toolChoiceResult.constraint;
   } catch (err) {
     logWarn(`openresponses: tool configuration failed: ${String(err)}`);
     sendJson(res, 400, {
@@ -705,6 +717,29 @@ export async function handleOpenResponsesHttpRequest(
       const usage = extractUsageFromResult(result);
       const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
+
+      // A `required`/pinned `tool_choice` must reject a text-only turn instead
+      // of returning ordinary assistant prose, mirroring /v1/chat/completions.
+      // Shared satisfaction check lives in openai-tool-choice.ts.
+      if (
+        toolChoiceConstraint &&
+        !isToolChoiceConstraintSatisfied({ constraint: toolChoiceConstraint, pendingToolCalls })
+      ) {
+        const failed = createResponseResource({
+          id: responseId,
+          model,
+          status: "failed",
+          output: [],
+          error: {
+            code: "api_error",
+            message: resolveUnsatisfiedToolChoiceMessage(toolChoiceConstraint),
+          },
+          usage,
+        });
+        rememberResponseSession();
+        sendJson(res, 502, failed);
+        return true;
+      }
 
       // If the agent invoked client tools, return one `function_call`
       // output item per call (in arrival order) plus any assistant text the
@@ -959,6 +994,16 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
 
+      // Hold assistant prose until the tool-choice contract is confirmed. A
+      // `required`/pinned request must reject text-only turns, so streaming
+      // deltas now could leak output we may have to fail. Buffered text is
+      // still flushed as commentary if a matching tool call arrives, matching
+      // the openai-http.ts streaming buffer.
+      if (toolChoiceConstraint) {
+        accumulatedText += content;
+        return;
+      }
+
       sawAssistantDelta = true;
       accumulatedText += content;
 
@@ -1011,6 +1056,35 @@ export async function handleOpenResponsesHttpRequest(
       const meta = resultAny.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
+      // Reject an unsatisfied `required`/pinned `tool_choice` before any
+      // buffered prose is flushed, mirroring the non-streaming path and
+      // /v1/chat/completions. Closes the stream with a `response.failed` event.
+      if (
+        !closed &&
+        toolChoiceConstraint &&
+        !isToolChoiceConstraintSatisfied({ constraint: toolChoiceConstraint, pendingToolCalls })
+      ) {
+        const failed = createResponseResource({
+          id: responseId,
+          model,
+          status: "failed",
+          output: [],
+          error: {
+            code: "api_error",
+            message: resolveUnsatisfiedToolChoiceMessage(toolChoiceConstraint),
+          },
+          usage: finalUsage ?? createEmptyUsage(),
+        });
+        closed = true;
+        stopWatchingDisconnect();
+        unsubscribe();
+        rememberResponseSession();
+        writeSseEvent(res, { type: "response.failed", response: failed });
+        writeDone(res);
+        res.end();
+        return;
+      }
+
       if (
         !closed &&
         stopReason === "tool_calls" &&
@@ -1027,6 +1101,16 @@ export async function handleOpenResponsesHttpRequest(
                 .join("\n\n")
             : "");
 
+        if (toolChoiceConstraint && accumulatedText) {
+          sawAssistantDelta = true;
+          writeSseEvent(res, {
+            type: "response.output_text.delta",
+            item_id: outputItemId,
+            output_index: 0,
+            content_index: 0,
+            delta: accumulatedText,
+          });
+        }
         writeSseEvent(res, {
           type: "response.output_text.done",
           item_id: outputItemId,


### PR DESCRIPTION
## Summary

- Accept OpenAI Chat Completions `tool_choice: "required"` and pinned function tool choice in `/v1/chat/completions`.
- Enforce the same required and pinned-function tool-choice contract in `/v1/responses`, including the Responses API flat pinned shape `{ "type": "function", "name": "..." }`.
- Narrow the exposed client tool set for pinned function requests and validate unknown or missing tool selections at the gateway boundary.
- Enforce the requested tool-choice contract on the response path: non-streaming requests fail if no matching structured tool call is produced, and streaming requests buffer assistant text until a matching tool call is confirmed.
- Update OpenAI-compatible HTTP gateway docs for the supported `tool_choice` forms.

Refs #45049.

## Verification

- `node scripts/run-vitest.mjs src/gateway/openai-http.test.ts -t "handles request validation and routing|streams SSE chunks" --reporter=verbose` - passed; 4 focused Gateway HTTP e2e cases across `gateway-server` and `gateway-client`.
- `node scripts/run-vitest.mjs src/gateway/openai-http.test.ts` - passed; 18/18 tests.
- `node scripts/run-vitest.mjs src/gateway/openresponses-http.test.ts src/gateway/openai-http.test.ts` - passed; 43/43 tests covering Chat Completions plus Responses required/pinned tool-choice success and failure paths.
- `pnpm docs:list` - passed; `docs/gateway/openresponses-http-api.md` was the relevant docs page.
- `git diff --check` - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex` - clean; no accepted/actionable findings after addressing two review findings.

## Real behavior proof

Behavior addressed: OpenAI-compatible Gateway HTTP requests now accept standard Chat Completions and Responses `tool_choice: "required"` and pinned function tool choice, return structured tool calls when the model complies, and reject invalid or unsatisfied tool-choice contracts instead of silently returning ordinary assistant text.

Real environment tested: Local Gateway HTTP server started from this checkout via `startGatewayServer`, loopback port `18812`, `auth: none`, `gateway.http.endpoints.chatCompletions.enabled=true`, model `deepseek/deepseek-chat`, provider base URL `https://api.deepseek.com`, and a temporary DeepSeek API key supplied only through the process environment. Responses behavior was also tested through the repo Gateway HTTP e2e harness with the real `/v1/responses` HTTP handler and mocked agent results for deterministic required/pinned success and failure paths.

Exact steps or command run after this patch: Started the Gateway in-process from the current checkout, then posted four local requests to `/v1/chat/completions`: one `tool_choice: "required"` request with a `get_weather` function tool, one pinned function request for `get_weather`, one `tool_choice: "required"` request without tools, and one pinned function request for a missing tool. After adding `/v1/responses` enforcement, ran `node scripts/run-vitest.mjs src/gateway/openresponses-http.test.ts src/gateway/openai-http.test.ts` to exercise Responses non-streaming and streaming required/pinned tool-choice success and failure cases through the HTTP endpoint.

Evidence after fix:

```json
{
  "ok": true,
  "modelRef": "deepseek/deepseek-chat",
  "chatCompletionsLiveResults": [
    {
      "label": "required",
      "httpStatus": 200,
      "finishReason": "tool_calls",
      "toolCallCount": 1,
      "toolNames": ["get_weather"],
      "contentPreview": ""
    },
    {
      "label": "pinned_function",
      "httpStatus": 200,
      "finishReason": "tool_calls",
      "toolCallCount": 1,
      "toolNames": ["get_weather"],
      "contentPreview": ""
    },
    {
      "label": "required_no_tools",
      "httpStatus": 400,
      "errorType": "invalid_request_error",
      "errorMessage": "Invalid tools/tool_choice: tool_choice=required but no tools were provided"
    },
    {
      "label": "missing_tool",
      "httpStatus": 400,
      "errorType": "invalid_request_error",
      "errorMessage": "Invalid tools/tool_choice: tool_choice requested unknown tool: missing_tool"
    }
  ],
  "responsesFocusedTests": {
    "command": "node scripts/run-vitest.mjs src/gateway/openresponses-http.test.ts src/gateway/openai-http.test.ts",
    "testFiles": 2,
    "tests": 43,
    "result": "passed"
  }
}
```

Observed result after fix: The valid Chat Completions `required` and pinned-function requests completed through the real local Gateway and live DeepSeek provider with `finish_reason: "tool_calls"` and a single `get_weather` structured tool call. Invalid Chat Completions tool-choice requests were rejected at the Gateway boundary with deterministic OpenAI-compatible `400 invalid_request_error` responses. Responses HTTP e2e tests now prove non-streaming unsatisfied `tool_choice` returns a failed `502 api_error`, streaming unsatisfied `tool_choice` emits `response.failed` without leaking buffered text, and satisfied required/pinned turns return or stream the matching `function_call` output.

What was not tested: Crabbox/Testbox and cross-OS proof were not run. The live provider proof used DeepSeek rather than OpenAI because the reported compatibility gap is OpenAI-compatible tool-choice protocol behavior and DeepSeek exposes an OpenAI-compatible Chat Completions API for this flow. `/v1/responses` was verified with deterministic local Gateway HTTP e2e tests rather than a live external Responses provider.
