### PR TITLE
fix(infra): prefix channelId with channel: when migrating to target

### DIFF
--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -192,6 +192,39 @@ describe("normalizeMessageActionInput", () => {
         action: "read",
         args: {
           channel: "discord",
+          channelId: "1507887702379335791",
+        },
+        toolContext: {
+          currentChannelProvider: "telegram",
+        },
+      },
+      expectedFields: {
+        target: "channel:1507887702379335791",
+        to: "channel:1507887702379335791",
+      },
+      absentFields: ["channelId"],
+    },
+    {
+      input: {
+        action: "read",
+        args: {
+          channelId: "1507887702379335791",
+        },
+        toolContext: {
+          currentChannelProvider: "discord",
+        },
+      },
+      expectedFields: {
+        target: "channel:1507887702379335791",
+        to: "channel:1507887702379335791",
+      },
+      absentFields: ["channelId"],
+    },
+    {
+      input: {
+        action: "read",
+        args: {
+          channel: "discord",
           channelId: "channel:1507887702379335791",
           limit: 50,
         },
@@ -228,6 +261,38 @@ describe("normalizeMessageActionInput", () => {
       expectedFields: {
         target: "group:1507887702379335791",
         to: "group:1507887702379335791",
+      },
+      absentFields: ["channelId"],
+    },
+    {
+      input: {
+        action: "read",
+        args: {
+          channel: "telegram",
+          channelId: "-1001234567890:topic:77",
+          limit: 20,
+        },
+      },
+      expectedFields: {
+        target: "-1001234567890:topic:77",
+        to: "-1001234567890:topic:77",
+        limit: 20,
+      },
+      absentFields: ["channelId"],
+    },
+    {
+      input: {
+        action: "send",
+        args: {
+          channel: "telegram",
+          channelId: "group:-1001234567890:topic:77",
+          text: "hello",
+        },
+      },
+      expectedFields: {
+        target: "group:-1001234567890:topic:77",
+        to: "group:-1001234567890:topic:77",
+        text: "hello",
       },
       absentFields: ["channelId"],
     },

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -158,6 +158,79 @@ describe("normalizeMessageActionInput", () => {
       expectedFields: { target: "C123", channelId: "C123" },
       absentFields: ["to"],
     },
+    {
+      input: {
+        action: "channel-info",
+        args: {
+          channelId: "1507887702379335791",
+        },
+      },
+      expectedFields: {
+        target: "1507887702379335791",
+        channelId: "1507887702379335791",
+      },
+      absentFields: ["to"],
+    },
+    {
+      input: {
+        action: "read",
+        args: {
+          channel: "discord",
+          channelId: "1507887702379335791",
+          limit: 50,
+        },
+      },
+      expectedFields: {
+        target: "channel:1507887702379335791",
+        to: "channel:1507887702379335791",
+        limit: 50,
+      },
+      absentFields: ["channelId"],
+    },
+    {
+      input: {
+        action: "read",
+        args: {
+          channel: "discord",
+          channelId: "channel:1507887702379335791",
+          limit: 50,
+        },
+      },
+      expectedFields: {
+        target: "channel:1507887702379335791",
+        to: "channel:1507887702379335791",
+        limit: 50,
+      },
+      absentFields: ["channelId"],
+    },
+    {
+      input: {
+        action: "read",
+        args: {
+          channel: "discord",
+          channelId: "discord:channel:1507887702379335791",
+        },
+      },
+      expectedFields: {
+        target: "discord:channel:1507887702379335791",
+        to: "discord:channel:1507887702379335791",
+      },
+      absentFields: ["channelId"],
+    },
+    {
+      input: {
+        action: "read",
+        args: {
+          channel: "discord",
+          channelId: "group:1507887702379335791",
+        },
+      },
+      expectedFields: {
+        target: "group:1507887702379335791",
+        to: "group:1507887702379335791",
+      },
+      absentFields: ["channelId"],
+    },
   ] satisfies NormalizeMessageActionInputCase[])(
     "normalizes message action input for %j",
     ({ input, expectedFields, absentFields }) => {

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -20,12 +20,16 @@ function hasExplicitTargetPrefix(value: string): boolean {
 
 function normalizeLegacyChannelIdTarget(params: {
   action: ChannelMessageActionName;
+  channel: string;
   channelId: string;
 }): string {
   if (MESSAGE_ACTION_TARGET_MODE[params.action] !== "to") {
     return params.channelId;
   }
   if (hasExplicitTargetPrefix(params.channelId)) {
+    return params.channelId;
+  }
+  if (params.channel !== "discord") {
     return params.channelId;
   }
   return `channel:${params.channelId}`;
@@ -76,6 +80,7 @@ export function normalizeMessageActionInput(params: {
     } else if (legacyChannelId) {
       normalizedArgs.target = normalizeLegacyChannelIdTarget({
         action,
+        channel: inferredChannel,
         channelId: legacyChannelId,
       });
       delete normalizedArgs.to;

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -8,7 +8,28 @@ import {
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { applyTargetToParams } from "./channel-target.js";
-import { actionHasTarget, actionRequiresTarget } from "./message-action-spec.js";
+import {
+  actionHasTarget,
+  actionRequiresTarget,
+  MESSAGE_ACTION_TARGET_MODE,
+} from "./message-action-spec.js";
+
+function hasExplicitTargetPrefix(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function normalizeLegacyChannelIdTarget(params: {
+  action: ChannelMessageActionName;
+  channelId: string;
+}): string {
+  if (MESSAGE_ACTION_TARGET_MODE[params.action] !== "to") {
+    return params.channelId;
+  }
+  if (hasExplicitTargetPrefix(params.channelId)) {
+    return params.channelId;
+  }
+  return `channel:${params.channelId}`;
+}
 
 export function normalizeMessageActionInput(params: {
   action: ChannelMessageActionName;
@@ -48,9 +69,15 @@ export function normalizeMessageActionInput(params: {
   if (!explicitTarget && actionRequiresTarget(action) && hasLegacyTarget) {
     const legacyTo = normalizeOptionalString(normalizedArgs.to) ?? "";
     const legacyChannelId = normalizeOptionalString(normalizedArgs.channelId) ?? "";
-    const legacyTarget = legacyTo || legacyChannelId;
-    if (legacyTarget) {
-      normalizedArgs.target = legacyTarget;
+    if (legacyTo) {
+      normalizedArgs.target = legacyTo;
+      delete normalizedArgs.to;
+      delete normalizedArgs.channelId;
+    } else if (legacyChannelId) {
+      normalizedArgs.target = normalizeLegacyChannelIdTarget({
+        action,
+        channelId: legacyChannelId,
+      });
       delete normalizedArgs.to;
       delete normalizedArgs.channelId;
     }


### PR DESCRIPTION
## Summary
- Normalize legacy Discord `channelId` targets by converting bare ids on `to`-mode message actions to `channel:<id>`.
- Preserve explicitly-prefixed targets (`channel:`, `dm:`, `group:`, `thread:`, `user:`) and keep `channelId`-mode actions unchanged.
- Keep non-Discord legacy `channelId` values raw so provider-specific target grammars such as Telegram topics and group ids are not rewritten.

## Root Cause
The message-action normalizer accepted legacy `channelId` fields in places where newer outbound routing expects recipient-shaped targets. For Discord send/edit/delete style actions, a bare channel snowflake can be ambiguous unless it is normalized to an explicit `channel:` recipient. The first version of this PR applied that rewrite to all providers, which was too broad because non-Discord providers can use their own channel id grammar.

## Validation
- `node scripts/run-vitest.mjs run src/infra/outbound/message-action-normalization.test.ts`
  - Test Files: 1 passed
  - Tests: 22 passed
- `./node_modules/.bin/oxlint src/infra/outbound/message-action-normalization.ts src/infra/outbound/message-action-normalization.test.ts`
  - no warnings/errors
- `git diff --check`
  - clean

## Regression Coverage
- Discord `send` with legacy bare `channelId` now resolves to `channel:<id>`.
- Discord current-provider fallback still prefixes bare legacy channel ids.
- Telegram topic-style and group-prefixed legacy `channelId` values stay unchanged.

## Live Proof
Still pending: a live Discord send/edit/delete path against a staging gateway or controlled test channel.