### PR TITLE
fix(ui): handle vite object resolve hooks

### DIFF
--- a/ui/src/ui/control-ui-vite-config.node.test.ts
+++ b/ui/src/ui/control-ui-vite-config.node.test.ts
@@ -55,11 +55,12 @@ describe("Control UI Vite config", () => {
   it("uses a browser-safe redactor for shared tool display imports", async () => {
     const plugin = controlUiBrowserOnlySharedModuleAliases();
     const resolveId = plugin.resolveId;
-    if (typeof resolveId !== "function") {
+    if (!resolveId) {
       throw new Error("Expected browser-only shared module alias plugin to expose resolveId");
     }
+    const resolveIdHandler = typeof resolveId === "function" ? resolveId : resolveId.handler;
 
-    const resolved = await resolveId.call(
+    const resolved = await resolveIdHandler.call(
       {} as never,
       "../logging/redact.js",
       path.join(repoRoot, "src/agents/tool-display-common.ts"),


### PR DESCRIPTION
## Summary
- unwrap Vite object-form `resolveId` hooks in the Control UI Vite config node test
- restores `check-test-types` compatibility with the current Vite hook type shape

## Verification
- `node scripts/run-vitest.mjs ui/src/ui/control-ui-vite-config.node.test.ts --reporter=dot`
- AWS Crabbox `pnpm check:changed`: provider=aws, lease=cbx_0573d9c7a337, slug=golden-lobster, run=run_4f976c1416da, base=5b310a7b27fa55dac0ab368f3d1372b7a17617dc, exit=0
- GitHub CI rerun passed for head `5992c2e3104dc12cea3db1e70ab3734c0396eb2c` after rerunning one unrelated outbound-actions timeout shard

Behavior addressed: current-main `check-test-types` failed because the test assumed `plugin.resolveId` was always directly callable.
Real environment tested: local Codex gwt focused Vitest; AWS Crabbox Linux changed gate; GitHub CI.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs ui/src/ui/control-ui-vite-config.node.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`; `gh run rerun 26717875426 --failed`.
Evidence after fix: focused test passed 4 tests; Crabbox run `run_4f976c1416da` exited 0; GitHub CI run `26717875426` completed successfully after failed-job rerun.
Observed result after fix: `check:changed` completed core test typecheck and lint for the changed test file with 0 errors, and full CI is green.
What was not tested: no live runtime path; this is a test/type compatibility patch.
