### PR TITLE
fix: restore speech core runtime surface

### DIFF
--- a/extensions/speech-core/api.ts
+++ b/extensions/speech-core/api.ts
@@ -1,0 +1,1 @@
+export * from "../../packages/speech-core/api.js";

--- a/extensions/speech-core/runtime-api.ts
+++ b/extensions/speech-core/runtime-api.ts
@@ -1,0 +1,1 @@
+export * from "../../packages/speech-core/runtime-api.js";

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -14,6 +14,7 @@ const EXCLUDED_CORE_BUNDLED_PLUGIN_DIRS = new Set(["qqbot", "whatsapp"]);
 const BUNDLED_PLUGIN_BUILD_IDS_ENV = "OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS";
 const TOP_LEVEL_PRIVATE_TEST_SURFACE_RE =
   /(?:^|[._-])(?:test|spec|test-support|test-helpers|test-fixtures|test-harness|mock-setup)(?:[._-]|$)/u;
+const MANIFESTLESS_CORE_RUNTIME_SUPPORT_DIRS = new Set(["speech-core"]);
 const toPosixPath = (value) => value.replaceAll("\\", "/");
 
 function parseBundledPluginBuildIdFilter(env = process.env) {
@@ -41,6 +42,9 @@ function readBundledPluginPackageJson(packageJsonPath, options = {}) {
 }
 
 function isManifestlessBundledRuntimeSupportPackage(params) {
+  if (MANIFESTLESS_CORE_RUNTIME_SUPPORT_DIRS.has(params.dirName)) {
+    return params.topLevelPublicSurfaceEntries.length > 0;
+  }
   if (params.packageJson?.openclaw?.release?.publishToNpm === true) {
     return false;
   }

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -52,6 +52,8 @@ describe("bundled plugin build entries", () => {
         "extensions/image-generation-core/runtime-api.ts",
       "extensions/media-understanding-core/runtime-api":
         "extensions/media-understanding-core/runtime-api.ts",
+      "extensions/speech-core/api": "extensions/speech-core/api.ts",
+      "extensions/speech-core/runtime-api": "extensions/speech-core/runtime-api.ts",
     };
 
     expect(pickEntries(entries, Object.keys(expectedEntries))).toStrictEqual(expectedEntries);
@@ -140,6 +142,9 @@ describe("bundled plugin build entries", () => {
     expect(artifacts).not.toContain(
       "dist/extensions/media-understanding-core/openclaw.plugin.json",
     );
+    expect(artifacts).toContain("dist/extensions/speech-core/api.js");
+    expect(artifacts).toContain("dist/extensions/speech-core/runtime-api.js");
+    expect(artifacts).not.toContain("dist/extensions/speech-core/openclaw.plugin.json");
   });
 
   it("packs the Matrix packaged runtime shim", () => {


### PR DESCRIPTION
## Summary
- add bundled `extensions/speech-core` public surface shims for `api` and `runtime-api`
- teach the bundled plugin build entry collector to include `speech-core` as a manifest-less runtime support package
- cover the expected build entries and npm pack artifacts in the bundled plugin build entries test

## Root cause
`@openclaw/speech-core` exposes `runtime-api` through the plugin SDK package, but the root package build did not emit the matching bundled plugin public surface at `dist/extensions/speech-core/runtime-api.js`. Runtime resolution paths that load bundled plugin public surfaces by extension id can therefore fail with `Unable to resolve bundled plugin public surface speech-core/runtime-api.js`.

## Validation
- `node -e 'import("./scripts/lib/bundled-plugin-build-entries.mjs").then(...)'` verified the `speech-core` build entries and pack artifacts are present without a plugin manifest artifact.
