### PR TITLE
fix(agents): wait for cron media completions

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
@@ -18,7 +18,13 @@ export type ResolveAttemptTrajectoryTerminalParams = {
   externalAbort: boolean;
   timedOut: boolean;
   assistantTexts: string[];
-  toolMetas: Array<{ toolName: string; meta?: string; asyncStarted?: boolean }>;
+  toolMetas: Array<{
+    toolName: string;
+    meta?: string;
+    asyncStarted?: boolean;
+    asyncTaskRunId?: string;
+    asyncTaskId?: string;
+  }>;
   didSendViaMessagingTool: boolean;
   didSendDeterministicApprovalPrompt: boolean;
   messagingToolSentTexts: string[];

--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "vitest";
+import {
+  completeTaskRunByRunId,
+  createRunningTaskRun,
+} from "../../../tasks/detached-task-runtime.js";
+import { resetTaskRegistryForTests } from "../../../tasks/task-registry.js";
+import {
+  requiresCompletionRequiredAsyncTaskWait,
+  waitForCompletionRequiredAsyncTasks,
+  type AsyncStartedToolMeta,
+} from "./attempt.async-tasks.js";
+
+describe("waitForCompletionRequiredAsyncTasks", () => {
+  it("waits for async task ids discovered during the attempt", async () => {
+    resetTaskRegistryForTests();
+    const task = createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "image_generation",
+      sourceId: "image_generate:openai",
+      requesterSessionKey: "agent:main:cron:daily-media:run:run-123",
+      ownerKey: "agent:main:cron:daily-media:run:run-123",
+      scopeKind: "session",
+      runId: "tool:image_generate:run-123",
+      task: "daily image",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 1,
+      lastEventAt: 1,
+    });
+    const metas: AsyncStartedToolMeta[] = [
+      {
+        toolName: "image_generate",
+        asyncStarted: true,
+        asyncTaskRunId: "tool:image_generate:run-123",
+        asyncTaskId: task.taskId,
+      },
+    ];
+
+    const waitPromise = waitForCompletionRequiredAsyncTasks({
+      getToolMetas: () => metas,
+      deadlineAtMs: Date.now() + 10_000,
+      pollIntervalMs: 1,
+    });
+    completeTaskRunByRunId({
+      runId: "tool:image_generate:run-123",
+      runtime: "cli",
+      sessionKey: "agent:main:cron:daily-media:run:run-123",
+      endedAt: Date.now(),
+      lastEventAt: Date.now(),
+      progressSummary: "Generated 1 image",
+      terminalSummary: "Generated 1 image.",
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      waitedRunIds: ["tool:image_generate:run-123"],
+      timedOutRunIds: [],
+    });
+  });
+
+  it("requires a wait when the cron run has an active tracked media task", () => {
+    resetTaskRegistryForTests();
+    const sessionKey = "agent:main:cron:daily-media:run:run-123";
+    createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "image_generation",
+      sourceId: "image_generate:openai",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      runId: "tool:image_generate:run-123",
+      task: "daily image",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 1,
+      lastEventAt: 1,
+    });
+
+    expect(
+      requiresCompletionRequiredAsyncTaskWait({
+        sessionKey,
+        toolMetas: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("waits for active cron media tasks from the task registry", async () => {
+    resetTaskRegistryForTests();
+    const sessionKey = "agent:main:cron:daily-media:run:run-123";
+    createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "image_generation",
+      sourceId: "image_generate:openai",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      runId: "tool:image_generate:run-123",
+      task: "daily image",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 1,
+      lastEventAt: 1,
+    });
+
+    const waitPromise = waitForCompletionRequiredAsyncTasks({
+      getToolMetas: () => [],
+      sessionKey,
+      deadlineAtMs: Date.now() + 10_000,
+      pollIntervalMs: 1,
+    });
+    completeTaskRunByRunId({
+      runId: "tool:image_generate:run-123",
+      runtime: "cli",
+      sessionKey,
+      endedAt: Date.now(),
+      lastEventAt: Date.now(),
+      progressSummary: "Generated 1 image",
+      terminalSummary: "Generated 1 image.",
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      waitedRunIds: ["tool:image_generate:run-123"],
+      timedOutRunIds: [],
+    });
+  });
+
+  it("waits for active cron video tasks from the task registry", async () => {
+    resetTaskRegistryForTests();
+    const sessionKey = "agent:main:cron:daily-media:run:run-123";
+    createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "video_generation",
+      sourceId: "video_generate:fal",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      runId: "tool:video_generate:run-123",
+      task: "daily video",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 1,
+      lastEventAt: 1,
+    });
+
+    const waitPromise = waitForCompletionRequiredAsyncTasks({
+      getToolMetas: () => [],
+      sessionKey,
+      deadlineAtMs: Date.now() + 10_000,
+      pollIntervalMs: 1,
+    });
+    completeTaskRunByRunId({
+      runId: "tool:video_generate:run-123",
+      runtime: "cli",
+      sessionKey,
+      endedAt: Date.now(),
+      lastEventAt: Date.now(),
+      progressSummary: "Generated 1 video",
+      terminalSummary: "Generated 1 video.",
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      waitedRunIds: ["tool:video_generate:run-123"],
+      timedOutRunIds: [],
+    });
+  });
+
+  it("waits for async task ids discovered after an earlier async completion", async () => {
+    resetTaskRegistryForTests();
+    const sessionKey = "agent:main:cron:daily-media:run:run-123";
+    const imageTask = createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "image_generation",
+      sourceId: "image_generate:openai",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      runId: "tool:image_generate:run-123",
+      task: "daily image",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 1,
+      lastEventAt: 1,
+    });
+    const metas: AsyncStartedToolMeta[] = [
+      {
+        toolName: "image_generate",
+        asyncStarted: true,
+        asyncTaskRunId: "tool:image_generate:run-123",
+        asyncTaskId: imageTask.taskId,
+      },
+    ];
+    let now = 1;
+    let pollCount = 0;
+
+    await expect(
+      waitForCompletionRequiredAsyncTasks({
+        getToolMetas: () => metas,
+        deadlineAtMs: 20,
+        now: () => now,
+        sleep: async (ms) => {
+          pollCount += 1;
+          now += ms;
+          if (pollCount === 1) {
+            completeTaskRunByRunId({
+              runId: "tool:image_generate:run-123",
+              runtime: "cli",
+              sessionKey,
+              endedAt: now,
+              lastEventAt: now,
+              progressSummary: "Generated 1 image",
+              terminalSummary: "Generated 1 image.",
+            });
+            const musicTask = createRunningTaskRun({
+              runtime: "cli",
+              taskKind: "music_generation",
+              sourceId: "music_generate:fal",
+              requesterSessionKey: sessionKey,
+              ownerKey: sessionKey,
+              scopeKind: "session",
+              runId: "tool:music_generate:run-456",
+              task: "daily track",
+              deliveryStatus: "not_applicable",
+              notifyPolicy: "silent",
+              startedAt: now,
+              lastEventAt: now,
+            });
+            metas.push({
+              toolName: "music_generate",
+              asyncStarted: true,
+              asyncTaskRunId: "tool:music_generate:run-456",
+              asyncTaskId: musicTask.taskId,
+            });
+          } else if (pollCount === 2) {
+            completeTaskRunByRunId({
+              runId: "tool:music_generate:run-456",
+              runtime: "cli",
+              sessionKey,
+              endedAt: now,
+              lastEventAt: now,
+              progressSummary: "Generated music",
+              terminalSummary: "Generated music.",
+            });
+          }
+        },
+        pollIntervalMs: 2,
+      }),
+    ).resolves.toMatchObject({
+      waitedRunIds: ["tool:image_generate:run-123", "tool:music_generate:run-456"],
+      timedOutRunIds: [],
+    });
+  });
+
+  it("reports tasks that do not finish before the deadline", async () => {
+    resetTaskRegistryForTests();
+    createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "music_generation",
+      sourceId: "music_generate:test",
+      requesterSessionKey: "agent:main:cron:daily-media:run:run-123",
+      ownerKey: "agent:main:cron:daily-media:run:run-123",
+      scopeKind: "session",
+      runId: "tool:music_generate:run-123",
+      task: "daily track",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 1,
+      lastEventAt: 1,
+    });
+    let now = 1;
+
+    await expect(
+      waitForCompletionRequiredAsyncTasks({
+        getToolMetas: () => [
+          {
+            toolName: "music_generate",
+            asyncStarted: true,
+            asyncTaskRunId: "tool:music_generate:run-123",
+          },
+        ],
+        deadlineAtMs: 5,
+        now: () => now,
+        sleep: async (ms) => {
+          now += ms;
+        },
+        pollIntervalMs: 2,
+      }),
+    ).resolves.toMatchObject({
+      waitedRunIds: ["tool:music_generate:run-123"],
+      timedOutRunIds: ["tool:music_generate:run-123"],
+    });
+  });
+
+  it("stops waiting when the run abort signal fires", async () => {
+    resetTaskRegistryForTests();
+    const sessionKey = "agent:main:cron:daily-media:run:run-123";
+    createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "music_generation",
+      sourceId: "music_generate:test",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      runId: "tool:music_generate:run-123",
+      task: "daily track",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      startedAt: 1,
+      lastEventAt: 1,
+    });
+    const controller = new AbortController();
+
+    await expect(
+      waitForCompletionRequiredAsyncTasks({
+        getToolMetas: () => [],
+        sessionKey,
+        deadlineAtMs: Date.now() + 10_000,
+        abortSignal: controller.signal,
+        sleep: async () => {
+          controller.abort();
+        },
+        pollIntervalMs: 2,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
@@ -1,0 +1,219 @@
+import { isCronRunSessionKey } from "../../../sessions/session-key-utils.js";
+import { isTerminalTaskStatus } from "../../../tasks/task-executor-policy.js";
+import { findTaskByRunId, listTaskRecords } from "../../../tasks/task-registry.js";
+import type { TaskRecord } from "../../../tasks/task-registry.types.js";
+
+export type AsyncStartedToolMeta = {
+  toolName?: string;
+  asyncStarted?: boolean;
+  asyncTaskRunId?: string;
+  asyncTaskId?: string;
+};
+
+export type CompletionRequiredAsyncTaskWaitResult = {
+  waitedRunIds: string[];
+  timedOutRunIds: string[];
+  terminalTasks: TaskRecord[];
+};
+
+const DEFAULT_ASYNC_TASK_POLL_INTERVAL_MS = 500;
+const COMPLETION_REQUIRED_TASK_KINDS = new Set([
+  "image_generation",
+  "music_generation",
+  "video_generation",
+]);
+
+function resolveAsyncTaskPollIntervalMs(): number {
+  return process.env.OPENCLAW_TEST_FAST === "1" ? 10 : DEFAULT_ASYNC_TASK_POLL_INTERVAL_MS;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, Math.max(1, ms));
+  });
+}
+
+function createAbortError(signal: AbortSignal): Error {
+  const err = new Error("aborted", {
+    cause: "reason" in signal ? (signal as { reason?: unknown }).reason : undefined,
+  });
+  err.name = "AbortError";
+  return err;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw createAbortError(signal);
+  }
+}
+
+async function sleepWithAbort(
+  ms: number,
+  signal: AbortSignal | undefined,
+  sleepFn: (ms: number) => Promise<void>,
+): Promise<void> {
+  if (!signal) {
+    await sleepFn(ms);
+    return;
+  }
+  throwIfAborted(signal);
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    sleepFn(ms).then(
+      () => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      },
+      (err) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
+function collectAsyncTaskRunIds(
+  toolMetas: readonly AsyncStartedToolMeta[],
+  sessionKey: string | undefined,
+  alreadyWaited: ReadonlySet<string>,
+): string[] {
+  const runIds: string[] = [];
+  const seen = new Set<string>();
+  const addRunId = (runIdRaw: string | undefined) => {
+    const runId = runIdRaw?.trim();
+    if (!runId || alreadyWaited.has(runId) || seen.has(runId)) {
+      return;
+    }
+    seen.add(runId);
+    runIds.push(runId);
+  };
+  for (const meta of toolMetas) {
+    addRunId(meta.asyncStarted === true ? meta.asyncTaskRunId : undefined);
+  }
+  const normalizedSessionKey = sessionKey?.trim();
+  if (!normalizedSessionKey) {
+    return runIds;
+  }
+  for (const task of listTaskRecords()) {
+    if (!COMPLETION_REQUIRED_TASK_KINDS.has(task.taskKind ?? "")) {
+      continue;
+    }
+    if (
+      task.requesterSessionKey !== normalizedSessionKey &&
+      task.ownerKey !== normalizedSessionKey
+    ) {
+      continue;
+    }
+    if (isTerminalTaskStatus(task.status)) {
+      continue;
+    }
+    addRunId(task.runId);
+  }
+  return runIds;
+}
+
+function findTerminalTasks(runIds: readonly string[]): {
+  pendingRunIds: string[];
+  terminalTasks: TaskRecord[];
+} {
+  const pendingRunIds: string[] = [];
+  const terminalTasks: TaskRecord[] = [];
+  for (const runId of runIds) {
+    const task = findTaskByRunId(runId);
+    if (task && isTerminalTaskStatus(task.status)) {
+      terminalTasks.push(task);
+      continue;
+    }
+    pendingRunIds.push(runId);
+  }
+  return { pendingRunIds, terminalTasks };
+}
+
+export function requiresCompletionRequiredAsyncTaskWait(params: {
+  sessionKey: string | undefined;
+  toolMetas: readonly AsyncStartedToolMeta[];
+}): boolean {
+  const sessionKey = params.sessionKey?.trim();
+  if (!isCronRunSessionKey(sessionKey)) {
+    return false;
+  }
+  if (
+    params.toolMetas.some(
+      (meta) => meta.asyncStarted === true && Boolean(meta.asyncTaskRunId?.trim()),
+    )
+  ) {
+    return true;
+  }
+  return listTaskRecords().some(
+    (task) =>
+      COMPLETION_REQUIRED_TASK_KINDS.has(task.taskKind ?? "") &&
+      !isTerminalTaskStatus(task.status) &&
+      (task.requesterSessionKey === sessionKey || task.ownerKey === sessionKey) &&
+      Boolean(task.runId?.trim()),
+  );
+}
+
+export async function waitForCompletionRequiredAsyncTasks(params: {
+  getToolMetas: () => readonly AsyncStartedToolMeta[];
+  sessionKey?: string;
+  deadlineAtMs: number;
+  now?: () => number;
+  pollIntervalMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  abortSignal?: AbortSignal;
+}): Promise<CompletionRequiredAsyncTaskWaitResult> {
+  const now = params.now ?? Date.now;
+  const sleepFn = params.sleep ?? sleep;
+  const pollIntervalMs = params.pollIntervalMs ?? resolveAsyncTaskPollIntervalMs();
+  const waitedRunIds = new Set<string>();
+  const timedOutRunIds = new Set<string>();
+  const terminalTasksByRunId = new Map<string, TaskRecord>();
+
+  while (true) {
+    throwIfAborted(params.abortSignal);
+    const runIds = collectAsyncTaskRunIds(params.getToolMetas(), params.sessionKey, waitedRunIds);
+    if (runIds.length === 0) {
+      return {
+        waitedRunIds: [...waitedRunIds],
+        timedOutRunIds: [...timedOutRunIds],
+        terminalTasks: [...terminalTasksByRunId.values()],
+      };
+    }
+
+    for (const runId of runIds) {
+      waitedRunIds.add(runId);
+    }
+
+    let pendingRunIds = runIds;
+    while (pendingRunIds.length > 0) {
+      throwIfAborted(params.abortSignal);
+      const terminalState = findTerminalTasks(pendingRunIds);
+      for (const task of terminalState.terminalTasks) {
+        const runId = task.runId?.trim();
+        if (runId) {
+          terminalTasksByRunId.set(runId, task);
+        }
+      }
+      pendingRunIds = terminalState.pendingRunIds;
+      if (pendingRunIds.length === 0) {
+        break;
+      }
+      const remainingMs = params.deadlineAtMs - now();
+      if (remainingMs <= 0) {
+        for (const runId of pendingRunIds) {
+          timedOutRunIds.add(runId);
+        }
+        return {
+          waitedRunIds: [...waitedRunIds],
+          timedOutRunIds: [...timedOutRunIds],
+          terminalTasks: [...terminalTasksByRunId.values()],
+        };
+      }
+      await sleepWithAbort(Math.min(pollIntervalMs, remainingMs), params.abortSignal, sleepFn);
+    }
+  }
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -304,6 +304,12 @@ import {
   resolveTerminalAssistantTexts,
 } from "./attempt-trajectory-status.js";
 import {
+  requiresCompletionRequiredAsyncTaskWait,
+  waitForCompletionRequiredAsyncTasks,
+  type AsyncStartedToolMeta,
+  type CompletionRequiredAsyncTaskWaitResult,
+} from "./attempt.async-tasks.js";
+import {
   isPrimaryBootstrapRun,
   remapInjectedContextFilesToWorkspace,
 } from "./attempt.bootstrap-context.js";
@@ -3035,6 +3041,7 @@ export async function runEmbeddedAttempt(
         ? bindOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, params.onBlockReplyFlush)
         : undefined;
 
+      let toolMetasForTerminal: readonly AsyncStartedToolMeta[] = [];
       const subscription = subscribeEmbeddedAgentSession(
         buildEmbeddedSubscriptionParams({
           session: activeSession,
@@ -3062,6 +3069,14 @@ export async function runEmbeddedAttempt(
           onAgentEvent: params.onAgentEvent,
           terminalLifecyclePhase: params.deferTerminalLifecycleEnd ? "finishing" : "end",
           onBeforeLifecycleTerminal: () => {
+            if (
+              requiresCompletionRequiredAsyncTaskWait({
+                sessionKey: params.sessionKey,
+                toolMetas: toolMetasForTerminal,
+              })
+            ) {
+              return;
+            }
             // Clear embedded-run activity before emitting terminal lifecycle events so
             // post-completion cleanup does not observe a logically finished run as active.
             clearActiveEmbeddedRun(
@@ -3108,6 +3123,7 @@ export async function runEmbeddedAttempt(
         getCompactionCount,
         getLastCompactionTokensAfter,
       } = subscription;
+      toolMetasForTerminal = toolMetas;
       isCompactionPendingForExternalSignal = subscription.isCompacting;
       isCompactionInFlightForExternalSignal = () => activeSession.isCompacting;
       toolSearchCatalogExecutor = async (toolParams) => {
@@ -3192,8 +3208,10 @@ export async function runEmbeddedAttempt(
       let abortWarnTimer: NodeJS.Timeout | undefined;
       const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
       let abortTimer: NodeJS.Timeout | undefined;
+      let runAbortDeadlineAtMs = Date.now() + params.timeoutMs;
       let compactionGraceUsed = false;
       const scheduleAbortTimer = (delayMs: number, reason: "initial" | "compaction-grace") => {
+        runAbortDeadlineAtMs = Date.now() + Math.max(1, delayMs);
         abortTimer = setTimeout(
           () => {
             const timeoutAction = resolveRunTimeoutDuringCompaction({
@@ -4250,6 +4268,62 @@ export async function runEmbeddedAttempt(
         await sessionLockController.waitForSessionEvents(activeSession);
         await sessionLockController.releaseForPrompt();
 
+        if (
+          requiresCompletionRequiredAsyncTaskWait({
+            sessionKey: params.sessionKey,
+            toolMetas,
+          })
+        ) {
+          const getAsyncStartedToolMetas = () =>
+            toolMetas
+              .filter(
+                (
+                  entry,
+                ): entry is {
+                  toolName: string;
+                  asyncStarted?: boolean;
+                  asyncTaskRunId?: string;
+                  asyncTaskId?: string;
+                } => typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
+              )
+              .map((entry) => ({
+                toolName: entry.toolName,
+                asyncStarted: entry.asyncStarted,
+                asyncTaskRunId: entry.asyncTaskRunId,
+                asyncTaskId: entry.asyncTaskId,
+              }));
+          const completionRequiredAsyncDeadlineAtMs = Math.max(
+            Date.now(),
+            runAbortDeadlineAtMs - 500,
+          );
+          let asyncTaskWait: CompletionRequiredAsyncTaskWaitResult;
+          try {
+            asyncTaskWait = await waitForCompletionRequiredAsyncTasks({
+              getToolMetas: getAsyncStartedToolMetas,
+              sessionKey: params.sessionKey,
+              deadlineAtMs: completionRequiredAsyncDeadlineAtMs,
+              abortSignal: runAbortController.signal,
+            });
+          } catch (err) {
+            if (!timedOut || !isRunnerAbortError(err)) {
+              throw err;
+            }
+            asyncTaskWait = await waitForCompletionRequiredAsyncTasks({
+              getToolMetas: getAsyncStartedToolMetas,
+              sessionKey: params.sessionKey,
+              deadlineAtMs: Date.now(),
+            });
+          }
+          if (asyncTaskWait.timedOutRunIds.length > 0) {
+            promptError = new Error(
+              `Timed out waiting for async task completion: ${asyncTaskWait.timedOutRunIds.join(", ")}`,
+            );
+            promptErrorSource = "prompt";
+          } else if (asyncTaskWait.waitedRunIds.length > 0) {
+            await sessionLockController.waitForSessionEvents(activeSession);
+          }
+        }
+
         // Capture snapshot before compaction wait so we have complete messages if timeout occurs
         // Check compaction state before and after to avoid race condition where compaction starts during capture
         // Use session state (not subscription) for snapshot decisions - need instantaneous compaction status
@@ -4582,10 +4656,38 @@ export async function runEmbeddedAttempt(
 
       const toolMetasNormalized = toolMetas
         .filter(
-          (entry): entry is { toolName: string; meta?: string } =>
-            typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
+          (
+            entry,
+          ): entry is {
+            toolName: string;
+            meta?: string;
+            asyncStarted?: boolean;
+            asyncTaskRunId?: string;
+            asyncTaskId?: string;
+          } => typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
         )
-        .map((entry) => ({ toolName: entry.toolName, meta: entry.meta }));
+        .map((entry) => {
+          const normalized: {
+            toolName: string;
+            meta?: string;
+            asyncStarted?: true;
+            asyncTaskRunId?: string;
+            asyncTaskId?: string;
+          } = {
+            toolName: entry.toolName,
+            meta: entry.meta,
+          };
+          if (entry.asyncStarted === true) {
+            normalized.asyncStarted = true;
+          }
+          if (entry.asyncTaskRunId) {
+            normalized.asyncTaskRunId = entry.asyncTaskRunId;
+          }
+          if (entry.asyncTaskId) {
+            normalized.asyncTaskId = entry.asyncTaskId;
+          }
+          return normalized;
+        });
       if (cacheObservabilityEnabled) {
         const cacheBreakForLog = cacheBreak as PromptCacheBreak | null;
         if (cacheBreakForLog) {

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -142,7 +142,13 @@ export type EmbeddedRunAttemptResult = {
   finalPromptText?: string;
   messagesSnapshot: AgentMessage[];
   assistantTexts: string[];
-  toolMetas: Array<{ toolName: string; meta?: string; asyncStarted?: boolean }>;
+  toolMetas: Array<{
+    toolName: string;
+    meta?: string;
+    asyncStarted?: boolean;
+    asyncTaskRunId?: string;
+    asyncTaskId?: string;
+  }>;
   acceptedSessionSpawns?: AcceptedSessionSpawn[];
   lastAssistant: AssistantMessage | undefined;
   currentAttemptAssistant?: AssistantMessage | undefined;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -289,6 +289,23 @@ function isAsyncStartedToolResult(result: unknown): boolean {
   return details?.async === true && details.status === "started";
 }
 
+function readAsyncStartedTaskIds(result: unknown): {
+  asyncTaskRunId?: string;
+  asyncTaskId?: string;
+} {
+  const details = readToolResultDetailsRecord(result);
+  if (!details) {
+    return {};
+  }
+  const nestedTask = readRecordField(details.task);
+  const asyncTaskRunId = readStringValue(details.runId) ?? readStringValue(nestedTask?.runId);
+  const asyncTaskId = readStringValue(details.taskId) ?? readStringValue(nestedTask?.taskId);
+  return {
+    ...(asyncTaskRunId ? { asyncTaskRunId } : {}),
+    ...(asyncTaskId ? { asyncTaskId } : {}),
+  };
+}
+
 function readExecToolDetails(result: unknown): ExecToolDetails | null {
   const details = readToolResultDetailsRecord(result);
   if (!details || typeof details.status !== "string") {
@@ -1152,10 +1169,11 @@ export async function handleToolExecutionEnd(
   const completedMutatingAction = !isToolError && Boolean(callSummary?.mutatingAction);
   const meta = callSummary?.meta;
   const asyncStarted = !isToolError && isAsyncStartedToolResult(sanitizedResult);
+  const asyncTaskIds = asyncStarted ? readAsyncStartedTaskIds(sanitizedResult) : {};
   ctx.state.toolMetas.push({
     toolName,
     meta,
-    ...(asyncStarted ? { asyncStarted: true } : {}),
+    ...(asyncStarted ? { asyncStarted: true, ...asyncTaskIds } : {}),
   });
   const acceptedSessionSpawn =
     toolName === "sessions_spawn" && !isToolError

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -43,7 +43,13 @@ export type ToolCallSummary = {
 
 export type EmbeddedAgentSubscribeState = {
   assistantTexts: string[];
-  toolMetas: Array<{ toolName?: string; meta?: string; asyncStarted?: boolean }>;
+  toolMetas: Array<{
+    toolName?: string;
+    meta?: string;
+    asyncStarted?: boolean;
+    asyncTaskRunId?: string;
+    asyncTaskId?: string;
+  }>;
   acceptedSessionSpawns: AcceptedSessionSpawn[];
   toolMetaById: Map<string, ToolCallSummary>;
   toolSummaryById: Set<string>;

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -215,6 +215,11 @@ export function createOpenClawTools(
     trimmedRunSessionKey && isCronRunSessionKey(trimmedRunSessionKey)
       ? trimmedRunSessionKey
       : options?.agentSessionKey;
+  const mediaGenerationAsyncStartCallback = mediaGenerationAgentSessionKey
+    ? isCronRunSessionKey(mediaGenerationAgentSessionKey)
+      ? undefined
+      : options?.onYield
+    : options?.onYield;
   const imageToolAgentDir = options?.agentDir;
   const imageTool = resolveImageToolFactoryAvailable({
     config: availabilityConfig ?? resolvedConfig,
@@ -248,7 +253,7 @@ export function createOpenClawTools(
         workspaceDir,
         sandbox,
         fsPolicy: options?.fsPolicy,
-        onAsyncTaskStarted: options?.onYield,
+        onAsyncTaskStarted: mediaGenerationAsyncStartCallback,
       })
     : null;
   options?.recordToolPrepStage?.("openclaw-tools:image-generate-tool");
@@ -262,7 +267,7 @@ export function createOpenClawTools(
         workspaceDir,
         sandbox,
         fsPolicy: options?.fsPolicy,
-        onAsyncTaskStarted: options?.onYield,
+        onAsyncTaskStarted: mediaGenerationAsyncStartCallback,
       })
     : null;
   options?.recordToolPrepStage?.("openclaw-tools:video-generate-tool");
@@ -276,7 +281,7 @@ export function createOpenClawTools(
         workspaceDir,
         sandbox,
         fsPolicy: options?.fsPolicy,
-        onAsyncTaskStarted: options?.onYield,
+        onAsyncTaskStarted: mediaGenerationAsyncStartCallback,
       })
     : null;
   options?.recordToolPrepStage?.("openclaw-tools:music-generate-tool");

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -305,11 +305,13 @@ describe("createOpenClawTools media generation session wiring", () => {
       runSessionKey: "agent:main:cron:daily-media:run:run-123",
       disableMessageTool: true,
       disablePluginTools: true,
+      onYield: vi.fn(),
     });
 
     expect(mocks.createImageGenerateToolOptions).toHaveBeenCalledWith(
       expect.objectContaining({
         agentSessionKey: "agent:main:cron:daily-media:run:run-123",
+        onAsyncTaskStarted: undefined,
       }),
     );
     expect(mocks.createVideoGenerateToolOptions).toHaveBeenCalledWith(

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -40,6 +40,7 @@ const slackThreadOrigin = {
 function createGatewayMock(response: Record<string, unknown> = {}) {
   return vi.fn(async () => response) as unknown as typeof runtimeCallGateway;
 }
+
 function createInProcessGatewayMock(response: Record<string, unknown> = {}) {
   return vi.fn(async () => response) as unknown as typeof runtimeDispatchGatewayMethodInProcess;
 }
@@ -1478,6 +1479,69 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expectFinal: true,
       forceSyntheticClient: true,
       timeoutMs: 120_000,
+    });
+  });
+
+  it("does not require generated media delivery for no-target cron completion handoffs", async () => {
+    const dispatchGatewayMethodInProcess = createInProcessGatewayMock({
+      result: {
+        payloads: [{ text: "cron saw generated media completion" }],
+      },
+    });
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(false);
+    testing.setDepsForTest({
+      dispatchGatewayMethodInProcess,
+      queueEmbeddedAgentMessageWithOutcome,
+      getRequesterSessionActivity: () => ({
+        sessionId: "cron-run-session",
+        isActive: true,
+      }),
+      getRuntimeConfig: () => ({}) as never,
+    });
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:cron:media-job:run:run-123",
+      targetRequesterSessionKey: "agent:main:cron:media-job:run:run-123",
+      triggerMessage: "image done",
+      steerMessage: "image done",
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-cron-media-no-target",
+      sourceTool: "image_generate",
+      sourceSessionKey: "image_generate:task-123",
+      sourceChannel: "internal",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "image_generation",
+          childSessionKey: "image_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "image generation task",
+          taskLabel: "cron proof image",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 image.\nMEDIA:/tmp/generated-cron-proof.png",
+          mediaUrls: ["/tmp/generated-cron-proof.png"],
+          replyInstruction: "Continue the cron job after the generated image is ready.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledWith(
+      "cron-run-session",
+      "image done",
+      expect.objectContaining({
+        waitForTranscriptCommit: true,
+      }),
+    );
+    expectInProcessAgentParams(dispatchGatewayMethodInProcess, {
+      deliver: false,
+      sessionKey: "agent:main:cron:media-job:run:run-123",
     });
   });
 

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1473,22 +1473,21 @@ async function sendSubagentAnnounceDirectly(params: {
       shouldDeliverAgentFinal || requiresMessageToolDelivery
         ? getGatewayAgentCommandDeliveryFailure(directAnnounceResponse)
         : undefined;
-    const missingExpectedMediaUrls =
-      agentMediatedCompletion && expectedMediaUrls.length > 0
-        ? resolveGeneratedMediaDirectFallbackUrls({
-            expectedMediaUrls,
-            announceResponse: directAnnounceResponse,
-            requiresMessageToolDelivery,
-            automaticDeliveryRequested: shouldDeliverAgentFinal,
-            automaticDeliveryFailed: !requiresMessageToolDelivery && Boolean(directDeliveryFailure),
-            deliveryTarget,
-          })
-        : [];
-    if (
+    const shouldRequireGeneratedMediaDelivery =
       agentMediatedCompletion &&
       expectedMediaUrls.length > 0 &&
-      missingExpectedMediaUrls.length > 0
-    ) {
+      (params.requesterIsSubagent || shouldDeliverAgentFinal || requiresMessageToolDelivery);
+    const missingExpectedMediaUrls = shouldRequireGeneratedMediaDelivery
+      ? resolveGeneratedMediaDirectFallbackUrls({
+          expectedMediaUrls,
+          announceResponse: directAnnounceResponse,
+          requiresMessageToolDelivery,
+          automaticDeliveryRequested: shouldDeliverAgentFinal,
+          automaticDeliveryFailed: !requiresMessageToolDelivery && Boolean(directDeliveryFailure),
+          deliveryTarget,
+        })
+      : [];
+    if (shouldRequireGeneratedMediaDelivery && missingExpectedMediaUrls.length > 0) {
       const generatedMediaDelivery = await tryGeneratedMediaDirectDelivery(
         directAnnounceResponse,
         missingExpectedMediaUrls,

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -781,7 +781,7 @@ describe("createImageGenerateTool", () => {
     expect(resultDetails(duplicateResult).duplicateGuard).toBe(true);
   });
 
-  it("keeps run-scoped cron image generation inline", async () => {
+  it("starts run-scoped cron image generation as a tracked async task", async () => {
     stubImageGenerationProviders();
     vi.stubEnv("OPENAI_API_KEY", "openai-test");
     const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
@@ -837,16 +837,16 @@ describe("createImageGenerateTool", () => {
       model: "openai/gpt-image-1",
     });
 
-    expect(generateImage).toHaveBeenCalledOnce();
-    expect(scheduled).toHaveLength(0);
-    expect(onAsyncTaskStarted).not.toHaveBeenCalled();
-    expect(resultText(result)).toContain("Generated 1 image with openai/gpt-image-1.");
-    expect(resultText(result)).toContain('path="/tmp/generated-cron.png"');
-    expect(resultDetails(result).async).toBeUndefined();
-    expect(taskRuntimeMocks.completeTaskRunByRunId).toHaveBeenCalledWith(
+    expect(generateImage).not.toHaveBeenCalled();
+    expect(scheduled).toHaveLength(1);
+    expect(onAsyncTaskStarted).toHaveBeenCalledOnce();
+    expect(resultText(result)).toContain("Background task started for image generation");
+    expect(resultDetails(result).async).toBe(true);
+    expect(resultDetails(result).runId).toEqual(expect.stringMatching(/^tool:image_generate:/));
+    expect(taskRuntimeMocks.createRunningTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: expect.stringMatching(/^tool:image_generate:/),
-        sessionKey: "agent:main:cron:daily-media:run:run-123",
+        requesterSessionKey: "agent:main:cron:daily-media:run:run-123",
       }),
     );
   });

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -781,6 +781,76 @@ describe("createImageGenerateTool", () => {
     expect(resultDetails(duplicateResult).duplicateGuard).toBe(true);
   });
 
+  it("keeps run-scoped cron image generation inline", async () => {
+    stubImageGenerationProviders();
+    vi.stubEnv("OPENAI_API_KEY", "openai-test");
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "openai",
+      model: "gpt-image-1",
+      attempts: [],
+      ignoredOverrides: [],
+      images: [
+        {
+          buffer: Buffer.from("png-out"),
+          mimeType: "image/png",
+          fileName: "cron.png",
+        },
+      ],
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/generated-cron.png",
+      id: "generated-cron.png",
+      size: 7,
+      contentType: "image/png",
+    });
+    taskRuntimeMocks.createRunningTaskRun.mockReturnValue({
+      taskId: "task-cron-image",
+    });
+    const scheduled: Array<() => Promise<void>> = [];
+    const onAsyncTaskStarted = vi.fn();
+    const tool = requireImageGenerateTool(
+      createImageGenerateTool({
+        config: {
+          agents: {
+            defaults: {
+              imageGenerationModel: {
+                primary: "openai/gpt-image-1",
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/agent",
+        agentSessionKey: "agent:main:cron:daily-media:run:run-123",
+        requesterOrigin: {
+          channel: "slack",
+          to: "channel:C123",
+        },
+        scheduleBackgroundWork: (work) => {
+          scheduled.push(work);
+        },
+        onAsyncTaskStarted,
+      }),
+    );
+
+    const result = await tool.execute("call-cron-inline", {
+      prompt: "Daily proof image",
+      model: "openai/gpt-image-1",
+    });
+
+    expect(generateImage).toHaveBeenCalledOnce();
+    expect(scheduled).toHaveLength(0);
+    expect(onAsyncTaskStarted).not.toHaveBeenCalled();
+    expect(resultText(result)).toContain("Generated 1 image with openai/gpt-image-1.");
+    expect(resultText(result)).toContain('path="/tmp/generated-cron.png"');
+    expect(resultDetails(result).async).toBeUndefined();
+    expect(taskRuntimeMocks.completeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: expect.stringMatching(/^tool:image_generate:/),
+        sessionKey: "agent:main:cron:daily-media:run:run-123",
+      }),
+    );
+  });
+
   it("starts a distinct image request while another image task is active", async () => {
     stubImageGenerationProviders();
     vi.stubEnv("OPENAI_API_KEY", "openai-test");

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -70,6 +70,7 @@ import {
   createDefaultMediaGenerateBackgroundScheduler,
   notifyMediaGenerationAsyncTaskStarted,
   scheduleMediaGenerationTaskCompletion,
+  shouldDetachMediaGenerationTask,
   type MediaGenerateAsyncStartCallback,
   type MediaGenerateBackgroundScheduler,
 } from "./media-generate-background-shared.js";
@@ -1018,7 +1019,9 @@ export function createImageGenerateTool(options?: {
         prompt,
         providerId: selectedProvider?.id,
       });
-      const shouldDetach = Boolean(taskHandle && options?.agentSessionKey?.trim());
+      const shouldDetach = Boolean(
+        taskHandle && shouldDetachMediaGenerationTask(options?.agentSessionKey),
+      );
 
       if (shouldDetach && taskHandle) {
         recordRecentMediaGenerationTaskStartForSession({

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -13,11 +13,21 @@ vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskRegistryDeliv
 import {
   createMediaGenerationTaskLifecycle,
   scheduleMediaGenerationTaskCompletion,
+  shouldDetachMediaGenerationTask,
 } from "./media-generate-background-shared.js";
 
 beforeEach(() => {
   subagentAnnounceDeliveryMocks.deliverSubagentAnnouncement.mockReset();
   taskRegistryDeliveryRuntimeMocks.sendMessage.mockReset();
+});
+
+describe("shouldDetachMediaGenerationTask", () => {
+  it("keeps run-scoped cron media inline", () => {
+    expect(shouldDetachMediaGenerationTask("agent:main:discord:direct:123")).toBe(true);
+    expect(shouldDetachMediaGenerationTask("agent:main:cron:daily-media")).toBe(true);
+    expect(shouldDetachMediaGenerationTask("agent:main:cron:daily-media:run:run-123")).toBe(false);
+    expect(shouldDetachMediaGenerationTask(undefined)).toBe(false);
+  });
 });
 
 describe("scheduleMediaGenerationTaskCompletion", () => {

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -22,10 +22,10 @@ beforeEach(() => {
 });
 
 describe("shouldDetachMediaGenerationTask", () => {
-  it("keeps run-scoped cron media inline", () => {
+  it("detaches session-backed media generation", () => {
     expect(shouldDetachMediaGenerationTask("agent:main:discord:direct:123")).toBe(true);
     expect(shouldDetachMediaGenerationTask("agent:main:cron:daily-media")).toBe(true);
-    expect(shouldDetachMediaGenerationTask("agent:main:cron:daily-media:run:run-123")).toBe(false);
+    expect(shouldDetachMediaGenerationTask("agent:main:cron:daily-media:run:run-123")).toBe(true);
     expect(shouldDetachMediaGenerationTask(undefined)).toBe(false);
   });
 });

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -4,6 +4,7 @@ import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { isCronRunSessionKey } from "../../sessions/session-key-utils.js";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -46,6 +47,11 @@ export type MediaGenerationTaskHandle = {
 export type MediaGenerateBackgroundScheduler = (work: () => Promise<void>) => void;
 
 export type MediaGenerateAsyncStartCallback = (message: string) => Promise<void> | void;
+
+export function shouldDetachMediaGenerationTask(sessionKey: string | undefined): boolean {
+  const normalizedSessionKey = sessionKey?.trim();
+  return Boolean(normalizedSessionKey && !isCronRunSessionKey(normalizedSessionKey));
+}
 
 export type MediaGenerationExecutionResult = {
   provider: string;

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -4,7 +4,6 @@ import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { isCronRunSessionKey } from "../../sessions/session-key-utils.js";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -50,7 +49,7 @@ export type MediaGenerateAsyncStartCallback = (message: string) => Promise<void>
 
 export function shouldDetachMediaGenerationTask(sessionKey: string | undefined): boolean {
   const normalizedSessionKey = sessionKey?.trim();
-  return Boolean(normalizedSessionKey && !isCronRunSessionKey(normalizedSessionKey));
+  return Boolean(normalizedSessionKey);
 }
 
 export type MediaGenerationExecutionResult = {

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -42,6 +42,7 @@ import {
   createDefaultMediaGenerateBackgroundScheduler,
   notifyMediaGenerationAsyncTaskStarted,
   scheduleMediaGenerationTaskCompletion,
+  shouldDetachMediaGenerationTask,
   type MediaGenerateAsyncStartCallback,
   type MediaGenerateBackgroundScheduler,
 } from "./media-generate-background-shared.js";
@@ -724,7 +725,9 @@ export function createMusicGenerateTool(options?: {
         prompt,
         providerId: selectedProvider?.id ?? selectedModelRef?.provider,
       });
-      const shouldDetach = Boolean(taskHandle && options?.agentSessionKey?.trim());
+      const shouldDetach = Boolean(
+        taskHandle && shouldDetachMediaGenerationTask(options?.agentSessionKey),
+      );
 
       if (shouldDetach && taskHandle) {
         recordRecentMediaGenerationTaskStartForSession({

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -52,6 +52,7 @@ import {
   createDefaultMediaGenerateBackgroundScheduler,
   notifyMediaGenerationAsyncTaskStarted,
   scheduleMediaGenerationTaskCompletion,
+  shouldDetachMediaGenerationTask,
   type MediaGenerateAsyncStartCallback,
   type MediaGenerateBackgroundScheduler,
 } from "./media-generate-background-shared.js";
@@ -1172,7 +1173,9 @@ export function createVideoGenerateTool(options?: {
         prompt,
         providerId: selectedProvider?.id,
       });
-      const shouldDetach = Boolean(taskHandle && options?.agentSessionKey?.trim());
+      const shouldDetach = Boolean(
+        taskHandle && shouldDetachMediaGenerationTask(options?.agentSessionKey),
+      );
 
       if (shouldDetach && taskHandle) {
         recordRecentMediaGenerationTaskStartForSession({


### PR DESCRIPTION
## Summary

- Keep cron media generation detached, but suppress the interactive yield path and make the embedded runner wait for cron-owned image, music, and video tasks to finish before final closeout.
- Record async task run IDs from tool results, with a task-registry fallback for already-active run-scoped media tasks and timeout-aware completion handling.
- Relax generated-media delivery only for no-target cron completion handoffs, where there is no external reply target to satisfy.

Fixes #88001.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/media-generate-background-shared.test.ts src/agents/openclaw-tools.tts-config.test.ts` (7 unit-fast tests, 157 agent tests)
- `node scripts/run-vitest.mjs src/agents/tools/video-generate-tool.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/cron/isolated-agent.session-identity.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts` (16 unit-fast tests, 49 cron tests, 253 agent tests)
- `git diff --check`
- `pnpm exec oxlint ...` on touched lint-fix files and async-task runner files
- `.agents/skills/autoreview/scripts/autoreview --mode local` (first pass found timeout/video wait gaps; fixed; rerun clean with no accepted/actionable findings)
- Testbox-through-Crabbox `tbx_01kszpcj4j4w3w4v2343bsgw4p`, Actions run `26721537214`: `corepack pnpm check:changed` passed
- Testbox-through-Crabbox `tbx_01kszqtqh324fypas2y1yaz3c7`, Actions run `26722125851`: final `corepack pnpm check:changed` passed

## Real behavior proof

Behavior addressed: isolated cron `agentTurn` runs that call `image_generate` followed by `music_generate` should not finish the cron turn while media tasks are still running.

Real environment tested: direct AWS Crabbox live cron harness with real provider credentials. OpenAI and MiniMax API keys were injected from 1Password for the command only; secret values were not printed. The direct lease was released after the run.

Exact steps or command run after this patch: Crabbox live cron harness executing an isolated cron agent turn that generated one image with OpenAI and one music track with MiniMax, then asserted the task registry for succeeded `image_generation` and `music_generation` task records.

Evidence after fix: live run `run_f0087434d34b` returned status `ok`; marker `cron-media-live-1780249952289`; image task `tool:image_generate:7a25d54e-d1e7-4b8b-af56-4ec315028e70`; music task `tool:music_generate:05703bea-b42c-45f9-9b49-46e5282e2f63`; task statuses `image_generation:succeeded` and `music_generation:succeeded`.

Observed result after fix: the cron agent turn waited through image completion, continued into music generation, waited for the music task, and returned final output containing both generated media paths instead of closing after the async-start response.

What was not tested: live video generation. Video uses the same registry-backed completion wait and has regression coverage here; the requested live proof was image plus music.
