### PR TITLE
fix(telegram): prevent preview duplication in partial and block streaming modes

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3639,6 +3639,30 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.update).toHaveBeenLastCalledWith("block after progress");
   });
 
+  it("does not suppress button-bearing blocks after answer streaming starts", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "partial answer" });
+        await dispatcherOptions.deliver(
+          { text: "choose now", channelData: { telegram: { buttons } } },
+          { kind: "block" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial" } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenLastCalledWith("choose now");
+    expectRecordFields(mockCallArg(editMessageTelegram, 0, 3), { buttons });
+  });
+
   it("keeps queued room events abortable after their source dispatch returns", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3573,6 +3573,54 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await sidePromise;
   });
 
+  it("does not drop the first chunk of a long final after a generic lane rotation", async () => {
+    setNoAbort();
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        // Force a generic rotation (tool-progress handoff)
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver(
+          { text: "A".repeat(4000) + "B".repeat(4000) },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      textLimit: 4000,
+    });
+
+    // The stream should receive the first chunk ("A"s), not skip it because of activeChunkIndex being falsely incremented
+    expect(answerDraftStream.update).toHaveBeenCalledWith("A".repeat(4000));
+  });
+
+  it("does not suppress text-only blocks as delivered when answer draft is inactive", async () => {
+    setNoAbort();
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "forced block" }, { kind: "block" });
+      await dispatcherOptions.deliver({ text: "final text" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    // Provide a config that disables partial answer streams (e.g. block mode explicitly enabled)
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial", block: { enabled: true } } } as any,
+    });
+
+    const deliveredTexts = deliverReplies.mock.calls.flatMap((call) =>
+      ((call[0] as { replies?: Array<{ text?: string }> }).replies ?? []).map(
+        (reply) => reply.text,
+      ),
+    );
+    expect(deliveredTexts).toContain("forced block");
+  });
+
   it("keeps queued room events abortable after their source dispatch returns", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3663,6 +3663,61 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectRecordFields(mockCallArg(editMessageTelegram, 0, 3), { buttons });
   });
 
+  it("finalizes a duplicate text-only block when no final follows", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "partial answer" });
+        await dispatcherOptions.deliver({ text: "partial answer" }, { kind: "block" });
+        return { queuedFinal: false };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial" } },
+    });
+
+    expect(answerDraftStream.stop).toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+      content: "partial answer",
+      messageId: 2001,
+    });
+    expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext), {
+      text: "partial answer",
+      messageId: 2001,
+    });
+  });
+
+  it("materializes a pending duplicate text-only block before finalizing it", async () => {
+    const { answerDraftStream } = setupDraftStreams();
+    answerDraftStream.stop.mockImplementation(async () => {
+      answerDraftStream.setMessageId(2001);
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "pending answer" });
+        await dispatcherOptions.deliver({ text: "pending answer" }, { kind: "block" });
+        return { queuedFinal: false };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial" } },
+    });
+
+    expect(answerDraftStream.stop).toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+      content: "pending answer",
+      messageId: 2001,
+    });
+  });
+
   it("keeps queued room events abortable after their source dispatch returns", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3577,7 +3577,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
-        // Force a generic rotation (tool-progress handoff)
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
         await dispatcherOptions.deliver(
           { text: "A".repeat(4000) + "B".repeat(4000) },
@@ -3592,7 +3591,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
       textLimit: 4000,
     });
 
-    // The stream should receive the first chunk ("A"s), not skip it because of activeChunkIndex being falsely incremented
     expect(answerDraftStream.update).toHaveBeenCalledWith("A".repeat(4000));
   });
 
@@ -3604,11 +3602,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
       return { queuedFinal: true };
     });
 
