### PR TITLE
Surface ACP reconcile errors in startup logs

### DIFF
--- a/src/acp/control-plane/manager.startup-identity-reconcile.ts
+++ b/src/acp/control-plane/manager.startup-identity-reconcile.ts
@@ -5,6 +5,10 @@ import {
 } from "@openclaw/acp-core/runtime/session-identity";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
+import { redactSensitiveText } from "../../logging/redact.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
+import { toAcpRuntimeError } from "../runtime/errors.js";
 import type {
   AcpSessionManagerDeps,
   AcpStartupIdentityReconcileResult,
@@ -13,6 +17,34 @@ import type {
   ResolveManagerSession,
   WithManagerSessionActor,
 } from "./manager.types.js";
+
+const ACP_RECONCILE_LOG_FIELD_MAX_LENGTH = 500;
+const acpManagerLog = createSubsystemLogger("acp/manager");
+
+function sanitizeAcpReconcileLogValue(value: string): string {
+  const normalized = sanitizeForLog(value);
+  const sanitized = sanitizeForLog(redactSensitiveText(normalized)).replace(/\s+/g, " ").trim();
+  if (!sanitized) {
+    return "<empty>";
+  }
+  if (sanitized.length <= ACP_RECONCILE_LOG_FIELD_MAX_LENGTH) {
+    return sanitized;
+  }
+  return `${sanitized.slice(0, ACP_RECONCILE_LOG_FIELD_MAX_LENGTH - 3)}...`;
+}
+
+function logStartupIdentityReconcileFailure(sessionKey: string, error: unknown) {
+  const acpError = toAcpRuntimeError({
+    error,
+    fallbackCode: "ACP_TURN_FAILED",
+    fallbackMessage: "ACP startup identity reconcile failed.",
+  });
+  const safeSessionKey = sanitizeAcpReconcileLogValue(sessionKey);
+  const safeMessage = sanitizeAcpReconcileLogValue(acpError.message);
+  acpManagerLog.warn(
+    `acp-manager: startup identity reconcile failed for ${safeSessionKey}: code=${acpError.code} message=${safeMessage}`,
+  );
+}
 
 /** Resolves pending ACP session identities opportunistically during manager startup. */
 export async function runManagerStartupIdentityReconcile(params: {
@@ -79,6 +111,7 @@ export async function runManagerStartupIdentityReconcile(params: {
       }
     } catch (error) {
       failed += 1;
+      logStartupIdentityReconcileFailure(session.sessionKey, error);
       logVerbose(
         `acp-manager: startup identity reconcile failed for ${session.sessionKey}: ${String(error)}`,
       );

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -27,6 +27,19 @@ import {
   type SessionAcpMeta,
 } from "./manager.test-helpers.js";
 
+const subsystemWarnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => ({
+      ...actual.createSubsystemLogger(subsystem),
+      warn: subsystemWarnMock,
+    }),
+  };
+});
+
 describe("AcpSessionManager", () => {
   installAcpSessionManagerTestLifecycle();
 
@@ -1638,5 +1651,61 @@ describe("AcpSessionManager", () => {
         clearMeta: true,
       }),
     ).rejects.toThrow("disk locked");
+  });
+
+  it("warns with the session and sanitized ACP error when startup reconcile fails", async () => {
+    subsystemWarnMock.mockReset();
+    const sessionKey = "agent:codex:acp:session-1";
+    const currentMeta: SessionAcpMeta = {
+      ...readySessionMeta(),
+      identity: {
+        state: "pending",
+        source: "ensure",
+        acpxSessionId: "acpx-stale",
+        lastUpdatedAt: Date.now(),
+      },
+    };
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
+      {
+        cfg: baseCfg,
+        storePath: "/tmp/sessions-acp.json",
+        sessionKey,
+        storeSessionKey: sessionKey,
+        entry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+          acp: currentMeta,
+        },
+        acp: currentMeta,
+      },
+    ]);
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey,
+      storeSessionKey: sessionKey,
+      acp: currentMeta,
+    });
+    const escape = String.fromCharCode(0x1b);
+    const rawSecret = "sk-startup-reconcile-secret-1234567890";
+    const obfuscatedSecret = `sk-startup-${escape}[31mreconcile-secret-1234567890`;
+    hoisted.requireAcpRuntimeBackendMock.mockImplementation(() => {
+      throw new AcpRuntimeError(
+        "ACP_BACKEND_UNAVAILABLE",
+        `backend unavailable: OPENAI_API_KEY=${obfuscatedSecret}`,
+      );
+    });
+
+    const manager = new AcpSessionManager();
+    const result = await manager.reconcilePendingSessionIdentities({ cfg: baseCfg });
+
+    expect(result).toEqual({ checked: 1, resolved: 0, failed: 1 });
+    expect(subsystemWarnMock).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining(
+        `acp-manager: startup identity reconcile failed for ${sessionKey}: code=ACP_BACKEND_UNAVAILABLE message=backend unavailable: OPENAI_API_KEY=`,
+      ),
+    );
+    const warnMessage = subsystemWarnMock.mock.calls[0]?.[0] ?? "";
+    expect(warnMessage).not.toContain(rawSecret);
+    expect(warnMessage).not.toContain(obfuscatedSecret);
+    expect(warnMessage).not.toContain("/tmp/sessions-acp.json");
   });
 });


