### PR TITLE
feat: add custom usage footer renderer

### DIFF
--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -21,7 +21,7 @@ title: "Usage tracking"
 ## Where it shows up
 
 - `/status` in chats: emoji-rich status card with session tokens + estimated cost (API key only). Provider usage shows for the **current model provider** when available as a normalized `X% left` window.
-- `/usage off|tokens|full` in chats: per-response usage footer (OAuth shows tokens only).
+- `/usage off|tokens|full` in chats: per-response usage footer (OAuth shows tokens only). Configure `messages.usageLine` to render this footer with a local command; see [Custom /usage footer](/reference/custom-usage-footer).
 - `/usage cost` in chats: local cost summary aggregated from OpenClaw session logs.
 - CLI: `openclaw status --usage` prints a full per-provider breakdown.
 - CLI: `openclaw channels list` prints the same usage snapshot alongside provider config (use `--no-usage` to skip).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1800,6 +1800,7 @@
                   "agent-runtime-architecture",
                   "reference/wizard",
                   "reference/token-use",
+                  "reference/custom-usage-footer",
                   "reference/secretref-credential-surface",
                   "reference/prompt-caching",
                   "reference/api-usage-costs",

--- a/docs/reference/custom-usage-footer.md
+++ b/docs/reference/custom-usage-footer.md
@@ -1,0 +1,227 @@
+---
+summary: "Customize the per-response /usage footer with a local renderer command"
+read_when:
+  - You want to customize the /usage footer
+  - You are writing a messages.usageLine renderer
+  - You need the usageLine JSON input contract
+title: "Custom /usage footer"
+---
+
+OpenClaw can render the existing per-response `/usage` footer with a local
+command. The command receives usage/context JSON on stdin and prints the footer
+text on stdout.
+
+The normal `/usage` command still controls whether a footer appears:
+
+- `/usage off` disables the footer for the current session.
+- `/usage tokens` appends a compact footer to normal replies.
+- `/usage full` appends a fuller built-in footer to normal replies.
+
+`messages.usageLine` only changes how that footer is rendered. A custom renderer
+receives the same available JSON fields in both `tokens` and `full` modes; the
+`mode` field is just a hint about the verbosity the user requested. If the
+renderer fails, times out, prints nothing, or prints too much, OpenClaw falls
+back to the built-in `Usage: ...` footer.
+
+## Configure A Renderer
+
+Use `messages.usageLine`:
+
+```json
+{
+  "messages": {
+    "usageLine": {
+      "enabled": true,
+      "timeoutMs": 1500,
+      "maxOutputChars": 500,
+      "maxOutputLines": 2,
+      "command": "/home/me/.openclaw/usage-line/footer.py",
+      "args": [],
+      "format": "plain"
+    }
+  }
+}
+```
+
+Surface-specific overrides let Discord, Telegram, TUI, or another surface use
+different scripts:
+
+```json
+{
+  "messages": {
+    "usageLine": {
+      "enabled": true,
+      "timeoutMs": 1500,
+      "maxOutputChars": 500,
+      "maxOutputLines": 2,
+      "surfaces": {
+        "discord": {
+          "command": "/home/me/.openclaw/usage-line/discord.py",
+          "format": "plain"
+        },
+        "telegram": {
+          "command": "/home/me/.openclaw/usage-line/telegram.py",
+          "format": "preformatted"
+        }
+      }
+    }
+  }
+}
+```
+
+Fields:
+
+- `enabled`: set `false` to disable the renderer while preserving config.
+- `command`: executable path. This is not a shell string.
+- `args`: arguments passed to the executable without shell parsing.
+- `format`: `plain`, `preformatted`, or `raw`.
+- `timeoutMs`: renderer timeout. Default: `1500`.
+- `maxOutputChars`: maximum accepted stdout characters. Default: `500`.
+- `maxOutputLines`: maximum accepted stdout lines. Default: `2`.
+- `surfaces`: per-surface overrides keyed by surface id, for example
+  `discord` or `telegram`.
+
+`plain` appends stdout as-is. `preformatted` wraps stdout in a `text` code block.
+`raw` appends stdout as-is for scripts that deliberately own all formatting.
+
+## Write A Renderer
+
+Renderers read JSON from stdin and print the footer to stdout.
+
+Minimal Python example:
+
+```python
+#!/usr/bin/env python3
+import json
+import sys
+
+ctx = json.load(sys.stdin)
+model = (ctx.get("model") or {}).get("display_name") or "model"
+usage = ctx.get("usage") or {}
+context = ctx.get("context") or {}
+
+input_tokens = usage.get("input_tokens") or 0
+output_tokens = usage.get("output_tokens") or 0
+max_tokens = context.get("max_tokens") or "?"
+
+print(f"{model} | ctx {max_tokens} | i/o {input_tokens}/{output_tokens}")
+```
+
+Make it executable:
+
+```bash
+chmod +x ~/.openclaw/usage-line/footer.py
+```
+
+Then enable the footer in the target chat:
+
+```text
+/usage tokens
+```
+
+The next normal reply should include the custom footer.
+
+## JSON Input
+
+The renderer receives a JSON object like this:
+
+```json
+{
+  "schema": "openclaw.usageLine.v1",
+  "mode": "tokens",
+  "surface": "discord",
+  "chat_type": "direct",
+  "model": {
+    "id": "gpt-5.5",
+    "display_name": "gpt-5.5",
+    "provider": "openai",
+    "reasoning": "medium"
+  },
+  "usage": {
+    "input_tokens": 774,
+    "output_tokens": 196,
+    "cache_read_tokens": 89000,
+    "cache_write_tokens": 0,
+    "total_tokens": 89970
+  },
+  "context": {
+    "used_tokens": 147000,
+    "max_tokens": 272000,
+    "pct_used": 54
+  },
+  "cost": {
+    "turn_usd": null,
+    "available": true
+  },
+  "rendering": {
+    "max_reasonable_chars": 220
+  },
+  "session": {
+    "key": "agent:main:discord:direct:...",
+    "id": "..."
+  },
+  "workspace": {
+    "current_dir": "/home/me/project",
+    "project_dir": "/home/me/project"
+  },
+  "timing": {
+    "duration_ms": 9200
+  }
+}
+```
+
+Scripts should tolerate missing or null fields. Some providers do not report
+every usage counter.
+
+## Smoke Test
+
+Run the script directly with sample JSON:
+
+```bash
+~/.openclaw/usage-line/footer.py <<'JSON'
+{
+  "schema": "openclaw.usageLine.v1",
+  "mode": "tokens",
+  "surface": "discord",
+  "chat_type": "direct",
+  "model": { "id": "gpt-5.5", "display_name": "GPT-5.5" },
+  "usage": {
+    "input_tokens": 774,
+    "output_tokens": 196,
+    "cache_read_tokens": 89000,
+    "cache_write_tokens": 0,
+    "total_tokens": 89970
+  },
+  "context": {
+    "used_tokens": 147000,
+    "max_tokens": 272000,
+    "pct_used": 54
+  },
+  "cost": { "turn_usd": null, "available": true },
+  "rendering": { "max_reasonable_chars": 220 }
+}
+JSON
+```
+
+Validate config after changing it:
+
+```bash
+openclaw config validate
+```
+
+## Safety Notes
+
+The renderer runs as a local command from local config. Keep scripts lightweight
+and deterministic:
+
+- avoid network calls in the hot reply path;
+- keep output within the configured line and character caps;
+- handle missing values;
+- exit nonzero when the script cannot render a valid footer so OpenClaw can
+  fall back cleanly.
+
+## Related
+
+- [Token use and costs](/reference/token-use)
+- [Usage tracking](/concepts/usage-tracking)
+- [Slash commands](/tools/slash-commands)

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -78,6 +78,7 @@ Use these in chat:
   - Persists per session (stored as `responseUsage`).
   - `/usage full` shows estimated cost only when OpenClaw has usage metadata and
     local pricing for the active model. Otherwise it shows tokens only.
