### PR TITLE
Tag embedded subagent gap-fill rows as delivery mirrors

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -93,7 +93,13 @@ async function readSessionMessages(sessionFile: string) {
     .filter((entry) => entry.type === "message")
     .map(
       (entry) =>
-        entry.message as { role?: string; content?: unknown; provider?: string; model?: string },
+        entry.message as {
+          role?: string;
+          content?: unknown;
+          api?: string;
+          provider?: string;
+          model?: string;
+        },
     );
 }
 
@@ -770,6 +776,9 @@ describe("CLI attempt execution", () => {
     expect(messages).toHaveLength(1);
     expectRecordFields(requireRecord(messages[0], "assistant message"), {
       role: "assistant",
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "delivery-mirror",
       content: [{ type: "text", text: "already mirrored" }],
     });
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -365,6 +365,18 @@ export async function persistCliTurnTranscript(params: {
   const provider = params.result.meta.agentMeta?.provider?.trim() ?? "cli";
   const model = params.result.meta.agentMeta?.model?.trim() ?? "default";
   const gapFill = params.embeddedAssistantGapFill ?? false;
+  const assistant = gapFill
+    ? {
+        api: "openai-responses",
+        provider: "openclaw",
+        model: "delivery-mirror",
+      }
+    : {
+        api: "cli",
+        provider,
+        model,
+        usage: params.result.meta.agentMeta?.usage,
+      };
 
   return await persistTextTurnTranscript({
     body: gapFill ? "" : params.body,
@@ -381,12 +393,7 @@ export async function persistCliTurnTranscript(params: {
     sessionCwd: params.sessionCwd,
     config: params.config,
     embeddedAssistantGapFill: gapFill,
-    assistant: {
-      api: "cli",
-      provider,
-      model,
-      usage: params.result.meta.agentMeta?.usage,
-    },
+    assistant,
   });
 }
 


### PR DESCRIPTION
Refs #87329 (Fix 1 — PRIMARY: tag echo messages correctly at write time)

> Scope note: issue #87329 proposes two fixes — Fix 1 (PRIMARY: tag echo messages as `openclaw/delivery-mirror` at write time) and Fix 2 (DEFENSE IN DEPTH: merge consecutive assistant turns in `validateAnthropicTurns`). This PR implements Fix 1 only; Fix 2 is covered by the separate open PR #87346 (Jefsky). Using a non-closing `Refs` reference so merging this primary writer fix does not auto-close the issue before the defense-in-depth layer lands or maintainers accept that scope.

## User-facing bug
Subagent announce / embedded handoff gap-fill can append a user-visible assistant mirror using the child runtime provider and model metadata, such as `anthropic/claude-*`, instead of marking the row as an OpenClaw transcript-only delivery mirror. Replay filters exclude transcript-only mirrors by `provider: "openclaw"` with `model: "delivery-mirror"` / `gateway-injected`, so a display-only mirror with child provider metadata can later be replayed back into a provider turn. In conversations with provider-managed thinking/signature blocks, that stale mirror can surface as errors like `thinking blocks cannot be modified`.

## Exact repro
Source-level reproduction:

1. Run `persistCliTurnTranscript` for an embedded assistant gap-fill with:
   - `embeddedAssistantGapFill: true`
   - `result.meta.agentMeta.provider: "claude-cli"` or another runtime provider
   - visible final text in `result.meta.finalAssistantVisibleText`
2. Before this fix, the appended transcript assistant row used `api: "cli"`, `provider: "claude-cli"`, and `model: "opus"`.
3. That row is user-visible display state, not provider conversation state, so replay filters did not identify it as transcript-only.
4. After this fix, the same gap-fill row is written as `api: "openai-responses"`, `provider: "openclaw"`, and `model: "delivery-mirror"`.

## Fix summary
- Changed embedded assistant gap-fill transcript persistence to write assistant mirrors as `openclaw/delivery-mirror`.
- Kept normal CLI transcript persistence unchanged: non-gap-fill CLI replies still preserve real CLI provider/model metadata and usage.
- Added regression coverage so the gap-fill path asserts the transcript-only mirror metadata.

## Metadata change (explicit callout)
This PR **intentionally changes the persisted shape of embedded gap-fill assistant rows**, so it is more than a replay fix — raw transcript / debug readers should be aware:

| field | before | after |
|---|---|---|
| `api` | `"cli"` | `"openai-responses"` |
| `provider` | child runtime provider (e.g. `"claude-cli"`) | `"openclaw"` |
| `model` | child model (e.g. `"opus"`) | `"delivery-mirror"` |
| `usage` | child usage block | omitted |

Scope is strictly the `gapFill` branch in `persistCliTurnTranscript` (`src/agents/command/attempt-execution.ts:365`). Normal (non-gap-fill) CLI rows are untouched and keep `api:"cli"` + real provider/model/usage.

**Downstream `api:"cli"` consumers — verified none affected.** The `.api` field is read only by the LLM transport/provider layer for foreign-tool-call detection (`src/llm/providers/transform-messages.ts:100`, `openai-responses-shared.ts:202`, comparing `source.api === model.api`). Gap-fill rows never reach those comparisons: rows tagged `provider:"openclaw"` + `model:"delivery-mirror"` are in `TRANSCRIPT_ONLY_OPENCLAW_MODELS` (`src/agents/embedded-agent-runner/replay-history.ts:241`) and are dropped from the replay copy before any provider prompt is built. Every other gap-fill/delivery-mirror filter in the tree keys on the `provider/model` pair, not `api`.


## Targeted tests
- Extended `src/agents/command/attempt-execution.cli.test.ts` to prove embedded gap-fill rows are tagged as `openclaw/delivery-mirror`.
- Re-ran replay-history coverage to confirm `delivery-mirror` rows remain excluded from embedded provider replay.

## Real behavior proof

Behavior addressed: Embedded subagent assistant gap-fill rows are now stored as OpenClaw delivery mirrors, so provider replay filters do not treat display-only text as provider conversation state.

Real environment tested: Local OpenClaw checkout on branch `fix/subagent-announce-delivery-metadata`, commit `5dcee2eae5`, rebased onto current `origin/main`; Node `v24.4.1`.

Exact steps or command run after this patch:
- `git diff --check origin/main...HEAD`
- `./node_modules/.bin/oxlint src/agents/command/attempt-execution.ts src/agents/command/attempt-execution.cli.test.ts`
- `node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts src/agents/embedded-agent-runner/replay-history.test.ts`

Evidence after fix:

Writer and replay halves verified together. The merge-readiness ask is to show the gap-fill row is written as `openclaw/delivery-mirror` and is then excluded from the next provider prompt. These two real test suites prove the two halves of exactly that path end to end:

- Writer half — `src/agents/command/attempt-execution.cli.test.ts` (25 tests passed): the embedded gap-fill assertion (`embeddedAssistantGapFill: true`) reads back the persisted transcript row and proves it is written as `api: "openai-responses"`, `provider: "openclaw"`, `model: "delivery-mirror"`, while non-gap-fill CLI rows keep real provider/model metadata.
- Replay half — `src/agents/embedded-agent-runner/replay-history.test.ts` (35 tests passed): `normalizeAssistantReplayContent` is given a history containing exactly that `provider: "openclaw"` / `model: "delivery-mirror"` row alongside a real provider reply, and the test asserts the delivery-mirror row is dropped from the replay copy (`out` length 2) while the real provider reply survives. That is the row never re-entering the provider prompt.

Together: the shape the writer persists (suite 1) is precisely the shape the replay filter excludes (suite 2). Copied terminal summary:

```text
 src/agents/command/attempt-execution.cli.test.ts
      Tests  25 passed (25)

 src/agents/embedded-agent-runner/replay-history.test.ts
      Tests  35 passed (35)

[test] passed 2 Vitest shards in 134.85s
```

- `oxlint` passed on the changed source and test files (exit 0).
- `git diff --check origin/main...HEAD` passed.

Live replay-path output — ran a single script that chains the **patched writer to the replay filter on real functions** (no hand-built input): it writes a session store, calls `persistCliTurnTranscript` with `embeddedAssistantGapFill: true`, reads the persisted JSONL row back off disk, then passes that exact row through `normalizeAssistantReplayContent` (`src/agents/embedded-agent-runner/replay-history.ts`):

```text
STEP 1 — patched persistCliTurnTranscript wrote this JSONL assistant row:
[
  {
    "role": "assistant",
    "api": "openai-responses",
    "provider": "openclaw",
    "model": "delivery-mirror",
    "content": [{ "type": "text", "text": "delivered to channel" }]
  }
]

STEP 2 — that exact persisted row passed through normalizeAssistantReplayContent:
  rows in: 3  rows out: 2
  persisted delivery-mirror row excluded from replay: true
  real provider reply retained: true
```

This is the full patched writer-to-replay path on real code: the patched writer persists the gap-fill row to disk as `openclaw/delivery-mirror`, and that exact persisted row is then excluded from the rebuilt replay (3 → 2 rows) so it never re-enters the provider prompt, while the genuine provider reply is retained.

Observed result after fix: Embedded gap-fill transcript rows use `api: "openai-responses"`, `provider: "openclaw"`, and `model: "delivery-mirror"` while normal CLI transcript rows still preserve real provider/model metadata.

What was not tested: No live provider-managed thinking/signature conversation was replayed end to end against a running embedded agent and a real provider. That path requires a live provider session, which was not available in this environment; the writer-to-replay contract is instead proven by the two connected real test suites above on the actual production functions (`persistCliTurnTranscript` output shape and `normalizeAssistantReplayContent` exclusion).

## Not tested / known gaps
- No external transcript/debug consumer was found in this checkout that depends on `api: "cli"` for embedded gap-fill rows, but external scripts that read raw transcript metadata may observe the intentional gap-fill metadata change from child CLI provider/model to `openclaw/delivery-mirror`.

## AI-assisted disclosure
This patch was prepared with AI assistance. I used local code inspection, targeted regression tests, and explicit command output to validate the behavior above.

