### PR TITLE
fix(config): type subagent thinking defaults

### DIFF
--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -135,6 +135,8 @@ export type AgentConfig = {
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
+    /** Per-agent default thinking level for spawned sub-agents. */
+    thinking?: string;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). */
     requireAgentId?: boolean;
   };


### PR DESCRIPTION
## Summary

- keep the handwritten `AgentConfig` type aligned with the zod schema/runtime contract for per-agent `subagents.thinking`
- unblock core test typechecking for ACP spawn defaults that already exercise this config shape

## Verification

- `node scripts/run-vitest.mjs src/agents/acp-spawn.test.ts --reporter=dot`
- AWS Crabbox `pnpm check:changed` provider=aws lease=cbx_e3d6a24e075a run=run_adf8a536956c exit=0
