### PR TITLE
fix(agent-core): allow benign session rewrites with different inode

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -263,7 +263,6 @@ async function sessionFenceRewriteIsBenign(params: {
     !params.previous?.fingerprint.exists ||
     !params.current.exists ||
     !params.previous.text ||
-    !sameSessionFileIdentity(params.previous.fingerprint, params.current) ||
     params.current.size > BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES) ||
     params.current.size > MAX_SAFE_FILE_OFFSET
   ) {


### PR DESCRIPTION
## Summary

Compaction rewrites session files via `writeFile+rename`, which always creates a new inode. Previously, `sessionFenceRewriteIsBenign` rejected such rewrites at the inode identity gate (`sameSessionFileIdentity`), so the content validation that follows never ran, causing `EmbeddedAttemptSessionTakeoverError` false positives.

## Root Cause

In `sessionFenceRewriteIsBenign` (line 266), the `sameSessionFileIdentity` check compares `dev + ino`. When compaction runs, it replaces the session file with a new inode, causing this check to return `false` and the function to exit early — without ever performing content validation.

The actual error path:
1. `releaseForPrompt()` records fingerprint (inode A)
2. Compaction runs, renames new file (inode B)
3. `assertSessionFileFence()` compares fingerprint: inode B ≠ inode A
4. `sessionFenceRewriteIsBenign` called, fails `sameSessionFileIdentity` check
5. `EmbeddedAttemptSessionTakeoverError` thrown — **false positive**

## Fix

Remove the inode identity gate from `sessionFenceRewriteIsBenign` while preserving all content validation. The content checks remain fully in place: file must exist, end with a newline, append only valid transcript lines, and stay within size limits. A file with a different inode but valid compaction-style content is indistinguishable from a compaction from the agent's perspective.

## Source

`src/agents/embedded-agent-runner/run/attempt.session-lock.ts`, function `sessionFenceRewriteIsBenign`, line 266.

## Testing

- [ ] Unit test: verify `sessionFenceRewriteIsBenign` returns `true` for same-content file with different inode
- [ ] Integration test: run compaction concurrently with message processing, verify no `EmbeddedAttemptSessionTakeoverError`
