### PR TITLE
fix(agents): avoid synthetic tool results during parallel races (#88168)

### DIFF
--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -370,6 +370,31 @@ describe("installSessionToolResultGuard", () => {
     expectPersistedRoles(sm, ["assistant", "toolResult"]);
   });
 
+  it("does not synthesize older pending results before a new assistant tool-call turn", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm);
+
+    appendAssistantToolCall(sm, { id: "call_1", name: "read" });
+    appendAssistantToolCall(sm, { id: "call_2", name: "exec" });
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "real output" }],
+        isError: false,
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "assistant", "toolResult"]);
+    expect((messages[2] as { toolCallId?: string; isError?: boolean }).toolCallId).toBe(
+      "call_1",
+    );
+    expect((messages[2] as { isError?: boolean }).isError).toBe(false);
+    expect(JSON.stringify(messages)).not.toContain("missing tool result");
+    expect(guard.getPendingIds()).toStrictEqual(["call_2"]);
+  });
+
   it("clears pending when a sanitized assistant message is dropped and synthetic results are disabled", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -745,8 +745,15 @@ export function installSessionToolResultGuard(
     ) {
       flushPendingToolResults();
     }
-    // If new tool calls arrive while older ones are pending, flush the old ones first.
-    if (pendingState.shouldFlushBeforeNewToolCalls(toolCalls.length)) {
+    // If synthetic results are disabled, a new assistant tool-call turn is a safe
+    // boundary to drop older pending ids. When synthetic results are enabled,
+    // do not synthesize here: parallel tool-result appends can still be racing
+    // this assistant append, and transcript repair can move late real results
+    // back into strict provider order before the next replay.
+    if (
+      !allowSyntheticToolResults &&
+      pendingState.shouldFlushBeforeNewToolCalls(toolCalls.length)
+    ) {
       flushPendingToolResults();
     }
 

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -193,6 +193,52 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result.moved).toBe(true);
   });
 
