### PR TITLE
fix(sms): cover native proof follow-ups

### DIFF
--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildTwilioInboundMessage,
   computeTwilioSignature,
@@ -12,6 +12,16 @@ import {
   verifyTwilioSignature,
 } from "./twilio.js";
 import type { ResolvedSmsAccount } from "./types.js";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
+  };
+});
 
 function createAccount(overrides: Partial<ResolvedSmsAccount> = {}): ResolvedSmsAccount {
   return {
@@ -43,6 +53,10 @@ function readUrlEncodedRequestBody(init: RequestInit | undefined): URLSearchPara
 }
 
 describe("Twilio SMS helpers", () => {
+  afterEach(() => {
+    fetchWithSsrFGuardMock.mockReset();
+  });
+
   it("parses Twilio form bodies and inbound messages", () => {
     const form = parseTwilioFormBody(
       "From=%2B15551234567&To=%2B15557654321&Body=hello+there&MessageSid=SM123",
@@ -439,6 +453,33 @@ describe("Twilio SMS helpers", () => {
     ).rejects.toThrow("Twilio SMS send failed (503): upstream unavailable");
   });
 
+  it("releases guarded Twilio egress on failed send responses", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("upstream unavailable", { status: 503 }),
+      release,
+    });
+
+    await expect(
+      sendSmsViaTwilio({
+        account: createAccount(),
+        to: "+15551234567",
+        text: "hello",
+      }),
+    ).rejects.toThrow("Twilio SMS send failed (503): upstream unavailable");
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auditContext: "sms-twilio-api",
+        policy: { allowedHostnames: ["api.twilio.com"] },
+        requireHttps: true,
+        timeoutMs: 30_000,
+        url: "https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json",
+      }),
+    );
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects malformed JSON from successful Twilio sends", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async () => new Response("not json", { status: 201 }));
 
@@ -450,6 +491,24 @@ describe("Twilio SMS helpers", () => {
         fetchImpl,
       }),
     ).rejects.toThrow("Twilio SMS send returned malformed JSON.");
+  });
+
+  it("releases guarded Twilio egress on malformed successful send responses", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("not json", { status: 201 }),
+      release,
+    });
+
+    await expect(
+      sendSmsViaTwilio({
+        account: createAccount(),
+        to: "+15551234567",
+        text: "hello",
+      }),
+    ).rejects.toThrow("Twilio SMS send returned malformed JSON.");
+
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("exposes a typed Twilio SMS API error", () => {

--- a/src/pairing/pairing-messages.test.ts
+++ b/src/pairing/pairing-messages.test.ts
@@ -54,6 +54,9 @@ describe("buildPairingReply", () => {
       `(?:openclaw|openclaw) --profile isolated pairing approve ${testCase.channel} ${testCase.code}`,
     );
     expect(text).toMatch(commandRe);
+    expect(
+      text.match(new RegExp(`pairing approve ${testCase.channel} ${testCase.code}`, "g")),
+    ).toHaveLength(1);
   }
 
   function expectProfileAwarePairingReply(testCase: (typeof pairingReplyCases)[number]) {

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -18,7 +18,6 @@ export function buildPairingReply(params: {
     "```",
     "",
     "Ask the bot owner to approve with:",
-    formatCliCommand(`openclaw pairing approve ${channel} ${code}`),
     "```",
     approveCommand,
     "```",


### PR DESCRIPTION
## Summary

- remove the duplicate plain approve command from pairing replies
- keep the single fenced approve command for easy copying
- add regression coverage that the approve command appears exactly once
- add focused Twilio guarded-egress release coverage for non-2xx and malformed-success responses

## Context

During the native SMS sidecar proof for #88476, the SMS pairing challenge rendered the owner approval command twice back-to-back:

```text
openclaw pairing approve sms <code>openclaw pairing approve sms <code>
```

The root cause was `buildPairingReply` emitting the formatted command once as a plain line and again inside the fenced copy block.

This also folds in the reviewer request from #88515 for explicit proof that guarded Twilio egress calls still release their SSRF guard handle when Twilio returns a non-2xx response or malformed JSON. Since #88476 merged and closed the branch-targeted helper PRs, keeping both tiny proof-discovered follow-ups here avoids another redundant one-file PR.

## Verification

- `git diff --check`
- `pnpm exec oxfmt --check src/pairing/pairing-messages.ts src/pairing/pairing-messages.test.ts extensions/sms/src/twilio.test.ts`
- `node scripts/run-vitest.mjs src/pairing/pairing-messages.test.ts src/pairing/pairing-challenge.test.ts src/plugin-sdk/channel-pairing.test.ts`
- `node scripts/run-vitest.mjs extensions/sms/src/twilio.test.ts`

## Real behavior proof

- **Behavior or issue addressed:** SMS pairing replies should show one copyable owner approval command, not two concatenated copies of `openclaw pairing approve sms <code>`.
- **Real environment tested:** Local OpenClaw source checkout on the VPS at PR head `17a0127319`, running Node/tsx against the patched production `buildPairingReply` implementation.
- **Exact steps or command run after this patch:** `pnpm exec tsx -e 'import { buildPairingReply } from "./src/pairing/pairing-messages.ts"; const text = buildPairingReply({ channel: "sms", idLine: "Your SMS phone number: +1 REDACTED", code: "REDACTED1" }); console.log(text); console.log("--- occurrence count:", (text.match(/pairing approve sms REDACTED1/g) ?? []).length);'`
- **Evidence after fix:** Terminal output from the real command above:

  ````text
  OpenClaw: access not configured.

  Your SMS phone number: +1 REDACTED
  Pairing code:
  ```
  REDACTED1
  ```

  Ask the bot owner to approve with:
  ```
  openclaw pairing approve sms REDACTED1
  ```
  --- occurrence count: 1
  ````

- **Observed result after fix:** The rendered SMS pairing reply contains exactly one `openclaw pairing approve sms REDACTED1` command and the copy block is no longer duplicated.
- **What was not tested:** No live Twilio failure response was induced for the guarded-egress release assertions; those are covered by the focused Twilio test because real Twilio non-2xx/malformed-success responses do not expose the internal SSRF guard `release()` handle.
