### PR TITLE
perf: speed up chat hydration and add 3D workboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1919,10 +1919,16 @@ importers:
       marked:
         specifier: 18.0.4
         version: 18.0.4
+      three:
+        specifier: 0.184.0
+        version: 0.184.0
     devDependencies:
       '@types/markdown-it':
         specifier: 14.1.2
         version: 14.1.2
+      '@types/three':
+        specifier: 0.184.1
+        version: 0.184.1
       '@vitest/browser-playwright':
         specifier: 4.1.7
         version: 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
@@ -2487,6 +2493,9 @@ packages:
 
   '@d-fischer/typed-event-emitter@3.3.3':
     resolution: {integrity: sha512-OvSEOa8icfdWDqcRtjSEZtgJTFOFNgTjje7zaL0+nAtu2/kZtRCSK5wUMrI/aXtCH8o0Qz2vA8UqkhWUTARFQQ==}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@discordjs/voice@0.19.2':
     resolution: {integrity: sha512-3yJ255e4ag3wfZu/DSxeOZK1UtnqNxnspmLaQetGT0pDkThNZoHs+Zg6dgZZ19JEVomXygvfHn9lNpICZuYtEA==}
@@ -4047,6 +4056,9 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@twurple/api-call@8.1.4':
     resolution: {integrity: sha512-qh2TpdxxyiSkwadcCSes6uBHQB6l4Fz8sVfmzk+Brb12asemHMXTEyQAdrMJT7LlgtZq01nr+RASzWM3jmGtkw==}
 
@@ -4174,6 +4186,12 @@ packages:
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.184.1':
+    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -4182,6 +4200,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -5100,6 +5121,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-type@22.0.1:
     resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
     engines: {node: '>=22'}
@@ -5852,6 +5876,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -6821,6 +6848,9 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -8094,6 +8124,8 @@ snapshots:
   '@d-fischer/typed-event-emitter@3.3.3':
     dependencies:
       tslib: 2.8.1
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@discordjs/voice@0.19.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -9520,6 +9552,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@twurple/api-call@8.1.4':
     dependencies:
       '@d-fischer/shared-utils': 3.6.4
@@ -9692,11 +9726,24 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 25.9.1
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.184.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -10642,6 +10689,8 @@ snapshots:
       node-domexception: '@nolyfill/domexception@1.0.28'
       web-streams-polyfill: 3.3.3
 
+  fflate@0.8.3: {}
+
   file-type@22.0.1:
     dependencies:
       '@tokenizer/inflate': 0.4.1
@@ -11537,6 +11586,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meshoptimizer@1.1.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -12809,6 +12860,8 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
+
+  three@0.184.0: {}
 
   tinybench@2.9.0: {}
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,10 +19,12 @@
     "lit": "3.3.3",
     "markdown-it": "14.2.0",
     "markdown-it-task-lists": "2.1.1",
