### PR TITLE
Reject unpublished npm targets consistently in update dry-run

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -528,6 +528,20 @@ describe("update-cli", () => {
     vi.mocked(runCommandWithTimeout).mock.calls as unknown as Array<
       [string[], Record<string, unknown>]
     >;
+  const expectRunCommandOptions = (options: Parameters<typeof runCommandWithTimeout>[1]) => {
+    expect(typeof options).toBe("object");
+    expect(options).not.toBeNull();
+    return options as { cwd?: string; env?: NodeJS.ProcessEnv };
+  };
+
+  const commandOk = (stdout = "") => ({
+    stdout,
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit" as const,
+  });
 
   const packageInstallCommandCall = () =>
     commandCalls().find(([argv]) => argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g");
@@ -2252,103 +2266,6 @@ describe("update-cli", () => {
     expect(pluginOutcome(jsonOutput)?.status).toBe("skipped");
   });
 
-  it("marks unacknowledged ClawHub risk skips as post-update warnings", async () => {
-    const trustWarning =
-      "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
-      "│ • Security scan:     suspicious                                      │\n" +
-      "│ • Finding:           suspicious payload strings                       │\n" +
-      "╰───────────────────────────────────────────────────────────────────────╯";
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: false,
-      config: baseConfig,
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "skipped",
-          code: CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED,
-          warning: trustWarning,
-          message:
-            "Skipped demo ClawHub update: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. Existing installed plugin left unchanged.",
-        },
-      ],
-    });
-    vi.mocked(defaultRuntime.writeJson).mockClear();
-
-    await updateCommand({ json: true, restart: false });
-
-    const jsonOutput = lastWriteJsonCall() as UpdateRunResult | undefined;
-    expect(jsonOutput?.postUpdate?.plugins?.status).toBe("warning");
-    expect(pluginWarning(jsonOutput)?.pluginId).toBe("demo");
-    expect(pluginWarning(jsonOutput)?.reason).toContain("Security scan:     suspicious");
-    expect(pluginWarning(jsonOutput)?.reason).toContain("suspicious payload strings");
-    expect(pluginWarning(jsonOutput)?.reason).toContain("--acknowledge-clawhub-risk");
-    expect(pluginWarning(jsonOutput)?.guidance).toEqual([
-      "Run openclaw update repair to retry post-update plugin repair.",
-      "Run openclaw plugins inspect demo --runtime --json for details.",
-    ]);
-    expect(pluginOutcome(jsonOutput)?.pluginId).toBe("demo");
-    expect(pluginOutcome(jsonOutput)?.status).toBe("skipped");
-  });
-
-  it("marks blocked ClawHub update skips as post-update warnings", async () => {
-    const trustWarning =
-      "╭─ BLOCKED - ClawHub flagged this release as malicious ─╮\n" +
-      "│ • Security scan: malicious                           │\n" +
-      "╰──────────────────────────────────────────────────────╯";
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: false,
-      config: baseConfig,
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "skipped",
-          code: "clawhub_download_blocked",
-          warning: trustWarning,
-          message:
-            "Skipped demo ClawHub update: ClawHub blocked this release; update was not started. Existing installed plugin left unchanged.",
-        },
-      ],
-    });
-    vi.mocked(defaultRuntime.writeJson).mockClear();
-
-    await updateCommand({ json: true, restart: false });
-
-    const jsonOutput = lastWriteJsonCall() as UpdateRunResult | undefined;
-    expect(jsonOutput?.postUpdate?.plugins?.status).toBe("warning");
-    expect(pluginWarning(jsonOutput)?.pluginId).toBe("demo");
-    expect(pluginWarning(jsonOutput)?.reason).toContain("Security scan: malicious");
-    expect(pluginWarning(jsonOutput)?.reason).toContain("ClawHub blocked this release");
-    expect(pluginOutcome(jsonOutput)?.pluginId).toBe("demo");
-    expect(pluginOutcome(jsonOutput)?.status).toBe("skipped");
-    expect(pluginOutcome(jsonOutput)?.message).toContain("Run openclaw update repair");
-  });
-
-  it("prints unacknowledged ClawHub risk skips in human post-update output", async () => {
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: false,
-      config: baseConfig,
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "skipped",
-          code: CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED,
-          message:
-            "Skipped demo ClawHub update: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. Existing installed plugin left unchanged.",
-        },
-      ],
-    });
-
-    await updateCommand({ yes: true, restart: false });
-
-    const logs = vi
-      .mocked(defaultRuntime.log)
-      .mock.calls.map((call) => String(call[0]))
-      .join("\n");
-    expect(logs).toContain("--acknowledge-clawhub-risk");
-    expect(logs).toContain("Run openclaw update repair to retry post-update plugin repair.");
-    expect(logs).toContain("Run openclaw plugins inspect demo --runtime --json for details.");
-  });
-
   it("fails unexpected post-core plugin sync exceptions", async () => {
     syncPluginsForUpdateChannel.mockRejectedValueOnce(new Error("plugin sync invariant broke"));
 
@@ -2473,6 +2390,1214 @@ describe("update-cli", () => {
       },
     },
   ] as const)("updateCommand dry-run behavior: $name", runUpdateCliScenario);
