### PR TITLE
Release session lock on user abort

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2976,6 +2976,9 @@ export async function runEmbeddedAttempt(
         }
         abortCompaction();
         void abortActiveSession();
+        void sessionLockController.releaseHeldLockForAbort().catch((err) => {
+          log.warn(`failed to release session lock on abort: runId=${params.runId} ${String(err)}`);
+        });
         if (isTimeout && queueHandleForAbandonment) {
           markActiveEmbeddedRunAbandoned({
             sessionId: params.sessionId,
@@ -2983,11 +2986,6 @@ export async function runEmbeddedAttempt(
             sessionKey: params.sessionKey,
             sessionFile: params.sessionFile,
             reason: "timeout",
-          });
-          void sessionLockController.releaseHeldLockForAbort().catch((err) => {
-            log.warn(
-              `failed to release session lock on timeout abort: runId=${params.runId} ${String(err)}`,
-            );
           });
         }
       };

--- a/src/agents/embedded-agent-runner/run/attempt.user-abort-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.user-abort-lock.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  createContextEngineBootstrapAndAssemble,
+  createDefaultEmbeddedSession,
+  getHoisted,
+  resetEmbeddedAttemptHarness,
+} from "./attempt.spawn-workspace.test-support.js";
+
+const tempPaths: string[] = [];
+
+beforeEach(() => {
+  resetEmbeddedAttemptHarness();
+});
+
+afterEach(async () => {
+  await cleanupTempPaths(tempPaths);
+});
+
+describe("embedded attempt user abort lock release", () => {
+  it("releases the retained session lock before cleanup after user abort", async () => {
+    const hoisted = getHoisted();
+    const lockEvents: string[] = [];
+    let lockCount = 0;
+    hoisted.acquireSessionWriteLockMock.mockReset().mockImplementation(async () => {
+      lockCount += 1;
+      const lockId = lockCount;
+      lockEvents.push(`acquire-${lockId}`);
+      return {
+        release: async () => {
+          lockEvents.push(`release-${lockId}`);
+        },
+      };
+    });
+
+    let markPromptStarted!: () => void;
+    const promptStarted = new Promise<void>((resolve) => {
+      markPromptStarted = resolve;
+    });
+    let settlePrompt!: () => void;
+    const promptCanSettle = new Promise<void>((resolve) => {
+      settlePrompt = resolve;
+    });
+    const abortController = new AbortController();
+    const contextEngine = createContextEngineBootstrapAndAssemble();
+
+    const run = createContextEngineAttemptRunner({
+      contextEngine,
+      sessionKey: "agent:main:user-abort-lock",
+      tempPaths,
+      createSession: () =>
+        createDefaultEmbeddedSession({
+          prompt: async () => {
+            markPromptStarted();
+            await promptCanSettle;
+          },
+        }),
+      attemptOverrides: {
+        abortSignal: abortController.signal,
+      },
+    });
+
+    await promptStarted;
+    abortController.abort(new Error("user abort"));
+    settlePrompt();
+
+    await run;
+
+    const retainedReleaseIndex = lockEvents.indexOf("release-1");
+    const cleanupAcquireIndex = lockEvents.indexOf("acquire-2");
+    expect(retainedReleaseIndex).toBeGreaterThan(-1);
+    expect(cleanupAcquireIndex).toBeGreaterThan(-1);
+    expect(retainedReleaseIndex).toBeLessThan(cleanupAcquireIndex);
+  });
+});


### PR DESCRIPTION
## Summary

- release the retained embedded-session write lock for manual/user aborts, not only timeout aborts
- keep timeout abandoned-run tracking restricted to timeout aborts
- add a regression test that proves the retained lock is released before cleanup reacquires a lock after user abort

Fixes #88600

## Motivation / Root Cause

`abortRun(false)` aborted compaction and the active session, but the retained session write lock release lived inside the timeout-only branch. A manual abort could leave the original attempt's lock held until teardown, so cleanup or the next turn could block behind the same run's stale held lock.

## User-Visible Behavior

Manual stop/interrupt of an embedded run should release the session write lock promptly, allowing cleanup and follow-up work for the same session to proceed without waiting for stale lock timeout recovery.

## Real Behavior Proof

Behavior addressed: manual/user abort of an embedded run now releases the retained session write lock before cleanup reacquires a lock for the same session.

Real environment tested: local macOS checkout using the real session-write-lock implementation and a temp persisted session file on disk.

Exact steps or command run after this patch:

```sh
node --import tsx /tmp/openclaw-user-abort-lock-proof.mjs
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.user-abort-lock.test.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts src/agents/embedded-agent-runner/runs.test.ts src/auto-reply/reply/reply-run-registry.test.ts src/auto-reply/reply/abort.test.ts
node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.user-abort-lock.test.ts
git diff --check
```

Evidence after fix:

```text
persistedSessionFile=/var/folders/yb/3wkthcjd5vddlnhd480pj8yr0000gn/T/openclaw-user-abort-lock-0H5QQs/agent/session.json
lockPath=/var/folders/yb/3wkthcjd5vddlnhd480pj8yr0000gn/T/openclaw-user-abort-lock-0H5QQs/agent/session.json.lock
beforeAbortRelease=blocked(SessionWriteLockTimeoutError)
abortRelease=releaseHeldLockForAbort completed
afterAbortRelease=cleanupLockAcquired
lockFileExistsAfterCleanup=false
```

Observed result after fix: before the abort-release call, a cleanup-style lock acquire against the same persisted session file timed out on the live lock; after `releaseHeldLockForAbort`, cleanup acquired and released the lock, and the lock file was gone. Focused Vitest passed 5 files / 102 tests; targeted lint passed; `git diff --check` passed.

What was not tested: no live gateway/manual-stop smoke or channel delivery smoke was run.

## Compatibility and Risks

No config, API, persistence format, provider, or channel contract changes. The risk is limited to abort/session-lock lifecycle ordering; the release helper is already used for timeout aborts and yield-abort cleanup, and timeout abandoned-run marking remains timeout-only.
