### PR TITLE
Make runtime plugin startup stalls name in-flight plugins

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -973,6 +973,13 @@ async function runEmbeddedAgentInternal(
         config: params.config,
         workspaceDir: resolvedWorkspace,
         allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+        ...(params.onExecutionPhase
+          ? {
+              onLoadProgress: (runtimePlugins) => {
+                notifyExecutionPhase("runtime_plugins", { runtimePlugins });
+              },
+            }
+          : {}),
       });
       startupStages.mark("runtime-plugins");
       notifyExecutionPhase("runtime_plugins");

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -15,6 +15,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { ImageContent } from "../../../llm/types.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { PluginHookChannelContext } from "../../../plugins/hook-types.js";
+import type { RuntimePluginLoadProgress } from "../../../plugins/runtime/load-diagnostics.js";
 import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
 import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
@@ -208,6 +209,7 @@ export type RunEmbeddedAgentParams = {
     tool?: string;
     toolCallId?: string;
     itemId?: string;
+    runtimePlugins?: RuntimePluginLoadProgress;
     firstModelCallStarted?: boolean;
   }) => void;
   onLaneWait?: (info: { waitMs: number; queuedAhead: number; waiting?: boolean }) => void;

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -200,6 +200,26 @@ describe("ensureRuntimePluginsLoaded", () => {
     });
   });
 