+  it("moves late real results ahead of newer assistant tool calls instead of synthesizing", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_read", name: "read", arguments: {} }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_exec", name: "exec", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_read",
+        toolName: "read",
+        content: [{ type: "text", text: "real read output" }],
+        isError: false,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_exec",
+        toolName: "exec",
+        content: [{ type: "text", text: "real exec output" }],
+        isError: false,
+      },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "assistant",
+      "toolResult",
+    ]);
+    expect((result.messages[1] as { toolCallId?: string; isError?: boolean }).toolCallId).toBe(
+      "call_read",
+    );
+    expect((result.messages[1] as { isError?: boolean }).isError).toBe(false);
+    expect((result.messages[3] as { toolCallId?: string; isError?: boolean }).toolCallId).toBe(
+      "call_exec",
+    );
+    expect(JSON.stringify(result.messages)).not.toContain("missing tool result");
+    expect(result.moved).toBe(true);
+  });
+
   it("repairs blank tool result names from matching tool calls", () => {
     const input = castAgentMessages([
       {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -445,6 +445,29 @@ function assistantHasToolCalls(message: AgentMessage): boolean {
   return extractToolCallsFromAssistant(message).length > 0;
 }
 
+function findLaterMatchingToolResult(params: {
+  messages: AgentMessage[];
+  startIndex: number;
+  toolCallId: string;
+  toolName?: string;
+  toolCalls: Array<{ id: string; name?: string }>;
+  seenToolResultIds: Set<string>;
+}): Extract<AgentMessage, { role: "toolResult" }> | undefined {
+  for (let index = params.startIndex; index < params.messages.length; index += 1) {
+    const candidate = params.messages[index];
+    if (!candidate || typeof candidate !== "object" || candidate.role !== "toolResult") {
+      continue;
+    }
+    const normalizedLegacyResult = normalizeLegacyToolResultId(candidate, params.toolCalls);
+    const id = extractToolResultId(normalizedLegacyResult);
+    if (!id || id !== params.toolCallId || params.seenToolResultIds.has(id)) {
+      continue;
+    }
+    return normalizeToolResultName(normalizedLegacyResult, params.toolName);
+  }
+  return undefined;
+}
+
 export function repairToolUseResultPairing(
   messages: AgentMessage[],
   options?: ToolUseResultPairingOptions,
@@ -540,12 +563,12 @@ export function repairToolUseResultPairing(
           toolCalls,
         );
         const id = extractToolResultId(toolResult);
+        if (id && seenToolResultIds.has(id)) {
+          droppedDuplicateCount += 1;
+          changed = true;
+          continue;
+        }
         if (id && toolCallIds.has(id)) {
-          if (seenToolResultIds.has(id)) {
-            droppedDuplicateCount += 1;
-            changed = true;
-            continue;
-          }
           if (toolResult !== next) {
             changed = true;
           }
@@ -612,14 +635,28 @@ export function repairToolUseResultPairing(
       if (existing) {
         pushToolResult(existing);
       } else {
-        const missing = makeMissingToolResult({
+        const laterResult = findLaterMatchingToolResult({
+          messages,
+          startIndex: j,
           toolCallId: call.id,
           toolName: call.name,
-          text: options?.missingToolResultText,
+          toolCalls,
+          seenToolResultIds,
         });
-        added.push(missing);
-        changed = true;
-        pushToolResult(missing);
+        if (laterResult) {
+          moved = true;
+          changed = true;
+          pushToolResult(laterResult);
+        } else {
+          const missing = makeMissingToolResult({
+            toolCallId: call.id,
+            toolName: call.name,
+            text: options?.missingToolResultText,
+          });
+          added.push(missing);
+          changed = true;
+          pushToolResult(missing);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Stops the session tool-result guard from inserting synthetic missing-result entries at the moment a newer assistant tool-call turn arrives while older tool results may still be in flight.
- Lets transcript repair move late real tool results back next to their matching assistant tool calls before synthesizing placeholders.
- Preserves missing-result repair for genuinely absent tool results and duplicate/orphan cleanup.
- Intentionally out of scope: changing Anthropic streaming/tool execution ordering outside the session transcript guard and repair layer.

## Linked context

Closes #88168

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Parallel tool-call batches should not persist `[openclaw] missing tool result...` placeholders before real in-flight tool results have a chance to land and be repaired into provider-valid order.
- Real environment tested: Local OpenClaw source checkout at `/private/tmp/openclaw-88168` on macOS, branch `fix/parallel-tool-result-race-88168`, rebased onto `f7a1d3f3f6`, running the repo's real SessionManager guard path, transcript repair path, Vitest, and tsgo test runners against the changed code.
- Exact steps or command run after this patch: `timeout 180 node scripts/test-projects.mjs src/agents/session-tool-result-guard.test.ts src/agents/session-transcript-repair.test.ts`; `node --import tsx -e '<inline script using SessionManager.inMemory(), installSessionToolResultGuard(), and repairToolUseResultPairing() with late real parallel tool results>'`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): After rebasing to `f7a1d3f3f6`, the focused test run passed 1 Vitest shard with `2 passed / 73 tests`. `git diff --check` exited 0. Type checking exited 0 for `timeout 240 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src-88168-rebased-f7a1.tsbuildinfo`.

  Redacted local runtime/session proof from the real SessionManager guard and transcript repair paths after rebasing to `f7a1d3f3f6`:

  ```json
  {
    "proof": "SessionManager guard plus transcript repair local runtime path",
    "base": "f7a1d3f3",
    "pendingAfterLateResults": [],
    "repairAddedSyntheticCount": 0,
    "repairMovedRealResults": true,
    "rawContainsMissingPlaceholder": false,
    "repairedContainsMissingPlaceholder": false,
    "repaired": [
      { "role": "assistant", "toolCallId": null, "isError": null, "text": "no missing placeholder" },
      { "role": "toolResult", "toolCallId": "call_read", "isError": false, "text": "no missing placeholder" },
      { "role": "assistant", "toolCallId": null, "isError": null, "text": "no missing placeholder" },
      { "role": "toolResult", "toolCallId": "call_exec", "isError": false, "text": "no missing placeholder" }
    ]
  }
  ```
- Observed result after fix: The SessionManager guard accepts two assistant tool-call turns followed by late real results without persisting synthetic missing-result text; transcript repair then moves the real `call_read` result beside its assistant turn and adds zero synthetic results.
- What was not tested: A live Anthropic Claude session with real parallel `exec`/`read` calls was not run from this workstation.
- Proof limitations or environment constraints: This uses a local SessionManager runtime invocation plus repository tests rather than live provider proof; the original production session JSONL and Anthropic credentials are not available here. The later `.jsonl.lock` field report on #88168 is treated as separate follow-up scope unless maintainers want it folded into this PR.
- Before evidence (optional but encouraged): Issue #88168 documents live sessions where real parallel tool side effects completed but persisted transcript history contained synthetic `[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.` entries instead of the real outputs.

## Tests and validation

- `timeout 180 node scripts/test-projects.mjs src/agents/session-tool-result-guard.test.ts src/agents/session-transcript-repair.test.ts`
- `timeout 240 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src-88168-rebased-f7a1.tsbuildinfo`
- `node --import tsx -e '<inline script using SessionManager.inMemory(), installSessionToolResultGuard(), and repairToolUseResultPairing() with late real parallel tool results>'`
- `git diff --check`

Regression coverage was added for the guard not synthesizing at the new-assistant boundary and for transcript repair moving late real results ahead of newer assistant tool calls.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Parallel tool-call transcripts should retain real results instead of premature synthetic error placeholders.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Delaying synthetic missing-result insertion could allow a temporarily invalid raw transcript shape until repair runs.

How is that risk mitigated?

The existing non-tool-result flush path still synthesizes genuinely missing results, and transcript repair now deterministically reorders late real results or synthesizes missing siblings before replay.

## Current review state

What is the next action?

Await ClawSweeper re-review and fresh CI after the rebase/proof update.

What is still waiting on author, maintainer, CI, or external proof?

CI, ClawSweeper, and maintainer review. No known author-side blocker after this proof update.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's request for redacted runtime/session proof showing late real tool results repaired without synthetic placeholders, then refreshed that proof after rebasing to `f7a1d3f3f6`.