### PR TITLE
fix(plugins): reuse current metadata snapshot in provider hot paths

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -283,6 +283,7 @@ vi.mock("../../../plugins/plugin-metadata-snapshot.js", () => ({
   isPluginMetadataSnapshotCompatible: () => true,
   listPluginOriginsFromMetadataSnapshot: () => new Map(),
   loadPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+  resolvePluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
 }));
 
 vi.mock("../../../trajectory/metadata.js", () => ({

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -16,7 +16,7 @@ import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
-import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { resolvePluginDiscoveryProvidersRuntime } from "./provider-discovery.runtime.js";
 import {
   clearProviderRuntimePluginCacheForTest,
@@ -902,7 +902,7 @@ export function resolveExternalAuthProfilesWithPlugins(params: {
 }): ProviderExternalAuthProfile[] {
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
   const env = params.env ?? process.env;
-  const { manifestRegistry } = loadPluginMetadataSnapshot({
+  const { manifestRegistry } = resolvePluginMetadataSnapshot({
     config: params.config ?? {},
     workspaceDir,
     env,

--- a/src/plugins/providers.runtime.consult-current-snapshot.test.ts
+++ b/src/plugins/providers.runtime.consult-current-snapshot.test.ts
@@ -14,11 +14,9 @@ import {
 } from "./plugin-metadata-snapshot.js";
 import { resetPluginRuntimeStateForTest } from "./runtime.js";
 
-// Mock the persisted-registry loaders so a direct disk load is observable as a
-// loader call. B2-core routes SITE A/B/C through the consult-first
-// resolvePluginMetadataSnapshot: when a compatible current snapshot is
-// registered, these loaders must not run; otherwise the fallback load keeps the
-// pre-existing behavior.
+// Mock the persisted-registry loaders so direct metadata loads are observable.
+// Provider hot paths should reuse a compatible current snapshot and only fall
+// back to the loader when no compatible lifecycle-owned snapshot exists.
 const loadPluginRegistrySnapshotWithMetadata = vi.hoisted(() => vi.fn());
 const loadPluginManifestRegistryForInstalledIndex = vi.hoisted(() => vi.fn());
 
@@ -139,7 +137,7 @@ describe("provider runtime consults the current plugin metadata snapshot", () =>
     resetPluginRuntimeStateForTest();
   });
 
-  describe("SITE A: isPluginProvidersLoadInFlight", () => {
+  describe("isPluginProvidersLoadInFlight", () => {
     it("reuses a compatible current snapshot without a direct disk load", () => {
       const config: OpenClawConfig = {};
       registerCurrentSnapshot(config);
@@ -185,7 +183,7 @@ describe("provider runtime consults the current plugin metadata snapshot", () =>
     });
   });
 
-  describe("SITE B: resolvePluginProviders", () => {
+  describe("resolvePluginProviders", () => {
     it("reuses a compatible current snapshot without a direct disk load", () => {
       const config: OpenClawConfig = {};
       registerCurrentSnapshot(config);
@@ -220,7 +218,7 @@ describe("provider runtime consults the current plugin metadata snapshot", () =>
     });
   });
 
-  describe("SITE C: resolveExternalAuthProfilesWithPlugins", () => {
+  describe("resolveExternalAuthProfilesWithPlugins", () => {
     it("reuses a compatible current snapshot without a direct disk load", () => {
       const config: OpenClawConfig = {};
       registerCurrentSnapshot(config);

--- a/src/plugins/providers.runtime.consult-current-snapshot.test.ts
+++ b/src/plugins/providers.runtime.consult-current-snapshot.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  clearCurrentPluginMetadataSnapshot,
+  setCurrentPluginMetadataSnapshot,
+} from "./current-plugin-metadata-snapshot.js";
+import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import {
+  clearLoadPluginMetadataSnapshotMemo,
+  loadPluginMetadataSnapshot,
+} from "./plugin-metadata-snapshot.js";
+import { resetPluginRuntimeStateForTest } from "./runtime.js";
+
+// Mock the persisted-registry loaders so a direct disk load is observable as a
+// loader call. B2-core routes SITE A/B/C through the consult-first
+// resolvePluginMetadataSnapshot: when a compatible current snapshot is
+// registered, these loaders must not run; otherwise the fallback load keeps the
+// pre-existing behavior.
+const loadPluginRegistrySnapshotWithMetadata = vi.hoisted(() => vi.fn());
+const loadPluginManifestRegistryForInstalledIndex = vi.hoisted(() => vi.fn());
+
+vi.mock("./plugin-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./plugin-registry.js")>();
+  return {
+    ...actual,
+    loadPluginRegistrySnapshotWithMetadata: (params: unknown) =>
+      loadPluginRegistrySnapshotWithMetadata(params),
+  };
+});
+
+vi.mock("./manifest-registry-installed.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./manifest-registry-installed.js")>();
+  return {
+    ...actual,
+    loadPluginManifestRegistryForInstalledIndex: (params: unknown) =>
+      loadPluginManifestRegistryForInstalledIndex(params),
+  };
+});
+
+import { resolveExternalAuthProfilesWithPlugins } from "./provider-runtime.js";
+import { isPluginProvidersLoadInFlight, resolvePluginProviders } from "./providers.runtime.js";
+
+const WORKSPACE = "/workspace/a";
+
+function makeIndex(pluginId = "demo"): InstalledPluginIndex {
+  const rootDir = `/plugins/${pluginId}`;
+  return {
+    version: 1,
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "test",
+    generatedAtMs: 1,
+    installRecords: {},
+    diagnostics: [],
+    plugins: [
+      {
+        pluginId,
+        manifestPath: `${rootDir}/openclaw.plugin.json`,
+        manifestHash: `${pluginId}-manifest`,
+        rootDir,
+        origin: "global",
+        enabled: true,
+        startup: {
+          sidecar: false,
+          memory: false,
+          deferConfiguredChannelFullLoadUntilAfterListen: false,
+          agentHarnesses: [],
+        },
+        compat: [],
+      },
+    ],
+  };
+}
+
+function makeManifestRegistry(pluginId = "demo"): PluginManifestRegistry {
+  const plugin: PluginManifestRecord = {
+    id: pluginId,
+    name: pluginId,
+    channels: [],
+    providers: [pluginId],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    commandAliases: [],
+    rootDir: `/plugins/${pluginId}`,
+    source: `/plugins/${pluginId}/index.js`,
+    manifestPath: `/plugins/${pluginId}/openclaw.plugin.json`,
+    origin: "global",
+  };
+  return { plugins: [plugin], diagnostics: [] };
+}
+
+// Build a snapshot from a provided index (no disk) and register it as the
+// process-current snapshot, then clear the loader spies so later assertions only
+// see calls triggered by the function under test.
+function registerCurrentSnapshot(config: OpenClawConfig, workspaceDir = WORKSPACE) {
+  const index = makeIndex();
+  index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
+  loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+    source: "runtime",
+    snapshot: index,
+    diagnostics: [],
+  });
+  const snapshot = loadPluginMetadataSnapshot({ config, env: {}, index, workspaceDir });
+  setCurrentPluginMetadataSnapshot(snapshot, { config, env: {}, workspaceDir });
+  loadPluginRegistrySnapshotWithMetadata.mockClear();
+  loadPluginManifestRegistryForInstalledIndex.mockClear();
+  return snapshot;
+}
+
+// Arm the loaders so a fallback disk load resolves to a usable snapshot.
+function armFallbackLoad() {
+  loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+    source: "runtime",
+    snapshot: makeIndex(),
+    diagnostics: [],
+  });
+}
+
+describe("provider runtime consults the current plugin metadata snapshot", () => {
+  beforeEach(() => {
+    resetPluginRuntimeStateForTest();
+    clearPluginMetadataLifecycleCaches();
+    clearLoadPluginMetadataSnapshotMemo();
+    clearCurrentPluginMetadataSnapshot();
+    loadPluginRegistrySnapshotWithMetadata.mockReset();
+    loadPluginManifestRegistryForInstalledIndex.mockReset();
+    loadPluginManifestRegistryForInstalledIndex.mockReturnValue(makeManifestRegistry());
+  });
+
+  afterEach(() => {
+    clearCurrentPluginMetadataSnapshot();
+    clearPluginMetadataLifecycleCaches();
+    clearLoadPluginMetadataSnapshotMemo();
+    resetPluginRuntimeStateForTest();
+  });
+
+  describe("SITE A: isPluginProvidersLoadInFlight", () => {
+    it("reuses a compatible current snapshot without a direct disk load", () => {
+      const config: OpenClawConfig = {};
+      registerCurrentSnapshot(config);
+
+      isPluginProvidersLoadInFlight({ config, env: {}, workspaceDir: WORKSPACE });
+
+      expect(loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
+      expect(loadPluginManifestRegistryForInstalledIndex).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a direct disk load when no current snapshot is registered", () => {
+      armFallbackLoad();
+
+      isPluginProvidersLoadInFlight({ config: {}, env: {}, workspaceDir: WORKSPACE });
+
+      expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalled();
+    });
+
+    it("falls back to a direct disk load when the workspace does not match", () => {
+      registerCurrentSnapshot({}, WORKSPACE);
+      armFallbackLoad();
+
+      // allowWorkspaceScopedCurrent is intentionally not used, so a different
+      // workspace misses the current snapshot and reloads.
+      isPluginProvidersLoadInFlight({ config: {}, env: {}, workspaceDir: "/workspace/b" });
+
+      expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalled();
+    });
+
+    it("keeps setup/doctor behavior on the direct disk load when no snapshot exists", () => {
+      // Fresh setup/doctor CLI processes never register a current snapshot, so
+      // consult-first resolves to the same fallback disk load as before.
+      armFallbackLoad();
+
+      isPluginProvidersLoadInFlight({
+        config: {},
+        env: {},
+        workspaceDir: WORKSPACE,
+        mode: "setup",
+      });
+
+      expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalled();
+    });
+  });
+
+  describe("SITE B: resolvePluginProviders", () => {
+    it("reuses a compatible current snapshot without a direct disk load", () => {
+      const config: OpenClawConfig = {};
+      registerCurrentSnapshot(config);
+
+      // onlyPluginIds:[] short-circuits provider materialization after the
+      // snapshot is resolved, isolating the consult-first routing.
+      const providers = resolvePluginProviders({
+        config,
+        env: {},
+        workspaceDir: WORKSPACE,
+        mode: "runtime",
+        onlyPluginIds: [],
+      });
+
+      expect(providers).toEqual([]);
+      expect(loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
+      expect(loadPluginManifestRegistryForInstalledIndex).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a direct disk load when no current snapshot is registered", () => {
+      armFallbackLoad();
+
+      resolvePluginProviders({
+        config: {},
+        env: {},
+        workspaceDir: WORKSPACE,
+        mode: "runtime",
+        onlyPluginIds: [],
+      });
+
+      expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalled();
+    });
+  });
+
+  describe("SITE C: resolveExternalAuthProfilesWithPlugins", () => {
+    it("reuses a compatible current snapshot without a direct disk load", () => {
+      const config: OpenClawConfig = {};
+      registerCurrentSnapshot(config);
+
+      // The demo manifest declares no external-auth contracts, so resolution
+      // short-circuits to [] right after the snapshot is consulted.
+      const profiles = resolveExternalAuthProfilesWithPlugins({
+        config,
+        env: {},
+        workspaceDir: WORKSPACE,
+        context: { env: {}, store: { version: 1, profiles: {} } },
+      });
+
+      expect(profiles).toEqual([]);
+      expect(loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a direct disk load when no current snapshot is registered", () => {
+      armFallbackLoad();
+
+      resolveExternalAuthProfilesWithPlugins({
+        config: {},
+        env: {},
+        workspaceDir: WORKSPACE,
+        context: { env: {}, store: { version: 1, profiles: {} } },
+      });
+
+      expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -159,6 +159,24 @@ function resolvePluginProviderLoadBase(
   };
 }
 
+function resolveProviderMetadataLookup(params: {
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+  pluginMetadataSnapshot?: PluginMetadataRegistryView;
+}) {
+  const env = params.env ?? process.env;
+  const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
+  const snapshot =
+    params.pluginMetadataSnapshot ??
+    resolvePluginMetadataSnapshot({
+      config: params.config ?? {},
+      workspaceDir,
+      env,
+    });
+  return { env, workspaceDir, snapshot };
+}
+
 function resolveSetupProviderPluginLoadState(
   params: Parameters<typeof resolvePluginProviders>[0],
   base: ReturnType<typeof resolvePluginProviderLoadBase>,
@@ -290,15 +308,7 @@ function resolveRuntimeProviderPluginLoadState(
 export function isPluginProvidersLoadInFlight(
   params: Parameters<typeof resolvePluginProviders>[0],
 ): boolean {
-  const env = params.env ?? process.env;
-  const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
-  const snapshot =
-    params.pluginMetadataSnapshot ??
-    resolvePluginMetadataSnapshot({
-      config: params.config ?? {},
-      workspaceDir,
-      env,
-    });
+  const { env, workspaceDir, snapshot } = resolveProviderMetadataLookup(params);
   const base = resolvePluginProviderLoadBase({ ...params, workspaceDir, env }, snapshot);
   const loadState =
     params.mode === "setup"
@@ -327,15 +337,7 @@ export function resolvePluginProviders(params: {
   includeUntrustedWorkspacePlugins?: boolean;
   pluginMetadataSnapshot?: PluginMetadataRegistryView;
 }): ProviderPlugin[] {
-  const env = params.env ?? process.env;
-  const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
-  const snapshot =
-    params.pluginMetadataSnapshot ??
-    resolvePluginMetadataSnapshot({
-      config: params.config ?? {},
-      workspaceDir,
-      env,
-    });
+  const { env, workspaceDir, snapshot } = resolveProviderMetadataLookup(params);
   const base = resolvePluginProviderLoadBase({ ...params, workspaceDir, env }, snapshot);
   if (params.mode === "setup") {
     const loadState = resolveSetupProviderPluginLoadState(params, base, snapshot);

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -10,7 +10,7 @@ import {
   loadOpenClawPlugins,
   type PluginLoadOptions,
 } from "./loader.js";
-import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
 import { hasExplicitPluginIdScope } from "./plugin-scope.js";
 import { resolveProviderConfigApiOwnerHint } from "./provider-config-owner.js";
@@ -294,7 +294,7 @@ export function isPluginProvidersLoadInFlight(
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
   const snapshot =
     params.pluginMetadataSnapshot ??
-    loadPluginMetadataSnapshot({
+    resolvePluginMetadataSnapshot({
       config: params.config ?? {},
       workspaceDir,
       env,
@@ -331,7 +331,7 @@ export function resolvePluginProviders(params: {
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
   const snapshot =
     params.pluginMetadataSnapshot ??
-    loadPluginMetadataSnapshot({
+    resolvePluginMetadataSnapshot({
       config: params.config ?? {},
       workspaceDir,
       env,

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -509,15 +509,19 @@ describe("resolvePluginProviders", () => {
       loadPluginManifestRegistry: (...args: Parameters<LoadPluginManifestRegistry>) =>
         loadPluginManifestRegistryMock(...args),
     }));
-    vi.doMock("./plugin-metadata-snapshot.js", () => ({
-      loadPluginMetadataSnapshot: (params: Parameters<LoadPluginMetadataSnapshot>[0]) => {
+    vi.doMock("./plugin-metadata-snapshot.js", () => {
+      const loadSnapshot = (params: Parameters<LoadPluginMetadataSnapshot>[0]) => {
         loadPluginMetadataSnapshotMock(params);
         return {
           manifestRegistry: loadPluginManifestRegistryMock(),
           index: createProviderRegistrySnapshotFixture(),
         };
-      },
-    }));
+      };
+      return {
+        loadPluginMetadataSnapshot: loadSnapshot,
+        resolvePluginMetadataSnapshot: loadSnapshot,
+      };
+    });
     vi.doMock("./current-plugin-metadata-snapshot.js", () => ({
       getCurrentPluginMetadataSnapshot: (...args: unknown[]) =>
         getCurrentPluginMetadataSnapshotMock(...args),


### PR DESCRIPTION
## Summary

On the reply hot path, three provider-runtime call sites reload the plugin
metadata snapshot from disk on every call via `loadPluginMetadataSnapshot(...)`,
even though the gateway already owns a lifecycle-validated current snapshot. This
routes those three sites through the existing consult-first helper
`resolvePluginMetadataSnapshot(...)`, which returns the current snapshot when it is
compatible and otherwise falls back to the same direct load. No new cache, no new
parameters, and no behavior change when no compatible snapshot exists.

## Mechanism

`loadPluginMetadataSnapshot(...)` recomputes a freshness fingerprint
(`statSync`/`readdirSync` + control-plane hash) and emits a `plugins.metadata.scan`
span on every call, including memo hits. The reply path calls it from several
provider-runtime features per turn. `resolvePluginMetadataSnapshot(...)` first
consults `getCurrentPluginMetadataSnapshot(...)` (the single-slot, gateway-owned
current snapshot) and skips the load entirely when the snapshot is compatible,
matching the guidance that hot paths reuse current snapshots rather than poll
freshness.

## What changed

Three one-line swaps (`loadPluginMetadataSnapshot` → `resolvePluginMetadataSnapshot`)
plus the matching imports:

- `src/plugins/providers.runtime.ts` — `isPluginProvidersLoadInFlight`, `resolvePluginProviders`
- `src/plugins/provider-runtime.ts` — `resolveExternalAuthProfilesWithPlugins`

Plus a unit test (`src/plugins/providers.runtime.consult-current-snapshot.test.ts`).
5 production line changes across 2 files.

## Safety / correctness

`resolvePluginMetadataSnapshot(params)` falls back to `loadPluginMetadataSnapshot(params)`
whenever the current snapshot is absent or incompatible, so behavior is identical to
today when:

- no current snapshot is registered (cold start, re-bootstrap, tests, and fresh
  setup/doctor CLI processes — which never register a current snapshot);
- the config / policy / index fingerprint does not match;
- the workspace does not match — `allowWorkspaceScopedCurrent` is intentionally not
  used, so a workspace mismatch misses and reloads (no cross-workspace reuse).

Plugin install/uninstall/reload/doctor re-set the snapshot through the existing
lifecycle, so no new staleness window is introduced. No workspace-scoped snapshot
check is relaxed.

## Performance evidence

### ClawBench benchmark comparison — without PR vs with PR (probe evidence)

Probe/benchmark evidence, captured via the native diagnostics timeline (not plain
runtime proof). Same upstream base; the only difference between the two builds is
this diff. Single warm turn (`turn1`).

| metric (turn1) | without PR | with PR | delta |
|---|---|---|---|
| reply-path `plugins.metadata.scan` count | 28 | 6 | -22 (-79%) |
| reply-path `plugins.metadata.scan` ms | 163.9 | 94.1 | -69.8 ms |
| startup scans (out of scope) | 14 | 14 | 0 |
| end-to-end latency p50 (n=1) | 327 ms | 300 ms | -27 ms |

The scan **count** delta is structural (call routing) and matches the unit test; the
startup scans are unchanged, so the change is confined to the reply path. The
removed calls are the reply-path direct loads now served consult-first.

### Maintainer CPU profile after refactor

Local loop on the rebased/fixed PR head (132 plugin records, current snapshot registered):

| path | iterations | total | per call |
|---|---:|---:|---:|
| `loadPluginMetadataSnapshot` warm memo | 2000 | 262.987 ms | 131.493 us |
| `resolvePluginMetadataSnapshot` current | 2000 | 0.917 ms | 0.459 us |

Speedup: 286.48x for the metadata lookup loop. V8 CPU profile captured locally at `/tmp/openclaw-pr88672-profile/provider-metadata-loop.cpuprofile`; top samples in the direct-load phase were metadata memo/hash/fs helpers such as `hashJson`, `existsSync`, `createBundledPluginsDirCacheKey`, and `computePluginMetadataSnapshotMemoKey`.

### Limitations / confidence

- `turn1` only (one warm turn). Per-turn reply-path reduction recurs each turn, but a
  multi-turn steady-state figure is not measured here. No full-path total is claimed.
- End-to-end latency is a single sample (n=1) — directional, not the main claim.
- This is probe evidence and is kept separate from the plain runtime proof below.

## Real behavior proof

- Behavior addressed: provider-runtime reply/auth hot paths reuse a lifecycle-compatible current plugin metadata snapshot instead of doing a direct metadata load on each call.
- Real environment tested: local OpenClaw source checkout on PR head `728bd53510f`; current snapshot registered from the real plugin metadata snapshot for this checkout.
- Exact steps or command run after this patch: ran the focused provider hot-path regression test, embedded-agent mock regression test, provider runtime mock regression test, and an inspector CPU profiling loop comparing warm direct metadata loads with current-snapshot resolution.
- Evidence after fix: `resolvePluginMetadataSnapshot` current path returned the same 132-plugin snapshot as `loadPluginMetadataSnapshot`, while avoiding the metadata load path; tests verified all three changed call sites skip direct loader calls on compatible current snapshots and fall back on no-current/workspace-mismatch/setup paths.
- Observed result after fix: focused Vitest proof passed (8 + 2 + 59 tests), autoreview rerun reported no accepted/actionable findings, and the CPU profile/timing showed 2000 current-snapshot resolves at 0.917 ms total versus 262.987 ms for 2000 warm direct metadata loads.
- What was not tested: full GitHub CI is pending on the pushed PR head; `pnpm test:changed` was stopped locally after stalling behind a cross-checkout test lock before target output.

## Tests

Commands and results on the rebased/fixed PR branch:

- `node scripts/run-vitest.mjs src/plugins/providers.runtime.consult-current-snapshot.test.ts` -> 8 passed
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts` -> 2 passed
- `node scripts/run-vitest.mjs src/plugins/providers.test.ts` -> 59 passed
- `git diff --check` -> passed
- `pnpm exec oxfmt --check src/plugins/providers.runtime.ts src/plugins/providers.runtime.consult-current-snapshot.test.ts src/plugins/provider-runtime.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts` -> clean
- `agent-scripts autoreview helper --mode branch --base origin/main --prompt-file /tmp/pr88672-review-notes.md` -> clean, no accepted/actionable findings

CI will rerun from pushed head `728bd53510f`.

## Out of scope

- One-time channel handoff / restart scan artifact — not a steady reply cost.
- memory_flush (#85767), system-prompt / C9, and the Codex agent path — untouched.
- A param-threading variant of this change — not pursued (same steady effect, far
  larger surface).

## Risk / rollback

Low. Single-helper substitution at three sites; the fallback preserves prior behavior
on every miss / incompatible / cold path. Rollback = swap the helper back.

## Review notes

Completes the consult-first snapshot-reuse pattern for the provider-runtime /
external-auth reply callers that were not previously covered. No `CHANGELOG.md` entry
(release-owned).

