### PR TITLE
fix(infra): prioritize lock files over package.json for package manager detection

### DIFF
--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -17,14 +17,38 @@ async function withPackageManagerRoot<T>(
 }
 
 describe("detectPackageManager", () => {
-  it("prefers packageManager from package.json when supported", async () => {
+  it("prefers lock files over package.json packageManager field", async () => {
+    // package.json says pnpm, but an npm lock file is present → npm wins.
+    // This protects npm global installs of pnpm-authored packages.
     await withPackageManagerRoot(
       [
         { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@10.8.1" }) },
         { path: "package-lock.json", content: "" },
       ],
       async (root) => {
-        await expect(detectPackageManager(root)).resolves.toBe("pnpm");
+        await expect(detectPackageManager(root)).resolves.toBe("npm");
+      },
+    );
+  });
+
+  it("detects npm from npm-shrinkwrap.json without package-lock.json", async () => {
+    // npm global installs produce npm-shrinkwrap.json but not package-lock.json.
+    await withPackageManagerRoot(
+      [
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@11.2.2" }) },
+        { path: "npm-shrinkwrap.json", content: "" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("npm");
+      },
+    );
+  });
+
+  it("falls back to package.json when no lock file exists", async () => {
+    await withPackageManagerRoot(
+      [{ path: "package.json", content: JSON.stringify({ packageManager: "bun@1.2.0" }) }],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("bun");
       },
     );
   });
@@ -41,14 +65,11 @@ describe("detectPackageManager", () => {
       expected: "bun",
     },
     {
-      name: "falls back to npm lockfiles for unsupported packageManager values",
-      files: [
-        { path: "package.json", content: JSON.stringify({ packageManager: "yarn@4.0.0" }) },
-        { path: "package-lock.json", content: "" },
-      ],
+      name: "detects npm from package-lock.json",
+      files: [{ path: "package-lock.json", content: "" }],
       expected: "npm",
     },
-  ])("falls back to lockfiles when $name", async ({ files, expected }) => {
+  ])("detects package manager from $name", async ({ files, expected }) => {
     await withPackageManagerRoot(files, async (root) => {
       await expect(detectPackageManager(root)).resolves.toBe(expected);
     });

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -3,21 +3,35 @@ import { readPackageManagerSpec } from "./package-json.js";
 
 type DetectedPackageManager = "pnpm" | "bun" | "npm";
 
+/**
+ * Lock files that serve as ground-truth evidence of the package manager
+ * actually used to install the package.  npm global installs ship
+ * `npm-shrinkwrap.json` rather than `package-lock.json`, so both must be
+ * recognised.
+ */
+const LOCK_FILE_MANAGERS: Array<{ files: readonly string[]; manager: DetectedPackageManager }> = [
+  { files: ["pnpm-lock.yaml"], manager: "pnpm" },
+  { files: ["bun.lock", "bun.lockb"], manager: "bun" },
+  { files: ["package-lock.json", "npm-shrinkwrap.json"], manager: "npm" },
+];
+
 export async function detectPackageManager(root: string): Promise<DetectedPackageManager | null> {
+  // 1. Lock files are the ground truth — they prove what package manager
+  //    was actually used to install.  Check them first so that an npm
+  //    global install of a pnpm-authored package (whose package.json
+  //    carries "packageManager": "pnpm") still reports "npm".
+  const entries = await fs.readdir(root).catch((): string[] => []);
+  for (const { files, manager } of LOCK_FILE_MANAGERS) {
+    if (files.some((f) => entries.includes(f))) {
+      return manager;
+    }
+  }
+
+  // 2. No lock file — fall back to the package.json declaration.
   const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (pm === "pnpm" || pm === "bun" || pm === "npm") {
     return pm;
   }
 
-  const files = await fs.readdir(root).catch((): string[] => []);
-  if (files.includes("pnpm-lock.yaml")) {
-    return "pnpm";
-  }
-  if (files.includes("bun.lock") || files.includes("bun.lockb")) {
-    return "bun";
-  }
-  if (files.includes("package-lock.json")) {
-    return "npm";
-  }
   return null;
 }


### PR DESCRIPTION
## Summary

- **Problem**: On npm global installs of OpenClaw (a pnpm monorepo), `openclaw status` reports `packageManager: "pnpm"` and looks for `pnpm-lock.yaml` even though the actual install used npm. Issue #87732.
- **Root Cause**: `detectPackageManager()` reads `package.json`'s `packageManager: "pnpm@11.2.2"` first and returns immediately, so lock-file detection is dead code.
- **Fix**: Reverse priority: check lock files first (ground truth), then fall back to `package.json`. Add `npm-shrinkwrap.json`.
- **What changed**: `src/infra/detect-package-manager.ts` (refactored to lock-file-first order + new npm-shrinkwrap entry) and `src/infra/detect-package-manager.test.ts` (updated expectations, new tests).
- **What did NOT change**: Supported managers, `readPackageManagerSpec` helper, no config/doctor/gateway/SDK changes.

## Real behavior proof

- **Behavior addressed**: On a real Raspberry Pi (Debian 13, arm64, Node 22.22.2) running OpenClaw 2026.5.27 installed via `npm install -g`, the command `openclaw status --json | jq .packageManager` returned `"pnpm"` and `deps.lockfilePath` pointed at a nonexistent `pnpm-lock.yaml`. The npm global install root contained `npm-shrinkwrap.json` but no pnpm artifacts, proving the detection was wrong.
- **Real environment tested**: Reporter's Pi (verbatim logs in #87732). Reproduced on Windows 11 / Node 24.16.0 by creating a temp directory with the reporter's exact file layout: `package.json` containing `"packageManager": "pnpm@11.2.2"` and `npm-shrinkwrap.json` on disk.
- **Exact steps or command run after this patch**: Created a temp directory matching the reporter's npm-global install, then executed the before-fix and after-fix detection logic via `node -e` against that real filesystem. The script read the directory, applied each logic path, and printed results to stdout.
- **Evidence after fix**: Real stdout from the `node -e` simulation on Windows 11 / Node 24.16.0:

```
=== Reporter Scenario: npm global install ===
Result BEFORE fix (main): "pnpm" (from package.json, WRONG)
Result AFTER fix (this PR): "npm" (from npm-shrinkwrap.json, CORRECT)
```

The before-fix path read `package.json`'s `packageManager: pnpm@11.2.2` and returned `"pnpm"` without ever checking lock files. The after-fix path read the directory, found `npm-shrinkwrap.json`, and returned `"npm"` — matching the actual package manager used.

- **Observed result after fix**: npm global install (has `npm-shrinkwrap.json`) returns `"npm"`. pnpm install (has `pnpm-lock.yaml`) returns `"pnpm"`. bun install (has `bun.lock`) returns `"bun"`. No lock file falls back to `package.json` — preserving behavior for development checkouts.
- **What was not tested**: A live `npm install -g openclaw && openclaw status` cycle on physical Pi hardware was not re-executed. The fix targets a single 53-line deterministic filesystem function; the real file-system simulation plus 6 unit tests cover all combinations.

Fixes #87732
