### PR TITLE
fix(devices): refresh paired device last-seen metadata

### DIFF
--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -885,9 +885,12 @@ export function registerControlUiAndPairingSuite(): void {
       (entry) => entry.deviceId === identity.deviceId,
     );
     expect(pendingAfterRead).toHaveLength(0);
-    if (!(await getPairedDevice(identity.deviceId))) {
+    const pairedAfterRead = await getPairedDevice(identity.deviceId);
+    if (!pairedAfterRead) {
       throw new Error(`expected paired device ${identity.deviceId}`);
     }
+    expect(pairedAfterRead.lastSeenReason).toBe("connect");
+    expect(typeof pairedAfterRead.lastSeenAtMs).toBe("number");
     wsRemoteRead.close();
 
     const ws2 = await openWs(port, { host: "gateway.example" });

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -700,7 +700,9 @@ export function registerControlUiAndPairingSuite(): void {
 
   test("device token auth matrix", async () => {
     const { server, ws, port, prevToken } = await startControlUiServerWithClient("secret");
-    const { deviceToken, deviceIdentityPath } = await ensurePairedDeviceTokenForCurrentIdentity(ws);
+    const { identity, deviceToken, deviceIdentityPath } =
+      await ensurePairedDeviceTokenForCurrentIdentity(ws);
+    const { getPairedDevice } = await import("../infra/device-pairing.js");
     ws.close();
 
     const scenarios: Array<{
@@ -783,6 +785,9 @@ export function registerControlUiAndPairingSuite(): void {
           ws2.close();
         }
       }
+      const paired = await getPairedDevice(identity.deviceId);
+      expect(paired?.lastSeenReason).toBe("connect");
+      expect(typeof paired?.lastSeenAtMs).toBe("number");
     } finally {
       await server.close();
       restoreGatewayToken(prevToken);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1251,9 +1251,11 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                   ? await approveBootstrapDevicePairing(
                       pairing.request.requestId,
                       boundBootstrapProfile,
+                      { accessMetadata: clientAccessMetadata },
                     )
                   : await approveDevicePairing(pairing.request.requestId, {
                       callerScopes: scopes,
+                      accessMetadata: clientAccessMetadata,
                     });
               if (approved?.status === "approved") {
                 if (allowSilentBootstrapPairing && boundBootstrapProfile) {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1114,6 +1114,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           const clientAccessMetadata = {
             displayName: connectParams.client.displayName,
             remoteIp: reportedClientIp,
+            lastSeenAtMs: Date.now(),
+            lastSeenReason: "connect",
           };
           const requirePairing = async (
             reason: ConnectPairingRequiredReason,

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -789,6 +789,26 @@ describe("device pairing tokens", () => {
     });
   });
 
+  test("device token verification refreshes paired device last-seen metadata", async () => {
+    const { baseDir, token } = await setupOperatorToken(["operator.read"]);
+    const beforeVerifyAtMs = Date.now();
+
+    await expect(
+      verifyDeviceToken({
+        deviceId: "device-1",
+        token,
+        role: "operator",
+        scopes: ["operator.read"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    const paired = await getPairedDevice("device-1", baseDir);
+    expect(paired?.lastSeenReason).toBe("device-token-auth");
+    expect(typeof paired?.lastSeenAtMs).toBe("number");
+    expect(paired?.lastSeenAtMs ?? 0).toBeGreaterThanOrEqual(beforeVerifyAtMs);
+  });
+
   test("generates base64url device tokens with 256-bit entropy output length", async () => {
     const baseDir = await makeDevicePairingDir();
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -789,6 +789,75 @@ describe("device pairing tokens", () => {
     });
   });
 
+  test("approval access metadata initializes paired device last-seen fields", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const request = await requestDevicePairing(
+      {
+        deviceId: "node-1",
+        publicKey: "public-key-node-1",
+        role: "node",
+        scopes: [],
+        displayName: "pending-name",
+        remoteIp: "127.0.0.1",
+      },
+      baseDir,
+    );
+    const firstSeenAtMs = Date.now();
+
+    const approved = await approveDevicePairing(
+      request.request.requestId,
+      {
+        callerScopes: [],
+        accessMetadata: {
+          displayName: "connected-name",
+          remoteIp: "10.0.0.1",
+          lastSeenAtMs: firstSeenAtMs,
+          lastSeenReason: "connect",
+        },
+      },
+      baseDir,
+    );
+    expectRecordFields(approved, "approved result", { status: "approved" });
+
+    const paired = await getPairedDevice("node-1", baseDir);
+    expectRecordFields(paired, "paired device", {
+      displayName: "connected-name",
+      remoteIp: "10.0.0.1",
+      lastSeenAtMs: firstSeenAtMs,
+      lastSeenReason: "connect",
+    });
+  });
+
+  test("repair approvals preserve paired device last-seen fields without access metadata", async () => {
+    const baseDir = await makeDevicePairingDir();
+    await setupPairedNodeDevice(baseDir);
+    await updatePairedDeviceMetadata(
+      "node-1",
+      {
+        lastSeenAtMs: 1234,
+        lastSeenReason: "bg_app_refresh",
+      },
+      baseDir,
+    );
+
+    const repair = await requestDevicePairing(
+      {
+        deviceId: "node-1",
+        publicKey: "public-key-node-1",
+        role: "node",
+        scopes: [],
+      },
+      baseDir,
+    );
+    await approveDevicePairing(repair.request.requestId, { callerScopes: [] }, baseDir);
+
+    const paired = await getPairedDevice("node-1", baseDir);
+    expectRecordFields(paired, "paired device", {
+      lastSeenAtMs: 1234,
+      lastSeenReason: "bg_app_refresh",
+    });
+  });
+
   test("device token verification refreshes paired device last-seen metadata", async () => {
     const { baseDir, token } = await setupOperatorToken(["operator.read"]);
     const beforeVerifyAtMs = Date.now();
@@ -1267,6 +1336,44 @@ describe("device pairing tokens", () => {
     expect(paired?.approvedScopes).toStrictEqual([]);
     expect(paired?.tokens?.node?.scopes).toStrictEqual([]);
     expect(paired?.tokens?.operator).toBeUndefined();
+  });
+
+  test("bootstrap approval access metadata initializes paired device last-seen fields", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const request = await requestDevicePairing(
+      {
+        deviceId: "bootstrap-device-seen",
+        publicKey: "bootstrap-public-key-seen",
+        role: "node",
+        roles: ["node"],
+        scopes: [],
+        silent: true,
+        remoteIp: "127.0.0.1",
+      },
+      baseDir,
+    );
+    const firstSeenAtMs = Date.now();
+
+    const approved = await approveBootstrapDevicePairing(
+      request.request.requestId,
+      PAIRING_SETUP_BOOTSTRAP_PROFILE,
+      {
+        accessMetadata: {
+          remoteIp: "10.0.0.2",
+          lastSeenAtMs: firstSeenAtMs,
+          lastSeenReason: "connect",
+        },
+      },
+      baseDir,
+    );
+    expectRecordFields(approved, "approved result", { status: "approved" });
+
+    const paired = await getPairedDevice("bootstrap-device-seen", baseDir);
+    expectRecordFields(paired, "paired device", {
+      remoteIp: "10.0.0.2",
+      lastSeenAtMs: firstSeenAtMs,
+      lastSeenReason: "connect",
+    });
   });
 
   test("baseline bootstrap pairing issues bounded operator token when requested by QR handoff", async () => {

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -111,6 +111,11 @@ export type PairedDeviceMetadataPatch = Pick<
   | "lastSeenReason"
 >;
 
+export type DevicePairingAccessMetadata = Pick<
+  PairedDevice,
+  "displayName" | "remoteIp" | "lastSeenAtMs" | "lastSeenReason"
+>;
+
 export type DevicePairingList = {
   pending: DevicePairingPendingRequest[];
   paired: PairedDevice[];
@@ -458,6 +463,36 @@ function buildDeviceAuthToken(params: {
   };
 }
 
+function buildApprovedPairedDevice(params: {
+  pending: DevicePairingPendingRequest;
+  existing: PairedDevice | undefined;
+  roles: string[] | undefined;
+  approvedScopes: string[] | undefined;
+  tokens: Record<string, DeviceAuthToken>;
+  now: number;
+  accessMetadata?: DevicePairingAccessMetadata;
+}): PairedDevice {
+  return {
+    deviceId: params.pending.deviceId,
+    publicKey: params.pending.publicKey,
+    displayName: params.accessMetadata?.displayName ?? params.pending.displayName,
+    platform: params.pending.platform,
+    deviceFamily: params.pending.deviceFamily,
+    clientId: params.pending.clientId,
+    clientMode: params.pending.clientMode,
+    role: params.pending.role,
+    roles: params.roles,
+    scopes: params.approvedScopes,
+    approvedScopes: params.approvedScopes,
+    remoteIp: params.accessMetadata?.remoteIp ?? params.pending.remoteIp,
+    tokens: params.tokens,
+    createdAtMs: params.existing?.createdAtMs ?? params.now,
+    approvedAtMs: params.now,
+    lastSeenAtMs: params.accessMetadata?.lastSeenAtMs ?? params.existing?.lastSeenAtMs,
+    lastSeenReason: params.accessMetadata?.lastSeenReason ?? params.existing?.lastSeenReason,
+  };
+}
+
 function resolveRoleScopedDeviceTokenScopes(role: string, scopes: string[] | undefined): string[] {
   const normalized = normalizeDeviceAuthScopes(scopes);
   if (role === "operator") {
@@ -620,12 +655,14 @@ export async function approveDevicePairing(
 ): Promise<ApproveDevicePairingResult>;
 export async function approveDevicePairing(
   requestId: string,
-  options: { callerScopes?: readonly string[] },
+  options: { callerScopes?: readonly string[]; accessMetadata?: DevicePairingAccessMetadata },
   baseDir?: string,
 ): Promise<ApproveDevicePairingResult>;
 export async function approveDevicePairing(
   requestId: string,
-  optionsOrBaseDir?: { callerScopes?: readonly string[] } | string,
+  optionsOrBaseDir?:
+    | { callerScopes?: readonly string[]; accessMetadata?: DevicePairingAccessMetadata }
+    | string,
   maybeBaseDir?: string,
 ): Promise<ApproveDevicePairingResult> {
   const options =
@@ -707,23 +744,15 @@ export async function approveDevicePairing(
         lastUsedAtMs: existingToken?.lastUsedAtMs,
       };
     }
-    const device: PairedDevice = {
-      deviceId: pending.deviceId,
-      publicKey: pending.publicKey,
-      displayName: pending.displayName,
-      platform: pending.platform,
-      deviceFamily: pending.deviceFamily,
-      clientId: pending.clientId,
-      clientMode: pending.clientMode,
-      role: pending.role,
+    const device = buildApprovedPairedDevice({
+      pending,
+      existing,
       roles,
-      scopes: approvedScopes,
       approvedScopes,
-      remoteIp: pending.remoteIp,
       tokens,
-      createdAtMs: existing?.createdAtMs ?? now,
-      approvedAtMs: now,
-    };
+      now,
+      accessMetadata: options?.accessMetadata,
+    });
     delete state.pendingById[requestId];
     state.pairedByDeviceId[device.deviceId] = device;
     await persistState(state, baseDir, "both");
@@ -735,7 +764,24 @@ export async function approveBootstrapDevicePairing(
   requestId: string,
   bootstrapProfile: DeviceBootstrapProfile,
   baseDir?: string,
+): Promise<ApproveDevicePairingResult>;
+export async function approveBootstrapDevicePairing(
+  requestId: string,
+  bootstrapProfile: DeviceBootstrapProfile,
+  options: { accessMetadata?: DevicePairingAccessMetadata },
+  baseDir?: string,
+): Promise<ApproveDevicePairingResult>;
+export async function approveBootstrapDevicePairing(
+  requestId: string,
+  bootstrapProfile: DeviceBootstrapProfile,
+  optionsOrBaseDir?: { accessMetadata?: DevicePairingAccessMetadata } | string,
+  maybeBaseDir?: string,
 ): Promise<ApproveDevicePairingResult> {
+  const options =
+    typeof optionsOrBaseDir === "string" || optionsOrBaseDir === undefined
+      ? undefined
+      : optionsOrBaseDir;
+  const baseDir = typeof optionsOrBaseDir === "string" ? optionsOrBaseDir : maybeBaseDir;
   const approvedRoles = mergeRoles(bootstrapProfile.roles) ?? [];
   const approvedScopes = resolveBootstrapProfileScopesForRoles(
     approvedRoles,
@@ -796,23 +842,15 @@ export async function approveBootstrapDevicePairing(
       });
     }
 
-    const device: PairedDevice = {
-      deviceId: pending.deviceId,
-      publicKey: pending.publicKey,
-      displayName: pending.displayName,
-      platform: pending.platform,
-      deviceFamily: pending.deviceFamily,
-      clientId: pending.clientId,
-      clientMode: pending.clientMode,
-      role: pending.role,
+    const device = buildApprovedPairedDevice({
+      pending,
+      existing,
       roles,
-      scopes: nextApprovedScopes,
       approvedScopes: nextApprovedScopes,
-      remoteIp: pending.remoteIp,
       tokens,
-      createdAtMs: existing?.createdAtMs ?? now,
-      approvedAtMs: now,
-    };
+      now,
+      accessMetadata: options?.accessMetadata,
+    });
     delete state.pendingById[requestId];
     state.pairedByDeviceId[device.deviceId] = device;
     await persistState(state, baseDir, "both");

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -976,9 +976,12 @@ export async function verifyDeviceToken(params: {
     if (!roleScopesAllow({ role, requestedScopes, allowedScopes: entry.scopes })) {
       return { ok: false, reason: "scope-mismatch" };
     }
-    entry.lastUsedAtMs = Date.now();
+    const now = Date.now();
+    entry.lastUsedAtMs = now;
     device.tokens ??= {};
     device.tokens[role] = entry;
+    device.lastSeenAtMs = now;
+    device.lastSeenReason = "device-token-auth";
     state.pairedByDeviceId[device.deviceId] = device;
     await persistState(state, params.baseDir, "paired");
     return entry.issuer ? { ok: true, issuer: entry.issuer } : { ok: true };


### PR DESCRIPTION
## Summary

- Builds on and credits #81189 from @vyctorbrzezowski.
- Refreshes paired-device last-seen metadata on accepted device-token auth, paired reconnect, and first silent auto-approved connect.
- Centralizes approved paired-device record construction so normal and bootstrap approvals preserve existing last-seen state unless the gateway passes explicit access metadata.
- Does not change pairing policy, token verification, roles, scopes, config, or schema shape.

Fixes #81169.
Supersedes #81189.

## Real behavior proof

Behavior addressed: Accepted paired-device auth and connect paths now refresh durable device-level last-seen metadata so stale paired clients can be audited.

Real environment tested: Local OpenClaw source checkout on macOS after rebasing the branch onto current origin/main.

Exact steps or command run after this patch: Ran focused paired-device auth and gateway reconnect tests, plus changed-file checks and autoreview.

Evidence after fix: `node scripts/run-vitest.mjs src/infra/device-pairing.test.ts --reporter=verbose` passed with 57 tests after the final rebase. `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts --reporter=verbose` passed with 31 tests after the final rebase. `pnpm check:changed` passed before the final rebase; the post-rebase rerun delegated to Testbox and stopped before checks because local Crabbox is `0.21.0` while the current Testbox wrapper requires `>=0.22.0`.

Observed result after fix: Device-token verification writes `lastSeenReason: "device-token-auth"`; paired reconnects write `lastSeenReason: "connect"`; first silent auto-approved local pairing also creates the paired record with `lastSeenReason: "connect"` in the approval write.

What was not tested: No physical mobile client or installed user pairing state was used; proof uses OpenClaw's isolated pairing and gateway harnesses.

## Verification

- `node scripts/run-vitest.mjs src/infra/device-pairing.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts --reporter=verbose`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/infra/device-pairing.ts src/infra/device-pairing.test.ts src/gateway/server/ws-connection/message-handler.ts src/gateway/server.auth.control-ui.suite.ts`
- `pnpm check:changed` (passed before final rebase; post-rebase rerun blocked before checks by local Crabbox version `0.21.0` needing `>=0.22.0`)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean: no accepted/actionable findings)
