### PR TITLE
fix(gateway): quarantine malformed MCP loopback schemas

### DIFF
--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -9,7 +9,11 @@ import {
   jsonRpcResult,
   type JsonRpcRequest,
 } from "./mcp-http.protocol.js";
-import type { McpLoopbackTool, McpToolSchemaEntry } from "./mcp-http.schema.js";
+import {
+  readMcpLoopbackToolName,
+  type McpLoopbackTool,
+  type McpToolSchemaEntry,
+} from "./mcp-http.schema.js";
 
 type McpTextContent = {
   type: "text";
@@ -62,9 +66,17 @@ export async function handleMcpJsonRpc(params: {
     case "tools/list":
       return jsonRpcResult(id, { tools: params.toolSchema });
     case "tools/call": {
-      const toolName = methodParams?.name as string;
+      const toolName = typeof methodParams?.name === "string" ? methodParams.name.trim() : "";
       const toolArgs = (methodParams?.arguments ?? {}) as Record<string, unknown>;
-      const tool = params.tools.find((candidate) => candidate.name === toolName);
+      if (!toolName || !params.toolSchema.some((tool) => tool.name === toolName)) {
+        return jsonRpcResult(id, {
+          content: [{ type: "text", text: `Tool not available: ${toolName || "unknown"}` }],
+          isError: true,
+        });
+      }
+      const tool = params.tools.find(
+        (candidate) => readMcpLoopbackToolName(candidate) === toolName,
+      );
       if (!tool) {
         return jsonRpcResult(id, {
           content: [{ type: "text", text: `Tool not available: ${toolName}` }],

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { logWarn } from "../logger.js";
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
@@ -10,23 +11,99 @@ export type McpToolSchemaEntry = {
   inputSchema: Record<string, unknown>;
 };
 
+const UNREADABLE_FIELD = Symbol("mcp-loopback-unreadable-field");
+
+function readLoopbackToolField(tool: McpLoopbackTool, key: "name" | "description" | "parameters") {
+  try {
+    return (tool as unknown as Record<typeof key, unknown>)[key];
+  } catch {
+    return UNREADABLE_FIELD;
+  }
+}
+
+export function readMcpLoopbackToolName(tool: McpLoopbackTool): string | undefined {
+  const value = readLoopbackToolField(tool, "name");
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const name = value.trim();
+  return name || undefined;
+}
+
+function readLoopbackToolDescription(tool: McpLoopbackTool): string | undefined {
+  const value = readLoopbackToolField(tool, "description");
+  return typeof value === "string" ? value : undefined;
+}
+
+function readLoopbackToolParameters(tool: McpLoopbackTool): Record<string, unknown> | undefined {
+  const value = readLoopbackToolField(tool, "parameters");
+  if (value === UNREADABLE_FIELD) {
+    return undefined;
+  }
+  if (value === undefined || value === null) {
+    return {};
+  }
+  if (!isRecord(value)) {
+    return {};
+  }
+  try {
+    return { ...value };
+  } catch {
+    return undefined;
+  }
+}
+
+function isPropertySchema(value: unknown): value is Record<string, unknown> | boolean {
+  return value === true || value === false || isRecord(value);
+}
+
 function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknown> {
-  const variants = (raw.anyOf ?? raw.oneOf) as Record<string, unknown>[] | undefined;
+  const variants = (raw.anyOf ?? raw.oneOf) as unknown[] | undefined;
   if (!Array.isArray(variants) || variants.length === 0) {
     return raw;
   }
   const mergedProps: Record<string, unknown> = {};
   const requiredSets: Set<string>[] = [];
   for (const variant of variants) {
-    const props = variant.properties as Record<string, unknown> | undefined;
+    if (variant === true) {
+      requiredSets.push(new Set());
+      continue;
+    }
+    if (!isRecord(variant)) {
+      continue;
+    }
+    const props = isRecord(variant.properties) ? variant.properties : undefined;
     if (props) {
       for (const [key, schema] of Object.entries(props)) {
+        if (!isPropertySchema(schema)) {
+          logWarn(`mcp loopback: malformed schema definition for "${key}", ignoring that variant`);
+          continue;
+        }
         if (!(key in mergedProps)) {
           mergedProps[key] = schema;
           continue;
         }
-        const existing = mergedProps[key] as Record<string, unknown>;
-        const incoming = schema as Record<string, unknown>;
+        const existing = mergedProps[key];
+        const incoming = schema;
+        if (existing === true || incoming === true) {
+          mergedProps[key] = true;
+          continue;
+        }
+        if (existing === false) {
+          mergedProps[key] = incoming;
+          continue;
+        }
+        if (incoming === false) {
+          continue;
+        }
+        if (!isRecord(existing) || !isRecord(incoming)) {
+          if (existing !== incoming) {
+            logWarn(
+              `mcp loopback: conflicting schema definitions for "${key}", keeping the first variant`,
+            );
+          }
+          continue;
+        }
         if (Array.isArray(existing.enum) && Array.isArray(incoming.enum)) {
           mergedProps[key] = {
             ...existing,
@@ -54,18 +131,22 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
   }
   const required =
     requiredSets.length > 0
-      ? [...(requiredSets[0] ?? [])].filter((key) => requiredSets.every((set) => set.has(key)))
+      ? [...(requiredSets[0] ?? [])].filter(
+          (key) => key in mergedProps && requiredSets.every((set) => set.has(key)),
+        )
       : [];
   const { anyOf: _anyOf, oneOf: _oneOf, ...rest } = raw;
   return { ...rest, type: "object", properties: mergedProps, required };
 }
 
 export function buildMcpToolSchema(tools: McpLoopbackTool[]): McpToolSchemaEntry[] {
-  return tools.map((tool) => {
-    let raw =
-      tool.parameters && typeof tool.parameters === "object"
-        ? { ...(tool.parameters as Record<string, unknown>) }
-        : {};
+  return tools.flatMap((tool) => {
+    const name = readMcpLoopbackToolName(tool);
+    const rawParameters = readLoopbackToolParameters(tool);
+    if (!name || rawParameters === undefined) {
+      return [];
+    }
+    let raw = rawParameters;
     if (raw.anyOf || raw.oneOf) {
       raw = flattenUnionSchema(raw);
     }
@@ -75,10 +156,12 @@ export function buildMcpToolSchema(tools: McpLoopbackTool[]): McpToolSchemaEntry
     if (!raw.properties) {
       raw.properties = {};
     }
-    return {
-      name: tool.name,
-      description: tool.description,
-      inputSchema: raw,
-    };
+    return [
+      {
+        name,
+        description: readLoopbackToolDescription(tool),
+        inputSchema: raw,
+      },
+    ];
   });
 }

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getFreePortBlockWithPermissionFallback } from "../test-utils/ports.js";
+import { buildMcpToolSchema } from "./mcp-http.schema.js";
 
 type MockGatewayTool = {
   name: string;
@@ -269,6 +270,72 @@ describe("mcp loopback server", () => {
     });
   });
 
+  it("omits malformed loopback tool metadata while preserving healthy schemas", () => {
+    const unreadableName = {
+      name: "fuzzplugin_unreadable",
+      description: "unreadable name",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({
+        content: [{ type: "text", text: "unreachable" }],
+      }),
+    } satisfies MockGatewayTool;
+    Object.defineProperty(unreadableName, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin loopback tool name getter exploded");
+      },
+    });
+    const unreadableParameters = {
+      name: "mockplugin_unreadable_parameters",
+      description: "unreadable parameters",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({
+        content: [{ type: "text", text: "unreachable" }],
+      }),
+    } satisfies MockGatewayTool;
+    Object.defineProperty(unreadableParameters, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("mockplugin loopback parameters getter exploded");
+      },
+    });
+    const malformedUnion = {
+      name: "fuzzplugin_move_delta",
+      description: "malformed union",
+      parameters: {
+        anyOf: [
+          { type: "object", properties: { angle: null }, required: ["angle"] },
+          {
+            type: "object",
+            properties: { angle: { type: "number" } },
+            required: ["angle"],
+          },
+        ],
+      },
+      execute: async () => ({
+        content: [{ type: "text", text: "ok" }],
+      }),
+    } satisfies MockGatewayTool;
+
+    expect(
+      buildMcpToolSchema([
+        unreadableName,
+        unreadableParameters,
+        malformedUnion,
+      ] as unknown as Parameters<typeof buildMcpToolSchema>[0]),
+    ).toEqual([
+      {
+        name: "fuzzplugin_move_delta",
+        description: "malformed union",
+        inputSchema: {
+          type: "object",
+          properties: { angle: { type: "number" } },
+          required: ["angle"],
+        },
+      },
+    ]);
+  });
+
   it("derives sender owner identity from the loopback bearer token", async () => {
     server = await startMcpLoopbackServer(0);
     const runtime = getActiveMcpLoopbackRuntime();
@@ -462,6 +529,134 @@ describe("mcp loopback server", () => {
     expect(cronExecute).toHaveBeenCalledTimes(1);
     expect(payload.result?.isError).not.toBe(true);
     expect(payload.result?.content?.[0]?.text).toBe("CRON_EXECUTED");
+  });
+
+  it("calls healthy tools when an earlier loopback tool name is unreadable", async () => {
+    const messageExecute = vi.fn<MockGatewayTool["execute"]>(async () => ({
+      content: [{ type: "text", text: "MESSAGE_EXECUTED" }],
+    }));
+    const unreadableName = {
+      name: "fuzzplugin_unreadable_call",
+      description: "unreadable name",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({
+        content: [{ type: "text", text: "unreachable" }],
+      }),
+    } satisfies MockGatewayTool;
+    Object.defineProperty(unreadableName, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin loopback call name getter exploded");
+      },
+    });
+    resolveGatewayScopedToolsMock.mockReturnValue({
+      agentId: "main",
+      tools: [
+        unreadableName,
+        {
+          name: "message",
+          description: "send a message",
+          parameters: { type: "object", properties: {} },
+          execute: messageExecute,
+        },
+      ],
+    });
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: {
+        "content-type": "application/json",
+        "x-session-key": "agent:main:main",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "message", arguments: {} },
+      }),
+    });
+    const payload = (await response.json()) as {
+      result?: { content?: Array<{ text?: string }>; isError?: boolean };
+    };
+
+    expect(response.status).toBe(200);
+    expect(messageExecute).toHaveBeenCalledTimes(1);
+    expect(payload.result?.isError).not.toBe(true);
+    expect(payload.result?.content?.[0]?.text).toBe("MESSAGE_EXECUTED");
+  });
+
+  it("does not execute tools omitted from the loopback schema", async () => {
+    const hiddenExecute = vi.fn<MockGatewayTool["execute"]>(async () => ({
+      content: [{ type: "text", text: "hidden" }],
+    }));
+    const hiddenTool = {
+      name: "fuzzplugin_hidden",
+      description: "hidden by malformed schema",
+      parameters: { type: "object", properties: {} },
+      execute: hiddenExecute,
+    } satisfies MockGatewayTool;
+    Object.defineProperty(hiddenTool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin loopback parameters getter exploded");
+      },
+    });
+    resolveGatewayScopedToolsMock.mockReturnValue({
+      agentId: "main",
+      tools: [
+        hiddenTool,
+        {
+          name: "mockplugin_visible",
+          description: "visible",
+          parameters: { type: "object", properties: {} },
+          execute: async () => ({
+            content: [{ type: "text", text: "visible" }],
+          }),
+        },
+      ],
+    });
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+
+    const listResponse = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: {
+        "content-type": "application/json",
+        "x-session-key": "agent:main:main",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    const listed = (await listResponse.json()) as {
+      result?: { tools?: Array<{ name: string }> };
+    };
+    expect((listed.result?.tools ?? []).map((tool) => tool.name)).toEqual(["mockplugin_visible"]);
+
+    const callResponse = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: {
+        "content-type": "application/json",
+        "x-session-key": "agent:main:main",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "fuzzplugin_hidden", arguments: {} },
+      }),
+    });
+    const payload = (await callResponse.json()) as {
+      result?: { content?: Array<{ text?: string }>; isError?: boolean };
+    };
+
+    expect(callResponse.status).toBe(200);
+    expect(hiddenExecute).not.toHaveBeenCalled();
+    expect(payload.result?.isError).toBe(true);
+    expect(payload.result?.content?.[0]?.text).toBe("Tool not available: fuzzplugin_hidden");
   });
 
   it("honors before-tool-call hook blocks before loopback tool execution", async () => {


### PR DESCRIPTION
## Summary

- hardens MCP loopback tool schema generation so unreadable tool metadata is omitted instead of breaking `tools/list`
- keeps `tools/call` aligned with the advertised schema so omitted tools cannot be executed by name
- preserves healthy loopback tools when a malformed sibling appears earlier in the tool list

## Verification

- `node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts --reporter=verbose` passed 1 shard / 23 tests
- `./node_modules/.bin/oxfmt --check src/gateway/mcp-http.handlers.ts src/gateway/mcp-http.schema.ts src/gateway/mcp-http.test.ts` passed
- `node scripts/run-oxlint.mjs src/gateway/mcp-http.handlers.ts src/gateway/mcp-http.schema.ts src/gateway/mcp-http.test.ts` passed
- `git diff --check origin/main...HEAD` passed
- added-line private-name scrub returned no `dofbot` / `doftbot` matches
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed clean, overall 0.84
- AWS Crabbox `run_108d0702c2de`, lease `cbx_a44f2a6c53ee`, slug `pearl-hermit`, provider `aws`, type `c7a.8xlarge`: `pnpm check:changed` passed; lease cleaned up
- post-gate rebase onto `origin/main` completed cleanly at `ddadd8e359b`; diff stayed 3 files (+308/-18), `node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts --reporter=verbose` passed 23 tests, `oxfmt`, `oxlint`, `git diff --check`, and private-name scrub stayed clean

## Real behavior proof

Behavior addressed: malformed MCP loopback tool metadata no longer breaks schema listing or makes hidden tools callable.

Real environment tested: local gateway Vitest through `scripts/run-vitest.mjs`; remote Linux AWS Crabbox `c7a.8xlarge` changed gate.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts --reporter=verbose`; `pnpm check:changed` on AWS Crabbox run `run_108d0702c2de`.

Evidence after fix: targeted gateway test passed 23 tests, including unreadable tool-name and omitted-schema call-path coverage; remote `pnpm check:changed` selected `core` and `coreTests` and exited 0.

Observed result after fix: healthy tools remain listed/callable, unreadable or omitted tools are skipped and return `Tool not available` instead of executing.

What was not tested: full repo-wide test suite; this PR is scoped to the gateway MCP loopback surface and changed-gate coverage.

