### PR TITLE
fix(secrets): treat Codex app-server marker as non-secret

### DIFF
--- a/src/agents/model-auth-markers.test.ts
+++ b/src/agents/model-auth-markers.test.ts
@@ -22,6 +22,7 @@ function cleanPluginManifestEnv(): Record<(typeof PLUGIN_MANIFEST_ENV_KEYS)[numb
 }
 
 let listKnownProviderEnvApiKeyNames: typeof import("./model-auth-env-vars.js").listKnownProviderEnvApiKeyNames;
+let CODEX_APP_SERVER_AUTH_MARKER: typeof import("./model-auth-markers.js").CODEX_APP_SERVER_AUTH_MARKER;
 let GCP_VERTEX_CREDENTIALS_MARKER: typeof import("./model-auth-markers.js").GCP_VERTEX_CREDENTIALS_MARKER;
 let NON_ENV_SECRETREF_MARKER: typeof import("./model-auth-markers.js").NON_ENV_SECRETREF_MARKER;
 let isKnownEnvApiKeyMarker: typeof import("./model-auth-markers.js").isKnownEnvApiKeyMarker;
@@ -39,6 +40,7 @@ async function loadMarkerModules() {
     import("./model-auth-markers.js"),
   ]);
   listKnownProviderEnvApiKeyNames = envVarsModule.listKnownProviderEnvApiKeyNames;
+  CODEX_APP_SERVER_AUTH_MARKER = markersModule.CODEX_APP_SERVER_AUTH_MARKER;
   GCP_VERTEX_CREDENTIALS_MARKER = markersModule.GCP_VERTEX_CREDENTIALS_MARKER;
   NON_ENV_SECRETREF_MARKER = markersModule.NON_ENV_SECRETREF_MARKER;
   isKnownEnvApiKeyMarker = markersModule.isKnownEnvApiKeyMarker;
@@ -69,8 +71,16 @@ describe("model auth markers", () => {
     expect(isNonSecretApiKeyMarker(resolveOAuthApiKeyMarker("chutes"))).toBe(true);
     expect(isNonSecretApiKeyMarker("ollama-local")).toBe(true);
     expect(isNonSecretApiKeyMarker("lmstudio-local")).toBe(true);
-    expect(isNonSecretApiKeyMarker("codex-app-server")).toBe(true);
+    expect(isNonSecretApiKeyMarker(CODEX_APP_SERVER_AUTH_MARKER)).toBe(true);
     expect(isNonSecretApiKeyMarker(GCP_VERTEX_CREDENTIALS_MARKER)).toBe(true);
+  });
+
+  it("recognizes the Codex app-server marker without bundled plugin discovery", async () => {
+    await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+      await loadMarkerModules();
+      expect(isNonSecretApiKeyMarker(CODEX_APP_SERVER_AUTH_MARKER)).toBe(true);
+    });
+    await withEnvAsync(cleanPluginManifestEnv(), loadMarkerModules);
   });
 
   it("reads bundled plugin-owned non-secret markers from manifests", () => {

--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -12,6 +12,8 @@ export const OAUTH_API_KEY_MARKER_PREFIX = "oauth:";
 export const OLLAMA_LOCAL_AUTH_MARKER = "ollama-local";
 /** @deprecated Bundled local-provider marker; do not use from third-party plugins. */
 export const CUSTOM_LOCAL_AUTH_MARKER = "custom-local";
+/** @deprecated Codex provider-owned marker; do not use from third-party plugins. */
+export const CODEX_APP_SERVER_AUTH_MARKER = "codex-app-server";
 export const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
 export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
 export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
@@ -23,6 +25,7 @@ const AWS_SDK_ENV_MARKERS = new Set([
 ]);
 const CORE_NON_SECRET_API_KEY_MARKERS = [
   CUSTOM_LOCAL_AUTH_MARKER,
+  CODEX_APP_SERVER_AUTH_MARKER,
   OLLAMA_LOCAL_AUTH_MARKER,
   NON_ENV_SECRETREF_MARKER,
 ] as const;


### PR DESCRIPTION
## Summary
- Treat the Codex app-server auth marker as a core non-secret marker.
- Keep the marker recognized when bundled plugin discovery is disabled.
- Add regression coverage for the disabled-bundled-plugins path.

## Verification
- `node scripts/run-vitest.mjs src/agents/model-auth-markers.test.ts -- --reporter=verbose` passed: 1 file, 8 tests.
- `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 OPENCLAW_STATE_DIR=<throwaway-state> OPENCLAW_CONFIG_PATH=<empty-config> node scripts/run-node.mjs secrets audit --check` passed with `Secrets audit: clean. plaintext=0, unresolved=0, shadowed=0, legacy=0.`
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported no accepted/actionable findings.

## Real Behavior Proof

Behavior addressed: `secrets audit --check` should not report the fixed synthetic Codex app-server marker `codex-app-server` as a plaintext secret when bundled plugin discovery is disabled.

Real environment tested: local OpenClaw checkout on this PR branch, with an isolated throwaway OpenClaw state directory, an empty config file, no real user config, no `.env`, no auth profiles, no logs, no tokens, and `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1`.

Exact steps or command run after this patch:

```console
$ mkdir -p <throwaway-state>/agents/main/agent
$ cat > <throwaway-state>/agents/main/agent/models.json <<'JSON'
{
  "providers": {
    "codex": {
      "apiKey": "codex-app-server"
    }
  }
}
JSON
$ printf '{}' > <empty-config>
$ OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 OPENCLAW_STATE_DIR=<throwaway-state> OPENCLAW_CONFIG_PATH=<empty-config> node scripts/run-node.mjs secrets audit --check
```

Evidence after fix:

```console
Secrets audit: clean. plaintext=0, unresolved=0, shadowed=0, legacy=0.
```

Observed result after fix: command exited 0, and the audit did not emit a `PLAINTEXT_FOUND` finding for `providers.codex.apiKey`.

What was not tested: no live Codex app-server login, no real credentials, and no user home directory state; this proof is limited to the secrets-audit path and the fixed synthetic auth marker.
