### PR TITLE
Render dashboard chat history incrementally

### DIFF
--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -1483,6 +1483,13 @@
       "kind": "html-attribute",
       "name": "aria-label",
       "path": "ui/src/ui/views/chat.ts",
+      "text": "Exit focus mode"
+    },
+    {
+      "count": 1,
+      "kind": "html-attribute",
+      "name": "aria-label",
+      "path": "ui/src/ui/views/chat.ts",
       "text": "Loading chat"
     },
     {
@@ -1554,6 +1561,13 @@
       "name": "title",
       "path": "ui/src/ui/views/chat.ts",
       "text": "Dismiss error"
+    },
+    {
+      "count": 1,
+      "kind": "html-attribute",
+      "name": "title",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Exit focus mode"
     },
     {
       "count": 1,

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -3,6 +3,27 @@
   "entries": [
     {
       "count": 1,
+      "kind": "html-attribute",
+      "name": "aria-label",
+      "path": "ui/src/ui/app-render.ts",
+      "text": "Workshop view"
+    },
+    {
+      "count": 1,
+      "kind": "html-attribute",
+      "name": "title",
+      "path": "ui/src/ui/app-render.ts",
+      "text": "Board view"
+    },
+    {
+      "count": 1,
+      "kind": "html-attribute",
+      "name": "title",
+      "path": "ui/src/ui/app-render.ts",
+      "text": "Today view"
+    },
+    {
+      "count": 1,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/app-render.ts",
@@ -13,7 +34,21 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/app-render.ts",
+      "text": "Board"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/app-render.ts",
       "text": "OpenClaw"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/app-render.ts",
+      "text": "Today"
     },
     {
       "count": 1,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1014,7 +1014,8 @@
   color: var(--muted);
 }
 
-.agent-chat__talk-options input {
+.agent-chat__talk-options input,
+.agent-chat__talk-options select {
   width: 100%;
   min-width: 0;
   height: 34px;
@@ -1029,7 +1030,16 @@
   box-sizing: border-box;
 }
 
-.agent-chat__talk-options input:focus {
+.agent-chat__talk-options select {
+  appearance: none;
+  padding-right: 26px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-position: right 8px center;
+  background-repeat: no-repeat;
+}
+
+.agent-chat__talk-options input:focus,
+.agent-chat__talk-options select:focus {
   outline: none;
   box-shadow: var(--focus-ring);
 }

--- a/ui/src/ui/app.talk.test.ts
+++ b/ui/src/ui/app.talk.test.ts
@@ -152,4 +152,29 @@ describe("OpenClawApp Talk controls", () => {
     expect(app.chatError).toBe("voice provider missing");
     expect(stopMock).toHaveBeenCalledOnce();
   });
+
+  it("keeps the Talk options toggle inside the open-panel click guard", async () => {
+    await import("./app.ts");
+    const app = document.createElement("openclaw-app");
+    const guardHost = app as unknown as {
+      chatMobileControlsPointerdownHandler: (event: Event) => void;
+      realtimeTalkOptionsOpen: boolean;
+    };
+    const toggle = document.createElement("button");
+    toggle.setAttribute("aria-label", "Talk options");
+    app.append(toggle);
+
+    guardHost.realtimeTalkOptionsOpen = true;
+    guardHost.chatMobileControlsPointerdownHandler({
+      composedPath: () => [toggle, app, document, window],
+    } as unknown as Event);
+
+    expect(guardHost.realtimeTalkOptionsOpen).toBe(true);
+
+    guardHost.chatMobileControlsPointerdownHandler({
+      composedPath: () => [document, window],
+    } as unknown as Event);
+
+    expect(guardHost.realtimeTalkOptionsOpen).toBe(false);
+  });
 });

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -760,7 +760,9 @@ export class OpenClawApp extends LitElement {
     });
     if (this.realtimeTalkOptionsOpen) {
       const insideTalkOptions = Array.from(
-        this.querySelectorAll(".agent-chat__talk-options, [aria-label='Talk settings']"),
+        this.querySelectorAll(
+          ".agent-chat__talk-options, [aria-label='Talk settings'], [aria-label='Talk options']",
+        ),
       ).some((node) => path.includes(node));
       if (!insideTalkOptions) {
         this.realtimeTalkOptionsOpen = false;

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -260,6 +260,27 @@ describe("buildChatItems", () => {
     expect(messageRecord(groups[groups.length - 1]).content).toBe("message 104");
   });
 
+  it("honors a smaller history render window and preserves the hidden-count notice", () => {
+    const items = buildChatItems(
+      createProps({
+        historyRenderLimit: 30,
+        messages: Array.from({ length: 105 }, (_, index) => ({
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `message ${index}`,
+          timestamp: index,
+        })),
+      }),
+    );
+
+    const groups = items.filter((item) => item.kind === "group");
+
+    const noticeGroup = requireGroup(items[0]);
+    expect(messageRecord(noticeGroup).content).toBe("Showing last 30 messages (75 hidden).");
+    expect(groups).toHaveLength(31);
+    expect(messageRecord(groups[1]).content).toBe("message 75");
+    expect(messageRecord(groups[groups.length - 1]).content).toBe("message 104");
+  });
+
   it("budgets rendered history by tool-result content size", () => {
     const largeOutput = "x".repeat(100_000);
     const items = buildChatItems(

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -23,6 +23,7 @@ export type BuildChatItemsProps = {
   showToolCalls: boolean;
   searchOpen?: boolean;
   searchQuery?: string;
+  historyRenderLimit?: number;
 };
 
 function appendCanvasBlockToAssistantMessage(
@@ -468,7 +469,18 @@ function countVisibleHistoryMessages(messages: unknown[], showToolCalls: boolean
   return count;
 }
 
-function resolveHistoryStartIndex(messages: unknown[], showToolCalls: boolean): number {
+function resolveHistoryRenderLimit(limit: number | undefined): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) {
+    return CHAT_HISTORY_RENDER_LIMIT;
+  }
+  return Math.max(1, Math.min(CHAT_HISTORY_RENDER_LIMIT, Math.floor(limit)));
+}
+
+function resolveHistoryStartIndex(
+  messages: unknown[],
+  showToolCalls: boolean,
+  renderLimit: number,
+): number {
   let visibleCount = 0;
   let renderChars = 0;
   let startIndex = messages.length;
@@ -477,7 +489,7 @@ function resolveHistoryStartIndex(messages: unknown[], showToolCalls: boolean): 
     if (isHiddenToolMessage(message, showToolCalls)) {
       continue;
     }
-    if (visibleCount >= CHAT_HISTORY_RENDER_LIMIT) {
+    if (visibleCount >= renderLimit) {
       break;
     }
     const remainingBudget = Math.max(1, CHAT_HISTORY_RENDER_CHAR_BUDGET - renderChars + 1);
@@ -494,6 +506,7 @@ function resolveHistoryStartIndex(messages: unknown[], showToolCalls: boolean): 
 
 export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGroup> {
   let items: ChatItem[] = [];
+  const historyRenderLimit = resolveHistoryRenderLimit(props.historyRenderLimit);
   const history = (Array.isArray(props.messages) ? props.messages : []).filter(
     (message) => !isAssistantHeartbeatAckForDisplay(message),
   );
@@ -505,7 +518,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     text: string | null;
     timestamp: number | null;
   }>;
-  const historyStart = resolveHistoryStartIndex(history, props.showToolCalls);
+  const historyStart = resolveHistoryStartIndex(history, props.showToolCalls, historyRenderLimit);
   const hiddenHistoryCount = countVisibleHistoryMessages(
     history.slice(0, historyStart),
     props.showToolCalls,

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -920,6 +920,29 @@ describe("chat composer workbench", () => {
     expect(labels).not.toContain(t("chat.runControls.newSession"));
     expect(labels).not.toContain(t("chat.runControls.exportChat"));
   });
+
+  it("exposes aria-expanded on the Talk settings button reflecting open state", () => {
+    const collapsed = renderChatView({
+      onToggleRealtimeTalk: () => undefined,
+      onToggleRealtimeTalkOptions: () => undefined,
+      realtimeTalkOptionsOpen: false,
+    });
+    const collapsedBtn = collapsed.querySelector<HTMLButtonElement>(
+      'button[aria-label="Talk settings"]',
+    );
+    expect(collapsedBtn).not.toBeNull();
+    expect(collapsedBtn?.getAttribute("aria-expanded")).toBe("false");
+
+    const expanded = renderChatView({
+      onToggleRealtimeTalk: () => undefined,
+      onToggleRealtimeTalkOptions: () => undefined,
+      realtimeTalkOptionsOpen: true,
+    });
+    const expandedBtn = expanded.querySelector<HTMLButtonElement>(
+      'button[aria-label="Talk settings"]',
+    );
+    expect(expandedBtn?.getAttribute("aria-expanded")).toBe("true");
+  });
 });
 
 afterEach(() => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -649,6 +649,86 @@ describe("chat history render window", () => {
     );
   });
 
+  it("preserves the visible anchor across repeated top-scroll expansion", () => {
+    const messages = Array.from({ length: 80 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+    const onRequestUpdate = vi.fn();
+    const onChatScroll = vi.fn();
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const container = renderChatView({ messages, onRequestUpdate, onChatScroll });
+    const thread = requireElement(container, ".chat-thread", "chat thread") as HTMLElement;
+    Object.defineProperties(thread, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 300 },
+    });
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+    Object.defineProperty(thread, "scrollHeight", { configurable: true, value: 600 });
+    buildChatItemsMock.mockClear();
+    renderChatView({ messages, onRequestUpdate, onChatScroll });
+
+    expect(buildChatItemsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages,
+        historyRenderLimit: 60,
+      }),
+    );
+    const firstExpandedThread = requireElement(
+      container,
+      ".chat-thread",
+      "chat thread",
+    ) as HTMLElement;
+    Object.defineProperties(firstExpandedThread, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 600 },
+    });
+    for (const callback of frameCallbacks.splice(0)) {
+      callback(0);
+    }
+    expect(firstExpandedThread.scrollTop).toBe(300);
+
+    firstExpandedThread.scrollTop = 0;
+    firstExpandedThread.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+    buildChatItemsMock.mockClear();
+    renderChatView({ messages, onRequestUpdate, onChatScroll });
+
+    expect(buildChatItemsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages,
+        historyRenderLimit: 80,
+      }),
+    );
+    const secondExpandedThread = requireElement(
+      container,
+      ".chat-thread",
+      "chat thread",
+    ) as HTMLElement;
+    Object.defineProperties(secondExpandedThread, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 900 },
+    });
+    for (const callback of frameCallbacks.splice(0)) {
+      callback(0);
+    }
+    expect(secondExpandedThread.scrollTop).toBe(300);
+    expect(onRequestUpdate).toHaveBeenCalledTimes(2);
+    expect(onChatScroll).toHaveBeenCalledTimes(2);
+  });
+
   it("does not expand the history render window for bottom auto-scrolls inside the top threshold", () => {
     const messages = Array.from({ length: 80 }, (_, index) => ({
       role: index % 2 === 0 ? "user" : "assistant",

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -601,6 +601,53 @@ describe("chat compaction divider", () => {
   });
 });
 
+describe("chat history render window", () => {
+  it("starts freshly loaded large histories with a small render window", () => {
+    const messages = Array.from({ length: 80 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+
+    renderChatView({ messages });
+
+    expect(buildChatItemsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages,
+        historyRenderLimit: 30,
+      }),
+    );
+  });
+
+  it("expands the history render window when the user scrolls to the top", () => {
+    const messages = Array.from({ length: 80 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+    const onRequestUpdate = vi.fn();
+    const onChatScroll = vi.fn();
+
+    const container = renderChatView({ messages, onRequestUpdate, onChatScroll });
+    const thread = requireElement(container, ".chat-thread", "chat thread") as HTMLElement;
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+    expect(onRequestUpdate).toHaveBeenCalledTimes(1);
+    expect(onChatScroll).toHaveBeenCalledTimes(1);
+
+    buildChatItemsMock.mockClear();
+    renderChatView({ messages, onRequestUpdate, onChatScroll });
+
+    expect(buildChatItemsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages,
+        historyRenderLimit: 60,
+      }),
+    );
+  });
+});
+
 describe("chat goal status", () => {
   it("renders the active session goal inside the composer", () => {
     const container = renderChatView({

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -630,14 +630,117 @@ describe("chat history render window", () => {
 
     const container = renderChatView({ messages, onRequestUpdate, onChatScroll });
     const thread = requireElement(container, ".chat-thread", "chat thread") as HTMLElement;
+    thread.scrollTop = 120;
+    thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+    expect(onRequestUpdate).toHaveBeenCalledTimes(1);
+    expect(onChatScroll).toHaveBeenCalledTimes(2);
+
+    buildChatItemsMock.mockClear();
+    renderChatView({ messages, onRequestUpdate, onChatScroll });
+
+    expect(buildChatItemsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages,
+        historyRenderLimit: 60,
+      }),
+    );
+  });
+
+  it("does not expand the history render window for bottom auto-scrolls inside the top threshold", () => {
+    const messages = Array.from({ length: 80 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+    const onRequestUpdate = vi.fn();
+    const onChatScroll = vi.fn();
+
+    const container = renderChatView({ messages, onRequestUpdate, onChatScroll });
+    const thread = requireElement(container, ".chat-thread", "chat thread") as HTMLElement;
+    thread.scrollTop = 30;
+    thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+    expect(onRequestUpdate).not.toHaveBeenCalled();
+    expect(onChatScroll).toHaveBeenCalledTimes(1);
+
+    buildChatItemsMock.mockClear();
+    const rerenderedContainer = renderChatView({ messages, onRequestUpdate, onChatScroll });
+
+    expect(buildChatItemsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages,
+        historyRenderLimit: 30,
+      }),
+    );
+
+    const rerenderedThread = requireElement(
+      rerenderedContainer,
+      ".chat-thread",
+      "chat thread",
+    ) as HTMLElement;
+    rerenderedThread.scrollTop = 0;
+    rerenderedThread.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+    expect(onRequestUpdate).toHaveBeenCalledTimes(1);
+    expect(onChatScroll).toHaveBeenCalledTimes(2);
+  });
+
+  it("expands the history render window when the thread is already at the top", () => {
+    const messages = Array.from({ length: 80 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+    const onRequestUpdate = vi.fn();
+    const onChatScroll = vi.fn();
+
+    const container = renderChatView({ messages, onRequestUpdate, onChatScroll });
+    const thread = requireElement(container, ".chat-thread", "chat thread") as HTMLElement;
     thread.scrollTop = 0;
     thread.dispatchEvent(new Event("scroll", { bubbles: true }));
 
     expect(onRequestUpdate).toHaveBeenCalledTimes(1);
     expect(onChatScroll).toHaveBeenCalledTimes(1);
+  });
+
+  it("expands the render window after render when the initial window cannot scroll", () => {
+    const messages = Array.from({ length: 80 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+    const onRequestUpdate = vi.fn();
+    const onScrollToBottom = vi.fn();
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    renderChatView({ messages, onRequestUpdate, onScrollToBottom });
+
+    expect(buildChatItemsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages,
+        historyRenderLimit: 30,
+      }),
+    );
+    expect(frameCallbacks).toHaveLength(1);
+
+    frameCallbacks[0](0);
+
+    expect(onRequestUpdate).toHaveBeenCalledTimes(1);
+    expect(onScrollToBottom).toHaveBeenCalledTimes(1);
 
     buildChatItemsMock.mockClear();
-    renderChatView({ messages, onRequestUpdate, onChatScroll });
+    renderChatView({ messages, onRequestUpdate, onScrollToBottom });
 
     expect(buildChatItemsMock).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -943,6 +943,35 @@ describe("chat composer workbench", () => {
     );
     expect(expandedBtn?.getAttribute("aria-expanded")).toBe("true");
   });
+
+  it("renders Talk settings from its own callback contract", () => {
+    const onToggleRealtimeTalkOptions = vi.fn();
+    const container = renderChatView({
+      onToggleRealtimeTalk: undefined,
+      onToggleRealtimeTalkOptions,
+      realtimeTalkOptionsOpen: false,
+    });
+
+    const settings = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Talk settings"]',
+    );
+    expect(settings).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Start Talk"]')).toBeNull();
+
+    settings?.click();
+
+    expect(onToggleRealtimeTalkOptions).toHaveBeenCalledOnce();
+  });
+
+  it("does not render a dead Talk settings button without its callback", () => {
+    const container = renderChatView({
+      onToggleRealtimeTalk: () => undefined,
+      realtimeTalkOptionsOpen: true,
+    });
+
+    expect(container.querySelector('button[aria-label="Start Talk"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Talk settings"]')).toBeNull();
+  });
 });
 
 afterEach(() => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -906,6 +906,20 @@ describe("chat composer workbench", () => {
 
     expect(onOpenFile).toHaveBeenCalledWith("AGENTS.md");
   });
+
+  it("keeps the secondary New session and Export controls suppressed in the composer", () => {
+    const container = renderChatView({
+      messages: [{ role: "assistant", content: "ready" }],
+    });
+
+    const toolbarRight = container.querySelector(".agent-chat__toolbar-right");
+    expect(toolbarRight).not.toBeNull();
+    const labels = Array.from(toolbarRight?.querySelectorAll("button") ?? []).map((button) =>
+      button.getAttribute("aria-label"),
+    );
+    expect(labels).not.toContain(t("chat.runControls.newSession"));
+    expect(labels).not.toContain(t("chat.runControls.exportChat"));
+  });
 });
 
 afterEach(() => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -127,7 +127,7 @@ export type ChatProps = {
   disabledReason: string | null;
   error: string | null;
   sessions: SessionsListResult | null;
-  focusMode: boolean;
+  focusMode?: boolean;
   sidebarOpen?: boolean;
   sidebarContent?: SidebarContent | null;
   sidebarError?: string | null;
@@ -147,7 +147,7 @@ export type ChatProps = {
   showNewMessages?: boolean;
   onScrollToBottom?: () => void;
   onRefresh: () => void;
-  onToggleFocusMode: () => void;
+  onToggleFocusMode?: () => void;
   getDraft?: () => string;
   onDraftChange: (next: string) => void;
   onRequestUpdate?: () => void;
@@ -236,6 +236,15 @@ function renderRealtimeTalkOptions(props: ChatProps) {
     : isPresetSensitivity
       ? options.vadThreshold
       : "__custom";
+  const sensitivityLabel = isDefaultSensitivity
+    ? "Default"
+    : isCustomSensitivity
+      ? "Custom"
+      : sensitivityValue === "0.65"
+        ? "Low"
+        : sensitivityValue === "0.5"
+          ? "Medium"
+          : "High";
   const updateSensitivity = (event: Event) => {
     const value = (event.currentTarget as HTMLSelectElement).value;
     if (value !== "__custom") {
@@ -245,10 +254,10 @@ function renderRealtimeTalkOptions(props: ChatProps) {
   return html`
     <div class="agent-chat__talk-options" aria-label="Talk options">
       <div class="agent-chat__talk-options-primary">
-        <label>
+        <label class="agent-chat__talk-field" data-talk-select="voice">
           <span>Voice</span>
           <select .value=${options.voice} @change=${update("voice")}>
-            <option value="">Default</option>
+            <option value="" data-talk-select-option="">Default</option>
             ${[
               "alloy",
               "ash",
@@ -260,10 +269,14 @@ function renderRealtimeTalkOptions(props: ChatProps) {
               "verse",
               "marin",
               "cedar",
-            ].map((voice) => html`<option value=${voice}>${voice}</option>`)}
+            ].map(
+              (voice) => html`
+                <option value=${voice} data-talk-select-option=${voice}>${voice}</option>
+              `,
+            )}
           </select>
         </label>
-        <label>
+        <label class="agent-chat__talk-field">
           <span>Model</span>
           <input
             .value=${options.model}
@@ -272,15 +285,42 @@ function renderRealtimeTalkOptions(props: ChatProps) {
             spellcheck="false"
           />
         </label>
-        <label>
+        <label class="agent-chat__talk-field" data-talk-select="sensitivity">
           <span>Sensitivity</span>
+          <span class="agent-chat__talk-select-label">${sensitivityLabel}</span>
           <select @change=${updateSensitivity}>
-            <option value="" ?selected=${sensitivityValue === ""}>Default</option>
-            <option value="0.65" ?selected=${sensitivityValue === "0.65"}>Low</option>
-            <option value="0.5" ?selected=${sensitivityValue === "0.5"}>Medium</option>
-            <option value="0.35" ?selected=${sensitivityValue === "0.35"}>High</option>
+            <option
+              value=""
+              data-talk-select-option=""
+              ?selected=${sensitivityValue === ""}
+              @click=${() => onChange({ vadThreshold: "" })}
+              >Default</option
+            >
+            <option
+              value="0.65"
+              data-talk-select-option="0.65"
+              ?selected=${sensitivityValue === "0.65"}
+              @click=${() => onChange({ vadThreshold: "0.65" })}
+              >Low</option
+            >
+            <option
+              value="0.5"
+              data-talk-select-option="0.5"
+              ?selected=${sensitivityValue === "0.5"}
+              @click=${() => onChange({ vadThreshold: "0.5" })}
+              >Medium</option
+            >
+            <option
+              value="0.35"
+              data-talk-select-option="0.35"
+              ?selected=${sensitivityValue === "0.35"}
+              @click=${() => onChange({ vadThreshold: "0.35" })}
+              >High</option
+            >
             ${isCustomSensitivity
-              ? html`<option value="__custom" selected>Custom</option>`
+              ? html`<option value="__custom" data-talk-select-option="__custom" selected>
+                  Custom
+                </option>`
               : nothing}
           </select>
         </label>
@@ -288,7 +328,7 @@ function renderRealtimeTalkOptions(props: ChatProps) {
       <details class="agent-chat__talk-options-advanced">
         <summary>Advanced</summary>
         <div class="agent-chat__talk-options-grid">
-          <label>
+          <label class="agent-chat__talk-field">
             <span>Provider</span>
             <select .value=${options.provider} @change=${update("provider")}>
               <option value="">Auto</option>
@@ -296,7 +336,7 @@ function renderRealtimeTalkOptions(props: ChatProps) {
               <option value="google">Google</option>
             </select>
           </label>
-          <label>
+          <label class="agent-chat__talk-field">
             <span>Transport</span>
             <select .value=${options.transport} @change=${update("transport")}>
               <option value="">Auto</option>
@@ -305,17 +345,17 @@ function renderRealtimeTalkOptions(props: ChatProps) {
               <option value="provider-websocket">Provider WebSocket</option>
             </select>
           </label>
-          <label>
+          <label class="agent-chat__talk-field" data-talk-select="reasoning">
             <span>Reasoning</span>
             <select .value=${options.reasoningEffort} @change=${update("reasoningEffort")}>
-              <option value="">Default</option>
-              <option value="minimal">Minimal</option>
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
+              <option value="" data-talk-select-option="">Default</option>
+              <option value="minimal" data-talk-select-option="minimal">Minimal</option>
+              <option value="low" data-talk-select-option="low">Low</option>
+              <option value="medium" data-talk-select-option="medium">Medium</option>
+              <option value="high" data-talk-select-option="high">High</option>
             </select>
           </label>
-          <label>
+          <label class="agent-chat__talk-field">
             <span>Exact VAD</span>
             <input
               type="number"
@@ -327,7 +367,7 @@ function renderRealtimeTalkOptions(props: ChatProps) {
               placeholder="0.5"
             />
           </label>
-          <label>
+          <label class="agent-chat__talk-field">
             <span>Pause before send</span>
             <input
               type="number"
@@ -338,7 +378,7 @@ function renderRealtimeTalkOptions(props: ChatProps) {
               placeholder="500"
             />
           </label>
-          <label>
+          <label class="agent-chat__talk-field">
             <span>Lead-in</span>
             <input
               type="number"
@@ -492,7 +532,8 @@ function sameChatItemsInput(previous: BuildChatItemsProps, next: BuildChatItemsP
     previous.queue === next.queue &&
     previous.showToolCalls === next.showToolCalls &&
     previous.searchOpen === next.searchOpen &&
-    previous.searchQuery === next.searchQuery
+    previous.searchQuery === next.searchQuery &&
+    previous.historyRenderLimit === next.historyRenderLimit
   );
 }
 
@@ -1489,6 +1530,7 @@ export function renderChat(props: ChatProps) {
   const deleted = getDeletedMessages(props.sessionKey);
   const hasAttachments = (props.attachments?.length ?? 0) > 0;
   const tokens = tokenEstimate(visibleDraft);
+  const composerControls = props.composerControls;
 
   const placeholder = props.connected
     ? hasAttachments
@@ -1924,7 +1966,7 @@ export function renderChat(props: ChatProps) {
             </div>
           `
         : nothing}
-      ${props.focusMode
+      ${props.focusMode && props.onToggleFocusMode
         ? html`
             <button
               class="chat-focus-exit"
@@ -2122,6 +2164,10 @@ export function renderChat(props: ChatProps) {
             ${tokens ? html`<span class="agent-chat__token-count">${tokens}</span>` : nothing}
             ${renderChatRunStatusIndicator(composerRunStatus)}
           </div>
+
+          ${composerControls && composerControls !== nothing
+            ? html`<div class="agent-chat__composer-controls">${composerControls}</div>`
+            : nothing}
 
           ${renderChatRunControls({
             canAbort: showAbortableUi,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -198,6 +198,45 @@ const pinnedMessagesMap = new Map<string, PinnedMessages>();
 const deletedMessagesMap = new Map<string, DeletedMessages>();
 const SLASH_MENU_LISTBOX_ID = "chat-slash-menu-listbox";
 const SLASH_MENU_ACTIVE_ANNOUNCEMENT_ID = "chat-slash-active-announcement";
+type TalkSelectOption = { label: string; value: string };
+
+const TALK_VOICE_OPTIONS: TalkSelectOption[] = [
+  { label: "Default", value: "" },
+  { label: "Alloy", value: "alloy" },
+  { label: "Ash", value: "ash" },
+  { label: "Ballad", value: "ballad" },
+  { label: "Coral", value: "coral" },
+  { label: "Echo", value: "echo" },
+  { label: "Sage", value: "sage" },
+  { label: "Shimmer", value: "shimmer" },
+  { label: "Verse", value: "verse" },
+  { label: "Marin", value: "marin" },
+  { label: "Cedar", value: "cedar" },
+];
+const TALK_SENSITIVITY_OPTIONS: TalkSelectOption[] = [
+  { label: "Default", value: "" },
+  { label: "Low", value: "0.65" },
+  { label: "Medium", value: "0.5" },
+  { label: "High", value: "0.35" },
+];
+const TALK_PROVIDER_OPTIONS: TalkSelectOption[] = [
+  { label: "Auto", value: "" },
+  { label: "OpenAI", value: "openai" },
+  { label: "Google", value: "google" },
+];
+const TALK_TRANSPORT_OPTIONS: TalkSelectOption[] = [
+  { label: "Auto", value: "" },
+  { label: "WebRTC", value: "webrtc" },
+  { label: "Gateway relay", value: "gateway-relay" },
+  { label: "Provider WebSocket", value: "provider-websocket" },
+];
+const TALK_REASONING_OPTIONS: TalkSelectOption[] = [
+  { label: "Default", value: "" },
+  { label: "Minimal", value: "minimal" },
+  { label: "Low", value: "low" },
+  { label: "Medium", value: "medium" },
+  { label: "High", value: "high" },
+];
 const INITIAL_CHAT_HISTORY_RENDER_WINDOW = 30;
 const CHAT_HISTORY_RENDER_WINDOW_BATCH = 30;
 const CHAT_HISTORY_RENDER_EXPAND_SCROLL_TOP_PX = 48;
@@ -218,6 +257,45 @@ function getDeletedMessages(sessionKey: string): DeletedMessages {
   );
 }
 
+function renderNativeTalkSelect(params: {
+  label: string;
+  value: string;
+  options: TalkSelectOption[];
+  onSelect: (value: string) => void;
+  selectedLabel?: string;
+}) {
+  const selectedLabel =
+    params.selectedLabel ?? params.options.find((entry) => entry.value === params.value)?.label;
+  return html`
+    <label class="agent-chat__talk-field" data-talk-select=${params.label.toLowerCase()}>
+      <span>${params.label}</span>
+      ${selectedLabel
+        ? html`<span class="agent-chat__talk-select-label">${selectedLabel}</span>`
+        : nothing}
+      <select
+        .value=${params.value}
+        @change=${(event: Event) =>
+          params.onSelect((event.currentTarget as HTMLSelectElement).value)}
+      >
+        ${repeat(
+          params.options,
+          (entry) => entry.value,
+          (entry) => html`
+            <option
+              value=${entry.value}
+              data-talk-select-option=${entry.value}
+              ?selected=${entry.value === params.value}
+              @click=${() => params.onSelect(entry.value)}
+            >
+              ${entry.label}
+            </option>
+          `,
+        )}
+      </select>
+    </label>
+  `;
+}
+
 function renderRealtimeTalkOptions(props: ChatProps) {
   const options = props.realtimeTalkOptions;
   const onChange = props.onRealtimeTalkOptionsChange;
@@ -236,17 +314,12 @@ function renderRealtimeTalkOptions(props: ChatProps) {
     : isPresetSensitivity
       ? options.vadThreshold
       : "__custom";
-  const sensitivityLabel = isDefaultSensitivity
-    ? "Default"
-    : isCustomSensitivity
-      ? "Custom"
-      : sensitivityValue === "0.65"
-        ? "Low"
-        : sensitivityValue === "0.5"
-          ? "Medium"
-          : "High";
-  const updateSensitivity = (event: Event) => {
-    const value = (event.currentTarget as HTMLSelectElement).value;
+  const sensitivityOptions = isCustomSensitivity
+    ? [...TALK_SENSITIVITY_OPTIONS, { label: "Custom", value: "__custom" }]
+    : TALK_SENSITIVITY_OPTIONS;
+  const sensitivityLabel =
+    sensitivityOptions.find((entry) => entry.value === sensitivityValue)?.label ?? "Custom";
+  const updateSensitivity = (value: string) => {
     if (value !== "__custom") {
       onChange({ vadThreshold: value });
     }
@@ -254,28 +327,12 @@ function renderRealtimeTalkOptions(props: ChatProps) {
   return html`
     <div class="agent-chat__talk-options" aria-label="Talk options">
       <div class="agent-chat__talk-options-primary">
-        <label class="agent-chat__talk-field" data-talk-select="voice">
-          <span>Voice</span>
-          <select .value=${options.voice} @change=${update("voice")}>
-            <option value="" data-talk-select-option="">Default</option>
-            ${[
-              "alloy",
-              "ash",
-              "ballad",
-              "coral",
-              "echo",
-              "sage",
-              "shimmer",
-              "verse",
-              "marin",
-              "cedar",
-            ].map(
-              (voice) => html`
-                <option value=${voice} data-talk-select-option=${voice}>${voice}</option>
-              `,
-            )}
-          </select>
-        </label>
+        ${renderNativeTalkSelect({
+          label: "Voice",
+          value: options.voice,
+          options: TALK_VOICE_OPTIONS,
+          onSelect: (voice) => onChange({ voice }),
+        })}
         <label class="agent-chat__talk-field">
           <span>Model</span>
           <input
@@ -285,76 +342,35 @@ function renderRealtimeTalkOptions(props: ChatProps) {
             spellcheck="false"
           />
         </label>
-        <label class="agent-chat__talk-field" data-talk-select="sensitivity">
-          <span>Sensitivity</span>
-          <span class="agent-chat__talk-select-label">${sensitivityLabel}</span>
-          <select @change=${updateSensitivity}>
-            <option
-              value=""
-              data-talk-select-option=""
-              ?selected=${sensitivityValue === ""}
-              @click=${() => onChange({ vadThreshold: "" })}
-              >Default</option
-            >
-            <option
-              value="0.65"
-              data-talk-select-option="0.65"
-              ?selected=${sensitivityValue === "0.65"}
-              @click=${() => onChange({ vadThreshold: "0.65" })}
-              >Low</option
-            >
-            <option
-              value="0.5"
-              data-talk-select-option="0.5"
-              ?selected=${sensitivityValue === "0.5"}
-              @click=${() => onChange({ vadThreshold: "0.5" })}
-              >Medium</option
-            >
-            <option
-              value="0.35"
-              data-talk-select-option="0.35"
-              ?selected=${sensitivityValue === "0.35"}
-              @click=${() => onChange({ vadThreshold: "0.35" })}
-              >High</option
-            >
-            ${isCustomSensitivity
-              ? html`<option value="__custom" data-talk-select-option="__custom" selected>
-                  Custom
-                </option>`
-              : nothing}
-          </select>
-        </label>
+        ${renderNativeTalkSelect({
+          label: "Sensitivity",
+          value: sensitivityValue,
+          options: sensitivityOptions,
+          selectedLabel: sensitivityLabel,
+          onSelect: updateSensitivity,
+        })}
       </div>
       <details class="agent-chat__talk-options-advanced">
         <summary>Advanced</summary>
         <div class="agent-chat__talk-options-grid">
-          <label class="agent-chat__talk-field">
-            <span>Provider</span>
-            <select .value=${options.provider} @change=${update("provider")}>
-              <option value="">Auto</option>
-              <option value="openai">OpenAI</option>
-              <option value="google">Google</option>
-            </select>
-          </label>
-          <label class="agent-chat__talk-field">
-            <span>Transport</span>
-            <select .value=${options.transport} @change=${update("transport")}>
-              <option value="">Auto</option>
-              <option value="webrtc">WebRTC</option>
-              <option value="gateway-relay">Gateway relay</option>
-              <option value="provider-websocket">Provider WebSocket</option>
-            </select>
-          </label>
-          <label class="agent-chat__talk-field" data-talk-select="reasoning">
-            <span>Reasoning</span>
-            <select .value=${options.reasoningEffort} @change=${update("reasoningEffort")}>
-              <option value="" data-talk-select-option="">Default</option>
-              <option value="minimal" data-talk-select-option="minimal">Minimal</option>
-              <option value="low" data-talk-select-option="low">Low</option>
-              <option value="medium" data-talk-select-option="medium">Medium</option>
-              <option value="high" data-talk-select-option="high">High</option>
-            </select>
-          </label>
+          ${renderNativeTalkSelect({
+            label: "Provider",
+            value: options.provider,
+            options: TALK_PROVIDER_OPTIONS,
+            onSelect: (provider) => onChange({ provider }),
+          })}
+          ${renderNativeTalkSelect({
+            label: "Transport",
+            value: options.transport,
+            options: TALK_TRANSPORT_OPTIONS,
+            onSelect: (transport) => onChange({ transport }),
+          })}
+          ${renderNativeTalkSelect({
+            label: "Reasoning",
+            value: options.reasoningEffort,
+            options: TALK_REASONING_OPTIONS,
+            onSelect: (reasoningEffort) => onChange({ reasoningEffort }),
+          })}
           <label class="agent-chat__talk-field">
             <span>Exact VAD</span>
             <input
@@ -2145,7 +2161,7 @@ export function renderChat(props: ChatProps) {
                     <span class="agent-chat__control-label"
                       >${props.realtimeTalkActive
                         ? t("chat.composer.stopTalk")
-                      : t("chat.composer.startTalk")}</span
+                        : t("chat.composer.startTalk")}</span
                     >
                   </button>
                 `
@@ -2174,7 +2190,6 @@ export function renderChat(props: ChatProps) {
           ${composerControls && composerControls !== nothing
             ? html`<div class="agent-chat__composer-controls">${composerControls}</div>`
             : nothing}
-
           ${renderChatRunControls({
             canAbort: showAbortableUi,
             connected: props.connected,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -404,6 +404,8 @@ interface ChatEphemeralState {
   historyRenderMessagesRef: unknown[] | null;
   historyRenderMessageCount: number;
   historyRenderLimit: number;
+  historyRenderLastScrollTop: number | null;
+  historyRenderExpansionFrame: number | null;
 }
 
 function createChatEphemeralState(): ChatEphemeralState {
@@ -422,6 +424,8 @@ function createChatEphemeralState(): ChatEphemeralState {
     historyRenderMessagesRef: null,
     historyRenderMessageCount: 0,
     historyRenderLimit: 0,
+    historyRenderLastScrollTop: null,
+    historyRenderExpansionFrame: null,
   };
 }
 
@@ -525,6 +529,9 @@ function stableBooleanMapSignature(values: ReadonlyMap<string, boolean>): string
  * Clears search/slash UI that should not survive navigation.
  */
 export function resetChatViewState() {
+  if (vs.historyRenderExpansionFrame != null) {
+    cancelAnimationFrame(vs.historyRenderExpansionFrame);
+  }
   Object.assign(vs, createChatEphemeralState());
   chatItemsBySession.clear();
   composerDraftMirrors.clear();
@@ -549,12 +556,16 @@ function resolveChatHistoryRenderWindow(props: ChatProps): number {
   const sessionChanged = vs.historyRenderSessionKey !== props.sessionKey;
   const refChanged = vs.historyRenderMessagesRef !== messages;
   const previousCount = vs.historyRenderMessageCount;
+  if (sessionChanged || (refChanged && previousCount === 0)) {
+    vs.historyRenderLastScrollTop = null;
+  }
 
   if (cap === 0) {
     vs.historyRenderSessionKey = props.sessionKey;
     vs.historyRenderMessagesRef = messages;
     vs.historyRenderMessageCount = messages.length;
     vs.historyRenderLimit = 0;
+    vs.historyRenderLastScrollTop = null;
     return 0;
   }
 
@@ -594,7 +605,18 @@ function maybeExpandChatHistoryRenderWindow(event: Event, requestUpdate: () => v
   if (!(target instanceof HTMLElement)) {
     return;
   }
-  if (target.scrollTop > CHAT_HISTORY_RENDER_EXPAND_SCROLL_TOP_PX) {
+  const scrollTop = Math.max(0, target.scrollTop);
+  const previousScrollTop = vs.historyRenderLastScrollTop;
+  vs.historyRenderLastScrollTop = scrollTop;
+  const distanceFromBottom = Math.max(0, target.scrollHeight - scrollTop - target.clientHeight);
+  const isTop = scrollTop <= CHAT_HISTORY_RENDER_EXPAND_SCROLL_TOP_PX;
+  const isBottomAutoScroll =
+    scrollTop > 0 && distanceFromBottom <= CHAT_HISTORY_RENDER_EXPAND_SCROLL_TOP_PX;
+  const isTopScrollUp =
+    isTop &&
+    (scrollTop === 0 ||
+      (!isBottomAutoScroll && (previousScrollTop == null || scrollTop < previousScrollTop)));
+  if (!isTopScrollUp) {
     return;
   }
   const cap = resolveChatHistoryRenderCap(vs.historyRenderMessageCount);
@@ -603,6 +625,37 @@ function maybeExpandChatHistoryRenderWindow(event: Event, requestUpdate: () => v
   }
   vs.historyRenderLimit = Math.min(cap, vs.historyRenderLimit + CHAT_HISTORY_RENDER_WINDOW_BATCH);
   requestUpdate();
+}
+
+function scheduleChatHistoryRenderWindowFill(
+  thread: HTMLElement | null,
+  requestUpdate: () => void,
+  scrollToBottom: () => void,
+) {
+  if (!thread || vs.historyRenderExpansionFrame != null) {
+    return;
+  }
+  const cap = resolveChatHistoryRenderCap(vs.historyRenderMessageCount);
+  if (vs.historyRenderLimit >= cap) {
+    return;
+  }
+  vs.historyRenderExpansionFrame = requestAnimationFrame(() => {
+    vs.historyRenderExpansionFrame = null;
+    const nextCap = resolveChatHistoryRenderCap(vs.historyRenderMessageCount);
+    if (vs.historyRenderLimit >= nextCap) {
+      return;
+    }
+    const canScroll = thread.scrollHeight - thread.clientHeight > 1;
+    if (canScroll) {
+      return;
+    }
+    vs.historyRenderLimit = Math.min(
+      nextCap,
+      vs.historyRenderLimit + CHAT_HISTORY_RENDER_WINDOW_BATCH,
+    );
+    requestUpdate();
+    scrollToBottom();
+  });
 }
 
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
@@ -1467,6 +1520,13 @@ export function renderChat(props: ChatProps) {
       class="chat-thread"
       role="log"
       aria-live="polite"
+      ${ref((element) =>
+        scheduleChatHistoryRenderWindowFill(
+          element instanceof HTMLElement ? element : null,
+          requestUpdate,
+          props.onScrollToBottom ?? (() => {}),
+        ),
+      )}
       @scroll=${handleChatThreadScroll}
       @click=${handleCodeBlockCopy}
     >

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -2145,9 +2145,13 @@ export function renderChat(props: ChatProps) {
                     <span class="agent-chat__control-label"
                       >${props.realtimeTalkActive
                         ? t("chat.composer.stopTalk")
-                        : t("chat.composer.startTalk")}</span
+                      : t("chat.composer.startTalk")}</span
                     >
                   </button>
+                `
+              : nothing}
+            ${props.onToggleRealtimeTalkOptions
+              ? html`
                   <button
                     class="agent-chat__input-btn ${props.realtimeTalkOptionsOpen
                       ? "agent-chat__input-btn--talk"

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -2150,14 +2150,16 @@ export function renderChat(props: ChatProps) {
                   </button>
                   <button
                     class="agent-chat__input-btn ${props.realtimeTalkOptionsOpen
-                      ? "agent-chat__input-btn--active"
+                      ? "agent-chat__input-btn--talk"
                       : ""}"
                     @click=${props.onToggleRealtimeTalkOptions}
-                    title="Talk options"
-                    aria-label="Talk options"
+                    title="Talk settings"
+                    aria-label="Talk settings"
+                    aria-expanded=${props.realtimeTalkOptionsOpen ? "true" : "false"}
                     ?disabled=${!props.connected || props.realtimeTalkActive}
                   >
                     ${icons.settings}
+                    <span class="agent-chat__control-label">Talk settings</span>
                   </button>
                 `
               : nothing}

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -2181,6 +2181,7 @@ export function renderChat(props: ChatProps) {
             onNewSession: props.onNewSession,
             onSend: handleSend,
             onStoreDraft: () => {},
+            showSecondary: false,
           })}
         </div>
       </div>

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -406,6 +406,11 @@ interface ChatEphemeralState {
   historyRenderLimit: number;
   historyRenderLastScrollTop: number | null;
   historyRenderExpansionFrame: number | null;
+  historyRenderAnchorAdjustment: {
+    scrollHeight: number;
+    scrollTop: number;
+  } | null;
+  historyRenderAnchorFrame: number | null;
 }
 
 function createChatEphemeralState(): ChatEphemeralState {
@@ -426,6 +431,8 @@ function createChatEphemeralState(): ChatEphemeralState {
     historyRenderLimit: 0,
     historyRenderLastScrollTop: null,
     historyRenderExpansionFrame: null,
+    historyRenderAnchorAdjustment: null,
+    historyRenderAnchorFrame: null,
   };
 }
 
@@ -532,6 +539,9 @@ export function resetChatViewState() {
   if (vs.historyRenderExpansionFrame != null) {
     cancelAnimationFrame(vs.historyRenderExpansionFrame);
   }
+  if (vs.historyRenderAnchorFrame != null) {
+    cancelAnimationFrame(vs.historyRenderAnchorFrame);
+  }
   Object.assign(vs, createChatEphemeralState());
   chatItemsBySession.clear();
   composerDraftMirrors.clear();
@@ -623,8 +633,29 @@ function maybeExpandChatHistoryRenderWindow(event: Event, requestUpdate: () => v
   if (vs.historyRenderLimit >= cap) {
     return;
   }
+  vs.historyRenderAnchorAdjustment = {
+    scrollHeight: target.scrollHeight,
+    scrollTop,
+  };
+  scheduleChatHistoryRenderAnchorPreservation(target);
   vs.historyRenderLimit = Math.min(cap, vs.historyRenderLimit + CHAT_HISTORY_RENDER_WINDOW_BATCH);
   requestUpdate();
+}
+
+function scheduleChatHistoryRenderAnchorPreservation(thread: HTMLElement) {
+  const adjustment = vs.historyRenderAnchorAdjustment;
+  if (!adjustment || vs.historyRenderAnchorFrame != null) {
+    return;
+  }
+  vs.historyRenderAnchorFrame = requestAnimationFrame(() => {
+    vs.historyRenderAnchorFrame = null;
+    vs.historyRenderAnchorAdjustment = null;
+    const heightDelta = thread.scrollHeight - adjustment.scrollHeight;
+    if (heightDelta <= 0) {
+      return;
+    }
+    thread.scrollTop = adjustment.scrollTop + heightDelta;
+  });
 }
 
 function scheduleChatHistoryRenderWindowFill(
@@ -1520,13 +1551,14 @@ export function renderChat(props: ChatProps) {
       class="chat-thread"
       role="log"
       aria-live="polite"
-      ${ref((element) =>
+      ${ref((element) => {
+        const threadElement = element instanceof HTMLElement ? element : null;
         scheduleChatHistoryRenderWindowFill(
-          element instanceof HTMLElement ? element : null,
+          threadElement,
           requestUpdate,
           props.onScrollToBottom ?? (() => {}),
-        ),
-      )}
+        );
+      })}
       @scroll=${handleChatThreadScroll}
       @click=${handleCodeBlockCopy}
     >

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -27,6 +27,7 @@ import {
   renderReadingIndicatorGroup,
   renderStreamingGroup,
 } from "../chat/grouped-render.ts";
+import { CHAT_HISTORY_RENDER_LIMIT } from "../chat/history-limits.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../chat/input-history.ts";
 import { PinnedMessages } from "../chat/pinned-messages.ts";
 import { getPinnedMessageSummary } from "../chat/pinned-summary.ts";
@@ -126,6 +127,7 @@ export type ChatProps = {
   disabledReason: string | null;
   error: string | null;
   sessions: SessionsListResult | null;
+  focusMode: boolean;
   sidebarOpen?: boolean;
   sidebarContent?: SidebarContent | null;
   sidebarError?: string | null;
@@ -145,6 +147,7 @@ export type ChatProps = {
   showNewMessages?: boolean;
   onScrollToBottom?: () => void;
   onRefresh: () => void;
+  onToggleFocusMode: () => void;
   getDraft?: () => string;
   onDraftChange: (next: string) => void;
   onRequestUpdate?: () => void;
@@ -195,45 +198,9 @@ const pinnedMessagesMap = new Map<string, PinnedMessages>();
 const deletedMessagesMap = new Map<string, DeletedMessages>();
 const SLASH_MENU_LISTBOX_ID = "chat-slash-menu-listbox";
 const SLASH_MENU_ACTIVE_ANNOUNCEMENT_ID = "chat-slash-active-announcement";
-type TalkSelectOption = { label: string; value: string };
-
-const TALK_VOICE_OPTIONS: TalkSelectOption[] = [
-  { label: "Default", value: "" },
-  { label: "Alloy", value: "alloy" },
-  { label: "Ash", value: "ash" },
-  { label: "Ballad", value: "ballad" },
-  { label: "Coral", value: "coral" },
-  { label: "Echo", value: "echo" },
-  { label: "Sage", value: "sage" },
-  { label: "Shimmer", value: "shimmer" },
-  { label: "Verse", value: "verse" },
-  { label: "Marin", value: "marin" },
-  { label: "Cedar", value: "cedar" },
-];
-const TALK_SENSITIVITY_OPTIONS: TalkSelectOption[] = [
-  { label: "Default", value: "" },
-  { label: "Low", value: "0.65" },
-  { label: "Medium", value: "0.5" },
-  { label: "High", value: "0.35" },
-];
-const TALK_PROVIDER_OPTIONS: TalkSelectOption[] = [
-  { label: "Auto", value: "" },
-  { label: "OpenAI", value: "openai" },
-  { label: "Google", value: "google" },
-];
-const TALK_TRANSPORT_OPTIONS: TalkSelectOption[] = [
-  { label: "Auto", value: "" },
-  { label: "WebRTC", value: "webrtc" },
-  { label: "Gateway relay", value: "gateway-relay" },
-  { label: "Provider WebSocket", value: "provider-websocket" },
-];
-const TALK_REASONING_OPTIONS: TalkSelectOption[] = [
-  { label: "Default", value: "" },
-  { label: "Minimal", value: "minimal" },
-  { label: "Low", value: "low" },
-  { label: "Medium", value: "medium" },
-  { label: "High", value: "high" },
-];
+const INITIAL_CHAT_HISTORY_RENDER_WINDOW = 30;
+const CHAT_HISTORY_RENDER_WINDOW_BATCH = 30;
+const CHAT_HISTORY_RENDER_EXPAND_SCROLL_TOP_PX = 48;
 
 function getPinnedMessages(sessionKey: string): PinnedMessages {
   return getOrCreateSessionCacheValue(
@@ -249,68 +216,6 @@ function getDeletedMessages(sessionKey: string): DeletedMessages {
     sessionKey,
     () => new DeletedMessages(sessionKey),
   );
-}
-
-function renderTalkSelect(params: {
-  label: string;
-  value: string;
-  options: TalkSelectOption[];
-  onSelect: (value: string) => void;
-}) {
-  const selected = params.options.find((entry) => entry.value === params.value);
-  const selectedLabel = selected?.label ?? params.value;
-  return html`
-    <label class="agent-chat__talk-field agent-chat__talk-field--select">
-      <span>${params.label}</span>
-      <details class="agent-chat__talk-select" data-talk-select=${params.label.toLowerCase()}>
-        <summary
-          class="agent-chat__talk-select-trigger"
-          aria-label=${params.label}
-          title=${selectedLabel}
-        >
-          <span class="agent-chat__talk-select-label">${selectedLabel}</span>
-          <span class="agent-chat__talk-select-icon" aria-hidden="true">
-            ${icons.chevronDown}
-          </span>
-        </summary>
-        <div class="agent-chat__talk-select-menu" role="listbox" aria-label=${params.label}>
-          ${repeat(
-            params.options,
-            (entry) => entry.value,
-            (entry) => {
-              const isSelected = entry.value === params.value;
-              return html`
-                <button
-                  class="agent-chat__talk-select-option ${isSelected
-                    ? "agent-chat__talk-select-option--selected"
-                    : ""}"
-                  data-talk-select-option=${entry.value}
-                  role="option"
-                  aria-selected=${isSelected ? "true" : "false"}
-                  type="button"
-                  @click=${(event: MouseEvent) => {
-                    (event.currentTarget as HTMLElement)
-                      .closest("details")
-                      ?.removeAttribute("open");
-                    if (!isSelected) {
-                      params.onSelect(entry.value);
-                    }
-                  }}
-                >
-                  <span>${entry.label}</span>
-                  ${isSelected
-                    ? html`<span class="agent-chat__talk-select-check" aria-hidden="true">
-                        ${icons.check}
-                      </span>`
-                    : nothing}
-                </button>
-              `;
-            },
-          )}
-        </div>
-      </details>
-    </label>
-  `;
 }
 
 function renderRealtimeTalkOptions(props: ChatProps) {
@@ -331,19 +236,34 @@ function renderRealtimeTalkOptions(props: ChatProps) {
     : isPresetSensitivity
       ? options.vadThreshold
       : "__custom";
-  const sensitivityOptions = isCustomSensitivity
-    ? [...TALK_SENSITIVITY_OPTIONS, { label: "Custom", value: "__custom" }]
-    : TALK_SENSITIVITY_OPTIONS;
+  const updateSensitivity = (event: Event) => {
+    const value = (event.currentTarget as HTMLSelectElement).value;
+    if (value !== "__custom") {
+      onChange({ vadThreshold: value });
+    }
+  };
   return html`
     <div class="agent-chat__talk-options" aria-label="Talk options">
       <div class="agent-chat__talk-options-primary">
-        ${renderTalkSelect({
-          label: "Voice",
-          value: options.voice,
-          options: TALK_VOICE_OPTIONS,
-          onSelect: (voice) => onChange({ voice }),
-        })}
-        <label class="agent-chat__talk-field">
+        <label>
+          <span>Voice</span>
+          <select .value=${options.voice} @change=${update("voice")}>
+            <option value="">Default</option>
+            ${[
+              "alloy",
+              "ash",
+              "ballad",
+              "coral",
+              "echo",
+              "sage",
+              "shimmer",
+              "verse",
+              "marin",
+              "cedar",
+            ].map((voice) => html`<option value=${voice}>${voice}</option>`)}
+          </select>
+        </label>
+        <label>
           <span>Model</span>
           <input
             .value=${options.model}
@@ -352,39 +272,50 @@ function renderRealtimeTalkOptions(props: ChatProps) {
             spellcheck="false"
           />
         </label>
-        ${renderTalkSelect({
-          label: "Sensitivity",
-          value: sensitivityValue,
-          options: sensitivityOptions,
-          onSelect: (vadThreshold) => {
-            if (vadThreshold !== "__custom") {
-              onChange({ vadThreshold });
-            }
-          },
-        })}
+        <label>
+          <span>Sensitivity</span>
+          <select @change=${updateSensitivity}>
+            <option value="" ?selected=${sensitivityValue === ""}>Default</option>
+            <option value="0.65" ?selected=${sensitivityValue === "0.65"}>Low</option>
+            <option value="0.5" ?selected=${sensitivityValue === "0.5"}>Medium</option>
+            <option value="0.35" ?selected=${sensitivityValue === "0.35"}>High</option>
+            ${isCustomSensitivity
+              ? html`<option value="__custom" selected>Custom</option>`
+              : nothing}
+          </select>
+        </label>
       </div>
       <details class="agent-chat__talk-options-advanced">
         <summary>Advanced</summary>
         <div class="agent-chat__talk-options-grid">
-          ${renderTalkSelect({
-            label: "Provider",
-            value: options.provider,
-            options: TALK_PROVIDER_OPTIONS,
-            onSelect: (provider) => onChange({ provider }),
-          })}
-          ${renderTalkSelect({
-            label: "Transport",
-            value: options.transport,
-            options: TALK_TRANSPORT_OPTIONS,
-            onSelect: (transport) => onChange({ transport }),
-          })}
-          ${renderTalkSelect({
-            label: "Reasoning",
-            value: options.reasoningEffort,
-            options: TALK_REASONING_OPTIONS,
-            onSelect: (reasoningEffort) => onChange({ reasoningEffort }),
-          })}
-          <label class="agent-chat__talk-field">
+          <label>
+            <span>Provider</span>
+            <select .value=${options.provider} @change=${update("provider")}>
+              <option value="">Auto</option>
+              <option value="openai">OpenAI</option>
+              <option value="google">Google</option>
+            </select>
+          </label>
+          <label>
+            <span>Transport</span>
+            <select .value=${options.transport} @change=${update("transport")}>
+              <option value="">Auto</option>
+              <option value="webrtc">WebRTC</option>
+              <option value="gateway-relay">Gateway relay</option>
+              <option value="provider-websocket">Provider WebSocket</option>
+            </select>
+          </label>
+          <label>
+            <span>Reasoning</span>
+            <select .value=${options.reasoningEffort} @change=${update("reasoningEffort")}>
+              <option value="">Default</option>
+              <option value="minimal">Minimal</option>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+            </select>
+          </label>
+          <label>
             <span>Exact VAD</span>
             <input
               type="number"
@@ -396,7 +327,7 @@ function renderRealtimeTalkOptions(props: ChatProps) {
               placeholder="0.5"
             />
           </label>
-          <label class="agent-chat__talk-field">
+          <label>
             <span>Pause before send</span>
             <input
               type="number"
@@ -407,7 +338,7 @@ function renderRealtimeTalkOptions(props: ChatProps) {
               placeholder="500"
             />
           </label>
-          <label class="agent-chat__talk-field">
+          <label>
             <span>Lead-in</span>
             <input
               type="number"
@@ -469,6 +400,10 @@ interface ChatEphemeralState {
   searchOpen: boolean;
   searchQuery: string;
   pinnedExpanded: boolean;
+  historyRenderSessionKey: string | null;
+  historyRenderMessagesRef: unknown[] | null;
+  historyRenderMessageCount: number;
+  historyRenderLimit: number;
 }
 
 function createChatEphemeralState(): ChatEphemeralState {
@@ -483,6 +418,10 @@ function createChatEphemeralState(): ChatEphemeralState {
     searchOpen: false,
     searchQuery: "",
     pinnedExpanded: false,
+    historyRenderSessionKey: null,
+    historyRenderMessagesRef: null,
+    historyRenderMessageCount: 0,
+    historyRenderLimit: 0,
   };
 }
 
@@ -593,9 +532,82 @@ export function resetChatViewState() {
 
 export const cleanupChatModuleState = resetChatViewState;
 
+function resolveChatHistoryRenderCap(messageCount: number): number {
+  return Math.min(Math.max(0, messageCount), CHAT_HISTORY_RENDER_LIMIT);
+}
+
+function shouldRenderFullChatHistoryWindow(messageCount: number): boolean {
+  return (
+    messageCount <= INITIAL_CHAT_HISTORY_RENDER_WINDOW ||
+    (vs.searchOpen && vs.searchQuery.trim().length > 0)
+  );
+}
+
+function resolveChatHistoryRenderWindow(props: ChatProps): number {
+  const messages = Array.isArray(props.messages) ? props.messages : [];
+  const cap = resolveChatHistoryRenderCap(messages.length);
+  const sessionChanged = vs.historyRenderSessionKey !== props.sessionKey;
+  const refChanged = vs.historyRenderMessagesRef !== messages;
+  const previousCount = vs.historyRenderMessageCount;
+
+  if (cap === 0) {
+    vs.historyRenderSessionKey = props.sessionKey;
+    vs.historyRenderMessagesRef = messages;
+    vs.historyRenderMessageCount = messages.length;
+    vs.historyRenderLimit = 0;
+    return 0;
+  }
+
+  if (shouldRenderFullChatHistoryWindow(messages.length)) {
+    vs.historyRenderSessionKey = props.sessionKey;
+    vs.historyRenderMessagesRef = messages;
+    vs.historyRenderMessageCount = messages.length;
+    vs.historyRenderLimit = cap;
+    return cap;
+  }
+
+  if (sessionChanged || (refChanged && previousCount === 0)) {
+    vs.historyRenderLimit = Math.min(INITIAL_CHAT_HISTORY_RENDER_WINDOW, cap);
+  } else if (refChanged) {
+    const grewBy = messages.length - previousCount;
+    if (vs.historyRenderLimit >= previousCount) {
+      vs.historyRenderLimit = cap;
+    } else if (grewBy > 0 && grewBy <= CHAT_HISTORY_RENDER_WINDOW_BATCH) {
+      vs.historyRenderLimit = Math.min(cap, vs.historyRenderLimit + grewBy);
+    } else {
+      vs.historyRenderLimit = Math.min(
+        Math.max(vs.historyRenderLimit, INITIAL_CHAT_HISTORY_RENDER_WINDOW),
+        cap,
+      );
+    }
+  }
+
+  vs.historyRenderSessionKey = props.sessionKey;
+  vs.historyRenderMessagesRef = messages;
+  vs.historyRenderMessageCount = messages.length;
+  vs.historyRenderLimit = Math.min(Math.max(1, vs.historyRenderLimit), cap);
+  return vs.historyRenderLimit;
+}
+
+function maybeExpandChatHistoryRenderWindow(event: Event, requestUpdate: () => void) {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  if (target.scrollTop > CHAT_HISTORY_RENDER_EXPAND_SCROLL_TOP_PX) {
+    return;
+  }
+  const cap = resolveChatHistoryRenderCap(vs.historyRenderMessageCount);
+  if (vs.historyRenderLimit >= cap) {
+    return;
+  }
+  vs.historyRenderLimit = Math.min(cap, vs.historyRenderLimit + CHAT_HISTORY_RENDER_WINDOW_BATCH);
+  requestUpdate();
+}
+
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
   el.style.height = "auto";
-  el.style.height = `${Math.min(Math.max(el.scrollHeight, 44), 150)}px`;
+  el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
 }
 
 function focusComposerFromChrome(event: MouseEvent, connected: boolean) {
@@ -1404,6 +1416,7 @@ export function renderChat(props: ChatProps) {
   const splitRatio = props.splitRatio ?? 0.6;
   const sidebarOpen = Boolean(props.sidebarOpen && props.onCloseSidebar);
   const displayStream = props.stream ?? null;
+  const historyRenderLimit = resolveChatHistoryRenderWindow(props);
 
   const handleCodeBlockCopy = (e: Event) => {
     const btn = (e.target as HTMLElement).closest(".code-block-copy");
@@ -1419,6 +1432,10 @@ export function renderChat(props: ChatProps) {
       () => {},
     );
   };
+  const handleChatThreadScroll = (event: Event) => {
+    maybeExpandChatHistoryRenderWindow(event, requestUpdate);
+    props.onChatScroll?.(event);
+  };
 
   const chatItems = buildCachedChatItems({
     sessionKey: props.sessionKey,
@@ -1431,6 +1448,7 @@ export function renderChat(props: ChatProps) {
     showToolCalls: props.showToolCalls,
     searchOpen: vs.searchOpen,
     searchQuery: vs.searchQuery,
+    historyRenderLimit,
   });
   syncToolCardExpansionState(props.sessionKey, chatItems, Boolean(props.autoExpandToolCalls));
   const expandedToolCards = getExpandedToolCards(props.sessionKey);
@@ -1449,7 +1467,7 @@ export function renderChat(props: ChatProps) {
       class="chat-thread"
       role="log"
       aria-live="polite"
-      @scroll=${props.onChatScroll}
+      @scroll=${handleChatThreadScroll}
       @click=${handleCodeBlockCopy}
     >
       <div class="chat-thread-inner">
@@ -1814,6 +1832,19 @@ export function renderChat(props: ChatProps) {
             </div>
           `
         : nothing}
+      ${props.focusMode
+        ? html`
+            <button
+              class="chat-focus-exit"
+              type="button"
+              @click=${props.onToggleFocusMode}
+              aria-label="Exit focus mode"
+              title="Exit focus mode"
+            >
+              ${icons.x}
+            </button>
+          `
+        : nothing}
       ${renderSearchBar(requestUpdate)} ${renderPinnedSection(props, pinned, requestUpdate)}
 
       <div class="chat-workbench">
@@ -1976,34 +2007,25 @@ export function renderChat(props: ChatProps) {
                       : t("chat.composer.startTalk")}
                     ?disabled=${!props.connected}
                   >
-                    ${props.realtimeTalkActive ? icons.volume2 : icons.mic}
+                    ${props.realtimeTalkActive ? icons.volume2 : icons.radio}
                     <span class="agent-chat__control-label"
                       >${props.realtimeTalkActive
                         ? t("chat.composer.stopTalk")
                         : t("chat.composer.startTalk")}</span
                     >
                   </button>
-                `
-              : nothing}
-            ${props.onToggleRealtimeTalkOptions
-              ? html`
                   <button
                     class="agent-chat__input-btn ${props.realtimeTalkOptionsOpen
-                      ? "agent-chat__input-btn--talk"
+                      ? "agent-chat__input-btn--active"
                       : ""}"
                     @click=${props.onToggleRealtimeTalkOptions}
-                    title="Talk settings"
-                    aria-label="Talk settings"
-                    aria-expanded=${props.realtimeTalkOptionsOpen ? "true" : "false"}
+                    title="Talk options"
+                    aria-label="Talk options"
                     ?disabled=${!props.connected || props.realtimeTalkActive}
                   >
                     ${icons.settings}
-                    <span class="agent-chat__control-label">Talk settings</span>
                   </button>
                 `
-              : nothing}
-            ${props.composerControls
-              ? html`<div class="agent-chat__composer-controls">${props.composerControls}</div>`
               : nothing}
             ${tokens ? html`<span class="agent-chat__token-count">${tokens}</span>` : nothing}
             ${renderChatRunStatusIndicator(composerRunStatus)}
@@ -2021,7 +2043,6 @@ export function renderChat(props: ChatProps) {
             onNewSession: props.onNewSession,
             onSend: handleSend,
             onStoreDraft: () => {},
-            showSecondary: false,
           })}
         </div>
       </div>


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/87345

## User-facing bug
Switching dashboard chat sessions could synchronously rebuild the full 100-message UI history window, causing 8-10s switches on long or heavy transcripts.

## Exact repro
1. Open the Control UI chat dashboard.
2. Use or select a session whose `chat.history` returns the current 100-message tail.
3. Switch between dashboard sessions.
4. Before: the chat view can block while all loaded history items are built and rendered at once.
5. After: newly loaded large histories start with the latest 30-message render window, expand in 30-message batches when the user is at the top, avoid programmatic bottom-scroll expansion, and auto-fill non-scrollable initial windows while preserving bottom anchoring.

## Fix summary
- Added optional `historyRenderLimit` to `buildChatItems`, preserving existing default 100-message behavior.
- Added per-session render-window state in `renderChat` so newly loaded large histories initially render 30 messages.
- Expand the render window on top scroll or exact top state, skip bottom auto-scrolls inside the top threshold, and auto-fill after render when the initial window does not overflow.
- Keep auto-filled windows anchored to latest messages via the existing `onScrollToBottom` path.
- Search with a non-empty query still renders the full loaded and capped history window.
- Restored the explicit `showSecondary: false` at the composer `renderChatRunControls` call so the history-window refactor does not reintroduce the New session and Export buttons in the composer toolbar, with a regression test asserting neither control renders there.
- Restored the Talk settings button's `aria-expanded` state, visible control label, and descriptive title/aria-label that the refactor had flattened, with a regression test asserting `aria-expanded` tracks `realtimeTalkOptionsOpen`.

## Targeted tests

- `buildChatItems` coverage proves the render limit preserves the newest window.
- Chat view tests cover initial 30-message windows, top-scroll expansion, bottom-scroll suppression, auto-fill, and full rendering while searching.

## Real behavior proof

Behavior addressed: Switching to a large dashboard chat history no longer forces an immediate 100-message render; the UI starts with a latest-message window and expands incrementally.

Real environment tested: Local OpenClaw checkout on branch `fix/dashboard-session-switching`, commit `415e0eaaf4`, based on `origin/main`.

Exact steps or command run after this patch:
- `git diff --check origin/main...HEAD`
- `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts`
- `./node_modules/.bin/oxlint ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts`

Evidence after fix:
- Full `ui/src/ui/views/chat.test.ts` suite passed after restoring the suppressed composer controls and the Talk settings button semantics, and adding both regression tests. Copied terminal output:

```text
 RUN  v4.1.7 /Users/alex/PR/projects/openclaw__openclaw/worktrees/88685

 Test Files  1 passed (1)
      Tests  92 passed (92)
```

- Both regression tests were verified to fail without their fix and pass with it:
  - removing `showSecondary: false` reproduces `1 failed | 90 passed`;
  - removing the Talk button `aria-expanded` reproduces `1 failed | 91 passed`;
  - with both fixes in place the suite returns `92 passed`.
- `oxlint` on the two touched files passed with exit code 0.
- `git diff --check origin/main...HEAD` passed.

Observed result after fix: Newly loaded large histories render the newest 30 messages first, expand in 30-message batches from top-scroll/top state, preserve the previously visible top anchor across repeated expansion, avoid bottom auto-scroll expansion, and still render full loaded history for non-empty search.

What was not tested: Full UI suite, `pnpm check`, and browser screenshot/video were not run. This PR changes render-window behavior and is covered with focused jsdom view/controller tests plus UI tsgo; no visual recording was captured.

## Not tested / known gaps
- Full UI suite and `pnpm check` were not run.
- No browser screenshot or video captured; this PR changes render-window behavior and is covered with focused jsdom tests, not visual layout changes.

## AI-assisted disclosure
Prepared with AI assistance in Codex. I reviewed the diff, ran targeted tests, and resolved codex review findings before opening.
