### PR TITLE
fix(gateway): reject pre-reset run lifecycle events from clobbering the rotated session row

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -11,7 +11,7 @@ import {
   resolveContextEngine,
   resolveContextEngineOwnerPluginId,
 } from "../../context-engine/registry.js";
-import { emitAgentPlanEvent } from "../../infra/agent-events.js";
+import { emitAgentPlanEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -1347,6 +1347,10 @@ export async function runEmbeddedAgent(
           const nextSessionFile = compactResult.result?.sessionFile;
           if (nextSessionId && nextSessionId !== activeSessionId) {
             activeSessionId = nextSessionId;
+            // Keep the run context's sessionId tracking the live session so
+            // lifecycle persistence isn't treated as stale after a legitimate
+            // mid-run compaction rotation (#88538).
+            registerAgentRunContext(params.runId, { sessionId: activeSessionId });
           }
           if (nextSessionFile && nextSessionFile !== activeSessionFile) {
             activeSessionFile = nextSessionFile;
@@ -1705,6 +1709,8 @@ export async function runEmbeddedAgent(
           const timedOutDuringToolExecution = attempt.timedOutDuringToolExecution ?? false;
           if (sessionIdUsed && sessionIdUsed !== activeSessionId) {
             activeSessionId = sessionIdUsed;
+            // Track the live session for lifecycle persistence identity (#88538).
+            registerAgentRunContext(params.runId, { sessionId: activeSessionId });
           }
           if (sessionFileUsed && sessionFileUsed !== activeSessionFile) {
             activeSessionFile = sessionFileUsed;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1584,6 +1584,7 @@ export async function runAgentTurnWithFallback(params: {
   if (params.sessionKey) {
     registerAgentRunContext(runId, {
       sessionKey: params.sessionKey,
+      ...(params.followupRun.run.sessionId ? { sessionId: params.followupRun.run.sessionId } : {}),
       verboseLevel: params.resolvedVerboseLevel,
       isHeartbeat: params.isHeartbeat,
       isControlUiVisible: shouldSurfaceToControlUi,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -684,6 +684,66 @@ describe("createFollowupRunner reply-lane admission", () => {
     expect(call.sessionId).toBe("post-compact-session");
     expect(call.sessionFile).toBe("/tmp/post-compact.jsonl");
   });
+
+  it("registers the admitted session id when the local session store is stale", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    realAgentEvents.resetAgentRunContextForTest();
+    const active = createReplyOperationForTest({
+      sessionKey: "main",
+      sessionId: "pre-compact-session",
+      resetTriggered: false,
+    });
+    active.setPhase("preflight_compacting");
+    let observedRunId: string | undefined;
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (params: { runId: string; sessionId?: string }) => {
+        observedRunId = params.runId;
+        expect(params.sessionId).toBe("post-compact-session");
+        return {
+          payloads: [],
+          meta: { agentMeta: { provider: "anthropic", model: "claude" } },
+        };
+      },
+    );
+    const sessionStore = {
+      main: {
+        sessionId: "pre-compact-session",
+        sessionFile: "/tmp/pre-compact.jsonl",
+        updatedAt: Date.now(),
+      },
+    };
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry: sessionStore.main,
+      sessionStore,
+      sessionKey: "main",
+      defaultModel: "anthropic/claude",
+    });
+
+    const pending = runner(
+      createQueuedRun({
+        run: {
+          sessionId: "queued-stale-session",
+          sessionKey: "main",
+          provider: "anthropic",
+          model: "claude",
+        },
+      }),
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    active.updateSessionId("post-compact-session");
+    active.complete();
+    await pending;
+
+    expect(observedRunId).toBeDefined();
+    expect(realAgentEvents.getAgentRunContext(observedRunId ?? "")?.sessionId).toBe(
+      "post-compact-session",
+    );
+    realAgentEvents.resetAgentRunContextForTest();
+  });
 });
 
 async function normalizeComparablePath(filePath: string): Promise<string> {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -542,14 +542,6 @@ export function createFollowupRunner(params: {
           provider: run.messageProvider,
         }),
       );
-      if (run.sessionKey) {
-        registerAgentRunContext(runId, {
-          sessionKey: run.sessionKey,
-          ...(run.sessionId ? { sessionId: run.sessionId } : {}),
-          verboseLevel: run.verboseLevel,
-          isControlUiVisible: shouldSurfaceToControlUi,
-        });
-      }
       let autoCompactionCount = 0;
       let runResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
       let fallbackProvider = run.provider;
@@ -567,6 +559,18 @@ export function createFollowupRunner(params: {
         isHeartbeat: opts?.isHeartbeat === true,
         replyOperation,
       });
+      if (run.sessionKey) {
+        const owningSessionId =
+          activeSessionEntry?.sessionId === run.sessionId
+            ? activeSessionEntry.sessionId
+            : run.sessionId;
+        registerAgentRunContext(runId, {
+          sessionKey: run.sessionKey,
+          ...(owningSessionId ? { sessionId: owningSessionId } : {}),
+          verboseLevel: run.verboseLevel,
+          isControlUiVisible: shouldSurfaceToControlUi,
+        });
+      }
       let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
         activeSessionEntry?.systemPromptReport,
       );

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -545,6 +545,7 @@ export function createFollowupRunner(params: {
       if (run.sessionKey) {
         registerAgentRunContext(runId, {
           sessionKey: run.sessionKey,
+          ...(run.sessionId ? { sessionId: run.sessionId } : {}),
           verboseLevel: run.verboseLevel,
           isControlUiVisible: shouldSurfaceToControlUi,
         });

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1903,6 +1903,75 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
+  it("does not project stale pre-reset lifecycle events into session subscriber snapshots", () => {
+    vi.mocked(loadGatewaySessionRow).mockReturnValue({
+      key: "session-reset",
+      kind: "direct",
+      sessionId: "new-session",
+      updatedAt: 2_000,
+      status: "done",
+      startedAt: 1_000,
+      endedAt: 1_500,
+      runtimeMs: 500,
+      abortedLastRun: false,
+    });
+    const { broadcastToConnIds, sessionEventSubscribers, handler } = createHarness({
+      lifecycleErrorRetryGraceMs: 0,
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+
+    handler({
+      runId: "old-run",
+      seq: 1,
+      stream: "lifecycle",
+      sessionKey: "session-reset",
+      sessionId: "old-session",
+      ts: 2_100,
+      data: {
+        phase: "start",
+        startedAt: 2_100,
+      },
+    });
+    handler({
+      runId: "old-run",
+      seq: 2,
+      stream: "lifecycle",
+      sessionKey: "session-reset",
+      sessionId: "old-session",
+      ts: 2_200,
+      data: {
+        phase: "error",
+        endedAt: 2_200,
+        error: "old run failed",
+      },
+    });
+
+    const sessionsChangedCalls = broadcastToConnIds.mock.calls.filter(
+      ([event]) => event === "sessions.changed",
+    );
+    expect(sessionsChangedCalls).toHaveLength(2);
+    for (const [, payload] of sessionsChangedCalls) {
+      expectPayloadFields(payload, {
+        sessionKey: "session-reset",
+        sessionId: "new-session",
+        status: "done",
+        startedAt: 1_000,
+        endedAt: 1_500,
+        runtimeMs: 500,
+        updatedAt: 2_000,
+        abortedLastRun: false,
+      });
+      expectRecordFields(requireRecord(requireRecord(payload, "payload").session, "session"), {
+        sessionId: "new-session",
+        status: "done",
+        startedAt: 1_000,
+        endedAt: 1_500,
+        runtimeMs: 500,
+      });
+    }
+    resetAgentRunContextForTest();
+  });
+
   it("clears tracked active runs before terminal sessions.changed broadcasts", () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-finished",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -23,7 +23,10 @@ import type {
 } from "./server-chat-state.js";
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
 import { persistGatewaySessionLifecycleEvent } from "./server-chat.persist-session-lifecycle.runtime.js";
-import { deriveGatewaySessionLifecycleSnapshot } from "./session-lifecycle-state.js";
+import {
+  deriveGatewaySessionLifecycleSnapshot,
+  isStaleLifecycleEventForSession,
+} from "./session-lifecycle-state.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
 
@@ -333,21 +336,26 @@ export function createAgentEventHandler({
   ) => {
     const row = loadGatewaySessionRowForSnapshot(sessionKey, agentId ? { agentId } : undefined);
     const omitUnscopedGlobalGoal = sessionKey === "global" && !agentId;
-    const lifecyclePatch = evt
-      ? deriveGatewaySessionLifecycleSnapshot({
-          session: row
-            ? {
-                updatedAt: row.updatedAt ?? undefined,
-                status: row.status,
-                startedAt: row.startedAt,
-                endedAt: row.endedAt,
-                runtimeMs: row.runtimeMs,
-                abortedLastRun: row.abortedLastRun,
-              }
-            : undefined,
-          event: evt,
-        })
-      : {};
+    const lifecyclePatch =
+      evt &&
+      !isStaleLifecycleEventForSession({
+        owningSessionId: evt.sessionId,
+        currentSessionId: row?.sessionId,
+      })
+        ? deriveGatewaySessionLifecycleSnapshot({
+            session: row
+              ? {
+                  updatedAt: row.updatedAt ?? undefined,
+                  status: row.status,
+                  startedAt: row.startedAt,
+                  endedAt: row.endedAt,
+                  runtimeMs: row.runtimeMs,
+                  abortedLastRun: row.abortedLastRun,
+                }
+              : undefined,
+            event: evt,
+          })
+        : {};
     const session = row ? { ...row, ...lifecyclePatch } : undefined;
     if (session && omitUnscopedGlobalGoal) {
       delete session.goal;

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -2,9 +2,28 @@ import { describe, expect, it } from "vitest";
 import {
   deriveGatewaySessionLifecycleSnapshot,
   derivePersistedSessionLifecyclePatch,
+  isStaleLifecycleEventForSession,
 } from "./session-lifecycle-state.js";
 
 describe("session lifecycle state", () => {
+  it("treats a pre-reset run's lifecycle event as stale once the row's sessionId rotated (#88538)", () => {
+    expect(
+      isStaleLifecycleEventForSession({ owningSessionId: "old-id", currentSessionId: "new-id" }),
+    ).toBe(true);
+  });
+
+  it("applies lifecycle events whose owning sessionId matches the current row", () => {
+    expect(
+      isStaleLifecycleEventForSession({ owningSessionId: "same-id", currentSessionId: "same-id" }),
+    ).toBe(false);
+  });
+
+  it("does not guard when the owning sessionId is unknown (preserves legacy behavior)", () => {
+    expect(
+      isStaleLifecycleEventForSession({ owningSessionId: undefined, currentSessionId: "new-id" }),
+    ).toBe(false);
+  });
+
   it("reactivates completed sessions on lifecycle start", () => {
     expect(
       deriveGatewaySessionLifecycleSnapshot({

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -9,7 +9,7 @@ import type { GatewaySessionRow, SessionRunStatus } from "./session-utils.types.
 
 type LifecyclePhase = "start" | "end" | "error";
 
-type LifecycleEventLike = Pick<AgentEventPayload, "ts"> & {
+type LifecycleEventLike = Pick<AgentEventPayload, "ts" | "sessionId"> & {
   data?: {
     phase?: unknown;
     startedAt?: unknown;
@@ -172,6 +172,22 @@ export function derivePersistedSessionLifecyclePatch(params: {
   };
 }
 
+/**
+ * A pre-`sessions.reset` run's lifecycle event must not mutate a session row
+ * whose sessionId was rotated by the reset. True only when both the owning
+ * run's sessionId and the current row's sessionId are known and differ.
+ */
+export function isStaleLifecycleEventForSession(params: {
+  owningSessionId?: string;
+  currentSessionId?: string;
+}): boolean {
+  return Boolean(
+    params.owningSessionId &&
+    params.currentSessionId &&
+    params.owningSessionId !== params.currentSessionId,
+  );
+}
+
 export async function persistGatewaySessionLifecycleEvent(params: {
   sessionKey: string;
   agentId?: string;
@@ -190,15 +206,27 @@ export async function persistGatewaySessionLifecycleEvent(params: {
     return;
   }
 
+  const owningSessionId =
+    typeof params.event.sessionId === "string" && params.event.sessionId
+      ? params.event.sessionId
+      : undefined;
+
   await updateSessionStoreEntry({
     storePath: sessionEntry.storePath,
     sessionKey: sessionEntry.canonicalKey,
     skipMaintenance: true,
     takeCacheOwnership: true,
-    update: async (entry) =>
-      derivePersistedSessionLifecyclePatch({
+    update: async (entry) => {
+      // Reject a pre-reset run's lifecycle event: sessions.reset rotates the row
+      // to a new sessionId under the same sessionKey, so an old in-flight run's
+      // late start/end/error must not overwrite the fresh row's status (#88538).
+      if (isStaleLifecycleEventForSession({ owningSessionId, currentSessionId: entry.sessionId })) {
+        return null;
+      }
+      return derivePersistedSessionLifecyclePatch({
         entry,
         event: params.event,
-      }),
+      });
+    },
   });
 }

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -30,6 +30,44 @@ describe("agent-events sequencing", () => {
     expect(getAgentRunContext("run-1")).toBeUndefined();
   });
 
+  test("stamps the owning sessionId onto lifecycle events for reset-stale guarding (#88538)", () => {
+    registerAgentRunContext("run-1", { sessionKey: "main", sessionId: "old-session-id" });
+    const seen: Array<{ stream: string; sessionId?: string }> = [];
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-1") {
+        seen.push({ stream: evt.stream, sessionId: evt.sessionId });
+      }
+    });
+
+    emitAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "error" } });
+    emitAgentEvent({ runId: "run-1", stream: "item", data: {} });
+
+    stop();
+
+    expect(seen.find((evt) => evt.stream === "lifecycle")?.sessionId).toBe("old-session-id");
+    // Only lifecycle events carry the sessionId; other streams stay unstamped.
+    expect(seen.find((evt) => evt.stream === "item")?.sessionId).toBeUndefined();
+  });
+
+  test("refreshes the stamped sessionId after a mid-run session rotation (#88538)", () => {
+    registerAgentRunContext("run-1", { sessionKey: "main", sessionId: "start-id" });
+    // A legitimate compaction rotation re-registers the run with its new session.
+    registerAgentRunContext("run-1", { sessionId: "rotated-id" });
+    let stamped: string | undefined;
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-1" && evt.stream === "lifecycle") {
+        stamped = evt.sessionId;
+      }
+    });
+
+    emitAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "end" } });
+
+    stop();
+    // Terminal event carries the rotated id, so persistence won't treat the
+    // run as stale against the row it rotated to.
+    expect(stamped).toBe("rotated-id");
+  });
+
   test("maintains monotonic seq per runId", () => {
     const seen: Record<string, number[]> = {};
     const stop = onAgentEvent((evt) => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -106,11 +106,19 @@ export type AgentEventPayload = {
   ts: number;
   data: Record<string, unknown>;
   sessionKey?: string;
+  /**
+   * sessionId the run was bound to when it started. Lifecycle persistence uses
+   * this to reject terminal events from a pre-`sessions.reset` run that would
+   * otherwise clobber the rotated session row resolved by the shared sessionKey.
+   */
+  sessionId?: string;
   agentId?: string;
 };
 
 export type AgentRunContext = {
   sessionKey?: string;
+  /** Owning run's sessionId; stamped onto lifecycle events (see AgentEventPayload.sessionId). */
+  sessionId?: string;
   verboseLevel?: VerboseLevel;
   isHeartbeat?: boolean;
   /** Whether control UI clients should receive chat/agent updates for this run. */
@@ -152,6 +160,9 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   }
   if (context.sessionKey && existing.sessionKey !== context.sessionKey) {
     existing.sessionKey = context.sessionKey;
+  }
+  if (context.sessionId && existing.sessionId !== context.sessionId) {
+    existing.sessionId = context.sessionId;
   }
   if (context.verboseLevel && existing.verboseLevel !== context.verboseLevel) {
     existing.verboseLevel = context.verboseLevel;
@@ -226,9 +237,14 @@ export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
   // stream remains redacted for hidden runs because it is observational only.
   const preserveSessionKey = isControlUiVisible || event.stream === "lifecycle";
   const sessionKey = preserveSessionKey ? (eventSessionKey ?? context?.sessionKey) : undefined;
+  // Stamp lifecycle events with the owning sessionId (see AgentEventPayload) at
+  // emit time, since the run context can be cleared before the terminal persists.
+  const sessionId =
+    event.stream === "lifecycle" ? (event.sessionId ?? context?.sessionId) : event.sessionId;
   const enriched: AgentEventPayload = {
     ...event,
     sessionKey,
+    ...(sessionId ? { sessionId } : {}),
     seq: nextSeq,
     ts: Date.now(),
   };


### PR DESCRIPTION
### Summary

- **Problem**: Issue #88538 reports that `sessions.reset` rotates a channel session to a fresh `sessionId`, but an old in-flight embedded run can still emit later lifecycle `start`/`end`/`error` events. Those events are persisted onto the **new** session row, leaving the fresh session marked `running`/`failed` even though `hasActiveRun=false`. A pre-reset run's terminal error overwrote a post-reset row's status.
- **Root Cause**: `persistGatewaySessionLifecycleEvent` in `src/gateway/session-lifecycle-state.ts` resolves the target SessionEntry purely by `sessionKey` (`loadSessionEntry(params.sessionKey)` → `updateSessionStoreEntry`) and writes `status`/`startedAt`/`endedAt`/`runtimeMs` with **no `sessionId` identity check**. After `sessions.reset` rotates the key to a new sessionId, a late lifecycle event from the old run still resolves that key and clobbers the new row. Lifecycle events carried `runId` but not the owning run's `sessionId`, and the runId→context map is cleared before the terminal event persists — so the owning sessionId had to be carried on the event itself.
- **Fix**: Carry the owning run's `sessionId` on lifecycle events and reject persistence when it differs from the current row's sessionId.
  - `emitAgentEvent` stamps the owning `sessionId` (from the registered run context) onto lifecycle-stream events at emit time, so it survives the run-context clear.
  - `persistGatewaySessionLifecycleEvent` skips the write when the event's owning sessionId and the current row's sessionId are both known and differ (`isStaleLifecycleEventForSession`).
  - This is the same identity-guard pattern the codebase already uses for reset/rebind hazards; it covers all lifecycle emitters centrally via the runId→context stamp rather than per-emitter.
- **What changed**:
  - `src/infra/agent-events.ts` — add `sessionId?` to `AgentEventPayload` and `AgentRunContext`; carry it through `registerAgentRunContext` merge; stamp it onto lifecycle events in `emitAgentEvent`.
  - `src/gateway/session-lifecycle-state.ts` — add the pure `isStaleLifecycleEventForSession` guard; apply it inside the `updateSessionStoreEntry` callback (race-safe against the live entry); `LifecycleEventLike` now also picks `sessionId`.
  - `src/auto-reply/reply/agent-runner-execution.ts`, `src/auto-reply/reply/followup-runner.ts` — register the embedded run's starting `sessionId` in its run context so the stamp has a value.
  - `src/agents/embedded-agent-runner/run.ts` — refresh the run context's `sessionId` whenever the live session rotates (compaction creates a new session id mid-run), so a legitimate rotated run's terminal event matches the rotated row and is NOT treated as stale. Only an external `sessions.reset` (which rotates the row without going through the run's own rotation) stays mismatched.
  - Tests in `session-lifecycle-state.test.ts` (guard decision) and `agent-events.test.ts` (lifecycle-event sessionId stamping + rotation refresh).
- **What did NOT change (scope boundary)**:
  - Guard only skips when **both** the owning and current sessionIds are known and differ; when the owning sessionId is absent (any emitter that doesn't stamp it) behavior is unchanged — never a new false-skip.
  - `sessionId` is an additive optional field on the in-memory event/run-context shapes (no persisted format change).
  - The pure derivers (`deriveGatewaySessionLifecycleSnapshot` / `derivePersistedSessionLifecyclePatch`) are unchanged.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. A channel session hits a long/overflowing embedded run.
2. `sessions.reset` returns a new sessionId for the same channel `sessionKey`.
3. The old pre-reset run then emits a terminal `error` (or `start`/`end`) lifecycle event.
4. **Before this PR**: the event resolves the rotated row by sessionKey and overwrites it to `failed`/`running` though the failing run belonged to the old sessionId.
5. **After this PR**: the event carries the old run's sessionId; persistence sees it differs from the rotated row's sessionId and skips the write, leaving the fresh session intact.

### Real behavior proof

**Behavior addressed (#88538)**: a lifecycle event from a pre-`sessions.reset` run no longer mutates the post-reset session row; the owning sessionId is stamped on lifecycle events and persistence rejects mismatches.

**Real environment tested (Linux, Node 22 — Vitest against the production emit + guard functions)**: `emitAgentEvent` lifecycle sessionId stamping and the `isStaleLifecycleEventForSession` persistence guard, exercised directly.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/gateway/session-lifecycle-state.test.ts src/infra/agent-events.test.ts`; `pnpm tsgo:core`; `pnpm check:test-types`; `pnpm exec oxfmt --check`; `node scripts/run-oxlint.mjs` on the changed files.

**Evidence after fix (Vitest output for the touched files)**:

```text
 session-lifecycle-state.test.ts   Tests  11 passed (11)
 agent-events.test.ts              Tests  13 passed (13)
```

The new cases: `treats a pre-reset run's lifecycle event as stale once the row's sessionId rotated (#88538)`, `applies lifecycle events whose owning sessionId matches the current row`, `does not guard when the owning sessionId is unknown (preserves legacy behavior)`, `stamps the owning sessionId onto lifecycle events for reset-stale guarding (#88538)`, and `refreshes the stamped sessionId after a mid-run session rotation (#88538)`.

**Observed result after fix**:

- A lifecycle event whose owning sessionId differs from the current row's sessionId is treated as stale → persistence returns `null` (no mutation).
- A matching sessionId still applies normally; an unknown owning sessionId preserves the prior behavior (no false-skip).
- `emitAgentEvent` stamps the owning sessionId onto `lifecycle`-stream events only; other streams stay unstamped.

**What was not tested**:

- The live Slack channel-overflow + reset race end-to-end on the reporter's deployment. The emit-side stamp and the persistence guard are covered deterministically by unit tests against the production functions; a full gateway store round-trip was not driven.

**Regression tests**:

- `session-lifecycle-state.test.ts` → guard-decision cases (stale-rotated / matching / unknown-owner).
- `agent-events.test.ts` → lifecycle sessionId stamping; existing sequencing/redaction cases remain green.

### Risk / Mitigation

- **Risk**: A legitimate event could be skipped — specifically a run whose session rotates mid-run via compaction. **Mitigation**: `run.ts` refreshes the run context's sessionId on every live-session rotation, so the run's lifecycle events always carry its current sessionId and match the rotated row; the guard fires only when both sessionIds are known and differ (i.e., an external reset rotated the row out from under the run), and equal/unknown-owner cases always apply.
- **Risk**: An emitter that doesn't stamp sessionId stays unguarded. **Mitigation**: the stamp is centralized in `emitAgentEvent` from the run context (keyed by runId), so any emitter whose run registered a sessionId is covered; unstamped events keep prior behavior (safe).
- **Risk**: Added field on a hot event shape. **Mitigation**: one optional field, only stamped for lifecycle events, no persisted-format or protocol change.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Sessions / storage

### Linked Issue/PR

Fixes #88538
