### PR TITLE
fix(gateway): reject stale lifecycle session updates

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -803,6 +803,7 @@ async function agentCommandInternal(
           ? { isControlUiVisible: false }
           : {
               sessionKey,
+              sessionId,
             },
       );
       attemptExecutionRuntime.emitAcpLifecycleStart({ runId, startedAt });
@@ -980,7 +981,7 @@ async function agentCommandInternal(
 
     if (sessionKey || suppressVisibleSessionEffects) {
       registerAgentRunContext(runId, {
-        ...(sessionKey && !suppressVisibleSessionEffects ? { sessionKey } : {}),
+        ...(sessionKey && !suppressVisibleSessionEffects ? { sessionKey, sessionId } : {}),
         verboseLevel: resolvedVerboseLevel,
         isControlUiVisible: !suppressVisibleSessionEffects,
       });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1177,6 +1177,7 @@ export async function runMemoryFlushIfNeeded(params: {
   if (params.sessionKey) {
     memoryDeps.registerAgentRunContext(flushRunId, {
       sessionKey: params.sessionKey,
+      ...(activeSessionEntry?.sessionId ? { sessionId: activeSessionEntry.sessionId } : {}),
       verboseLevel: params.resolvedVerboseLevel,
     });
   }

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2630,6 +2630,69 @@ describe("createFollowupRunner compaction", () => {
     expect(embeddedCalls[0]?.extraSystemPrompt).toContain("Read AGENTS.md before replying.");
     expect(sessionStore.main?.compactionCount).toBe(2);
   });
+
+  it("registers the post-preflight session id for lifecycle event stamping", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    realAgentEvents.resetAgentRunContextForTest();
+    const sessionEntry: SessionEntry = {
+      sessionId: "old-session",
+      updatedAt: Date.now(),
+      sessionFile: "/tmp/old-session.jsonl",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      main: sessionEntry,
+    };
+    runPreflightCompactionIfNeededMock.mockImplementationOnce(
+      async (params: {
+        followupRun: FollowupRun;
+        sessionEntry?: SessionEntry;
+        sessionStore?: Record<string, SessionEntry>;
+        sessionKey?: string;
+      }) => {
+        const updatedEntry: SessionEntry = {
+          ...(params.sessionEntry ?? sessionEntry),
+          sessionId: "new-session",
+          sessionFile: "/tmp/new-session.jsonl",
+          updatedAt: Date.now(),
+        };
+        params.followupRun.run.sessionId = updatedEntry.sessionId;
+        params.followupRun.run.sessionFile = "/tmp/new-session.jsonl";
+        if (params.sessionKey && params.sessionStore) {
+          params.sessionStore[params.sessionKey] = updatedEntry;
+        }
+        return updatedEntry;
+      },
+    );
+
+    let observedRunId: string | undefined;
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (params: { runId: string; sessionId?: string }) => {
+        observedRunId = params.runId;
+        expect(params.sessionId).toBe("new-session");
+        return {
+          payloads: [{ text: "final" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    await runner(createQueuedRun());
+
+    expect(observedRunId).toBeDefined();
+    expect(realAgentEvents.getAgentRunContext(observedRunId ?? "")?.sessionId).toBe("new-session");
+    realAgentEvents.resetAgentRunContextForTest();
+  });
 });
 
 describe("createFollowupRunner bootstrap warning dedupe", () => {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -135,6 +135,8 @@ export type AgentConfig = {
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
+    /** Per-agent default thinking level for spawned sub-agents. */
+    thinking?: string;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). */
     requireAgentId?: boolean;
   };

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -396,6 +396,7 @@ export async function executeCronRun(params: {
     "off";
   registerAgentRunContext(params.cronSession.sessionEntry.sessionId, {
     sessionKey: params.runSessionKey,
+    sessionId: params.cronSession.sessionEntry.sessionId,
     verboseLevel: resolvedVerboseLevel,
   });
   const executor = createCronPromptExecutor({

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -49,9 +49,9 @@ describe("agent-events sequencing", () => {
     expect(seen.find((evt) => evt.stream === "item")?.sessionId).toBeUndefined();
   });
 
-  test("refreshes the stamped sessionId after a mid-run session rotation (#88538)", () => {
+  test("refreshes the stamped sessionId when run context is re-registered (#88538)", () => {
     registerAgentRunContext("run-1", { sessionKey: "main", sessionId: "start-id" });
-    // A legitimate compaction rotation re-registers the run with its new session.
+    // Callers that already persisted a rotation can re-register the new owner.
     registerAgentRunContext("run-1", { sessionId: "rotated-id" });
     let stamped: string | undefined;
     const stop = onAgentEvent((evt) => {


### PR DESCRIPTION
## Summary
- Carry the owning run `sessionId` into lifecycle event context for the remaining session-backed run paths.
- Keep lifecycle stamping aligned with the stale lifecycle guards already on `main`, so post-reset rows are not overwritten by old in-flight run events.
- Add regression coverage for post-preflight followup session ownership.
- Add the narrow per-agent `subagents.thinking` type field already used by current `main` tests/runtime so `check:test-types` stays green.

Fixes #88538.
Replaces #88583 / #88625 after the contributor branch and then the first replacement PR could not be updated cleanly.

## Verification
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings.
- `node scripts/run-vitest.mjs src/infra/agent-events.test.ts src/gateway/session-lifecycle-state.test.ts src/gateway/server-chat.agent-events.test.ts src/auto-reply/reply/followup-runner.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/agent-command.compaction-rotation.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts` -> passed.
- `pnpm check:test-types` -> passed.
- `pnpm lint --threads=8` -> passed.
- `pnpm tsgo:core` -> passed.

## Review notes
- Posted the initial blocking finding on #88583 before replacing the PR.
- Fixed autoreview findings around in-flight compaction session stamping and stale followup admission registration before landing.
- Latest autoreview remained clean after rebasing onto current `origin/main`.
