### PR TITLE
docs: document gateway method types

### DIFF
--- a/src/agents/agent-settings.ts
+++ b/src/agents/agent-settings.ts
@@ -5,6 +5,7 @@ import type { ContextEngineInfo } from "../context-engine/types.js";
 import { MIN_PROMPT_BUDGET_RATIO, MIN_PROMPT_BUDGET_TOKENS } from "./agent-compaction-constants.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 
+/** Default minimum reserve kept for agent compaction unless config or context-budget caps override it. */
 export const DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
 
 type AgentSettingsManagerLike = {
@@ -43,6 +44,7 @@ export function ensureAgentCompactionReserveTokens(params: {
   return { didOverride: true, reserveTokens: minReserveTokens };
 }
 
+/** Resolves the configured compaction reserve floor, falling back to the product default for invalid values. */
 export function resolveCompactionReserveTokensFloor(cfg?: OpenClawConfig): number {
   const raw = cfg?.agents?.defaults?.compaction?.reserveTokensFloor;
   if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
@@ -65,6 +67,7 @@ function toPositiveInt(value: unknown): number | undefined {
   return Math.floor(value);
 }
 
+/** Applies config-driven compaction reserve/keepRecent settings to a runtime settings manager. */
 export function applyAgentCompactionSettingsFromConfig(params: {
   settingsManager: AgentSettingsManagerLike;
   cfg?: OpenClawConfig;

--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -4,6 +4,7 @@ import { resolveAgentConfig } from "./agent-scope.js";
 
 const DEFAULT_ACK_REACTION = "👀";
 
+/** Returns the configured identity block for an agent, after default-agent resolution. */
 export function resolveAgentIdentity(
   cfg: OpenClawConfig,
   agentId: string,
@@ -11,12 +12,13 @@ export function resolveAgentIdentity(
   return resolveAgentConfig(cfg, agentId)?.identity;
 }
 
+/** Resolves the acknowledgement reaction using account, channel, global, then identity fallback precedence. */
 export function resolveAckReaction(
   cfg: OpenClawConfig,
   agentId: string,
   opts?: { channel?: string; accountId?: string },
 ): string {
-  // L1: Channel account level
+  // Account-level channel config wins because the same provider can host multiple differently-branded accounts.
   if (opts?.channel && opts?.accountId) {
     const channelCfg = getChannelConfig(cfg, opts.channel);
     const accounts = channelCfg?.accounts as Record<string, Record<string, unknown>> | undefined;
@@ -26,7 +28,7 @@ export function resolveAckReaction(
     }
   }
 
-  // L2: Channel level
+  // Channel-wide config is shared across accounts but still more specific than global message defaults.
   if (opts?.channel) {
     const channelCfg = getChannelConfig(cfg, opts.channel);
     const channelReaction = channelCfg?.ackReaction as string | undefined;
@@ -35,17 +37,16 @@ export function resolveAckReaction(
     }
   }
 
-  // L3: Global messages level
   const configured = cfg.messages?.ackReaction;
   if (configured !== undefined) {
     return configured.trim();
   }
 
-  // L4: Agent identity emoji fallback
   const emoji = resolveAgentIdentity(cfg, agentId)?.emoji?.trim();
   return emoji || DEFAULT_ACK_REACTION;
 }
 
+/** Converts an agent identity name into the bracketed prefix used by outbound messages. */
 export function resolveIdentityNamePrefix(
   cfg: OpenClawConfig,
   agentId: string,
@@ -57,6 +58,7 @@ export function resolveIdentityNamePrefix(
   return `[${name}]`;
 }
 
+/** Resolves the outbound message prefix, preserving explicit empty strings for allow-from flows. */
 export function resolveMessagePrefix(
   cfg: OpenClawConfig,
   agentId: string,
@@ -87,12 +89,13 @@ function getChannelConfig(
     : undefined;
 }
 
+/** Resolves response-prefix overrides where the special `auto` value expands to the agent identity name. */
 export function resolveResponsePrefix(
   cfg: OpenClawConfig,
   agentId: string,
   opts?: { channel?: string; accountId?: string },
 ): string | undefined {
-  // L1: Channel account level
+  // Account overrides are checked first so multi-account channels can opt into separate visible identities.
   if (opts?.channel && opts?.accountId) {
     const channelCfg = getChannelConfig(cfg, opts.channel);
     const accounts = channelCfg?.accounts as Record<string, Record<string, unknown>> | undefined;
@@ -105,7 +108,7 @@ export function resolveResponsePrefix(
     }
   }
 
-  // L2: Channel level
+  // Channel-level `auto` keeps plugin config concise while still deriving the current agent name.
   if (opts?.channel) {
     const channelCfg = getChannelConfig(cfg, opts.channel);
     const channelPrefix = channelCfg?.responsePrefix as string | undefined;
@@ -117,7 +120,6 @@ export function resolveResponsePrefix(
     }
   }
 
-  // L4: Global level
   const configured = cfg.messages?.responsePrefix;
   if (configured !== undefined) {
     if (configured === "auto") {
@@ -128,6 +130,7 @@ export function resolveResponsePrefix(
   return undefined;
 }
 
+/** Projects the message-prefix and response-prefix rules into the compact shape used by channel senders. */
 export function resolveEffectiveMessagesConfig(
   cfg: OpenClawConfig,
   agentId: string,
@@ -150,6 +153,7 @@ export function resolveEffectiveMessagesConfig(
   };
 }
 
+/** Merges global human-delay defaults with per-agent overrides while preserving unset fields. */
 export function resolveHumanDelayConfig(
   cfg: OpenClawConfig,
   agentId: string,

--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -10,24 +10,28 @@ import type {
   ProviderEnvVarLookupParams,
 } from "../secrets/provider-env-vars.js";
 
+/** Returns provider-to-env-var candidates used when resolving API-key auth from process env. */
 export function resolveProviderEnvApiKeyCandidates(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, readonly string[]> {
   return resolveProviderAuthEnvVarCandidates(params);
 }
 
+/** Returns provider auth evidence from env/config so status surfaces can explain how auth was found. */
 export function resolveProviderEnvAuthEvidence(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, readonly ProviderAuthEvidence[]> {
   return resolveProviderAuthEvidence(params);
 }
 
+/** Returns lookup maps for provider env aliases and auth evidence in one reusable snapshot. */
 export function resolveProviderEnvAuthLookupMaps(
   params?: ProviderEnvVarLookupParams,
 ): ProviderAuthLookupMaps {
   return resolveProviderAuthLookupMaps(params);
 }
 
+/** Combines env candidate and auth evidence provider keys into sorted display order. */
 export function listProviderEnvAuthLookupKeys(params: {
   envCandidateMap: Readonly<Record<string, readonly string[]>>;
   authEvidenceMap: Readonly<Record<string, readonly ProviderAuthEvidence[]>>;
@@ -37,6 +41,7 @@ export function listProviderEnvAuthLookupKeys(params: {
   ).toSorted((a, b) => a.localeCompare(b));
 }
 
+/** Resolves the provider ids that have env-auth lookup data for model/auth status displays. */
 export function resolveProviderEnvAuthLookupKeys(params?: ProviderEnvVarLookupParams): string[] {
   const lookupMaps = resolveProviderEnvAuthLookupMaps(params);
   return listProviderEnvAuthLookupKeys({
@@ -45,6 +50,7 @@ export function resolveProviderEnvAuthLookupKeys(params?: ProviderEnvVarLookupPa
   });
 }
 
+/** Lists all known API-key env var names across built-in and contributed provider metadata. */
 export function listKnownProviderEnvApiKeyNames(): string[] {
   return listKnownProviderAuthEnvVarNames();
 }

--- a/src/agents/model-auth-runtime-shared.ts
+++ b/src/agents/model-auth-runtime-shared.ts
@@ -14,6 +14,7 @@ export type ResolvedProviderAuth = {
 
 export type ProviderAuthErrorCode = "missing-api-key" | "missing-provider-auth";
 
+/** Error type used by model runtimes to expose provider and auth-failure class without parsing text. */
 export class ProviderAuthError extends Error {
   readonly code: ProviderAuthErrorCode;
   readonly provider: string;
@@ -26,6 +27,7 @@ export class ProviderAuthError extends Error {
   }
 }
 
+/** Narrows provider auth failures, optionally matching one stable error code. */
 export function isProviderAuthError(
   err: unknown,
   code?: ProviderAuthErrorCode,
@@ -33,6 +35,7 @@ export function isProviderAuthError(
   return err instanceof ProviderAuthError && (!code || err.code === code);
 }
 
+/** Chooses the AWS SDK env var that best explains available Bedrock credentials. */
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {
   if (env[AWS_BEARER_ENV]?.trim()) {
     return AWS_BEARER_ENV;
@@ -46,10 +49,12 @@ export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): s
   return undefined;
 }
 
+/** Builds the standard missing-auth message used before throwing ProviderAuthError. */
 export function formatMissingAuthError(auth: ResolvedProviderAuth, provider: string): string {
   return `No API key resolved for provider "${provider}" (auth mode: ${auth.mode}, checked: ${auth.source}).`;
 }
 
+/** Returns a normalized API key or throws a typed provider auth error for callers to handle. */
 export function requireApiKey(auth: ResolvedProviderAuth, provider: string): string {
   const key = normalizeSecretInput(auth.apiKey);
   if (key) {

--- a/src/agents/model-registry-loader.ts
+++ b/src/agents/model-registry-loader.ts
@@ -12,6 +12,7 @@ export type LoadAgentModelRegistryOptions = {
   workspaceDir?: string;
 };
 
+/** Builds the agent model registry using the same auth store and plugin metadata view as runtime model selection. */
 export function loadAgentModelRegistry(
   config: OpenClawConfig,
   options: LoadAgentModelRegistryOptions = {},

--- a/src/agents/model-selection-normalize.ts
+++ b/src/agents/model-selection-normalize.ts
@@ -18,10 +18,12 @@ export type ModelManifestNormalizationContext = {
   manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
 };
 
+/** Builds the canonical provider/model key used by config, registry, and model-list paths. */
 export function modelKey(provider: string, model: string) {
   return sharedModelKey(provider, model);
 }
 
+/** Returns the pre-normalized key when callers need to preserve legacy config aliases. */
 export function legacyModelKey(provider: string, model: string): string | null {
   const providerId = provider.trim();
   const modelId = model.trim();
@@ -33,14 +35,17 @@ export function legacyModelKey(provider: string, model: string): string | null {
   return rawKey === canonicalKey ? null : rawKey;
 }
 
+/** Normalizes provider ids for model identity and config lookup. */
 export function normalizeProviderId(provider: string): string {
   return normalizeProviderIdCore(provider);
 }
 
+/** Normalizes provider ids for auth lookup, where provider aliases can intentionally collapse. */
 export function normalizeProviderIdForAuth(provider: string): string {
   return normalizeProviderIdForAuthCore(provider);
 }
 
+/** Finds a provider value by normalized id while preserving the original map keys. */
 export function findNormalizedProviderValue<T>(
   entries: Record<string, T> | undefined,
   provider: string,
@@ -48,6 +53,7 @@ export function findNormalizedProviderValue<T>(
   return findNormalizedProviderValueCore(entries, provider);
 }
 
+/** Finds the original provider key that matches a normalized provider id. */
 export function findNormalizedProviderKey(
   entries: Record<string, unknown> | undefined,
   provider: string,
@@ -86,6 +92,7 @@ type ModelRefNormalizeOptions = ModelManifestNormalizationContext & {
   allowPluginNormalization?: boolean;
 };
 
+/** Normalizes provider/model parts using static, manifest, and optional plugin model-id rules. */
 export function normalizeModelRef(
   provider: string,
   model: string,
@@ -99,6 +106,7 @@ export function normalizeModelRef(
 type ParseModelRefOptions = ModelRefNormalizeOptions;
 const OPENROUTER_AUTO_COMPAT_ALIAS = "openrouter:auto";
 
+/** Parses `provider/model` or bare model refs, applying the default provider when omitted. */
 export function parseModelRef(
   raw: string,
   defaultProvider: string,
@@ -108,6 +116,7 @@ export function parseModelRef(
   if (!trimmed) {
     return null;
   }
+  // Preserve the historical colon spelling while canonicalizing to the normal openrouter/auto key.
   if (normalizeLowercaseStringOrEmpty(trimmed) === OPENROUTER_AUTO_COMPAT_ALIAS) {
     return normalizeModelRef("openrouter", "auto", options);
   }

--- a/src/agents/model-suppression.runtime.ts
+++ b/src/agents/model-suppression.runtime.ts
@@ -8,12 +8,14 @@ type ShouldSuppressBuiltInModel =
 type BuildShouldSuppressBuiltInModel =
   typeof import("./model-suppression.js").buildShouldSuppressBuiltInModel;
 
+/** Runtime wrapper kept as a narrow mock seam for built-in model suppression decisions. */
 export function shouldSuppressBuiltInModel(
   ...args: Parameters<ShouldSuppressBuiltInModel>
 ): ReturnType<ShouldSuppressBuiltInModel> {
   return shouldSuppressBuiltInModelImpl(...args);
 }
 
+/** Builds a provider-aware suppression predicate without exposing the heavier implementation module to callers. */
 export function buildShouldSuppressBuiltInModel(
   ...args: Parameters<BuildShouldSuppressBuiltInModel>
 ): ReturnType<BuildShouldSuppressBuiltInModel> {

--- a/src/agents/model-suppression.ts
+++ b/src/agents/model-suppression.ts
@@ -1,11 +1,11 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { normalizeLowercaseStringOrEmpty } from "../../packages/normalization-core/src/string-coerce.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getCurrentPluginMetadataSnapshotState } from "../plugins/current-plugin-metadata-state.js";
 import { buildManifestBuiltInModelSuppressionResolver } from "../plugins/manifest-model-suppression.js";
 import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "../plugins/plugin-metadata-lifecycle.js";
 import { resolvePluginMetadataSnapshotMemoEnvFingerprint } from "../plugins/plugin-metadata-snapshot.js";
-import { normalizeLowercaseStringOrEmpty } from "../../packages/normalization-core/src/string-coerce.js";
 
 type ManifestSuppressionResolver = ReturnType<typeof buildManifestBuiltInModelSuppressionResolver>;
 
@@ -21,6 +21,7 @@ type CachedManifestSuppressionResolver = {
 
 let cachedManifestSuppressionResolver: CachedManifestSuppressionResolver | undefined;
 
+/** Clears the process-local manifest suppression resolver cache for tests and metadata lifecycle resets. */
 export function clearModelSuppressionResolverCacheForTest(): void {
   cachedManifestSuppressionResolver = undefined;
 }
@@ -117,6 +118,7 @@ function resolveBuiltInModelSuppression(params: {
   return undefined;
 }
 
+/** Checks manifest-declared built-in model suppression without deprecated runtime suppression hooks. */
 export function shouldSuppressBuiltInModelFromManifest(params: {
   provider?: string | null;
   id?: string | null;
@@ -126,6 +128,7 @@ export function shouldSuppressBuiltInModelFromManifest(params: {
   return resolveBuiltInModelSuppressionFromManifest(params)?.suppress ?? false;
 }
 
+/** Checks whether a built-in model should be hidden from runtime/catalog use. */
 export function shouldSuppressBuiltInModel(params: {
   provider?: string | null;
   id?: string | null;
@@ -151,6 +154,7 @@ export function shouldUnconditionallySuppress(params: {
   );
 }
 
+/** Builds the configured suppression error text for a blocked built-in model, when one applies. */
 export function buildSuppressedBuiltInModelError(params: {
   provider?: string | null;
   id?: string | null;
@@ -161,6 +165,7 @@ export function buildSuppressedBuiltInModelError(params: {
   return resolveBuiltInModelSuppression(params)?.errorMessage;
 }
 
+/** Builds a reusable predicate for repeated model suppression checks in one config/workspace scope. */
 export function buildShouldSuppressBuiltInModel(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;

--- a/src/agents/sender-tool-policy.ts
+++ b/src/agents/sender-tool-policy.ts
@@ -14,6 +14,7 @@ type SenderToolPolicyParams = {
   senderE164?: string | null;
 };
 
+/** Resolves the sandbox policy for a sender, preferring agent-local rules over global tool rules. */
 export function resolveSenderToolPolicy(
   params: SenderToolPolicyParams,
 ): SandboxToolPolicy | undefined {
@@ -39,6 +40,7 @@ export function resolveSenderToolPolicy(
   if (agentPolicy) {
     return pickSandboxToolPolicy(agentPolicy);
   }
+  // Global sender rules are fallback only; an agent-local match owns the decision even if it narrows tools.
   const globalPolicy = resolveToolsBySender({
     toolsBySender: cfg.tools?.toolsBySender,
     ...sender,

--- a/src/agents/tool-call-shared.ts
+++ b/src/agents/tool-call-shared.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 const TOOL_CALL_NAME_MAX_CHARS = 64;
 const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_:.-]+$/;
 
+/** Normalizes an optional tool allowlist; null means any syntactically valid tool name is allowed. */
 export function normalizeAllowedToolNames(allowedToolNames?: Iterable<string>): Set<string> | null {
   if (!allowedToolNames) {
     return null;
@@ -21,6 +22,7 @@ export function normalizeAllowedToolNames(allowedToolNames?: Iterable<string>): 
   return normalized.size > 0 ? normalized : null;
 }
 
+/** Validates a tool-call name against syntax limits and an optional normalized allowlist. */
 export function isAllowedToolCallName(
   name: unknown,
   allowedToolNames: Set<string> | null,
@@ -35,6 +37,7 @@ export function isAllowedToolCallName(
   if (trimmed.length > TOOL_CALL_NAME_MAX_CHARS || !TOOL_CALL_NAME_RE.test(trimmed)) {
     return false;
   }
+  // A missing allowlist is intentionally permissive after syntax validation for transcript repair callers.
   if (!allowedToolNames) {
     return true;
   }

--- a/src/agents/tools/web-search-provider-credentials.ts
+++ b/src/agents/tools/web-search-provider-credentials.ts
@@ -1,6 +1,7 @@
 import { normalizeSecretInputString, resolveSecretInputRef } from "../../config/types.secrets.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 
+/** Resolves a web-search provider credential from explicit config, env secret refs, or fallback env vars. */
 export function resolveWebSearchProviderCredential(params: {
   credentialValue: unknown;
   path: string;
@@ -12,6 +13,7 @@ export function resolveWebSearchProviderCredential(params: {
     return fromConfig;
   }
 
+  // Secret refs are authoritative: only env refs are resolved here, and missing refs do not fall back.
   const credentialRef = resolveSecretInputRef({ value: params.credentialValue }).ref;
   if (credentialRef) {
     if (credentialRef.source !== "env") {

--- a/src/channels/account-inspection.ts
+++ b/src/channels/account-inspection.ts
@@ -15,6 +15,7 @@ type AccountInspectionFields = {
   configured?: boolean;
 } | null;
 
+/** Inspect an account through plugin logic, falling back to read-only config projection. */
 export async function inspectChannelAccount(params: {
   plugin: ChannelPlugin;
   cfg: OpenClawConfig;
@@ -30,6 +31,12 @@ export async function inspectChannelAccount(params: {
   );
 }
 
+/**
+ * Resolve the account object and status flags used by channel status views.
+ *
+ * When source config carries a configured-but-unavailable credential snapshot,
+ * prefer that snapshot over a resolved config that would appear unconfigured.
+ */
 export async function resolveInspectedChannelAccount(params: {
   plugin: ChannelPlugin;
   cfg: OpenClawConfig;

--- a/src/channels/account-snapshot-fields.ts
+++ b/src/channels/account-snapshot-fields.ts
@@ -6,10 +6,6 @@ import { isRecord } from "../utils.js";
 import { asBoolean } from "../utils/boolean.js";
 import type { ChannelAccountSnapshot } from "./plugins/types.core.js";
 
-// Read-only status commands project a safe subset of account fields into snapshots
-// so renderers can preserve "configured but unavailable" state without touching
-// strict runtime-only credential helpers.
-
 const CREDENTIAL_STATUS_KEYS = [
   "tokenStatus",
   "botTokenStatus",
@@ -57,6 +53,12 @@ function readCredentialStatus(record: Record<string, unknown>, key: CredentialSt
     : undefined;
 }
 
+/**
+ * Infer whether any credential is configured from safe status fields only.
+ *
+ * `configured_unavailable` still means configured; status commands use this to
+ * avoid reading or resolving secret material just to render setup state.
+ */
 export function resolveConfiguredFromCredentialStatuses(account: unknown): boolean | undefined {
   const record = isRecord(account) ? account : null;
   if (!record) {
@@ -76,6 +78,12 @@ export function resolveConfiguredFromCredentialStatuses(account: unknown): boole
   return sawCredentialStatus ? false : undefined;
 }
 
+/**
+ * Infer configured state for a required credential subset.
+ *
+ * Missing required credentials make the whole subset unconfigured even when
+ * other credential status keys are present.
+ */
 export function resolveConfiguredFromRequiredCredentialStatuses(
   account: unknown,
   requiredKeys: CredentialStatusKey[],
@@ -98,6 +106,7 @@ export function resolveConfiguredFromRequiredCredentialStatuses(
   return sawCredentialStatus ? true : undefined;
 }
 
+/** Detect credentials that exist but cannot currently be resolved safely. */
 export function hasConfiguredUnavailableCredentialStatus(account: unknown): boolean {
   const record = isRecord(account) ? account : null;
   if (!record) {
@@ -108,6 +117,7 @@ export function hasConfiguredUnavailableCredentialStatus(account: unknown): bool
   );
 }
 
+/** Detect inline/resolved credential values or explicit available statuses. */
 export function hasResolvedCredentialValue(account: unknown): boolean {
   const record = isRecord(account) ? account : null;
   if (!record) {
@@ -120,6 +130,7 @@ export function hasResolvedCredentialValue(account: unknown): boolean {
   );
 }
 
+/** Project only credential source/status fields that are safe for status UIs. */
 export function projectCredentialSnapshotFields(
   account: unknown,
 ): Pick<
@@ -166,6 +177,12 @@ export function projectCredentialSnapshotFields(
   };
 }
 
+/**
+ * Project the read-only account/runtime fields exposed in channel snapshots.
+ *
+ * This strips URL userinfo and leaves strict credential helpers untouched so
+ * status renderers can consume partial runtime/account objects safely.
+ */
 export function projectSafeChannelAccountSnapshotFields(
   account: unknown,
 ): Partial<ChannelAccountSnapshot> {

--- a/src/channels/account-summary.ts
+++ b/src/channels/account-summary.ts
@@ -5,6 +5,7 @@ import { projectSafeChannelAccountSnapshotFields } from "./account-snapshot-fiel
 import type { ChannelAccountSnapshot } from "./plugins/types.core.js";
 import type { ChannelPlugin } from "./plugins/types.plugin.js";
 
+/** Build the safe status snapshot for one channel account. */
 export function buildChannelAccountSnapshot(params: {
   plugin: ChannelPlugin;
   account: unknown;
@@ -23,6 +24,7 @@ export function buildChannelAccountSnapshot(params: {
   };
 }
 
+/** Format allowFrom entries through plugin-specific display rules when present. */
 export function formatChannelAllowFrom(params: {
   plugin: ChannelPlugin;
   cfg: OpenClawConfig;
@@ -39,6 +41,7 @@ export function formatChannelAllowFrom(params: {
   return normalizeStringEntries(params.allowFrom);
 }
 
+/** Resolve account enabled state, defaulting absent flags to enabled. */
 export function resolveChannelAccountEnabled(params: {
   plugin: ChannelPlugin;
   account: unknown;
@@ -51,6 +54,7 @@ export function resolveChannelAccountEnabled(params: {
   return enabled !== false;
 }
 
+/** Resolve account configured state through plugin hooks or conservative defaults. */
 export async function resolveChannelAccountConfigured(params: {
   plugin: ChannelPlugin;
   account: unknown;

--- a/src/channels/ack-reactions.ts
+++ b/src/channels/ack-reactions.ts
@@ -19,6 +19,7 @@ export type AckReactionGateParams = {
   shouldBypassMention?: boolean;
 };
 
+/** Resolve whether a generic channel should send a temporary acknowledgement reaction. */
 export function shouldAckReaction(params: AckReactionGateParams): boolean {
   const scope = params.scope ?? "group-mentions";
   if (scope === "off" || scope === "none") {
@@ -48,6 +49,7 @@ export function shouldAckReaction(params: AckReactionGateParams): boolean {
   return false;
 }
 
+/** Translate WhatsApp-specific direct/group settings into the shared ack gate. */
 export function shouldAckReactionForWhatsApp(params: {
   emoji: string;
   isDirect: boolean;
@@ -84,6 +86,10 @@ export function shouldAckReactionForWhatsApp(params: {
   });
 }
 
+/**
+ * Start sending an acknowledgement reaction and return a handle that only
+ * reports success/failure; send errors are observed without rejecting callers.
+ */
 export function createAckReactionHandle(params: {
   ackReactionValue: string;
   send: () => Promise<void>;
@@ -115,6 +121,10 @@ export function createAckReactionHandle(params: {
   };
 }
 
+/**
+ * Remove an acknowledgement reaction after the reply only if the original send
+ * succeeded. Fire-and-forget removal keeps reply delivery off the cleanup path.
+ */
 export function removeAckReactionAfterReply(params: {
   removeAfterReply: boolean;
   ackReactionPromise: Promise<boolean> | null;
@@ -139,6 +149,7 @@ export function removeAckReactionAfterReply(params: {
   });
 }
 
+/** Convenience wrapper for SDK/runtime callers that carry the full ack handle. */
 export function removeAckReactionHandleAfterReply(params: {
   removeAfterReply: boolean;
   ackReaction: AckReactionHandle | null | undefined;

--- a/src/channels/allow-from.ts
+++ b/src/channels/allow-from.ts
@@ -2,6 +2,7 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 
 export const ACCESS_GROUP_ALLOW_FROM_PREFIX = "accessGroup:";
 
+/** Extracts the access-group name from an allowFrom entry, or null for direct sender ids. */
 export function parseAccessGroupAllowFromEntry(entry: string): string | null {
   const trimmed = entry.trim();
   if (!trimmed.startsWith(ACCESS_GROUP_ALLOW_FROM_PREFIX)) {
@@ -16,6 +17,8 @@ export function mergeDmAllowFromSources(params: {
   storeAllowFrom?: Array<string | number>;
   dmPolicy?: string;
 }): string[] {
+  // Explicit open/allowlist DM policy owns access; legacy store allowFrom values
+  // are only merged when policy falls back to stored sender allowlists.
   const storeEntries =
     params.dmPolicy === "allowlist" || params.dmPolicy === "open"
       ? []
@@ -40,6 +43,7 @@ export function resolveGroupAllowFromSources(params: {
   return normalizeStringEntries(scoped);
 }
 
+/** Returns the first argument that was supplied, preserving false/null values. */
 export function firstDefined<T>(...values: Array<T | undefined>) {
   for (const value of values) {
     if (value !== undefined) {

--- a/src/channels/channel-config.ts
+++ b/src/channels/channel-config.ts
@@ -14,6 +14,7 @@ export type ChannelEntryMatch<T> = {
   matchSource?: ChannelMatchSource;
 };
 
+/** Attach the winning channel key/source to a resolved config payload. */
 export function applyChannelMatchMeta<
   TResult extends { matchKey?: string; matchSource?: ChannelMatchSource },
 >(result: TResult, match: ChannelEntryMatch<unknown>): TResult {
@@ -24,6 +25,7 @@ export function applyChannelMatchMeta<
   return result;
 }
 
+/** Resolve a matched channel config entry and preserve where the match came from. */
 export function resolveChannelMatchConfig<
   TEntry,
   TResult extends { matchKey?: string; matchSource?: ChannelMatchSource },
@@ -34,6 +36,7 @@ export function resolveChannelMatchConfig<
   return applyChannelMatchMeta(resolveEntry(match.entry), match);
 }
 
+/** Convert user/channel labels into stable config keys. */
 export function normalizeChannelSlug(value: string): string {
   return normalizeLowercaseStringOrEmpty(value)
     .replace(/^#/, "")
@@ -41,10 +44,12 @@ export function normalizeChannelSlug(value: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+/** Normalize candidate config keys while preserving caller priority order. */
 export function buildChannelKeyCandidates(...keys: Array<string | undefined | null>): string[] {
   return normalizeUniqueSingleOrTrimmedStringList(keys);
 }
 
+/** Find direct and wildcard entries without choosing fallback precedence yet. */
 export function resolveChannelEntryMatch<T>(params: {
   entries?: Record<string, T>;
   keys: string[];
@@ -67,6 +72,10 @@ export function resolveChannelEntryMatch<T>(params: {
   return match;
 }
 
+/**
+ * Resolve a channel entry using direct, normalized direct, parent, normalized
+ * parent, then wildcard precedence.
+ */
 export function resolveChannelEntryMatchWithFallback<T>(params: {
   entries?: Record<string, T>;
   keys: string[];
@@ -151,6 +160,10 @@ export function resolveChannelEntryMatchWithFallback<T>(params: {
   return direct;
 }
 
+/**
+ * Apply nested allowlist semantics: an unconfigured outer or inner list does
+ * not constrain access, but configured lists must match at each configured level.
+ */
 export function resolveNestedAllowlistDecision(params: {
   outerConfigured: boolean;
   outerMatched: boolean;

--- a/src/channels/command-gating.ts
+++ b/src/channels/command-gating.ts
@@ -1,10 +1,14 @@
 export type CommandAuthorizer = {
+  /** Whether this authorization source has a configured rule to evaluate. */
   configured: boolean;
+  /** Whether the configured rule allows the current sender/request. */
   allowed: boolean;
 };
 
+/** Fallback command policy when access-group checks are disabled. */
 export type CommandGatingModeWhenAccessGroupsOff = "allow" | "deny" | "configured";
 
+/** Resolves whether any configured authorizer permits a control command. */
 export function resolveCommandAuthorizedFromAuthorizers(params: {
   useAccessGroups: boolean;
   authorizers: CommandAuthorizer[];
@@ -19,6 +23,8 @@ export function resolveCommandAuthorizedFromAuthorizers(params: {
     if (mode === "deny") {
       return false;
     }
+    // In configured mode, absence of any configured authorizer keeps old open
+    // behavior; once configured, at least one matching authorizer must allow.
     const anyConfigured = authorizers.some((entry) => entry.configured);
     if (!anyConfigured) {
       return true;
@@ -28,6 +34,7 @@ export function resolveCommandAuthorizedFromAuthorizers(params: {
   return authorizers.some((entry) => entry.configured && entry.allowed);
 }
 
+/** Resolves both authorization and whether a text control command should be blocked. */
 export function resolveControlCommandGate(params: {
   useAccessGroups: boolean;
   authorizers: CommandAuthorizer[];
@@ -44,6 +51,7 @@ export function resolveControlCommandGate(params: {
   return { commandAuthorized, shouldBlock };
 }
 
+/** Convenience gate for channels with two independent text authorization sources. */
 export function resolveDualTextControlCommandGate(params: {
   useAccessGroups: boolean;
   primaryConfigured: boolean;

--- a/src/channels/config-presence.ts
+++ b/src/channels/config-presence.ts
@@ -36,6 +36,7 @@ type ChannelPresenceSignal = {
   source: ChannelPresenceSignalSource;
 };
 
+/** Returns true when a channel config has settings beyond an enabled/disabled marker. */
 export function hasMeaningfulChannelConfig(value: unknown): boolean {
   if (!isRecord(value)) {
     return false;
@@ -43,6 +44,7 @@ export function hasMeaningfulChannelConfig(value: unknown): boolean {
   return Object.keys(value).some((key) => key !== "enabled");
 }
 
+/** Lists channels explicitly disabled in config, normalized for channel-id comparisons. */
 export function listExplicitlyDisabledChannelIdsForConfig(cfg: OpenClawConfig): string[] {
   const channels = isRecord(cfg.channels) ? cfg.channels : null;
   if (!channels) {
@@ -102,6 +104,7 @@ function hasPersistedAuthState(params: {
   });
 }
 
+/** Lists potentially configured channel ids from config, env, and persisted auth state. */
 export function listPotentialConfiguredChannelIds(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
@@ -114,6 +117,7 @@ export function listPotentialConfiguredChannelIds(
   );
 }
 
+/** Lists channel presence signals with source provenance for setup/startup decisions. */
 export function listPotentialConfiguredChannelPresenceSignals(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
@@ -126,6 +130,8 @@ export function listPotentialConfiguredChannelPresenceSignals(
     if (seenSignals.has(key)) {
       return;
     }
+    // De-dupe per source so callers can still see that one channel was found
+    // through config and env without repeating identical provenance.
     seenSignals.add(key);
     signals.push({ channelId, source });
   };
@@ -166,6 +172,8 @@ export function listPotentialConfiguredChannelPresenceSignals(
     }
   }
 
+  // Only return signals for ids that survived the same configured-channel set
+  // used by listPotentialConfiguredChannelIds.
   return signals.filter((signal) => configuredChannelIds.has(signal.channelId));
 }
 
@@ -192,6 +200,7 @@ function hasEnvConfiguredChannel(
   );
 }
 
+/** Fast boolean check for any config/env/persisted-auth channel presence. */
 export function hasPotentialConfiguredChannels(
   cfg: OpenClawConfig | null | undefined,
   env: NodeJS.ProcessEnv = process.env,

--- a/src/channels/conversation-label.ts
+++ b/src/channels/conversation-label.ts
@@ -24,6 +24,12 @@ function shouldAppendId(id: string): boolean {
   return false;
 }
 
+/**
+ * Resolve a stable human-readable conversation label for transcript/session UI.
+ *
+ * Group labels append numeric/email-like ids only when the visible name does
+ * not already carry the unique identifier.
+ */
 export function resolveConversationLabel(ctx: MsgContext): string | undefined {
   const explicit = normalizeOptionalString(ctx.ConversationLabel);
   if (explicit) {

--- a/src/channels/direct-dm-access.ts
+++ b/src/channels/direct-dm-access.ts
@@ -15,6 +15,7 @@ import type { ChannelId } from "./plugins/types.public.js";
 export type { AccessGroupMembershipResolver } from "../plugin-sdk/access-groups.js";
 
 export type DirectDmCommandAuthorizationRuntime = {
+  /** Returns true only for messages that should run command authorization. */
   shouldComputeCommandAuthorized: (rawBody: string, cfg: OpenClawConfig) => boolean;
   /** @deprecated Command authorization is resolved by channel ingress. Kept for runtime injection compatibility. */
   resolveCommandAuthorizedFromAuthorizers?: (params: {
@@ -80,6 +81,8 @@ export async function resolveInboundDirectDmAccessWithRuntime(params: {
         })
       : [];
   const [allowFrom, effectiveStoreAllowFrom] = await Promise.all([
+    // Expand config and persisted pairing allowlists separately so the access
+    // result can preserve which source made the DM reachable.
     expandAllowFromWithAccessGroups({
       cfg: params.cfg,
       allowFrom: params.allowFrom,
@@ -158,6 +161,8 @@ export function createPreCryptoDirectDmAuthorizer(params: {
     reply: (text: string) => Promise<void>;
   }): Promise<"allow" | "block" | "pairing"> => {
     const resolved = await params.resolveAccess(input.senderId);
+    // Older callers may return either the whole legacy result or just the
+    // nested access object; accept both while this compatibility helper exists.
     const access = "access" in resolved ? resolved.access : resolved;
     if (access.decision === "allow") {
       return "allow";

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -1,6 +1,7 @@
 import { formatErrorMessage } from "../infra/errors.js";
 import { createDraftStreamLoop } from "./draft-stream-loop.js";
 
+/** Mutable finalization state shared between draft stream controls and channel cleanup. */
 export type FinalizableDraftStreamState = {
   stopped: boolean;
   final: boolean;
@@ -29,6 +30,7 @@ type FinalizableDraftLifecycleParams<T> = Omit<
   sendOrEditStreamMessage: (text: string) => Promise<boolean>;
 };
 
+/** Creates controls that can flush a final draft, seal it, or discard pending updates. */
 export function createFinalizableDraftStreamControls(params: {
   throttleMs: number;
   isStopped: () => boolean;
@@ -58,6 +60,8 @@ export function createFinalizableDraftStreamControls(params: {
   const stopForClear = async (): Promise<void> => {
     params.markStopped();
     loop.stop();
+    // Wait for the in-flight edit before deleting its message id, otherwise a
+    // late edit can recreate visible draft text after clear/delete succeeds.
     await loop.waitForInFlight();
   };
 
@@ -77,6 +81,7 @@ export function createFinalizableDraftStreamControls(params: {
   };
 }
 
+/** Creates finalizable draft controls backed by a shared mutable state object. */
 export function createFinalizableDraftStreamControlsForState(params: {
   throttleMs: number;
   state: FinalizableDraftStreamState;
@@ -96,6 +101,7 @@ export function createFinalizableDraftStreamControlsForState(params: {
   });
 }
 
+/** Stops draft updates, reads the current message id once, then clears the stored id. */
 export async function takeMessageIdAfterStop<T>(
   params: StopAndClearMessageIdParams<T>,
 ): Promise<T | undefined> {
@@ -105,6 +111,7 @@ export async function takeMessageIdAfterStop<T>(
   return messageId;
 }
 
+/** Deletes a finalizable draft message after stopping further draft updates. */
 export async function clearFinalizableDraftMessage<T>(
   params: ClearFinalizableDraftMessageParams<T>,
 ): Promise<void> {
@@ -124,6 +131,7 @@ export async function clearFinalizableDraftMessage<T>(
   }
 }
 
+/** Bundles stream controls with the clear/delete lifecycle used by channel drafts. */
 export function createFinalizableDraftLifecycle<T>(params: FinalizableDraftLifecycleParams<T>) {
   const controls = createFinalizableDraftStreamControlsForState({
     throttleMs: params.throttleMs,

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -8,6 +8,7 @@ import {
 } from "../auto-reply/inbound-debounce.js";
 import type { OpenClawConfig } from "../config/types.js";
 
+/** Decide whether a plain-text inbound message can be delayed for coalescing. */
 export function shouldDebounceTextInbound(params: {
   text: string | null | undefined;
   cfg: OpenClawConfig;
@@ -28,6 +29,7 @@ export function shouldDebounceTextInbound(params: {
   return !isControlCommandMessage(text, params.cfg, params.commandOptions);
 }
 
+/** Build a channel debouncer using config/default debounce timing resolution. */
 export function createChannelInboundDebouncer<T>(
   params: Omit<InboundDebounceCreateParams<T>, "debounceMs"> & {
     cfg: OpenClawConfig;

--- a/src/channels/location.ts
+++ b/src/channels/location.ts
@@ -35,6 +35,7 @@ function formatCoords(latitude: number, longitude: number): string {
   return `${latitude.toFixed(6)}, ${longitude.toFixed(6)}`;
 }
 
+/** Format inbound location metadata into the compact text shown to agents. */
 export function formatLocationText(location: NormalizedLocation): string {
   const resolved = resolveLocation(location);
   const coords = formatCoords(resolved.latitude, resolved.longitude);
@@ -47,6 +48,7 @@ export function formatLocationText(location: NormalizedLocation): string {
   return `📍 ${coords}${accuracy}`;
 }
 
+/** Convert inbound location metadata into stable template/context fields. */
 export function toLocationContext(location: NormalizedLocation): {
   LocationLat: number;
   LocationLon: number;

--- a/src/channels/logging.ts
+++ b/src/channels/logging.ts
@@ -1,5 +1,6 @@
 export type LogFn = (message: string) => void;
 
+/** Emits a stable one-line inbound drop log shared by channel plugins. */
 export function logInboundDrop(params: {
   log: LogFn;
   channel: string;
@@ -10,6 +11,7 @@ export function logInboundDrop(params: {
   params.log(`${params.channel}: drop ${params.reason}${target}`);
 }
 
+/** Emits a stable one-line typing lifecycle failure log shared by channel plugins. */
 export function logTypingFailure(params: {
   log: LogFn;
   channel: string;
@@ -22,6 +24,7 @@ export function logTypingFailure(params: {
   params.log(`${params.channel} typing${action} failed${target}: ${String(params.error)}`);
 }
 
+/** Emits a stable one-line acknowledgement cleanup failure log shared by channel plugins. */
 export function logAckFailure(params: {
   log: LogFn;
   channel: string;

--- a/src/channels/mention-gating.ts
+++ b/src/channels/mention-gating.ts
@@ -71,6 +71,7 @@ export type InboundMentionDecision = MentionGateResult & {
   shouldBypassMention: boolean;
 };
 
+/** Convenience helper for conditionally appending a single implicit mention reason. */
 export function implicitMentionKindWhen(
   kind: InboundImplicitMentionKind,
   enabled: boolean,
@@ -94,6 +95,8 @@ function resolveMatchedImplicitMentionKinds(params: {
     if (allowedKinds && !allowedKinds.has(kind)) {
       continue;
     }
+    // Preserve first-seen order but de-dupe, so diagnostics stay stable when
+    // multiple channel-specific detectors report the same implicit reason.
     if (!matched.includes(kind)) {
       matched.push(kind);
     }
@@ -168,10 +171,13 @@ function normalizeMentionDecisionParams(
   };
 }
 
+/** Resolves whether an inbound group message satisfies mention-gating policy. */
 export function resolveInboundMentionDecision(
   params: ResolveInboundMentionDecisionParams,
 ): InboundMentionDecision {
   const { facts, policy } = normalizeMentionDecisionParams(params);
+  // Text commands may bypass required mention only when no other mention was
+  // detected; an unrelated human mention should not authorize a bot command.
   const shouldBypassMention =
     policy.isGroup &&
     policy.requireMention &&

--- a/src/channels/message-access/decision.ts
+++ b/src/channels/message-access/decision.ts
@@ -53,6 +53,8 @@ function routeSenderEmptyGate(state: ChannelIngressState): AccessGraphGate | nul
     return null;
   }
   const reasonCode = "route_sender_empty";
+  // A matched route with an empty sender allowlist is an explicit deny. Without
+  // this gate, route-only configs could accidentally dispatch to every sender.
   return {
     id: `${route.id}:sender`,
     phase: "route",
@@ -253,6 +255,10 @@ function activationGate(params: {
   });
 }
 
+/**
+ * Decide the final ingress admission from normalized sender, route, command,
+ * event, and activation gates.
+ */
 export function decideChannelIngress(
   state: ChannelIngressState,
   policy: ChannelIngressPolicyInput,
@@ -267,6 +273,8 @@ export function decideChannelIngress(
     return decisiveDecision({ admission: "drop", decision: "block", gate: routeBlock, gates });
   }
 
+  // before-sender activation lets mention-only group messages short-circuit
+  // before sender allowlists, but text commands still need sender auth first.
   const activationBeforeSender =
     policy.activation?.order === "before-sender" && !policy.activation.allowTextCommands
       ? activationGate({

--- a/src/channels/message-access/runtime-access-groups.ts
+++ b/src/channels/message-access/runtime-access-groups.ts
@@ -20,6 +20,10 @@ export function allReferencedAccessGroupNames(
   return uniqueStrings(entries.flatMap((entryGroup) => accessGroupNames(entryGroup)));
 }
 
+/**
+ * Normalize literal allowlist entries while preserving access-group references
+ * for the runtime membership pass.
+ */
 export async function normalizeEffectiveEntries(params: {
   adapter: ChannelIngressAdapter;
   accountId: string;
@@ -45,6 +49,12 @@ export async function normalizeEffectiveEntries(params: {
   ]);
 }
 
+/**
+ * Resolve dynamic access-group membership facts for non-message-sender groups.
+ *
+ * Static `message.senders` groups are expanded later by the state resolver so
+ * the access graph can report configured, invalid, disabled, and matched entries.
+ */
 export async function resolveRuntimeAccessGroupMembershipFacts(params: {
   input: ResolveChannelMessageIngressParams;
   channelId: ChannelIngressChannelId;

--- a/src/channels/message-access/runtime-identity.ts
+++ b/src/channels/message-access/runtime-identity.ts
@@ -51,6 +51,8 @@ function fieldDangerous(field: ResolvedIdentityField, value: string): boolean | 
 }
 
 function identityFields(identity: ChannelIngressIdentityDescriptor): ResolvedIdentityField[] {
+  // Primary identities default to the historical stableId/stable-id contract;
+  // aliases get plugin-scoped kinds unless a channel opts into a shared kind.
   const fields: ResolvedIdentityField[] = [
     {
       ...identity.primary,
@@ -104,6 +106,8 @@ export function createIdentityAdapter(
     normalizeEntries({ entries }) {
       const matchable = entries.flatMap((entry, entryIndex) => {
         if (isWildcardEntry(entry)) {
+          // Wildcards bind to the primary field only, preserving legacy allowFrom
+          // behavior where "*" means any sender, not every alias namespace.
           return [
             adapterEntry({
               identity,
@@ -144,6 +148,8 @@ export function createIdentityAdapter(
       const matchedEntryIds = entries
         .filter((entry) => {
           const fallback = entry.value === "*" || subjectKeys.has(identityMatchKey(entry));
+          // Custom matchEntry hooks can support composite/platform matching but
+          // still fall back to normalized field equality when omitted.
           return identity.matchEntry?.({ subject, entry, context }) ?? fallback;
         })
         .map((entry) => entry.opaqueEntryId);
@@ -161,6 +167,8 @@ export function createIdentitySubject(
 ): ChannelIngressSubject {
   const fields = identityFields(identity);
   const identifiers: InternalMatchMaterial[] = fields.flatMap((field, index) => {
+    // The first field consumes stableId; aliases are keyed by their descriptor
+    // names so plugins can expose multiple safe identifiers for one sender.
     const rawValue = index === 0 ? input.stableId : input.aliases?.[field.key];
     if (rawValue == null) {
       return [];

--- a/src/channels/message-access/runtime.ts
+++ b/src/channels/message-access/runtime.ts
@@ -286,6 +286,8 @@ export function createChannelIngressResolver(
       route: input.route,
       routeFacts: input.routeFacts,
       accessGroups: base.accessGroups ?? base.cfg?.accessGroups,
+      // Resolver-level memberships are stable for the account; per-message
+      // facts can add transient sender/group membership without replacing them.
       accessGroupMembership: [
         ...(base.accessGroupMembership ?? []),
         ...(input.accessGroupMembership ?? []),
@@ -319,6 +321,8 @@ export function createChannelIngressResolver(
 export async function resolveStableChannelMessageIngress(
   params: ResolveStableChannelMessageIngressParams,
 ): Promise<ResolvedChannelMessageIngress> {
+  // This convenience path keeps simple plugins on the stable-id contract while
+  // still using the full route/sender/command/activation resolver underneath.
   return await createChannelIngressResolver({
     ...params,
     identity: defineStableChannelIngressIdentity(params.identity),
@@ -414,6 +418,8 @@ function routeFactsFromDescriptors(
     ) {
       return [];
     }
+    // A descriptor with only sender metadata is not a route gate; it becomes a
+    // route-sender fact unless deny-when-empty must surface as a route block.
     return [
       routeFact({
         ...defaults,
@@ -633,6 +639,8 @@ export async function resolveChannelMessageIngress(
     channelId,
     names: referencedAccessGroups,
   });
+  // Runtime resolution happens only for groups referenced by the effective
+  // allowlists/route facts, then caller-supplied membership facts are appended.
   const accessGroupMembership = [
     ...runtimeAccessGroupMembership,
     ...(params.accessGroupMembership ?? []),
@@ -664,6 +672,8 @@ export async function resolveChannelMessageIngress(
     ...params.policy,
     ...(params.command !== undefined ? { command: params.command } : {}),
   };
+  // Decision state keeps raw allowlist values for graph/explainability while
+  // normalized lists below are returned to callers for enforcement display.
   const state = await resolveChannelIngressState({
     channelId,
     accountId: params.accountId,

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -176,6 +176,8 @@ async function originSubjectMatched(input: ChannelIngressStateInput): Promise<bo
     context,
     opaquePrefix: "origin",
   });
+  // Origin and current subjects may carry different identifier kinds for the
+  // same user; run both match directions so adapter aliases can bridge them.
   if (originEntries.length > 0) {
     const currentMatch = await input.adapter.matchSubject({
       subject: input.subject,
@@ -253,6 +255,8 @@ async function resolveAccessGroupEntries(params: {
       continue;
     }
 
+    // message.senders groups are concrete allowlists; dynamic groups arrive as
+    // membership facts and should not be flattened into entry diagnostics here.
     const groupEntries = groupSenderEntries({ groupName, input: params.input });
     const resolved = await normalizeAndMatch({
       adapter: params.input.adapter,
@@ -350,6 +354,12 @@ async function resolveRouteFacts(
   return resolved;
 }
 
+/**
+ * Build the redacted, normalized ingress state used by the policy decider.
+ *
+ * This is the single place that expands sender access groups, computes route
+ * sender allowlists, and compares event origin subjects against the live sender.
+ */
 export async function resolveChannelIngressState(
   input: ChannelIngressStateInput,
 ): Promise<ChannelIngressState> {

--- a/src/channels/model-overrides.ts
+++ b/src/channels/model-overrides.ts
@@ -58,6 +58,10 @@ function resolveProviderEntry(
   );
 }
 
+/**
+ * Build candidate keys for group/channel overrides from live message metadata
+ * and parent session bindings.
+ */
 function buildChannelCandidates(
   params: Pick<
     ChannelModelOverrideParams,
@@ -123,6 +127,10 @@ function buildGenericParentOverrideCandidates(sessionKey: string | null | undefi
   return buildChannelKeyCandidates(threadId ? baseSessionKey : raw.rawId);
 }
 
+/**
+ * Resolve legacy direct/group override keys before richer conversation binding
+ * candidates so existing config keeps precedence.
+ */
 function resolveDirectChannelModelMatch(params: {
   channel: string;
   providerEntries: Record<string, string>;
@@ -154,6 +162,7 @@ function resolveDirectChannelModelMatch(params: {
   return { model, matchKey: match.matchKey, matchSource: match.matchSource };
 }
 
+/** Resolve the configured model override for an inbound channel conversation. */
 export function resolveChannelModelOverride(
   params: ChannelModelOverrideParams,
 ): ChannelModelOverride | null {

--- a/src/channels/plugins/setup-wizard-proxy.ts
+++ b/src/channels/plugins/setup-wizard-proxy.ts
@@ -35,6 +35,7 @@ type DelegatedStatusBase = Omit<
   "resolveConfigured" | "resolveStatusLines" | "resolveSelectionHint" | "resolveQuickstartScore"
 >;
 
+/** Builds a lightweight setup wizard whose expensive status hooks are loaded on demand. */
 export function createDelegatedSetupWizardProxy(params: {
   channel: string;
   loadWizard: () => Promise<ChannelSetupWizard>;
@@ -54,6 +55,8 @@ export function createDelegatedSetupWizardProxy(params: {
     status: {
       ...params.status,
       resolveConfigured: createDelegatedResolveConfigured(params.loadWizard),
+      // Keep optional status resolvers lazy so startup can advertise setup
+      // metadata without importing each channel's full wizard implementation.
       ...createDelegatedSetupWizardStatusResolvers(params.loadWizard),
     },
     ...(params.resolveShouldPromptAccountIds
@@ -70,6 +73,7 @@ export function createDelegatedSetupWizardProxy(params: {
   } satisfies ChannelSetupWizard;
 }
 
+/** Builds an allowlist-aware proxy that falls back when a channel lacks optional handlers. */
 export function createAllowlistSetupWizardProxy<TGroupResolved>(params: {
   loadWizard: () => Promise<ChannelSetupWizard>;
   createBase: (handlers: {
@@ -92,6 +96,8 @@ export function createAllowlistSetupWizardProxy<TGroupResolved>(params: {
     resolveAllowFromEntries: async ({ cfg, accountId, credentialValues, entries }) => {
       const wizard = await params.loadWizard();
       if (!wizard.allowFrom) {
+        // Preserve user-entered entries even when a delegated channel has no
+        // resolver; callers can still display unresolved ids consistently.
         return entries.map((input) => ({ input, resolved: false, id: null }));
       }
       return await wizard.allowFrom.resolveEntries({

--- a/src/channels/read-only-account-inspect.ts
+++ b/src/channels/read-only-account-inspect.ts
@@ -5,6 +5,7 @@ import type { ChannelId } from "./plugins/types.public.js";
 
 export type ReadOnlyInspectedAccount = Record<string, unknown>;
 
+/** Inspect a channel account without starting or mutating the channel runtime. */
 export async function inspectReadOnlyChannelAccount(params: {
   channelId: ChannelId;
   cfg: OpenClawConfig;

--- a/src/channels/route-projection.ts
+++ b/src/channels/route-projection.ts
@@ -20,6 +20,7 @@ import {
   type DeliveryContext,
 } from "../utils/delivery-context.js";
 
+/** Channel route with the minimum fields needed for reply delivery. */
 export type RoutableChannelRouteRef = ChannelRouteRef & {
   channel: string;
   target: {
@@ -38,6 +39,7 @@ export type SessionRouteDeliveryFields = {
   lastThreadId?: string | number;
 };
 
+/** Normalizes a route and narrows it to routes that carry a channel and target. */
 export function normalizeRoutableChannelRoute(
   route?: ChannelRouteRef | null,
 ): RoutableChannelRouteRef | undefined {
@@ -70,6 +72,7 @@ export function routeFromSessionEntry(entry?: SessionEntry | null): ChannelRoute
     return undefined;
   }
   return (
+    // Canonical route wins over older delivery-context/last-* fields when sessions carry both.
     normalizeSessionDeliveryFields(entry).route ??
     routeFromDeliveryContext(deliveryContextFromSession(entry))
   );
@@ -92,6 +95,8 @@ export function routeFromConversationRef(
     conversationId: conversation.conversationId,
     parentConversationId: conversation.parentConversationId,
   });
+  // Plugin target projection can split a parent conversation into route target
+  // plus thread id; that keeps later reply code transport-agnostic.
   return normalizeChannelRouteRef({
     channel: conversation.channel,
     accountId: conversation.accountId,
@@ -148,6 +153,7 @@ export function routesShareDeliveryTarget(params: {
   return (
     left.channel === right.channel &&
     channelRouteTarget(left) === channelRouteTarget(right) &&
+    // Missing account ids are wildcards because older routes did not always persist them.
     (left.accountId == null || right.accountId == null || left.accountId === right.accountId) &&
     String(channelRouteThreadId(left) ?? "") === String(channelRouteThreadId(right) ?? "")
   );

--- a/src/channels/run-state-machine.ts
+++ b/src/channels/run-state-machine.ts
@@ -4,6 +4,7 @@ type RunStateStatusPatch = {
   lastRunActivityAt?: number | null;
 };
 
+/** Receives channel run-state patches for presence/status publishing. */
 export type RunStateStatusSink = (patch: RunStateStatusPatch) => void;
 
 type RunStateMachineParams = {
@@ -15,6 +16,7 @@ type RunStateMachineParams = {
 
 const DEFAULT_RUN_ACTIVITY_HEARTBEAT_MS = 60_000;
 
+/** Tracks active channel runs and emits periodic activity while any run is alive. */
 export function createRunStateMachine(params: RunStateMachineParams) {
   const heartbeatMs = params.heartbeatMs ?? DEFAULT_RUN_ACTIVITY_HEARTBEAT_MS;
   const now = params.now ?? Date.now;
@@ -50,6 +52,7 @@ export function createRunStateMachine(params: RunStateMachineParams) {
         clearHeartbeat();
         return;
       }
+      // Long-running runs need activity refreshes even when no new run events arrive.
       publish();
     }, heartbeatMs);
     runActivityHeartbeat.unref?.();

--- a/src/channels/sender-identity.ts
+++ b/src/channels/sender-identity.ts
@@ -2,6 +2,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { MsgContext } from "../auto-reply/templating.js";
 import { normalizeChatType } from "./chat-type.js";
 
+/** Returns user-facing sender identity validation issues for plugin contract tests. */
 export function validateSenderIdentity(ctx: MsgContext): string[] {
   const issues: string[] = [];
 
@@ -14,6 +15,8 @@ export function validateSenderIdentity(ctx: MsgContext): string[] {
   const senderE164 = normalizeOptionalString(ctx.SenderE164) || "";
 
   if (!isDirect) {
+    // Group channels need at least one sender marker so replies, audit logs, and
+    // access checks can distinguish the author from the room itself.
     if (!senderId && !senderName && !senderUsername && !senderE164) {
       issues.push("missing sender identity (SenderId/SenderName/SenderUsername/SenderE164)");
     }

--- a/src/channels/session-meta.ts
+++ b/src/channels/session-meta.ts
@@ -10,6 +10,10 @@ function loadInboundSessionRuntime() {
   return inboundSessionRuntimePromise;
 }
 
+/**
+ * Best-effort inbound session metadata write used when callers cannot let
+ * session persistence failures interrupt channel processing.
+ */
 export async function recordInboundSessionMetaSafe(params: {
   cfg: OpenClawConfig;
   agentId: string;

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -29,6 +29,10 @@ function shouldSkipPinnedMainDmRouteUpdate(
   return true;
 }
 
+/**
+ * Persist inbound session metadata and optionally update the last route used for
+ * replies. Metadata writes are tracked asynchronously; route updates stay awaitable.
+ */
 export async function recordInboundSession(params: {
   storePath: string;
   sessionKey: string;
@@ -51,6 +55,8 @@ export async function recordInboundSession(params: {
       createIfMissing,
     })
     .catch(params.onRecordError);
+  // Recording inbound metadata should not block reply routing, but callers can
+  // still observe the task for shutdown/test synchronization.
   params.trackSessionMetaTask?.(metaTask);
   void metaTask;
 

--- a/src/channels/session.types.ts
+++ b/src/channels/session.types.ts
@@ -2,6 +2,7 @@ import type { MsgContext } from "../auto-reply/templating.js";
 import type { GroupKeyResolution, SessionEntry } from "../config/sessions/types.js";
 import type { ChannelRouteRef } from "../plugin-sdk/channel-route.js";
 
+/** Last-route update payload recorded alongside inbound session metadata. */
 export type InboundLastRouteUpdate = {
   sessionKey: string;
   channel: SessionEntry["lastChannel"];
@@ -16,6 +17,7 @@ export type InboundLastRouteUpdate = {
   };
 };
 
+/** Runtime hook used by channel plugins to persist inbound session metadata. */
 export type RecordInboundSession = (params: {
   storePath: string;
   sessionKey: string;

--- a/src/channels/status/read-model.ts
+++ b/src/channels/status/read-model.ts
@@ -23,6 +23,7 @@ function readRuntimeAccountsByChannel(payload: unknown): Record<string, unknown>
   return asRecord(asRecord(payload).channelAccounts);
 }
 
+/** Return live runtime account objects for one channel from a gateway payload. */
 export function getRuntimeChannelAccounts(params: {
   payload: unknown;
   channelId: string;
@@ -31,6 +32,7 @@ export function getRuntimeChannelAccounts(params: {
   return Array.isArray(raw) ? raw.map(asRecord) : [];
 }
 
+/** Normalize gateway channel account snapshots into a channel-keyed lookup map. */
 export function normalizeRuntimeChannelAccountSnapshots(
   payload: unknown,
 ): Map<string, ChannelAccountSnapshot[]> {
@@ -52,6 +54,7 @@ export function normalizeRuntimeChannelAccountSnapshots(
   return out;
 }
 
+/** Resolve the account id used to correlate runtime and config account rows. */
 export function resolveRuntimeChannelAccountId(account: RuntimeChannelAccount): string {
   return (
     normalizeOptionalString(account.accountId) ??
@@ -61,6 +64,7 @@ export function resolveRuntimeChannelAccountId(account: RuntimeChannelAccount): 
   );
 }
 
+/** Find the live runtime account matching a config account id. */
 export function findRuntimeChannelAccount(params: {
   liveAccounts: RuntimeChannelAccount[];
   accountId: string;
@@ -75,6 +79,7 @@ export function findRuntimeChannelAccount(params: {
   );
 }
 
+/** Treat running/connected runtime accounts as proof that credentials are usable. */
 export function hasRuntimeCredentialAvailable(params: {
   liveAccounts: RuntimeChannelAccount[];
   accountId: string;
@@ -89,6 +94,7 @@ export function hasRuntimeCredentialAvailable(params: {
   return account.running === true || account.connected === true;
 }
 
+/** Upgrade credential status snapshots when live runtime proof shows availability. */
 export function markConfiguredUnavailableCredentialStatusesAvailable(
   account: unknown,
 ): Record<string, unknown> {
@@ -101,6 +107,7 @@ export function markConfiguredUnavailableCredentialStatusesAvailable(
   return record;
 }
 
+/** Merge configured and gateway-reported accounts into display rows. */
 export async function resolveChannelAccountStatusRows(params: {
   localAccountIds: string[];
   runtimeAccounts: ChannelAccountSnapshot[];

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -141,6 +141,7 @@ function stripTrailingEllipsis(text: string): string {
   return text.replace(/(?:\s*(?:\.{3}|\u2026))+$/u, "").trimEnd();
 }
 
+/** Detects final messages that look clipped by a trailing ellipsis. */
 export function isPotentialTruncatedFinal(finalText: string): boolean {
   const trimmedFinal = finalText.trimEnd();
   const untruncatedFinal = stripTrailingEllipsis(trimmedFinal);
@@ -149,6 +150,7 @@ export function isPotentialTruncatedFinal(finalText: string): boolean {
   );
 }
 
+/** Selects a longer transcript-backed final when it is a clear continuation of the emitted text. */
 export function selectLongerFinalText(params: {
   finalText: string;
   candidateTexts: readonly (string | undefined)[];
@@ -170,6 +172,8 @@ export function selectLongerFinalText(params: {
     const continuation = candidateText.slice(untruncatedFinal.length).trimStart();
     if (
       continuation.length >= MIN_TRUNCATED_FINAL_CONTINUATION_CHARS &&
+      // Require an alphanumeric continuation so decorative punctuation does not
+      // turn an intentionally shortened final into a transcript replacement.
       /^[\p{L}\p{N}]/u.test(continuation)
     ) {
       return candidateText;
@@ -178,6 +182,7 @@ export function selectLongerFinalText(params: {
   return undefined;
 }
 
+/** Replaces a possibly truncated final with a transcript candidate when the candidate is safer. */
 export async function resolveTranscriptBackedChannelFinalText(params: {
   finalText: string;
   resolveCandidateText: () => Promise<string | undefined>;
@@ -204,6 +209,7 @@ export type ChannelProgressDraftRenderMode = "text" | "rich";
 
 const EMOJI_PREFIX_RE = /^\p{Extended_Pictographic}/u;
 
+/** Structured progress event accepted by channel progress draft renderers. */
 export type ChannelProgressDraftLineInput =
   | {
       event: "tool";
@@ -265,6 +271,7 @@ export type ChannelProgressDraftLineInput =
 
 export type ChannelProgressDraftLineKind = ChannelProgressDraftLineInput["event"];
 
+/** Normalized progress line used by text and rich channel draft renderers. */
 export type ChannelProgressDraftLine = {
   id?: string;
   kind: ChannelProgressDraftLineKind;
@@ -373,6 +380,7 @@ function shouldPrefixProgressLine(line: string): boolean {
   return !EMOJI_PREFIX_RE.test(line);
 }
 
+/** Formats one progress event into display text, dropping events that should stay silent. */
 export function formatChannelProgressDraftLine(
   input: ChannelProgressDraftLineInput,
   options?: ChannelProgressLineOptions,
@@ -380,6 +388,7 @@ export function formatChannelProgressDraftLine(
   return buildChannelProgressDraftLine(input, options)?.text;
 }
 
+/** Resolves line-formatting options from channel streaming config plus caller overrides. */
 export function resolveChannelProgressDraftLineOptions(
   entry: StreamingCompatEntry | null | undefined,
   options?: ChannelProgressLineOptions,
@@ -390,6 +399,7 @@ export function resolveChannelProgressDraftLineOptions(
   };
 }
 
+/** Builds a normalized progress line using channel config for command text handling. */
 export function buildChannelProgressDraftLineForEntry(
   entry: StreamingCompatEntry | null | undefined,
   input: ChannelProgressDraftLineInput,
@@ -401,6 +411,7 @@ export function buildChannelProgressDraftLineForEntry(
   );
 }
 
+/** Formats one progress event using channel config for command text handling. */
 export function formatChannelProgressDraftLineForEntry(
   entry: StreamingCompatEntry | null | undefined,
   input: ChannelProgressDraftLineInput,
@@ -409,6 +420,7 @@ export function formatChannelProgressDraftLineForEntry(
   return buildChannelProgressDraftLineForEntry(entry, input, options)?.text;
 }
 
+/** Converts a structured progress event into a normalized progress draft line. */
 export function buildChannelProgressDraftLine(
   input: ChannelProgressDraftLineInput,
   options?: ChannelProgressLineOptions,
@@ -571,6 +583,8 @@ export function createChannelProgressDraftGate(params: {
         return true;
       }
       if (workEvents > 1) {
+        // Start immediately on the second work event; sustained work should not
+        // wait for the initial quiet-period timer.
         await start();
         return true;
       }
@@ -705,6 +719,8 @@ export function resolveChannelStreamingSuppressDefaultToolProgressMessages(
     return true;
   }
   if (options?.draftStreamActive === true) {
+    // Active draft streams own tool progress so channels do not emit duplicate
+    // default progress messages beside the draft.
     return true;
   }
   return options?.previewToolProgressEnabled ?? resolveChannelStreamingPreviewToolProgress(entry);
@@ -733,11 +749,14 @@ export function resolveChannelPreviewStreamMode(
     return legacy;
   }
   if (typeof entry?.streaming === "boolean") {
+    // Boolean streaming predates mode strings: true means partial preview,
+    // false keeps streaming fully disabled.
     return entry.streaming ? "partial" : "off";
   }
   return defaultMode;
 }
 
+/** Returns the progress-draft config object, tolerating absent or malformed config. */
 export function resolveChannelProgressDraftConfig(
   entry: StreamingCompatEntry | null | undefined,
 ): ChannelStreamingProgressConfig {
@@ -778,7 +797,8 @@ export function resolveChannelProgressDraftLabel(params: {
   const labels = normalizeProgressLabels(progress.labels);
   const index =
     typeof params.seed === "string" && params.seed.length > 0
-      ? hashProgressSeed(params.seed) % labels.length
+      ? // Seeded labels keep a session's draft header stable across rerenders.
+        hashProgressSeed(params.seed) % labels.length
       : Math.floor(Math.max(0, Math.min(0.999999, params.random?.() ?? 0)) * labels.length);
   return labels[index] ?? labels[0];
 }
@@ -926,6 +946,7 @@ export function normalizeChannelProgressDraftLineIdentity(
   return text?.replace(/\s+/g, " ").trim() ?? "";
 }
 
+/** Merges a progress line by id or content while keeping the newest bounded window. */
 export function mergeChannelProgressDraftLine<TLine extends string | ChannelProgressDraftLine>(
   lines: TLine[],
   line: TLine,
@@ -945,6 +966,8 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
       if (normalizeChannelProgressDraftLineIdentity(lines[existingIndex]) === normalized) {
         return lines;
       }
+      // Same id means update in place, preserving the existing ordering instead
+      // of appending noisy duplicates for one running item/tool call.
       const next = [...lines];
       next[existingIndex] = line;
       return next.slice(-maxLines);
@@ -957,6 +980,7 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
   return [...lines, line].slice(-maxLines);
 }
 
+/** Formats a bounded progress draft body with optional label, bullets, and line compaction. */
 export function formatChannelProgressDraftText(params: {
   entry?: StreamingCompatEntry | null;
   lines: Array<string | ChannelProgressDraftLine>;

--- a/src/channels/targets.ts
+++ b/src/channels/targets.ts
@@ -17,10 +17,12 @@ export type MessagingTargetParseOptions = {
   ambiguousMessage?: string;
 };
 
+/** Builds the canonical target lookup key used to compare plugin message destinations. */
 export function normalizeTargetId(kind: MessagingTargetKind, id: string): string {
   return normalizeLowercaseStringOrEmpty(`${kind}:${id}`);
 }
 
+/** Materializes a parsed user/channel target while preserving the operator input. */
 export function buildMessagingTarget(
   kind: MessagingTargetKind,
   id: string,
@@ -73,6 +75,8 @@ export function parseTargetPrefixes(params: {
   raw: string;
   prefixes: Array<{ prefix: string; kind: MessagingTargetKind }>;
 }): MessagingTarget | undefined {
+  // Prefix order is caller-owned so channel plugins can prefer platform-native
+  // mention syntax before generic channel:/user: forms.
   for (const entry of params.prefixes) {
     const parsed = parseTargetPrefix({
       raw: params.raw,
@@ -110,6 +114,8 @@ export function parseMentionPrefixOrAtUserTarget(params: {
   atUserPattern: RegExp;
   atUserErrorMessage: string;
 }): MessagingTarget | undefined {
+  // Prefer explicit platform mentions, then typed prefixes, then @user
+  // shorthand. This keeps ambiguous bare @ values out of channel targets.
   const mentionTarget = parseTargetMention({
     raw: params.raw,
     mentionPattern: params.mentionPattern,

--- a/src/channels/thread-bindings-policy.ts
+++ b/src/channels/thread-bindings-policy.ts
@@ -34,6 +34,7 @@ type ChannelThreadBindingsContainerShape = {
 
 export type ThreadBindingSpawnKind = "subagent" | "acp";
 
+/** Resolved spawn policy for a channel/account/kind combination. */
 export type ThreadBindingSpawnPolicy = {
   channel: string;
   accountId: string;
@@ -48,14 +49,17 @@ function normalizeChannelId(value: string | undefined | null): string {
   return normalizeLowercaseStringOrEmpty(value);
 }
 
+/** Returns true when a channel's top-level thread binding should spawn a child session. */
 export function supportsAutomaticThreadBindingSpawn(channel: string): boolean {
   return resolveDefaultTopLevelPlacement(channel) === "child";
 }
 
+/** Returns true when `/thread here` needs native thread context instead of current session reuse. */
 export function requiresNativeThreadContextForThreadHere(channel: string): boolean {
   return resolveDefaultTopLevelPlacement(channel) === "child";
 }
 
+/** Resolves whether a thread binding should use the current session or spawn a child. */
 export function resolveThreadBindingPlacementForCurrentContext(params: {
   channel: string;
   threadId?: string;
@@ -72,6 +76,8 @@ function resolveDefaultTopLevelPlacement(channel: string): "current" | "child" {
     return "current";
   }
   return (
+    // Loaded plugins win over bundled defaults so external channels can define
+    // their native top-level thread behavior without core channel ids.
     getLoadedChannelPlugin(normalized)?.conversationBindings?.defaultTopLevelPlacement ??
     resolveBundledChannelThreadBindingDefaultPlacement(normalized) ??
     "current"
@@ -104,6 +110,7 @@ function resolveThreadBindingHoursMs(raw: unknown, fallbackHours: number): numbe
   return Math.min(durationMs, MAX_DATE_TIMESTAMP_MS);
 }
 
+/** Resolves idle expiry in milliseconds, with channel/account config overriding session defaults. */
 export function resolveThreadBindingIdleTimeoutMs(params: {
   channelIdleHoursRaw: unknown;
   sessionIdleHoursRaw: unknown;
@@ -114,6 +121,7 @@ export function resolveThreadBindingIdleTimeoutMs(params: {
   );
 }
 
+/** Resolves absolute max-age expiry in milliseconds, with zero meaning no max-age limit. */
 export function resolveThreadBindingMaxAgeMs(params: {
   channelMaxAgeHoursRaw: unknown;
   sessionMaxAgeHoursRaw: unknown;
@@ -125,6 +133,7 @@ export function resolveThreadBindingMaxAgeMs(params: {
   );
 }
 
+/** Returns the effective expiry timestamp for a binding lifecycle record. */
 export function resolveThreadBindingEffectiveExpiresAt(params: {
   record: ThreadBindingLifecycleRecord;
   defaultIdleTimeoutMs: number;
@@ -133,6 +142,7 @@ export function resolveThreadBindingEffectiveExpiresAt(params: {
   return resolveSharedThreadBindingLifecycle(params).expiresAt;
 }
 
+/** Resolves whether thread bindings are enabled, defaulting open when unset. */
 export function resolveThreadBindingsEnabled(params: {
   channelEnabledRaw: unknown;
   sessionEnabledRaw: unknown;
@@ -171,6 +181,7 @@ function normalizeSpawnContext(value: unknown): ThreadBindingSpawnContext | unde
   return value === "isolated" || value === "fork" ? value : undefined;
 }
 
+/** Resolves account/channel/global spawn policy for subagent or ACP thread bindings. */
 export function resolveThreadBindingSpawnPolicy(params: {
   cfg: OpenClawConfig;
   channel: string;
@@ -191,6 +202,7 @@ export function resolveThreadBindingSpawnPolicy(params: {
     true;
   const spawnFlagKey = resolveSpawnFlagKey(params.kind);
   const spawnEnabledRaw =
+    // Kind-specific flags override the broad spawnSessions flag at each scope.
     normalizeBoolean(account?.[spawnFlagKey]) ??
     normalizeBoolean(account?.spawnSessions) ??
     normalizeBoolean(root?.[spawnFlagKey]) ??
@@ -211,6 +223,7 @@ export function resolveThreadBindingSpawnPolicy(params: {
   };
 }
 
+/** Resolves idle timeout using channel/account scoped thread-binding config. */
 export function resolveThreadBindingIdleTimeoutMsForChannel(params: {
   cfg: OpenClawConfig;
   channel: string;
@@ -223,6 +236,7 @@ export function resolveThreadBindingIdleTimeoutMsForChannel(params: {
   });
 }
 
+/** Resolves max age using channel/account scoped thread-binding config. */
 export function resolveThreadBindingMaxAgeMsForChannel(params: {
   cfg: OpenClawConfig;
   channel: string;
@@ -249,6 +263,7 @@ function resolveThreadBindingChannelScope(params: {
   });
 }
 
+/** Formats a user-facing error for disabled thread bindings. */
 export function formatThreadBindingDisabledError(params: {
   channel: string;
   accountId: string;
@@ -257,6 +272,7 @@ export function formatThreadBindingDisabledError(params: {
   return `Thread bindings are disabled for ${params.channel} (set channels.${params.channel}.threadBindings.enabled=true to override for this account, or session.threadBindings.enabled=true globally).`;
 }
 
+/** Formats a user-facing error for disabled thread-bound session spawning. */
 export function formatThreadBindingSpawnDisabledError(params: {
   channel: string;
   accountId: string;

--- a/src/channels/typing-lifecycle.ts
+++ b/src/channels/typing-lifecycle.ts
@@ -7,6 +7,7 @@ type TypingKeepaliveLoop = {
   isRunning: () => boolean;
 };
 
+/** Creates a non-overlapping interval loop for refreshing channel typing indicators. */
 export function createTypingKeepaliveLoop(params: {
   intervalMs: number;
   onTick: AsyncTick;
@@ -18,6 +19,8 @@ export function createTypingKeepaliveLoop(params: {
     if (tickInFlight) {
       return;
     }
+    // Typing transports can be slow; skip overlapping ticks so a stuck refresh
+    // cannot build an unbounded queue of start calls.
     tickInFlight = true;
     try {
       await params.onTick();

--- a/src/channels/typing-start-guard.ts
+++ b/src/channels/typing-start-guard.ts
@@ -4,6 +4,10 @@ type TypingStartGuard = {
   isTripped: () => boolean;
 };
 
+/**
+ * Guard repeated typing-start attempts so sealed replies and failing channel
+ * APIs stop scheduling more typing work.
+ */
 export function createTypingStartGuard(params: {
   isSealed: () => boolean;
   shouldBlock?: () => boolean;
@@ -19,6 +23,8 @@ export function createTypingStartGuard(params: {
   let consecutiveFailures = 0;
   let tripped = false;
 
+  // The sealed/tripped checks are intentionally evaluated at each start call;
+  // typing indicators may be scheduled after the reply has already completed.
   const isBlocked = () => {
     if (params.isSealed()) {
       return true;
@@ -43,6 +49,8 @@ export function createTypingStartGuard(params: {
       if (params.rethrowOnError) {
         throw err;
       }
+      // A tripped guard is sticky until reset so noisy channel failures do not
+      // keep producing errors for the same reply lifecycle.
       if (maxConsecutiveFailures && consecutiveFailures >= maxConsecutiveFailures) {
         tripped = true;
         params.onTrip?.();

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -5,6 +5,7 @@ import {
 import { createTypingKeepaliveLoop } from "./typing-lifecycle.js";
 import { createTypingStartGuard } from "./typing-start-guard.js";
 
+/** Lifecycle hooks used by reply pipelines to start, stop, and clean up typing indicators. */
 export type TypingCallbacks = {
   onReplyStart: () => Promise<void>;
   onIdle?: () => void;
@@ -12,6 +13,7 @@ export type TypingCallbacks = {
   onCleanup?: () => void;
 };
 
+/** Channel-provided typing transport callbacks plus keepalive and safety limits. */
 export type CreateTypingCallbacksParams = {
   start: () => Promise<void>;
   stop?: () => Promise<void>;
@@ -41,7 +43,7 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
   const stop = params.stop;
   const keepaliveIntervalMs = resolveKeepaliveIntervalMs(params.keepaliveIntervalMs);
   const maxConsecutiveFailures = resolvePositiveIntegerOption(params.maxConsecutiveFailures, 2);
-  const maxDurationMs = resolveDurationMsOption(params.maxDurationMs, 60_000); // Default 60s TTL
+  const maxDurationMs = resolveDurationMsOption(params.maxDurationMs, 60_000);
   let stopSent = false;
   let closed = false;
   let ttlTimer: ReturnType<typeof setTimeout> | undefined;
@@ -64,7 +66,6 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
     onTick: fireStart,
   });
 
-  // TTL safety: auto-stop typing after maxDurationMs
   const startTtlTimer = () => {
     if (maxDurationMs <= 0) {
       return;
@@ -108,7 +109,7 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
   const fireStop = () => {
     closed = true;
     keepaliveLoop.stop();
-    clearTtlTimer(); // Clear TTL timer on normal stop
+    clearTtlTimer();
     if (!stop || stopSent) {
       return;
     }

--- a/src/commands/auth-choice-options.static.ts
+++ b/src/commands/auth-choice-options.static.ts
@@ -20,6 +20,7 @@ export type AuthChoiceGroup = {
   options: AuthChoiceOption[];
 };
 
+/** Core auth choices that are always available before plugin/provider contributions are discovered. */
 export const CORE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
   {
     value: "custom-api-key",
@@ -31,6 +32,7 @@ export const CORE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
   },
 ];
 
+/** Formats the static auth-choice enum used by CLI parsers before dynamic provider metadata loads. */
 export function formatStaticAuthChoiceChoicesForCli(params?: {
   includeSkip?: boolean;
   includeLegacyAliases?: boolean;

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -31,6 +31,7 @@ function compareLabelsCaseInsensitive(a: string, b: string): number {
   return a.localeCompare(b, undefined, { sensitivity: "base" });
 }
 
+/** Sorts provider auth groups with featured first, then stable case-insensitive labels for CLI/help output. */
 export function compareAuthChoiceGroups(a: AuthChoiceGroup, b: AuthChoiceGroup): number {
   const priorityA = FEATURED_AUTH_GROUP_ORDER.get(a.value) ?? Number.POSITIVE_INFINITY;
   const priorityB = FEATURED_AUTH_GROUP_ORDER.get(b.value) ?? Number.POSITIVE_INFINITY;
@@ -89,9 +90,11 @@ export function formatAuthChoiceChoicesForCli(params?: {
     }).map((contribution) => contribution.option.value),
   ];
 
+  // Provider manifests can repeat core or legacy values; CLI enums need each value once for help and validation.
   return uniqueStrings(values).join("|");
 }
 
+/** Builds the flat auth-choice list consumed by prompts, preserving dynamic provider overrides by value. */
 export function buildAuthChoiceOptions(params: {
   store: AuthProfileStore;
   includeSkip: boolean;
@@ -105,6 +108,7 @@ export function buildAuthChoiceOptions(params: {
   for (const option of CORE_AUTH_CHOICE_OPTIONS) {
     optionByValue.set(option.value, option);
   }
+  // Dynamic providers can refine core choices by reusing the value; the latest option owns display metadata.
   for (const option of resolveProviderChoiceOptions({
     config: params.config,
     workspaceDir: params.workspaceDir,
@@ -126,6 +130,7 @@ export function buildAuthChoiceOptions(params: {
   return options;
 }
 
+/** Builds grouped assistant-facing auth choices, returning the skip action separately from provider groups. */
 export function buildAuthChoiceGroups(params: {
   store: AuthProfileStore;
   includeSkip: boolean;
@@ -149,6 +154,7 @@ export function buildAuthChoiceGroups(params: {
     }
     const existing = groupsById.get(option.groupId);
     if (existing) {
+      // Same group id can collect options from multiple plugins; first group metadata remains canonical.
       existing.options.push(option);
       continue;
     }

--- a/src/commands/channel-setup/discovery.ts
+++ b/src/commands/channel-setup/discovery.ts
@@ -20,6 +20,7 @@ type ChannelCatalogEntry = {
   meta: ChannelMeta;
 };
 
+/** Mirrors channel manifest exposure rules for setup screens and tests. */
 export function shouldShowChannelInSetup(
   meta: Pick<ChannelMeta, "exposure" | "showConfigured" | "showInSetup">,
 ): boolean {
@@ -38,6 +39,7 @@ function resolveWorkspaceDir(cfg: OpenClawConfig, workspaceDir?: string): string
   return workspaceDir ?? resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
 }
 
+/** Returns channel ids contributed by installed manifests after auto-enable config has been applied. */
 export function listManifestInstalledChannelIds(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
@@ -57,6 +59,7 @@ export function listManifestInstalledChannelIds(params: {
   );
 }
 
+/** Checks whether a catalog entry is already installed through manifest-discovered channel contributions. */
 export function isCatalogChannelInstalled(params: {
   cfg: OpenClawConfig;
   entry: ChannelPluginCatalogEntry;
@@ -66,6 +69,7 @@ export function isCatalogChannelInstalled(params: {
   return listManifestInstalledChannelIds(params).has(params.entry.id as ChannelChoice);
 }
 
+/** Resolves built-in, installed, and installable channel setup entries for onboarding prompts. */
 export function resolveChannelSetupEntries(params: {
   cfg: OpenClawConfig;
   installedPlugins: ChannelPlugin[];
@@ -137,6 +141,7 @@ export function resolveChannelSetupEntries(params: {
       }),
     );
   }
+  // Catalog metadata fills only missing ids so loaded plugins remain the canonical source for active channels.
   for (const entry of installedCatalogEntries) {
     if (!metaById.has(entry.id)) {
       metaById.set(

--- a/src/commands/channel-setup/plugin-install.ts
+++ b/src/commands/channel-setup/plugin-install.ts
@@ -39,6 +39,7 @@ function toOnboardingPluginInstallEntry(
   };
 }
 
+/** Installs the plugin behind a channel setup catalog entry using the shared onboarding installer. */
 export async function ensureChannelSetupPluginInstalled(params: {
   cfg: OpenClawConfig;
   entry: ChannelPluginCatalogEntry;
@@ -67,6 +68,7 @@ export async function ensureChannelSetupPluginInstalled(params: {
   };
 }
 
+/** Reloads channel setup plugins from config so newly installed setup wizards become available. */
 export function reloadChannelSetupPluginRegistry(params: {
   cfg: OpenClawConfig;
   runtime: RuntimeEnv;
@@ -121,6 +123,7 @@ function resolveScopedChannelPluginId(params: {
   if (explicitPluginId) {
     return explicitPluginId;
   }
+  // Prefer trusted catalog plugin ids; manifest discovery is a fallback only when exactly one plugin owns the channel.
   return (
     getTrustedChannelPluginCatalogEntry(params.channel, {
       cfg: params.cfg,
@@ -143,6 +146,7 @@ function resolveUniqueManifestScopedChannelPluginId(params: {
   return matches.length === 1 ? matches[0] : undefined;
 }
 
+/** Reloads the registry for a single channel, narrowing activation when a unique plugin owner is known. */
 export function reloadChannelSetupPluginRegistryForChannel(params: {
   cfg: OpenClawConfig;
   runtime: RuntimeEnv;
@@ -162,6 +166,7 @@ export function reloadChannelSetupPluginRegistryForChannel(params: {
   });
 }
 
+/** Loads an inactive setup registry snapshot for one channel so setup status can be inspected without activation. */
 export function loadChannelSetupPluginRegistrySnapshotForChannel(params: {
   cfg: OpenClawConfig;
   runtime: RuntimeEnv;

--- a/src/commands/channel-setup/registry.ts
+++ b/src/commands/channel-setup/registry.ts
@@ -31,6 +31,7 @@ function isDeclarativeChannelSetupWizard(
   );
 }
 
+/** Resolves either an imperative setup adapter or a cached adapter for a declarative channel wizard. */
 export function resolveChannelSetupWizardAdapterForPlugin(
   plugin?: ChannelPlugin,
 ): ChannelSetupWizardAdapter | undefined {
@@ -46,6 +47,7 @@ export function resolveChannelSetupWizardAdapterForPlugin(
     if (cached) {
       return cached;
     }
+    // Declarative wizards are wrapped once per plugin object so repeated setup prompts share adapter state.
     const adapter = buildChannelSetupWizardAdapterFromSetupWizard({
       plugin,
       wizard: setupWizard,
@@ -68,6 +70,7 @@ const getChannelSetupWizardAdapterMap = () => {
   return adapters;
 };
 
+/** Looks up the setup wizard adapter for a channel from the current channel plugin registry snapshot. */
 export function getChannelSetupWizardAdapter(
   channel: ChannelChoice,
 ): ChannelSetupWizardAdapter | undefined {

--- a/src/commands/channel-setup/trusted-catalog.ts
+++ b/src/commands/channel-setup/trusted-catalog.ts
@@ -33,6 +33,7 @@ function isTrustedWorkspaceChannelCatalogEntry(
   ).enabled;
 }
 
+/** Returns a catalog entry only when workspace entries are trusted, otherwise falling back to bundled catalog data. */
 export function getTrustedChannelPluginCatalogEntry(
   channelId: string,
   params: {
@@ -79,6 +80,7 @@ function listChannelPluginCatalogEntriesWithTrustedFallback(
   });
 }
 
+/** Lists catalog entries visible to setup after replacing untrusted workspace entries with safe fallbacks. */
 export function listTrustedChannelPluginCatalogEntries(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
@@ -87,6 +89,7 @@ export function listTrustedChannelPluginCatalogEntries(params: {
   return listChannelPluginCatalogEntriesWithTrustedFallback(params, () => []);
 }
 
+/** Lists setup-discovery entries while keeping untrusted workspace entries visible as install candidates. */
 export function listSetupDiscoveryChannelPluginCatalogEntries(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;

--- a/src/commands/cleanup-plan.ts
+++ b/src/commands/cleanup-plan.ts
@@ -7,6 +7,9 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildCleanupPlan } from "./cleanup-utils.js";
 
+/**
+ * Reads current runtime paths and builds the cleanup plan used by CLI cleanup flows.
+ */
 export function resolveCleanupPlanFromDisk(): {
   cfg: OpenClawConfig;
   stateDir: string;

--- a/src/commands/doctor-command-owner.ts
+++ b/src/commands/doctor-command-owner.ts
@@ -13,10 +13,14 @@ function resolveConfiguredCommandOwners(cfg: OpenClawConfig): string[] {
   return normalizeStringEntries(owners.map((entry) => String(entry ?? "")));
 }
 
+/** Returns whether owner-only command senders are configured. */
 export function hasConfiguredCommandOwners(cfg: OpenClawConfig): boolean {
   return resolveConfiguredCommandOwners(cfg).length > 0;
 }
 
+/**
+ * Formats a channel sender id into the canonical ownerAllowFrom entry shape.
+ */
 export function formatCommandOwnerFromChannelSender(params: {
   channel: PairingChannel;
   id: string;
@@ -26,6 +30,8 @@ export function formatCommandOwnerFromChannelSender(params: {
     return null;
   }
   const separatorIndex = id.indexOf(":");
+  // Pairing records may already include a channel prefix; keep matching prefixes
+  // intact so doctor does not suggest `telegram:telegram:123`.
   if (separatorIndex > 0) {
     const prefix = id.slice(0, separatorIndex);
     if (prefix.toLowerCase() === String(params.channel).toLowerCase()) {
@@ -35,6 +41,7 @@ export function formatCommandOwnerFromChannelSender(params: {
   return `${params.channel}:${id}`;
 }
 
+/** Emits the owner-configuration warning used by doctor output. */
 export function noteCommandOwnerHealth(cfg: OpenClawConfig): void {
   if (hasConfiguredCommandOwners(cfg)) {
     return;

--- a/src/commands/doctor-service-repair-policy.ts
+++ b/src/commands/doctor-service-repair-policy.ts
@@ -7,6 +7,7 @@ export const SERVICE_REPAIR_POLICY_ENV = "OPENCLAW_SERVICE_REPAIR_POLICY";
 export const EXTERNAL_SERVICE_REPAIR_NOTE =
   "Gateway service is managed externally; skipped service install/start repair. Start or repair the gateway through your supervisor.";
 
+/** Resolves whether doctor may repair OpenClaw-managed gateway services. */
 export function resolveServiceRepairPolicy(
   env: NodeJS.ProcessEnv = process.env,
 ): ServiceRepairPolicy {
@@ -20,12 +21,16 @@ export function resolveServiceRepairPolicy(
   }
 }
 
+/** True when doctor must leave service lifecycle repair to an external supervisor. */
 export function isServiceRepairExternallyManaged(
   policy: ServiceRepairPolicy = resolveServiceRepairPolicy(),
 ): boolean {
   return policy === "external";
 }
 
+/**
+ * Applies the service-repair policy before prompting for gateway runtime repair.
+ */
 export async function confirmDoctorServiceRepair(
   prompter: DoctorPrompter,
   params: Parameters<DoctorPrompter["confirmRuntimeRepair"]>[0],

--- a/src/commands/doctor-skills-core.ts
+++ b/src/commands/doctor-skills-core.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SkillStatusEntry, SkillStatusReport } from "../skills/discovery/status.js";
 
+/**
+ * Returns skills that doctor can safely offer to disable for the current agent.
+ */
 export function collectUnavailableAgentSkills(report: SkillStatusReport): SkillStatusEntry[] {
   return report.skills.filter(
     (skill) =>
@@ -11,6 +14,9 @@ export function collectUnavailableAgentSkills(report: SkillStatusReport): SkillS
   );
 }
 
+/**
+ * Writes disabled entries for unavailable skills while preserving existing skill config.
+ */
 export function disableUnavailableSkillsInConfig(
   config: OpenClawConfig,
   skills: readonly SkillStatusEntry[],

--- a/src/commands/gateway-status/discovery.ts
+++ b/src/commands/gateway-status/discovery.ts
@@ -5,6 +5,7 @@ import {
   serializeGatewayDiscoveryBeacon,
 } from "../../infra/gateway-discovery-targets.js";
 
+/** Infers an SSH target from a configured remote gateway URL using the local username when available. */
 export function inferSshTargetFromRemoteUrl(rawUrl?: string | null): string | null {
   if (typeof rawUrl !== "string") {
     return null;
@@ -40,6 +41,7 @@ function buildSshTarget(input: { user?: string; host?: string; port?: number }):
   return base;
 }
 
+/** Resolves a raw SSH target through ssh config, preserving explicit identity overrides. */
 export async function resolveSshTarget(params: {
   rawTarget: string;
   identity: string | null;
@@ -77,6 +79,7 @@ export async function resolveSshTarget(params: {
   return { target, identity: identityFile };
 }
 
+/** Picks the first Bonjour-discovered SSH target that the tunnel parser accepts. */
 export function pickAutoSshTargetFromDiscovery(params: {
   discovery: GatewayBonjourBeacon[];
   parseSshTarget: (target: string) => unknown;

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -67,6 +67,7 @@ function parseIntOrNull(value: unknown): number | null {
   return parseStrictInteger(s) ?? null;
 }
 
+/** Parses CLI timeout values with the gateway-status fallback contract. */
 export function parseTimeoutMs(raw: unknown, fallbackMs: number): number {
   return parseTimeoutMsWithFallback(raw, fallbackMs);
 }
@@ -82,6 +83,7 @@ function normalizeWsUrl(value: string): string | null {
   return trimmed;
 }
 
+/** Builds the ordered probe target list from explicit URL, remote config, and local loopback fallback. */
 export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): GatewayStatusTarget[] {
   const targets: GatewayStatusTarget[] = [];
   const add = (t: GatewayStatusTarget) => {
@@ -129,6 +131,7 @@ function isLoopbackProbeTarget(target: Pick<GatewayStatusTarget, "kind" | "url">
   }
 }
 
+/** Caps probe time by target kind so inactive or remote checks cannot consume the whole status budget. */
 export function resolveProbeBudgetMs(
   overallMs: number,
   target: Pick<GatewayStatusTarget, "kind" | "active" | "url">,
@@ -148,6 +151,7 @@ export function resolveProbeBudgetMs(
   return overallMs;
 }
 
+/** Normalizes SSH targets from CLI-style input while rejecting empty or non-string values. */
 export function sanitizeSshTarget(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
@@ -159,6 +163,7 @@ export function sanitizeSshTarget(value: unknown): string | null {
   return trimmed.replace(/^ssh\s+/, "");
 }
 
+/** Resolves token/password auth for a status probe, with explicit CLI overrides taking precedence. */
 export async function resolveAuthForTarget(
   cfg: OpenClawConfig,
   target: GatewayStatusTarget,
@@ -178,6 +183,7 @@ export async function resolveAuthForTarget(
 
 export { pickGatewaySelfPresence };
 
+/** Projects a raw config snapshot into the stable gateway-status JSON/text summary shape. */
 export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSummary {
   const snap = snapshotUnknown as Partial<ConfigFileSnapshot> | null;
   const path = typeof snap?.path === "string" ? snap.path : null;
@@ -244,6 +250,7 @@ export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSum
   };
 }
 
+/** Builds local gateway URL hints from configured port/TLS and best-effort tailnet discovery. */
 export function buildNetworkHints(cfg: OpenClawConfig) {
   const { tailnetIPv4 } = inspectBestEffortPrimaryTailnetIPv4();
   const port = resolveGatewayPort(cfg);
@@ -255,6 +262,7 @@ export function buildNetworkHints(cfg: OpenClawConfig) {
   };
 }
 
+/** Renders a human-readable target heading while preserving the probed URL. */
 export function renderTargetHeader(target: GatewayStatusTarget, rich: boolean) {
   const kindLabel =
     target.kind === "localLoopback"
@@ -269,6 +277,7 @@ export function renderTargetHeader(target: GatewayStatusTarget, rich: boolean) {
   return `${colorize(rich, theme.heading, kindLabel)} ${colorize(rich, theme.muted, target.url)}`;
 }
 
+/** Detects read-probe failures caused by missing operator scopes after a successful connection. */
 export function isScopeLimitedProbeFailure(probe: GatewayProbeResult): boolean {
   if (probe.ok || probe.connectLatencyMs == null) {
     return false;
@@ -276,10 +285,12 @@ export function isScopeLimitedProbeFailure(probe: GatewayProbeResult): boolean {
   return MISSING_SCOPE_PATTERN.test(probe.error ?? "");
 }
 
+/** Returns true when the gateway connected but a follow-up detail probe failed. */
 export function isPostConnectProbeFailure(probe: GatewayProbeResult): boolean {
   return !probe.ok && probe.connectLatencyMs != null;
 }
 
+/** Treats successful WebSocket connection as reachable even when read diagnostics degrade. */
 export function isProbeReachable(probe: GatewayProbeResult): boolean {
   return probe.ok || probe.connectLatencyMs != null;
 }
@@ -291,6 +302,7 @@ function getGatewayProbeCapability(probe: GatewayProbeResult): GatewayProbeCapab
 export function summarizeGatewayProbeCapability(
   probes: GatewayProbeResult[],
 ): GatewayProbeCapability {
+  // Highest observed capability wins so a weaker duplicate target cannot downgrade the overall status.
   const priority: GatewayProbeCapability[] = [
     "admin_capable",
     "write_capable",
@@ -347,6 +359,7 @@ function renderProbeCapabilityLine(probe: GatewayProbeResult, rich: boolean) {
   );
 }
 
+/** Renders the compact connect/read/capability line used by gateway-status text output. */
 export function renderProbeSummaryLine(probe: GatewayProbeResult, rich: boolean) {
   const capability = renderProbeCapabilityLine(probe, rich);
   if (probe.ok) {

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -38,8 +38,10 @@ function readModelPricingDegradedDetail(health: unknown): string | null {
     : "pricing bootstrap or refresh failed";
 }
 
+/** Chooses the target whose details should anchor gateway-status summaries and JSON primaryTargetId. */
 export function pickPrimaryProbedTarget(probed: GatewayStatusProbedTarget[]) {
   const reachable = probed.filter((entry) => isProbeReachable(entry.probe));
+  // Explicit and SSH targets reflect the operator's intent, so they outrank auto-discovered config targets.
   return (
     reachable.find((entry) => entry.target.kind === "explicit") ??
     reachable.find((entry) => entry.target.kind === "sshTunnel") ??
@@ -49,6 +51,7 @@ export function pickPrimaryProbedTarget(probed: GatewayStatusProbedTarget[]) {
   );
 }
 
+/** Converts probe, tunnel, TLS, and degraded health states into user-facing gateway warnings. */
 export function buildGatewayStatusWarnings(params: {
   probed: GatewayStatusProbedTarget[];
   sshTarget: string | null;
@@ -137,6 +140,7 @@ export function buildGatewayStatusWarnings(params: {
   return warnings;
 }
 
+/** Emits the machine-readable gateway-status payload and exits nonzero when no target is reachable. */
 export function writeGatewayStatusJson(params: {
   runtime: RuntimeEnv;
   startedAt: number;
@@ -193,6 +197,7 @@ export function writeGatewayStatusJson(params: {
   }
 }
 
+/** Emits the terminal gateway-status report with discovery, target, config, and warning sections. */
 export function writeGatewayStatusText(params: {
   runtime: RuntimeEnv;
   rich: boolean;

--- a/src/commands/model-picker.runtime.ts
+++ b/src/commands/model-picker.runtime.ts
@@ -9,6 +9,7 @@ import {
 } from "../plugins/provider-wizard.js";
 import { resolvePluginProviders } from "../plugins/providers.runtime.js";
 
+/** Lazy runtime bundle used by model picker flows and mocked as one unit in tests. */
 export const modelPickerRuntime = {
   resolveProviderModelPickerContributions: resolveProviderModelPickerFlowContributions,
   resolveProviderModelPickerEntries: resolveProviderModelPickerFlowEntries,

--- a/src/commands/models/list.errors.ts
+++ b/src/commands/models/list.errors.ts
@@ -1,5 +1,6 @@
 export const MODEL_AVAILABILITY_UNAVAILABLE_CODE = "MODEL_AVAILABILITY_UNAVAILABLE";
 
+/** Formats unknown errors with stack traces when available for verbose model-list diagnostics. */
 export function formatErrorWithStack(err: unknown): string {
   if (err instanceof Error) {
     return err.stack ?? `${err.name}: ${err.message}`;
@@ -7,6 +8,7 @@ export function formatErrorWithStack(err: unknown): string {
   return String(err);
 }
 
+/** Detects registry availability failures where provider-auth heuristics are allowed as a fallback. */
 export function shouldFallbackToAuthHeuristics(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false;

--- a/src/commands/models/list.model-row.ts
+++ b/src/commands/models/list.model-row.ts
@@ -14,6 +14,7 @@ export type ListRowModel = {
 
 export type ModelAuthAvailabilityResolver = (provider: string) => boolean;
 
+/** Projects a registry/configured model into the stable row shape used by model-list renderers. */
 export function toModelRow(params: {
   model?: ListRowModel;
   key: string;

--- a/src/commands/models/list.registry-load.ts
+++ b/src/commands/models/list.registry-load.ts
@@ -7,6 +7,7 @@ import { loadModelRegistry } from "./list.registry.js";
 import type { ConfiguredEntry } from "./list.types.js";
 import { modelKey } from "./shared.js";
 
+/** Loads the full model registry for list output and precomputes discovered model keys. */
 export async function loadListModelRegistry(
   cfg: OpenClawConfig,
   opts?: {
@@ -45,6 +46,7 @@ function findConfiguredRegistryModel(params: {
   return model;
 }
 
+/** Loads only configured model entries, filtering suppressed models and tracking auth-backed availability. */
 export function loadConfiguredListModelRegistry(
   cfg: OpenClawConfig,
   entries: ConfiguredEntry[],

--- a/src/commands/non-interactive-prompter.ts
+++ b/src/commands/non-interactive-prompter.ts
@@ -1,6 +1,9 @@
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
+/**
+ * Creates a prompter that logs passive wizard output but rejects interactive prompts.
+ */
 export function createNonInteractiveLoggingPrompter(
   runtime: RuntimeEnv,
   formatPromptError: (message: string) => string,
@@ -17,6 +20,8 @@ export function createNonInteractiveLoggingPrompter(
     async note(message, title) {
       runtime.log(title ? `${title}\n${message}` : message);
     },
+    // Selection/input prompts cannot be answered in non-interactive mode; reject
+    // with the original prompt text so callers can surface the blocked question.
     async select(params) {
       return unavailable(params.message);
     },

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -6,6 +6,7 @@ import type { ToolProfileId } from "../config/types.tools.js";
 export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
 export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "coding";
 
+/** Applies local setup defaults while preserving explicit DM scope and tool profile choices. */
 export function applyLocalSetupWorkspaceConfig(
   baseConfig: OpenClawConfig,
   workspaceDir: string,
@@ -34,6 +35,7 @@ export function applyLocalSetupWorkspaceConfig(
   };
 }
 
+/** Marks the default agent to skip bootstrap prompts without mutating the original config object. */
 export function applySkipBootstrapConfig(cfg: OpenClawConfig): OpenClawConfig {
   const next = structuredClone(cfg);
   setConfigValueAtPath(

--- a/src/commands/provider-auth-guidance.ts
+++ b/src/commands/provider-auth-guidance.ts
@@ -41,6 +41,9 @@ function resolveProviderAuthLoginCommand(params: {
   return formatCliCommand(`openclaw models auth login --provider ${providerId}`);
 }
 
+/**
+ * Builds a short operator hint for recovering missing provider authentication.
+ */
 export function buildProviderAuthRecoveryHint(params: {
   provider: string;
   config?: OpenClawConfig;
@@ -54,6 +57,8 @@ export function buildProviderAuthRecoveryHint(params: {
   if (loginCommand) {
     parts.push(`Run \`${loginCommand}\``);
   }
+  // Configure remains the broad fallback because provider manifests are optional
+  // and some providers still use env/API-key flows instead of auth profiles.
   if (params.includeConfigure !== false) {
     parts.push(`\`${formatCliCommand("openclaw configure")}\``);
   }

--- a/src/commands/session-store-targets.ts
+++ b/src/commands/session-store-targets.ts
@@ -8,6 +8,9 @@ import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 export { resolveSessionStoreTargets, type SessionStoreSelectionOptions, type SessionStoreTarget };
 
+/**
+ * Resolves requested session stores, reporting selection errors through the CLI runtime.
+ */
 export function resolveSessionStoreTargetsOrExit(params: {
   cfg: OpenClawConfig;
   opts: SessionStoreSelectionOptions;

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -32,6 +32,7 @@ export const SESSION_KEY_PAD = 26;
 export const SESSION_AGE_PAD = 9;
 export const SESSION_MODEL_PAD = 14;
 
+/** Projects a stored session entry into the display row consumed by table renderers. */
 export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDisplayRow {
   const updatedAt = entry?.updatedAt ?? null;
   return {
@@ -60,6 +61,7 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
   };
 }
 
+/** Builds session display rows sorted newest-first for stable CLI output. */
 export function toSessionDisplayRows(store: Record<string, SessionEntry>): SessionDisplayRow[] {
   return Object.entries(store)
     .map(([key, entry]) => toSessionDisplayRow(key, entry))
@@ -70,26 +72,31 @@ function truncateSessionKey(key: string): string {
   if (key.length <= SESSION_KEY_PAD) {
     return key;
   }
+  // Preserve the tail because provider/session suffixes are often the distinguishing part of long keys.
   const head = Math.max(4, SESSION_KEY_PAD - 10);
   return `${key.slice(0, head)}...${key.slice(-6)}`;
 }
 
+/** Formats the session key cell with fixed width and optional rich coloring. */
 export function formatSessionKeyCell(key: string, rich: boolean): string {
   const label = truncateSessionKey(key).padEnd(SESSION_KEY_PAD);
   return rich ? theme.accent(label) : label;
 }
 
+/** Formats the age cell from updatedAt timestamps, falling back to an explicit unknown label. */
 export function formatSessionAgeCell(updatedAt: number | null | undefined, rich: boolean): string {
   const ageLabel = updatedAt ? formatTimeAgo(Date.now() - updatedAt) : "unknown";
   const padded = ageLabel.padEnd(SESSION_AGE_PAD);
   return rich ? theme.muted(padded) : padded;
 }
 
+/** Formats the model cell with a fixed width so flags and token columns stay aligned. */
 export function formatSessionModelCell(model: string | null | undefined, rich: boolean): string {
   const label = (model ?? "unknown").padEnd(SESSION_MODEL_PAD);
   return rich ? theme.info(label) : label;
 }
 
+/** Formats optional session diagnostics and runtime flags into the trailing table cell. */
 export function formatSessionFlagsCell(
   row: Pick<
     SessionDisplayRow,

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -6,6 +6,10 @@ import { resolveStatusServiceSummaries } from "./status-runtime-shared.ts";
 import { resolveNodeOnlyGatewayInfo } from "./status.node-mode.js";
 import { collectStatusScanOverview } from "./status.scan-overview.ts";
 
+/**
+ * Runs the full read-only `openclaw status --all` flow and prints the assembled
+ * diagnostic report through the provided runtime logger.
+ */
 export async function statusAllCommand(
   runtime: RuntimeEnv,
   opts?: { timeoutMs?: number },
@@ -18,6 +22,8 @@ export async function statusAllCommand(
       },
       showSecrets: false,
       runtime,
+      // Channel status should reuse the already-probed gateway path so local
+      // and node-only modes report the same gateway target throughout the run.
       useGatewayCallOverridesForChannelsStatus: true,
       progress,
       labels: {

--- a/src/commands/status-all/channel-issues.ts
+++ b/src/commands/status-all/channel-issues.ts
@@ -1,3 +1,7 @@
+/**
+ * Groups gateway-reported channel issues by plugin id while preserving the
+ * original issue order for first-issue table summaries.
+ */
 export function groupChannelIssuesByChannel<T extends { channel: string }>(
   issues: readonly T[],
 ): Map<string, T[]> {

--- a/src/commands/status-all/channels-table.ts
+++ b/src/commands/status-all/channels-table.ts
@@ -39,10 +39,14 @@ export function buildStatusChannelsTableRows(params: {
   const formatIssueMessage = params.formatIssueMessage ?? ((message: string) => message);
   return params.rows.map((row) => {
     const issues = channelIssuesByChannel.get(row.id) ?? [];
+    // Disabled channels stay OFF even if gateway diagnostics reported stale
+    // issues for the same id; enabled/setup rows surface live issues as WARN.
     const effectiveState = row.state === "off" ? "off" : issues.length > 0 ? "warn" : row.state;
     const issueSuffix =
       issues.length > 0
-        ? ` · ${params.warn(`gateway: ${formatIssueMessage(issues[0]?.message ?? "issue")}`)}`
+        ? // Keep only the first issue in the overview; full details stay in the
+          // diagnosis section, while this table needs one-line scanability.
+          ` · ${params.warn(`gateway: ${formatIssueMessage(issues[0]?.message ?? "issue")}`)}`
         : "";
     return {
       Channel: row.label,

--- a/src/commands/status-all/channels-table.ts
+++ b/src/commands/status-all/channels-table.ts
@@ -13,6 +13,7 @@ type ChannelIssueLike = {
   message: string;
 };
 
+/** Column contract for the `status --all` channel overview table renderer. */
 export const statusChannelsTableColumns = [
   { key: "Channel", header: "Channel", minWidth: 10 },
   { key: "Enabled", header: "Enabled", minWidth: 7 },
@@ -20,6 +21,11 @@ export const statusChannelsTableColumns = [
   { key: "Detail", header: "Detail", flex: true, minWidth: 24 },
 ] as const;
 
+/**
+ * Converts collected channel state into display rows, letting gateway-reported
+ * channel issues upgrade an otherwise healthy row to WARN without mutating the
+ * underlying collector result.
+ */
 export function buildStatusChannelsTableRows(params: {
   rows: readonly ChannelTableRowInput[];
   channelIssues: readonly ChannelIssueLike[];

--- a/src/commands/status-all/channels-token-summary.ts
+++ b/src/commands/status-all/channels-token-summary.ts
@@ -4,12 +4,16 @@ import { hasConfiguredUnavailableCredentialStatus } from "../../channels/account
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import { sha256HexPrefix } from "../../logging/redact-identifier.js";
 
+/** Enabled account plus snapshot data used to summarize channel credentials. */
 export type ChannelAccountTokenSummaryRow = {
   account: unknown;
   enabled: boolean;
   snapshot: ChannelAccountSnapshot;
 };
 
+/**
+ * Counts credential source labels while preserving the most common source first.
+ */
 function summarizeSources(sources: Array<string | undefined>): {
   label: string;
   parts: string[];
@@ -26,6 +30,9 @@ function summarizeSources(sources: Array<string | undefined>): {
   return { label, parts };
 }
 
+/**
+ * Formats a token sample without exposing raw secrets unless explicitly allowed.
+ */
 function formatTokenHint(token: string, opts: { showSecrets: boolean }): string {
   const t = token.trim();
   if (!t) {
@@ -65,6 +72,8 @@ export function summarizeTokenConfig(params: {
   );
   const hasTokenField = accountRecs.some((r) => "token" in r);
 
+  // Plugins without known token-shaped account fields still appear in channel
+  // status, but token summary should not invent a credential state for them.
   if (!hasBotTokenField && !hasAppTokenField && !hasSigningSecretField && !hasTokenField) {
     return { state: null, detail: null };
   }
@@ -123,6 +132,8 @@ export function summarizeTokenConfig(params: {
       return { state: "setup", detail: "no credentials (need bot+signing)" };
     }
 
+    // Group source labels after readiness checks so unavailable or partial
+    // accounts never contribute misleading "ok" credential provenance.
     const botSources = summarizeSources(ready.map((a) => a.snapshot.botTokenSource ?? "none"));
     const signingSources = summarizeSources(
       ready.map((a) => a.snapshot.signingSecretSource ?? "none"),
@@ -179,6 +190,8 @@ export function summarizeTokenConfig(params: {
       return { state: "setup", detail: "no tokens (need bot+app)" };
     }
 
+    // Bot+app providers report both source sets because either half can be
+    // supplied by a different credential mechanism.
     const botSources = summarizeSources(ready.map((a) => a.snapshot.botTokenSource ?? "none"));
     const appSources = summarizeSources(ready.map((a) => a.snapshot.appTokenSource ?? "none"));
 

--- a/src/commands/status-all/channels-token-summary.ts
+++ b/src/commands/status-all/channels-token-summary.ts
@@ -42,6 +42,12 @@ function formatTokenHint(token: string, opts: { showSecrets: boolean }): string 
   return `${head}…${tail} · len ${t.length}`;
 }
 
+/**
+ * Summarize credential readiness for enabled channel accounts.
+ *
+ * Multi-token providers are intentionally checked before single-token providers
+ * so bot+signing and bot+app setups report partial/missing credentials precisely.
+ */
 export function summarizeTokenConfig(params: {
   accounts: ChannelAccountTokenSummaryRow[];
   showSecrets: boolean;
@@ -97,6 +103,8 @@ export function summarizeTokenConfig(params: {
       return (hasBot && !hasSigning) || (!hasBot && hasSigning);
     });
 
+    // HTTP channel webhook setup needs both bot token and signing secret; either
+    // credential alone is unsafe to report as ready.
     if (unavailable.length > 0) {
       return {
         state: "warn",

--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -30,6 +30,7 @@ import {
 } from "./channels-token-summary.js";
 import { formatTimeAgo } from "./format.js";
 
+/** Summary row emitted by the generic `status --all` channel collector. */
 export type ChannelRow = {
   id: ChannelId;
   label: string;
@@ -91,6 +92,11 @@ const formatAccountLabel = (params: { accountId: string; name?: string }) => {
   return base;
 };
 
+/**
+ * Formats per-account notes for the detail section without re-deciding channel
+ * readiness; the summary row owns state precedence, this keeps row notes
+ * diagnostic and account-local.
+ */
 const buildAccountNotes = (params: {
   plugin: ChannelPlugin;
   cfg: OpenClawConfig;
@@ -177,6 +183,10 @@ function resolveLinkFields(summary: unknown): {
   return { statusState, linked, authAgeMs, selfE164 };
 }
 
+/**
+ * Checks configured file-backed channel inputs after account normalization so
+ * plugin-projected snapshots and raw config fields share one warning path.
+ */
 function collectMissingPaths(accounts: ChannelAccountRow[]): string[] {
   const missing: string[] = [];
   for (const entry of accounts) {
@@ -214,8 +224,13 @@ function formatLoadFailureDetail(message: string): string {
   return `plugin load failed: ${reason}; run openclaw doctor --fix`;
 }
 
-// `status --all` channels table.
-// Keep this generic: channel-specific rules belong in the channel plugin.
+/**
+ * Builds the generic `status --all` channel table and account detail sections.
+ *
+ * Keep this boundary generic: channel-specific readiness rules belong in the
+ * channel plugin's status/config hooks, while this layer only merges plugin
+ * snapshots, live gateway credential proof, and configured-plugin fallbacks.
+ */
 export async function buildChannelsTable(
   cfg: OpenClawConfig,
   opts?: {
@@ -282,6 +297,8 @@ export async function buildChannelsTable(
         !credentialResolutionSkipped &&
         !hasRuntimeCredentialAvailable({ liveAccounts, accountId: a.accountId }),
     );
+    // Fast status paths may not read secrets, while a live gateway snapshot can
+    // still prove that configured credentials are available in the runtime.
     const accountsForTokenSummary = accounts.map((entry) =>
       hasConfiguredUnavailableCredentialStatus(entry.account) &&
       (credentialResolutionSkipped ||
@@ -318,6 +335,8 @@ export async function buildChannelsTable(
     const label = plugin.meta.label ?? plugin.id;
 
     const state = (() => {
+      // Hard failures win over token/link success so missing files or plugin
+      // issues stay visible even when another source reports the account ready.
       if (!anyEnabled) {
         return "off";
       }
@@ -349,6 +368,8 @@ export async function buildChannelsTable(
     })();
 
     const detail = (() => {
+      // Match the state precedence above; the detail explains the first
+      // actionable condition rather than appending every lower-priority hint.
       if (!anyEnabled) {
         if (!defaultEntry) {
           return "disabled";

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -83,6 +83,7 @@ type AgentStatusLike = {
 
 const AGENT_ACTIVITY_SOFT_WARNING_MS = 30 * 60_000;
 
+/** Counts agents with recent session activity for the soft inbound-health warning. */
 function countRecentAgentSessions(agentStatus: AgentStatusLike, thresholdMs: number): number {
   return agentStatus.agents.filter(
     (agent) => agent.lastActiveAgeMs != null && agent.lastActiveAgeMs <= thresholdMs,
@@ -106,6 +107,7 @@ function isDeliveryDiagnosticsLike(value: unknown): value is DeliveryDiagnostics
   return Boolean(value && typeof value === "object");
 }
 
+/** Reads the summary counter format returned by gateway delivery diagnostics. */
 function countDeliveryEvent(snapshot: DeliveryDiagnosticsLike, type: string): number {
   const value = snapshot.summary?.byType?.[type];
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
@@ -129,6 +131,13 @@ function latestDeliveryEventAgeMs(snapshot: DeliveryDiagnosticsLike): number | n
   return latestTs > 0 ? Date.now() - latestTs : null;
 }
 
+/**
+ * Appends the read-only diagnosis section for `status --all`.
+ *
+ * This renderer intentionally degrades unavailable local probes into warnings so
+ * one broken config, port, log, gateway, or telemetry source does not hide the
+ * rest of the pasteable debug report.
+ */
 export async function appendStatusAllDiagnosis(params: {
   lines: string[];
   progress: ProgressReporter;
@@ -178,6 +187,8 @@ export async function appendStatusAllDiagnosis(params: {
     const status = !params.snap.exists ? "fail" : params.snap.valid ? "ok" : "warn";
     emitCheck(`Config: ${params.snap.path ?? "(unknown)"}`, status);
     const issues = [...(params.snap.legacyIssues ?? []), ...(params.snap.issues ?? [])];
+    // Legacy and current validators can report the same path/message pair; show
+    // each unique issue once so config noise does not crowd out later checks.
     const uniqueIssues = issues.filter(
       (issue, index) =>
         issues.findIndex((x) => x.path === issue.path && x.message === issue.message) === index,
@@ -244,6 +255,8 @@ export async function appendStatusAllDiagnosis(params: {
       params.portUsage.listeners,
       params.port,
     );
+    // Dual-stack loopback listeners are normal for one local gateway process;
+    // unrelated or duplicate listeners should stay visible as warnings.
     const portOk = params.portUsage.listeners.length === 0 || expectedGatewayListeners;
     emitCheck(`Port ${params.port}`, portOk ? "ok" : "warn");
     if (!portOk) {
@@ -347,6 +360,8 @@ export async function appendStatusAllDiagnosis(params: {
       const dispatchGap = dispatchStarted - dispatchCompleted;
       const hasDispatchGap = dispatchGap >= 2;
       const latestAgeMs = latestDeliveryEventAgeMs(params.deliveryDiagnostics);
+      // These ratios distinguish routing failures, session creation failures,
+      // and stuck in-flight dispatches without needing channel-specific logic.
       emitCheck(
         `Inbound delivery telemetry: received ${received} · dispatch ${dispatchStarted}/${dispatchCompleted} · turns ${turnsCreated} · processed ${processed}`,
         hasReceivedWithoutDispatch || hasDispatchWithoutTurn || hasDispatchGap ? "warn" : "ok",

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -404,6 +404,8 @@ export async function appendStatusAllDiagnosis(params: {
   if (logPaths) {
     params.progress.setLabel("Reading logs…");
     const restartLogPath = resolveGatewayRestartLogPath(process.env);
+    // launchd combines useful service output on stdout; Linux keeps stderr
+    // separate, so only read stderr where the log path is expected to exist.
     const readStderr = process.platform !== "darwin";
     const [stderrTail, stdoutTail, restartTail] = await Promise.all([
       readStderr ? readFileTailLines(logPaths.stderrPath, 40).catch(() => []) : [],
@@ -476,6 +478,8 @@ export async function appendStatusAllDiagnosis(params: {
       return value;
     }
     try {
+      // Preserve object-shaped health errors for pasteable diagnosis while still
+      // passing through the same redaction path as string errors.
       return JSON.stringify(value, null, 2);
     } catch {
       return "[unserializable error]";

--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -13,6 +13,7 @@ import { formatUpdateOneLiner, resolveUpdateAvailability } from "../status.updat
 
 export { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
 
+/** Key/value row consumed by the `status --all` overview table renderer. */
 export type StatusOverviewRow = {
   Item: string;
   Value: string;
@@ -57,6 +58,7 @@ type StatusManagedService = {
   } | null;
 };
 
+/** Resolves the configured update channel into the label shown by status output. */
 export function resolveStatusUpdateChannelInfo(params: {
   updateConfigChannel?: string | null;
   update: {
@@ -76,6 +78,7 @@ export function resolveStatusUpdateChannelInfo(params: {
   });
 }
 
+/** Builds all update-related strings needed by overview text and JSON surfaces. */
 export function buildStatusUpdateSurface(params: {
   updateConfigChannel?: string | null;
   update: StatusUpdateLike;
@@ -93,11 +96,16 @@ export function buildStatusUpdateSurface(params: {
   };
 }
 
+/** Formats the dashboard URL cell, using `disabled` for all absent URL shapes. */
 export function formatStatusDashboardValue(value: string | null | undefined): string {
   const trimmed = normalizeOptionalString(value);
   return trimmed && trimmed.length > 0 ? trimmed : "disabled";
 }
 
+/**
+ * Formats Tailscale exposure with caller-provided decorators so rich terminal
+ * output and plain JSON/text tests share the same status decision.
+ */
 export function formatStatusTailscaleValue(params: {
   tailscaleMode: string;
   dnsName?: string | null;
@@ -139,6 +147,10 @@ export function formatStatusTailscaleValue(params: {
   return decorateWarn(parts.join(" · "));
 }
 
+/**
+ * Formats a launchd/service row while preserving the distinction between
+ * install ownership, loaded state, and runtime process status.
+ */
 export function formatStatusServiceValue(params: {
   label: string;
   installed: boolean;
@@ -161,6 +173,7 @@ export function formatStatusServiceValue(params: {
   return `${params.label} ${installedPrefix}${params.loadedText}${runtimeSuffix}`;
 }
 
+/** Resolves the local Control UI URL when the dashboard surface is enabled. */
 export function resolveStatusDashboardUrl(params: {
   cfg: Pick<OpenClawConfig, "gateway">;
 }): string | null {
@@ -176,6 +189,10 @@ export function resolveStatusDashboardUrl(params: {
   }).httpUrl;
 }
 
+/**
+ * Orders overview rows for stable CLI output while allowing callers to splice
+ * extra rows around the gateway/self/service block.
+ */
 export function buildStatusOverviewRows(params: {
   prefixRows?: StatusOverviewRow[];
   dashboardValue: string;
@@ -224,6 +241,10 @@ export function buildStatusOverviewRows(params: {
   return rows;
 }
 
+/**
+ * Builds the complete overview table model from raw status probes and service
+ * snapshots, centralizing display precedence for dashboard/gateway/update rows.
+ */
 export function buildStatusOverviewSurfaceRows(params: {
   cfg: Pick<OpenClawConfig, "update" | "gateway">;
   update: StatusUpdateLike;
@@ -310,6 +331,7 @@ export function buildStatusOverviewSurfaceRows(params: {
   });
 }
 
+/** Summarizes which gateway auth mechanisms were accepted by the probe. */
 export function formatGatewayAuthUsed(
   auth: {
     token?: string;
@@ -330,6 +352,7 @@ export function formatGatewayAuthUsed(
   return "none";
 }
 
+/** Formats the gateway `/self` payload into a compact host/version summary. */
 export function formatGatewaySelfSummary(gatewaySelf: StatusGatewaySelf): string | null {
   return gatewaySelf?.host || gatewaySelf?.ip || gatewaySelf?.version || gatewaySelf?.platform
     ? [
@@ -343,6 +366,12 @@ export function formatGatewaySelfSummary(gatewaySelf: StatusGatewaySelf): string
     : null;
 }
 
+/**
+ * Builds reusable gateway status fragments before terminal coloring is applied.
+ *
+ * Remote-url misconfiguration overrides reachability because the fallback URL is
+ * diagnostic only and should not be presented as a healthy remote connection.
+ */
 export function buildGatewayStatusSummaryParts(params: {
   gatewayMode: "local" | "remote";
   remoteUrlMissing: boolean;
@@ -383,6 +412,10 @@ export function buildGatewayStatusSummaryParts(params: {
   };
 }
 
+/**
+ * Builds gateway-related overview values, including local dashboard URL and
+ * managed service rows, from the already-probed gateway state.
+ */
 export function buildStatusGatewaySurfaceValues(params: {
   cfg: Pick<OpenClawConfig, "gateway">;
   gatewayMode: "local" | "remote";
@@ -411,6 +444,8 @@ export function buildStatusGatewaySurfaceValues(params: {
     gatewayProbeAuth: params.gatewayProbeAuth,
   });
   const gatewaySelfValue = formatGatewaySelfSummary(params.gatewaySelf);
+  // Node-only mode supplies its own gateway value; otherwise compose the normal
+  // mode/target/reachability/auth/self chain in one stable order.
   const gatewayValue =
     params.nodeOnlyGateway?.gatewayValue ??
     `${gatewaySummary.modeLabel} · ${gatewaySummary.targetTextWithSource} · ${
@@ -452,6 +487,7 @@ export function buildStatusGatewaySurfaceValues(params: {
   };
 }
 
+/** Builds the machine-readable gateway status payload for `status --all --json`. */
 export function buildGatewayStatusJsonPayload(params: {
   gatewayMode: "local" | "remote";
   gatewayConnection: {
@@ -499,6 +535,7 @@ export function buildGatewayStatusJsonPayload(params: {
   };
 }
 
+/** Redacts common credential shapes before status diagnostics echo text. */
 export function redactSecrets(text: string): string {
   if (!text) {
     return text;

--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -528,7 +528,9 @@ export function buildGatewayStatusJsonPayload(params: {
     ...(params.gatewayProbe?.health &&
     typeof params.gatewayProbe.health === "object" &&
     "modelPricing" in params.gatewayProbe.health
-      ? {
+      ? // Preserve the gateway health pricing payload verbatim for JSON callers;
+        // text output formats it elsewhere and should not stringify it here.
+        {
           modelPricing: (params.gatewayProbe.health as { modelPricing?: unknown }).modelPricing,
         }
       : {}),
@@ -541,6 +543,8 @@ export function redactSecrets(text: string): string {
     return text;
   }
   let out = text;
+  // Key/value redaction runs before bearer/openai-shaped token redaction so
+  // quoted diagnostics keep their surrounding syntax intact.
   out = out.replace(
     /(\b(?:access[_-]?token|refresh[_-]?token|token|password|secret|api[_-]?key)\b\s*[:=]\s*)("?)([^"\\s]+)("?)/gi,
     "$1$2***$4",

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -53,6 +53,8 @@ function consumeJsonBlock(
   const parts: string[] = [startLine.slice(braceAt)];
   let depth = countMatches(parts[0] ?? "", "{") - countMatches(parts[0] ?? "", "}");
   let i = startIndex;
+  // Log tails may start after the opening line of a pretty-printed JSON error;
+  // depth tracking keeps multi-line OAuth payloads grouped before redaction.
   while (depth > 0 && i + 1 < lines.length) {
     i += 1;
     const next = lines[i] ?? "";
@@ -184,6 +186,8 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
 
   const head = Math.min(6, Math.floor(maxLines / 3));
   const tail = Math.max(1, maxLines - head - 1);
+  // Keep the earliest grouped symptom and the newest tail evidence; both are
+  // usually needed to explain a recent gateway failure from a compact paste.
   const kept = [
     ...deduped.slice(0, head),
     `… ${deduped.length - head - tail} lines omitted …`,

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { classifyOAuthRefreshFailureReason } from "../../agents/auth-profiles/oauth-refresh-failure.js";
 
+/**
+ * Reads a best-effort non-empty log tail for status diagnostics; unreadable
+ * files are treated as absent so `status --all` stays read-only and resilient.
+ */
 export async function readFileTailLines(filePath: string, maxLines: number): Promise<string[]> {
   const raw = await fs.readFile(filePath, "utf8").catch(() => "");
   if (!raw.trim()) {
@@ -58,6 +62,12 @@ function consumeJsonBlock(
   return { json: parts.join("\n"), endIndex: i };
 }
 
+/**
+ * Compacts noisy gateway log tails into stable diagnostic lines for humans.
+ *
+ * Repeated OAuth refresh and GWS failure shapes are grouped before the final
+ * head/tail trim so one failure storm does not hide unrelated nearby evidence.
+ */
 export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number }): string[] {
   const maxLines = Math.max(6, opts?.maxLines ?? 26);
 
@@ -99,7 +109,8 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
       continue;
     }
 
-    // "[openai] Token refresh failed: 401 { ...json... }"
+    // OAuth refresh failures span JSON blocks in provider logs; consume the
+    // whole block so the raw credential error body does not leak line-by-line.
     const tokenRefresh = line.match(/^\[([^\]]+)\]\s+Token refresh failed:\s*(\d+)\s*(\{)?\s*$/);
     if (tokenRefresh) {
       const tag = tokenRefresh[1] ?? "unknown";
@@ -126,7 +137,8 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
       }
     }
 
-    // "Embedded agent failed before reply: OAuth token refresh failed for openai: ..."
+    // Embedded-agent failures repeat the same provider-level OAuth symptom
+    // without useful per-run details, so collapse them by provider.
     const embedded = line.match(
       /^Embedded agent failed before reply:\s+OAuth token refresh failed for ([^:]+):/,
     );
@@ -136,7 +148,8 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
       continue;
     }
 
-    // "[gws] ⇄ res ✗ agent ... errorCode=UNAVAILABLE errorMessage=Error: OAuth token refresh failed ... runId=..."
+    // Gateway websocket traces include volatile ids; normalize before grouping
+    // so repeated refresh failures collapse to one actionable line.
     if (
       line.startsWith("[gws]") &&
       line.includes("errorCode=UNAVAILABLE") &&

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -37,6 +37,10 @@ function resolveStatusAllConfigPath(path: string | null | undefined): string {
   return trimmed && trimmed.length > 0 ? trimmed : "(unknown config path)";
 }
 
+/**
+ * Collects local-only diagnosis inputs that are not part of the initial overview
+ * scan, keeping failures best-effort so report generation remains read-only.
+ */
 async function resolveStatusAllLocalDiagnosis(params: {
   overview: StatusScanOverviewResult;
   progress: StatusAllProgress;
@@ -88,6 +92,8 @@ async function resolveStatusAllLocalDiagnosis(params: {
         gatewayProbeError: params.gatewayProbe?.error ?? null,
         ...(params.gatewayCallOverrides ? { callOverrides: params.gatewayCallOverrides } : {}),
       });
+  // Node-only gateway mode has no local gateway endpoint to query; skip health
+  // and delivery calls instead of reporting the expected absence as a failure.
   const diagnostics = params.nodeOnlyGateway
     ? null
     : await resolveStatusGatewayDiagnosticsSafe({
@@ -109,6 +115,8 @@ async function resolveStatusAllLocalDiagnosis(params: {
       ?.workspaceDir ??
     overview.agentStatus.agents[0]?.workspaceDir ??
     null;
+  // Skill discovery is diagnostic only; broken workspace metadata should not
+  // prevent the rest of `status --all` from rendering.
   const skillStatus =
     defaultWorkspace != null
       ? (() => {
@@ -163,6 +171,10 @@ async function resolveStatusAllLocalDiagnosis(params: {
   };
 }
 
+/**
+ * Builds the render-ready `status --all` report model from scan output,
+ * service summaries, and local diagnosis probes.
+ */
 export async function buildStatusAllReportData(params: {
   overview: StatusScanOverviewResult;
   daemon: StatusGatewayServiceSummary;
@@ -188,6 +200,8 @@ export async function buildStatusAllReportData(params: {
     nodeService: params.nodeService,
     nodeOnlyGateway: params.nodeOnlyGateway,
   });
+  // Overview rows use the local diagnosis config path/sentinel data so the top
+  // table matches the detailed diagnosis section that follows.
   const overviewRows = buildStatusAllOverviewRows({
     surface: overviewSurface,
     osLabel: params.overview.osSummary.label,

--- a/src/commands/status-all/report-lines.ts
+++ b/src/commands/status-all/report-lines.ts
@@ -90,6 +90,8 @@ export async function buildStatusAllReportLines(params: {
         warn,
         muted,
         accentDim: theme.accentDim,
+        // Issue details can include plugin-provided prose; cap them before
+        // table wrapping so the channel overview remains scannable.
         formatIssueMessage: (message) => message.slice(0, 90),
       }),
       ...buildStatusChannelDetailsSections({

--- a/src/commands/status-all/report-lines.ts
+++ b/src/commands/status-all/report-lines.ts
@@ -43,6 +43,10 @@ type AgentStatusLike = {
   }>;
 };
 
+/**
+ * Assembles the complete read-only `status --all` text report from precomputed
+ * status models, keeping terminal styling and diagnosis output in one place.
+ */
 export async function buildStatusAllReportLines(params: {
   progress: ProgressReporter;
   overviewRows: OverviewRow[];
@@ -66,6 +70,8 @@ export async function buildStatusAllReportLines(params: {
 
   const lines: string[] = [];
   lines.push(heading("OpenClaw status --all"));
+  // Sections are built before diagnosis so table output is deterministic even
+  // when the diagnosis collector performs async read-only checks afterwards.
   appendStatusReportSections({
     lines,
     heading,

--- a/src/commands/status-all/report-sections.ts
+++ b/src/commands/status-all/report-sections.ts
@@ -10,6 +10,7 @@ import type { StatusReportSection } from "./text-report.js";
 
 type TableRenderer = (input: RenderTableOptions) => string;
 
+/** Builds the overview table section from already formatted key/value rows. */
 export function buildStatusOverviewSection(params: {
   width: number;
   renderTable: TableRenderer;
@@ -25,6 +26,10 @@ export function buildStatusOverviewSection(params: {
   };
 }
 
+/**
+ * Builds the canonical channel overview section and lets channel issue rows
+ * override display state without changing the collected channel model.
+ */
 export function buildStatusChannelsSection(params: {
   width: number;
   renderTable: TableRenderer;
@@ -65,6 +70,7 @@ export function buildStatusChannelsSection(params: {
   } as StatusReportSection;
 }
 
+/** Builds a caller-supplied channel table section for legacy status surfaces. */
 export function buildStatusChannelsTableSection(params: {
   width: number;
   renderTable: TableRenderer;
@@ -81,6 +87,7 @@ export function buildStatusChannelsTableSection(params: {
   };
 }
 
+/** Wraps configured channel account detail tables with shared status coloring. */
 export function buildStatusChannelDetailsSections(params: {
   details: Array<{
     title: string;
@@ -101,6 +108,7 @@ export function buildStatusChannelDetailsSections(params: {
   });
 }
 
+/** Builds the agent session table from the collected status agent snapshot. */
 export function buildStatusAgentsSection(params: {
   width: number;
   renderTable: TableRenderer;
@@ -131,6 +139,7 @@ export function buildStatusAgentsSection(params: {
   };
 }
 
+/** Builds the sessions table section from caller-owned columns and rows. */
 export function buildStatusSessionsSection(params: {
   width: number;
   renderTable: TableRenderer;
@@ -147,6 +156,10 @@ export function buildStatusSessionsSection(params: {
   };
 }
 
+/**
+ * Builds the optional system-events section; empty rows are intentionally hidden
+ * so clean systems do not emit an empty table.
+ */
 export function buildStatusSystemEventsSection(params: {
   width: number;
   renderTable: TableRenderer;
@@ -165,6 +178,7 @@ export function buildStatusSystemEventsSection(params: {
   };
 }
 
+/** Builds the optional health section with caller-provided checks. */
 export function buildStatusHealthSection(params: {
   width: number;
   renderTable: TableRenderer;
@@ -182,6 +196,7 @@ export function buildStatusHealthSection(params: {
   };
 }
 
+/** Builds the optional usage section when diagnostics include actionable steps. */
 export function buildStatusUsageSection(params: { usageLines?: string[] }): StatusReportSection {
   return {
     kind: "lines",

--- a/src/commands/status-all/report-tables.ts
+++ b/src/commands/status-all/report-tables.ts
@@ -19,11 +19,13 @@ type ChannelDetailLike = {
   rows: Array<Record<string, string>>;
 };
 
+/** Column contract for the top-level `status --all` overview table. */
 export const statusOverviewTableColumns = [
   { key: "Item", header: "Item", minWidth: 10 },
   { key: "Value", header: "Value", flex: true, minWidth: 24 },
 ] as const;
 
+/** Column contract for the `status --all` agent session summary table. */
 export const statusAgentsTableColumns = [
   { key: "Agent", header: "Agent", minWidth: 12 },
   { key: "BootstrapFile", header: "Bootstrap file", minWidth: 14 },
@@ -32,6 +34,10 @@ export const statusAgentsTableColumns = [
   { key: "Store", header: "Store", flex: true, minWidth: 34 },
 ] as const;
 
+/**
+ * Converts agent session metadata into table rows while preserving the
+ * bootstrap-file tri-state: present, absent, or unavailable from this path.
+ */
 export function buildStatusAgentTableRows(params: {
   agentStatus: AgentStatusLike;
   ok: (text: string) => string;
@@ -51,6 +57,10 @@ export function buildStatusAgentTableRows(params: {
   }));
 }
 
+/**
+ * Builds one detail table per configured channel account group and colors only
+ * canonical `OK`/`WARN` statuses so plugins can keep richer notes unmodified.
+ */
 export function buildStatusChannelDetailSections(params: {
   details: ChannelDetailLike[];
   width: number;

--- a/src/commands/status-all/text-report.ts
+++ b/src/commands/status-all/text-report.ts
@@ -114,6 +114,8 @@ export function appendStatusReportSections(params: {
       rows: section.rows,
     });
     if (section.trailer) {
+      // Table trailers belong directly under their table, before the next
+      // section heading inserts a separator.
       params.lines.push(section.trailer);
     }
   }

--- a/src/commands/status-all/text-report.ts
+++ b/src/commands/status-all/text-report.ts
@@ -3,6 +3,7 @@ import type { RenderTableOptions, TableColumn } from "../../../packages/terminal
 type HeadingFn = (text: string) => string;
 type TableRenderer = (input: RenderTableOptions) => string;
 
+/** Render-ready section model used by `status --all` text assembly. */
 export type StatusReportSection =
   | {
       kind: "lines";
@@ -26,6 +27,7 @@ export type StatusReportSection =
       skipIfEmpty?: boolean;
     };
 
+/** Appends a styled section heading, inserting the blank separator when needed. */
 export function appendStatusSectionHeading(params: {
   lines: string[];
   heading: HeadingFn;
@@ -68,6 +70,10 @@ function appendStatusTableSection<Row extends Record<string, string>>(params: {
   );
 }
 
+/**
+ * Appends mixed raw, line, and table sections in order, honoring `skipIfEmpty`
+ * before headings so optional sections do not leave blank output gaps.
+ */
 export function appendStatusReportSections(params: {
   lines: string[];
   heading: HeadingFn;
@@ -78,6 +84,8 @@ export function appendStatusReportSections(params: {
       if (section.skipIfEmpty && section.body.length === 0) {
         continue;
       }
+      // Raw sections are already formatted by their caller, so they bypass the
+      // heading/separator path used by named sections.
       params.lines.push(...section.body);
       continue;
     }

--- a/src/commands/status-json-command.ts
+++ b/src/commands/status-json-command.ts
@@ -8,6 +8,10 @@ type StatusJsonCommandOptions = {
   all?: boolean;
 };
 
+/**
+ * Runs the injectable JSON status flow used by the CLI and tests, then writes
+ * the resolved payload through the runtime JSON sink.
+ */
 export async function runStatusJsonCommand(params: {
   opts: StatusJsonCommandOptions;
   runtime: RuntimeEnv;

--- a/src/commands/status-json-payload.ts
+++ b/src/commands/status-json-payload.ts
@@ -4,6 +4,12 @@ import {
   type StatusOverviewSurface,
 } from "./status-overview-surface.ts";
 
+/**
+ * Builds the stable `openclaw status --json` payload from scan/runtime pieces.
+ *
+ * Optional runtime sections are omitted unless they were requested or resolved,
+ * keeping default JSON output compact while preserving field names for callers.
+ */
 export function buildStatusJsonPayload(params: {
   summary: Record<string, unknown>;
   surface: StatusOverviewSurface;
@@ -44,6 +50,8 @@ export function buildStatusJsonPayload(params: {
           },
         }
       : {}),
+    // Keep deep/usage-only fields grouped so consumers can distinguish default
+    // status JSON from explicitly requested runtime probes.
     ...(params.health || params.usage || params.lastHeartbeat
       ? {
           health: params.health,

--- a/src/commands/status-json-runtime.ts
+++ b/src/commands/status-json-runtime.ts
@@ -48,6 +48,10 @@ type StatusJsonScanLike = {
   pluginCompatibility?: Array<Record<string, unknown>> | null | undefined;
 };
 
+/**
+ * Resolves the machine-readable status payload, including optional deep, usage,
+ * security, and compatibility sections according to the JSON command flags.
+ */
 export async function resolveStatusJsonOutput(params: {
   scan: StatusJsonScanLike;
   opts: {

--- a/src/commands/status-json.ts
+++ b/src/commands/status-json.ts
@@ -2,6 +2,10 @@ import type { RuntimeEnv } from "../runtime.js";
 import { runStatusJsonCommand } from "./status-json-command.ts";
 import { scanStatusJsonFast } from "./status.scan.fast-json.js";
 
+/**
+ * CLI entrypoint for `openclaw status --json`; `--all` opts into the heavier
+ * security audit while health probe failures stay encoded in the JSON payload.
+ */
 export async function statusJsonCommand(
   opts: {
     deep?: boolean;

--- a/src/commands/status-overview-rows.ts
+++ b/src/commands/status-overview-rows.ts
@@ -34,6 +34,8 @@ function readModelPricingHealth(params: {
   if (params.health?.modelPricing) {
     return params.health.modelPricing;
   }
+  // Deep status passes structured health directly; fast status can still expose
+  // model-pricing state through the gateway probe health payload.
   const probeHealth = params.surface.gatewayProbe?.health;
   if (!probeHealth || typeof probeHealth !== "object") {
     return undefined;
@@ -66,6 +68,7 @@ function buildModelPricingOverviewValue(params: {
   return params.warn(`warning · optional pricing refresh degraded${detail}`);
 }
 
+/** Builds the regular `openclaw status` overview rows from scan and summary data. */
 export function buildStatusCommandOverviewRows(
   params: {
     opts: {
@@ -155,6 +158,8 @@ export function buildStatusCommandOverviewRows(
     prefixRows: [{ Item: "OS", Value: `${params.osLabel} · node ${process.versions.node}` }],
     updateValue: params.updateValue,
     agentsValue,
+    // Keep operational warnings near the top of the suffix block, before the
+    // lower-signal counters that are useful but less urgent during triage.
     suffixRows: [
       ...(modelPricingValue ? [{ Item: "Model pricing", Value: modelPricingValue }] : []),
       ...(params.updateRestartValue
@@ -181,6 +186,7 @@ export function buildStatusCommandOverviewRows(
   });
 }
 
+/** Builds the expanded `status --all` overview rows used in pasteable reports. */
 export function buildStatusAllOverviewRows(params: {
   surface: StatusOverviewSurface;
   osLabel: string;

--- a/src/commands/status-overview-surface.ts
+++ b/src/commands/status-overview-surface.ts
@@ -191,6 +191,8 @@ export function buildStatusOverviewRowsFromSurface(params: {
     suffixRows: params.suffixRows,
     agentsValue: params.agentsValue,
     updateValue: params.updateValue,
+    // Callers may override these when a richer status path already computed a
+    // display-safe warning or fallback; keep the normalized surface unchanged.
     gatewayAuthWarningValue: params.gatewayAuthWarningValue,
     gatewaySelfFallbackValue: params.gatewaySelfFallbackValue,
   });

--- a/src/commands/status-overview-surface.ts
+++ b/src/commands/status-overview-surface.ts
@@ -47,6 +47,7 @@ type StatusServiceSummary = {
   } | null;
 };
 
+/** Normalized status overview inputs shared by regular and `--all` renderers. */
 export type StatusOverviewSurface = {
   cfg: Pick<OpenClawConfig, "update" | "gateway">;
   update: UpdateCheckResult;
@@ -66,6 +67,7 @@ export type StatusOverviewSurface = {
   nodeOnlyGateway?: NodeOnlyGatewayInfo | null;
 };
 
+/** Projects the full status scan result into the shared overview surface shape. */
 export function buildStatusOverviewSurfaceFromScan(params: {
   scan: Pick<
     StatusScanResult,
@@ -107,6 +109,7 @@ export function buildStatusOverviewSurfaceFromScan(params: {
   };
 }
 
+/** Projects the lighter `status --all` overview scan into the same surface shape. */
 export function buildStatusOverviewSurfaceFromOverview(params: {
   overview: Pick<
     StatusScanOverviewResult,
@@ -136,6 +139,10 @@ export function buildStatusOverviewSurfaceFromOverview(params: {
   };
 }
 
+/**
+ * Builds overview rows from the normalized surface, preserving caller-controlled
+ * row insertion points while centralizing gateway/update/tailscale formatting.
+ */
 export function buildStatusOverviewRowsFromSurface(params: {
   surface: StatusOverviewSurface;
   prefixRows?: StatusOverviewRow[];
@@ -189,6 +196,7 @@ export function buildStatusOverviewRowsFromSurface(params: {
   });
 }
 
+/** Builds gateway JSON from the normalized surface used by text rendering. */
 export function buildStatusGatewayJsonPayloadFromSurface(params: {
   surface: Pick<
     StatusOverviewSurface,

--- a/src/commands/status-overview-values.ts
+++ b/src/commands/status-overview-values.ts
@@ -25,12 +25,15 @@ function countActiveStatusAgents(params: {
   agentStatus: AgentStatusLike;
   activeThresholdMs?: number;
 }) {
+  // The overview treats recently touched sessions as "active" signal without
+  // requiring a live gateway probe for every agent.
   const activeThresholdMs = params.activeThresholdMs ?? 10 * 60_000;
   return params.agentStatus.agents.filter(
     (agent) => agent.lastActiveAgeMs != null && agent.lastActiveAgeMs <= activeThresholdMs,
   ).length;
 }
 
+/** Builds the compact agent activity value for `status --all` overview rows. */
 export function buildStatusAllAgentsValue(params: {
   agentStatus: AgentStatusLike;
   activeThresholdMs?: number;
@@ -39,16 +42,19 @@ export function buildStatusAllAgentsValue(params: {
   return `${params.agentStatus.agents.length} total · ${params.agentStatus.bootstrapPendingCount} bootstrapping · ${activeAgents} active · ${params.agentStatus.totalSessions} sessions`;
 }
 
+/** Formats the number of secret diagnostics found during status scanning. */
 export function buildStatusSecretsValue(count: number) {
   return count > 0 ? `${count} diagnostic${count === 1 ? "" : "s"}` : "none";
 }
 
+/** Formats queued system-event count for the regular status overview. */
 export function buildStatusEventsValue(params: { queuedSystemEvents: string[] }) {
   return params.queuedSystemEvents.length > 0
     ? `${params.queuedSystemEvents.length} queued`
     : "none";
 }
 
+/** Formats whether deep health probes ran for the regular status overview. */
 export function buildStatusProbesValue(params: {
   health?: unknown;
   ok: (value: string) => string;
@@ -57,6 +63,7 @@ export function buildStatusProbesValue(params: {
   return params.health ? params.ok("enabled") : params.muted("skipped (use --deep)");
 }
 
+/** Summarizes plugin compatibility notices and affected plugin count. */
 export function buildStatusPluginCompatibilityValue(params: {
   notices: PluginCompatibilityNoticeLike[];
   ok: (value: string) => string;
@@ -73,6 +80,7 @@ export function buildStatusPluginCompatibilityValue(params: {
   );
 }
 
+/** Formats active session count, default model context, and store coverage. */
 export function buildStatusSessionsOverviewValue(params: {
   sessions: SummarySessionsLike;
   formatKTokens: (value: number) => string;

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -30,6 +30,7 @@ function loadGatewayCallModule() {
   return gatewayCallModuleLoader.load();
 }
 
+/** Runs the lightweight security audit used by status reports. */
 export async function resolveStatusSecurityAudit(params: {
   config: OpenClawConfig;
   sourceConfig: OpenClawConfig;
@@ -61,6 +62,7 @@ type StatusUsageSummaryOptions = {
   agentDir?: string;
 };
 
+/** Loads provider usage data for status without importing the usage module up front. */
 export async function resolveStatusUsageSummary(params: StatusUsageSummaryOptions) {
   const { loadProviderUsageSummary } = await loadProviderUsage();
   return await loadProviderUsageSummary({
@@ -70,10 +72,12 @@ export async function resolveStatusUsageSummary(params: StatusUsageSummaryOption
   });
 }
 
+/** Exposes the lazy provider-usage module for tests and JSON status callers. */
 export async function loadStatusProviderUsageModule() {
   return await loadProviderUsage();
 }
 
+/** Calls the gateway health probe and lets errors surface to the caller. */
 export async function resolveStatusGatewayHealth(params: {
   config: OpenClawConfig;
   timeoutMs?: number;
@@ -87,6 +91,7 @@ export async function resolveStatusGatewayHealth(params: {
   });
 }
 
+/** Calls gateway health for diagnostics, converting unreachable/errors into payloads. */
 export async function resolveStatusGatewayHealthSafe(params: {
   config: OpenClawConfig;
   timeoutMs?: number;
@@ -111,6 +116,7 @@ export async function resolveStatusGatewayHealthSafe(params: {
   }).catch((err) => ({ error: String(err) }));
 }
 
+/** Reads gateway delivery diagnostics when reachable, returning null on failure. */
 export async function resolveStatusGatewayDiagnosticsSafe(params: {
   config: OpenClawConfig;
   timeoutMs?: number;
@@ -134,6 +140,7 @@ export async function resolveStatusGatewayDiagnosticsSafe(params: {
   }).catch(() => null);
 }
 
+/** Reads the latest heartbeat event in deep status mode. */
 export async function resolveStatusLastHeartbeat(params: {
   config: OpenClawConfig;
   timeoutMs?: number;
@@ -151,6 +158,7 @@ export async function resolveStatusLastHeartbeat(params: {
   }).catch(() => null);
 }
 
+/** Reads managed gateway and node service summaries in parallel. */
 export async function resolveStatusServiceSummaries() {
   return await Promise.all([getDaemonStatusSummary(), getNodeDaemonStatusSummary()]);
 }
@@ -162,6 +170,10 @@ type StatusGatewayServiceSummary = Awaited<ReturnType<typeof getDaemonStatusSumm
 type StatusNodeServiceSummary = Awaited<ReturnType<typeof getNodeDaemonStatusSummary>>;
 type StatusSecurityAudit = Awaited<ReturnType<typeof resolveStatusSecurityAudit>>;
 
+/**
+ * Resolves optional runtime details for status commands, gating expensive probes
+ * behind `usage` and `deep` so default status remains fast.
+ */
 export async function resolveStatusRuntimeDetails(params: {
   config: OpenClawConfig;
   timeoutMs?: number;
@@ -218,6 +230,10 @@ export async function resolveStatusRuntimeDetails(params: {
   };
 }
 
+/**
+ * Resolves the full runtime snapshot shared by text and JSON status commands,
+ * optionally adding the security audit before the common runtime details.
+ */
 export async function resolveStatusRuntimeSnapshot(params: {
   config: OpenClawConfig;
   sourceConfig: OpenClawConfig;

--- a/src/commands/status-update-restart.ts
+++ b/src/commands/status-update-restart.ts
@@ -16,6 +16,9 @@ function readAfterVersion(payload: RestartSentinelPayload): string | null {
   return typeof version === "string" && version.trim().length > 0 ? version : null;
 }
 
+/**
+ * Formats the last update-triggered restart sentinel for the status overview.
+ */
 export function formatUpdateRestartStatusValue(
   payload: RestartSentinelPayload | null | undefined,
   opts: {
@@ -55,10 +58,15 @@ export function formatUpdateRestartStatusValue(
     return muted(`skipped · ${reason ?? "restart skipped"}${age}`);
   }
 
+  // A successful sentinel may omit after.version for older update flows; keep
+  // the green status useful without claiming a gateway version we did not see.
   const version = readAfterVersion(payload);
   return ok(`verified${version ? ` · gateway ${version}` : ""}${age}`);
 }
 
+/**
+ * Returns follow-up commands for update restart states that need operator action.
+ */
 export function formatUpdateRestartActionLines(
   payload: RestartSentinelPayload | null | undefined,
 ): string[] {
@@ -77,6 +85,8 @@ export function formatUpdateRestartActionLines(
     (reason === CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON ||
       reason === CONTROL_PLANE_UPDATE_RESTART_HEALTH_PENDING_REASON)
   ) {
+    // Pending handoff states are not failures yet; direct users to the handoff
+    // state first, then the deeper gateway probe only if it remains stuck.
     return [
       "Update restart is still pending; run openclaw update status --json for handoff state.",
       "If it stays pending, run openclaw gateway status --deep.",

--- a/src/commands/status.agent-local.ts
+++ b/src/commands/status.agent-local.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
 import { pathExists } from "../infra/fs-safe.js";
 
+/** Local per-agent state summarized by `openclaw status`. */
 export type AgentLocalStatus = {
   id: string;
   name?: string;
@@ -24,6 +25,9 @@ type AgentLocalStatusesResult = {
   bootstrapPendingCount: number;
 };
 
+/**
+ * Collects local workspace/bootstrap/session counters for configured agents.
+ */
 export async function getAgentLocalStatuses(
   cfg: OpenClawConfig,
 ): Promise<AgentLocalStatusesResult> {
@@ -46,6 +50,8 @@ export async function getAgentLocalStatuses(
 
     const sessionsPath = resolveStorePath(cfg.session?.store, { agentId });
     const store = readSessionStoreReadOnly(sessionsPath);
+    // The shared store keeps aggregate buckets under reserved keys; status only
+    // counts real per-session records when reporting local agent activity.
     const sessions = Object.entries(store)
       .filter(([key]) => key !== "global" && key !== "unknown")
       .map(([, entry]) => entry);

--- a/src/commands/status.command-report-data.ts
+++ b/src/commands/status.command-report-data.ts
@@ -29,6 +29,12 @@ import {
 import type { MemoryPluginStatus, MemoryStatusSnapshot } from "./status.scan.shared.js";
 import type { SessionStatus, StatusSummary } from "./status.types.js";
 
+/**
+ * Builds the render-ready data model for the text `openclaw status` report.
+ *
+ * Runtime probes, scan results, and color/table helpers stay injected so tests
+ * can verify section decisions without touching live gateway state.
+ */
 export async function buildStatusCommandReportData(
   params: {
     opts: {
@@ -117,6 +123,8 @@ export async function buildStatusCommandReportData(
     updateRestartValue: params.updateRestartValue,
   });
 
+  // The optional cache column is intentionally verbose-only; keeping the default
+  // table narrower preserves readable status output on small terminals.
   const sessionsColumns = [
     { key: "Key", header: "Key", minWidth: 20, flex: true },
     { key: "Kind", header: "Kind", minWidth: 6 },
@@ -134,6 +142,8 @@ export async function buildStatusCommandReportData(
         formatCliCommand: params.formatCliCommand,
       })
     : [
+        // Fast status skips the expensive audit but must still tell operators
+        // which command produces the authoritative security report.
         params.theme.muted(
           `Skipped in fast status. Full report: ${params.formatCliCommand("openclaw security audit")}`,
         ),

--- a/src/commands/status.command-report.ts
+++ b/src/commands/status.command-report.ts
@@ -9,6 +9,12 @@ import {
 } from "./status-all/report-sections.js";
 import { appendStatusReportSections } from "./status-all/text-report.js";
 
+/**
+ * Renders the normalized status command report into terminal lines.
+ *
+ * The caller owns all probing and formatting decisions; this helper only keeps
+ * section order, empty-section handling, and table rendering consistent.
+ */
 export async function buildStatusCommandReportLines(params: {
   heading: (text: string) => string;
   muted: (text: string) => string;
@@ -36,6 +42,8 @@ export async function buildStatusCommandReportLines(params: {
   const lines: string[] = [];
   lines.push(params.heading("OpenClaw status"));
 
+  // Overview stays first because later diagnostics often refer to the selected
+  // gateway, update, and runtime states summarized there.
   appendStatusReportSections({
     lines,
     heading: params.heading,

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -26,6 +26,7 @@ type MemoryPluginLike = MemoryPluginStatus;
 type SessionsRecentLike = SessionStatus;
 type EventLoopHealthLike = NonNullable<HealthSummary["eventLoop"]>;
 
+/** Formatter hooks that translate memory backend state into status text tones. */
 export type StatusMemoryStateResolvers = {
   resolveMemoryVectorState: (value: NonNullable<MemoryStatusSnapshot["vector"]>) => {
     state: string;
@@ -51,12 +52,14 @@ type PairingRecoveryLike = {
   remediationHint?: string | null;
 };
 
+/** Column contract for the regular `status` health table. */
 export const statusHealthColumns: TableColumn[] = [
   { key: "Item", header: "Item", minWidth: 10 },
   { key: "Status", header: "Status", minWidth: 8 },
   { key: "Detail", header: "Detail", flex: true, minWidth: 28 },
 ];
 
+/** Builds the compact agent/workspace summary shown in the overview table. */
 export function buildStatusAgentsValue(params: {
   agentStatus: AgentStatusLike;
   formatTimeAgo: (ageMs: number) => string;
@@ -72,6 +75,7 @@ export function buildStatusAgentsValue(params: {
   return `${params.agentStatus.agents.length} · ${pending} · sessions ${params.agentStatus.totalSessions}${defSuffix}`;
 }
 
+/** Builds the task/audit overview value, highlighting runtime and audit issues. */
 export function buildStatusTasksValue(params: {
   summary: Pick<SummaryLike, "tasks" | "taskAudit">;
   warn: (value: string) => string;
@@ -100,6 +104,7 @@ export function buildStatusTasksValue(params: {
   ].join(" · ");
 }
 
+/** Formats configured heartbeat intervals for each agent. */
 export function buildStatusHeartbeatValue(params: { summary: Pick<SummaryLike, "heartbeat"> }) {
   const parts = params.summary.heartbeat.agents
     .map((agent) => {
@@ -112,6 +117,7 @@ export function buildStatusHeartbeatValue(params: { summary: Pick<SummaryLike, "
   return parts.length > 0 ? parts.join(", ") : "disabled";
 }
 
+/** Formats the deep-status last-heartbeat row when gateway data is available. */
 export function buildStatusLastHeartbeatValue(params: {
   deep?: boolean;
   gatewayReachable: boolean;
@@ -139,6 +145,10 @@ export function buildStatusLastHeartbeatValue(params: {
     .join(" · ");
 }
 
+/**
+ * Builds the memory overview value across disabled, unavailable, builtin, and
+ * plugin-backed memory states.
+ */
 export function buildStatusMemoryValue(
   params: {
     memory: MemoryLike;
@@ -169,6 +179,8 @@ export function buildStatusMemoryValue(
   const colorByTone = (tone: Tone, text: string) =>
     tone === "ok" ? params.ok(text) : tone === "warn" ? params.warn(text) : params.muted(text);
   if (params.memory.vector) {
+    // Builtin memory exposes vector availability through the store layer; use it
+    // for the displayed state so missing vector stores are surfaced correctly.
     const vector =
       params.memory.backend === "builtin" && params.memory.vector.storeAvailable !== undefined
         ? { ...params.memory.vector, available: params.memory.vector.storeAvailable }
@@ -190,6 +202,7 @@ export function buildStatusMemoryValue(
   return parts.join(" · ");
 }
 
+/** Builds the condensed security audit section for the regular status report. */
 export function buildStatusSecurityAuditLines(params: {
   securityAudit: {
     summary: { critical: number; warn: number; info: number };
@@ -253,6 +266,7 @@ export function buildStatusSecurityAuditLines(params: {
   return lines;
 }
 
+/** Builds health table rows from gateway health and channel health lines. */
 export function buildStatusHealthRows(params: {
   health: HealthSummary;
   formatHealthChannelLines: (summary: HealthSummary, opts: { accountMode: "all" }) => string[];
@@ -291,6 +305,8 @@ export function buildStatusHealthRows(params: {
     const item = line.slice(0, colon).trim();
     const detail = line.slice(colon + 1).trim();
     const normalized = normalizeLowercaseStringOrEmpty(detail);
+    // Channel health lines are still string-formatted by adapters; map the
+    // stable prefixes into table states until the health contract is structured.
     const status = normalized.startsWith("ok")
       ? params.ok("OK")
       : normalized.startsWith("failed")
@@ -309,6 +325,7 @@ export function buildStatusHealthRows(params: {
   return rows;
 }
 
+/** Formats event-loop delay/utilization counters into one table detail cell. */
 export function formatEventLoopHealthDetail(eventLoop: EventLoopHealthLike): string {
   const parts = [
     eventLoop.reasons.length > 0 ? `reasons ${eventLoop.reasons.join(",")}` : "healthy",
@@ -320,6 +337,7 @@ export function formatEventLoopHealthDetail(eventLoop: EventLoopHealthLike): str
   return parts.join(" · ");
 }
 
+/** Builds recent session rows, adding prompt-cache details only in verbose mode. */
 export function buildStatusSessionsRows(params: {
   recent: SessionsRecentLike[];
   verbose?: boolean;
@@ -345,6 +363,10 @@ export function buildStatusSessionsRows(params: {
   }));
 }
 
+/**
+ * Builds warnings for sessions pinned to a model that differs from current
+ * config, treating runtime aliases as equivalent to avoid noisy false positives.
+ */
 export function buildStatusModelSelectionLines(params: {
   recent: SessionsRecentLike[];
   limit?: number;
@@ -388,6 +410,7 @@ export function buildStatusModelSelectionLines(params: {
   return lines;
 }
 
+/** Builds static footer help plus the next best command for the current state. */
 export function buildStatusFooterLines(params: {
   updateHint: string | null;
   warn: (value: string) => string;
@@ -410,6 +433,7 @@ export function buildStatusFooterLines(params: {
   ];
 }
 
+/** Formats plugin compatibility notices with a bounded output limit. */
 export function buildStatusPluginCompatibilityLines<
   TNotice extends PluginCompatibilityNoticeLike,
 >(params: {
@@ -434,6 +458,7 @@ export function buildStatusPluginCompatibilityLines<
   ];
 }
 
+/** Builds device-pairing recovery commands from the latest pairing failure. */
 export function buildStatusPairingRecoveryLines(params: {
   pairingRecovery: PairingRecoveryLike | null;
   warn: (value: string) => string;
@@ -467,6 +492,7 @@ export function buildStatusPairingRecoveryLines(params: {
   ];
 }
 
+/** Builds bounded system-event rows, returning undefined when there is no table. */
 export function buildStatusSystemEventsRows(params: {
   queuedSystemEvents: string[];
   limit?: number;
@@ -478,6 +504,7 @@ export function buildStatusSystemEventsRows(params: {
   return params.queuedSystemEvents.slice(0, limit).map((event) => ({ Event: event }));
 }
 
+/** Builds the overflow trailer for hidden system-event rows. */
 export function buildStatusSystemEventsTrailer(params: {
   queuedSystemEvents: string[];
   limit?: number;

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -53,6 +53,10 @@ function loadStatusNodeModeModule() {
   return statusNodeModeModuleLoader.load();
 }
 
+/**
+ * Normalizes pairing-required connection failures into the compact recovery
+ * payload shown by `openclaw status`.
+ */
 export function resolvePairingRecoveryContext(params: {
   error?: string | null;
   closeReason?: string | null;
@@ -72,6 +76,8 @@ export function resolvePairingRecoveryContext(params: {
         : null,
     };
   }
+  // Older gateway/client combinations only carried pairing failures in text.
+  // Keep the fallback narrow so unrelated connection errors stay unclassified.
   const source = [params.error, params.closeReason]
     .filter((part) => typeof part === "string" && part.trim().length > 0)
     .join(" ");
@@ -86,6 +92,10 @@ export function resolvePairingRecoveryContext(params: {
   };
 }
 
+/**
+ * Runs the status command entrypoint, routing JSON/all modes through their
+ * specialized scanners while keeping the default text report on the rich path.
+ */
 export async function statusCommand(
   opts: {
     json?: boolean;

--- a/src/commands/status.daemon.ts
+++ b/src/commands/status.daemon.ts
@@ -34,10 +34,12 @@ async function buildDaemonStatusSummary(
   };
 }
 
+/** Reads the OpenClaw gateway service summary for status output. */
 export async function getDaemonStatusSummary(): Promise<DaemonStatusSummary> {
   return await buildDaemonStatusSummary("gateway");
 }
 
+/** Reads the OpenClaw node service summary for status output. */
 export async function getNodeDaemonStatusSummary(): Promise<DaemonStatusSummary> {
   return await buildDaemonStatusSummary("node");
 }

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -5,9 +5,11 @@ import { formatRuntimeStatusWithDetails } from "../infra/runtime-status.ts";
 import type { SessionStatus } from "./status.types.js";
 export { shortenText } from "./text-format.js";
 
+/** Formats token counts in the compact `k` style used by status tables. */
 export const formatKTokens = (value: number) =>
   `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
 
+/** Formats nullable millisecond durations for status output. */
 export const formatDuration = (ms: number | null | undefined) => {
   if (ms == null || !Number.isFinite(ms)) {
     return "unknown";
@@ -15,6 +17,7 @@ export const formatDuration = (ms: number | null | undefined) => {
   return formatDurationPrecise(ms, { decimals: 1 });
 };
 
+/** Formats session token usage and prompt-cache hit summary for status rows. */
 export const formatTokensCompact = (
   sess: Pick<
     SessionStatus,
@@ -42,6 +45,7 @@ export const formatTokensCompact = (
   return result;
 };
 
+/** Formats prompt-cache hit/read/write counters for verbose session rows. */
 export const formatPromptCacheCompact = (
   sess: Pick<SessionStatus, "inputTokens" | "totalTokens" | "cacheRead" | "cacheWrite">,
 ) => {
@@ -98,6 +102,7 @@ function resolvePromptCacheStats(
   };
 }
 
+/** Formats launchd/systemd runtime status into a compact service summary. */
 export const formatDaemonRuntimeShort = (runtime?: {
   status?: string;
   pid?: number;
@@ -114,6 +119,8 @@ export const formatDaemonRuntimeShort = (runtime?: {
   const noisyLaunchctlDetail =
     runtime.missingUnit === true &&
     normalizeLowercaseStringOrEmpty(detail).includes("could not find service");
+  // Missing launchd units already have a structured state; suppress the common
+  // launchctl boilerplate so useful runtime details stay visible.
   if (detail && !noisyLaunchctlDetail) {
     details.push(detail);
   }

--- a/src/commands/status.gateway-connection.ts
+++ b/src/commands/status.gateway-connection.ts
@@ -2,6 +2,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import type { NodeOnlyGatewayInfo } from "./status.node-mode.js";
 import type { StatusScanOverviewResult } from "./status.scan-overview.ts";
 
+/** Logs a preformatted gateway connection block with status command styling. */
 export function logGatewayConnectionDetails(params: {
   runtime: Pick<RuntimeEnv, "log">;
   info: (value: string) => string;
@@ -17,6 +18,10 @@ export function logGatewayConnectionDetails(params: {
   }
 }
 
+/**
+ * Builds the gateway connection block used in pasteable `status --all` reports,
+ * including node-only and missing-remote-url fallbacks.
+ */
 export function resolveStatusAllConnectionDetails(params: {
   nodeOnlyGateway: NodeOnlyGatewayInfo | null;
   remoteUrlMissing: boolean;

--- a/src/commands/status.gateway-probe.ts
+++ b/src/commands/status.gateway-probe.ts
@@ -5,6 +5,7 @@ import {
 } from "../gateway/probe-auth.js";
 export { pickGatewaySelfPresence } from "./gateway-presence.js";
 
+/** Resolves gateway probe credentials plus any non-fatal auth-source warning. */
 export async function resolveGatewayProbeAuthResolution(cfg: OpenClawConfig): Promise<{
   auth: {
     token?: string;
@@ -20,6 +21,7 @@ export async function resolveGatewayProbeAuthResolution(cfg: OpenClawConfig): Pr
   });
 }
 
+/** Resolves only the credential payload for callers that do not display warnings. */
 export async function resolveGatewayProbeAuth(cfg: OpenClawConfig): Promise<{
   token?: string;
   password?: string;

--- a/src/commands/status.link-channel.ts
+++ b/src/commands/status.link-channel.ts
@@ -12,6 +12,9 @@ export type LinkChannelContext = {
   plugin: ChannelPlugin;
 };
 
+/**
+ * Finds the first read-only channel plugin that can report linked-account state.
+ */
 export async function resolveLinkChannelContext(
   cfg: OpenClawConfig,
   options: { sourceConfig?: OpenClawConfig } = {},
@@ -42,6 +45,8 @@ export async function resolveLinkChannelContext(
         })
       : undefined;
     const summaryRecord = summary;
+    // Only summaries that explicitly expose a linked boolean are usable here;
+    // setup-capable plugins without that contract should not affect status.
     const linked =
       summaryRecord && typeof summaryRecord.linked === "boolean" ? summaryRecord.linked : null;
     if (linked === null) {

--- a/src/commands/status.node-mode.ts
+++ b/src/commands/status.node-mode.ts
@@ -14,6 +14,7 @@ type NodeOnlyServiceLike = {
   runtimeShort?: string | null;
 };
 
+/** Status metadata used when this machine runs only the node service. */
 export type NodeOnlyGatewayInfo = {
   gatewayTarget: string;
   gatewayValue: string;
@@ -50,9 +51,15 @@ function isNodeServiceActive(node: NodeOnlyServiceLike): boolean {
   if (hasRunningRuntime(node.runtime)) {
     return true;
   }
+  // Some service backends only provide the compact runtime string; accept the
+  // canonical running prefix so node-only status works across launchd/systemd.
   return typeof node.runtimeShort === "string" && node.runtimeShort.startsWith("running");
 }
 
+/**
+ * Detects node-only installations where the local gateway is absent but the
+ * node service is active and points at a remote gateway.
+ */
 export async function resolveNodeOnlyGatewayInfo(params: {
   daemon: Pick<NodeOnlyServiceLike, "installed">;
   node: NodeOnlyServiceLike;

--- a/src/commands/status.scan-execute.ts
+++ b/src/commands/status.scan-execute.ts
@@ -9,6 +9,10 @@ import {
   type MemoryStatusSnapshot,
 } from "./status.scan.shared.js";
 
+/**
+ * Completes a status scan from the shared overview result by resolving memory
+ * and summary data, then packaging the legacy scan result shape.
+ */
 export async function executeStatusScanFromOverview(params: {
   overview: StatusScanOverviewResult;
   runtime?: RuntimeEnv;
@@ -26,6 +30,8 @@ export async function executeStatusScanFromOverview(params: {
   pluginCompatibility: PluginCompatibilityNotice[];
 }) {
   const memoryPlugin = resolveMemoryPluginStatus(params.overview.cfg);
+  // Memory and summary collection are independent; keep them parallel so deep
+  // status does not serialize disk-backed memory work with summary assembly.
   const [memory, summary] = await Promise.all([
     params.resolveMemory({
       cfg: params.overview.cfg,

--- a/src/commands/status.scan-memory.ts
+++ b/src/commands/status.scan-memory.ts
@@ -19,10 +19,15 @@ function loadStatusScanDepsRuntimeModule() {
   return statusScanDepsRuntimeModuleLoader.load();
 }
 
+/** Resolves the default per-agent builtin memory database path. */
 export function resolveDefaultMemoryStorePath(agentId: string): string {
   return path.join(resolveStateDir(process.env, os.homedir), "memory", `${agentId}.sqlite`);
 }
 
+/**
+ * Resolves memory status for scan output while lazy-loading runtime-only memory
+ * dependencies outside the default status module graph.
+ */
 export async function resolveStatusMemoryStatusSnapshot(params: {
   cfg: OpenClawConfig;
   agentStatus: Awaited<ReturnType<typeof getAgentLocalStatusesFn>>;

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -101,6 +101,7 @@ async function resolveStatusChannelsStatus(params: {
   }).catch(() => null);
 }
 
+/** Shared status scan facts used by text and JSON status paths. */
 export type StatusScanOverviewResult = {
   coldStart: boolean;
   hasConfiguredChannels: boolean;
@@ -131,6 +132,12 @@ export type StatusScanOverviewResult = {
   agentStatus: Awaited<ReturnType<typeof getAgentLocalStatusesFn>>;
 };
 
+/**
+ * Collects the common status overview in dependency-light stages.
+ *
+ * Optional live channel probes and fallback runtimes are controlled by callers
+ * so fast JSON, text status, and deep status can share the same scan shape.
+ */
 export async function collectStatusScanOverview(params: {
   commandName: string;
   opts: { timeoutMs?: number; all?: boolean };
@@ -298,6 +305,8 @@ export async function collectStatusScanOverview(params: {
         return { channelsStatus, channelIssues, channels };
       })()
     : {
+        // Fast callers can skip channel table construction entirely but still
+        // receive the same overview shape as the full scan path.
         channelsStatus: null,
         channelIssues: [],
         channels: { rows: [], details: [] },
@@ -323,6 +332,10 @@ export async function collectStatusScanOverview(params: {
   };
 }
 
+/**
+ * Resolves the full status summary unless cold-start mode deliberately skipped
+ * network and store checks.
+ */
 export async function resolveStatusSummaryFromOverview(params: {
   overview: Pick<StatusScanOverviewResult, "skipColdStartNetworkChecks" | "cfg" | "sourceConfig">;
   includeChannelSummary?: boolean;

--- a/src/commands/status.scan-result.ts
+++ b/src/commands/status.scan-result.ts
@@ -13,6 +13,7 @@ import type {
 } from "./status.scan.shared.js";
 import type { getStatusSummary as getStatusSummaryFn } from "./status.summary.js";
 
+/** Complete scan payload consumed by regular status rendering and JSON output. */
 export type StatusScanResult = {
   cfg: OpenClawConfig;
   sourceConfig: OpenClawConfig;
@@ -42,6 +43,10 @@ export type StatusScanResult = {
   pluginCompatibility: PluginCompatibilityNotice[];
 };
 
+/**
+ * Flattens gateway snapshot fields into the historical scan result shape while
+ * keeping the scan collector's grouped gateway data as the single input.
+ */
 export function buildStatusScanResult(params: {
   cfg: OpenClawConfig;
   sourceConfig: OpenClawConfig;

--- a/src/commands/status.scan.bootstrap-shared.ts
+++ b/src/commands/status.scan.bootstrap-shared.ts
@@ -22,6 +22,7 @@ function buildColdStartAgentLocalStatuses() {
   };
 }
 
+/** Builds the empty summary used when status runs before a config exists. */
 export function buildColdStartStatusSummary() {
   return {
     runtimeVersion: null,
@@ -77,6 +78,10 @@ type StatusScanCoreBootstrapParams<TAgentStatus> = {
   getAgentLocalStatuses: (cfg: OpenClawConfig) => Promise<TAgentStatus>;
 };
 
+/**
+ * Starts the independent status bootstrap probes and returns their promises so
+ * overview scans can await only the pieces they need in their preferred order.
+ */
 export async function createStatusScanCoreBootstrap<TAgentStatus>(
   params: StatusScanCoreBootstrapParams<TAgentStatus>,
 ) {
@@ -89,6 +94,8 @@ export async function createStatusScanCoreBootstrap<TAgentStatus>(
   const statusTimeoutMs = params.opts.timeoutMs ?? 10_000;
   const updateTimeoutMs = Math.min(params.opts.all ? 6500 : 2500, statusTimeoutMs);
   const tailscaleTimeoutMs = Math.min(1200, statusTimeoutMs);
+  // First-run status without configured channels avoids network probes unless
+  // the caller explicitly requested the full `--all` view.
   const tailscaleDnsPromise =
     tailscaleMode === "off"
       ? Promise.resolve<string | null>(null)

--- a/src/commands/status.scan.config-shared.ts
+++ b/src/commands/status.scan.config-shared.ts
@@ -3,12 +3,14 @@ import { resolveConfigPath } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveGatewayAuthTokenSourceConflict } from "../gateway/auth-token-source-conflict.js";
 
+/** Returns true in test runners where missing-config cold-start shortcuts are disabled. */
 export function shouldSkipStatusScanMissingConfigFastPath(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   return env.VITEST === "true" || env.VITEST_POOL_ID !== undefined || env.NODE_ENV === "test";
 }
 
+/** Detects whether status should use the missing-config cold-start path. */
 export function resolveStatusScanColdStart(params?: {
   env?: NodeJS.ProcessEnv;
   allowMissingConfigFastPath?: boolean;
@@ -19,6 +21,10 @@ export function resolveStatusScanColdStart(params?: {
   return !skipMissingConfigFastPath && !existsSync(resolveConfigPath(env));
 }
 
+/**
+ * Loads best-effort config for status scans, optionally avoiding config reads on
+ * first-run cold start while still reporting auth-token source conflicts.
+ */
 export async function loadStatusScanCommandConfig(params: {
   commandName: string;
   readBestEffortConfig: () => Promise<OpenClawConfig>;

--- a/src/commands/status.scan.deps.runtime.ts
+++ b/src/commands/status.scan.deps.runtime.ts
@@ -12,6 +12,12 @@ type StatusMemoryManager = {
   close?(): Promise<void>;
 };
 
+/**
+ * Returns a narrow memory manager adapter for status probes.
+ *
+ * The adapter exposes only read/status methods so scan code cannot accidentally
+ * depend on broader memory runtime capabilities.
+ */
 export async function getMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -21,6 +27,8 @@ export async function getMemorySearchManager(params: {
   if (!manager) {
     return { manager: null };
   }
+  // Older memory runtimes may not expose the store-level probe; keep that
+  // optional so status can still report provider availability.
   const probeVectorStoreAvailability = manager.probeVectorStoreAvailability
     ? async () => await manager.probeVectorStoreAvailability!()
     : undefined;

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -76,6 +76,10 @@ function hasPotentialConfiguredChannelsForStatusJson(cfg: OpenClawConfig): boole
   return hasExplicitStatusJsonChannelConfig(cfg) || hasStatusJsonChannelEnvConfig();
 }
 
+/**
+ * Runs a policy-driven JSON status scan, sharing the overview collector while
+ * letting callers choose channel, update, gateway, and memory behavior.
+ */
 export async function scanStatusJsonWithPolicy(
   opts: {
     timeoutMs?: number;
@@ -91,6 +95,8 @@ export async function scanStatusJsonWithPolicy(
     runtime,
     allowMissingConfigFastPath: policy.allowMissingConfigFastPath,
     resolveHasConfiguredChannels: policy.resolveHasConfiguredChannels,
+    // JSON status keeps channel rows out of the fast path; callers can still
+    // request summary data through the policy when compatibility needs it.
     includeChannelsData: false,
     includeChannelSecretTargets: false,
     skipConfigPluginValidation: true,
@@ -112,6 +118,10 @@ export async function scanStatusJsonWithPolicy(
   });
 }
 
+/**
+ * Runs the default fast `status --json` scan, using cheap config/env heuristics
+ * to decide whether channel probing is worth doing before full config exists.
+ */
 export async function scanStatusJsonFast(
   opts: {
     timeoutMs?: number;

--- a/src/commands/status.scan.runtime.ts
+++ b/src/commands/status.scan.runtime.ts
@@ -1,6 +1,7 @@
 import { collectChannelStatusIssues } from "../infra/channels-status-issues.js";
 import { buildChannelsTable } from "./status-all/channels.js";
 
+/** Runtime hooks used by status scan overview code for channel-specific data. */
 export const statusScanRuntime = {
   collectChannelStatusIssues,
   buildChannelsTable,

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -36,16 +36,19 @@ function loadGatewayCallModule() {
   return gatewayCallModuleLoader.load();
 }
 
+/** Memory provider status annotated with the agent it was resolved for. */
 export type MemoryStatusSnapshot = MemoryProviderStatus & {
   agentId: string;
 };
 
+/** Resolved memory plugin enablement and slot state for status scans. */
 export type MemoryPluginStatus = {
   enabled: boolean;
   slot: string | null;
   reason?: string;
 };
 
+/** Gateway connection/probe/auth snapshot shared by text and JSON status scans. */
 export type GatewayProbeSnapshot = {
   gatewayConnection: ReturnType<typeof buildGatewayConnectionDetailsWithResolvers>;
   remoteUrlMissing: boolean;
@@ -131,6 +134,8 @@ async function applyLocalStatusRpcFallback(params: {
   if (!shouldTryLocalStatusRpcFallback(params)) {
     return params.gatewayProbe;
   }
+  // Presence probes can time out on local startup while the gateway status RPC
+  // is already usable; keep this fallback short so status stays responsive.
   const boundedFallbackTimeoutMs = Math.min(2000, Math.max(1000, params.timeoutMs));
   const status = await loadGatewayCallModule()
     .then(({ callGateway }) =>
@@ -177,6 +182,7 @@ function hasExplicitMemorySearchConfig(cfg: OpenClawConfig, agentId: string): bo
   return agents.some((agent) => agent?.id === agentId && Object.hasOwn(agent, "memorySearch"));
 }
 
+/** Resolves whether status should inspect memory and which slot owns it. */
 export function resolveMemoryPluginStatus(cfg: OpenClawConfig): MemoryPluginStatus {
   const pluginsEnabled = cfg.plugins?.enabled !== false;
   if (!pluginsEnabled) {
@@ -189,6 +195,10 @@ export function resolveMemoryPluginStatus(cfg: OpenClawConfig): MemoryPluginStat
   return { enabled: true, slot: raw || defaultSlotIdForKey("memory") };
 }
 
+/**
+ * Resolves gateway target, auth, reachability, optional presence, and fallback
+ * call overrides in one snapshot for all status surfaces.
+ */
 export async function resolveGatewayProbeSnapshot(params: {
   cfg: OpenClawConfig;
   opts: {
@@ -250,6 +260,8 @@ export async function resolveGatewayProbeSnapshot(params: {
     gatewayProbeAuthWarning &&
     gatewayProbe?.ok === false
   ) {
+    // Auth warnings are most actionable beside the failed probe error; merge
+    // them unless the caller wants a separate warning field.
     gatewayProbe.error = gatewayProbe.error
       ? `${gatewayProbe.error}; ${gatewayProbeAuthWarning}`
       : gatewayProbeAuthWarning;
@@ -280,6 +292,7 @@ export async function resolveGatewayProbeSnapshot(params: {
   };
 }
 
+/** Builds the Control UI HTTPS URL advertised through Tailscale MagicDNS. */
 export function buildTailscaleHttpsUrl(params: {
   tailscaleMode: string;
   tailscaleDns: string | null;
@@ -290,6 +303,10 @@ export function buildTailscaleHttpsUrl(params: {
     : null;
 }
 
+/**
+ * Resolves memory status while avoiding implicit creation/inspection of the
+ * default builtin store when the user has not configured memory search.
+ */
 export async function resolveSharedMemoryStatusSnapshot(params: {
   cfg: OpenClawConfig;
   agentStatus: { defaultId?: string | null };

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -8,6 +8,10 @@ import { collectStatusScanOverview } from "./status.scan-overview.ts";
 import type { StatusScanResult } from "./status.scan-result.ts";
 import { scanStatusJsonWithPolicy } from "./status.scan.fast-json.js";
 
+/**
+ * Runs the status scan entrypoint, choosing the fast JSON policy path or the
+ * interactive text scan path from CLI options.
+ */
 export async function scanStatus(
   opts: {
     json?: boolean;
@@ -18,6 +22,8 @@ export async function scanStatus(
   _runtime: RuntimeEnv,
 ): Promise<StatusScanResult> {
   if (opts.json) {
+    // JSON status uses a policy wrapper so read-only fallback decisions stay
+    // consistent between fast JSON and the richer text scan.
     return await scanStatusJsonWithPolicy(
       {
         timeoutMs: opts.timeoutMs,
@@ -54,6 +60,8 @@ export async function scanStatus(
         showSecrets: process.env.OPENCLAW_SHOW_SECRETS?.trim() !== "0",
         includeLiveChannelStatus: isFullScan,
         includeChannelSetupRuntimeFallback: isFullScan,
+        // Default status avoids secret reads and live channel fallback; deep/all
+        // status opts into those slower probes for richer diagnostics.
         channelCredentialResolutionSkipped: !isFullScan,
         includeChannelSecretTargets: isFullScan ? undefined : false,
         fetchGitUpdate: isFullScan,

--- a/src/commands/status.service-summary.ts
+++ b/src/commands/status.service-summary.ts
@@ -5,6 +5,7 @@ import {
 import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
 import { readGatewayServiceState, type GatewayService } from "../daemon/service.js";
 
+/** Normalized launchd/systemd service state shown by status commands. */
 export type ServiceStatusSummary = {
   label: string;
   installed: boolean | null;
@@ -16,6 +17,10 @@ export type ServiceStatusSummary = {
   layout?: GatewayServiceLayoutSummary;
 };
 
+/**
+ * Reads a managed service state and classifies externally running services as
+ * installed but not managed by OpenClaw.
+ */
 export async function readServiceStatusSummary(
   service: GatewayService,
   fallbackLabel: string,

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -14,6 +14,9 @@ import type { OpenClawConfig } from "../config/types.js";
 import { classifySessionKind } from "../sessions/classify-session-kind.js";
 import { resolveAgentRuntimeLabel } from "../status/agent-runtime-label.js";
 
+/**
+ * Resolves a status-facing model ref from raw config or session text.
+ */
 function resolveStatusModelRefFromRaw(params: {
   cfg: OpenClawConfig;
   rawModel: string;
@@ -26,6 +29,8 @@ function resolveStatusModelRefFromRaw(params: {
   const configuredModels = params.cfg.agents?.defaults?.models ?? {};
   if (!trimmed.includes("/")) {
     const aliasKey = normalizeLowercaseStringOrEmpty(trimmed);
+    // Bare model names can be aliases for provider-qualified defaults; scan the
+    // configured registry before falling back to the default provider.
     for (const [modelKey, entry] of Object.entries(configuredModels)) {
       const aliasValue = (entry as { alias?: unknown } | undefined)?.alias;
       const alias = normalizeOptionalString(aliasValue) ?? "";
@@ -46,6 +51,9 @@ function resolveStatusModelRefFromRaw(params: {
   });
 }
 
+/**
+ * Resolves the configured model used for status defaults and drift checks.
+ */
 function resolveConfiguredStatusModelRef(params: {
   cfg: OpenClawConfig;
   defaultProvider: string;
@@ -91,6 +99,9 @@ function resolveConfiguredStatusModelRef(params: {
   return { provider: params.defaultProvider, model: params.defaultModel };
 }
 
+/**
+ * Reads context-window overrides from configured provider model entries.
+ */
 function resolveConfiguredProviderContextTokens(
   cfg: OpenClawConfig | undefined,
   provider: string,
@@ -125,6 +136,9 @@ function resolveConfiguredProviderContextTokens(
   return undefined;
 }
 
+/**
+ * Resolves the effective model for a persisted session.
+ */
 function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
@@ -150,6 +164,9 @@ function resolveSessionModelRef(
   );
 }
 
+/**
+ * Computes the runtime label shown for a status session row.
+ */
 function resolveSessionRuntimeLabel(params: {
   cfg: OpenClawConfig;
   entry?: SessionEntry;
@@ -177,6 +194,9 @@ function resolveSessionRuntimeLabel(params: {
   });
 }
 
+/**
+ * Resolves context tokens without triggering async catalog loading.
+ */
 function resolveContextTokensForModel(params: {
   cfg?: OpenClawConfig;
   provider?: string;
@@ -185,6 +205,8 @@ function resolveContextTokensForModel(params: {
   fallbackContextTokens?: number;
   allowAsyncLoad?: boolean;
 }): number | undefined {
+  // Status summaries run in read-only CLI paths; this runtime intentionally
+  // ignores async catalog loading and relies on explicit config/fallback data.
   void params.allowAsyncLoad;
   if (typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0) {
     return params.contextTokensOverride;

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -202,6 +202,7 @@ function resolveContextTokensForModel(params: {
   return params.fallbackContextTokens ?? DEFAULT_CONTEXT_TOKENS;
 }
 
+/** Runtime helpers used by status summary assembly and kept lazy for startup. */
 export const statusSummaryRuntime = {
   resolveContextTokensForModel,
   classifySessionKey: classifySessionKind,

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -139,6 +139,7 @@ function listSessionCandidates(store: Record<string, SessionEntry | undefined>) 
     .toSorted(compareSessionCandidatesByUpdatedAt);
 }
 
+/** Removes paths, defaults, and recent session details from shareable summaries. */
 export function redactSensitiveStatusSummary(summary: StatusSummary): StatusSummary {
   return {
     ...summary,
@@ -159,6 +160,10 @@ export function redactSensitiveStatusSummary(summary: StatusSummary): StatusSumm
   };
 }
 
+/**
+ * Builds the status summary for text and JSON status commands, with optional
+ * sensitive session details and channel summary enrichment.
+ */
 export async function getStatusSummary(
   options: {
     includeSensitive?: boolean;
@@ -280,6 +285,8 @@ export async function getStatusSummary(
       const model = resolvedModel.model ?? configuredSessionModel ?? null;
       const selectedModelLabel =
         resolvedModel.provider && model ? `${resolvedModel.provider}/${model}` : model;
+      // Only warn about pinned session models when the user chose the override;
+      // automatic fallback provenance should not look like an actionable drift.
       const modelSelectionDiffers =
         selectedModelLabel != null &&
         selectedModelLabel !== configuredSessionModelLabel &&

--- a/src/commands/status.test-support.ts
+++ b/src/commands/status.test-support.ts
@@ -13,11 +13,13 @@ import type { StatusSummary } from "./status.types.js";
 type StatusCommandOverviewRowsParams = Parameters<typeof buildStatusCommandOverviewRows>[0];
 type StatusCommandReportDataParams = Parameters<typeof buildStatusCommandReportData>[0];
 
+/** Minimal config fixture shared by status overview/report tests. */
 export const baseStatusCfg = {
   update: { channel: "stable" },
   gateway: { bind: "loopback" },
 } as const;
 
+/** Update fixture with both git and registry data populated. */
 export const baseStatusUpdate = {
   installKind: "git",
   git: {
@@ -46,6 +48,7 @@ export const baseStatusExpectedUpdateChannelInfo = isBetaTag(VERSION)
 
 export const baseStatusExpectedUpdateChannelLabel = baseStatusExpectedUpdateChannelInfo.label;
 
+/** Gateway probe fixture used by tests that need a reachable remote gateway. */
 export const baseStatusGatewaySnapshot = {
   gatewayMode: "remote",
   remoteUrlMissing: false,
@@ -91,6 +94,7 @@ export const baseStatusServices = {
   nodeOnlyGateway: null,
 };
 
+/** Fully assembled status overview fixture with services attached. */
 export const baseStatusOverviewSurface = {
   ...baseStatusOverviewScanFields,
   ...baseStatusServices,
@@ -217,6 +221,12 @@ const statusTestTheme = {
   error: (value: string) => `error(${value})`,
 };
 
+/**
+ * Creates render params for status overview row tests.
+ *
+ * Callers override only the fields under test so fixtures stay aligned with the
+ * production report shape.
+ */
 export function createStatusCommandOverviewRowsParams(
   overrides: Partial<StatusCommandOverviewRowsParams> = {},
 ): StatusCommandOverviewRowsParams {
@@ -239,6 +249,9 @@ export function createStatusCommandOverviewRowsParams(
   };
 }
 
+/**
+ * Creates render-ready status report data params for section-level tests.
+ */
 export function createStatusCommandReportDataParams(
   overrides: Partial<StatusCommandReportDataParams> = {},
 ): StatusCommandReportDataParams {

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -6,6 +6,7 @@ import type {
 } from "../tasks/task-registry.audit.js";
 import type { TaskRegistrySummary } from "../tasks/task-registry.types.js";
 
+/** Recent session row shown by status summaries and status tables. */
 export type SessionStatus = {
   agentId?: string;
   key: string;
@@ -38,6 +39,7 @@ export type SessionStatus = {
   flags: string[];
 };
 
+/** Heartbeat configuration summary for one agent. */
 export type HeartbeatStatus = {
   agentId: string;
   enabled: boolean;
@@ -45,6 +47,7 @@ export type HeartbeatStatus = {
   everyMs: number | null;
 };
 
+/** Aggregated local status snapshot used by text, JSON, and health views. */
 export type StatusSummary = {
   runtimeVersion?: string | null;
   eventLoop?: import("../gateway/server/event-loop-health.js").GatewayEventLoopHealth;
@@ -67,6 +70,7 @@ export type StatusSummary = {
     paths: string[];
     count: number;
     defaults: { model: string | null; contextTokens: number | null };
+    /** Newest sessions first, already normalized for display. */
     recent: SessionStatus[];
     byAgent: Array<{
       agentId: string;

--- a/src/commands/status.update.ts
+++ b/src/commands/status.update.ts
@@ -8,6 +8,9 @@ import {
 } from "../infra/update-check.js";
 import { VERSION } from "../version.js";
 
+/**
+ * Resolves the current install root and checks git/registry update state.
+ */
 export async function getUpdateCheckResult(params: {
   timeoutMs: number;
   fetchGit: boolean;
@@ -40,6 +43,9 @@ export type UpdateAvailability = {
   gitBehind: number | null;
 };
 
+/**
+ * Collapses git and registry update checks into a single availability summary.
+ */
 export function resolveUpdateAvailability(update: UpdateCheckResult): UpdateAvailability {
   const latestVersion = update.registry?.latestVersion ?? null;
   const registryCmp = latestVersion ? compareSemverStrings(VERSION, latestVersion) : null;
@@ -59,6 +65,9 @@ export function resolveUpdateAvailability(update: UpdateCheckResult): UpdateAvai
   };
 }
 
+/**
+ * Formats a short update hint for status footer output.
+ */
 export function formatUpdateAvailableHint(update: UpdateCheckResult): string | null {
   const availability = resolveUpdateAvailability(update);
   if (!availability.available) {
@@ -76,6 +85,9 @@ export function formatUpdateAvailableHint(update: UpdateCheckResult): string | n
   return `Update available${suffix}. Run: ${formatCliCommand("openclaw update")}`;
 }
 
+/**
+ * Builds the one-line update summary shown in status and update commands.
+ */
 export function formatUpdateOneLiner(update: UpdateCheckResult): string {
   const parts: string[] = [];
 

--- a/src/gateway/server-methods/agent-timestamp.ts
+++ b/src/gateway/server-methods/agent-timestamp.ts
@@ -16,6 +16,7 @@ const CRON_TIME_MARKER = "Current time: ";
  */
 const TIMESTAMP_ENVELOPE_PATTERN = /^\[.*\d{4}-\d{2}-\d{2} \d{2}:\d{2}/;
 
+/** Optional clock and timezone controls for gateway-side timestamp injection. */
 export interface TimestampInjectionOptions {
   timezone?: string;
   now?: Date;
@@ -70,9 +71,7 @@ export function injectTimestamp(message: string, opts?: TimestampInjectionOption
   return `[${dow} ${formatted}] ${message}`;
 }
 
-/**
- * Build TimestampInjectionOptions from an OpenClawConfig.
- */
+/** Build timestamp injection options from the configured default user timezone. */
 export function timestampOptsFromConfig(cfg: OpenClawConfig): TimestampInjectionOptions {
   return {
     timezone: resolveUserTimezone(cfg.agents?.defaults?.userTimezone),

--- a/src/gateway/server-methods/commands.ts
+++ b/src/gateway/server-methods/commands.ts
@@ -78,6 +78,8 @@ function resolveNativeName(cmd: ChatCommandDefinition, provider?: string): strin
   if (!provider || !cmd.nativeName) {
     return baseName;
   }
+  // Channel plugins may remap native slash-command names per provider while
+  // the command key remains the stable registry identity.
   return (
     getChannelPlugin(provider)?.commands?.resolveNativeCommandName?.({
       commandKey: cmd.key,
@@ -158,6 +160,8 @@ function mapCommand(
 ): CommandEntry {
   const shouldIncludeArgs = includeArgs && cmd.acceptsArgs && cmd.args?.length;
   const nativeName = cmd.scope === "text" ? undefined : resolveNativeName(cmd, provider);
+  // Text views expose slash-less primary names plus aliases; native views use
+  // provider-specific command names so control UIs can mirror platform menus.
   return {
     name: clampString(
       nameSurface === "text" ? resolvePrimaryTextName(cmd) : (nativeName ?? cmd.key),
@@ -245,6 +249,8 @@ export function buildCommandsListResult(params: {
 
   commands.push(...buildPluginCommandEntries({ provider, nameSurface, cfg: params.cfg }));
 
+  // The protocol caps response size; keep discovery deterministic by truncating
+  // only after all native, skill, and plugin command sources are merged.
   return { commands: commands.slice(0, COMMAND_LIST_MAX_ITEMS) };
 }
 

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -50,7 +50,7 @@ function normalizeTrustedProxyAuthForCompare(auth: ReturnType<typeof resolveGate
   };
 }
 
-/** Compares the effective shared Gateway auth surface that active clients use. */
+/** Compares the effective shared Gateway auth surface that active clients use after env expansion. */
 export function didSharedGatewayAuthChange(prev: OpenClawConfig, next: OpenClawConfig): boolean {
   const prevResolvedAuth = resolveGatewayAuth({
     authConfig: prev.gateway?.auth,
@@ -94,7 +94,7 @@ export function didSharedGatewayAuthChange(prev: OpenClawConfig, next: OpenClawC
   return prevAuth.mode !== nextAuth.mode || !isDeepStrictEqual(prevAuth.secret, nextAuth.secret);
 }
 
-/** Compares against the active secrets-expanded config when one is available. */
+/** Compares against the active secrets-expanded config when one is available in the gateway. */
 export function didActiveSharedGatewayAuthChange(params: {
   fallbackPrev: OpenClawConfig;
   next: OpenClawConfig;
@@ -225,6 +225,8 @@ export async function commitGatewayConfigWrite(params: {
       ...params.writeOptions,
       runtimeRefresh: {
         ...params.writeOptions.runtimeRefresh,
+        // Config writes already refresh runtime state; keep auth-store refs out
+        // so secret-backed auth is compared against the active expanded snapshot.
         includeAuthStoreRefs: false,
       },
     },
@@ -269,6 +271,8 @@ export async function resolveGatewayConfigRestartWriteResult(params: {
     note,
   });
   const sentinelPath = await tryWriteRestartSentinelPayload(payload);
+  // Hot reload handles reloadable paths itself. Direct restarts are reserved
+  // for disabled reload mode or gateway-owned paths that cannot be hot-applied.
   const restart = shouldScheduleDirectConfigRestart({
     changedPaths: params.changedPaths,
     nextConfig: params.nextConfig,

--- a/src/gateway/server-methods/connect.ts
+++ b/src/gateway/server-methods/connect.ts
@@ -1,6 +1,7 @@
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Rejects post-handshake `connect` calls; connection setup is handled before method dispatch. */
 export const connectHandlers: GatewayRequestHandlers = {
   connect: ({ respond }) => {
     respond(

--- a/src/gateway/server-methods/nodes-wake-state.ts
+++ b/src/gateway/server-methods/nodes-wake-state.ts
@@ -1,7 +1,11 @@
+/** Time to wait for a node to reconnect after a successful wake send. */
 export const NODE_WAKE_RECONNECT_WAIT_MS = 3_000;
+/** Longer wait after retrying a wake for an already nudged node. */
 export const NODE_WAKE_RECONNECT_RETRY_WAIT_MS = 12_000;
+/** Poll interval while waiting for a woken node to reconnect. */
 export const NODE_WAKE_RECONNECT_POLL_MS = 150;
 
+/** Summary of one push/nudge attempt used by node invocation wake logic. */
 export type NodeWakeAttempt = {
   available: boolean;
   throttled: boolean;
@@ -19,6 +23,7 @@ type NodeWakeState = {
 export const nodeWakeById = new Map<string, NodeWakeState>();
 export const nodeWakeNudgeById = new Map<string, number>();
 
+/** Clear all wake bookkeeping for a node after reconnect, failure, or test cleanup. */
 export function clearNodeWakeState(nodeId: string): void {
   nodeWakeById.delete(nodeId);
   nodeWakeNudgeById.delete(nodeId);

--- a/src/gateway/server-methods/nodes.helpers.ts
+++ b/src/gateway/server-methods/nodes.helpers.ts
@@ -13,6 +13,7 @@ type ValidatorFn = ((value: unknown) => boolean) & {
   errors?: ValidationError[] | null;
 };
 
+/** Send the standard gateway INVALID_REQUEST response for validator failures. */
 export function respondInvalidParams(params: {
   respond: RespondFn;
   method: string;
@@ -28,6 +29,7 @@ export function respondInvalidParams(params: {
   );
 }
 
+/** Wrap async handler bodies that should surface thrown errors as UNAVAILABLE. */
 export async function respondUnavailableOnThrow(respond: RespondFn, fn: () => Promise<void>) {
   try {
     await fn();
@@ -36,6 +38,7 @@ export async function respondUnavailableOnThrow(respond: RespondFn, fn: () => Pr
   }
 }
 
+/** Convert failed node invocation results into gateway UNAVAILABLE responses. */
 export function respondUnavailableOnNodeInvokeError<T extends { ok: boolean; error?: unknown }>(
   respond: RespondFn,
   res: T,

--- a/src/gateway/server-methods/record-shared.ts
+++ b/src/gateway/server-methods/record-shared.ts
@@ -1,5 +1,6 @@
 export { asOptionalRecord as asRecord } from "../../../packages/normalization-core/src/record-coerce.js";
 
+/** Return a trimmed non-empty string for permissive gateway payload fields. */
 export function normalizeTrimmedString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -24,6 +24,7 @@ import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
+/** Connection metadata trusted by gateway method handlers after handshake validation. */
 export type GatewayClient = {
   connect: ConnectParams;
   connId?: string;
@@ -46,6 +47,7 @@ export type RespondFn = (
   meta?: Record<string, unknown>,
 ) => void;
 
+/** Shared gateway services and mutable runtime state exposed to method handlers. */
 export type GatewayRequestContext = {
   deps: CliDeps;
   cron: CronServiceContract;
@@ -142,6 +144,7 @@ export type GatewayRequestContext = {
   unavailableGatewayMethods?: ReadonlySet<string>;
 };
 
+/** Raw method-dispatch input before the request params have been normalized. */
 export type GatewayRequestOptions = {
   req: RequestFrame;
   client: GatewayClient | null;
@@ -151,6 +154,7 @@ export type GatewayRequestOptions = {
   methodRegistry?: GatewayMethodRegistryView;
 };
 
+/** Per-method handler input with params narrowed to a record by the dispatcher. */
 export type GatewayRequestHandlerOptions = {
   req: RequestFrame;
   params: Record<string, unknown>;
@@ -160,6 +164,8 @@ export type GatewayRequestHandlerOptions = {
   context: GatewayRequestContext;
 };
 
+/** Gateway method implementation signature. */
 export type GatewayRequestHandler = (opts: GatewayRequestHandlerOptions) => Promise<void> | void;
 
+/** Registry object keyed by gateway protocol method name. */
 export type GatewayRequestHandlers = Record<string, GatewayRequestHandler>;

--- a/src/gateway/server-methods/talk-client.ts
+++ b/src/gateway/server-methods/talk-client.ts
@@ -27,6 +27,7 @@ import {
 } from "./talk-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Handles browser-owned Talk sessions and their agent-consult control calls. */
 export const talkClientHandlers: GatewayRequestHandlers = {
   "talk.client.create": async ({ params, respond, context }) => {
     if (!validateTalkClientCreateParams(params)) {
@@ -257,6 +258,8 @@ function hasOwnedActiveTalkClientRun(params: {
     return false;
   }
   for (const entry of params.context.chatAbortControllers.values()) {
+    // Browser-owned Talk runs use non-agent abort entries scoped to the owning
+    // websocket connection; otherwise another tab could steer the same session.
     if (entry.sessionKey === sessionKey && entry.ownerConnId === connId && entry.kind !== "agent") {
       return true;
     }

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -66,6 +66,7 @@ import {
 } from "./talk-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Defaults omitted Talk session mode from transport so managed-room calls stay STT/TTS. */
 function normalizeTalkSessionMode(params: { mode?: string; transport?: string }): TalkMode {
   const mode = normalizeOptionalLowercaseString(params.mode) as TalkMode | undefined;
   if (mode) {
@@ -76,6 +77,7 @@ function normalizeTalkSessionMode(params: { mode?: string; transport?: string })
     : "realtime";
 }
 
+/** Defaults the Gateway-owned transport for each normalized Talk mode. */
 function normalizeTalkSessionTransport(params: {
   mode: TalkMode;
   transport?: string;
@@ -87,6 +89,7 @@ function normalizeTalkSessionTransport(params: {
   return params.mode === "stt-tts" ? "managed-room" : "gateway-relay";
 }
 
+/** Defaults agent ownership for conversational modes and disables it for transcription-only sessions. */
 function normalizeTalkSessionBrain(params: { mode: TalkMode; brain?: string }): TalkBrain {
   const brain = normalizeOptionalLowercaseString(params.brain) as TalkBrain | undefined;
   if (brain) {
@@ -111,6 +114,8 @@ function canCloseManagedRoomSession(
   connId: string | undefined,
 ): boolean {
   const handoff = getTalkHandoff(session.handoffId);
+  // Empty rooms are closeable by cleanup callers; occupied rooms stay owned by
+  // the active client connection so a stale tab cannot end another user's room.
   return !handoff?.room.activeClientId || handoff.room.activeClientId === connId;
 }
 
@@ -127,6 +132,7 @@ function managedRoomOwnershipError(action: string) {
   );
 }
 
+/** Handles Gateway-owned Talk sessions across relay, transcription, and managed-room transports. */
 export const talkSessionHandlers: GatewayRequestHandlers = {
   "talk.session.create": async ({ params, respond, context, client }) => {
     if (!validateTalkSessionCreateParams(params)) {

--- a/src/gateway/server-methods/tools-invoke.ts
+++ b/src/gateway/server-methods/tools-invoke.ts
@@ -29,6 +29,7 @@ function resolveRpcErrorCode(params: {
   return "internal_error";
 }
 
+/** Gateway method for invoking registered tools through the shared tool dispatcher. */
 export const toolsInvokeHandlers: GatewayRequestHandlers = {
   "tools.invoke": async ({ params, respond, context }) => {
     if (!validateToolsInvokeParams(params)) {

--- a/src/gateway/server-methods/update-managed-service-handoff.ts
+++ b/src/gateway/server-methods/update-managed-service-handoff.ts
@@ -286,6 +286,7 @@ function resolveUpdateCliArgv(params: {
   return ["openclaw", ...updateArgs];
 }
 
+/** Formats the shell command shown to operators when a managed update cannot be handed off. */
 export function formatManagedServiceUpdateCommand(timeoutMs?: number): string {
   const args = ["openclaw", "update", "--yes"];
   if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs)) {
@@ -294,6 +295,7 @@ export function formatManagedServiceUpdateCommand(timeoutMs?: number): string {
   return args.join(" ");
 }
 
+/** Removes inherited supervisor hints that would make the handoff helper look like the gateway. */
 export function stripSupervisorHintEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const next = { ...env };
   for (const key of SUPERVISOR_HINT_ENV_VARS) {
@@ -405,6 +407,7 @@ async function resolveHandoffSpawn(params: {
   };
 }
 
+/** Starts a detached helper that waits for the gateway to exit before running the update CLI. */
 export async function startManagedServiceUpdateHandoff(params: {
   root: string;
   timeoutMs?: number;
@@ -443,6 +446,8 @@ export async function startManagedServiceUpdateHandoff(params: {
     logPath,
     metaPath,
     sentinelPath: resolveRestartSentinelPath(),
+    // These files carry restart metadata and helper args; the child deletes
+    // them after launch so temp dirs do not retain operator/session context.
     sensitivePaths: [scriptPath, paramsPath, metaPath],
   };
 
@@ -479,6 +484,7 @@ export async function startManagedServiceUpdateHandoff(params: {
   };
 }
 
+/** Builds the operator-facing fallback text when a global install needs manual update. */
 export function buildManagedServiceHandoffUnavailableMessage(command: string): string {
   return [
     "Package updates cannot safely run inside the live gateway process.",

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -64,6 +64,7 @@ function resolveManagedServiceHandoffRestartDelayMs(
   );
 }
 
+/** Gateway RPC handlers for update status and control-plane initiated package updates. */
 export const updateHandlers: GatewayRequestHandlers = {
   "update.status": async ({ params, respond }) => {
     if (!assertValidParams(params, validateUpdateStatusParams, "update.status", respond)) {
@@ -88,6 +89,8 @@ export const updateHandlers: GatewayRequestHandlers = {
     } = parseRestartRequestParams(params);
     const { deliveryContext: sessionDeliveryContext, threadId: sessionThreadId } =
       extractDeliveryInfo(sessionKey);
+    // Explicit delivery fields win over values encoded in sessionKey so callers
+    // can redirect the post-restart continuation without minting a new session.
     const deliveryContext = requestedDeliveryContext ?? sessionDeliveryContext;
     const threadId = requestedThreadId ?? sessionThreadId;
     const timeoutMsRaw = (params as { timeoutMs?: unknown }).timeoutMs;
@@ -218,6 +221,8 @@ export const updateHandlers: GatewayRequestHandlers = {
           };
         }
       } else {
+        // Non-global installs can update in-process because the restart path is
+        // controlled by this gateway and the package root is local to it.
         result = await runGatewayUpdate({
           timeoutMs,
           cwd: root,
@@ -242,6 +247,8 @@ export const updateHandlers: GatewayRequestHandlers = {
 
     let sentinelPath: string | null = null;
     try {
+      // Persist restart metadata even for skipped/error results so status calls
+      // can explain the last update attempt after the handler returns.
       sentinelPath = await writeRestartSentinel(payload);
       recordLatestUpdateRestartSentinel(payload);
     } catch {

--- a/src/gateway/server-methods/voicewake-routing.ts
+++ b/src/gateway/server-methods/voicewake-routing.ts
@@ -7,6 +7,7 @@ import {
 } from "../../infra/voicewake-routing.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Gateway methods for reading and replacing voice-wake trigger routing rules. */
 export const voicewakeRoutingHandlers: GatewayRequestHandlers = {
   "voicewake.routing.get": async ({ respond }) => {
     try {

--- a/src/gateway/server-methods/voicewake.ts
+++ b/src/gateway/server-methods/voicewake.ts
@@ -4,6 +4,7 @@ import { normalizeVoiceWakeTriggers } from "../server-utils.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Gateway methods for reading and updating the global voice-wake trigger list. */
 export const voicewakeHandlers: GatewayRequestHandlers = {
   "voicewake.get": async ({ respond }) => {
     try {

--- a/src/infra/channel-summary.ts
+++ b/src/infra/channel-summary.ts
@@ -119,6 +119,7 @@ const buildAccountDetails = (params: {
   return details;
 };
 
+/** Build the user-facing channel status summary lines for CLI/status prompts. */
 export async function buildChannelSummary(
   cfg?: OpenClawConfig,
   options?: ChannelSummaryOptions,
@@ -183,6 +184,8 @@ export async function buildChannelSummary(
         ? summaryRecord.configured
         : configuredEntries.length > 0;
 
+    // Adapter summaries are authoritative for linked/status state, but account
+    // inspection still decides whether any configured account exists.
     const status = !anyEnabled
       ? "disabled"
       : statusState

--- a/src/plugins/agent-prompt-surface-kind.ts
+++ b/src/plugins/agent-prompt-surface-kind.ts
@@ -1,11 +1,13 @@
 import type { AgentPromptSurfaceKind } from "./types.js";
 
+/** Normalizes legacy Pi surface names to the current OpenClaw main prompt surface. */
 export function normalizeAgentPromptSurfaceKind(
   surface: AgentPromptSurfaceKind,
 ): AgentPromptSurfaceKind {
   return surface === "pi_main" ? "openclaw_main" : surface;
 }
 
+/** Returns true for the canonical main prompt surface and its legacy aliases. */
 export function isOpenClawMainPromptSurface(surface: AgentPromptSurfaceKind): boolean {
   return normalizeAgentPromptSurfaceKind(surface) === "openclaw_main";
 }

--- a/src/plugins/channel-validation.ts
+++ b/src/plugins/channel-validation.ts
@@ -50,6 +50,7 @@ function collectMissingChannelMetaFields(meta?: Partial<ChannelMeta> | null): st
   return missing;
 }
 
+/** Validates a channel plugin registration and fills public metadata fallbacks. */
 export function normalizeRegisteredChannelPlugin(params: {
   pluginId: string;
   source: string;
@@ -98,6 +99,8 @@ export function normalizeRegisteredChannelPlugin(params: {
 
   const missingFields = collectMissingChannelMetaFields(rawMeta);
   if (missingFields.length > 0) {
+    // Metadata is displayed in setup/status UIs, so keep the channel usable but
+    // emit diagnostics when we fill labels/docs/blurb from bundled fallbacks.
     pushPluginValidationDiagnostic({
       level: "warn",
       pluginId: params.pluginId,
@@ -110,6 +113,8 @@ export function normalizeRegisteredChannelPlugin(params: {
   return {
     ...params.plugin,
     id,
+    // Force the registration id to be canonical even if plugin meta carried a
+    // stale id; routing and config lookup key off the registered channel id.
     meta: normalizeChannelMeta({
       id,
       meta: rawMeta,

--- a/src/plugins/hook-before-agent-start.types.ts
+++ b/src/plugins/hook-before-agent-start.types.ts
@@ -1,9 +1,10 @@
-// before_model_resolve hook
+/** Attachment metadata exposed before model selection so plugins can route by modality. */
 export type PluginHookBeforeModelResolveAttachment = {
   kind: "image" | "video" | "audio" | "document" | "other";
   mimeType?: string;
 };
 
+/** Early hook event for choosing a provider/model before session messages exist. */
 export type PluginHookBeforeModelResolveEvent = {
   /** User prompt for this run. No session messages are available yet in this phase. */
   prompt: string;
@@ -11,6 +12,7 @@ export type PluginHookBeforeModelResolveEvent = {
   attachments?: PluginHookBeforeModelResolveAttachment[];
 };
 
+/** Provider/model override payload returned by before_model_resolve hooks. */
 export type PluginHookBeforeModelResolveResult = {
   /** Override the model for this agent run. E.g. "llama3.3:8b" */
   modelOverride?: string;
@@ -18,13 +20,14 @@ export type PluginHookBeforeModelResolveResult = {
   providerOverride?: string;
 };
 
-// before_prompt_build hook
+/** Prompt-build hook event after session messages have been prepared. */
 export type PluginHookBeforePromptBuildEvent = {
   prompt: string;
   /** Session messages prepared for this run. */
   messages: unknown[];
 };
 
+/** Prompt mutation payload merged into the system prompt/context for one run. */
 export type PluginHookBeforePromptBuildResult = {
   systemPrompt?: string;
   prependContext?: string;
@@ -41,6 +44,7 @@ export type PluginHookBeforePromptBuildResult = {
   appendSystemContext?: string;
 };
 
+/** Fields stripped from legacy before_agent_start when prompt mutation is disabled. */
 export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
   "systemPrompt",
   "prependContext",
@@ -80,6 +84,10 @@ export type PluginHookBeforeAgentStartOverrideResult = Omit<
   keyof PluginHookBeforePromptBuildResult
 >;
 
+/**
+ * Keep legacy before_agent_start model/provider overrides while removing prompt
+ * mutation fields that are governed by the newer prompt-build policy gate.
+ */
 export const stripPromptMutationFieldsFromLegacyHookResult = (
   result: PluginHookBeforeAgentStartResult | void,
 ): PluginHookBeforeAgentStartOverrideResult | void => {

--- a/src/plugins/host-hook-json.ts
+++ b/src/plugins/host-hook-json.ts
@@ -12,6 +12,7 @@ export type PluginJsonValueLimits = {
   maxSerializedBytes: number;
 };
 
+/** Limits for JSON values crossing plugin host-hook boundaries. */
 export const PLUGIN_JSON_VALUE_LIMITS: PluginJsonValueLimits = {
   maxDepth: 32,
   maxNodes: 4096,
@@ -49,6 +50,8 @@ function isPluginJsonValueWithinLimits(
   }
   const prototype = Object.getPrototypeOf(value);
   if (prototype !== Object.prototype && prototype !== null) {
+    // Reject class instances, Date, Map, and other objects whose JSON shape
+    // would hide runtime identity or drop data during serialization.
     return false;
   }
   const entries = Object.entries(value as Record<string, unknown>);
@@ -64,6 +67,7 @@ function isPluginJsonValueWithinLimits(
   return ok;
 }
 
+/** Validates that a value is finite, plain JSON, and small enough for plugin host hooks. */
 export function isPluginJsonValue(value: unknown): value is PluginJsonValue {
   if (!isPluginJsonValueWithinLimits(value, PLUGIN_JSON_VALUE_LIMITS, { depth: 0, nodes: 0 })) {
     return false;

--- a/src/plugins/interactive-registry.ts
+++ b/src/plugins/interactive-registry.ts
@@ -18,6 +18,7 @@ export type InteractiveRegistrationResult = {
   error?: string;
 };
 
+/** Resolves a channel payload to the registered plugin interactive handler and stripped payload. */
 export function resolvePluginInteractiveNamespaceMatch(
   channel: string,
   data: string,
@@ -29,6 +30,7 @@ export function resolvePluginInteractiveNamespaceMatch(
   });
 }
 
+/** Registers one plugin interactive namespace for a channel, rejecting duplicate ownership. */
 export function registerPluginInteractiveHandler(
   pluginId: string,
   registration: PluginInteractiveHandlerRegistration,
@@ -51,6 +53,7 @@ export function registerPluginInteractiveHandler(
   interactiveHandlers.set(key, {
     ...registration,
     namespace,
+    // Store normalized channels so restore/list/match use the same registry key shape.
     channel: normalizeOptionalLowercaseString(registration.channel) ?? "",
     pluginId,
     pluginName: opts?.pluginName,
@@ -76,10 +79,12 @@ export function clearPluginInteractiveHandlersForPlugin(pluginId: string): void 
   }
 }
 
+/** Returns a snapshot of registered interactive handlers for diagnostics or restoration. */
 export function listPluginInteractiveHandlers(): RegisteredInteractiveHandler[] {
   return Array.from(getPluginInteractiveHandlersState().values());
 }
 
+/** Replaces registrations from a trusted snapshot, skipping entries with invalid namespaces. */
 export function restorePluginInteractiveHandlers(
   registrations: readonly RegisteredInteractiveHandler[],
 ): void {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -155,6 +155,8 @@ export function registerMemoryCorpusSupplement(
   pluginId: string,
   supplement: MemoryCorpusSupplement,
 ): void {
+  // Registration is keyed by plugin id so reloads replace stale corpus hooks
+  // instead of accumulating duplicate search/get providers.
   const next = memoryPluginState.corpusSupplements.filter(
     (registration) => registration.pluginId !== pluginId,
   );
@@ -167,7 +169,8 @@ export function registerMemoryCapability(
   capability: MemoryPluginCapability,
 ): void {
   const existingCapability = memoryPluginState.capability?.capability;
-  // A selected memory plugin can add bridge artifacts while memory-core owns sidecar runtime hooks.
+  // A selected memory plugin can add bridge artifacts while memory-core owns
+  // sidecar runtime hooks; preserve those core hooks when only artifacts arrive.
   const shouldPreserveExisting =
     existingCapability &&
     Boolean(capability.publicArtifacts) &&
@@ -192,6 +195,8 @@ function patchMemoryCapability(pluginId: string, patch: MemoryPluginCapability):
 }
 
 export function getMemoryCapabilityRegistration(): MemoryPluginCapabilityRegistration | undefined {
+  // Return shallow copies so callers cannot mutate the process-global
+  // registration object without going through the registration APIs.
   return memoryPluginState.capability
     ? {
         pluginId: memoryPluginState.capability.pluginId,
@@ -213,6 +218,8 @@ export function registerMemoryPromptSectionForPlugin(
   pluginId: string,
   builder: MemoryPromptSectionBuilder,
 ): void {
+  // Legacy prompt registration patches the primary capability, not the
+  // supplement list, so older memory plugins still define the main section.
   patchMemoryCapability(pluginId, { promptBuilder: builder });
 }
 
@@ -220,6 +227,8 @@ export function registerMemoryPromptSupplement(
   pluginId: string,
   builder: MemoryPromptSectionBuilder,
 ): void {
+  // Supplements are additive but single-slot per plugin; repeated registration
+  // replaces that plugin's previous builder to keep prompt output deterministic.
   const next = memoryPluginState.promptSupplements.filter(
     (registration) => registration.pluginId !== pluginId,
   );
@@ -313,6 +322,8 @@ export async function listActiveMemoryPublicArtifacts(params: {
 }): Promise<MemoryPluginPublicArtifact[]> {
   const artifacts =
     (await memoryPluginState.capability?.capability.publicArtifacts?.listArtifacts(params)) ?? [];
+  // Clone and sort artifacts before exposing them so UI/catalog callers get a
+  // stable view and cannot mutate plugin-owned arrays such as agentIds.
   return artifacts.map(cloneMemoryPublicArtifact).toSorted((left, right) => {
     const workspaceOrder = left.workspaceDir.localeCompare(right.workspaceDir);
     if (workspaceOrder !== 0) {

--- a/src/plugins/plugin-cache-primitives.ts
+++ b/src/plugins/plugin-cache-primitives.ts
@@ -1,7 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
+/** Cache lookup result that preserves cached `undefined`-like values through an explicit hit flag. */
 export type PluginLruCacheResult<T> = { hit: true; value: T } | { hit: false };
 
+/** Small insertion-ordered LRU cache for process-local plugin metadata. */
 export class PluginLruCache<T> {
   readonly #defaultMaxEntries: number;
   #maxEntries: number;
@@ -42,6 +44,7 @@ export class PluginLruCache<T> {
       return { hit: false };
     }
     const cached = this.#entries.get(cacheKey) as T;
+    // Reinsert hits so Map iteration order tracks recency for oldest-entry eviction.
     this.#entries.delete(cacheKey);
     this.#entries.set(cacheKey, cached);
     return { hit: true, value: cached };
@@ -73,6 +76,7 @@ export type ConfigScopedPromiseLoader<T> = {
   clear(): void;
 };
 
+/** Resolves a synchronous runtime value scoped to one config object and cache key. */
 export function resolveConfigScopedRuntimeCacheValue<T>(params: {
   cache: ConfigScopedRuntimeCache<T>;
   config?: OpenClawConfig;
@@ -99,6 +103,7 @@ export function createPluginCacheKey(parts: readonly unknown[]): string {
   return JSON.stringify(parts);
 }
 
+/** Coalesces async loads by config object, resetting failed promises for retry. */
 export function createConfigScopedPromiseLoader<T>(
   load: (config?: OpenClawConfig) => T | Promise<T>,
 ): ConfigScopedPromiseLoader<T> {

--- a/src/plugins/provider-auth-helpers.ts
+++ b/src/plugins/provider-auth-helpers.ts
@@ -61,6 +61,12 @@ function resolveProviderDefaultEnvSecretRef(provider: string, config?: OpenClawC
   return buildEnvSecretRef(envVar);
 }
 
+/**
+ * Build the auth-profile credential for API-key providers.
+ *
+ * Ref mode stores a trusted env ref instead of plaintext; plaintext mode keeps
+ * `${ENV_VAR}`-looking input literal so explicit user input is not reinterpreted.
+ */
 function resolveApiKeySecretInput(
   provider: string,
   input: SecretInput,
@@ -84,6 +90,7 @@ function resolveApiKeySecretInput(
   return normalized;
 }
 
+/** Convert setup/onboarding API-key input into an auth-profile credential. */
 export function buildApiKeyCredential(
   provider: string,
   input: SecretInput,
@@ -113,6 +120,7 @@ export function buildApiKeyCredential(
   };
 }
 
+/** Store or replace an API-key auth profile and return the selected profile id. */
 export function upsertApiKeyProfile(params: {
   provider: string;
   input: SecretInput;
@@ -144,6 +152,12 @@ async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams)
   }
 }
 
+/**
+ * Add an auth profile entry to config and keep provider auth order stable.
+ *
+ * Existing `auth.order` wins; new mixed-mode provider configs derive an order so
+ * the freshly configured profile is preferred without discarding older profiles.
+ */
 export function applyAuthProfileConfig(
   cfg: OpenClawConfig,
   params: {
@@ -244,6 +258,7 @@ function safeRealpathSync(dir: string): string | null {
   }
 }
 
+/** Discover sibling agent profile stores that should receive OAuth credentials. */
 function resolveSiblingAgentDirs(primaryAgentDir: string): string[] {
   const normalized = path.resolve(primaryAgentDir);
   const parentOfAgent = path.dirname(normalized);
@@ -278,6 +293,10 @@ function resolveSiblingAgentDirs(primaryAgentDir: string): string[] {
   return result;
 }
 
+/**
+ * Persist OAuth credentials for one provider and optionally mirror them to
+ * sibling agent dirs created by the standard multi-agent layout.
+ */
 export async function writeOAuthCredentials(
   provider: string,
   creds: OAuthCredentials,
@@ -316,6 +335,8 @@ export async function writeOAuthCredentials(
         continue;
       }
       try {
+        // Mirroring keeps sibling agents usable after OAuth setup, but the
+        // primary credential already succeeded and must remain the source of truth.
         await upsertAuthProfileWithLock({
           profileId,
           credential,

--- a/src/plugins/provider-auth-mode.ts
+++ b/src/plugins/provider-auth-mode.ts
@@ -9,6 +9,7 @@ export type SecretInputModePromptCopy = {
   refHint?: string;
 };
 
+/** Resolves whether setup stores a plaintext secret or an external secret reference. */
 export async function resolveSecretInputModeForEnvSelection(params: {
   prompter: Pick<WizardPrompter, "select">;
   explicitMode?: SecretInputMode;
@@ -18,6 +19,8 @@ export async function resolveSecretInputModeForEnvSelection(params: {
     return params.explicitMode;
   }
   if (typeof params.prompter.select !== "function") {
+    // Non-interactive or minimal prompters cannot ask for a mode, so keep the
+    // historical plaintext path unless the caller supplied an explicit mode.
     return "plaintext";
   }
   const selected = await params.prompter.select<SecretInputMode>({
@@ -38,5 +41,7 @@ export async function resolveSecretInputModeForEnvSelection(params: {
       },
     ],
   });
+  // Treat unknown prompt return values as plaintext so custom prompt adapters
+  // cannot accidentally switch users into an unsupported secret-ref flow.
   return selected === "ref" ? "ref" : "plaintext";
 }

--- a/src/plugins/provider-auth-ref.ts
+++ b/src/plugins/provider-auth-ref.ts
@@ -63,6 +63,8 @@ export function resolveRefFallbackInput(params: {
   preferredEnvVar?: string;
   env?: NodeJS.ProcessEnv;
 }): { ref: SecretRef; resolvedValue: string } {
+  // Non-interactive ref setup must only trust env vars from bundled/catalog
+  // metadata; workspace plugin suggestions are not part of the trusted config.
   const fallbackEnvVar =
     params.preferredEnvVar ??
     getProviderEnvVars(params.provider, {
@@ -240,6 +242,8 @@ async function promptProviderSecretRefForSetup(params: {
   };
 
   try {
+    // Validate the external ref before writing config so setup never persists a
+    // file/exec pointer that cannot resolve in the current runtime environment.
     const { resolveSecretRefString } = await loadSecretResolve();
     const resolvedValue = await resolveSecretRefString(ref, {
       config: params.config,
@@ -318,6 +322,8 @@ export async function promptSecretRefForSetup(params: {
         env: params.env,
       });
     } catch (error) {
+      // Provider selection errors are recoverable prompt states; validation and
+      // unexpected runtime errors still escape so callers can abort setup.
       if (error instanceof Error && error.message === "retry") {
         continue;
       }

--- a/src/plugins/provider-catalog-unified-text.ts
+++ b/src/plugins/provider-catalog-unified-text.ts
@@ -1,6 +1,7 @@
 import type { UnifiedModelCatalogEntry } from "@openclaw/model-catalog-core/model-catalog-types";
 import type { ProviderCatalogResult } from "./types.js";
 
+/** Projects provider plugin catalog output into unified text-model catalog rows. */
 export function projectProviderCatalogResultToUnifiedTextRows(params: {
   providerId: string;
   result: ProviderCatalogResult;
@@ -9,6 +10,7 @@ export function projectProviderCatalogResultToUnifiedTextRows(params: {
   if (!params.result) {
     return [];
   }
+  // Single-provider catalog hooks inherit the provider id from registration.
   const providers =
     "provider" in params.result
       ? { [params.providerId]: params.result.provider }

--- a/src/plugins/provider-config-owner.ts
+++ b/src/plugins/provider-config-owner.ts
@@ -1,6 +1,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
+/** Returns the API owner when a configured provider delegates auth/catalog behavior elsewhere. */
 export function resolveProviderConfigApiOwnerHint(params: {
   provider: string;
   config?: OpenClawConfig;
@@ -18,6 +19,8 @@ export function resolveProviderConfigApiOwnerHint(params: {
     Object.entries(providers).find(
       ([candidateId]) => normalizeProviderId(candidateId) === normalizedProvider,
     )?.[1];
+  // Provider config keys can use aliases/casing; compare normalized ids before
+  // deciding whether the api field points at a different owner.
   const api =
     typeof providerConfig?.api === "string" ? normalizeProviderId(providerConfig.api) : "";
   if (!api || api === normalizedProvider) {

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -35,6 +35,8 @@ export function buildOpenAICompatibleReplayPolicy(
     modelApi === "openai-chatgpt-responses" ||
     modelApi === "azure-openai-responses";
 
+  // Responses-family transports can accept synthetic tool results during
+  // replay; legacy completions relies on stricter turn validation instead.
   return {
     ...(sanitizeToolCallIds
       ? { sanitizeToolCallIds: true, toolCallIdMode: "strict" as const }
@@ -73,6 +75,8 @@ export function buildStrictAnthropicReplayPolicy(
       ? {
           sanitizeToolCallIds: true,
           toolCallIdMode: "strict" as const,
+          // Native Anthropic providers can replay original tool_use ids, while
+          // OpenAI-compatible Anthropic shims need sanitized strict ids.
           ...(options.preserveNativeAnthropicToolUseIds
             ? { preserveNativeAnthropicToolUseIds: true }
             : {}),
@@ -165,6 +169,8 @@ function hasGoogleTurnOrderingMarker(sessionState: ProviderReplaySessionState): 
 }
 
 function markGoogleTurnOrderingMarker(sessionState: ProviderReplaySessionState): void {
+  // One marker per session is enough: it tells diagnostics that history was
+  // repaired for Google assistant-first ordering without bloating transcripts.
   sessionState.appendCustomEntry(GOOGLE_TURN_ORDERING_CUSTOM_TYPE, {
     timestamp: Date.now(),
   });
@@ -177,6 +183,8 @@ export function buildGoogleGeminiReplayPolicy(): ProviderReplayPolicy {
     sanitizeToolCallIds: true,
     toolCallIdMode: "strict",
     sanitizeThoughtSignatures: {
+      // Gemini signatures are opaque base64 blobs; preserve camelCase too
+      // because older adapters emitted thoughtSignature instead of snake_case.
       allowBase64Only: true,
       includeCamelCase: true,
     },
@@ -213,6 +221,8 @@ export function sanitizeGoogleGeminiReplayHistory(
   ctx: ProviderSanitizeReplayHistoryContext,
 ): AgentMessage[] {
   const messages = sanitizeGoogleAssistantFirstOrdering(ctx.messages);
+  // Record a marker only when ordering actually changed, so session state
+  // distinguishes repaired history from already-valid Gemini transcripts.
   if (
     messages !== ctx.messages &&
     ctx.sessionState &&

--- a/src/plugins/provider-wizard.ts
+++ b/src/plugins/provider-wizard.ts
@@ -44,6 +44,7 @@ type ProviderWizardProvidersResolver = (params: {
 
 let providerWizardProvidersResolverForTest: ProviderWizardProvidersResolver | undefined;
 
+/** Installs a temporary provider resolver so wizard tests can avoid loading real plugins. */
 export function setProviderWizardProvidersResolverForTest(
   resolver: ProviderWizardProvidersResolver | undefined,
 ): () => void {
@@ -124,6 +125,7 @@ function buildSetupOptionForMethod(params: {
   };
 }
 
+/** Encodes a provider+auth-method pair into the stable wizard choice value. */
 export function buildProviderPluginMethodChoice(providerId: string, methodId: string): string {
   return `${PROVIDER_PLUGIN_CHOICE_PREFIX}${normalizeOptionalString(providerId) ?? ""}:${normalizeOptionalString(methodId) ?? ""}`;
 }
@@ -186,6 +188,8 @@ export function resolveProviderWizardOptions(params: {
       continue;
     }
 
+    // Provider-level setup without a method id expands across every auth
+    // method, keeping multi-method providers selectable in non-interactive flows.
     for (const method of provider.auth) {
       options.push(
         buildSetupOptionForMethod({
@@ -252,6 +256,8 @@ export function resolveProviderPluginChoice(params: {
   }
 
   if (choice.startsWith(PROVIDER_PLUGIN_CHOICE_PREFIX)) {
+    // Encoded choices are the canonical path for generated wizard options;
+    // legacy custom choice ids below stay supported for provider-owned labels.
     const payload = choice.slice(PROVIDER_PLUGIN_CHOICE_PREFIX.length);
     const separator = payload.indexOf(":");
     const providerId = separator >= 0 ? payload.slice(0, separator) : payload;
@@ -317,6 +323,8 @@ export async function runProviderModelSelectedHook(params: {
     return;
   }
 
+  // Prefer setup-provider resolution because some providers expose setup hooks
+  // before they are active runtime providers in the current config.
   const setupProvider = resolvePluginSetupProvider({
     provider: selectedProviderId,
     config: params.config,

--- a/src/plugins/roots.ts
+++ b/src/plugins/roots.ts
@@ -14,6 +14,7 @@ export type PluginCacheInputs = {
   loadPaths: string[];
 };
 
+/** Resolves stock, global, and workspace plugin roots for a runtime environment. */
 export function resolvePluginSourceRoots(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
@@ -26,7 +27,7 @@ export function resolvePluginSourceRoots(params: {
   return { stock, global, workspace };
 }
 
-// Shared env-aware key inputs for plugin loader registry reuse.
+/** Resolves normalized roots and load paths used as plugin loader cache inputs. */
 export function resolvePluginCacheInputs(params: {
   workspaceDir?: string;
   loadPaths?: string[];

--- a/src/plugins/source-display.ts
+++ b/src/plugins/source-display.ts
@@ -18,6 +18,7 @@ function tryRelative(root: string, filePath: string): string | null {
   return rel.replaceAll("\\", "/");
 }
 
+/** Formats a plugin source path as stock/workspace/global-relative when possible. */
 export function formatPluginSourceForTable(
   plugin: Pick<PluginRecord, "source" | "origin">,
   roots: PluginSourceRoots,

--- a/src/plugins/tool-contracts.ts
+++ b/src/plugins/tool-contracts.ts
@@ -1,5 +1,6 @@
 import type { PluginManifestContracts } from "./manifest.js";
 
+/** Normalizes tool names declared in a plugin manifest contract. */
 export function normalizePluginToolContractNames(
   contracts: Pick<PluginManifestContracts, "tools"> | undefined,
 ): string[] {
@@ -17,6 +18,7 @@ export function normalizePluginToolNames(names: readonly string[] | undefined): 
   return [...normalized];
 }
 
+/** Finds runtime tools missing from the manifest-declared tool contract. */
 export function findUndeclaredPluginToolNames(params: {
   declaredNames: readonly string[];
   toolNames: readonly string[];

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -20,10 +20,12 @@ let nextDescriptorCacheObjectId = 1;
 
 export type PluginToolDescriptorConfigCacheKeyMemo = WeakMap<object, string | number | null>;
 
+/** Creates a per-resolution memo so equivalent config objects share descriptor cache keys. */
 export function createPluginToolDescriptorConfigCacheKeyMemo(): PluginToolDescriptorConfigCacheKeyMemo {
   return new WeakMap();
 }
 
+/** Clears process-local plugin tool descriptor cache state for tests and plugin lifecycle resets. */
 export function resetPluginToolDescriptorCache(): void {
   descriptorCache.clear();
   descriptorCacheObjectIds = new WeakMap();
@@ -61,6 +63,8 @@ function stripDescriptorVolatileConfigFields(
   if (!("meta" in value) && !("wizard" in value)) {
     return value;
   }
+  // Wizard/meta fields are UI discovery state, not runtime tool inputs. Dropping
+  // them prevents setup progress churn from invalidating stable descriptors.
   const { meta: _meta, wizard: _wizard, ...stableConfig } = value as Record<string, unknown>;
   return stableConfig as NonNullable<PluginLoadOptions["config"]>;
 }
@@ -122,6 +126,8 @@ export function buildPluginToolDescriptorCacheKey(params: {
   currentRuntimeConfig?: PluginLoadOptions["config"] | null;
   configCacheKeyMemo?: PluginToolDescriptorConfigCacheKeyMemo;
 }): string {
+  // Include source fingerprint and selected runtime context so descriptor reuse
+  // tracks both plugin code changes and per-agent/per-channel tool visibility.
   return JSON.stringify({
     version: PLUGIN_TOOL_DESCRIPTOR_CACHE_VERSION,
     pluginId: params.pluginId,
@@ -148,6 +154,8 @@ export function capturePluginToolDescriptor(params: {
 }): CachedPluginToolDescriptor {
   const label = (params.tool as { label?: unknown }).label;
   const title = typeof label === "string" && label.trim() ? label.trim() : undefined;
+  // The descriptor is the model-facing shape; executor metadata keeps dispatch
+  // pointed at the plugin-owned tool even after descriptors are cached.
   return {
     ...(params.tool.displaySummary ? { displaySummary: params.tool.displaySummary } : {}),
     optional: params.optional,
@@ -176,6 +184,8 @@ export function writeCachedPluginToolDescriptors(params: {
     !descriptorCache.has(params.cacheKey) &&
     descriptorCache.size >= PLUGIN_TOOL_DESCRIPTOR_CACHE_LIMIT
   ) {
+    // Map iteration order is insertion order; deleting the first key gives a
+    // tiny FIFO cap without adding request-time bookkeeping.
     const oldestKey = descriptorCache.keys().next().value;
     if (oldestKey !== undefined) {
       descriptorCache.delete(oldestKey);


### PR DESCRIPTION
## Summary

- Continue the inline-comment pass after PR #88554 on a fresh branch from current `main`.
- Document the gateway method type/helper contracts for post-handshake `connect` rejection, shared record/string normalization, and method request/client/context handler shapes, timestamp injection options, node wake state contracts, voicewake handler registry contracts, node helper response wrappers, tools.invoke handler contract, Talk session/client handler ownership defaults, plugin cache primitive lifecycle semantics, channel route projection contracts, channel command/run lifecycle helpers, channel typing lifecycle helpers, finalizable draft stream controls, thread-binding policy helpers, channel streaming progress helpers, channel config presence helpers, legacy direct-DM access helpers, setup wizard proxies, plugin interactive registry helpers, plugin host-hook JSON validation, provider auth mode selection, provider config owner hints, prompt surface normalization, plugin source root/display helpers, channel registration validation, provider catalog projection helpers, sender identity validation, channel logging helpers, update gateway handlers, managed update handoff helpers, config write/restart flow, channel allow-from/target parsing helpers, channel mention-gating policy helpers, provider replay helpers, plugin tool descriptor helpers, provider wizard helpers, commands.list helpers, memory plugin state helpers, channel ingress identity helpers, channel ingress runtime helpers, ingress decision/state helpers, provider auth ref/helpers, plugin hook payload helpers, ack reaction helpers, channel config matching helpers, channel inbound guard helpers, account snapshot projection helpers, channel context helpers, channel model override helpers, inbound session recording helpers, channel account summary helpers, channel inspection summary helpers, channel status read-model helpers, channel token summary helpers, channel status table helpers, status report renderer helpers, status report section helpers, gateway log-tail helpers, status format helpers, and status report data helpers, and status diagnosis helpers, and status-all command entrypoint, and status command section helpers, and status overview surface helpers, and status overview row helpers, and status overview value helpers, and status formatter helpers, and status runtime helper probes, and status JSON helpers, and status JSON command helpers, and status scan helpers, and status scan execute/memory helpers, and status cold-start scan helpers, and status scan shared helpers, and status fast JSON scan helpers, and status service summary helpers, and status gateway helpers, and status node-mode helpers, and status summary helpers, and status command entrypoint helpers, and status report assembly helpers, and status update/link helpers, and status overview agent helpers, and status type/test fixture helpers, and status runtime adapter helpers, and status channel token summary helpers, and status gateway log-tail helpers, and status-all report assembly helpers, and status channel table helpers, and status-all format helpers, and status-all diagnosis helpers, and status overview surface helpers, and cleanup/session target helpers, and doctor policy/owner helpers, and doctor skills/auth helpers, model picker/noninteractive helpers, and agent identity/model helpers, and auth choice/onboard helpers, and channel setup helpers, and gateway status helpers, and provider auth helpers, and model suppression helpers, and agent compaction settings helpers, and model list helpers, and sessions table helpers, and model selection normalization helpers, and tool call name helpers.
- Keep comments out of file headers and import blocks.

## Verification

Behavior addressed: comment-only follow-up for reusable gateway, channel, status, doctor, model, and agent helper contracts; no runtime behavior intended.
Real environment tested: local source checkout.
Exact steps or command run after this patch: git diff --check; pnpm test src/agents/tool-call-id.test.ts src/agents/session-transcript-repair.test.ts; pnpm test src/agents/model-selection.test.ts src/agents/model-selection.plugin-runtime.test.ts src/plugin-activation-boundary.test.ts; pnpm test src/commands/sessions.test.ts src/commands/sessions-cleanup.test.ts src/commands/session-store-targets.test.ts; pnpm test src/commands/models/list.model-row.test.ts src/commands/models/list.list-command.forward-compat.test.ts src/commands/models/list.status.test.ts; pnpm test src/agents/agent-settings.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts; pnpm test src/agents/model-suppression.test.ts src/commands/models/list.rows.test.ts src/commands/models/list.list-command.forward-compat.test.ts; pnpm test src/agents/model-auth.test.ts src/commands/models/list.auth-index.test.ts src/agents/tools/web-search-provider-credentials.test.ts; pnpm test src/commands/gateway-status/helpers.test.ts src/commands/gateway-status/output.test.ts src/commands/gateway-status.test.ts; pnpm test src/commands/channel-setup/discovery.test.ts src/commands/channel-setup/registry.test.ts src/commands/channel-setup/plugin-install.test.ts src/commands/channel-setup/workspace-shadow-bypass.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts src/commands/plugin-control-plane-cold-imports.test.ts; pnpm test src/commands/auth-choice-options.test.ts src/commands/onboard-config.test.ts src/commands/plugin-control-plane-cold-imports.test.ts src/commands/provider-setup-cold-imports.test.ts; pnpm test src/agents/identity.test.ts src/agents/identity.per-channel-prefix.test.ts src/agents/model-suppression.test.ts src/commands/models/list.rows.test.ts; pnpm test src/commands/doctor-skills.test.ts src/commands/provider-setup-cold-imports.test.ts; pnpm test src/commands/doctor-command-owner.test.ts src/commands/doctor-gateway-daemon-flow.test.ts src/commands/doctor-gateway-services.test.ts; pnpm test src/commands/session-store-targets.test.ts src/commands/sessions-cleanup.test.ts; pnpm test src/commands/status-overview-surface.test.ts src/commands/status-all/format.test.ts; pnpm test src/commands/status-all/diagnosis.test.ts src/commands/status-all/report-lines.test.ts; pnpm test src/commands/status-all/format.test.ts src/commands/status-json-payload.test.ts; pnpm test src/commands/status-all/channels-table.test.ts src/commands/status-all/channels.test.ts; pnpm test src/commands/status-all/text-report.test.ts src/commands/status-all/report-lines.test.ts; pnpm test src/commands/status-all/gateway.test.ts src/commands/status-all/diagnosis.test.ts; pnpm test src/commands/status-all/channels.mattermost-token-summary.test.ts src/commands/status-all/channels.test.ts; pnpm test src/commands/status.summary.runtime.test.ts src/commands/status.scan-memory.test.ts src/commands/status.summary.test.ts; pnpm test src/commands/status-overview-rows.test.ts src/commands/status.command-sections.test.ts src/commands/status.test.ts; pnpm test src/commands/status.scan-overview.test.ts src/commands/status.scan.test.ts src/commands/status.test.ts; pnpm test src/commands/status-update-restart.test.ts src/commands/status.update.test.ts src/commands/status.link-channel.test.ts src/commands/status.summary.test.ts; pnpm test src/commands/status.test.ts src/commands/status.command-sections.test.ts; pnpm test src/commands/status.test.ts; pnpm test src/commands/status.summary.test.ts src/commands/status.summary.runtime.test.ts src/commands/status.summary.redaction.test.ts; pnpm test src/commands/status.node-mode.test.ts src/commands/status.test.ts; pnpm test src/commands/status.gateway-connection.test.ts src/commands/status.scan.shared.test.ts; pnpm test src/commands/status.daemon.test.ts src/commands/status.service-summary.test.ts src/commands/status-runtime-shared.test.ts; pnpm test src/commands/status.scan.fast-json.test.ts src/commands/status-json.test.ts; pnpm test src/commands/status.scan.shared.test.ts src/commands/status.scan-memory.test.ts; pnpm test src/commands/status.scan.config-shared.test.ts src/commands/status.scan-overview.test.ts src/commands/status.scan-result.test.ts; pnpm test src/commands/status.scan-execute.test.ts src/commands/status.scan-memory.test.ts; pnpm test src/commands/status.scan.test.ts src/commands/status.scan-result.test.ts; pnpm test src/commands/status-json.test.ts src/commands/status-json-command.test.ts; pnpm test src/commands/status-json-runtime.test.ts src/commands/status-json-payload.test.ts src/commands/status-json-command.test.ts; pnpm test src/commands/status-runtime-shared.test.ts src/commands/status-json-runtime.test.ts; pnpm test src/commands/status.format.test.ts src/commands/status.command-sections.test.ts; pnpm test src/commands/status-overview-values.test.ts src/commands/status-overview-rows.test.ts; pnpm test src/commands/status-overview-rows.test.ts src/commands/status-overview-surface.test.ts; pnpm test src/commands/status-overview-surface.test.ts src/commands/status-all/format.test.ts; pnpm test src/commands/status.command-sections.test.ts; pnpm test src/commands/status.test.ts; pnpm test src/commands/status-all/diagnosis.test.ts src/commands/status-all/gateway.test.ts; pnpm test src/commands/status.test.ts src/commands/status.scan-overview.test.ts; pnpm test src/commands/status-all/format.test.ts; pnpm test src/commands/status-all/gateway.test.ts src/commands/status-all/diagnosis.test.ts; pnpm test src/commands/status-all/text-report.test.ts src/commands/status-all/report-lines.test.ts; pnpm test src/commands/status-all/report-lines.test.ts src/commands/status-all/report-tables.test.ts; pnpm test src/commands/status-all/channels.test.ts src/commands/status-all/channels-table.test.ts; pnpm test src/commands/status-all/channels.mattermost-token-summary.test.ts src/commands/status-all/channels.test.ts; pnpm test src/commands/status-all/channels.test.ts src/commands/channels.list.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/infra/channel-summary.test.ts src/commands/status-all/channels.test.ts src/gateway/server-methods/channels.status.test.ts; pnpm test src/plugins/contracts/plugin-sdk-subpaths.test.ts src/commands/channels.config-only-status-output.test.ts src/gateway/server-methods/channels.status.test.ts; pnpm test src/channels/session.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts src/plugin-sdk/inbound-reply-dispatch.test.ts; pnpm test src/channels/model-overrides.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/channels/location.test.ts src/channels/conversation-label.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/channels/account-snapshot-fields.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts src/plugin-sdk/discord.test.ts; pnpm test src/channels/typing-start-guard.test.ts src/channels/inbound-debounce-policy.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/channels/channel-config.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/channels/ack-reactions.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/plugins/provider-auth-env-trust.test.ts src/commands/onboard-auth.test.ts src/commands/models/auth.test.ts; pnpm test src/plugins/hooks.phase-hooks.test.ts src/plugins/hooks.model-override-wiring.test.ts src/plugins/hooks.before-agent-start.test.ts; pnpm test src/plugins/provider-auth-env-trust.test.ts src/plugins/provider-auth-input.test.ts; pnpm test src/channels/message-access/message-access.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/plugins/memory-state.test.ts src/plugins/loader.runtime-registry.test.ts; pnpm test src/gateway/server-methods/commands.test.ts; pnpm test src/plugins/provider-wizard.test.ts src/plugins/contracts/wizard.choice-resolution.contract.test.ts src/plugins/contracts/wizard.setup-options.contract.test.ts src/plugins/contracts/wizard.model-picker.contract.test.ts; pnpm test src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.optional.test.ts; pnpm test src/plugins/provider-replay-helpers.test.ts src/agents/transcript-policy.test.ts; pnpm test src/channels/mention-gating.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/channels/allow-from.test.ts src/channels/targets.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/gateway/server-methods/config.shared-auth.test.ts src/gateway/server-methods/config.test.ts; pnpm test src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts; pnpm test src/gateway/server-methods/update.test.ts; pnpm test src/channels/channel-config.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/plugins/channel-validation.test.ts src/plugins/registry.provider-like.test.ts; pnpm test src/plugins/source-display.test.ts src/cli/plugins-list-command.test.ts; pnpm test src/plugins/provider-auth-input.test.ts src/plugins/providers.test.ts src/agents/system-prompt.test.ts src/plugins/commands.test.ts; pnpm test src/plugins/interactive.test.ts src/plugins/contracts/host-hooks.contract.test.ts; pnpm test src/plugin-sdk/direct-dm.test.ts src/channels/plugins/setup-wizard-proxy.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/channels/config-presence.test.ts src/plugins/channel-plugin-ids.test.ts; pnpm test src/plugin-sdk/channel-streaming.test.ts src/gateway/server-chat.agent-events.test.ts; pnpm test src/channels/thread-bindings-policy.test.ts src/shared/thread-binding-lifecycle.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/channels/draft-stream-controls.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts; pnpm test src/channels/typing.test.ts src/plugin-sdk/channel-reply-pipeline.test.ts; pnpm test src/channels/command-gating.test.ts src/channels/run-state-machine.test.ts; pnpm test src/channels/route-projection.test.ts; pnpm test src/plugins/plugin-cache-primitives.test.ts; pnpm test src/gateway/server-methods/talk.test.ts; pnpm test src/gateway/tools-invoke-http.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/method-scopes.test.ts; pnpm test src/gateway/server.models-voicewake-misc.test.ts src/gateway/gateway-misc.test.ts src/infra/voicewake.test.ts src/infra/voicewake-routing.test.ts; pnpm test src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods/nodes.wake-leak.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts; pnpm test src/gateway/server-methods/server-methods.test.ts src/gateway/method-scopes.test.ts
Evidence after fix: latest pushed commit 80d4be0c5d documents tool-call allowlist normalization, syntactic name validation, and null-allowlist permissive behavior; whitespace/diff checks plus targeted tool-call id and transcript repair tests passed locally.
Observed result after fix: PR branch pushed after the tool call name helper slice.
What was not tested: broader gateway/runtime suites; this slice only adds comments.











