### PR TITLE
fix(types): restore current changed gate

### DIFF
--- a/src/agents/embedded-agent-runner.sanitize-session-history.test-harness.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test-harness.ts
@@ -1,4 +1,5 @@
 import { expect, vi } from "vitest";
+import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import type { AgentMessage } from "./runtime/index.js";
 import type { SessionManager } from "./sessions/index.js";
 import type { TranscriptPolicy } from "./transcript-policy.js";
@@ -12,6 +13,7 @@ export type SanitizeSessionHistoryFn = (params: {
   sessionManager: SessionManager;
   sessionId: string;
   modelId?: string;
+  model?: ProviderRuntimeModel;
   policy?: TranscriptPolicy;
   preserveLatestAssistantThinking?: boolean;
 }) => Promise<AgentMessage[]>;

--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import {
   clearDeviceAuthTokenFromStore,
+  copyCanonicalDeviceAuthTokens,
   type DeviceAuthEntry,
   loadDeviceAuthTokenFromStore,
   storeDeviceAuthTokenInStore,
@@ -29,7 +30,7 @@ function parseDeviceAuthStore(value: unknown): DeviceAuthStore | null {
   return {
     version: 1,
     deviceId: value.deviceId,
-    tokens: value.tokens,
+    tokens: copyCanonicalDeviceAuthTokens(value.tokens),
   };
 }
 

--- a/src/shared/device-auth-store.ts
+++ b/src/shared/device-auth-store.ts
@@ -28,7 +28,7 @@ function coerceDeviceAuthEntry(role: string, value: unknown): DeviceAuthEntry | 
   };
 }
 
-function copyCanonicalDeviceAuthTokens(
+export function copyCanonicalDeviceAuthTokens(
   tokens: Record<string, unknown>,
 ): Record<string, DeviceAuthEntry> {
   const out: Record<string, DeviceAuthEntry> = {};


### PR DESCRIPTION
## Summary

- updates the sanitize-session-history test harness type so tests can pass the runtime `model` metadata used by current callers
- parses persisted device-auth token maps through the existing canonical token copier instead of returning raw `Record<string, unknown>` JSON as `DeviceAuthStore.tokens`
- restores the current `pnpm check:changed` path that was failing in `typecheck core tests` and plugin SDK boundary dts/type jobs

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner.sanitize-session-history.test.ts src/shared/device-auth-store.test.ts src/infra/device-auth-store.test.ts --reporter=dot` passed, 84 tests
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner.sanitize-session-history.test-harness.ts src/agents/embedded-agent-runner.sanitize-session-history.test.ts src/shared/device-auth-store.ts src/infra/device-auth-store.ts` passed
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner.sanitize-session-history.test-harness.ts src/agents/embedded-agent-runner.sanitize-session-history.test.ts src/shared/device-auth-store.ts src/infra/device-auth-store.ts` passed
- `node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true` passed
- `git diff --check origin/main...HEAD` passed
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 90m --ttl 180m --timing-json --shell -- "pnpm check:changed"` passed on AWS Crabbox: run `run_c069f1613aed`, lease `cbx_2739bf102a52`, slug `blue-krill`, machine `c7a.8xlarge`, exit 0

## Notes

- local full `tsconfig.core.json` typecheck was not run because this sparse gwt lacks `ui/config`; the AWS Crabbox changed gate ran from a full synced checkout and covered that path.
