### PR TITLE
fix(agents): release session lock on manual abort

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
+
+describe("releaseEmbeddedAttemptSessionLockForAbort", () => {
+  it("releases the retained session lock for manual aborts", async () => {
+    const releaseHeldLockForAbort = vi.fn(async () => {});
+    const warn = vi.fn();
+
+    releaseEmbeddedAttemptSessionLockForAbort({
+      sessionLockController: { releaseHeldLockForAbort },
+      log: { warn },
+      runId: "run-manual",
+      abortKind: "abort",
+    });
+
+    await Promise.resolve();
+
+    expect(releaseHeldLockForAbort).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("logs release failures without throwing from the abort path", async () => {
+    const releaseError = new Error("locked");
+    const releaseHeldLockForAbort = vi.fn(async () => {
+      throw releaseError;
+    });
+    const warn = vi.fn();
+
+    releaseEmbeddedAttemptSessionLockForAbort({
+      sessionLockController: { releaseHeldLockForAbort },
+      log: { warn },
+      runId: "run-timeout",
+      abortKind: "timeout abort",
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(releaseHeldLockForAbort).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "failed to release session lock on timeout abort: runId=run-timeout Error: locked",
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-abort.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.ts
@@ -1,0 +1,18 @@
+import type { EmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
+
+type AbortLockReleaseLog = {
+  warn(message: string): void;
+};
+
+export function releaseEmbeddedAttemptSessionLockForAbort(params: {
+  sessionLockController: Pick<EmbeddedAttemptSessionLockController, "releaseHeldLockForAbort">;
+  log: AbortLockReleaseLog;
+  runId: string;
+  abortKind: "abort" | "timeout abort";
+}): void {
+  void params.sessionLockController.releaseHeldLockForAbort().catch((err) => {
+    params.log.warn(
+      `failed to release session lock on ${params.abortKind}: runId=${params.runId} ${String(err)}`,
+    );
+  });
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -308,6 +308,7 @@ import {
   rotateTranscriptAfterCompaction,
   shouldRotateCompactionTranscript,
 } from "../compaction-successor-transcript.js";
+import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
 import { resolveAttemptWorkspaceBootstrapRouting } from "./attempt-bootstrap-routing.js";
 import { configureEmbeddedAttemptHttpRuntime } from "./attempt-http-runtime.js";
 import {
@@ -2984,12 +2985,13 @@ export async function runEmbeddedAttempt(
             sessionFile: params.sessionFile,
             reason: "timeout",
           });
-          void sessionLockController.releaseHeldLockForAbort().catch((err) => {
-            log.warn(
-              `failed to release session lock on timeout abort: runId=${params.runId} ${String(err)}`,
-            );
-          });
         }
+        releaseEmbeddedAttemptSessionLockForAbort({
+          sessionLockController,
+          log,
+          runId: params.runId,
+          abortKind: isTimeout ? "timeout abort" : "abort",
+        });
       };
       abortRunForExternalSignal = abortRun;
       const idleTimeoutTrigger: ((error: Error) => void) | undefined = (error) => {


### PR DESCRIPTION
## Summary
- Release the embedded attempt session lock on manual aborts through the same best-effort abort cleanup path used by timeout aborts.
- Keep timeout abandonment marking scoped to timeout aborts, so manual aborts only release the retained lock.
- Add focused regression coverage for manual abort lock release and release failures.

## Verification
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-abort.test.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.test.ts test/scripts/plugin-prerelease-test-plan.test.ts`
- `pnpm check:test-types`
- `pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt-abort.ts src/agents/embedded-agent-runner/run/attempt-abort.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Refs #88600

## Real behavior proof

Behavior addressed: manual embedded-attempt aborts release the session lock retained while the attempt owns the session, preventing later turns from getting stuck behind the abandoned lock.
Real environment tested: local source checkout on Node 24-era toolchain, plus GitHub PR CI on the branch head.
Exact steps or command run after this patch: focused Vitest for abort/session-lock cleanup, `pnpm check:test-types`, oxfmt check, `git diff --check`, and branch autoreview.
Evidence after fix: `attempt-abort.test.ts` proves manual abort invokes `releaseHeldLockForAbort()` and logs release failures without throwing; existing session-lock/subscription cleanup tests still pass.
Observed result after fix: manual abort cleanup path now schedules the lock release independently from timeout-only abandonment marking.
What was not tested: live multi-agent queue reproduction against a real stuck local session lock.
