### PR TITLE
fix(minimax): use account OAuth device endpoints

### DIFF
--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -29,6 +29,67 @@ describe("normalizeOAuthExpires", () => {
 });
 
 describe("loginMiniMaxPortalOAuth", () => {
+  it("uses MiniMax account OAuth endpoints directly for global and CN login", async () => {
+    for (const [region, expectedHosts] of [
+      [
+        "global",
+        [
+          "https://account.minimax.io/oauth2/device/code",
+          "https://account.minimax.io/oauth2/token",
+        ],
+      ],
+      [
+        "cn",
+        [
+          "https://account.minimaxi.com/oauth2/device/code",
+          "https://account.minimaxi.com/oauth2/token",
+        ],
+      ],
+    ] as const) {
+      const requestedUrls: string[] = [];
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requestedUrls.push(String(input));
+        const body =
+          init?.body instanceof URLSearchParams
+            ? init.body
+            : new URLSearchParams(typeof init?.body === "string" ? init.body : "");
+        if (requestedUrls.length === 1) {
+          return new Response(
+            JSON.stringify({
+              user_code: "CODE",
+              verification_uri: "https://example.com/device",
+              expired_in: Date.now() + 10_000,
+              state: body.get("state"),
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            status: "success",
+            access_token: "access",
+            refresh_token: "refresh",
+            expired_in: 3600,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        loginMiniMaxPortalOAuth({
+          region,
+          openUrl: vi.fn(async () => undefined),
+          note: vi.fn(async () => undefined),
+          progress: { update: vi.fn(), stop: vi.fn() },
+        }),
+      ).resolves.toMatchObject({ access: "access", refresh: "refresh" });
+      expect(requestedUrls).toEqual(expectedHosts);
+
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("rejects Date-invalid authorization expiries before formatting instructions", async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const body =

--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -48,7 +48,7 @@ describe("loginMiniMaxPortalOAuth", () => {
     ] as const) {
       const requestedUrls: string[] = [];
       const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        requestedUrls.push(String(input));
+        requestedUrls.push(input instanceof Request ? input.url : String(input));
         const body =
           init?.body instanceof URLSearchParams
             ? init.body

--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -14,10 +14,12 @@ export type MiniMaxRegion = "cn" | "global";
 const MINIMAX_OAUTH_CONFIG = {
   cn: {
     baseUrl: "https://api.minimaxi.com",
+    oauthBaseUrl: "https://account.minimaxi.com",
     clientId: "78257093-7e40-4613-99e0-527b14b39113",
   },
   global: {
     baseUrl: "https://api.minimax.io",
+    oauthBaseUrl: "https://account.minimax.io",
     clientId: "78257093-7e40-4613-99e0-527b14b39113",
   },
 } as const;
@@ -30,11 +32,11 @@ const MINIMAX_ABSOLUTE_EXPIRY_MS_THRESHOLD = 1_000_000_000_000;
 function getOAuthEndpoints(region: MiniMaxRegion) {
   const config = MINIMAX_OAUTH_CONFIG[region];
   return {
-    codeEndpoint: `${config.baseUrl}/oauth/code`,
-    tokenEndpoint: `${config.baseUrl}/oauth/token`,
+    codeEndpoint: `${config.oauthBaseUrl}/oauth2/device/code`,
+    tokenEndpoint: `${config.oauthBaseUrl}/oauth2/token`,
     clientId: config.clientId,
     baseUrl: config.baseUrl,
-    hostname: new URL(config.baseUrl).hostname,
+    hostname: new URL(config.oauthBaseUrl).hostname,
   };
 }
 


### PR DESCRIPTION
## Summary
- update MiniMax OAuth to call the current account device-code endpoints directly
- keep the provider API base URLs unchanged for post-login resource/config handling
- add a regression test for both global and CN OAuth endpoint selection

## Why
MiniMax now redirects `api.minimax.io/oauth/code` and `api.minimaxi.com/oauth/code` to `account.*` device-code endpoints. OpenClaw's guarded fetch intentionally strips POST bodies on cross-origin redirects, so the redirected MiniMax request receives an empty form and fails with `client_id is required`.

## Validation
- `pnpm test extensions/minimax/oauth.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/minimax/oauth.ts extensions/minimax/oauth.test.ts`
- `git diff --check origin/main...HEAD`

## Real behavior proof
Behavior addressed: MiniMax OAuth login no longer posts the device-code form to API hosts that redirect cross-origin and lose the POST body under OpenClaw's guarded fetch.

Real environment tested: OpenClaw MiniMax OAuth setup against live MiniMax global and CN OAuth endpoints.

Exact steps or command run after this patch: `openclaw models auth login --provider minimax-portal --method oauth`; maintainer also ran live POST probes against the old API OAuth URLs and the new account OAuth URLs for both global and CN.

Evidence after fix: The after-patch screenshot shows the MiniMax OAuth browser approval prompt. Live probes also showed old API code/token URLs redirect to `account.minimax.io` / `account.minimaxi.com` `/oauth2/*` endpoints, direct account device-code endpoints return valid `user_code` and `verification_uri`, and direct token endpoints return pending for fresh unapproved user codes.

Observed result after fix: OpenClaw reaches the MiniMax account authorization prompt instead of failing before authorization with `client_id is required`.

What was not tested: Full browser approval and persisted-token storage with a real MiniMax account was not completed.

After patch:
![image](https://github.com/user-attachments/assets/15f50a48-41ad-43a5-877f-4d2ab0c604cc)

Before patch:
![image](https://github.com/user-attachments/assets/5ebc6ef6-4b15-4491-8490-7de34369dd85)
![image](https://github.com/user-attachments/assets/3a4b0b80-86ce-4c3b-89e9-974aa34c9bc3)
