### PR TITLE
fix(agents): retry transient stale session locks

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -453,6 +453,48 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("retries when a stale lock report disappears before diagnostics", async () => {
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {
+        stdio: "ignore",
+      });
+      if (!owner.pid) {
+        throw new Error("missing lock owner pid");
+      }
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: owner.pid,
+          createdAt: new Date(Date.now() - 120_000).toISOString(),
+        }),
+        "utf8",
+      );
+
+      const originalReadFile = fs.readFile.bind(fs);
+      let lockReads = 0;
+      vi.spyOn(fs, "readFile").mockImplementation((async (filePath, options) => {
+        if (path.basename(String(filePath)) === path.basename(lockPath)) {
+          lockReads += 1;
+          if (lockReads === 3) {
+            await fs.rm(String(filePath), { force: true });
+            await fs.rm(lockPath, { force: true });
+            throw Object.assign(new Error("lock disappeared"), { code: "ENOENT" });
+          }
+        }
+        return await originalReadFile(filePath, options as never);
+      }) as typeof fs.readFile);
+
+      try {
+        const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500, staleMs: 10 });
+        await lock.release();
+        expect(lockReads).toBeGreaterThanOrEqual(3);
+        await expectPathMissing(lockPath);
+      } finally {
+        owner.kill("SIGTERM");
+      }
+    });
+  });
+
   it("watchdog releases stale in-process locks", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -598,6 +640,14 @@ describe("acquireSessionWriteLock", () => {
       timeoutMs: Number.POSITIVE_INFINITY,
       staleMs: 30 * 60 * 1000,
     });
+  });
+
+  it("preserves one acquire timeout budget across retries", () => {
+    expect(testing.resolveRemainingAcquireTimeoutMs(500, 1_000, 1_125)).toBe(375);
+    expect(testing.resolveRemainingAcquireTimeoutMs(500, 1_000, 1_500)).toBe(0);
+    expect(testing.resolveRemainingAcquireTimeoutMs(Number.POSITIVE_INFINITY, 1_000, 9_000)).toBe(
+      Number.POSITIVE_INFINITY,
+    );
   });
 
   it("uses resolved stale policy when cleaning stale lock files", async () => {

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -569,6 +569,55 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("retries when a stale lock report is replaced by a fresh payload-less lock", async () => {
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {
+        stdio: "ignore",
+      });
+      if (!owner.pid) {
+        throw new Error("missing lock owner pid");
+      }
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: owner.pid,
+          createdAt: new Date(Date.now() - 120_000).toISOString(),
+        }),
+        "utf8",
+      );
+
+      const originalReadFile = fs.readFile.bind(fs);
+      let lockReads = 0;
+      const readFileSpy = vi.spyOn(fs, "readFile").mockImplementation((async (
+        filePath,
+        options,
+      ) => {
+        const lockFilePath = readFilePathToString(filePath);
+        if (lockFilePath && path.basename(lockFilePath) === path.basename(lockPath)) {
+          lockReads += 1;
+          if (lockReads === 3) {
+            await fs.rm(lockFilePath, { force: true });
+            await fs.writeFile(lockFilePath, "", "utf8");
+            setTimeout(() => {
+              void fs.rm(lockFilePath, { force: true });
+            }, 10);
+          }
+        }
+        return await originalReadFile(filePath, options as never);
+      }) as typeof fs.readFile);
+
+      try {
+        const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 800, staleMs: 10 });
+        await lock.release();
+        expect(lockReads).toBeGreaterThanOrEqual(3);
+        await expectPathMissing(lockPath);
+      } finally {
+        readFileSpy.mockRestore();
+        owner.kill("SIGTERM");
+      }
+    });
+  });
+
   it("watchdog releases stale in-process locks", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { SessionWriteLockStaleError } from "./session-write-lock-error.js";
@@ -85,6 +86,19 @@ async function writeCurrentProcessLock(lockPath: string, extra?: Record<string, 
     }),
     "utf8",
   );
