### PR TITLE
fix(codex): clear stale context-engine projection after overflow retry

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -1233,7 +1233,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     const savedBinding = await readCodexAppServerBinding(sessionFile);
     expect(savedBinding?.threadId).toBe("thread-fresh");
     expect(savedBinding?.contextEngine?.engineId).toBe("lossless-claw");
-    expect(savedBinding?.contextEngine?.projection?.epoch).toBe("epoch-before");
+    expect(savedBinding?.contextEngine?.projection).toBeUndefined();
   });
 
   it("preserves a newer context-engine binding when a stale resumed thread overflows", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1873,6 +1873,38 @@ export async function runCodexAppServerAttempt(
           );
         } else {
           thread = await restartContextEngineCodexThread();
+          // The fresh retry thread was not bootstrapped with the
+          // context-engine projection. Clear the stale projection from
+          // the saved binding so the next run will re-project instead
+          // of assuming the old epoch is still in the thread.
+          {
+            const retryBinding = await readCodexAppServerBinding(activeSessionFile);
+            if (
+              retryBinding &&
+              retryBinding.threadId === thread.threadId &&
+              retryBinding.contextEngine?.projection
+            ) {
+              const {
+                schemaVersion: _schemaVersion,
+                sessionFile: _boundSessionFile,
+                updatedAt: _updatedAt,
+                ...bindingForWrite
+              } = retryBinding;
+              await writeCodexAppServerBinding(activeSessionFile, {
+                ...bindingForWrite,
+                contextEngine: bindingForWrite.contextEngine
+                  ? { ...bindingForWrite.contextEngine, projection: undefined }
+                  : undefined,
+              });
+              embeddedAgentLog.info(
+                "codex app-server cleared stale context-engine projection after overflow retry",
+                {
+                  threadId: thread.threadId,
+                  previousEpoch: retryBinding.contextEngine.projection.epoch,
+                },
+              );
+            }
+          }
           emitCodexAppServerEvent(params, {
             stream: "codex_app_server.lifecycle",
             data: { phase: "thread_ready_retry", threadId: thread.threadId },


### PR DESCRIPTION
## Summary

When a resumed Codex thread with a `thread_bootstrap` context-engine binding overflows during `turn/start`, OpenClaw retries on a fresh thread but preserves the old projection epoch in the saved binding. The fresh thread never received the projected context, so the binding creates a false invariant: future runs treat the thread as if it already contains the context-engine bootstrap, skipping re-projection and silently losing context.

Closes #88355

## Changes

**`extensions/codex/src/app-server/run-attempt.ts`**

After `restartContextEngineCodexThread()` creates the fresh retry thread, the fix reads the newly saved binding and clears the stale `contextEngine.projection` field. This ensures future runs will re-project instead of assuming the old epoch is still bootstrapped on the fresh thread.

The fix follows the same binding read/strip/write pattern used by `markCodexAppServerBindingCoveredThroughTurn` (same file) and adds an info-level log entry for observability.

**`extensions/codex/src/app-server/run-attempt.context-engine.test.ts`**

Updated the "retries a resumed context-engine thread on a fresh Codex thread without plugin compaction" test to assert the correct behavior: `savedBinding.contextEngine.projection` is undefined after overflow retry, not the stale `epoch-before`.

## Real behavior proof

- **Behavior addressed:** Context-engine overflow retry preserves a stale `thread_bootstrap` projection binding on the fresh Codex thread. The fresh thread never received the projected context, creating a false binding invariant that causes future runs to skip re-projection and silently lose context.
- **Real environment tested:** macOS 15.5, Node v22.19, OpenClaw built from patched source at `/tmp/fix-88355`.
- **Exact steps or command run after this patch:**

  Step 1. Build from the fix branch:

  ```bash
  cd /tmp/fix-88355
  CI=true pnpm install --frozen-lockfile
  pnpm build
  ```

  Step 2. Verify the fix is active in the production bundle:

  ```bash
  grep -n "cleared stale context-engine projection" dist/run-attempt-*.js
  ```

  Step 3. Run the context-engine test to verify behavioral change:

  ```bash
  node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts
  ```

- **Evidence after fix:** terminal output from the patched build:

  The fix is active in the production bundle:

  ```console
  $ grep -n "cleared stale context-engine projection" dist/run-attempt-Bls4uL3x.js
  8465:log.info("codex app-server cleared stale context-engine projection after overflow retry", {
  ```

  The compiled overflow retry path correctly clears the stale projection binding before continuing:

  ```console
  $ sed -n '8455,8470p' dist/run-attempt-Bls4uL3x.js
  const retryBinding = await readCodexAppServerBinding(activeSessionFile);
  if (retryBinding && retryBinding.threadId === thread.threadId && retryBinding.contextEngine?.projection) {
  const { schemaVersion: _schemaVersion, sessionFile: _boundSessionFile, updatedAt: _updatedAt, ...bindingForWrite } = retryBinding;
  await writeCodexAppServerBinding(activeSessionFile, {
  ...bindingForWrite,
  contextEngine: bindingForWrite.contextEngine ? {
  ...bindingForWrite.contextEngine,
  projection: void 0
  } : void 0
  });
  log.info("codex app-server cleared stale context-engine projection after overflow retry", {
  threadId: thread.threadId,
  previousEpoch: retryBinding.contextEngine.projection.epoch
  });
  }
  ```

  Terminal confirms the overflow retry test correctly asserts projection is cleared:

  ```console
  $ node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts 2>&1 | grep "retries.*resumed"
  ✓ retries a resumed context-engine thread on a fresh Codex thread without plugin compaction 115ms
  ```

  Full test results: 22/23 pass (1 pre-existing failure in "does not inject mirrored history" unrelated to this change, same failure on upstream/main).

- **Observed result after fix:** The compiled production code at `dist/run-attempt-Bls4uL3x.js:8455-8468` correctly reads the freshly saved binding after overflow retry, detects the stale `thread_bootstrap` projection, clears it via `projection: void 0`, and logs the previous epoch for observability. The test "retries a resumed context-engine thread on a fresh Codex thread without plugin compaction" now correctly asserts `savedBinding.contextEngine.projection` is undefined instead of asserting the stale `epoch-before`.
- **What was not tested:** Live gateway session with a real context-engine plugin (lossless-claw) triggering a Codex context window overflow. The fix was verified through compiled production bundle inspection and the existing context-engine test harness.
