### PR TITLE
fix #81214: [Bug]: OpenClaw 2026.5.7 subagent regression

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -91,7 +91,7 @@ For the bundled non-ACP Codex harness, OpenClaw applies the same lifecycle by pr
 OpenClaw calls two optional subagent lifecycle hooks:
 
 <ParamField path="prepareSubagentSpawn" type="method">
-  Prepare shared context state before a child run starts. The hook receives parent/child session keys, `contextMode` (`isolated` or `fork`), available transcript ids/files, and optional TTL. If it returns a rollback handle, OpenClaw calls it when spawn fails after preparation succeeds.
+  Prepare shared context state before a child run starts. The hook receives parent/child session keys, `contextMode` (`isolated` or `fork`), available transcript ids/files, and optional TTL. If it returns a rollback handle, OpenClaw calls it when spawn fails after preparation succeeds. Native subagent spawns that request `lightContext` and resolve to `contextMode="isolated"` intentionally skip this hook so the child starts from the lightweight bootstrap context without context-engine-managed pre-spawn state.
 </ParamField>
 <ParamField path="onSubagentEnded" type="method">
   Clean up when a subagent session completes or is swept.

--- a/src/agents/subagent-spawn.context.test.ts
+++ b/src/agents/subagent-spawn.context.test.ts
@@ -154,6 +154,28 @@ describe("sessions_spawn context modes", () => {
     expect(prepareContext.contextMode).toBe("isolated");
   });
 
+  it("keeps lightContext isolated spawns out of context-engine preparation", async () => {
+    const store: SessionStore = {
+      main: { sessionId: "parent-session-id", updatedAt: 1 },
+    };
+    usePersistentStoreMock(store);
+    const prepareSubagentSpawn = vi.fn(async () => undefined);
+    resolveContextEngineMock.mockResolvedValue({ prepareSubagentSpawn });
+
+    const result = await spawnSubagentDirect(
+      { task: "clean worker", context: "isolated", lightContext: true },
+      { agentSessionKey: "main" },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(forkSessionFromParentMock).not.toHaveBeenCalled();
+    expect(ensureContextEnginesInitializedMock).not.toHaveBeenCalled();
+    expect(resolveContextEngineMock).not.toHaveBeenCalled();
+    expect(prepareSubagentSpawn).not.toHaveBeenCalled();
+    const agentRequest = requireGatewayRequest("agent");
+    expect(agentRequest.params?.bootstrapContextMode).toBe("lightweight");
+  });
+
   it("caps oversized context engine subagent TTLs at the timer-safe ceiling", async () => {
     const store: SessionStore = {
       main: { sessionId: "parent-session-id", updatedAt: 1 },

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1485,13 +1485,16 @@ export async function spawnSubagentDirect(
       childSessionKey,
     };
   }
-  const contextEnginePrepareResult = await prepareContextEngineSubagentSpawn({
-    cfg,
-    context: preparedSpawnContext,
-    requesterInternalKey,
-    childSessionKey,
-    runTimeoutSeconds,
-  });
+  const contextEnginePrepareResult =
+    params.lightContext && preparedSpawnContext.mode === "isolated"
+      ? ({ status: "ok", preparation: undefined } as const)
+      : await prepareContextEngineSubagentSpawn({
+          cfg,
+          context: preparedSpawnContext,
+          requesterInternalKey,
+          childSessionKey,
+          runTimeoutSeconds,
+        });
   if (contextEnginePrepareResult.status === "error") {
     await cleanupFailedSpawnBeforeAgentStart({
       childSessionKey,


### PR DESCRIPTION
## Summary
- Keep `context="isolated"` + `lightContext=true` native subagent spawns lightweight by skipping context-engine spawn preparation for that specific combination.
- Preserve the existing context-engine lifecycle for default isolated spawns and forked spawns.
- Add a focused regression test covering the lightweight isolated path.

Fixes #81214

## Root Cause
- **Root cause:** `spawnSubagentDirect` resolved `context="isolated"` without forking the requester transcript, but then still unconditionally called `prepareContextEngineSubagentSpawn`. That allowed context-engine preparation to run on lightweight isolated subagent starts, defeating the lightweight/isolated contract and enabling extra inherited context work before the child run.
- **Why this is root-cause fix:** The change removes the unconditional context-engine preparation only when both conditions that define the reported lightweight path are true: `lightContext=true` and the prepared spawn context is `isolated`. Default isolated spawns and forked spawns still call `prepareSubagentSpawn`, so the existing plugin-facing lifecycle remains intact outside the problematic lightweight path.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High
- **Patch quality notes:** Narrow conditional change with a regression test. The test asserts context-engine initialization/resolution/preparation is not reached for `lightContext + isolated`, while existing tests continue to cover default isolated and fork behavior.
- **Architecture / source-of-truth check:** This changes the pre-run model-consumed path, not a post-run mirror/projection. For lightweight isolated subagents, no context-engine preparation artifact is created before the child agent receives its prompt. Stored transcript and actual model input remain aligned because the child transcript is created by the same agent run that consumes the lightweight bootstrap prompt; no transcript is post-processed after execution. Raw vs transformed boundaries are unchanged for default isolated and forked spawns.

## Real behavior proof
- **Behavior or issue addressed:** `sessions_spawn` with `context="isolated"`, `lightContext=true`, `mode="run"` should start a lightweight child subagent without entering context-engine spawn preparation.
- **Real environment tested:** Local OpenClaw dev gateway from this worktree on Linux, using `deepseek/deepseek-chat` for the child subagent run.
- **Exact steps or command run after this patch:** Started the dev gateway, invoked the real `sessions_spawn` tool with `{ task: "Reply only with: OK", context: "isolated", lightContext: true, mode: "run", runTimeoutSeconds: 90 }`, then checked the child session store and transcript.
- **Evidence after fix:** `/media/vdc/code/ai/aispace/openclaw-issue-81214-evidence/after-direct-sessions-spawn-final.json` and `/media/vdc/code/ai/aispace/openclaw-issue-81214-evidence/after-runtime-proof-final.json`.
- **Observed result after fix:** Spawn was accepted with `resolvedProvider=deepseek`; the child session reached `status=done` in 1783ms and the transcript assistant message was exactly `OK`.
- **What was not tested:** I did not reproduce the reporter's distributed Ollama CPU spike because that multi-host Ollama setup is not available in this environment.

## Regression Test Plan
- **Target test file:** `src/agents/subagent-spawn.context.test.ts`
- `node scripts/test-projects.mjs src/agents/subagent-spawn.context.test.ts src/agents/subagent-spawn.workspace.test.ts src/agents/tools/sessions-spawn-tool.test.ts` — PASS, 3 files / 68 tests
- `pnpm check:test-types` — PASS
- `pnpm test:changed` — PASS, agents shard / 2 files / 18 tests
- `pnpm lint` — PASS
- `pnpm exec oxfmt --check --threads=1 src/agents/subagent-spawn.ts src/agents/subagent-spawn.context.test.ts` — PASS
