### PR TITLE
fix #70559: runUnsafeReindex crashes with "no such table: chunks_vec" when sqlite-vec is enabled

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -345,6 +345,27 @@ describe("memory index", () => {
     }
   }
 
+  it("does not prepare vector deletes after unsafe reset drops a missing vector table", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-vector-missing-table.sqlite"),
+      vectorEnabled: true,
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getFreshManager(cfg);
+    managersForCleanup.add(manager);
+    type VectorState = { available: boolean | null; dims?: number };
+    const vector = Reflect.get(manager, "vector") as VectorState;
+    vector.available = true;
+    vector.dims = 4;
+    Reflect.set(manager, "vectorReady", Promise.resolve(true));
+
+    await expect(
+      Reflect.apply(Reflect.get(manager, "runUnsafeReindex"), manager, [
+        { reason: "test", force: true },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
   async function getFtsSessionManager(params: {
     stateDirName: string;
     storeFileName: string;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1817,8 +1817,19 @@ export abstract class MemoryManagerSyncOps {
       } catch {}
     }
     this.ensureSchema();
-    this.dropVectorTable();
-    this.vector.dims = undefined;
+    if (this.vector.enabled && this.vector.available) {
+      try {
+        this.db.exec(`DELETE FROM ${VECTOR_TABLE}`);
+      } catch {
+        this.dropVectorTable();
+        this.vector.dims = undefined;
+        this.vector.available = null;
+        this.vectorReady = null;
+      }
+    } else {
+      this.dropVectorTable();
+      this.vector.dims = undefined;
+    }
     this.sessionsDirtyFiles.clear();
   }
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?

`runUnsafeReindex` crashed with `SqliteError: no such table: chunks_vec` when sqlite-vec was enabled. Root cause: `resetIndex()` could drop the `chunks_vec` virtual table while cached vector readiness still described it as available, so later sync setup prepared vector-table deletes against a missing table.

Why does this matter now?

#70559 is a user-visible memory-core crash in unsafe reindex. Users with sqlite-vec enabled can lose the ability to rebuild the memory index cleanly, which makes memory recovery/reindex workflows unreliable.

What is the intended outcome?

Unsafe full reindex preserves the sqlite-vec table schema on the normal path, clears vector rows in place, and resets cached vector readiness if the delete path fails.

What is intentionally out of scope?

Out of scope: safe reindex, embedding provider selection, external embedding transport, config defaults, schema migrations, gateway behavior, and Windows handle-contention behavior. This PR only changes builtin memory-core unsafe reset lifecycle and its regression coverage.

What does success look like?

Unsafe reindex completes with sqlite-vec enabled, stale vector rows are removed, `chunks_vec` still exists, new indexed vector rows can be written, and vector metadata remains valid.

What should reviewers focus on?

Review focus: the unsafe-reindex vector lifecycle choice, especially whether preserving `chunks_vec` while clearing rows is the desired persisted-index reset contract.

Additional maintainer fields:

- Fix classification: root-cause fix.
- Maintainer-ready confidence: high, with the remaining decision points called out under Current review state.
- Scope boundary: one issue, two files, builtin memory-core unsafe reset lifecycle only.
- Source of truth boundary: `resetIndex()` owns the full-index reset invariant between persisted SQLite tables and cached vector readiness; downstream vector delete/insert code should not compensate for stale table-availability state.
- Related open PR scan: this is the existing contributor PR for #70559; this update does not create a competing narrower PR and treats gateway-core CI as outside the memory-core diff unless maintainers decide otherwise.

## Linked context

Closes #70559.

Related: existing PR #88696 review state and ClawSweeper RF-001 through RF-005.

This was not requested by a maintainer directly; it addresses the linked user-visible memory-core crash.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: unsafe full reindex with sqlite-vec enabled no longer crashes at the reset/prepare boundary after stale vector-table state exists.
- Real environment tested: Linux x64, Node.js 22.22.0, OpenClaw source checkout, real SQLite database, real sqlite-vec Linux x64 extension, builtin memory backend, isolated config/state/workspace, and an in-process local proof embedding provider so no external API key or network provider was required.
- Exact steps or command run after this patch:
  - Seeded an isolated SQLite memory index with real `files`, `chunks`, `meta`, and `chunks_vec` (`vec0`) tables.
  - Loaded the real sqlite-vec extension and inserted one stale vector row with `vectorDims: 4` metadata.
  - Ran the current-head memory manager sync path with `force: true` and `OPENCLAW_TEST_FAST=1` / `OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX=1`, using a config that resolves to the seeded DB and vector-enabled builtin memory backend.
  - Re-opened the DB with sqlite-vec loaded and verified the virtual table still exists, stale vector/chunk/file rows are gone, new indexed rows exist, and metadata has `vectorDims: 4`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  Validation `live-sqlite-vec-proof` (pass, exit_code=0, 7590ms)
  before: sqliteVecLoadable=true chunksVecExists=true vectorRows=1 seededVectorDims=4
  resolvedConfig {"backend":"builtin","storePath":"[local path redacted]","vectorEnabled":true,"provider":"proof"}
  managerBefore ... "vector":{"enabled":true,"dims":4} ... "indexIdentity":{"status":"mismatched","reason":"index scope changed"}
  managerAfter ... "vector":{"enabled":true,"storeAvailable":true,"extensionPath":"[local path redacted]","dims":4} ... "providerState":{"mode":"active","providerId":"proof"} ... "indexIdentity":{"status":"valid"}
  after: cliExit=0 chunksVecExists=true vectorRows=1 staleVectorRows=0 chunksRows=1 staleChunkRows=0 filesRows=1 staleFileRows=0 metaWritten=true metaProvider=proof metaModel=proof-embed metaVectorDims=4
  platform: linux x64 node=22.22.0
  ```

- Observed result after fix: the unsafe reindex path completed with sqlite-vec enabled, preserved `chunks_vec`, removed the stale `seed-row`, wrote a new vector row for the indexed memory file, and persisted valid vector metadata.
- What was not tested: the original Windows live-agent handle-contention deployment was not reproduced end to end; this proof isolates the sqlite-vec reset/prepare boundary that causes the `chunks_vec` crash.
- Proof limitations or environment constraints: the proof uses a local in-process proof embedding provider to avoid external API/network dependency; it validates sqlite-vec table lifecycle and vector writes, not remote embedding transport.
- Before evidence (optional but encouraged): source inspection and the regression test model the broken pre-fix invariant: cached vector availability can remain true while the physical `chunks_vec` table is missing, which makes later prepared deletes fail with `no such table: chunks_vec`.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/memory/index.test.ts -t 'does not prepare vector deletes after unsafe reset drops a missing vector table'` — passed, 1 test / 38 skipped.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/memory/index.test.ts` — passed, 39 tests.
- `node <evidence>/live-sqlite-vec-proof.mjs` via `daily_fix.sh run-validation --name live-sqlite-vec-proof` — passed; real sqlite-vec table existed before and after unsafe reset, stale rows were removed, new vector rows and `vectorDims: 4` metadata were written.
- Remote `checks-node-agentic-gateway-core` failure was attributed from the CI log to `src/gateway/gateway-cli-backend.connect.test.ts > gateway cli backend connect > connects a test gateway client through the live helper`, which timed out after 5000ms in the `test/vitest/vitest.gateway-client.config.ts` shard. Local mapping for the shard was attempted with `node scripts/test-projects.mjs test/vitest/vitest.gateway-core.config.ts test/vitest/vitest.gateway-client.config.ts`; it produced repeated no-output/hang messages and was stopped without a local memory-core assertion failure. The failing test is in gateway client/live-helper code and is outside this PR's memory-core diff.

What regression coverage was added or updated?

- Added/kept focused memory-core regression coverage for the stale cached-vector state: vector availability and dimensions are cached, the physical `chunks_vec` table is missing, and unsafe reindex must not prepare deletes against a missing table.

What failed before this fix, if known?

- The issue path failed with `SqliteError: no such table: chunks_vec` during unsafe reindex when sqlite-vec was enabled and vector-table lifecycle state became inconsistent.

If no test was added, why not?

- Not applicable; regression coverage and real behavior proof are both included.

## Root cause and patch quality

- Root cause: `resetIndex()` could make the physical SQLite schema and cached vector state disagree by dropping `chunks_vec` while leaving vector availability/readiness cached as usable.
- Why this is root-cause fix: the fix restores the invariant at the reset boundary itself. When sqlite-vec is available, reset clears vector rows without destroying the virtual table schema. If that path fails, cached vector dimensions/readiness/availability are cleared before later sync setup can prepare statements against stale state.
- Patch quality notes: production changes remain limited to `extensions/memory-core/src/memory/manager-sync-ops.ts`; regression coverage is limited to `extensions/memory-core/src/memory/index.test.ts`; no public config, protocol, provider API, or schema migration is added.
- Canonical scope: `resetIndex()` is the canonical owner for unsafe full-index clearing; fixing it there avoids special-casing later vector delete preparation or hiding the problem in search/index callers.
- Target test file: `extensions/memory-core/src/memory/index.test.ts`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Unsafe full reindex with sqlite-vec enabled should now complete instead of crashing when vector state was stale.

Did config, environment, or migration behavior change? (`Yes/No`)

No config or environment contract changed. Yes, the persisted sqlite-vec index reset lifecycle changes for unsafe reindex: the normal path now preserves `chunks_vec` schema and clears rows in place, while fallback clears cached vector readiness before future sync work.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Persisted memory index/session-state lifecycle for sqlite-vec during unsafe reindex.

How is that risk mitigated?

- The change is limited to fixed-table memory-core reset logic.
- Normal sqlite-vec-available reset uses `DELETE FROM chunks_vec` rather than dropping the virtual table, matching the table's existing row-delete usage in vector writes.
- If vector-table delete fails, cached vector dimensions/readiness/availability are cleared so subsequent sync setup does not treat a missing table as available.
- Targeted regression, full `index.test.ts`, and live sqlite-vec proof all passed on current head.

## Current review state

What is the next action?

Contributor side: ready for maintainer review after this PR body update and submit flow. Maintainer side: decide whether to accept the unsafe-reindex sqlite-vec lifecycle contract and whether the Linux sqlite-vec boundary proof is sufficient without Windows live-agent handle-contention proof.

What is still waiting on author, maintainer, CI, or external proof?

- RF-001 / RF-005: `checks-node-agentic-gateway-core` was failing on the reviewed remote head. CI log attribution points to `src/gateway/gateway-cli-backend.connect.test.ts` timing out after 5000ms in the gateway-client shard, while this PR only changes memory-core reset/test files. Local shard reproduction attempt hung with no memory-core assertion output. If the check remains required, it needs CI-side resolution, rerun, waiver, or maintainer investigation.
- RF-002 / RF-003: maintainers should explicitly accept the persisted sqlite-vec lifecycle behavior: preserve `chunks_vec` on normal unsafe reset, clear rows, and reset cached vector state on fallback.
- RF-004: Windows live-agent handle-contention behavior was not reproduced end to end; current proof covers Linux sqlite-vec reset/prepare boundary with real sqlite-vec and vector writes.

Which bot or reviewer comments were addressed?

- Addressed ClawSweeper's proof concern with a current-head live sqlite-vec proof that uses the actual builtin memory backend, vector-enabled manager state, real sqlite-vec extension loading, stale vector-row seed, unsafe reindex, and post-run DB assertions.
- Addressed lifecycle-risk comments by documenting the intended reset contract and calling out the maintainer acceptance decision explicitly.
- Addressed the failing gateway-core signal by mapping it to `test/vitest/vitest.gateway-core.config.ts` plus `test/vitest/vitest.gateway-client.config.ts`, attempting local validation, and disclosing the no-output/hang limitation instead of treating it as memory-core evidence.
