### PR TITLE
Drop reasoning-only length turns from replay

### DIFF
--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -20,6 +20,7 @@ Scope includes:
 - Thinking signature cleanup
 - Image payload sanitization
 - Blank text-block cleanup before provider replay
+- Incomplete reasoning-only length-turn cleanup before provider replay
 - User-input provenance tagging (for inter-session routed prompts)
 - Empty assistant error-turn repair for Bedrock Converse replay
 
@@ -88,6 +89,21 @@ Implementation:
 
 - `sanitizeToolCallInputs` in `src/agents/session-transcript-repair.ts`
 - Applied in `sanitizeSessionHistory` in `src/agents/embedded-agent-runner/replay-history.ts`
+
+---
+
+## Global rule: incomplete reasoning-only turns
+
+Assistant turns that hit the provider output limit with only thinking or
+redacted-thinking content are omitted from the in-memory replay copy. Such turns
+contain incomplete provider state and may carry a partial thinking signature.
+
+Empty length turns remain unchanged, as do length turns with visible text, tool
+calls, or unknown content blocks. Stored transcripts are not rewritten.
+
+Implementation:
+
+- `normalizeAssistantReplayContent` in `src/agents/embedded-agent-runner/replay-history.ts`
 
 ---
 

--- a/src/agents/embedded-agent-runner/replay-history.test.ts
+++ b/src/agents/embedded-agent-runner/replay-history.test.ts
@@ -154,6 +154,79 @@ describe("normalizeAssistantReplayContent", () => {
     expect(out[2]).toBe(length);
   });
 
