### PR TITLE
fix #88537: [Bug]: tokenjuice - main Codex bash results are not compacted

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -16,7 +16,11 @@ import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "openclaw/plugin-sdk/hook-runtime";
-import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  createMockPluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CodexAppServerEventProjector,
@@ -99,11 +103,13 @@ async function createProjectorWithAssistantHooks() {
 beforeEach(() => {
   resetAgentEventsForTest();
   resetDiagnosticEventsForTest();
+  resetPluginRuntimeStateForTest();
 });
 
 afterEach(async () => {
   resetAgentEventsForTest();
   resetDiagnosticEventsForTest();
+  resetPluginRuntimeStateForTest();
   resetGlobalHookRunner();
   resetCodexRateLimitCacheForTests();
   vi.restoreAllMocks();
@@ -1540,6 +1546,83 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResultContentItem.toolName).toBe("bash");
     expect(toolResultContentItem.toolCallId).toBe("cmd-1");
     expect(toolResultContentItem.content).toBe("ok");
+  });
+
+  it("runs Codex-native bash transcript results through codex tool-result middleware", async () => {
+    const registry = createMockPluginRegistry([]);
+    const handler = vi.fn(async (event) => ({
+      result: {
+        content: [
+          {
+            type: "text" as const,
+            text: "[tokenjuice compacted bash output]\ncompact git status",
+          },
+        ],
+        details: {
+          ...(event.result.details as Record<string, unknown>),
+          tokenjuice: { compacted: true },
+        },
+      },
+    }));
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "tokenjuice",
+      pluginName: "Tokenjuice",
+      rawHandler: handler,
+      handler,
+      runtimes: ["codex"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-tokenjuice",
+          command: "git status",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "On branch main",
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: THREAD_ID,
+        turnId: TURN_ID,
+        toolCallId: "cmd-tokenjuice",
+        toolName: "bash",
+        args: { command: "git status", cwd: "/workspace" },
+        cwd: "/workspace",
+        isError: false,
+        result: expect.objectContaining({
+          content: [{ type: "text", text: "On branch main" }],
+          details: expect.objectContaining({
+            status: "completed",
+            exitCode: 0,
+            aggregated: "On branch main",
+            cwd: "/workspace",
+          }),
+        }),
+      }),
+      expect.objectContaining({ runtime: "codex" }),
+    );
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
+    const toolResultContent = requireArray(toolResultMessage.content, "tool result content");
+    const toolResultContentItem = requireRecord(toolResultContent[0], "tool result content item");
+    expect(toolResultContentItem.content).toBe(
+      "[tokenjuice compacted bash output]\ncompact git status",
+    );
+    const details = requireRecord(toolResultMessage.details, "tool result details");
+    expect(details.tokenjuice).toEqual({ compacted: true });
   });
 
   it("synthesizes native tool progress from turn completion snapshots", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1,5 +1,6 @@
 import {
   classifyAgentHarnessTerminalOutcome,
+  createAgentToolResultMiddlewareRunner,
   embeddedAgentLog,
   emitAgentEvent as emitGlobalAgentEvent,
   formatErrorMessage,
@@ -17,6 +18,7 @@ import {
   type HeartbeatToolResponse,
   type MessagingToolSend,
   type MessagingToolSourceReplyPayload,
+  type OpenClawAgentToolResult,
   type ToolProgressDetailMode,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
@@ -138,7 +140,10 @@ type ToolTranscriptResultInput = {
   id: string;
   name: string;
   text?: string;
+  args?: Record<string, unknown>;
+  cwd?: string;
   isError: boolean;
+  result?: OpenClawAgentToolResult;
 };
 
 export class CodexAppServerEventProjector {
@@ -190,6 +195,7 @@ export class CodexAppServerEventProjector {
   private guardianReviewCount = 0;
   private completedCompactionCount = 0;
   private latestRateLimits: JsonValue | undefined;
+  private toolResultMiddlewareRunner?: ReturnType<typeof createAgentToolResultMiddlewareRunner>;
 
   constructor(
     private readonly params: EmbeddedRunAttemptParams,
@@ -627,7 +633,7 @@ export class CodexAppServerEventProjector {
     this.emitStandardItemEvent({ phase: "end", item });
     this.emitNormalizedToolItemEvent({ phase: "result", item });
     this.recordNativeToolTranscriptCall(item);
-    this.recordNativeToolTranscriptResult(item);
+    await this.recordNativeToolTranscriptResult(item);
     this.emitToolResultSummary(item);
     this.emitToolResultOutput(item);
     this.emitAgentEvent({
@@ -731,7 +737,7 @@ export class CodexAppServerEventProjector {
       this.recordToolMeta(item);
       this.emitSnapshotOnlyNativeToolProgress(item);
       this.recordNativeToolTranscriptCall(item);
-      this.recordNativeToolTranscriptResult(item);
+      await this.recordNativeToolTranscriptResult(item);
       this.emitAfterToolCallObservation(item);
       this.emitToolResultSummary(item);
       this.emitToolResultOutput(item);
@@ -1363,7 +1369,7 @@ export class CodexAppServerEventProjector {
     });
   }
 
-  private recordNativeToolTranscriptResult(item: CodexThreadItem | undefined): void {
+  private async recordNativeToolTranscriptResult(item: CodexThreadItem | undefined): Promise<void> {
     if (!item || !shouldRecordNativeToolTranscript(item)) {
       return;
     }
@@ -1371,11 +1377,26 @@ export class CodexAppServerEventProjector {
     if (!name) {
       return;
     }
+    const text = itemTranscriptResultText(item, this.toolResultOutputTextByItem);
+    const isError = isNonSuccessItemStatus(itemStatus(item));
+    const args = itemToolArgs(item) ?? {};
+    const transcriptResult = await this.applyToolTranscriptResultMiddleware({
+      id: item.id,
+      name,
+      text,
+      args,
+      cwd: item.type === "commandExecution" && typeof item.cwd === "string" ? item.cwd : undefined,
+      isError,
+      result: createNativeToolTranscriptResult(item, text, isError),
+    });
     this.recordToolTranscriptResult({
       id: item.id,
       name,
-      text: itemTranscriptResultText(item, this.toolResultOutputTextByItem),
-      isError: isNonSuccessItemStatus(itemStatus(item)),
+      text,
+      args,
+      cwd: item.type === "commandExecution" && typeof item.cwd === "string" ? item.cwd : undefined,
+      isError,
+      result: transcriptResult,
     });
   }
 
@@ -1411,6 +1432,35 @@ export class CodexAppServerEventProjector {
         `${this.turnId}:tool:${params.id}:result`,
       ),
     );
+  }
+
+  private async applyToolTranscriptResultMiddleware(
+    params: ToolTranscriptResultInput,
+  ): Promise<OpenClawAgentToolResult> {
+    const result = params.result ?? createTextToolTranscriptResult(params);
+    return await this.nativeToolResultMiddlewareRunner().applyToolResultMiddleware({
+      threadId: this.threadId,
+      turnId: this.turnId,
+      toolCallId: params.id,
+      toolName: params.name,
+      args: params.args ?? {},
+      ...(params.cwd ? { cwd: params.cwd } : {}),
+      isError: params.isError,
+      result,
+    });
+  }
+
+  private nativeToolResultMiddlewareRunner(): ReturnType<
+    typeof createAgentToolResultMiddlewareRunner
+  > {
+    this.toolResultMiddlewareRunner ??= createAgentToolResultMiddlewareRunner({
+      runtime: "codex",
+      agentId: this.params.agentId,
+      sessionId: this.params.sessionId,
+      sessionKey: this.params.sessionKey,
+      runId: this.params.runId,
+    });
+    return this.toolResultMiddlewareRunner;
   }
 
   private emitTranscriptToolCallProgress(params: ToolTranscriptCallInput): void {
@@ -1610,7 +1660,8 @@ export class CodexAppServerEventProjector {
   }
 
   private createToolResultMessage(params: ToolTranscriptResultInput): AgentMessage {
-    const text = truncateToolTranscriptText(params.text?.trim() || toolResultStatusText(params));
+    const result = params.result ?? createTextToolTranscriptResult(params);
+    const text = toolTranscriptTextFromResult(result) ?? toolResultStatusText(params);
     return {
       role: "toolResult",
       toolCallId: params.id,
@@ -1629,6 +1680,7 @@ export class CodexAppServerEventProjector {
           text,
         },
       ],
+      details: result.details,
       timestamp: Date.now(),
     } as unknown as AgentMessage;
   }
@@ -2221,6 +2273,65 @@ function normalizeToolTranscriptArguments(value: unknown): Record<string, unknow
     return {};
   }
   return value as Record<string, unknown>;
+}
+
+function createNativeToolTranscriptResult(
+  item: CodexThreadItem,
+  text: string | undefined,
+  isError: boolean,
+): OpenClawAgentToolResult {
+  return createTextToolTranscriptResult({
+    id: item.id,
+    name: itemName(item) ?? "tool",
+    text,
+    isError,
+    result: {
+      content: [],
+      details: nativeToolTranscriptDetails(item, text),
+    },
+  });
+}
+
+function nativeToolTranscriptDetails(
+  item: CodexThreadItem,
+  text: string | undefined,
+): Record<string, unknown> {
+  const details = itemToolResult(item).result ?? { status: itemStatus(item) };
+  if (item.type !== "commandExecution") {
+    return details;
+  }
+  return sanitizeCodexAgentEventRecord({
+    ...details,
+    status: itemStatus(item),
+    aggregated: truncateToolTranscriptText(
+      text?.trim() ||
+        toolResultStatusText({
+          id: item.id,
+          name: "bash",
+          isError: isNonSuccessItemStatus(itemStatus(item)),
+        }),
+    ),
+    ...(typeof item.cwd === "string" ? { cwd: item.cwd } : {}),
+  });
+}
+
+function createTextToolTranscriptResult(
+  params: ToolTranscriptResultInput,
+): OpenClawAgentToolResult {
+  const text = truncateToolTranscriptText(params.text?.trim() || toolResultStatusText(params));
+  const details = params.result?.details ?? { status: params.isError ? "failed" : "completed" };
+  return {
+    content: [{ type: "text", text }],
+    details,
+  };
+}
+
+function toolTranscriptTextFromResult(result: OpenClawAgentToolResult): string | undefined {
+  const text = result.content
+    .flatMap((entry) => (entry.type === "text" && entry.text.trim() ? [entry.text] : []))
+    .join("\n")
+    .trim();
+  return text ? truncateToolTranscriptText(text) : undefined;
 }
 
 function collectDynamicToolContentText(contentItems: CodexThreadItem["contentItems"]): string {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1438,7 +1438,7 @@ export class CodexAppServerEventProjector {
     params: ToolTranscriptResultInput,
   ): Promise<OpenClawAgentToolResult> {
     const result = params.result ?? createTextToolTranscriptResult(params);
-    return await this.nativeToolResultMiddlewareRunner().applyToolResultMiddleware({
+    return this.nativeToolResultMiddlewareRunner().applyToolResultMiddleware({
       threadId: this.threadId,
       turnId: this.turnId,
       toolCallId: params.id,


### PR DESCRIPTION
## Summary

- Fixes #88537.
- Routes Codex-native `commandExecution` transcript results through the existing codex agent tool-result middleware before mirrored session persistence.
- Normalizes native bash transcript results with exec-style details (`status`, `exitCode`, `aggregated`, `cwd`) so TokenJuice can compact real `main`/Codex bash output on the same contract used by dynamic tools.
- Keeps dynamic OpenClaw tool transcript recording synchronous and unchanged.

## Root Cause

- Root cause: The Codex native transcript projector violated the codex tool-result middleware contract because it persisted `commandExecution`/`bash` tool results directly from text, without exec-style `details` and without running codex tool-result middleware.
- Why this is root-cause fix: This patch fixes the boundary that produced the bad transcript shape by constructing the existing `OpenClawAgentToolResult` shape for native transcript results and applying `createAgentToolResultMiddlewareRunner({ runtime: "codex" })` before the mirrored transcript message is stored. TokenJuice is not special-cased; it now receives the same middleware contract as other codex tool-result middleware.
- Fix classification: Root cause fix
- Maintainer-ready confidence: High
- Patch quality notes: Reuses the existing codex tool-result middleware runner instead of adding a TokenJuice-specific fallback; adds regression coverage at the transcript projection boundary; avoids changing dynamic tool transcript recording semantics. Round 2 only rebased onto latest `origin/main` to pick up unrelated CI repairs, with the PR diff preserved.
- Target test file: `extensions/codex/src/app-server/event-projector.test.ts`

## Real behavior proof

- Behavior or issue addressed: Codex-native `commandExecution` transcript results now enter the codex agent tool-result middleware with exec-style details before being persisted to the mirrored session transcript.
- Real environment tested: local OpenClaw source worktree on Linux with hydrated dependencies. The after-fix boundary proof directly instantiated the current-source Codex app-server event projector and registered the actual bundled TokenJuice tool-result middleware.
- Exact steps or command run after this patch:

```bash
node --import tsx "$EVIDENCE_DIR/codex-native-tokenjuice-proof.mjs" | tee "$EVIDENCE_DIR/codex-native-tokenjuice-proof.out"
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts src/agents/harness/tool-result-middleware.test.ts extensions/tokenjuice/index.test.ts src/agents/codex-app-server.extensions.test.ts
pnpm lint --threads=8
pnpm check:test-types
```

- Evidence after fix: copied terminal output from the real boundary proof command:

```json
{
  "ok": true,
  "contentText": "working tree clean\n\n[tokenjuice compacted bash output]",
  "tokenjuice": {
    "compacted": true,
    "rawChars": 97,
    "reducedChars": 18,
    "savedChars": 79,
    "reducer": "git/status"
  },
  "status": "completed",
  "exitCode": 0,
  "cwdPresent": true,
  "aggregatedPresent": true
}
```

Additional regression coverage also passed: `src/agents/harness/tool-result-middleware.test.ts` (20 tests), `src/agents/codex-app-server.extensions.test.ts` (10 tests), `extensions/codex/src/app-server/event-projector.test.ts` (77 tests), and `extensions/tokenjuice/index.test.ts` (2 tests). After rebasing onto latest `origin/main`, `pnpm lint --threads=8` and `pnpm check:test-types` also passed locally.
- Observed result after fix: the current-source Codex projector persisted a native `bash` tool result after the actual TokenJuice middleware compacted it; the observed terminal output shows the compacted marker, `details.tokenjuice.compacted: true`, `reducer: git/status`, `status: completed`, `exitCode: 0`, `cwdPresent: true`, and `aggregatedPresent: true`.
- What was not tested: a live `openclaw agent --agent main` run against an external model was not run in this environment; the Codex transcript projection boundary and actual TokenJuice middleware integration were exercised directly without external model credentials.

## Regression Test Plan

- `node --import tsx "$EVIDENCE_DIR/codex-native-tokenjuice-proof.mjs" | tee "$EVIDENCE_DIR/codex-native-tokenjuice-proof.out"`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts src/agents/harness/tool-result-middleware.test.ts extensions/tokenjuice/index.test.ts src/agents/codex-app-server.extensions.test.ts`
- `pnpm lint --threads=8`
- `pnpm check:test-types`
