### PR TITLE
test(outbound): align implicit source reply sink

### DIFF
--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -228,7 +228,7 @@ describe("runMessageAction core send routing", () => {
     expect(payload.dryRun).toBe(true);
   });
 
-  it("uses best-effort delivery for implicit message-tool-only source replies", async () => {
+  it("uses the internal source sink for implicit message-tool-only source replies", async () => {
     const sendText = registerSlackTextPlugin();
 
     const result = await runMessageAction({
@@ -248,7 +248,20 @@ describe("runMessageAction core send routing", () => {
     });
 
     expect(result.kind).toBe("send");
-    expect(sendText).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      channel: "webchat",
+      to: "current-run",
+      handledBy: "internal-source",
+      payload: {
+        status: "ok",
+        sourceReplyDeliveryMode: "message_tool_only",
+        sourceReplySink: "internal-ui",
+        sourceReply: {
+          text: "visible source reply",
+        },
+      },
+    });
+    expect(sendText).not.toHaveBeenCalled();
   });
 
   it("uses best-effort delivery for explicit current-source message-tool-only replies", async () => {


### PR DESCRIPTION
## Summary

- Updates the current-main outbound routing test to expect the internal source sink for implicit `message_tool_only` source replies.
- Keeps explicit current-source sends covered by the following Slack plugin-delivery test.

## Verification

- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.core-send.test.ts --reporter=verbose`: passed, 8 tests.
- `./node_modules/.bin/oxfmt --check src/infra/outbound/message-action-runner.core-send.test.ts`: passed.
- `node scripts/run-oxlint.mjs src/infra/outbound/message-action-runner.core-send.test.ts`: passed.
- `git diff --check`: passed.
- `node scripts/changed-lanes.mjs --json`: selected only `coreTests`.
- `node scripts/check-changed.mjs --dry-run`: selected only `coreTests`.
- GitHub checks after ready-for-review: pass/skipped only, no pending/failing checks in the final poll.

## Real behavior proof

Behavior addressed: current main's CI expected implicit non-webchat `message_tool_only` source replies to call the Slack plugin send path, but the runtime now routes that implicit source reply through the internal source sink.

Real environment tested: local linked gwt worktree with the exact failing outbound test file.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.core-send.test.ts --reporter=verbose`; `./node_modules/.bin/oxfmt --check src/infra/outbound/message-action-runner.core-send.test.ts`; `node scripts/run-oxlint.mjs src/infra/outbound/message-action-runner.core-send.test.ts`; `git diff --check`; `node scripts/changed-lanes.mjs --json`; `node scripts/check-changed.mjs --dry-run`; `ghx pr checks 88673`.

Evidence after fix: the previously failing test file now passes 8/8, and GitHub checks are pass/skipped only.

Observed result after fix: the implicit source-reply test asserts `handledBy: "internal-source"`, `to: "current-run"`, and no Slack `sendText` call.

What was not tested: no broad local `pnpm check:changed`; this is a one-file test-only CI unblocker and GitHub PR checks covered the ready-for-review gate.