+  it("drops reasoning-only length turns before provider replay", () => {
+    const reasoningOnly = bedrockAssistant(
+      [
+        {
+          type: "thinking",
+          thinking: "partial hidden reasoning",
+          thinkingSignature: "partial-signature",
+        },
+        { type: "text", text: "  " },
+      ],
+      "length",
+      { output: 42, totalTokens: 42 },
+    );
+    const messages = [userMessage("before"), reasoningOnly, userMessage("continue")];
+
+    const out = normalizeAssistantReplayContent(messages);
+
+    expect(out).toEqual([messages[0], messages[2]]);
+    expect(JSON.stringify(out)).not.toContain("partial-signature");
+  });
+
+  it("drops length turns that become reasoning-only after content normalization", () => {
+    const messages = [
+      userMessage("before"),
+      bedrockAssistant(
+        [
+          {
+            type: "thinking",
+            thinking: "partial hidden reasoning",
+            thinkingSignature: "partial-signature",
+          },
+          { type: "text", text: "NO_REPLY" },
+        ],
+        "length",
+      ),
+      {
+        ...bedrockAssistant([], "length"),
+        content: {
+          type: "thinking",
+          thinking: "partial object reasoning",
+          thinkingSignature: "partial-object-signature",
+        },
+      },
+      userMessage("continue"),
+    ] as AgentMessage[];
+
+    const out = normalizeAssistantReplayContent(messages);
+
+    expect(out).toEqual([messages[0], messages[3]]);
+  });
+
+  it("preserves length turns with visible text or tool calls", () => {
+    const visible = bedrockAssistant(
+      [
+        { type: "thinking", thinking: "partial reasoning", thinkingSignature: "sig_visible" },
+        { type: "text", text: "partial visible answer" },
+      ],
+      "length",
+    );
+    const toolCall = bedrockAssistant(
+      [
+        { type: "thinking", thinking: "partial reasoning", thinkingSignature: "sig_tool" },
+        { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+      ],
+      "length",
+    );
+    const messages = [userMessage("before"), visible, toolCall, userMessage("continue")];
+
+    const out = normalizeAssistantReplayContent(messages);
+
+    expect(out).toBe(messages);
+  });
+
   it("wraps legacy string assistant content as a single text block (regression)", () => {
     const messages = [userMessage("hi"), bedrockAssistant("plain string content")];
     const out = normalizeAssistantReplayContent(messages);

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -29,6 +29,7 @@ import {
   validateGeminiTurns,
 } from "../embedded-agent-helpers.js";
 import { resolveImageSanitizationLimits } from "../image-sanitization.js";
+import { isReasoningOnlyLengthAssistantTurn } from "../replay-turn-classification.js";
 import type { AgentMessage } from "../runtime/index.js";
 import {
   sanitizeToolCallInputs,
@@ -361,12 +362,19 @@ export function normalizeAssistantReplayContent(messages: AgentMessage[]): Agent
     if (Array.isArray(replayContent)) {
       const normalized = normalizeAssistantReplayBlockContent(assistantMessage, replayContent);
       if (normalized !== assistantMessage) {
-        if (normalized) {
-          out.push(normalized);
-        }
         touched = true;
-        continue;
+        if (!normalized) {
+          continue;
+        }
+        assistantMessage = normalized as AssistantReplayMessage;
+        replayContent = assistantMessage.content;
       }
+    }
+    if (isReasoningOnlyLengthAssistantTurn(assistantMessage)) {
+      // Token-limited thinking is incomplete provider state. Replaying it can
+      // resend a partial signature, while visible text or tool calls remain useful.
+      touched = true;
+      continue;
     }
     if (Array.isArray(replayContent) && replayContent.length === 0) {
       // An assistant turn can legitimately end with `content: []` — for

--- a/src/agents/replay-turn-classification.ts
+++ b/src/agents/replay-turn-classification.ts
@@ -1,0 +1,33 @@
+type AssistantTurnLike = {
+  role?: unknown;
+  stopReason?: unknown;
+  content?: unknown;
+};
+
+/** Returns true when a token-limited turn contains only incomplete provider reasoning. */
+export function isReasoningOnlyLengthAssistantTurn(message: AssistantTurnLike): boolean {
+  if (message.role !== "assistant" || message.stopReason !== "length") {
+    return false;
+  }
+  const content = Array.isArray(message.content)
+    ? message.content
+    : message.content != null && typeof message.content === "object"
+      ? [message.content]
+      : [];
+  let hasThinking = false;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const record = block as { type?: unknown; text?: unknown };
+    if (record.type === "thinking" || record.type === "redacted_thinking") {
+      hasThinking = true;
+      continue;
+    }
+    if (record.type === "text" && typeof record.text === "string" && !record.text.trim()) {
+      continue;
+    }
+    return false;
+  }
+  return hasThinking;
+}

--- a/src/agents/tool-replay-repair.live.test.ts
+++ b/src/agents/tool-replay-repair.live.test.ts
@@ -36,6 +36,34 @@ type TargetModelRef = {
   modelId: string;
 };
 
+function createDirectTargetModel(target: TargetModelRef): Model | null {
+  const common = {
+    id: target.modelId,
+    name: target.modelId,
+    provider: target.provider,
+    reasoning: true,
+    input: ["text"] as Model["input"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8_192,
+  };
+  if (target.provider === "openai") {
+    return {
+      ...common,
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    };
+  }
+  if (target.provider === "anthropic") {
+    return {
+      ...common,
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+    };
+  }
+  return null;
+}
+
 function parseTargetModelRefs(raw: string | undefined): TargetModelRef[] {
   const refs: TargetModelRef[] = [];
   for (const item of (raw ?? "").split(",")) {
@@ -102,6 +130,21 @@ function buildReplayMessages(model: Model): AgentMessage[] {
         };
 
   return [
+    {
+      role: "assistant",
+      provider: source.provider,
+      api: source.api,
+      model: source.model,
+      stopReason: "length",
+      timestamp: now - 1,
+      content: [
+        {
+          type: "thinking",
+          thinking: "partial hidden reasoning",
+          thinkingSignature: "partial-signature",
+        },
+      ],
+    },
     {
       role: "user",
       content: "Use noop.",
@@ -205,7 +248,9 @@ describeLive("tool replay repair live", () => {
         const agentDir = resolveDefaultAgentDir(cfg);
         const authStorage = discoverAuthStorage(agentDir);
         const modelRegistry = discoverModels(authStorage, agentDir);
-        const model = modelRegistry.find(target.provider, target.modelId) as Model | null;
+        const model =
+          (modelRegistry.find(target.provider, target.modelId) as Model | null) ??
+          createDirectTargetModel(target);
 
         if (!model) {
           logProgress(`[tool-replay-repair] model missing from registry: ${target.ref}`);
@@ -316,7 +361,9 @@ describeLive("tool replay repair live", () => {
         const agentDir = resolveDefaultAgentDir(cfg);
         const authStorage = discoverAuthStorage(agentDir);
         const modelRegistry = discoverModels(authStorage, agentDir);
-        const model = modelRegistry.find(target.provider, target.modelId) as Model | null;
+        const model =
+          (modelRegistry.find(target.provider, target.modelId) as Model | null) ??
+          createDirectTargetModel(target);
 
         if (!model) {
           logProgress(`[tool-replay-repair] model missing from registry: ${target.ref}`);

--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -477,31 +477,30 @@ describe("transformTransportMessages synthetic tool-result policy", () => {
     expect(JSON.stringify(result)).not.toContain("partial-signature");
   });
 
-  it("keeps max-token assistant turns that have visible text before replay", () => {
+  it("keeps max-token transport turns with visible or tool content", () => {
     const messages: Context["messages"] = [
       {
         role: "assistant",
-        provider: "amazon-bedrock",
-        api: "bedrock-converse-stream",
-        model: "global.anthropic.claude-sonnet-4-6",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        model: "claude-sonnet-4-6",
         stopReason: "length",
         timestamp: Date.now(),
-        content: [{ type: "text", text: "partial visible answer" }],
-      } as Extract<Context["messages"][number], { role: "assistant" }>,
-      { role: "user", content: "continue", timestamp: Date.now() },
-    ];
+        content: [
+          { type: "thinking", thinking: "partial", thinkingSignature: "sig-visible" },
+          { type: "text", text: "partial visible answer" },
+        ],
+      },
+      assistantToolCall("call_length", "exec", "length"),
+    ] as Context["messages"];
 
     const result = transformTransportMessages(
       messages,
-      makeModel(
-        "bedrock-converse-stream" as Api,
-        "amazon-bedrock",
-        "global.anthropic.claude-sonnet-4-6",
-      ),
+      makeModel("anthropic-messages", "anthropic", "claude-sonnet-4-6"),
     );
 
-    expect(result.map((msg) => msg.role)).toEqual(["assistant", "user"]);
-    expect(JSON.stringify(result)).toContain("partial visible answer");
+    expect(result[0]).toMatchObject({ role: "assistant", stopReason: "length" });
+    expect(result[1]).toMatchObject({ role: "assistant", stopReason: "length" });
   });
 
   it("drops errored Anthropic transport assistant tool calls and matching results before replay", () => {

--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -444,6 +444,66 @@ describe("transformTransportMessages synthetic tool-result policy", () => {
     expect(JSON.stringify(result)).not.toContain("partial error output");
   });
 
+  it("drops max-token reasoning-only transport assistant turns before replay", () => {
+    const messages: Context["messages"] = [
+      {
+        role: "assistant",
+        provider: "amazon-bedrock",
+        api: "bedrock-converse-stream",
+        model: "global.anthropic.claude-sonnet-4-6",
+        stopReason: "length",
+        timestamp: Date.now(),
+        content: [
+          {
+            type: "thinking",
+            thinking: "partial hidden reasoning",
+            thinkingSignature: "partial-signature",
+          },
+        ],
+      } as Extract<Context["messages"][number], { role: "assistant" }>,
+      { role: "user", content: "retry after max token thinking", timestamp: Date.now() },
+    ];
+
+    const result = transformTransportMessages(
+      messages,
+      makeModel(
+        "bedrock-converse-stream" as Api,
+        "amazon-bedrock",
+        "global.anthropic.claude-sonnet-4-6",
+      ),
+    );
+
+    expect(result.map((msg) => msg.role)).toEqual(["user"]);
+    expect(JSON.stringify(result)).not.toContain("partial-signature");
+  });
+
+  it("keeps max-token assistant turns that have visible text before replay", () => {
+    const messages: Context["messages"] = [
+      {
+        role: "assistant",
+        provider: "amazon-bedrock",
+        api: "bedrock-converse-stream",
+        model: "global.anthropic.claude-sonnet-4-6",
+        stopReason: "length",
+        timestamp: Date.now(),
+        content: [{ type: "text", text: "partial visible answer" }],
+      } as Extract<Context["messages"][number], { role: "assistant" }>,
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+
+    const result = transformTransportMessages(
+      messages,
+      makeModel(
+        "bedrock-converse-stream" as Api,
+        "amazon-bedrock",
+        "global.anthropic.claude-sonnet-4-6",
+      ),
+    );
+
+    expect(result.map((msg) => msg.role)).toEqual(["assistant", "user"]);
+    expect(JSON.stringify(result)).toContain("partial visible answer");
+  });
+
   it("drops errored Anthropic transport assistant tool calls and matching results before replay", () => {
     const messages: Context["messages"] = [
       assistantToolCall("call_error", "exec", "error"),

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -40,7 +40,22 @@ function isFailedAssistantTurn(message: Context["messages"][number]): boolean {
   if (message.role !== "assistant") {
     return false;
   }
-  return message.stopReason === "error" || message.stopReason === "aborted";
+  if (message.stopReason === "error" || message.stopReason === "aborted") {
+    return true;
+  }
+  if (message.stopReason !== "length") {
+    return false;
+  }
+  const content = Array.isArray(message.content) ? message.content : [];
+  return !content.some((block) => {
+    if (block.type === "toolCall") {
+      return true;
+    }
+    if (block.type === "text") {
+      return block.text.trim().length > 0;
+    }
+    return false;
+  });
 }
 
 /** Transforms transcript messages into a provider-safe replay context. */

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -5,6 +5,7 @@
  */
 import type { Api, Context, Model } from "../llm/types.js";
 import { resolveModelBoundThinkingReplayMode } from "../shared/anthropic-model-contract.js";
+import { isReasoningOnlyLengthAssistantTurn } from "./replay-turn-classification.js";
 import { repairToolUseResultPairing } from "./session-transcript-repair.js";
 
 const SYNTHETIC_TOOL_RESULT_APIS = new Set<string>([
@@ -40,22 +41,11 @@ function isFailedAssistantTurn(message: Context["messages"][number]): boolean {
   if (message.role !== "assistant") {
     return false;
   }
-  if (message.stopReason === "error" || message.stopReason === "aborted") {
-    return true;
-  }
-  if (message.stopReason !== "length") {
-    return false;
-  }
-  const content = Array.isArray(message.content) ? message.content : [];
-  return !content.some((block) => {
-    if (block.type === "toolCall") {
-      return true;
-    }
-    if (block.type === "text") {
-      return block.text.trim().length > 0;
-    }
-    return false;
-  });
+  return (
+    message.stopReason === "error" ||
+    message.stopReason === "aborted" ||
+    isReasoningOnlyLengthAssistantTurn(message)
+  );
 }
 
 /** Transforms transcript messages into a provider-safe replay context. */
@@ -168,7 +158,10 @@ export function transformTransportMessages(
   // Preserve the old transport replay filter: failed streamed turns can contain
   // partial text, partial tool calls, or both, and strict providers can treat
   // them as valid assistant context on retry unless we drop the whole turn.
-  const replayable = transformed.filter((msg) => !isFailedAssistantTurn(msg));
+  const replayable = transformed.filter((_, index) => {
+    const original = messages[index];
+    return original ? !isFailedAssistantTurn(original) : true;
+  });
 
   if (!allowSyntheticToolResults) {
     return replayable;


### PR DESCRIPTION
## Summary

- Drop replayed assistant turns that ended at the token limit with only incomplete hidden reasoning.
- Preserve turns containing visible text, tool calls, empty content, or unknown content shapes.
- Apply the same predicate to embedded replay and the public transport transform without changing persisted transcripts.
- Add regression coverage and transcript-hygiene documentation.

## Verification

- `pnpm test src/agents/embedded-agent-runner/replay-history.test.ts src/agents/transport-message-transform.test.ts` (52 tests passed)
- `OPENCLAW_LIVE_TEST=1 OPENAI_LIVE_TEST=1 ANTHROPIC_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=0 OPENCLAW_LIVE_TOOL_REPLAY_REPAIR_MODELS="openai/gpt-5.5,anthropic/claude-sonnet-4-6" pnpm test:live -- src/agents/tool-replay-repair.live.test.ts src/agents/openai-tool-projection.live.test.ts src/agents/anthropic-transport-stream.live.test.ts src/agents/embedded-agent-runner.anthropic-tool-replay.live.test.ts` (13 tests passed)
- Testbox `tbx_01kv35w8vcd2xhr6xn8nq71cnt`, GitHub Actions run `27500694085` (green)
- Fresh local autoreview: no accepted/actionable findings

## Real behavior proof

Behavior addressed: Incomplete reasoning-only assistant turns ending with `stopReason: "length"` are omitted from replay while visible text and tool-call turns remain intact.

Real environment tested: Local OpenClaw checkout using the official OpenAI and Anthropic provider transports with live credentials, plus Testbox Linux CI-equivalent validation.

Exact steps or command run after this patch: Ran the four-file live provider command listed under Verification with `openai/gpt-5.5` and `anthropic/claude-sonnet-4-6`, including an injected partial reasoning-only length turn before the real request.

Evidence after fix: Copied live console output from the after-fix run:

```text
[live] [tool-replay-repair] target=openai/gpt-5.5 auth source=profile:openai:default
[live] [tool-replay-repair] target=anthropic/claude-sonnet-4-6 auth source=env: ANTHROPIC_API_KEY
[live-cache] anthropic regular replay live result="REGULAR_ANTHROPIC_REPLAY_OK - confirmed."
[live-cache] anthropic omitted-reasoning replay live result="OK"
[live-cache] anthropic replay live result="OK"

Test Files  4 passed (4)
Tests       13 passed (13)
Duration    52.47s
```

The replay test asserted the injected incomplete turn was absent before the provider request, and official OpenAI/Anthropic tool projection and replay completed successfully.

Observed result after fix: OpenAI and Anthropic accepted subsequent tool-calling requests, returned live responses, and retained valid visible/tool replay content.

What was not tested: A live Amazon Bedrock request is still being run separately because Bedrock is an external provider plugin and is not loaded by the default gateway live fixture. Unit coverage exercises the shared Bedrock-shaped replay case.
