### PR TITLE
fix: suppress raw provider errors in channel delivery

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -5,6 +5,7 @@ import {
   BILLING_ERROR_USER_MESSAGE,
   formatBillingErrorMessage,
   formatAssistantErrorText,
+  formatUserFacingAssistantErrorText,
   getApiErrorPayloadFingerprint,
   formatRawAssistantErrorForUi,
   isRawApiErrorPayload,
@@ -115,6 +116,13 @@ describe("formatAssistantErrorText", () => {
       '{"type":"error","error":{"message":"Something exploded","type":"server_error"}}',
     );
     expect(formatAssistantErrorText(msg)).toBe("LLM error server_error: Something exploded");
+  });
+  it("uses generic user-facing copy for escaped structured provider messages", () => {
+    const msg = makeAssistantError(
+      '{"type":"error","error":{"message":"SECRET\\nCANARY","type":"invalid_request_error"}}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe("LLM error invalid_request_error: SECRET\nCANARY");
+    expect(formatUserFacingAssistantErrorText(msg)).toBe("LLM request failed.");
   });
   it("sanitizes Codex error-prefixed JSON payloads", () => {
     const msg = makeAssistantError(

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -262,6 +262,7 @@ describe("formatAssistantErrorText", () => {
     const result = formatAssistantErrorText(msg);
     expect(result).toContain("30 seconds");
     expect(result).not.toBe("⚠️ API rate limit reached. Please try again later.");
+    expect(formatUserFacingAssistantErrorText(msg)).toContain("30 seconds");
   });
 
   it("returns generic rate limit message when no specific details are present", () => {

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -122,7 +122,9 @@ describe("formatAssistantErrorText", () => {
       '{"type":"error","error":{"message":"SECRET\\nCANARY","type":"invalid_request_error"}}',
     );
     expect(formatAssistantErrorText(msg)).toBe("LLM error invalid_request_error: SECRET\nCANARY");
-    expect(formatUserFacingAssistantErrorText(msg)).toBe("LLM request failed.");
+    expect(formatUserFacingAssistantErrorText(msg)).toBe(
+      "LLM request failed: provider rejected the request schema or tool payload.",
+    );
   });
   it("sanitizes Codex error-prefixed JSON payloads", () => {
     const msg = makeAssistantError(
@@ -551,6 +553,9 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toBe(
       "LLM request rejected: Expected value in JSON at position 12 for messages.0.content",
+    );
+    expect(formatUserFacingAssistantErrorText(msg)).toBe(
+      "LLM request failed: provider rejected the request schema or tool payload.",
     );
   });
 });

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -244,6 +244,11 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError("429 rate limit reached");
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");
   });
+  it("keeps plain HTTP rate-limit guidance user-facing", () => {
+    const msg = makeAssistantError("429 Your quota has been exhausted, try again in 24 hours");
+    expect(formatAssistantErrorText(msg)).toContain("24 hours");
+    expect(formatUserFacingAssistantErrorText(msg)).toContain("24 hours");
+  });
 
   it("surfaces provider-specific rate limit message with reset time (#54433)", () => {
     const msg = makeAssistantError(

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -18,6 +18,8 @@ export {
   classifyFailoverReasonFromHttpStatus,
   formatRawAssistantErrorForUi,
   formatAssistantErrorText,
+  formatUserFacingAssistantErrorText,
+  GENERIC_ASSISTANT_ERROR_TEXT,
   getApiErrorPayloadFingerprint,
   isAuthAssistantError,
   isAuthErrorMessage,

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1377,7 +1377,6 @@ export function isRawAssistantErrorPassthrough(params: {
     friendlyError === rawError ||
     (rawError.length > 600 && friendlyError === `${rawError.slice(0, 600)}…`) ||
     Boolean(parsedMessage && hasRawDerivedProviderPrefix) ||
-    Boolean(parsedMessage && friendlyError.includes(parsedMessage)) ||
     Boolean(leadingStatusRest && friendlyError.includes(leadingStatusRest))
   );
 }

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1367,9 +1367,13 @@ export function isRawAssistantErrorPassthrough(params: {
   if (!friendlyError || !rawError) {
     return false;
   }
+  const parsedMessage = parseApiErrorInfo(rawError)?.message?.trim();
+  const leadingStatusRest = extractLeadingHttpStatus(rawError)?.rest?.trim();
   return (
     friendlyError === rawError ||
-    (rawError.length > 600 && friendlyError === `${rawError.slice(0, 600)}…`)
+    (rawError.length > 600 && friendlyError === `${rawError.slice(0, 600)}…`) ||
+    Boolean(parsedMessage && friendlyError.includes(parsedMessage)) ||
+    Boolean(leadingStatusRest && friendlyError.includes(leadingStatusRest))
   );
 }
 

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1369,9 +1369,14 @@ export function isRawAssistantErrorPassthrough(params: {
   }
   const parsedMessage = parseApiErrorInfo(rawError)?.message?.trim();
   const leadingStatusRest = extractLeadingHttpStatus(rawError)?.rest?.trim();
+  const hasRawDerivedProviderPrefix =
+    friendlyError.startsWith("LLM request rejected:") ||
+    friendlyError.startsWith("LLM error") ||
+    friendlyError.startsWith("HTTP ");
   return (
     friendlyError === rawError ||
     (rawError.length > 600 && friendlyError === `${rawError.slice(0, 600)}…`) ||
+    Boolean(parsedMessage && hasRawDerivedProviderPrefix) ||
     Boolean(parsedMessage && friendlyError.includes(parsedMessage)) ||
     Boolean(leadingStatusRest && friendlyError.includes(leadingStatusRest))
   );

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1377,7 +1377,7 @@ export function isRawAssistantErrorPassthrough(params: {
     friendlyError === rawError ||
     (rawError.length > 600 && friendlyError === `${rawError.slice(0, 600)}…`) ||
     Boolean(parsedMessage && hasRawDerivedProviderPrefix) ||
-    Boolean(leadingStatusRest && friendlyError.includes(leadingStatusRest))
+    Boolean(leadingStatusRest && friendlyError.startsWith("HTTP "))
   );
 }
 

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -71,6 +71,7 @@ export {
 
 const log = createSubsystemLogger("errors");
 const sandboxToolPolicyAuditMessages = new WeakSet<AssistantMessage>();
+export const GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed.";
 
 export function isReasoningConstraintErrorMessage(raw: string): boolean {
   if (!raw) {
@@ -1355,6 +1356,33 @@ export function formatAssistantErrorText(
     log.warn(`Long error truncated: ${raw.slice(0, 200)}`);
   }
   return raw.length > 600 ? `${raw.slice(0, 600)}…` : raw;
+}
+
+export function isRawAssistantErrorPassthrough(params: {
+  friendlyError?: string;
+  rawError?: string;
+}): boolean {
+  const friendlyError = params.friendlyError?.trim();
+  const rawError = params.rawError?.trim();
+  if (!friendlyError || !rawError) {
+    return false;
+  }
+  return (
+    friendlyError === rawError ||
+    (rawError.length > 600 && friendlyError === `${rawError.slice(0, 600)}…`)
+  );
+}
+
+export function formatUserFacingAssistantErrorText(
+  msg: AssistantMessage,
+  opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string; model?: string },
+): string {
+  const friendlyError = formatAssistantErrorText(msg, opts);
+  const rawError = msg.errorMessage?.trim();
+  const safeFriendlyError = isRawAssistantErrorPassthrough({ friendlyError, rawError })
+    ? undefined
+    : friendlyError;
+  return (safeFriendlyError || GENERIC_ASSISTANT_ERROR_TEXT).trim();
 }
 
 export function isRateLimitAssistantError(msg: AssistantMessage | undefined): boolean {

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -72,6 +72,8 @@ export {
 const log = createSubsystemLogger("errors");
 const sandboxToolPolicyAuditMessages = new WeakSet<AssistantMessage>();
 export const GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed.";
+const PROVIDER_SCHEMA_REJECTION_USER_TEXT =
+  "LLM request failed: provider rejected the request schema or tool payload.";
 
 export function isReasoningConstraintErrorMessage(raw: string): boolean {
   if (!raw) {
@@ -1333,7 +1335,7 @@ export function formatAssistantErrorText(
   }
 
   if (providerRuntimeFailureKind === "schema") {
-    return "LLM request failed: provider rejected the request schema or tool payload.";
+    return PROVIDER_SCHEMA_REJECTION_USER_TEXT;
   }
 
   if (providerRuntimeFailureKind === "replay_invalid") {
@@ -1387,8 +1389,15 @@ export function formatUserFacingAssistantErrorText(
 ): string {
   const friendlyError = formatAssistantErrorText(msg, opts);
   const rawError = msg.errorMessage?.trim();
-  const safeFriendlyError = isRawAssistantErrorPassthrough({ friendlyError, rawError })
-    ? undefined
+  const rawPassthrough = isRawAssistantErrorPassthrough({ friendlyError, rawError });
+  const parsedErrorType = parseApiErrorInfo(rawError ?? "")?.type?.toLowerCase() ?? "";
+  const rawProviderSchemaError =
+    friendlyError?.startsWith("LLM request rejected:") ||
+    parsedErrorType.includes("invalid_request");
+  const safeFriendlyError = rawPassthrough
+    ? rawProviderSchemaError
+      ? PROVIDER_SCHEMA_REJECTION_USER_TEXT
+      : undefined
     : friendlyError;
   return (safeFriendlyError || GENERIC_ASSISTANT_ERROR_TEXT).trim();
 }

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -172,6 +172,25 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "SECRET_CANARY_69737");
   });
 
+  it("suppresses structured provider error messages in user-facing reply payloads", () => {
+    const rawError =
+      '{"type":"error","error":{"type":"invalid_request_error","message":"SECRET_CANARY_69737"}}';
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistant({
+        stopReason: "error",
+        errorMessage: rawError,
+        content: [{ type: "text", text: rawError }],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request failed.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "SECRET_CANARY_69737");
+    expectNoPayloadTextContaining(payloads, "LLM request rejected");
+  });
+
   it("surfaces OpenAI model capacity errors instead of generic empty-response copy", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -251,6 +251,24 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "[[reply_to_current]]");
   });
 
+  it("suppresses raw aborted assistant error messages in user-facing reply payloads", () => {
+    const payloads = buildPayloads({
+      runAborted: true,
+      assistantTexts: [],
+      lastAssistant: makeAssistant({
+        stopReason: "aborted",
+        errorMessage: "SECRET_CANARY_69737",
+        content: [],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request failed.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "SECRET_CANARY_69737");
+  });
+
   it("suppresses aborted assistant reasoning text as well as partial answer text", () => {
     const payloads = buildPayloads({
       runAborted: true,

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -191,6 +191,26 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "LLM request rejected");
   });
 
+  it("suppresses escaped structured provider error messages in user-facing reply payloads", () => {
+    const rawError =
+      '{"type":"error","error":{"type":"invalid_request_error","message":"SECRET\\nCANARY_69737"}}';
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistant({
+        stopReason: "error",
+        errorMessage: rawError,
+        content: [{ type: "text", text: rawError }],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request failed.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "SECRET");
+    expectNoPayloadTextContaining(payloads, "CANARY_69737");
+    expectNoPayloadTextContaining(payloads, "LLM request rejected");
+  });
+
   it("surfaces OpenAI model capacity errors instead of generic empty-response copy", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -235,6 +235,20 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "partial answer that should not leak");
   });
 
+  it("preserves aborted-without-error behavior without adding a generic error payload", () => {
+    const payloads = buildPayloads({
+      runAborted: true,
+      assistantTexts: [],
+      lastAssistant: makeAssistant({
+        stopReason: "aborted",
+        errorMessage: undefined,
+        content: [],
+      }),
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
   it("does not replay a stale previous assistant when an aborted run has no new text", () => {
     const payloads = buildPayloads({
       runAborted: true,

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -184,7 +184,7 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "LLM request failed.",
+      text: "LLM request failed: provider rejected the request schema or tool payload.",
       isError: true,
     });
     expectNoPayloadTextContaining(payloads, "SECRET_CANARY_69737");
@@ -203,7 +203,7 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "LLM request failed.",
+      text: "LLM request failed: provider rejected the request schema or tool payload.",
       isError: true,
     });
     expectNoPayloadTextContaining(payloads, "SECRET");

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -156,6 +156,22 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "req_synthetic_provider_request_001");
   });
 
+  it("suppresses raw assistant error messages in user-facing reply payloads", () => {
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistant({
+        stopReason: "error",
+        errorMessage: "SECRET_CANARY_69737",
+        content: [],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request failed.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "SECRET_CANARY_69737");
+  });
+
   it("surfaces OpenAI model capacity errors instead of generic empty-response copy", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -25,6 +25,7 @@ import { extractAssistantTextForPhase } from "../../../shared/chat-message-conte
 import { parseInlineDirectives } from "../../../utils/directive-tags.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
+  formatAssistantErrorText,
   formatRawAssistantErrorForUi,
   formatUserFacingAssistantErrorText,
   getApiErrorPayloadFingerprint,
@@ -299,12 +300,19 @@ export function buildEmbeddedRunPayloads(params: {
     assistantForPayload && lastAssistantNeedsErrorSurface
       ? suppressAssistantArtifacts
         ? undefined
-        : formatUserFacingAssistantErrorText(assistantForPayload, {
-            cfg: params.config,
-            sessionKey: params.sessionKey,
-            provider: params.provider,
-            model: params.model,
-          })
+        : lastAssistantErrored
+          ? formatUserFacingAssistantErrorText(assistantForPayload, {
+              cfg: params.config,
+              sessionKey: params.sessionKey,
+              provider: params.provider,
+              model: params.model,
+            })
+          : formatAssistantErrorText(assistantForPayload, {
+              cfg: params.config,
+              sessionKey: params.sessionKey,
+              provider: params.provider,
+              model: params.model,
+            })
       : undefined;
   const rawErrorMessage = lastAssistantNeedsErrorSurface
     ? normalizeOptionalString(assistantForPayload?.errorMessage)

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -296,11 +296,14 @@ export function buildEmbeddedRunPayloads(params: {
   const lastAssistantAborted = lastAssistantStopReason === "aborted";
   const runAborted = params.runAborted === true || lastAssistantAborted;
   const lastAssistantNeedsErrorSurface = lastAssistantErrored || lastAssistantAborted;
+  const rawErrorMessage = lastAssistantNeedsErrorSurface
+    ? normalizeOptionalString(assistantForPayload?.errorMessage)
+    : undefined;
   const errorText =
     assistantForPayload && lastAssistantNeedsErrorSurface
       ? suppressAssistantArtifacts
         ? undefined
-        : lastAssistantErrored
+        : lastAssistantErrored || rawErrorMessage
           ? formatUserFacingAssistantErrorText(assistantForPayload, {
               cfg: params.config,
               sessionKey: params.sessionKey,
@@ -314,9 +317,6 @@ export function buildEmbeddedRunPayloads(params: {
               model: params.model,
             })
       : undefined;
-  const rawErrorMessage = lastAssistantNeedsErrorSurface
-    ? normalizeOptionalString(assistantForPayload?.errorMessage)
-    : undefined;
   const rawErrorFingerprint = rawErrorMessage
     ? getApiErrorPayloadFingerprint(rawErrorMessage)
     : null;

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -25,8 +25,8 @@ import { extractAssistantTextForPhase } from "../../../shared/chat-message-conte
 import { parseInlineDirectives } from "../../../utils/directive-tags.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
-  formatAssistantErrorText,
   formatRawAssistantErrorForUi,
+  formatUserFacingAssistantErrorText,
   getApiErrorPayloadFingerprint,
   isRawApiErrorPayload,
   normalizeTextForComparison,
@@ -299,7 +299,7 @@ export function buildEmbeddedRunPayloads(params: {
     assistantForPayload && lastAssistantNeedsErrorSurface
       ? suppressAssistantArtifacts
         ? undefined
-        : formatAssistantErrorText(assistantForPayload, {
+        : formatUserFacingAssistantErrorText(assistantForPayload, {
             cfg: params.config,
             sessionKey: params.sessionKey,
             provider: params.provider,

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -86,6 +86,35 @@ function firstWarnMeta(ctx: EmbeddedAgentSubscribeContext): Record<string, unkno
 }
 
 describe("handleAgentEnd", () => {
+  it("suppresses raw assistant error messages in user-facing lifecycle events", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "SECRET_CANARY_69737",
+        content: [],
+      },
+      { onAgentEvent },
+    );
+
+    await handleAgentEnd(ctx);
+
+    const meta = firstWarnMeta(ctx);
+    expect(meta.error).not.toContain("SECRET_CANARY_69737");
+    expect(meta.error).toBe("LLM request failed.");
+    const userFacingLifecycleText = JSON.stringify(onAgentEvent.mock.calls);
+    expect(userFacingLifecycleText).not.toContain("SECRET_CANARY_69737");
+    expect(userFacingLifecycleText).toContain("LLM request failed.");
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        error: "LLM request failed.",
+      },
+    });
+  });
+
   it("logs the resolved error message when run ends with assistant error", async () => {
     const onAgentEvent = vi.fn();
     const ctx = createContext(
@@ -205,13 +234,13 @@ describe("handleAgentEnd", () => {
 
     const meta = firstWarnMeta(ctx);
     expect(meta.event).toBe("embedded_run_agent_end");
-    expect(meta.error).toBe("x-api-key: ***");
+    expect(meta.error).toBe("LLM request failed.");
     expect(meta.rawErrorPreview).toBe("x-api-key: ***");
     expect(onAgentEvent).toHaveBeenCalledWith({
       stream: "lifecycle",
       data: {
         phase: "error",
-        error: "x-api-key: ***",
+        error: "LLM request failed.",
       },
     });
   });

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -115,6 +115,36 @@ describe("handleAgentEnd", () => {
     });
   });
 
+  it("suppresses structured provider error messages in user-facing lifecycle events", async () => {
+    const onAgentEvent = vi.fn();
+    const rawError =
+      '{"type":"error","error":{"type":"server_error","message":"SECRET_CANARY_69737"}}';
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: rawError,
+        content: [{ type: "text", text: rawError }],
+      },
+      { onAgentEvent },
+    );
+
+    await handleAgentEnd(ctx);
+
+    const meta = firstWarnMeta(ctx);
+    expect(meta.error).toBe("LLM request failed.");
+    const userFacingLifecycleText = JSON.stringify(onAgentEvent.mock.calls);
+    expect(userFacingLifecycleText).not.toContain("SECRET_CANARY_69737");
+    expect(userFacingLifecycleText).not.toContain("LLM error server_error");
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        error: "LLM request failed.",
+      },
+    });
+  });
+
   it("logs the resolved error message when run ends with assistant error", async () => {
     const onAgentEvent = vi.fn();
     const ctx = createContext(

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -7,7 +7,11 @@ import {
   sanitizeForConsole,
   shouldSuppressRawErrorConsoleSuffix,
 } from "./embedded-agent-error-observation.js";
-import { classifyFailoverReason, formatAssistantErrorText } from "./embedded-agent-helpers.js";
+import {
+  classifyFailoverReason,
+  formatUserFacingAssistantErrorText,
+  GENERIC_ASSISTANT_ERROR_TEXT,
+} from "./embedded-agent-helpers.js";
 import { hasCommittedMessagingToolDeliveryEvidence } from "./embedded-agent-runner/delivery-evidence.js";
 import { isIncompleteTerminalAssistantTurn } from "./embedded-agent-runner/run/incomplete-turn.js";
 import {
@@ -72,24 +76,23 @@ export function handleAgentEnd(ctx: EmbeddedAgentSubscribeContext): void | Promi
     ctx.state.livenessState === "working" ? derivedWorkingTerminalState : ctx.state.livenessState;
 
   if (isError && lastAssistant) {
-    const friendlyError = formatAssistantErrorText(lastAssistant, {
+    const rawError = lastAssistant.errorMessage?.trim();
+    const failoverReason = classifyFailoverReason(rawError ?? "", {
+      provider: lastAssistant.provider,
+    });
+    const errorText = formatUserFacingAssistantErrorText(lastAssistant, {
       cfg: ctx.params.config,
       sessionKey: ctx.params.sessionKey,
       provider: lastAssistant.provider,
       model: lastAssistant.model,
     });
-    const rawError = lastAssistant.errorMessage?.trim();
-    const failoverReason = classifyFailoverReason(rawError ?? "", {
-      provider: lastAssistant.provider,
-    });
-    const errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
     const observedError = buildApiErrorObservationFields(rawError, {
       provider: lastAssistant.provider,
     });
     const safeErrorText =
       buildTextObservationFields(errorText, {
         provider: lastAssistant.provider,
-      }).textPreview ?? "LLM request failed.";
+      }).textPreview ?? GENERIC_ASSISTANT_ERROR_TEXT;
     lifecycleErrorText = safeErrorText;
     const safeRunId = sanitizeForConsole(ctx.params.runId) ?? "-";
     const safeModel = sanitizeForConsole(lastAssistant.model) ?? "unknown";
@@ -131,7 +134,7 @@ export function handleAgentEnd(ctx: EmbeddedAgentSubscribeContext): void | Promi
         stream: "lifecycle",
         data: {
           phase: "error",
-          error: lifecycleErrorText ?? "LLM request failed.",
+          error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT,
           ...terminalMeta,
           ...(livenessState ? { livenessState } : {}),
           ...(replayInvalid ? { replayInvalid } : {}),
@@ -142,7 +145,7 @@ export function handleAgentEnd(ctx: EmbeddedAgentSubscribeContext): void | Promi
         stream: "lifecycle",
         data: {
           phase: "error",
-          error: lifecycleErrorText ?? "LLM request failed.",
+          error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT,
           ...terminalMeta,
           ...(livenessState ? { livenessState } : {}),
           ...(replayInvalid ? { replayInvalid } : {}),


### PR DESCRIPTION
Fixes #69737.

## Summary

This change blocks raw unclassified assistant `errorMessage` text at the user-facing delivery boundary.

It adds a shared `formatUserFacingAssistantErrorText(...)` wrapper around the existing assistant error formatter. Classified friendly errors still use the existing sanitizer/classification behavior, but formatter output that is only raw upstream pass-through now falls back to:

```text
LLM request failed.
```

Terminal lifecycle events and reply payload construction now use the safe wrapper for actual assistant error turns. Raw diagnostic details are not globally deleted, provider-side error objects are not changed, and internal observation fields such as `rawErrorPreview` remain available for maintainers.

The follow-up repair preserves aborted-without-error behavior by keeping non-error aborted turns on the existing formatter path, so an aborted assistant with no `errorMessage` does not create a synthetic generic error payload.

## Evidence

- Synthetic canary: `SECRET_CANARY_69737`
- Current HEAD tested: `5bb04e6997717541b9c0ede4f0abf7784f49f06f`
- Raw provider-error suppression remains scoped to `stopReason="error"`.
- Aborted-without-error payload behavior is preserved.

## Real behavior proof

- Behavior addressed: Terminal assistant errors with unclassified raw upstream `errorMessage` must not send that raw text through user-facing lifecycle or reply payload delivery text. The repair also preserves aborted-without-error behavior so no synthetic generic error payload is emitted for aborted assistant turns with no `errorMessage`.

- Real environment tested: Local OpenClaw checkout at HEAD `5bb04e6997717541b9c0ede4f0abf7784f49f06f`, running the actual `handleAgentEnd` lifecycle function and actual `buildEmbeddedRunPayloads` reply payload builder through `node --import tsx`, plus a live Telegram DM through my existing OpenClaw Telegram bot.

- Exact steps or command run after this patch: Direct Node/tsx proof imported `src/agents/embedded-agent-subscribe.handlers.lifecycle.ts` and `src/agents/embedded-agent-runner/run/payloads.ts`, passed a terminal assistant payload with `stopReason: "error"`, `content: []`, and `errorMessage: "SECRET_CANARY_69737"`, then captured user-facing lifecycle event text and reply payload text. For Telegram, the PR checkout was started locally, `openai/gpt-5.5` was temporarily routed to a local OpenAI Responses-compatible endpoint at `127.0.0.1:8787/v1`, and a live Telegram DM triggered a provider 500 containing `SECRET_CANARY_69737`.

- Evidence after fix: Terminal output from the direct proof command and live Telegram gateway log excerpt:

```json
{
  "command": "node --import tsx direct handleAgentEnd plus buildEmbeddedRunPayloads canary proof",
  "head": "5bb04e6997717541b9c0ede4f0abf7784f49f06f",
  "containsCanaryInUserFacingLifecycleText": false,
  "containsGenericFallbackInUserFacingLifecycleText": true,
  "containsCanaryInUserFacingReplyPayloadText": false,
  "containsGenericFallbackInUserFacingReplyPayloadText": true,
  "replyPayloads": [
    {
      "text": "LLM request failed.",
      "isError": true
    }
  ],
  "internalRawPreviewRetainedForMaintainers": true
}
```

```text
[openai-transport] [responses] error provider=openai api=openai-responses model=gpt-5.5 status=500 code=telegram_live_proof_canary type=server_error message=500 SECRET_CANARY_69737
[telegram] embedded run agent end: isError=true model=gpt-5.5 provider=openai error=LLM request failed. rawError=500 SECRET_CANARY_69737
```

![Live Telegram proof screenshot](https://github.com/user-attachments/assets/6f223a2e-76f5-430f-b99c-1be7f2045063)

- Observed result after fix: `SECRET_CANARY_69737` is absent from both user-facing lifecycle text and user-facing reply payload text. The live Telegram transcript displays a generic failure response and does not show `SECRET_CANARY_69737`. Internal diagnostic preview retention still reports true for maintainers. The aborted-without-error regression is covered by the added payload regression test and preserves the no-payload behavior.

- What was not tested: Slack delivery was not exercised. The direct lifecycle/payload behavior and live Telegram DM delivery path were exercised for this PR scope.

## Testing

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts src/agents/embedded-agent-helpers/errors.test.ts
```

Result:

```text
Test Files  4 passed (4)
Tests  156 passed (156)
```

```bash
git diff --check upstream/main...HEAD
node_modules/.bin/oxfmt --check --threads=1 --config .oxfmtrc.jsonc src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-helpers.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts src/agents/embedded-agent-runner/run/payloads.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts
```

Result:

```text
All matched files use the correct format.
```