### PR TITLE
fix(models): keep auth login out of main config

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -212,11 +212,13 @@ plugins.
         - `/fast on|off` persists a session override; use the Sessions UI `inherit` option to clear it.
         - `/fast` is provider-specific: OpenAI/Codex map it to `service_tier=priority`; direct Anthropic requests map it to `service_tier=auto` or `standard_only`.
         - `/reasoning`, `/verbose`, and `/trace` are risky in group settings — they may reveal internal reasoning or plugin diagnostics. Keep them off in group chats.
+
       </Accordion>
       <Accordion title="Model switching details">
         - `/model` persists the new model immediately to the session.
         - If the agent is idle, the next run uses it right away.
         - If a run is active, the switch is marked pending and applied at the next clean retry point.
+
       </Accordion>
     </AccordionGroup>
 
@@ -468,6 +470,7 @@ See [BTW side questions](/tools/btw) for the full behavior.
     - **Native Slack commands:** `agent:<agentId>:slack:slash:<userId>` (prefix configurable via `channels.slack.slashCommand.sessionPrefix`)
     - **Native Telegram commands:** `telegram:slash:<userId>` (targets the chat session via `CommandTargetSessionKey`)
     - **`/stop`** targets the active chat session to abort the current run.
+
   </Accordion>
   <Accordion title="Slack specifics">
     `channels.slack.slashCommand` supports a single `/openclaw`-style command.
@@ -479,11 +482,13 @@ See [BTW side questions](/tools/btw) for the full behavior.
     - Command-only messages from allowlisted senders are handled immediately (bypass queue + model).
     - Inline shortcuts (`/help`, `/commands`, `/status`, `/whoami`) also work embedded in normal messages and are stripped before the model sees the remaining text.
     - Unauthorized command-only messages are silently ignored; inline `/...` tokens are treated as plain text.
+
   </Accordion>
   <Accordion title="Argument notes">
     - Commands accept an optional `:` between the command and args (`/think: high`, `/send: on`).
     - `/new <model>` accepts a model alias, `provider/model`, or a provider name (fuzzy match); if no match, the text is treated as the message body.
     - `/allowlist add|remove` requires `commands.config: true` and honors channel `configWrites`.
+
   </Accordion>
 </AccordionGroup>
 

--- a/src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.test.ts
@@ -478,6 +478,43 @@ describe("resolveAuthProfileOrder", () => {
     });
     expect(order).toEqual(["anthropic:work", "anthropic:default"]);
   });
