### PR TITLE
fix(gateway): reject stale lifecycle session updates

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -803,6 +803,7 @@ async function agentCommandInternal(
           ? { isControlUiVisible: false }
           : {
               sessionKey,
+              sessionId,
             },
       );
       attemptExecutionRuntime.emitAcpLifecycleStart({ runId, startedAt });
@@ -980,7 +981,7 @@ async function agentCommandInternal(
 
     if (sessionKey || suppressVisibleSessionEffects) {
       registerAgentRunContext(runId, {
-        ...(sessionKey && !suppressVisibleSessionEffects ? { sessionKey } : {}),
+        ...(sessionKey && !suppressVisibleSessionEffects ? { sessionKey, sessionId } : {}),
         verboseLevel: resolvedVerboseLevel,
         isControlUiVisible: !suppressVisibleSessionEffects,
       });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1584,6 +1584,7 @@ export async function runAgentTurnWithFallback(params: {
   if (params.sessionKey) {
     registerAgentRunContext(runId, {
       sessionKey: params.sessionKey,
+      ...(params.followupRun.run.sessionId ? { sessionId: params.followupRun.run.sessionId } : {}),
       verboseLevel: params.resolvedVerboseLevel,
       isHeartbeat: params.isHeartbeat,
       isControlUiVisible: shouldSurfaceToControlUi,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1177,6 +1177,7 @@ export async function runMemoryFlushIfNeeded(params: {
   if (params.sessionKey) {
     memoryDeps.registerAgentRunContext(flushRunId, {
       sessionKey: params.sessionKey,
+      ...(activeSessionEntry?.sessionId ? { sessionId: activeSessionEntry.sessionId } : {}),
       verboseLevel: params.resolvedVerboseLevel,
     });
   }

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -684,6 +684,66 @@ describe("createFollowupRunner reply-lane admission", () => {
     expect(call.sessionId).toBe("post-compact-session");
     expect(call.sessionFile).toBe("/tmp/post-compact.jsonl");
   });
+
+  it("registers the admitted session id when the local session store is stale", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    realAgentEvents.resetAgentRunContextForTest();
+    const active = createReplyOperationForTest({
+      sessionKey: "main",
+      sessionId: "pre-compact-session",
+      resetTriggered: false,
+    });
+    active.setPhase("preflight_compacting");
+    let observedRunId: string | undefined;
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (params: { runId: string; sessionId?: string }) => {
+        observedRunId = params.runId;
+        expect(params.sessionId).toBe("post-compact-session");
+        return {
+          payloads: [],
+          meta: { agentMeta: { provider: "anthropic", model: "claude" } },
+        };
+      },
+    );
+    const sessionStore = {
+      main: {
+        sessionId: "pre-compact-session",
+        sessionFile: "/tmp/pre-compact.jsonl",
+        updatedAt: Date.now(),
+      },
+    };
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry: sessionStore.main,
+      sessionStore,
+      sessionKey: "main",
+      defaultModel: "anthropic/claude",
+    });
+
+    const pending = runner(
+      createQueuedRun({
+        run: {
+          sessionId: "queued-stale-session",
+          sessionKey: "main",
+          provider: "anthropic",
+          model: "claude",
+        },
+      }),
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    active.updateSessionId("post-compact-session");
+    active.complete();
+    await pending;
+
+    expect(observedRunId).toBeDefined();
+    expect(realAgentEvents.getAgentRunContext(observedRunId ?? "")?.sessionId).toBe(
+      "post-compact-session",
+    );
+    realAgentEvents.resetAgentRunContextForTest();
+  });
 });
 
 async function normalizeComparablePath(filePath: string): Promise<string> {
@@ -2569,6 +2629,69 @@ describe("createFollowupRunner compaction", () => {
     expect(embeddedCalls[0]?.extraSystemPrompt).toContain("Post-compaction context refresh");
     expect(embeddedCalls[0]?.extraSystemPrompt).toContain("Read AGENTS.md before replying.");
     expect(sessionStore.main?.compactionCount).toBe(2);
+  });
+
+  it("registers the post-preflight session id for lifecycle event stamping", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    realAgentEvents.resetAgentRunContextForTest();
+    const sessionEntry: SessionEntry = {
+      sessionId: "old-session",
+      updatedAt: Date.now(),
+      sessionFile: "/tmp/old-session.jsonl",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      main: sessionEntry,
+    };
+    runPreflightCompactionIfNeededMock.mockImplementationOnce(
+      async (params: {
+        followupRun: FollowupRun;
+        sessionEntry?: SessionEntry;
+        sessionStore?: Record<string, SessionEntry>;
+        sessionKey?: string;
+      }) => {
+        const updatedEntry: SessionEntry = {
+          ...(params.sessionEntry ?? sessionEntry),
+          sessionId: "new-session",
+          sessionFile: "/tmp/new-session.jsonl",
+          updatedAt: Date.now(),
+        };
+        params.followupRun.run.sessionId = updatedEntry.sessionId;
+        params.followupRun.run.sessionFile = "/tmp/new-session.jsonl";
+        if (params.sessionKey && params.sessionStore) {
+          params.sessionStore[params.sessionKey] = updatedEntry;
+        }
+        return updatedEntry;
+      },
+    );
+
+    let observedRunId: string | undefined;
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (params: { runId: string; sessionId?: string }) => {
+        observedRunId = params.runId;
+        expect(params.sessionId).toBe("new-session");
+        return {
+          payloads: [{ text: "final" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    await runner(createQueuedRun());
+
+    expect(observedRunId).toBeDefined();
+    expect(realAgentEvents.getAgentRunContext(observedRunId ?? "")?.sessionId).toBe("new-session");
+    realAgentEvents.resetAgentRunContextForTest();
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -542,13 +542,6 @@ export function createFollowupRunner(params: {
           provider: run.messageProvider,
         }),
       );
-      if (run.sessionKey) {
-        registerAgentRunContext(runId, {
-          sessionKey: run.sessionKey,
-          verboseLevel: run.verboseLevel,
-          isControlUiVisible: shouldSurfaceToControlUi,
-        });
-      }
       let autoCompactionCount = 0;
       let runResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
       let fallbackProvider = run.provider;
@@ -566,6 +559,18 @@ export function createFollowupRunner(params: {
         isHeartbeat: opts?.isHeartbeat === true,
         replyOperation,
       });
+      if (run.sessionKey) {
+        const owningSessionId =
+          activeSessionEntry?.sessionId === run.sessionId
+            ? activeSessionEntry.sessionId
+            : run.sessionId;
+        registerAgentRunContext(runId, {
+          sessionKey: run.sessionKey,
+          ...(owningSessionId ? { sessionId: owningSessionId } : {}),
+          verboseLevel: run.verboseLevel,
+          isControlUiVisible: shouldSurfaceToControlUi,
+        });
+      }
       let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
         activeSessionEntry?.systemPromptReport,
       );

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -396,6 +396,7 @@ export async function executeCronRun(params: {
     "off";
   registerAgentRunContext(params.cronSession.sessionEntry.sessionId, {
     sessionKey: params.runSessionKey,
+    sessionId: params.cronSession.sessionEntry.sessionId,
     verboseLevel: resolvedVerboseLevel,
   });
   const executor = createCronPromptExecutor({

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1903,6 +1903,75 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
+  it("does not project stale pre-reset lifecycle events into session subscriber snapshots", () => {
+    vi.mocked(loadGatewaySessionRow).mockReturnValue({
+      key: "session-reset",
+      kind: "direct",
+      sessionId: "new-session",
+      updatedAt: 2_000,
+      status: "done",
+      startedAt: 1_000,
+      endedAt: 1_500,
+      runtimeMs: 500,
+      abortedLastRun: false,
+    });
+    const { broadcastToConnIds, sessionEventSubscribers, handler } = createHarness({
+      lifecycleErrorRetryGraceMs: 0,
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+
+    handler({
+      runId: "old-run",
+      seq: 1,
+      stream: "lifecycle",
+      sessionKey: "session-reset",
+      sessionId: "old-session",
+      ts: 2_100,
+      data: {
+        phase: "start",
+        startedAt: 2_100,
+      },
+    });
+    handler({
+      runId: "old-run",
+      seq: 2,
+      stream: "lifecycle",
+      sessionKey: "session-reset",
+      sessionId: "old-session",
+      ts: 2_200,
+      data: {
+        phase: "error",
+        endedAt: 2_200,
+        error: "old run failed",
+      },
+    });
+
+    const sessionsChangedCalls = broadcastToConnIds.mock.calls.filter(
+      ([event]) => event === "sessions.changed",
+    );
+    expect(sessionsChangedCalls).toHaveLength(2);
+    for (const [, payload] of sessionsChangedCalls) {
+      expectPayloadFields(payload, {
+        sessionKey: "session-reset",
+        sessionId: "new-session",
+        status: "done",
+        startedAt: 1_000,
+        endedAt: 1_500,
+        runtimeMs: 500,
+        updatedAt: 2_000,
+        abortedLastRun: false,
+      });
+      expectRecordFields(requireRecord(requireRecord(payload, "payload").session, "session"), {
+        sessionId: "new-session",
+        status: "done",
+        startedAt: 1_000,
+        endedAt: 1_500,
+        runtimeMs: 500,
+      });
+    }
+    resetAgentRunContextForTest();
+  });
+
   it("clears tracked active runs before terminal sessions.changed broadcasts", () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-finished",

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -23,7 +23,10 @@ import type {
 } from "./server-chat-state.js";
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
 import { persistGatewaySessionLifecycleEvent } from "./server-chat.persist-session-lifecycle.runtime.js";
-import { deriveGatewaySessionLifecycleSnapshot } from "./session-lifecycle-state.js";
+import {
+  deriveGatewaySessionLifecycleSnapshot,
+  isStaleLifecycleEventForSession,
+} from "./session-lifecycle-state.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
 
@@ -333,21 +336,26 @@ export function createAgentEventHandler({
   ) => {
     const row = loadGatewaySessionRowForSnapshot(sessionKey, agentId ? { agentId } : undefined);
     const omitUnscopedGlobalGoal = sessionKey === "global" && !agentId;
-    const lifecyclePatch = evt
-      ? deriveGatewaySessionLifecycleSnapshot({
-          session: row
-            ? {
-                updatedAt: row.updatedAt ?? undefined,
-                status: row.status,
-                startedAt: row.startedAt,
-                endedAt: row.endedAt,
-                runtimeMs: row.runtimeMs,
-                abortedLastRun: row.abortedLastRun,
-              }
-            : undefined,
-          event: evt,
-        })
-      : {};
+    const lifecyclePatch =
+      evt &&
+      !isStaleLifecycleEventForSession({
+        owningSessionId: evt.sessionId,
+        currentSessionId: row?.sessionId,
+      })
+        ? deriveGatewaySessionLifecycleSnapshot({
+            session: row
+              ? {
+                  updatedAt: row.updatedAt ?? undefined,
+                  status: row.status,
+                  startedAt: row.startedAt,
+                  endedAt: row.endedAt,
+                  runtimeMs: row.runtimeMs,
+                  abortedLastRun: row.abortedLastRun,
+                }
+              : undefined,
+            event: evt,
+          })
+        : {};
     const session = row ? { ...row, ...lifecyclePatch } : undefined;
     if (session && omitUnscopedGlobalGoal) {
       delete session.goal;

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -2,9 +2,28 @@ import { describe, expect, it } from "vitest";
 import {
   deriveGatewaySessionLifecycleSnapshot,
   derivePersistedSessionLifecyclePatch,
+  isStaleLifecycleEventForSession,
 } from "./session-lifecycle-state.js";
 
 describe("session lifecycle state", () => {
+  it("treats a pre-reset run's lifecycle event as stale once the row's sessionId rotated (#88538)", () => {
+    expect(
+      isStaleLifecycleEventForSession({ owningSessionId: "old-id", currentSessionId: "new-id" }),
+    ).toBe(true);
+  });
+
+  it("applies lifecycle events whose owning sessionId matches the current row", () => {
+    expect(
+      isStaleLifecycleEventForSession({ owningSessionId: "same-id", currentSessionId: "same-id" }),
+    ).toBe(false);
+  });
+
+  it("does not guard when the owning sessionId is unknown (preserves legacy behavior)", () => {
+    expect(
+      isStaleLifecycleEventForSession({ owningSessionId: undefined, currentSessionId: "new-id" }),
+    ).toBe(false);
+  });
+
   it("reactivates completed sessions on lifecycle start", () => {
     expect(
       deriveGatewaySessionLifecycleSnapshot({

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -9,7 +9,7 @@ import type { GatewaySessionRow, SessionRunStatus } from "./session-utils.types.
 
 type LifecyclePhase = "start" | "end" | "error";
 
-type LifecycleEventLike = Pick<AgentEventPayload, "ts"> & {
+type LifecycleEventLike = Pick<AgentEventPayload, "ts" | "sessionId"> & {
   data?: {
     phase?: unknown;
     startedAt?: unknown;
@@ -172,6 +172,22 @@ export function derivePersistedSessionLifecyclePatch(params: {
   };
 }
 
+/**
+ * A pre-`sessions.reset` run's lifecycle event must not mutate a session row
+ * whose sessionId was rotated by the reset. True only when both the owning
+ * run's sessionId and the current row's sessionId are known and differ.
+ */
+export function isStaleLifecycleEventForSession(params: {
+  owningSessionId?: string;
+  currentSessionId?: string;
+}): boolean {
+  return Boolean(
+    params.owningSessionId &&
+    params.currentSessionId &&
+    params.owningSessionId !== params.currentSessionId,
+  );
+}
+
 export async function persistGatewaySessionLifecycleEvent(params: {
   sessionKey: string;
   agentId?: string;
@@ -190,15 +206,27 @@ export async function persistGatewaySessionLifecycleEvent(params: {
     return;
   }
 
+  const owningSessionId =
+    typeof params.event.sessionId === "string" && params.event.sessionId
+      ? params.event.sessionId
+      : undefined;
+
   await updateSessionStoreEntry({
     storePath: sessionEntry.storePath,
     sessionKey: sessionEntry.canonicalKey,
     skipMaintenance: true,
     takeCacheOwnership: true,
-    update: async (entry) =>
-      derivePersistedSessionLifecyclePatch({
+    update: async (entry) => {
+      // Reject a pre-reset run's lifecycle event: sessions.reset rotates the row
+      // to a new sessionId under the same sessionKey, so an old in-flight run's
+      // late start/end/error must not overwrite the fresh row's status (#88538).
+      if (isStaleLifecycleEventForSession({ owningSessionId, currentSessionId: entry.sessionId })) {
+        return null;
+      }
+      return derivePersistedSessionLifecyclePatch({
         entry,
         event: params.event,
-      }),
+      });
+    },
   });
 }

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -30,6 +30,44 @@ describe("agent-events sequencing", () => {
     expect(getAgentRunContext("run-1")).toBeUndefined();
   });
 
+  test("stamps the owning sessionId onto lifecycle events for reset-stale guarding (#88538)", () => {
+    registerAgentRunContext("run-1", { sessionKey: "main", sessionId: "old-session-id" });
+    const seen: Array<{ stream: string; sessionId?: string }> = [];
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-1") {
+        seen.push({ stream: evt.stream, sessionId: evt.sessionId });
+      }
+    });
+
+    emitAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "error" } });
+    emitAgentEvent({ runId: "run-1", stream: "item", data: {} });
+
+    stop();
+
+    expect(seen.find((evt) => evt.stream === "lifecycle")?.sessionId).toBe("old-session-id");
+    // Only lifecycle events carry the sessionId; other streams stay unstamped.
+    expect(seen.find((evt) => evt.stream === "item")?.sessionId).toBeUndefined();
+  });
+
+  test("refreshes the stamped sessionId when run context is re-registered (#88538)", () => {
+    registerAgentRunContext("run-1", { sessionKey: "main", sessionId: "start-id" });
+    // Callers that already persisted a rotation can re-register the new owner.
+    registerAgentRunContext("run-1", { sessionId: "rotated-id" });
+    let stamped: string | undefined;
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-1" && evt.stream === "lifecycle") {
+        stamped = evt.sessionId;
+      }
+    });
+
+    emitAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "end" } });
+
+    stop();
+    // Terminal event carries the rotated id, so persistence won't treat the
+    // run as stale against the row it rotated to.
+    expect(stamped).toBe("rotated-id");
+  });
+
   test("maintains monotonic seq per runId", () => {
     const seen: Record<string, number[]> = {};
     const stop = onAgentEvent((evt) => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -106,11 +106,19 @@ export type AgentEventPayload = {
   ts: number;
   data: Record<string, unknown>;
   sessionKey?: string;
+  /**
+   * sessionId the run was bound to when it started. Lifecycle persistence uses
+   * this to reject terminal events from a pre-`sessions.reset` run that would
+   * otherwise clobber the rotated session row resolved by the shared sessionKey.
+   */
+  sessionId?: string;
   agentId?: string;
 };
 
 export type AgentRunContext = {
   sessionKey?: string;
+  /** Owning run's sessionId; stamped onto lifecycle events (see AgentEventPayload.sessionId). */
+  sessionId?: string;
   verboseLevel?: VerboseLevel;
   isHeartbeat?: boolean;
   /** Whether control UI clients should receive chat/agent updates for this run. */
@@ -152,6 +160,9 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   }
   if (context.sessionKey && existing.sessionKey !== context.sessionKey) {
     existing.sessionKey = context.sessionKey;
+  }
+  if (context.sessionId && existing.sessionId !== context.sessionId) {
+    existing.sessionId = context.sessionId;
   }
   if (context.verboseLevel && existing.verboseLevel !== context.verboseLevel) {
     existing.verboseLevel = context.verboseLevel;
@@ -226,9 +237,14 @@ export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
   // stream remains redacted for hidden runs because it is observational only.
   const preserveSessionKey = isControlUiVisible || event.stream === "lifecycle";
   const sessionKey = preserveSessionKey ? (eventSessionKey ?? context?.sessionKey) : undefined;
+  // Stamp lifecycle events with the owning sessionId (see AgentEventPayload) at
+  // emit time, since the run context can be cleared before the terminal persists.
+  const sessionId =
+    event.stream === "lifecycle" ? (event.sessionId ?? context?.sessionId) : event.sessionId;
   const enriched: AgentEventPayload = {
     ...event,
     sessionKey,
+    ...(sessionId ? { sessionId } : {}),
     seq: nextSeq,
     ts: Date.now(),
   };


### PR DESCRIPTION
## Summary

- Recreates #88583 as a maintainer branch because the contributor branch could not be pushed from this environment despite `maintainerCanModify=true`.
- Stamps the owning run `sessionId` onto lifecycle events, rejects stale persistence when `sessions.reset` rotated the row, and applies the same stale guard to `sessions.changed` snapshot projection.
- Refreshes followup run-context registration after preflight compaction so legitimate rotated sessions are not treated as stale.

Fixes #88538.
Replaces #88583.

## Verification

Behavior addressed: stale lifecycle `start`/`end`/`error` events from a pre-reset run no longer mutate or project status onto the fresh post-reset session row.

Real environment tested: local source tests on the maintainer branch, plus branch-level Codex autoreview.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/session-lifecycle-state.test.ts src/infra/agent-events.test.ts src/gateway/server-chat.agent-events.test.ts src/auto-reply/reply/followup-runner.test.ts`; `pnpm exec oxfmt --check src/agents/embedded-agent-runner/run.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/followup-runner.test.ts src/gateway/server-chat.ts src/gateway/server-chat.agent-events.test.ts src/gateway/session-lifecycle-state.ts src/gateway/session-lifecycle-state.test.ts src/infra/agent-events.ts src/infra/agent-events.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: Vitest passed 3 shards: gateway 93 tests, infra 14 tests, auto-reply 64 tests. oxfmt check passed. Autoreview reported clean: no accepted/actionable findings.

Observed result after fix: stale lifecycle events with mismatched owning/current session ids are skipped for persistence and keep subscriber snapshots on the current row state; matching/unknown session ids preserve existing behavior; preflight-compacted followups stamp the post-preflight session id.

What was not tested: full live Slack race on the reporter deployment. `pnpm tsgo:core` was attempted but currently fails in untouched `src/infra/device-auth-store.ts` with TS2322 on `Record<string, unknown>` vs `Record<string, DeviceAuthEntry>`.
