### PR TITLE
Replay sessions_yield wait text in WebChat history

### DIFF
--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -8,6 +8,7 @@ import {
   buildChildCompletionFindings,
   readSubagentOutput,
 } from "./subagent-announce-output.js";
+import { projectChatDisplayMessages } from "../gateway/chat-display-projection.js";
 
 type CallGateway = typeof import("../gateway/call.js").callGateway;
 type GetRuntimeConfig = typeof import("./subagent-announce.runtime.js").getRuntimeConfig;
@@ -31,7 +32,7 @@ function installOutputDeps(params: {
   return { callGateway, readSessionMessagesAsync };
 }
 
-function sessionsYieldTurn(message = "Waiting for subagent completion.") {
+function sessionsYieldTurn(message = "Waiting for subagent completion.", toolCallType = "toolCall") {
   // sessions_yield is requester control flow, not child output; fixtures keep
   // that wait turn adjacent to later assistant completions.
   return [
@@ -41,7 +42,7 @@ function sessionsYieldTurn(message = "Waiting for subagent completion.") {
       content: [
         { type: "text", text: message },
         {
-          type: "toolCall",
+          type: toolCallType,
           id: "call-yield",
           name: "sessions_yield",
           arguments: { message },
@@ -102,6 +103,36 @@ describe("readSubagentOutput", () => {
 
     await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
     expect(deps.callGateway).toHaveBeenCalledOnce();
+  });
+
+  it("does not treat projected duplicate sessions_yield wait text as completion output", async () => {
+    const projected = projectChatDisplayMessages(sessionsYieldTurn());
+    installOutputDeps({ messages: projected });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
+    expect(
+      (projected[0] as { openclawSessionsYieldMirror?: unknown }).openclawSessionsYieldMirror,
+    ).toEqual({
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+      duplicateAssistantText: true,
+    });
+  });
+
+  it("does not treat normalized projected sessions_yield wait text as completion output", async () => {
+    const projected = projectChatDisplayMessages(
+      sessionsYieldTurn("Waiting for subagent completion.", "tool_call"),
+    );
+    installOutputDeps({ messages: projected });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
+    expect(
+      (projected[0] as { openclawSessionsYieldMirror?: unknown }).openclawSessionsYieldMirror,
+    ).toEqual({
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+      duplicateAssistantText: true,
+    });
   });
 
   it("returns final assistant output that arrives after a sessions_yield wait turn", async () => {

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -134,6 +134,18 @@ function countAssistantToolCalls(message: unknown): number {
   return contentToolCalls + (Array.isArray(toolCalls) ? toolCalls.length : 0);
 }
 
+function isSessionsYieldMirrorMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const marker = (message as { openclawSessionsYieldMirror?: unknown })
+    .openclawSessionsYieldMirror;
+  if (!marker || typeof marker !== "object") {
+    return false;
+  }
+  return (marker as { toolName?: unknown }).toolName === "sessions_yield";
+}
+
 function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutputSnapshot {
   const snapshot: SubagentOutputSnapshot = {};
   let previousAssistantCalledYield = false;
@@ -143,7 +155,7 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
     }
     const role = (message as { role?: unknown }).role;
     if (role === "assistant") {
-      if (assistantCallsSessionsYield(message)) {
+      if (isSessionsYieldMirrorMessage(message) || assistantCallsSessionsYield(message)) {
         snapshot.latestAssistantText = undefined;
         snapshot.latestSilentText = undefined;
         snapshot.waitingForContinuation = true;

--- a/src/agents/subagent-yield-output.ts
+++ b/src/agents/subagent-yield-output.ts
@@ -24,13 +24,9 @@ function isToolCallBlock(value: unknown): boolean {
   if (!record) {
     return false;
   }
-  return (
-    record.type === "toolCall" ||
-    record.type === "tool_use" ||
-    record.type === "toolUse" ||
-    record.type === "functionCall" ||
-    record.type === "function_call"
-  );
+  const type =
+    typeof record.type === "string" ? record.type.trim().toLowerCase().replace(/_/g, "") : "";
+  return type === "toolcall" || type === "tooluse" || type === "functioncall";
 }
 
 /** Returns true when an assistant message requested the sessions_yield tool. */
@@ -96,6 +92,9 @@ export function isSessionsYieldToolResult(
   const toolName = readToolName(record);
   if (toolName === "sessions_yield") {
     return true;
+  }
+  if (toolName !== undefined) {
+    return false;
   }
   if (!previousAssistantCalledYield) {
     return false;

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -6,6 +6,10 @@ import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/rec
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE } from "../agents/internal-runtime-context.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
+import {
+  assistantCallsSessionsYield,
+  isSessionsYieldToolResult,
+} from "../agents/subagent-yield-output.js";
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import { extractCanvasFromText } from "../chat/canvas-render.js";
@@ -41,6 +45,37 @@ type PendingMessageToolVisibleReply = {
   succeeded: boolean;
 };
 
+type SessionsYieldVisibleReply = {
+  toolCallId?: string;
+  text: string;
+  anchor: Record<string, unknown>;
+};
+
+const SESSIONS_YIELD_MIRROR_MESSAGE_ID_SUFFIX = ":sessions_yield_mirror";
+
+export function resolveSessionsYieldMirrorMessageId(sourceMessageId: string): string {
+  return sourceMessageId.endsWith(SESSIONS_YIELD_MIRROR_MESSAGE_ID_SUFFIX)
+    ? sourceMessageId
+    : `${sourceMessageId}${SESSIONS_YIELD_MIRROR_MESSAGE_ID_SUFFIX}`;
+}
+
+export function resolveSessionsYieldMirrorSourceMessageId(messageId: string): string | undefined {
+  return messageId.endsWith(SESSIONS_YIELD_MIRROR_MESSAGE_ID_SUFFIX)
+    ? messageId.slice(0, -SESSIONS_YIELD_MIRROR_MESSAGE_ID_SUFFIX.length)
+    : undefined;
+}
+
+type PendingSessionsYieldCall = {
+  assistantIndex?: number;
+  text?: string;
+};
+
+type ProjectChatDisplayOptions = {
+  maxChars?: number;
+  stripEnvelope?: boolean;
+  mirrorSessionsYieldToolResults?: boolean;
+};
+
 /** Resolve the text cap used when projecting chat history for display. */
 export function resolveEffectiveChatHistoryMaxChars(_cfg: unknown, maxChars?: number): number {
   if (typeof maxChars === "number") {
@@ -73,6 +108,8 @@ export function isToolHistoryBlockType(type: unknown): boolean {
     normalized === "tool_call" ||
     normalized === "tooluse" ||
     normalized === "tool_use" ||
+    normalized === "functioncall" ||
+    normalized === "function_call" ||
     normalized === "toolresult" ||
     normalized === "tool_result"
   );
@@ -669,6 +706,20 @@ function readToolBlockCallId(block: Record<string, unknown>): string | undefined
   );
 }
 
+function readYieldToolBlockCallId(
+  block: Record<string, unknown>,
+  normalizedType: string,
+): string | undefined {
+  if (normalizedType === "functioncall") {
+    return (
+      normalizeOptionalString(block.call_id) ??
+      normalizeOptionalString(block.callId) ??
+      readToolBlockCallId(block)
+    );
+  }
+  return readToolBlockCallId(block);
+}
+
 function readToolBlockArguments(block: Record<string, unknown>): Record<string, unknown> {
   for (const key of ["arguments", "input", "args", "params"] as const) {
     const args = readMaybeJsonRecord(block[key]);
@@ -783,6 +834,31 @@ function extractMessageToolVisibleReplies(
   return replies;
 }
 
+function extractSessionsYieldToolCallIds(message: Record<string, unknown>): string[] {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) {
+    return [];
+  }
+  const callIds: string[] = [];
+  for (const block of message.content) {
+    const record = readRecord(block);
+    if (!record) {
+      continue;
+    }
+    const type = normalizeToolHistoryType(record.type);
+    if (type !== "toolcall" && type !== "tooluse" && type !== "functioncall") {
+      continue;
+    }
+    if (readToolBlockName(record)?.toLowerCase() !== "sessions_yield") {
+      continue;
+    }
+    const toolCallId = readYieldToolBlockCallId(record, type);
+    if (toolCallId) {
+      callIds.push(toolCallId);
+    }
+  }
+  return callIds;
+}
+
 function isAssistantSilentControlReplyOnly(message: Record<string, unknown>): boolean {
   const text = extractAssistantTextForSilentCheck(message);
   return (
@@ -796,6 +872,42 @@ function isRenderableAssistantDisplayMessage(message: Record<string, unknown>): 
   }
   const text = extractAssistantTextForSilentCheck(message);
   return text !== undefined && !isSuppressedControlReplyText(text);
+}
+
+function isSessionsYieldToolCallBlock(block: unknown): boolean {
+  const record = readRecord(block);
+  if (!record) {
+    return false;
+  }
+  const type = normalizeToolHistoryType(record.type);
+  return (
+    (type === "toolcall" || type === "tooluse" || type === "functioncall") &&
+    readToolBlockName(record)?.toLowerCase() === "sessions_yield"
+  );
+}
+
+function isSessionsYieldToolCallOnlyMessage(message: Record<string, unknown>): boolean {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) {
+    return false;
+  }
+  let hasSessionsYieldCall = false;
+  for (const block of message.content) {
+    const record = readRecord(block);
+    if (!record) {
+      return false;
+    }
+    if (record.type === "text") {
+      if (typeof record.text === "string" && record.text.trim()) {
+        return false;
+      }
+      continue;
+    }
+    if (!isSessionsYieldToolCallBlock(record)) {
+      return false;
+    }
+    hasSessionsYieldCall = true;
+  }
+  return hasSessionsYieldCall;
 }
 
 function readMessageToolResultName(message: Record<string, unknown>): string | undefined {
@@ -1065,6 +1177,296 @@ function mirrorMessageToolVisibleReplies(messages: unknown[]): unknown[] {
     }
     next.push(message);
     flushSelectedMirrors(flushAfterCurrentMessage);
+  }
+
+  return changed ? next : messages;
+}
+
+function readSessionsYieldPayloadMessage(value: unknown): string | undefined {
+  const record = readMaybeJsonRecord(value);
+  if (record) {
+    const status = normalizeOptionalString(record.status)?.toLowerCase();
+    const message = normalizeOptionalString(record.message);
+    if (status === "yielded" && message) {
+      return stripInlineDirectiveTagsForDisplay(message).text;
+    }
+    for (const key of ["details", "result", "output", "content", "text"] as const) {
+      const nested = readSessionsYieldPayloadMessage(record[key]);
+      if (nested) {
+        return nested;
+      }
+    }
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  for (const block of value) {
+    const nested = readSessionsYieldPayloadMessage(block);
+    if (nested) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+function readSessionsYieldToolResultMessage(
+  message: Record<string, unknown>,
+  previousAssistantCalledYield: boolean,
+): string | undefined {
+  if (!isSessionsYieldToolResult(message, previousAssistantCalledYield)) {
+    return undefined;
+  }
+  return readSessionsYieldPayloadMessage(message);
+}
+
+function readAssistantSessionsYieldVisibleText(
+  message: Record<string, unknown>,
+): string | undefined {
+  if (message.role !== "assistant") {
+    return undefined;
+  }
+  const text = extractProjectedText(message.content ?? message.text);
+  const stripped = stripInlineDirectiveTagsForDisplay(text).text.trim();
+  if (!stripped || isSuppressedControlReplyText(stripped)) {
+    return undefined;
+  }
+  return stripped;
+}
+
+function buildSessionsYieldVisibleReplyMirror(
+  reply: SessionsYieldVisibleReply,
+): Record<string, unknown> {
+  const mirror: Record<string, unknown> = {
+    role: "assistant",
+    content: [{ type: "text", text: reply.text }],
+    openclawSessionsYieldMirror: {
+      toolName: "sessions_yield",
+      ...(reply.toolCallId ? { toolCallId: reply.toolCallId } : {}),
+    },
+  };
+  for (const field of ["timestamp", "createdAt", "agentId"] as const) {
+    if (reply.anchor[field] !== undefined) {
+      mirror[field] = reply.anchor[field];
+    }
+  }
+  const transcriptMeta = readRecord(reply.anchor["__openclaw"]);
+  if (transcriptMeta) {
+    const sourceMessageId = normalizeOptionalString(transcriptMeta.id);
+    mirror["__openclaw"] = {
+      ...transcriptMeta,
+      ...(sourceMessageId
+        ? {
+            id: resolveSessionsYieldMirrorMessageId(sourceMessageId),
+            sourceId: sourceMessageId,
+          }
+        : {}),
+    };
+  }
+  return mirror;
+}
+
+function markSessionsYieldVisibleReplyMirror(
+  message: unknown,
+  reply: SessionsYieldVisibleReply,
+): unknown {
+  const record = readRecord(message);
+  if (!record) {
+    return message;
+  }
+  return {
+    ...record,
+    openclawSessionsYieldMirror: {
+      toolName: "sessions_yield",
+      ...(reply.toolCallId ? { toolCallId: reply.toolCallId } : {}),
+      duplicateAssistantText: true,
+    },
+  };
+}
+
+function markSessionsYieldPendingReplyMirror(
+  message: unknown,
+  reply: { toolCallId?: string },
+): unknown {
+  const record = readRecord(message);
+  if (!record) {
+    return message;
+  }
+  return {
+    ...record,
+    openclawSessionsYieldMirror: {
+      toolName: "sessions_yield",
+      ...(reply.toolCallId ? { toolCallId: reply.toolCallId } : {}),
+      pendingToolResult: true,
+    },
+  };
+}
+
+function readSessionsYieldPendingMirrorToolCallId(
+  message: Record<string, unknown>,
+): string | undefined {
+  const marker = readRecord(message.openclawSessionsYieldMirror);
+  if (!marker || marker.toolName !== "sessions_yield" || marker.pendingToolResult !== true) {
+    return undefined;
+  }
+  return normalizeOptionalString(marker.toolCallId);
+}
+
+function mirrorSessionsYieldToolResults(messages: unknown[]): unknown[] {
+  if (messages.length === 0) {
+    return messages;
+  }
+  if (!messages.some((message) => readRecord(message))) {
+    return messages;
+  }
+
+  let changed = false;
+  const next: unknown[] = [];
+  let previousAssistantCalledYield = false;
+  let previousAssistantYieldText: string | undefined;
+  let previousAssistantVisibleText: string | undefined;
+  let previousAssistantIndex: number | undefined;
+  const pendingYieldCalls = new Map<string, PendingSessionsYieldCall>();
+  let pendingYieldWithoutCallId: PendingSessionsYieldCall | undefined;
+
+  for (const message of messages) {
+    const record = readRecord(message);
+    if (!record) {
+      next.push(message);
+      previousAssistantCalledYield = false;
+      previousAssistantYieldText = undefined;
+      previousAssistantVisibleText = undefined;
+      previousAssistantIndex = undefined;
+      continue;
+    }
+
+    const resultCallId = readMessageToolResultCallId(record);
+    const resultToolName = readMessageToolResultName(record)?.toLowerCase();
+    const resultIsExplicitSessionsYield = resultToolName === "sessions_yield";
+    const resultIsExplicitNonYieldTool =
+      resultToolName !== undefined && !resultIsExplicitSessionsYield;
+    let pendingYieldCallId: string | undefined;
+    let pendingYieldCall: PendingSessionsYieldCall | undefined;
+    if (resultCallId !== undefined) {
+      pendingYieldCallId = resultCallId;
+      pendingYieldCall = pendingYieldCalls.get(resultCallId);
+    } else if (pendingYieldWithoutCallId !== undefined) {
+      pendingYieldCall = pendingYieldWithoutCallId;
+    } else if (resultIsExplicitSessionsYield || pendingYieldCalls.size === 1) {
+      const [firstPendingCallId, firstPendingCall] = pendingYieldCalls.entries().next().value ?? [];
+      pendingYieldCallId =
+        typeof firstPendingCallId === "string" && firstPendingCallId ? firstPendingCallId : undefined;
+      pendingYieldCall = firstPendingCall;
+    }
+    const hasYieldContext =
+      !resultIsExplicitNonYieldTool &&
+      (pendingYieldCall !== undefined ||
+        (previousAssistantCalledYield &&
+          resultCallId === undefined &&
+          pendingYieldCalls.size === 0 &&
+          pendingYieldWithoutCallId === undefined));
+    const yieldText = hasYieldContext
+      ? readSessionsYieldToolResultMessage(record, true)
+      : undefined;
+    if (yieldText?.trim()) {
+      const normalizedYieldText = yieldText.trim();
+      const pendingYieldAssistantIndex =
+        pendingYieldCall?.text === normalizedYieldText
+          ? pendingYieldCall.assistantIndex
+          : undefined;
+      const previousAssistantMatchesYieldText =
+        (previousAssistantCalledYield && previousAssistantYieldText === normalizedYieldText) ||
+        previousAssistantVisibleText === normalizedYieldText;
+      const duplicatesPreviousAssistantText =
+        previousAssistantMatchesYieldText || pendingYieldCall?.text === normalizedYieldText;
+      if (!duplicatesPreviousAssistantText) {
+        next.push(message);
+        next.push(
+          buildSessionsYieldVisibleReplyMirror({
+            text: normalizedYieldText,
+            anchor: record,
+            ...(pendingYieldCallId ? { toolCallId: pendingYieldCallId } : {}),
+          }),
+        );
+      } else {
+        const mirrorAssistantIndex = previousAssistantMatchesYieldText
+          ? previousAssistantIndex
+          : pendingYieldAssistantIndex;
+        if (mirrorAssistantIndex !== undefined) {
+          next[mirrorAssistantIndex] = markSessionsYieldVisibleReplyMirror(
+            next[mirrorAssistantIndex],
+            {
+              text: normalizedYieldText,
+              anchor: record,
+              ...(pendingYieldCallId ? { toolCallId: pendingYieldCallId } : {}),
+            },
+          );
+        }
+        next.push(message);
+      }
+      changed = true;
+      if (pendingYieldCallId) {
+        pendingYieldCalls.delete(pendingYieldCallId);
+      } else {
+        pendingYieldWithoutCallId = undefined;
+      }
+      previousAssistantCalledYield = false;
+      previousAssistantYieldText = undefined;
+      previousAssistantVisibleText = undefined;
+      previousAssistantIndex = undefined;
+      continue;
+    }
+
+    const nextIndex = next.length;
+    next.push(message);
+    if (record.role === "assistant") {
+      const assistantText = readAssistantSessionsYieldVisibleText(record);
+      const yieldCallIds = extractSessionsYieldToolCallIds(record);
+      const pendingMirrorToolCallId = readSessionsYieldPendingMirrorToolCallId(record);
+      const assistantHasYieldCall = assistantCallsSessionsYield(record) || yieldCallIds.length > 0;
+      const pendingYieldContext = {
+        ...(assistantText ? { text: assistantText } : {}),
+        assistantIndex: nextIndex,
+      };
+      for (const callId of yieldCallIds) {
+        pendingYieldCalls.set(callId, pendingYieldContext);
+      }
+      if (pendingMirrorToolCallId) {
+        pendingYieldCalls.set(pendingMirrorToolCallId, pendingYieldContext);
+      }
+      if (
+        assistantHasYieldCall &&
+        yieldCallIds.length === 0 &&
+        pendingMirrorToolCallId === undefined
+      ) {
+        pendingYieldWithoutCallId = pendingYieldContext;
+      }
+      previousAssistantCalledYield =
+        assistantHasYieldCall || pendingMirrorToolCallId !== undefined;
+      previousAssistantYieldText = previousAssistantCalledYield ? assistantText : undefined;
+      previousAssistantVisibleText = assistantText;
+      previousAssistantIndex = nextIndex;
+      if (assistantHasYieldCall && assistantText) {
+        next[nextIndex] = markSessionsYieldPendingReplyMirror(
+          record,
+          yieldCallIds[0] ? { toolCallId: yieldCallIds[0] } : {},
+        );
+        changed = true;
+      }
+    } else if (record.role === "user") {
+      pendingYieldCalls.clear();
+      pendingYieldWithoutCallId = undefined;
+      previousAssistantCalledYield = false;
+      previousAssistantYieldText = undefined;
+      previousAssistantVisibleText = undefined;
+      previousAssistantIndex = undefined;
+    } else if (record.role === "toolResult" || record.role === "tool") {
+      previousAssistantCalledYield = false;
+      previousAssistantYieldText = undefined;
+      previousAssistantVisibleText = undefined;
+      previousAssistantIndex = undefined;
+    }
   }
 
   return changed ? next : messages;
@@ -1426,6 +1828,9 @@ function shouldHideProjectedHistoryMessage(message: Record<string, unknown>): bo
   if (isProjectedSessionsSendForwardedMessage(message)) {
     return false;
   }
+  if (isSessionsYieldToolCallOnlyMessage(message)) {
+    return true;
+  }
   const roleContent = asRoleContentMessage(message);
   if (!roleContent) {
     return false;
@@ -1700,10 +2105,14 @@ function projectEmptyAssistantErrorMessages(
 
 export function projectChatDisplayMessages(
   messages: unknown[],
-  options?: { maxChars?: number; stripEnvelope?: boolean },
+  options?: ProjectChatDisplayOptions,
 ): Array<Record<string, unknown>> {
   const source = options?.stripEnvelope === false ? messages : stripEnvelopeFromMessages(messages);
-  const mirrored = mirrorMessageToolVisibleReplies(source);
+  const mirroredMessageReplies = mirrorMessageToolVisibleReplies(source);
+  const mirrored =
+    options?.mirrorSessionsYieldToolResults === false
+      ? mirroredMessageReplies
+      : mirrorSessionsYieldToolResults(mirroredMessageReplies);
   const projectedErrors = projectEmptyAssistantErrorMessages(toProjectedMessages(mirrored));
   const projectedForwarded = mergeTtsSupplementMessages(
     filterVisibleProjectedHistoryMessages(
@@ -1732,7 +2141,7 @@ function limitChatDisplayMessages<T>(messages: T[], maxMessages?: number): T[] {
 
 export function projectRecentChatDisplayMessages(
   messages: unknown[],
-  options?: { maxChars?: number; maxMessages?: number; stripEnvelope?: boolean },
+  options?: ProjectChatDisplayOptions & { maxMessages?: number },
 ): Array<Record<string, unknown>> {
   return limitChatDisplayMessages(
     projectChatDisplayMessages(messages, options),
@@ -1742,7 +2151,10 @@ export function projectRecentChatDisplayMessages(
 
 export function projectChatDisplayMessage(
   message: unknown,
-  options?: { maxChars?: number; stripEnvelope?: boolean },
+  options?: ProjectChatDisplayOptions,
 ): Record<string, unknown> | undefined {
-  return projectChatDisplayMessages([message], options)[0];
+  return projectChatDisplayMessages([message], {
+    ...options,
+    mirrorSessionsYieldToolResults: false,
+  })[0];
 }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -45,6 +45,7 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
+import { isSessionsYieldToolResult } from "../../agents/subagent-yield-output.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import {
@@ -137,8 +138,10 @@ import {
   augmentChatHistoryWithCanvasBlocks,
   dropPreSessionStartAnnouncePairs,
   projectChatDisplayMessage,
+  projectChatDisplayMessages,
   projectRecentChatDisplayMessages,
   resolveEffectiveChatHistoryMaxChars,
+  resolveSessionsYieldMirrorSourceMessageId,
 } from "../chat-display-projection.js";
 import { sanitizeChatSendMessageInput } from "../chat-input-sanitize.js";
 import { stripEnvelopeFromMessage } from "../chat-sanitize.js";
@@ -2558,6 +2561,37 @@ async function isChatMessageIdVisibleAfterHistoryFilters(params: {
   );
 }
 
+function isSessionsYieldHistoryResult(message: unknown): boolean {
+  return isSessionsYieldToolResult(message, true);
+}
+
+async function projectChatMessageWithHistoryContext(params: {
+  sessionId: string;
+  storePath: string | undefined;
+  sessionFile: string | undefined;
+  agentId?: string;
+  messageId: string;
+  sessionStartedAt?: number;
+  maxChars: number;
+}): Promise<Record<string, unknown> | undefined> {
+  const messages = await readSessionMessagesAsync(
+    {
+      agentId: params.agentId,
+      sessionFile: params.sessionFile,
+      sessionId: params.sessionId,
+      storePath: params.storePath,
+    },
+    {
+      mode: "full",
+      reason: "chat.message.get projection context",
+    },
+  );
+  const visibleMessages = dropPreSessionStartAnnouncePairs(messages, params.sessionStartedAt);
+  return projectChatDisplayMessages(visibleMessages, { maxChars: params.maxChars }).find(
+    (message) => readChatHistoryMessageId(message) === params.messageId,
+  );
+}
+
 function dropLocalHistoryOverreadContextMessage(
   messages: unknown[],
   contextMessage: unknown,
@@ -2853,6 +2887,8 @@ export const chatHandlers: GatewayRequestHandlers = {
       config: cfg,
       agentId: selectedAgent.agentId,
     });
+    const sourceMessageId = resolveSessionsYieldMirrorSourceMessageId(messageId);
+    const transcriptMessageId = sourceMessageId ?? messageId;
     const resolved = await readSessionMessageByIdAsync(
       {
         agentId: sessionAgentId,
@@ -2860,7 +2896,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         sessionId,
         storePath,
       },
-      messageId,
+      transcriptMessageId,
       { allowResetArchiveFallback: true },
     );
     if (!resolved.found) {
@@ -2872,7 +2908,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: sessionAgentId,
-      messageId,
+      messageId: transcriptMessageId,
       sessionStartedAt:
         typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
       allowResetArchiveFallback: true,
@@ -2888,11 +2924,37 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     const effectiveMaxChars =
       typeof maxChars === "number" ? maxChars : Math.min(MAX_PAYLOAD_BYTES, 1_000_000);
-    const projectedMessage = resolved.message
+    const projectedSingleMessage = resolved.message
       ? projectChatDisplayMessage(resolved.message, {
           maxChars: effectiveMaxChars,
         })
       : undefined;
+    let projectedMessage: Record<string, unknown> | undefined;
+    if (sourceMessageId !== undefined) {
+      projectedMessage = await projectChatMessageWithHistoryContext({
+        sessionId,
+        storePath,
+        sessionFile: entry?.sessionFile,
+        agentId: sessionAgentId,
+        messageId,
+        sessionStartedAt:
+          typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
+        maxChars: effectiveMaxChars,
+      });
+    } else if (resolved.message && isSessionsYieldHistoryResult(resolved.message)) {
+      projectedMessage = await projectChatMessageWithHistoryContext({
+        sessionId,
+        storePath,
+        sessionFile: entry?.sessionFile,
+        agentId: sessionAgentId,
+        messageId,
+        sessionStartedAt:
+          typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
+        maxChars: effectiveMaxChars,
+      });
+    } else {
+      projectedMessage = projectedSingleMessage;
+    }
     const projected = projectedMessage
       ? augmentChatHistoryWithCanvasBlocks([projectedMessage])[0]
       : undefined;

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2768,6 +2768,214 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.message.get expands truncated sessions_yield mirrors with history context", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      const yieldMessage = "Waiting for child completion with a long visible status.";
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          id: "msg-yield-user",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "spawn a child" }],
+            timestamp: Date.now(),
+          },
+        }),
+        JSON.stringify({
+          id: "msg-yield-call",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call-yield",
+                name: "sessions_yield",
+                arguments: { message: yieldMessage },
+              },
+            ],
+            timestamp: Date.now(),
+          },
+        }),
+        JSON.stringify({
+          id: "msg-yield-result",
+          message: {
+            role: "toolResult",
+            toolName: "sessions_yield",
+            toolCallId: "call-yield",
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+              },
+            ],
+            details: { status: "yielded", message: yieldMessage },
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const historyMessages = await fetchHistoryMessages(ws, { maxChars: 18 });
+      const yieldMirror = historyMessages.find(
+        (message) =>
+          Boolean(message) &&
+          typeof message === "object" &&
+          Boolean((message as { openclawSessionsYieldMirror?: unknown }).openclawSessionsYieldMirror),
+      ) as { __openclaw?: { id?: string }; content?: Array<{ text?: string }> } | undefined;
+      expect(yieldMirror?.["__openclaw"]?.id).toBe(
+        "msg-yield-result:sessions_yield_mirror",
+      );
+      expect(yieldMirror?.content?.[0]?.text).toContain("...(truncated)...");
+
+      const full = await fetchChatMessage(ws, {
+        sessionKey: "main",
+        messageId: "msg-yield-result:sessions_yield_mirror",
+      });
+
+      expect(full.ok).toBe(true);
+      expect(full.unavailableReason).toBeUndefined();
+      expect((full.message as { role?: unknown } | undefined)?.role).toBe("assistant");
+      expect(
+        (full.message as { openclawSessionsYieldMirror?: unknown } | undefined)
+          ?.openclawSessionsYieldMirror,
+      ).toEqual({
+        toolName: "sessions_yield",
+        toolCallId: "call-yield",
+      });
+      expect(JSON.stringify(full.message)).toContain(yieldMessage);
+      expect(JSON.stringify(full.message)).not.toContain("toolResult");
+
+      const raw = await fetchChatMessage(ws, {
+        sessionKey: "main",
+        messageId: "msg-yield-result",
+      });
+
+      expect(raw.ok).toBe(true);
+      expect(raw.unavailableReason).toBeUndefined();
+      expect((raw.message as { role?: unknown } | undefined)?.role).toBe("toolResult");
+      expect(JSON.stringify(raw.message)).toContain(yieldMessage);
+    });
+  });
+
+  test("chat.message.get keeps duplicate sessions_yield raw results addressable", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      const yieldMessage = "Waiting for child completion.";
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          id: "msg-yield-call",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: yieldMessage },
+              {
+                type: "toolCall",
+                id: "call-yield",
+                name: "sessions_yield",
+                arguments: { message: yieldMessage },
+              },
+            ],
+            timestamp: Date.now(),
+          },
+        }),
+        JSON.stringify({
+          id: "msg-yield-result",
+          message: {
+            role: "toolResult",
+            toolName: "sessions_yield",
+            toolCallId: "call-yield",
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+              },
+            ],
+            details: { status: "yielded", message: yieldMessage },
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const historyMessages = await fetchHistoryMessages(ws);
+      expect(
+        historyMessages.some(
+          (message) =>
+            (message as { ["__openclaw"]?: { id?: string } } | undefined)?.["__openclaw"]?.id ===
+            "msg-yield-result",
+        ),
+      ).toBe(true);
+
+      const raw = await fetchChatMessage(ws, {
+        sessionKey: "main",
+        messageId: "msg-yield-result",
+      });
+
+      expect(raw.ok).toBe(true);
+      expect(raw.unavailableReason).toBeUndefined();
+      expect((raw.message as { role?: unknown } | undefined)?.role).toBe("toolResult");
+      expect(JSON.stringify(raw.message)).toContain(yieldMessage);
+    });
+  });
+
+  test("chat.message.get keeps ordinary tool results on the indexed message path", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          id: "msg-yield-call",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call-yield",
+                name: "sessions_yield",
+                arguments: { message: "Waiting for child completion." },
+              },
+            ],
+            timestamp: Date.now(),
+          },
+        }),
+        JSON.stringify({
+          id: "msg-exec-result",
+          message: {
+            role: "toolResult",
+            toolName: "exec",
+            toolCallId: "call-exec",
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  status: "yielded",
+                  message: "ordinary tool output, not sessions_yield",
+                }),
+              },
+            ],
+            details: {
+              status: "yielded",
+              message: "ordinary tool output, not sessions_yield",
+            },
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const full = await fetchChatMessage(ws, {
+        sessionKey: "main",
+        messageId: "msg-exec-result",
+      });
+
+      expect(full.ok).toBe(true);
+      expect(full.unavailableReason).toBeUndefined();
+      expect((full.message as { role?: unknown } | undefined)?.role).toBe("toolResult");
+      expect((full.message as { toolName?: unknown } | undefined)?.toolName).toBe("exec");
+      expect(
+        (full.message as { openclawSessionsYieldMirror?: unknown } | undefined)
+          ?.openclawSessionsYieldMirror,
+      ).toBeUndefined();
+      expect(JSON.stringify(full.message)).toContain("ordinary tool output, not sessions_yield");
+    });
+  });
+
   test("chat.message.get accepts the selected agent for global sessions", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await writeGatewayConfig({

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -1180,6 +1180,68 @@ describe("gateway server chat", () => {
     ).toBe(false);
   });
 
+  test("chat.history replays sessions_yield tool results as visible assistant text", async () => {
+    const yieldMessage = "Waiting for child completion.";
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "spawn a child" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-yield",
+            name: "sessions_yield",
+            arguments: { message: yieldMessage },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolName: "sessions_yield",
+        toolCallId: "call-yield",
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+          },
+        ],
+        details: { status: "yielded", message: yieldMessage },
+        timestamp: 3,
+      },
+    ]);
+
+    const defaultVisibleMessages = historyMessages.filter(
+      (message) => (message as { role?: unknown } | undefined)?.role !== "toolResult",
+    );
+    expect(collectHistoryTextValues(defaultVisibleMessages)).toEqual([
+      "spawn a child",
+      yieldMessage,
+    ]);
+    expect(
+      historyMessages.some(
+        (message) =>
+          Boolean(message) &&
+          typeof message === "object" &&
+          (message as { role?: unknown }).role === "toolResult",
+      ),
+    ).toBe(true);
+    expect(
+      historyMessages.some(
+        (message) =>
+          Boolean(message) &&
+          typeof message === "object" &&
+          Boolean(
+            (message as { openclawSessionsYieldMirror?: unknown }).openclawSessionsYieldMirror,
+          ),
+      ),
+    ).toBe(true);
+  });
+
   test("chat.history hides commentary-only assistant entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -4,6 +4,7 @@
 import { createHash } from "node:crypto";
 import { describe, expect, test, vi } from "vitest";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
+import { projectChatDisplayMessage, projectChatDisplayMessages } from "./chat-display-projection.js";
 import { buildSessionHistorySnapshot, SessionHistorySseState } from "./session-history-state.js";
 import * as sessionTranscriptReaders from "./session-transcript-readers.js";
 
@@ -88,6 +89,40 @@ function appendAssistantText(state: SessionHistorySseState, text: string, messag
 }
 
 describe("SessionHistorySseState", () => {
+  const hasHistoryContentBlockType = (messages: unknown[], type: string): boolean =>
+    messages.some((message) => {
+      if (!message || typeof message !== "object") {
+        return false;
+      }
+      const content = (message as { content?: unknown }).content;
+      return (
+        Array.isArray(content) &&
+        content.some((block) => {
+          return Boolean(
+            block && typeof block === "object" && (block as { type?: unknown }).type === type,
+          );
+        })
+      );
+    });
+  const collectVisibleTextValues = (messages: unknown[]): string[] =>
+    messages.flatMap((message) => {
+      if (!message || typeof message !== "object") {
+        return [];
+      }
+      const role = (message as { role?: unknown }).role;
+      if (role === "toolResult" || role === "tool") {
+        return [];
+      }
+      return (message as { content?: Array<{ text?: string }> }).content?.[0]?.text ?? [];
+    });
+  const hasToolResult = (messages: unknown[]): boolean =>
+    messages.some((message) => {
+      if (!message || typeof message !== "object") {
+        return false;
+      }
+      return (message as { role?: unknown }).role === "toolResult";
+    });
+
   test("uses the initial raw snapshot for both first history and seq seeding", () => {
     const readSpy = vi
       .spyOn(sessionTranscriptReaders, "readSessionMessagesAsync")
@@ -282,6 +317,543 @@ describe("SessionHistorySseState", () => {
     expect(
       (snapshot.history.messages[0] as { content?: Array<{ text?: string }> }).content?.[0]?.text,
     ).toBe("Cursor-visible reply.");
+  });
+
+  test("projects sessions_yield tool results as visible history mirrors", () => {
+    const yieldMessage = "Waiting for child completion.";
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "spawn a child" }],
+          __openclaw: { seq: 1 },
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-yield",
+              name: "sessions_yield",
+              arguments: { message: yieldMessage },
+            },
+          ],
+          __openclaw: { seq: 2 },
+        },
+        {
+          role: "toolResult",
+          toolName: "sessions_yield",
+          toolCallId: "call-yield",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+            },
+          ],
+          details: { status: "yielded", message: yieldMessage },
+          __openclaw: { seq: 3 },
+        },
+      ],
+    });
+
+    expect(collectVisibleTextValues(snapshot.history.messages)).toEqual([
+      "spawn a child",
+      yieldMessage,
+    ]);
+    expect(hasToolResult(snapshot.history.messages)).toBe(true);
+    expect(
+      Boolean(
+        snapshot.history.messages.find(
+          (message) => message.openclawSessionsYieldMirror !== undefined,
+        ),
+      ),
+    ).toBe(true);
+    expect(snapshot.history.messages.at(-1)?.["__openclaw"]?.seq).toBe(3);
+    expect(hasHistoryContentBlockType(snapshot.history.messages, "toolCall")).toBe(false);
+  });
+
+  test("projects sessions_yield results separated from their call by visible assistant text", () => {
+    const yieldMessage = "Waiting for child completion.";
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "spawn a child" }],
+          __openclaw: { seq: 1 },
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-yield",
+              name: "sessions_yield",
+              arguments: { message: yieldMessage },
+            },
+          ],
+          __openclaw: { seq: 2 },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "I started the child session." }],
+          __openclaw: { seq: 3 },
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-yield",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+            },
+          ],
+          details: { status: "yielded", message: yieldMessage },
+          __openclaw: { seq: 4 },
+        },
+      ],
+    });
+
+    expect(collectVisibleTextValues(snapshot.history.messages)).toEqual([
+      "spawn a child",
+      "I started the child session.",
+      yieldMessage,
+    ]);
+    expect(hasToolResult(snapshot.history.messages)).toBe(true);
+    expect(snapshot.history.messages.at(-1)?.openclawSessionsYieldMirror).toEqual({
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+    });
+    expect(snapshot.history.messages.at(-1)?.["__openclaw"]?.seq).toBe(4);
+  });
+
+  test("projects OpenAI function_call sessions_yield results by call_id", () => {
+    const yieldMessage = "Waiting for child completion.";
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "function_call",
+              id: "fc-item-yield",
+              call_id: "call-yield",
+              name: "sessions_yield",
+              arguments: { message: yieldMessage },
+            },
+          ],
+          __openclaw: { seq: 1 },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "I started the child session." }],
+          __openclaw: { seq: 2 },
+        },
+        {
+          role: "toolResult",
+          call_id: "call-yield",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+            },
+          ],
+          details: { status: "yielded", message: yieldMessage },
+          __openclaw: { seq: 3 },
+        },
+      ],
+    });
+
+    expect(collectVisibleTextValues(snapshot.history.messages)).toEqual([
+      "I started the child session.",
+      yieldMessage,
+    ]);
+    expect(hasToolResult(snapshot.history.messages)).toBe(true);
+    expect(snapshot.history.messages.at(-1)?.openclawSessionsYieldMirror).toEqual({
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+    });
+    expect(hasHistoryContentBlockType(snapshot.history.messages, "function_call")).toBe(false);
+  });
+
+  test("projects explicit sessions_yield results that omit result call ids", () => {
+    const yieldMessage = "Waiting for child completion.";
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-yield",
+              name: "sessions_yield",
+              arguments: { message: yieldMessage },
+            },
+          ],
+          __openclaw: { seq: 1 },
+        },
+        {
+          role: "toolResult",
+          toolName: "sessions_yield",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+            },
+          ],
+          details: { status: "yielded", message: yieldMessage },
+          __openclaw: { seq: 2 },
+        },
+      ],
+    });
+
+    expect(collectVisibleTextValues(snapshot.history.messages)).toEqual([yieldMessage]);
+    expect(hasToolResult(snapshot.history.messages)).toBe(true);
+    expect(snapshot.history.messages.at(-1)?.openclawSessionsYieldMirror).toEqual({
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+    });
+  });
+
+  test("projects unnamed yielded results when one sessions_yield call is pending", () => {
+    const yieldMessage = "Waiting for child completion.";
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-yield",
+              name: "sessions_yield",
+              arguments: { message: yieldMessage },
+            },
+          ],
+          __openclaw: { seq: 1 },
+        },
+        {
+          role: "toolResult",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+            },
+          ],
+          details: { status: "yielded", message: yieldMessage },
+          __openclaw: { seq: 2 },
+        },
+      ],
+    });
+
+    expect(collectVisibleTextValues(snapshot.history.messages)).toEqual([yieldMessage]);
+    expect(hasToolResult(snapshot.history.messages)).toBe(true);
+    expect(snapshot.history.messages.at(-1)?.openclawSessionsYieldMirror).toEqual({
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+    });
+  });
+
+  test("does not mirror a single sessions_yield tool result without prior assistant context", () => {
+    const orphanToolResult = {
+      role: "toolResult",
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ status: "yielded", message: "Waiting for child completion." }),
+        },
+      ],
+      details: { status: "yielded", message: "Waiting for child completion." },
+      __openclaw: { seq: 3 },
+    };
+    const projected = projectChatDisplayMessage(orphanToolResult);
+    const projectedHistory = projectChatDisplayMessages([orphanToolResult]);
+
+    expect(projected?.role).toBe("toolResult");
+    expect(projected?.openclawSessionsYieldMirror).toBeUndefined();
+    expect(projectedHistory).toHaveLength(1);
+    expect(projectedHistory[0]?.role).toBe("toolResult");
+    expect(projectedHistory[0]?.openclawSessionsYieldMirror).toBeUndefined();
+  });
+
+  test("does not reuse completed sessions_yield mirrors as pending context", () => {
+    const projected = projectChatDisplayMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Waiting for child completion." }],
+        openclawSessionsYieldMirror: {
+          toolName: "sessions_yield",
+          toolCallId: "call-yield",
+        },
+        __openclaw: { seq: 1 },
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call-other",
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ status: "yielded", message: "Unrelated wait." }),
+          },
+        ],
+        details: { status: "yielded", message: "Unrelated wait." },
+        __openclaw: { seq: 2 },
+      },
+    ]);
+
+    expect(projected).toHaveLength(2);
+    expect(projected[1]?.role).toBe("toolResult");
+    expect(projected[1]?.openclawSessionsYieldMirror).toBeUndefined();
+  });
+
+  test("does not mirror explicit non-yield tool results after a pending sessions_yield call", () => {
+    const projected = projectChatDisplayMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "sessions_yield",
+            arguments: { message: "Waiting for child completion." },
+          },
+        ],
+        __openclaw: { seq: 1 },
+      },
+      {
+        role: "toolResult",
+        toolName: "exec",
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              status: "yielded",
+              message: "ordinary tool output, not sessions_yield",
+            }),
+          },
+        ],
+        details: { status: "yielded", message: "ordinary tool output, not sessions_yield" },
+        __openclaw: { id: "msg-exec", seq: 2 },
+      },
+    ]);
+
+    expect(projected).toHaveLength(1);
+    expect(projected[0]?.role).toBe("toolResult");
+    expect(projected[0]?.toolName).toBe("exec");
+    expect(projected[0]?.openclawSessionsYieldMirror).toBeUndefined();
+  });
+
+  test("does not duplicate visible sessions_yield text during inline SSE appends", () => {
+    const yieldMessage = "Waiting for child completion.";
+    const toolCallBlocks = [
+      { type: "toolCall", id: "call-yield" },
+      { type: "tool_call", id: "call-yield" },
+      { type: "toolcall", id: "call-yield" },
+      { type: "function_call", id: "fc-item-yield", call_id: "call-yield" },
+    ];
+    for (const toolCallBlock of toolCallBlocks) {
+      const state = SessionHistorySseState.fromRawSnapshot({
+        target: { sessionId: "sess-main" },
+        rawMessages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: yieldMessage },
+              {
+                ...toolCallBlock,
+                name: "sessions_yield",
+                arguments: { message: yieldMessage },
+              },
+            ],
+            __openclaw: { seq: 1 },
+          },
+        ],
+      });
+
+      const appended = state.appendInlineMessage({
+        message: {
+          role: "toolResult",
+          toolName: "sessions_yield",
+          toolCallId: "call-yield",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+            },
+          ],
+          details: { status: "yielded", message: yieldMessage },
+        },
+        messageSeq: 2,
+      });
+
+      expect(appended?.messageSeq).toBe(2);
+      expect((appended?.message as { role?: unknown } | undefined)?.role).toBe("toolResult");
+      expect(collectVisibleTextValues(state.snapshot().messages)).toEqual([yieldMessage]);
+      expect(
+        hasHistoryContentBlockType(state.snapshot().messages, "function_call"),
+      ).toBe(false);
+      expect(
+        state
+          .snapshot()
+          .messages[0]?.openclawSessionsYieldMirror,
+      ).toMatchObject({
+        toolName: "sessions_yield",
+        toolCallId: "call-yield",
+      });
+      expect(hasToolResult(state.snapshot().messages)).toBe(true);
+    }
+  });
+
+  test("does not duplicate visible sessions_yield text after interleaved tool results", () => {
+    const yieldMessage = "Waiting for child completion.";
+    const projected = projectChatDisplayMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: yieldMessage },
+          {
+            type: "toolCall",
+            id: "call-yield",
+            name: "sessions_yield",
+            arguments: { message: yieldMessage },
+          },
+          {
+            type: "toolCall",
+            id: "call-other",
+            name: "exec",
+            arguments: { command: "echo done" },
+          },
+        ],
+        __openclaw: { seq: 1 },
+      },
+      {
+        role: "toolResult",
+        toolName: "exec",
+        toolCallId: "call-other",
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              status: "yielded",
+              message: "ordinary tool output, not sessions_yield",
+            }),
+          },
+        ],
+        details: {
+          status: "yielded",
+          message: "ordinary tool output, not sessions_yield",
+        },
+        __openclaw: { seq: 2 },
+      },
+      {
+        role: "toolResult",
+        toolName: "sessions_yield",
+        toolCallId: "call-yield",
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+          },
+        ],
+        details: { status: "yielded", message: yieldMessage },
+        __openclaw: { seq: 3 },
+      },
+    ]);
+
+    const visibleYieldTextRows = projected.filter(
+      (message) =>
+        message.role === "assistant" &&
+        (message as { content?: Array<{ text?: string }> }).content?.[0]?.text === yieldMessage,
+    );
+    expect(visibleYieldTextRows).toHaveLength(1);
+    expect(visibleYieldTextRows[0]?.openclawSessionsYieldMirror).toEqual({
+      toolName: "sessions_yield",
+      toolCallId: "call-yield",
+      duplicateAssistantText: true,
+    });
+    expect(
+      projected.some(
+        (message) => message.role === "toolResult" && message.toolName === "sessions_yield",
+      ),
+    ).toBe(true);
+  });
+
+  test("uses hidden sessions_yield calls as inline context for following tool results", () => {
+    const yieldMessage = "Waiting for child completion.";
+    const toolCallBlocks = [
+      { type: "toolCall", id: "call-yield" },
+      { type: "function_call", id: "fc-item-yield", call_id: "call-yield" },
+    ];
+    for (const toolCallBlock of toolCallBlocks) {
+      const state = SessionHistorySseState.fromRawSnapshot({
+        target: { sessionId: "sess-main" },
+        rawMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "spawn a child" }],
+            __openclaw: { seq: 1 },
+          },
+        ],
+      });
+
+      const hiddenCallAppend = state.appendInlineMessage({
+        message: {
+          role: "assistant",
+          content: [
+            {
+              ...toolCallBlock,
+              name: "sessions_yield",
+              arguments: { message: yieldMessage },
+            },
+          ],
+        },
+        messageSeq: 2,
+      });
+
+      expect(hiddenCallAppend).toBeNull();
+      expect(
+        state
+          .snapshot()
+          .messages.flatMap(
+            (message) =>
+              (message as { content?: Array<{ text?: string }> }).content?.[0]?.text ?? [],
+          ),
+      ).toEqual(["spawn a child"]);
+      expect(hasHistoryContentBlockType(state.snapshot().messages, toolCallBlock.type)).toBe(
+        false,
+      );
+
+      const yieldedResultAppend = state.appendInlineMessage({
+        message: {
+          role: "toolResult",
+          toolName: "sessions_yield",
+          toolCallId: "call-yield",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ status: "yielded", message: yieldMessage }),
+            },
+          ],
+          details: { status: "yielded", message: yieldMessage },
+        },
+        messageSeq: 3,
+      });
+
+      expect(yieldedResultAppend?.shouldRefresh).toBe(true);
+      expect(collectVisibleTextValues(state.snapshot().messages)).toEqual([
+        "spawn a child",
+        yieldMessage,
+      ]);
+      expect(hasToolResult(state.snapshot().messages)).toBe(true);
+      expect(
+        Boolean(
+          state
+            .snapshot()
+            .messages.find(
+              (message) => message.openclawSessionsYieldMirror !== undefined,
+            ),
+        ),
+      ).toBe(true);
+    }
   });
 
   test("does not coerce partial cursor values", () => {

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -183,6 +183,7 @@ export class SessionHistorySseState {
   private readonly limit: number | undefined;
   private readonly cursor: string | undefined;
   private sentHistory: PaginatedSessionHistory;
+  private rawMessages: SessionHistoryMessage[];
   private rawTranscriptSeq: number;
   private transcriptPath: string | undefined;
 
@@ -231,6 +232,7 @@ export class SessionHistorySseState {
         ? { totalRawMessages: params.totalRawMessages }
         : {}),
     });
+    this.rawMessages = toSessionHistoryMessages(params.initialRawMessages);
     this.sentHistory = snapshot.history;
     this.rawTranscriptSeq = snapshot.rawTranscriptSeq;
     this.transcriptPath = normalizeTranscriptPathForComparison(params.transcriptPath);
@@ -264,11 +266,16 @@ export class SessionHistorySseState {
     // Projection can split, drop, or rewrite raw transcript messages. When one
     // raw append changes multiple visible rows, callers must refresh instead of
     // emitting a misleading single SSE item.
+    const rawMessages = toSessionHistoryMessages([...this.rawMessages, nextMessage]);
     const projectedMessages = toSessionHistoryMessages(
-      projectChatDisplayMessages([...this.sentHistory.messages, nextMessage], {
+      projectChatDisplayMessages(rawMessages, {
         maxChars: this.maxChars,
       }),
     );
+    // Some transcript records are intentionally hidden but still carry context
+    // for the following record, such as sessions_yield tool calls before their
+    // yielded tool result. Keep that raw tail even when no SSE item is emitted.
+    this.rawMessages = rawMessages;
     if (projectedMessages.length > this.sentHistory.messages.length) {
       const addedMessages = projectedMessages.slice(this.sentHistory.messages.length);
       if (addedMessages.length > 1) {
@@ -340,6 +347,7 @@ export class SessionHistorySseState {
     const snapshot = this.buildSnapshot(rawSnapshot);
     this.rawTranscriptSeq = snapshot.rawTranscriptSeq;
     this.transcriptPath = normalizeTranscriptPathForComparison(rawSnapshot.transcriptPath);
+    this.rawMessages = toSessionHistoryMessages(rawSnapshot.rawMessages);
     this.sentHistory = snapshot.history;
     return snapshot.history;
   }


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/87321

> **Rebased 2026-06-16** onto current `origin/main` (`6b3e23aba7`); HEAD now `c438ace324`. 5 iterative commits squashed into one for a single-pass rebase. Resolved 4 conflict files (chat-display-projection.ts, server-methods/chat.ts, session-history-state.ts, +1 test): all additive compose (kept main's `projectEmptyAssistantErrorMessages` + `resolveSessionAgentId` + this PR's `mirrorSessionsYieldToolResults` / `transcriptMessageId` / raw-tail refresh). **Caught one convergent-refactor silent break:** main moved `readSessionMessagesAsync` to an object-arg `(scope, opts)` signature; this PR's new `projectChatMessageWithHistoryContext` caller still used the positional form (tsgo TS2554) — fixed to object-arg + threaded `agentId: sessionAgentId` to match the sibling visibility helper. Post-rebase: tsgo core clean, 293 gateway/agents tests pass (incl. both this PR's and main's new chat.message.get tests), oxlint clean.

## User-facing bug

WebChat replay could drop a visible `sessions_yield` wait message when that wait text was stored as a transcript tool result instead of a normal assistant text row. In practice, reopening a session could hide text such as "Waiting for child completion.", or expose a raw `toolResult` shape when `chat.message.get` asked for the stored row directly.

## Exact repro

1. Create or load a transcript with an assistant `sessions_yield` tool call.
2. Store the corresponding tool result with `{ "status": "yielded", "message": "Waiting for child completion." }`.
3. Reopen the session through `chat.history` / WebChat replay, or fetch the transcript row through `chat.message.get`.
4. Before this patch, the user-visible wait text could be absent, duplicated in incremental replay, or returned as a raw hidden tool-result row.
5. After this patch, replay projects the yielded wait text as assistant text while preserving the raw `sessions_yield` tool-result row for show-tool-calls/debug/API consumers.

## Fix summary

- Added `sessions_yield` display projection in `src/gateway/chat-display-projection.ts`.
- Tracks pending `sessions_yield` calls by `toolCall`, `tool_use`, and OpenAI `function_call` / `call_id` shapes.
- Mirrors successful yielded tool results into assistant-shaped text marked with `openclawSessionsYieldMirror`.
- Preserves the underlying raw `sessions_yield` tool-result row in `chat.history` instead of consuming it during projection.
- Gives visible `sessions_yield` mirrors a derived transcript id such as `<source-id>:sessions_yield_mirror`, while keeping the original source id addressable for raw `toolResult` reads.
- Keeps hidden `sessions_yield` call rows as raw SSE context so later inline tool results can still be projected correctly.
- Prevents orphan, duplicate, and explicit non-yield tool results from being converted into assistant text.
- Makes `chat.message.get` expand visible `sessions_yield` mirrors from full transcript context while original result ids still return raw tool-result rows.
- Aligns subagent announce summaries with projected yield mirrors.

## Targeted tests

- Added session-history coverage for basic yield projection, separated assistant text, OpenAI `function_call` / `call_id`, missing result call id, unnamed yielded result with one pending call, raw tool-result preservation, orphan results, completed pending context, explicit non-yield tool results, inline SSE dedupe, interleaved tool results, and hidden-call inline context.
- Added gateway `chat.message.get` coverage for derived mirror-id expansion, raw source-result access, duplicate yielded result access, and ordinary tool-result indexing.
- Added subagent announce coverage for projected `sessions_yield` mirror semantics.

## Real behavior proof

Behavior addressed: WebChat replay now shows transcript-backed `sessions_yield` wait text as normal assistant text without fabricating assistant output from unrelated tool results, while still preserving raw `sessions_yield` tool-result rows for debug/show-tool/API consumers.

Real environment tested: Local OpenClaw checkout on branch `fix/webchat-replay-sessions-yield`, commit `c438ace324`, rebased onto current `origin/main` commit `6b3e23aba7`.

Exact steps or command run after this patch:

- `git diff --check`
- `./node_modules/.bin/oxlint src/gateway/chat-display-projection.ts src/gateway/session-history-state.ts src/gateway/session-history-state.test.ts src/gateway/server-methods/chat.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/agents/subagent-yield-output.ts src/agents/subagent-announce-output.ts src/agents/subagent-announce-output.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-vitest.mjs src/gateway/session-history-state.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/agents/subagent-announce-output.test.ts`

Evidence after fix:

- Rebased the five-commit branch onto current `origin/main` (1293 commits ahead of the previous base). Three conflicts, all textual convergence rather than competing behavior:
  - `src/gateway/chat-display-projection.ts` (twice, in the same `resolveEffectiveChatHistoryMaxChars` helper): main added a doc comment above the helper and main independently arrived at the same `(_cfg: unknown, maxChars?: number)` signature this branch lands at — the branch's commit 1 added a temporary `cfg.gateway.webchat.chatHistoryMaxChars` read, then commit 3 (`Keep WebChat replay projection off retired config`) removed it again. Resolved by taking the converged `_cfg: unknown` signature plus main's doc comment, keeping this branch's new `SessionsYieldVisibleReply` / `ProjectChatDisplayOptions` type declarations.
  - `src/agents/subagent-announce-output.test.ts` (test helper `sessionsYieldTurn`): main added a doc comment; this branch parameterized the helper as `(message, toolCallType = "toolCall")` so fixtures can exercise alternate tool-call type spellings. Resolved as a union — kept the parameterized signature and main's doc comment.
  - No same-symbol/different-import-path conflict surfaced (the supersession signature); issue #87321 remains open and no main-side commit implements this `sessions_yield` replay projection. The other commits replayed cleanly.
- After-fix projection output — ran the real production projector `projectChatDisplayMessages` (`src/gateway/chat-display-projection.ts`) on this commit against a `sessions_yield` call+result transcript (the exact shape from the regression fixtures):

  ```text
  $ node --import tsx -e "import { projectChatDisplayMessages } from './src/gateway/chat-display-projection.ts'; ..."
  [
    { "role": "user",       "yieldMirror": false, "text": "spawn a child" },
    { "role": "toolResult", "yieldMirror": false, "text": "{\"status\":\"yielded\",\"message\":\"Waiting for child completion.\"}" },
    { "role": "assistant",  "yieldMirror": true,  "text": "Waiting for child completion." }
  ]
  visible text values: ["spawn a child","{...yielded...}","Waiting for child completion."]
  raw sessions_yield toolResult preserved: true
  ```

  This proves both halves of the contract on the real function: a visible assistant mirror (`openclawSessionsYieldMirror`) carrying the wait text `Waiting for child completion.` is produced, while the raw `sessions_yield` `toolResult` row remains in the projected output for show-tool-calls / debug / API consumers.
- `git diff --check` passed.
- Changed-file `oxlint` passed with exit code 0.
- Core `tsgo` typecheck (`tsconfig.core.json`) passed with exit code 0 after the conflict resolution.
- Focused Vitest passed after the rebase: 7 test files, 204 tests passed (the four changed/covering suites — `src/gateway/session-history-state.test.ts`, `src/gateway/server.chat.gateway-server-chat.test.ts`, `src/gateway/server.chat.gateway-server-chat-b.test.ts`, `src/agents/subagent-announce-output.test.ts` — plus the additional gateway-chat suites pulled in by the shared config shard). Exit code 0.
- The targeted tests cover:
  - `function_call` / `call_id` projection.
  - explicit `sessions_yield` results that omit result call ids.
  - unnamed yielded results when one `sessions_yield` call is pending.
  - raw yielded `toolResult` rows remaining in projected history.
  - orphan tool results remaining raw.
  - explicit non-yield yielded tool results remaining raw.
  - interleaved other tool results not duplicating wait rows.
  - inline hidden `sessions_yield` call context for following tool results.
  - derived mirror ids such as `msg-yield-result:sessions_yield_mirror` returning the expanded visible assistant mirror.
  - original yielded result ids returning the raw `toolResult`.
  - ordinary tool results staying on the indexed single-message path.
- `codex review --base origin/main` reported no actionable correctness issues. Its own Vitest attempt was blocked by sandbox EPERM while writing Vite temp files under `node_modules`; the same focused Vitest command passed locally with worktree lock scope and the required permissions.

Observed result after fix: History snapshots include assistant-shaped yield mirrors with wait text and transcript metadata, raw successful `sessions_yield` tool results remain in projected history for debug/show-tool/API consumers, bounded `chat.message.get` expands derived mirror ids using full transcript context, original result ids return raw tool results, and ordinary tool results stay on the existing single-message path.

What was not tested: I did not run the full `pnpm check` / full test matrix locally, and I did not drive a browser WebChat replay manually. Coverage is through focused gateway/session-history/subagent tests plus direct local projection proof.

## AI-assisted disclosure

This patch was prepared with AI assistance. I used local code inspection, targeted regression tests, explicit local command output, and `codex review --base origin/main` before updating the PR.