+  it("prefers store order over stale configured profiles", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          profiles: {
+            "openai:old-login": {
+              provider: "openai",
+              mode: "oauth",
+            },
+          },
+        },
+      },
+      store: {
+        version: 1,
+        order: { openai: ["openai:new-login", "openai:old-login"] },
+        profiles: {
+          "openai:new-login": {
+            type: "oauth",
+            provider: "openai",
+            access: "new-access",
+            refresh: "new-refresh",
+            expires: Date.now() + 60_000,
+          },
+          "openai:old-login": {
+            type: "oauth",
+            provider: "openai",
+            access: "old-access",
+            refresh: "old-refresh",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      provider: "openai",
+    });
+
+    expect(order).toEqual(["openai:new-login", "openai:old-login"]);
+  });
   it.each(["store", "config"] as const)(
     "pushes cooldown profiles to the end even with %s order",
     (orderSource) => {

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -204,6 +204,29 @@ describe("resolveAuthProfileOrder", () => {
     expect(order).toStrictEqual([]);
   });
 
+  it("falls back to stored profiles when a stored order only has missing credentials", async () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "fixture-provider:primary": {
+          type: "api_key",
+          provider: "fixture-provider",
+          key: "sk-primary",
+        },
+      },
+      order: {
+        "fixture-provider": ["fixture-provider:deleted"],
+      },
+    };
+
+    const order = resolveAuthProfileOrder({
+      store,
+      provider: "fixture-provider",
+    });
+
+    expect(order).toStrictEqual(["fixture-provider:primary"]);
+  });
+
   it("lets Codex auth use friendly OpenAI auth order entries", async () => {
     const store: AuthProfileStore = {
       version: 1,

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -227,6 +227,33 @@ describe("resolveAuthProfileOrder", () => {
     expect(order).toStrictEqual(["fixture-provider:primary"]);
   });
 
+  it("does not fall back past an explicit configured auth order", async () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "fixture-provider:primary": {
+          type: "api_key",
+          provider: "fixture-provider",
+          key: "sk-primary",
+        },
+      },
+    };
+
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: {
+            "fixture-provider": ["fixture-provider:missing"],
+          },
+        },
+      },
+      store,
+      provider: "fixture-provider",
+    });
+
+    expect(order).toStrictEqual([]);
+  });
+
   it("lets Codex auth use friendly OpenAI auth order entries", async () => {
     const store: AuthProfileStore = {
       version: 1,

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -208,10 +208,17 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:primary": {
+        "fixture-provider:key": {
           type: "api_key",
           provider: "fixture-provider",
           key: "sk-primary",
+        },
+        "fixture-provider:oauth": {
+          type: "oauth",
+          provider: "fixture-provider",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
         },
       },
       order: {
@@ -224,7 +231,7 @@ describe("resolveAuthProfileOrder", () => {
       provider: "fixture-provider",
     });
 
-    expect(order).toStrictEqual(["fixture-provider:primary"]);
+    expect(order).toStrictEqual(["fixture-provider:oauth", "fixture-provider:key"]);
   });
 
   it("does not fall back past an explicit configured auth order", async () => {

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -246,6 +246,9 @@ export function resolveAuthProfileOrder(params: {
     : undefined;
   const directExplicitOrder = directStoredOrder ?? directConfiguredOrder;
   const aliasExplicitOrder = aliasStoredOrder ?? aliasConfiguredOrder;
+  const explicitOrderFromStore =
+    directStoredOrder !== undefined ||
+    (directExplicitOrder === undefined && aliasStoredOrder !== undefined);
   const explicitProfiles = cfg?.auth?.profiles
     ? Object.entries(cfg.auth.profiles)
         .filter(([profileId, profile]) =>
@@ -299,11 +302,15 @@ export function resolveAuthProfileOrder(params: {
     }).eligible;
   let filtered = baseOrder.filter(isValidProfile);
 
-  // Repair explicit order drift from older setup flows or deleted credentials:
-  // order state can also name config-only profiles, so only fall back when every
-  // ordered id is missing from the persisted credential store and none is usable.
+  // Repair stored-order and config-profile drift from older setup flows:
+  // bare config auth.order is a hard constraint, but configured profile ids
+  // can drift from their stored credential ids and still need repair.
   const allBaseProfilesMissing = baseOrder.every((profileId) => !store.profiles[profileId]);
-  if (filtered.length === 0 && allBaseProfilesMissing) {
+  if (
+    filtered.length === 0 &&
+    allBaseProfilesMissing &&
+    (explicitOrderFromStore || explicitProfiles.length > 0)
+  ) {
     filtered = storeProfiles.filter(isValidProfile);
   }
 

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -299,11 +299,11 @@ export function resolveAuthProfileOrder(params: {
     }).eligible;
   let filtered = baseOrder.filter(isValidProfile);
 
-  // Repair config/store profile-id drift from older setup flows:
-  // if configured profile ids no longer exist in auth-profiles.json, scan the
-  // provider's stored credentials and use any valid entries.
+  // Repair explicit order drift from older setup flows or deleted credentials:
+  // order state can also name config-only profiles, so only fall back when every
+  // ordered id is missing from the persisted credential store and none is usable.
   const allBaseProfilesMissing = baseOrder.every((profileId) => !store.profiles[profileId]);
-  if (filtered.length === 0 && explicitProfiles.length > 0 && allBaseProfilesMissing) {
+  if (filtered.length === 0 && allBaseProfilesMissing) {
     filtered = storeProfiles.filter(isValidProfile);
   }
 

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -301,6 +301,7 @@ export function resolveAuthProfileOrder(params: {
       now,
     }).eligible;
   let filtered = baseOrder.filter(isValidProfile);
+  let repairedFallbackToStoreProfiles = false;
 
   // Repair stored-order and config-profile drift from older setup flows:
   // bare config auth.order is a hard constraint, but configured profile ids
@@ -312,6 +313,7 @@ export function resolveAuthProfileOrder(params: {
     (explicitOrderFromStore || explicitProfiles.length > 0)
   ) {
     filtered = storeProfiles.filter(isValidProfile);
+    repairedFallbackToStoreProfiles = true;
   }
 
   const deduped = dedupeProfileIds(filtered);
@@ -319,7 +321,7 @@ export function resolveAuthProfileOrder(params: {
   // If user specified explicit order (store override or config), respect it
   // exactly, but still apply cooldown sorting to avoid repeatedly selecting
   // known-bad/rate-limited keys as the first candidate.
-  if (explicitOrder && explicitOrder.length > 0) {
+  if (explicitOrder && explicitOrder.length > 0 && !repairedFallbackToStoreProfiles) {
     // ...but still respect cooldown tracking to avoid repeatedly selecting a
     // known-bad/rate-limited key as the first candidate.
     const available: string[] = [];

--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -22,6 +22,12 @@ describe("persisted auth profile boundary", () => {
           provider: "openai",
           apiKey: "legacy-openai-key",
         },
+        "openai:legacy-malformed-ref": {
+          type: "apiKey",
+          provider: "openai",
+          apiKey: "legacy-fallback-key",
+          keyRef: { source: "env", id: "" },
+        },
         "minimax:default": {
           type: "token",
           provider: "minimax",
@@ -79,6 +85,11 @@ describe("persisted auth profile boundary", () => {
           type: "api_key",
           provider: "openai",
           key: "legacy-openai-key",
+        },
+        "openai:legacy-malformed-ref": {
+          type: "api_key",
+          provider: "openai",
+          key: "legacy-fallback-key",
         },
         "minimax:default": {
           type: "token",

--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -8,9 +8,9 @@ describe("persisted auth profile boundary", () => {
       version: "not-a-version",
       profiles: {
         "openai:default": {
-          type: "api_key",
+          type: "apiKey",
           provider: " OpenAI ",
-          key: 42,
+          apiKey: "demo-openai-key",
           keyRef: { source: "env", id: "OPENAI_API_KEY" },
           metadata: { account: "acct_123", bad: 123 },
           copyToAgents: "yes",
@@ -66,6 +66,7 @@ describe("persisted auth profile boundary", () => {
         "openai:default": {
           type: "api_key",
           provider: "openai",
+          key: "demo-openai-key",
           keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
           metadata: { account: "acct_123" },
           displayName: "Work",
@@ -98,7 +99,6 @@ describe("persisted auth profile boundary", () => {
       },
     });
     expect(store?.profiles["broken:array"]).toBeUndefined();
-    expect(store?.profiles["openai:default"]).not.toHaveProperty("key");
     expect(store?.profiles["openai:default"]).not.toHaveProperty("copyToAgents");
     expect(store?.profiles["openai:oauth"]).not.toHaveProperty("oauthRef");
   });

--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -203,6 +203,36 @@ describe("persisted auth profile boundary", () => {
     expect(merged.lastGood?.anthropic).toBe(profileId);
   });
 
+  it("preserves config-only order fallbacks during agent-store merges", () => {
+    const merged = mergeAuthProfileStores(
+      {
+        version: AUTH_STORE_VERSION,
+        profiles: {},
+        order: {
+          openai: ["openai:aws-sdk"],
+        },
+      },
+      {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:new-login": {
+            type: "oauth",
+            provider: "openai",
+            access: "new-access",
+            refresh: "new-refresh",
+            expires: 1,
+          },
+        },
+        order: {
+          openai: ["openai:new-login", "openai:aws-sdk"],
+        },
+      },
+      { preserveBaseRuntimeExternalProfiles: true },
+    );
+
+    expect(merged.order?.openai).toEqual(["openai:new-login", "openai:aws-sdk"]);
+  });
+
   it("preserves inherited base runtime external profiles during agent-store merges", () => {
     const profileId = "anthropic:claude-cli";
     const merged = mergeAuthProfileStores(

--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -17,6 +17,11 @@ describe("persisted auth profile boundary", () => {
           email: ["wrong"],
           displayName: "Work",
         },
+        "openai:legacy-api-key": {
+          type: "apiKey",
+          provider: "openai",
+          apiKey: "legacy-openai-key",
+        },
         "minimax:default": {
           type: "token",
           provider: "minimax",
@@ -66,10 +71,14 @@ describe("persisted auth profile boundary", () => {
         "openai:default": {
           type: "api_key",
           provider: "openai",
-          key: "demo-openai-key",
           keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
           metadata: { account: "acct_123" },
           displayName: "Work",
+        },
+        "openai:legacy-api-key": {
+          type: "api_key",
+          provider: "openai",
+          key: "legacy-openai-key",
         },
         "minimax:default": {
           type: "token",

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -109,7 +109,11 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
   if (entry.type === "apiKey") {
     entry.type = "api_key";
   }
-  if (!("key" in entry) && !("keyRef" in entry) && typeof entry["apiKey"] === "string") {
+  if (
+    !("key" in entry) &&
+    !coerceSecretRef(entry["keyRef"]) &&
+    typeof entry["apiKey"] === "string"
+  ) {
     entry["key"] = entry["apiKey"];
   }
   normalizeSecretBackedField({ entry, valueField: "key", refField: "keyRef" });

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -526,7 +526,10 @@ export function mergeAuthProfileStores(
         Object.entries(mergedOrder)
           .map(([provider, profileIds]) => [
             provider,
-            profileIds.filter((profileId) => profiles[profileId]),
+            profileIds.filter(
+              (profileId) =>
+                profiles[profileId] || !removedRuntimeExternalProfileIds.has(profileId),
+            ),
           ])
           .filter(([, profileIds]) => profileIds.length > 0),
       )

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -106,6 +106,9 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
   if (!("type" in entry) && typeof entry["mode"] === "string") {
     entry["type"] = entry["mode"];
   }
+  if (entry.type === "apiKey") {
+    entry.type = "api_key";
+  }
   if (!("key" in entry) && typeof entry["apiKey"] === "string") {
     entry["key"] = entry["apiKey"];
   }

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -109,7 +109,7 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
   if (entry.type === "apiKey") {
     entry.type = "api_key";
   }
-  if (!("key" in entry) && typeof entry["apiKey"] === "string") {
+  if (!("key" in entry) && !("keyRef" in entry) && typeof entry["apiKey"] === "string") {
     entry["key"] = entry["apiKey"];
   }
   normalizeSecretBackedField({ entry, valueField: "key", refField: "keyRef" });
@@ -122,11 +122,10 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
     const key = normalizeOptionalCredentialString(entry.key);
     const keyRef = coerceSecretRef(entry.keyRef);
     const metadata = normalizeCredentialMetadata(entry.metadata);
-    if (key !== undefined) {
-      normalized.key = key;
-    }
     if (keyRef) {
       normalized.keyRef = keyRef;
+    } else if (key !== undefined) {
+      normalized.key = key;
     }
     if (metadata) {
       normalized.metadata = metadata;

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -484,16 +484,24 @@ describe("promoteAuthProfileInOrder", () => {
     try {
       fs.mkdirSync(agentDir, { recursive: true });
       const newProfileId = "openai:new-login";
-      const oldProfileId = "openai:old-login";
+      const primaryProfileId = "openai:primary-login";
+      const backupProfileId = "openai:backup-login";
       saveAuthProfileStore(
         {
           version: AUTH_STORE_VERSION,
           profiles: {
-            [oldProfileId]: {
+            [primaryProfileId]: {
               type: "oauth",
               provider: "openai",
-              access: "old-access",
-              refresh: "old-refresh",
+              access: "primary-access",
+              refresh: "primary-refresh",
+              expires: Date.now() + 30 * 60 * 1000,
+            },
+            [backupProfileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "backup-access",
+              refresh: "backup-refresh",
               expires: Date.now() + 30 * 60 * 1000,
             },
             [newProfileId]: {
@@ -513,12 +521,14 @@ describe("promoteAuthProfileInOrder", () => {
         provider: "openai",
         profileId: newProfileId,
         createIfMissing: true,
+        createFromOrder: [backupProfileId, primaryProfileId],
       });
 
-      expect(updated?.order?.["openai"]).toEqual([newProfileId, oldProfileId]);
+      expect(updated?.order?.["openai"]).toEqual([newProfileId, backupProfileId, primaryProfileId]);
       expect(loadAuthProfileStoreForRuntime(agentDir).order?.["openai"]).toEqual([
         newProfileId,
-        oldProfileId,
+        backupProfileId,
+        primaryProfileId,
       ]);
     } finally {
       if (previousStateDir === undefined) {

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -540,6 +540,62 @@ describe("promoteAuthProfileInOrder", () => {
     }
   });
 
+  it("preserves config-only fallback ids when creating a relogin order", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-order-config-only-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const newProfileId = "openai:new-login";
+      const existingProfileId = "openai:old-login";
+      const configOnlyProfileId = "openai:aws-sdk";
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [existingProfileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "old-access",
+              refresh: "old-refresh",
+              expires: Date.now() + 30 * 60 * 1000,
+            },
+            [newProfileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "new-access",
+              refresh: "new-refresh",
+              expires: Date.now() + 60 * 60 * 1000,
+            },
+          },
+        },
+        agentDir,
+      );
+
+      await promoteAuthProfileInOrder({
+        agentDir,
+        provider: "openai",
+        profileId: newProfileId,
+        createIfMissing: true,
+        createFromOrder: [existingProfileId, configOnlyProfileId],
+      });
+
+      expect(loadAuthProfileStoreForRuntime(agentDir).order?.["openai"]).toEqual([
+        newProfileId,
+        existingProfileId,
+        configOnlyProfileId,
+      ]);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps implicit round-robin when relogin has no existing order by default", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-order-implicit-"));
     const agentDir = path.join(stateDir, "agents", "main", "agent");

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -458,6 +458,7 @@ describe("promoteAuthProfileInOrder", () => {
         agentDir,
         provider: "openai",
         profileId: newProfileId,
+        createIfMissing: true,
       });
 
       expect(updated?.order?.["openai"]).toEqual([newProfileId, staleProfileId]);
@@ -511,6 +512,7 @@ describe("promoteAuthProfileInOrder", () => {
         agentDir,
         provider: "openai",
         profileId: newProfileId,
+        createIfMissing: true,
       });
 
       expect(updated?.order?.["openai"]).toEqual([newProfileId, oldProfileId]);
@@ -518,6 +520,48 @@ describe("promoteAuthProfileInOrder", () => {
         newProfileId,
         oldProfileId,
       ]);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps implicit round-robin when relogin has no existing order by default", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-order-implicit-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const newProfileId = "openai:new-login";
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [newProfileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "new-access",
+              refresh: "new-refresh",
+              expires: Date.now() + 60 * 60 * 1000,
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const updated = await promoteAuthProfileInOrder({
+        agentDir,
+        provider: "openai",
+        profileId: newProfileId,
+      });
+
+      expect(updated?.order?.["openai"]).toBeUndefined();
+      expect(loadAuthProfileStoreForRuntime(agentDir).order?.["openai"]).toBeUndefined();
     } finally {
       if (previousStateDir === undefined) {
         delete process.env.OPENCLAW_STATE_DIR;

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -586,6 +586,12 @@ describe("promoteAuthProfileInOrder", () => {
         existingProfileId,
         configOnlyProfileId,
       ]);
+      saveAuthProfileStore(loadAuthProfileStoreForRuntime(agentDir), agentDir);
+      expect(loadAuthProfileStoreForRuntime(agentDir).order?.["openai"]).toEqual([
+        newProfileId,
+        existingProfileId,
+        configOnlyProfileId,
+      ]);
     } finally {
       if (previousStateDir === undefined) {
         delete process.env.OPENCLAW_STATE_DIR;

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -486,6 +486,7 @@ describe("promoteAuthProfileInOrder", () => {
       const newProfileId = "openai:new-login";
       const primaryProfileId = "openai:primary-login";
       const backupProfileId = "openai:backup-login";
+      const unrelatedProfileId = "openai:unrelated-login";
       saveAuthProfileStore(
         {
           version: AUTH_STORE_VERSION,
@@ -510,6 +511,13 @@ describe("promoteAuthProfileInOrder", () => {
               access: "new-access",
               refresh: "new-refresh",
               expires: Date.now() + 60 * 60 * 1000,
+            },
+            [unrelatedProfileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "unrelated-access",
+              refresh: "unrelated-refresh",
+              expires: Date.now() + 30 * 60 * 1000,
             },
           },
         },

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -475,6 +475,59 @@ describe("promoteAuthProfileInOrder", () => {
     }
   });
 
+  it("creates a per-agent provider order when relogin has no existing order", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-order-create-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const newProfileId = "openai:new-login";
+      const oldProfileId = "openai:old-login";
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [oldProfileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "old-access",
+              refresh: "old-refresh",
+              expires: Date.now() + 30 * 60 * 1000,
+            },
+            [newProfileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "new-access",
+              refresh: "new-refresh",
+              expires: Date.now() + 60 * 60 * 1000,
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const updated = await promoteAuthProfileInOrder({
+        agentDir,
+        provider: "openai",
+        profileId: newProfileId,
+      });
+
+      expect(updated?.order?.["openai"]).toEqual([newProfileId, oldProfileId]);
+      expect(loadAuthProfileStoreForRuntime(agentDir).order?.["openai"]).toEqual([
+        newProfileId,
+        oldProfileId,
+      ]);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("clears matching lastGood after a stale refresh_token_reused profile", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-clear-lastgood-"));
     const agentDir = path.join(stateDir, "agents", "main", "agent");

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -97,9 +97,6 @@ export async function promoteAuthProfileInOrder(params: {
   const providerKey = resolveProviderIdForAuth(params.provider);
   return await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
-    ...(params.createFromOrder
-      ? { saveOptions: { preserveOrderProfileIds: params.createFromOrder } }
-      : {}),
     updater: (store) => {
       const profile = store.profiles[params.profileId];
       if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -92,6 +92,7 @@ export async function promoteAuthProfileInOrder(params: {
   provider: string;
   profileId: string;
   createIfMissing?: boolean;
+  createFromOrder?: string[];
 }): Promise<AuthProfileStore | null> {
   const providerKey = resolveProviderIdForAuth(params.provider);
   return await updateAuthProfileStoreWithLock({
@@ -110,7 +111,10 @@ export async function promoteAuthProfileInOrder(params: {
         if (!params.createIfMissing) {
           return false;
         }
-        const providerProfiles = listProfilesForProvider(store, providerKey);
+        const providerProfiles = dedupeProfileIds([
+          ...(params.createFromOrder ?? []),
+          ...listProfilesForProvider(store, providerKey),
+        ]);
         const next = dedupeProfileIds([
           params.profileId,
           ...providerProfiles.filter((profileId) => profileId !== params.profileId),

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -97,6 +97,9 @@ export async function promoteAuthProfileInOrder(params: {
   const providerKey = resolveProviderIdForAuth(params.provider);
   return await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
+    ...(params.createFromOrder
+      ? { saveOptions: { preserveOrderProfileIds: params.createFromOrder } }
+      : {}),
     updater: (store) => {
       const profile = store.profiles[params.profileId];
       if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -91,6 +91,7 @@ export async function promoteAuthProfileInOrder(params: {
   agentDir?: string;
   provider: string;
   profileId: string;
+  createIfMissing?: boolean;
 }): Promise<AuthProfileStore | null> {
   const providerKey = resolveProviderIdForAuth(params.provider);
   return await updateAuthProfileStoreWithLock({
@@ -104,10 +105,19 @@ export async function promoteAuthProfileInOrder(params: {
         findProviderAuthStateKey(store.order, providerKey) ??
         findNormalizedProviderKey(store.order, providerKey) ??
         normalizeProviderId(providerKey);
-      const existing =
-        store.order?.[orderKey] && store.order[orderKey].length > 0
-          ? store.order[orderKey]
-          : listProfilesForProvider(store, providerKey);
+      const existing = store.order?.[orderKey];
+      if (!existing || existing.length === 0) {
+        if (!params.createIfMissing) {
+          return false;
+        }
+        const providerProfiles = listProfilesForProvider(store, providerKey);
+        const next = dedupeProfileIds([
+          params.profileId,
+          ...providerProfiles.filter((profileId) => profileId !== params.profileId),
+        ]);
+        store.order = { ...store.order, [orderKey]: next };
+        return true;
+      }
       const next = dedupeProfileIds([
         params.profileId,
         ...existing.filter((profileId) => profileId !== params.profileId),

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -104,10 +104,10 @@ export async function promoteAuthProfileInOrder(params: {
         findProviderAuthStateKey(store.order, providerKey) ??
         findNormalizedProviderKey(store.order, providerKey) ??
         normalizeProviderId(providerKey);
-      const existing = store.order?.[orderKey];
-      if (!existing || existing.length === 0) {
-        return false;
-      }
+      const existing =
+        store.order?.[orderKey] && store.order[orderKey].length > 0
+          ? store.order[orderKey]
+          : listProfilesForProvider(store, providerKey);
       const next = dedupeProfileIds([
         params.profileId,
         ...existing.filter((profileId) => profileId !== params.profileId),

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -114,10 +114,11 @@ export async function promoteAuthProfileInOrder(params: {
         if (!params.createIfMissing) {
           return false;
         }
-        const providerProfiles = dedupeProfileIds([
-          ...(params.createFromOrder ?? []),
-          ...listProfilesForProvider(store, providerKey),
-        ]);
+        const providerProfiles = dedupeProfileIds(
+          params.createFromOrder !== undefined
+            ? params.createFromOrder
+            : listProfilesForProvider(store, providerKey),
+        );
         const next = dedupeProfileIds([
           params.profileId,
           ...providerProfiles.filter((profileId) => profileId !== params.profileId),

--- a/src/agents/auth-profiles/store.runtime-external.test.ts
+++ b/src/agents/auth-profiles/store.runtime-external.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ProviderExternalAuthProfile } from "../../plugins/types.js";
 import { testing as externalAuthTesting } from "./external-auth.js";
-import { resolveAuthStorePath } from "./paths.js";
+import { resolveAuthStatePath, resolveAuthStorePath } from "./paths.js";
 import { getRuntimeAuthProfileStoreSnapshot } from "./runtime-snapshots.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -90,8 +90,12 @@ describe("auth profile store runtime external snapshots", () => {
     const persisted = JSON.parse(
       await fs.readFile(resolveAuthStorePath(agentDir), "utf8"),
     ) as AuthProfileStore;
+    const persistedState = JSON.parse(
+      await fs.readFile(resolveAuthStatePath(agentDir), "utf8"),
+    ) as AuthProfileStore;
     expect(persisted.profiles[externalProfileId]).toBeUndefined();
     expect(persisted.order?.["claude-cli"]).toBeUndefined();
+    expect(persistedState.order?.["claude-cli"]).toBeUndefined();
 
     const snapshot = getRuntimeAuthProfileStoreSnapshot(agentDir);
     expect(snapshot?.profiles[externalProfileId]).toEqual(externalCredential);

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -60,6 +60,7 @@ type LoadAuthProfileStoreOptions = {
 
 type SaveAuthProfileStoreOptions = {
   filterExternalAuthProfiles?: boolean;
+  preserveOrderProfileIds?: Iterable<string>;
   syncExternalCli?: boolean;
 };
 
@@ -474,13 +475,14 @@ function shouldKeepProfileInLocalStore(params: {
 function pruneAuthProfileStoreReferences(
   store: AuthProfileStore,
   keptProfileIds: Set<string>,
+  keptOrderProfileIds = keptProfileIds,
 ): void {
   store.order = store.order
     ? Object.fromEntries(
         Object.entries(store.order)
           .map(([provider, profileIds]) => [
             provider,
-            profileIds.filter((profileId) => keptProfileIds.has(profileId)),
+            profileIds.filter((profileId) => keptOrderProfileIds.has(profileId)),
           ])
           .filter(([, profileIds]) => profileIds.length > 0),
       )
@@ -534,7 +536,14 @@ function buildLocalAuthProfileStoreForSave(params: {
     ),
   );
   const keptProfileIds = new Set(Object.keys(localStore.profiles));
-  pruneAuthProfileStoreReferences(localStore, keptProfileIds);
+  const keptOrderProfileIds = new Set(keptProfileIds);
+  for (const profileId of params.options?.preserveOrderProfileIds ?? []) {
+    const normalizedProfileId = profileId.trim();
+    if (normalizedProfileId) {
+      keptOrderProfileIds.add(normalizedProfileId);
+    }
+  }
+  pruneAuthProfileStoreReferences(localStore, keptProfileIds, keptOrderProfileIds);
   if (params.options?.filterExternalAuthProfiles !== false) {
     localStore.runtimeExternalProfileIds = undefined;
     localStore.runtimeExternalProfileIdsAuthoritative = undefined;

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -40,7 +40,7 @@ import {
   replaceRuntimeAuthProfileStoreSnapshots as replaceRuntimeAuthProfileStoreSnapshotsImpl,
   setRuntimeAuthProfileStoreSnapshot,
 } from "./runtime-snapshots.js";
-import { savePersistedAuthProfileState } from "./state.js";
+import { loadPersistedAuthProfileState, savePersistedAuthProfileState } from "./state.js";
 import {
   clearLoadedAuthStoreCache,
   readCachedAuthProfileStore,
@@ -60,6 +60,7 @@ type LoadAuthProfileStoreOptions = {
 
 type SaveAuthProfileStoreOptions = {
   filterExternalAuthProfiles?: boolean;
+  preserveOrderProfileIds?: Iterable<string>;
   pruneOrderProfileIds?: Iterable<string>;
   syncExternalCli?: boolean;
 };
@@ -475,18 +476,18 @@ function shouldKeepProfileInLocalStore(params: {
 function pruneAuthProfileStoreReferences(
   store: AuthProfileStore,
   keptProfileIds: Set<string>,
-  prunedOrderProfileIds = new Set<string>(),
+  keptOrderProfileIds = keptProfileIds,
 ): void {
-  if (prunedOrderProfileIds.size > 0 && store.order) {
-    store.order = Object.fromEntries(
-      Object.entries(store.order)
-        .map(([provider, profileIds]) => [
-          provider,
-          profileIds.filter((profileId) => !prunedOrderProfileIds.has(profileId)),
-        ])
-        .filter(([, profileIds]) => profileIds.length > 0),
-    );
-  }
+  store.order = store.order
+    ? Object.fromEntries(
+        Object.entries(store.order)
+          .map(([provider, profileIds]) => [
+            provider,
+            profileIds.filter((profileId) => keptOrderProfileIds.has(profileId)),
+          ])
+          .filter(([, profileIds]) => profileIds.length > 0),
+      )
+    : undefined;
   store.lastGood = store.lastGood
     ? Object.fromEntries(
         Object.entries(store.lastGood).filter(([, profileId]) => keptProfileIds.has(profileId)),
@@ -536,6 +537,20 @@ function buildLocalAuthProfileStoreForSave(params: {
     ),
   );
   const keptProfileIds = new Set(Object.keys(localStore.profiles));
+  const keptOrderProfileIds = new Set(keptProfileIds);
+  for (const profileIds of Object.values(
+    loadPersistedAuthProfileState(params.agentDir).order ?? {},
+  )) {
+    for (const profileId of profileIds) {
+      keptOrderProfileIds.add(profileId);
+    }
+  }
+  for (const profileId of params.options?.preserveOrderProfileIds ?? []) {
+    const normalizedProfileId = profileId.trim();
+    if (normalizedProfileId) {
+      keptOrderProfileIds.add(normalizedProfileId);
+    }
+  }
   const prunedOrderProfileIds = new Set<string>();
   for (const profileId of params.options?.pruneOrderProfileIds ?? []) {
     const normalizedProfileId = profileId.trim();
@@ -543,7 +558,10 @@ function buildLocalAuthProfileStoreForSave(params: {
       prunedOrderProfileIds.add(normalizedProfileId);
     }
   }
-  pruneAuthProfileStoreReferences(localStore, keptProfileIds, prunedOrderProfileIds);
+  for (const profileId of prunedOrderProfileIds) {
+    keptOrderProfileIds.delete(profileId);
+  }
+  pruneAuthProfileStoreReferences(localStore, keptProfileIds, keptOrderProfileIds);
   if (params.options?.filterExternalAuthProfiles !== false) {
     localStore.runtimeExternalProfileIds = undefined;
     localStore.runtimeExternalProfileIdsAuthoritative = undefined;

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -60,7 +60,6 @@ type LoadAuthProfileStoreOptions = {
 
 type SaveAuthProfileStoreOptions = {
   filterExternalAuthProfiles?: boolean;
-  preserveOrderProfileIds?: Iterable<string>;
   syncExternalCli?: boolean;
 };
 
@@ -475,18 +474,7 @@ function shouldKeepProfileInLocalStore(params: {
 function pruneAuthProfileStoreReferences(
   store: AuthProfileStore,
   keptProfileIds: Set<string>,
-  keptOrderProfileIds = keptProfileIds,
 ): void {
-  store.order = store.order
-    ? Object.fromEntries(
-        Object.entries(store.order)
-          .map(([provider, profileIds]) => [
-            provider,
-            profileIds.filter((profileId) => keptOrderProfileIds.has(profileId)),
-          ])
-          .filter(([, profileIds]) => profileIds.length > 0),
-      )
-    : undefined;
   store.lastGood = store.lastGood
     ? Object.fromEntries(
         Object.entries(store.lastGood).filter(([, profileId]) => keptProfileIds.has(profileId)),
@@ -536,14 +524,7 @@ function buildLocalAuthProfileStoreForSave(params: {
     ),
   );
   const keptProfileIds = new Set(Object.keys(localStore.profiles));
-  const keptOrderProfileIds = new Set(keptProfileIds);
-  for (const profileId of params.options?.preserveOrderProfileIds ?? []) {
-    const normalizedProfileId = profileId.trim();
-    if (normalizedProfileId) {
-      keptOrderProfileIds.add(normalizedProfileId);
-    }
-  }
-  pruneAuthProfileStoreReferences(localStore, keptProfileIds, keptOrderProfileIds);
+  pruneAuthProfileStoreReferences(localStore, keptProfileIds);
   if (params.options?.filterExternalAuthProfiles !== false) {
     localStore.runtimeExternalProfileIds = undefined;
     localStore.runtimeExternalProfileIdsAuthoritative = undefined;

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -60,6 +60,7 @@ type LoadAuthProfileStoreOptions = {
 
 type SaveAuthProfileStoreOptions = {
   filterExternalAuthProfiles?: boolean;
+  pruneOrderProfileIds?: Iterable<string>;
   syncExternalCli?: boolean;
 };
 
@@ -474,7 +475,18 @@ function shouldKeepProfileInLocalStore(params: {
 function pruneAuthProfileStoreReferences(
   store: AuthProfileStore,
   keptProfileIds: Set<string>,
+  prunedOrderProfileIds = new Set<string>(),
 ): void {
+  if (prunedOrderProfileIds.size > 0 && store.order) {
+    store.order = Object.fromEntries(
+      Object.entries(store.order)
+        .map(([provider, profileIds]) => [
+          provider,
+          profileIds.filter((profileId) => !prunedOrderProfileIds.has(profileId)),
+        ])
+        .filter(([, profileIds]) => profileIds.length > 0),
+    );
+  }
   store.lastGood = store.lastGood
     ? Object.fromEntries(
         Object.entries(store.lastGood).filter(([, profileId]) => keptProfileIds.has(profileId)),
@@ -524,7 +536,14 @@ function buildLocalAuthProfileStoreForSave(params: {
     ),
   );
   const keptProfileIds = new Set(Object.keys(localStore.profiles));
-  pruneAuthProfileStoreReferences(localStore, keptProfileIds);
+  const prunedOrderProfileIds = new Set<string>();
+  for (const profileId of params.options?.pruneOrderProfileIds ?? []) {
+    const normalizedProfileId = profileId.trim();
+    if (normalizedProfileId) {
+      prunedOrderProfileIds.add(normalizedProfileId);
+    }
+  }
+  pruneAuthProfileStoreReferences(localStore, keptProfileIds, prunedOrderProfileIds);
   if (params.options?.filterExternalAuthProfiles !== false) {
     localStore.runtimeExternalProfileIds = undefined;
     localStore.runtimeExternalProfileIdsAuthoritative = undefined;

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
@@ -250,7 +250,9 @@ async function repairStaleOAuthProfilesForAgent(params: {
       if (result.removedProfileIds.length === 0) {
         return { status: "unchanged" };
       }
-      saveAuthProfileStore(result.store, params.agentDir);
+      saveAuthProfileStore(result.store, params.agentDir, {
+        pruneOrderProfileIds: result.removedProfileIds,
+      });
       return {
         status: "changed",
         removedProfileIds: result.removedProfileIds,

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -521,6 +521,27 @@ describe("modelsAuthLoginCommand", () => {
     });
   });
 
+  it("creates store order for relogin when configured order would shadow the new profile", async () => {
+    const runtime = createRuntime();
+    currentConfig = {
+      auth: {
+        order: {
+          openai: ["openai:old-login"],
+        },
+      },
+    };
+
+    await modelsAuthLoginCommand({ provider: "openai" }, runtime);
+
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.promoteAuthProfileInOrder).toHaveBeenCalledWith({
+      agentDir: "/tmp/openclaw/agents/main",
+      provider: "openai",
+      profileId: "openai:user@example.com",
+      createIfMissing: true,
+    });
+  });
+
   it("defaults OpenAI login to ChatGPT OAuth when API key is also available", async () => {
     const runtime = createRuntime();
     const initialConfig = currentConfig;

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -484,6 +484,7 @@ describe("modelsAuthLoginCommand", () => {
       agentDir: "/tmp/openclaw/agents/main",
       provider: "openai",
       profileId: "openai:user@example.com",
+      createIfMissing: false,
     });
     expect(mocks.updateConfig).not.toHaveBeenCalled();
     expect(mocks.logConfigUpdated).not.toHaveBeenCalled();
@@ -494,6 +495,30 @@ describe("modelsAuthLoginCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       "Default model available: openai/gpt-5.5 (use --set-default to apply)",
     );
+  });
+
+  it("creates store order for relogin when configured profiles would shadow the new profile", async () => {
+    const runtime = createRuntime();
+    currentConfig = {
+      auth: {
+        profiles: {
+          "openai:old-login": {
+            provider: "openai",
+            mode: "oauth",
+          },
+        },
+      },
+    };
+
+    await modelsAuthLoginCommand({ provider: "openai" }, runtime);
+
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.promoteAuthProfileInOrder).toHaveBeenCalledWith({
+      agentDir: "/tmp/openclaw/agents/main",
+      provider: "openai",
+      profileId: "openai:user@example.com",
+      createIfMissing: true,
+    });
   });
 
   it("defaults OpenAI login to ChatGPT OAuth when API key is also available", async () => {

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -518,6 +518,7 @@ describe("modelsAuthLoginCommand", () => {
       provider: "openai",
       profileId: "openai:user@example.com",
       createIfMissing: true,
+      createFromOrder: ["openai:old-login"],
     });
   });
 
@@ -539,6 +540,7 @@ describe("modelsAuthLoginCommand", () => {
       provider: "openai",
       profileId: "openai:user@example.com",
       createIfMissing: true,
+      createFromOrder: ["openai:old-login"],
     });
   });
 

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -485,9 +485,9 @@ describe("modelsAuthLoginCommand", () => {
       provider: "openai",
       profileId: "openai:user@example.com",
     });
-    const savedProfile = lastUpdatedConfig?.auth?.profiles?.["openai:user@example.com"];
-    expect(savedProfile?.provider).toBe("openai");
-    expect(savedProfile?.mode).toBe("oauth");
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(mocks.logConfigUpdated).not.toHaveBeenCalled();
+    expect(lastUpdatedConfig).toBeNull();
     expect(runtime.log).toHaveBeenCalledWith(
       "Auth profile: openai:user@example.com (openai/oauth)",
     );

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -1107,6 +1107,7 @@ describe("modelsAuthLoginCommand", () => {
       "anthropic/claude-sonnet-4-6": {},
       "openai/gpt-5.5": { alias: "GPT" },
     });
+    expect(lastUpdatedConfig?.auth).toBeUndefined();
     expect(runtime.log).toHaveBeenCalledWith(
       "Default model available: openai/gpt-5.5 (use --set-default to apply)",
     );

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -427,6 +427,10 @@ async function persistProviderAuthResult(params: {
   );
 
   for (const profile of profiles) {
+    const configuredSelection = resolveConfiguredAuthSelectionForProvider(
+      params.config,
+      profile.credential.provider,
+    );
     await upsertAuthProfileWithLockOrThrow({
       profileId: profile.profileId,
       credential: profile.credential,
@@ -436,10 +440,8 @@ async function persistProviderAuthResult(params: {
       agentDir: params.agentDir,
       provider: profile.credential.provider,
       profileId: profile.profileId,
-      createIfMissing: hasConfiguredAuthSelectionForProvider(
-        params.config,
-        profile.credential.provider,
-      ),
+      createIfMissing: configuredSelection.createIfMissing,
+      ...(configuredSelection.order ? { createFromOrder: configuredSelection.order } : {}),
     });
   }
 
@@ -505,20 +507,28 @@ async function persistProviderAuthResult(params: {
   }
 }
 
-function hasConfiguredAuthSelectionForProvider(cfg: OpenClawConfig, provider: string): boolean {
+function resolveConfiguredAuthSelectionForProvider(
+  cfg: OpenClawConfig,
+  provider: string,
+): { createIfMissing: boolean; order?: string[] } {
   const providerAuthKey = resolveProviderIdForAuth(provider, { config: cfg });
-  if (
-    Object.values(cfg.auth?.profiles ?? {}).some(
-      (profile) => resolveProviderIdForAuth(profile.provider, { config: cfg }) === providerAuthKey,
-    )
-  ) {
-    return true;
-  }
-  return Object.entries(cfg.auth?.order ?? {}).some(
-    ([orderProvider, profileIds]) =>
+  for (const [orderProvider, profileIds] of Object.entries(cfg.auth?.order ?? {})) {
+    if (
       profileIds.length > 0 &&
-      resolveProviderIdForAuth(orderProvider, { config: cfg }) === providerAuthKey,
-  );
+      resolveProviderIdForAuth(orderProvider, { config: cfg }) === providerAuthKey
+    ) {
+      return { createIfMissing: true, order: profileIds };
+    }
+  }
+  const profileIds = Object.entries(cfg.auth?.profiles ?? {})
+    .filter(
+      ([, profile]) =>
+        resolveProviderIdForAuth(profile.provider, { config: cfg }) === providerAuthKey,
+    )
+    .map(([profileId]) => profileId);
+  return profileIds.length > 0
+    ? { createIfMissing: true, order: profileIds }
+    : { createIfMissing: false };
 }
 
 async function runProviderAuthMethod(params: {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -30,6 +30,7 @@ import { loadAuthProfileStoreForRuntime } from "../../agents/auth-profiles/store
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { clearAuthProfileCooldown } from "../../agents/auth-profiles/usage.js";
 import { normalizeProviderId } from "../../agents/model-selection-normalize.js";
+import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
@@ -411,6 +412,7 @@ async function pickProviderTokenMethod(params: {
 async function persistProviderAuthResult(params: {
   result: ProviderAuthResult;
   profiles?: ProviderAuthResult["profiles"];
+  config: OpenClawConfig;
   agentDir: string;
   runtime: RuntimeEnv;
   prompter: ReturnType<typeof createClackPrompter>;
@@ -434,6 +436,7 @@ async function persistProviderAuthResult(params: {
       agentDir: params.agentDir,
       provider: profile.credential.provider,
       profileId: profile.profileId,
+      createIfMissing: hasConfiguredProfileForProvider(params.config, profile.credential.provider),
     });
   }
 
@@ -499,6 +502,13 @@ async function persistProviderAuthResult(params: {
   }
 }
 
+function hasConfiguredProfileForProvider(cfg: OpenClawConfig, provider: string): boolean {
+  const providerAuthKey = resolveProviderIdForAuth(provider, { config: cfg });
+  return Object.values(cfg.auth?.profiles ?? {}).some(
+    (profile) => resolveProviderIdForAuth(profile.provider, { config: cfg }) === providerAuthKey,
+  );
+}
+
 async function runProviderAuthMethod(params: {
   config: OpenClawConfig;
   agentDir: string;
@@ -547,6 +557,7 @@ async function runProviderAuthMethod(params: {
   await persistProviderAuthResult({
     result,
     profiles,
+    config: params.config,
     agentDir: params.agentDir,
     runtime: params.runtime,
     prompter: params.prompter,

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -420,6 +420,9 @@ async function persistProviderAuthResult(params: {
     ? normalizeAgentModelRefForConfig(params.result.defaultModel)
     : undefined;
   const profiles = params.profiles ?? params.result.profiles;
+  const shouldUpdateConfig = Boolean(
+    params.result.configPatch || (params.setDefault && defaultModel),
+  );
 
   for (const profile of profiles) {
     await upsertAuthProfileWithLockOrThrow({
@@ -434,46 +437,51 @@ async function persistProviderAuthResult(params: {
     });
   }
 
-  const updated = await updateConfig((cfg) => {
-    const priorAgentsDefaultsModel = cfg.agents?.defaults?.model;
-    let next = cfg;
-    if (params.result.configPatch) {
-      next = applyProviderAuthConfigPatch(next, params.result.configPatch, {
-        replaceDefaultModels: params.result.replaceDefaultModels,
+  // Auth login owns the credential store. Keep openclaw.json untouched unless
+  // the provider explicitly returns a config patch or the user opts into a
+  // default-model write.
+  if (shouldUpdateConfig) {
+    const updated = await updateConfig((cfg) => {
+      const priorAgentsDefaultsModel = cfg.agents?.defaults?.model;
+      let next = cfg;
+      if (params.result.configPatch) {
+        next = applyProviderAuthConfigPatch(next, params.result.configPatch, {
+          replaceDefaultModels: params.result.replaceDefaultModels,
+        });
+      }
+      for (const profile of profiles) {
+        next = applyAuthProfileConfig(next, {
+          profileId: profile.profileId,
+          provider: profile.credential.provider,
+          mode: credentialMode(profile.credential),
+        });
+      }
+      next = restorePriorAgentsDefaultsModelUnlessOptIn({
+        cfg: next,
+        priorAgentsDefaultsModel,
+        setDefault: params.setDefault,
       });
-    }
-    for (const profile of profiles) {
-      next = applyAuthProfileConfig(next, {
-        profileId: profile.profileId,
-        provider: profile.credential.provider,
-        mode: credentialMode(profile.credential),
+      if (params.setDefault && defaultModel) {
+        next = applyDefaultModel(next, defaultModel);
+      }
+      return next;
+    });
+    if (defaultModel) {
+      const repaired = await repairCodexRuntimePluginInstallForModelSelection({
+        cfg: updated,
+        model: defaultModel,
       });
+      const copilotRepaired = await repairCopilotRuntimePluginInstallForModelSelection({
+        cfg: updated,
+        model: defaultModel,
+      });
+      for (const warning of [...repaired.warnings, ...copilotRepaired.warnings]) {
+        params.runtime.error?.(warning);
+      }
     }
-    next = restorePriorAgentsDefaultsModelUnlessOptIn({
-      cfg: next,
-      priorAgentsDefaultsModel,
-      setDefault: params.setDefault,
-    });
-    if (params.setDefault && defaultModel) {
-      next = applyDefaultModel(next, defaultModel);
-    }
-    return next;
-  });
-  if (defaultModel) {
-    const repaired = await repairCodexRuntimePluginInstallForModelSelection({
-      cfg: updated,
-      model: defaultModel,
-    });
-    const copilotRepaired = await repairCopilotRuntimePluginInstallForModelSelection({
-      cfg: updated,
-      model: defaultModel,
-    });
-    for (const warning of [...repaired.warnings, ...copilotRepaired.warnings]) {
-      params.runtime.error?.(warning);
-    }
+    logConfigUpdated(params.runtime);
   }
 
-  logConfigUpdated(params.runtime);
   for (const profile of profiles) {
     params.runtime.log(
       `Auth profile: ${profile.profileId} (${profile.credential.provider}/${credentialMode(profile.credential)})`,

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -436,7 +436,10 @@ async function persistProviderAuthResult(params: {
       agentDir: params.agentDir,
       provider: profile.credential.provider,
       profileId: profile.profileId,
-      createIfMissing: hasConfiguredProfileForProvider(params.config, profile.credential.provider),
+      createIfMissing: hasConfiguredAuthSelectionForProvider(
+        params.config,
+        profile.credential.provider,
+      ),
     });
   }
 
@@ -502,10 +505,19 @@ async function persistProviderAuthResult(params: {
   }
 }
 
-function hasConfiguredProfileForProvider(cfg: OpenClawConfig, provider: string): boolean {
+function hasConfiguredAuthSelectionForProvider(cfg: OpenClawConfig, provider: string): boolean {
   const providerAuthKey = resolveProviderIdForAuth(provider, { config: cfg });
-  return Object.values(cfg.auth?.profiles ?? {}).some(
-    (profile) => resolveProviderIdForAuth(profile.provider, { config: cfg }) === providerAuthKey,
+  if (
+    Object.values(cfg.auth?.profiles ?? {}).some(
+      (profile) => resolveProviderIdForAuth(profile.provider, { config: cfg }) === providerAuthKey,
+    )
+  ) {
+    return true;
+  }
+  return Object.entries(cfg.auth?.order ?? {}).some(
+    ([orderProvider, profileIds]) =>
+      profileIds.length > 0 &&
+      resolveProviderIdForAuth(orderProvider, { config: cfg }) === providerAuthKey,
   );
 }
 

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -457,13 +457,6 @@ async function persistProviderAuthResult(params: {
           replaceDefaultModels: params.result.replaceDefaultModels,
         });
       }
-      for (const profile of profiles) {
-        next = applyAuthProfileConfig(next, {
-          profileId: profile.profileId,
-          provider: profile.credential.provider,
-          mode: credentialMode(profile.credential),
-        });
-      }
       next = restorePriorAgentsDefaultsModelUnlessOptIn({
         cfg: next,
         priorAgentsDefaultsModel,

--- a/src/infra/device-auth-store.test.ts
+++ b/src/infra/device-auth-store.test.ts
@@ -107,6 +107,30 @@ describe("infra/device-auth-store", () => {
     });
   });
 
+  it("loads valid roles when another persisted token entry is malformed", async () => {
+    await withTempDir("openclaw-device-auth-", async (stateDir) => {
+      const env = createEnv(stateDir);
+      await fs.mkdir(path.dirname(deviceAuthFile(stateDir)), { recursive: true });
+      await fs.writeFile(
+        deviceAuthFile(stateDir),
+        JSON.stringify({
+          version: 1,
+          deviceId: "device-1",
+          tokens: {
+            operator: { token: "operator-token", role: "operator", scopes: [], updatedAtMs: 1 },
+            broken: { role: "broken", scopes: [], updatedAtMs: 1 },
+          },
+        }),
+        "utf8",
+      );
+
+      expect(loadDeviceAuthToken({ deviceId: "device-1", role: "operator", env })?.token).toBe(
+        "operator-token",
+      );
+      expect(loadDeviceAuthToken({ deviceId: "device-1", role: "broken", env })).toBeNull();
+    });
+  });
+
   it("clears only the requested role and leaves unrelated tokens intact", async () => {
     await withTempDir("openclaw-device-auth-", async (stateDir) => {
       const env = createEnv(stateDir);


### PR DESCRIPTION
Summary
- Keep ordinary provider auth login credentials in auth-profiles.json without rewriting openclaw.json.
- Preserve openclaw.json writes for provider config patches and explicit --set-default model updates.
- Normalize persisted auth profile type: apiKey to api_key, and create per-agent store order only when stale configured auth selection would otherwise shadow the newly logged-in profile.

Verification
- OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/models/auth.test.ts
- OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/auth-profiles/persisted-boundary.test.ts
- OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/auth-profiles/profiles.test.ts
- OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.test.ts
- git diff --check origin/main...HEAD
- pnpm tsgo:core
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Behavior addressed
models auth login now stores plain login credentials in the auth profile store and does not touch openclaw.json unless the provider returns a config patch or the user passes --set-default.

Real environment tested
Local OpenClaw checkout on macOS, Node repo test wrappers.

Exact steps or command run after this patch
The verification commands listed above were run after the final patch.

Evidence after fix
Focused tests cover plain login not calling updateConfig, config/profile and config/order shadowing cases, apiKey persisted type normalization, and store order creation preserving configured order tails.

Observed result after fix
All listed tests and checks passed, and autoreview reported no accepted/actionable findings.

What was not tested
No live provider OAuth flow was run.

Fixes #88565
