### PR TITLE
docs(openai): clarify openai-codex auth profile mismatch

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -22,6 +22,13 @@ under `auth.order.openai`; older legacy Codex auth profile ids and
 legacy Codex auth order entries are legacy state repaired by
 `openclaw doctor --fix`.
 
+<Note>
+If you see auth lookup errors referencing `openai-codex`, it usually means an
+older config or a manual edit is still pointing at the legacy provider. Run
+`openclaw doctor --fix` and keep both model refs and `auth.order` on canonical
+`openai`.
+</Note>
+
 When no OpenClaw sandbox is active, OpenClaw starts Codex app-server threads
 with Codex native code mode enabled while leaving code-mode-only off by default.
 That keeps Codex native workspace and code capabilities available while

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -62,6 +62,14 @@ legacy Codex model refs, legacy Codex auth profile ids, and
 legacy Codex auth order to the canonical OpenAI route.
 
 <Note>
+If you see an error like `No available auth profile for openai-codex`, some part
+of your setup is still pointing at the legacy `openai-codex` provider. Run
+`openclaw doctor --fix` and switch to canonical `openai/*` model refs plus
+`auth.order.openai`. Avoid editing `auth-profiles.json` provider fields by hand
+unless a maintainer explicitly asked you to.
+</Note>
+
+<Note>
 GPT-5.5 is available through both direct OpenAI Platform API-key access and
 subscription/OAuth routes. For ChatGPT/Codex subscription plus native Codex
 execution, use `openai/gpt-5.5`; unset runtime config now selects the Codex


### PR DESCRIPTION
Addresses #88125 by adding a short note in the OpenAI provider and Codex harness docs.

If users see `No available auth profile for openai-codex`, it usually means some legacy `openai-codex` config/profile state is still in play. The docs now point to `openclaw doctor --fix` and canonical `openai/*` + `auth.order.openai` rather than manual edits.

Docs-only change.