### PR TITLE
fix(sms): diagnose Twilio webhook setup

### DIFF
--- a/docs/channels/sms.md
+++ b/docs/channels/sms.md
@@ -84,6 +84,18 @@ https://gateway.example.com/webhooks/sms
 
   </Step>
 
+  <Step title="Expose the exact SMS webhook path">
+    Your public URL must route the SMS path to the Gateway process. If you use Tailscale Funnel for local testing, expose `/webhooks/sms` explicitly:
+
+```bash
+tailscale funnel --bg --set-path /webhooks/sms http://127.0.0.1:<gateway-port>/webhooks/sms
+tailscale funnel status
+```
+
+    Voice Call and SMS use separate webhook paths. If the same Twilio number handles both, keep both routes configured in Twilio and in your tunnel.
+
+  </Step>
+
   <Step title="Start the Gateway and approve first sender">
 
 ```bash
@@ -148,6 +160,27 @@ Then enable the channel in config:
 ```
 
 `TWILIO_SMS_FROM` is accepted as an alias for `TWILIO_PHONE_NUMBER`. Use `TWILIO_MESSAGING_SERVICE_SID` instead of a phone-number sender when Twilio should choose the sender from a Messaging Service.
+
+### SecretRef auth token
+
+`authToken` can be a SecretRef. Use this when the Gateway should resolve the Twilio Auth Token from the OpenClaw secrets runtime instead of storing plaintext config:
+
+```json5
+{
+  channels: {
+    sms: {
+      enabled: true,
+      accountSid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      authToken: { source: "env", provider: "default", id: "TWILIO_AUTH_TOKEN" },
+      fromNumber: "+15551234567",
+      publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+      dmPolicy: "pairing",
+    },
+  },
+}
+```
+
+The referenced environment variable or secret provider must be visible to the Gateway runtime. Restart managed Gateway processes after changing host environment variables.
 
 ### Allowlist-only private number
 
@@ -245,16 +278,36 @@ SMS output is plain text. OpenClaw strips markdown, flattens fenced code blocks,
 After the Gateway starts:
 
 1. Confirm the Gateway log shows the SMS webhook route.
-2. Send an SMS to the Twilio number from your phone.
-3. Run `openclaw pairing list sms`.
-4. Approve the pairing code with `openclaw pairing approve sms <CODE>`.
-5. Send another SMS and confirm the agent replies.
+2. Run a Twilio-side probe:
+
+```bash
+openclaw channels capabilities --channel sms
+openclaw channels status --channel sms --probe --json
+```
+
+3. Send an SMS to the Twilio number from your phone.
+4. Run `openclaw pairing list sms`.
+5. Approve the pairing code with `openclaw pairing approve sms <CODE>`.
+6. Send another SMS and confirm the agent replies.
 
 For outbound-only testing, use:
 
 ```bash
 openclaw message send --channel sms --target sms:+15557654321 --message "OpenClaw SMS test"
 ```
+
+### End-to-end test from macOS iMessage/SMS
+
+On a Mac that can send carrier SMS through Messages, you can use `imsg` to drive the sender side without touching your phone:
+
+```bash
+imsg send --to "+15551234567" --service sms --text "OpenClaw SMS E2E $(date -u +%Y%m%dT%H%M%SZ)" --json
+openclaw pairing list sms
+openclaw pairing approve sms <CODE>
+imsg send --to "+15551234567" --service sms --text "reply exactly SMS pong" --json
+```
+
+The first message should create a pairing request. The second message should receive the agent reply through Twilio.
 
 ## Webhook security
 
@@ -310,6 +363,13 @@ Check that `publicWebhookUrl` exactly matches the URL configured in Twilio, incl
 ### No pairing request appears
 
 Check the Twilio number's **Messaging** webhook URL and method. It must point to the SMS webhook URL and use `POST`. Also confirm the Gateway is reachable from the public internet or through your tunnel.
+
+If the Twilio message log shows error `11200`, Twilio accepted the inbound SMS but could not reach your webhook. Check:
+
+- Twilio **Messaging > A message comes in** points at `publicWebhookUrl`.
+- The method is `POST`.
+- The tunnel or reverse proxy exposes the exact `webhookPath`; for Tailscale Funnel, run `tailscale funnel status` and confirm `/webhooks/sms` is listed.
+- `publicWebhookUrl` uses the same scheme, host, path, and query string Twilio sends, so signature validation can reproduce the signed URL.
 
 ### Outbound sends fail
 

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -73,6 +73,8 @@ Scope intent:
 - `channels.slack.accounts.*.appToken`
 - `channels.slack.accounts.*.userToken`
 - `channels.slack.accounts.*.signingSecret`
