### PR TITLE
Preserve Mattermost streamed blocks in block mode

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -12,9 +12,11 @@ import {
   formatMattermostFinalDeliveryOutcomeLog,
   MattermostRetryableInboundError,
   processMattermostReplayGuardedPost,
+  resolveMattermostPreviewFinalText,
   resolveMattermostReactionChannelId,
   resolveMattermostEffectiveReplyToId,
   resolveMattermostReplyRootId,
+  resolveMattermostStreamingDeliveryPolicy,
   resolveMattermostThreadSessionContext,
   shouldFinalizeMattermostPreviewAfterDispatch,
   shouldClearMattermostDraftPreview,
@@ -365,6 +367,111 @@ describe("shouldSuppressMattermostDefaultToolProgressMessages", () => {
         },
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveMattermostStreamingDeliveryPolicy", () => {
+  it("keeps regular draft preview mode isolated from block streaming", () => {
+    expect(
+      resolveMattermostStreamingDeliveryPolicy({
+        account: { streamingMode: "partial" },
+        cfg: {},
+      }),
+    ).toEqual({
+      draftPreviewEnabled: true,
+      disableBlockStreaming: true,
+    });
+  });
+
+  it("keeps an active draft preview even when the agent block streaming default is on", () => {
+    expect(
+      resolveMattermostStreamingDeliveryPolicy({
+        account: { streamingMode: "partial" },
+        cfg: { agents: { defaults: { blockStreamingDefault: "on" } } },
+      }),
+    ).toEqual({
+      draftPreviewEnabled: true,
+      disableBlockStreaming: true,
+    });
+  });
+
+  it("lets explicit block streaming create normal block posts instead of draft edits", () => {
+    expect(
+      resolveMattermostStreamingDeliveryPolicy({
+        account: { streamingMode: "partial", blockStreaming: true },
+        cfg: {},
+      }),
+    ).toEqual({
+      draftPreviewEnabled: false,
+      disableBlockStreaming: false,
+    });
+  });
+
+  it("honors the agent block streaming default when the account is unset", () => {
+    expect(
+      resolveMattermostStreamingDeliveryPolicy({
+        account: { streamingMode: "off" },
+        cfg: { agents: { defaults: { blockStreamingDefault: "on" } } },
+      }),
+    ).toEqual({
+      draftPreviewEnabled: false,
+      disableBlockStreaming: false,
+    });
+  });
+});
+
+describe("resolveMattermostPreviewFinalText", () => {
+  it("preserves accumulated block preview text when the final is only the last segment", () => {
+    expect(
+      resolveMattermostPreviewFinalText({
+        streamingMode: "block",
+        finalText: "final answer",
+        lastPartialText: "first block\n\nTool finished\n\nfinal answer",
+        allowAccumulatedPreviewText: true,
+      }),
+    ).toBe("first block\n\nTool finished\n\nfinal answer");
+  });
+
+  it("does not preserve accumulated block preview text when the final matches earlier text", () => {
+    expect(
+      resolveMattermostPreviewFinalText({
+        streamingMode: "block",
+        finalText: "Tool finished",
+        lastPartialText: "first block\n\nTool finished\n\nfinal answer",
+      }),
+    ).toBe("Tool finished");
+  });
+
+  it("does not preserve suffix-matched block preview text without an accumulated transcript signal", () => {
+    expect(
+      resolveMattermostPreviewFinalText({
+        streamingMode: "block",
+        finalText: "Done",
+        lastPartialText: "temporary draft status\n\nDone",
+      }),
+    ).toBe("Done");
+  });
+
+  it("skips accumulated block preview finalization when the accumulated text is not sendable", () => {
+    expect(
+      resolveMattermostPreviewFinalText({
+        streamingMode: "block",
+        finalText: "final answer",
+        lastPartialText: "first block\n\nTool finished\n\nfinal answer",
+        allowAccumulatedPreviewText: true,
+        resolvePreviewText: (text) => (text.length <= "final answer".length ? text : undefined),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps non-block previews from overwriting longer draft text with a prefix", () => {
+    expect(
+      resolveMattermostPreviewFinalText({
+        streamingMode: "partial",
+        finalText: "Final",
+        lastPartialText: "Final answer still streaming",
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -147,6 +147,54 @@ export function shouldSuppressMattermostDefaultToolProgressMessages(
   return account.streamingMode !== "off";
 }
 
+export function resolveMattermostStreamingDeliveryPolicy(params: {
+  account: Pick<ResolvedMattermostAccount, "streamingMode" | "blockStreaming">;
+  cfg: Pick<OpenClawConfig, "agents">;
+}): {
+  draftPreviewEnabled: boolean;
+  disableBlockStreaming: boolean;
+} {
+  const previewStreamingEnabled = params.account.streamingMode !== "off";
+  const blockStreamingEnabled =
+    params.account.blockStreaming === true ||
+    (!previewStreamingEnabled &&
+      (params.account.blockStreaming ??
+        params.cfg.agents?.defaults?.blockStreamingDefault === "on"));
+  const draftPreviewEnabled = previewStreamingEnabled && params.account.blockStreaming !== true;
+  return {
+    draftPreviewEnabled,
+    disableBlockStreaming: draftPreviewEnabled ? true : !blockStreamingEnabled,
+  };
+}
+
+export function resolveMattermostPreviewFinalText(params: {
+  streamingMode: ResolvedMattermostAccount["streamingMode"];
+  finalText: string;
+  lastPartialText?: string;
+  allowAccumulatedPreviewText?: boolean;
+  resolvePreviewText?: (text: string) => string | undefined;
+}): string | undefined {
+  const trimmed = params.finalText.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const lastPartialText = params.lastPartialText?.trim();
+  if (!lastPartialText || trimmed.length >= lastPartialText.length) {
+    return trimmed;
+  }
+  if (
+    params.streamingMode === "block" &&
+    params.allowAccumulatedPreviewText === true &&
+    lastPartialText.endsWith(trimmed)
+  ) {
+    return params.resolvePreviewText ? params.resolvePreviewText(lastPartialText) : lastPartialText;
+  }
+  if (lastPartialText.startsWith(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
 type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
 type MattermostReaction = {
@@ -695,11 +743,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           threadRootId: post.root_id,
         }).sessionKey;
       },
-      dispatchButtonClick: async (optsLocal) => {
-        const channelInfo = await resolveChannelInfo(optsLocal.channelId);
+      dispatchButtonClick: async (opts) => {
+        const channelInfo = await resolveChannelInfo(opts.channelId);
         if (!channelInfo?.type) {
           logVerboseMessage(
-            `mattermost: drop interaction dispatch (cannot resolve channel type for ${optsLocal.channelId})`,
+            `mattermost: drop interaction dispatch (cannot resolve channel type for ${opts.channelId})`,
           );
           return;
         }
@@ -707,7 +755,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const chatType = channelChatType(kind);
         const teamId = channelInfo?.team_id ?? undefined;
         const channelName = channelInfo?.name ?? undefined;
-        const channelDisplay = channelInfo?.display_name ?? channelName ?? optsLocal.channelId;
+        const channelDisplay = channelInfo?.display_name ?? channelName ?? opts.channelId;
         const route = core.channel.routing.resolveAgentRoute({
           cfg,
           channel: "mattermost",
@@ -715,20 +763,19 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           teamId,
           peer: {
             kind,
-            id: kind === "direct" ? optsLocal.userId : optsLocal.channelId,
+            id: kind === "direct" ? opts.userId : opts.channelId,
           },
         });
         const replyToMode = resolveMattermostReplyToMode(account, kind);
         const threadContext = resolveMattermostThreadSessionContext({
           baseSessionKey: route.sessionKey,
           kind,
-          postId: optsLocal.post.id || optsLocal.postId,
+          postId: opts.post.id || opts.postId,
           replyToMode,
-          threadRootId: optsLocal.post.root_id,
+          threadRootId: opts.post.root_id,
         });
-        const to =
-          kind === "direct" ? `user:${optsLocal.userId}` : `channel:${optsLocal.channelId}`;
-        const bodyText = `[Button click: user @${optsLocal.userName} selected "${optsLocal.actionName}"]`;
+        const to = kind === "direct" ? `user:${opts.userId}` : `channel:${opts.channelId}`;
+        const bodyText = `[Button click: user @${opts.userName} selected "${opts.actionName}"]`;
         const ctxPayload = core.channel.reply.finalizeInboundContext({
           Body: bodyText,
           BodyForAgent: bodyText,
@@ -736,24 +783,24 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           CommandBody: bodyText,
           From:
             kind === "direct"
-              ? `mattermost:${optsLocal.userId}`
+              ? `mattermost:${opts.userId}`
               : kind === "group"
-                ? `mattermost:group:${optsLocal.channelId}`
-                : `mattermost:channel:${optsLocal.channelId}`,
+                ? `mattermost:group:${opts.channelId}`
+                : `mattermost:channel:${opts.channelId}`,
           To: to,
           SessionKey: threadContext.sessionKey,
           ParentSessionKey: threadContext.parentSessionKey,
           AccountId: route.accountId,
           ChatType: chatType,
-          ConversationLabel: `mattermost:${optsLocal.userName}`,
+          ConversationLabel: `mattermost:${opts.userName}`,
           GroupSubject: kind !== "direct" ? channelDisplay : undefined,
           GroupChannel: channelName ? `#${channelName}` : undefined,
           GroupSpace: teamId,
-          SenderName: optsLocal.userName,
-          SenderId: optsLocal.userId,
+          SenderName: opts.userName,
+          SenderId: opts.userId,
           Provider: "mattermost" as const,
           Surface: "mattermost" as const,
-          MessageSid: `interaction:${optsLocal.postId}:${optsLocal.actionId}`,
+          MessageSid: `interaction:${opts.postId}:${opts.actionId}`,
           ReplyToId: threadContext.effectiveReplyToId,
           MessageThreadId: threadContext.effectiveReplyToId,
           WasMentioned: true,
@@ -780,13 +827,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             channel: "mattermost",
             accountId: account.accountId,
             typing: {
-              start: () =>
-                sendTypingIndicator(optsLocal.channelId, threadContext.effectiveReplyToId),
+              start: () => sendTypingIndicator(opts.channelId, threadContext.effectiveReplyToId),
               onStartError: (err) => {
                 logTypingFailure({
                   log: (message) => logger.debug?.(message),
                   channel: "mattermost",
-                  target: optsLocal.channelId,
+                  target: opts.channelId,
                   error: err,
                 });
               },
@@ -1666,10 +1712,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               },
             },
           });
-        const draftPreviewEnabled = account.streamingMode !== "off";
-        const draftToolProgressEnabled = shouldUpdateMattermostDraftToolProgress(account);
+        const streamingDeliveryPolicy = resolveMattermostStreamingDeliveryPolicy({
+          account,
+          cfg,
+        });
+        const draftPreviewEnabled = streamingDeliveryPolicy.draftPreviewEnabled;
+        const draftToolProgressEnabled =
+          draftPreviewEnabled && shouldUpdateMattermostDraftToolProgress(account);
         const suppressDefaultToolProgressMessages =
-          shouldSuppressMattermostDefaultToolProgressMessages(account);
+          draftPreviewEnabled && shouldSuppressMattermostDefaultToolProgressMessages(account);
         const draftStream = draftPreviewEnabled
           ? createMattermostDraftStream({
               client,
@@ -1684,8 +1735,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
+        let lastPartialTextCanFinalizeAsAccumulated = false;
 
-        const resolvePreviewFinalText = (text?: string) => {
+        const resolveSinglePreviewChunk = (text?: string) => {
           if (typeof text !== "string") {
             return undefined;
           }
@@ -1710,18 +1762,30 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           if (!trimmed) {
             return undefined;
           }
-          if (
-            lastPartialText &&
-            lastPartialText.startsWith(trimmed) &&
-            trimmed.length < lastPartialText.length
-          ) {
-            return undefined;
-          }
           return trimmed;
         };
 
-        const updateDraftFromPartial = (text?: string) => {
-          const cleaned = text?.trim();
+        const resolvePreviewFinalText = (text?: string) => {
+          const trimmed = resolveSinglePreviewChunk(text);
+          if (!trimmed) {
+            return undefined;
+          }
+          return resolveMattermostPreviewFinalText({
+            streamingMode: account.streamingMode,
+            finalText: trimmed,
+            lastPartialText,
+            allowAccumulatedPreviewText: lastPartialTextCanFinalizeAsAccumulated,
+            resolvePreviewText: resolveSinglePreviewChunk,
+          });
+        };
+
+        const updateDraftFromPartial = (payload: {
+          text?: string;
+          delta?: string;
+          replace?: true;
+          phase?: string;
+        }) => {
+          const cleaned = payload.text?.trim();
           if (!cleaned) {
             return;
           }
@@ -1735,6 +1799,14 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           ) {
             return;
           }
+          lastPartialTextCanFinalizeAsAccumulated =
+            account.streamingMode === "block" &&
+            payload.replace !== true &&
+            payload.phase === "final_answer" &&
+            typeof payload.delta === "string" &&
+            payload.delta.trim().length > 0 &&
+            Boolean(lastPartialText) &&
+            cleaned.startsWith(lastPartialText);
           lastPartialText = cleaned;
           draftStream.update(cleaned);
         };
@@ -1744,9 +1816,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             ...replyPipeline,
             humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
             typingCallbacks,
-            deliver: async (payloadEntry: ReplyPayload, info) => {
+            deliver: async (payload: ReplyPayload, info) => {
               await deliverMattermostReplyWithDraftPreview({
-                payload: payloadEntry,
+                payload,
                 info,
                 kind,
                 client,
@@ -1880,39 +1952,41 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                         dispatcher,
                         replyOptions: {
                           ...replyOptions,
-                          disableBlockStreaming: true,
+                          disableBlockStreaming: streamingDeliveryPolicy.disableBlockStreaming,
                           ...(suppressDefaultToolProgressMessages
                             ? { suppressDefaultToolProgressMessages: true }
                             : {}),
                           onModelSelected,
-                          onPartialReply: (payloadResult) => {
+                          onPartialReply: (payload) => {
                             if (account.streamingMode !== "progress") {
-                              updateDraftFromPartial(payloadResult.text);
+                              updateDraftFromPartial(payload);
                             }
                           },
                           onAssistantMessageStart: () => {
                             lastPartialText = "";
+                            lastPartialTextCanFinalizeAsAccumulated = false;
                           },
                           onReasoningEnd: () => {
                             lastPartialText = "";
+                            lastPartialTextCanFinalizeAsAccumulated = false;
                           },
                           onReasoningStream: async () => {
                             if (!lastPartialText) {
                               draftStream.update("Thinking…");
                             }
                           },
-                          onToolStart: async (payloadValue) => {
+                          onToolStart: async (payload) => {
                             if (!draftToolProgressEnabled) {
                               return;
                             }
                             draftStream.update(
                               buildMattermostToolStatusText({
-                                ...payloadValue,
+                                ...payload,
                                 config: account.config,
                               }),
                             );
                           },
-                          onItemEvent: async (payloadLocal) => {
+                          onItemEvent: async (payload) => {
                             if (!draftToolProgressEnabled) {
                               return;
                             }
@@ -1920,15 +1994,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                               account.config,
                               {
                                 event: "item",
-                                itemId: payloadLocal.itemId,
-                                itemKind: payloadLocal.kind,
-                                title: payloadLocal.title,
-                                name: payloadLocal.name,
-                                phase: payloadLocal.phase,
-                                status: payloadLocal.status,
-                                summary: payloadLocal.summary,
-                                progressText: payloadLocal.progressText,
-                                meta: payloadLocal.meta,
+                                itemId: payload.itemId,
+                                itemKind: payload.kind,
+                                title: payload.title,
+                                name: payload.name,
+                                phase: payload.phase,
+                                status: payload.status,
+                                summary: payload.summary,
+                                progressText: payload.progressText,
+                                meta: payload.meta,
                               },
                             );
                             if (progressText) {
@@ -2165,7 +2239,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         client,
         commands,
         log: (msg) => runtime.log?.(msg),
-      }).catch((err: unknown) => {
+      }).catch((err) => {
         runtime.error?.(`mattermost: slash cleanup failed: ${String(err)}`);
       });
     };

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -1,6 +1,7 @@
 import type { ImageContent } from "../llm/types.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { UserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.js";
+import type { AssistantPhase } from "../shared/chat-message-content.js";
 import type { ReplyPayload } from "./reply-payload.js";
 import type { TypingController } from "./reply/typing.js";
 
@@ -44,6 +45,7 @@ export type QueuedReplyLifecycle = {
 export type PartialReplyPayload = Pick<ReplyPayload, "text" | "mediaUrls"> & {
   delta?: string;
   replace?: true;
+  phase?: AssistantPhase;
 };
 
 export type GetReplyOptions = {

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -10,6 +10,7 @@ import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
 import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
 import { emitAgentEvent, onAgentEvent } from "../../infra/agent-events.js";
+import { normalizeAssistantPhase, type AssistantPhase } from "../../shared/chat-message-content.js";
 
 function shouldBridgeCliAssistantTextToReasoning(provider: string): boolean {
   return normalizeLowercaseStringOrEmpty(provider) === "claude-cli";
@@ -57,10 +58,17 @@ function createAgentEventBridge<T>(params: {
   };
 }
 
+export type CliAssistantTextPayload = {
+  text: string;
+  delta?: string;
+  replace?: true;
+  phase?: AssistantPhase;
+};
+
 function createAssistantTextBridge(params: {
   runId: string;
   suppressed?: boolean;
-  deliver?: (text: string) => Promise<void>;
+  deliver?: (payload: CliAssistantTextPayload) => Promise<void>;
 }) {
   let lastText: string | undefined;
   return createAgentEventBridge({
@@ -76,7 +84,14 @@ function createAssistantTextBridge(params: {
         return undefined;
       }
       lastText = text;
-      return text;
+      const delta = typeof evt.data.delta === "string" ? evt.data.delta : undefined;
+      const phase = normalizeAssistantPhase(evt.data.phase);
+      return {
+        text,
+        ...(delta !== undefined ? { delta } : {}),
+        ...(evt.data.replace === true ? { replace: true as const } : {}),
+        ...(phase ? { phase } : {}),
+      };
     },
   });
 }
@@ -181,7 +196,7 @@ export async function runCliAgentWithLifecycle(params: {
   emitLifecycleTerminal?: boolean;
   onAgentRunStart?: () => void;
   suppressAssistantBridge?: boolean;
-  onAssistantText?: (text: string) => Promise<void>;
+  onAssistantText?: (payload: CliAssistantTextPayload) => Promise<void>;
   onReasoningText?: (text: string) => Promise<void>;
   onToolEvent?: (payload: CliToolEventPayload) => Promise<void>;
   onErrorBeforeLifecycle?: (err: unknown) => Promise<void>;
@@ -209,9 +224,12 @@ export async function runCliAgentWithLifecycle(params: {
   const reasoningBridge = createAssistantTextBridge({
     runId: params.runId,
     suppressed: params.suppressAssistantBridge,
-    deliver: shouldBridgeCliAssistantTextToReasoning(params.provider)
-      ? params.onReasoningText
-      : undefined,
+    deliver:
+      shouldBridgeCliAssistantTextToReasoning(params.provider) && params.onReasoningText
+        ? async (payload) => {
+            await params.onReasoningText?.(payload.text);
+          }
+        : undefined,
   });
   const toolBridge = createToolEventBridge({
     runId: params.runId,

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -225,6 +225,13 @@ type FallbackRunnerParams = {
 
 type EmbeddedAgentParams = {
   onBlockReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
+  onPartialReply?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    delta?: string;
+    replace?: true;
+    phase?: "commentary" | "final_answer";
+  }) => Promise<void> | void;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
   onItemEvent?: (payload: {
     itemId?: string;
@@ -2152,12 +2159,12 @@ describe("runAgentTurnWithFallback", () => {
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
         stream: "assistant",
-        data: { text: "Hello", delta: "Hello" },
+        data: { text: "Hello", delta: "Hello", phase: "final_answer" },
       });
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
         stream: "assistant",
-        data: { text: "Hello world", delta: " world" },
+        data: { text: "Hello world", delta: " world", phase: "final_answer" },
       });
       return { payloads: [{ text: "Hello world" }], meta: {} };
     });
@@ -2195,6 +2202,50 @@ describe("runAgentTurnWithFallback", () => {
 
     const partialTexts = onPartialReply.mock.calls.map((call) => call[0].text);
     expect(partialTexts).toEqual(["Hello", "Hello world"]);
+    expect(onPartialReply.mock.calls.map((call) => call[0].delta)).toEqual(["Hello", " world"]);
+    expect(onPartialReply.mock.calls.map((call) => call[0].phase)).toEqual([
+      "final_answer",
+      "final_answer",
+    ]);
+  });
+
+  it("preserves embedded assistant partial metadata for channel previews", async () => {
+    state.isCliProviderMock.mockReturnValue(false);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("anthropic", "claude-sonnet-4-7"),
+      provider: "anthropic",
+      model: "claude-sonnet-4-7",
+      attempts: [],
+    }));
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onPartialReply?.({
+        text: "Hello",
+        delta: "Hello",
+        phase: "final_answer",
+      });
+      await params.onPartialReply?.({
+        text: "Hello world",
+        delta: " world",
+        phase: "final_answer",
+      });
+      return { payloads: [{ text: "Hello world" }], meta: {} };
+    });
+
+    const onPartialReply = vi.fn<NonNullable<GetReplyOptions["onPartialReply"]>>(
+      async (_payload) => undefined,
+    );
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+
+    await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        opts: { onPartialReply },
+      }),
+    );
+
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      { text: "Hello", delta: "Hello", phase: "final_answer" },
+      { text: "Hello world", delta: " world", phase: "final_answer" },
+    ]);
   });
 
   it("serializes and drains bridged CLI assistant previews before completing (#76869)", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2072,12 +2072,21 @@ export async function runAgentTurnWithFallback(params: {
                   provider: cliExecutionProvider,
                   onAgentRunStart: notifyAgentRunStart,
                   suppressAssistantBridge: params.followupRun.run.silentExpected,
-                  onAssistantText: async (text) => {
-                    const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
+                  onAssistantText: async (payload) => {
+                    const textForTyping = await handlePartialForTyping({
+                      text: payload.text,
+                    } as ReplyPayload);
                     if (textForTyping === undefined || !params.opts?.onPartialReply) {
                       return;
                     }
-                    await params.opts.onPartialReply({ text: textForTyping });
+                    await params.opts.onPartialReply({
+                      text: textForTyping,
+                      ...(payload.delta !== undefined && textForTyping === payload.text
+                        ? { delta: payload.delta }
+                        : {}),
+                      ...(payload.replace === true ? { replace: true as const } : {}),
+                      ...(payload.phase ? { phase: payload.phase } : {}),
+                    });
                   },
                   onReasoningText: async (text) => {
                     await params.opts?.onReasoningStream?.({ text });
@@ -2302,6 +2311,9 @@ export async function runAgentTurnWithFallback(params: {
                       await params.opts.onPartialReply({
                         text: textForTyping,
                         mediaUrls: payload.mediaUrls,
+                        ...(payload.delta !== undefined ? { delta: payload.delta } : {}),
+                        ...(payload.replace === true ? { replace: true as const } : {}),
+                        ...(payload.phase ? { phase: payload.phase } : {}),
                       });
                     },
                     onAssistantMessageStart: async () => {


### PR DESCRIPTION
Fixes #87322

## User-facing bug

Mattermost used the live draft-preview path even when the account opted into completed-block delivery. That meant logical block replies were edited into one draft preview instead of being delivered as stable visible block posts. In `streaming.mode: "block"`, finalizing the preview could also collapse a longer accumulated draft to only the last final segment.

## Exact repro

1. Configure Mattermost with preview streaming enabled and `blockStreaming: true`, or set `streaming.mode: "block"` and produce a final payload that is only the last streamed segment.
2. Send a prompt that produces multiple visible text blocks around tool/progress events.
3. Observe Mattermost editing/suppressing the block surface instead of preserving visible block delivery or a validated accumulated preview.

## Fix summary

- Added a Mattermost streaming delivery policy that keeps draft preview and block delivery mutually exclusive unless Mattermost explicitly chooses block delivery.
- Explicit Mattermost `blockStreaming: true` now disables draft preview and passes `disableBlockStreaming: false` to the reply pipeline.
- Active draft previews remain active even when `agents.defaults.blockStreamingDefault` is on unless Mattermost explicitly opts into block delivery.
- Partial-reply `delta`/`replace`/`phase` metadata now reaches channel preview callbacks, so Mattermost can distinguish accumulated final-answer transcript updates from stale progress text.
- Mattermost block-preview finalization can reuse accumulated preview text only when the partial stream proves it is an accumulated final-answer transcript, and the accumulated candidate passes the same chunk/limit validation as normal finals.
- Tool/progress suppression is now tied to an active draft preview so block delivery does not hide default progress messages.

## Targeted tests

- Mattermost monitor tests cover streaming policy selection, accumulated preview finalization, and draft-preview delivery.
- Auto-reply tests cover partial-reply metadata propagation through CLI assistant events and dispatch.

## Real behavior proof

Behavior addressed: Mattermost block-streaming configurations now preserve visible completed blocks instead of editing them into one draft preview or collapsing the final preview to only the last segment.

Real environment tested: Local OpenClaw checkout on branch `fix/mattermost-block-streaming-posts`, commit `7672dcdd`.

Exact steps or command run after this patch:

- `git diff --check`
- `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=10000 node scripts/run-vitest.mjs --run --maxWorkers 1 extensions/mattermost/src/mattermost/monitor.test.ts -t "resolveMattermostStreamingDeliveryPolicy|resolveMattermostPreviewFinalText|deliverMattermostReplyWithDraftPreview"`
- `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=10000 node scripts/run-vitest.mjs --run --maxWorkers 1 extensions/mattermost/src/mattermost/monitor.test.ts`
- `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=10000 node scripts/run-vitest.mjs --run --maxWorkers 1 src/auto-reply/reply/agent-runner-execution.test.ts -t "bridges CLI assistant agent events into onPartialReply|preserves embedded assistant partial metadata|bridges CLI assistant agent events into onReasoningStream"`
- `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=10000 node scripts/run-vitest.mjs --run --maxWorkers 1 src/auto-reply/reply/agent-runner-cli-dispatch.test.ts`
- `codex review --base origin/main`

Evidence after fix:
- Targeted Mattermost and auto-reply Vitest commands passed.
- `git diff --check` passed.
- `codex review --base origin/main` found no blocking regression after the local fixes.

Observed result after fix: Mattermost only uses draft preview when the delivery policy selects preview mode, and explicit block streaming keeps completed blocks visible while progress suppression remains tied to active draft preview.

What was not tested: Live Mattermost server delivery was not run. `pnpm check:changed` is blocked by dependency install/network in this environment. `tsgo` typecheck is blocked because `node_modules/.bin/tsgo` is missing in this checkout.

## Not tested / known gaps

- Live Mattermost server delivery.
- `pnpm check:changed`, blocked by dependency install/network in this environment.
- `tsgo` typecheck, blocked because `node_modules/.bin/tsgo` is missing in this checkout.

## AI-assisted disclosure

This PR was prepared with AI assistance and local command/test verification.
