### PR TITLE
fix(feishu): restore full-text streaming card updates to prevent content truncation

### DIFF
--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -180,7 +180,7 @@ describe("FeishuStreamingSession", () => {
 
     expect(updateBodies).toHaveLength(1);
     expect(JSON.parse(updateBodies[0] ?? "{}")).toEqual({
-      content: " small",
+      content: "hello small",
       sequence: 2,
       uuid: "s_card_1_2",
     });
@@ -212,13 +212,13 @@ describe("FeishuStreamingSession", () => {
 
     expect(updateBodies).toHaveLength(1);
     expect(JSON.parse(updateBodies[0] ?? "{}")).toEqual({
-      content: "!",
+      content: "hello!",
       sequence: 2,
       uuid: "s_card_2_2",
     });
   });
 
-  it("retries unsent suffix content after a failed delta update", async () => {
+  it("retries full content after a failed streaming update", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(3_000);
     const updateBodies: string[] = [];
@@ -245,18 +245,18 @@ describe("FeishuStreamingSession", () => {
 
     expect(updateBodies).toHaveLength(2);
     expect(JSON.parse(updateBodies[0] ?? "{}")).toEqual({
-      content: " world",
+      content: "hello world",
       sequence: 2,
       uuid: "s_card_3_2",
     });
     expect(JSON.parse(updateBodies[1] ?? "{}")).toEqual({
-      content: " world!",
+      content: "hello world!",
       sequence: 3,
       uuid: "s_card_3_3",
     });
   });
 
-  it("retries unsent suffix content after a non-OK delta update", async () => {
+  it("retries full content after a non-OK streaming update", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(3_500);
     const updateBodies: string[] = [];
@@ -283,14 +283,60 @@ describe("FeishuStreamingSession", () => {
 
     expect(updateBodies).toHaveLength(2);
     expect(JSON.parse(updateBodies[0] ?? "{}")).toEqual({
-      content: " world",
+      content: "hello world",
       sequence: 2,
       uuid: "s_card_5_2",
     });
     expect(JSON.parse(updateBodies[1] ?? "{}")).toEqual({
-      content: " world!",
+      content: "hello world!",
       sequence: 3,
       uuid: "s_card_5_3",
+    });
+  });
+
+  it("replaces final content even when it extends the visible streaming text", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(3_800);
+    const updateBodies: string[] = [];
+    const replaceBodies: string[] = [];
+    mockFetches(updateBodies, new Set<number>(), replaceBodies);
+
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_final_extends_stream",
+      appSecret: "secret",
+    });
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_8",
+        messageId: "om_8",
+        sequence: 1,
+        currentText: "hello",
+        sentText: "hello",
+        hasNote: false,
+      },
+      lastUpdateTime: 3_000,
+    });
+
+    await session.close("hello world");
+
+    expect(updateBodies).toHaveLength(0);
+    expect(replaceBodies).toHaveLength(1);
+    const replacePayload = JSON.parse(replaceBodies[0] ?? "{}") as {
+      element?: string;
+      sequence?: number;
+      uuid?: string;
+    };
+    expect({
+      ...replacePayload,
+      element: JSON.parse(replacePayload.element ?? "{}"),
+    }).toEqual({
+      element: {
+        tag: "markdown",
+        content: "hello world",
+        element_id: "content",
+      },
+      sequence: 2,
+      uuid: "r_card_8_2",
     });
   });
 
@@ -383,12 +429,18 @@ describe("FeishuStreamingSession", () => {
     );
   });
 
-  it("reports no visible content when final close update fails before any accepted text", async () => {
+  it("reports no visible content when final close replacement fails before any accepted text", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(4_800);
     const updateBodies: string[] = [];
     const replaceBodies: string[] = [];
-    mockFetches(updateBodies, new Set<number>(), replaceBodies, new Map([[0, 500]]));
+    mockFetches(
+      updateBodies,
+      new Set<number>(),
+      replaceBodies,
+      new Map<number, number>(),
+      new Map([[0, 500]]),
+    );
     const log = vi.fn();
 
     const session = new FeishuStreamingSession(
@@ -413,10 +465,10 @@ describe("FeishuStreamingSession", () => {
 
     await expect(session.close("final answer")).resolves.toBe(false);
 
-    expect(updateBodies).toHaveLength(1);
-    expect(replaceBodies).toHaveLength(0);
+    expect(updateBodies).toHaveLength(0);
+    expect(replaceBodies).toHaveLength(1);
     expect(log).toHaveBeenCalledWith(
-      "Final update failed: Error: Update card content failed with HTTP 500",
+      "Final replace failed: Error: Replace card content failed with HTTP 500",
     );
   });
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -154,16 +154,6 @@ function shouldPushStreamingUpdate(previousText: string, nextText: string): bool
   return nextText.length - previousText.length >= STREAMING_SIGNIFICANT_DELTA_CHARS;
 }
 
-function resolveStreamingCardAppendContent(previousText: string, nextText: string): string {
-  if (!nextText || nextText === previousText) {
-    return "";
-  }
-  if (!previousText) {
-    return nextText;
-  }
-  return nextText.startsWith(previousText) ? nextText.slice(previousText.length) : nextText;
-}
-
 export function mergeStreamingText(
   previousText: string | undefined,
   nextText: string | undefined,
@@ -477,13 +467,9 @@ export class FeishuStreamingSession {
       if (!mergedText || mergedText === this.state.currentText) {
         return;
       }
-      const appendContent = resolveStreamingCardAppendContent(this.state.sentText, mergedText);
-      if (!appendContent) {
-        return;
-      }
       this.pendingText = null;
       this.state.currentText = mergedText;
-      const sent = await this.updateCardContent(appendContent, (e) =>
+      const sent = await this.updateCardContent(mergedText, (e) =>
         this.log?.(`Update failed: ${String(e)}`),
       );
       if (sent && this.state) {
@@ -539,14 +525,9 @@ export class FeishuStreamingSession {
     // Only send final update if content differs from what's already displayed.
     // An explicit empty final text clears a transient preview before closeout.
     if ((text || finalText !== undefined) && text !== this.state.sentText) {
-      const sent = text.startsWith(this.state.sentText)
-        ? await this.updateCardContent(
-            resolveStreamingCardAppendContent(this.state.sentText, text),
-            (e) => this.log?.(`Final update failed: ${String(e)}`),
-          )
-        : await this.replaceCardContent(text, (e) =>
-            this.log?.(`Final replace failed: ${String(e)}`),
-          );
+      const sent = await this.replaceCardContent(text, (e) =>
+        this.log?.(`Final replace failed: ${String(e)}`),
+      );
       this.state.currentText = text;
       if (sent) {
         this.state.sentText = text;


### PR DESCRIPTION
## Summary

- Send the full accumulated text to Feishu CardKit streaming content updates instead of a suffix delta.
- Always replace the markdown element on final close when final text differs from the visible streaming text.
- Add regression coverage for full-text streaming payloads, retry payloads, and final replacement.

## Root cause

Feishu CardKit streaming text updates expect the full element content. When the old text is a prefix of the new text, Feishu computes the incremental typewriter rendering itself. The previous OpenClaw code sent only `nextText.slice(previousText.length)`, so CardKit replaced the element with the latest suffix and silently truncated earlier content.

## Fix

`FeishuStreamingSession.update()` now passes `mergedText` to `updateCardContent()`. `close()` now uses `replaceCardContent()` for final differing text, including prefix-extension final text, so the final card body is always reconciled as full markdown content.

## Real behavior proof

Behavior addressed: Feishu/Lark streaming cards were losing previously streamed content because OpenClaw sent only suffix deltas to the CardKit content endpoint.

Real environment tested: Author-tested against a real Feishu setup on OpenClaw 2026.5.28 by patching the built dist file with this behavior change.

Exact steps or command run after this patch: Patched the OpenClaw Feishu streaming card dist file, sent multi-section streaming card messages through Feishu, then repeated short streaming replies under 1KB that previously showed truncation.

Evidence after fix: Copied live output from the author’s Feishu test notes after the patched OpenClaw run:

```text
Feishu streaming card run:
- multi-section streaming card messages displayed all content sections
- short messages under 1KB that previously truncated displayed in full
- Feishu returned successful streaming-card update responses during the run
```

Observed result after fix: The Feishu card body displayed the complete accumulated answer instead of only the final fragment.

What was not tested: Maintainer did not rerun an exact-head live Feishu credentialed setup; maintainer verification was focused on source contract, regression tests, typecheck, lint, autoreview, and the contributor’s real Feishu proof notes.

## Verification

- `node scripts/run-vitest.mjs extensions/feishu/src/streaming-card.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-oxlint.mjs extensions/feishu/src/streaming-card.ts extensions/feishu/src/streaming-card.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
