### PR TITLE
fix: scope plugin tools and async media starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/media: keep async image, music, and video generation starts from ending the Codex turn, so mixed requests can continue with summaries or other work while media renders in the background.
 - Agents/Codex: keep public OpenAI API-key profiles from being treated as native Codex app-server auth while preserving persisted Codex OAuth sessions.
 - Control UI: keep collapsed tool cards labeled with the tool name and action instead of generic output text. Thanks @shakkernerd.
 - Agents/Codex: surface Skill Workshop guidance in Codex app-server prompts when `skill_workshop` is available. Thanks @shakkernerd.

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -8,6 +8,7 @@ import {
   handleDynamicToolCallWithTimeout,
   resolveDynamicToolCallTimeoutMs,
   resolveTerminalDynamicToolBatchAction,
+  shouldBlockTerminalReleaseForNonTerminalDynamicToolResult,
   shouldReleaseTurnAfterTerminalDynamicTool,
   toCodexDynamicToolProgressResponse,
   toCodexDynamicToolProtocolResponse,
@@ -362,5 +363,27 @@ describe("dynamic tool execution helpers", () => {
         hasPendingTerminalDynamicToolRelease: true,
       }),
     ).toBe("release-pending-terminal");
+  });
+
+  it("does not let async-start tool results block terminal side-effect batches", () => {
+    const asyncStartedResponse = {
+      contentItems: [{ type: "inputText" as const, text: "Background task started." }],
+      success: true,
+    };
+    Object.defineProperty(asyncStartedResponse, "asyncStarted", {
+      configurable: true,
+      enumerable: false,
+      value: true,
+    });
+
+    expect(shouldBlockTerminalReleaseForNonTerminalDynamicToolResult(asyncStartedResponse)).toBe(
+      false,
+    );
+    expect(
+      shouldBlockTerminalReleaseForNonTerminalDynamicToolResult({
+        contentItems: [{ type: "inputText", text: "regular output" }],
+        success: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -250,6 +250,12 @@ export function shouldReleaseTurnAfterTerminalDynamicTool(
   );
 }
 
+export function shouldBlockTerminalReleaseForNonTerminalDynamicToolResult(
+  response: CodexDynamicToolCallResponse,
+): boolean {
+  return response.asyncStarted !== true;
+}
+
 export type TerminalDynamicToolBatchAction =
   | "idle"
   | "wait"

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -158,6 +158,7 @@ import {
   isMatchingDynamicToolTerminalDiagnostic,
   resolveDynamicToolCallTimeoutMs,
   resolveTerminalDynamicToolBatchAction,
+  shouldBlockTerminalReleaseForNonTerminalDynamicToolResult,
   shouldReleaseTurnAfterTerminalDynamicTool,
   toCodexDynamicToolProgressResponse,
   toCodexDynamicToolProtocolResponse,
@@ -1595,6 +1596,8 @@ export async function runCodexAppServerAttempt(
             response,
             durationMs: toolDurationMs,
           });
+        } else if (!shouldBlockTerminalReleaseForNonTerminalDynamicToolResult(response)) {
+          scheduleTerminalDynamicToolReleaseCheck();
         } else {
           currentTurnHadNonTerminalDynamicToolResult = true;
           pendingTerminalDynamicToolRelease = undefined;

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1589,8 +1589,8 @@ export async function runCodexAppServerAttempt(
             durationMs: toolDurationMs,
           });
         }
+        pendingOpenClawDynamicToolCompletionIds.delete(call.callId);
         if (response.terminate === true) {
-          pendingOpenClawDynamicToolCompletionIds.delete(call.callId);
           scheduleTurnReleaseAfterTerminalDynamicTool({
             call,
             response,
@@ -1604,6 +1604,7 @@ export async function runCodexAppServerAttempt(
         }
         return protocolResponse as JsonValue;
       } catch (error) {
+        pendingOpenClawDynamicToolCompletionIds.delete(call.callId);
         if (
           !terminalDiagnosticObserved &&
           !hasPendingDynamicToolTerminalDiagnostic({

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -49,6 +49,7 @@ const rawSqliteAllowPathGroups = {
     "src/acp/event-ledger.ts",
     "src/agents/subagent-registry.store.ts",
     "src/cron/run-log.ts",
+    "src/cron/run-log/sqlite-store.ts",
     "src/cron/store.ts",
     "src/infra/outbound/current-conversation-bindings.ts",
     "src/media/store.ts",

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -758,7 +758,7 @@ describe("createImageGenerateTool", () => {
     expect(details.async).toBe(true);
     expect(details.status).toBe("started");
     expect(details.taskId).toBe("task-image-123");
-    expect((result as { terminate?: boolean }).terminate).toBe(true);
+    expect((result as { terminate?: boolean }).terminate).toBeUndefined();
     expect(taskRuntimeMocks.createRunningTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
         taskKind: "image_generation",

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -331,7 +331,6 @@ export function buildMediaGenerationStartedToolResult(params: {
         : {}),
       ...params.detailExtras,
     },
-    terminate: true,
   };
 }
 

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -629,7 +629,7 @@ describe("createMusicGenerateTool", () => {
       applied: 120_000,
       minimum: 120_000,
     });
-    expect((result as { terminate?: boolean }).terminate).toBe(true);
+    expect((result as { terminate?: boolean }).terminate).toBeUndefined();
     if (!scheduledWork) {
       throw new Error("expected scheduled music generation work");
     }

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -933,7 +933,7 @@ describe("createVideoGenerateTool", () => {
     expect(details.async).toBe(true);
     expect(details.status).toBe("started");
     expect((details.task as { taskId?: string }).taskId).toBe("task-123");
-    expect((result as { terminate?: boolean }).terminate).toBe(true);
+    expect((result as { terminate?: boolean }).terminate).toBeUndefined();
     if (!scheduledWork) {
       throw new Error("expected scheduled video generation work");
     }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -668,8 +668,11 @@ describe("resolvePluginTools optional tools", () => {
     const observed: Array<{ phase: string; pluginId?: string }> = [];
 
     class AccessorTool {
+      #name = "class_tool";
+      #parameters = { type: "object", properties: {} };
+
       get name() {
-        return "class_tool";
+        return this.#name;
       }
 
       get description() {
@@ -677,7 +680,7 @@ describe("resolvePluginTools optional tools", () => {
       }
 
       get parameters() {
-        return { type: "object", properties: {} };
+        return this.#parameters;
       }
 
       prepareArguments(args: unknown) {

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -663,6 +663,61 @@ describe("resolvePluginTools optional tools", () => {
     ]);
   });
 
+  it("preserves class-backed plugin tool shape while scoping callbacks", async () => {
+    const context = createContext();
+    const observed: Array<{ phase: string; pluginId?: string }> = [];
+
+    class AccessorTool {
+      get name() {
+        return "class_tool";
+      }
+
+      get description() {
+        return "class backed tool";
+      }
+
+      get parameters() {
+        return { type: "object", properties: {} };
+      }
+
+      prepareArguments(args: unknown) {
+        observed.push({
+          phase: "prepare",
+          pluginId: getPluginRuntimeGatewayRequestScope()?.pluginId,
+        });
+        return args;
+      }
+
+      async execute() {
+        observed.push({
+          phase: "execute",
+          pluginId: getPluginRuntimeGatewayRequestScope()?.pluginId,
+        });
+        return { content: [{ type: "text", text: "ok" }] };
+      }
+    }
+
+    setRegistry([
+      {
+        pluginId: "multi",
+        optional: false,
+        source: "/tmp/multi.js",
+        names: ["class_tool"],
+        factory: () => new AccessorTool(),
+      },
+    ]);
+
+    const [tool] = resolvePluginTools(createResolveToolsParams({ context }));
+    expect(tool?.name).toBe("class_tool");
+    expect(Object.getPrototypeOf(tool)).toBe(AccessorTool.prototype);
+    await tool?.execute("call-class", tool.prepareArguments?.({}) ?? {}, undefined);
+
+    expect(observed).toEqual([
+      { phase: "prepare", pluginId: "multi" },
+      { phase: "execute", pluginId: "multi" },
+    ]);
+  });
+
   it("does not load plugin-owned tools whose manifest metadata has no available signal", () => {
     const config = createContext().config;
     installToolManifestSnapshot({

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -40,6 +40,8 @@ let resetPluginRuntimeStateForTest: typeof import("./runtime.js").resetPluginRun
 let setActivePluginRegistry: typeof import("./runtime.js").setActivePluginRegistry;
 let clearCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
 let setCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-snapshot.js").setCurrentPluginMetadataSnapshot;
+let getPluginRuntimeGatewayRequestScope: typeof import("./runtime/gateway-request-scope.js").getPluginRuntimeGatewayRequestScope;
+let withPluginRuntimeGatewayRequestScope: typeof import("./runtime/gateway-request-scope.js").withPluginRuntimeGatewayRequestScope;
 
 function makeTool(name: string) {
   return {
@@ -480,6 +482,8 @@ describe("resolvePluginTools optional tools", () => {
       resetPluginRuntimeStateForTest,
       setActivePluginRegistry,
     } = await import("./runtime.js"));
+    ({ getPluginRuntimeGatewayRequestScope, withPluginRuntimeGatewayRequestScope } =
+      await import("./runtime/gateway-request-scope.js"));
     ({ clearCurrentPluginMetadataSnapshot, setCurrentPluginMetadataSnapshot } =
       await import("./current-plugin-metadata-snapshot.js"));
   });
@@ -508,6 +512,155 @@ describe("resolvePluginTools optional tools", () => {
     loggingState.rawConsole = null;
     resetLogger();
     vi.useRealTimers();
+  });
+
+  it("runs plugin tool factories, prepare callbacks, and execute callbacks under the owning plugin scope", async () => {
+    const context = createContext();
+    const observed: Array<{
+      phase: "factory" | "prepare" | "execute";
+      pluginId?: string;
+      pluginSource?: string;
+    }> = [];
+
+    setRegistry(
+      ["multi", "optional-demo"].map((pluginId) => ({
+        pluginId,
+        optional: false,
+        source: `/tmp/${pluginId}.js`,
+        names: [`${pluginId}_tool`],
+        factory: () => {
+          const scope = getPluginRuntimeGatewayRequestScope();
+          observed.push({
+            phase: "factory",
+            pluginId: scope?.pluginId,
+            pluginSource: scope?.pluginSource,
+          });
+          return {
+            name: `${pluginId}_tool`,
+            description: `${pluginId} tool`,
+            parameters: { type: "object", properties: {} },
+            prepareArguments(args: unknown) {
+              const prepareScope = getPluginRuntimeGatewayRequestScope();
+              observed.push({
+                phase: "prepare",
+                pluginId: prepareScope?.pluginId,
+                pluginSource: prepareScope?.pluginSource,
+              });
+              return args;
+            },
+            async execute() {
+              const executeScope = getPluginRuntimeGatewayRequestScope();
+              observed.push({
+                phase: "execute",
+                pluginId: executeScope?.pluginId,
+                pluginSource: executeScope?.pluginSource,
+              });
+              return { content: [{ type: "text", text: pluginId }] };
+            },
+          };
+        },
+      })),
+    );
+
+    await withPluginRuntimeGatewayRequestScope(
+      {
+        pluginId: "outer",
+        pluginSource: "/tmp/outer.js",
+        isWebchatConnect: () => false,
+      },
+      async () => {
+        const tools = resolvePluginTools(createResolveToolsParams({ context }));
+        expect(tools.map((tool) => tool.name)).toEqual(["multi_tool", "optional-demo_tool"]);
+        for (const tool of tools) {
+          await tool.execute(`call-${tool.name}`, tool.prepareArguments?.({}) ?? {}, undefined);
+          expect(getPluginRuntimeGatewayRequestScope()).toMatchObject({
+            pluginId: "outer",
+            pluginSource: "/tmp/outer.js",
+          });
+        }
+      },
+    );
+
+    expect(getPluginRuntimeGatewayRequestScope()).toBeUndefined();
+    expect(observed).toEqual([
+      { phase: "factory", pluginId: "multi", pluginSource: "/tmp/multi.js" },
+      {
+        phase: "factory",
+        pluginId: "optional-demo",
+        pluginSource: "/tmp/optional-demo.js",
+      },
+      { phase: "prepare", pluginId: "multi", pluginSource: "/tmp/multi.js" },
+      { phase: "execute", pluginId: "multi", pluginSource: "/tmp/multi.js" },
+      {
+        phase: "prepare",
+        pluginId: "optional-demo",
+        pluginSource: "/tmp/optional-demo.js",
+      },
+      {
+        phase: "execute",
+        pluginId: "optional-demo",
+        pluginSource: "/tmp/optional-demo.js",
+      },
+    ]);
+  });
+
+  it("wraps every array tool callback and restores caller scope after errors", async () => {
+    const context = createContext();
+    const observed: Array<{ name: string; pluginId?: string; pluginSource?: string }> = [];
+    setRegistry([
+      {
+        pluginId: "multi",
+        optional: false,
+        source: "/tmp/multi.js",
+        names: ["array_first", "array_second"],
+        factory: () =>
+          ["array_first", "array_second"].map((name) => ({
+            name,
+            description: `${name} tool`,
+            parameters: { type: "object", properties: {} },
+            prepareArguments() {
+              const scope = getPluginRuntimeGatewayRequestScope();
+              observed.push({ name: `${name}:prepare`, pluginId: scope?.pluginId });
+              if (name === "array_second") {
+                throw new Error("bad args");
+              }
+              return {};
+            },
+            async execute() {
+              const scope = getPluginRuntimeGatewayRequestScope();
+              observed.push({
+                name,
+                pluginId: scope?.pluginId,
+                pluginSource: scope?.pluginSource,
+              });
+              return { content: [{ type: "text", text: name }] };
+            },
+          })),
+      },
+    ]);
+
+    await withPluginRuntimeGatewayRequestScope(
+      {
+        pluginId: "outer",
+        pluginSource: "/tmp/outer.js",
+        isWebchatConnect: () => false,
+      },
+      async () => {
+        const tools = resolvePluginTools(createResolveToolsParams({ context }));
+        await tools[0]?.execute("call-first", tools[0].prepareArguments?.({}) ?? {}, undefined);
+        expect(() => tools[1]?.prepareArguments?.({})).toThrow("bad args");
+        expect(getPluginRuntimeGatewayRequestScope()).toMatchObject({
+          pluginId: "outer",
+          pluginSource: "/tmp/outer.js",
+        });
+      },
+    );
+
+    expect(observed).toEqual([
+      { name: "array_first:prepare", pluginId: "multi" },
+      { name: "array_first", pluginId: "multi", pluginSource: "/tmp/multi.js" },
+      { name: "array_second:prepare", pluginId: "multi" },
+    ]);
   });
 
   it("does not load plugin-owned tools whose manifest metadata has no available signal", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -116,35 +116,53 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
   }
 
   const prepareArguments = tool.prepareArguments;
-  const descriptors = Object.getOwnPropertyDescriptors(tool);
-  delete descriptors.execute;
-  delete descriptors.prepareArguments;
-  const wrapped = Object.create(Object.getPrototypeOf(tool)) as AnyAgentTool;
-  Object.defineProperties(wrapped, descriptors);
-  if (prepareArguments) {
-    Object.defineProperty(wrapped, "prepareArguments", {
-      configurable: true,
-      enumerable: Object.prototype.propertyIsEnumerable.call(tool, "prepareArguments"),
-      value(args: unknown) {
-        return runWithPluginToolScope(entry, () => Reflect.apply(prepareArguments, tool, [args]));
-      },
-      writable: true,
-    });
-  }
-  Object.defineProperty(wrapped, "execute", {
-    configurable: true,
-    enumerable: Object.prototype.propertyIsEnumerable.call(tool, "execute"),
-    value(toolCallId: string, params: unknown, signal?: AbortSignal, onUpdate?: unknown) {
-      return runWithPluginToolScope(
-        entry,
-        () =>
-          Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
-            AnyAgentTool["execute"]
-          >,
-      );
+  const scopedPrepareArguments = prepareArguments
+    ? (args: unknown) =>
+        runWithPluginToolScope(entry, () => Reflect.apply(prepareArguments, tool, [args]))
+    : undefined;
+  const scopedExecute = (
+    toolCallId: string,
+    params: unknown,
+    signal?: AbortSignal,
+    onUpdate?: unknown,
+  ) =>
+    runWithPluginToolScope(
+      entry,
+      () =>
+        Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
+          AnyAgentTool["execute"]
+        >,
+    );
+  const wrapped = new Proxy(tool, {
+    get(target, prop) {
+      if (prop === "prepareArguments" && scopedPrepareArguments) {
+        return scopedPrepareArguments;
+      }
+      if (prop === "execute") {
+        return scopedExecute;
+      }
+      return Reflect.get(target, prop, target);
     },
-    writable: true,
-  });
+    getOwnPropertyDescriptor(target, prop) {
+      if (prop === "prepareArguments" && scopedPrepareArguments) {
+        return {
+          configurable: true,
+          enumerable: Object.prototype.propertyIsEnumerable.call(target, prop),
+          value: scopedPrepareArguments,
+          writable: true,
+        };
+      }
+      if (prop === "execute") {
+        return {
+          configurable: true,
+          enumerable: Object.prototype.propertyIsEnumerable.call(target, prop),
+          value: scopedExecute,
+          writable: true,
+        };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+  }) as AnyAgentTool;
 
   copyPluginToolMeta(tool, wrapped);
   const nextScopedByKey = scopedByKey ?? new Map<string, AnyAgentTool>();

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -133,7 +133,7 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
           AnyAgentTool["execute"]
         >,
     );
-  const wrapped = new Proxy(tool, {
+  const wrapped = new Proxy<AnyAgentTool>(tool, {
     get(target, prop) {
       if (prop === "prepareArguments" && scopedPrepareArguments) {
         return scopedPrepareArguments;
@@ -162,7 +162,7 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
       }
       return Reflect.getOwnPropertyDescriptor(target, prop);
     },
-  }) as AnyAgentTool;
+  });
 
   copyPluginToolMeta(tool, wrapped);
   const nextScopedByKey = scopedByKey ?? new Map<string, AnyAgentTool>();

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -116,18 +116,25 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
   }
 
   const prepareArguments = tool.prepareArguments;
-  const wrapped: AnyAgentTool = {
-    ...tool,
-    ...(prepareArguments
-      ? {
-          prepareArguments(args) {
-            return runWithPluginToolScope(entry, () =>
-              Reflect.apply(prepareArguments, tool, [args]),
-            );
-          },
-        }
-      : {}),
-    execute(toolCallId, params, signal, onUpdate) {
+  const descriptors = Object.getOwnPropertyDescriptors(tool);
+  delete descriptors.execute;
+  delete descriptors.prepareArguments;
+  const wrapped = Object.create(Object.getPrototypeOf(tool)) as AnyAgentTool;
+  Object.defineProperties(wrapped, descriptors);
+  if (prepareArguments) {
+    Object.defineProperty(wrapped, "prepareArguments", {
+      configurable: true,
+      enumerable: Object.prototype.propertyIsEnumerable.call(tool, "prepareArguments"),
+      value(args: unknown) {
+        return runWithPluginToolScope(entry, () => Reflect.apply(prepareArguments, tool, [args]));
+      },
+      writable: true,
+    });
+  }
+  Object.defineProperty(wrapped, "execute", {
+    configurable: true,
+    enumerable: Object.prototype.propertyIsEnumerable.call(tool, "execute"),
+    value(toolCallId: string, params: unknown, signal?: AbortSignal, onUpdate?: unknown) {
       return runWithPluginToolScope(
         entry,
         () =>
@@ -136,7 +143,8 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
           >,
       );
     },
-  };
+    writable: true,
+  });
 
   copyPluginToolMeta(tool, wrapped);
   const nextScopedByKey = scopedByKey ?? new Map<string, AnyAgentTool>();

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -18,6 +18,7 @@ import type { PluginManifestRecord } from "./manifest-registry.js";
 import { hasManifestToolAvailability } from "./manifest-tool-availability.js";
 import type { PluginMetadataManifestView } from "./plugin-metadata-snapshot.types.js";
 import type { PluginRegistry, PluginToolRegistration } from "./registry-types.js";
+import { withPluginRuntimePluginScope } from "./runtime/gateway-request-scope.js";
 import {
   buildPluginRuntimeLoadOptions,
   resolvePluginRuntimeLoadContext,
@@ -66,6 +67,7 @@ const PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS = 1_000;
 const PLUGIN_TOOL_FACTORY_SUMMARY_LIMIT = 20;
 
 const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
+const scopedPluginTools = new WeakMap<AnyAgentTool, Map<string, AnyAgentTool>>();
 
 export function setPluginToolMeta(tool: AnyAgentTool, meta: PluginToolMeta): void {
   pluginToolMeta.set(tool, meta);
@@ -80,6 +82,83 @@ export function copyPluginToolMeta(source: AnyAgentTool, target: AnyAgentTool): 
   if (meta) {
     pluginToolMeta.set(target, meta);
   }
+}
+
+function pluginToolScopeKey(entry: PluginToolRegistration): string {
+  return JSON.stringify([entry.pluginId, entry.source]);
+}
+
+function runWithPluginToolScope<T>(entry: PluginToolRegistration, run: () => T): T {
+  return withPluginRuntimePluginScope(
+    {
+      pluginId: entry.pluginId,
+      ...(entry.source ? { pluginSource: entry.source } : {}),
+    },
+    run,
+  );
+}
+
+function isAgentTool(value: unknown): value is AnyAgentTool {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as { execute?: unknown }).execute === "function"
+  );
+}
+
+function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTool): AnyAgentTool {
+  const key = pluginToolScopeKey(entry);
+  const scopedByKey = scopedPluginTools.get(tool);
+  const cached = scopedByKey?.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const prepareArguments = tool.prepareArguments;
+  const wrapped: AnyAgentTool = {
+    ...tool,
+    ...(prepareArguments
+      ? {
+          prepareArguments(args) {
+            return runWithPluginToolScope(entry, () =>
+              Reflect.apply(prepareArguments, tool, [args]),
+            );
+          },
+        }
+      : {}),
+    execute(toolCallId, params, signal, onUpdate) {
+      return runWithPluginToolScope(
+        entry,
+        () =>
+          Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
+            AnyAgentTool["execute"]
+          >,
+      );
+    },
+  };
+
+  copyPluginToolMeta(tool, wrapped);
+  const nextScopedByKey = scopedByKey ?? new Map<string, AnyAgentTool>();
+  nextScopedByKey.set(key, wrapped);
+  scopedPluginTools.set(tool, nextScopedByKey);
+  return wrapped;
+}
+
+function wrapPluginToolFactoryResult(
+  entry: PluginToolRegistration,
+  result: PluginToolFactoryResult,
+): PluginToolFactoryResult {
+  if (Array.isArray(result)) {
+    return result.map((tool) => (isAgentTool(tool) ? wrapPluginToolCallbacks(entry, tool) : tool));
+  }
+  return isAgentTool(result) ? wrapPluginToolCallbacks(entry, result) : result;
+}
+
+function resolvePluginToolFactory(entry: PluginToolRegistration, ctx: OpenClawPluginToolContext) {
+  return runWithPluginToolScope(entry, () =>
+    wrapPluginToolFactoryResult(entry, entry.factory(ctx)),
+  );
 }
 
 /**
@@ -263,7 +342,7 @@ function resolvePluginToolFactoryEntry(params: {
   const factoryStartedAt = Date.now();
 
   try {
-    resolved = params.entry.factory(params.ctx);
+    resolved = resolvePluginToolFactory(params.entry, params.ctx);
   } catch (err) {
     failed = true;
     params.logError(`plugin tool failed (${params.entry.pluginId}): ${String(err)}`);
@@ -574,7 +653,7 @@ function createCachedDescriptorPluginTool(params: {
       const resolveCandidateTool = (
         candidate: PluginToolRegistration,
       ): AnyAgentTool | undefined => {
-        const resolved = candidate.factory(params.ctx);
+        const resolved = resolvePluginToolFactory(candidate, params.ctx);
         const listRaw: unknown[] = Array.isArray(resolved) ? resolved : resolved ? [resolved] : [];
         for (const toolRaw of listRaw) {
           const malformedReason = describeMalformedPluginTool(toolRaw);


### PR DESCRIPTION
## Summary
- Scope plugin tool factory resolution plus `prepareArguments` and `execute` callbacks using the owning `PluginToolRegistration` metadata, including cached descriptor execution.
- Preserve class-backed/proxy-like plugin tool shape while intercepting only `prepareArguments` and `execute`.
- Replace the deep extension-import regression shape from #87829 with fixture-based core tests.
- Unblock current CI by allowlisting the cron run-log SQLite submodule in the existing Kysely-backed raw SQLite guardrail group.
- Keep async image, music, video, and Codex dynamic media starts from ending or blocking the turn while media continues in the background.

Alternative implementation for #87829. Credit to @vincentkoc for the original report and patch direction.

## Verification
- `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts -- --reporter=verbose` (66 tests passed)
- `node scripts/run-vitest.mjs src/agents/tools/image-generate-tool.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts -- --reporter=verbose` (97 tests passed)
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-execution.test.ts -- --reporter=verbose` (12 tests passed)
- `pnpm lint:plugins:no-extension-test-core-imports`
- `pnpm format:check src/plugins/tools.ts src/plugins/tools.optional.test.ts`
- `pnpm format:check src/agents/tools/media-generate-background-shared.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts`
- `pnpm format:check extensions/codex/src/app-server/dynamic-tool-execution.ts extensions/codex/src/app-server/dynamic-tool-execution.test.ts extensions/codex/src/app-server/run-attempt.ts src/plugins/tools.ts`
- `node scripts/check-kysely-guardrails.mjs`
- `pnpm check:architecture`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean: no accepted/actionable findings)
- PR CI on `ca991f6908e08859562c38a2b330a776e8ae8b07` (merge state `CLEAN`)

## Real behavior proof
Behavior addressed: Plugin tool factories, `prepareArguments`, and `execute` callbacks now run under the owning plugin scope instead of inheriting the caller's current scope; async media generation starts no longer force or block terminal Codex/OpenClaw turn release.
Real environment tested: Local OpenClaw checkout on Node/pnpm repo tooling, branch `codex/plugin-tool-callback-scope-materialization`, commit `ca991f6908e08859562c38a2b330a776e8ae8b07`, plus exact-head PR CI.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts -- --reporter=verbose`; `node scripts/run-vitest.mjs src/agents/tools/image-generate-tool.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts -- --reporter=verbose`; `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-execution.test.ts -- --reporter=verbose`; `pnpm check:architecture`; `pnpm lint:plugins:no-extension-test-core-imports`; `node scripts/check-kysely-guardrails.mjs`.
Evidence after fix: The plugin suite passed 66/66 tests, including owner-scope and private class-backed tool regressions; the media suite passed 97/97 tests; the Codex dynamic-tool suite passed 12/12 tests; local architecture guard passed with `Kysely guardrails OK`; PR CI is clean.
Observed result after fix: Single, array, cached, and class-backed plugin tools preserve their public shape while factory, prepare, and execute run under owner plugin scope; async media starts report `started` without ending or blocking the turn.
What was not tested: A full changed gate on Blacksmith Testbox was attempted twice, but both runs failed during dependency install before project checks; exact-head PR CI supplied the broad proof.