+  - `messages.usageLine` can render this footer with a local command. See [Custom /usage footer](/reference/custom-usage-footer).
 - `/usage cost` → shows a local cost summary from OpenClaw session logs.
 
 Other surfaces:

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -159,7 +159,7 @@ Current source-of-truth:
     - `/tasks` lists active/recent background tasks for the current session.
     - `/context [list|detail|map|json]` explains how context is assembled. `map` sends a treemap image of the current session context.
     - `/whoami` shows your sender id. Alias: `/id`.
-    - `/usage off|tokens|full|cost` controls the per-response usage footer or prints a local cost summary.
+    - `/usage off|tokens|full|cost` controls the per-response usage footer or prints a local cost summary. The footer can be rendered by a local `messages.usageLine` command; see [Custom /usage footer](/reference/custom-usage-footer).
 
   </Accordion>
   <Accordion title="Skills, allowlists, approvals">
@@ -314,7 +314,7 @@ For profile and override editing, use the Control UI Tools panel or config/catal
 - **Provider usage/quota** (example: "Claude 80% left") shows up in `/status` for the current model provider when usage tracking is enabled. OpenClaw normalizes provider windows to `% left`; for MiniMax, remaining-only percent fields are inverted before display, and `model_remains` responses prefer the chat-model entry plus a model-tagged plan label.
 - **Token/cache lines** in `/status` can fall back to the latest transcript usage entry when the live session snapshot is sparse. Existing nonzero live values still win, and transcript fallback can also recover the active runtime model label plus a larger prompt-oriented total when stored totals are missing or smaller.
 - **Execution vs runtime:** `/status` reports `Execution` for the effective sandbox path and `Runtime` for who is actually running the session: `OpenClaw Default`, `OpenAI Codex`, a CLI backend, or an ACP backend.
