### PR TITLE
fix(cron): delete deleteAfterRun one-shot jobs after permanent failure

### DIFF
--- a/src/cron/service.issue-88197-delete-after-run-on-error.test.ts
+++ b/src/cron/service.issue-88197-delete-after-run-on-error.test.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+type CronServiceParams = ConstructorParameters<typeof CronService>[0];
+
+// Regression for #88197: a one-shot `deleteAfterRun` job that fails permanently
+// (or exhausts its retries) was disabled but kept in the store forever. Real
+// listener-spawn isolated turns that hit "isolated agent setup timed out before
+// runner start" accumulated as enabled=false orphans. A `deleteAfterRun` job
+// means "run once, then delete" and must be removed once it is done running,
+// regardless of run success.
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-88197-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function createCron(params: {
+  storePath: string;
+  cronConfig?: CronServiceParams["cronConfig"];
+  runIsolatedAgentJob: NonNullable<CronServiceParams["runIsolatedAgentJob"]>;
+}) {
+  return new CronService({
+    storePath: params.storePath,
+    cronEnabled: true,
+    cronConfig: params.cronConfig,
+    log: noopLogger,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeat: vi.fn(),
+    runIsolatedAgentJob: params.runIsolatedAgentJob,
+  });
+}
+
+async function addOneShotIsolatedJob(
+  cron: CronService,
+  params: { atMs: number; name: string; deleteAfterRun: boolean },
+) {
+  return cron.add({
+    name: params.name,
+    enabled: true,
+    deleteAfterRun: params.deleteAfterRun,
+    schedule: { kind: "at", at: new Date(params.atMs).toISOString() },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "spawn isolated turn" },
+  });
+}
+
+describe("cron deleteAfterRun on permanent/exhausted error (#88197)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("deletes a deleteAfterRun one-shot after a non-retryable error", async () => {
+    const store = await makeStorePath();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "isolated agent setup failed: invalid configuration",
+    }));
+    const cron = createCron({ storePath: store.storePath, runIsolatedAgentJob });
+
+    await cron.start();
+    const job = await addOneShotIsolatedJob(cron, {
+      atMs: Date.parse("2026-01-01T00:00:02.000Z"),
+      name: "listener-spawn",
+      deleteAfterRun: true,
+    });
+
+    await cron.run(job.id, "force");
+
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    // The failed deleteAfterRun job must not linger as an orphan.
+    expect(cron.getJob(job.id)).toBeUndefined();
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("deletes a deleteAfterRun one-shot after retries are exhausted on the issue's timeout error", async () => {
+    const store = await makeStorePath();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "isolated agent setup timed out before runner start",
+    }));
+    // Exhaust retries immediately so the single run reaches the permanent path.
+    const cron = createCron({
+      storePath: store.storePath,
+      cronConfig: { retry: { maxAttempts: 0 } },
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+    const job = await addOneShotIsolatedJob(cron, {
+      atMs: Date.parse("2026-01-01T00:00:02.000Z"),
+      name: "listener-spawn-timeout",
+      deleteAfterRun: true,
+    });
+
+    await cron.run(job.id, "force");
+
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    expect(cron.getJob(job.id)).toBeUndefined();
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("keeps a failed one-shot in the store when deleteAfterRun is not set", async () => {
+    const store = await makeStorePath();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "isolated agent setup failed: invalid configuration",
+    }));
+    const cron = createCron({ storePath: store.storePath, runIsolatedAgentJob });
+
+    await cron.start();
+    const job = await addOneShotIsolatedJob(cron, {
+      atMs: Date.parse("2026-01-01T00:00:02.000Z"),
+      name: "keep-for-inspection",
+      deleteAfterRun: false,
+    });
+
+    await cron.run(job.id, "force");
+
+    // Without deleteAfterRun the disabled job is retained for inspection.
+    const kept = cron.getJob(job.id);
+    expect(kept).toBeDefined();
+    expect(kept?.enabled).toBe(false);
+    expect(kept?.state.lastStatus).toBe("error");
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -480,7 +480,7 @@ export function applyJobResult(
     job.state.lastFailureAlertAtMs = undefined;
   }
 
-  const shouldDelete =
+  let shouldDelete =
     job.schedule.kind === "at" && job.deleteAfterRun === true && result.status === "ok";
 
   if (!shouldDelete) {
@@ -511,23 +511,49 @@ export function applyJobResult(
             "cron: scheduling one-shot retry after transient error",
           );
         } else {
-          // Permanent error or max retries exhausted: disable.
-          // Note: deleteAfterRun:true only triggers on ok (see shouldDelete above),
-          // so exhausted-retry jobs are disabled but intentionally kept in the store
-          // to preserve the error state for inspection.
-          job.enabled = false;
-          job.state.nextRunAtMs = undefined;
-          state.deps.log.warn(
-            {
-              jobId: job.id,
-              jobName: job.name,
-              consecutiveErrors: retryDecision.consecutiveErrors,
-              error: result.error,
-              reason: retryDecision.reason,
-              retryCategory: retryDecision.retryCategory,
-            },
-            "cron: disabling one-shot job after error",
-          );
+          // Permanent error or max retries exhausted.
+          //
+          // A `deleteAfterRun` one-shot is supposed to be removed once it is
+          // done running — "run once, then delete" — regardless of whether the
+          // run succeeded. Previously this branch only disabled the job and kept
+          // it in the store, so transiently-failing/timing-out one-shots (e.g.
+          // listener-spawn isolated turns that hit "isolated agent setup timed
+          // out before runner start") accumulated forever as enabled=false
+          // orphans (#88197). Delete the job here too once retries are exhausted.
+          //
+          // Retryable errors still fall through the branch above and wait for
+          // their backoff retry, so a deleteAfterRun job is only removed after a
+          // permanent/exhausted failure, never while a retry is still pending.
+          if (job.deleteAfterRun === true) {
+            shouldDelete = true;
+            state.deps.log.warn(
+              {
+                jobId: job.id,
+                jobName: job.name,
+                consecutiveErrors: retryDecision.consecutiveErrors,
+                error: result.error,
+                reason: retryDecision.reason,
+                retryCategory: retryDecision.retryCategory,
+              },
+              "cron: deleting one-shot deleteAfterRun job after permanent error",
+            );
+          } else {
+            // Without deleteAfterRun, keep the disabled job in the store to
+            // preserve the error state for inspection.
+            job.enabled = false;
+            job.state.nextRunAtMs = undefined;
+            state.deps.log.warn(
+              {
+                jobId: job.id,
+                jobName: job.name,
+                consecutiveErrors: retryDecision.consecutiveErrors,
+                error: result.error,
+                reason: retryDecision.reason,
+                retryCategory: retryDecision.retryCategory,
+              },
+              "cron: disabling one-shot job after error",
+            );
+          }
         }
       }
     } else if (result.status === "error" && isJobEnabled(job)) {


### PR DESCRIPTION
Fixes #88197

## Real behavior proof

**Behavior addressed:** A one-shot `deleteAfterRun` cron job is meant to be removed once it has run ("run once, then delete"), regardless of whether the run succeeded. Post-run cleanup in `src/cron/service/timer.ts` only deleted the job when the final status was `ok`; on a permanent or retries-exhausted error the job was merely disabled and kept in the store. Listener-spawn isolated turns that fail (e.g. `isolated agent setup timed out before runner start`) therefore accumulated indefinitely as `enabled=false` orphans. This patch deletes the job once retries are exhausted / the error is permanent when `deleteAfterRun` is set. Retryable errors still fall through to the backoff-retry path, so a `deleteAfterRun` job is only removed after a terminal failure, never while a retry is still pending; jobs without `deleteAfterRun` are still retained disabled for inspection.

**Real environment tested:** Linux x86_64, Node.js v22.x, HEAD `ddd79f01d492776268f51242a2cf9aecfd19e139` based on `origin/main` `e6782254e45752eb1ba51df0b0968c5f12d74826`. Real run drives the production `CronService` against a real on-disk cron job store in a temp dir.

**Exact steps or command run after this patch:** A small harness (repo root, removed after) constructs the real `CronService`, adds a one-shot isolated `deleteAfterRun` job whose runner reports the issue's exact timeout failure, runs it, then queries the real store via `cron.getJob(id)`:
```bash
node --import tsx proof-88197.mjs
```

**Evidence after fix:** Real `CronService` store state after the failed run — the failed `deleteAfterRun` job is gone from the store:
```
job created: 355bb5ab-4b64-482b-8bb5-beeea3b052cf deleteAfterRun: true
after a failed run -> getJob(id): undefined (deleted)
```
For contrast, the same `node --import tsx` run against current `origin/main` (before this patch) leaves the failed job behind as an enabled=false orphan:
```
job created: 4a66c9a5-8a76-4108-ab73-e371384d4bb9 deleteAfterRun: true
after a failed run -> getJob(id): {"enabled":false,"lastStatus":"error"}
```

**Observed result after fix:** A `deleteAfterRun` one-shot that fails permanently (or exhausts retries) is removed from the cron store via the production `CronService` path, so failed listener-spawn jobs no longer accumulate. Supplemental: a new focused suite `src/cron/service.issue-88197-delete-after-run-on-error.test.ts` runs 3/3, and the full cron config suite stays green at 987/987.

**What was not tested:** No live multi-day gateway scheduler was run; the proof drives the real `CronService` with a real on-disk job store and an isolated-runner stub that returns the issue's exact timeout error, which is precisely the failure path that produced the orphans.
