### PR TITLE
fix(cli): keep json startup output free of progress glyphs

### DIFF
--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -19,6 +19,23 @@ function withStdinIsRaw<T>(isRaw: boolean, run: () => T): T {
   }
 }
 
+function withStdoutIsTty<T>(isTty: boolean, run: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value: isTty,
+  });
+  try {
+    return run();
+  } finally {
+    if (original) {
+      Object.defineProperty(process.stdout, "isTTY", original);
+    } else {
+      Reflect.deleteProperty(process.stdout, "isTTY");
+    }
+  }
+}
+
 describe("cli progress", () => {
   it("logs progress when non-tty and fallback=log", () => {
     const writes: string[] = [];
@@ -73,9 +90,43 @@ describe("cli progress", () => {
     expect(
       shouldUseInteractiveProgressSpinner({
         streamIsTty: true,
+        stdoutIsTty: true,
         stdinIsRaw: false,
       }),
     ).toBe(true);
+  });
+
+  it("does not use the interactive spinner when stdout is not tty-safe", () => {
+    expect(
+      shouldUseInteractiveProgressSpinner({
+        streamIsTty: true,
+        stdoutIsTty: false,
+        stdinIsRaw: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not emit default tty progress when stdout is piped", () => {
+    const writes: string[] = [];
+    const stream = {
+      isTTY: true,
+      write: vi.fn((chunk: string) => {
+        writes.push(chunk);
+      }),
+    } as unknown as NodeJS.WriteStream;
+
+    withStdoutIsTty(false, () => {
+      const progress = createCliProgress({
+        label: "Scanning",
+        total: 2,
+        stream,
+      });
+      progress.setLabel("Still scanning");
+      progress.tick();
+      progress.done();
+    });
+
+    expect(writes).toStrictEqual([]);
   });
 
   it("does not write terminal controls when raw TUI input suppresses the default spinner", () => {
@@ -114,20 +165,22 @@ describe("cli progress", () => {
       write: vi.fn(),
     } as unknown as NodeJS.WriteStream;
 
-    const delayed = createCliProgress({
-      label: "Delayed",
-      stream: firstStream,
-      fallback: "line",
-      delayMs: 10_000,
-    });
-    delayed.done();
+    withStdoutIsTty(true, () => {
+      const delayed = createCliProgress({
+        label: "Delayed",
+        stream: firstStream,
+        fallback: "line",
+        delayMs: 10_000,
+      });
+      delayed.done();
 
-    const next = createCliProgress({
-      label: "Next",
-      stream: secondStream,
-      fallback: "line",
+      const next = createCliProgress({
+        label: "Next",
+        stream: secondStream,
+        fallback: "line",
+      });
+      next.done();
     });
-    next.done();
 
     expect(firstWrites).toStrictEqual([]);
   });
@@ -139,13 +192,15 @@ describe("cli progress", () => {
     } as unknown as NodeJS.WriteStream;
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      const progress = createCliProgress({
-        label: "Delayed",
-        stream,
-        fallback: "line",
-        delayMs: Number.MAX_SAFE_INTEGER,
+      withStdoutIsTty(true, () => {
+        const progress = createCliProgress({
+          label: "Delayed",
+          stream,
+          fallback: "line",
+          delayMs: Number.MAX_SAFE_INTEGER,
+        });
+        progress.done();
       });
-      progress.done();
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     } finally {

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -40,10 +40,17 @@ export type ProgressTotalsUpdate = {
 export function shouldUseInteractiveProgressSpinner(params: {
   fallback?: ProgressOptions["fallback"];
   streamIsTty?: boolean;
+  stdoutIsTty?: boolean;
   stdinIsRaw?: boolean;
 }): boolean {
   const spinnerRequested = params.fallback === undefined || params.fallback === "spinner";
-  return spinnerRequested && params.streamIsTty === true && params.stdinIsRaw !== true;
+  const stdoutIsTty = params.stdoutIsTty ?? true;
+  return (
+    spinnerRequested &&
+    params.streamIsTty === true &&
+    stdoutIsTty === true &&
+    params.stdinIsRaw !== true
+  );
 }
 
 const noopReporter: ProgressReporter = {
@@ -63,21 +70,27 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
 
   const stream = options.stream ?? process.stderr;
   const isTty = stream.isTTY;
+  const stdoutIsTty = process.stdout.isTTY === true;
   const allowLog = !isTty && options.fallback === "log";
   if (!isTty && !allowLog) {
     return noopReporter;
   }
 
   const delayMs = resolveTimerTimeoutMs(options.delayMs, DEFAULT_DELAY_MS, 0);
-  const canOsc = isTty && supportsOscProgress(process.env, isTty);
+  const canUseInteractiveOutput = isTty && stdoutIsTty;
+  const canOsc = canUseInteractiveOutput && supportsOscProgress(process.env, isTty);
   const stdinIsRaw = process.stdin.isRaw;
   const allowSpinner = shouldUseInteractiveProgressSpinner({
     fallback: options.fallback,
     streamIsTty: isTty,
+    stdoutIsTty,
     stdinIsRaw,
   });
-  const allowLine = isTty && options.fallback === "line";
+  const allowLine = canUseInteractiveOutput && options.fallback === "line";
   if (isTty && stdinIsRaw && (options.fallback === undefined || options.fallback === "spinner")) {
+    return noopReporter;
+  }
+  if (!canOsc && !allowSpinner && !allowLine && !allowLog) {
     return noopReporter;
   }
 
@@ -102,7 +115,7 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
       })
     : null;
 
-  const spin = allowSpinner ? spinner() : null;
+  const spin = allowSpinner ? spinner({ output: stream }) : null;
   const renderLine = allowLine
     ? () => {
         if (!started) {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -379,7 +379,28 @@ describe("runCli exit behavior", () => {
       label: "Loading OpenClaw CLI…",
       indeterminate: true,
       delayMs: 0,
+      enabled: true,
     });
+    expect(progressDoneMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables startup progress for full CLI json output", async () => {
+    tryRouteCliMock.mockResolvedValueOnce(false);
+    const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
+    buildProgramMock.mockReturnValueOnce({
+      commands: [{ name: () => "mcp", aliases: () => [] }],
+      parseAsync,
+    });
+
+    await runCli(["node", "openclaw", "mcp", "list", "--json"]);
+
+    expect(createCliProgressMock).toHaveBeenCalledWith({
+      label: "Loading OpenClaw CLI…",
+      indeterminate: true,
+      delayMs: 0,
+      enabled: false,
+    });
+    expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "mcp", "list", "--json"]);
     expect(progressDoneMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -747,6 +747,7 @@ export async function runCli(argv: string[] = process.argv) {
       label: "Loading OpenClaw CLI…",
       indeterminate: true,
       delayMs: 0,
+      enabled: !hasJsonOutputFlag(normalizedArgv),
     });
     let startupProgressStopped = false;
     const stopStartupProgress = () => {


### PR DESCRIPTION
Fixes #88602

## Summary

This keeps startup/progress UI out of machine-readable CLI output.

- disables the global full-CLI startup progress reporter whenever the invocation includes `--json` before `--`
- requires stdout to be TTY-safe before enabling interactive Clack spinner/line/OSC progress output, because Clack can otherwise write terminal glyphs into stdout
- passes OpenClaw's selected progress stream into `spinner({ output })` instead of relying on Clack's stdout default
- adds regression coverage for JSON startup progress suppression and piped stdout progress safety

## Real behavior proof

**Behavior addressed:** Full CLI invocations that produce JSON, such as non-route-first `--json` commands, could start global Clack progress before Commander parsed the command. Clack's spinner defaults to stdout, so terminal glyphs could appear before the JSON payload and break parsers like `jq`.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, PR HEAD `87f2c9731b8094c3bfb9122f81b8d5a21346ac36` based on upstream main `44512b5297b16abc1e5f4976b8987f2f1ad15042`.

**Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs \
  src/cli/progress.test.ts \
  src/cli/run-main.exit.test.ts \
  src/cli/json-output-mode.test.ts \
  src/cli/program/routes.test.ts \
  test/cli-json-stdout.e2e.test.ts

node --import tsx --input-type=module -e 'import { createCliProgress } from "./src/cli/progress.ts"; const desc=Object.getOwnPropertyDescriptor(process.stdout,"isTTY"); Object.defineProperty(process.stdout,"isTTY",{configurable:true,value:false}); const writes=[]; const stream={isTTY:true, write(chunk){writes.push(String(chunk)); return true;}}; const progress=createCliProgress({label:"Loading OpenClaw CLI...", indeterminate:true, delayMs:0, stream}); progress.setLabel("Still loading"); progress.done(); if(desc) Object.defineProperty(process.stdout,"isTTY",desc); else Reflect.deleteProperty(process.stdout,"isTTY"); console.log(JSON.stringify({writes:writes.length, output:writes.join("")}));'

git diff --check
```

**Evidence after fix:**

```text
$ node scripts/run-vitest.mjs src/cli/progress.test.ts src/cli/run-main.exit.test.ts src/cli/json-output-mode.test.ts src/cli/program/routes.test.ts test/cli-json-stdout.e2e.test.ts

Test Files  1 passed (1)
Tests       3 passed (3)

Test Files  3 passed (3)
Tests       136 passed (136)

Test Files  1 passed (1)
Tests       1 passed (1)

[test] passed 3 Vitest shards in 28.96s
```

```text
$ node --import tsx --input-type=module -e '...createCliProgress piped stdout check...'
{"writes":0,"output":""}
```

`src/cli/run-main.exit.test.ts` now verifies that `openclaw mcp list --json` reaches the full CLI path with startup progress created as `enabled: false`. `src/cli/progress.test.ts` verifies that even if the progress stream itself is TTY-like, default interactive progress writes nothing when stdout is piped.

**Observed result after fix:** JSON-mode full CLI startup no longer starts progress UI. Progress output is also suppressed when stdout is not TTY-safe, and Clack spinner output is explicitly bound to the configured progress stream when it is allowed.

**What was not tested:** A real interactive PTY recording of `openclaw mcp list --json | jq`. The production command path is covered by `runCli` tests and the stdout-pipe safety behavior is exercised directly against the real `createCliProgress` implementation.