-- **Per-response tokens/cost** is controlled by `/usage off|tokens|full` (appended to normal replies).
+- **Per-response tokens/cost** is controlled by `/usage off|tokens|full` (appended to normal replies). Configure `messages.usageLine` to render that footer with a local command.
 - `/model status` is about **models/auth/endpoints**, not usage.
 
 ## Model selection (`/model`)

--- a/src/auto-reply/reply/agent-runner-usage-renderer.ts
+++ b/src/auto-reply/reply/agent-runner-usage-renderer.ts
@@ -1,0 +1,222 @@
+import { spawn } from "node:child_process";
+import type { UsageLineConfig, UsageLineSurfaceConfig } from "../../config/types.messages.js";
+import { logVerbose } from "../../globals.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { resolveUserPath } from "../../utils.js";
+import { estimateUsageCost, type ModelCostConfig } from "../../utils/usage-format.js";
+
+type UsageLineMode = "tokens" | "full";
+type UsageLineFormat = "plain" | "preformatted" | "raw";
+
+type UsageLineUsage = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+};
+
+export type UsageLineRenderParams = {
+  config?: UsageLineConfig;
+  defaultLine: string | null;
+  mode: UsageLineMode;
+  surface?: string;
+  chatType?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  model?: string;
+  provider?: string;
+  reasoning?: string;
+  workspaceDir?: string;
+  projectDir?: string;
+  usage?: UsageLineUsage;
+  context?: {
+    usedTokens?: number;
+    maxTokens?: number;
+  };
+  costConfig?: ModelCostConfig;
+  durationMs?: number;
+};
+
+type ResolvedUsageLineRenderer = {
+  command: string;
+  args: string[];
+  format: UsageLineFormat;
+  timeoutMs: number;
+  maxOutputChars: number;
+  maxOutputLines: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 1500;
+const DEFAULT_MAX_OUTPUT_CHARS = 500;
+const DEFAULT_MAX_OUTPUT_LINES = 2;
+
+const resolveRenderer = (
+  config: UsageLineConfig | undefined,
+  surface: string | undefined,
+): ResolvedUsageLineRenderer | null => {
+  if (!config || config.enabled === false) {
+    return null;
+  }
+  const surfaceConfig = surface ? config.surfaces?.[surface] : undefined;
+  if (surfaceConfig?.enabled === false) {
+    return null;
+  }
+  const merged: UsageLineConfig & UsageLineSurfaceConfig = {
+    ...config,
+    ...(surfaceConfig ?? {}),
+  };
+  const command = typeof merged.command === "string" ? merged.command.trim() : "";
+  if (!command) {
+    return null;
+  }
+  return {
+    command: resolveUserPath(command),
+    args: Array.isArray(merged.args) ? merged.args : [],
+    format: merged.format ?? "plain",
+    timeoutMs: merged.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    maxOutputChars: merged.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS,
+    maxOutputLines: merged.maxOutputLines ?? DEFAULT_MAX_OUTPUT_LINES,
+  };
+};
+
+const buildUsageLineContext = (params: UsageLineRenderParams) => {
+  const inputTokens = params.usage?.input;
+  const outputTokens = params.usage?.output;
+  const cacheReadTokens = params.usage?.cacheRead;
+  const cacheWriteTokens = params.usage?.cacheWrite;
+  const totalTokens =
+    params.usage?.total ??
+    (typeof inputTokens === "number" || typeof outputTokens === "number"
+      ? (inputTokens ?? 0) + (outputTokens ?? 0) + (cacheReadTokens ?? 0) + (cacheWriteTokens ?? 0)
+      : undefined);
+  const maxTokens = params.context?.maxTokens;
+  const usedTokens = params.context?.usedTokens;
+  const pctUsed =
+    typeof usedTokens === "number" && typeof maxTokens === "number" && maxTokens > 0
+      ? Math.round((usedTokens / maxTokens) * 1000) / 10
+      : undefined;
+  const turnUsd =
+    params.usage && params.costConfig
+      ? estimateUsageCost({ usage: params.usage, cost: params.costConfig })
+      : undefined;
+
+  return {
+    schema: "openclaw.usageLine.v1",
+    mode: params.mode,
+    surface: params.surface,
+    chat_type: params.chatType,
+    model: {
+      id: params.model,
+      display_name: params.model,
+      provider: params.provider,
+      reasoning: params.reasoning,
+    },
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cache_read_tokens: cacheReadTokens,
+      cache_write_tokens: cacheWriteTokens,
+      total_tokens: totalTokens,
+    },
+    context: {
+      used_tokens: usedTokens,
+      max_tokens: maxTokens,
+      pct_used: pctUsed,
+    },
+    cost: {
+      turn_usd: turnUsd ?? null,
+      available: params.costConfig !== undefined,
+    },
+    rendering: {
+      max_reasonable_chars: params.surface === "telegram" ? 180 : 220,
+    },
+    session: {
+      key: params.sessionKey,
+      id: params.sessionId,
+    },
+    workspace: {
+      current_dir: params.workspaceDir,
+      project_dir: params.projectDir,
+    },
+    timing: {
+      duration_ms: params.durationMs,
+    },
+  };
+};
+
+const applyUsageLineFormat = (output: string, format: UsageLineFormat): string => {
+  if (format === "raw" || format === "plain") {
+    return output;
+  }
+  const safeOutput = output.replaceAll("```", "`\u200b``");
+  return `\`\`\`text\n${safeOutput}\n\`\`\``;
+};
+
+const runRendererCommand = async (
+  renderer: ResolvedUsageLineRenderer,
+  context: unknown,
+): Promise<string | null> =>
+  await new Promise((resolve) => {
+    let stdout = "";
+    let settled = false;
+    const child = spawn(renderer.command, renderer.args, {
+      stdio: ["pipe", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    const finish = (value: string | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(null);
+    }, renderer.timeoutMs);
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      if (stdout.length > renderer.maxOutputChars) {
+        child.kill("SIGTERM");
+        finish(null);
+      }
+    });
+    child.on("error", () => finish(null));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        finish(null);
+        return;
+      }
+      const normalized = stdout.replaceAll("\r\n", "\n").trim();
+      if (!normalized || normalized.length > renderer.maxOutputChars) {
+        finish(null);
+        return;
+      }
+      if (normalized.split("\n").length > renderer.maxOutputLines) {
+        finish(null);
+        return;
+      }
+      finish(normalized);
+    });
+    child.stdin.end(`${JSON.stringify(context)}\n`);
+  });
+
+export const renderUsageLine = async (params: UsageLineRenderParams): Promise<string | null> => {
+  const renderer = resolveRenderer(params.config, params.surface);
+  if (!renderer) {
+    return params.defaultLine;
+  }
+  try {
+    const output = await runRendererCommand(renderer, buildUsageLineContext(params));
+    if (!output) {
+      return params.defaultLine;
+    }
+    return applyUsageLineFormat(output, renderer.format);
+  } catch (error) {
+    logVerbose(`usage-line renderer failed: ${formatErrorMessage(error)}`);
+    return params.defaultLine;
+  }
+};

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2738,6 +2738,126 @@ describe("runReplyAgent response usage footer", () => {
     expect(text).toContain("est $0.04");
     expect(text).toContain(`· session \`${sessionKey}\``);
   });