+- `channels.sms.authToken`
+- `channels.sms.accounts.*.authToken`
 - `channels.discord.token`
 - `channels.discord.pluralkit.token`
 - `channels.discord.voice.tts.providers.*.apiKey`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -338,6 +338,20 @@
       "optIn": true
     },
     {
+      "id": "channels.sms.accounts.*.authToken",
+      "configFile": "openclaw.json",
+      "path": "channels.sms.accounts.*.authToken",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.sms.authToken",
+      "configFile": "openclaw.json",
+      "path": "channels.sms.authToken",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "channels.telegram.accounts.*.botToken",
       "configFile": "openclaw.json",
       "path": "channels.telegram.accounts.*.botToken",

--- a/extensions/sms/contract-api.ts
+++ b/extensions/sms/contract-api.ts
@@ -1,0 +1,4 @@
+export {
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from "./src/secret-contract.js";

--- a/extensions/sms/secret-contract-api.ts
+++ b/extensions/sms/secret-contract-api.ts
@@ -1,0 +1,5 @@
+export {
+  channelSecrets,
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from "./src/secret-contract.js";

--- a/extensions/sms/src/channel.test.ts
+++ b/extensions/sms/src/channel.test.ts
@@ -65,6 +65,12 @@ describe("smsPlugin status", () => {
 describe("smsPlugin outbound", () => {
   it("declares an active text chunker and account-aware chunk limit", () => {
     expect(smsPlugin.configSchema).toBeDefined();
+    expect(smsPlugin.status?.probeAccount).toBeDefined();
+    expect(smsPlugin.status?.formatCapabilitiesProbe).toBeDefined();
+    expect(smsPlugin.secrets?.secretTargetRegistryEntries?.map((entry) => entry.id)).toEqual([
+      "channels.sms.accounts.*.authToken",
+      "channels.sms.authToken",
+    ]);
     expect(smsPlugin.messaging?.targetPrefixes).toEqual(["twilio-sms"]);
     expect(smsPlugin.outbound?.chunker?.("alpha beta", 6)).toEqual(["alpha", "beta"]);
     expect(

--- a/extensions/sms/src/channel.ts
+++ b/extensions/sms/src/channel.ts
@@ -28,7 +28,9 @@ import {
   normalizeSmsAllowFrom,
   normalizeSmsPhoneNumber,
 } from "./phone.js";
+import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { sendSmsTextChunks, toSmsPlainText } from "./send.js";
+import { formatSmsProbeLines, probeSmsAccount, type SmsProbe } from "./status.js";
 import type { ResolvedSmsAccount } from "./types.js";
 
 const CHANNEL_ID = "sms";
@@ -227,7 +229,7 @@ const smsMessageAdapter = defineChannelMessageAdapter({
   },
 });
 
-export const smsPlugin: ChannelPlugin<ResolvedSmsAccount> = createChatChannelPlugin({
+export const smsPlugin: ChannelPlugin<ResolvedSmsAccount, SmsProbe> = createChatChannelPlugin({
   base: {
     id: CHANNEL_ID,
     meta: {
@@ -302,10 +304,16 @@ export const smsPlugin: ChannelPlugin<ResolvedSmsAccount> = createChatChannelPlu
         lastInboundAt: null,
         lastOutboundAt: null,
       },
+      probeAccount: async ({ account, timeoutMs }) => await probeSmsAccount({ account, timeoutMs }),
+      formatCapabilitiesProbe: ({ probe }) => formatSmsProbeLines(probe),
       buildAccountSnapshot: buildSmsAccountSnapshot,
       buildCapabilitiesDiagnostics: async ({ account }) => ({
         lines: collectSmsStartupWarnings(account).map((text) => ({ text, tone: "warn" })),
       }),
+    },
+    secrets: {
+      secretTargetRegistryEntries,
+      collectRuntimeConfigAssignments,
     },
     agentPrompt: {
       messageToolHints: () => [

--- a/extensions/sms/src/secret-contract.test.ts
+++ b/extensions/sms/src/secret-contract.test.ts
@@ -96,6 +96,39 @@ describe("sms secret contract", () => {
     expect(resolved.warnings).toStrictEqual([]);
   });
 
+  it("keeps top-level authToken active for env-backed default senders plus named accounts", async () => {
+    const resolved = await resolveSmsSecretAssignments(
+      {
+        channels: {
+          sms: {
+            enabled: true,
+            authToken: { source: "env", provider: "default", id: "TWILIO_DEFAULT_TOKEN" },
+            accounts: {
+              support: {
+                enabled: true,
+                accountSid: "AC456",
+                authToken: { source: "env", provider: "default", id: "TWILIO_SUPPORT_TOKEN" },
+                fromNumber: "+15558675309",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      {
+        TWILIO_ACCOUNT_SID: "AC-env",
+        TWILIO_PHONE_NUMBER: "+15550001111",
+        TWILIO_DEFAULT_TOKEN: "resolved-default-token",
+        TWILIO_SUPPORT_TOKEN: "resolved-support-token",
+      },
+    );
+
+    expect(resolved.config.channels?.sms?.authToken).toBe("resolved-default-token");
+    expect(resolved.config.channels?.sms?.accounts?.support?.authToken).toBe(
+      "resolved-support-token",
+    );
+    expect(resolved.warnings).toStrictEqual([]);
+  });
+
   it("treats top-level authToken refs as inactive when all enabled accounts override them", async () => {
     const resolved = await resolveSmsSecretAssignments(
       {

--- a/extensions/sms/src/secret-contract.test.ts
+++ b/extensions/sms/src/secret-contract.test.ts
@@ -1,0 +1,129 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  applyResolvedAssignments,
+  createResolverContext,
+  resolveSecretRefValues,
+} from "openclaw/plugin-sdk/secret-ref-runtime";
+import { describe, expect, it } from "vitest";
+import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
+
+async function resolveSmsSecretAssignments(
+  sourceConfig: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): Promise<{
+  config: OpenClawConfig;
+  warnings: ReturnType<typeof createResolverContext>["warnings"];
+}> {
+  const resolvedConfig: OpenClawConfig = structuredClone(sourceConfig);
+  const context = createResolverContext({ sourceConfig, env });
+
+  collectRuntimeConfigAssignments({
+    config: resolvedConfig,
+    defaults: sourceConfig.secrets?.defaults,
+    context,
+  });
+
+  const resolved = await resolveSecretRefValues(
+    context.assignments.map((assignment) => assignment.ref),
+    {
+      config: sourceConfig,
+      env: context.env,
+      cache: context.cache,
+    },
+  );
+  applyResolvedAssignments({ assignments: context.assignments, resolved });
+
+  return { config: resolvedConfig, warnings: context.warnings };
+}
+
+describe("sms secret contract", () => {
+  it("publishes SMS auth token targets", () => {
+    expect(secretTargetRegistryEntries.map((entry) => entry.id)).toEqual([
+      "channels.sms.accounts.*.authToken",
+      "channels.sms.authToken",
+    ]);
+  });
+
+  it("resolves top-level authToken SecretRefs for SMS accounts", async () => {
+    const resolved = await resolveSmsSecretAssignments(
+      {
+        channels: {
+          sms: {
+            enabled: true,
+            accountSid: "AC123",
+            authToken: { source: "env", provider: "default", id: "TWILIO_AUTH_TOKEN" },
+            fromNumber: "+15557654321",
+          },
+        },
+      } as OpenClawConfig,
+      { TWILIO_AUTH_TOKEN: "resolved-token" },
+    );
+
+    expect(resolved.config.channels?.sms?.authToken).toBe("resolved-token");
+    expect(resolved.warnings).toStrictEqual([]);
+  });
+
+  it("keeps top-level authToken active for an implicit default sender plus named accounts", async () => {
+    const resolved = await resolveSmsSecretAssignments(
+      {
+        channels: {
+          sms: {
+            enabled: true,
+            accountSid: "AC123",
+            authToken: { source: "env", provider: "default", id: "TWILIO_DEFAULT_TOKEN" },
+            fromNumber: "+15557654321",
+            accounts: {
+              support: {
+                enabled: true,
+                accountSid: "AC456",
+                authToken: { source: "env", provider: "default", id: "TWILIO_SUPPORT_TOKEN" },
+                fromNumber: "+15558675309",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      {
+        TWILIO_DEFAULT_TOKEN: "resolved-default-token",
+        TWILIO_SUPPORT_TOKEN: "resolved-support-token",
+      },
+    );
+
+    expect(resolved.config.channels?.sms?.authToken).toBe("resolved-default-token");
+    expect(resolved.config.channels?.sms?.accounts?.support?.authToken).toBe(
+      "resolved-support-token",
+    );
+    expect(resolved.warnings).toStrictEqual([]);
+  });
+
+  it("treats top-level authToken refs as inactive when all enabled accounts override them", async () => {
+    const resolved = await resolveSmsSecretAssignments(
+      {
+        channels: {
+          sms: {
+            authToken: { source: "env", provider: "default", id: "UNUSED_TWILIO_TOKEN" },
+            accounts: {
+              support: {
+                enabled: true,
+                accountSid: "AC456",
+                authToken: { source: "env", provider: "default", id: "TWILIO_SUPPORT_TOKEN" },
+                fromNumber: "+15558675309",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      { TWILIO_SUPPORT_TOKEN: "resolved-support-token" },
+    );
+
+    expect(resolved.config.channels?.sms?.authToken).toEqual({
+      source: "env",
+      provider: "default",
+      id: "UNUSED_TWILIO_TOKEN",
+    });
+    expect(resolved.config.channels?.sms?.accounts?.support?.authToken).toBe(
+      "resolved-support-token",
+    );
+    expect(resolved.warnings.map((warning) => warning.path)).toContain("channels.sms.authToken");
+  });
+});

--- a/extensions/sms/src/secret-contract.ts
+++ b/extensions/sms/src/secret-contract.ts
@@ -1,0 +1,79 @@
+import {
+  collectConditionalChannelFieldAssignments,
+  getChannelSurface,
+  hasOwnProperty,
+  type ResolverContext,
+  type SecretDefaults,
+  type SecretTargetRegistryEntry,
+} from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+
+const DEFAULT_ACCOUNT_ID = "default";
+
+export const secretTargetRegistryEntries = [
+  {
+    id: "channels.sms.accounts.*.authToken",
+    targetType: "channels.sms.accounts.*.authToken",
+    configFile: "openclaw.json",
+    pathPattern: "channels.sms.accounts.*.authToken",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
+    id: "channels.sms.authToken",
+    targetType: "channels.sms.authToken",
+    configFile: "openclaw.json",
+    pathPattern: "channels.sms.authToken",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+] satisfies SecretTargetRegistryEntry[];
+
+function hasTopLevelSmsAccount(channel: Record<string, unknown>): boolean {
+  for (const field of ["accountSid", "fromNumber", "messagingServiceSid", "defaultTo"]) {
+    if (typeof channel[field] === "string" && channel[field].trim().length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function collectRuntimeConfigAssignments(params: {
+  config: { channels?: Record<string, unknown> };
+  defaults?: SecretDefaults;
+  context: ResolverContext;
+}): void {
+  const resolved = getChannelSurface(params.config, "sms");
+  if (!resolved) {
+    return;
+  }
+  const { channel: sms, surface } = resolved;
+  const hasExplicitDefaultAccount = surface.accounts.some(
+    ({ accountId }) => accountId === DEFAULT_ACCOUNT_ID,
+  );
+  const topLevelSmsAccountActive = hasTopLevelSmsAccount(sms) && !hasExplicitDefaultAccount;
+  collectConditionalChannelFieldAssignments({
+    channelKey: "sms",
+    field: "authToken",
+    channel: sms,
+    surface,
+    defaults: params.defaults,
+    context: params.context,
+    topLevelActiveWithoutAccounts: true,
+    topLevelInheritedAccountActive: ({ account, enabled }) =>
+      topLevelSmsAccountActive || (enabled && !hasOwnProperty(account, "authToken")),
+    accountActive: ({ enabled }) => enabled,
+    topInactiveReason: "no enabled SMS surface inherits this top-level authToken.",
+    accountInactiveReason: "SMS account is disabled.",
+  });
+}
+
+export const channelSecrets = {
+  secretTargetRegistryEntries,
+  collectRuntimeConfigAssignments,
+};

--- a/extensions/sms/src/secret-contract.ts
+++ b/extensions/sms/src/secret-contract.ts
@@ -43,6 +43,21 @@ function hasTopLevelSmsAccount(channel: Record<string, unknown>): boolean {
   return false;
 }
 
+function hasEnvBackedDefaultSmsAccount(env: NodeJS.ProcessEnv): boolean {
+  for (const name of [
+    "TWILIO_ACCOUNT_SID",
+    "TWILIO_AUTH_TOKEN",
+    "TWILIO_PHONE_NUMBER",
+    "TWILIO_SMS_FROM",
+    "TWILIO_MESSAGING_SERVICE_SID",
+  ]) {
+    if (typeof env[name] === "string" && env[name].trim().length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function collectRuntimeConfigAssignments(params: {
   config: { channels?: Record<string, unknown> };
   defaults?: SecretDefaults;
@@ -56,7 +71,9 @@ export function collectRuntimeConfigAssignments(params: {
   const hasExplicitDefaultAccount = surface.accounts.some(
     ({ accountId }) => accountId === DEFAULT_ACCOUNT_ID,
   );
-  const topLevelSmsAccountActive = hasTopLevelSmsAccount(sms) && !hasExplicitDefaultAccount;
+  const topLevelSmsAccountActive =
+    (hasTopLevelSmsAccount(sms) || hasEnvBackedDefaultSmsAccount(params.context.env)) &&
+    !hasExplicitDefaultAccount;
   collectConditionalChannelFieldAssignments({
     channelKey: "sms",
     field: "authToken",

--- a/extensions/sms/src/status.test.ts
+++ b/extensions/sms/src/status.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatSmsProbeLines, probeSmsAccount } from "./status.js";
+import type { ResolvedSmsAccount } from "./types.js";
+
+function createAccount(overrides: Partial<ResolvedSmsAccount> = {}): ResolvedSmsAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    accountSid: "AC123",
+    authToken: "secret",
+    fromNumber: "+15557654321",
+    messagingServiceSid: "",
+    defaultTo: "",
+    webhookPath: "/webhooks/sms",
+    publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+    dangerouslyDisableSignatureValidation: false,
+    dmPolicy: "pairing",
+    allowFrom: [],
+    textChunkLimit: 1500,
+    ...overrides,
+  };
+}
+
+function createFetch(responses: Array<unknown>): typeof fetch {
+  return vi.fn(async () => {
+    const payload = responses.shift();
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+describe("SMS status probe", () => {
+  it("reports a healthy Twilio SMS webhook", async () => {
+    const fetchImpl = createFetch([
+      {
+        incoming_phone_numbers: [
+          {
+            phone_number: "+15557654321",
+            sms_url: "https://gateway.example.com/webhooks/sms",
+            sms_method: "POST",
+            voice_url: "https://gateway.example.com/voice/webhook",
+          },
+        ],
+      },
+      {
+        messages: [
+          {
+            sid: "SM123",
+            direction: "inbound",
+            status: "received",
+            to: "+15557654321",
+            from: "+15551234567",
+          },
+        ],
+      },
+    ]);
+
+    await expect(
+      probeSmsAccount({
+        account: createAccount(),
+        timeoutMs: 1000,
+        options: { fetchImpl },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      webhook: {
+        status: "matches",
+        configuredUrl: "https://gateway.example.com/webhooks/sms",
+        voiceUrl: "https://gateway.example.com/voice/webhook",
+      },
+      recentInbound: {
+        sid: "SM123",
+        status: "received",
+      },
+    });
+  });
+
+  it("detects a Twilio SMS webhook URL mismatch", async () => {
+    const fetchImpl = createFetch([
+      {
+        incoming_phone_numbers: [
+          {
+            phone_number: "+15557654321",
+            sms_url: "https://old.example.com/webhooks/sms",
+            sms_method: "POST",
+          },
+        ],
+      },
+      { messages: [] },
+    ]);
+
+    await expect(
+      probeSmsAccount({
+        account: createAccount(),
+        timeoutMs: 1000,
+        options: { fetchImpl },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error:
+        "Twilio number +15557654321 points SMS webhooks at https://old.example.com/webhooks/sms; expected https://gateway.example.com/webhooks/sms.",
+      webhook: {
+        status: "url-mismatch",
+      },
+    });
+  });
+
+  it("surfaces Twilio 11200 recent inbound failures and Funnel hints", async () => {
+    const fetchImpl = createFetch([
+      {
+        incoming_phone_numbers: [
+          {
+            phone_number: "+15557654321",
+            sms_url: "https://mac-studio.example.ts.net/webhooks/sms",
+            sms_method: "POST",
+          },
+        ],
+      },
+      {
+        messages: [
+          {
+            sid: "SM11200",
+            direction: "inbound",
+            status: "received",
+            to: "+15557654321",
+            from: "+15551234567",
+            error_code: 11200,
+          },
+        ],
+      },
+    ]);
+
+    const result = await probeSmsAccount({
+      account: createAccount({
+        publicWebhookUrl: "https://mac-studio.example.ts.net/webhooks/sms",
+      }),
+      timeoutMs: 1000,
+      options: { fetchImpl },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "Recent inbound SMS SM11200 has Twilio error 11200.",
+      recentInbound: {
+        sid: "SM11200",
+        errorCode: "11200",
+      },
+    });
+    expect(result.hints).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Tailscale Funnel must expose the exact SMS path"),
+        expect.stringContaining("Twilio error 11200 means Twilio could not reach"),
+      ]),
+    );
+  });
+
+  it("formats probe details for channel capability output", () => {
+    expect(
+      formatSmsProbeLines({
+        ok: false,
+        error: "Recent inbound SMS SM11200 has Twilio error 11200.",
+        webhook: { status: "matches", configuredUrl: "https://gateway.example.com/webhooks/sms" },
+        recentInbound: { sid: "SM11200", status: "received", errorCode: "11200" },
+        hints: ["Check the public route."],
+      }),
+    ).toEqual([
+      {
+        text: "Probe: failed (Recent inbound SMS SM11200 has Twilio error 11200.)",
+        tone: "error",
+      },
+      { text: "Twilio SMS webhook: https://gateway.example.com/webhooks/sms" },
+      { text: "Recent inbound: received error=11200", tone: "warn" },
+      { text: "Check the public route.", tone: "warn" },
+    ]);
+  });
+});

--- a/extensions/sms/src/status.test.ts
+++ b/extensions/sms/src/status.test.ts
@@ -75,6 +75,36 @@ describe("SMS status probe", () => {
         status: "received",
       },
     });
+    const result = await probeSmsAccount({
+      account: createAccount(),
+      timeoutMs: 1000,
+      options: {
+        fetchImpl: createFetch([
+          {
+            incoming_phone_numbers: [
+              {
+                phone_number: "+15557654321",
+                sms_url: "https://gateway.example.com/webhooks/sms",
+                sms_method: "POST",
+              },
+            ],
+          },
+          {
+            messages: [
+              {
+                sid: "SM456",
+                direction: "inbound",
+                status: "received",
+                to: "+15557654321",
+                from: "+15551234567",
+              },
+            ],
+          },
+        ]),
+      },
+    });
+    expect(result.recentInbound).not.toHaveProperty("from");
+    expect(result.recentInbound).not.toHaveProperty("to");
   });
 
   it("detects a Twilio SMS webhook URL mismatch", async () => {

--- a/extensions/sms/src/status.test.ts
+++ b/extensions/sms/src/status.test.ts
@@ -186,6 +186,64 @@ describe("SMS status probe", () => {
     );
   });
 
+  it("validates Twilio Messaging Service webhook settings", async () => {
+    const fetchImpl = createFetch([
+      {
+        sid: "MG123",
+        inbound_request_url: "https://gateway.example.com/webhooks/sms",
+        inbound_method: "POST",
+        use_inbound_webhook_on_number: false,
+      },
+    ]);
+
+    await expect(
+      probeSmsAccount({
+        account: createAccount({
+          fromNumber: "",
+          messagingServiceSid: "MG123",
+        }),
+        timeoutMs: 1000,
+        options: { fetchImpl },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      webhook: {
+        status: "messaging-service-matches",
+        serviceSid: "MG123",
+        configuredUrl: "https://gateway.example.com/webhooks/sms",
+      },
+    });
+  });
+
+  it("does not report Messaging Service defer-to-number probes as healthy", async () => {
+    const fetchImpl = createFetch([
+      {
+        sid: "MG123",
+        inbound_request_url: "https://gateway.example.com/webhooks/sms",
+        inbound_method: "POST",
+        use_inbound_webhook_on_number: true,
+      },
+    ]);
+
+    await expect(
+      probeSmsAccount({
+        account: createAccount({
+          fromNumber: "",
+          messagingServiceSid: "MG123",
+        }),
+        timeoutMs: 1000,
+        options: { fetchImpl },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error:
+        "Twilio Messaging Service defers inbound webhooks to sender phone numbers; configure fromNumber or disable defer-to-sender before probing.",
+      webhook: {
+        status: "unavailable",
+      },
+    });
+  });
+
   it("formats probe details for channel capability output", () => {
     expect(
       formatSmsProbeLines({

--- a/extensions/sms/src/status.ts
+++ b/extensions/sms/src/status.ts
@@ -164,6 +164,7 @@ function webhookError(probe: SmsTwilioWebhookProbe): string | undefined {
     case "url-mismatch":
       return `Twilio number ${probe.phoneNumber} points SMS webhooks at ${probe.configuredUrl}; expected ${probe.expectedUrl}.`;
   }
+  return undefined;
 }
 
 export async function probeSmsAccount(params: {

--- a/extensions/sms/src/status.ts
+++ b/extensions/sms/src/status.ts
@@ -1,0 +1,246 @@
+import {
+  listTwilioIncomingPhoneNumbers,
+  listTwilioMessages,
+  type TwilioIncomingPhoneNumber,
+  type TwilioMessageLogEntry,
+} from "./twilio.js";
+import type { ResolvedSmsAccount } from "./types.js";
+
+const TWILIO_ERROR_WEBHOOK_REACHABILITY = "11200";
+
+type ChannelCapabilitiesDisplayLine = {
+  text: string;
+  tone?: "default" | "muted" | "success" | "warn" | "error";
+};
+
+export type SmsTwilioWebhookProbe =
+  | {
+      status: "skipped";
+      reason: string;
+    }
+  | {
+      status: "number-not-found";
+      expectedNumber: string;
+    }
+  | {
+      status: "missing";
+      phoneNumber: string;
+      expectedUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "method-mismatch";
+      phoneNumber: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "url-mismatch";
+      phoneNumber: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "matches";
+      phoneNumber: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+      voiceUrl: string;
+    };
+
+export type SmsProbe = {
+  ok: boolean;
+  error?: string;
+  webhook: SmsTwilioWebhookProbe;
+  recentInbound?: Pick<
+    TwilioMessageLogEntry,
+    "sid" | "direction" | "status" | "from" | "to" | "errorCode" | "dateCreated" | "dateSent"
+  >;
+  hints: string[];
+};
+
+type ProbeOptions = {
+  fetchImpl?: typeof fetch;
+};
+
+function addTailscaleHint(account: ResolvedSmsAccount, hints: string[]): void {
+  let host = "";
+  try {
+    host = new URL(account.publicWebhookUrl).hostname;
+  } catch {
+    return;
+  }
+  if (!host.endsWith(".ts.net")) {
+    return;
+  }
+  hints.push(
+    `Tailscale Funnel must expose the exact SMS path: tailscale funnel --bg --set-path ${account.webhookPath} http://127.0.0.1:<gateway-port>${account.webhookPath}`,
+  );
+}
+
+function compareTwilioWebhook(
+  account: ResolvedSmsAccount,
+  phoneNumber: TwilioIncomingPhoneNumber | undefined,
+): SmsTwilioWebhookProbe {
+  if (!account.fromNumber) {
+    return {
+      status: "skipped",
+      reason: "Messaging Service senders do not have one phone-number SMS webhook to inspect.",
+    };
+  }
+  if (!phoneNumber) {
+    return { status: "number-not-found", expectedNumber: account.fromNumber };
+  }
+  const configuredMethod = phoneNumber.smsMethod.toUpperCase();
+  if (!phoneNumber.smsUrl) {
+    return {
+      status: "missing",
+      phoneNumber: phoneNumber.phoneNumber || account.fromNumber,
+      expectedUrl: account.publicWebhookUrl,
+      configuredMethod,
+    };
+  }
+  if (configuredMethod && configuredMethod !== "POST") {
+    return {
+      status: "method-mismatch",
+      phoneNumber: phoneNumber.phoneNumber || account.fromNumber,
+      expectedUrl: account.publicWebhookUrl,
+      configuredUrl: phoneNumber.smsUrl,
+      configuredMethod,
+    };
+  }
+  if (phoneNumber.smsUrl !== account.publicWebhookUrl) {
+    return {
+      status: "url-mismatch",
+      phoneNumber: phoneNumber.phoneNumber || account.fromNumber,
+      expectedUrl: account.publicWebhookUrl,
+      configuredUrl: phoneNumber.smsUrl,
+      configuredMethod,
+    };
+  }
+  return {
+    status: "matches",
+    phoneNumber: phoneNumber.phoneNumber || account.fromNumber,
+    expectedUrl: account.publicWebhookUrl,
+    configuredUrl: phoneNumber.smsUrl,
+    configuredMethod,
+    voiceUrl: phoneNumber.voiceUrl,
+  };
+}
+
+function recentInboundSummary(
+  messages: TwilioMessageLogEntry[],
+): SmsProbe["recentInbound"] | undefined {
+  const message = messages[0];
+  if (!message) {
+    return undefined;
+  }
+  return {
+    sid: message.sid,
+    direction: message.direction,
+    status: message.status,
+    from: message.from,
+    to: message.to,
+    errorCode: message.errorCode,
+    dateCreated: message.dateCreated,
+    dateSent: message.dateSent,
+  };
+}
+
+function webhookError(probe: SmsTwilioWebhookProbe): string | undefined {
+  switch (probe.status) {
+    case "matches":
+    case "skipped":
+      return undefined;
+    case "number-not-found":
+      return `Twilio account does not list ${probe.expectedNumber} as an incoming phone number.`;
+    case "missing":
+      return `Twilio number ${probe.phoneNumber} has no SMS webhook URL configured.`;
+    case "method-mismatch":
+      return `Twilio number ${probe.phoneNumber} uses ${probe.configuredMethod || "an unknown method"} for SMS webhooks; use POST.`;
+    case "url-mismatch":
+      return `Twilio number ${probe.phoneNumber} points SMS webhooks at ${probe.configuredUrl}; expected ${probe.expectedUrl}.`;
+  }
+}
+
+export async function probeSmsAccount(params: {
+  account: ResolvedSmsAccount;
+  timeoutMs: number;
+  options?: ProbeOptions;
+}): Promise<SmsProbe> {
+  const hints: string[] = [];
+  addTailscaleHint(params.account, hints);
+  const phoneNumbers = params.account.fromNumber
+    ? await listTwilioIncomingPhoneNumbers({
+        account: params.account,
+        phoneNumber: params.account.fromNumber,
+        fetchImpl: params.options?.fetchImpl,
+        timeoutMs: params.timeoutMs,
+      })
+    : [];
+  const webhook = compareTwilioWebhook(params.account, phoneNumbers[0]);
+  const messages = params.account.fromNumber
+    ? await listTwilioMessages({
+        account: params.account,
+        to: params.account.fromNumber,
+        pageSize: 3,
+        fetchImpl: params.options?.fetchImpl,
+        timeoutMs: params.timeoutMs,
+      })
+    : [];
+  const recentInbound = recentInboundSummary(messages);
+  if (recentInbound?.errorCode === TWILIO_ERROR_WEBHOOK_REACHABILITY) {
+    hints.push(
+      "Twilio error 11200 means Twilio could not reach the SMS webhook. Check the public URL, tunnel/Funnel route, and Twilio Messaging webhook method.",
+    );
+  }
+  const error =
+    webhookError(webhook) ??
+    (recentInbound?.errorCode === TWILIO_ERROR_WEBHOOK_REACHABILITY
+      ? `Recent inbound SMS ${recentInbound.sid} has Twilio error 11200.`
+      : undefined);
+  return {
+    ok: !error,
+    ...(error ? { error } : {}),
+    webhook,
+    ...(recentInbound ? { recentInbound } : {}),
+    hints,
+  };
+}
+
+export function formatSmsProbeLines(probe: unknown): ChannelCapabilitiesDisplayLine[] {
+  if (!probe || typeof probe !== "object") {
+    return [];
+  }
+  const smsProbe = probe as Partial<SmsProbe>;
+  const lines: ChannelCapabilitiesDisplayLine[] = [];
+  if (smsProbe.ok === true) {
+    lines.push({ text: "Probe: ok", tone: "success" });
+  } else if (smsProbe.ok === false) {
+    lines.push({
+      text: `Probe: failed${smsProbe.error ? ` (${smsProbe.error})` : ""}`,
+      tone: "error",
+    });
+  }
+  if (smsProbe.webhook?.status === "matches") {
+    lines.push({ text: `Twilio SMS webhook: ${smsProbe.webhook.configuredUrl}` });
+  } else if (smsProbe.webhook?.status && smsProbe.webhook.status !== "skipped") {
+    lines.push({ text: `Twilio SMS webhook: ${smsProbe.webhook.status}`, tone: "warn" });
+  }
+  if (smsProbe.recentInbound?.sid) {
+    const error = smsProbe.recentInbound.errorCode
+      ? ` error=${smsProbe.recentInbound.errorCode}`
+      : "";
+    lines.push({
+      text: `Recent inbound: ${smsProbe.recentInbound.status || "unknown"}${error}`,
+      tone: smsProbe.recentInbound.errorCode ? "warn" : "muted",
+    });
+  }
+  for (const hint of smsProbe.hints ?? []) {
+    lines.push({ text: hint, tone: "warn" });
+  }
+  return lines;
+}

--- a/extensions/sms/src/status.ts
+++ b/extensions/sms/src/status.ts
@@ -1,7 +1,9 @@
 import {
   listTwilioIncomingPhoneNumbers,
   listTwilioMessages,
+  retrieveTwilioMessagingService,
   type TwilioIncomingPhoneNumber,
+  type TwilioMessagingService,
   type TwilioMessageLogEntry,
 } from "./twilio.js";
 import type { ResolvedSmsAccount } from "./types.js";
@@ -16,6 +18,10 @@ type ChannelCapabilitiesDisplayLine = {
 export type SmsTwilioWebhookProbe =
   | {
       status: "skipped";
+      reason: string;
+    }
+  | {
+      status: "unavailable";
       reason: string;
     }
   | {
@@ -49,6 +55,33 @@ export type SmsTwilioWebhookProbe =
       configuredUrl: string;
       configuredMethod: string;
       voiceUrl: string;
+    }
+  | {
+      status: "messaging-service-missing";
+      serviceSid: string;
+      expectedUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "messaging-service-method-mismatch";
+      serviceSid: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "messaging-service-url-mismatch";
+      serviceSid: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "messaging-service-matches";
+      serviceSid: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
     };
 
 export type SmsProbe = {
@@ -131,6 +164,53 @@ function compareTwilioWebhook(
   };
 }
 
+function compareTwilioMessagingService(
+  account: ResolvedSmsAccount,
+  service: TwilioMessagingService,
+): SmsTwilioWebhookProbe {
+  if (service.useInboundWebhookOnNumber) {
+    return {
+      status: "unavailable",
+      reason:
+        "Twilio Messaging Service defers inbound webhooks to sender phone numbers; configure fromNumber or disable defer-to-sender before probing.",
+    };
+  }
+  const configuredMethod = service.inboundMethod.toUpperCase();
+  if (!service.inboundRequestUrl) {
+    return {
+      status: "messaging-service-missing",
+      serviceSid: service.sid || account.messagingServiceSid,
+      expectedUrl: account.publicWebhookUrl,
+      configuredMethod,
+    };
+  }
+  if (configuredMethod && configuredMethod !== "POST") {
+    return {
+      status: "messaging-service-method-mismatch",
+      serviceSid: service.sid || account.messagingServiceSid,
+      expectedUrl: account.publicWebhookUrl,
+      configuredUrl: service.inboundRequestUrl,
+      configuredMethod,
+    };
+  }
+  if (service.inboundRequestUrl !== account.publicWebhookUrl) {
+    return {
+      status: "messaging-service-url-mismatch",
+      serviceSid: service.sid || account.messagingServiceSid,
+      expectedUrl: account.publicWebhookUrl,
+      configuredUrl: service.inboundRequestUrl,
+      configuredMethod,
+    };
+  }
+  return {
+    status: "messaging-service-matches",
+    serviceSid: service.sid || account.messagingServiceSid,
+    expectedUrl: account.publicWebhookUrl,
+    configuredUrl: service.inboundRequestUrl,
+    configuredMethod,
+  };
+}
+
 function recentInboundSummary(
   messages: TwilioMessageLogEntry[],
 ): SmsProbe["recentInbound"] | undefined {
@@ -153,6 +233,8 @@ function webhookError(probe: SmsTwilioWebhookProbe): string | undefined {
     case "matches":
     case "skipped":
       return undefined;
+    case "unavailable":
+      return probe.reason;
     case "number-not-found":
       return `Twilio account does not list ${probe.expectedNumber} as an incoming phone number.`;
     case "missing":
@@ -161,6 +243,14 @@ function webhookError(probe: SmsTwilioWebhookProbe): string | undefined {
       return `Twilio number ${probe.phoneNumber} uses ${probe.configuredMethod || "an unknown method"} for SMS webhooks; use POST.`;
     case "url-mismatch":
       return `Twilio number ${probe.phoneNumber} points SMS webhooks at ${probe.configuredUrl}; expected ${probe.expectedUrl}.`;
+    case "messaging-service-missing":
+      return `Twilio Messaging Service ${probe.serviceSid} has no inbound request URL configured.`;
+    case "messaging-service-method-mismatch":
+      return `Twilio Messaging Service ${probe.serviceSid} uses ${probe.configuredMethod || "an unknown method"} for inbound webhooks; use POST.`;
+    case "messaging-service-url-mismatch":
+      return `Twilio Messaging Service ${probe.serviceSid} points inbound webhooks at ${probe.configuredUrl}; expected ${probe.expectedUrl}.`;
+    case "messaging-service-matches":
+      return undefined;
   }
   return undefined;
 }
@@ -172,15 +262,32 @@ export async function probeSmsAccount(params: {
 }): Promise<SmsProbe> {
   const hints: string[] = [];
   addTailscaleHint(params.account, hints);
-  const phoneNumbers = params.account.fromNumber
-    ? await listTwilioIncomingPhoneNumbers({
-        account: params.account,
-        phoneNumber: params.account.fromNumber,
-        fetchImpl: params.options?.fetchImpl,
-        timeoutMs: params.timeoutMs,
-      })
-    : [];
-  const webhook = compareTwilioWebhook(params.account, phoneNumbers[0]);
+  const webhook: SmsTwilioWebhookProbe = params.account.fromNumber
+    ? compareTwilioWebhook(
+        params.account,
+        (
+          await listTwilioIncomingPhoneNumbers({
+            account: params.account,
+            phoneNumber: params.account.fromNumber,
+            fetchImpl: params.options?.fetchImpl,
+            timeoutMs: params.timeoutMs,
+          })
+        )[0],
+      )
+    : params.account.messagingServiceSid
+      ? compareTwilioMessagingService(
+          params.account,
+          await retrieveTwilioMessagingService({
+            account: params.account,
+            serviceSid: params.account.messagingServiceSid,
+            fetchImpl: params.options?.fetchImpl,
+            timeoutMs: params.timeoutMs,
+          }),
+        )
+      : {
+          status: "unavailable",
+          reason: "Twilio SMS probe requires fromNumber or messagingServiceSid.",
+        };
   const messages = params.account.fromNumber
     ? await listTwilioMessages({
         account: params.account,
@@ -224,7 +331,10 @@ export function formatSmsProbeLines(probe: unknown): ChannelCapabilitiesDisplayL
       tone: "error",
     });
   }
-  if (smsProbe.webhook?.status === "matches") {
+  if (
+    smsProbe.webhook?.status === "matches" ||
+    smsProbe.webhook?.status === "messaging-service-matches"
+  ) {
     lines.push({ text: `Twilio SMS webhook: ${smsProbe.webhook.configuredUrl}` });
   } else if (smsProbe.webhook?.status && smsProbe.webhook.status !== "skipped") {
     lines.push({ text: `Twilio SMS webhook: ${smsProbe.webhook.status}`, tone: "warn" });

--- a/extensions/sms/src/status.ts
+++ b/extensions/sms/src/status.ts
@@ -57,7 +57,7 @@ export type SmsProbe = {
   webhook: SmsTwilioWebhookProbe;
   recentInbound?: Pick<
     TwilioMessageLogEntry,
-    "sid" | "direction" | "status" | "from" | "to" | "errorCode" | "dateCreated" | "dateSent"
+    "sid" | "direction" | "status" | "errorCode" | "dateCreated" | "dateSent"
   >;
   hints: string[];
 };
@@ -142,8 +142,6 @@ function recentInboundSummary(
     sid: message.sid,
     direction: message.direction,
     status: message.status,
-    from: message.from,
-    to: message.to,
     errorCode: message.errorCode,
     dateCreated: message.dateCreated,
     dateSent: message.dateSent,

--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -184,7 +184,7 @@ describe("Twilio SMS helpers", () => {
   });
 
   it("lists Twilio phone-number webhook settings", async () => {
-    const fetchImpl = vi.fn(
+    const fetchImpl = vi.fn<typeof fetch>(
       async () =>
         new Response(
           JSON.stringify({
@@ -231,7 +231,7 @@ describe("Twilio SMS helpers", () => {
   });
 
   it("lists recent Twilio messages for diagnostics", async () => {
-    const fetchImpl = vi.fn(
+    const fetchImpl = vi.fn<typeof fetch>(
       async () =>
         new Response(
           JSON.stringify({

--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildTwilioInboundMessage,
   computeTwilioSignature,
+  listTwilioIncomingPhoneNumbers,
+  listTwilioMessages,
   parseTwilioFormBody,
   resolveTwilioWebhookSignatureUrl,
   sendSmsViaTwilio,
@@ -179,6 +181,106 @@ describe("Twilio SMS helpers", () => {
     expect(body.get("From")).toBe("+15557654321");
     expect(body.get("To")).toBe("+15551234567");
     expect(body.get("Body")).toBe("hello");
+  });
+
+  it("lists Twilio phone-number webhook settings", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            incoming_phone_numbers: [
+              {
+                sid: "PN123",
+                phone_number: "+15557654321",
+                sms_url: "https://gateway.example.com/webhooks/sms",
+                sms_method: "POST",
+                voice_url: "https://gateway.example.com/voice/webhook",
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+
+    await expect(
+      listTwilioIncomingPhoneNumbers({
+        account: createAccount(),
+        phoneNumber: "+15557654321",
+        fetchImpl,
+      }),
+    ).resolves.toEqual([
+      {
+        sid: "PN123",
+        phoneNumber: "+15557654321",
+        smsUrl: "https://gateway.example.com/webhooks/sms",
+        smsMethod: "POST",
+        voiceUrl: "https://gateway.example.com/voice/webhook",
+      },
+    ]);
+
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(url).toBe(
+      "https://api.twilio.com/2010-04-01/Accounts/AC123/IncomingPhoneNumbers.json?PhoneNumber=%2B15557654321",
+    );
+    expect(init?.headers).toMatchObject({
+      authorization: `Basic ${Buffer.from("AC123:secret").toString("base64")}`,
+    });
+  });
+
+  it("lists recent Twilio messages for diagnostics", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            messages: [
+              {
+                sid: "SM123",
+                direction: "inbound",
+                status: "received",
+                to: "+15557654321",
+                from: "+15551234567",
+                error_code: 11200,
+                body: "hello",
+                date_created: "Sun, 31 May 2026 10:00:00 +0000",
+                date_sent: null,
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+
+    await expect(
+      listTwilioMessages({
+        account: createAccount(),
+        to: "+15557654321",
+        pageSize: 3,
+        fetchImpl,
+      }),
+    ).resolves.toEqual([
+      {
+        sid: "SM123",
+        direction: "inbound",
+        status: "received",
+        to: "+15557654321",
+        from: "+15551234567",
+        errorCode: "11200",
+        body: "hello",
+        dateCreated: "Sun, 31 May 2026 10:00:00 +0000",
+        dateSent: "",
+      },
+    ]);
+
+    const [url] = fetchImpl.mock.calls[0] ?? [];
+    expect(url).toBe(
+      "https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json?To=%2B15557654321&PageSize=3",
+    );
   });
 
   it("can send through a Twilio Messaging Service SID", async () => {

--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -6,6 +6,7 @@ import {
   listTwilioMessages,
   parseTwilioFormBody,
   resolveTwilioWebhookSignatureUrl,
+  retrieveTwilioMessagingService,
   sendSmsViaTwilio,
   TwilioSmsApiError,
   verifyTwilioSignature,
@@ -281,6 +282,43 @@ describe("Twilio SMS helpers", () => {
     expect(url).toBe(
       "https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json?To=%2B15557654321&PageSize=3",
     );
+  });
+
+  it("retrieves Twilio Messaging Service webhook settings", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            sid: "MG123",
+            inbound_request_url: "https://gateway.example.com/webhooks/sms",
+            inbound_method: "POST",
+            use_inbound_webhook_on_number: false,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+
+    await expect(
+      retrieveTwilioMessagingService({
+        account: createAccount({ messagingServiceSid: "MG123", fromNumber: "" }),
+        serviceSid: "MG123",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      sid: "MG123",
+      inboundRequestUrl: "https://gateway.example.com/webhooks/sms",
+      inboundMethod: "POST",
+      useInboundWebhookOnNumber: false,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(url).toBe("https://messaging.twilio.com/v1/Services/MG123");
+    expect(init?.headers).toMatchObject({
+      authorization: `Basic ${Buffer.from("AC123:secret").toString("base64")}`,
+    });
   });
 
   it("can send through a Twilio Messaging Service SID", async () => {

--- a/extensions/sms/src/twilio.ts
+++ b/extensions/sms/src/twilio.ts
@@ -5,7 +5,7 @@ import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { readRequestBodyWithLimit } from "openclaw/plugin-sdk/webhook-ingress";
 import type { ResolvedSmsAccount, SmsInboundMessage, SmsSendResult } from "./types.js";
 
-const TWILIO_MESSAGES_URL = "https://api.twilio.com/2010-04-01/Accounts";
+const TWILIO_ACCOUNTS_URL = "https://api.twilio.com/2010-04-01/Accounts";
 const TWILIO_API_HOSTNAME = "api.twilio.com";
 const TWILIO_API_TIMEOUT_MS = 30_000;
 const WEBHOOK_BODY_LIMIT_BYTES = 32 * 1024;
@@ -29,6 +29,26 @@ type TwilioMessagePayload = {
   status?: string;
 };
 
+export type TwilioIncomingPhoneNumber = {
+  sid: string;
+  phoneNumber: string;
+  smsUrl: string;
+  smsMethod: string;
+  voiceUrl: string;
+};
+
+export type TwilioMessageLogEntry = {
+  sid: string;
+  direction: string;
+  status: string;
+  to: string;
+  from: string;
+  errorCode: string;
+  body: string;
+  dateCreated: string;
+  dateSent: string;
+};
+
 function firstString(value: unknown): string {
   if (Array.isArray(value)) {
     return firstString(value[0]);
@@ -38,6 +58,14 @@ function firstString(value: unknown): string {
 
 function firstTrimmedString(value: unknown): string {
   return firstString(value).trim();
+}
+
+function firstStringish(value: unknown): string {
+  const first = Array.isArray(value) ? value[0] : value;
+  if (typeof first === "string") {
+    return first;
+  }
+  return typeof first === "number" ? String(first) : "";
 }
 
 function parseTwilioApiError(text: string): ParsedTwilioApiError {
@@ -117,10 +145,10 @@ export class TwilioSmsApiError extends Error {
   readonly responseText: string;
   readonly twilioCode?: number;
 
-  constructor(httpStatus: number, responseText: string) {
+  constructor(httpStatus: number, responseText: string, operation = "send") {
     const parsed = parseTwilioApiError(responseText);
     const detail = parsed.message ?? (responseText || "unknown");
-    super(`Twilio SMS send failed (${httpStatus}): ${detail}`);
+    super(`Twilio SMS ${operation} failed (${httpStatus}): ${detail}`);
     this.name = "TwilioSmsApiError";
     this.httpStatus = httpStatus;
     this.responseText = responseText;
@@ -205,13 +233,37 @@ export function respondTwiml(res: ServerResponse, statusCode: number, body = "")
   res.end(body || "<Response></Response>");
 }
 
-async function postTwilioMessages(params: {
-  url: string;
-  init: RequestInit;
+function twilioApiUrl(accountSid: string, path: string, query?: URLSearchParams): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(`${TWILIO_ACCOUNTS_URL}/${encodeURIComponent(accountSid)}${normalizedPath}`);
+  if (query) {
+    url.search = query.toString();
+  }
+  return url.toString();
+}
+
+function basicAuthHeader(account: ResolvedSmsAccount): string {
+  return `Basic ${Buffer.from(`${account.accountSid}:${account.authToken}`).toString("base64")}`;
+}
+
+async function requestTwilioApi(params: {
+  account: ResolvedSmsAccount;
+  path: string;
+  query?: URLSearchParams;
+  init?: RequestInit;
   fetchImpl?: typeof fetch;
+  timeoutMs?: number;
 }): Promise<TwilioApiResponse> {
+  const url = twilioApiUrl(params.account.accountSid, params.path, params.query);
+  const init = {
+    ...params.init,
+    headers: {
+      authorization: basicAuthHeader(params.account),
+      ...(params.init?.headers ?? {}),
+    },
+  } satisfies RequestInit;
   if (params.fetchImpl) {
-    const response = await params.fetchImpl(params.url, params.init);
+    const response = await params.fetchImpl(url, init);
     return {
       ok: response.ok,
       status: response.status,
@@ -220,12 +272,12 @@ async function postTwilioMessages(params: {
   }
 
   const guarded = await fetchWithSsrFGuard({
-    url: params.url,
-    init: params.init,
+    url,
+    init,
     auditContext: "sms-twilio-api",
     policy: { allowedHostnames: [TWILIO_API_HOSTNAME] },
     requireHttps: true,
-    timeoutMs: TWILIO_API_TIMEOUT_MS,
+    timeoutMs: params.timeoutMs ?? TWILIO_API_TIMEOUT_MS,
   });
   try {
     return {
@@ -236,6 +288,111 @@ async function postTwilioMessages(params: {
   } finally {
     await guarded.release();
   }
+}
+
+function parseTwilioIncomingPhoneNumber(
+  record: Record<string, unknown>,
+): TwilioIncomingPhoneNumber {
+  return {
+    sid: firstTrimmedString(record.sid),
+    phoneNumber: firstTrimmedString(record.phone_number ?? record.phoneNumber),
+    smsUrl: firstTrimmedString(record.sms_url ?? record.smsUrl),
+    smsMethod: firstTrimmedString(record.sms_method ?? record.smsMethod),
+    voiceUrl: firstTrimmedString(record.voice_url ?? record.voiceUrl),
+  };
+}
+
+function parseTwilioMessageLogEntry(record: Record<string, unknown>): TwilioMessageLogEntry {
+  return {
+    sid: firstTrimmedString(record.sid),
+    direction: firstTrimmedString(record.direction),
+    status: firstTrimmedString(record.status),
+    to: firstTrimmedString(record.to),
+    from: firstTrimmedString(record.from),
+    errorCode: firstStringish(record.error_code ?? record.errorCode).trim(),
+    body: firstString(record.body),
+    dateCreated: firstTrimmedString(record.date_created ?? record.dateCreated),
+    dateSent: firstTrimmedString(record.date_sent ?? record.dateSent),
+  };
+}
+
+function parseTwilioListPayload<T>(
+  text: string,
+  key: string,
+  parseEntry: (record: Record<string, unknown>) => T,
+): T[] {
+  if (!text.trim()) {
+    return [];
+  }
+  const parsed: unknown = JSON.parse(text);
+  if (!parsed || typeof parsed !== "object") {
+    return [];
+  }
+  const items = (parsed as Record<string, unknown>)[key];
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items
+    .filter((item): item is Record<string, unknown> =>
+      Boolean(item && typeof item === "object" && !Array.isArray(item)),
+    )
+    .map(parseEntry);
+}
+
+export async function listTwilioIncomingPhoneNumbers(params: {
+  account: ResolvedSmsAccount;
+  phoneNumber?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<TwilioIncomingPhoneNumber[]> {
+  const query = new URLSearchParams();
+  if (params.phoneNumber) {
+    query.set("PhoneNumber", params.phoneNumber);
+  }
+  const response = await requestTwilioApi({
+    account: params.account,
+    path: "/IncomingPhoneNumbers.json",
+    query,
+    fetchImpl: params.fetchImpl,
+    timeoutMs: params.timeoutMs,
+  });
+  if (!response.ok) {
+    throw new TwilioSmsApiError(response.status, response.text, "phone-number lookup");
+  }
+  return parseTwilioListPayload(
+    response.text,
+    "incoming_phone_numbers",
+    parseTwilioIncomingPhoneNumber,
+  );
+}
+
+export async function listTwilioMessages(params: {
+  account: ResolvedSmsAccount;
+  to?: string;
+  from?: string;
+  pageSize?: number;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<TwilioMessageLogEntry[]> {
+  const query = new URLSearchParams();
+  if (params.to) {
+    query.set("To", params.to);
+  }
+  if (params.from) {
+    query.set("From", params.from);
+  }
+  query.set("PageSize", String(params.pageSize ?? 5));
+  const response = await requestTwilioApi({
+    account: params.account,
+    path: "/Messages.json",
+    query,
+    fetchImpl: params.fetchImpl,
+    timeoutMs: params.timeoutMs,
+  });
+  if (!response.ok) {
+    throw new TwilioSmsApiError(response.status, response.text, "message lookup");
+  }
+  return parseTwilioListPayload(response.text, "messages", parseTwilioMessageLogEntry);
 }
 
 export async function sendSmsViaTwilio(params: {
@@ -256,19 +413,19 @@ export async function sendSmsViaTwilio(params: {
   } else {
     body.set("MessagingServiceSid", params.account.messagingServiceSid);
   }
-  const auth = Buffer.from(`${params.account.accountSid}:${params.account.authToken}`).toString(
-    "base64",
-  );
-  const url = `${TWILIO_MESSAGES_URL}/${encodeURIComponent(params.account.accountSid)}/Messages.json`;
   const init = {
     method: "POST",
     headers: {
-      authorization: `Basic ${auth}`,
       "content-type": "application/x-www-form-urlencoded",
     },
     body,
   } satisfies RequestInit;
-  const response = await postTwilioMessages({ url, init, fetchImpl: params.fetchImpl });
+  const response = await requestTwilioApi({
+    account: params.account,
+    path: "/Messages.json",
+    init,
+    fetchImpl: params.fetchImpl,
+  });
   if (!response.ok) {
     throw new TwilioSmsApiError(response.status, response.text);
   }

--- a/extensions/sms/src/twilio.ts
+++ b/extensions/sms/src/twilio.ts
@@ -246,6 +246,19 @@ function basicAuthHeader(account: ResolvedSmsAccount): string {
   return `Basic ${Buffer.from(`${account.accountSid}:${account.authToken}`).toString("base64")}`;
 }
 
+function normalizeRequestHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers.map(([key, value]) => [key, value]));
+  }
+  return Object.fromEntries(Object.entries(headers));
+}
+
 async function requestTwilioApi(params: {
   account: ResolvedSmsAccount;
   path: string;
@@ -258,8 +271,8 @@ async function requestTwilioApi(params: {
   const init = {
     ...params.init,
     headers: {
+      ...normalizeRequestHeaders(params.init?.headers),
       authorization: basicAuthHeader(params.account),
-      ...(params.init?.headers ?? {}),
     },
   } satisfies RequestInit;
   if (params.fetchImpl) {

--- a/extensions/sms/src/twilio.ts
+++ b/extensions/sms/src/twilio.ts
@@ -6,7 +6,9 @@ import { readRequestBodyWithLimit } from "openclaw/plugin-sdk/webhook-ingress";
 import type { ResolvedSmsAccount, SmsInboundMessage, SmsSendResult } from "./types.js";
 
 const TWILIO_ACCOUNTS_URL = "https://api.twilio.com/2010-04-01/Accounts";
+const TWILIO_MESSAGING_URL = "https://messaging.twilio.com/v1";
 const TWILIO_API_HOSTNAME = "api.twilio.com";
+const TWILIO_MESSAGING_HOSTNAME = "messaging.twilio.com";
 const TWILIO_API_TIMEOUT_MS = 30_000;
 const WEBHOOK_BODY_LIMIT_BYTES = 32 * 1024;
 const WEBHOOK_BODY_TIMEOUT_MS = 5_000;
@@ -47,6 +49,13 @@ export type TwilioMessageLogEntry = {
   body: string;
   dateCreated: string;
   dateSent: string;
+};
+
+export type TwilioMessagingService = {
+  sid: string;
+  inboundRequestUrl: string;
+  inboundMethod: string;
+  useInboundWebhookOnNumber: boolean;
 };
 
 function firstString(value: unknown): string {
@@ -242,6 +251,15 @@ function twilioApiUrl(accountSid: string, path: string, query?: URLSearchParams)
   return url.toString();
 }
 
+function twilioMessagingUrl(path: string, query?: URLSearchParams): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(`${TWILIO_MESSAGING_URL}${normalizedPath}`);
+  if (query) {
+    url.search = query.toString();
+  }
+  return url.toString();
+}
+
 function basicAuthHeader(account: ResolvedSmsAccount): string {
   return `Basic ${Buffer.from(`${account.accountSid}:${account.authToken}`).toString("base64")}`;
 }
@@ -260,14 +278,13 @@ function normalizeRequestHeaders(headers: HeadersInit | undefined): Record<strin
 }
 
 async function requestTwilioApi(params: {
+  url: string;
   account: ResolvedSmsAccount;
-  path: string;
-  query?: URLSearchParams;
+  allowedHostname: string;
   init?: RequestInit;
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
 }): Promise<TwilioApiResponse> {
-  const url = twilioApiUrl(params.account.accountSid, params.path, params.query);
   const init = {
     ...params.init,
     headers: {
@@ -276,7 +293,7 @@ async function requestTwilioApi(params: {
     },
   } satisfies RequestInit;
   if (params.fetchImpl) {
-    const response = await params.fetchImpl(url, init);
+    const response = await params.fetchImpl(params.url, init);
     return {
       ok: response.ok,
       status: response.status,
@@ -285,10 +302,10 @@ async function requestTwilioApi(params: {
   }
 
   const guarded = await fetchWithSsrFGuard({
-    url,
+    url: params.url,
     init,
     auditContext: "sms-twilio-api",
-    policy: { allowedHostnames: [TWILIO_API_HOSTNAME] },
+    policy: { allowedHostnames: [params.allowedHostname] },
     requireHttps: true,
     timeoutMs: params.timeoutMs ?? TWILIO_API_TIMEOUT_MS,
   });
@@ -329,6 +346,17 @@ function parseTwilioMessageLogEntry(record: Record<string, unknown>): TwilioMess
   };
 }
 
+function parseTwilioMessagingService(record: Record<string, unknown>): TwilioMessagingService {
+  return {
+    sid: firstTrimmedString(record.sid),
+    inboundRequestUrl: firstTrimmedString(record.inbound_request_url ?? record.inboundRequestUrl),
+    inboundMethod: firstTrimmedString(record.inbound_method ?? record.inboundMethod),
+    useInboundWebhookOnNumber: Boolean(
+      record.use_inbound_webhook_on_number ?? record.useInboundWebhookOnNumber,
+    ),
+  };
+}
+
 function parseTwilioListPayload<T>(
   text: string,
   key: string,
@@ -364,8 +392,8 @@ export async function listTwilioIncomingPhoneNumbers(params: {
   }
   const response = await requestTwilioApi({
     account: params.account,
-    path: "/IncomingPhoneNumbers.json",
-    query,
+    url: twilioApiUrl(params.account.accountSid, "/IncomingPhoneNumbers.json", query),
+    allowedHostname: TWILIO_API_HOSTNAME,
     fetchImpl: params.fetchImpl,
     timeoutMs: params.timeoutMs,
   });
@@ -377,6 +405,29 @@ export async function listTwilioIncomingPhoneNumbers(params: {
     "incoming_phone_numbers",
     parseTwilioIncomingPhoneNumber,
   );
+}
+
+export async function retrieveTwilioMessagingService(params: {
+  account: ResolvedSmsAccount;
+  serviceSid: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<TwilioMessagingService> {
+  const response = await requestTwilioApi({
+    account: params.account,
+    url: twilioMessagingUrl(`/Services/${encodeURIComponent(params.serviceSid)}`),
+    allowedHostname: TWILIO_MESSAGING_HOSTNAME,
+    fetchImpl: params.fetchImpl,
+    timeoutMs: params.timeoutMs,
+  });
+  if (!response.ok) {
+    throw new TwilioSmsApiError(response.status, response.text, "messaging-service lookup");
+  }
+  const parsed: unknown = JSON.parse(response.text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Twilio Messaging Service lookup returned malformed JSON.");
+  }
+  return parseTwilioMessagingService(parsed as Record<string, unknown>);
 }
 
 export async function listTwilioMessages(params: {
@@ -397,8 +448,8 @@ export async function listTwilioMessages(params: {
   query.set("PageSize", String(params.pageSize ?? 5));
   const response = await requestTwilioApi({
     account: params.account,
-    path: "/Messages.json",
-    query,
+    url: twilioApiUrl(params.account.accountSid, "/Messages.json", query),
+    allowedHostname: TWILIO_API_HOSTNAME,
     fetchImpl: params.fetchImpl,
     timeoutMs: params.timeoutMs,
   });
@@ -435,7 +486,8 @@ export async function sendSmsViaTwilio(params: {
   } satisfies RequestInit;
   const response = await requestTwilioApi({
     account: params.account,
-    path: "/Messages.json",
+    url: twilioApiUrl(params.account.accountSid, "/Messages.json"),
+    allowedHostname: TWILIO_API_HOSTNAME,
     init,
     fetchImpl: params.fetchImpl,
   });


### PR DESCRIPTION
Summary
- Add a Twilio-backed SMS status probe that checks the configured phone-number SMS webhook URL/method and recent inbound Twilio error 11200 failures.
- Register SMS authToken SecretRef targets and runtime resolution sidecars for top-level and per-account config.
- Expand SMS docs with Tailscale Funnel path setup, SecretRef usage, probe commands, and macOS imsg E2E examples.

Verification
- node scripts/run-vitest.mjs extensions/sms/src/twilio.test.ts extensions/sms/src/status.test.ts extensions/sms/src/secret-contract.test.ts extensions/sms/src/channel.test.ts
- pnpm exec tsgo -p extensions/sms/tsconfig.json --pretty false
- pnpm docs:list
- pnpm docs:check-mdx
- pnpm docs:check-links
- pnpm docs:check-i18n-glossary
- git diff --check
- env -u OPENCLAW_TESTBOX pnpm check:changed
- OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=core-runtime-secrets OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TEST_PROJECTS_PARALLEL=2 pnpm exec node scripts/test-projects.mjs test/vitest/vitest.secrets.config.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Real behavior proof
Behavior addressed: SMS setup now detects the Twilio webhook/Funnel route failure that caused inbound SMS to show Twilio error 11200 without creating a pairing request.
Real environment tested: Mac Studio local Gateway plus Twilio SMS number and macOS imsg sender before this patch; unit/type/docs/check gates after this patch.
Exact steps or command run after this patch: node scripts/run-vitest.mjs extensions/sms/src/twilio.test.ts extensions/sms/src/status.test.ts extensions/sms/src/secret-contract.test.ts extensions/sms/src/channel.test.ts; env -u OPENCLAW_TESTBOX pnpm check:changed.
Evidence after fix: Focused SMS tests passed 33 tests; exact core-runtime-secrets shard passed 58 files / 479 tests; changed gate passed extension typecheck, extension-test typecheck, extension lint, runtime sidecar loader guard, and import-cycle guard; autoreview reported no accepted/actionable findings.
Observed result after fix: The SMS probe reports webhook mismatch/missing route cases and surfaces recent inbound 11200 with a Tailscale Funnel path hint; SMS SecretRefs resolve through the runtime contract.
What was not tested: No live post-patch Twilio webhook call was run from CI; live pre-patch E2E was used to identify the route failure.



