### PR TITLE
fix(whatsapp): suppress spurious typing indicator on silent tool-only runs

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -25,6 +25,7 @@ type CapturedDispatchParams = {
   replyOptions?: {
     disableBlockStreaming?: boolean;
     sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
+    suppressTyping?: boolean;
   };
 };
 
@@ -1085,6 +1086,33 @@ describe("whatsapp inbound dispatch", () => {
       sourceReplyDeliveryMode: "automatic",
       disableBlockStreaming: false,
     });
+  });
+
+  it("suppresses typing for group chat without mention", async () => {
+    await dispatchBufferedReply({
+      context: { Body: "hi", ChatType: "group" },
+      msg: makeMsg({ from: "120363000000000000@g.us", chatType: "group", wasMentioned: false }),
+    });
+
+    expect(getCapturedReplyOptions()?.suppressTyping).toBe(true);
+  });
+
+  it("does not suppress typing for group chat when mentioned", async () => {
+    await dispatchBufferedReply({
+      context: { Body: "@bot hi", ChatType: "group" },
+      msg: makeMsg({ from: "120363000000000000@g.us", chatType: "group", wasMentioned: true }),
+    });
+
+    expect(getCapturedReplyOptions()?.suppressTyping).toBe(false);
+  });
+
+  it("does not suppress typing for direct chat", async () => {
+    await dispatchBufferedReply({
+      context: { Body: "hi", ChatType: "direct" },
+      msg: makeMsg({ from: "+15550001000", chatType: "direct" }),
+    });
+
+    expect(getCapturedReplyOptions()?.suppressTyping).toBe(false);
   });
 
   it("treats block-only turns as visible replies instead of silent turns", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -1069,6 +1069,7 @@ describe("whatsapp inbound dispatch", () => {
     expectRecordFields(requireRecord(getCapturedReplyOptions(), "reply options"), {
       sourceReplyDeliveryMode: "automatic",
       disableBlockStreaming: false,
+      suppressTyping: false,
     });
   });
 
@@ -1085,10 +1086,11 @@ describe("whatsapp inbound dispatch", () => {
     expectRecordFields(requireRecord(getCapturedReplyOptions(), "reply options"), {
       sourceReplyDeliveryMode: "automatic",
       disableBlockStreaming: false,
+      suppressTyping: false,
     });
   });
 
-  it("suppresses typing for group chat without mention", async () => {
+  it("suppresses typing for message-tool-only group chat without mention", async () => {
     await dispatchBufferedReply({
       context: { Body: "hi", ChatType: "group" },
       msg: makeMsg({ from: "120363000000000000@g.us", chatType: "group", wasMentioned: false }),

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -779,6 +779,9 @@ export async function dispatchWhatsAppBufferedReply(params: {
       },
     },
     replyOptions: {
+      // In group chats where the bot was not mentioned, suppress composing — spurious typing
+      // indicators are especially visible and disruptive when the run produces no reply.
+      suppressTyping: params.msg.chatType === "group" && !params.msg.wasMentioned,
       disableBlockStreaming,
       ...(sourceReplyDeliveryMode ? { sourceReplyDeliveryMode } : {}),
       onModelSelected: params.onModelSelected,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -779,9 +779,10 @@ export async function dispatchWhatsAppBufferedReply(params: {
       },
     },
     replyOptions: {
-      // In group chats where the bot was not mentioned, suppress composing — spurious typing
-      // indicators are especially visible and disruptive when the run produces no reply.
-      suppressTyping: params.msg.chatType === "group" && !params.msg.wasMentioned,
+      // Message-tool-only unmentioned group turns have no automatic visible reply.
+      // Suppress composing there so silent background runs do not leak presence.
+      suppressTyping:
+        sourceRepliesAreToolOnly && params.msg.chatType === "group" && !params.msg.wasMentioned,
       disableBlockStreaming,
       ...(sourceReplyDeliveryMode ? { sourceReplyDeliveryMode } : {}),
       onModelSelected: params.onModelSelected,

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -807,19 +807,21 @@ describe("createTypingSignaler", () => {
   });
 
   it("suppresses typing when disabled", async () => {
-    const typing = createMockTypingController();
-    const signaler = createTypingSignaler({
-      typing,
-      mode: "instant",
-      isHeartbeat: true,
-    });
+    const disabledCases = [
+      { mode: "instant" as const, isHeartbeat: true },
+      { mode: "never" as const, isHeartbeat: false },
+    ];
+    for (const params of disabledCases) {
+      const typing = createMockTypingController();
+      const signaler = createTypingSignaler({ typing, ...params });
 
-    await signaler.signalRunStart();
-    await signaler.signalTextDelta("hi");
-    await signaler.signalReasoningDelta();
+      await signaler.signalRunStart();
+      await signaler.signalTextDelta("hi");
+      await signaler.signalReasoningDelta();
 
-    expect(typing.startTypingLoop).not.toHaveBeenCalled();
-    expect(typing.startTypingOnText).not.toHaveBeenCalled();
+      expect(typing.startTypingLoop, `mode=${params.mode}`).not.toHaveBeenCalled();
+      expect(typing.startTypingOnText, `mode=${params.mode}`).not.toHaveBeenCalled();
+    }
   });
 });
 

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -769,7 +769,7 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
 
-  it("handles tool-start typing before and after active text mode", async () => {
+  it("suppresses tool-start typing in message mode until renderable text arrives", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({
       typing,
@@ -777,18 +777,33 @@ describe("createTypingSignaler", () => {
       isHeartbeat: false,
     });
 
+    // Tool fires before any text — suppressed in message mode.
     await signaler.signalToolStart();
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
 
-    expect(typing.startTypingLoop).toHaveBeenCalledTimes(1);
-    expect(typing.refreshTypingTtl).toHaveBeenCalledTimes(1);
-    expect(typing.startTypingOnText).not.toHaveBeenCalled();
+    // Renderable text arrives — typing starts via startTypingOnText.
+    await signaler.signalTextDelta("hello");
+    expect(typing.startTypingOnText).toHaveBeenCalledTimes(1);
+
+    // Typing now active; subsequent tool calls keep TTL alive.
     (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
-    (typing.startTypingLoop as ReturnType<typeof vi.fn>).mockClear();
     (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();
     await signaler.signalToolStart();
-
     expect(typing.refreshTypingTtl).toHaveBeenCalledTimes(1);
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
+  it("starts typing on tool-start for instant and thinking modes", async () => {
+    for (const mode of ["instant", "thinking"] as const) {
+      const typing = createMockTypingController();
+      const signaler = createTypingSignaler({ typing, mode, isHeartbeat: false });
+
+      await signaler.signalToolStart();
+
+      expect(typing.startTypingLoop).toHaveBeenCalledTimes(1);
+      expect(typing.refreshTypingTtl).toHaveBeenCalledTimes(1);
+    }
   });
 
   it("suppresses typing when disabled", async () => {

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -137,8 +137,12 @@ export function createTypingSignaler(params: {
     if (disabled) {
       return;
     }
-    // Start typing as soon as tools begin executing, even before the first text delta.
     if (!typing.isActive()) {
+      // In message mode, only start typing on tool calls after renderable text
+      // has been confirmed.
+      if (shouldStartOnMessageStart && !hasRenderableText) {
+        return;
+      }
       await typing.startTypingLoop();
       typing.refreshTypingTtl();
       return;


### PR DESCRIPTION
# fix(whatsapp): suppress spurious typing indicator on silent tool-only runs

## Summary

_This fix was developed with assistance from GitHub Copilot (Claude Sonnet 4.6)._

_Maintainer update: the WhatsApp `suppressTyping` path is scoped to unmentioned message-tool-only group turns, so automatic visible replies and authorized group commands keep their typing indicators._

**What problem does this PR solve?**

WhatsApp shows a "typing..." indicator to group members whenever an agent run executes a tool silently — even when the run produces no visible reply. Two distinct causes both contribute to the same false positive:

- **Cause 1** (`src/auto-reply/reply/typing-mode.ts`): In message-mode typing, `signalToolStart` unconditionally started the composing loop as soon as a tool call began, before any renderable text had been produced. A run that only ever calls a tool and returns a silent token would flash "typing..." for the entire tool execution window with no message following it. The fix adds a `!hasRenderableText` guard so the indicator stays active during tool calls on runs that already started composing, but stays silent on runs that have not yet produced any text.
- **Cause 2** (`extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts`): When using Gemini with thinking enabled, the model sometimes emits its reasoning about why it should stay silent as a regular `text` stream part (not tagged `thought: true`), before the silent-reply token. OpenClaw's streaming tap sees these as renderable text deltas, fires composing, and by the time the reply resolver identifies the silent token the indicator has already been sent.

**Why does this matter now?**

The "typing..." indicator in WhatsApp is highly visible. It appears under the contact name in the chat list and in the conversation header of the group — it's impossible to miss. In group chats where the bot was not mentioned, the overwhelming majority of agent runs are background tool-only runs: passive observation, ambient web search, context collection, and so on. Every one of those runs currently produces a false positive: group members see the bot start "typing," wait, and then nothing arrives. Over time this erodes trust in the agent and makes the bot look broken.

**Why WhatsApp specifically, and not Telegram or other channels?**

The combination of three factors makes this particularly acute for WhatsApp groups:

1. **Persistence of the composing state.** WhatsApp presence is a push-and-hold model: `sendPresenceUpdate("composing")` stays active until explicitly cleared with `"paused"`. A single false-positive lasts for the full duration of the tool execution (seconds to tens of seconds). Telegram's `sendChatAction` is a fire-and-forget signal that auto-expires in ~5 seconds; it is far less noticeable and corrects itself quickly without any action.

2. **The passive group agent use case is WhatsApp-dominant.** WhatsApp group chats without an @mention are the primary deployment pattern for ambient/background agents (e.g., a bot that silently searches the web on every message but only replies when it has something to say). This pattern is much less common in Telegram groups, where bots are typically explicitly invoked.

3. **Mention semantics.** WhatsApp's `wasMentioned` signal is the natural boundary between "bot was addressed" (typing indicator is appropriate) and "bot is listening silently" (typing indicator is disruptive). This PR uses exactly that boundary for the Cause 2 mitigation.

**What is the intended outcome?**

- Silent tool-only runs in WhatsApp groups without a mention no longer send any composing presence update.
- Runs that produce a visible reply (whether the bot was mentioned or not) are unaffected.
- Direct-chat runs and group runs where the bot was mentioned retain the typing indicator as before.

**What is intentionally out of scope?**

- A complete architectural fix for Cause 2. The root problem — Gemini emitting reasoning as a regular text stream before a silent token — cannot be fully eliminated within the current two-pipeline model (eager streaming tap vs. lazy delivery decision). A complete fix would require collapsing the pipelines or introducing a speculative/rollback composing model.
- Changes to direct-chat behavior in WhatsApp.

**What does success look like?**

A multi-turn Gemini run in a WhatsApp group where the bot is not mentioned, instructed to call a tool silently and not reply, produces no "typing..." indicator at any point. The group sees nothing until (if ever) the bot decides to send a message.

**What should reviewers focus on?**

- The scoped Cause 2 mitigation: unmentioned message-tool-only group turns suppress composing, while automatic visible replies and authorized group commands keep typing indicators.

---

## Linked context

Which issue does this close?

No dedicated issue exists for this exact bug. Self-identified from live session logs showing false positive composing on every silent Gemini tool run in WhatsApp groups.

Which issues, PRs, or discussions are related?

- Related commit `da95b58a2a` (closes #450, #447) — "Typing: keep indicators active during tool runs." That commit added unconditional `startTypingLoop()` in `signalToolStart` when typing was not yet active, to fix the indicator dropping out mid-tool-call. The fix was correct for instant/thinking modes but had no mode guard, so message-mode runs that never produced renderable text would also fire composing. Our Cause 1 fix adds the missing `!hasRenderableText` guard — silent runs stay silent, and the indicator still stays alive for any run that already started composing before the tool call.

- Related #78963 — "WhatsApp: add listen-only / hooks-only mode for inbound messages without agent runs." The use case described there — passive agents monitoring WhatsApp groups without replying — is exactly the scenario where the spurious typing indicator is most disruptive. This PR does not implement listen-only mode, but it eliminates the most visible symptom for users already running passive group agents today.

- Related #87665 — "Discord subagent tasks default to done_only, leaving channel stuck on typing indicator." A sibling bug on Discord: typing indicator fired on a run that produces no message. Not addressed here but shares the same root cause class.

Was this requested by a maintainer or owner?

Self-identified.

---

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Spurious WhatsApp "typing..." indicator on silent agent tool runs in group chats.
- **Real environment tested:** macOS, local OpenClaw gateway (Node 26, pnpm dev), WhatsApp group chat, provider `google/gemini-3.1-pro-preview` with thinking enabled. Agent config below (obfuscated).
- **Exact steps or command run after this patch:** Sent three consecutive messages into a WhatsApp group: (1) plain message without @mention, (2) @mention with a question, (3) plain message without @mention. All three were received and processed by the running patched gateway.
- **Evidence after fix:** Gateway log excerpt and config below; screenshots attached _(before/after to be added)_.
- **Observed result after fix:** No "typing..." indicator appeared for messages 1 and 3. A "typing..." indicator appeared normally before the bot's reply to message 2 (the @mention). All three runs called `web_search`.
- **What was not tested:** Telegram, Discord, and other channel behavior. The Cause 1 fix is in shared typing-mode code (`src/auto-reply/reply/typing-mode.ts`) and applies to all channels, but only WhatsApp was tested live. The Cause 2 mitigation (`suppressTyping`) is WhatsApp-specific.
- **Proof limitations or environment constraints:** Cause 2 was only reliably reproduced with a Gemini model with thinking enabled and a system prompt that instructs the model to be silent. Other models were not tested for this specific cause.

**Agent and channel config (obfuscated `openclaw.json` excerpt):**

```jsonc
{
  "agents": {
    "defaults": {
      "model": { "primary": "google/gemini-3.1-pro-preview" }
    },
    "list": [
      {
        "id": "dev",
        "identity": { "name": "C3-PO", "theme": "protocol droid", "emoji": "🤖" }
      }
    ]
  },
  "channels": {
    "whatsapp": {
      "enabled": true,
      "accounts": {
        "test": {
          "groupPolicy": "allowlist",
          "groupAllowFrom": ["*"],
          "groups": {
            "[group-jid]@g.us": {
              "requireMention": false,
              "systemPrompt": "For every message, silently call the web_search tool on it. Do not produce any text in your response under any circumstances."
            }
          }
        }
      }
    }
  }
}
```

**Messages sent (sender redacted) and bot response:**

```
# Run 1 — no @mention
→ "[user]: Should I eat a biscuit?"
← (no reply sent — silent run)

# Run 2 — @mention
→ "[user]: @C3-PO should I eat a biscuit?"
← C3-PO: "If you need a quick energy boost and it fits into your diet, a biscuit
   should be fine! ..."  (reply delivered to group)

# Run 3 — no @mention
→ "[user]: Should I drink some water?"
← (no reply sent — silent run)
```

**Before evidence (observed, from session 2026-05-27, run `7477d410`):**

```
19:10:55  signalTextDelta renderable text detected: "The"    ← false positive triggers composing
19:10:55  [TYPING] sendComposing → 120363406415684625@g.us   ← visible to group members
19:10:55  Skipping auto-reply: silent token or no text/media returned from resolver
19:10:55  (no WhatsApp message sent)
```

Typing indication for empty respones prior to fix: 
<img width="1288" height="108" alt="Screenshot 2026-05-27 at 19 11 05" src="https://github.com/user-attachments/assets/d9aec327-ece6-4091-a4c7-de091d035ff4" />


**After evidence (2026-05-31, three runs in group `120363406415684625@g.us`):**

```
# Run 1 — no @mention (runId d43777cf), web_search, silent
15:34:09  embedded run start
15:34:25  embedded run tool start: tool=web_search
15:34:36  embedded run tool end
15:34:43  embedded run done
15:34:43  Skipping auto-reply: silent token or no text/media returned from resolver
            ← zero [TYPING] sendComposing entries; group saw no typing indicator ✓

# Run 2 — WITH @mention (runId fde88fe3), web_search, replied
15:34:57  embedded run start
15:34:59  embedded run tool start: tool=web_search
15:34:59  embedded run tool end
15:35:03  embedded run done
15:35:04  Skipping recent outbound WhatsApp echo 3EB00C85BA15C4733E7BDF
            ← outbound message confirmed; group saw typing indicator before reply ✓

# Run 3 — no @mention (runId f52d483d), web_search, silent
15:35:21  embedded run start
15:35:27  embedded run tool start: tool=web_search
15:35:31  embedded run tool end
15:35:34  embedded run done
15:35:34  Skipping auto-reply: silent token or no text/media returned from resolver
            ← zero [TYPING] sendComposing entries; group saw no typing indicator ✓
```
The exchange after the fix. No typing indications for message 1 and 3:
<img width="1271" height="225" alt="Screenshot 2026-05-31 at 15 35 41" src="https://github.com/user-attachments/assets/e75fbc2b-5002-4049-b95b-be93cd2ec756" />

Typing idications for message 2 (with mention):
<img width="1283" height="132" alt="Screenshot 2026-05-31 at 15 35 02" src="https://github.com/user-attachments/assets/e99fa0cd-7009-4156-9922-8b3290deaaa3" />


---

## Tests and validation

**Which commands did you run?**

```
pnpm test extensions/whatsapp
pnpm test src/auto-reply/reply/reply-utils.test.ts
```

Both pass — 72 WhatsApp test files (including 3 new `suppressTyping` tests), all green.

**What regression coverage was added or updated?**

- `extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts`: tests cover `suppressTyping` for unmentioned message-tool-only groups (`true`), mentioned groups and direct chats (`false`), plus automatic visible reply and authorized command paths (`false`).
- `src/auto-reply/reply/reply-utils.test.ts`: 2 new tests covering the suppressed-signaler path for `mode: "instant", isHeartbeat: true` and `mode: "never", isHeartbeat: false`.

**What failed before this fix, if known?**

Session log from 2026-05-27 shows `[TYPING] sendComposing` firing on every silent Gemini group run that produced no message, consistently reproducible with the agent config shown in the Real behavior proof section above.

**If no test was added, why not?**

Tests were added for all three code changes.

---

## Risk checklist

**Did user-visible behavior change?** Yes — WhatsApp group members no longer see a typing indicator on silent background runs when the bot was not mentioned.

**Did config, environment, or migration behavior change?** No — no config keys added or removed. No migration needed.

**Did security, auth, secrets, network, or tool execution behavior change?** No.

**What is the highest-risk area?**

The `suppressTyping` flag is set only for unmentioned WhatsApp group turns whose source reply mode is `message_tool_only`. Automatic visible replies and authorized group commands remain eligible for typing indicators.

**How is that risk mitigated?**

The scope keeps the silent-background-run fix while avoiding a regression for visible automatic replies.

---

## Current review state

**What is the next action?**

Ready for review. Real behavior proof complete — three live runs on 2026-05-31 confirm the fix. Screenshots (before/after) to be attached to the PR.

