### PR TITLE
fix(ci): restore cron run-log Kysely guard

### DIFF
--- a/src/cron/run-log/sqlite-store.ts
+++ b/src/cron/run-log/sqlite-store.ts
@@ -1,6 +1,10 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { Insertable, Selectable } from "kysely";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import type { CronRunLogEntry } from "../run-log-types.js";
 import type { CronDeliveryStatus, CronRunStatus } from "../types.js";
@@ -110,37 +114,44 @@ export function readCronRunLogRows(
   return executeSqliteQuerySync(db, query.orderBy("ts", "asc").orderBy("seq", "asc")).rows;
 }
 
-function buildRunLogWhereClause(params: {
-  storeKey: string;
-  jobId?: string;
-  statuses: CronRunStatus[] | null;
-  deliveryStatuses: CronDeliveryStatus[] | null;
-  runId?: string;
-}): { whereSql: string; values: Array<string | number> } {
-  const clauses = ["store_key = ?"];
-  const values: Array<string | number> = [params.storeKey];
+function selectFilteredCronRunLogs(
+  db: DatabaseSync,
+  params: {
+    storeKey: string;
+    jobId?: string;
+    statuses: CronRunStatus[] | null;
+    deliveryStatuses: CronDeliveryStatus[] | null;
+    runId?: string;
+  },
+) {
+  let query = getCronRunLogKysely(db)
+    .selectFrom("cron_run_logs")
+    .where("store_key", "=", params.storeKey);
   if (params.jobId) {
-    clauses.push("job_id = ?");
-    values.push(params.jobId);
+    query = query.where("job_id", "=", params.jobId);
   }
   if (params.statuses?.length) {
-    clauses.push(`status IN (${params.statuses.map(() => "?").join(", ")})`);
-    values.push(...params.statuses);
+    query = query.where("status", "in", params.statuses);
   }
   if (params.deliveryStatuses?.length) {
-    clauses.push(
-      `COALESCE(delivery_status, 'not-requested') IN (${params.deliveryStatuses
-        .map(() => "?")
-        .join(", ")})`,
-    );
-    values.push(...params.deliveryStatuses);
+    const concreteStatuses = params.deliveryStatuses.filter((status) => status !== "not-requested");
+    const includeNotRequested = params.deliveryStatuses.includes("not-requested");
+    query = query.where((eb) => {
+      const clauses = [];
+      if (concreteStatuses.length > 0) {
+        clauses.push(eb("delivery_status", "in", concreteStatuses));
+      }
+      if (includeNotRequested) {
+        clauses.push(eb("delivery_status", "is", null));
+      }
+      return clauses.length === 1 ? clauses[0] : eb.or(clauses);
+    });
   }
   const runId = params.runId?.trim();
   if (runId) {
-    clauses.push("run_id = ?");
-    values.push(runId);
+    query = query.where("run_id", "=", runId);
   }
-  return { whereSql: clauses.join(" AND "), values };
+  return query;
 }
 
 export function countCronRunLogRows(params: {
@@ -151,10 +162,12 @@ export function countCronRunLogRows(params: {
   deliveryStatuses: CronDeliveryStatus[] | null;
   runId?: string;
 }): number {
-  const { whereSql, values } = buildRunLogWhereClause(params);
-  const row = params.db
-    .prepare(`SELECT COUNT(*) AS count FROM cron_run_logs WHERE ${whereSql}`)
-    .get(...values) as { count?: number | bigint } | undefined;
+  const row = executeSqliteQueryTakeFirstSync(
+    params.db,
+    selectFilteredCronRunLogs(params.db, params).select((eb) =>
+      eb.fn.countAll<number | bigint>().as("count"),
+    ),
+  );
   return normalizeNumber(row?.count ?? null) ?? 0;
 }
 
@@ -169,25 +182,25 @@ export function readCronRunLogRowsPage(params: {
   offset?: number;
   limit?: number;
 }): CronRunLogRow[] {
-  const { whereSql, values } = buildRunLogWhereClause(params);
-  const order = params.sortDir === "asc" ? "ASC" : "DESC";
-  const limitSql =
-    params.limit === undefined || params.offset === undefined ? "" : " LIMIT ? OFFSET ?";
-  const limitValues =
-    params.limit === undefined || params.offset === undefined ? [] : [params.limit, params.offset];
-  return params.db
-    .prepare(
-      `SELECT * FROM cron_run_logs WHERE ${whereSql} ORDER BY ts ${order}, seq ${order}${limitSql}`,
-    )
-    .all(...values, ...limitValues) as CronRunLogRow[];
+  let query = selectFilteredCronRunLogs(params.db, params)
+    .selectAll()
+    .orderBy("ts", params.sortDir)
+    .orderBy("seq", params.sortDir);
+  if (params.limit !== undefined && params.offset !== undefined) {
+    query = query.limit(params.limit).offset(params.offset);
+  }
+  return executeSqliteQuerySync(params.db, query).rows;
 }
 
 function nextCronRunLogSeq(db: DatabaseSync, storeKey: string, jobId: string): number {
-  const row = db
-    .prepare(
-      "SELECT COALESCE(MAX(seq), 0) AS seq FROM cron_run_logs WHERE store_key = ? AND job_id = ?",
-    )
-    .get(storeKey, jobId) as { seq?: number | bigint } | undefined;
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getCronRunLogKysely(db)
+      .selectFrom("cron_run_logs")
+      .select((eb) => eb.fn.max<number | bigint>("seq").as("seq"))
+      .where("store_key", "=", storeKey)
+      .where("job_id", "=", jobId),
+  );
   return (normalizeNumber(row?.seq ?? null) ?? 0) + 1;
 }
 
@@ -212,14 +225,20 @@ export function pruneCronRunLogRows(
   keepLines: number,
 ): void {
   const keep = Math.max(1, Math.floor(keepLines));
-  db.prepare(
-    `DELETE FROM cron_run_logs
-     WHERE store_key = ? AND job_id = ?
-       AND seq NOT IN (
-         SELECT seq FROM cron_run_logs
-         WHERE store_key = ? AND job_id = ?
-         ORDER BY seq DESC
-         LIMIT ?
-       )`,
-  ).run(storeKey, jobId, storeKey, jobId, keep);
+  const kysely = getCronRunLogKysely(db);
+  const keepSeqs = kysely
+    .selectFrom("cron_run_logs")
+    .select("seq")
+    .where("store_key", "=", storeKey)
+    .where("job_id", "=", jobId)
+    .orderBy("seq", "desc")
+    .limit(keep);
+  executeSqliteQuerySync(
+    db,
+    kysely
+      .deleteFrom("cron_run_logs")
+      .where("store_key", "=", storeKey)
+      .where("job_id", "=", jobId)
+      .where("seq", "not in", keepSeqs),
+  );
 }


### PR DESCRIPTION
## Summary

- routes cron run-log count, page, max-seq, and prune queries through Kysely instead of raw SQLite strings
- preserves the existing filter semantics, including `not-requested` delivery status rows stored as `NULL`
- keeps this as a one-file current-main CI unblocker for the runtime schema quarantine PR

## Verification

- `node scripts/check-kysely-guardrails.mjs`
- `./node_modules/.bin/oxfmt --check src/cron/run-log/sqlite-store.ts`
- `node scripts/run-oxlint.mjs src/cron/run-log/sqlite-store.ts`
- `node scripts/run-vitest.mjs src/cron/run-log.test.ts src/cron/run-log.error-reason.test.ts`
- `git diff --check origin/main...HEAD`

## Real behavior proof

Behavior addressed: current-main CI guardrails rejected raw SQLite usage in `src/cron/run-log/sqlite-store.ts`, which also showed up as unrelated failures on the runtime schema quarantine PR.
Real environment tested: local OpenClaw worktree with shared dependencies.
Exact steps or command run after this patch: the verification commands listed above.
Evidence after fix: Kysely guardrails reported `Kysely guardrails OK`; focused cron run-log Vitest passed 2 files / 20 tests.
Observed result after fix: the cron run-log store no longer trips the Kysely guardrail, and the focused cron behavior tests still pass.
What was not tested: full CI; this PR is intentionally scoped to the guardrail failure and focused cron tests.
