### PR TITLE
fix: allow missing native hook relay without policy

### DIFF
--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -185,6 +185,41 @@ describe("Codex native hook relay config", () => {
     });
   });
 
+  it("keeps selected no-policy PreToolUse installed with an unavailable no-op marker", () => {
+    expect(
+      buildCodexNativeHookRelayConfig({
+        relay: createRelay({ inactiveEvents: ["pre_tool_use"] }),
+        events: ["pre_tool_use"],
+      }),
+    ).toEqual({
+      "features.hooks": true,
+      "hooks.PreToolUse": [
+        {
+          hooks: [
+            {
+              type: "command",
+              command:
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop",
+              timeout: 5,
+              async: false,
+              statusMessage: "OpenClaw native hook relay",
+            },
+          ],
+        },
+      ],
+      "hooks.state": {
+        "/<session-flags>/config.toml:pre_tool_use:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+        "<session-flags>/config.toml:pre_tool_use:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+      },
+    });
+  });
+
   it("clears omitted hook events when requested", () => {
     expect(
       buildCodexNativeHookRelayConfig({
@@ -276,7 +311,11 @@ function createRelay(options?: {
     expiresAtMs: Date.now() + 1000,
     shouldRelayEvent: (event) => !inactiveEvents.has(event),
     commandForEvent: (event) =>
-      `openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event ${event}`,
+      `openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event ${event}${
+        event === "pre_tool_use" && inactiveEvents.has(event)
+          ? " --pre-tool-use-unavailable noop"
+          : ""
+      }`,
     renew: () => undefined,
     unregister: () => undefined,
   };

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -231,7 +231,11 @@ export function buildCodexNativeHookRelayConfig(params: {
   for (const event of CODEX_NATIVE_HOOK_RELAY_EVENTS) {
     const codexEvent = CODEX_HOOK_EVENT_BY_NATIVE_EVENT[event];
     const selected = selectedEvents.has(event);
-    if (!selected || !params.relay.shouldRelayEvent(event)) {
+    const shouldRelay = params.relay.shouldRelayEvent(event);
+    // Keep no-policy PreToolUse commands installed with an explicit no-op marker;
+    // otherwise a stale relay fallback cannot distinguish no policy from unknown policy.
+    const selectedNoopPreToolUse = selected && event === "pre_tool_use" && !shouldRelay;
+    if (!selected || (!shouldRelay && !selectedNoopPreToolUse)) {
       if (selected || params.clearOmittedEvents) {
         config[`hooks.${codexEvent}`] = [] satisfies JsonValue;
       }

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -525,6 +525,10 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("post_tool_use")).toBe(false);
     expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(false);
     expect(relay.shouldRelayEvent("permission_request")).toBe(true);
+    expect(relay.commandForEvent("pre_tool_use")).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
+    );
   });
 
   it("builds pre-tool relay commands only when before-tool policy is active", () => {
@@ -3194,6 +3198,21 @@ describe("native hook relay command builder", () => {
       }),
     ).toBe(
       "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request --timeout 5000",
+    );
+  });
+
+  it("includes explicit unavailable noop mode only for PreToolUse", () => {
+    expect(
+      buildNativeHookRelayCommand({
+        provider: "codex",
+        relayId: "relay-1",
+        generation: "generation-1",
+        event: "pre_tool_use",
+        preToolUseUnavailable: "noop",
+        executable: "openclaw",
+      }),
+    ).toBe(
+      "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop --timeout 5000",
     );
   });
 });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -439,6 +439,10 @@ export function registerNativeHookRelay(
         relayId,
         generation: registration.generation,
         event,
+        preToolUseUnavailable:
+          event === "pre_tool_use" && !nativeHookRelayEventHasLocalWork(registration, event)
+            ? "noop"
+            : undefined,
         nice: params.command?.nice,
         timeoutMs: params.command?.timeoutMs,
         executable: params.command?.executable,
@@ -517,6 +521,7 @@ export function buildNativeHookRelayCommand(params: {
   relayId: string;
   generation?: string;
   event: NativeHookRelayEvent;
+  preToolUseUnavailable?: "noop";
   timeoutMs?: number;
   executable?: string;
   nice?: number | false;
@@ -541,6 +546,9 @@ export function buildNativeHookRelayCommand(params: {
     ...(params.generation ? ["--generation", params.generation] : []),
     "--event",
     params.event,
+    ...(params.event === "pre_tool_use" && params.preToolUseUnavailable
+      ? ["--pre-tool-use-unavailable", params.preToolUseUnavailable]
+      : []),
     "--timeout",
     String(timeoutMs),
   ]);
@@ -752,6 +760,7 @@ export async function invokeNativeHookRelayBridge(
 export function renderNativeHookRelayUnavailableResponse(params: {
   provider: unknown;
   event: unknown;
+  preToolUseUnavailable?: unknown;
   message?: string;
 }): NativeHookRelayProcessResponse {
   const provider = readNativeHookRelayProvider(params.provider);
@@ -759,10 +768,10 @@ export function renderNativeHookRelayUnavailableResponse(params: {
   const adapter = getNativeHookRelayProviderAdapter(provider);
   const message = params.message?.trim() || "Native hook relay unavailable";
   if (event === "pre_tool_use") {
-    // A stale or missing relay should not turn basic tool execution into a
-    // hard failure when OpenClaw has no before-tool policy to enforce. If a
-    // policy exists, keep the fail-closed behavior.
-    if (!hasBeforeToolCallPolicy()) {
+    // The standalone CLI cannot reconstruct the originating registration after
+    // relay lookup fails, so unavailable PreToolUse must fail closed unless the
+    // generated command explicitly recorded that no before-tool policy existed.
+    if (params.preToolUseUnavailable === "noop") {
       return adapter.renderNoopResponse(event);
     }
     return adapter.renderPreToolUseBlockResponse(message);

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -759,6 +759,12 @@ export function renderNativeHookRelayUnavailableResponse(params: {
   const adapter = getNativeHookRelayProviderAdapter(provider);
   const message = params.message?.trim() || "Native hook relay unavailable";
   if (event === "pre_tool_use") {
+    // A stale or missing relay should not turn basic tool execution into a
+    // hard failure when OpenClaw has no before-tool policy to enforce. If a
+    // policy exists, keep the fail-closed behavior.
+    if (!hasBeforeToolCallPolicy()) {
+      return adapter.renderNoopResponse(event);
+    }
     return adapter.renderPreToolUseBlockResponse(message);
   }
   if (event === "permission_request") {

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -530,6 +530,10 @@ export function registerHooksCli(program: Command): void {
     .requiredOption("--relay-id <id>", "Native hook relay id")
     .option("--generation <generation>", "Native hook relay registration generation")
     .requiredOption("--event <event>", "Native hook event")
+    .option(
+      "--pre-tool-use-unavailable <mode>",
+      "PreToolUse fallback mode when the originating relay is unavailable",
+    )
     .option("--timeout <ms>", "Gateway timeout in ms", "5000")
     .action(async (opts: NativeHookRelayCliOptions) =>
       runHooksCliAction(async () => {

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -159,13 +159,7 @@ describe("native hook relay CLI", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout.text())).toEqual({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: "Native hook relay unavailable",
-      },
-    });
+    expect(stdout.text()).toBe("");
     expect(stderr.text()).toContain("native hook relay unavailable");
     expect(stderr.text()).toContain("generation must be non-empty string");
     expect(callGateway).toHaveBeenCalledWith(
@@ -179,13 +173,7 @@ describe("native hook relay CLI", () => {
   it.each([
     {
       event: "pre_tool_use",
-      stdout: {
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-          permissionDecision: "deny",
-          permissionDecisionReason: "Native hook relay unavailable",
-        },
-      },
+      stdout: null,
     },
     {
       event: "permission_request",
@@ -277,7 +265,7 @@ describe("native hook relay CLI", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
-  it("fails closed for PreToolUse when the gateway relay is unavailable", async () => {
+  it("keeps PreToolUse unavailable handling observational when there is no before-tool policy", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error("gateway closed");
     });
@@ -295,13 +283,7 @@ describe("native hook relay CLI", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout.text())).toEqual({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: "Native hook relay unavailable",
-      },
-    });
+    expect(stdout.text()).toBe("");
     expect(stderr.text()).toContain("native hook relay unavailable");
   });
 

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -159,7 +159,13 @@ describe("native hook relay CLI", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(stdout.text()).toBe("");
+    expect(JSON.parse(stdout.text())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
     expect(stderr.text()).toContain("native hook relay unavailable");
     expect(stderr.text()).toContain("generation must be non-empty string");
     expect(callGateway).toHaveBeenCalledWith(
@@ -173,7 +179,13 @@ describe("native hook relay CLI", () => {
   it.each([
     {
       event: "pre_tool_use",
-      stdout: null,
+      stdout: {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: "Native hook relay unavailable",
+        },
+      },
     },
     {
       event: "permission_request",
@@ -265,7 +277,7 @@ describe("native hook relay CLI", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
-  it("keeps PreToolUse unavailable handling observational when there is no before-tool policy", async () => {
+  it("fails closed for PreToolUse when the gateway relay is unavailable", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error("gateway closed");
     });
@@ -274,6 +286,40 @@ describe("native hook relay CLI", () => {
 
     const exitCode = await runNativeHookRelayCli(
       { provider: "codex", relayId: "relay-1", generation: "generation-1", event: "pre_tool_use" },
+      {
+        stdin: createReadableTextStream("{}"),
+        stdout,
+        stderr,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.text())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
+    expect(stderr.text()).toContain("native hook relay unavailable");
+  });
+
+  it("keeps PreToolUse unavailable handling observational only with an explicit no-policy marker", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("gateway closed");
+    });
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      {
+        provider: "codex",
+        relayId: "relay-1",
+        generation: "generation-1",
+        event: "pre_tool_use",
+        preToolUseUnavailable: "noop",
+      },
       {
         stdin: createReadableTextStream("{}"),
         stdout,

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -16,6 +16,7 @@ export type NativeHookRelayCliOptions = {
   relayId?: string;
   generation?: string;
   event?: string;
+  preToolUseUnavailable?: string;
   timeout?: string;
 };
 
@@ -76,6 +77,7 @@ export async function runNativeHookRelayCli(
       const response = renderNativeHookRelayUnavailableResponse({
         provider,
         event,
+        preToolUseUnavailable: opts.preToolUseUnavailable,
         message: "Native hook relay unavailable",
       });
       writeText(stdout, response.stdout);
@@ -101,6 +103,7 @@ export async function runNativeHookRelayCli(
     const response = renderNativeHookRelayUnavailableResponse({
       provider,
       event,
+      preToolUseUnavailable: opts.preToolUseUnavailable,
       message: "Native hook relay unavailable",
     });
     writeText(stdout, response.stdout);


### PR DESCRIPTION
## Summary
- Preserve fail-closed PreToolUse behavior whenever unavailable fallback policy state is unknown.
- Add an explicit generated-command marker, `--pre-tool-use-unavailable noop`, for the no-policy PreToolUse case.
- Keep PermissionRequest fail-closed and keep PostToolUse / before_agent_finalize observational.
- Add regression coverage for stale/missing PreToolUse default-deny, explicit no-policy no-op fallback, and generated command marker behavior.

## Review feedback addressed
- ClawSweeper concern: fallback used process-local `hasBeforeToolCallPolicy()` after relay/gateway failure.
- Fix: the standalone CLI no longer infers policy state. It denies unavailable PreToolUse unless the original generated hook command explicitly carried the no-policy marker.
- The marker is only emitted when the originating registration has no local PreToolUse work, including loop detection.

## Real behavior proof
**Behavior or issue addressed:** Native hook relay unavailable fallback for Codex hooks after the fix. Explicit no-policy PreToolUse marker returns no-op; missing/unknown PreToolUse state denies; PermissionRequest denies.

**Real environment tested:** Raspberry Pi local checkout of this PR head `26d360b`, Node `v22.22.2`, source CLI run with `node --import tsx src/entry.ts`, isolated temporary `HOME` and `OPENCLAW_HOME` so no user gateway credentials or local OpenClaw config were reused.

**Exact steps or command run after this patch:**
1. Verified the source CLI reports `OpenClaw 2026.5.30 (26d360b)`.
2. Ran `hooks relay` for missing `pre_tool_use` with `--pre-tool-use-unavailable noop`.
3. Ran `hooks relay` for missing `pre_tool_use` without the marker.
4. Ran `hooks relay` for missing `permission_request`.

**Evidence after fix:**

```
$ HOME="$proof_home" OPENCLAW_HOME="$proof_home/.openclaw" \
  node --import tsx src/entry.ts --version
OpenClaw 2026.5.30 (26d360b)

$ printf '{}' | HOME="$proof_home" OPENCLAW_HOME="$proof_home/.openclaw" \
  node --import tsx src/entry.ts hooks relay \
  --provider codex \
  --relay-id missing \
  --generation generation-1 \
  --event pre_tool_use \
  --pre-tool-use-unavailable noop \
  --timeout 1000

stdout: <empty>
stderr:
native hook relay unavailable: gateway nativeHook.invoke requires credentials before opening a websocket
Fix: configure gateway.auth token/password, pair this device, or pass --token/--password.

$ printf '{}' | HOME="$proof_home" OPENCLAW_HOME="$proof_home/.openclaw" \
  node --import tsx src/entry.ts hooks relay \
  --provider codex \
  --relay-id missing \
  --generation generation-1 \
  --event pre_tool_use \
  --timeout 1000

stdout:
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Native hook relay unavailable"}}

stderr:
native hook relay unavailable: gateway nativeHook.invoke requires credentials before opening a websocket
Fix: configure gateway.auth token/password, pair this device, or pass --token/--password.

$ printf '{}' | HOME="$proof_home" OPENCLAW_HOME="$proof_home/.openclaw" \
  node --import tsx src/entry.ts hooks relay \
  --provider codex \
  --relay-id missing \
  --generation generation-1 \
  --event permission_request \
  --timeout 1000

stdout:
{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"Native hook relay unavailable"}}}

stderr:
native hook relay unavailable: gateway nativeHook.invoke requires credentials before opening a websocket
Fix: configure gateway.auth token/password, pair this device, or pass --token/--password.
```

**Observed result after fix:** The amended branch fails closed when PreToolUse policy state is unknown, no-ops only when the generated command carries the explicit no-policy marker, and keeps PermissionRequest denied.

**What was not tested:** Full local Vitest did not complete in the sparse/partial checkout; GitHub CI is the full test gate. The proof does not exercise a live registered relay because this change is specifically the unavailable-relay fallback path.

## Additional validation
```
$ node --experimental-strip-types --check src/cli/native-hook-relay-cli.ts
cli_rc:0
$ node --experimental-strip-types --check src/agents/harness/native-hook-relay.ts
harness_rc:0
$ node --experimental-strip-types --check src/cli/hooks-cli.ts
hooks_rc:0
$ git diff --check
# no output
```