### PR DESCRIPTION
## Summary

Problem: startup reconcile failures for individual ACP sessions were invisible at non-verbose log levels; operators only saw the aggregate failed count.

Fix: add an additive warn log for each failed startup identity reconcile with sanitized `sessionKey`, ACP error `code`, and sanitized `message`. The reconcile counts and control flow are unchanged.

Note: this is an observability prerequisite for diagnosing the restart reconcile-failed bug.

## Verification

Behavior addressed: Per-session ACP startup reconcile failures now emit a normal warning with sanitized diagnostic fields.

Real environment tested: Local isolated worktree on macOS for the OpenClaw repo.

Exact steps or command run after this patch:
- `pnpm build`
- `node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs --base upstream/main`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

Evidence after fix: The reconcile test covers the warning payload and verifies an ANSI/control-character-obfuscated API key and the session store path are not present in the warning. The one-off production-code run below separately exercises the same startup reconcile warning path outside Vitest.

Observed result after fix: Build, focused reconcile tests, changed gate fallback, whitespace check, and autoreview all passed.

What was not tested: A live ACP backend restart scenario was not run; this patch only adds sanitized observability and does not change reconcile behavior.

## Real behavior proof

Behavior addressed: Startup identity reconcile now emits a per-session warning at normal log level when one pending ACP session fails to reconnect, while keeping the aggregate reconcile result unchanged.

Real environment tested: Local macOS OpenClaw worktree on branch `fix/acp-reconcile-error-visibility-wt` at `e06569a7eafd00d175f6a0f86cf3e396a26506d7`, invoking production `AcpSessionManager.reconcilePendingSessionIdentities` with `node --import tsx`.

Exact steps or command run after this patch: Ran a one-off `node --import tsx --input-type=module` command that constructed a pending ACP session, called `AcpSessionManager.reconcilePendingSessionIdentities({ cfg: {} })`, and made the runtime backend throw `ACP_BACKEND_UNAVAILABLE` with an ANSI-obfuscated fake `OPENAI_API_KEY` value.

Evidence after fix: Terminal output captured from that production-code run:

```text
[acp/manager] acp-manager: startup identity reconcile failed for agent:codex:acp:proof-session: code=ACP_BACKEND_UNAVAILABLE message=backend unavailable: OPENAI_API_KEY=***
result: {"checked":1,"resolved":0,"failed":1}
```

Observed result after fix: The warning includes the affected session key, ACP error code, and redacted message (`OPENAI_API_KEY=***`), and the reconcile result still reports one checked session, zero resolved sessions, and one failed session.

What was not tested: A live ACP backend restart with a real provider was not run; this is a logging-only change, and the one-off run intentionally used a synthetic backend failure to exercise the startup reconcile warning path.