+}
+
+function readFilePathToString(filePath: Parameters<typeof fs.readFile>[0]): string | undefined {
+  if (typeof filePath === "string") {
+    return filePath;
+  }
+  if (Buffer.isBuffer(filePath)) {
+    return filePath.toString("utf8");
+  }
+  if (filePath instanceof URL) {
+    return fileURLToPath(filePath);
+  }
+  return undefined;
 }
 
 async function withSymlinkedSessionPaths(
@@ -472,11 +486,15 @@ describe("acquireSessionWriteLock", () => {
 
       const originalReadFile = fs.readFile.bind(fs);
       let lockReads = 0;
-      vi.spyOn(fs, "readFile").mockImplementation((async (filePath, options) => {
-        if (path.basename(String(filePath)) === path.basename(lockPath)) {
+      const readFileSpy = vi.spyOn(fs, "readFile").mockImplementation((async (
+        filePath,
+        options,
+      ) => {
+        const lockFilePath = readFilePathToString(filePath);
+        if (lockFilePath && path.basename(lockFilePath) === path.basename(lockPath)) {
           lockReads += 1;
           if (lockReads === 3) {
-            await fs.rm(String(filePath), { force: true });
+            await fs.rm(lockFilePath, { force: true });
             await fs.rm(lockPath, { force: true });
             throw Object.assign(new Error("lock disappeared"), { code: "ENOENT" });
           }
@@ -490,6 +508,62 @@ describe("acquireSessionWriteLock", () => {
         expect(lockReads).toBeGreaterThanOrEqual(3);
         await expectPathMissing(lockPath);
       } finally {
+        readFileSpy.mockRestore();
+        owner.kill("SIGTERM");
+      }
+    });
+  });
+
+  it("retries when a stale lock report is replaced before diagnostics", async () => {
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {
+        stdio: "ignore",
+      });
+      if (!owner.pid) {
+        throw new Error("missing lock owner pid");
+      }
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: owner.pid,
+          createdAt: new Date(Date.now() - 120_000).toISOString(),
+        }),
+        "utf8",
+      );
+
+      const originalReadFile = fs.readFile.bind(fs);
+      let lockReads = 0;
+      const readFileSpy = vi.spyOn(fs, "readFile").mockImplementation((async (
+        filePath,
+        options,
+      ) => {
+        const lockFilePath = readFilePathToString(filePath);
+        if (lockFilePath && path.basename(lockFilePath) === path.basename(lockPath)) {
+          lockReads += 1;
+          if (lockReads === 3) {
+            await fs.rm(lockFilePath, { force: true });
+            await fs.rm(lockPath, { force: true });
+            await fs.writeFile(
+              lockFilePath,
+              JSON.stringify({ pid: owner.pid, createdAt: new Date().toISOString() }),
+              "utf8",
+            );
+            setTimeout(() => {
+              void fs.rm(lockFilePath, { force: true });
+            }, 10);
+            throw Object.assign(new Error("lock disappeared"), { code: "ENOENT" });
+          }
+        }
+        return await originalReadFile(filePath, options as never);
+      }) as typeof fs.readFile);
+
+      try {
+        const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500, staleMs: 10 });
+        await lock.release();
+        expect(lockReads).toBeGreaterThanOrEqual(3);
+        await expectPathMissing(lockPath);
+      } finally {
+        readFileSpy.mockRestore();
         owner.kill("SIGTERM");
       }
     });

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -626,6 +626,41 @@ function resolveOrphanLockPayloadGraceMs(timeoutMs: number): number {
   return ORPHAN_LOCK_PAYLOAD_GRACE_MS;
 }
 
+function resolveRemainingAcquireTimeoutMs(
+  timeoutMs: number,
+  startedAtMs: number,
+  nowMs: number,
+): number {
+  if (timeoutMs === Number.POSITIVE_INFINITY) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const elapsedMs = Math.max(0, nowMs - startedAtMs);
+  return Math.max(0, timeoutMs - elapsedMs);
+}
+
+async function lockFileExists(lockPath: string): Promise<boolean> {
+  try {
+    await fs.access(lockPath);
+    return true;
+  } catch (error) {
+    const code = (error as { code?: string } | null)?.code;
+    if (code === "ENOENT") {
+      return false;
+    }
+    return true;
+  }
+}
+
+async function shouldRetryStaleAcquireFailure(params: {
+  lockPath: string;
+  inspected: LockInspectionDetails;
+}): Promise<boolean> {
+  if (!(await lockFileExists(params.lockPath))) {
+    return true;
+  }
+  return !params.inspected.stale;
+}
+
 async function shouldRemoveLockDuringCleanup(
   lockPath: string,
   details: LockInspectionDetails,
@@ -845,12 +880,30 @@ export async function acquireSessionWriteLock(params: {
   const normalizedSessionFile = await resolveNormalizedSessionFile(sessionFile);
   const lockPath = `${normalizedSessionFile}.lock`;
   await fs.mkdir(sessionDir, { recursive: true });
+  const startedAtMs = Date.now();
 
   while (true) {
+    const remainingTimeoutMs = resolveRemainingAcquireTimeoutMs(timeoutMs, startedAtMs, Date.now());
+    if (remainingTimeoutMs <= 0) {
+      const payload = await readLockPayload(lockPath);
+      const nowMs = Date.now();
+      const heldByThisProcess = sessionLockHeldByThisProcess(normalizedSessionFile);
+      const inspected = inspectLockPayloadForSession({
+        payload,
+        staleMs,
+        nowMs,
+        heldByThisProcess,
+        reclaimLockWithoutStarttime: true,
+        readOwnerProcessArgs: readProcessArgsSync,
+        respectMaxHold: !heldByThisProcess,
+      });
+      const owner = describeLockOwnerForError({ payload, inspected });
+      throw new SessionWriteLockTimeoutError({ timeoutMs, owner, lockPath });
+    }
     try {
       const lock = await SESSION_LOCKS.acquire(sessionFile, {
         staleMs,
-        timeoutMs,
+        timeoutMs: remainingTimeoutMs,
         retry: { minTimeout: 50, maxTimeout: 1000, factor: 1 },
         staleRecovery: "remove-if-unchanged",
         allowReentrant,
@@ -928,6 +981,15 @@ export async function acquireSessionWriteLock(params: {
       });
       const owner = describeLockOwnerForError({ payload, inspected });
       if (isFileLockError(err, "file_lock_stale")) {
+        if (
+          resolveRemainingAcquireTimeoutMs(timeoutMs, startedAtMs, Date.now()) > 0 &&
+          (await shouldRetryStaleAcquireFailure({
+            lockPath: errorLockPath,
+            inspected,
+          }))
+        ) {
+          continue;
+        }
         throw new SessionWriteLockStaleError({
           owner,
           lockPath: errorLockPath,
@@ -945,6 +1007,7 @@ export const testing = {
   inspectLockPayloadForTest: inspectLockPayload,
   releaseAllLocksSync,
   runLockWatchdogCheck,
+  resolveRemainingAcquireTimeoutMs,
   setProcessStartTimeResolverForTest(resolver: ((pid: number) => number | null) | null): void {
     resolveProcessStartTimeForLock = resolver ?? getProcessStartTime;
   },

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -654,14 +654,26 @@ function resolveRemainingAcquireTimeoutMs(
   return Math.max(0, timeoutMs - elapsedMs);
 }
 
-function shouldRetryStaleAcquireFailure(params: {
+async function shouldRetryStaleAcquireFailure(params: {
+  lockPath: string;
   lockMissingAtDiagnostics: boolean;
   inspected: LockInspectionDetails;
-}): boolean {
+  heldByThisProcess: boolean;
+  staleMs: number;
+  nowMs: number;
+  orphanPayloadGraceMs: number;
+}): Promise<boolean> {
   if (params.lockMissingAtDiagnostics) {
     return true;
   }
-  return !params.inspected.stale;
+  return !(await shouldReportContendedLockStale({
+    lockPath: params.lockPath,
+    details: params.inspected,
+    heldByThisProcess: params.heldByThisProcess,
+    staleMs: params.staleMs,
+    nowMs: params.nowMs,
+    orphanPayloadGraceMs: params.orphanPayloadGraceMs,
+  }));
 }
 
 async function shouldRemoveLockDuringCleanup(
@@ -987,10 +999,15 @@ export async function acquireSessionWriteLock(params: {
       if (isFileLockError(err, "file_lock_stale")) {
         if (
           resolveRemainingAcquireTimeoutMs(timeoutMs, startedAtMs, Date.now()) > 0 &&
-          shouldRetryStaleAcquireFailure({
+          (await shouldRetryStaleAcquireFailure({
+            lockPath: errorLockPath,
             lockMissingAtDiagnostics,
             inspected,
-          })
+            heldByThisProcess,
+            staleMs,
+            nowMs,
+            orphanPayloadGraceMs,
+          }))
         ) {
           continue;
         }

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -389,26 +389,42 @@ function unregisterCleanupHandlers(): void {
   cleanupState.registered = false;
 }
 
+function parseLockPayload(raw: string): LockFilePayload | null {
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  const payload: LockFilePayload = {};
+  if (isValidLockNumber(parsed.pid) && parsed.pid > 0) {
+    payload.pid = parsed.pid;
+  }
+  if (typeof parsed.createdAt === "string") {
+    payload.createdAt = parsed.createdAt;
+  }
+  if (isValidLockNumber(parsed.starttime)) {
+    payload.starttime = parsed.starttime;
+  }
+  if (isValidLockNumber(parsed.maxHoldMs) && parsed.maxHoldMs > 0) {
+    payload.maxHoldMs = parsed.maxHoldMs;
+  }
+  return payload;
+}
+
 async function readLockPayload(lockPath: string): Promise<LockFilePayload | null> {
   try {
     const raw = await fs.readFile(lockPath, "utf8");
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const payload: LockFilePayload = {};
-    if (isValidLockNumber(parsed.pid) && parsed.pid > 0) {
-      payload.pid = parsed.pid;
-    }
-    if (typeof parsed.createdAt === "string") {
-      payload.createdAt = parsed.createdAt;
-    }
-    if (isValidLockNumber(parsed.starttime)) {
-      payload.starttime = parsed.starttime;
-    }
-    if (isValidLockNumber(parsed.maxHoldMs) && parsed.maxHoldMs > 0) {
-      payload.maxHoldMs = parsed.maxHoldMs;
-    }
-    return payload;
+    return parseLockPayload(raw);
   } catch {
     return null;
+  }
+}
+
+async function readLockPayloadForDiagnostics(
+  lockPath: string,
+): Promise<{ payload: LockFilePayload | null; missing: boolean }> {
+  try {
+    const raw = await fs.readFile(lockPath, "utf8");
+    return { payload: parseLockPayload(raw), missing: false };
+  } catch (error) {
+    const code = (error as { code?: string } | null)?.code;
+    return { payload: null, missing: code === "ENOENT" };
   }
 }
 
@@ -638,24 +654,11 @@ function resolveRemainingAcquireTimeoutMs(
   return Math.max(0, timeoutMs - elapsedMs);
 }
 
-async function lockFileExists(lockPath: string): Promise<boolean> {
-  try {
-    await fs.access(lockPath);
-    return true;
-  } catch (error) {
-    const code = (error as { code?: string } | null)?.code;
-    if (code === "ENOENT") {
-      return false;
-    }
-    return true;
-  }
-}
-
-async function shouldRetryStaleAcquireFailure(params: {
-  lockPath: string;
+function shouldRetryStaleAcquireFailure(params: {
+  lockMissingAtDiagnostics: boolean;
   inspected: LockInspectionDetails;
-}): Promise<boolean> {
-  if (!(await lockFileExists(params.lockPath))) {
+}): boolean {
+  if (params.lockMissingAtDiagnostics) {
     return true;
   }
   return !params.inspected.stale;
@@ -967,7 +970,8 @@ export async function acquireSessionWriteLock(params: {
         throw err;
       }
       const errorLockPath = (err as { lockPath?: string }).lockPath ?? lockPath;
-      const payload = await readLockPayload(errorLockPath);
+      const { payload, missing: lockMissingAtDiagnostics } =
+        await readLockPayloadForDiagnostics(errorLockPath);
       const nowMs = Date.now();
       const heldByThisProcess = sessionLockHeldByThisProcess(normalizedSessionFile);
       const inspected = inspectLockPayloadForSession({
@@ -983,10 +987,10 @@ export async function acquireSessionWriteLock(params: {
       if (isFileLockError(err, "file_lock_stale")) {
         if (
           resolveRemainingAcquireTimeoutMs(timeoutMs, startedAtMs, Date.now()) > 0 &&
-          (await shouldRetryStaleAcquireFailure({
-            lockPath: errorLockPath,
+          shouldRetryStaleAcquireFailure({
+            lockMissingAtDiagnostics,
             inspected,
-          }))
+          })
         ) {
           continue;
         }


### PR DESCRIPTION
## Summary

Refs #87217.

Follow-up to #88658. Live OpenClaw-owned stale locks still surface as `SessionWriteLockStaleError`, but a stale report that is already gone or no longer stale by the time session-lock diagnostics run now retries inside the original acquire timeout budget.

This keeps the safe diagnostic policy for real live-owner contention while covering the transient parallel-tool race shape reported in #87217: the sidecar lock can disappear before an operator or caller can inspect it, a fresh valid replacement lock is no longer misclassified from the old stale report, and a fresh payload-less replacement lock uses the same mtime grace rule as normal contention.

No config, env, CLI, plugin API, or migration surface added.

## Verification

Behavior addressed: transient disappearing, valid-replaced, or fresh payload-less replaced stale session-lock reports can retry instead of failing the tool/session write, while still-present stale locks remain typed diagnostics.

Real environment tested: local OpenClaw source checkout on macOS, branch `fix/session-stale-transient-retry`, rebased on `origin/main` `e18099b8c3`, head `7e1663635a90`.

Exact steps or command run after this patch:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts -- --reporter=dot
pnpm tsgo:test:src
pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/session-write-lock.ts src/agents/session-write-lock.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:

```text
Test Files 1 passed (1)
Tests 53 passed (53)
pnpm tsgo:test:src passed
oxlint on touched files passed
git diff --check passed
autoreview clean: no accepted/actionable findings reported
```

Observed result after fix: the regression suite covers stale-lock disappearance, valid-payload replacement before diagnostics, and fresh payload-less replacement before diagnostics; all retry and acquire within the original timeout. Existing live-owned stale-lock coverage still expects `SessionWriteLockStaleError` and the lock file remains in place.

What was not tested: no live Telegram/Discord multi-tool production repro was available in this checkout; this is targeted source-level coverage for the reported transient sidecar race.
