### PR TITLE
Fix outbound registry fallback for pinned channels

### DIFF
--- a/extensions/minimax/provider-http.test-helpers.ts
+++ b/extensions/minimax/provider-http.test-helpers.ts
@@ -1,9 +1,28 @@
 import type { resolveProviderHttpRequestConfig } from "openclaw/plugin-sdk/provider-http";
-import { afterEach, vi } from "vitest";
+import { afterEach, vi, type Mock } from "vitest";
 
 type ResolveProviderHttpRequestConfigParams = Parameters<
   typeof resolveProviderHttpRequestConfig
 >[0];
+
+type ResolveProviderHttpRequestConfigResult = {
+  baseUrl: string;
+  allowPrivateNetwork: boolean;
+  headers: Headers;
+  dispatcherPolicy: undefined;
+};
+
+type AnyMock = Mock<(...args: any[]) => any>;
+
+interface MinimaxProviderHttpMocks {
+  resolveApiKeyForProviderMock: Mock<() => Promise<{ apiKey: string }>>;
+  postJsonRequestMock: AnyMock;
+  fetchWithTimeoutMock: AnyMock;
+  assertOkOrThrowHttpErrorMock: Mock<() => Promise<void>>;
+  resolveProviderHttpRequestConfigMock: Mock<
+    (params: ResolveProviderHttpRequestConfigParams) => ResolveProviderHttpRequestConfigResult
+  >;
+}
 
 const minimaxProviderHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
@@ -42,7 +61,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   waitProviderOperationPollInterval: async () => {},
 }));
 
