### PR TITLE
test(ci): refresh lint suppression baseline

### DIFF
--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -184,11 +184,8 @@ describe("production lint suppressions", () => {
       "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
       "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
       "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
-      "extensions/telegram/src/telegram-ingress-worker.runtime.ts|unicorn/require-post-message-target-origin|1",
-      "extensions/telegram/src/telegram-ingress-worker.ts|unicorn/require-post-message-target-origin|1",
       "scripts/lib/extension-package-boundary.ts|typescript/no-unnecessary-type-parameters|1",
       "scripts/lib/plugin-npm-release.ts|typescript/no-unnecessary-type-parameters|1",
-      "src/agents/code-mode.worker.ts|unicorn/require-post-message-target-origin|1",
       "src/channels/plugins/channel-runtime-surface.types.ts|typescript/no-unnecessary-type-parameters|1",
       "src/channels/plugins/contracts/test-helpers.ts|typescript/no-unnecessary-type-parameters|1",
       "src/channels/plugins/types.plugin.ts|typescript/no-explicit-any|1",
@@ -227,7 +224,6 @@ describe("production lint suppressions", () => {
       "src/test-utils/vitest-mock-fn.ts|typescript/no-explicit-any|1",
       "src/utils.ts|typescript/no-unnecessary-type-parameters|1",
       "src/version.ts|eslint/no-underscore-dangle|1",
-      "ui/src/ui/views/overview-log-tail.ts|no-control-regex|1",
     ]);
   });
 


### PR DESCRIPTION
## Summary

Refreshes the production lint-suppression allowlist after current `main` stopped reporting four suppressions that the baseline still expected.

This is a one-file CI repair for the current `build-artifacts` failure on `main` and on the active hardening PRs. No production code changed.

## Verification

- Current `main` CI run `26709939193` on `4b1e5b79435` has `build-artifacts` failing in `test/scripts/lint-suppressions.test.ts` because the scanner returns 48 suppression rows while the allowlist expects 52.
- `node scripts/run-vitest.mjs test/scripts/lint-suppressions.test.ts` passed: 1 file, 3 tests, 3.89s.
- `node_modules/.bin/oxfmt --check --threads=1 test/scripts/lint-suppressions.test.ts` passed.
- `git diff --check` passed.
- Added-line scrub for reported fixture names, private local paths, and secret-looking strings passed.
- AWS Crabbox `pnpm check:changed` passed: run `run_8cc8f54417d2`, lease `cbx_d509e5ff871f` / `quick-barnacle`, provider `aws`, command 1m02s, total 3m28s, selected lane `tooling`; lease cleanup reported `stopped=true`.

## Real behavior proof

Behavior addressed: `build-artifacts` no longer fails the lint-suppression baseline because the expected allowlist matches the current production suppression scan.

Real environment tested: linked OpenClaw `gwt` worktree based on current `origin/main`; remote Linux changed gate through AWS Crabbox.

Exact steps or command run after this patch: focused lint-suppression Vitest file, formatter check, diff check, added-line scrub, and AWS Crabbox `pnpm check:changed`.

Evidence after fix: the failing lint-suppression test passes locally, and the remote changed gate passes the impacted `tooling` lane.

Observed result after fix: the stale four suppression rows are no longer expected by the baseline.

What was not tested: full CI is left to GitHub Actions on this PR.
