### PR TITLE
fix(discord): avoid impossible close-code comparison

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -161,8 +161,7 @@ function shouldLogDiscordGatewayTransportClose(params: {
   return (
     (params.code !== 1000 && params.code !== 1001) ||
     params.reason.length > 0 ||
-    params.lastError !== undefined ||
-    params.code === DISCORD_GATEWAY_POLICY_VIOLATION_CLOSE_CODE
+    params.lastError !== undefined
   );
 }
 


### PR DESCRIPTION
## Summary

- Remove the redundant Discord gateway close-code comparison that TypeScript narrows to an impossible `1008` branch.
- Keep policy-violation close logging unchanged because non-normal close codes are already logged by the existing `code !== 1000 && code !== 1001` branch.

## Verification

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/gateway-plugin.test.ts --reporter=dot` passed: 1 shard, 16 tests.
- `node_modules/.bin/oxfmt --check --threads=1 extensions/discord/src/monitor/gateway-plugin.ts extensions/discord/src/monitor/gateway-plugin.test.ts` passed.
- `node scripts/run-oxlint.mjs extensions/discord/src/monitor/gateway-plugin.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- AWS Crabbox `pnpm check:changed` passed with exit 0: provider `aws`, lease `cbx_143106768f9c`, run `run_78668023fdac`, machine `c7a.8xlarge`, lanes `extensions`, `extensionTests`, lease stopped.

## Real behavior proof

Behavior addressed: current `main` fails changed-gate lint preparation because the Discord boundary DTS build reports TS2367 on an impossible close-code comparison.

Real environment tested: local focused Discord tests and AWS Crabbox Linux changed-gate runner.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/discord/src/monitor/gateway-plugin.test.ts --reporter=dot`; `node_modules/.bin/oxfmt --check --threads=1 extensions/discord/src/monitor/gateway-plugin.ts extensions/discord/src/monitor/gateway-plugin.test.ts`; `node scripts/run-oxlint.mjs extensions/discord/src/monitor/gateway-plugin.ts`; `git diff --check origin/main...HEAD`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 90m --ttl 180m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: AWS Crabbox `run_78668023fdac` completed with exit 0 and covered the extension changed-gate lanes.

Observed result after fix: Discord gateway close logging remains covered by existing tests, and the changed gate no longer fails during Discord boundary DTS preparation.

What was not tested: live Discord gateway disconnect behavior; this is a typecheck-only cleanup of an already-covered predicate.