+
+  it("fails dry-run when an explicit npm version target has not propagated", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValueOnce({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeUndefined();
+    const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+    expect(errors.join("\n")).toContain(
+      "openclaw@2026.5.26 is not available on the npm registry yet.",
+    );
+    expect(errors.join("\n")).toContain("npm install will reject with ETARGET");
+  });
+
+  it("fails package updates before install when an explicit npm version target is absent", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValueOnce({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+
+    await updateCommand({ yes: true, tag: "2026.5.26", restart: false });
+
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeUndefined();
+    expect(serviceStop).not.toHaveBeenCalled();
+    const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+    expect(errors.join("\n")).toContain(
+      "openclaw@2026.5.26 is not available on the npm registry yet.",
+    );
+  });
+
+  it("normalizes v-prefixed exact npm targets before checking registry availability", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockImplementation(async ({ target }) => ({
+      target,
+      version: target === "2026.5.26" ? "2026.5.26" : null,
+      nodeEngine: ">=22.19.0",
+    }));
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    await updateCommand({ dryRun: true, tag: "v2026.5.26", json: true });
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@v2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it.each(["2026q2", "V1", "V1.x", "1.x-beta"])(
+    "checks npm dist-tags before reporting dry-run success (%s)",
+    async (tag) => {
+      mockPackageInstallStatus(createCaseDir("openclaw-update"));
+      readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+      vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValueOnce({
+        target: tag,
+        version: null,
+        nodeEngine: null,
+        error: "HTTP 404",
+      });
+      vi.mocked(defaultRuntime.writeJson).mockClear();
+
+      await updateCommand({ dryRun: true, tag, json: true });
+
+      expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+        target: tag,
+        timeoutMs: undefined,
+      });
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+      expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+      expect(runGatewayUpdate).not.toHaveBeenCalled();
+      expect(packageInstallCommandCall()).toBeUndefined();
+      const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+      expect(errors.join("\n")).toContain(
+        `openclaw@${tag} is not available on the npm registry yet.`,
+      );
+    },
+  );
+
+  it("skips only the npm availability preflight when npm registry env points at a custom registry", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    const npmRoot = createCaseDir("openclaw-npm-root");
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      if (argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
+        return commandOk(`${npmRoot}\n`);
+      }
+      expect(argv).toEqual(["npm", "config", "get", "registry", "--global"]);
+      expect(expectRunCommandOptions(options).env?.NPM_CONFIG_REGISTRY).toBe(
+        "https://npm.internal.example/",
+      );
+      return commandOk("https://npm.internal.example/\n");
+    });
+
+    await withEnvAsync({ NPM_CONFIG_REGISTRY: "https://npm.internal.example/" }, async () => {
+      await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+    });
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it("uses pnpm registry config before deciding availability preflight", async () => {
+    const root = createCaseDir("openclaw-update-pnpm");
+    const pnpmGlobalProject = path.join(root, "pnpm-global", "5");
+    const pnpmGlobalRoot = path.join(pnpmGlobalProject, "node_modules");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("pnpm");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "pnpm",
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      if (argv[0] === "pnpm" && argv[1] === "root" && argv[2] === "-g") {
+        return {
+          stdout: `${pnpmGlobalRoot}\n`,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      expect(argv).toEqual(["pnpm", "config", "get", "registry"]);
+      expect(expectRunCommandOptions(options).cwd).toBe(pnpmGlobalProject);
+      return {
+        stdout: "https://pnpm.internal.example/\n",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it("honors PNPM_CONFIG_REGISTRY before public npm availability preflight", async () => {
+    const root = createCaseDir("openclaw-update-pnpm-env-registry");
+    const pnpmGlobalProject = path.join(root, "pnpm-global", "5");
+    const pnpmGlobalRoot = path.join(pnpmGlobalProject, "node_modules");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("pnpm");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "pnpm",
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (argv[0] === "pnpm" && argv[1] === "root" && argv[2] === "-g") {
+        return {
+          stdout: `${pnpmGlobalRoot}\n`,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (argv[0] === "pnpm" && argv[1] === "config" && argv[2] === "get") {
+        throw new Error("pnpm registry env should bypass config probing");
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await withEnvAsync({ PNPM_CONFIG_REGISTRY: "https://pnpm.internal.example/" }, async () => {
+      await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+    });
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const commands = vi.mocked(runCommandWithTimeout).mock.calls.map(([argv]) => argv.join(" "));
+    expect(commands).toContain("pnpm root -g");
+    expect(commands).not.toContain("pnpm config get registry");
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it("honors pnpm_config_registry before public npm availability preflight", async () => {
+    const root = createCaseDir("openclaw-update-pnpm-env-registry-precedence");
+    const pnpmGlobalRoot = path.join(root, "pnpm-global", "5", "node_modules");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("pnpm");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "pnpm",
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (argv[0] === "pnpm" && argv[1] === "root" && argv[2] === "-g") {
+        return {
+          stdout: `${pnpmGlobalRoot}\n`,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (argv[0] === "pnpm" && argv[1] === "config" && argv[2] === "get") {
+        throw new Error("pnpm registry env should bypass config probing");
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await withEnvAsync({ pnpm_config_registry: "https://pnpm.internal.example/" }, async () => {
+      await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+    });
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const commands = vi.mocked(runCommandWithTimeout).mock.calls.map(([argv]) => argv.join(" "));
+    expect(commands).toContain("pnpm root -g");
+    expect(commands).not.toContain("pnpm config get registry");
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it("ignores npm registry env for pnpm-managed package updates", async () => {
+    const root = createCaseDir("openclaw-update-pnpm-env-registry-precedence-uppercase");
+    const pnpmGlobalProject = path.join(root, "pnpm-global", "5");
+    const pnpmGlobalRoot = path.join(pnpmGlobalProject, "node_modules");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("pnpm");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "pnpm",
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      if (argv[0] === "pnpm" && argv[1] === "root" && argv[2] === "-g") {
+        return {
+          stdout: `${pnpmGlobalRoot}\n`,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (argv[0] === "pnpm" && argv[1] === "config" && argv[2] === "get") {
+        expect(argv).toEqual(["pnpm", "config", "get", "registry"]);
+        expect(expectRunCommandOptions(options).cwd).toBe(pnpmGlobalProject);
+        return commandOk("https://registry.npmjs.org/\n");
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await withEnvAsync(
+      {
+        NPM_CONFIG_REGISTRY: "https://pnpm.internal.example/",
+        npm_config_registry: "https://npm.internal.example/",
+      },
+      async () => {
+        await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+      },
+    );
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    const commands = vi.mocked(runCommandWithTimeout).mock.calls.map(([argv]) => argv.join(" "));
+    expect(commands).toContain("pnpm root -g");
+    expect(commands).toContain("pnpm config get registry");
+  });
+
+  it("uses pnpm registry config when PNPM registry env casing conflicts", async () => {
+    const root = createCaseDir("openclaw-update-pnpm-env-registry-conflict");
+    const pnpmGlobalProject = path.join(root, "pnpm-global", "5");
+    const pnpmGlobalRoot = path.join(pnpmGlobalProject, "node_modules");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("pnpm");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "pnpm",
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      if (argv[0] === "pnpm" && argv[1] === "root" && argv[2] === "-g") {
+        return commandOk(`${pnpmGlobalRoot}\n`);
+      }
+      if (argv[0] === "pnpm" && argv[1] === "config" && argv[2] === "get") {
+        expect(argv).toEqual(["pnpm", "config", "get", "registry"]);
+        expect(expectRunCommandOptions(options).cwd).toBe(pnpmGlobalProject);
+        return commandOk("https://registry.npmjs.org/\n");
+      }
+      return commandOk();
+    });
+
+    await withEnvAsync(
+      {
+        PNPM_CONFIG_REGISTRY: "https://registry.npmjs.org/",
+        pnpm_config_registry: "https://pnpm.internal.example/",
+      },
+      async () => {
+        await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+      },
+    );
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    const commands = vi.mocked(runCommandWithTimeout).mock.calls.map(([argv]) => argv.join(" "));
+    expect(commands).toContain("pnpm root -g");
+    expect(commands).toContain("pnpm config get registry");
+  });
+
+  it("ignores caller-local pnpm registry config before public npm availability preflight", async () => {
+    const root = createCaseDir("openclaw-update-pnpm-local-registry");
+    const pnpmGlobalProject = path.join(root, "pnpm-global", "5");
+    const pnpmGlobalRoot = path.join(pnpmGlobalProject, "node_modules");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("pnpm");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "pnpm",
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      if (argv[0] === "pnpm" && argv[1] === "root" && argv[2] === "-g") {
+        return {
+          stdout: `${pnpmGlobalRoot}\n`,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (argv[0] === "pnpm" && argv[1] === "config" && argv[2] === "get") {
+        const commandOptions = expectRunCommandOptions(options);
+        return {
+          stdout:
+            commandOptions.cwd === pnpmGlobalProject
+              ? "https://registry.npmjs.org/\n"
+              : "https://pnpm.internal.example/\n",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("uses the resolved global manager instead of package metadata for registry config", async () => {
+    const root = createCaseDir("openclaw-update-npm-with-pnpm-metadata");
+    const npmRoot = createCaseDir("openclaw-npm-root");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("npm");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "pnpm",
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      if (argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
+        return commandOk(`${npmRoot}\n`);
+      }
+      expect(argv).toEqual(["npm", "config", "get", "registry", "--global"]);
+      expect(expectRunCommandOptions(options).cwd).toBe(process.cwd());
+      return commandOk("https://npm.internal.example/\n");
+    });
+
+    await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it("uses the owning npm binary for registry config before public npm availability preflight", async () => {
+    const prefix = await createTrackedTempDir("openclaw-owning-npm-");
+    const globalRoot = path.join(prefix, "lib", "node_modules");
+    const root = path.join(globalRoot, "openclaw");
+    const owningNpm = path.join(
+      prefix,
+      process.platform === "win32" ? "npm.cmd" : path.join("bin", "npm"),
+    );
+    await fs.mkdir(path.dirname(owningNpm), { recursive: true });
+    await fs.writeFile(owningNpm, "", "utf8");
+    mockPackageInstallStatus(root);
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      if (argv[0] === owningNpm && argv[1] === "root" && argv[2] === "-g") {
+        return commandOk(`${globalRoot}\n`);
+      }
+      if (
+        argv[0] === owningNpm &&
+        argv[1] === "config" &&
+        argv[2] === "get" &&
+        argv[3] === "registry"
+      ) {
+        expect(argv).toEqual([owningNpm, "config", "get", "registry", "--global"]);
+        expect(expectRunCommandOptions(options).cwd).toBe(process.cwd());
+        return commandOk("https://npm.internal.example/\n");
+      }
+      return commandOk();
+    });
+
+    await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const commands = commandCalls().map(([argv]) => argv.join(" "));
+    expect(commands).toContain(`${owningNpm} root -g`);
+    expect(commands).toContain(`${owningNpm} config get registry --global`);
+    expect(commands).not.toContain("npm config get registry --global");
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it("checks npm availability preflight for Bun-managed package updates when Bun registry is public", async () => {
+    const root = createCaseDir("openclaw-update-bun");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("bun");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "bun",
+      deps: {
+        manager: "bun",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    await withEnvAsync({ BUN_CONFIG_REGISTRY: "https://registry.npmjs.org/" }, async () => {
+      await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+    });
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeUndefined();
+    const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+    expect(errors.join("\n")).toContain(
+      "openclaw@2026.5.26 is not available on the npm registry yet.",
+    );
+  });
+
+  it("honors Bun registry env before npm registry env for Bun-managed package updates", async () => {
+    const root = createCaseDir("openclaw-update-bun-env-precedence");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("bun");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "bun",
+      deps: {
+        manager: "bun",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    await withEnvAsync(
+      {
+        BUN_CONFIG_REGISTRY: "https://bun.internal.example/",
+        NPM_CONFIG_REGISTRY: "https://registry.npmjs.org/",
+      },
+      async () => {
+        await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+      },
+    );
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it("honors caller-local .npmrc registry for Bun-managed package updates", async () => {
+    const root = createCaseDir("openclaw-update-bun-npmrc");
+    const invocationCwd = await createTrackedTempDir("openclaw-update-bun-npmrc-");
+    await fs.writeFile(
+      path.join(invocationCwd, ".npmrc"),
+      "registry=https://bun.internal.example/\n",
+    );
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("bun");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "bun",
+      deps: {
+        manager: "bun",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(invocationCwd);
+    try {
+      await withEnvAsync(
+        {
+          BUN_CONFIG_REGISTRY: undefined,
+          NPM_CONFIG_REGISTRY: undefined,
+          npm_config_registry: undefined,
+        },
+        async () => {
+          await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+        },
+      );
+    } finally {
+      cwdSpy.mockRestore();
+    }
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it("honors caller-local bunfig registry for Bun-managed package updates", async () => {
+    const root = createCaseDir("openclaw-update-bun-bunfig");
+    const invocationCwd = await createTrackedTempDir("openclaw-update-bun-bunfig-");
+    await fs.writeFile(
+      path.join(invocationCwd, "bunfig.toml"),
+      '[install]\nregistry = "https://bun.internal.example/"\n',
+    );
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("bun");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "bun",
+      deps: {
+        manager: "bun",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(invocationCwd);
+    try {
+      await withEnvAsync(
+        {
+          BUN_CONFIG_REGISTRY: undefined,
+          NPM_CONFIG_REGISTRY: undefined,
+          npm_config_registry: undefined,
+        },
+        async () => {
+          await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+        },
+      );
+    } finally {
+      cwdSpy.mockRestore();
+    }
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    const jsonOutput = lastWriteJsonCall() as { tag?: string; targetVersion?: string } | undefined;
+    expect(jsonOutput?.tag).toBe("openclaw@2026.5.26");
+    expect(jsonOutput?.targetVersion).toBe("2026.5.26");
+  });
+
+  it("checks npm availability preflight for Bun-managed updates when no registry env is set", async () => {
+    const root = createCaseDir("openclaw-update-bun-default");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    resolveGlobalManager.mockResolvedValue("bun");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "package",
+      packageManager: "bun",
+      deps: {
+        manager: "bun",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    await withEnvAsync(
+      {
+        BUN_CONFIG_REGISTRY: undefined,
+        NPM_CONFIG_REGISTRY: undefined,
+        npm_config_registry: undefined,
+      },
+      async () => {
+        await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+      },
+    );
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("uses npm registry config output instead of guessing registry env casing", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    const npmRoot = createCaseDir("openclaw-npm-root");
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      if (argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
+        return commandOk(`${npmRoot}\n`);
+      }
+      expect(argv).toEqual(["npm", "config", "get", "registry", "--global"]);
+      const commandOptions = expectRunCommandOptions(options);
+      expect(commandOptions.env?.npm_config_registry).toBe("https://registry.npmjs.org/");
+      expect(commandOptions.env?.NPM_CONFIG_REGISTRY).toBe("https://npm.internal.example/");
+      return commandOk("https://npm.internal.example/\n");
+    });
+
+    await withEnvAsync(
+      {
+        npm_config_registry: "https://registry.npmjs.org/",
+        NPM_CONFIG_REGISTRY: "https://npm.internal.example/",
+      },
+      async () => {
+        await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+      },
+    );
+
+    expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+  });
+
+  it("treats protocol-relative npmjs registry env as public", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    await withEnvAsync({ NPM_CONFIG_REGISTRY: "//registry.npmjs.org/" }, async () => {
+      await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+    });
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("marks unacknowledged ClawHub risk skips as post-update warnings", async () => {
+    const trustWarning =
+      "╭─ WARNING - ClawHub found security risks in this release ─╮\n" +
+      "│ • Security scan:     suspicious                                      │\n" +
+      "│ • Finding:           suspicious payload strings                       │\n" +
+      "╰───────────────────────────────────────────────────────────────────────╯";
+    updateNpmInstalledPlugins.mockResolvedValueOnce({
+      changed: false,
+      config: baseConfig,
+      outcomes: [
+        {
+          pluginId: "demo",
+          status: "skipped",
+          code: CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED,
+          warning: trustWarning,
+          message:
+            "Skipped demo ClawHub update: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. Existing installed plugin left unchanged.",
+        },
+      ],
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    await updateCommand({ json: true, restart: false });
+
+    const jsonOutput = lastWriteJsonCall() as UpdateRunResult | undefined;
+    expect(jsonOutput?.postUpdate?.plugins?.status).toBe("warning");
+    expect(pluginWarning(jsonOutput)?.pluginId).toBe("demo");
+    expect(pluginWarning(jsonOutput)?.reason).toContain("Security scan:     suspicious");
+    expect(pluginWarning(jsonOutput)?.reason).toContain("suspicious payload strings");
+    expect(pluginWarning(jsonOutput)?.reason).toContain("--acknowledge-clawhub-risk");
+    expect(pluginWarning(jsonOutput)?.guidance).toEqual([
+      "Run openclaw update repair to retry post-update plugin repair.",
+      "Run openclaw plugins inspect demo --runtime --json for details.",
+    ]);
+    expect(pluginOutcome(jsonOutput)?.pluginId).toBe("demo");
+    expect(pluginOutcome(jsonOutput)?.status).toBe("skipped");
+  });
+
+  it("marks blocked ClawHub update skips as post-update warnings", async () => {
+    const trustWarning =
+      "╭─ BLOCKED - ClawHub flagged this release as malicious ─╮\n" +
+      "│ • Security scan: malicious                           │\n" +
+      "╰──────────────────────────────────────────────────────╯";
+    updateNpmInstalledPlugins.mockResolvedValueOnce({
+      changed: false,
+      config: baseConfig,
+      outcomes: [
+        {
+          pluginId: "demo",
+          status: "skipped",
+          code: "clawhub_download_blocked",
+          warning: trustWarning,
+          message:
+            "Skipped demo ClawHub update: ClawHub blocked this release; update was not started. Existing installed plugin left unchanged.",
+        },
+      ],
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    await updateCommand({ json: true, restart: false });
+
+    const jsonOutput = lastWriteJsonCall() as UpdateRunResult | undefined;
+    expect(jsonOutput?.postUpdate?.plugins?.status).toBe("warning");
+    expect(pluginWarning(jsonOutput)?.pluginId).toBe("demo");
+    expect(pluginWarning(jsonOutput)?.reason).toContain("Security scan: malicious");
+    expect(pluginWarning(jsonOutput)?.reason).toContain("ClawHub blocked this release");
+    expect(pluginOutcome(jsonOutput)?.pluginId).toBe("demo");
+    expect(pluginOutcome(jsonOutput)?.status).toBe("skipped");
+    expect(pluginOutcome(jsonOutput)?.message).toContain("Run openclaw update repair");
+  });
+
+  it("prints unacknowledged ClawHub risk skips in human post-update output", async () => {
+    updateNpmInstalledPlugins.mockResolvedValueOnce({
+      changed: false,
+      config: baseConfig,
+      outcomes: [
+        {
+          pluginId: "demo",
+          status: "skipped",
+          code: CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED,
+          message:
+            "Skipped demo ClawHub update: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. Existing installed plugin left unchanged.",
+        },
+      ],
+    });
+
+    await updateCommand({ yes: true, restart: false });
+
+    const logs = vi
+      .mocked(defaultRuntime.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(logs).toContain("--acknowledge-clawhub-risk");
+    expect(logs).toContain("Run openclaw update repair to retry post-update plugin repair.");
+    expect(logs).toContain("Run openclaw plugins inspect demo --runtime --json for details.");
+  });
+
+  it("treats HTTP npmjs registry env as public", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+
+    await withEnvAsync({ NPM_CONFIG_REGISTRY: "http://registry.npmjs.org/" }, async () => {
+      await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+    });
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("ignores the default npmrc when npm userconfig is set", async () => {
+    const home = await createTrackedTempDir("openclaw-update-home-npmrc-");
+    const configDir = await createTrackedTempDir("openclaw-update-userconfig-");
+    const userConfig = path.join(configDir, ".npmrc");
+    await fs.writeFile(path.join(home, ".npmrc"), "registry=https://npm.internal.example/\n");
+    await fs.writeFile(userConfig, "registry=https://registry.npmjs.org/\n");
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementationOnce(async (argv, options) => {
+      expect(argv).toEqual(["npm", "config", "get", "registry", "--global"]);
+      expect(expectRunCommandOptions(options).env?.NPM_CONFIG_USERCONFIG).toBe(userConfig);
+      return {
+        stdout: "https://registry.npmjs.org/\n",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await withEnvAsync({ HOME: home, NPM_CONFIG_USERCONFIG: userConfig }, async () => {
+      await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+    });
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("does not skip npm availability when the custom registry only exists in the target prefix", async () => {
+    const prefix = await createTrackedTempDir("openclaw-update-custom-registry-");
+    const root = path.join(prefix, "lib", "node_modules", "openclaw");
+    mockPackageInstallStatus(root);
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+    vi.mocked(defaultRuntime.writeJson).mockClear();
+    vi.mocked(runCommandWithTimeout).mockImplementationOnce(async (argv) => {
+      expect(argv).toEqual(["npm", "config", "get", "registry", "--global"]);
+      return {
+        stdout: "https://registry.npmjs.org/\n",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await updateCommand({ dryRun: true, tag: "2026.5.26", json: true });
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeUndefined();
+    const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+    expect(errors.join("\n")).toContain(
+      "openclaw@2026.5.26 is not available on the npm registry yet.",
+    );
+  });
+
+  it.each([
+    "^2026.5.0",
+    "2026.5.x",
+    "01",
+    "2026.05",
+    "1.02.x",
+    "vv1",
+    "vv1.2.3",
+    "1.02.3",
+    "1.2.x-beta",
+    "v1.x.x-beta",
+    "x.x.x-beta",
+    "1",
+  ])(
+    "skips npm availability preflight for semver range package specs (%s)",
+    async (tag) => {
+      mockPackageInstallStatus(createCaseDir("openclaw-update"));
+      readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+      vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+        target: tag,
+        version: null,
+        nodeEngine: null,
+        error: "HTTP 404",
+      });
+      vi.mocked(fetchNpmPackageTargetStatus).mockClear();
+      vi.mocked(defaultRuntime.writeJson).mockClear();
+
+      await updateCommand({ dryRun: true, tag, json: true });
+
+      expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+      expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+      const jsonOutput = lastWriteJsonCall() as { tag?: string } | undefined;
+      expect(jsonOutput?.tag).toBe(`openclaw@${tag}`);
+    },
+  );
+
+  it("skips npm availability preflight for explicit package spec overrides", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "latest",
+      version: null,
+      nodeEngine: null,
+      error: "HTTP 404",
+    });
+
+    await withEnvAsync(
+      { OPENCLAW_UPDATE_PACKAGE_SPEC: "http://10.211.55.2:8138/openclaw-next.tgz" },
+      async () => {
+        await updateCommand({ yes: true, tag: "latest", restart: false });
+      },
+    );
+
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    expectPackageInstallSpec("http://10.211.55.2:8138/openclaw-next.tgz");
+  });
+
+  it("runs npm availability preflight for absent registry-style package spec overrides", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockImplementation(async ({ target }) => ({
+      target,
+      version: target === "2026.5.26" ? "2026.5.26" : null,
+      nodeEngine: target === "2026.5.26" ? ">=22.19.0" : null,
+      error: target === "next" ? "HTTP 404" : undefined,
+    }));
+
+    await withEnvAsync({ OPENCLAW_UPDATE_PACKAGE_SPEC: "openclaw@next" }, async () => {
+      await updateCommand({ yes: true, tag: "2026.5.26", restart: false });
+    });
+
+    // `openclaw@next` is the spec the package manager will actually install, so
+    // the availability preflight must check that override target, not just the
+    // requested `--tag`. An absent override must fail closed before install.
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "next",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeUndefined();
+    expect(serviceStop).not.toHaveBeenCalled();
+    const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+    expect(errors.join("\n")).toContain(
+      "openclaw@next is not available on the npm registry yet.",
+    );
+  });
+
+  it("allows available registry-style package spec overrides through the preflight", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    readPackageVersion.mockResolvedValue("2026.5.24-beta.2");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: "2026.5.26",
+      nodeEngine: ">=22.19.0",
+    });
+
+    await withEnvAsync(
+      { OPENCLAW_UPDATE_PACKAGE_SPEC: "openclaw@2026.5.26" },
+      async () => {
+        await updateCommand({ yes: true, tag: "latest", restart: false });
+      },
+    );
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
+      target: "2026.5.26",
+      timeoutMs: undefined,
+    });
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    expectPackageInstallSpec("openclaw@2026.5.26");
+  });
 
   it.each([
     {
@@ -2904,7 +4029,8 @@ describe("update-cli", () => {
     await updateCommand({ yes: true });
 
     expectPackageInstallSpec("openclaw@latest");
-    const preflightParams = vi.mocked(fetchNpmPackageTargetStatus).mock.calls[0]?.[0];
+    // The availability preflight probes first; the Node runtime preflight is the last call.
+    const preflightParams = vi.mocked(fetchNpmPackageTargetStatus).mock.calls.at(-1)?.[0];
     expect(preflightParams).toEqual(
       expect.objectContaining({
         target: "latest",
@@ -3129,6 +4255,46 @@ describe("update-cli", () => {
     expect(errors.join("\n")).toContain(
       "Bare `npm i -g openclaw` can silently install an older compatible release.",
     );
+  });
+
+  it("keeps the Node runtime preflight when npm registry env points at a custom registry", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    const npmRoot = createCaseDir("openclaw-npm-root");
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "2026.5.26",
+      version: "2026.5.26",
+      nodeEngine: ">=22.19.0",
+    });
+    nodeVersionSatisfiesEngine.mockReturnValue(false);
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      if (argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
+        return commandOk(`${npmRoot}\n`);
+      }
+      expect(argv).toEqual(["npm", "config", "get", "registry", "--global"]);
+      expect(expectRunCommandOptions(options).env?.NPM_CONFIG_REGISTRY).toBe(
+        "https://npm.internal.example/",
+      );
+      return commandOk("https://npm.internal.example/\n");
+    });
+
+    await withEnvAsync({ NPM_CONFIG_REGISTRY: "https://npm.internal.example/" }, async () => {
+      await updateCommand({ yes: true, tag: "2026.5.26" });
+    });
+
+    expect(fetchNpmPackageTargetStatus).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchNpmPackageTargetStatus).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        target: "2026.5.26",
+        spec: "openclaw@2026.5.26",
+        command: "npm",
+      }),
+    );
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeUndefined();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+    expect(errors.join("\n")).toContain("Node ");
+    expect(errors.join("\n")).toContain("openclaw@2026.5.26");
   });
 
   it.each([

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,7 +1,9 @@
 // Main update orchestration for source checkouts and package installs.
+import fs from "node:fs/promises";
 import path from "node:path";
 import { confirm, isCancel } from "@clack/prompts";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { stylePromptMessage } from "../../../packages/terminal-core/src/prompt-style.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import {
@@ -22,6 +24,10 @@ import { disableCurrentOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js"
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
 import { createLowDiskSpaceWarning } from "../../infra/disk-space.js";
 import {
+  isExactSemverVersion,
+  isRegistryNpmDistTagSelector,
+} from "../../infra/npm-registry-spec.js";
+import {
   markPackagePostInstallDoctorAdvisory,
   runGlobalPackageUpdateSteps,
 } from "../../infra/package-update-steps.js";
@@ -36,9 +42,11 @@ import {
 import {
   checkUpdateStatus,
   compareSemverStrings,
+  fetchNpmPackageTargetStatus,
   resolveExtendedStablePackage,
   resolveNpmChannelTag,
 } from "../../infra/update-check.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
 import {
   buildControlPlaneUpdateRestartHealthPendingResult,
   readControlPlaneUpdateSentinelMeta,
@@ -56,6 +64,7 @@ import {
   resolveGlobalInstallTarget,
   resolveGlobalInstallSpec,
   resolvePnpmGlobalDirFromGlobalRoot,
+  type GlobalInstallManager,
   type ResolvedGlobalInstallTarget,
 } from "../../infra/update-global.js";
 import { cleanupStaleManagedServiceUpdateHandoffs } from "../../infra/update-managed-service-handoff-cleanup.js";
@@ -144,6 +153,8 @@ export { updateFinalizeCommand } from "./update-command-post-core.js";
 
 const CLI_NAME = resolveCliName();
 const DEFAULT_UPDATE_STEP_TIMEOUT_MS = 30 * 60_000;
+const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org/";
+const NPM_REGISTRY_CONFIG_TIMEOUT_MS = 5_000;
 
 const UPDATE_QUIPS = [
   "Leveled up! New skills unlocked. You're welcome.",
@@ -511,6 +522,315 @@ async function withUpdateInProgressEnv<T>(run: () => Promise<T>): Promise<T> {
   });
 }
 
+function normalizeNpmRegistryUrl(value: string | undefined | null): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const urlInput = trimmed.startsWith("//")
+    ? `https:${trimmed}`
+    : /^[a-z][a-z0-9+.-]*:\/\//iu.test(trimmed)
+      ? trimmed
+      : `https://${trimmed}`;
+  try {
+    const url = new URL(urlInput);
+    url.hash = "";
+    url.search = "";
+    const pathname = url.pathname.replace(/\/+$/u, "");
+    return `${url.protocol.toLowerCase()}//${url.host.toLowerCase()}${pathname}/`;
+  } catch {
+    return `${trimmed.replace(/\/+$/u, "").toLowerCase()}/`;
+  }
+}
+
+function isPublicNpmRegistry(value: string | undefined | null): boolean {
+  const normalized = normalizeNpmRegistryUrl(value);
+  if (!normalized) {
+    return false;
+  }
+  try {
+    const url = new URL(normalized);
+    return (
+      (url.protocol === "https:" || url.protocol === "http:") &&
+      url.host === "registry.npmjs.org" &&
+      url.pathname === "/"
+    );
+  } catch {
+    return normalized === PUBLIC_NPM_REGISTRY;
+  }
+}
+
+function readRegistryEnv(env: NodeJS.ProcessEnv, preferredNames: string[]): string | null {
+  const preferredLowerNames = new Set(preferredNames.map((name) => name.toLowerCase()));
+  const registries: string[] = [];
+  for (const [key, value] of Object.entries(env)) {
+    if (!preferredLowerNames.has(key.toLowerCase())) {
+      continue;
+    }
+    const next = normalizeOptionalString(value);
+    if (next) {
+      registries.push(next);
+    }
+  }
+  const customRegistry = registries.find((registry) => !isPublicNpmRegistry(registry));
+  if (registries.length > 1 && customRegistry) {
+    return customRegistry;
+  }
+  return registries.at(-1) ?? null;
+}
+
+function readNpmRegistryEnv(env: NodeJS.ProcessEnv): string | null {
+  return readRegistryEnv(env, ["NPM_CONFIG_REGISTRY", "npm_config_registry"]);
+}
+
+function readPnpmRegistryEnv(env: NodeJS.ProcessEnv): string | null {
+  const upper = normalizeOptionalString(env.PNPM_CONFIG_REGISTRY);
+  const lower = normalizeOptionalString(env.pnpm_config_registry);
+  if (upper && lower && normalizeNpmRegistryUrl(upper) !== normalizeNpmRegistryUrl(lower)) {
+    return null;
+  }
+  return readRegistryEnv(env, ["PNPM_CONFIG_REGISTRY", "pnpm_config_registry"]);
+}
+
+function readBunRegistryEnv(env: NodeJS.ProcessEnv): string | null {
+  return (
+    readRegistryEnv(env, ["BUN_CONFIG_REGISTRY", "bun_config_registry"]) ??
+    readNpmRegistryEnv(env)
+  );
+}
+
+function parseNpmrcDefaultRegistry(contents: string): string | null {
+  for (const rawLine of contents.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#") || line.startsWith(";")) {
+      continue;
+    }
+    const match = /^registry\s*=\s*(?<value>.+)$/iu.exec(line);
+    const value = normalizeOptionalString(match?.groups?.value);
+    if (value) {
+      return stripConfigStringQuotes(value);
+    }
+  }
+  return null;
+}
+
+function stripConfigStringQuotes(value: string): string {
+  const trimmed = value.trim();
+  const quote = trimmed[0];
+  if (
+    (quote === `"` || quote === "'") &&
+    trimmed.endsWith(quote) &&
+    trimmed.length >= 2
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function parseBunfigInstallRegistry(contents: string): string | null {
+  let inInstallSection = false;
+  for (const rawLine of contents.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    const section = /^\[(?<name>[^\]]+)\]$/u.exec(line);
+    if (section?.groups?.name) {
+      inInstallSection = section.groups.name.trim() === "install";
+      continue;
+    }
+    if (!inInstallSection) {
+      continue;
+    }
+    const registry = /^registry\s*=\s*(?<value>.+)$/u.exec(line)?.groups?.value;
+    const normalized = normalizeOptionalString(registry);
+    if (!normalized) {
+      continue;
+    }
+    if (normalized.startsWith("{")) {
+      const url = /\burl\s*=\s*(?<value>"[^"]*"|'[^']*'|[^,}#\s]+)/u.exec(normalized)?.groups
+        ?.value;
+      const parsedUrl = normalizeOptionalString(url);
+      return parsedUrl ? stripConfigStringQuotes(parsedUrl) : null;
+    }
+    const bareValue = normalized.split(/\s+#/u)[0]?.trim() ?? "";
+    return stripConfigStringQuotes(bareValue);
+  }
+  return null;
+}
+
+async function readRegistryConfigFile(
+  filePath: string,
+  parse: (contents: string) => string | null,
+): Promise<string | null> {
+  try {
+    return parse(await fs.readFile(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function readBunRegistryConfig(cwd: string | undefined): Promise<string | null> {
+  if (!cwd) {
+    return null;
+  }
+  return (
+    (await readRegistryConfigFile(path.join(cwd, "bunfig.toml"), parseBunfigInstallRegistry)) ??
+    (await readRegistryConfigFile(path.join(cwd, ".npmrc"), parseNpmrcDefaultRegistry))
+  );
+}
+
+function resolvePackageManagerRegistryConfigArgs(params: {
+  manager?: GlobalInstallManager | null;
+  command?: string | null;
+}): string[] | null {
+  const manager = params.manager ?? "npm";
+  const command = params.command ?? manager;
+  if (manager === "pnpm") {
+    return [command, "config", "get", "registry"];
+  }
+  if (manager !== "npm") {
+    return null;
+  }
+  return [command, "config", "get", "registry", "--global"];
+}
+
+async function resolveEffectiveNpmRegistry(params: {
+  env: NodeJS.ProcessEnv;
+  invocationCwd?: string;
+  registryConfigCwd?: string;
+  registryConfigCommand?: string;
+  timeoutMs?: number;
+  manager?: GlobalInstallManager | null;
+}): Promise<string | null> {
+  if (params.manager === "bun") {
+    return (
+      readBunRegistryEnv(params.env) ??
+      (await readBunRegistryConfig(params.registryConfigCwd ?? params.invocationCwd))
+    );
+  }
+  if (params.manager === "pnpm") {
+    const registryEnv = readPnpmRegistryEnv(params.env);
+    if (registryEnv) {
+      return registryEnv;
+    }
+  }
+  const argv = resolvePackageManagerRegistryConfigArgs({
+    manager: params.manager,
+    command: params.registryConfigCommand,
+  });
+  if (!argv) {
+    return readNpmRegistryEnv(params.env);
+  }
+  const result = await runCommandWithTimeout(
+    argv,
+    {
+      cwd: params.registryConfigCwd ?? params.invocationCwd,
+      env: params.env,
+      timeoutMs: Math.min(
+        params.timeoutMs ?? NPM_REGISTRY_CONFIG_TIMEOUT_MS,
+        NPM_REGISTRY_CONFIG_TIMEOUT_MS,
+      ),
+    },
+  ).catch(() => null);
+  if (!result || result.code !== 0) {
+    return params.manager === "pnpm"
+      ? readPnpmRegistryEnv(params.env)
+      : readNpmRegistryEnv(params.env);
+  }
+  return normalizeOptionalString(result.stdout) ?? null;
+}
+
+async function hasCustomNpmRegistryOverride(params: {
+  env?: NodeJS.ProcessEnv;
+  invocationCwd?: string;
+  registryConfigCwd?: string;
+  registryConfigCommand?: string;
+  timeoutMs?: number;
+  manager?: GlobalInstallManager | null;
+}): Promise<boolean> {
+  const env = params.env ?? process.env;
+  const registry = await resolveEffectiveNpmRegistry({
+    env,
+    invocationCwd: params.invocationCwd,
+    registryConfigCwd: params.registryConfigCwd,
+    registryConfigCommand: params.registryConfigCommand,
+    timeoutMs: params.timeoutMs,
+    manager: params.manager,
+  });
+  return registry ? !isPublicNpmRegistry(registry) : false;
+}
+
+function isNpmRegistryMissingTargetError(error: string | undefined): boolean {
+  return /^HTTP 404\b/u.test(error?.trim() ?? "");
+}
+
+function resolveRegistryLookupTarget(target: string): string | null {
+  const trimmed = target.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (isExactSemverVersion(trimmed)) {
+    return trimmed.startsWith("v") ? trimmed.slice(1) : trimmed;
+  }
+  return isRegistryNpmDistTagSelector(trimmed) ? trimmed : null;
+}
+
+function resolvePackageRegistryTargetFromInstallSpec(installSpec: string | null): string | null {
+  const trimmed = installSpec?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const packagePrefix = `${DEFAULT_PACKAGE_NAME}@`;
+  if (!trimmed.toLowerCase().startsWith(packagePrefix)) {
+    return null;
+  }
+  const target = trimmed.slice(packagePrefix.length).trim();
+  if (!target || !canResolveRegistryVersionForPackageTarget(target)) {
+    return null;
+  }
+  return resolveRegistryLookupTarget(target);
+}
+
+async function resolvePackageTargetAvailabilityPreflightError(params: {
+  installSpec: string | null;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  invocationCwd?: string;
+  registryConfigCwd?: string;
+  registryConfigCommand?: string;
+  manager?: GlobalInstallManager | null;
+}): Promise<string | null> {
+  const target = resolvePackageRegistryTargetFromInstallSpec(params.installSpec);
+  if (!target) {
+    return null;
+  }
+  if (
+    await hasCustomNpmRegistryOverride({
+      env: params.env,
+      invocationCwd: params.invocationCwd,
+      registryConfigCwd: params.registryConfigCwd,
+      registryConfigCommand: params.registryConfigCommand,
+      timeoutMs: params.timeoutMs,
+      manager: params.manager,
+    })
+  ) {
+    return null;
+  }
+  const status = await fetchNpmPackageTargetStatus({
+    target,
+    timeoutMs: params.timeoutMs,
+  });
+  if (status.version || !isNpmRegistryMissingTargetError(status.error)) {
+    return null;
+  }
+  return [
+    `openclaw@${target} is not available on the npm registry yet.`,
+    "`openclaw update --dry-run` checks npm before apply so it does not green-light a target that npm install will reject with ETARGET.",
+    "Wait for npm propagation, choose an available dist-tag, or use a GitHub package spec such as `--tag github:openclaw/openclaw#v<version>`.",
+  ].join("\n");
+}
+
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   const recoveryState: UpdateCommandRecoveryState = {};
   return await withUpdateInProgressEnv(async () => {
@@ -783,6 +1103,71 @@ async function updateCommandInternal(
     }
   }
 
+  let packageUpdateManager: GlobalInstallManager | null = null;
+  const resolvePackageUpdateManager = async (): Promise<GlobalInstallManager | null> => {
+    if (updateInstallKind !== "package") {
+      return null;
+    }
+    if (packageUpdateManager) {
+      return packageUpdateManager;
+    }
+    packageUpdateManager = await resolveGlobalManager({
+      root,
+      installKind,
+      timeoutMs: updateStepTimeoutMs,
+    });
+    return packageUpdateManager;
+  };
+  let packageRegistryPreflightTarget:
+    | {
+        manager: GlobalInstallManager | null;
+        installTarget?: ResolvedGlobalInstallTarget;
+        registryConfigCwd?: string;
+      }
+    | undefined;
+  const resolvePackageRegistryPreflightTarget = async (
+    manager: GlobalInstallManager | null,
+  ): Promise<{
+    manager: GlobalInstallManager | null;
+    registryConfigCommand?: string;
+    registryConfigCwd?: string;
+  }> => {
+    if (!manager) {
+      return { manager: null, registryConfigCwd: invocationCwd };
+    }
+    if (packageRegistryPreflightTarget?.manager === manager) {
+      return {
+        manager: packageRegistryPreflightTarget.installTarget?.manager ?? manager,
+        ...(packageRegistryPreflightTarget.installTarget?.command
+          ? { registryConfigCommand: packageRegistryPreflightTarget.installTarget.command }
+          : {}),
+        ...(packageRegistryPreflightTarget.registryConfigCwd
+          ? { registryConfigCwd: packageRegistryPreflightTarget.registryConfigCwd }
+          : {}),
+      };
+    }
+    const installTarget = await resolveGlobalInstallTarget({
+      manager,
+      runCommand: createGlobalCommandRunner(),
+      timeoutMs: updateStepTimeoutMs,
+      pkgRoot: root,
+    });
+    const registryConfigCwd =
+      installTarget.manager === "pnpm" && installTarget.globalRoot
+        ? path.dirname(installTarget.globalRoot)
+        : invocationCwd;
+    packageRegistryPreflightTarget = {
+      manager,
+      installTarget,
+      registryConfigCwd,
+    };
+    return {
+      manager: installTarget.manager,
+      ...(installTarget.command ? { registryConfigCommand: installTarget.command } : {}),
+      ...(registryConfigCwd ? { registryConfigCwd } : {}),
+    };
+  };
+
   if (updateInstallKind !== "git") {
     packageInstallEnv = await createGlobalInstallEnv();
     packageInstallCwd = tryResolveInvocationCwd();
@@ -869,6 +1254,39 @@ async function updateCommandInternal(
       tag,
       env: packageInstallEnv,
     });
+    // Run the availability preflight against the spec the package manager will
+    // actually install. When OPENCLAW_UPDATE_PACKAGE_SPEC is set, that override
+    // *is* the install target, so a registry-style override such as
+    // `openclaw@<version|tag>` must be preflighted too — otherwise dry-run/apply
+    // green-lights an override target npm install later rejects with ETARGET.
+    // Non-registry overrides (tarball/git/URL specs) and custom registries stay
+    // exempt because resolvePackageTargetAvailabilityPreflightError only probes
+    // registry-style `openclaw@<target>` specs on the public npm registry.
+    const availabilityInstallSpec = packageInstallSpec;
+    const packageTargetManager = resolvePackageRegistryTargetFromInstallSpec(availabilityInstallSpec)
+      ? await resolvePackageUpdateManager()
+      : null;
+    const registryPreflightTarget =
+      packageTargetManager === null
+        ? {
+            manager: packageTargetManager,
+            ...(invocationCwd ? { registryConfigCwd: invocationCwd } : {}),
+          }
+        : await resolvePackageRegistryPreflightTarget(packageTargetManager);
+    const targetAvailabilityError = await resolvePackageTargetAvailabilityPreflightError({
+      installSpec: availabilityInstallSpec,
+      timeoutMs,
+      env: process.env,
+      invocationCwd,
+      registryConfigCwd: registryPreflightTarget.registryConfigCwd,
+      registryConfigCommand: registryPreflightTarget.registryConfigCommand,
+      manager: registryPreflightTarget.manager,
+    });
+    if (targetAvailabilityError) {
+      defaultRuntime.error(targetAvailabilityError);
+      defaultRuntime.exit(1);
+      return;
+    }
   }
 
   if (opts.dryRun) {
@@ -876,11 +1294,7 @@ async function updateCommandInternal(
     if (updateInstallKind === "git") {
       mode = "git";
     } else if (updateInstallKind === "package") {
-      mode = await resolveGlobalManager({
-        root,
-        installKind,
-        timeoutMs: updateStepTimeoutMs,
-      });
+      mode = (await resolvePackageUpdateManager()) ?? "unknown";
     }
 
     const actions: string[] = [];

--- a/src/infra/npm-registry-spec.test.ts
+++ b/src/infra/npm-registry-spec.test.ts
@@ -26,6 +26,12 @@ describe("npm registry spec validation", () => {
     "@openclaw/voice-call@1.2.3-beta.4",
     "@openclaw/voice-call@latest",
     "@openclaw/voice-call@beta",
+    "@openclaw/voice-call@2026q2",
+    "@openclaw/voice-call@1.x-beta",
+    "@openclaw/voice-call@x-beta",
+    "@openclaw/voice-call@V1",
+    "@openclaw/voice-call@V1.x",
+    "@openclaw/voice-call@Vx",
   ])("accepts %s", (spec) => {
     expect(validateRegistryNpmSpec(spec)).toBeNull();
   });
@@ -37,6 +43,50 @@ describe("npm registry spec validation", () => {
     },
     {
       spec: "@openclaw/voice-call@~1.2.3",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@2026.5.x",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@01",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@2026.05",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@1.02.x",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@vv1",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@vv1.2.3",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@1.02.3",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@1.2.x-beta",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@v1.x.x-beta",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@x.x.x-beta",
+      expected: "exact version or dist-tag",
+    },
+    {
+      spec: "@openclaw/voice-call@1",
       expected: "exact version or dist-tag",
     },
     {

--- a/src/infra/npm-registry-spec.ts
+++ b/src/infra/npm-registry-spec.ts
@@ -10,6 +10,16 @@ import { compareOpenClawSemver, isOpenClawCorrectionSemver } from "./semver.js";
 
 const OPENCLAW_RELEASE_PREFIX_RE = /^\d{4}\./;
 const DIST_TAG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const SEMVER_PARTIAL_IDENTIFIER_RE = "(?:\\d+|x|\\*)";
+const SIMPLE_SEMVER_RANGE_SELECTOR_RE = new RegExp(
+  `^v*${SEMVER_PARTIAL_IDENTIFIER_RE}(?:\\.${SEMVER_PARTIAL_IDENTIFIER_RE}){0,2}$`,
+  "u",
+);
+const WILDCARD_PRERELEASE_SEMVER_RANGE_SELECTOR_RE =
+  new RegExp(
+    `^v*${SEMVER_PARTIAL_IDENTIFIER_RE}(?:\\.${SEMVER_PARTIAL_IDENTIFIER_RE}){0,2}-[0-9a-z][0-9a-z.-]*(?:\\+[0-9a-z.-]+)?$`,
+    "u",
+  );
 
 /**
  * Parsed registry-only npm spec accepted by plugin install flows.
@@ -23,6 +33,39 @@ export type ParsedRegistryNpmSpec = {
   selectorKind: "none" | "exact-version" | "tag";
   selectorIsPrerelease: boolean;
 };
+
+function isSemverRangeSelector(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || isExactSemverVersion(trimmed)) {
+    return false;
+  }
+  if (trimmed.startsWith("V")) {
+    return false;
+  }
+  const lowered = trimmed.toLowerCase();
+  const wildcardPrereleaseCore = lowered
+    .slice(0, lowered.indexOf("-"))
+    .replace(/^v/u, "")
+    .split(".");
+  const wildcardPrereleaseRange =
+    WILDCARD_PRERELEASE_SEMVER_RANGE_SELECTOR_RE.test(lowered) &&
+    wildcardPrereleaseCore.length === 3 &&
+    wildcardPrereleaseCore.some((part) => part === "x" || part === "*");
+  return (
+    lowered === "*" ||
+    lowered === "x" ||
+    /^(?:[~^<>]=?|=)/u.test(lowered) ||
+    lowered.includes("||") ||
+    /\s+-\s+/u.test(lowered) ||
+    SIMPLE_SEMVER_RANGE_SELECTOR_RE.test(lowered) ||
+    wildcardPrereleaseRange
+  );
+}
+
+export function isRegistryNpmDistTagSelector(value: string): boolean {
+  const trimmed = value.trim();
+  return DIST_TAG_RE.test(trimmed) && !isSemverRangeSelector(trimmed);
+}
 
 function parseRegistryNpmSpecInternal(
   rawSpec: string,
@@ -94,7 +137,7 @@ function parseRegistryNpmSpecInternal(
       },
     };
   }
-  if (!DIST_TAG_RE.test(selector)) {
+  if (!isRegistryNpmDistTagSelector(selector)) {
     return {
       ok: false,
       error: "unsupported npm spec: use an exact version or dist-tag (ranges are not allowed)",


### PR DESCRIPTION
Fixes #87320

> **Re-ported 2026-07-16** onto current `origin/main` (`d11f304519`); HEAD now `7006bafd95`. Upstream split the monolithic `update-command.ts` into `update-command-service.ts` / `shared.ts` / `update-command-post-core.ts` since the last rebase (~9.6k commits of drift), so this was a structural re-port, not a mechanical rebase. Diff semantics unchanged; one convergent-refactor dedup: main independently evolved `resolvePackageRuntimePreflightError` (now in `update-command-service.ts` with a richer `spec`/`command`/`cwd`/`env` signature) — this PR now composes with that version instead of carrying its own copy, and the Node-runtime-preflight tests were updated to match main's call shape. Post-port verification against the committed head (`git status` clean, Node 22.23.1): `tsgo` core/ui/extensions/core-test/extensions-test all exit 0; `src/cli/update-cli.test.ts` 223/223; `src/infra/npm-registry-spec.test.ts` 63/63; `oxlint` clean; `git diff --check` clean. Fresh real-behavior proof at the new head is appended below (2026-07-16 section); the 2026-06-16 proof blocks are retained unchanged for review history.
>
> *(Previous note, 2026-06-16:)* **Rebased 2026-06-16** onto current `origin/main` (`6b3e23aba7`); HEAD now `d8b9d242ab`. The 19 iterative re-review commits were squashed into one for a clean single-pass rebase. One import-block conflict in `update-command.ts` (main added `markPackagePostInstallDoctorAdvisory`; this PR adds `isExactSemverVersion`/`isRegistryNpmDistTagSelector`) — kept both, both verified in-use. Post-rebase: tsgo core clean, 251 update-cli/npm-spec tests pass, oxlint clean. Diff content unchanged from the proof-cleared head.

## User-facing bug
`openclaw update --tag <version> --dry-run` could report a clean package-update plan when the requested OpenClaw version was not actually available from the npm registry that the update would use. Running the same update without `--dry-run` then failed later in the package manager, so dry-run and apply gave contradictory signals during npm publication/registry propagation windows.

## Exact repro
Source-level reproduction:

1. Use a package-manager install of OpenClaw.
2. Request an exact registry version target that is syntactically valid but absent from public npm, for example:
   - `openclaw update --tag 2026.5.31 --dry-run --json`
3. Before this fix, the exact semver tag could be accepted locally as the planned install target without proving npm availability, so dry-run emitted a green plan.
4. Running apply with the same target later reached a package-manager install such as `npm install -g openclaw@2026.5.31` and failed with `ETARGET`/`E404`.
5. After this fix, dry-run and apply run the same availability preflight for public-registry package targets and fail early with a clear npm propagation message when the registry returns `HTTP 404`.

## Fix summary
- Added a package-target availability preflight for OpenClaw package updates before both dry-run preview output and real package install/service-stop work.
- The preflight blocks only confirmed npm `HTTP 404` target misses; transient fetch errors remain non-blocking.
- Resolved the preflight target from the actual install spec, including `OPENCLAW_UPDATE_PACKAGE_SPEC` overrides, exact `v`-prefixed versions, and npm dist-tags.
- Ran the availability preflight against the spec the package manager will actually install, so a registry-style `OPENCLAW_UPDATE_PACKAGE_SPEC` override (`openclaw@<version|tag>`) is preflighted too, while tarball/git/URL overrides and custom registries stay exempt.
- Kept semver ranges/non-registry specs out of the public npm availability preflight so dry-run does not over-validate targets npm will resolve differently.
- Aligned custom-registry detection with the resolved package manager path:
  - npm: owning npm binary plus npm global registry config/env.
  - pnpm: `PNPM_CONFIG_REGISTRY` / `pnpm_config_registry`, with conflicting casing resolved by `pnpm config get registry` from the global project.
  - Bun: Bun registry env, caller-local `bunfig.toml`, and caller-local `.npmrc`.
- Normalized public npm registry aliases, including `http://registry.npmjs.org/` and protocol-relative `//registry.npmjs.org/`.

## Targeted tests
- Added dry-run coverage proving confirmed-missing public npm exact targets fail before JSON preview output.
- Added apply coverage proving the same missing target fails before package install or managed-service stop.
- Added coverage for `v`-prefixed exact versions, npm dist-tags, semver/range selectors, explicit package spec overrides, custom registries, public npm registry aliases, npm/pnpm/Bun registry source handling, and Node runtime preflight preservation.
- Added coverage proving registry-style `OPENCLAW_UPDATE_PACKAGE_SPEC` overrides run the availability preflight: an absent `openclaw@<version>` override fails closed before install, an available override passes the preflight, while tarball/git overrides stay exempt.
- Added source-level spec tests for npm registry selector classification so update preflight does not treat semver ranges as dist-tags.

## Real behavior proof

Behavior addressed: `openclaw update --tag <exact-version> --dry-run` and real apply now use the same npm target availability preflight, so dry-run does not approve a public npm target that apply will reject with `ETARGET`/`E404`.

Real environment tested: Local OpenClaw checkout on branch `fix/update-dry-run-npm-target`, commit `d8b9d242ab`, rebased onto current `origin/main`; Node `v24.4.1`; npm `11.4.2`.

Exact steps or command run after this patch:
- `git diff --check origin/main...HEAD`
- `./node_modules/.bin/oxlint src/cli/update-cli/update-command.ts src/cli/update-cli.test.ts src/infra/npm-registry-spec.ts src/infra/npm-registry-spec.test.ts`
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/infra/npm-registry-spec.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- Live npm registry proof through the PR's own availability probe (`src/infra/update-check.ts:fetchNpmPackageTargetStatus`), the exact function the dry-run/apply preflight gates on:
  ```bash
  node --import tsx -e "import { fetchNpmPackageTargetStatus } from './src/infra/update-check.ts'; \
    console.log(JSON.stringify({ absent: await fetchNpmPackageTargetStatus({ target: '2099.1.1', timeoutMs: 8000 }), \
    present: await fetchNpmPackageTargetStatus({ target: 'latest', timeoutMs: 8000 }) }, null, 2));"
  ```
- Real CLI dry-run on the override path, in an isolated `OPENCLAW_HOME`/`OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH`:
  ```bash
  OPENCLAW_UPDATE_PACKAGE_SPEC="openclaw@2099.1.1" \
    node --import tsx src/entry.ts update --channel stable --tag 2099.1.1 --dry-run --json
  ```

Evidence after fix:

- Live-registry preflight proof — ran the PR's own availability probe (`src/infra/update-check.ts:fetchNpmPackageTargetStatus`, the exact function the dry-run/apply preflight gates on) against the real public npm registry, from the branch checkout at commit `d8b9d242ab`:

  ```bash
  node --import tsx -e "import { fetchNpmPackageTargetStatus } from './src/infra/update-check.ts'; console.log(JSON.stringify({ absent: await fetchNpmPackageTargetStatus({ target: '2099.1.1', timeoutMs: 8000 }), present: await fetchNpmPackageTargetStatus({ target: 'latest', timeoutMs: 8000 }) }, null, 2));"
  ```

  Real output copied from the terminal — a confirmed `HTTP 404` for an unpublished exact version (which the preflight converts into the early dry-run/apply hard-fail) and a real resolved version for a published tag:

  ```json
  {
    "absent": { "target": "2099.1.1", "version": null, "nodeEngine": null, "error": "HTTP 404" },
    "present": { "target": "latest", "version": "2026.6.1", "nodeEngine": ">=22.19.0" }
  }
  ```

  This is the real-behavior signal the preflight acts on: a confirmed 404 for an absent public target, distinct from a transient network error (which stays non-blocking).
- Real CLI override-path proof — ran the actual `openclaw update --channel stable --dry-run --json` command (package-mode update) with a registry-style `OPENCLAW_UPDATE_PACKAGE_SPEC` override against the real public npm registry, in an isolated `OPENCLAW_HOME`/`OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH`. This is the override path that previously bypassed the preflight:

  - Absent registry-style override `openclaw@2099.1.1` now fails closed before any install (`exit 1`):

    ```text
    $ OPENCLAW_UPDATE_PACKAGE_SPEC="openclaw@2099.1.1" node --import tsx src/entry.ts update --channel stable --tag 2099.1.1 --dry-run --json
    openclaw@2099.1.1 is not available on the npm registry yet.
    `openclaw update --dry-run` checks npm before apply so it does not green-light a target that npm install will reject with ETARGET.
    Wait for npm propagation, choose an available dist-tag, or use a GitHub package spec such as `--tag github:openclaw/openclaw#v<version>`.
    # exit code: 1
    ```

  - Present registry-style override `openclaw@latest` passes the preflight and produces a normal dry-run plan (`exit 0`, real resolved `targetVersion`):

    ```json
    {
      "dryRun": true,
      "mode": "npm",
      "updateInstallKind": "package",
      "tag": "openclaw@latest",
      "targetVersion": "2026.6.1"
    }
    ```

  - Non-registry tarball override `http://…/openclaw-next.tgz` stays exempt — no public npm 404 check, normal dry-run plan (`exit 0`):

    ```json
    {
      "dryRun": true,
      "mode": "npm",
      "updateInstallKind": "package",
      "tag": "http://10.211.55.2:8138/openclaw-next.tgz",
      "targetVersion": "2026.6.1"
    }
    ```
- Focused Vitest passed after the rebase: `src/cli/update-cli.test.ts` → 169 tests passed; `src/infra/npm-registry-spec.test.ts` → 65 tests passed.
- `tsgo` core typecheck (`tsconfig.core.json`) passed with exit 0 after the rebase.
- `oxlint` passed (exit 0) on the changed update CLI and npm registry spec files.
- `git diff --check origin/main...HEAD` passed.

Observed result after fix: Exact public npm targets absent from the registry fail before both JSON dry-run preview output and real package install/service-stop work, including registry-style `OPENCLAW_UPDATE_PACKAGE_SPEC` overrides (`openclaw@<version|tag>`). Custom registry paths, non-registry overrides (tarball/git/URL specs), semver ranges, and non-registry specs keep their existing authority instead of being forced through public npm availability checks.

What was not tested: No live package-manager update was applied to a real globally installed OpenClaw package. A full unfiltered `src/cli/update-cli.test.ts` run hit an existing unrelated long-handle/kill-count failure in `finishes package updates when the post-core process writes a result but keeps handles open`; this PR was verified with targeted update CLI/spec coverage plus type/lint/review gates.

## Not tested / known gaps
- Live npm registry requests can still return local DNS/fetch failures in restricted environments. The preflight intentionally treats those as non-blocking network errors and only blocks confirmed `HTTP 404` target misses.

## Real behavior proof (2026-07-16, re-ported head `7006bafd95`)

Same three probes as the 2026-06-16 proof, re-run against the re-ported head on current main, real public npm registry, Node `v22.23.1`:

- Live-registry preflight probe through `src/infra/update-check.ts:fetchNpmPackageTargetStatus` (the exact function the preflight gates on):

  ```json
  {
    "absent": { "target": "2099.1.1", "version": null, "nodeEngine": null, "error": "HTTP 404" },
    "present": { "target": "latest", "version": "2026.7.1", "nodeEngine": ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0" }
  }
  ```

- Real CLI dry-run, direct `--tag` with an absent exact version (the original #87320 repro path), isolated `OPENCLAW_HOME`/`OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` — fails closed before preview output (`exit 1`):

  ```text
  $ node --import tsx src/entry.ts update --channel stable --tag 2099.1.1 --dry-run --json
  openclaw@2099.1.1 is not available on the npm registry yet.
  `openclaw update --dry-run` checks npm before apply so it does not green-light a target that npm install will reject with ETARGET.
  Wait for npm propagation, choose an available dist-tag, or use a GitHub package spec such as `--tag github:openclaw/openclaw#v<version>`.
  # exit code: 1
  ```

- Absent registry-style override `OPENCLAW_UPDATE_PACKAGE_SPEC="openclaw@2099.1.1"` — same fail-closed message, `exit 1`. Present override `openclaw@latest` — passes the preflight and produces a normal dry-run plan (`exit 0`):

  ```json
  { "dryRun": true, "mode": "npm", "tag": "openclaw@latest", "targetVersion": "2026.7.1" }
  ```

## AI-assisted disclosure
This patch was prepared with AI assistance. I used source-level issue reproduction, targeted regression tests, real package-manager behavior probes, and explicit command output to validate the behavior above.


