### PR TITLE
docs(providers): register Ace Data Cloud third-party provider plugin

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -229,6 +229,10 @@
       "destination": "/providers/openrouter"
     },
     {
+      "source": "/acedatacloud",
+      "destination": "/providers/acedatacloud"
+    },
+    {
       "source": "/opencode",
       "destination": "/providers/opencode"
     },
@@ -1411,6 +1415,7 @@
               {
                 "group": "Providers",
                 "pages": [
+                  "providers/acedatacloud",
                   "providers/alibaba",
                   "providers/bedrock",
                   "providers/bedrock-mantle",

--- a/docs/providers/acedatacloud.md
+++ b/docs/providers/acedatacloud.md
@@ -1,0 +1,127 @@
+---
+summary: "Ace Data Cloud unified provider for chat + web search in OpenClaw"
+title: "Ace Data Cloud"
+read_when:
+  - You want one API key for 60+ LLMs across Claude / GPT / Gemini / Grok / DeepSeek / Kimi / GLM
+  - You want OpenClaw web search via Google SERP without a separate provider
+  - You want to use Ace Data Cloud as the default model provider
+---
+
+[Ace Data Cloud](https://platform.acedata.cloud) is a unified, OpenAI-compatible AI gateway. The `acedatacloud` plugin exposes its chat catalog (60+ curated models plus arbitrary upstream model-id passthrough) and its Google SERP web search through OpenClaw's standard provider contracts.
+
+| Property        | Value                                                                                              |
+| --------------- | -------------------------------------------------------------------------------------------------- |
+| Provider id     | `acedatacloud`                                                                                     |
+| Plugin package  | [`@acedatacloud/openclaw-provider`](https://www.npmjs.com/package/@acedatacloud/openclaw-provider) |
+| Auth env vars   | `ACEDATA_API_KEY`, `ACEDATACLOUD_API_KEY`                                                          |
+| Onboarding flag | `--auth-choice acedatacloud-api-key`                                                               |
+| Direct CLI flag | `--acedata-api-key <key>`                                                                          |
+| Endpoint        | `https://api.acedata.cloud/v1` (OpenAI-compatible)                                                 |
+| Web-search      | Google SERP (search, images, news, videos, maps, places)                                           |
+| Source          | <https://github.com/AceDataCloud/OpenClawProvider>                                                 |
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Create an API key at [platform.acedata.cloud](https://platform.acedata.cloud).
+  </Step>
+  <Step title="Install the plugin">
+    ```bash
+    openclaw plugins install '@acedatacloud/openclaw-provider'
+    openclaw gateway restart
+    ```
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice acedatacloud-api-key
+    ```
+  </Step>
+  <Step title="Set Ace Data Cloud as the default model provider">
+    ```bash
+    openclaw models set acedatacloud/claude-opus-4-8
+    ```
+  </Step>
+</Steps>
+
+## Config example
+
+```json5
+{
+  env: { ACEDATA_API_KEY: "ace-..." },
+  agents: {
+    defaults: {
+      model: { primary: "acedatacloud/claude-opus-4-8" },
+    },
+  },
+}
+```
+
+## Model references
+
+Model refs follow the pattern `acedatacloud/<model-name>`. The plugin ships with a curated catalog and also accepts arbitrary upstream model ids as a passthrough — anything Ace Data Cloud lists at [docs.acedata.cloud/aichat/models](https://docs.acedata.cloud/aichat/models) is valid.
+
+Examples (all current as of 2026-05):
+
+| Model ref                                | Notes                              |
+| ---------------------------------------- | ---------------------------------- |
+| `acedatacloud/claude-opus-4-8`           | Anthropic Claude Opus 4.8 (latest) |
+| `acedatacloud/claude-sonnet-4-6`         | Anthropic Claude Sonnet 4.6        |
+| `acedatacloud/claude-haiku-4-5-20251001` | Anthropic Claude Haiku 4.5         |
+| `acedatacloud/gpt-5.2-pro`               | OpenAI GPT-5.2 Pro                 |
+| `acedatacloud/gpt-5.4-mini`              | OpenAI GPT-5.4 Mini                |
+| `acedatacloud/o4-mini`                   | OpenAI o4-mini reasoning           |
+| `acedatacloud/gemini-3.1-pro`            | Google Gemini 3.1 Pro              |
+| `acedatacloud/grok-4-1-fast`             | xAI Grok 4.1 Fast                  |
+| `acedatacloud/deepseek-v4-flash`         | DeepSeek V4 Flash                  |
+| `acedatacloud/kimi-k2.5`                 | Moonshot Kimi K2.5                 |
+| `acedatacloud/glm-5.1`                   | Zhipu GLM-5.1                      |
+
+## Web search
+
+The plugin also registers `acedatacloud` as a web-search provider. It reuses the chat API key and submits queries to `https://api.acedata.cloud/serp/google` across six verticals: `search`, `images`, `news`, `videos`, `maps`, `places`.
+
+```bash
+openclaw config set tools.web.search.provider acedatacloud
+openclaw config set tools.web.search.enabled true
+```
+
+Or override the search key independently:
+
+```json5
+{
+  plugins: {
+    entries: {
+      acedatacloud: {
+        config: {
+          webSearch: {
+            apiKey: "ace-...", // optional override
+            baseUrl: "https://api.acedata.cloud", // optional override
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+## Authentication
+
+The plugin reads credentials in this order:
+
+1. `models.providers.acedatacloud.apiKey` in `openclaw.json`
+2. `ACEDATA_API_KEY`
+3. `ACEDATACLOUD_API_KEY`
+
+All requests use `Authorization: Bearer <key>` against the Ace Data Cloud OpenAI-compatible endpoint.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Models concepts" href="/concepts/models" icon="brain">
+    How OpenClaw resolves model refs and provider selection.
+  </Card>
+  <Card title="Web search" href="/tools/web" icon="magnifying-glass">
+    The shared web-search tool contract used by Ace Data Cloud's SERP provider.
+  </Card>
+</CardGroup>

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -1062,6 +1062,63 @@
           "minHostVersion": ">=2026.6.8"
         }
       }
+    },
+    {
+      "name": "@acedatacloud/openclaw-provider",
+      "description": "Ace Data Cloud unified provider plugin (chat + web search via a single OpenAI-compatible endpoint)",
+      "source": "external",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "acedatacloud",
+          "label": "Ace Data Cloud"
+        },
+        "providers": [
+          {
+            "id": "acedatacloud",
+            "name": "Ace Data Cloud",
+            "docs": "/providers/acedatacloud",
+            "categories": ["cloud", "llm"],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "acedatacloud-api-key",
+                "choiceLabel": "Ace Data Cloud API key",
+                "choiceHint": "One key for 60+ LLMs plus Google web search.",
+                "groupId": "acedatacloud",
+                "groupLabel": "Ace Data Cloud",
+                "groupHint": "API key",
+                "optionKey": "acedataApiKey",
+                "cliFlag": "--acedata-api-key",
+                "cliOption": "--acedata-api-key <key>",
+                "cliDescription": "Ace Data Cloud API key (https://platform.acedata.cloud)",
+                "onboardingScopes": ["text-inference"]
+              }
+            ]
+          }
+        ],
+        "webSearchProviders": [
+          {
+            "id": "acedatacloud",
+            "label": "Ace Data Cloud (Google SERP)",
+            "hint": "Google search, images, news, videos, maps, places via Ace Data Cloud.",
+            "onboardingScopes": ["text-inference"],
+            "requiresCredential": true,
+            "credentialLabel": "Ace Data Cloud API key",
+            "envVars": ["ACEDATA_API_KEY", "ACEDATACLOUD_API_KEY"],
+            "placeholder": "ace-...",
+            "signupUrl": "https://platform.acedata.cloud",
+            "docsUrl": "https://docs.acedata.cloud/serp/google",
+            "credentialPath": "plugins.entries.acedatacloud.config.webSearch.apiKey"
+          }
+        ],
+        "install": {
+          "npmSpec": "@acedatacloud/openclaw-provider@2026.5.34",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.4.2",
+          "expectedIntegrity": "sha512-sEqhlHCXQrcuA119ML14FuXZ/8XAppquz7Oh5iB/fF3tsKblJiOnCcLqZkBzlAoh0gNCzf3cBUKvWgaSV9xjYQ=="
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds [`@acedatacloud/openclaw-provider`](https://www.npmjs.com/package/@acedatacloud/openclaw-provider) as an external provider entry so the package becomes discoverable through `openclaw plugins install` and the onboarding wizard, and ships a `/providers/acedatacloud` docs page describing setup.

[Ace Data Cloud](https://platform.acedata.cloud) is a unified, OpenAI-compatible AI gateway. The plugin exposes:

- **Chat** — 60+ curated models plus passthrough for any upstream Ace Data Cloud model id, all routed through `https://api.acedata.cloud/v1`.
- **Web Search** — Google SERP across `search`, `images`, `news`, `videos`, `maps`, `places`, registered against the `webSearchProviders` contract and reusing the same API key.

## What this PR changes

| File | Change |
|---|---|
| `scripts/lib/official-external-provider-catalog.json` | Add `@acedatacloud/openclaw-provider` entry (`source: "external"`, `kind: "provider"`), with a chat auth-choice for the `text-inference` onboarding scope and a `webSearchProviders` registration. |
| `docs/providers/acedatacloud.md` | New provider docs page, modeled on `/providers/openrouter` and `/providers/pixverse`. |
| `docs/docs.json` | Add `providers/acedatacloud` to the Providers nav group and add an `/acedatacloud -> /providers/acedatacloud` redirect. |

> **Rebased on current `main` (2026-06-20).** The branch was rebased onto latest `main`; the diff is exactly `+189 / −0` across the 3 files above (additive only — one catalog entry, one nav line + one redirect, one new docs page). No merge conflicts remain.

## All ClawSweeper review findings resolved

1. **Pin + integrity** — `install.npmSpec` is pinned to `@acedatacloud/openclaw-provider@2026.5.34` with `expectedIntegrity` (`sha512-sEqhlHC…`), so official discovery trusts the exact reviewed artifact.
2. **Plugin-scoped web-search credentialPath** — changed from `acedatacloud.webSearch.apiKey` to `plugins.entries.acedatacloud.config.webSearch.apiKey` (where the published plugin actually reads the key).
3. **Docs web-search override** — the provider docs snippet now uses the same plugin-scoped `webSearch` config path.
4. **Docs card route** — fixed the related card link from `/tools/web-search` to the existing `/tools/web`.
5. **Onboarding `optionKey`** — additionally found and fixed a non-interactive onboarding bug: `--acedata-api-key` is parsed by Commander as `acedataApiKey`, but the auth choice declared `acedatacloudApiKey`. The catalog entry now uses `acedataApiKey`, and the same fix was published in the provider package itself as `2026.5.34` (AceDataCloud/OpenClawProvider#9).

## Real behavior proof — pinned / integrity-protected install path (end-to-end)

Environment: macOS (arm64), host CLI `openclaw 2026.6.8`, isolated `HOME=$(mktemp -d)` so the real `~/.openclaw` is untouched. The API key is redacted. This run exercises the **exact pinned npm spec** this PR registers (`@acedatacloud/openclaw-provider@2026.5.34`).

**0. The catalog's `expectedIntegrity` matches the published artifact byte-for-byte** (so the protected install fails closed on any drift):

```text
$ npm view @acedatacloud/openclaw-provider@2026.5.34 dist.integrity
sha512-sEqhlHCXQrcuA119ML14FuXZ/8XAppquz7Oh5iB/fF3tsKblJiOnCcLqZkBzlAoh0gNCzf3cBUKvWgaSV9xjYQ==
# == install.expectedIntegrity in this PR's catalog entry  ✓
```

**1. Pinned install** (exact version + recorded pin — the protected path, not a floating tag):

```text
$ openclaw plugins install npm:@acedatacloud/openclaw-provider@2026.5.34 --pin
Installing @acedatacloud/openclaw-provider@2026.5.34 into $HOME/.openclaw/npm/projects/acedatacloud-openclaw-provider-…
Linked peerDependency "openclaw" -> …/node_modules/openclaw
Pinned npm install record to @acedatacloud/openclaw-provider@2026.5.34.
Installed plugin: acedatacloud
```

**2. Non-interactive onboarding through the catalog auth-choice** (the path that previously failed with `Missing --acedata-api-key`):

```text
$ openclaw onboard --auth-choice acedatacloud-api-key --acedata-api-key <redacted> --non-interactive --accept-risk
Updated config: $HOME/.openclaw/openclaw.json
Workspace OK:   $HOME/.openclaw/workspace
Sessions OK:    $HOME/.openclaw/agents/main/sessions
```

**3. Chat** (one-shot through the pinned provider):

```text
$ openclaw infer model run --model acedatacloud/gpt-4o-mini --prompt "Reply with exactly: OPENCLAW_OK" --local
model.run via local
provider: acedatacloud
model: acedatacloud/gpt-4o-mini
outputs: 1
OPENCLAW_OK
```

**4. Web search through the plugin-scoped credential path**:

```text
$ openclaw infer web search --provider acedatacloud --query "OpenAI" --limit 2 --json
{ "capability": "web.search", "provider": "acedatacloud",
  "outputs": [ { "result": { "type": "search", "query": "OpenAI",
    "knowledge_graph": { "title": "OpenAI", "type": "Artificial intelligence company", … },
    "related_searches": [ {"query":"OpenAI login"}, {"query":"OpenAI chat"}, … ] } } ] }
```

Web search returns a real Google SERP knowledge-graph result read from `plugins.entries.acedatacloud.config.webSearch.apiKey` — the corrected `credentialPath`.

## Provider-side fix shipped

The onboarding `optionKey` mismatch also existed in the published provider package. It is fixed and released:

- AceDataCloud/OpenClawProvider#9 — `optionKey` → `acedataApiKey` in both the runtime registration and the static manifest, with a regression test asserting each manifest `providerAuthChoices[].optionKey` equals the Commander-parsed form of its `cliFlag`.
- Published as `@acedatacloud/openclaw-provider@2026.5.34` (the version this PR now pins).
