### PR TITLE
Emit sessions.changed for in-chat command metadata

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -42,6 +42,8 @@ command handling is enabled for the surface.
       persist to the session and reply with an acknowledgement.
     - In **normal chat** messages with other text, they act as inline hints and
       do **not** persist session settings.
+    - Session metadata updates from command-only turns, such as `/goal` state
+      changes, refresh subscribed clients without requiring a session reload.
     - Directives only apply for **authorized senders**. If `commands.allowFrom`
       is set, it is the only allowlist used; otherwise authorization comes from
       channel allowlists/pairing plus `commands.useAccessGroups`. Unauthorized

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -46,6 +46,12 @@ export type QueuedReplyLifecycle = {
   onComplete?: () => void;
 };
 
+export type SessionMetadataChangedEvent = {
+  sessionKey: string;
+  agentId?: string;
+  reason: "command-metadata";
+};
+
 /** Partial assistant payload emitted during streaming or replacement updates. */
 export type PartialReplyPayload = Pick<ReplyPayload, "text" | "mediaUrls"> & {
   delta?: string;
@@ -193,6 +199,8 @@ export type GetReplyOptions = {
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;
+  /** Called after an in-chat command mutates visible session metadata. */
+  onSessionMetadataChanged?: (event: SessionMetadataChangedEvent) => Promise<void> | void;
   /**
    * Controls whether normal assistant replies are automatically delivered to
    * the source conversation. `message_tool_only` prefers message-tool visible

--- a/src/auto-reply/reply/commands-goal.test.ts
+++ b/src/auto-reply/reply/commands-goal.test.ts
@@ -2,9 +2,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getSessionEntry, upsertSessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { onSessionLifecycleEvent } from "../../sessions/session-lifecycle-events.js";
 import {
   formatGoalContinuationPrompt,
   handleGoalCommand,
@@ -110,6 +111,111 @@ describe("goal commands", () => {
     expect(params.command.commandBodyNormalized).toBe("build a 3d game");
     expect((params.ctx as { BodyForAgent?: string }).BodyForAgent).toBe("build a 3d game");
     expect(getSessionEntry({ storePath, sessionKey })?.goal?.objective).toBe("build a 3d game");
+  });
+
+  it("notifies subscribers when goal commands mutate session metadata", async () => {
+    const storePath = await createStorePath();
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: { sessionId: "sess-main", updatedAt: 1, totalTokens: 0, totalTokensFresh: true },
+    });
+    const onSessionMetadataChanged = vi.fn();
+    const params = {
+      ...buildGoalParams("/goal start refresh dashboard state", storePath),
+      opts: { onSessionMetadataChanged },
+    } as HandleCommandsParams;
+
+    const result = await handleGoalCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(true);
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey,
+      agentId: "main",
+      reason: "command-metadata",
+    });
+  });
+
+  it("emits a shared lifecycle event when no direct session metadata subscriber is installed", async () => {
+    const storePath = await createStorePath();
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: { sessionId: "sess-main", updatedAt: 1, totalTokens: 0, totalTokensFresh: true },
+    });
+    const events: Array<{ sessionKey: string; reason: string }> = [];
+    const unsubscribe = onSessionLifecycleEvent((event) => {
+      events.push({ sessionKey: event.sessionKey, reason: event.reason });
+    });
+    try {
+      const params = buildGoalParams("/goal start refresh channel state", storePath);
+
+      const result = await handleGoalCommand(params, true);
+
+      expect(result?.shouldContinue).toBe(true);
+      expect(events).toEqual([{ sessionKey, reason: "command-metadata" }]);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("does not notify subscribers for no-op goal status", async () => {
+    const storePath = await createStorePath();
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: { sessionId: "sess-main", updatedAt: 1 },
+    });
+    const onSessionMetadataChanged = vi.fn();
+    const params = {
+      ...buildGoalParams("/goal status", storePath),
+      opts: { onSessionMetadataChanged },
+    } as HandleCommandsParams;
+
+    await handleGoalCommand(params, true);
+
+    expect(onSessionMetadataChanged).not.toHaveBeenCalled();
+  });
+
+  it("notifies subscribers when goal status persists usage accounting", async () => {
+    const storePath = await createStorePath();
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-main",
+        updatedAt: 1,
+        totalTokens: 20,
+        totalTokensFresh: true,
+        goal: {
+          schemaVersion: 1,
+          id: "goal-1",
+          objective: "stay within budget",
+          status: "active",
+          createdAt: 1,
+          updatedAt: 1,
+          tokenStart: 0,
+          tokenStartFresh: true,
+          tokensUsed: 0,
+          tokenBudget: 10,
+          continuationTurns: 0,
+        },
+      },
+    });
+    const onSessionMetadataChanged = vi.fn();
+    const params = {
+      ...buildGoalParams("/goal status", storePath),
+      opts: { onSessionMetadataChanged },
+    } as HandleCommandsParams;
+
+    await handleGoalCommand(params, true);
+
+    expect(getSessionEntry({ storePath, sessionKey })?.goal?.status).toBe("budget_limited");
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey,
+      agentId: "main",
+      reason: "command-metadata",
+    });
   });
 
   it("wraps command-prefixed goal objectives before continuing", async () => {

--- a/src/auto-reply/reply/commands-goal.ts
+++ b/src/auto-reply/reply/commands-goal.ts
@@ -12,6 +12,7 @@ import {
   updateSessionGoalStatus,
 } from "../../config/sessions.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
+import { notifySessionMetadataChanged } from "./commands-session-store.js";
 import type {
   CommandHandler,
   CommandHandlerResult,
@@ -60,16 +61,46 @@ export function parseGoalCommand(raw: string): { action: string; text: string } 
   };
 }
 
-function syncGoalSessionEntry(params: HandleCommandsParams): void {
-  if (!params.sessionStore || !params.sessionKey) {
-    return;
+function syncGoalSessionEntry(params: HandleCommandsParams): boolean {
+  if (!params.sessionKey) {
+    return false;
   }
   const entry = getSessionEntry({ sessionKey: params.sessionKey, storePath: params.storePath });
   if (!entry) {
+    return false;
+  }
+  if (params.sessionStore) {
+    params.sessionStore[params.sessionKey] = entry;
+  }
+  params.sessionEntry = entry;
+  return true;
+}
+
+async function syncChangedGoalSessionEntry(params: HandleCommandsParams): Promise<void> {
+  if (syncGoalSessionEntry(params)) {
+    await notifySessionMetadataChanged(params);
+  }
+}
+
+function readStoredGoalFingerprint(params: HandleCommandsParams): string | undefined {
+  if (!params.sessionKey) {
+    return undefined;
+  }
+  const entry = getSessionEntry({ sessionKey: params.sessionKey, storePath: params.storePath });
+  return JSON.stringify(entry?.goal ?? null);
+}
+
+async function syncPotentiallyChangedGoalSessionEntry(
+  params: HandleCommandsParams,
+  previousGoalFingerprint: string | undefined,
+): Promise<void> {
+  if (!syncGoalSessionEntry(params)) {
     return;
   }
-  params.sessionStore[params.sessionKey] = entry;
-  params.sessionEntry = entry;
+  const nextGoalFingerprint = JSON.stringify(params.sessionEntry?.goal ?? null);
+  if (nextGoalFingerprint !== previousGoalFingerprint) {
+    await notifySessionMetadataChanged(params);
+  }
 }
 
 function goalReply(text: string): CommandHandlerResult {
@@ -167,11 +198,12 @@ export const handleGoalCommand: CommandHandler = async (params, allowTextCommand
   try {
     switch (parsed.action) {
       case "status": {
+        const previousGoalFingerprint = readStoredGoalFingerprint(params);
         const snapshot = await getSessionGoal({
           sessionKey: params.sessionKey,
           storePath: params.storePath,
         });
-        syncGoalSessionEntry(params);
+        await syncPotentiallyChangedGoalSessionEntry(params, previousGoalFingerprint);
         return goalReply(formatSessionGoalStatus(snapshot.goal));
       }
       case "start":
@@ -187,7 +219,7 @@ export const handleGoalCommand: CommandHandler = async (params, allowTextCommand
           objective,
           fallbackEntry: params.sessionEntry,
         });
-        syncGoalSessionEntry(params);
+        await syncChangedGoalSessionEntry(params);
         applyGoalContinuationPrompt(params, formatGoalContinuationPrompt(goal.objective));
         return goalContinuation();
       }
@@ -198,7 +230,7 @@ export const handleGoalCommand: CommandHandler = async (params, allowTextCommand
           status: "paused",
           ...(parsed.text ? { note: parsed.text } : {}),
         });
-        syncGoalSessionEntry(params);
+        await syncChangedGoalSessionEntry(params);
         return goalReply(`Goal paused: ${goal.objective}`);
       }
       case "resume": {
@@ -208,7 +240,7 @@ export const handleGoalCommand: CommandHandler = async (params, allowTextCommand
           status: "active",
           ...(parsed.text ? { note: parsed.text } : {}),
         });
-        syncGoalSessionEntry(params);
+        await syncChangedGoalSessionEntry(params);
         const message = formatGoalResumeContinuationPrompt(parsed.text);
         applyGoalContinuationPrompt(params, message);
         return goalContinuation();
@@ -221,7 +253,7 @@ export const handleGoalCommand: CommandHandler = async (params, allowTextCommand
           status: "complete",
           ...(parsed.text ? { note: parsed.text } : {}),
         });
-        syncGoalSessionEntry(params);
+        await syncChangedGoalSessionEntry(params);
         return goalReply(`Goal complete: ${goal.objective}\nTokens used: ${goal.tokensUsed}`);
       }
       case "block":
@@ -232,7 +264,7 @@ export const handleGoalCommand: CommandHandler = async (params, allowTextCommand
           status: "blocked",
           ...(parsed.text ? { note: parsed.text } : {}),
         });
-        syncGoalSessionEntry(params);
+        await syncChangedGoalSessionEntry(params);
         return goalReply(`Goal blocked: ${goal.objective}`);
       }
       case "clear": {
@@ -240,7 +272,10 @@ export const handleGoalCommand: CommandHandler = async (params, allowTextCommand
           sessionKey: params.sessionKey,
           storePath: params.storePath,
         });
-        syncGoalSessionEntry(params);
+        const synced = syncGoalSessionEntry(params);
+        if (removed && synced) {
+          await notifySessionMetadataChanged(params);
+        }
         return goalReply(removed ? "Goal cleared." : "No goal to clear.");
       }
       default:

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { SessionEntry } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import type { GetReplyOptions } from "../types.js";
 import {
   resolveAbortCutoffFromContext,
   shouldPersistAbortCutoff,
@@ -85,6 +86,8 @@ async function applyAbortTarget(params: {
   storePath?: string;
   abortKey?: string;
   abortCutoff?: AbortCutoff;
+  agentId?: string;
+  onSessionMetadataChanged?: GetReplyOptions["onSessionMetadataChanged"];
 }) {
   const { abortTarget } = params;
   abortSessionRunTarget({ key: abortTarget.key, sessionId: abortTarget.sessionId });
@@ -95,6 +98,8 @@ async function applyAbortTarget(params: {
     sessionStore: params.sessionStore,
     storePath: params.storePath,
     abortCutoff: params.abortCutoff,
+    agentId: params.agentId,
+    onSessionMetadataChanged: params.onSessionMetadataChanged,
   });
   if (!persisted && params.abortKey) {
     setAbortMemory(params.abortKey, true);
@@ -110,6 +115,8 @@ function buildAbortTargetApplyParams(
     sessionStore: params.sessionStore,
     storePath: params.storePath,
     abortKey: params.command.abortKey,
+    agentId: params.agentId,
+    onSessionMetadataChanged: params.opts?.onSessionMetadataChanged,
     abortCutoff: resolveAbortCutoffForTarget({
       ctx: params.ctx,
       commandSessionKey: params.sessionKey,

--- a/src/auto-reply/reply/commands-session-store.test.ts
+++ b/src/auto-reply/reply/commands-session-store.test.ts
@@ -50,6 +50,26 @@ describe("command session metadata notifications", () => {
     });
   });
 
+  it("canonicalizes scoped global metadata to the global row and parsed agent", async () => {
+    const entry = createEntry();
+    const sessionStore: Record<string, SessionEntry> = {};
+    const onSessionMetadataChanged = vi.fn();
+
+    await persistSessionEntry({
+      sessionKey: "agent:target:global",
+      agentId: "main",
+      sessionEntry: entry,
+      sessionStore,
+      opts: { onSessionMetadataChanged },
+    } as never);
+
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey: "global",
+      agentId: "target",
+      reason: "command-metadata",
+    });
+  });
+
   it("derives abort-target metadata agentId from the changed key", async () => {
     const entry = createEntry();
     const sessionStore: Record<string, SessionEntry> = {};

--- a/src/auto-reply/reply/commands-session-store.test.ts
+++ b/src/auto-reply/reply/commands-session-store.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import { persistAbortTargetEntry, persistSessionEntry } from "./commands-session-store.js";
+
+function createEntry(): SessionEntry {
+  return {
+    sessionId: "sess-1",
+    updatedAt: 1,
+  };
+}
+
+describe("command session metadata notifications", () => {
+  it("derives metadata agentId from agent-scoped session keys", async () => {
+    const entry = createEntry();
+    const sessionStore: Record<string, SessionEntry> = {};
+    const onSessionMetadataChanged = vi.fn();
+
+    await persistSessionEntry({
+      sessionKey: "agent:target:telegram:direct:123",
+      agentId: "main",
+      sessionEntry: entry,
+      sessionStore,
+      opts: { onSessionMetadataChanged },
+    } as never);
+
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey: "agent:target:telegram:direct:123",
+      agentId: "target",
+      reason: "command-metadata",
+    });
+  });
+
+  it("keeps fallback agentId only for global session metadata", async () => {
+    const entry = createEntry();
+    const sessionStore: Record<string, SessionEntry> = {};
+    const onSessionMetadataChanged = vi.fn();
+
+    await persistSessionEntry({
+      sessionKey: "global",
+      agentId: "target",
+      sessionEntry: entry,
+      sessionStore,
+      opts: { onSessionMetadataChanged },
+    } as never);
+
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey: "global",
+      agentId: "target",
+      reason: "command-metadata",
+    });
+  });
+
+  it("derives abort-target metadata agentId from the changed key", async () => {
+    const entry = createEntry();
+    const sessionStore: Record<string, SessionEntry> = {};
+    const onSessionMetadataChanged = vi.fn();
+
+    await persistAbortTargetEntry({
+      key: "agent:target:telegram:direct:123",
+      agentId: "main",
+      entry,
+      sessionStore,
+      onSessionMetadataChanged,
+    });
+
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey: "agent:target:telegram:direct:123",
+      agentId: "target",
+      reason: "command-metadata",
+    });
+  });
+});

--- a/src/auto-reply/reply/commands-session-store.ts
+++ b/src/auto-reply/reply/commands-session-store.ts
@@ -24,6 +24,14 @@ function createSessionMetadataChangedEvent(params: {
   sessionKey: string;
   agentId?: string;
 }): SessionMetadataChangedEvent {
+  const parsed = parseAgentSessionKey(params.sessionKey);
+  if (parsed?.rest === "global") {
+    return {
+      sessionKey: "global",
+      agentId: normalizeAgentId(parsed.agentId),
+      reason: "command-metadata",
+    };
+  }
   const agentId = resolveSessionMetadataAgentId(params.sessionKey, params.agentId);
   return {
     sessionKey: params.sessionKey,

--- a/src/auto-reply/reply/commands-session-store.ts
+++ b/src/auto-reply/reply/commands-session-store.ts
@@ -1,10 +1,61 @@
 // Shared session-store helpers for command handlers that mutate sessions.
 import type { SessionEntry } from "../../config/sessions.js";
 import { updateSessionStore } from "../../config/sessions.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { emitSessionLifecycleEvent } from "../../sessions/session-lifecycle-events.js";
+import type { SessionMetadataChangedEvent } from "../get-reply-options.types.js";
 import { applyAbortCutoffToSessionEntry, type AbortCutoff } from "./abort-cutoff.js";
 import type { CommandHandler } from "./commands-types.js";
 
 type CommandParams = Parameters<CommandHandler>[0];
+type SessionMetadataChangedCallback = (event: SessionMetadataChangedEvent) => Promise<void> | void;
+
+function resolveSessionMetadataAgentId(
+  sessionKey: string,
+  agentId?: string,
+): string | undefined {
+  if (sessionKey === "global") {
+    return agentId ? normalizeAgentId(agentId) : undefined;
+  }
+  return parseAgentSessionKey(sessionKey)?.agentId;
+}
+
+function createSessionMetadataChangedEvent(params: {
+  sessionKey: string;
+  agentId?: string;
+}): SessionMetadataChangedEvent {
+  const agentId = resolveSessionMetadataAgentId(params.sessionKey, params.agentId);
+  return {
+    sessionKey: params.sessionKey,
+    ...(agentId ? { agentId } : {}),
+    reason: "command-metadata",
+  };
+}
+
+export async function dispatchSessionMetadataChanged(
+  event: SessionMetadataChangedEvent,
+  onSessionMetadataChanged?: SessionMetadataChangedCallback,
+): Promise<void> {
+  const normalizedEvent = createSessionMetadataChangedEvent(event);
+  if (onSessionMetadataChanged) {
+    await onSessionMetadataChanged(normalizedEvent);
+    return;
+  }
+  emitSessionLifecycleEvent(normalizedEvent);
+}
+
+export async function notifySessionMetadataChanged(params: CommandParams): Promise<void> {
+  if (!params.sessionKey) {
+    return;
+  }
+  await dispatchSessionMetadataChanged(
+    createSessionMetadataChangedEvent({
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+    }),
+    params.opts?.onSessionMetadataChanged,
+  );
+}
 
 export async function persistSessionEntry(params: CommandParams): Promise<boolean> {
   if (!params.sessionEntry || !params.sessionStore || !params.sessionKey) {
@@ -29,6 +80,7 @@ export async function persistSessionEntry(params: CommandParams): Promise<boolea
       },
     );
   }
+  await notifySessionMetadataChanged(params);
   return true;
 }
 
@@ -38,6 +90,8 @@ export async function persistAbortTargetEntry(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   abortCutoff?: AbortCutoff;
+  agentId?: string;
+  onSessionMetadataChanged?: SessionMetadataChangedCallback;
 }): Promise<boolean> {
   const { entry, key, sessionStore, storePath, abortCutoff } = params;
   if (!entry || !key || !sessionStore) {
@@ -70,5 +124,12 @@ export async function persistAbortTargetEntry(params: {
     );
   }
 
+  await dispatchSessionMetadataChanged(
+    createSessionMetadataChangedEvent({
+      sessionKey: key,
+      agentId: params.agentId,
+    }),
+    params.onSessionMetadataChanged,
+  );
   return true;
 }

--- a/src/auto-reply/reply/commands-stop-target.test.ts
+++ b/src/auto-reply/reply/commands-stop-target.test.ts
@@ -190,6 +190,26 @@ describe("handleStopCommand target fallback", () => {
     );
   });
 
+  it("passes session metadata notifications through abort target persistence", async () => {
+    const params = buildStopParams();
+    const onSessionMetadataChanged = vi.fn();
+    params.agentId = "main";
+    params.opts = { onSessionMetadataChanged } as never;
+
+    await handleStopCommand(params, true);
+
+    const [[persistAbortTargetParams]] = persistAbortTargetEntryMock.mock.calls as unknown as Array<
+      [
+        {
+          agentId?: string;
+          onSessionMetadataChanged?: unknown;
+        },
+      ]
+    >;
+    expect(persistAbortTargetParams?.agentId).toBe("main");
+    expect(persistAbortTargetParams?.onSessionMetadataChanged).toBe(onSessionMetadataChanged);
+  });
+
   it("rejects native stop commands from non-owner senders when the plugin enforces owner-only commands", async () => {
     registerOwnerEnforcingTelegramPlugin();
     const params = buildStopParams();

--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -91,11 +91,13 @@ export async function applyInlineDirectivesFastLane(
     currentReasoningLevel,
     currentElevatedLevel,
     ctx,
+    agentId,
     messageProvider: ctx.Provider,
     surface: ctx.Surface,
     gatewayClientScopes: ctx.GatewayClientScopes,
     commandAuthorized,
     senderIsOwner: params.senderIsOwner,
+    onSessionMetadataChanged: params.onSessionMetadataChanged,
     workspaceDir: params.workspaceDir,
   });
 

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -16,6 +16,7 @@ import {
   resolveSupportedThinkingLevel,
 } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
+import { dispatchSessionMetadataChanged } from "./commands-session-store.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
 import { maybeHandleModelDirectiveInfo } from "./directive-handling.model.js";
 import type { HandleDirectiveOnlyParams } from "./directive-handling.params.js";
@@ -479,6 +480,16 @@ export async function handleDirectiveOnly(
       await updateSessionStore(storePath, (store) => {
         store[sessionKey] = sessionEntry;
       });
+    }
+    if (!params.suppressSessionMetadataChanged) {
+      await dispatchSessionMetadataChanged(
+        {
+          sessionKey,
+          ...(params.agentId ? { agentId: params.agentId } : {}),
+          reason: "command-metadata",
+        },
+        params.onSessionMetadataChanged,
+      );
     }
     if (modelSelection && modelSelectionUpdated && sessionKey) {
       triggerSessionPatchHook({

--- a/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
+++ b/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
@@ -51,11 +51,12 @@ describe("mixed inline directives", () => {
     vi.clearAllMocks();
   });
 
-  it("emits directive ack while persisting inline reasoning in mixed messages", async () => {
+  it("emits directive ack and metadata notification for mixed inline reasoning", async () => {
     const directives = parseInlineDirectives("please reply\n/reasoning on");
     const cfg = createConfig();
     const sessionEntry = createSessionEntry();
     const sessionStore = { "agent:main:dm:1": sessionEntry };
+    const onSessionMetadataChanged = vi.fn();
 
     const fastLane = await applyInlineDirectivesFastLane({
       directives,
@@ -64,6 +65,7 @@ describe("mixed inline directives", () => {
       ctx: { Surface: "whatsapp" } as never,
       cfg,
       agentId: "main",
+      onSessionMetadataChanged,
       isGroup: false,
       sessionEntry,
       sessionStore,
@@ -96,6 +98,12 @@ describe("mixed inline directives", () => {
     expect(fastLane.directiveAck).toEqual({
       text: "⚙️ Reasoning visibility enabled.",
     });
+    expect(onSessionMetadataChanged).toHaveBeenCalledTimes(1);
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey: "agent:main:dm:1",
+      agentId: "main",
+      reason: "command-metadata",
+    });
 
     const persisted = await persistInlineDirectives({
       directives,
@@ -118,11 +126,65 @@ describe("mixed inline directives", () => {
       messageProvider: "whatsapp",
       surface: "whatsapp",
       gatewayClientScopes: [],
+      agentId: "main",
+      onSessionMetadataChanged,
     });
 
     expect(sessionEntry.reasoningLevel).toBe("on");
+    expect(onSessionMetadataChanged).toHaveBeenCalledTimes(2);
     expect(persisted.provider).toBe("anthropic");
     expect(persisted.model).toBe("claude-opus-4-6");
+  });
+
+  it("scopes global-session fast-lane metadata notifications to the active agent", async () => {
+    const directives = parseInlineDirectives("please reply\n/reasoning on");
+    const cfg = createConfig();
+    const sessionEntry = createSessionEntry();
+    const sessionStore = { global: sessionEntry };
+    const onSessionMetadataChanged = vi.fn();
+
+    await applyInlineDirectivesFastLane({
+      directives,
+      commandAuthorized: true,
+      senderIsOwner: false,
+      ctx: { Surface: "whatsapp" } as never,
+      cfg,
+      agentId: "ops",
+      onSessionMetadataChanged,
+      isGroup: false,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "global",
+      storePath: undefined,
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      elevatedFailures: [],
+      messageProviderKey: "whatsapp",
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-6",
+      aliasIndex: { byAlias: new Map(), byKey: new Map() },
+      allowedModelKeys: new Set(),
+      allowedModelCatalog: [],
+      resetModelOverride: false,
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      initialModelLabel: "anthropic/claude-opus-4-6",
+      formatModelSwitchEvent: (label) => label,
+      agentCfg: cfg.agents?.defaults,
+      modelState: {
+        resolveDefaultThinkingLevel: async () => "off",
+        resolveThinkingCatalog: async () => [],
+        allowedModelKeys: new Set(),
+        allowedModelCatalog: [],
+        resetModelOverride: false,
+      },
+    });
+
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey: "global",
+      agentId: "ops",
+      reason: "command-metadata",
+    });
   });
 
   it("persists reasoning off and emits the disabled ack", async () => {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -295,6 +295,7 @@ import type { ElevatedLevel } from "../thinking.js";
 let handleDirectiveOnly: typeof import("./directive-handling.impl.js").handleDirectiveOnly;
 let cliBackendsTesting: typeof import("../../agents/cli-backends.js").testing;
 let maybeHandleModelDirectiveInfo: typeof import("./directive-handling.model.js").maybeHandleModelDirectiveInfo;
+let onSessionLifecycleEvent: typeof import("../../sessions/session-lifecycle-events.js").onSessionLifecycleEvent;
 let resolveModelSelectionFromDirective: typeof import("./directive-handling.model.js").resolveModelSelectionFromDirective;
 let parseInlineDirectives: typeof import("./directive-handling.parse.js").parseInlineDirectives;
 let persistInlineDirectives: typeof import("./directive-handling.persist.js").persistInlineDirectives;
@@ -302,6 +303,7 @@ let persistInlineDirectives: typeof import("./directive-handling.persist.js").pe
 beforeAll(async () => {
   ({ testing: cliBackendsTesting } = await import("../../agents/cli-backends.js"));
   ({ handleDirectiveOnly } = await import("./directive-handling.impl.js"));
+  ({ onSessionLifecycleEvent } = await import("../../sessions/session-lifecycle-events.js"));
   ({ maybeHandleModelDirectiveInfo, resolveModelSelectionFromDirective } =
     await import("./directive-handling.model.js"));
   ({ parseInlineDirectives } = await import("./directive-handling.parse.js"));
@@ -1550,6 +1552,54 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     });
   });
 
+  it("notifies subscribed clients when directive-only handling mutates session metadata", async () => {
+    const onSessionMetadataChanged = vi.fn();
+    const sessionEntry = createSessionEntry();
+
+    await handleDirectiveOnly(
+      createHandleParams({
+        directives: parseInlineDirectives("/think high"),
+        sessionEntry,
+        agentId: "main",
+        onSessionMetadataChanged,
+      }),
+    );
+
+    expect(sessionEntry.thinkingLevel).toBe("high");
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey,
+      agentId: "main",
+      reason: "command-metadata",
+    });
+  });
+
+  it("honors explicit session metadata notification suppression", async () => {
+    const onSessionMetadataChanged = vi.fn();
+    const lifecycleEvents: unknown[] = [];
+    const unsubscribe = onSessionLifecycleEvent((event) => {
+      lifecycleEvents.push(event);
+    });
+    const sessionEntry = createSessionEntry();
+
+    try {
+      await handleDirectiveOnly(
+        createHandleParams({
+          directives: parseInlineDirectives("/think high"),
+          sessionEntry,
+          agentId: "main",
+          onSessionMetadataChanged,
+          suppressSessionMetadataChanged: true,
+        }),
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    expect(sessionEntry.thinkingLevel).toBe("high");
+    expect(onSessionMetadataChanged).not.toHaveBeenCalled();
+    expect(lifecycleEvents).toHaveLength(0);
+  });
+
   it("keeps xhigh when switching to OpenCode Claude Opus 4.7", async () => {
     const sessionEntry = createSessionEntry({ thinkingLevel: "xhigh" });
     const sessionStore = { [sessionKey]: sessionEntry };
@@ -2144,6 +2194,21 @@ describe("persistInlineDirectives session directive persistence policy", () => {
     });
 
     expect(sessionEntry.verboseLevel).toBe("full");
+  });
+
+  it("notifies subscribed clients when directive persistence mutates session metadata", async () => {
+    const onSessionMetadataChanged = vi.fn();
+
+    await persistInternalOperatorWriteDirective("/think high", {
+      agentId: "main",
+      onSessionMetadataChanged,
+    });
+
+    expect(onSessionMetadataChanged).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      reason: "command-metadata",
+    });
   });
 
   it("skips exec persistence for non-webchat channel callers without gateway scopes", async () => {

--- a/src/auto-reply/reply/directive-handling.params.ts
+++ b/src/auto-reply/reply/directive-handling.params.ts
@@ -3,6 +3,7 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { GetReplyOptions } from "../types.js";
 import type { MsgContext } from "../templating.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./directives.js";
@@ -48,6 +49,9 @@ export type HandleDirectiveOnlyParams = HandleDirectiveOnlyCoreParams & {
   gatewayClientScopes?: string[];
   commandAuthorized?: boolean;
   senderIsOwner?: boolean;
+  agentId?: string;
+  onSessionMetadataChanged?: GetReplyOptions["onSessionMetadataChanged"];
+  suppressSessionMetadataChanged?: boolean;
 };
 
 /** Inputs for applying inline directives before the full reply run is prepared. */
@@ -57,6 +61,7 @@ export type ApplyInlineDirectivesFastLaneParams = HandleDirectiveOnlyCoreParams 
   ctx: MsgContext;
   workspaceDir?: string;
   agentId?: string;
+  onSessionMetadataChanged?: GetReplyOptions["onSessionMetadataChanged"];
   isGroup: boolean;
   agentCfg?: NonNullable<OpenClawConfig["agents"]>["defaults"];
   modelState: {

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -17,6 +17,8 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyTraceOverride, applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { isThinkingLevelSupported, resolveSupportedThinkingLevel } from "../thinking.js";
+import type { GetReplyOptions } from "../types.js";
+import { dispatchSessionMetadataChanged } from "./commands-session-store.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import {
@@ -100,6 +102,8 @@ export async function persistInlineDirectives(params: {
   senderIsOwner?: boolean;
   markLiveSwitchPending?: boolean;
   thinkingCatalog?: ModelCatalogEntry[];
+  agentId?: string;
+  onSessionMetadataChanged?: GetReplyOptions["onSessionMetadataChanged"];
 }): Promise<{
   provider: string;
   model: string;
@@ -378,6 +382,14 @@ export async function persistInlineDirectives(params: {
         elevatedChanged,
         reasoningChanged,
       });
+      await dispatchSessionMetadataChanged(
+        {
+          sessionKey,
+          ...(params.agentId ? { agentId: params.agentId } : {}),
+          reason: "command-metadata",
+        },
+        params.onSessionMetadataChanged,
+      );
     }
   }
 

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -5,7 +5,7 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { MsgContext } from "../templating.js";
 import type { ElevatedLevel } from "../thinking.js";
-import type { ReplyPayload } from "../types.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { CommandContext } from "./commands-types.js";
 import { isDirectiveOnly } from "./directive-handling.directive-only.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
@@ -126,6 +126,7 @@ export async function applyInlineDirectiveOverrides(params: {
   contextTokens: number;
   effectiveModelDirective?: string;
   typing: TypingController;
+  onSessionMetadataChanged?: GetReplyOptions["onSessionMetadataChanged"];
 }): Promise<ApplyDirectiveResult> {
   const {
     ctx,
@@ -252,6 +253,8 @@ export async function applyInlineDirectiveOverrides(params: {
     gatewayClientScopes: ctx.GatewayClientScopes,
     commandAuthorized: command.isAuthorizedSender,
     senderIsOwner: command.senderIsOwner,
+    agentId,
+    onSessionMetadataChanged: params.onSessionMetadataChanged,
   };
 
   if (
@@ -346,6 +349,8 @@ export async function applyInlineDirectiveOverrides(params: {
       gatewayClientScopes: ctx.GatewayClientScopes,
       commandAuthorized: command.isAuthorizedSender,
       senderIsOwner: command.senderIsOwner,
+      agentId,
+      onSessionMetadataChanged: params.onSessionMetadataChanged,
       workspaceDir,
     });
     let statusReply: ReplyPayload | undefined;
@@ -395,6 +400,7 @@ export async function applyInlineDirectiveOverrides(params: {
       workspaceDir,
       cfg,
       agentId,
+      onSessionMetadataChanged: params.onSessionMetadataChanged,
       isGroup,
       sessionEntry,
       sessionStore,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -633,6 +633,7 @@ export async function resolveReplyDirectives(params: {
     contextTokens,
     effectiveModelDirective,
     typing,
+    onSessionMetadataChanged: opts?.onSessionMetadataChanged,
   });
   if (applyResult.kind === "reply") {
     return { kind: "reply", reply: applyResult.reply };

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -4,6 +4,7 @@ export type {
   GetReplyOptions,
   PartialReplyPayload,
   ReplyThreadingPolicy,
+  SessionMetadataChangedEvent,
   TypingPolicy,
 } from "./get-reply-options.types.js";
 export {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -3360,7 +3360,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       let appendedWebchatAgentMedia = false;
       let agentRunStarted = false;
       const pendingSessionMetadataEvents: SessionMetadataChangedEvent[] = [];
-      const flushSessionMetadataEvents = (options?: {
+      const flushSessionMetadataEvents = async (options?: {
         excludeActiveRunIds?: readonly string[];
       }) => {
         while (pendingSessionMetadataEvents.length > 0) {
@@ -3368,14 +3368,20 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (!event) {
             continue;
           }
-          emitSessionsChanged(context, {
-            sessionKey: event.sessionKey,
-            ...(event.agentId ? { agentId: event.agentId } : {}),
-            reason: event.reason,
-            ...(options?.excludeActiveRunIds
-              ? { excludeActiveRunIds: options.excludeActiveRunIds }
-              : {}),
-          });
+          try {
+            await emitSessionsChanged(context, {
+              sessionKey: event.sessionKey,
+              ...(event.agentId ? { agentId: event.agentId } : {}),
+              reason: event.reason,
+              ...(options?.excludeActiveRunIds
+                ? { excludeActiveRunIds: options.excludeActiveRunIds }
+                : {}),
+            });
+          } catch (err) {
+            context.logGateway.warn(
+              `sessions.changed metadata broadcast failed: ${formatForLog(err)}`,
+            );
+          }
         }
       };
       const userTurnRecorder: UserTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
@@ -3602,7 +3608,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                   runId !== clientRunId ? { agentRunId: runId } : undefined,
                   dispatchStartedAtMs,
                 );
-                flushSessionMetadataEvents();
+                void flushSessionMetadataEvents();
                 const connId = typeof client?.connId === "string" ? client.connId : undefined;
                 const wantsToolEvents = hasGatewayClientCap(
                   client?.connect?.caps,
@@ -3655,7 +3661,7 @@ export const chatHandlers: GatewayRequestHandlers = {
               onSessionMetadataChanged: (event) => {
                 pendingSessionMetadataEvents.push(event);
                 if (agentRunStarted) {
-                  flushSessionMetadataEvents();
+                  void flushSessionMetadataEvents();
                 }
               },
             },
@@ -3663,7 +3669,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (dispatchResult.beforeAgentRunBlocked === true) {
             userTurnRecorder.markBlocked();
           }
-          flushSessionMetadataEvents(
+          await flushSessionMetadataEvents(
             agentRunStarted ? undefined : { excludeActiveRunIds: [clientRunId] },
           );
           return dispatchResult;
@@ -4276,8 +4282,8 @@ export const chatHandlers: GatewayRequestHandlers = {
             dispatchStartedAtMs,
           );
         })
-        .catch(async (err) => {
-          flushSessionMetadataEvents(
+        .catch(async (err: unknown) => {
+          await flushSessionMetadataEvents(
             agentRunStarted ? undefined : { excludeActiveRunIds: [clientRunId] },
           );
           const emitAfterError =

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -48,6 +48,7 @@ import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/rep
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
+import type { SessionMetadataChangedEvent } from "../../auto-reply/types.js";
 import { resolveSessionFilePath, updateSessionStoreEntry } from "../../config/sessions.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
@@ -164,6 +165,8 @@ import {
 } from "./chat-webchat-media.js";
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
+import { emitSessionsChanged } from "./session-change-events.js";
+import { loadOptionalSessionMetadataModelCatalog } from "./session-model-catalog.js";
 import type {
   GatewayClient,
   GatewayRequestContext,
@@ -3357,6 +3360,25 @@ export const chatHandlers: GatewayRequestHandlers = {
       const deliveredReplies: Array<{ payload: ReplyPayload; kind: "block" | "final" }> = [];
       let appendedWebchatAgentMedia = false;
       let agentRunStarted = false;
+      const pendingSessionMetadataEvents: SessionMetadataChangedEvent[] = [];
+      const flushSessionMetadataEvents = (options?: {
+        excludeActiveRunIds?: readonly string[];
+      }) => {
+        while (pendingSessionMetadataEvents.length > 0) {
+          const event = pendingSessionMetadataEvents.shift();
+          if (!event) {
+            continue;
+          }
+          emitSessionsChanged(context, {
+            sessionKey: event.sessionKey,
+            ...(event.agentId ? { agentId: event.agentId } : {}),
+            reason: event.reason,
+            ...(options?.excludeActiveRunIds
+              ? { excludeActiveRunIds: options.excludeActiveRunIds }
+              : {}),
+          });
+        }
+      };
       const userTurnRecorder: UserTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
         input: baseUserTurnInput,
         resolveInput: () => userTurnInputPromise,
@@ -3581,6 +3603,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                   runId !== clientRunId ? { agentRunId: runId } : undefined,
                   dispatchStartedAtMs,
                 );
+                flushSessionMetadataEvents();
                 const connId = typeof client?.connId === "string" ? client.connId : undefined;
                 const wantsToolEvents = hasGatewayClientCap(
                   client?.connect?.caps,
@@ -3630,11 +3653,20 @@ export const chatHandlers: GatewayRequestHandlers = {
                   dispatchStartedAtMs,
                 );
               },
+              onSessionMetadataChanged: (event) => {
+                pendingSessionMetadataEvents.push(event);
+                if (agentRunStarted) {
+                  flushSessionMetadataEvents();
+                }
+              },
             },
           });
           if (dispatchResult.beforeAgentRunBlocked === true) {
             userTurnRecorder.markBlocked();
           }
+          flushSessionMetadataEvents(
+            agentRunStarted ? undefined : { excludeActiveRunIds: [clientRunId] },
+          );
           return dispatchResult;
         },
         {
@@ -4245,7 +4277,10 @@ export const chatHandlers: GatewayRequestHandlers = {
             dispatchStartedAtMs,
           );
         })
-        .catch(async (err: unknown) => {
+        .catch(async (err) => {
+          flushSessionMetadataEvents(
+            agentRunStarted ? undefined : { excludeActiveRunIds: [clientRunId] },
+          );
           const emitAfterError =
             userTurnRecorder.hasPersisted() || userTurnRecorder.isBlocked()
               ? Promise.resolve()

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -166,7 +166,6 @@ import {
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-events.js";
-import { loadOptionalSessionMetadataModelCatalog } from "./session-model-catalog.js";
 import type {
   GatewayClient,
   GatewayRequestContext,

--- a/src/gateway/server-methods/optional-model-catalog.ts
+++ b/src/gateway/server-methods/optional-model-catalog.ts
@@ -13,9 +13,10 @@ const loggedSlowCatalogKeys = new Set<string>();
 
 /** Loads the gateway model catalog with a short timeout and one-time slow logs. */
 export async function loadOptionalServerMethodModelCatalog(
-  context: GatewayRequestContext,
+  context: Pick<GatewayRequestContext, "loadGatewayModelCatalog"> &
+    Partial<Pick<GatewayRequestContext, "logGateway">>,
   surface: string,
-  options?: { logOnceKey?: string },
+  options?: { logOnceKey?: string; readOnly?: boolean },
 ): Promise<ModelCatalogEntry[] | undefined> {
   let timeout: NodeJS.Timeout | undefined;
   const timedOut = Symbol("server-method-model-catalog-timeout");
@@ -25,14 +26,16 @@ export async function loadOptionalServerMethodModelCatalog(
   });
   try {
     const result = await Promise.race([
-      context.loadGatewayModelCatalog().catch(() => undefined),
+      context.loadGatewayModelCatalog({ readOnly: options?.readOnly ?? true }).catch(
+        () => undefined,
+      ),
       timeoutPromise,
     ]);
     if (result === timedOut) {
       const logOnceKey = options?.logOnceKey ?? "session-metadata";
       if (!loggedSlowCatalogKeys.has(logOnceKey)) {
         loggedSlowCatalogKeys.add(logOnceKey);
-        context.logGateway.debug(
+        context.logGateway?.debug(
           `${surface} continuing without model catalog after ${OPTIONAL_MODEL_CATALOG_TIMEOUT_MS}ms`,
         );
       }

--- a/src/gateway/server-methods/session-change-events.ts
+++ b/src/gateway/server-methods/session-change-events.ts
@@ -1,6 +1,7 @@
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { normalizeAgentId, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
 import { loadGatewaySessionRow } from "../session-utils.js";
+import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
 import type { GatewayRequestContext } from "./types.js";
 
 type TrackedActiveSessionRun = {
@@ -105,7 +106,8 @@ export function emitSessionsChanged(
     | "chatAbortControllers"
     | "getRuntimeConfig"
     | "getSessionEventSubscriberConnIds"
-  >,
+  > &
+    Partial<Pick<GatewayRequestContext, "loadGatewayModelCatalog" | "logGateway">>,
   payload: {
     sessionKey?: string;
     agentId?: string;
@@ -114,17 +116,51 @@ export function emitSessionsChanged(
     hasActiveRun?: boolean;
     excludeActiveRunIds?: readonly string[];
   },
-) {
+): Promise<void> {
   const connIds = context.getSessionEventSubscriberConnIds();
   if (connIds.size === 0) {
-    return;
+    return Promise.resolve();
   }
+  return emitSessionsChangedWithSubscribers(context, payload, connIds);
+}
+
+async function emitSessionsChangedWithSubscribers(
+  context: Pick<
+    GatewayRequestContext,
+    "broadcastToConnIds" | "chatAbortControllers" | "getRuntimeConfig"
+  > &
+    Partial<Pick<GatewayRequestContext, "loadGatewayModelCatalog" | "logGateway">>,
+  payload: {
+    sessionKey?: string;
+    agentId?: string;
+    reason: string;
+    compacted?: boolean;
+    hasActiveRun?: boolean;
+    excludeActiveRunIds?: readonly string[];
+  },
+  connIds: ReadonlySet<string>,
+) {
+  const modelCatalog =
+    payload.sessionKey && context.loadGatewayModelCatalog
+      ? await loadOptionalServerMethodModelCatalog(
+          {
+            loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+            ...(context.logGateway ? { logGateway: context.logGateway } : {}),
+          },
+          "sessions.changed",
+          { logOnceKey: "sessions.changed", readOnly: true },
+        )
+      : undefined;
+  const hasCatalogBackedThinkingMetadata = Array.isArray(modelCatalog);
   const sessionRow = payload.sessionKey
     ? loadGatewaySessionRow(
         payload.sessionKey,
-        payload.sessionKey === "global" && payload.agentId
-          ? { agentId: payload.agentId }
-          : undefined,
+        {
+          ...(payload.sessionKey === "global" && payload.agentId
+            ? { agentId: payload.agentId }
+            : {}),
+          ...(hasCatalogBackedThinkingMetadata ? { modelCatalog } : {}),
+        },
       )
     : null;
   const omitUnscopedGlobalGoal = payload.sessionKey === "global" && !payload.agentId;
@@ -183,9 +219,13 @@ export function emitSessionsChanged(
             responseUsage: sessionRow.responseUsage,
             modelProvider: sessionRow.modelProvider,
             model: sessionRow.model,
-            thinkingLevels: sessionRow.thinkingLevels,
-            thinkingOptions: sessionRow.thinkingOptions,
-            thinkingDefault: sessionRow.thinkingDefault,
+            ...(hasCatalogBackedThinkingMetadata
+              ? {
+                  thinkingLevels: sessionRow.thinkingLevels,
+                  thinkingOptions: sessionRow.thinkingOptions,
+                  thinkingDefault: sessionRow.thinkingDefault,
+                }
+              : {}),
             status: sessionRow.status,
             hasActiveRun:
               payload.hasActiveRun ??

--- a/src/gateway/server-methods/session-change-events.ts
+++ b/src/gateway/server-methods/session-change-events.ts
@@ -176,6 +176,9 @@ export function emitSessionsChanged(
             responseUsage: sessionRow.responseUsage,
             modelProvider: sessionRow.modelProvider,
             model: sessionRow.model,
+            thinkingLevels: sessionRow.thinkingLevels,
+            thinkingOptions: sessionRow.thinkingOptions,
+            thinkingDefault: sessionRow.thinkingDefault,
             status: sessionRow.status,
             hasActiveRun:
               payload.hasActiveRun ??

--- a/src/gateway/server-methods/session-change-events.ts
+++ b/src/gateway/server-methods/session-change-events.ts
@@ -1,5 +1,5 @@
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
+import { normalizeAgentId, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
 import { loadGatewaySessionRow } from "../session-utils.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -58,11 +58,20 @@ function hasTrackedActiveSessionRun(params: {
   canonicalKey: string;
   agentId?: string;
   defaultAgentId?: string;
+  mainKey?: string;
   excludeRunIds?: ReadonlySet<string>;
 }): boolean {
   const activeRuns = collectTrackedActiveSessionRuns(params.context, {
     excludeRunIds: params.excludeRunIds,
   });
+  const scopedGlobalKey =
+    params.canonicalKey === "global" && params.agentId
+      ? scopeLegacySessionKeyToAgent({
+          agentId: params.agentId,
+          sessionKey: params.canonicalKey,
+          mainKey: params.mainKey,
+        })
+      : undefined;
   return activeRuns.some(
     (active) =>
       isTrackedActiveSessionRunForKey(
@@ -76,7 +85,9 @@ function hasTrackedActiveSessionRun(params: {
         params.requestedKey,
         params.agentId,
         params.defaultAgentId,
-      ),
+      ) ||
+      (scopedGlobalKey !== undefined &&
+        isTrackedActiveSessionRunForKey(active, scopedGlobalKey)),
   );
 }
 
@@ -110,7 +121,8 @@ export function emitSessionsChanged(
       )
     : null;
   const omitUnscopedGlobalGoal = payload.sessionKey === "global" && !payload.agentId;
-  const defaultAgentId = resolveDefaultAgentId(context.getRuntimeConfig());
+  const cfg = context.getRuntimeConfig();
+  const defaultAgentId = resolveDefaultAgentId(cfg);
   const { excludeActiveRunIds, ...eventPayload } = payload;
   const excludeRunIds = new Set(excludeActiveRunIds ?? []);
   context.broadcastToConnIds(
@@ -173,6 +185,7 @@ export function emitSessionsChanged(
                 canonicalKey: sessionRow.key,
                 agentId: sessionRow.key === "global" ? payload.agentId : undefined,
                 defaultAgentId,
+                mainKey: cfg.session?.mainKey,
                 excludeRunIds,
               }),
             startedAt: sessionRow.startedAt,

--- a/src/gateway/server-methods/session-change-events.ts
+++ b/src/gateway/server-methods/session-change-events.ts
@@ -1,0 +1,190 @@
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import { loadGatewaySessionRow } from "../session-utils.js";
+import type { GatewayRequestContext } from "./types.js";
+
+type TrackedActiveSessionRun = {
+  runId: string;
+  sessionKey: string;
+  agentId?: string;
+};
+
+function collectTrackedActiveSessionRuns(
+  context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>,
+  options?: { excludeRunIds?: ReadonlySet<string> },
+): TrackedActiveSessionRun[] {
+  const runs: TrackedActiveSessionRun[] = [];
+  if (!(context.chatAbortControllers instanceof Map)) {
+    return runs;
+  }
+  for (const [runId, active] of context.chatAbortControllers) {
+    if (options?.excludeRunIds?.has(runId)) {
+      continue;
+    }
+    if (
+      active.projectSessionActive !== false &&
+      typeof active.sessionKey === "string" &&
+      active.sessionKey.trim()
+    ) {
+      runs.push({
+        runId,
+        sessionKey: active.sessionKey,
+        agentId: typeof active.agentId === "string" ? normalizeAgentId(active.agentId) : undefined,
+      });
+    }
+  }
+  return runs;
+}
+
+function isTrackedActiveSessionRunForKey(
+  active: TrackedActiveSessionRun,
+  key: string,
+  agentId?: string,
+  defaultAgentId?: string,
+): boolean {
+  if (active.sessionKey !== key) {
+    return false;
+  }
+  if (key !== "global" || agentId === undefined) {
+    return true;
+  }
+  const activeAgentId = active.agentId ?? defaultAgentId;
+  return activeAgentId ? normalizeAgentId(activeAgentId) === normalizeAgentId(agentId) : false;
+}
+
+function hasTrackedActiveSessionRun(params: {
+  context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>;
+  requestedKey: string;
+  canonicalKey: string;
+  agentId?: string;
+  defaultAgentId?: string;
+  excludeRunIds?: ReadonlySet<string>;
+}): boolean {
+  const activeRuns = collectTrackedActiveSessionRuns(params.context, {
+    excludeRunIds: params.excludeRunIds,
+  });
+  return activeRuns.some(
+    (active) =>
+      isTrackedActiveSessionRunForKey(
+        active,
+        params.canonicalKey,
+        params.agentId,
+        params.defaultAgentId,
+      ) ||
+      isTrackedActiveSessionRunForKey(
+        active,
+        params.requestedKey,
+        params.agentId,
+        params.defaultAgentId,
+      ),
+  );
+}
+
+export function emitSessionsChanged(
+  context: Pick<
+    GatewayRequestContext,
+    | "broadcastToConnIds"
+    | "chatAbortControllers"
+    | "getRuntimeConfig"
+    | "getSessionEventSubscriberConnIds"
+  >,
+  payload: {
+    sessionKey?: string;
+    agentId?: string;
+    reason: string;
+    compacted?: boolean;
+    hasActiveRun?: boolean;
+    excludeActiveRunIds?: readonly string[];
+  },
+) {
+  const connIds = context.getSessionEventSubscriberConnIds();
+  if (connIds.size === 0) {
+    return;
+  }
+  const sessionRow = payload.sessionKey
+    ? loadGatewaySessionRow(
+        payload.sessionKey,
+        payload.sessionKey === "global" && payload.agentId
+          ? { agentId: payload.agentId }
+          : undefined,
+      )
+    : null;
+  const omitUnscopedGlobalGoal = payload.sessionKey === "global" && !payload.agentId;
+  const defaultAgentId = resolveDefaultAgentId(context.getRuntimeConfig());
+  const { excludeActiveRunIds, ...eventPayload } = payload;
+  const excludeRunIds = new Set(excludeActiveRunIds ?? []);
+  context.broadcastToConnIds(
+    "sessions.changed",
+    {
+      ...eventPayload,
+      ts: Date.now(),
+      ...(sessionRow
+        ? {
+            updatedAt: sessionRow.updatedAt ?? undefined,
+            sessionId: sessionRow.sessionId,
+            kind: sessionRow.kind,
+            channel: sessionRow.channel,
+            subject: sessionRow.subject,
+            groupChannel: sessionRow.groupChannel,
+            space: sessionRow.space,
+            chatType: sessionRow.chatType,
+            origin: sessionRow.origin,
+            spawnedBy: sessionRow.spawnedBy,
+            spawnedWorkspaceDir: sessionRow.spawnedWorkspaceDir,
+            spawnedCwd: sessionRow.spawnedCwd,
+            forkedFromParent: sessionRow.forkedFromParent,
+            spawnDepth: sessionRow.spawnDepth,
+            subagentRole: sessionRow.subagentRole,
+            subagentControlScope: sessionRow.subagentControlScope,
+            label: sessionRow.label,
+            displayName: sessionRow.displayName,
+            deliveryContext: sessionRow.deliveryContext,
+            parentSessionKey: sessionRow.parentSessionKey,
+            childSessions: sessionRow.childSessions,
+            thinkingLevel: sessionRow.thinkingLevel,
+            fastMode: sessionRow.fastMode,
+            verboseLevel: sessionRow.verboseLevel,
+            traceLevel: sessionRow.traceLevel,
+            reasoningLevel: sessionRow.reasoningLevel,
+            elevatedLevel: sessionRow.elevatedLevel,
+            sendPolicy: sessionRow.sendPolicy,
+            systemSent: sessionRow.systemSent,
+            abortedLastRun: sessionRow.abortedLastRun,
+            inputTokens: sessionRow.inputTokens,
+            outputTokens: sessionRow.outputTokens,
+            lastChannel: sessionRow.lastChannel,
+            lastTo: sessionRow.lastTo,
+            lastAccountId: sessionRow.lastAccountId,
+            lastThreadId: sessionRow.lastThreadId,
+            totalTokens: sessionRow.totalTokens,
+            totalTokensFresh: sessionRow.totalTokensFresh,
+            ...(omitUnscopedGlobalGoal ? {} : { goal: sessionRow.goal ?? null }),
+            contextTokens: sessionRow.contextTokens,
+            estimatedCostUsd: sessionRow.estimatedCostUsd,
+            responseUsage: sessionRow.responseUsage,
+            modelProvider: sessionRow.modelProvider,
+            model: sessionRow.model,
+            status: sessionRow.status,
+            hasActiveRun:
+              payload.hasActiveRun ??
+              hasTrackedActiveSessionRun({
+                context,
+                requestedKey: payload.sessionKey ?? sessionRow.key,
+                canonicalKey: sessionRow.key,
+                agentId: sessionRow.key === "global" ? payload.agentId : undefined,
+                defaultAgentId,
+                excludeRunIds,
+              }),
+            startedAt: sessionRow.startedAt,
+            endedAt: sessionRow.endedAt,
+            runtimeMs: sessionRow.runtimeMs,
+            compactionCheckpointCount: sessionRow.compactionCheckpointCount,
+            latestCompactionCheckpoint: sessionRow.latestCompactionCheckpoint,
+            pluginExtensions: sessionRow.pluginExtensions,
+          }
+        : {}),
+    },
+    connIds,
+    { dropIfSlow: true },
+  );
+}

--- a/src/gateway/server-methods/session-change-events.ts
+++ b/src/gateway/server-methods/session-change-events.ts
@@ -23,6 +23,7 @@ function collectTrackedActiveSessionRuns(
     }
     if (
       active.projectSessionActive !== false &&
+      active.controlUiVisible !== false &&
       typeof active.sessionKey === "string" &&
       active.sessionKey.trim()
     ) {
@@ -45,11 +46,17 @@ function isTrackedActiveSessionRunForKey(
   if (active.sessionKey !== key) {
     return false;
   }
-  if (key !== "global" || agentId === undefined) {
+  if (key !== "global") {
+    return true;
+  }
+  const requestedAgentId = agentId ?? defaultAgentId;
+  if (!requestedAgentId) {
     return true;
   }
   const activeAgentId = active.agentId ?? defaultAgentId;
-  return activeAgentId ? normalizeAgentId(activeAgentId) === normalizeAgentId(agentId) : false;
+  return activeAgentId
+    ? normalizeAgentId(activeAgentId) === normalizeAgentId(requestedAgentId)
+    : false;
 }
 
 function hasTrackedActiveSessionRun(params: {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -912,7 +912,7 @@ async function handleSessionSend(params: {
         runId: startedRunId,
       });
     }
-    emitSessionsChanged(params.context, {
+    await emitSessionsChanged(params.context, {
       sessionKey: canonicalKey,
       ...(canonicalKey === "global" && requestedAgentId ? { agentId: requestedAgentId } : {}),
       reason: interruptedActiveRun ? "steer" : "send",
@@ -1037,7 +1037,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       });
       respond(true, result, undefined);
       for (const summary of appliedSummaries) {
-        emitSessionsChanged(context, {
+        await emitSessionsChanged(context, {
           reason: "cleanup",
           sessionKey: undefined,
         });
@@ -1424,7 +1424,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           },
           undefined,
         );
-        emitSessionsChanged(context, {
+        await emitSessionsChanged(context, {
           sessionKey: resetResult.key,
           ...(resetResult.key === "global" ? { agentId: resetResult.agentId } : {}),
           reason: "new",
@@ -1609,13 +1609,13 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
-    emitSessionsChanged(context, {
+    await emitSessionsChanged(context, {
       sessionKey: target.canonicalKey,
       ...(target.canonicalKey === "global" ? { agentId: target.agentId } : {}),
       reason: "create",
     });
     if (runStarted) {
-      emitSessionsChanged(context, {
+      await emitSessionsChanged(context, {
         sessionKey: target.canonicalKey,
         ...(target.canonicalKey === "global" ? { agentId: target.agentId } : {}),
         reason: "send",
@@ -1750,14 +1750,14 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
-    emitSessionsChanged(context, {
+    await emitSessionsChanged(context, {
       sessionKey: canonicalKey,
       ...(canonicalKey === "global" && requestedAgent.agentId
         ? { agentId: requestedAgent.agentId }
         : {}),
       reason: "checkpoint-branch",
     });
-    emitSessionsChanged(context, {
+    await emitSessionsChanged(context, {
       sessionKey: nextKey,
       reason: "checkpoint-branch",
     });
@@ -1871,7 +1871,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
-    emitSessionsChanged(context, {
+    await emitSessionsChanged(context, {
       sessionKey: canonicalKey,
       ...(canonicalKey === "global" && requestedAgent.agentId
         ? { agentId: requestedAgent.agentId }
@@ -2066,7 +2066,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       isWebchatConnect,
     });
     if (abortedRunId) {
-      emitSessionsChanged(context, {
+      await emitSessionsChanged(context, {
         sessionKey: canonicalKey,
         ...(canonicalKey === "global" && abortAgentId ? { agentId: abortAgentId } : {}),
         reason: "abort",
@@ -2159,7 +2159,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
     };
     respond(true, result, undefined);
-    emitSessionsChanged(context, {
+    await emitSessionsChanged(context, {
       sessionKey: target.canonicalKey,
       ...(target.canonicalKey === "global" && requestedAgentId
         ? { agentId: requestedAgentId }
@@ -2237,7 +2237,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     respond(true, { ok: true, key: patched.key, value: patched.value }, undefined);
-    emitSessionsChanged(context, {
+    await emitSessionsChanged(context, {
       sessionKey: patched.key,
       reason: "plugin-patch",
     });
@@ -2265,7 +2265,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     respond(true, { ok: true, key: result.key, entry: result.entry }, undefined);
-    emitSessionsChanged(context, {
+    await emitSessionsChanged(context, {
       sessionKey: result.key,
       ...(result.key === "global" ? { agentId: result.agentId } : {}),
       reason,
@@ -2382,7 +2382,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     respond(true, { ok: true, key: target.canonicalKey, deleted, archived }, undefined);
     if (deleted) {
-      emitSessionsChanged(context, {
+      await emitSessionsChanged(context, {
         sessionKey: target.canonicalKey,
         ...(target.canonicalKey === "global" && requestedAgentId
           ? { agentId: requestedAgentId }
@@ -2631,7 +2631,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         undefined,
       );
       if (result.ok) {
-        emitSessionsChanged(context, {
+        await emitSessionsChanged(context, {
           sessionKey: target.canonicalKey,
           ...(target.canonicalKey === "global" && target.agentId
             ? { agentId: target.agentId }
@@ -2694,7 +2694,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
-    emitSessionsChanged(context, {
+    await emitSessionsChanged(context, {
       sessionKey: target.canonicalKey,
       ...(target.canonicalKey === "global" && target.agentId ? { agentId: target.agentId } : {}),
       reason: "compact",

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -124,7 +124,6 @@ import { chatHandlers } from "./chat.js";
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-events.js";
-import { loadOptionalSessionMetadataModelCatalog } from "./session-model-catalog.js";
 import type {
   GatewayClient,
   GatewayRequestContext,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -100,7 +100,6 @@ import {
   buildGatewaySessionRow,
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
-  loadGatewaySessionRow,
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,
   readRecentSessionMessagesWithStatsAsync,
@@ -124,6 +123,8 @@ import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { chatHandlers } from "./chat.js";
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
+import { emitSessionsChanged } from "./session-change-events.js";
+import { loadOptionalSessionMetadataModelCatalog } from "./session-model-catalog.js";
 import type {
   GatewayClient,
   GatewayRequestContext,
@@ -283,103 +284,6 @@ function shouldAttachPendingMessageSeq(params: { payload: unknown; cached?: bool
       ? (params.payload as { status?: unknown }).status
       : undefined;
   return status === "started";
-}
-
-function emitSessionsChanged(
-  context: Pick<
-    GatewayRequestContext,
-    | "broadcastToConnIds"
-    | "chatAbortControllers"
-    | "getRuntimeConfig"
-    | "getSessionEventSubscriberConnIds"
-  >,
-  payload: { sessionKey?: string; agentId?: string; reason: string; compacted?: boolean },
-) {
-  const connIds = context.getSessionEventSubscriberConnIds();
-  if (connIds.size === 0) {
-    return;
-  }
-  const sessionRow = payload.sessionKey
-    ? loadGatewaySessionRow(
-        payload.sessionKey,
-        payload.sessionKey === "global" && payload.agentId
-          ? { agentId: payload.agentId }
-          : undefined,
-      )
-    : null;
-  const omitUnscopedGlobalGoal = payload.sessionKey === "global" && !payload.agentId;
-  const defaultAgentId = resolveDefaultAgentId(context.getRuntimeConfig());
-  context.broadcastToConnIds(
-    "sessions.changed",
-    {
-      ...payload,
-      ts: Date.now(),
-      ...(sessionRow
-        ? {
-            updatedAt: sessionRow.updatedAt ?? undefined,
-            sessionId: sessionRow.sessionId,
-            kind: sessionRow.kind,
-            channel: sessionRow.channel,
-            subject: sessionRow.subject,
-            groupChannel: sessionRow.groupChannel,
-            space: sessionRow.space,
-            chatType: sessionRow.chatType,
-            origin: sessionRow.origin,
-            spawnedBy: sessionRow.spawnedBy,
-            spawnedWorkspaceDir: sessionRow.spawnedWorkspaceDir,
-            spawnedCwd: sessionRow.spawnedCwd,
-            forkedFromParent: sessionRow.forkedFromParent,
-            spawnDepth: sessionRow.spawnDepth,
-            subagentRole: sessionRow.subagentRole,
-            subagentControlScope: sessionRow.subagentControlScope,
-            label: sessionRow.label,
-            displayName: sessionRow.displayName,
-            deliveryContext: sessionRow.deliveryContext,
-            parentSessionKey: sessionRow.parentSessionKey,
-            childSessions: sessionRow.childSessions,
-            thinkingLevel: sessionRow.thinkingLevel,
-            fastMode: sessionRow.fastMode,
-            verboseLevel: sessionRow.verboseLevel,
-            traceLevel: sessionRow.traceLevel,
-            reasoningLevel: sessionRow.reasoningLevel,
-            elevatedLevel: sessionRow.elevatedLevel,
-            sendPolicy: sessionRow.sendPolicy,
-            systemSent: sessionRow.systemSent,
-            abortedLastRun: sessionRow.abortedLastRun,
-            inputTokens: sessionRow.inputTokens,
-            outputTokens: sessionRow.outputTokens,
-            lastChannel: sessionRow.lastChannel,
-            lastTo: sessionRow.lastTo,
-            lastAccountId: sessionRow.lastAccountId,
-            lastThreadId: sessionRow.lastThreadId,
-            totalTokens: sessionRow.totalTokens,
-            totalTokensFresh: sessionRow.totalTokensFresh,
-            ...(omitUnscopedGlobalGoal ? {} : { goal: sessionRow.goal ?? null }),
-            contextTokens: sessionRow.contextTokens,
-            estimatedCostUsd: sessionRow.estimatedCostUsd,
-            responseUsage: sessionRow.responseUsage,
-            modelProvider: sessionRow.modelProvider,
-            model: sessionRow.model,
-            status: sessionRow.status,
-            hasActiveRun: hasTrackedActiveSessionRun({
-              context,
-              requestedKey: payload.sessionKey ?? sessionRow.key,
-              canonicalKey: sessionRow.key,
-              agentId: sessionRow.key === "global" ? payload.agentId : undefined,
-              defaultAgentId,
-            }),
-            startedAt: sessionRow.startedAt,
-            endedAt: sessionRow.endedAt,
-            runtimeMs: sessionRow.runtimeMs,
-            compactionCheckpointCount: sessionRow.compactionCheckpointCount,
-            latestCompactionCheckpoint: sessionRow.latestCompactionCheckpoint,
-            pluginExtensions: sessionRow.pluginExtensions,
-          }
-        : {}),
-    },
-    connIds,
-    { dropIfSlow: true },
-  );
 }
 
 function emitSessionOperation(

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -242,13 +242,18 @@ export function createLifecycleEventBroadcastHandler(params: {
       "sessions.changed",
       {
         sessionKey: event.sessionKey,
+        ...(event.agentId ? { agentId: event.agentId } : {}),
         reason: event.reason,
         parentSessionKey: event.parentSessionKey,
         label: event.label,
         displayName: event.displayName,
         ts: Date.now(),
         ...buildGatewaySessionSnapshot({
-          sessionRow: loadGatewaySessionRow(event.sessionKey),
+          sessionRow: loadGatewaySessionRow(
+            event.sessionKey,
+            event.agentId ? { agentId: event.agentId } : undefined,
+          ),
+          agentId: event.agentId,
           label: event.label,
           displayName: event.displayName,
           parentSessionKey: event.parentSessionKey,

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -1031,6 +1031,65 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.send broadcasts sessions.changed when in-chat command metadata changes", async () => {
+    await withMainSessionStore(async () => {
+      const subscribeRes = await rpcReq(ws, "sessions.subscribe", {});
+      expect(subscribeRes.ok).toBe(true);
+      const changedPromise = onceMessage(
+        ws,
+        (o) =>
+          o.type === "event" &&
+          o.event === "sessions.changed" &&
+          o.payload?.reason === "command-metadata",
+        8000,
+      );
+
+      dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            replyOptions?: {
+              onSessionMetadataChanged?: (event: {
+                sessionKey: string;
+                reason: "command-metadata";
+              }) => Promise<void> | void;
+            };
+          },
+        ];
+        await writeSessionStore({
+          entries: {
+            main: {
+              sessionId: "sess-main",
+              updatedAt: 99,
+              label: "Command label",
+            },
+          },
+        });
+        await params.replyOptions?.onSessionMetadataChanged?.({
+          sessionKey: "agent:main:main",
+          reason: "command-metadata",
+        });
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+      });
+
+      const res = await rpcReq(ws, "chat.send", {
+        sessionKey: "main",
+        message: "/goal clear",
+        idempotencyKey: "idem-command-metadata-1",
+      });
+
+      expect(res.ok).toBe(true);
+      const changed = await changedPromise;
+      expectRecordFields(changed.payload, {
+        sessionKey: "agent:main:main",
+        reason: "command-metadata",
+        sessionId: "sess-main",
+        label: "Command label",
+        goal: null,
+        hasActiveRun: false,
+      });
+    });
+  });
+
   test("routes /btw replies through side-result events without transcript injection", async () => {
     await withMainSessionStore(async (dir) => {
       await fs.writeFile(

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -149,7 +149,7 @@ async function invokeSessionMutation({
     context: {
       broadcastToConnIds,
       getSessionEventSubscriberConnIds: () => subscribedConnIds,
-      loadGatewayModelCatalog: async () => ({ providers: [] }),
+      loadGatewayModelCatalog: async () => [],
       getRuntimeConfig,
       ...context,
     } as never,
@@ -162,8 +162,8 @@ async function invokeSessionMutation({
   };
 }
 
-async function invokeSessionsPatch(params: Record<string, unknown>) {
-  return invokeSessionMutation({ method: "sessions.patch", params });
+async function invokeSessionsPatch(params: Record<string, unknown>, context = {}) {
+  return invokeSessionMutation({ method: "sessions.patch", params, context });
 }
 
 async function writeMainSessionStore(options?: SessionStoreEntryOptions) {
@@ -442,6 +442,50 @@ test("sessions.list does not block on slow model catalog discovery", async () =>
   }
 });
 
+test("sessions.changed command metadata does not block on slow model catalog discovery", async () => {
+  await writeMainSessionStore({
+    modelProvider: "test-provider",
+    model: "reasoner",
+  });
+
+  vi.useFakeTimers();
+  try {
+    const deferredCatalog = createDeferred<never>();
+    const broadcastToConnIds = vi.fn();
+    const { getRuntimeConfig } = await getGatewayConfigModule();
+    const request = emitSessionsChanged(
+      {
+        broadcastToConnIds,
+        getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+        getRuntimeConfig,
+        loadGatewayModelCatalog: vi.fn(() => deferredCatalog.promise),
+        logGateway: {
+          debug: vi.fn(),
+        },
+      } as never,
+      {
+        sessionKey: "agent:main:main",
+        reason: "command-metadata",
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(800);
+    await request;
+
+    const payload = expectChangedBroadcast(broadcastToConnIds, {
+      sessionKey: "agent:main:main",
+      reason: "command-metadata",
+      modelProvider: "test-provider",
+      model: "reasoner",
+    });
+    expect(payload.thinkingLevels).toBeUndefined();
+    expect(payload.thinkingOptions).toBeUndefined();
+    expect(payload.thinkingDefault).toBeUndefined();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 test("sessions.changed mutation events include live usage metadata", async () => {
   const { dir } = await createSessionStoreDir();
   await fs.writeFile(
@@ -504,7 +548,7 @@ test("sessions.changed command metadata excludes only the command run from activ
 
   const broadcastToConnIds = vi.fn();
   const { getRuntimeConfig } = await getGatewayConfigModule();
-  emitSessionsChanged(
+  await emitSessionsChanged(
     {
       broadcastToConnIds,
       getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
@@ -539,7 +583,7 @@ test("sessions.changed command metadata ignores hidden internal active runs", as
 
   const broadcastToConnIds = vi.fn();
   const { getRuntimeConfig } = await getGatewayConfigModule();
-  emitSessionsChanged(
+  await emitSessionsChanged(
     {
       broadcastToConnIds,
       getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
@@ -616,7 +660,7 @@ test("sessions.changed command metadata marks selected global runs active", asyn
   clearConfigCache();
 
   const broadcastToConnIds = vi.fn();
-  emitSessionsChanged(
+  await emitSessionsChanged(
     {
       broadcastToConnIds,
       getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
@@ -649,10 +693,10 @@ test("sessions.changed command metadata marks selected global runs active", asyn
 });
 
 test("sessions.changed command metadata scopes untagged global runs to the default agent", async () => {
-  const globalStores = await setupGlobalAgentSessionStores({ writePrimeStore: true });
+  const globalStores = await createConfiguredGlobalAgentSessionStore({ writePrimeStore: true });
 
   const broadcastToConnIds = vi.fn();
-  emitSessionsChanged(
+  await emitSessionsChanged(
     {
       broadcastToConnIds,
       getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
@@ -671,7 +715,7 @@ test("sessions.changed command metadata scopes untagged global runs to the defau
     sessionId: "sess-main-global",
     hasActiveRun: false,
   });
-  await resetGlobalAgentSessionStores(globalStores);
+  await resetConfiguredGlobalAgentSessionStore(globalStores);
 });
 
 test("sessions.changed mutation events include live session setting metadata", async () => {
@@ -700,6 +744,41 @@ test("sessions.changed mutation events include live session setting metadata", a
     "high",
   );
   expect(changedPayload.thinkingDefault).toEqual(expect.any(String));
+});
+
+test("sessions.changed mutation events use catalog-backed thinking metadata", async () => {
+  await writeMainSessionStore({
+    modelProvider: "test-provider",
+    model: "reasoner",
+  });
+  const loadGatewayModelCatalog = vi.fn(async () => [
+    {
+      provider: "test-provider",
+      id: "reasoner",
+      name: "Reasoner",
+      reasoning: true,
+      compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
+    },
+  ]);
+
+  const result = await invokeSessionsPatch(
+    {
+      key: "main",
+      label: "Renamed",
+    },
+    { loadGatewayModelCatalog },
+  );
+
+  const changedPayload = expectMainPatchBroadcast(result, {
+    label: "Renamed",
+  });
+  expect(requireArray(changedPayload.thinkingLevels, "broadcast thinking levels")).toContainEqual(
+    expect.objectContaining({ id: "xhigh" }),
+  );
+  expect(requireArray(changedPayload.thinkingOptions, "broadcast thinking options")).toContain(
+    "xhigh",
+  );
+  expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ readOnly: true });
 });
 
 test("sessions.changed mutation events include sendPolicy metadata", async () => {

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -529,6 +529,91 @@ test("sessions.changed command metadata excludes only the command run from activ
   expect(payload.excludeActiveRunIds).toBeUndefined();
 });
 
+test("sessions.changed command metadata marks selected global runs active", async () => {
+  const { dir } = await createSessionStoreDir();
+  const storeTemplate = path.join(dir, "{agentId}", "sessions.json");
+  testState.sessionStorePath = storeTemplate;
+  testState.sessionConfig = { scope: "global" };
+  await writeSessionStore({
+    entries: {},
+    storePath: path.join(dir, "prime-sessions.json"),
+  });
+  const mainStorePath = storeTemplate.replace("{agentId}", "main");
+  const workStorePath = storeTemplate.replace("{agentId}", "work");
+  await fs.mkdir(path.dirname(mainStorePath), { recursive: true });
+  await fs.mkdir(path.dirname(workStorePath), { recursive: true });
+  await fs.writeFile(
+    mainStorePath,
+    JSON.stringify({ global: sessionStoreEntry("sess-main-global") }, null, 2),
+    "utf-8",
+  );
+  await fs.writeFile(
+    workStorePath,
+    JSON.stringify(
+      {
+        global: sessionStoreEntry("sess-work-global", {
+          label: "Work global",
+        }),
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  const configPath = process.env.OPENCLAW_CONFIG_PATH;
+  if (!configPath) {
+    throw new Error("OPENCLAW_CONFIG_PATH is required");
+  }
+  await fs.writeFile(
+    configPath,
+    `${JSON.stringify(
+      {
+        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+        session: { scope: "global", store: storeTemplate },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+  const { clearConfigCache, clearRuntimeConfigSnapshot, getRuntimeConfig } =
+    await getGatewayConfigModule();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+
+  const broadcastToConnIds = vi.fn();
+  emitSessionsChanged(
+    {
+      broadcastToConnIds,
+      getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+      getRuntimeConfig,
+      chatAbortControllers: new Map([["agent-run", { sessionKey: "agent:work:global" }]]),
+    } as never,
+    {
+      sessionKey: "global",
+      agentId: "work",
+      reason: "command-metadata",
+      excludeActiveRunIds: ["command-run"],
+    },
+  );
+
+  const payload = expectChangedBroadcast(broadcastToConnIds, {
+    sessionKey: "global",
+    agentId: "work",
+    reason: "command-metadata",
+    sessionId: "sess-work-global",
+    label: "Work global",
+    hasActiveRun: true,
+  });
+  expect(payload.excludeActiveRunIds).toBeUndefined();
+
+  testState.sessionStorePath = undefined;
+  testState.sessionConfig = undefined;
+  await fs.writeFile(configPath, "{}\n", "utf-8");
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+});
+
 test("sessions.changed mutation events include live session setting metadata", async () => {
   const sessionSettings = {
     verboseLevel: "on",

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -529,6 +529,40 @@ test("sessions.changed command metadata excludes only the command run from activ
   expect(payload.excludeActiveRunIds).toBeUndefined();
 });
 
+test("sessions.changed command metadata ignores hidden internal active runs", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main"),
+    },
+  });
+
+  const broadcastToConnIds = vi.fn();
+  const { getRuntimeConfig } = await getGatewayConfigModule();
+  emitSessionsChanged(
+    {
+      broadcastToConnIds,
+      getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+      getRuntimeConfig,
+      chatAbortControllers: new Map([
+        ["command-run", { sessionKey: "agent:main:main" }],
+        ["hidden-run", { sessionKey: "agent:main:main", controlUiVisible: false }],
+      ]),
+    } as never,
+    {
+      sessionKey: "agent:main:main",
+      reason: "command-metadata",
+      excludeActiveRunIds: ["command-run"],
+    },
+  );
+
+  expectChangedBroadcast(broadcastToConnIds, {
+    sessionKey: "agent:main:main",
+    reason: "command-metadata",
+    hasActiveRun: false,
+  });
+});
+
 test("sessions.changed command metadata marks selected global runs active", async () => {
   const { dir } = await createSessionStoreDir();
   const storeTemplate = path.join(dir, "{agentId}", "sessions.json");
@@ -612,6 +646,32 @@ test("sessions.changed command metadata marks selected global runs active", asyn
   await fs.writeFile(configPath, "{}\n", "utf-8");
   clearRuntimeConfigSnapshot();
   clearConfigCache();
+});
+
+test("sessions.changed command metadata scopes untagged global runs to the default agent", async () => {
+  const globalStores = await setupGlobalAgentSessionStores({ writePrimeStore: true });
+
+  const broadcastToConnIds = vi.fn();
+  emitSessionsChanged(
+    {
+      broadcastToConnIds,
+      getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+      getRuntimeConfig: globalStores.getRuntimeConfig,
+      chatAbortControllers: new Map([["work-run", { sessionKey: "global", agentId: "work" }]]),
+    } as never,
+    {
+      sessionKey: "global",
+      reason: "command-metadata",
+    },
+  );
+
+  expectChangedBroadcast(broadcastToConnIds, {
+    sessionKey: "global",
+    reason: "command-metadata",
+    sessionId: "sess-main-global",
+    hasActiveRun: false,
+  });
+  await resetGlobalAgentSessionStores(globalStores);
 });
 
 test("sessions.changed mutation events include live session setting metadata", async () => {

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -180,7 +180,7 @@ function expectMainPatchBroadcast(
   expected: Record<string, unknown>,
 ) {
   expectFields(result.responsePayload, { ok: true, key: "agent:main:main" });
-  expectChangedBroadcast(result.broadcastToConnIds, {
+  return expectChangedBroadcast(result.broadcastToConnIds, {
     sessionKey: "agent:main:main",
     reason: "patch",
     ...expected,
@@ -616,6 +616,7 @@ test("sessions.changed command metadata marks selected global runs active", asyn
 
 test("sessions.changed mutation events include live session setting metadata", async () => {
   const sessionSettings = {
+    thinkingLevel: "high",
     verboseLevel: "on",
     responseUsage: "full",
     fastMode: true,
@@ -631,7 +632,14 @@ test("sessions.changed mutation events include live session setting metadata", a
     verboseLevel: "on",
   });
 
-  expectMainPatchBroadcast(result, sessionSettings);
+  const changedPayload = expectMainPatchBroadcast(result, sessionSettings);
+  expect(requireArray(changedPayload.thinkingLevels, "broadcast thinking levels")).toContainEqual(
+    expect.objectContaining({ id: "high" }),
+  );
+  expect(requireArray(changedPayload.thinkingOptions, "broadcast thinking options")).toContain(
+    "high",
+  );
+  expect(changedPayload.thinkingDefault).toEqual(expect.any(String));
 });
 
 test("sessions.changed mutation events include sendPolicy metadata", async () => {

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
+import { emitSessionsChanged } from "./server-methods/session-change-events.js";
 import { embeddedRunMock, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
@@ -491,6 +492,41 @@ test("sessions.changed mutation events include live usage metadata", async () =>
     modelProvider: "openai",
     model: "gpt-5.3-codex-spark",
   });
+});
+
+test("sessions.changed command metadata excludes only the command run from active state", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main"),
+    },
+  });
+
+  const broadcastToConnIds = vi.fn();
+  const { getRuntimeConfig } = await getGatewayConfigModule();
+  emitSessionsChanged(
+    {
+      broadcastToConnIds,
+      getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+      getRuntimeConfig,
+      chatAbortControllers: new Map([
+        ["command-run", { sessionKey: "agent:main:main" }],
+        ["other-run", { sessionKey: "agent:main:main" }],
+      ]),
+    } as never,
+    {
+      sessionKey: "agent:main:main",
+      reason: "command-metadata",
+      excludeActiveRunIds: ["command-run"],
+    },
+  );
+
+  const payload = expectChangedBroadcast(broadcastToConnIds, {
+    sessionKey: "agent:main:main",
+    reason: "command-metadata",
+    hasActiveRun: true,
+  });
+  expect(payload.excludeActiveRunIds).toBeUndefined();
 });
 
 test("sessions.changed mutation events include live session setting metadata", async () => {

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -225,6 +225,46 @@ describe("session.message websocket events", () => {
     });
   });
 
+  test("broadcasts command metadata lifecycle changes to session subscribers", async () => {
+    const storePath = await createSessionStoreFile();
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          label: "Updated by command",
+        },
+      },
+      storePath,
+    });
+
+    await withOperatorSessionSubscriber(async (ws) => {
+      const changedEvent = onceMessage(
+        ws,
+        (message) =>
+          message.type === "event" &&
+          message.event === "sessions.changed" &&
+          (message.payload as { reason?: string; sessionKey?: string } | undefined)?.reason ===
+            "command-metadata" &&
+          (message.payload as { sessionKey?: string } | undefined)?.sessionKey ===
+            "agent:main:main",
+      );
+
+      emitSessionLifecycleEvent({
+        sessionKey: "agent:main:main",
+        reason: "command-metadata",
+      });
+
+      const event = await changedEvent;
+      expectRecordFields(event.payload, {
+        sessionKey: "agent:main:main",
+        reason: "command-metadata",
+        sessionId: "sess-main",
+        label: "Updated by command",
+      });
+    });
+  });
+
   test("only sends transcript events to subscribed operator clients", async () => {
     const storePath = await createSessionStoreFile();
     await writeSessionStore({

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -2327,6 +2327,7 @@ export function loadGatewaySessionRow(
     agentId?: string;
     includeDerivedTitles?: boolean;
     includeLastMessage?: boolean;
+    modelCatalog?: ModelCatalogEntry[];
     now?: number;
     transcriptUsageMaxBytes?: number;
   },
@@ -2354,6 +2355,7 @@ export function loadGatewaySessionRow(
     now,
     includeDerivedTitles: options?.includeDerivedTitles,
     includeLastMessage: options?.includeLastMessage,
+    modelCatalog: options?.modelCatalog,
     transcriptUsageMaxBytes: options?.transcriptUsageMaxBytes,
     storeChildSessionsByKey,
     ...(options?.agentId ? { agentId: options.agentId } : {}),

--- a/src/sessions/session-lifecycle-events.ts
+++ b/src/sessions/session-lifecycle-events.ts
@@ -2,6 +2,7 @@
 export type SessionLifecycleEvent = {
   sessionKey: string;
   reason: string;
+  agentId?: string;
   parentSessionKey?: string;
   label?: string;
   displayName?: string;

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -23,11 +23,13 @@ const buildGatewaySessionInfoMock = vi.fn(
     thinkingLevel: params.entry?.thinkingLevel,
   }),
 );
-const getSessionDefaultsMock = vi.fn(() => ({
-  modelProvider: null,
-  model: null,
-  contextTokens: null,
-}));
+const getSessionDefaultsMock = vi.fn(
+  (_cfg?: unknown, _modelCatalog?: unknown, _options?: unknown) => ({
+    modelProvider: null,
+    model: null,
+    contextTokens: null,
+  }),
+);
 const loadCombinedSessionStoreForGatewayMock = vi.fn((_options?: unknown) => ({
   storePath: "/tmp/openclaw-sessions.json",
   store: {},
@@ -143,7 +145,8 @@ vi.mock("../gateway/server-methods/chat.js", () => ({
 vi.mock("../gateway/session-utils.js", () => ({
   buildGatewaySessionInfo: (params: Parameters<typeof buildGatewaySessionInfoMock>[0]) =>
     buildGatewaySessionInfoMock(params),
-  getSessionDefaults: (...args: unknown[]) => getSessionDefaultsMock(...args),
+  getSessionDefaults: (cfg?: unknown, modelCatalog?: unknown, options?: unknown) =>
+    getSessionDefaultsMock(cfg, modelCatalog, options),
   listAgentsForGateway: () => [],
   listSessionsFromStoreAsync: (...args: unknown[]) => listSessionsFromStoreAsyncMock(...args),
   loadCombinedSessionStoreForGateway: (...args: unknown[]) =>
@@ -625,6 +628,96 @@ describe("EmbeddedTuiBackend", () => {
       expect.objectContaining({
         cfg,
         modelCatalog,
+        key: "agent:main:main",
+      }),
+    );
+  });
+
+  it("loads history model catalog when a thinking level is already persisted", async () => {
+    const modelCatalog = [
+      {
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+        provider: "openai",
+      },
+    ];
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.4" }],
+          },
+        },
+      },
+    };
+    loadGatewayModelCatalogMock.mockReturnValue(modelCatalog);
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      canonicalKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: { sessionId: "sess-main", thinkingLevel: "high" },
+    });
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.loadHistory({ sessionKey: "agent:main:main" })).resolves.toMatchObject({
+      sessionKey: "agent:main:main",
+      sessionId: "sess-main",
+      thinkingLevel: "high",
+      sessionInfo: { thinkingLevel: "high" },
+    });
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalled();
+    expect(getSessionDefaultsMock).toHaveBeenCalledWith(cfg, modelCatalog, {
+      allowPluginNormalization: false,
+    });
+    expect(buildGatewaySessionInfoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        modelCatalog,
+        key: "agent:main:main",
+      }),
+    );
+  });
+
+  it("loads history when model catalog discovery fails", async () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.4" }],
+          },
+        },
+      },
+    };
+    loadGatewayModelCatalogMock.mockImplementation(() => {
+      throw new Error("catalog unavailable");
+    });
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      canonicalKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: { sessionId: "sess-main", thinkingLevel: "high" },
+    });
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.loadHistory({ sessionKey: "agent:main:main" })).resolves.toMatchObject({
+      sessionKey: "agent:main:main",
+      sessionId: "sess-main",
+      thinkingLevel: "high",
+      sessionInfo: { thinkingLevel: "high" },
+    });
+    expect(getSessionDefaultsMock).toHaveBeenCalledWith(cfg, undefined, {
+      allowPluginNormalization: false,
+    });
+    expect(buildGatewaySessionInfoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        modelCatalog: undefined,
         key: "agent:main:main",
       }),
     );

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -143,7 +143,7 @@ vi.mock("../gateway/server-methods/chat.js", () => ({
 vi.mock("../gateway/session-utils.js", () => ({
   buildGatewaySessionInfo: (params: Parameters<typeof buildGatewaySessionInfoMock>[0]) =>
     buildGatewaySessionInfoMock(params),
-  getSessionDefaults: () => getSessionDefaultsMock(),
+  getSessionDefaults: (...args: unknown[]) => getSessionDefaultsMock(...args),
   listAgentsForGateway: () => [],
   listSessionsFromStoreAsync: (...args: unknown[]) => listSessionsFromStoreAsyncMock(...args),
   loadCombinedSessionStoreForGateway: (...args: unknown[]) =>
@@ -581,6 +581,53 @@ describe("EmbeddedTuiBackend", () => {
       thinkingLevel: undefined,
     });
     expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses loaded history model catalog for embedded session metadata", async () => {
+    const modelCatalog = [
+      {
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+        provider: "openai",
+      },
+    ];
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.4" }],
+          },
+        },
+      },
+    };
+    loadGatewayModelCatalogMock.mockReturnValue(modelCatalog);
+    loadSessionEntryMock.mockReturnValue({
+      cfg,
+      canonicalKey: "agent:main:main",
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: { sessionId: "sess-main" },
+    });
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(backend.loadHistory({ sessionKey: "agent:main:main" })).resolves.toMatchObject({
+      sessionKey: "agent:main:main",
+      sessionId: "sess-main",
+      messages: [],
+    });
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalled();
+    expect(getSessionDefaultsMock).toHaveBeenCalledWith(cfg, modelCatalog, {
+      allowPluginNormalization: false,
+    });
+    expect(buildGatewaySessionInfoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        modelCatalog,
+        key: "agent:main:main",
+      }),
+    );
   });
 
   it("loads selected-agent global history from the selected agent store", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -99,6 +99,7 @@ type QueuedSessionRun = {
 };
 
 const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
+const EMBEDDED_TUI_MODEL_CATALOG_TIMEOUT_MS = 750;
 
 const silentRuntime = {
   log: (..._args: unknown[]) => undefined,
@@ -140,6 +141,25 @@ async function loadEmbeddedTuiModelCatalog(cfg: OpenClawConfig) {
   return await loadGatewayModelCatalog(
     shouldLoadFullGatewayCatalogForReplaceMode(cfg) ? { readOnly: false } : undefined,
   );
+}
+
+async function loadEmbeddedTuiModelCatalogBestEffort(cfg: OpenClawConfig) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = Symbol("embedded-tui-model-catalog-timeout");
+  try {
+    const result = await Promise.race([
+      loadEmbeddedTuiModelCatalog(cfg).catch(() => undefined),
+      new Promise<typeof timedOut>((resolve) => {
+        timeout = setTimeout(() => resolve(timedOut), EMBEDDED_TUI_MODEL_CATALOG_TIMEOUT_MS);
+        timeout.unref?.();
+      }),
+    ]);
+    return result === timedOut ? undefined : result;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 function resolveBtwQuestion(message: string): string | undefined {
@@ -450,10 +470,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
     const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
     const messages = bounded.messages;
 
-    let modelCatalog: Awaited<ReturnType<typeof loadEmbeddedTuiModelCatalog>> | undefined;
+    const modelCatalog = await loadEmbeddedTuiModelCatalogBestEffort(cfg);
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
-      modelCatalog = await loadEmbeddedTuiModelCatalog(cfg);
       thinkingLevel = resolveThinkingDefault({
         cfg,
         provider: resolvedSessionModel.provider,

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -450,18 +450,19 @@ export class EmbeddedTuiBackend implements TuiBackend {
     const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
     const messages = bounded.messages;
 
+    let modelCatalog: Awaited<ReturnType<typeof loadEmbeddedTuiModelCatalog>> | undefined;
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
-      const catalog = await loadEmbeddedTuiModelCatalog(cfg);
+      modelCatalog = await loadEmbeddedTuiModelCatalog(cfg);
       thinkingLevel = resolveThinkingDefault({
         cfg,
         provider: resolvedSessionModel.provider,
         model: resolvedSessionModel.model,
-        catalog,
+        catalog: modelCatalog,
       });
     }
 
-    const defaults = getSessionDefaults(cfg, undefined, { allowPluginNormalization: false });
+    const defaults = getSessionDefaults(cfg, modelCatalog, { allowPluginNormalization: false });
     const sessionInfo = buildGatewaySessionInfo({
       cfg,
       storePath,
@@ -469,6 +470,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       key: canonicalKey,
       entry,
       agentId: opts.agentId,
+      modelCatalog,
     });
     sessionInfo.thinkingLevel = thinkingLevel;
     sessionInfo.verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -187,6 +187,21 @@ describe("handleChatEvent", () => {
     expect(state.chatRunId).toBeNull();
   });
 
+  it("ignores canonical global events for another selected agent global alias", () => {
+    const state = createState({
+      sessionKey: "agent:work:global",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-main-global",
+      sessionKey: "global",
+      agentId: "main",
+      state: "final",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatRunId).toBeNull();
+  });
+
   it("treats unscoped global events as default-agent events only", () => {
     const state = createState({
       sessionKey: "global",
@@ -224,6 +239,30 @@ describe("handleChatEvent", () => {
     expect(handleChatEvent(state, payload)).toBe("delta");
     expect(state.chatRunId).toBe("run-work-global");
     expect(state.chatStream).toBe("Work reply");
+    expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
+  });
+
+  it("adopts canonical global deltas for the selected agent global alias", () => {
+    const state = createState({
+      sessionKey: "agent:work:global",
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-work-global",
+      sessionKey: "global",
+      agentId: "work",
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Work global reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatRunId).toBe("run-work-global");
+    expect(state.chatStream).toBe("Work global reply");
     expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
   });
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -446,7 +446,8 @@ function isSelectedGlobalEventSessionKey(sessionKey: string | undefined | null):
     return true;
   }
   const parsed = parseAgentSessionKey(sessionKey);
-  return normalizeLowercaseStringOrEmpty(parsed?.rest) === "main";
+  const rest = normalizeLowercaseStringOrEmpty(parsed?.rest);
+  return rest === "main" || rest === "global";
 }
 
 function resolveSelectedAgentId(state: ChatState): string | undefined {


### PR DESCRIPTION
Fixes #88598

## User-facing bug

Control UI clients subscribed to session updates could miss metadata changes made by in-chat commands. A command-only turn such as `/goal complete`, `/goal pause`, or `/goal clear` can update the session store without starting a model run, but the Gateway did not emit a `sessions.changed` event for that mutation. The visible session row could keep stale goal/status metadata until a manual reload or another unrelated session event.

## Exact repro

Source-level reproduction:

1. Connect a Control UI/WebChat client that subscribes to `sessions.changed`.
2. Send an in-chat `/goal` command that mutates the persisted session goal, for example `/goal complete shipped`.
3. The command handler writes the updated goal to the session store and returns command output.
4. Before this patch, no command-metadata `sessions.changed` event was broadcast for the store write, so subscribed clients did not get a scoped refresh for that session.

## Fix summary

- Add a typed `onSessionMetadataChanged` reply option for command handlers.
- Notify after successful command-session store writes through the shared `persistSessionEntry` helper.
- Notify `/goal` start, pause, resume, complete, blocked, clear, and status paths when they actually change the persisted goal metadata.
- Share the Gateway `sessions.changed` emitter between session RPC handlers and `chat.send`, so command-only chat turns can broadcast a scoped session row update.
- Delay command-metadata broadcasts until after the current command turn leaves the active-run map, while still preserving `hasActiveRun: true` if another run for the same session is active.
- Fall back to the shared session lifecycle event bus when command metadata changes happen outside `chat.send`, so raw channel dispatchers that use the same command-session store helper also refresh Gateway subscribers.
- Preserve selected-agent global alias handling so canonical `global` updates still refresh a selected `agent:<id>:global` Control UI/WebChat session, and normalize command lifecycle metadata from `agent:<id>:global` back to `sessionKey: "global"` plus `agentId`.
- Include live session setting metadata (`thinkingLevels`, `thinkingOptions`, `thinkingDefault`) on command-metadata `sessions.changed` events when a read-only catalog is available, avoid overwriting richer UI metadata when catalog discovery is unavailable or slow, and reuse the TUI-loaded model catalog when rebuilding embedded session defaults.
- Document that command-only session metadata changes refresh subscribed clients.

## Targeted tests

- Added `/goal` command unit coverage for metadata-change notifications on mutating goal actions and no-op clear paths.
- Added `/goal` command unit coverage for the shared lifecycle fallback when no direct Gateway subscriber callback is installed.
- Added Gateway sessions coverage for command-metadata `sessions.changed` payloads, active-run exclusion, catalog-backed thinking metadata, slow catalog fallback, hidden internal runs, selected global runs, and default-agent scoped literal `global` active runs.
- Added Gateway chat coverage proving command-only `/goal` turns broadcast scoped session updates and do not report their own command turn as active.
- Added Gateway lifecycle coverage proving command metadata lifecycle events are broadcast to session subscribers.
- Added command-store coverage proving scoped global metadata is canonicalized to `sessionKey: "global"` plus the parsed agent id.
- Added UI controller coverage for canonical `global` deltas against selected agent-global aliases.
- Added embedded TUI coverage proving history model catalogs are reused for session metadata/defaults and history still loads when catalog discovery fails.

## Real behavior proof

Behavior addressed: In-chat command metadata writes now emit scoped `sessions.changed` events, so subscribed Control UI/WebChat clients can refresh visible session metadata after command-only turns.

Real environment tested: Local OpenClaw checkout on branch `fix/sessions-changed-in-chat-commands`, commit `677e3d3c01d3df9943da18e7b4509dc618797606`, rebased onto current `origin/main` at `9cbf18293b`. The Gateway proof exercises the `sessions.changed` command-metadata path used by subscribed Control UI/WebChat clients.

Exact steps or command run after this patch:
- `git diff --check origin/main...HEAD`
- `./node_modules/.bin/oxlint src/auto-reply/reply/commands-session-store.ts src/auto-reply/reply/commands-session-store.test.ts src/gateway/server-methods/session-change-events.ts src/gateway/server-methods/optional-model-catalog.ts src/gateway/session-utils.ts src/gateway/server-methods/sessions.ts src/gateway/server-methods/chat.ts src/gateway/server.sessions.list-changed.test.ts src/tui/embedded-backend.ts src/tui/embedded-backend.test.ts`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=10000 node scripts/run-vitest.mjs --run --maxWorkers 1 src/auto-reply/reply/commands-session-store.test.ts`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=10000 node scripts/run-vitest.mjs --run --maxWorkers 1 src/auto-reply/reply/commands-goal.test.ts src/auto-reply/reply/commands-session-store.test.ts src/auto-reply/reply/directive-handling.mixed-inline.test.ts src/gateway/server.sessions.list-changed.test.ts ui/src/ui/controllers/chat.test.ts src/tui/embedded-backend.test.ts`
- `CI=1 NODE_OPTIONS=--max-old-space-size=4096 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-88690-rebase.tsbuildinfo`
- `node --import tsx src/entry.ts --version`
- `node --import tsx .artifacts/pr-88690-fn-proof.mjs` (function-level real-behavior proof on the current head; see below)
- `node --import tsx .artifacts/pr-88690-sessions-changed-proof.mjs` (full live-gateway subscriber proof; captured on a prior head — see the note below on why it cannot re-run in this no-build checkout)
- `codex review --base origin/main`

Evidence after fix:
- `git diff --check origin/main...HEAD` passed.
- Direct `oxlint` on the touched command/gateway/TUI files passed.
- Focused command-store regression passed: `Test Files 1 passed (1)`, `Tests 4 passed (4)`. This includes the scoped-global proof that `agent:target:global` metadata notifications become `sessionKey: "global"` with `agentId: "target"`.
- Expanded command/gateway/UI/TUI regression run passed after rebasing onto current `origin/main`: 10 focused test files, 431 tests passed (auto-reply command + directive-handling suites, `src/gateway/server.chat.gateway-server-chat.test.ts`, `src/gateway/server.sessions.list-changed.test.ts`, `src/gateway/session-message-events.test.ts`, `src/tui/embedded-backend.test.ts`, `ui/src/ui/controllers/chat.test.ts`). Core + UI `tsgo` typecheck both passed with exit 0; `oxlint` passed on all changed `src/` and `ui/` files.
- `run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` exited successfully.
- Source CLI entry check passed: `OpenClaw 2026.6.2 (677e3d3)`.
- Standalone WebSocket subscriber proof passed against a local Gateway launched from the source CLI entry. The proof created an isolated temporary `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`, preloaded one session with an active goal, connected one operator client that only subscribed to `sessions.changed`, connected a second operator client that sent `/goal complete redacted websocket proof` through `chat.send`, and did not call `chat.history`.
- `codex review --base origin/main` found no discrete, actionable correctness issue after the scoped-global fix. Its sandboxed gateway socket shard was blocked by `listen EPERM` on `127.0.0.1`, while the expanded Gateway-containing regression above passed outside that sandbox restriction.
- Copied terminal output from the expanded local regression after the rebase:

```text
RUN  v4.1.7 /Users/alex/PR/projects/openclaw__openclaw/repo

Test Files  8 passed (8)
Tests  172 passed (172)
Test Files  1 passed (1)
Tests  40 passed (40)
Test Files  5 passed (5)
Tests  100 passed (100)
Test Files  1 passed (1)
Tests  119 passed (119)
```

Copied redacted standalone subscriber proof:

```json
{
  "ok": true,
  "pr": 88690,
  "proof": "standalone websocket subscriber",
  "command": "/goal complete redacted websocket proof",
  "token": "<redacted-gateway-token>",
  "sessionKeySent": "main",
  "event": "sessions.changed",
  "reason": "command-metadata",
  "eventSessionKey": "agent:main:main",
  "sessionId": "sess-pr-88690-proof",
  "label": "PR 88690 sessions.changed proof",
  "goalStatus": "complete",
  "goalObjective": "redacted PR 88690 websocket subscriber proof objective",
  "hasActiveRun": false,
  "chatSendStatus": "started",
  "chatSendRunId": "<redacted-run-id>",
  "subscriberSawEventBeforeHistoryReload": true,
  "chatHistoryCallsSent": 0,
  "isolatedState": {
    "configPath": "<redacted-temp-openclaw.json>",
    "stateDir": "<redacted-temp-state-dir>",
    "storePath": "<redacted-temp-sessions-json>"
  },
  "localStorePathExisted": true
}
```

Observed result after fix: Command-only `/goal` metadata mutations produce scoped `sessions.changed` broadcasts with fresh session row metadata. A standalone WebSocket subscriber receives the `command-metadata` event before any history reload, and the payload excludes the transient command-only `chat.send` active run (`hasActiveRun: false`). `chat.send` keeps selected agent-global aliases receiving canonical global deltas, slow or failed model catalog discovery does not block the broadcast or TUI history, and non-`chat.send` command paths get the shared lifecycle fallback instead of leaving subscribers stale.

Note on the standalone subscriber proof above: that JSON was captured on a prior head. This refresh is a rebase onto current `origin/main` (`9cbf18293b`). The only conflict on the `sessions.changed` path was a one-line import union in `chat.ts` (kept main's new `updateSessionStoreEntry` alongside this PR's `SessionMetadataChangedEvent` type import); the patched event-emitting function `dispatchSessionMetadataChanged` (`src/auto-reply/reply/commands-session-store.ts`) is byte-for-byte identical to the prior head, and the 431-test focused suite (including the scoped-global regression and `ui/src/ui/controllers/chat.test.ts`) passes on this head. The full live-gateway subscriber script could not be re-run in this checkout because the gateway's provider-auth worker thread fails to resolve `src/agents/auth-profiles.js` (a tsx-worker/no-build limitation of running from source, unrelated to this PR). To prove the patched path on this exact head without that environment dependency, I ran the patched exported function directly:

```text
$ node --import tsx .artifacts/pr-88690-fn-proof.mjs
```

The script imports the real `dispatchSessionMetadataChanged` (`src/auto-reply/reply/commands-session-store.ts`), passes a real subscriber callback, and prints the events the patched code actually emits on commit `677e3d3c01`:

```json
{
  "ok": true,
  "pr": 88690,
  "proof": "function-level dispatchSessionMetadataChanged",
  "results": [
    {
      "case": "agent-scoped key derives agentId from the key (not the caller agentId)",
      "input": { "sessionKey": "agent:target:telegram:direct:123", "agentId": "main", "reason": "command-metadata" },
      "emittedToSubscriber": { "sessionKey": "agent:target:telegram:direct:123", "agentId": "target", "reason": "command-metadata" }
    },
    {
      "case": "scoped-global key canonicalizes to global row + parsed agent",
      "input": { "sessionKey": "agent:target:global", "agentId": "main", "reason": "command-metadata" },
      "emittedToSubscriber": { "sessionKey": "global", "agentId": "target", "reason": "command-metadata" }
    },
    {
      "case": "plain global keeps fallback agentId",
      "input": { "sessionKey": "global", "agentId": "target", "reason": "command-metadata" },
      "emittedToSubscriber": { "sessionKey": "global", "agentId": "target", "reason": "command-metadata" }
    }
  ]
}
```

This proves the patched dispatch on the current head: an agent-scoped session key derives its `agentId` from the key (`target`, not the caller's `main`), a scoped `agent:target:global` key canonicalizes to the `global` row with the parsed agent, and a plain `global` key keeps its fallback agent — each delivered to a live subscriber callback as a `command-metadata` event.

What was not tested: Full gateway/core suites and full `pnpm check` were not run. I did not run a browser-rendered Control UI session; the added proof uses the same Gateway WebSocket subscription contract that Control UI/WebChat clients consume. The Gateway tests and standalone proof require local `127.0.0.1` listening; default sandboxed review attempts returned `listen EPERM`, so I reran the expanded Gateway-containing regression and standalone subscriber proof with elevated local-network permission. I did not implement or test `/name` because this checkout does not contain a `/name` handler.

## Not tested / known gaps

- This patch focuses on command metadata changes that happen through `chat.send` reply options and the shared command-session store helper.
- Channel command flows that bypass the shared command-session store helper are unchanged.
- Full gateway/core suites and full `pnpm check` were not run in this remediation pass.

## AI-assisted disclosure

This patch was prepared with AI assistance. I used source-level reproduction, targeted regression tests, and `codex review --base origin/main` to validate the behavior above.
