### PR TITLE
fix(memory): rehydrate daily list promotions

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -165,6 +165,8 @@ const config = {
         "vite.config.ts!",
         "vitest*.ts!",
       ],
+      // Workboard lazy-loads Three.js at runtime; Knip's dependency pass misses it.
+      ignoreDependencies: ["three"],
       project: ["src/**/*.{ts,tsx}!"],
     },
     "packages/sdk": {

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2026,6 +2026,56 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("rehydrates daily-ingested heading-prefixed list snippets from the live note", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## 模型切换 (16:23)",
+        "- **需求**: 用户想使用小米 Mimo 模型作为默认",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 4,
+            endLine: 4,
+            score: 0.91,
+            snippet: "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(4);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(4);
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("memory/2026-05-28.md:4-4");
+    });
+  });
+
   it("keeps rehydrated promotion snippets capped in the recall store", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2235,6 +2235,57 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("does not add heading context to ordinary list-item rehydration", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## Model routing",
+        "- Keep Xiaomi Mimo as the low-cost default.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 4,
+            endLine: 4,
+            score: 0.91,
+            snippet: "Keep Xiaomi Mimo as the low-cost default.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.snippet).toBe(
+        "Keep Xiaomi Mimo as the low-cost default.",
+      );
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).not.toContain("Model routing: Keep Xiaomi");
+    });
+  });
+
   it("rehydrates capped heading-prefixed list snippets from the live note", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const longBody = `Keep Xiaomi Mimo as the low-cost default ${"route ".repeat(80)}`.trim();

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2338,6 +2338,57 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("rehydrates capped heading-prefixed list snippets after the heading changes", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const longBody = `Keep Xiaomi Mimo as the low-cost default ${"route ".repeat(80)}`.trim();
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## New model routing",
+        `- ${longBody}`,
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 4,
+            endLine: 4,
+            score: 0.91,
+            snippet: `Old model routing: ${longBody}`.slice(0, 280).replace(/\s+/g, " ").trim(),
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.snippet).toContain(
+        "New model routing: Keep Xiaomi Mimo",
+      );
+      expect(applied.appliedCandidates[0]?.snippet).not.toContain("Old model routing");
+    });
+  });
+
   it("preserves the full range for capped heading-prefixed multi-line list snippets", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const maxDailySnippetChars = 280;

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2189,6 +2189,52 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("does not rehydrate heading-prefixed list snippets without a live body", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## Model routing",
+        "",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 4,
+            endLine: 4,
+            score: 0.91,
+            snippet: "Model routing: Keep Xiaomi Mimo as the low-cost default.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(0);
+    });
+  });
+
   it("rehydrates capped heading-prefixed list snippets from the live note", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const longBody = `Keep Xiaomi Mimo as the low-cost default ${"route ".repeat(80)}`.trim();

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2071,8 +2071,12 @@ describe("short-term promotion", () => {
       expect(applied.applied).toBe(1);
       expect(applied.appliedCandidates[0]?.startLine).toBe(4);
       expect(applied.appliedCandidates[0]?.endLine).toBe(4);
+      expect(applied.appliedCandidates[0]?.snippet).toBe(
+        "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认",
+      );
       const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
       expect(memoryText).toContain("memory/2026-05-28.md:4-4");
+      expect(memoryText).toContain("模型切换 (16:23): **需求**");
     });
   });
 
