### PR TITLE
fix(agents): normalize prefixed Anthropic fallback model ids (#88560)

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -34,4 +34,16 @@ describe("provider model id policy normalization", () => {
       ),
     ).toBe("openrouter/google/gemini-3.1-pro-preview");
   });
+
+  it("normalizes native Anthropic catalog refs without retaining the provider prefix", () => {
+    expect(
+      normalizeStaticProviderModelIdWithPolicies(
+        "anthropic",
+        "anthropic/claude-haiku-4-5",
+      ),
+    ).toBe("claude-haiku-4-5");
+    expect(
+      normalizeConfiguredProviderCatalogModelId("anthropic", "anthropic/claude-haiku-4-5"),
+    ).toBe("claude-haiku-4-5");
+  });
 });

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -119,7 +119,12 @@ export function normalizeBuiltInProviderModelId(provider: string, model: string)
       "opus-4.6": "claude-opus-4-6",
       "sonnet-4.6": "claude-sonnet-4-6",
     };
-    return anthropicAliases[normalizeLowercaseStringOrEmpty(model)] ?? model;
+    const anthropicPrefix = "anthropic/";
+    const normalizedModel = normalizeLowercaseStringOrEmpty(model);
+    const providerModel = normalizedModel.startsWith(anthropicPrefix)
+      ? model.trim().slice(anthropicPrefix.length)
+      : model;
+    return anthropicAliases[normalizeLowercaseStringOrEmpty(providerModel)] ?? providerModel;
   }
   if (normalizedProvider === "vercel-ai-gateway") {
     const vercelAliases: Record<string, string> = {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -556,6 +556,70 @@ describe("resolveModel", () => {
     expect(discoverModels).not.toHaveBeenCalled();
   });
 
+  it("looks up each static fallback candidate with its own normalized model id", async () => {
+    resolveBundledStaticCatalogModelMock.mockImplementation(({ provider, modelId }) => ({
+      provider,
+      id: modelId,
+      name: modelId,
+      api: "openai-responses",
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    }));
+
+    const anthropicResult = await resolveModelAsync(
+      "anthropic",
+      "anthropic/claude-haiku-4-5",
+      "/tmp/agent",
+      undefined,
+      {
+        allowBundledStaticCatalogFallback: true,
+        runtimeHooks: createRuntimeHooks(),
+        skipAgentDiscovery: true,
+        skipProviderRuntimeHooks: true,
+      },
+    );
+    const openaiResult = await resolveModelAsync("openai", "gpt-4o", "/tmp/agent", undefined, {
+      allowBundledStaticCatalogFallback: true,
+      runtimeHooks: createRuntimeHooks(),
+      skipAgentDiscovery: true,
+      skipProviderRuntimeHooks: true,
+    });
+
+    expectRecordFields(expectResolvedModel(anthropicResult), {
+      provider: "anthropic",
+      id: "claude-haiku-4-5",
+    });
+    expectRecordFields(expectResolvedModel(openaiResult), {
+      provider: "openai",
+      id: "gpt-4o",
+    });
+    expect(resolveBundledStaticCatalogModelMock).toHaveBeenCalledWith({
+      provider: "anthropic",
+      modelId: "claude-haiku-4-5",
+      cfg: undefined,
+      workspaceDir: undefined,
+    });
+    expect(resolveBundledStaticCatalogModelMock).toHaveBeenCalledWith({
+      provider: "openai",
+      modelId: "gpt-4o",
+      cfg: undefined,
+      workspaceDir: undefined,
+    });
+    expect(resolveBundledStaticCatalogModelMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        modelId: "claude-haiku-4-5",
+      }),
+    );
+    expect(resolveBundledStaticCatalogModelMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: "anthropic/claude-haiku-4-5",
+      }),
+    );
+    expect(discoverAuthStorage).not.toHaveBeenCalled();
+    expect(discoverModels).not.toHaveBeenCalled();
+  });
+
   it("applies provider overrides to bundled static catalog rows while skipping agent discovery", async () => {
     resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
       provider: "mistral",

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1716,6 +1716,36 @@ describe("runWithModelFallback", () => {
     ]);
   });
 