+  it("forwards runtime plugin load progress diagnostics to the registry loader", () => {
+    const onLoadProgress = vi.fn();
+
+    ensureRuntimePluginsLoaded({
+      config: {} as never,
+      workspaceDir: "/tmp/workspace",
+      onLoadProgress,
+    });
+
+    expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
+      requiredPluginIds: undefined,
+      loadOptions: {
+        config: {} as never,
+        workspaceDir: "/tmp/workspace",
+        runtimePluginLoadProgress: onLoadProgress,
+        runtimeOptions: undefined,
+      },
+    });
+  });
+
   it("inherits gateway-bindable mode from an active gateway registry", () => {
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
 

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { getActivePluginRuntimeSubagentMode } from "../plugins/runtime.js";
+import type { RuntimePluginLoadProgressReporter } from "../plugins/runtime/load-diagnostics.js";
 import { ensureStandaloneRuntimePluginRegistryLoaded } from "../plugins/runtime/standalone-runtime-registry-loader.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -37,6 +38,7 @@ export function ensureRuntimePluginsLoaded(params: {
   config?: OpenClawConfig;
   workspaceDir?: string | null;
   allowGatewaySubagentBinding?: boolean;
+  onLoadProgress?: RuntimePluginLoadProgressReporter;
 }): void {
   if (params.config && !normalizePluginsConfig(params.config.plugins).enabled) {
     return;
@@ -59,6 +61,7 @@ export function ensureRuntimePluginsLoaded(params: {
       workspaceDir,
       ...(startupPluginIds === undefined ? {} : { onlyPluginIds: startupPluginIds }),
       ...(startupPluginIds === undefined ? {} : { forceFullRuntimeForChannelPlugins: true }),
+      ...(params.onLoadProgress ? { runtimePluginLoadProgress: params.onLoadProgress } : {}),
       runtimeOptions: allowGatewaySubagentBinding
         ? { allowGatewaySubagentBinding: true }
         : undefined,

--- a/src/cron/isolated-agent/run.runtime-plugins.test.ts
+++ b/src/cron/isolated-agent/run.runtime-plugins.test.ts
@@ -53,7 +53,7 @@ describe("runCronIsolatedAgentTurn runtime plugins loading", () => {
     });
 
     const result = await runCronIsolatedAgentTurn({
-      ...makeIsolatedAgentTurnParams(),
+      ...makeIsolatedAgentParamsFixture(),
       onExecutionPhase: (info) => {
         phases.push(info);
       },

--- a/src/cron/isolated-agent/run.runtime-plugins.test.ts
+++ b/src/cron/isolated-agent/run.runtime-plugins.test.ts
@@ -37,4 +37,39 @@ describe("runCronIsolatedAgentTurn runtime plugins loading", () => {
       resolveCronDeliveryPlanMock.mock.invocationCallOrder[0],
     );
   });
+
+  it("reports runtime plugin load progress through cron execution phases", async () => {
+    const phases: unknown[] = [];
+    ensureRuntimePluginsLoadedMock.mockImplementation((options: Record<string, unknown>) => {
+      const onLoadProgress = options.onLoadProgress;
+      if (typeof onLoadProgress === "function") {
+        onLoadProgress({
+          pluginIds: ["telegram", "memory-core"],
+          completedPluginIds: ["telegram"],
+          inFlightPluginId: "memory-core",
+          inFlightPhase: "register",
+        });
+      }
+    });
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeIsolatedAgentTurnParams(),
+      onExecutionPhase: (info) => {
+        phases.push(info);
+      },
+    });
+
+    expect(result.status).toBe("ok");
+    expect(phases).toContainEqual(
+      expect.objectContaining({
+        phase: "runtime_plugins",
+        runtimePlugins: {
+          pluginIds: ["telegram", "memory-core"],
+          completedPluginIds: ["telegram"],
+          inFlightPluginId: "memory-core",
+          inFlightPhase: "register",
+        },
+      }),
+    );
+  });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -571,6 +571,18 @@ async function prepareCronRunContext(params: {
     config: cfgWithAgentDefaults,
     workspaceDir,
     allowGatewaySubagentBinding: true,
+    ...(input.onExecutionPhase
+      ? {
+          onLoadProgress: (runtimePlugins) => {
+            input.onExecutionPhase?.({
+              jobId: input.job.id,
+              agentId,
+              phase: "runtime_plugins",
+              runtimePlugins,
+            });
+          },
+        }
+      : {}),
   });
 
   const isGmailHook = hookExternalContentSource === "gmail";

--- a/src/cron/service/execution-errors.test.ts
+++ b/src/cron/service/execution-errors.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { timeoutErrorMessage } from "./execution-errors.js";
+
+describe("cron execution error formatting", () => {
+  it("includes runtime plugin diagnostics during the runtime plugin phase", () => {
+    const message = timeoutErrorMessage({
+      jobId: "job",
+      phase: "runtime_plugins",
+      runtimePlugins: {
+        pluginIds: ["telegram", "memory-core"],
+        completedPluginIds: ["telegram"],
+        inFlightPluginId: "memory-core",
+        inFlightPhase: "register",
+      },
+    });
+
+    expect(message).toContain("last phase: runtime-plugins");
+    expect(message).toContain("attempted=[telegram, memory-core]");
+    expect(message).toContain("completed=[telegram]");
+    expect(message).toContain("in-flight=memory-core/register");
+  });
+
+  it("does not carry stale runtime plugin diagnostics into later phases", () => {
+    expect(
+      timeoutErrorMessage({
+        jobId: "job",
+        phase: "context_engine",
+        runtimePlugins: {
+          pluginIds: ["telegram"],
+          completedPluginIds: ["telegram"],
+        },
+      }),
+    ).toBe("cron: job execution timed out (last phase: context-engine)");
+  });
+});

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -2,13 +2,63 @@
 import { formatEmbeddedAgentExecutionPhase } from "../../agents/embedded-agent-runner/execution-phase.js";
 import type { CronAgentExecutionStarted } from "../types.js";
 
+const MAX_RUNTIME_PLUGIN_DIAGNOSTIC_IDS = 12;
+
 function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): string | undefined {
   return formatEmbeddedAgentExecutionPhase(execution?.phase);
 }
 
+function formatRuntimePluginIds(ids: readonly string[] | undefined): string | undefined {
+  if (!ids || ids.length === 0) {
+    return undefined;
+  }
+  const visible = ids.slice(0, MAX_RUNTIME_PLUGIN_DIAGNOSTIC_IDS);
+  const suffix = ids.length > visible.length ? `, +${ids.length - visible.length} more` : "";
+  return `[${visible.join(", ")}${suffix}]`;
+}
+
+function formatRuntimePluginLoadDiagnostics(
+  execution?: CronAgentExecutionStarted,
+): string | undefined {
+  const runtimePlugins = execution?.runtimePlugins;
+  if (!runtimePlugins) {
+    return undefined;
+  }
+  if (execution?.phase !== "runtime_plugins") {
+    return undefined;
+  }
+  const parts: string[] = [];
+  const attempted = formatRuntimePluginIds(runtimePlugins.pluginIds);
+  if (attempted) {
+    parts.push(`attempted=${attempted}`);
+  }
+  const completed = formatRuntimePluginIds(runtimePlugins.completedPluginIds);
+  if (completed) {
+    parts.push(`completed=${completed}`);
+  }
+  if (runtimePlugins.inFlightPluginId) {
+    parts.push(
+      `in-flight=${runtimePlugins.inFlightPluginId}${
+        runtimePlugins.inFlightPhase ? `/${runtimePlugins.inFlightPhase}` : ""
+      }`,
+    );
+  }
+  return parts.length > 0 ? `; runtime plugins: ${parts.join("; ")}` : undefined;
+}
+
+function formatCronAgentExecutionPhaseSuffix(
+  execution?: CronAgentExecutionStarted,
+): string | undefined {
+  const phase = formatCronAgentExecutionPhase(execution);
+  if (!phase) {
+    return undefined;
+  }
+  return `${phase}${formatRuntimePluginLoadDiagnostics(execution) ?? ""}`;
+}
+
 /** Formats the generic cron execution timeout message with last-known phase context when available. */
 export function timeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
-  const phase = formatCronAgentExecutionPhase(execution);
+  const phase = formatCronAgentExecutionPhaseSuffix(execution);
   if (!phase) {
     return "cron: job execution timed out";
   }
@@ -17,7 +67,7 @@ export function timeoutErrorMessage(execution?: CronAgentExecutionStarted): stri
 
 /** Formats timeout text for runs that stalled before the isolated runner started. */
 export function setupTimeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
-  const phase = formatCronAgentExecutionPhase(execution);
+  const phase = formatCronAgentExecutionPhaseSuffix(execution);
   if (!phase) {
     return "cron: isolated agent setup timed out before runner start";
   }
@@ -31,7 +81,7 @@ export function isSetupTimeoutErrorText(error: string): boolean {
 
 /** Formats timeout text for runs that stalled after setup but before execution start. */
 export function preExecutionTimeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
-  const phase = formatCronAgentExecutionPhase(execution);
+  const phase = formatCronAgentExecutionPhaseSuffix(execution);
   if (!phase) {
     return "cron: isolated agent run stalled before execution start";
   }

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -3244,6 +3244,12 @@ describe("cron service timer regressions", () => {
             onExecutionPhase?.({
               jobId: "isolated-before-agent-reply-unhandled-82811",
               phase: "runtime_plugins",
+              runtimePlugins: {
+                pluginIds: ["telegram", "memory-core"],
+                completedPluginIds: ["telegram"],
+                inFlightPluginId: "memory-core",
+                inFlightPhase: "register",
+              },
             });
             started.resolve();
             abortSignal?.addEventListener(
@@ -3269,6 +3275,9 @@ describe("cron service timer regressions", () => {
       expect(job.state.lastStatus).toBe("error");
       expect(job.state.lastError).toContain("stalled before execution start");
       expect(job.state.lastError).toContain("runtime-plugins");
+      expect(job.state.lastError).toContain("attempted=[telegram, memory-core]");
+      expect(job.state.lastError).toContain("completed=[telegram]");
+      expect(job.state.lastError).toContain("in-flight=memory-core/register");
       expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -2,6 +2,7 @@
 import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
 import type { EmbeddedAgentExecutionPhase } from "../agents/embedded-agent-runner/execution-phase.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
+import type { RuntimePluginLoadProgress } from "../plugins/runtime/load-diagnostics.js";
 import type { HookExternalContentSource } from "../security/external-content.js";
 import type { CronJobBase } from "./types-shared.js";
 
@@ -198,6 +199,7 @@ export type CronAgentExecutionStarted = {
   tool?: string;
   toolCallId?: string;
   itemId?: string;
+  runtimePlugins?: RuntimePluginLoadProgress;
   /** @deprecated Use phase-specific execution milestones for watchdog progress. */
   firstModelCallStarted?: boolean;
 };

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -109,6 +109,7 @@ import {
   testing as runtimeRegistryLoaderTesting,
   ensurePluginRegistryLoaded,
 } from "./runtime/runtime-registry-loader.js";
+import type { RuntimePluginLoadProgress } from "./runtime/load-diagnostics.js";
 import type { PluginSdkResolutionPreference } from "./sdk-alias.js";
 let cachedBundledTelegramDir = "";
 let cachedBundledMemoryDir = "";
@@ -1099,6 +1100,51 @@ describe("loadOpenClawPlugins", () => {
     expect(metrics.registerMs).toEqual(expect.any(Number));
     expect(metrics.registerFailedCount).toBe(0);
     expect(metrics.loadAndRegisterMs).toEqual(expect.any(Number));
+  });
+
+  it("reports runtime plugin load progress with attempted, in-flight, and completed plugin ids", () => {
+    useNoBundledPlugins();
+    const first = writePlugin({
+      id: "progress-a",
+      filename: "progress-a.cjs",
+      body: `module.exports = { id: "progress-a", register() {} };`,
+    });
+    const second = writePlugin({
+      id: "progress-b",
+      filename: "progress-b.cjs",
+      body: `module.exports = { id: "progress-b", register() {} };`,
+    });
+    const progress: RuntimePluginLoadProgress[] = [];
+
+    loadRegistryFromAllowedPlugins([first, second], {
+      runtimePluginLoadProgress: (event: RuntimePluginLoadProgress) => {
+        progress.push(event);
+      },
+    });
+
+    expect(progress[0]?.pluginIds).toEqual(["progress-a", "progress-b"]);
+    expect(progress).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          inFlightPluginId: "progress-a",
+          inFlightPhase: "load",
+        }),
+        expect.objectContaining({
+          inFlightPluginId: "progress-a",
+          inFlightPhase: "register",
+        }),
+        expect.objectContaining({
+          completedPluginIds: ["progress-a"],
+          inFlightPluginId: "progress-b",
+          inFlightPhase: "load",
+        }),
+      ]),
+    );
+    expect(progress.at(-1)).toMatchObject({
+      pluginIds: ["progress-a", "progress-b"],
+      completedPluginIds: ["progress-a", "progress-b"],
+    });
+    expect(progress.at(-1)?.inFlightPluginId).toBeUndefined();
   });
 
   it("resolves ${ENV_VAR} references in plugin config before handing config to the plugin", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -150,6 +150,10 @@ import {
   recordImportedPluginId,
   setActivePluginRegistry,
 } from "./runtime.js";
+import type {
+  RuntimePluginLoadProgressPhase,
+  RuntimePluginLoadProgressReporter,
+} from "./runtime/load-diagnostics.js";
 import type { CreatePluginRuntimeOptions } from "./runtime/types.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
@@ -201,6 +205,7 @@ export type PluginLoadOptions = {
   startupTrace?: {
     detail: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => void;
   };
+  runtimePluginLoadProgress?: RuntimePluginLoadProgressReporter;
   pluginSdkResolution?: PluginSdkResolutionPreference;
   cache?: boolean;
   mode?: "full" | "validate";
@@ -240,6 +245,53 @@ function detailPluginStartupTrace(
     `plugins.gateway-load.plugin.${encodeStartupTraceSegment(pluginId)}`,
     metrics,
   );
+}
+
+function createRuntimePluginLoadProgressTracker(
+  reporter: RuntimePluginLoadProgressReporter | undefined,
+) {
+  let pluginIds: string[] = [];
+  const completedPluginIds: string[] = [];
+  let inFlightPluginId: string | undefined;
+  let inFlightPhase: RuntimePluginLoadProgressPhase | undefined;
+
+  const emit = () => {
+    if (!reporter) {
+      return;
+    }
+    try {
+      reporter({
+        pluginIds: [...pluginIds],
+        completedPluginIds: [...completedPluginIds],
+        ...(inFlightPluginId ? { inFlightPluginId } : {}),
+        ...(inFlightPhase ? { inFlightPhase } : {}),
+      });
+    } catch {
+      // Diagnostic observers must not affect plugin activation.
+    }
+  };
+
+  return {
+    plan(ids: readonly string[]): void {
+      pluginIds = [...new Set(ids)];
+      emit();
+    },
+    enter(pluginId: string, phase: RuntimePluginLoadProgressPhase): void {
+      inFlightPluginId = pluginId;
+      inFlightPhase = phase;
+      emit();
+    },
+    complete(pluginId: string): void {
+      if (!completedPluginIds.includes(pluginId)) {
+        completedPluginIds.push(pluginId);
+      }
+      if (inFlightPluginId === pluginId) {
+        inFlightPluginId = undefined;
+        inFlightPhase = undefined;
+      }
+      emit();
+    },
+  };
 }
 
 const CLI_METADATA_ENTRY_BASENAMES = [
@@ -2087,6 +2139,31 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     });
     const pluginLoadStartMs = performance.now();
     let pluginLoadAttemptCount = 0;
+    const pluginLoadProgress = createRuntimePluginLoadProgressTracker(
+      options.runtimePluginLoadProgress,
+    );
+    pluginLoadProgress.plan(
+      orderedCandidates.flatMap((candidate) => {
+        const manifestRecord = manifestByRoot.get(candidate.rootDir);
+        if (!manifestRecord) {
+          return [];
+        }
+        return matchesScopedPluginRequest({
+          onlyPluginIdSet,
+          pluginId: manifestRecord.id,
+        })
+          ? [manifestRecord.id]
+          : [];
+      }),
+    );
+    let activeRuntimePluginProgressId: string | undefined;
+    const completeActiveRuntimePluginProgress = () => {
+      if (!activeRuntimePluginProgressId) {
+        return;
+      }
+      pluginLoadProgress.complete(activeRuntimePluginProgressId);
+      activeRuntimePluginProgressId = undefined;
+    };
 
     for (const candidate of orderedCandidates) {
       const manifestRecord = manifestByRoot.get(candidate.rootDir);
@@ -2104,6 +2181,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       if (!matchesRequestedScope) {
         continue;
       }
+      completeActiveRuntimePluginProgress();
+      activeRuntimePluginProgressId = pluginId;
+      pluginLoadProgress.enter(pluginId, "resolve");
       const isDreamingSidecar = isAuthorizedDreamingSidecarPlugin({
         sidecar: dreamingSidecar,
         pluginId,
@@ -2470,6 +2550,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         recordImportedPluginId(record.id);
         pluginLoadAttemptCount++;
         logger.debug?.(`[plugins] loading ${record.id} from ${safeSource}`);
+        pluginLoadProgress.enter(pluginId, "load");
         mod = withProfile(
           { pluginId: record.id, source: safeSource },
           registrationMode,
@@ -2571,6 +2652,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             fs.closeSync(runtimeOpened.fd);
             let runtimeMod: OpenClawPluginModule | null = null;
             try {
+              pluginLoadProgress.enter(pluginId, "setup-runtime-load");
               runtimeMod = withProfile(
                 { pluginId: record.id, source: safeRuntimeSource },
                 "load-setup-runtime-entry",
@@ -2601,6 +2683,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             }
             if (runtimeRegistration.setChannelRuntime) {
               try {
+                pluginLoadProgress.enter(pluginId, "setup-runtime-apply");
                 runtimeRegistration.setChannelRuntime(api.runtime);
                 runtimeSetterApplied = true;
               } catch (err) {
@@ -2678,6 +2761,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           }
           if (!runtimeSetterApplied) {
             try {
+              pluginLoadProgress.enter(pluginId, "setup-runtime-apply");
               mergedSetupRegistration.setChannelRuntime?.(api.runtime);
             } catch (err) {
               recordPluginError({
@@ -2701,6 +2785,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             if (registerSetupRuntime) {
               const registrySnapshot = snapshotPluginRegistry(registry);
               try {
+                pluginLoadProgress.enter(pluginId, "setup-runtime-register");
                 runPluginRegisterSync(
                   (registrationApi) => registerSetupRuntime(registrationApi),
                   api,
@@ -2856,6 +2941,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const beforeRegister = performance.now();
       let registerFailed = false;
       try {
+        pluginLoadProgress.enter(pluginId, "register");
         withProfile(
           { pluginId: record.id, source: record.source },
           `${registrationMode}:register`,
@@ -2911,6 +2997,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         ]);
       }
     }
+    completeActiveRuntimePluginProgress();
 
     const pluginLoadElapsedMs = performance.now() - pluginLoadStartMs;
     if (pluginLoadAttemptCount > 0) {

--- a/src/plugins/runtime/load-diagnostics.ts
+++ b/src/plugins/runtime/load-diagnostics.ts
@@ -1,0 +1,16 @@
+export type RuntimePluginLoadProgressPhase =
+  | "resolve"
+  | "load"
+  | "setup-runtime-load"
+  | "setup-runtime-apply"
+  | "setup-runtime-register"
+  | "register";
+
+export type RuntimePluginLoadProgress = {
+  pluginIds: readonly string[];
+  completedPluginIds: readonly string[];
+  inFlightPluginId?: string;
+  inFlightPhase?: RuntimePluginLoadProgressPhase;
+};
+
+export type RuntimePluginLoadProgressReporter = (progress: RuntimePluginLoadProgress) => void;


### PR DESCRIPTION
## Summary

- Adds diagnostic progress snapshots while runtime plugins load.
- Threads runtime plugin progress into embedded-agent and cron execution phase reporting.
- Appends attempted/completed/in-flight plugin ids to cron timeout messages only while the last phase is `runtime_plugins`.

Refs https://github.com/openclaw/openclaw/issues/87327 (Ask #1 — name the failing plugin)

> Scope note: #87327 lists five asks. This PR implements only **Ask #1** (per-plugin diagnostics naming the in-flight plugin at stall time). Asks #2–#5 — per-plugin init timeouts, retry-on-phase-stall, a cron failure-rate metric, and confirming the relationship to #86239 — are intentionally out of scope and remain open follow-up work, so this uses a non-closing `Refs` reference rather than `Fixes` to avoid auto-closing the broader issue.

## User-facing Bug

When an isolated cron/agent run stalls while loading runtime plugins, the watchdog currently reports only a coarse phase such as `runtime-plugins`. That does not identify which plugin was being resolved, loaded, or registered, so operators cannot tell which plugin to disable, inspect, or report.

## Exact Repro

Source-level reproduction:

1. Arrange runtime plugin loading to report progress for two plugins, with `memory-core` still in `register`.
2. Let the cron pre-execution watchdog time out while the last execution phase is `runtime_plugins`.
3. Before this patch, the timeout text only identified the coarse `runtime-plugins` phase.
4. After this patch, the timeout text includes:

```text
runtime plugins: attempted=[telegram, memory-core]; completed=[telegram]; in-flight=memory-core/register
```

The regression coverage in `src/cron/service/timer.regression.test.ts` exercises this watchdog path.

## Fix Summary

- Added `RuntimePluginLoadProgress` diagnostics types under `src/plugins/runtime/load-diagnostics.ts`.
- Added a loader progress tracker that reports planned plugin ids, completed ids, and the current in-flight plugin phase without letting observer errors affect activation.
- Forwarded the diagnostics through `ensureRuntimePluginsLoaded`, embedded runner phase callbacks, and cron isolated setup.
- Formatted runtime plugin details in cron timeout messages, gated to the `runtime_plugins` phase so stale progress does not pollute later `auth` or `context_engine` timeouts.

## Real behavior proof

Behavior addressed: cron/plugin startup stalls now name attempted, completed, and in-flight runtime plugins in timeout diagnostics.

Real environment tested: local OpenClaw worktree on macOS, branch `fix/runtime-plugins-stall-diagnostics` at commit `1260a5febd`, rebased onto current `origin/main` (`78c66742ab`); Node `v24.4.1`.

Exact steps or command run after this patch:

```bash
git diff --check
./node_modules/.bin/oxlint <changed files>
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-vitest.mjs src/agents/runtime-plugins.test.ts src/cron/isolated-agent/run.runtime-plugins.test.ts src/cron/service/execution-errors.test.ts src/cron/service/timer.regression.test.ts src/plugins/loader.test.ts
```

Evidence after fix:

- `oxlint` passed (exit 0) on all changed files.
- `tsgo` core typecheck (`tsconfig.core.json`) passed (exit 0) after the rebase.
- Focused Vitest passed: cron config `47` tests, agents config `9` tests, plugin loader `153` tests.
- Live formatter output — invoked the real production timeout formatters (`src/cron/service/execution-errors.ts`) directly on a stalled `runtime_plugins` execution state (telegram completed, memory-core in-flight at `register`), reproducing the exact operator-facing strings all three cron timeout paths emit:

```text
$ node --import tsx -e "import { timeoutErrorMessage, setupTimeoutErrorMessage, preExecutionTimeoutErrorMessage } from './src/cron/service/execution-errors.ts'; ..."
timeoutErrorMessage:
  cron: job execution timed out (last phase: runtime-plugins; runtime plugins: attempted=[telegram, memory-core]; completed=[telegram]; in-flight=memory-core/register)
setupTimeoutErrorMessage:
  cron: isolated agent setup timed out before runner start (last phase: runtime-plugins; runtime plugins: attempted=[telegram, memory-core]; completed=[telegram]; in-flight=memory-core/register)
preExecutionTimeoutErrorMessage:
  cron: isolated agent run stalled before execution start (last phase: runtime-plugins; runtime plugins: attempted=[telegram, memory-core]; completed=[telegram]; in-flight=memory-core/register)
contrast (no plugin diagnostics):
  cron: job execution timed out (last phase: runtime-plugins)
```

  The last line is the pre-fix behavior from the linked issue (coarse `runtime-plugins` only); `preExecutionTimeoutErrorMessage` is exactly the issue's reported symptom string (`stalled before execution start`), now naming the in-flight plugin and its phase.
- The cron timeout regression in `src/cron/service/timer.regression.test.ts` drives the watchdog through the `runtime_plugins` phase with two plugins (one still in `register`) and asserts the timeout text includes `attempted`, `completed`, and `in-flight` runtime plugin details. Asserted user-facing output:

```text
Error: isolated agent timed out during runtime-plugins
runtime plugins: attempted=[telegram, memory-core]; completed=[telegram]; in-flight=memory-core/register
```

Observed result after fix: the timeout text names the in-flight plugin and phase instead of only saying `runtime-plugins`.

**Real-loader proof — a genuinely slow plugin, observed by the real loader (re-review update)**

Following the [P2] rank-up ask, the in-flight diagnostics are now sourced from the **real `loadOpenClawPlugins` load loop observing a real stalling plugin**, not a hand-built execution state. A throwaway tsx harness wrote two real on-disk plugins and loaded them through the production loader: `progress-a` registers normally; `progress-b`'s `register()` is an intentional busy-wait. The real `runtimePluginLoadProgress` reporter (the exact type the cron/embedded runners wire in) captured the snapshot at the moment the loader was stuck in the slow plugin, and that captured object was fed verbatim into the real `timeoutErrorMessage` / `setupTimeoutErrorMessage` / `preExecutionTimeoutErrorMessage` formatters:

```text
$ OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 node --import tsx <harness>
=== loader actually busy-waited in slow plugin register (ms): 3117 ===

REAL loader-emitted in-flight snapshot (watchdog's last-known):
{
  "pluginIds": ["progress-a", "progress-b"],
  "completedPluginIds": ["progress-a"],
  "inFlightPluginId": "progress-b",
  "inFlightPhase": "register"
}

production timeout formatters fed that real snapshot:
timeoutErrorMessage:
  cron: job execution timed out (last phase: runtime-plugins; runtime plugins: attempted=[progress-a, progress-b]; completed=[progress-a]; in-flight=progress-b/register)
setupTimeoutErrorMessage:
  cron: isolated agent setup timed out before runner start (last phase: runtime-plugins; runtime plugins: attempted=[progress-a, progress-b]; completed=[progress-a]; in-flight=progress-b/register)
preExecutionTimeoutErrorMessage:
  cron: isolated agent run stalled before execution start (last phase: runtime-plugins; runtime plugins: attempted=[progress-a, progress-b]; completed=[progress-a]; in-flight=progress-b/register)

pre-fix contrast (coarse phase only, no plugin diagnostics):
  cron: job execution timed out (last phase: runtime-plugins)
```

The loader spent 3,117 ms inside the slow plugin's `register()` — i.e. the snapshot was taken while a plugin was genuinely mid-load — and every field in the operator-facing message (`attempted` / `completed` / `in-flight=progress-b/register`) originates from the real loader, then the real formatter. The final line is the pre-fix behavior from the linked issue: bare `runtime-plugins` with no way to tell which plugin hung.

This was re-run after rebasing onto current `origin/main` (`78c66742ab`); the single rebase conflict (in `src/agents/runtime-plugins.ts`) was a textual-convergence union — main added `forceFullRuntimeForChannelPlugins` and this branch added `runtimePluginLoadProgress` to the same `loadOptions`, both retained. Post-rebase: `oxlint` clean, `tsgo` core typecheck exit 0, and the focused suites pass (`230` tests across runtime-plugins / cron execution-errors / isolated-agent runtime-plugins / loader / timer regression).

What was not tested:

- I did not run this inside a fully deployed gateway/cron daemon with the real watchdog timer firing end-to-end — that needs a deployed environment. The hang itself is real (a plugin busy-waiting in `register()` observed by the production loader) and the timeout strings come from the real formatters, but the watchdog's own timer-fire path is covered by the regression test in `src/cron/service/timer.regression.test.ts` rather than a live daemon.
- I did not run the full `pnpm check`; coverage is focused lint, typecheck, and Vitest on the changed surfaces.

## AI-assisted disclosure

This PR was implemented with AI assistance. I reviewed the generated diff, ran the targeted tests above, and addressed the actionable `codex review` finding before preparing this PR.