+
+  it("uses configured usageLine renderer output", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "usage-line-"));
+    const scriptPath = path.join(tmpDir, "renderer.mjs");
+    await fs.writeFile(
+      scriptPath,
+      [
+        "let raw = '';",
+        "process.stdin.setEncoding('utf8');",
+        "process.stdin.on('data', (chunk) => { raw += chunk; });",
+        "process.stdin.on('end', () => {",
+        "  const ctx = JSON.parse(raw);",
+        "  console.log([",
+        "    ctx.surface,",
+        "    ctx.mode,",
+        "    ctx.model.provider,",
+        "    ctx.model.reasoning,",
+        "    ctx.session.key,",
+        "    ctx.timing.duration_ms !== undefined,",
+        "    `${ctx.usage.input_tokens}->${ctx.usage.output_tokens}`,",
+        "  ].join(':'));",
+        "});",
+      ].join("\n"),
+    );
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+          usage: { input: 12, output: 3 },
+        },
+      },
+    });
+
+    const res = await createRun({
+      responseUsage: "tokens",
+      sessionKey: "agent:main:whatsapp:dm:+1000",
+      config: {
+        ...createCliBackendTestConfig(),
+        messages: {
+          usageLine: {
+            command: process.execPath,
+            args: [scriptPath],
+            format: "plain",
+          },
+        },
+      },
+    });
+    const payload = Array.isArray(res) ? res[0] : res;
+
+    expect(payload?.text).toContain(
+      "ok\nwhatsapp:tokens:anthropic:low:agent:main:whatsapp:dm:+1000:true:12->3",
+    );
+    expect(payload?.text).not.toContain("Usage:");
+  });
+
+  it("falls back when configured usageLine renderer fails", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+          usage: { input: 12, output: 3 },
+        },
+      },
+    });
+
+    const res = await createRun({
+      responseUsage: "tokens",
+      sessionKey: "agent:main:whatsapp:dm:+1000",
+      config: {
+        ...createCliBackendTestConfig(),
+        messages: {
+          usageLine: {
+            command: process.execPath,
+            args: ["-e", "process.exit(2)"],
+          },
+        },
+      },
+    });
+    const payload = Array.isArray(res) ? res[0] : res;
+
+    expect(payload?.text).toContain("ok\nUsage: 12 in / 3 out");
+  });
+
+  it("wraps configured usageLine preformatted output", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "usage-line-"));
+    const scriptPath = path.join(tmpDir, "renderer.mjs");
+    await fs.writeFile(scriptPath, "console.log('line one\\nline two');\n");
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+          usage: { input: 12, output: 3 },
+        },
+      },
+    });
+
+    const res = await createRun({
+      responseUsage: "tokens",
+      sessionKey: "agent:main:whatsapp:dm:+1000",
+      config: {
+        ...createCliBackendTestConfig(),
+        messages: {
+          usageLine: {
+            command: process.execPath,
+            args: [scriptPath],
+            format: "preformatted",
+          },
+        },
+      },
+    });
+    const payload = Array.isArray(res) ? res[0] : res;
+
+    expect(payload?.text).toContain("```text\nline one\nline two\n```");
+  });
 });
 
 describe("runReplyAgent transient HTTP retry", () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -84,6 +84,7 @@ import {
 } from "./agent-runner-reminder-guard.js";
 import { resetReplyRunSession } from "./agent-runner-session-reset.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-line.js";
+import { renderUsageLine } from "./agent-runner-usage-renderer.js";
 import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
@@ -2038,14 +2039,40 @@ export async function runReplyAgent(params: {
         allowPluginNormalization: false,
       });
       const showCost = responseUsageMode === "full" && costConfig !== undefined;
-      let formatted = formatResponseUsageLine({
+      let defaultFormatted = formatResponseUsageLine({
         usage,
         showCost,
         costConfig,
       });
-      if (formatted && responseUsageMode === "full" && sessionKey) {
-        formatted = `${formatted} · session \`${sessionKey}\``;
+      if (defaultFormatted && responseUsageMode === "full" && sessionKey) {
+        defaultFormatted = `${defaultFormatted} · session \`${sessionKey}\``;
       }
+      const contextUsedTokens = deriveContextPromptTokens({
+        lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
+        promptTokens,
+        usage,
+      });
+      const formatted = await renderUsageLine({
+        config: cfg.messages?.usageLine,
+        defaultLine: defaultFormatted,
+        mode: responseUsageMode,
+        surface: replyToChannel,
+        chatType: sessionCtx.ChatType,
+        sessionKey,
+        sessionId: followupRun.run.sessionId,
+        model: modelUsed,
+        provider: providerUsed,
+        reasoning: followupRun.run.thinkLevel,
+        workspaceDir: followupRun.run.workspaceDir,
+        projectDir: followupRun.run.workspaceDir,
+        usage,
+        context: {
+          maxTokens: contextTokensUsed,
+          ...(contextUsedTokens !== undefined ? { usedTokens: contextUsedTokens } : {}),
+        },
+        costConfig,
+        durationMs: Date.now() - runStartedAt,
+      });
       if (formatted) {
         responseUsageLine = formatted;
       }

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -106,6 +106,35 @@ export type StatusReactionsConfig = {
   timing?: StatusReactionsTimingConfig;
 };
 
+export type UsageLineFormat = "plain" | "preformatted" | "raw";
+
+export type UsageLineRendererConfig = {
+  /** Executable path for rendering the per-response /usage line. */
+  command?: string;
+  /** Arguments passed to command without shell parsing. */
+  args?: string[];
+  /** Output wrapping mode. Default: "plain". */
+  format?: UsageLineFormat;
+  /** Renderer timeout in milliseconds. Default: 1500. */
+  timeoutMs?: number;
+  /** Maximum accepted stdout characters. Default: 500. */
+  maxOutputChars?: number;
+  /** Maximum accepted stdout lines. Default: 2. */
+  maxOutputLines?: number;
+};
+
+export type UsageLineSurfaceConfig = UsageLineRendererConfig & {
+  /** Disable the usage line renderer on this surface. */
+  enabled?: boolean;
+};
+
+export type UsageLineConfig = UsageLineRendererConfig & {
+  /** Enable custom rendering for the existing /usage line. */
+  enabled?: boolean;
+  /** Per-surface overrides keyed by provider/surface id, e.g. "discord". */
+  surfaces?: Record<string, UsageLineSurfaceConfig>;
+};
+
 export type MessagesConfig = {
   /** @deprecated Use `whatsapp.messagePrefix` (WhatsApp-only inbound prefix). */
   messagePrefix?: string;
@@ -150,6 +179,8 @@ export type MessagesConfig = {
   removeAckAfterReply?: boolean;
   /** Lifecycle status reactions configuration. */
   statusReactions?: StatusReactionsConfig;
+  /** Optional command renderer for the per-response /usage line. */
+  usageLine?: UsageLineConfig;
   /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
   suppressToolErrors?: boolean;
   /** Text-to-speech settings for outbound replies. */

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -198,6 +198,34 @@ export const MessagesSchema = z
       })
       .strict()
       .optional(),
+    usageLine: z
+      .object({
+        enabled: z.boolean().optional(),
+        command: z.string().min(1).optional(),
+        args: z.array(z.string()).optional(),
+        format: z.enum(["plain", "preformatted", "raw"]).optional(),
+        timeoutMs: z.number().int().min(1).max(5000).optional(),
+        maxOutputChars: z.number().int().min(1).max(5000).optional(),
+        maxOutputLines: z.number().int().min(1).max(10).optional(),
+        surfaces: z
+          .record(
+            z.string(),
+            z
+              .object({
+                enabled: z.boolean().optional(),
+                command: z.string().min(1).optional(),
+                args: z.array(z.string()).optional(),
+                format: z.enum(["plain", "preformatted", "raw"]).optional(),
+                timeoutMs: z.number().int().min(1).max(5000).optional(),
+                maxOutputChars: z.number().int().min(1).max(5000).optional(),
+                maxOutputLines: z.number().int().min(1).max(10).optional(),
+              })
+              .strict(),
+          )
+          .optional(),
+      })
+      .strict()
+      .optional(),
     suppressToolErrors: z.boolean().optional(),
     tts: TtsConfigSchema,
   })

--- a/src/config/zod-schema.visible-replies.test.ts
+++ b/src/config/zod-schema.visible-replies.test.ts
@@ -109,4 +109,59 @@ describe("visible reply config schema", () => {
       expect(issue?.path).toBe("messages.groupChat.unmentionedInbound");
     }
   });
+
+  it("accepts usageLine renderer config", () => {
+    const result = validateConfigObjectRaw({
+      messages: {
+        usageLine: {
+          command: "/tmp/render-usage-line",
+          args: ["--compact"],
+          format: "plain",
+          timeoutMs: 300,
+          maxOutputChars: 500,
+          maxOutputLines: 2,
+          surfaces: {
+            discord: {
+              format: "raw",
+            },
+            telegram: {
+              command: "/tmp/render-telegram-usage-line",
+              format: "preformatted",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.messages?.usageLine?.surfaces?.telegram?.format).toBe("preformatted");
+    }
+  });
+
+  it("rejects malformed usageLine renderer config", () => {
+    const result = validateConfigObjectRaw({
+      messages: {
+        usageLine: {
+          command: "",
+          format: "codeblock",
+          unknown: true,
+          surfaces: {
+            discord: {
+              args: "not-an-array",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.some((issue) => issue.path === "messages.usageLine.command")).toBe(true);
+      expect(result.issues.some((issue) => issue.path === "messages.usageLine.format")).toBe(true);
+      expect(
+        result.issues.some((issue) => issue.path === "messages.usageLine.surfaces.discord.args"),
+      ).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- add `messages.usageLine`, a local command renderer for the existing per-response `/usage` footer
- pass usage/context/model/session/workspace/timing/cost JSON to the renderer on stdin, with `mode` as a presentation hint rather than a data filter
- document how users can write and configure custom footer renderers

## Behavior

The existing `/usage off|tokens|full` commands still control whether a footer appears for a session. When `messages.usageLine` is configured, OpenClaw builds the normal default usage footer, runs the configured command, sends JSON on stdin, and appends stdout instead of the built-in `Usage: ...` line.

Renderer failure is non-fatal. Missing command, timeout, nonzero exit, empty output, excessive lines, or excessive characters all fall back to the built-in usage footer.

## Real behavior proof

Verified on a live OpenClaw install with `messages.usageLine` configured for Telegram and Discord renderer scripts.

Config validation:

```text
Config valid: ~/.openclaw/openclaw.json
```

Discord renderer smoke test with redacted live-style `openclaw.usageLine.v1` JSON:

```text
-# -
-# gpt55 🔄 | med | 📚 [⣿⣿⣧⠀⠀]272k | 🗄99% | ↔️ 774/196
```

Telegram renderer smoke test with redacted live-style `openclaw.usageLine.v1` JSON:

```text
peter | GPT-5.5 | marvin
[#####-----] ctx 147k/272k | 774->196 | cache 89k | 9.2s
```

## Validation

- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-usage-renderer.ts src/auto-reply/reply/agent-runner.ts src/config/types.messages.ts src/config/zod-schema.session.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/config/zod-schema.visible-replies.test.ts`
- `pnpm format:docs:check`
- `pnpm tsgo:core`
- `node scripts/test-projects.mjs src/config/zod-schema.visible-replies.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
