### PR TITLE
fix(memory): retry transient embedding failures

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -572,6 +572,90 @@ describe("memory index", () => {
     );
   });
 
+  it("retries transient query embedding transport failures during search", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-search-query-retry.sqlite"),
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+
+    let queryCalls = 0;
+    (
+      manager as unknown as {
+        provider: {
+          id: string;
+          model: string;
+          embedQuery: (text: string) => Promise<number[]>;
+          embedBatch: (texts: string[]) => Promise<number[][]>;
+          close: () => Promise<void>;
+        };
+        waitForEmbeddingRetry: (delayMs: number, action: string) => Promise<void>;
+      }
+    ).provider = {
+      id: "openai",
+      model: "mock-embed",
+      embedQuery: async () => {
+        queryCalls += 1;
+        if (queryCalls === 1) {
+          throw new Error("TypeError: fetch failed | other side closed");
+        }
+        return [1, 0, 0, 0];
+      },
+      embedBatch: async (texts: string[]) => texts.map(() => [1, 0, 0, 0]),
+      close: async () => {},
+    };
+    (
+      manager as unknown as {
+        waitForEmbeddingRetry: (delayMs: number, action: string) => Promise<void>;
+      }
+    ).waitForEmbeddingRetry = async () => {};
+
+    const results = await manager.search("alpha");
+
+    expect(queryCalls).toBe(2);
+    expect(results.some((result) => result.path.endsWith("memory/2026-01-12.md"))).toBe(true);
+  });
+
+  it("fails search after bounded query embedding retries are exhausted", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-search-query-retry-exhausted.sqlite"),
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+
+    let queryCalls = 0;
+    (
+      manager as unknown as {
+        provider: {
+          id: string;
+          model: string;
+          embedQuery: (text: string) => Promise<number[]>;
+          embedBatch: (texts: string[]) => Promise<number[][]>;
+          close: () => Promise<void>;
+        };
+      }
+    ).provider = {
+      id: "openai",
+      model: "mock-embed",
+      embedQuery: async () => {
+        queryCalls += 1;
+        throw new Error("TypeError: fetch failed | other side closed");
+      },
+      embedBatch: async (texts: string[]) => texts.map(() => [1, 0, 0, 0]),
+      close: async () => {},
+    };
+    (
+      manager as unknown as {
+        waitForEmbeddingRetry: (delayMs: number, action: string) => Promise<void>;
+      }
+    ).waitForEmbeddingRetry = async () => {};
+
+    await expect(manager.search("alpha")).rejects.toThrow("fetch failed");
+    expect(queryCalls).toBe(3);
+  });
+
   it("preserves keyword-only hybrid hits when minScore exceeds text weight", async () => {
     await expectHybridKeywordSearchFindsMemory(
       createCfg({

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -32,7 +32,9 @@ import {
   buildTextEmbeddingInputs,
   filterNonEmptyMemoryChunks,
   isRetryableMemoryEmbeddingError,
+  isSplittableMemoryEmbeddingTransportError,
   resolveMemoryEmbeddingRetryDelay,
+  runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
 import { deleteMemoryFtsRows } from "./manager-fts-state.js";
@@ -344,26 +346,33 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       throw new Error("Cannot embed batch in FTS-only mode (no embedding provider)");
     }
     try {
-      return await runMemoryEmbeddingRetryLoop({
-        run: async () => {
+      return await runMemoryEmbeddingBatchRetryWithSplit({
+        items: texts,
+        run: async (batchTexts) => {
           const timeoutMs = this.resolveEmbeddingTimeout("batch");
           log.debug("memory embeddings: batch start", {
             provider: provider.id,
-            items: texts.length,
+            items: batchTexts.length,
             timeoutMs,
           });
           return await runEmbeddingOperationWithTimeout({
             timeoutMs,
             message: `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
-            run: async (signal) => await provider.embedBatch(texts, { signal }),
+            run: async (signal) => await provider.embedBatch(batchTexts, { signal }),
           });
         },
         isRetryable: isRetryableMemoryEmbeddingError,
+        isSplittable: isSplittableMemoryEmbeddingTransportError,
         waitForRetry: async (delayMs) => {
           await this.waitForEmbeddingRetry(delayMs, "retrying");
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        onSplit: ({ itemCount, splitAt }) => {
+          log.warn(
+            `memory embeddings transport failed after retries; splitting batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
+          );
+        },
       });
     } catch (err) {
       this.markLocalEmbeddingProviderDegraded(err);
@@ -385,26 +394,33 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       return await this.embedBatchWithRetry(inputs.map((input) => input.text));
     }
     try {
-      return await runMemoryEmbeddingRetryLoop({
-        run: async () => {
+      return await runMemoryEmbeddingBatchRetryWithSplit({
+        items: inputs,
+        run: async (batchInputs) => {
           const timeoutMs = this.resolveEmbeddingTimeout("batch");
           log.debug("memory embeddings: structured batch start", {
             provider: provider.id,
-            items: inputs.length,
+            items: batchInputs.length,
             timeoutMs,
           });
           return await runEmbeddingOperationWithTimeout({
             timeoutMs,
             message: `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
-            run: async (signal) => await embedBatchInputs(inputs, { signal }),
+            run: async (signal) => await embedBatchInputs(batchInputs, { signal }),
           });
         },
         isRetryable: isRetryableMemoryEmbeddingError,
+        isSplittable: isSplittableMemoryEmbeddingTransportError,
         waitForRetry: async (delayMs) => {
           await this.waitForEmbeddingRetry(delayMs, "retrying structured batch");
         },
         maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
         baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
+        onSplit: ({ itemCount, splitAt }) => {
+          log.warn(
+            `memory embeddings transport failed after retries; splitting structured batch of ${itemCount} into ${splitAt} + ${itemCount - splitAt}`,
+          );
+        },
       });
     } catch (err) {
       this.markLocalEmbeddingProviderDegraded(err);
@@ -422,7 +438,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       Math.random(),
       EMBEDDING_RETRY_MAX_DELAY_MS,
     );
-    log.warn(`memory embeddings rate limited; ${action} in ${waitMs}ms`);
+    log.warn(`memory embeddings retryable error; ${action} in ${waitMs}ms`);
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }
 
@@ -435,18 +451,28 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  protected async embedQueryWithTimeout(text: string): Promise<number[]> {
+  protected async embedQueryWithRetry(text: string): Promise<number[]> {
     const provider = this.provider;
     if (!provider) {
       throw new Error("Cannot embed query in FTS-only mode (no embedding provider)");
     }
-    const timeoutMs = this.resolveEmbeddingTimeout("query");
-    log.debug("memory embeddings: query start", { provider: provider.id, timeoutMs });
     try {
-      return await runEmbeddingOperationWithTimeout({
-        timeoutMs,
-        message: `memory embeddings query timed out after ${Math.round(timeoutMs / 1000)}s`,
-        run: async (signal) => await provider.embedQuery(text, { signal }),
+      return await runMemoryEmbeddingRetryLoop({
+        run: async () => {
+          const timeoutMs = this.resolveEmbeddingTimeout("query");
+          log.debug("memory embeddings: query start", { provider: provider.id, timeoutMs });
+          return await runEmbeddingOperationWithTimeout({
+            timeoutMs,
+            message: `memory embeddings query timed out after ${Math.round(timeoutMs / 1000)}s`,
+            run: async (signal) => await provider.embedQuery(text, { signal }),
+          });
+        },
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          await this.waitForEmbeddingRetry(delayMs, "retrying query");
+        },
+        maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
+        baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
       });
     } catch (err) {
       this.markLocalEmbeddingProviderDegraded(err);

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildMemoryEmbeddingBatches,
   filterNonEmptyMemoryChunks,
+  isRetryableMemoryEmbeddingTransportError,
   isRetryableMemoryEmbeddingError,
+  isSplittableMemoryEmbeddingTransportError,
   isStructuredInputTooLargeMemoryEmbeddingError,
   resolveMemoryEmbeddingRetryDelay,
+  runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
 
@@ -72,17 +75,30 @@ describe("memory embedding policy", () => {
   });
 
   it("retries transient socket/network embedding errors", () => {
-    const messages = [
+    const splittableMessages = [
       "TypeError: fetch failed | other side closed",
       "undici error: UND_ERR_SOCKET",
       "read ECONNRESET",
       "socket hang up",
-      "ETIMEDOUT",
     ];
 
-    for (const message of messages) {
+    for (const message of splittableMessages) {
       expect(isRetryableMemoryEmbeddingError(message)).toBe(true);
+      expect(isRetryableMemoryEmbeddingTransportError(message)).toBe(true);
+      expect(isSplittableMemoryEmbeddingTransportError(message)).toBe(true);
     }
+    expect(isRetryableMemoryEmbeddingTransportError("ECONNREFUSED")).toBe(true);
+    expect(isSplittableMemoryEmbeddingTransportError("ECONNREFUSED")).toBe(false);
+    expect(isRetryableMemoryEmbeddingTransportError("EHOSTUNREACH")).toBe(true);
+    expect(isSplittableMemoryEmbeddingTransportError("EHOSTUNREACH")).toBe(false);
+    expect(isRetryableMemoryEmbeddingTransportError("memory embeddings batch timed out")).toBe(
+      true,
+    );
+    expect(isSplittableMemoryEmbeddingTransportError("memory embeddings batch timed out")).toBe(
+      false,
+    );
+    expect(isRetryableMemoryEmbeddingTransportError("worker terminated by user")).toBe(false);
+    expect(isRetryableMemoryEmbeddingTransportError("embedding validation failed")).toBe(false);
   });
 
   it("retries too-many-tokens-per-day errors", async () => {
@@ -108,6 +124,97 @@ describe("memory embedding policy", () => {
     expect(result).toBe("ok");
     expect(calls).toBe(2);
     expect(waits).toEqual([500]);
+  });
+
+  it("stops after the configured maximum attempts", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("TypeError: fetch failed | other side closed");
+    });
+    const waits: number[] = [];
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry: async (delayMs) => {
+          waits.push(delayMs);
+        },
+        maxAttempts: 3,
+        baseDelayMs: 500,
+      }),
+    ).rejects.toThrow("fetch failed");
+
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(waits).toEqual([500, 1000]);
+  });
+
+  it("splits transport-failed batches after retries are exhausted", async () => {
+    const waits: number[] = [];
+    const splits: string[] = [];
+    const run = vi.fn(async (items: string[]) => {
+      if (items.length > 1) {
+        throw new TypeError("fetch failed | other side closed");
+      }
+      return items.map((item) => [item.charCodeAt(0)]);
+    });
+
+    const result = await runMemoryEmbeddingBatchRetryWithSplit({
+      items: ["a", "b", "c", "d"],
+      run,
+      isRetryable: isRetryableMemoryEmbeddingError,
+      isSplittable: isSplittableMemoryEmbeddingTransportError,
+      waitForRetry: async (delayMs) => {
+        waits.push(delayMs);
+      },
+      maxAttempts: 2,
+      baseDelayMs: 500,
+      onSplit: ({ itemCount, splitAt }) => {
+        splits.push(`${itemCount}:${splitAt}`);
+      },
+    });
+
+    expect(result).toEqual([[97], [98], [99], [100]]);
+    expect(run.mock.calls.map(([items]) => items.length)).toEqual([4, 4, 2, 2, 1, 1, 2, 2, 1, 1]);
+    expect(waits).toEqual([500, 500, 500]);
+    expect(splits).toEqual(["4:2", "2:1", "2:1"]);
+  });
+
+  it("does not split exhausted service retry errors", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("openai embeddings failed: 429 rate limit");
+    });
+
+    await expect(
+      runMemoryEmbeddingBatchRetryWithSplit({
+        items: ["a", "b"],
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        isSplittable: isSplittableMemoryEmbeddingTransportError,
+        waitForRetry: async () => {},
+        maxAttempts: 1,
+        baseDelayMs: 500,
+      }),
+    ).rejects.toThrow("429 rate limit");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not split whole-endpoint transport outages", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:11434");
+    });
+
+    await expect(
+      runMemoryEmbeddingBatchRetryWithSplit({
+        items: ["a", "b"],
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        isSplittable: isSplittableMemoryEmbeddingTransportError,
+        waitForRetry: async () => {},
+        maxAttempts: 2,
+        baseDelayMs: 500,
+      }),
+    ).rejects.toThrow("ECONNREFUSED");
+    expect(run).toHaveBeenCalledTimes(2);
   });
 
   it("classifies oversized structured-input errors", () => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -80,9 +80,27 @@ export function buildMemoryEmbeddingBatches<T extends MemoryEmbeddingChunk>(
   return batches;
 }
 
+const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE =
+  /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day)/i;
+
+const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
+  /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
+
+const SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
+  /(other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted))/i;
+
+export function isRetryableMemoryEmbeddingTransportError(message: string): boolean {
+  return RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message);
+}
+
+export function isSplittableMemoryEmbeddingTransportError(message: string): boolean {
+  return SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message);
+}
+
 export function isRetryableMemoryEmbeddingError(message: string): boolean {
-  return /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day|fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|network error|read ECONN|timed out)/i.test(
-    message,
+  return (
+    RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message) ||
+    isRetryableMemoryEmbeddingTransportError(message)
   );
 }
 
@@ -107,7 +125,7 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
   maxAttempts: number;
   baseDelayMs: number;
 }): Promise<T> {
-  let attempt = 0;
+  let attempt = 1;
   let delayMs = params.baseDelayMs;
   while (true) {
     try {
@@ -121,6 +139,44 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
       delayMs *= 2;
       attempt += 1;
     }
+  }
+}
+
+export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(params: {
+  items: TInput[];
+  run: (items: TInput[]) => Promise<TOutput[]>;
+  isRetryable: (message: string) => boolean;
+  isSplittable: (message: string) => boolean;
+  waitForRetry: (delayMs: number) => Promise<void>;
+  maxAttempts: number;
+  baseDelayMs: number;
+  onSplit?: (info: { itemCount: number; splitAt: number; message: string }) => void;
+}): Promise<TOutput[]> {
+  try {
+    return await runMemoryEmbeddingRetryLoop({
+      run: async () => await params.run(params.items),
+      isRetryable: params.isRetryable,
+      waitForRetry: params.waitForRetry,
+      maxAttempts: params.maxAttempts,
+      baseDelayMs: params.baseDelayMs,
+    });
+  } catch (err) {
+    const message = formatErrorMessage(err);
+    if (params.items.length <= 1 || !params.isSplittable(message)) {
+      throw err;
+    }
+
+    const splitAt = Math.ceil(params.items.length / 2);
+    params.onSplit?.({ itemCount: params.items.length, splitAt, message });
+    const left = await runMemoryEmbeddingBatchRetryWithSplit({
+      ...params,
+      items: params.items.slice(0, splitAt),
+    });
+    const right = await runMemoryEmbeddingBatchRetryWithSplit({
+      ...params,
+      items: params.items.slice(splitAt),
+    });
+    return [...left, ...right];
   }
 }
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -540,7 +540,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
     let queryVec: number[];
     try {
-      queryVec = await this.embedQueryWithTimeout(cleaned);
+      queryVec = await this.embedQueryWithRetry(cleaned);
     } catch (err) {
       const message = formatErrorMessage(err);
       const activatedFallback = this.shouldFallbackOnError(err)
@@ -554,7 +554,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       if (activatedFallback) {
         await this.runSafeReindex({ reason: "fallback", force: true });
         keywordResults = await loadKeywordResults();
-        queryVec = await this.embedQueryWithTimeout(cleaned);
+        queryVec = await this.embedQueryWithRetry(cleaned);
       } else if (!this.provider && this.fts.enabled && this.fts.available) {
         log.warn(`memory search: embeddings unavailable; using keyword-only results: ${message}`);
         return this.selectScoredResults(keywordResults, maxResults, minScore, 0);


### PR DESCRIPTION
## Summary

- Retry live memory-search query embeddings on transient provider transport failures instead of failing the search after one socket hiccup.
- Split eligible text and structured embedding batches after bounded retries are exhausted, preserving result order so valid chunks can still index.
- Keep service outages, endpoint-refused/unreachable failures, service throttles, and OpenClaw's own batch timeouts as retry-only failures so batch splitting does not amplify outages.

Fixes #71784
Fixes #44166
Supersedes #44167

## Verification

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-embedding-policy.test.ts extensions/memory-core/src/memory/index.test.ts` passed, 34 tests.
- `env -u OPENCLAW_TESTBOX pnpm check:changed` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean.

## Real behavior proof

Behavior addressed: `memory_search` and memory reindex no longer fail immediately on transient embedding socket failures.
Real environment tested: local OpenClaw source checkout with mocked memory-core embedding providers.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-embedding-policy.test.ts extensions/memory-core/src/memory/index.test.ts`; `env -u OPENCLAW_TESTBOX pnpm check:changed`; `.agents/skills/autoreview/scripts/autoreview --mode local`.
Evidence after fix: focused Vitest passed 34 tests; changed gate passed; autoreview reported no accepted/actionable findings.
Observed result after fix: query embeddings retry after `fetch failed | other side closed`; exhausted splittable batch socket failures split recursively and preserve embedding order; `ECONNREFUSED`, unreachable hosts, service throttles, and manager batch timeouts do not split.
What was not tested: live external embedding provider outage behavior; coverage uses deterministic mocked provider failures.