-    "marked": "18.0.4"
+    "marked": "18.0.4",
+    "three": "0.184.0"
   },
   "devDependencies": {
     "@types/markdown-it": "14.1.2",
+    "@types/three": "0.184.1",
     "@vitest/browser-playwright": "4.1.7",
     "jsdom": "29.1.1",
     "playwright": "1.60.0",

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -132,7 +132,7 @@
 .workboard-game {
   display: grid;
   gap: 14px;
-  width: min(420px, calc(100vw - 44px));
+  width: min(620px, calc(100vw - 44px));
   padding: 16px;
   border: 1px solid color-mix(in srgb, var(--border) 86%, transparent);
   border-radius: 10px;
@@ -258,48 +258,78 @@
   line-height: 1;
 }
 
-.workboard-game__grid {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 6px;
-  aspect-ratio: 1;
-  min-width: 0;
+.workboard-game__scene {
+  position: relative;
+  display: block;
+  width: 100%;
+  min-height: min(58vh, 430px);
+  overflow: hidden;
+  border-radius: 8px;
+  background:
+    radial-gradient(
+      circle at 24% 20%,
+      color-mix(in srgb, var(--accent) 24%, transparent),
+      transparent 30%
+    ),
+    linear-gradient(180deg, color-mix(in srgb, var(--bg-elevated) 92%, #10171d), var(--bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border) 72%, transparent);
 }
 
-.workboard-game__cell {
+.workboard-game__canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.workboard-game__fallback {
+  position: absolute;
+  inset: 12%;
   display: grid;
-  place-items: center;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  transform: perspective(720px) rotateX(58deg) rotateZ(-35deg);
+  transform-origin: center;
+}
+
+.workboard-game__scene--ready .workboard-game__fallback {
+  opacity: 0;
+}
+
+.workboard-game__accessible-grid {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.workboard-game__fallback-tile {
   min-width: 0;
   border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
   border-radius: 7px;
   background: color-mix(in srgb, var(--bg) 84%, var(--panel) 16%);
-  color: var(--muted);
-  font-size: 0.84rem;
-  font-weight: 750;
-  line-height: 1;
+  box-shadow:
+    0 10px 0 color-mix(in srgb, #000 28%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
 }
 
-.workboard-game__cell--player {
+.workboard-game__fallback-tile--player {
   border-color: color-mix(in srgb, var(--accent) 54%, var(--border));
-  background: color-mix(in srgb, var(--accent) 18%, var(--bg));
-  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 30%, var(--bg));
 }
 
-.workboard-game__cell--goal {
+.workboard-game__fallback-tile--goal {
   border-color: color-mix(in srgb, var(--ok) 48%, var(--border));
-  background: color-mix(in srgb, var(--ok) 14%, var(--bg));
-  color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 24%, var(--bg));
 }
 
-.workboard-game__cell--blocker {
-  background:
-    linear-gradient(
-      135deg,
-      transparent 0 45%,
-      color-mix(in srgb, var(--danger) 46%, transparent) 45% 55%,
-      transparent 55% 100%
-    ),
-    color-mix(in srgb, var(--danger) 10%, var(--bg));
+.workboard-game__fallback-tile--blocker {
+  background: color-mix(in srgb, var(--danger) 32%, var(--bg));
 }
 
 .workboard-game__controls {

--- a/ui/src/styles/workboard.test.ts
+++ b/ui/src/styles/workboard.test.ts
@@ -15,4 +15,13 @@ describe("workboard styles", () => {
     expect(css).toContain("grid-auto-columns: minmax(260px, 82vw);");
     expect(css).not.toContain("grid-template-columns: repeat(6");
   });
+
+  it("keeps the mini game scene framed for a 3d canvas and fallback board", () => {
+    const css = readWorkboardCss();
+
+    expect(css).toContain(".workboard-game__scene {\n  position: relative;");
+    expect(css).toContain("min-height: min(58vh, 430px);");
+    expect(css).toContain(".workboard-game__canvas {\n  position: absolute;");
+    expect(css).toContain("transform: perspective(720px) rotateX(58deg) rotateZ(-35deg);");
+  });
 });

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -223,7 +223,7 @@ describe("refreshChat", () => {
     await loadChatHelpers();
   });
 
-  it("dispatches chat refresh work without waiting for slow history or secondary RPCs", async () => {
+  it("dispatches chat refresh work without waiting for slow history or metadata RPCs", async () => {
     const request = vi.fn(() => new Promise<unknown>(() => undefined));
     const requestUpdate = vi.fn();
     const host = makeHost({
@@ -242,7 +242,7 @@ describe("refreshChat", () => {
       limit: 100,
       maxChars: 4000,
     });
-    expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
+    expect(request).not.toHaveBeenCalledWith("models.list", { view: "configured" });
     const sessionsListPayload = findRequestPayload(
       request as unknown as MockCallSource,
       "sessions.list",
@@ -253,12 +253,20 @@ describe("refreshChat", () => {
     expect(sessionsListPayload.includeGlobal).toBe(true);
     expect(sessionsListPayload.includeUnknown).toBe(true);
     expect(sessionsListPayload.limit).toBe(50);
-    expect(request).toHaveBeenCalledWith("commands.list", {
+    expect(request).not.toHaveBeenCalledWith("commands.list", {
       agentId: "main",
       includeArgs: true,
       scope: "text",
     });
     expect(requestUpdate).not.toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("models.list", { view: "configured" }),
+    );
+    expect(request).toHaveBeenCalledWith("commands.list", {
+      agentId: "main",
+      includeArgs: true,
+      scope: "text",
+    });
   });
 
   it("scopes global chat refresh session rows to the selected agent", async () => {
@@ -287,6 +295,13 @@ describe("refreshChat", () => {
     );
     expect(sessionsListPayload.agentId).toBe("work");
     expect(sessionsListPayload.includeGlobal).toBe(true);
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("commands.list", {
+        agentId: "work",
+        includeArgs: true,
+        scope: "text",
+      }),
+    );
   });
 
   it("scopes agent main aliases as selected global chat refreshes", async () => {
@@ -423,7 +438,10 @@ describe("refreshChat", () => {
     expect(host.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "ready" }] },
     ]);
-    expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
+    expect(request).not.toHaveBeenCalledWith("models.list", { view: "configured" });
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("models.list", { view: "configured" }),
+    );
     expect(requestUpdate).toHaveBeenCalled();
   });
 
@@ -779,6 +797,67 @@ describe("refreshChatAvatar", () => {
     expect(fetchUrl(fetchMock as unknown as MockCallSource, 2)).toBe("/avatar/ops");
     expect(fetchInit(fetchMock as unknown as MockCallSource, 2).method).toBe("GET");
   });
+
+  it("ignores stale global avatar responses after switching selected agents", async () => {
+    const createObjectURL = vi.fn(() => "blob:ops-avatar");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal(
+      "URL",
+      class extends URL {
+        static override createObjectURL = createObjectURL;
+        static override revokeObjectURL = revokeObjectURL;
+      },
+    );
+    const workRequest = createDeferred<{ avatarUrl?: string }>();
+    const opsRequest = createDeferred<{ avatarUrl?: string }>();
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = requestUrl(input);
+      if (url === "/avatar/work?meta=1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => workRequest.promise,
+        });
+      }
+      if (url === "/avatar/ops?meta=1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => opsRequest.promise,
+        });
+      }
+      if (url === "/avatar/ops") {
+        return Promise.resolve({
+          ok: true,
+          blob: async () => new Blob(["avatar"]),
+        });
+      }
+      throw new Error(`Unexpected avatar URL: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const host = makeHost({
+      basePath: "",
+      sessionKey: "global",
+      assistantAgentId: "work",
+      agentsList: { defaultId: "main" },
+    });
+
+    const firstRefresh = refreshChatAvatar(host);
+    host.assistantAgentId = "ops";
+    const secondRefresh = refreshChatAvatar(host);
+
+    workRequest.resolve({ avatarUrl: "/avatar/work" });
+    await firstRefresh;
+    expect(host.chatAvatarUrl).toBeNull();
+
+    opsRequest.resolve({ avatarUrl: "/avatar/ops" });
+    await secondRefresh;
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(host.chatAvatarUrl).toBe("blob:ops-avatar");
+    expect(fetchUrl(fetchMock as unknown as MockCallSource, 0)).toBe("/avatar/work?meta=1");
+    expect(fetchUrl(fetchMock as unknown as MockCallSource, 1)).toBe("/avatar/ops?meta=1");
+    expect(fetchUrl(fetchMock as unknown as MockCallSource, 2)).toBe("/avatar/ops");
+  });
 });
 
 describe("refreshChat", () => {
@@ -819,7 +898,9 @@ describe("refreshChat", () => {
       expect(sessionsListPayload.includeGlobal).toBe(true);
       expect(sessionsListPayload.includeUnknown).toBe(true);
       expect(sessionsListPayload.limit).toBe(50);
-      expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
+      await vi.waitFor(() =>
+        expect(request).toHaveBeenCalledWith("models.list", { view: "configured" }),
+      );
       const commandsListPayload = findRequestPayload(
         request as unknown as MockCallSource,
         "commands.list",

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1390,12 +1390,17 @@ export async function refreshChat(
     sessionsRefresh,
     previousSessionsResult,
   );
-  const secondaryRefresh = Promise.allSettled([
-    sessionsRefresh,
-    refreshChatAvatar(host),
-    refreshChatModels(host),
-    refreshChatCommands(host),
-  ]).finally(requestUpdate);
+  const secondaryRefresh = Promise.allSettled([sessionsRefresh]).finally(requestUpdate);
+  scheduleChatMetadataRefresh(() => {
+    if (host.sessionKey !== refreshedSessionKey || !host.connected) {
+      return;
+    }
+    void Promise.allSettled([
+      refreshChatAvatar(host),
+      refreshChatModels(host),
+      refreshChatCommands(host),
+    ]).finally(requestUpdate);
+  });
   void historyRefresh;
   void secondaryRefresh;
   if (opts?.awaitHistory === true) {
@@ -1403,6 +1408,16 @@ export async function refreshChat(
     return;
   }
   await Promise.resolve();
+}
+
+function scheduleChatMetadataRefresh(callback: () => void) {
+  const requestIdleCallback =
+    typeof globalThis.requestIdleCallback === "function" ? globalThis.requestIdleCallback : null;
+  if (requestIdleCallback) {
+    requestIdleCallback(callback, { timeout: 750 });
+    return;
+  }
+  globalThis.setTimeout(callback, 50);
 }
 
 async function refreshChatModels(host: ChatHost) {
@@ -1438,9 +1453,16 @@ function beginChatAvatarRequest(host: ChatHost): number {
   return nextVersion;
 }
 
-function shouldApplyChatAvatarResult(host: ChatHost, version: number, sessionKey: string): boolean {
+function shouldApplyChatAvatarResult(
+  host: ChatHost,
+  version: number,
+  sessionKey: string,
+  agentId: string | null,
+): boolean {
   return (
-    chatAvatarRequestVersions.get(host as object) === version && host.sessionKey === sessionKey
+    chatAvatarRequestVersions.get(host as object) === version &&
+    host.sessionKey === sessionKey &&
+    resolveAgentIdForSession(host) === agentId
   );
 }
 
@@ -1448,6 +1470,9 @@ function resolveAgentIdForSession(host: ChatHost): string | null {
   const parsed = parseAgentSessionKey(host.sessionKey);
   if (parsed?.agentId) {
     return parsed.agentId;
+  }
+  if (isGlobalSessionKey(host.sessionKey)) {
+    return resolveSelectedGlobalAgentId(host) || DEFAULT_AGENT_ID;
   }
   return readHelloDefaultAgentId(host) || DEFAULT_AGENT_ID;
 }
@@ -1531,7 +1556,7 @@ export async function refreshChatAvatar(host: ChatHost) {
   const requestVersion = beginChatAvatarRequest(host);
   const agentId = resolveAgentIdForSession(host);
   if (!agentId) {
-    if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+    if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
       clearChatAvatarState(host);
     }
     return;
@@ -1542,7 +1567,7 @@ export async function refreshChatAvatar(host: ChatHost) {
   const url = buildAvatarMetaUrl(host.basePath, agentId);
   try {
     const res = await fetch(url, { method: "GET", ...(headers ? { headers } : {}) });
-    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
       return;
     }
     if (!res.ok) {
@@ -1555,7 +1580,7 @@ export async function refreshChatAvatar(host: ChatHost) {
       avatarStatus?: unknown;
       avatarReason?: unknown;
     };
-    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
       return;
     }
     setChatAvatarMeta(host, data);
@@ -1573,19 +1598,19 @@ export async function refreshChatAvatar(host: ChatHost) {
       ...(headers ? { headers } : {}),
     });
     if (!avatarRes.ok) {
-      if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+      if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
         clearChatAvatarUrl(host);
       }
       return;
     }
     const blobUrl = URL.createObjectURL(await avatarRes.blob());
-    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
       URL.revokeObjectURL(blobUrl);
       return;
     }
     setChatAvatarUrl(host, blobUrl);
   } catch {
-    if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+    if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey, agentId)) {
       clearChatAvatarState(host);
     }
   }

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -8,7 +8,7 @@ import { extractTextCached } from "./message-extract.ts";
 import { normalizeMessage, stripMessageDisplayMetadataText } from "./message-normalizer.ts";
 import { normalizeRoleForGrouping } from "./role-normalizer.ts";
 import { messageMatchesSearchQuery } from "./search-match.ts";
-import { extractToolCards, extractToolPreview } from "./tool-cards.ts";
+import { extractToolCardsCached, extractToolPreview } from "./tool-cards.ts";
 
 export type BuildChatItemsProps = {
   sessionKey: string;
@@ -92,7 +92,7 @@ function extractChatMessagePreview(toolMessage: unknown): {
   if (!normalized) {
     return null;
   }
-  const cards = extractToolCards(toolMessage, "preview");
+  const cards = extractToolCardsCached(toolMessage, "preview");
   for (let index = cards.length - 1; index >= 0; index--) {
     const card = cards[index];
     if (card?.preview?.kind === "canvas") {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -24,7 +24,7 @@ import { extractThinkingCached, formatReasoningMarkdown } from "./message-extrac
 import { isToolResultMessage, normalizeMessage } from "./message-normalizer.ts";
 import { normalizeRoleForGrouping } from "./role-normalizer.ts";
 import {
-  extractToolCards,
+  extractToolCardsCached,
   formatCollapsedToolPreviewText,
   formatCollapsedToolSummaryText,
   isToolCardError,
@@ -1499,7 +1499,7 @@ function renderGroupedMessage(
     typeof m.toolCallId === "string" ||
     typeof m.tool_call_id === "string";
 
-  const toolCards = (opts.showToolCalls ?? true) ? extractToolCards(message, messageKey) : [];
+  const toolCards = (opts.showToolCalls ?? true) ? extractToolCardsCached(message, messageKey) : [];
   const hasToolCards = toolCards.length > 0;
   const imageRenderOptions = {
     localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],

--- a/ui/src/ui/chat/slash-commands.node.test.ts
+++ b/ui/src/ui/chat/slash-commands.node.test.ts
@@ -383,15 +383,42 @@ describe("parseSlashCommand", () => {
     });
   });
 
-  it("ignores stale refresh responses and keeps the latest command set", async () => {
+  it("keeps local fallback commands after repeated gateway failures", async () => {
+    const request = vi.fn().mockRejectedValue(new Error("offline"));
+    const client = { request } as never;
+
+    await refreshSlashCommands({ client, agentId: "main" });
+    expectRecordFields(requireCommandByName("help"), "first fallback help command", {
+      key: "help",
+      executeLocal: true,
+    });
+
+    await refreshSlashCommands({ client, agentId: "main" });
+    expect(request).toHaveBeenCalledTimes(2);
+    expectRecordFields(requireCommandByName("help"), "second fallback help command", {
+      key: "help",
+      executeLocal: true,
+    });
+  });
+
+  it("coalesces duplicate refreshes for the same agent", async () => {
     let resolveFirst: ((value: unknown) => void) | undefined;
     const first = new Promise((resolve) => {
       resolveFirst = resolve;
     });
-    const request = vi
-      .fn()
-      .mockImplementationOnce(async () => await first)
-      .mockImplementationOnce(async () => ({
+    const request = vi.fn().mockImplementationOnce(async () => await first);
+    const client = { request } as never;
+
+    const pending = refreshSlashCommands({
+      client,
+      agentId: "main",
+    });
+    const duplicate = refreshSlashCommands({
+      client,
+      agentId: "main",
+    });
+    if (resolveFirst) {
+      resolveFirst({
         commands: [
           {
             name: "pair",
@@ -402,38 +429,89 @@ describe("parseSlashCommand", () => {
             acceptsArgs: true,
           },
         ],
-      }));
-
-    const pending = refreshSlashCommands({
-      client: { request } as never,
-      agentId: "main",
-    });
-    await refreshSlashCommands({
-      client: { request } as never,
-      agentId: "main",
-    });
-    if (resolveFirst) {
-      resolveFirst({
-        commands: [
-          {
-            name: "dreaming",
-            textAliases: ["/dreaming"],
-            description: "Enable or disable memory dreaming.",
-            source: "plugin",
-            scope: "both",
-            acceptsArgs: true,
-          },
-        ],
       });
     }
     await pending;
+    await duplicate;
 
+    expect(request).toHaveBeenCalledTimes(1);
     expectRecordFields(requireCommandByName("pair"), "pair command", {
       name: "pair",
       description: "Generate setup codes.",
       executeLocal: false,
       tier: "standard",
     });
+  });
+
+  it("ignores stale refresh responses after switching agents", async () => {
+    let resolveFirst: ((value: unknown) => void) | undefined;
+    const first = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    const request = vi.fn((_: string, params: { agentId?: string }) => {
+      if (params.agentId === "main") {
+        return first;
+      }
+      return Promise.resolve({
+        commands: [
+          {
+            name: "pair",
+            textAliases: ["/pair"],
+            description: "Generate setup codes.",
+            source: "plugin",
+            scope: "both",
+            acceptsArgs: true,
+          },
+        ],
+      });
+    });
+    const client = { request } as never;
+
+    const pending = refreshSlashCommands({ client, agentId: "main" });
+    await refreshSlashCommands({ client, agentId: "other" });
+    resolveFirst?.({
+      commands: [
+        {
+          name: "dreaming",
+          textAliases: ["/dreaming"],
+          description: "Enable or disable memory dreaming.",
+          source: "plugin",
+          scope: "both",
+          acceptsArgs: true,
+        },
+      ],
+    });
+    await pending;
+
+    expectRecordFields(requireCommandByName("pair"), "pair command", {
+      name: "pair",
+      description: "Generate setup codes.",
+    });
     expect(SLASH_COMMANDS.find((entry) => entry.name === "dreaming")).toBeUndefined();
+  });
+
+  it("uses the fresh remote command cache for repeated refreshes", async () => {
+    const request = vi.fn().mockResolvedValue({
+      commands: [
+        {
+          name: "pair",
+          textAliases: ["/pair"],
+          description: "Generate setup codes.",
+          source: "plugin",
+          scope: "both",
+          acceptsArgs: true,
+        },
+      ],
+    });
+    const client = { request } as never;
+
+    await refreshSlashCommands({ client, agentId: "main" });
+    await refreshSlashCommands({ client, agentId: "main" });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expectRecordFields(requireCommandByName("pair"), "pair command", {
+      name: "pair",
+      description: "Generate setup codes.",
+    });
   });
 });

--- a/ui/src/ui/chat/slash-commands.ts
+++ b/ui/src/ui/chat/slash-commands.ts
@@ -427,6 +427,87 @@ function buildFallbackSlashCommands(): SlashCommandDef[] {
 export const SLASH_COMMANDS: SlashCommandDef[] = buildFallbackSlashCommands();
 
 let refreshSeq = 0;
+const REMOTE_SLASH_COMMAND_CACHE_TTL_MS = 60_000;
+
+type RemoteSlashCommandCacheEntry = {
+  commands?: SlashCommandDef[];
+  expiresAt: number;
+  inFlight?: Promise<SlashCommandDef[]>;
+};
+
+let remoteSlashCommandCache = new WeakMap<
+  GatewayBrowserClient,
+  Map<string, RemoteSlashCommandCacheEntry>
+>();
+
+function remoteSlashCommandCacheKey(agentId: string | undefined): string {
+  return agentId ?? "";
+}
+
+function getRemoteSlashCommandCache(
+  client: GatewayBrowserClient,
+): Map<string, RemoteSlashCommandCacheEntry> {
+  let cache = remoteSlashCommandCache.get(client);
+  if (!cache) {
+    cache = new Map();
+    remoteSlashCommandCache.set(client, cache);
+  }
+  return cache;
+}
+
+async function requestRemoteSlashCommands(
+  client: GatewayBrowserClient,
+  agentId: string | undefined,
+  fallback: SlashCommandDef[] | undefined,
+): Promise<SlashCommandDef[]> {
+  try {
+    const result = await client.request<CommandsListResult>("commands.list", {
+      ...(agentId ? { agentId } : {}),
+      includeArgs: true,
+      scope: "text",
+    });
+    if (!Array.isArray(result?.commands)) {
+      return buildFallbackSlashCommands();
+    }
+    const commands = buildSlashCommandsFromEntries(getRemoteCommandEntries(result));
+    const cache = getRemoteSlashCommandCache(client);
+    cache.set(remoteSlashCommandCacheKey(agentId), {
+      commands,
+      expiresAt: Date.now() + REMOTE_SLASH_COMMAND_CACHE_TTL_MS,
+    });
+    return commands;
+  } catch {
+    return fallback ?? buildFallbackSlashCommands();
+  }
+}
+
+function loadRemoteSlashCommands(
+  client: GatewayBrowserClient,
+  agentId: string | undefined,
+): Promise<SlashCommandDef[]> {
+  const cache = getRemoteSlashCommandCache(client);
+  const key = remoteSlashCommandCacheKey(agentId);
+  const cached = cache.get(key);
+  const now = Date.now();
+  if (cached?.commands && cached.expiresAt > now) {
+    return Promise.resolve(cached.commands);
+  }
+  if (cached?.inFlight) {
+    return cached.inFlight;
+  }
+  const inFlight = requestRemoteSlashCommands(client, agentId, cached?.commands).finally(() => {
+    const latest = cache.get(key);
+    if (latest?.inFlight === inFlight) {
+      delete latest.inFlight;
+    }
+  });
+  cache.set(key, {
+    ...(cached?.commands ? { commands: cached.commands } : {}),
+    expiresAt: cached?.expiresAt ?? 0,
+    inFlight,
+  });
+  return inFlight;
+}
 
 export async function refreshSlashCommands(params: {
   client: GatewayBrowserClient | null;
@@ -441,26 +522,16 @@ export async function refreshSlashCommands(params: {
     replaceSlashCommands(buildFallbackSlashCommands());
     return;
   }
-  try {
-    const result = await params.client.request<CommandsListResult>("commands.list", {
-      ...(agentId ? { agentId } : {}),
-      includeArgs: true,
-      scope: "text",
-    });
-    if (seq !== refreshSeq) {
-      return;
-    }
-    replaceSlashCommands(buildSlashCommandsFromEntries(getRemoteCommandEntries(result)));
-  } catch {
-    if (seq !== refreshSeq) {
-      return;
-    }
-    replaceSlashCommands(buildFallbackSlashCommands());
+  const commands = await loadRemoteSlashCommands(params.client, agentId);
+  if (seq !== refreshSeq) {
+    return;
   }
+  replaceSlashCommands(commands);
 }
 
 export function resetSlashCommandsForTest(): void {
   refreshSeq = 0;
+  remoteSlashCommandCache = new WeakMap();
   replaceSlashCommands(buildFallbackSlashCommands());
 }
 

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -342,6 +342,26 @@ export function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] 
   return cards;
 }
 
+const toolCardsByMessage = new WeakMap<object, Map<string, ToolCard[]>>();
+
+export function extractToolCardsCached(message: unknown, prefix = "tool"): ToolCard[] {
+  if (!message || typeof message !== "object") {
+    return extractToolCards(message, prefix);
+  }
+  let byPrefix = toolCardsByMessage.get(message);
+  if (!byPrefix) {
+    byPrefix = new Map();
+    toolCardsByMessage.set(message, byPrefix);
+  }
+  const cached = byPrefix.get(prefix);
+  if (cached) {
+    return cached;
+  }
+  const cards = extractToolCards(message, prefix);
+  byPrefix.set(prefix, cards);
+  return cards;
+}
+
 export function buildToolCardSidebarContent(card: ToolCard): string {
   const display = resolveToolDisplay({ name: card.name, args: card.args });
   const detail = formatToolDetail(display);

--- a/ui/src/ui/chat/tool-expansion-state.ts
+++ b/ui/src/ui/chat/tool-expansion-state.ts
@@ -1,7 +1,7 @@
 import type { ChatItem, MessageGroup } from "../types/chat-types.ts";
 import { isToolResultMessage, normalizeRoleForGrouping } from "./role-normalizer.ts";
 import { getOrCreateSessionCacheValue } from "./session-cache.ts";
-import { extractToolCards } from "./tool-cards.ts";
+import { extractToolCardsCached } from "./tool-cards.ts";
 
 const expandedToolCardsBySession = new Map<string, Map<string, boolean>>();
 const initializedToolCardsBySession = new Map<string, Set<string>>();
@@ -35,7 +35,7 @@ export function syncToolCardExpansionState(
       continue;
     }
     for (const entry of item.messages) {
-      const cards = extractToolCards(entry.message, entry.key);
+      const cards = extractToolCardsCached(entry.message, entry.key);
       for (let cardIndex = 0; cardIndex < cards.length; cardIndex++) {
         const disclosureId = `${entry.key}:toolcard:${cardIndex}`;
         currentToolCardIds.add(disclosureId);

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1770,6 +1770,66 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatLoading).toBe(false);
   });
 
+  it("coalesces duplicate in-flight history loads for the selected session", async () => {
+    const history = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const request = vi.fn(() => history.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const firstLoad = loadChatHistory(state);
+    const secondLoad = loadChatHistory(state);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    history.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "ready" }] }],
+      thinkingLevel: "low",
+    });
+    await firstLoad;
+    await secondLoad;
+
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "ready" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("low");
+    expect(state.chatLoading).toBe(false);
+  });
+
+  it("starts a fresh same-session history load after local messages change", async () => {
+    const staleRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const freshRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => staleRequest.promise)
+      .mockImplementationOnce(() => freshRequest.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const staleLoad = loadChatHistory(state);
+    state.chatMessages = [{ role: "user", content: [{ type: "text", text: "new local ask" }] }];
+    const freshLoad = loadChatHistory(state);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    staleRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "old history" }] }],
+    });
+    await staleLoad;
+    expect(state.chatMessages).toEqual([
+      { role: "user", content: [{ type: "text", text: "new local ask" }] },
+    ]);
+
+    freshRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "fresh history" }] }],
+    });
+    await freshLoad;
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "fresh history" }] },
+    ]);
+  });
+
   it("ignores stale history responses after switching sessions", async () => {
     const mainRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
     const otherRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -49,7 +49,7 @@ function shouldApplyChatHistoryResult(
   state: ChatState,
   version: number,
   sessionKey: string,
-  agentId?: string | null,
+  agentId?: string,
 ): boolean {
   if (!isLatestChatHistoryRequest(state, version) || state.sessionKey !== sessionKey) {
     return false;
@@ -394,15 +394,55 @@ function maybeResetToolStream(state: ChatState) {
   }
 }
 
+type InFlightChatHistoryRequest = {
+  client: NonNullable<ChatState["client"]>;
+  key: string;
+  messages: unknown[];
+  promise: Promise<void>;
+};
+
+const inFlightChatHistoryRequests = new WeakMap<ChatState, InFlightChatHistoryRequest>();
+
 export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;
   }
   const sessionKey = state.sessionKey;
-  const requestVersion = beginChatHistoryRequest(state);
   const requestAgentId = isSelectedGlobalEventSessionKey(sessionKey)
     ? resolveSelectedAgentId(state)
-    : null;
+    : undefined;
+  const requestKey = `${sessionKey}\0${requestAgentId ?? ""}`;
+  const inFlight = inFlightChatHistoryRequests.get(state);
+  if (
+    inFlight?.key === requestKey &&
+    inFlight.client === state.client &&
+    inFlight.messages === state.chatMessages
+  ) {
+    return inFlight.promise;
+  }
+  const promise = loadChatHistoryUncached(state, state.client, sessionKey, requestAgentId).finally(
+    () => {
+      if (inFlightChatHistoryRequests.get(state)?.promise === promise) {
+        inFlightChatHistoryRequests.delete(state);
+      }
+    },
+  );
+  inFlightChatHistoryRequests.set(state, {
+    client: state.client,
+    key: requestKey,
+    messages: state.chatMessages,
+    promise,
+  });
+  return promise;
+}
+
+async function loadChatHistoryUncached(
+  state: ChatState,
+  client: NonNullable<ChatState["client"]>,
+  sessionKey: string,
+  requestAgentId: string | undefined,
+) {
+  const requestVersion = beginChatHistoryRequest(state);
   const startedAt = Date.now();
   const previousMessages = state.chatMessages;
   // Any pending input-history snapshot becomes invalid once we start reloading transcript state.
@@ -413,7 +453,7 @@ export async function loadChatHistory(state: ChatState) {
     let res: { messages?: Array<unknown>; sessionId?: string; thinkingLevel?: string };
     for (;;) {
       try {
-        res = await state.client.request<{
+        res = await client.request<{
           messages?: Array<unknown>;
           sessionId?: string;
           thinkingLevel?: string;

--- a/ui/src/ui/controllers/models.test.ts
+++ b/ui/src/ui/controllers/models.test.ts
@@ -17,4 +17,17 @@ describe("loadModels", () => {
       { id: "MiniMax-M2.7-highspeed", name: "MiniMax M2.7 Highspeed", provider: "minimax" },
     ]);
   });
+
+  it("reuses the configured model list while the cache is fresh", async () => {
+    const request = vi.fn(async () => ({
+      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
+    }));
+    const client = { request } as unknown as GatewayBrowserClient;
+
+    const first = await loadModels(client);
+    const second = await loadModels(client);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
 });

--- a/ui/src/ui/controllers/models.ts
+++ b/ui/src/ui/controllers/models.ts
@@ -1,6 +1,16 @@
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ModelCatalogEntry } from "../types.ts";
 
+const MODEL_CATALOG_CACHE_TTL_MS = 60_000;
+
+type ModelCatalogCacheEntry = {
+  expiresAt: number;
+  models: ModelCatalogEntry[];
+  inFlight?: Promise<ModelCatalogEntry[]>;
+};
+
+const modelCatalogCache = new WeakMap<GatewayBrowserClient, ModelCatalogCacheEntry>();
+
 /**
  * Fetch the model catalog from the gateway.
  *
@@ -9,12 +19,44 @@ import type { ModelCatalogEntry } from "../types.ts";
  * caller receives an empty array rather than throwing.
  */
 export async function loadModels(client: GatewayBrowserClient): Promise<ModelCatalogEntry[]> {
+  const cached = modelCatalogCache.get(client);
+  const now = Date.now();
+  if (cached?.models && cached.expiresAt > now) {
+    return cached.models;
+  }
+  if (cached?.inFlight) {
+    return cached.inFlight;
+  }
+
+  const inFlight = requestModels(client, cached?.models).finally(() => {
+    const latest = modelCatalogCache.get(client);
+    if (latest?.inFlight === inFlight) {
+      delete latest.inFlight;
+    }
+  });
+  modelCatalogCache.set(client, {
+    expiresAt: cached?.expiresAt ?? 0,
+    models: cached?.models ?? [],
+    inFlight,
+  });
+  return inFlight;
+}
+
+async function requestModels(
+  client: GatewayBrowserClient,
+  fallback: ModelCatalogEntry[] | undefined,
+): Promise<ModelCatalogEntry[]> {
   try {
     const result = await client.request<{ models: ModelCatalogEntry[] }>("models.list", {
       view: "configured",
     });
-    return result?.models ?? [];
+    const models = result?.models ?? [];
+    modelCatalogCache.set(client, {
+      expiresAt: Date.now() + MODEL_CATALOG_CACHE_TTL_MS,
+      models,
+    });
+    return models;
   } catch {
-    return [];
+    return fallback ?? [];
   }
 }

--- a/ui/src/ui/views/workboard-3d-game.ts
+++ b/ui/src/ui/views/workboard-3d-game.ts
@@ -1,0 +1,320 @@
+import type * as THREE from "three";
+
+type ThreeModule = typeof THREE;
+
+type WorkboardGameSceneObjects = {
+  camera: THREE.PerspectiveCamera;
+  player: THREE.Group;
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+};
+
+const TILE_SPACING = 1.05;
+
+function parseIntegerAttribute(element: Element, name: string, fallback: number): number {
+  const value = Number.parseInt(element.getAttribute(name) ?? "", 10);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function parseBlockers(value: string | null): Set<number> {
+  if (!value) {
+    return new Set();
+  }
+  return new Set(
+    value
+      .split(",")
+      .map((entry) => Number.parseInt(entry.trim(), 10))
+      .filter((entry) => Number.isFinite(entry)),
+  );
+}
+
+function boardPosition(index: number, size: number, three: ThreeModule) {
+  const row = Math.floor(index / size);
+  const column = index % size;
+  const center = (size - 1) / 2;
+  return new three.Vector3((column - center) * TILE_SPACING, 0.25, (row - center) * TILE_SPACING);
+}
+
+class Workboard3dGameElement extends HTMLElement {
+  static get observedAttributes() {
+    return ["blockers", "board-size", "goal-index", "player-index", "wins"];
+  }
+
+  private animationFrame = 0;
+  private canvas: HTMLCanvasElement | null = null;
+  private sceneObjects: WorkboardGameSceneObjects | null = null;
+  private resizeObserver: ResizeObserver | null = null;
+  private startVersion = 0;
+  private three: ThreeModule | null = null;
+
+  connectedCallback() {
+    this.ensureDom();
+    void this.start();
+  }
+
+  disconnectedCallback() {
+    this.startVersion += 1;
+    if (this.animationFrame) {
+      cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = 0;
+    }
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    this.disposeSceneObjects();
+  }
+
+  attributeChangedCallback() {
+    this.updateScene();
+  }
+
+  private ensureDom() {
+    if (this.canvas) {
+      return;
+    }
+    this.replaceChildren();
+    this.canvas = document.createElement("canvas");
+    this.canvas.className = "workboard-game__canvas";
+    this.canvas.setAttribute("aria-hidden", "true");
+    this.append(this.canvas);
+    this.renderFallback();
+  }
+
+  private renderFallback() {
+    const size = parseIntegerAttribute(this, "board-size", 5);
+    const goalIndex = parseIntegerAttribute(this, "goal-index", size * size - 1);
+    const playerIndex = parseIntegerAttribute(this, "player-index", 0);
+    const blockers = parseBlockers(this.getAttribute("blockers"));
+    const fallback = document.createElement("div");
+    fallback.className = "workboard-game__fallback";
+    fallback.setAttribute("aria-hidden", "true");
+    for (let index = 0; index < size * size; index += 1) {
+      const tile = document.createElement("span");
+      tile.className = [
+        "workboard-game__fallback-tile",
+        index === playerIndex ? "workboard-game__fallback-tile--player" : "",
+        index === goalIndex ? "workboard-game__fallback-tile--goal" : "",
+        blockers.has(index) ? "workboard-game__fallback-tile--blocker" : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+      fallback.append(tile);
+    }
+    this.querySelector(".workboard-game__fallback")?.remove();
+    this.append(fallback);
+  }
+
+  private resetToFallback() {
+    this.classList.remove("workboard-game__scene--ready");
+    if (this.animationFrame) {
+      cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = 0;
+    }
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    this.disposeSceneObjects();
+    this.renderFallback();
+  }
+
+  private disposeSceneObjects() {
+    const objects = this.sceneObjects;
+    if (!objects) {
+      return;
+    }
+    const geometries = new Set<THREE.BufferGeometry>();
+    const materials = new Set<THREE.Material>();
+    objects.scene.traverse((object) => {
+      const mesh = object as THREE.Mesh;
+      if (mesh.geometry) {
+        geometries.add(mesh.geometry);
+      }
+      const material = mesh.material;
+      if (Array.isArray(material)) {
+        for (const entry of material) {
+          materials.add(entry);
+        }
+      } else if (material) {
+        materials.add(material);
+      }
+    });
+    for (const geometry of geometries) {
+      geometry.dispose();
+    }
+    for (const material of materials) {
+      material.dispose();
+    }
+    objects.renderer.dispose();
+    this.sceneObjects = null;
+  }
+
+  private async start() {
+    this.ensureDom();
+    const canvas = this.canvas;
+    if (!canvas || this.sceneObjects) {
+      return;
+    }
+    const startVersion = ++this.startVersion;
+    try {
+      const context = canvas.getContext("webgl2") ?? canvas.getContext("webgl");
+      if (!context) {
+        this.renderFallback();
+        return;
+      }
+      this.three = await import("three");
+      if (!this.isConnected || startVersion !== this.startVersion || this.sceneObjects) {
+        return;
+      }
+      const three = this.three;
+      const renderer = new three.WebGLRenderer({
+        alpha: true,
+        antialias: true,
+        canvas,
+        context,
+        preserveDrawingBuffer: true,
+      });
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      const scene = new three.Scene();
+      const camera = new three.PerspectiveCamera(42, 1, 0.1, 100);
+      const player = new three.Group();
+      this.sceneObjects = { camera, player, renderer, scene };
+      this.buildScene();
+      this.resize();
+      this.resizeObserver = new ResizeObserver(() => this.resize());
+      this.resizeObserver.observe(this);
+      this.classList.add("workboard-game__scene--ready");
+      this.renderFrame();
+    } catch {
+      this.resetToFallback();
+    }
+  }
+
+  private resize() {
+    const { camera, renderer } = this.sceneObjects ?? {};
+    if (!camera || !renderer) {
+      return;
+    }
+    const width = Math.max(1, this.clientWidth);
+    const height = Math.max(1, this.clientHeight);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+    renderer.setSize(width, height, false);
+  }
+
+  private buildScene() {
+    const three = this.three;
+    const objects = this.sceneObjects;
+    if (!three || !objects) {
+      return;
+    }
+    const { camera, player, scene } = objects;
+    scene.clear();
+    const size = parseIntegerAttribute(this, "board-size", 5);
+    const goalIndex = parseIntegerAttribute(this, "goal-index", size * size - 1);
+    const blockers = parseBlockers(this.getAttribute("blockers"));
+    const baseMaterial = new three.MeshStandardMaterial({
+      color: 0x21313b,
+      metalness: 0.28,
+      roughness: 0.58,
+    });
+    const openMaterial = new three.MeshStandardMaterial({
+      color: 0x2f4650,
+      metalness: 0.24,
+      roughness: 0.5,
+    });
+    const blockerMaterial = new three.MeshStandardMaterial({
+      color: 0xe55b4d,
+      emissive: 0x3b0804,
+      metalness: 0.18,
+      roughness: 0.42,
+    });
+    const goalMaterial = new three.MeshStandardMaterial({
+      color: 0x52d273,
+      emissive: 0x123d1c,
+      metalness: 0.2,
+      roughness: 0.36,
+    });
+    const playerMaterial = new three.MeshStandardMaterial({
+      color: 0x67a6ff,
+      emissive: 0x112b62,
+      metalness: 0.34,
+      roughness: 0.26,
+    });
+    const tileGeometry = new three.BoxGeometry(0.94, 0.14, 0.94);
+    const blockerGeometry = new three.ConeGeometry(0.28, 0.7, 5);
+    for (let index = 0; index < size * size; index += 1) {
+      const tile = new three.Mesh(
+        tileGeometry,
+        index === goalIndex ? goalMaterial : blockers.has(index) ? baseMaterial : openMaterial,
+      );
+      const position = boardPosition(index, size, three);
+      tile.position.set(position.x, 0, position.z);
+      tile.receiveShadow = true;
+      scene.add(tile);
+      if (blockers.has(index)) {
+        const blocker = new three.Mesh(blockerGeometry, blockerMaterial);
+        blocker.position.set(position.x, 0.42, position.z);
+        blocker.rotation.y = index * 0.61;
+        scene.add(blocker);
+      }
+    }
+    const goalPosition = boardPosition(goalIndex, size, three);
+    const ring = new three.Mesh(new three.TorusGeometry(0.34, 0.045, 10, 28), goalMaterial);
+    ring.position.set(goalPosition.x, 0.25, goalPosition.z);
+    ring.rotation.x = Math.PI / 2;
+    scene.add(ring);
+
+    player.clear();
+    const body = new three.Mesh(new three.IcosahedronGeometry(0.29, 1), playerMaterial);
+    const base = new three.Mesh(new three.CylinderGeometry(0.24, 0.3, 0.16, 16), playerMaterial);
+    base.position.y = -0.2;
+    player.add(body, base);
+    scene.add(player);
+
+    scene.add(new three.AmbientLight(0xa8c7ff, 0.7));
+    const keyLight = new three.DirectionalLight(0xffffff, 1.75);
+    keyLight.position.set(-3.5, 6, 4);
+    scene.add(keyLight);
+    const rimLight = new three.PointLight(0x67a6ff, 6, 9);
+    rimLight.position.set(3, 2.8, -4);
+    scene.add(rimLight);
+    camera.position.set(3.4, 5.5, 6.8);
+    camera.lookAt(0, 0, 0);
+    this.updateScene();
+  }
+
+  private updateScene() {
+    this.renderFallback();
+    const three = this.three;
+    const { player } = this.sceneObjects ?? {};
+    if (!three || !player) {
+      return;
+    }
+    const size = parseIntegerAttribute(this, "board-size", 5);
+    const playerIndex = parseIntegerAttribute(this, "player-index", 0);
+    const target = boardPosition(playerIndex, size, three);
+    player.position.copy(target);
+  }
+
+  private renderFrame = () => {
+    const three = this.three;
+    const objects = this.sceneObjects;
+    if (!three || !objects) {
+      return;
+    }
+    const size = parseIntegerAttribute(this, "board-size", 5);
+    const playerIndex = parseIntegerAttribute(this, "player-index", 0);
+    const target = boardPosition(playerIndex, size, three);
+    objects.player.position.lerp(target, 0.2);
+    objects.player.rotation.y += 0.035;
+    objects.player.position.y = target.y + Math.sin(performance.now() / 210) * 0.06;
+    const orbit = performance.now() / 8200;
+    objects.camera.position.x = Math.sin(orbit) * 1.2 + 3.4;
+    objects.camera.position.z = Math.cos(orbit) * 1.2 + 6.8;
+    objects.camera.lookAt(0, 0, 0);
+    objects.renderer.render(objects.scene, objects.camera);
+    this.animationFrame = requestAnimationFrame(this.renderFrame);
+  };
+}
+
+if ("customElements" in globalThis && !customElements.get("workboard-3d-game")) {
+  customElements.define("workboard-3d-game", Workboard3dGameElement);
+}

--- a/ui/src/ui/views/workboard.test.ts
+++ b/ui/src/ui/views/workboard.test.ts
@@ -370,6 +370,12 @@ describe("renderWorkboard", () => {
     render(renderWorkboard(props), container);
 
     expect(container.querySelector('[role="dialog"]')?.textContent).toContain("Card Chase");
+    expect(container.querySelector("workboard-3d-game")?.getAttribute("player-index")).toBe("0");
+    expect(container.querySelector("workboard-3d-game")?.getAttribute("aria-hidden")).toBe("true");
+    expect(container.querySelector('[role="grid"]')?.getAttribute("aria-label")).toBe(
+      "Card Chase board",
+    );
+    expect(container.querySelector('[role="gridcell"][aria-label="Agent 1"]')).not.toBeNull();
     const controls = container.querySelector<HTMLElement>(".workboard-game__controls");
     controls
       ?.querySelector<HTMLButtonElement>('button[aria-label="Move right"]')
@@ -377,6 +383,8 @@ describe("renderWorkboard", () => {
     render(renderWorkboard(props), container);
 
     expect(state.gamePlayerIndex).toBe(1);
+    expect(container.querySelector("workboard-3d-game")?.getAttribute("player-index")).toBe("1");
+    expect(container.querySelector('[role="gridcell"][aria-label="Agent 2"]')).not.toBeNull();
     expect(container.querySelector(".workboard-game__stats")?.textContent).toContain("Moves 1");
   });
 

--- a/ui/src/ui/views/workboard.ts
+++ b/ui/src/ui/views/workboard.ts
@@ -28,6 +28,7 @@ import { formatDateMs } from "../format.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import { icons } from "../icons.ts";
 import type { AgentsListResult, GatewaySessionRow } from "../types.ts";
+import "./workboard-3d-game.ts";
 
 type WorkboardProps = {
   host: object;
@@ -441,6 +442,28 @@ function renderGameArrow(
   `;
 }
 
+function gameCellLabel(state: WorkboardUiState, index: number) {
+  const label =
+    index === state.gamePlayerIndex
+      ? t("workboard.gameAgent")
+      : index === WORKBOARD_GAME_GOAL
+        ? t("workboard.gameLaunch")
+        : WORKBOARD_GAME_BLOCKERS.has(index)
+          ? t("workboard.gameBlockedCell")
+          : t("workboard.gameOpenCell");
+  return `${label} ${index + 1}`;
+}
+
+function renderAccessibleGameGrid(state: WorkboardUiState) {
+  return html`
+    <div class="workboard-game__accessible-grid" role="grid" aria-label=${t("workboard.gameBoard")}>
+      ${Array.from({ length: WORKBOARD_GAME_SIZE * WORKBOARD_GAME_SIZE }, (_, index) => {
+        return html`<span role="gridcell" aria-label=${gameCellLabel(state, index)}></span>`;
+      })}
+    </div>
+  `;
+}
+
 function renderGameModal(props: WorkboardProps) {
   const state = getWorkboardState(props.host);
   if (!state.gameOpen) {
@@ -500,30 +523,16 @@ function renderGameModal(props: WorkboardProps) {
           <span>${t("workboard.gameMoves", { count: String(state.gameMoves) })}</span>
           <span>${t("workboard.gameWins", { count: String(state.gameWins) })}</span>
         </div>
-        <div class="workboard-game__grid" role="grid" aria-label=${t("workboard.gameBoard")}>
-          ${Array.from({ length: WORKBOARD_GAME_SIZE * WORKBOARD_GAME_SIZE }, (_, index) => {
-            const player = index === state.gamePlayerIndex;
-            const goal = index === WORKBOARD_GAME_GOAL;
-            const blocker = WORKBOARD_GAME_BLOCKERS.has(index);
-            return html`
-              <div
-                class="workboard-game__cell ${player ? "workboard-game__cell--player" : ""} ${goal
-                  ? "workboard-game__cell--goal"
-                  : ""} ${blocker ? "workboard-game__cell--blocker" : ""}"
-                role="gridcell"
-                aria-label=${player
-                  ? t("workboard.gameAgent")
-                  : goal
-                    ? t("workboard.gameLaunch")
-                    : blocker
-                      ? t("workboard.gameBlockedCell")
-                      : t("workboard.gameOpenCell")}
-              >
-                ${player ? "A" : goal ? "L" : blocker ? "" : ""}
-              </div>
-            `;
-          })}
-        </div>
+        <workboard-3d-game
+          class="workboard-game__scene"
+          board-size=${String(WORKBOARD_GAME_SIZE)}
+          goal-index=${String(WORKBOARD_GAME_GOAL)}
+          player-index=${String(state.gamePlayerIndex)}
+          blockers=${[...WORKBOARD_GAME_BLOCKERS].join(",")}
+          wins=${String(state.gameWins)}
+          aria-hidden="true"
+        ></workboard-3d-game>
+        ${renderAccessibleGameGrid(state)}
         <div class="workboard-game__controls" aria-label=${t("workboard.gameControls")}>
           ${renderGameArrow(
             t("workboard.gameMoveUp"),


### PR DESCRIPTION
## Summary
- defer chat avatar/model/slash metadata hydration off the initial history path
- cache/coalesce configured model, slash-command, chat-history, and tool-card work with selected-agent scoping guards
- replace the Workboard mini-game grid with a lazy Three.js scene while preserving fallback/a11y state and resource cleanup

## Verification
- `pnpm test ui/src/ui/controllers/chat.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/chat/slash-commands.node.test.ts ui/src/ui/controllers/models.test.ts ui/src/ui/chat/tool-cards.node.test.ts ui/src/ui/views/workboard.test.ts ui/src/styles/workboard.test.ts -- --reporter=verbose`
- `pnpm test ui/src/ui/app-chat.test.ts ui/src/ui/views/workboard.test.ts ui/src/styles/workboard.test.ts -- --reporter=verbose`
- `pnpm test ui/src/ui/views/workboard.test.ts ui/src/styles/workboard.test.ts -- --reporter=verbose`
- `pnpm ui:build`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`
- autoreview clean: no accepted/actionable findings reported

## Real behavior proof
Behavior addressed: Slow chat initial load and late tool visibility on Control UI chat sessions, plus Workboard mini-game parity with the Hermes-inspired 3D treatment.
Real environment tested: Local OpenClaw Control UI at 127.0.0.1:19001 in the existing Chrome profile.
Exact steps or command run after this patch: Reloaded the affected chat URL with Chrome DevTools MCP and measured navigation/render state from the page.
Evidence after fix: DOMContentLoaded 145 ms, load 567 ms, responseEnd 13 ms, hydrated body 9154 chars, 100 chat rows, no loading text.
Observed result after fix: The chat route reached a complete hydrated state without waiting on secondary metadata RPCs.
What was not tested: Cross-browser manual visual inspection beyond the existing Chrome profile and automated UI/build/check lanes.
