### PR TITLE
fix(agents): strip redundant anthropic/ self-prefix in static model id normalization (#88560)

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -113,13 +113,17 @@ export function normalizeBuiltInProviderModelId(provider: string, model: string)
     return trimmed && !trimmed.includes("/") ? `openrouter/${trimmed}` : model;
   }
   if (normalizedProvider === "anthropic") {
+    const prefix = "anthropic/";
+    const bareModel = normalizeLowercaseStringOrEmpty(model).startsWith(prefix)
+      ? model.slice(prefix.length)
+      : model;
     const anthropicAliases: Record<string, string> = {
       "opus-4.8": "claude-opus-4-8",
       opus: "claude-opus-4-8",
       "opus-4.6": "claude-opus-4-6",
       "sonnet-4.6": "claude-sonnet-4-6",
     };
-    return anthropicAliases[normalizeLowercaseStringOrEmpty(model)] ?? model;
+    return anthropicAliases[normalizeLowercaseStringOrEmpty(bareModel)] ?? bareModel;
   }
   if (normalizedProvider === "vercel-ai-gateway") {
     const vercelAliases: Record<string, string> = {

--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -29,6 +29,23 @@ describe("normalizeStaticProviderModelId", () => {
     );
   });
 
+  it("strips a redundant anthropic/ self-prefix from catalog-keyed model ids", () => {
+    // agents.defaults.models keys are stored provider-qualified
+    // (e.g. "anthropic/claude-haiku-4-5"). The native anthropic registry is
+    // keyed on the bare id, so the self-prefix must be stripped to avoid the
+    // doubled-prefix lookup "anthropic/anthropic/claude-haiku-4-5".
+    expect(normalizeStaticProviderModelId("anthropic", "anthropic/claude-haiku-4-5")).toBe(
+      "claude-haiku-4-5",
+    );
+    // Bare ids and aliases keep working after the strip.
+    expect(normalizeStaticProviderModelId("anthropic", "anthropic/sonnet-4.6")).toBe(
+      "claude-sonnet-4-6",
+    );
+    expect(normalizeStaticProviderModelId("anthropic", "claude-haiku-4-5")).toBe(
+      "claude-haiku-4-5",
+    );
+  });
+
   it("applies shipped bundled provider model aliases without manifest lookup", () => {
     expect(normalizeStaticProviderModelId("anthropic", "sonnet-4.6")).toBe("claude-sonnet-4-6");
     expect(normalizeStaticProviderModelId("vercel-ai-gateway", "sonnet-4.6")).toBe(


### PR DESCRIPTION
Fixes #88560

## Summary

For an agent whose `agents.defaults.models` catalog uses the provider-qualified key form (e.g. `"anthropic/claude-haiku-4-5"`), failover produced doubled-prefix errors like `Unknown model: anthropic/anthropic/claude-haiku-4-5`, and the agent had no working fallback path.

Root cause: `normalizeBuiltInProviderModelId` strips a redundant self-prefix for `huggingface` and avoids doubling for `nvidia`/`openrouter`, but the `anthropic` branch returned the model id unchanged. So a catalog-keyed ref reached the resolver as `provider=anthropic, modelId=anthropic/claude-haiku-4-5`; the native anthropic registry is keyed on the bare id, the lookup missed, and the unknown-model error builder interpolated `${provider}/${modelId}` into the doubled string.

This PR strips a leading `anthropic/` from the model id before applying aliases, so the registry is queried with the bare `claude-haiku-4-5`, matching the existing nvidia/huggingface self-prefix handling. This addresses the doubled-prefix root cause (compounding regression #1 in the issue). The fallback-iterator state-leak (#2) is a separate concern in the failover orchestrator and is out of scope for this focused change.

## Real behavior proof

**Behavior addressed:** Catalog-keyed `anthropic/claude-*` model refs no longer produce a doubled `anthropic/anthropic/...` provider prefix during static model id normalization; the bare id is used for registry lookup and for any resulting unknown-model error string.

**Real environment tested:** Linux x86_64, Node.js v22.x, HEAD `6155e06e313001fc279fd69127fa7a62867e9224` based on `origin/main` `84b025eb622176483ebb1615a88059a4368b3775`.

**Exact steps or command run after this patch:**
```
# Drive the production normalizer directly with the catalog-key form:
node --import tsx -e 'import("./packages/model-catalog-core/src/provider-model-id-normalization.ts").then(m => console.log(m.normalizeBuiltInProviderModelId("anthropic","anthropic/claude-haiku-4-5")))'

# Focused regression suites:
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config vitest.config.ts \
  src/agents/model-ref-shared.test.ts \
  packages/model-catalog-core/src/provider-model-id-normalization.test.ts \
  src/agents/model-selection.test.ts --reporter=dot
```

**Evidence after fix:**
```
# normalizeStaticProviderModelId("anthropic", "anthropic/claude-haiku-4-5")
BEFORE: anthropic/claude-haiku-4-5   -> downstream lookup/error: anthropic/anthropic/claude-haiku-4-5
AFTER:  claude-haiku-4-5             -> downstream lookup/error: anthropic/claude-haiku-4-5

model-ref-shared.test.ts:                         Tests 12 passed (12)
provider-model-id-normalization.test.ts:          Tests  2 passed (2)
model-selection.test.ts:                          Tests 230 passed (230)
```

**Observed result after fix:** The self-prefixed catalog ref normalizes to the bare `claude-haiku-4-5`; aliases (e.g. `anthropic/sonnet-4.6` -> `claude-sonnet-4-6`) and already-bare ids continue to resolve unchanged. No regressions in the model-selection suite.

**What was not tested:** The fallback-iterator state-leak (issue's compounding regression #2) in the failover orchestrator — intentionally out of scope. No live provider/network/runtime gateway was exercised; verification was done by driving the production normalization functions and the focused unit suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