-    // Provide a config that disables partial answer streams (e.g. block mode explicitly enabled)
     await dispatchWithContext({
       context: createContext(),
       streamMode: "partial",
-      telegramCfg: { streaming: { mode: "partial", block: { enabled: true } } } as any,
+      telegramCfg: {
+        streaming: { mode: "partial", block: { enabled: true } },
+      } satisfies Parameters<typeof dispatchTelegramMessage>[0]["telegramCfg"],
     });
 
     const deliveredTexts = deliverReplies.mock.calls.flatMap((call) =>

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3574,7 +3574,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   it("does not drop the first chunk of a long final after a generic lane rotation", async () => {
-    setNoAbort();
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
@@ -3598,7 +3597,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   it("does not suppress text-only blocks as delivered when answer draft is inactive", async () => {
-    setNoAbort();
     setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver({ text: "forced block" }, { kind: "block" });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3619,6 +3619,26 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliveredTexts).toContain("forced block");
   });
 
+  it("does not suppress text-only blocks after a tool-progress draft", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "block after progress" }, { kind: "block" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial" } },
+    });
+
+    expect(mockCallArg(answerDraftStream.update)).toContain("Exec");
+    expect(answerDraftStream.update).toHaveBeenLastCalledWith("block after progress");
+  });
+
   it("keeps queued room events abortable after their source dispatch returns", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -899,6 +899,7 @@ export const dispatchTelegramMessage = async ({
           renderText: renderStreamText,
           onSupersededPreview: (superseded) => {
             if (superseded.retain) {
+              lanes[laneName].activeChunkIndex += 1;
               return;
             }
             void bot.api.deleteMessage(chatId, superseded.messageId).catch((err: unknown) => {
@@ -1076,7 +1077,7 @@ export const dispatchTelegramMessage = async ({
     }
     lane.hasStreamedMessage = false;
     lane.finalized = false;
-    lane.activeChunkIndex += 1;
+    lane.activeChunkIndex = 0;
     if (lane === answerLane) {
       resetAnswerToolProgressDraft();
     }
@@ -1767,10 +1768,11 @@ export const dispatchTelegramMessage = async ({
                         streamMode === "partial" &&
                         info.kind === "block" &&
                         !reply.hasMedia &&
-                        !hasExecApprovalPayload(effectivePayload);
+                        !hasExecApprovalPayload(effectivePayload) &&
+                        Boolean(answerLane.stream);
 
                       if (skipTextOnlyBlock) {
-                        blockDelivered = true;
+                        blockDelivered = blockDelivered || answerLane.hasStreamedMessage;
                         continue;
                       }
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1770,6 +1770,7 @@ export const dispatchTelegramMessage = async ({
                         segment.lane === "answer" &&
                         !reply.hasMedia &&
                         !hasExecApprovalPayload(effectivePayload) &&
+                        telegramButtons === undefined &&
                         answerLane.hasStreamedMessage &&
                         !activeAnswerDraftIsToolProgressOnly;
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1769,10 +1769,10 @@ export const dispatchTelegramMessage = async ({
                         info.kind === "block" &&
                         !reply.hasMedia &&
                         !hasExecApprovalPayload(effectivePayload) &&
-                        Boolean(answerLane.stream);
+                        answerLane.hasStreamedMessage;
 
                       if (skipTextOnlyBlock) {
-                        blockDelivered = blockDelivered || answerLane.hasStreamedMessage;
+                        blockDelivered = true;
                         continue;
                       }
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -916,6 +916,7 @@ export const dispatchTelegramMessage = async ({
       lastPartialText: "",
       hasStreamedMessage: false,
       finalized: false,
+      activeChunkIndex: 0,
     };
   };
   const lanes: Record<LaneName, DraftLaneState> = {
@@ -1075,6 +1076,7 @@ export const dispatchTelegramMessage = async ({
     }
     lane.hasStreamedMessage = false;
     lane.finalized = false;
+    lane.activeChunkIndex += 1;
     if (lane === answerLane) {
       resetAnswerToolProgressDraft();
     }
@@ -1760,6 +1762,18 @@ export const dispatchTelegramMessage = async ({
                         }
                         await prepareAnswerLaneForToolProgress();
                       }
+
+                      const skipTextOnlyBlock =
+                        streamMode === "partial" &&
+                        info.kind === "block" &&
+                        !reply.hasMedia &&
+                        !hasExecApprovalPayload(effectivePayload);
+
+                      if (skipTextOnlyBlock) {
+                        blockDelivered = true;
+                        continue;
+                      }
+
                       const result =
                         segment.lane === "answer" && info.kind === "final"
                           ? await deliverFinalAnswerText(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -19,6 +19,7 @@ import { CURRENT_MESSAGE_MARKER } from "openclaw/plugin-sdk/channel-mention-gati
 import {
   createChannelMessageReplyPipeline,
   createOutboundPayloadPlan,
+  createPreviewMessageReceipt,
   deriveDurableFinalDeliveryRequirements,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -1296,6 +1297,7 @@ export const dispatchTelegramMessage = async ({
   const silentErrorReplies = telegramCfg.silentErrorReplies === true;
   const isDmTopic = !isGroup && threadSpec.scope === "dm" && threadSpec.id != null;
   let queuedFinal = false;
+  let skippedDuplicateAnswerBlockDraftDelivery = false;
   let suppressSilentReplyFallback = false;
   let hadErrorReplyFailureOrSkip = false;
   let isFirstTurnInSession = false;
@@ -1493,6 +1495,43 @@ export const dispatchTelegramMessage = async ({
             );
           });
       }
+    };
+    const finalizeSkippedDuplicateAnswerBlockDraft = async () => {
+      if (
+        !skippedDuplicateAnswerBlockDraftDelivery ||
+        queuedFinal ||
+        dispatchError ||
+        isDispatchSuperseded() ||
+        answerLane.finalized
+      ) {
+        return;
+      }
+      const stream = answerLane.stream;
+      const content = answerLane.lastPartialText;
+      if (!stream || !content) {
+        return;
+      }
+      await stream.stop();
+      const messageId = stream.messageId();
+      if (typeof messageId !== "number") {
+        if (stream.sendMayHaveLanded?.()) {
+          answerLane.finalized = true;
+          deliveryState.markDelivered();
+        }
+        return;
+      }
+      answerLane.finalized = true;
+      deliveryState.markDelivered();
+      await emitPreviewFinalizedHook({
+        kind: "preview-finalized",
+        delivery: {
+          content,
+          promptContextContent: content,
+          messageId,
+          buttonsAttached: false,
+          receipt: createPreviewMessageReceipt({ id: messageId }),
+        },
+      });
     };
     const deliverLaneText = createLaneTextDeliverer({
       lanes,
@@ -1772,9 +1811,11 @@ export const dispatchTelegramMessage = async ({
                         !hasExecApprovalPayload(effectivePayload) &&
                         telegramButtons === undefined &&
                         answerLane.hasStreamedMessage &&
-                        !activeAnswerDraftIsToolProgressOnly;
+                        !activeAnswerDraftIsToolProgressOnly &&
+                        segment.update.text.trimEnd() === answerLane.lastPartialText.trimEnd();
 
                       if (skipTextOnlyBlock) {
+                        skippedDuplicateAnswerBlockDraftDelivery = true;
                         blockDelivered = true;
                         continue;
                       }
@@ -2104,6 +2145,7 @@ export const dispatchTelegramMessage = async ({
       progressDraft.cancel();
       await draftLaneEventQueue;
       nativeToolProgressDraft?.stop();
+      await finalizeSkippedDuplicateAnswerBlockDraft();
       const lanesToCleanup: Array<{ laneName: LaneName; lane: DraftLaneState }> = [
         { laneName: "answer", lane: answerLane },
         { laneName: "reasoning", lane: reasoningLane },

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1767,9 +1767,11 @@ export const dispatchTelegramMessage = async ({
                       const skipTextOnlyBlock =
                         streamMode === "partial" &&
                         info.kind === "block" &&
+                        segment.lane === "answer" &&
                         !reply.hasMedia &&
                         !hasExecApprovalPayload(effectivePayload) &&
-                        answerLane.hasStreamedMessage;
+                        answerLane.hasStreamedMessage &&
+                        !activeAnswerDraftIsToolProgressOnly;
 
                       if (skipTextOnlyBlock) {
                         blockDelivered = true;

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -302,6 +302,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     const finalizeDeliveredPrefix = async (
       deliveredStreamText: string,
       messageId: number,
+      suffixSourceText = activeFullText,
     ): Promise<LaneDeliveryResult> => {
       lane.finalized = true;
       params.markDelivered();
@@ -320,7 +321,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           }
         }
       }
-      const suffix = activeFullText.slice(deliveredStreamText.length);
+      const suffix = suffixSourceText.slice(deliveredStreamText.length);
       if (suffix.trim().length > 0) {
         for (const chunk of compactChunks(params.splitFinalTextForStream?.(suffix) ?? [])) {
           if (chunk.trim().length === 0) {
@@ -418,6 +419,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       await params.flushDraftLane(lane);
     }
     const activeChunkIndexAfterStop = isFinal ? clampActiveChunkIndex() : activeChunkIndex;
+    const activeChunkAfterStop = chunks[activeChunkIndexAfterStop] ?? firstChunk;
     const remainingChunksAfterStop = chunks.slice(activeChunkIndexAfterStop + 1);
 
     const messageId = stream.messageId();
@@ -431,14 +433,19 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
 
     const deliveredStreamTextAfterStop = stream.lastDeliveredText?.();
+    const activeChunkTextAfterStop = activeChunkAfterStop.trimEnd();
+    const retainedFirstChunkAfterStop =
+      activeChunkIndexAfterStop !== activeChunkIndex &&
+      deliveredStreamTextAfterStop === firstChunk.trimEnd();
     if (
       isFinal &&
       deliveredStreamTextAfterStop !== undefined &&
-      deliveredStreamTextAfterStop !== firstChunk.trimEnd()
+      deliveredStreamTextAfterStop !== activeChunkTextAfterStop &&
+      !retainedFirstChunkAfterStop
     ) {
       if (
         isDeliveredPrefix({ deliveredText: deliveredStreamTextAfterStop, finalText }) &&
-        deliveredStreamTextAfterStop.length > firstChunk.trimEnd().length
+        deliveredStreamTextAfterStop.length > activeChunkTextAfterStop.length
       ) {
         return await finalizeDeliveredPrefix(deliveredStreamTextAfterStop, messageId);
       }
@@ -453,7 +460,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     let buttonsAttached = false;
     if (buttons) {
       try {
-        await params.editStreamMessage({ laneName, messageId, text: firstChunk, buttons });
+        await params.editStreamMessage({
+          laneName,
+          messageId,
+          text: activeChunkAfterStop,
+          buttons,
+        });
         buttonsAttached = true;
       } catch (err) {
         params.log(`telegram: ${laneName} stream button edit failed: ${String(err)}`);
@@ -470,7 +482,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       return result("preview-finalized", {
         content: text,
-        promptContextContent: firstChunk,
+        promptContextContent: activeChunkAfterStop,
         messageId,
         buttonsAttached,
       });

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -278,12 +278,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         : [text];
 
     const clampActiveChunkIndex = () =>
-      Math.min(lane.activeChunkIndex ?? 0, Math.max(0, chunks.length - 1));
+      Math.min(lane.activeChunkIndex, Math.max(0, chunks.length - 1));
     const activeChunkIndex = clampActiveChunkIndex();
-    const firstChunk = chunks[activeChunkIndex];
+    const activeChunk = chunks[activeChunkIndex];
     const remainingChunks = chunks.slice(activeChunkIndex + 1);
 
-    if (!firstChunk || firstChunk.length > params.draftMaxChars) {
+    if (!activeChunk || activeChunk.length > params.draftMaxChars) {
       return undefined;
     }
 
@@ -297,12 +297,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         deliveredText: deliveredStreamTextBeforeUpdate,
         finalText,
       }) &&
-      deliveredStreamTextBeforeUpdate.length > firstChunk.trimEnd().length;
+      deliveredStreamTextBeforeUpdate.length > activeChunk.trimEnd().length;
 
     const finalizeDeliveredPrefix = async (
       deliveredStreamText: string,
       messageId: number,
-      suffixSourceText = activeFullText,
     ): Promise<LaneDeliveryResult> => {
       lane.finalized = true;
       params.markDelivered();
@@ -321,7 +320,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           }
         }
       }
-      const suffix = suffixSourceText.slice(deliveredStreamText.length);
+      const suffix = activeFullText.slice(deliveredStreamText.length);
       if (suffix.trim().length > 0) {
         for (const chunk of compactChunks(params.splitFinalTextForStream?.(suffix) ?? [])) {
           if (chunk.trim().length === 0) {
@@ -408,10 +407,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
 
     if (!deliveredPrefixBeforeUpdate) {
-      lane.lastPartialText = firstChunk;
+      lane.lastPartialText = activeChunk;
       lane.hasStreamedMessage = true;
       lane.finalized = false;
-      stream.update(firstChunk);
+      stream.update(activeChunk);
     }
     if (isFinal) {
       await params.stopDraftLane(lane);
@@ -419,7 +418,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       await params.flushDraftLane(lane);
     }
     const activeChunkIndexAfterStop = isFinal ? clampActiveChunkIndex() : activeChunkIndex;
-    const activeChunkAfterStop = chunks[activeChunkIndexAfterStop] ?? firstChunk;
+    const activeChunkAfterStop = chunks[activeChunkIndexAfterStop] ?? activeChunk;
     const remainingChunksAfterStop = chunks.slice(activeChunkIndexAfterStop + 1);
 
     const messageId = stream.messageId();
@@ -434,14 +433,14 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
 
     const deliveredStreamTextAfterStop = stream.lastDeliveredText?.();
     const activeChunkTextAfterStop = activeChunkAfterStop.trimEnd();
-    const retainedFirstChunkAfterStop =
+    const retainedActiveChunkAfterStop =
       activeChunkIndexAfterStop !== activeChunkIndex &&
-      deliveredStreamTextAfterStop === firstChunk.trimEnd();
+      deliveredStreamTextAfterStop === activeChunk.trimEnd();
     if (
       isFinal &&
       deliveredStreamTextAfterStop !== undefined &&
       deliveredStreamTextAfterStop !== activeChunkTextAfterStop &&
-      !retainedFirstChunkAfterStop
+      !retainedActiveChunkAfterStop
     ) {
       if (
         isDeliveredPrefix({ deliveredText: deliveredStreamTextAfterStop, finalText }) &&

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -277,7 +277,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         ? compactChunks(params.splitFinalTextForStream?.(text) ?? [])
         : [text];
 
-    const activeChunkIndex = Math.min(lane.activeChunkIndex ?? 0, Math.max(0, chunks.length - 1));
+    const clampActiveChunkIndex = () =>
+      Math.min(lane.activeChunkIndex ?? 0, Math.max(0, chunks.length - 1));
+    const activeChunkIndex = clampActiveChunkIndex();
     const firstChunk = chunks[activeChunkIndex];
     const remainingChunks = chunks.slice(activeChunkIndex + 1);
 
@@ -397,7 +399,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       lane.finalized = true;
       params.markDelivered();
       return result("preview-finalized", {
-        content: text,
+        content: previewText,
         promptContextContent: previewText,
         messageId,
         buttonsAttached,
@@ -415,6 +417,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     } else {
       await params.flushDraftLane(lane);
     }
+    const activeChunkIndexAfterStop = isFinal ? clampActiveChunkIndex() : activeChunkIndex;
+    const remainingChunksAfterStop = chunks.slice(activeChunkIndexAfterStop + 1);
 
     const messageId = stream.messageId();
     if (typeof messageId !== "number") {
@@ -458,7 +462,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
 
     if (isFinal) {
       lane.finalized = true;
-      for (const chunk of remainingChunks) {
+      for (const chunk of remainingChunksAfterStop) {
         if (chunk.trim().length === 0) {
           continue;
         }

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -22,6 +22,7 @@ export type DraftLaneState = {
   lastPartialText: string;
   hasStreamedMessage: boolean;
   finalized: boolean;
+  activeChunkIndex: number;
 };
 
 type LanePreviewFinalizedDelivery = {
@@ -275,11 +276,17 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       text.length > params.draftMaxChars
         ? compactChunks(params.splitFinalTextForStream?.(text) ?? [])
         : [text];
-    const [firstChunk, ...remainingChunks] = chunks;
+
+    const activeChunkIndex = Math.min(lane.activeChunkIndex ?? 0, Math.max(0, chunks.length - 1));
+    const firstChunk = chunks[activeChunkIndex];
+    const remainingChunks = chunks.slice(activeChunkIndex + 1);
+
     if (!firstChunk || firstChunk.length > params.draftMaxChars) {
       return undefined;
     }
-    const finalText = text.trimEnd();
+
+    const activeFullText = chunks.slice(activeChunkIndex).join("");
+    const finalText = activeFullText.trimEnd();
     const deliveredStreamTextBeforeUpdate = stream.lastDeliveredText?.();
     const deliveredPrefixBeforeUpdate =
       isFinal &&
@@ -289,6 +296,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         finalText,
       }) &&
       deliveredStreamTextBeforeUpdate.length > firstChunk.trimEnd().length;
+
     const finalizeDeliveredPrefix = async (
       deliveredStreamText: string,
       messageId: number,
@@ -310,7 +318,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           }
         }
       }
-      const suffix = finalText.slice(deliveredStreamText.length);
+      const suffix = activeFullText.slice(deliveredStreamText.length);
       if (suffix.trim().length > 0) {
         for (const chunk of compactChunks(params.splitFinalTextForStream?.(suffix) ?? [])) {
           if (chunk.trim().length === 0) {
@@ -327,17 +335,29 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       });
     };
 
+    const candidateTexts = [stream.lastDeliveredText?.(), lane.lastPartialText];
+    if (isFinal && remainingChunks.length === 0 && isPotentialTruncatedFinal(activeFullText)) {
+      const resolvedFullCandidate = await params.resolveFinalTextCandidate?.({
+        finalText: text,
+        laneName,
+      });
+      if (resolvedFullCandidate) {
+        const resolvedChunks =
+          resolvedFullCandidate.length > params.draftMaxChars
+            ? compactChunks(params.splitFinalTextForStream?.(resolvedFullCandidate) ?? [])
+            : [resolvedFullCandidate];
+        candidateTexts.push(resolvedChunks.slice(activeChunkIndex).join(""));
+      }
+    }
+
     const retainedPreview =
-      isFinal && remainingChunks.length === 0 && isPotentialTruncatedFinal(text)
+      isFinal && remainingChunks.length === 0 && isPotentialTruncatedFinal(activeFullText)
         ? selectLongerFinalText({
-            finalText: text,
-            candidateTexts: [
-              await params.resolveFinalTextCandidate?.({ finalText: text, laneName }),
-              stream.lastDeliveredText?.(),
-              lane.lastPartialText,
-            ],
+            finalText: activeFullText,
+            candidateTexts,
           })
         : undefined;
+
     if (retainedPreview && (!buttons || retainedPreview.length <= params.draftMaxChars)) {
       const previewText = retainedPreview;
       lane.lastPartialText = previewText;
@@ -376,7 +396,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       lane.finalized = true;
       params.markDelivered();
-      return result("preview-finalized", { content: previewText, messageId, buttonsAttached });
+      return result("preview-finalized", {
+        content: text,
+        promptContextContent: previewText,
+        messageId,
+        buttonsAttached,
+      });
     }
 
     if (!deliveredPrefixBeforeUpdate) {

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -764,6 +764,27 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
   });
 
+  it("does not resend chunks retained while stopping a long streamed final", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 5,
+      splitFinalTextForStream: () => ["Hello", " world", " again"],
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+    answer.stop.mockImplementation(async () => {
+      harness.lanes.answer.activeChunkIndex = 1;
+    });
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe("Hello world again");
+    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " again" });
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps inline buttons on the current chunk of an already-streamed long final", async () => {
     const buttons = [[{ text: "OK", callback_data: "ok" }]];
     const fullAnswer = "Hello world again";

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -31,12 +31,14 @@ function createHarness(params?: {
       lastPartialText: "",
       hasStreamedMessage: false,
       finalized: false,
+      activeChunkIndex: 0,
     },
     reasoning: {
       stream: reasoning,
       lastPartialText: "",
       hasStreamedMessage: false,
       finalized: false,
+      activeChunkIndex: 0,
     },
   };
   const sendPayload = vi.fn().mockResolvedValue(true);

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -785,6 +785,66 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
   });
 
+  it("compares retained delivered prefixes against the full final text", async () => {
+    let deliveredText = "Hello";
+    const answer = createTestDraftStream({ messageId: 999 });
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 5,
+      splitFinalTextForStream: (text) =>
+        text === " again" ? [" again"] : ["Hello", " world", " again"],
+    });
+    answer.lastDeliveredText.mockImplementation(() => deliveredText);
+    answer.stop.mockImplementation(async () => {
+      harness.lanes.answer.activeChunkIndex = 1;
+      deliveredText = "Hello world";
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.promptContextContent).toBe("Hello world");
+    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " again" });
+  });
+
+  it("edits buttons onto the chunk active after stopping a retained long final", async () => {
+    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+    const answer = createTestDraftStream({ messageId: 999 });
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 6,
+      splitFinalTextForStream: () => ["Hello", " world", " again"],
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+    answer.stop.mockImplementation(async () => {
+      harness.lanes.answer.activeChunkIndex = 1;
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello world again",
+      payload: { text: "Hello world again", channelData: { telegram: { buttons } } },
+      infoKind: "final",
+      buttons,
+    });
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.buttonsAttached).toBe(true);
+    expect(harness.editStreamMessage).toHaveBeenCalledWith({
+      laneName: "answer",
+      messageId: 999,
+      text: " world",
+      buttons,
+    });
+    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith({
+      text: " again",
+      channelData: { telegram: { buttons } },
+    });
+  });
+
   it("keeps inline buttons on the current chunk of an already-streamed long final", async () => {
     const buttons = [[{ text: "OK", callback_data: "ok" }]];
     const fullAnswer = "Hello world again";


### PR DESCRIPTION
<img width="1224" height="2700" alt="Screenshot_20260531_070007_org_telegram_messenger_LaunchActivity" src="https://github.com/user-attachments/assets/51f74cb4-721a-436a-81b4-a25de3ceb4e6" />

## Summary

What problem does this PR solve?
In Telegram, `channels.telegram.streaming.mode: "partial"` and `"block"` modes duplicated the entire stream preview content on final emit if the reply size exceeded the ~4096 characters per-message cap. When the message was block-rotated into a new message, the draft stream controller unknowingly replayed chunks that were already delivered in preceding block/partial transmissions because it received the full cumulative text for final emit processing.

Why does this matter now?
This created broken and frustrating user experiences where long responses on Telegram were sent twice, interrupting reading flow and visually inflating output length.

What is the intended outcome?
The final stream text delivery respects the current `activeChunkIndex` tracked across stream rotations. The system now accurately targets the current active preview chunk for inline finalization and accurately distributes the remainder of the payload downstream sequentially. Additionally, `partial` streaming skips redundant text-only block deliveries that were needlessly stepping over incremental partial streaming. 

What is intentionally out of scope?
Refactoring the larger core outbound block delivery protocol is out of scope. This addresses the Telegram-specific `lane-delivery` module interface handling.

What does success look like?
Long Telegram responses (>4096 characters) seamlessly transition to multiple paginated messages without repeating the initial content.

What should reviewers focus on?
- Verification that `lane.activeChunkIndex` is scoped securely to `onSupersededPreview` so it only increments for retained overflow chunks.
- Re-checking bounds clamp logic so active chunks perfectly index valid active streams.
- Reviewing `isDeliveredPrefix` and `suffix` handling changes, ensuring they use `activeFullText` rather than `text`.

## Linked context

Which issue does this close?

Closes #87624

Which issues, PRs, or discussions are related?

Related #84885

Was this requested by a maintainer or owner?

Yes.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Final emit duplicating messages for Telegram single-turn replies exceeding the per-message chunk limit.
- Real environment tested: Live Telegram Bot API via GitHub Codespaces running `pnpm gateway:dev` (using OpenRouter/GLM for generation).
- Exact steps or command run after this patch:
  1. Set Telegram config to `streaming.mode: "partial"`, `chunkMode: "length"`, and artificially lowered `textChunkLimit: 15` to force the chunking behavior on a short prompt.
  2. Sent the bot the prompt: *"What is the capital of France?"*
- Evidence after fix: See the screenshot at the top of this PR.
- Observed result after fix: The reply cleanly split into 3 small chunks (due to the 15-char limit) and successfully finalized in place without duplicating the first chunks at the end of the generation.
- What was not tested: Exhaustive combinations of all available bot presentation controls (buttons/media) crossing the chunk boundary.
- Proof limitations or environment constraints: Tested using an artificially low chunk limit (15) to efficiently simulate the 4096-character overflow behavior on a live connection.
- Before evidence: Without the fix, this exact 15-char limit configuration would result in the first chunks printing again at the very bottom of the chat.

## Tests and validation

Which commands did you run?
`pnpm test:extensions` & `pnpm test:unit`

What regression coverage was added or updated?
Coverage checks updated inside `lane-delivery.test.ts` and `bot-message-dispatch.test.ts` to properly account for the internal track increment value `activeChunkIndex`. Additional regressions created targeting long finals post-rotation.

What failed before this fix, if known?
The final delivery loops assumed message sequences weren't rotated locally by previous block triggers inside `deliverLaneText`. Text-only blocks would also get silently dropped if streams weren't properly enabled.

If no test was added, why not?
Tests were successfully added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
`Yes` (duplicate spam was removed)

Did config, environment, or migration behavior change? (`Yes/No`)
`No`

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
`No`

What is the highest-risk area?
Draft lane text rotation bounds targeting potentially non-existent sequence indexes.

How is that risk mitigated?
Indices are firmly clamped against `0` and `chunks.length - 1` with logical fallbacks handling edge-case length disparities securely.

## Current review state

What is the next action?
Maintainer review and functional verification.

What is still waiting on author, maintainer, CI, or external proof?
CI success.

Which bot or reviewer comments were addressed?
Codex recommendation to provide concrete source-backed bounds correction targeting the final delivery overflow chunks. Re-scoped `activeChunkIndex` increments to `onSupersededPreview` specifically, ensured it isn't incremented in generic resets, and modified text-block delivery skips so they only suppress when an active partial draft exists.

## AI Assistance Transparency

- [x] **AI-assisted:** This PR was generated with the assistance of an LLM.
- [x] **Code Understanding:** I have reviewed the logic regarding `activeChunkIndex` and how it correctly targets the active stream without duplicating already-delivered final chunks. I confirm I understand how this code works.
- [x] **Prompts used:** I provided the exact GitHub issue text and the codebase context to the LLM.
- [x] **Real behavior proof:** Attached in the section above. I have personally compiled and run this against a local Telegram bot to verify the duplicate messages are gone.
- [x] **Codex Review:** N/A (I do not have access to the local codex CLI tool, but I addressed the Codex bot's comments from the issue ticket).

## Maintainer update (2026-06-01)

Maintainer repair pushed to this PR branch at `5d9f143b5f7811a1199315d0f84a0fcc1647b1f3`.

Additional fixes on top of the contributor patch:
- Recomputes retained long-final chunks after stopping the draft lane so already-visible overflow chunks are not resent.
- Limits partial-mode text-only block suppression to true duplicate answer blocks, preserving tool-progress, button-bearing, and differing block deliveries.
- Finalizes duplicate streamed blocks when no final payload follows, including pending draft streams that materialize their message id only after `stop()`.
- Keeps inline buttons attached to the post-stop active retained chunk instead of editing a stale first chunk.

Maintainer verification:
- `node scripts/run-vitest.mjs extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/draft-stream.test.ts` (170 tests)
- `node scripts/run-oxlint.mjs extensions/telegram/src/lane-delivery-text-deliverer.ts extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean on the repaired branch before the final unrelated main rebase
- L2 tmux proof on pushed head `5d9f143b5f7`: `L2_TELEGRAM_EXIT=0 vitest=0 lint=0 diff=0`
- Testbox-through-Crabbox changed gate: `tbx_01kt0wfts5fck0xvqp05zg9erx`, lanes `extensions, extensionTests`, exit 0
