### PR TITLE
ci: stabilize Testbox changed checks

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -128,6 +128,7 @@ runs:
         if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then
           mkdir -p "$PNPM_CONFIG_MODULES_DIR"
           ln -sfn . "$PNPM_CONFIG_MODULES_DIR/node_modules"
+          export NODE_PATH="$PNPM_CONFIG_MODULES_DIR${NODE_PATH:+:$NODE_PATH}"
         fi
         pnpm "${install_args[@]}" || pnpm "${install_args[@]}"
         if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -16,6 +16,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   PNPM_CONFIG_STORE_DIR: "/tmp/openclaw-pnpm-store"
+  PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
 
 jobs:
   check:

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -123,6 +123,7 @@ jobs:
           if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then
             mkdir -p "$PNPM_CONFIG_MODULES_DIR"
             ln -sfn . "$PNPM_CONFIG_MODULES_DIR/node_modules"
+            export NODE_PATH="$PNPM_CONFIG_MODULES_DIR${NODE_PATH:+:$NODE_PATH}"
           fi
           pnpm "${install_args[@]}" || pnpm "${install_args[@]}"
           if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -119,6 +119,7 @@ export function buildChangedCheckCrabboxArgs(argv = [], options = {}) {
     "OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1",
     "OPENCLAW_CHANGED_LANES_RAW_SYNC=1",
     "CI=1",
+    "PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false",
     "corepack",
     "pnpm",
     "check:changed",

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -541,6 +541,7 @@ describe("scripts/changed-lanes", () => {
       "OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1",
       "OPENCLAW_CHANGED_LANES_RAW_SYNC=1",
       "CI=1",
+      "PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false",
       "corepack",
       "pnpm",
       "check:changed",


### PR DESCRIPTION
Summary
- Stabilize Blacksmith Testbox changed checks by disabling pnpm verify-deps auto-installs in the delegated child command and workflow env.
- Expose the alternate external pnpm modules dir via NODE_PATH while setup lifecycle scripts run, matching the external modules-dir CI layout.
- Update the changed-lanes unit expectation for the delegated Testbox command.

Context
- This was found while validating the ACP zombie-task restart fix for #88205.
- The ACP production fix itself is already on current main in 02c7b5b82f (fix(tasks): reclaim ACP zombie runs blocking gateway restart).

Verification
- autoreview --mode branch --base origin/main: clean, no accepted/actionable findings
- actionlint .github/workflows/ci-check-testbox.yml .github/workflows/crabbox-hydrate.yml
- ruby YAML load for .github/actions/setup-node-env/action.yml, .github/workflows/ci-check-testbox.yml, .github/workflows/crabbox-hydrate.yml
- node scripts/check-changed.mjs --dry-run
- node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts
- pnpm check:changed via Blacksmith Testbox before rebase: tbx_01ksz66cjf8xkfpht9wsb2f6sj, GitHub Actions run 26714987125, exit 0