+  it("normalizes prefixed Anthropic fallback candidates independently", () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+            fallbacks: ["anthropic/claude-haiku-4-5", "anthropic/claude-opus-4-7"],
+          },
+          models: {
+            "anthropic/claude-sonnet-4-6": {},
+            "anthropic/claude-haiku-4-5": {},
+            "anthropic/claude-opus-4-7": {},
+          },
+        },
+      },
+    });
+
+    const candidates = testing.resolveFallbackCandidates({
+      cfg,
+      provider: "anthropic",
+      model: "anthropic/claude-sonnet-4-6",
+    });
+
+    expect(candidates).toEqual([
+      { provider: "anthropic", model: "claude-sonnet-4-6" },
+      { provider: "anthropic", model: "claude-haiku-4-5" },
+      { provider: "anthropic", model: "claude-opus-4-7" },
+    ]);
+  });
+
   it("tries configured fallbacks before primary for override credential validation errors", async () => {
     const cfg = makeCfg();
     const run = createOverrideFailureRun({

--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -39,6 +39,12 @@ describe("normalizeStaticProviderModelId", () => {
     );
   });
 
+  it("strips native Anthropic provider prefixes from static catalog ids", () => {
+    expect(normalizeStaticProviderModelId("anthropic", "anthropic/claude-haiku-4-5")).toBe(
+      "claude-haiku-4-5",
+    );
+  });
+
   it("uses supplied manifest normalization policies when provided", () => {
     const manifestPlugins = [
       {


### PR DESCRIPTION
## Summary

- Fixes prefixed Anthropic static catalog ids such as `anthropic/claude-haiku-4-5` resolving as a literal nested model id.
- Keeps fallback candidate normalization independent so a prefixed catalog key does not leak into later provider/model lookups.
- Adds regression coverage at the shared model-catalog normalization layer, OpenClaw model-ref wrapper, embedded model lookup, and fallback candidate chain.
- Intentionally out of scope: broader provider alias policy changes outside the native Anthropic provider prefix case.

## Linked context

Closes #88560

Related #88517, #77167, #88470

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A configured fallback chain with prefixed Anthropic entries should resolve each candidate to its own provider/model pair, and Anthropic static catalog ids should not retain a nested `anthropic/` prefix.
- Real environment tested: Local OpenClaw source checkout at `/private/tmp/openclaw-88560` on macOS, branch `fix/fallback-modelid-normalization-88560`, rebased onto `f7a1d3f3f6`, running the repo's real fallback runtime path, Vitest, and tsgo test runners against the changed code.
- Exact steps or command run after this patch: `timeout 180 node scripts/test-projects.mjs packages/model-catalog-core/src/provider-model-id-normalization.test.ts src/agents/model-ref-shared.test.ts src/agents/embedded-agent-runner/model.test.ts src/agents/model-fallback.test.ts`; `node --import tsx -e '<inline script invoking runWithModelFallback with prefixed Anthropic primary/fallbacks and redacted local FailoverError failures>'`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): After rebasing to `f7a1d3f3f6`, the focused test run passed 3 Vitest shards: unit-fast `1 passed / 12 tests`, unit `1 passed / 3 tests`, agents `2 passed / 177 tests`. `git diff --check` exited 0. Type checks exited 0 for `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src-88560-rebased-f7a1.tsbuildinfo` and `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.packages.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-packages-88560-rebased-f7a1.tsbuildinfo`.

  Redacted local runtime proof from the real `runWithModelFallback` path after rebasing to `f7a1d3f3f6`:

  ```text
  [model-fallback/decision] model fallback decision: decision=candidate_failed requested=anthropic/anthropic/claude-sonnet-4-6 candidate=anthropic/claude-sonnet-4-6 reason=server_error next=anthropic/claude-haiku-4-5 detail=redacted local proof failure
  [model-fallback/decision] model fallback decision: decision=candidate_failed requested=anthropic/anthropic/claude-sonnet-4-6 candidate=anthropic/claude-haiku-4-5 reason=server_error next=openai/gpt-4o detail=redacted local proof failure
  [model-fallback/decision] model fallback decision: decision=candidate_failed requested=anthropic/anthropic/claude-sonnet-4-6 candidate=openai/gpt-4o reason=server_error next=xai/grok-4 detail=redacted local proof failure
  [model-fallback/decision] model fallback decision: decision=candidate_failed requested=anthropic/anthropic/claude-sonnet-4-6 candidate=xai/grok-4 reason=server_error next=none detail=redacted local proof failure
  runAttempts: anthropic/claude-sonnet-4-6, anthropic/claude-haiku-4-5, openai/gpt-4o, xai/grok-4
  containsLeakedAnthropicPrefix: false
  ```
- Observed result after fix: `normalizeStaticProviderModelId("anthropic", "anthropic/claude-haiku-4-5")` returns `claude-haiku-4-5`, fallback candidates resolve to `claude-sonnet-4-6`, `claude-haiku-4-5`, and `claude-opus-4-7`, and the real fallback runtime receives unprefixed Anthropic model ids while keeping OpenAI/XAI candidates separate.
- What was not tested: A live gateway failover run against production Anthropic/OpenAI/Google/XAI credentials was not run from this workstation.
- Proof limitations or environment constraints: This uses a local runtime invocation with redacted synthetic provider failures plus repository tests; the issue's production logs and production provider credentials are not available in this local environment.
- Before evidence (optional but encouraged): Issue #88560 documents production failures where all fallback candidates were reported with leaked ids such as `openai/anthropic/claude-haiku-4-5`, `xai/anthropic/claude-haiku-4-5`, and `anthropic/anthropic/claude-haiku-4-5`.

## Tests and validation

- `timeout 180 node scripts/test-projects.mjs packages/model-catalog-core/src/provider-model-id-normalization.test.ts src/agents/model-ref-shared.test.ts src/agents/embedded-agent-runner/model.test.ts src/agents/model-fallback.test.ts`
- `timeout 240 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src-88560-rebased-f7a1.tsbuildinfo`
- `timeout 240 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.packages.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-packages-88560-rebased-f7a1.tsbuildinfo`
- `node --import tsx -e '<inline script invoking runWithModelFallback with prefixed Anthropic primary/fallbacks and redacted local FailoverError failures>'`
- `git diff --check`

Regression coverage was added for Anthropic prefix stripping, configured provider catalog normalization, fallback candidate chain normalization, and embedded model lookup arguments.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Prefixed Anthropic model ids now resolve to the native Anthropic model id for static catalog lookup.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Anthropic model-id normalization compatibility for existing configs.

How is that risk mitigated?

The change is scoped to the native `anthropic` provider prefix and preserves existing Anthropic aliases; tests cover both the shared package and OpenClaw wrapper paths.

## Current review state

What is the next action?

Await ClawSweeper re-review and fresh CI after the rebase/proof update.

What is still waiting on author, maintainer, CI, or external proof?

CI, ClawSweeper, and maintainer review. No known author-side blocker after this proof update.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's request for redacted runtime fallback proof showing prefixed Anthropic entries resolving to their own provider/model ids, then refreshed that proof after rebasing to `f7a1d3f3f6`.