@@ -2123,9 +2127,174 @@ describe("short-term promotion", () => {
       expect(applied.applied).toBe(1);
       expect(applied.appliedCandidates[0]?.startLine).toBe(4);
       expect(applied.appliedCandidates[0]?.endLine).toBe(5);
+      expect(applied.appliedCandidates[0]?.snippet).toBe(
+        "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认; **偏好**: 保持低成本默认路由",
+      );
       const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
       expect(memoryText).toContain("memory/2026-05-28.md:4-5");
+      expect(memoryText).toContain("模型切换 (16:23): **需求**");
       expect(memoryText).toContain("**偏好**: 保持低成本默认路由");
+    });
+  });
+
+  it("rebuilds heading context from the live note during list rehydration", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## New model routing (16:23)",
+        "- Keep Xiaomi Mimo as the low-cost default.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 4,
+            endLine: 4,
+            score: 0.91,
+            snippet: "Old model routing: Keep Xiaomi Mimo as the low-cost default.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.snippet).toBe(
+        "New model routing (16:23): Keep Xiaomi Mimo as the low-cost default.",
+      );
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("New model routing (16:23)");
+      expect(memoryText).not.toContain("Old model routing");
+    });
+  });
+
+  it("does not reintroduce generic daily headings during list rehydration", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## Model routing",
+        "- Keep Xiaomi Mimo as the low-cost default.",
+        "",
+        "## Morning",
+        "- Reviewed travel timing before the workshop.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 7,
+            endLine: 7,
+            score: 0.91,
+            snippet: "Reviewed travel timing before the workshop.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.snippet).toBe(
+        "Reviewed travel timing before the workshop.",
+      );
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).not.toContain("Morning:");
+      expect(memoryText).not.toContain("Model routing: Reviewed travel timing");
+    });
+  });
+
+  it("does not reintroduce managed dreaming headings during list rehydration", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## Light Sleep",
+        "<!-- openclaw:dreaming:light:start -->",
+        "- Candidate: scratch reflection",
+        "<!-- openclaw:dreaming:light:end -->",
+        "- Reviewed travel timing before the workshop.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 7,
+            endLine: 7,
+            score: 0.91,
+            snippet: "Reviewed travel timing before the workshop.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.snippet).toBe(
+        "Reviewed travel timing before the workshop.",
+      );
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).not.toContain("Light Sleep:");
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2189,6 +2189,58 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("rehydrates capped heading-prefixed list snippets from the live note", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const longBody = `Keep Xiaomi Mimo as the low-cost default ${"route ".repeat(80)}`.trim();
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## Long model routing",
+        `- ${longBody}`,
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 4,
+            endLine: 4,
+            score: 0.91,
+            snippet: `Long model routing: ${longBody}`.slice(0, 280).replace(/\s+/g, " ").trim(),
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(4);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(4);
+      expect(applied.appliedCandidates[0]?.snippet).toContain(
+        "Long model routing: Keep Xiaomi Mimo",
+      );
+    });
+  });
+
   it("does not reintroduce generic daily headings during list rehydration", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-05-28", [

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2076,6 +2076,59 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("rehydrates daily-ingested multi-line list snippets from the full live note range", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## 模型切换 (16:23)",
+        "- **需求**: 用户想使用小米 Mimo 模型作为默认",
+        "- **偏好**: 保持低成本默认路由",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 4,
+            endLine: 5,
+            score: 0.91,
+            snippet:
+              "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认; **偏好**: 保持低成本默认路由",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(4);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(5);
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("memory/2026-05-28.md:4-5");
+      expect(memoryText).toContain("**偏好**: 保持低成本默认路由");
+    });
+  });
+
   it("keeps rehydrated promotion snippets capped in the recall store", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2389,6 +2389,59 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("keeps renamed heading fallback bound to colon-prefixed list bodies", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## Nearby shortcut",
+        "- use Mimo",
+        "",
+        "## New model routing",
+        "- **需求**: use Mimo",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 7,
+            endLine: 7,
+            score: 0.91,
+            snippet: "Old model routing: **需求**: use Mimo",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(7);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(7);
+      expect(applied.appliedCandidates[0]?.snippet).toBe("New model routing: **需求**: use Mimo");
+      expect(applied.appliedCandidates[0]?.snippet).not.toContain("Nearby shortcut");
+    });
+  });
+
   it("preserves the full range for capped heading-prefixed multi-line list snippets", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const maxDailySnippetChars = 280;

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2241,6 +2241,76 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("preserves the full range for capped heading-prefixed multi-line list snippets", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const maxDailySnippetChars = 280;
+      const firstListItem =
+        `Keep Xiaomi Mimo as the low-cost default ${"route ".repeat(12)}`.trim();
+      const secondListItem =
+        `Preserve the fallback routing note when the ingestion cap cuts this chunk ${"tail ".repeat(
+          42,
+        )}`.trim();
+      const fullIngestedSnippet = `Long model routing: ${firstListItem}; ${secondListItem}`
+        .replace(/\s+/g, " ")
+        .trim();
+      const ingestedSnippet = fullIngestedSnippet
+        .slice(0, maxDailySnippetChars)
+        .replace(/\s+/g, " ")
+        .trim();
+      expect(ingestedSnippet.length).toBeLessThan(fullIngestedSnippet.length);
+
+      await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+        "# 2026-05-28",
+        "",
+        "## Long model routing",
+        `- ${firstListItem}`,
+        `- ${secondListItem}`,
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-05-28",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-05-28",
+        results: [
+          {
+            path: "memory/2026-05-28.md",
+            startLine: 4,
+            endLine: 5,
+            score: 0.91,
+            snippet: ingestedSnippet,
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(4);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(5);
+      expect(applied.appliedCandidates[0]?.snippet).toContain(firstListItem);
+      expect(applied.appliedCandidates[0]?.snippet).toContain(secondListItem);
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("memory/2026-05-28.md:4-5");
+      expect(memoryText).toContain(secondListItem);
+    });
+  });
+
   it("does not reintroduce generic daily headings during list rehydration", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-05-28", [

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1683,6 +1683,24 @@ function targetSnippetHasHeadingContext(targetSnippet: string, bodySnippet: stri
   return targetSnippet.slice(0, bodyIndex).trimEnd().endsWith(":");
 }
 
+function extractTargetHeadingBodySnippet(
+  targetSnippet: string,
+  bodySnippet: string,
+): string | null {
+  if (!targetSnippet || !bodySnippet || targetSnippet === bodySnippet) {
+    return null;
+  }
+  if (bodySnippet.startsWith(targetSnippet)) {
+    return null;
+  }
+  const separatorIndex = targetSnippet.lastIndexOf(": ");
+  if (separatorIndex <= 0) {
+    return null;
+  }
+  const targetBody = normalizeSnippet(targetSnippet.slice(separatorIndex + 2));
+  return targetBody || null;
+}
+
 function compareCandidateWindow(
   targetSnippet: string,
   windowSnippet: string,
@@ -1753,26 +1771,42 @@ function relocateCandidateRange(
         listMarkerFreeMatchSnippet === listMarkerFreeSnippet
           ? { matched: false, quality: 0 }
           : compareCandidateWindow(targetSnippet, listMarkerFreeMatchSnippet);
+      const targetHeadingBodySnippet = extractTargetHeadingBodySnippet(
+        targetSnippet,
+        listMarkerFreeSnippet,
+      );
+      const targetHeadingBodyComparison =
+        targetHeadingBodySnippet && listMarkerFreeMatchSnippet !== listMarkerFreeSnippet
+          ? compareCandidateWindow(targetHeadingBodySnippet, listMarkerFreeSnippet)
+          : { matched: false, quality: 0 };
+      const useTargetHeadingBodyContext =
+        targetHeadingBodyComparison.matched &&
+        targetHeadingBodyComparison.quality >= comparison.quality &&
+        targetHeadingBodyComparison.quality >= listMarkerFreeComparison.quality;
       const useListMarkerFreeContext =
+        !useTargetHeadingBodyContext &&
         listMarkerFreeContextComparison.quality > comparison.quality &&
         listMarkerFreeContextComparison.quality >= listMarkerFreeComparison.quality;
       const useListMarkerFree =
         !useListMarkerFreeContext && listMarkerFreeComparison.quality > comparison.quality;
-      const bestComparison = useListMarkerFreeContext
-        ? listMarkerFreeContextComparison
-        : useListMarkerFree
-          ? listMarkerFreeComparison
-          : comparison;
+      const bestComparison = useTargetHeadingBodyContext
+        ? targetHeadingBodyComparison
+        : useListMarkerFreeContext
+          ? listMarkerFreeContextComparison
+          : useListMarkerFree
+            ? listMarkerFreeComparison
+            : comparison;
       if (!bestComparison.matched) {
         continue;
       }
-      const matchedSnippet = useListMarkerFreeContext
-        ? listMarkerFreeMatchSnippet
-        : useListMarkerFree
-          ? targetSnippetHasHeadingContext(targetSnippet, listMarkerFreeSnippet)
-            ? listMarkerFreeMatchSnippet
-            : listMarkerFreeSnippet
-          : snippet;
+      const matchedSnippet =
+        useTargetHeadingBodyContext || useListMarkerFreeContext
+          ? listMarkerFreeMatchSnippet
+          : useListMarkerFree
+            ? targetSnippetHasHeadingContext(targetSnippet, listMarkerFreeSnippet)
+              ? listMarkerFreeMatchSnippet
+              : listMarkerFreeSnippet
+            : snippet;
       const distance = Math.abs(startLine - candidate.startLine);
       if (
         !bestMatch ||

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1672,6 +1672,17 @@ function buildListMarkerFreeMatchSnippet(
   return heading ? normalizeSnippet(`${heading}: ${listMarkerFreeSnippet}`) : listMarkerFreeSnippet;
 }
 
+function targetSnippetHasHeadingContext(targetSnippet: string, bodySnippet: string): boolean {
+  if (!targetSnippet || !bodySnippet || targetSnippet === bodySnippet) {
+    return false;
+  }
+  const bodyIndex = targetSnippet.indexOf(bodySnippet);
+  if (bodyIndex <= 0) {
+    return false;
+  }
+  return targetSnippet.slice(0, bodyIndex).trimEnd().endsWith(":");
+}
+
 function compareCandidateWindow(
   targetSnippet: string,
   windowSnippet: string,
@@ -1755,8 +1766,13 @@ function relocateCandidateRange(
       if (!bestComparison.matched) {
         continue;
       }
-      const matchedSnippet =
-        useListMarkerFree || useListMarkerFreeContext ? listMarkerFreeMatchSnippet : snippet;
+      const matchedSnippet = useListMarkerFreeContext
+        ? listMarkerFreeMatchSnippet
+        : useListMarkerFree
+          ? targetSnippetHasHeadingContext(targetSnippet, listMarkerFreeSnippet)
+            ? listMarkerFreeMatchSnippet
+            : listMarkerFreeSnippet
+          : snippet;
       const distance = Math.abs(startLine - candidate.startLine);
       if (
         !bestMatch ||

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1605,12 +1605,14 @@ function normalizeListMarkerFreeRangeSnippet(
   if (startIndex >= endIndex) {
     return "";
   }
-  return normalizeSnippet(
-    lines
-      .slice(startIndex, endIndex)
-      .map((line) => line.trim().replace(PROMOTION_LIST_MARKER_RE, ""))
-      .join(" "),
-  );
+  const strippedLines = lines.slice(startIndex, endIndex).map((line) => {
+    const trimmed = line.trim();
+    const withoutMarker = trimmed.replace(PROMOTION_LIST_MARKER_RE, "");
+    return { text: withoutMarker, hadListMarker: withoutMarker !== trimmed };
+  });
+  const joiner =
+    strippedLines.length > 1 && strippedLines.every((line) => line.hadListMarker) ? "; " : " ";
+  return normalizeSnippet(strippedLines.map((line) => line.text).join(joiner));
 }
 
 function compareCandidateWindow(

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1665,6 +1665,9 @@ function buildListMarkerFreeMatchSnippet(
   startLine: number,
   listMarkerFreeSnippet: string,
 ): string {
+  if (!listMarkerFreeSnippet) {
+    return listMarkerFreeSnippet;
+  }
   const heading = findRelocatedDailyHeading(lines, startLine);
   return heading ? normalizeSnippet(`${heading}: ${listMarkerFreeSnippet}`) : listMarkerFreeSnippet;
 }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -53,6 +53,7 @@ const PHASE_SIGNAL_HALF_LIFE_DAYS = 14;
 const DREAMING_TRANSCRIPT_PROMPT_LINE_RE =
   /\[[^\]]*dreaming-narrative[^\]]*]\s*(?:User|Assistant):\s*Write a dream diary entry from these memory fragments:?/i;
 const DREAMING_DIFF_PREFIX_RE = /@@\s*-\d+(?:,\d+)?\s+[-*+]\s+/iy;
+const PROMOTION_LIST_MARKER_RE = /^(?:\d+\.\s+|[-*+]\s+)/;
 const inProcessShortTermLocks = new Map<string, Promise<void>>();
 const ensuredShortTermDirs = new Map<string, Promise<void>>();
 
@@ -1594,6 +1595,24 @@ function normalizeRangeSnippet(lines: string[], startLine: number, endLine: numb
   return normalizeSnippet(lines.slice(startIndex, endIndex).join(" "));
 }
 
+function normalizeListMarkerFreeRangeSnippet(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+): string {
+  const startIndex = Math.max(0, startLine - 1);
+  const endIndex = Math.min(lines.length, endLine);
+  if (startIndex >= endIndex) {
+    return "";
+  }
+  return normalizeSnippet(
+    lines
+      .slice(startIndex, endIndex)
+      .map((line) => line.trim().replace(PROMOTION_LIST_MARKER_RE, ""))
+      .join(" "),
+  );
+}
+
 function compareCandidateWindow(
   targetSnippet: string,
   windowSnippet: string,
@@ -1650,15 +1669,24 @@ function relocateCandidateRange(
       const endLine = startIndex + span;
       const snippet = normalizeRangeSnippet(lines, startLine, endLine);
       const comparison = compareCandidateWindow(targetSnippet, snippet);
-      if (!comparison.matched) {
+      const listMarkerFreeSnippet = normalizeListMarkerFreeRangeSnippet(lines, startLine, endLine);
+      const listMarkerFreeComparison =
+        listMarkerFreeSnippet === snippet
+          ? { matched: false, quality: 0 }
+          : compareCandidateWindow(targetSnippet, listMarkerFreeSnippet);
+      const bestComparison =
+        listMarkerFreeComparison.quality > comparison.quality
+          ? listMarkerFreeComparison
+          : comparison;
+      if (!bestComparison.matched) {
         continue;
       }
       const distance = Math.abs(startLine - candidate.startLine);
       if (
         !bestMatch ||
-        comparison.quality > bestMatch.quality ||
-        (comparison.quality === bestMatch.quality && distance < bestMatch.distance) ||
-        (comparison.quality === bestMatch.quality &&
+        bestComparison.quality > bestMatch.quality ||
+        (bestComparison.quality === bestMatch.quality && distance < bestMatch.distance) ||
+        (bestComparison.quality === bestMatch.quality &&
           distance === bestMatch.distance &&
           Math.abs(span - preferredSpan) <
             Math.abs(bestMatch.endLine - bestMatch.startLine + 1 - preferredSpan))
@@ -1667,7 +1695,7 @@ function relocateCandidateRange(
           startLine,
           endLine,
           snippet,
-          quality: comparison.quality,
+          quality: bestComparison.quality,
           distance,
         };
       }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -53,7 +53,10 @@ const PHASE_SIGNAL_HALF_LIFE_DAYS = 14;
 const DREAMING_TRANSCRIPT_PROMPT_LINE_RE =
   /\[[^\]]*dreaming-narrative[^\]]*]\s*(?:User|Assistant):\s*Write a dream diary entry from these memory fragments:?/i;
 const DREAMING_DIFF_PREFIX_RE = /@@\s*-\d+(?:,\d+)?\s+[-*+]\s+/iy;
+const GENERIC_DAY_HEADING_RE =
+  /^(?:(?:mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|sun|sunday)(?:,\s+)?)?(?:(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4}[/-]\d{2}[/-]\d{2})$/i;
 const PROMOTION_LIST_MARKER_RE = /^(?:\d+\.\s+|[-*+]\s+)/;
+const MANAGED_DREAMING_HEADINGS = new Set(["light sleep", "rem sleep"]);
 const inProcessShortTermLocks = new Map<string, Promise<void>>();
 const ensuredShortTermDirs = new Map<string, Promise<void>>();
 
@@ -1615,6 +1618,57 @@ function normalizeListMarkerFreeRangeSnippet(
   return normalizeSnippet(strippedLines.map((line) => line.text).join(joiner));
 }
 
+function normalizeDailyHeadingForPromotion(line: string): string | null {
+  const match = line.trim().match(/^#{1,6}\s+(.+)$/);
+  const heading = match?.[1]?.replace(PROMOTION_LIST_MARKER_RE, "").trim() ?? "";
+  const normalized = normalizeSnippet(heading);
+  if (
+    !normalized ||
+    SHORT_TERM_BASENAME_RE.test(normalized) ||
+    isGenericDailyHeadingForPromotion(normalized)
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function isGenericDailyHeadingForPromotion(heading: string): boolean {
+  const normalized = heading.trim().replace(/\s+/g, " ");
+  const lower = normalized.toLowerCase();
+  if (MANAGED_DREAMING_HEADINGS.has(lower)) {
+    return true;
+  }
+  if (lower === "today" || lower === "yesterday" || lower === "tomorrow") {
+    return true;
+  }
+  if (lower === "morning" || lower === "afternoon" || lower === "evening" || lower === "night") {
+    return true;
+  }
+  return GENERIC_DAY_HEADING_RE.test(normalized);
+}
+
+function findRelocatedDailyHeading(lines: string[], startLine: number): string | null {
+  for (let index = Math.max(0, startLine - 2); index >= 0; index -= 1) {
+    const line = lines[index] ?? "";
+    if (DREAMING_FENCE_START_RE.test(line) || DREAMING_FENCE_END_RE.test(line)) {
+      return null;
+    }
+    if (/^#{1,6}\s+.+$/.test(line.trim())) {
+      return normalizeDailyHeadingForPromotion(line);
+    }
+  }
+  return null;
+}
+
+function buildListMarkerFreeMatchSnippet(
+  lines: string[],
+  startLine: number,
+  listMarkerFreeSnippet: string,
+): string {
+  const heading = findRelocatedDailyHeading(lines, startLine);
+  return heading ? normalizeSnippet(`${heading}: ${listMarkerFreeSnippet}`) : listMarkerFreeSnippet;
+}
+
 function compareCandidateWindow(
   targetSnippet: string,
   windowSnippet: string,
@@ -1676,13 +1730,14 @@ function relocateCandidateRange(
         listMarkerFreeSnippet === snippet
           ? { matched: false, quality: 0 }
           : compareCandidateWindow(targetSnippet, listMarkerFreeSnippet);
-      const bestComparison =
-        listMarkerFreeComparison.quality > comparison.quality
-          ? listMarkerFreeComparison
-          : comparison;
+      const useListMarkerFree = listMarkerFreeComparison.quality > comparison.quality;
+      const bestComparison = useListMarkerFree ? listMarkerFreeComparison : comparison;
       if (!bestComparison.matched) {
         continue;
       }
+      const matchedSnippet = useListMarkerFree
+        ? buildListMarkerFreeMatchSnippet(lines, startLine, listMarkerFreeSnippet)
+        : snippet;
       const distance = Math.abs(startLine - candidate.startLine);
       if (
         !bestMatch ||
@@ -1696,7 +1751,7 @@ function relocateCandidateRange(
         bestMatch = {
           startLine,
           endLine,
-          snippet,
+          snippet: matchedSnippet,
           quality: bestComparison.quality,
           distance,
         };

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1726,18 +1726,34 @@ function relocateCandidateRange(
       const snippet = normalizeRangeSnippet(lines, startLine, endLine);
       const comparison = compareCandidateWindow(targetSnippet, snippet);
       const listMarkerFreeSnippet = normalizeListMarkerFreeRangeSnippet(lines, startLine, endLine);
+      const listMarkerFreeMatchSnippet = buildListMarkerFreeMatchSnippet(
+        lines,
+        startLine,
+        listMarkerFreeSnippet,
+      );
       const listMarkerFreeComparison =
         listMarkerFreeSnippet === snippet
           ? { matched: false, quality: 0 }
           : compareCandidateWindow(targetSnippet, listMarkerFreeSnippet);
-      const useListMarkerFree = listMarkerFreeComparison.quality > comparison.quality;
-      const bestComparison = useListMarkerFree ? listMarkerFreeComparison : comparison;
+      const listMarkerFreeContextComparison =
+        listMarkerFreeMatchSnippet === listMarkerFreeSnippet
+          ? { matched: false, quality: 0 }
+          : compareCandidateWindow(targetSnippet, listMarkerFreeMatchSnippet);
+      const useListMarkerFreeContext =
+        listMarkerFreeContextComparison.quality > comparison.quality &&
+        listMarkerFreeContextComparison.quality >= listMarkerFreeComparison.quality;
+      const useListMarkerFree =
+        !useListMarkerFreeContext && listMarkerFreeComparison.quality > comparison.quality;
+      const bestComparison = useListMarkerFreeContext
+        ? listMarkerFreeContextComparison
+        : useListMarkerFree
+          ? listMarkerFreeComparison
+          : comparison;
       if (!bestComparison.matched) {
         continue;
       }
-      const matchedSnippet = useListMarkerFree
-        ? buildListMarkerFreeMatchSnippet(lines, startLine, listMarkerFreeSnippet)
-        : snippet;
+      const matchedSnippet =
+        useListMarkerFree || useListMarkerFreeContext ? listMarkerFreeMatchSnippet : snippet;
       const distance = Math.abs(startLine - candidate.startLine);
       if (
         !bestMatch ||

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1647,28 +1647,30 @@ function isGenericDailyHeadingForPromotion(heading: string): boolean {
   return GENERIC_DAY_HEADING_RE.test(normalized);
 }
 
-function findRelocatedDailyHeading(lines: string[], startLine: number): string | null {
-  for (let index = Math.max(0, startLine - 2); index >= 0; index -= 1) {
+function buildRelocatedDailyHeadingLookup(lines: string[]): (string | null)[] {
+  const headings: (string | null)[] = Array.from({ length: lines.length + 1 }, () => null);
+  let currentHeading: string | null = null;
+  for (let index = 0; index < lines.length; index += 1) {
+    headings[index + 1] = currentHeading;
     const line = lines[index] ?? "";
     if (DREAMING_FENCE_START_RE.test(line) || DREAMING_FENCE_END_RE.test(line)) {
-      return null;
+      currentHeading = null;
+      continue;
     }
     if (/^#{1,6}\s+.+$/.test(line.trim())) {
-      return normalizeDailyHeadingForPromotion(line);
+      currentHeading = normalizeDailyHeadingForPromotion(line);
     }
   }
-  return null;
+  return headings;
 }
 
 function buildListMarkerFreeMatchSnippet(
-  lines: string[],
-  startLine: number,
+  heading: string | null,
   listMarkerFreeSnippet: string,
 ): string {
   if (!listMarkerFreeSnippet) {
     return listMarkerFreeSnippet;
   }
-  const heading = findRelocatedDailyHeading(lines, startLine);
   return heading ? normalizeSnippet(`${heading}: ${listMarkerFreeSnippet}`) : listMarkerFreeSnippet;
 }
 
@@ -1751,6 +1753,7 @@ function relocateCandidateRange(
   }
 
   const maxSpan = Math.min(lines.length, Math.max(preferredSpan + 3, 8));
+  const headingLookup = buildRelocatedDailyHeadingLookup(lines);
   let bestMatch:
     | { startLine: number; endLine: number; snippet: string; quality: number; distance: number }
     | undefined;
@@ -1762,8 +1765,7 @@ function relocateCandidateRange(
       const comparison = compareCandidateWindow(targetSnippet, snippet);
       const listMarkerFreeSnippet = normalizeListMarkerFreeRangeSnippet(lines, startLine, endLine);
       const listMarkerFreeMatchSnippet = buildListMarkerFreeMatchSnippet(
-        lines,
-        startLine,
+        headingLookup[startLine] ?? null,
         listMarkerFreeSnippet,
       );
       const listMarkerFreeComparison =

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1693,12 +1693,15 @@ function extractTargetHeadingBodySnippet(
   if (bodySnippet.startsWith(targetSnippet)) {
     return null;
   }
-  const separatorIndex = targetSnippet.lastIndexOf(": ");
-  if (separatorIndex <= 0) {
-    return null;
+  const normalizedBody = normalizeSnippet(bodySnippet);
+  for (let separatorIndex = targetSnippet.indexOf(": "); separatorIndex > 0; ) {
+    const targetBody = normalizeSnippet(targetSnippet.slice(separatorIndex + 2));
+    if (targetBody && normalizedBody.startsWith(targetBody)) {
+      return targetBody;
+    }
+    separatorIndex = targetSnippet.indexOf(": ", separatorIndex + 2);
   }
-  const targetBody = normalizeSnippet(targetSnippet.slice(separatorIndex + 2));
-  return targetBody || null;
+  return null;
 }
 
 function compareCandidateWindow(

--- a/extensions/microsoft-foundry/provider.ts
+++ b/extensions/microsoft-foundry/provider.ts
@@ -58,7 +58,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         const nextModel = Object.assign({}, model, {
           name: selectedModelCapabilities.modelName,
           api: selectedModelCapabilities.api,
-          reasoning: selectedModelCapabilities.reasoning || model.reasoning === true,
+          reasoning: selectedModelCapabilities.reasoning || model.reasoning,
           thinkingLevelMap: selectedModelCapabilities.thinkingLevelMap ?? model.thinkingLevelMap,
           input: selectedModelCapabilities.input,
         });
@@ -69,7 +69,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
               : undefined;
           const preserveExplicitReasoningEffort =
             !selectedModelCapabilities.reasoning &&
-            model.reasoning === true &&
+            model.reasoning &&
             explicitSupportsReasoningEffort !== false;
           const explicitMaxTokensField =
             typeof model.compat?.maxTokensField === "string"
@@ -78,7 +78,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
                 ? "max_completion_tokens"
                 : undefined;
           nextModel.compat = {
-            ...(model.compat ?? {}),
+            ...model.compat,
             ...selectedModelCapabilities.compat,
             ...(explicitSupportsReasoningEffort !== undefined
               ? { supportsReasoningEffort: explicitSupportsReasoningEffort }
@@ -138,7 +138,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         typeof model.compat?.supportsReasoningEffort === "boolean"
           ? model.compat.supportsReasoningEffort
           : undefined;
-      const preserveExplicitReasoningEffort = !capabilities.reasoning && model.reasoning === true;
+      const preserveExplicitReasoningEffort = !capabilities.reasoning && model.reasoning;
       const explicitMaxTokensField =
         typeof model.compat?.maxTokensField === "string"
           ? model.compat.maxTokensField
@@ -147,7 +147,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
             : undefined;
       const compat = capabilities.compat
         ? {
-            ...(model.compat ?? {}),
+            ...model.compat,
             ...capabilities.compat,
             ...(explicitSupportsReasoningEffort !== undefined
               ? { supportsReasoningEffort: explicitSupportsReasoningEffort }
@@ -161,7 +161,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         ...model,
         name: capabilities.modelName,
         api: capabilities.api,
-        reasoning: capabilities.reasoning || model.reasoning === true,
+        reasoning: capabilities.reasoning || model.reasoning,
         thinkingLevelMap: capabilities.thinkingLevelMap ?? model.thinkingLevelMap,
         input: capabilities.input,
         baseUrl: buildFoundryProviderBaseUrl(

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -536,7 +536,7 @@ vi.mock("./model-selection.js", () => {
       return fallback ? { provider: fallback.provider, model: fallback.id } : null;
     },
     modelKey: (p: string, m: string) => `${p}/${m}`,
-    normalizeModelRef: (p: string, m: string) => ({ provider: p, model: m }),
+    normalizeModelRef: (p: string, m: string) => ({ provider: normalizeProviderId(p), model: m }),
     normalizeProviderId,
     normalizeProviderIdForAuth: normalizeProviderId,
     parseModelRef: (m: string, p: string) => ({ provider: p, model: m }),

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -81,11 +81,11 @@ vi.mock("../agents/model-selection.js", () => {
     return { provider: defaultProvider, model: value };
   };
   const parseModelRef = vi.fn(parseModelRefImpl);
+  const normalizeProviderId = (provider: string) => provider.trim().toLowerCase();
   const normalizeModelRef = (provider: string, model: string): ModelRef => ({
-    provider: provider.trim().toLowerCase(),
+    provider: normalizeProviderId(provider),
     model: model.trim(),
   });
-  const normalizeProviderId = (provider: string) => provider.trim().toLowerCase();
   const modelKey = (provider: string, model: string) =>
     `${normalizeProviderId(provider)}/${model.trim().toLowerCase()}`;
   const isModelKeyAllowedBySet = (allowedKeys: ReadonlySet<string>, key: string) => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -845,8 +845,11 @@ describe("chat voice controls", () => {
     const model = container.querySelector<HTMLInputElement>(
       '.agent-chat__talk-options-primary input[placeholder="Auto"]',
     );
-    const voice = container.querySelector<HTMLElement>('[data-talk-select="voice"]');
-    const sensitivity = container.querySelector<HTMLElement>('[data-talk-select="sensitivity"]');
+    const sensitivity = requireElement(
+      container,
+      '[data-talk-select="sensitivity"]',
+      "Talk sensitivity select",
+    ) as HTMLElement;
     const voiceOptions = Array.from(
       container.querySelectorAll<HTMLOptionElement>(
         '[data-talk-select="voice"] [data-talk-select-option]',
@@ -858,12 +861,6 @@ describe("chat voice controls", () => {
       ),
     ).map((option) => option.dataset.talkSelectOption ?? "");
 
-    if (voice === null) {
-      throw new Error("expected Talk voice select");
-    }
-    if (sensitivity === null) {
-      throw new Error("expected Talk sensitivity select");
-    }
     expect(voiceOptions).toEqual([
       "",
       "alloy",

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -845,11 +845,8 @@ describe("chat voice controls", () => {
     const model = container.querySelector<HTMLInputElement>(
       '.agent-chat__talk-options-primary input[placeholder="Auto"]',
     );
-    const sensitivity = requireElement(
-      container,
-      '[data-talk-select="sensitivity"]',
-      "Talk sensitivity select",
-    ) as HTMLElement;
+    const voice = container.querySelector<HTMLElement>('[data-talk-select="voice"]');
+    const sensitivity = container.querySelector<HTMLElement>('[data-talk-select="sensitivity"]');
     const voiceOptions = Array.from(
       container.querySelectorAll<HTMLOptionElement>(
         '[data-talk-select="voice"] [data-talk-select-option]',
@@ -861,6 +858,12 @@ describe("chat voice controls", () => {
       ),
     ).map((option) => option.dataset.talkSelectOption ?? "");
 
+    if (voice === null) {
+      throw new Error("expected Talk voice select");
+    }
+    if (sensitivity === null) {
+      throw new Error("expected Talk sensitivity select");
+    }
     expect(voiceOptions).toEqual([
       "",
       "alloy",


### PR DESCRIPTION
## Summary

- Fix short-term promotion rehydration when daily-ingested snippets dropped Markdown list markers before being recorded.
- Keep promotion output grounded in the raw live note range while adding a list-marker-free comparison fallback for matching.
- Add a regression test for the #87854 shape: a heading-prefixed daily snippet recorded from a live Markdown list item.

Fixes #87854.

## Root Cause

Daily ingestion records daily note list items after removing the leading Markdown list marker, and it can prefix the active heading. Promotion rehydration only compared the stored snippet against the raw live note range, so a stored snippet like `模型切换 (16:23): **需求**...` did not match a live range like `- **需求**...`; the candidate was dropped before promotion.

## Verification

- `node scripts/run-vitest.mjs extensions/memory-core/src/short-term-promotion.test.ts` (`2b4c2fd5a578`: 77 tests passed)
- `node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts`
- `git diff --check origin/main...HEAD`
- `node --import tsx /private/tmp/openclaw-87854-current-head-proof.mjs`

## Real behavior proof

Behavior addressed: daily memory promotion candidates whose stored snippets omit Markdown list markers and include daily heading context now rehydrate from the live note, including capped multi-line list chunks, instead of being dropped or promoted as a shorter partial range.
Real environment tested: local macOS detached worktree at current PR head `2b4c2fd5a578`; Node `v26.0.0`; proof script created temporary workspaces with `memory/2026-05-28.md`, seeded the live short-term recall store, ranked candidates, and called `applyShortTermPromotions` for both the heading-prefixed single-line case and the capped multi-line list case.
Exact steps or command run after this patch: `node --import tsx /private/tmp/openclaw-87854-current-head-proof.mjs`.
Evidence after fix: copied live console output from the current-head temp-workspace promotion proof:

```console
{
  "head": "2b4c2fd5a578",
  "node": "v26.0.0",
  "cases": [
    {
      "name": "heading_single_line",
      "ranked": 1,
      "rankedSnippet": "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认",
      "applied": 1,
      "appliedRange": "memory/2026-05-28.md:4-4",
      "appliedSnippet": "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认",
      "memoryContainsExpectedSource": true,
      "promotedLine": "- 模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认 [score=0.602 recalls=0 avg=0.910 source=memory/2026-05-28.md:4-4]"
    },
    {
      "name": "capped_multi_line",
      "ranked": 1,
      "rankedSnippet": "Long model routing: Keep Xiaomi Mimo as the low-cost default route route route route route route route route route route route route; Preserve the fallback routing note when the ingestion cap cuts this chunk tail tail tail tail tail tail tail tail tail tail tail tail tail tail ta",
      "applied": 1,
      "appliedRange": "memory/2026-05-28.md:4-5",
      "appliedSnippet": "Long model routing: Keep Xiaomi Mimo as the low-cost default route route route route route route route route route route route route; Preserve the fallback routing note when the ingestion cap cuts this chunk tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail",
      "memoryContainsExpectedSource": true,
      "promotedLine": "- Long model routing: Keep Xiaomi Mimo as the low-cost default route route route route route route route route route route route route; Preserve the fallback routing note when the ingestion cap cuts this chunk tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail tail [score=0.602 recalls=0 avg=0.910 source=memory/2026-05-28.md:4-5]"
    }
  ],
  "cappedMultiLineInput": {
    "cap": 280,
    "storedSnippetLength": 280,
    "fullSnippetLength": 417,
    "wasCapped": true
  }
}
```

Observed result after fix: `applyShortTermPromotions` applied both current-head cases. The heading-prefixed single-line case promoted the heading-restored snippet from `memory/2026-05-28.md:4-4`; the capped multi-line case kept the full `memory/2026-05-28.md:4-5` source range and promoted text from both live list lines even though the stored recall snippet was capped at 280 characters.
What was not tested: no broad `check:changed` or Testbox run; validation was scoped to the touched memory-core promotion behavior plus current-head format and whitespace checks.