### PR TITLE
Fix silent internal aborts after tool-use turns

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -30,7 +30,7 @@ import {
   resolvePlanningOnlyRetryLimit,
   resolvePlanningOnlyRetryInstruction,
   isIncompleteTerminalAssistantTurn,
-  resolveIncompleteTurnPayloadText,
+  resolveIncompleteTurnPayloadText as resolveIncompleteTurnPayloadTextCore,
   resolveReasoningOnlyRetryInstruction,
   STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
@@ -42,6 +42,14 @@ import {
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
+
+function resolveIncompleteTurnPayloadText(
+  params: Omit<Parameters<typeof resolveIncompleteTurnPayloadTextCore>[0], "externalAbort"> & {
+    externalAbort?: boolean;
+  },
+): string | null {
+  return resolveIncompleteTurnPayloadTextCore({ externalAbort: false, ...params });
+}
 
 describe("runEmbeddedAgent incomplete-turn safety", () => {
   beforeAll(async () => {
@@ -127,6 +135,38 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(mockedClassifyFailoverReason).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("verify before retrying");
+  });
+
+  it("surfaces internal aborts after tool-use as visible incomplete-turn failures", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        aborted: true,
+        externalAbort: false,
+        assistantTexts: [],
+        toolMetas: [{ toolName: "web_search", meta: "query=next voice note" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-internal-abort-tool-use-incomplete",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads).toEqual([
+      { text: "⚠️ Agent couldn't generate a response. Please try again.", isError: true },
+    ]);
+    expect(result.meta?.livenessState).toBe("abandoned");
   });
 
   it("synthesizes a silent cron payload from a trailing current-attempt NO_REPLY tool result", () => {
@@ -1305,11 +1345,22 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const explicitCancellationText = resolveIncompleteTurnPayloadText({
       payloadCount: interruptedToolOnlyAttempt.assistantTexts.length,
       aborted: true,
+      externalAbort: true,
       timedOut: false,
       attempt: interruptedToolOnlyAttempt,
     });
 
     expect(explicitCancellationText).toBeNull();
+
+    const internalAbortText = resolveIncompleteTurnPayloadText({
+      payloadCount: interruptedToolOnlyAttempt.assistantTexts.length,
+      aborted: true,
+      externalAbort: false,
+      timedOut: false,
+      attempt: interruptedToolOnlyAttempt,
+    });
+
+    expect(internalAbortText).toContain("couldn't generate a response");
   });
 
   it("allows a same-prompt retry only for replay-safe missing assistant turns", () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3208,6 +3208,7 @@ export async function runEmbeddedAgent(
             : resolveIncompleteTurnPayloadText({
                 payloadCount,
                 aborted,
+                externalAbort,
                 timedOut,
                 attempt,
               });

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
@@ -11,6 +11,7 @@ function baseParams(
 ): ResolveAttemptTrajectoryTerminalParams {
   return {
     aborted: false,
+    externalAbort: false,
     timedOut: false,
     assistantTexts: [],
     toolMetas: [],
@@ -177,6 +178,21 @@ describe("attempt trajectory status", () => {
     ).toEqual({ status: "success" });
   });
 
+  it("marks internally aborted tool-use attempts without delivery as non-deliverable", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          aborted: true,
+          toolMetas: [{ toolName: "web_search" }],
+          lastAssistantStopReason: "toolUse",
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
   it("keeps async-started media tool-use attempts as terminal progress", () => {
     expect(
       resolveAttemptTrajectoryTerminal(
@@ -193,6 +209,11 @@ describe("attempt trajectory status", () => {
       resolveAttemptTrajectoryTerminal(baseParams({ promptError: new Error("boom") })),
     ).toEqual({ status: "error" });
     expect(resolveAttemptTrajectoryTerminal(baseParams({ timedOut: true }))).toEqual({
+      status: "interrupted",
+    });
+    expect(
+      resolveAttemptTrajectoryTerminal(baseParams({ aborted: true, externalAbort: true })),
+    ).toEqual({
       status: "interrupted",
     });
   });

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
@@ -15,6 +15,7 @@ export type AttemptTrajectoryTerminal = {
 export type ResolveAttemptTrajectoryTerminalParams = {
   promptError?: unknown;
   aborted: boolean;
+  externalAbort: boolean;
   timedOut: boolean;
   assistantTexts: string[];
   toolMetas: Array<{ toolName: string; meta?: string; asyncStarted?: boolean }>;
@@ -81,7 +82,7 @@ export function resolveAttemptTrajectoryTerminal(
   if (params.promptError) {
     return { status: "error" };
   }
-  if (params.aborted || params.timedOut) {
+  if ((params.aborted && params.externalAbort) || params.timedOut) {
     return { status: "interrupted" };
   }
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3100,6 +3100,10 @@ export async function runEmbeddedAttempt(
         }
       };
 
+      const abortActiveRunExternally = () => {
+        externalAbort = true;
+        abortRun();
+      };
       const queueHandle: EmbeddedAgentQueueHandle & {
         kind: "embedded";
         cancel: (reason?: "user_abort" | "restart" | "superseded") => void;
@@ -3115,10 +3119,8 @@ export async function runEmbeddedAttempt(
         isCompacting: () => subscription.isCompacting(),
         supportsTranscriptCommitWait: true,
         sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-        cancel: () => {
-          abortRun();
-        },
-        abort: abortRun,
+        cancel: abortActiveRunExternally,
+        abort: abortActiveRunExternally,
       };
       let lastAssistant: AssistantMessage | undefined;
       let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4658,6 +4658,7 @@ export async function runEmbeddedAttempt(
       const attemptTrajectoryTerminal = resolveAttemptTrajectoryTerminal({
         promptError,
         aborted,
+        externalAbort,
         timedOut,
         assistantTexts: terminalAssistantTexts,
         toolMetas: toolMetasNormalized,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -243,6 +243,7 @@ export function resolveAttemptReplayMetadata(attempt: {
 export function resolveIncompleteTurnPayloadText(params: {
   payloadCount: number;
   aborted: boolean;
+  externalAbort: boolean;
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): string | null {
@@ -255,7 +256,7 @@ export function resolveIncompleteTurnPayloadText(params: {
 
   if (
     (params.payloadCount !== 0 && !toolUseTerminal) ||
-    params.aborted ||
+    (params.aborted && params.externalAbort) ||
     params.timedOut ||
     params.attempt.clientToolCalls ||
     params.attempt.yieldDetected ||


### PR DESCRIPTION
## Summary
- Distinguish internal runner aborts from explicit external/user cancellations.
- Mark internally aborted tool-use turns with no committed delivery as non-deliverable instead of silently interrupted.
- Keep explicit active-run aborts on the existing cancellation path.

## Verification
- Regression proof: the new terminal-status test failed before the fix with `received { status: "interrupted" }`; after the fix it passes as `error/non_deliverable_terminal_turn`.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts src/auto-reply/reply/agent-runner-execution.test.ts --reporter=verbose` — 3 shards, 289 tests passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean before final rebase; final rebase was conflict-free and the focused tests above were rerun after it.
- `git diff --check origin/main...HEAD`

## Real behavior proof
Behavior addressed: internally aborted embedded agent turns after tool use no longer disappear as successful silent interruptions.
Real environment tested: local Vitest runner against embedded-agent and auto-reply boundaries.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts src/auto-reply/reply/agent-runner-execution.test.ts --reporter=verbose`
Evidence after fix: regression covers an internally aborted tool-use turn with no delivery; runner integration returns visible incomplete-turn error payload instead of no payload.
Observed result after fix: 3 shards, 289 tests passed.
What was not tested: live Telegram voice-note E2E.