-export function getMinimaxProviderHttpMocks() {
+export function getMinimaxProviderHttpMocks(): MinimaxProviderHttpMocks {
   return minimaxProviderHttpMocks;
 }
 

--- a/extensions/minimax/provider-http.test-helpers.ts
+++ b/extensions/minimax/provider-http.test-helpers.ts
@@ -1,4 +1,9 @@
-import type { resolveProviderHttpRequestConfig } from "openclaw/plugin-sdk/provider-http";
+import type {
+  assertOkOrThrowHttpError,
+  fetchWithTimeout,
+  postJsonRequest,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
 import { afterEach, vi, type Mock } from "vitest";
 
 type ResolveProviderHttpRequestConfigParams = Parameters<
@@ -12,13 +17,23 @@ type ResolveProviderHttpRequestConfigResult = {
   dispatcherPolicy: undefined;
 };
 
-type AnyMock = Mock<(...args: any[]) => any>;
+type PostJsonRequestMock = Mock<
+  (params: Parameters<typeof postJsonRequest>[0]) => Promise<unknown>
+>;
+type FetchWithTimeoutMock = Mock<
+  (
+    url: Parameters<typeof fetchWithTimeout>[0],
+    init: Parameters<typeof fetchWithTimeout>[1],
+    timeoutMs: Parameters<typeof fetchWithTimeout>[2],
+    fetchFn?: Parameters<typeof fetchWithTimeout>[3],
+  ) => Promise<unknown>
+>;
 
 interface MinimaxProviderHttpMocks {
   resolveApiKeyForProviderMock: Mock<() => Promise<{ apiKey: string }>>;
-  postJsonRequestMock: AnyMock;
-  fetchWithTimeoutMock: AnyMock;
-  assertOkOrThrowHttpErrorMock: Mock<() => Promise<void>>;
+  postJsonRequestMock: PostJsonRequestMock;
+  fetchWithTimeoutMock: FetchWithTimeoutMock;
+  assertOkOrThrowHttpErrorMock: Mock<typeof assertOkOrThrowHttpError>;
   resolveProviderHttpRequestConfigMock: Mock<
     (params: ResolveProviderHttpRequestConfigParams) => ResolveProviderHttpRequestConfigResult
   >;
@@ -26,9 +41,19 @@ interface MinimaxProviderHttpMocks {
 
 const minimaxProviderHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
-  postJsonRequestMock: vi.fn(),
-  fetchWithTimeoutMock: vi.fn(),
-  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  postJsonRequestMock: vi.fn<(params: Parameters<typeof postJsonRequest>[0]) => Promise<unknown>>(),
+  fetchWithTimeoutMock:
+    vi.fn<
+      (
+        url: Parameters<typeof fetchWithTimeout>[0],
+        init: Parameters<typeof fetchWithTimeout>[1],
+        timeoutMs: Parameters<typeof fetchWithTimeout>[2],
+        fetchFn?: Parameters<typeof fetchWithTimeout>[3],
+      ) => Promise<unknown>
+    >(),
+  assertOkOrThrowHttpErrorMock: vi.fn<typeof assertOkOrThrowHttpError>(
+    async (_response: Response, _label: string) => {},
+  ),
   resolveProviderHttpRequestConfigMock: vi.fn((params: ResolveProviderHttpRequestConfigParams) => ({
     baseUrl: params.baseUrl ?? params.defaultBaseUrl,
     allowPrivateNetwork: false,

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,5 @@
 import type { PluginChannelRegistration } from "../../plugins/registry-types.js";
-import { getActivePluginChannelRegistry } from "../../plugins/runtime.js";
+import { getActivePluginChannelRegistry, getActivePluginRegistry } from "../../plugins/runtime.js";
 import type { ChannelId } from "./channel-id.types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -10,11 +10,24 @@ export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginChannelRegistry();
-    const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
-    if (!pluginEntry) {
-      return undefined;
+    const resolveFromRegistry = (
+      registry: ReturnType<typeof getActivePluginRegistry>,
+    ): TValue | undefined => {
+      const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
+      return pluginEntry ? resolveValue(pluginEntry) : undefined;
+    };
+
+    const channelRegistry = getActivePluginChannelRegistry();
+    const channelValue = resolveFromRegistry(channelRegistry);
+    if (channelValue !== undefined) {
+      return channelValue;
     }
-    return resolveValue(pluginEntry);
+
+    const activeRegistry = getActivePluginRegistry();
+    if (activeRegistry && activeRegistry !== channelRegistry) {
+      return resolveFromRegistry(activeRegistry);
+    }
+
+    return undefined;
   };
 }

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -6,26 +6,32 @@ type ChannelRegistryValueResolver<TValue> = (
   entry: PluginChannelRegistration,
 ) => TValue | undefined;
 
+type ChannelRegistryLookup<TValue> = { found: true; value: TValue | undefined } | { found: false };
+
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
   return async (id: ChannelId): Promise<TValue | undefined> => {
     const resolveFromRegistry = (
       registry: ReturnType<typeof getActivePluginRegistry>,
-    ): TValue | undefined => {
+    ): ChannelRegistryLookup<TValue> => {
       const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
-      return pluginEntry ? resolveValue(pluginEntry) : undefined;
+      return pluginEntry ? { found: true, value: resolveValue(pluginEntry) } : { found: false };
     };
 
     const channelRegistry = getActivePluginChannelRegistry();
-    const channelValue = resolveFromRegistry(channelRegistry);
-    if (channelValue !== undefined) {
-      return channelValue;
+    const channelResult = resolveFromRegistry(channelRegistry);
+    if (!channelResult.found) {
+      return undefined;
+    }
+    if (channelResult.value !== undefined) {
+      return channelResult.value;
     }
 
     const activeRegistry = getActivePluginRegistry();
     if (activeRegistry && activeRegistry !== channelRegistry) {
-      return resolveFromRegistry(activeRegistry);
+      const activeResult = resolveFromRegistry(activeRegistry);
+      return activeResult.found ? activeResult.value : undefined;
     }
 
     return undefined;

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -8,11 +8,16 @@ import { createHookRunner } from "../../plugins/hooks.js";
 import { addTestHook } from "../../plugins/hooks.test-helpers.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry.js";
 import {
+  pinActivePluginChannelRegistry,
   releasePinnedPluginChannelRegistry,
   setActivePluginRegistry,
 } from "../../plugins/runtime.js";
 import type { PluginHookRegistration } from "../../plugins/types.js";
-import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createOutboundTestPlugin,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
 import {
   onInternalDiagnosticEvent,
@@ -369,6 +374,43 @@ describe("deliverOutboundPayloads", () => {
     expect(
       JSON.stringify(events.filter((event) => event.type.startsWith("message.delivery."))),
     ).not.toContain("secret delivery body");
+  });
+
+  it("delivers through full active plugin when pinned setup channel has no sender", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+    const setupRegistry = createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "setup",
+        plugin: createChannelTestPluginBase({ id: "matrix" }),
+      },
+    ]);
+    const runtimeRegistry = createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "runtime",
+        plugin: createOutboundTestPlugin({ id: "matrix", outbound: matrixOutboundForTest }),
+      },
+    ]);
+
+    setActivePluginRegistry(setupRegistry);
+    pinActivePluginChannelRegistry(setupRegistry);
+    setActivePluginRegistry(runtimeRegistry);
+
+    const results = await deliverOutboundPayloads({
+      cfg: matrixChunkConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello from queue" }],
+      deps: { matrix: sendMatrix },
+    });
+
+    expect(sendMatrix).toHaveBeenCalledWith("!room:example", "hello from queue", {
+      cfg: matrixChunkConfig,
+      accountId: undefined,
+      gifPlayback: undefined,
+    });
+    expect(results).toEqual([{ channel: "matrix", messageId: "m1", roomId: "!room:example" }]);
   });
 
   it("keeps requester session channel authoritative for delivery media policy", async () => {

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -1,4 +1,4 @@
-import { afterEach, vi } from "vitest";
+import { afterEach, vi, type Mock } from "vitest";
 import type {
   pollProviderOperationJson,
   resolveProviderHttpRequestConfig,
@@ -12,6 +12,32 @@ type PollProviderOperationJsonParams = Parameters<typeof pollProviderOperationJs
 type SanitizeConfiguredModelProviderRequestParams = Parameters<
   typeof sanitizeConfiguredModelProviderRequest
 >[0];
+
+type ResolveProviderHttpRequestConfigResult = {
+  baseUrl: string;
+  allowPrivateNetwork: boolean;
+  headers: Headers;
+  dispatcherPolicy: undefined;
+};
+
+type AnyMock = Mock<(...args: any[]) => any>;
+
+interface ProviderHttpMocks {
+  resolveApiKeyForProviderMock: Mock<() => Promise<{ apiKey: string }>>;
+  postJsonRequestMock: AnyMock;
+  fetchWithTimeoutMock: AnyMock;
+  pollProviderOperationJsonMock: AnyMock;
+  assertOkOrThrowHttpErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
+  assertOkOrThrowProviderErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
+  sanitizeConfiguredModelProviderRequestMock: Mock<
+    (
+      request: SanitizeConfiguredModelProviderRequestParams,
+    ) => SanitizeConfiguredModelProviderRequestParams
+  >;
+  resolveProviderHttpRequestConfigMock: Mock<
+    (params: ResolveProviderHttpRequestConfigParams) => ResolveProviderHttpRequestConfigResult
+  >;
+}
 
 const providerHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
@@ -85,7 +111,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   waitProviderOperationPollInterval: async () => {},
 }));
 
-export function getProviderHttpMocks() {
+export function getProviderHttpMocks(): ProviderHttpMocks {
   return providerHttpMocks;
 }
 

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -1,6 +1,10 @@
 import { afterEach, vi, type Mock } from "vitest";
 import type {
+  assertOkOrThrowHttpError,
+  assertOkOrThrowProviderError,
+  fetchWithTimeout,
   pollProviderOperationJson,
+  postJsonRequest,
   resolveProviderHttpRequestConfig,
   sanitizeConfiguredModelProviderRequest,
 } from "../provider-http.js";
@@ -20,15 +24,28 @@ type ResolveProviderHttpRequestConfigResult = {
   dispatcherPolicy: undefined;
 };
 
-type AnyMock = Mock<(...args: any[]) => any>;
+type PostJsonRequestMock = Mock<
+  (params: Parameters<typeof postJsonRequest>[0]) => Promise<unknown>
+>;
+type FetchWithTimeoutMock = Mock<
+  (
+    url: Parameters<typeof fetchWithTimeout>[0],
+    init: Parameters<typeof fetchWithTimeout>[1],
+    timeoutMs: Parameters<typeof fetchWithTimeout>[2],
+    fetchFn?: Parameters<typeof fetchWithTimeout>[3],
+  ) => Promise<unknown>
+>;
+type PollProviderOperationJsonMock = Mock<
+  (params: PollProviderOperationJsonParams) => Promise<unknown>
+>;
 
 interface ProviderHttpMocks {
   resolveApiKeyForProviderMock: Mock<() => Promise<{ apiKey: string }>>;
-  postJsonRequestMock: AnyMock;
-  fetchWithTimeoutMock: AnyMock;
-  pollProviderOperationJsonMock: AnyMock;
-  assertOkOrThrowHttpErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
-  assertOkOrThrowProviderErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
+  postJsonRequestMock: PostJsonRequestMock;
+  fetchWithTimeoutMock: FetchWithTimeoutMock;
+  pollProviderOperationJsonMock: PollProviderOperationJsonMock;
+  assertOkOrThrowHttpErrorMock: Mock<typeof assertOkOrThrowHttpError>;
+  assertOkOrThrowProviderErrorMock: Mock<typeof assertOkOrThrowProviderError>;
   sanitizeConfiguredModelProviderRequestMock: Mock<
     (
       request: SanitizeConfiguredModelProviderRequestParams,
@@ -41,11 +58,24 @@ interface ProviderHttpMocks {
 
 const providerHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
-  postJsonRequestMock: vi.fn(),
-  fetchWithTimeoutMock: vi.fn(),
-  pollProviderOperationJsonMock: vi.fn(),
-  assertOkOrThrowHttpErrorMock: vi.fn(async (_response: Response, _label: string) => {}),
-  assertOkOrThrowProviderErrorMock: vi.fn(async (_response: Response, _label: string) => {}),
+  postJsonRequestMock: vi.fn<(params: Parameters<typeof postJsonRequest>[0]) => Promise<unknown>>(),
+  fetchWithTimeoutMock:
+    vi.fn<
+      (
+        url: Parameters<typeof fetchWithTimeout>[0],
+        init: Parameters<typeof fetchWithTimeout>[1],
+        timeoutMs: Parameters<typeof fetchWithTimeout>[2],
+        fetchFn?: Parameters<typeof fetchWithTimeout>[3],
+      ) => Promise<unknown>
+    >(),
+  pollProviderOperationJsonMock:
+    vi.fn<(params: PollProviderOperationJsonParams) => Promise<unknown>>(),
+  assertOkOrThrowHttpErrorMock: vi.fn<typeof assertOkOrThrowHttpError>(
+    async (_response: Response, _label: string) => {},
+  ),
+  assertOkOrThrowProviderErrorMock: vi.fn<typeof assertOkOrThrowProviderError>(
+    async (_response: Response, _label: string) => {},
+  ),
   sanitizeConfiguredModelProviderRequestMock: vi.fn(
     (request: SanitizeConfiguredModelProviderRequestParams) => request,
   ),
@@ -60,7 +90,7 @@ const providerHttpMocks = vi.hoisted(() => ({
 providerHttpMocks.pollProviderOperationJsonMock.mockImplementation(
   async (params: PollProviderOperationJsonParams) => {
     for (let attempt = 0; attempt < params.maxAttempts; attempt += 1) {
-      const response = await providerHttpMocks.fetchWithTimeoutMock(
+      const response = (await providerHttpMocks.fetchWithTimeoutMock(
         params.url,
         {
           method: "GET",
@@ -68,7 +98,7 @@ providerHttpMocks.pollProviderOperationJsonMock.mockImplementation(
         },
         params.defaultTimeoutMs,
         params.fetchFn,
-      );
+      )) as Response;
       await providerHttpMocks.assertOkOrThrowHttpErrorMock(response, params.requestFailedMessage);
       const payload = await response.json();
       if (params.isComplete(payload)) {

--- a/src/plugins/runtime.channel-pin.test.ts
+++ b/src/plugins/runtime.channel-pin.test.ts
@@ -196,4 +196,31 @@ describe("channel registry pinning", () => {
     const adapter = await loadChannelOutboundAdapter("telegram");
     expect(adapter).toBe(outboundAdapter);
   });
+
+  it("loadChannelOutboundAdapter falls back to active registry when pinned setup entry cannot send", async () => {
+    const outboundAdapter = { sendText: async () => ({ messageId: "1" }) };
+    const startup = createEmptyPluginRegistry();
+    startup.channels = [
+      {
+        pluginId: "telegram",
+        plugin: { id: "telegram", meta: {} },
+        source: "setup",
+      },
+    ] as never;
+    const replacement = createEmptyPluginRegistry();
+    replacement.channels = [
+      {
+        pluginId: "telegram",
+        plugin: { id: "telegram", meta: {}, outbound: outboundAdapter },
+        source: "runtime",
+      },
+    ] as never;
+
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+    setActivePluginRegistry(replacement);
+
+    const adapter = await loadChannelOutboundAdapter("telegram");
+    expect(adapter).toBe(outboundAdapter);
+  });
 });

--- a/src/plugins/runtime.channel-pin.test.ts
+++ b/src/plugins/runtime.channel-pin.test.ts
@@ -223,4 +223,23 @@ describe("channel registry pinning", () => {
     const adapter = await loadChannelOutboundAdapter("telegram");
     expect(adapter).toBe(outboundAdapter);
   });
+
+  it("loadChannelOutboundAdapter does not fall back when pinned registry lacks the channel", async () => {
+    const outboundAdapter = { sendText: async () => ({ messageId: "1" }) };
+    const startup = createEmptyPluginRegistry();
+    const replacement = createEmptyPluginRegistry();
+    replacement.channels = [
+      {
+        pluginId: "telegram",
+        plugin: { id: "telegram", meta: {}, outbound: outboundAdapter },
+        source: "runtime",
+      },
+    ] as never;
+
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+    setActivePluginRegistry(replacement);
+
+    await expect(loadChannelOutboundAdapter("telegram")).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- fall back to the active plugin registry when a pinned setup channel entry has no outbound adapter
- add regressions for pinned setup/no-sender plus runtime active/sender delivery
- backport provider HTTP mock type annotations needed for declaration builds

## Validation
- git diff --check
- pnpm format:check -- extensions/minimax/provider-http.test-helpers.ts src/channels/plugins/registry-loader.ts src/infra/outbound/deliver.test.ts src/plugin-sdk/test-helpers/provider-http-mocks.ts src/plugins/runtime.channel-pin.test.ts
- node scripts/run-vitest.mjs src/plugins/runtime.channel-pin.test.ts src/infra/outbound/deliver.test.ts
- pnpm tsgo
- pnpm check:test-types
- pnpm build

Full pnpm test was also run; it completed with unrelated failures in run-opengrep.sh Bash portability, GPT-5 transport contract expectations, one memory CLI fixture, and one QA lab timeout. Telegram extension tests passed.

## Real behavior proof

- **Behavior or issue addressed**: Telegram/outbound channel loading falls back from a pinned setup channel entry with no outbound adapter to the active runtime plugin that can send, while preserving pin isolation when the pinned registry does not contain that channel.
- **Real environment tested**: Local OpenClaw source runtime in `/Users/pedro/Projects/openclaw-port-v2026.5.2` after building this PR branch.
- **Exact steps or command run after this patch**: `node --import tsx --input-type=module` with source runtime imports for `loadChannelOutboundAdapter`, `createEmptyPluginRegistry`, and plugin runtime pinning APIs.
- **Evidence after fix**: Terminal output from the runtime command:

```json
{
  "sourceRuntime": true,
  "pinnedSetupMissingOutboundFallsBack": true,
  "pinnedRegistryLacksChannelStaysHidden": true
}
```

- **Observed result after fix**: The setup-pinned/no-outbound case resolves the active runtime outbound adapter, and the pinned-registry-missing-channel case remains hidden instead of leaking the active registry.
- **What was not tested**: No live Telegram bot token or VPS deployment was used in this PR validation.