### PR TITLE
fix(cli): allow agent gateway auth overrides

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -35,6 +35,9 @@ Related:
 - `--reply-to <target>`: delivery target override
 - `--reply-channel <channel>`: delivery channel override
 - `--reply-account <id>`: delivery account override
+- `--url <url>`: Gateway WebSocket URL override
+- `--token <token>`: Gateway token override
+- `--password <password>`: Gateway password override
 - `--local`: run the embedded agent directly (after plugin registry preload)
 - `--deliver`: send the reply back to the selected channel/target
 - `--timeout <seconds>`: override agent timeout (default 600 or config value)
@@ -57,6 +60,7 @@ openclaw agent --agent ops --message "Run locally" --local
 ## Notes
 
 - Gateway mode falls back to the embedded agent when the Gateway request fails. Use `--local` to force embedded execution up front.
+- `--url`, `--token`, and `--password` apply only to the Gateway request for this invocation. Use them when the configured Gateway auth SecretRef is unavailable in the local shell.
 - `--local` still preloads the plugin registry first, so plugin-provided providers, tools, and channels stay available during embedded runs.
 - `--local` and embedded fallback runs are treated as one-shot runs. Bundled MCP loopback resources and warm Claude stdio sessions opened for that local process are retired after the reply, so scripted invocations do not keep local child processes alive.
 - Gateway-backed runs leave Gateway-owned MCP loopback resources under the running Gateway process; older clients may still send the historical cleanup flag, but the Gateway accepts it as a compatibility no-op.

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -50,6 +50,9 @@ export function registerAgentTurnCommand(
     .option("--reply-to <target>", "Delivery target override (separate from session routing)")
     .option("--reply-channel <channel>", "Delivery channel override (separate from routing)")
     .option("--reply-account <id>", "Delivery account id override")
+    .option("--url <url>", "Gateway WebSocket URL override")
+    .option("--token <token>", "Gateway token override")
+    .option("--password <password>", "Gateway password override")
     .option(
       "--local",
       "Run the embedded agent locally (requires model provider API keys in your shell)",

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -136,6 +136,29 @@ describe("registerAgentCommands", () => {
     expect(deps).toBeUndefined();
   });
 
+  it("forwards gateway connection overrides to the agent command", async () => {
+    await runCli([
+      "agent",
+      "--message",
+      "hi",
+      "--agent",
+      "ops",
+      "--url",
+      "ws://127.0.0.1:18789",
+      "--token",
+      "token-override",
+      "--password",
+      "password-override",
+    ]);
+
+    const [options, callRuntime, deps] = commandCall(agentCliCommandMock);
+    expect((options as { url?: string }).url).toBe("ws://127.0.0.1:18789");
+    expect((options as { token?: string }).token).toBe("token-override");
+    expect((options as { password?: string }).password).toBe("password-override");
+    expect(callRuntime).toBe(runtime);
+    expect(deps).toBeUndefined();
+  });
+
   it("runs agents add and computes hasFlags based on explicit options", async () => {
     await runCli(["agents", "add", "alpha"]);
     const [alphaOptions, alphaRuntime, alphaFlags] = commandCall(agentsAddCommandMock, 0);

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -297,6 +297,29 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("forwards explicit gateway auth overrides", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand(
+        {
+          message: "hi",
+          to: "+1555",
+          url: "ws://127.0.0.1:18789",
+          token: "token-override",
+          password: "password-override",
+        },
+        runtime,
+      );
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
+      expect(request.url).toBe("ws://127.0.0.1:18789");
+      expect(request.token).toBe("token-override");
+      expect(request.password).toBe("password-override");
+    });
+  });
+
   it.each(["/new", "/RESET", "/reset check status"] as const)(
     "uses backend admin authority for %s gateway commands",
     async (message) => {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -77,6 +77,9 @@ type AgentCliOpts = {
   runId?: string;
   extraSystemPrompt?: string;
   local?: boolean;
+  url?: string;
+  token?: string;
+  password?: string;
 };
 
 type AgentCliSignal = "SIGINT" | "SIGTERM";
@@ -90,6 +93,10 @@ type AgentCliDeps = CliDeps & {
 type AgentGatewayCallIdentity = Pick<
   Parameters<typeof callGateway>[0],
   "clientName" | "mode" | "scopes"
+>;
+type AgentGatewayAuthOverrides = Pick<
+  Parameters<typeof callGateway>[0],
+  "url" | "token" | "password"
 >;
 type EmbeddedAgentCommandModule = typeof import("./agent.js");
 type AgentSessionModule = typeof import("./agent/session.js");
@@ -439,6 +446,7 @@ async function abortAcceptedGatewayAgentRunWithGatewayCall(params: {
   signal: AgentCliSignal | undefined;
   runtime: RuntimeEnv;
   gatewayIdentity: AgentGatewayCallIdentity;
+  gatewayAuthOverrides: AgentGatewayAuthOverrides;
   config: OpenClawConfig;
 }): Promise<void> {
   const request: GatewayRequestFunction = async <T = Record<string, unknown>>(
@@ -453,6 +461,7 @@ async function abortAcceptedGatewayAgentRunWithGatewayCall(params: {
       expectFinal: opts?.expectFinal,
       config: params.config,
       ...params.gatewayIdentity,
+      ...params.gatewayAuthOverrides,
     });
   const retryDelaysMs = resolveGatewayAbortRetryDelaysMs();
   for (const [attempt, retryDelayMs] of [...retryDelaysMs, 0].entries()) {
@@ -640,6 +649,11 @@ async function agentViaGatewayCommand(
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
       };
+  const gatewayAuthOverrides: AgentGatewayAuthOverrides = {
+    url: opts.url,
+    token: opts.token,
+    password: opts.password,
+  };
 
   let acceptedRunId: string | undefined = idempotencyKey;
   let acceptedSessionKey: string | undefined = sessionKey;
@@ -680,6 +694,7 @@ async function agentViaGatewayCommand(
           timeoutMs: gatewayTimeoutMs,
           config: cfg,
           signal: signalBridge.signal,
+          ...gatewayAuthOverrides,
           onAccepted: (payload) => {
             acceptedGatewayRun = true;
             const accepted = readAcceptedRunContext(payload);
@@ -711,6 +726,7 @@ async function agentViaGatewayCommand(
         signal: signalBridge.getReceivedSignal(),
         runtime,
         gatewayIdentity,
+        gatewayAuthOverrides,
         config: cfg,
       });
     }


### PR DESCRIPTION
Summary
- Add --url, --token, and --password overrides to openclaw agent.
- Forward those overrides into the Gateway agent RPC and the follow-up abort RPC.
- Document the overrides as per-invocation Gateway auth escapes for unavailable SecretRefs.

Verification
- node scripts/run-vitest.mjs src/commands/agent-via-gateway.test.ts src/cli/program/register.agent.test.ts
- git diff --check
- /Users/marianobelinky/agent-shared/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Real behavior proof
Behavior addressed: openclaw agent had no CLI way to pass explicit Gateway auth even though the Gateway caller supports explicit url/token/password overrides.
Real environment tested: local OpenClaw linked worktree with dependencies installed for the focused Vitest wrapper.
Exact steps or command run after this patch: node scripts/run-vitest.mjs src/commands/agent-via-gateway.test.ts src/cli/program/register.agent.test.ts
Evidence after fix: parser test forwards url/token/password to agentCliCommand; gateway dispatch test forwards url/token/password to callGateway.
Observed result after fix: 2 Vitest shards passed, 70 tests passed total.
What was not tested: live jpclawhq gateway invocation from the deployed wrapper, because this PR is not deployed yet.
