### PR TITLE
fix: preserve explicit provider in resolveConfiguredProviderFallback

### DIFF
--- a/src/agents/configured-provider-fallback.ts
+++ b/src/agents/configured-provider-fallback.ts
@@ -28,7 +28,7 @@ export function resolveConfiguredProviderFallback(params: {
     return null;
   }
 
-  // If a specific model was requested, try to find a configured provider that
+  // When a specific model was requested, try to find a configured provider that
   // carries that exact model. This preserves the user's model choice and only
   // switches the provider — which is the correct behavior when the default
   // provider doesn't carry the model but another provider does.
@@ -45,18 +45,17 @@ export function resolveConfiguredProviderFallback(params: {
     if (providerWithModel) {
       return { provider: providerWithModel[0], model: defaultModel };
     }
+    // The default provider is not configured and no other provider has the
+    // requested model. Return null so the caller preserves the explicitly-
+    // specified provider/model pair rather than silently replacing it with
+    // an unrelated provider's first model.
+    if (!defaultProviderConfig) {
+      return null;
+    }
   }
 
-  // If the default provider is NOT configured at all (e.g., "openai" when only
-  // "openai-codex" exists), return null so the caller preserves the explicitly-
-  // specified provider/model pair rather than silently replacing it with an
-  // unrelated provider's first model.
-  if (!defaultProviderConfig) {
-    return null;
-  }
-
-  // The default provider exists but doesn't have the requested model, and no
-  // other provider has it either. Fall back to the first provider that has
+  // No specific model was requested (or the default provider IS configured
+  // but doesn't carry the model). Fall back to the first provider that has
   // any models configured.
   const availableProvider = Object.entries(configuredProviders).find(
     ([, providerCfg]) =>

--- a/src/agents/configured-provider-fallback.ts
+++ b/src/agents/configured-provider-fallback.ts
@@ -16,6 +16,9 @@ export function resolveConfiguredProviderFallback(params: {
   }
   const defaultProviderConfig = configuredProviders[params.defaultProvider];
   const defaultModel = params.defaultModel?.trim();
+
+  // If the default provider is configured and either has no model requirement
+  // or already has the requested model, no fallback is needed.
   const defaultProviderHasDefaultModel =
     Boolean(defaultProviderConfig) &&
     Boolean(defaultModel) &&
@@ -24,6 +27,37 @@ export function resolveConfiguredProviderFallback(params: {
   if (defaultProviderConfig && (!defaultModel || defaultProviderHasDefaultModel)) {
     return null;
   }
+
+  // If a specific model was requested, try to find a configured provider that
+  // carries that exact model. This preserves the user's model choice and only
+  // switches the provider — which is the correct behavior when the default
+  // provider doesn't carry the model but another provider does.
+  // Previously, the function would replace BOTH provider and model with the
+  // first available provider's first model, producing incorrect refs like
+  // "ollama/kimi-k2.6:cloud" when the user specified "openai/gpt-5.5".
+  if (defaultModel) {
+    const providerWithModel = Object.entries(configuredProviders).find(
+      ([, providerCfg]) =>
+        providerCfg &&
+        Array.isArray(providerCfg.models) &&
+        providerCfg.models.some((model) => model?.id === defaultModel),
+    );
+    if (providerWithModel) {
+      return { provider: providerWithModel[0], model: defaultModel };
+    }
+  }
+
+  // If the default provider is NOT configured at all (e.g., "openai" when only
+  // "openai-codex" exists), return null so the caller preserves the explicitly-
+  // specified provider/model pair rather than silently replacing it with an
+  // unrelated provider's first model.
+  if (!defaultProviderConfig) {
+    return null;
+  }
+
+  // The default provider exists but doesn't have the requested model, and no
+  // other provider has it either. Fall back to the first provider that has
+  // any models configured.
   const availableProvider = Object.entries(configuredProviders).find(
     ([, providerCfg]) =>
       providerCfg &&

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -864,6 +864,7 @@ export function resolveConfiguredModelRef(
   const fallbackProvider = resolveConfiguredProviderFallback({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
   });
   if (fallbackProvider) {
     return fallbackProvider;

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -83,6 +83,7 @@ function resolveConfiguredStatusModelRef(params: {
   const fallbackProvider = resolveConfiguredProviderFallback({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
   });
   if (fallbackProvider) {
     return fallbackProvider;


### PR DESCRIPTION
## Summary

Fixes #88710

`resolveConfiguredProviderFallback` currently replaces **both** the provider and model with the first available provider's first model when the default provider is not configured. This produces incorrect refs like `ollama/kimi-k2.6:cloud` when the user configured `openai/gpt-5.5`.

## Changes

Three behavioral changes in `src/agents/configured-provider-fallback.ts`:

1. **Model-first lookup**: When `defaultModel` is specified, search all configured providers for one that carries that exact model ID. If found, return that provider with the same model — switching only the provider, preserving the model.

2. **Unknown provider → `null`**: When the default provider is not a configured key at all (e.g., `"openai"` when only `"openai-codex"` exists), return `null` so the caller preserves the user's explicitly-specified `provider/model` pair.

3. **Existing fallback preserved**: Only fall back to the first available provider's first model when the default provider IS configured but doesn't carry the model and no other provider has it either.

## Test Evidence
<img width="1355" height="1382" alt="Screenshot 2026-05-31 at 6 58 50 PM" src="https://github.com/user-attachments/assets/537e497c-5183-44b1-ac84-e60e4a865914" />

**Before fix:**
```
resolveConfiguredProviderFallback({ cfg, defaultProvider: "openai", defaultModel: "gpt-5.5" })
→ { provider: "ollama", model: "kimi-k2.6:cloud" }  // BUG: wrong provider AND model
```
404 Errors

**After fix:**
```
resolveConfiguredProviderFallback({ cfg, defaultProvider: "openai", defaultModel: "gpt-5.5" })
→ null  // Caller preserves openai/gpt-5.5
```
New session, everything works again

**Production log before fix:**
```
[agent/embedded] embedded run agent end: isError=true model=gpt-5.5 provider=ollama error=404 {"error": "model 'gpt-5.5' not found"}
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=ollama/gpt-5.5 candidate=ollama/gpt-5.5 reason=model_not_found next=none
```

The model `gpt-5.5` was incorrectly routed to the ollama API endpoint, which doesn't have it.

## Caller Safety

All callers handle `null` gracefully:
- `model-selection-shared.ts:864` → falls back to `{ provider: defaultProvider, model: defaultModel }`
- `codex-route-warnings.ts:438` → falls back to `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}`
- `status.summary.runtime.ts:83` → falls back to `{ provider: defaultProvider, model: defaultModel }`

## Real behavior proof

**Behavior or issue addressed**: resolveConfiguredProviderFallback replaces both provider and model with the first available provider's first model when the default provider is not configured, producing incorrect refs like ollama/gpt-5.5 (404) instead of openai/gpt-5.5.

**Real environment tested**: OpenClaw gateway on Umbrel (Cyber WSL) with configured ollama + openai providers. Real production gateway with live Discord/Telegram bindings.

**Exact steps or command run after this patch**: 1) Patched configured-provider-fallback-C0W42MAj.js with model-first lookup. 2) Patched model-selection-shared-BjN7MgG0.js to pass defaultModel to resolveConfiguredProviderFallback. 3) Restarted OpenClaw gateway. 4) Sent a message requesting ollama/gpt-5.5 through the Telegram binding. 5) Observed successful fallback to openai/gpt-5.5 (correct provider routing).

**Evidence after fix**:
![Screenshot 2026-05-31 at 6 58 50 PM](https://github.com/user-attachments/assets/537e497c-5183-44b1-ac84-e60e4a865914)

Before fix: 404 errors model 'gpt-5.5' not found on ollama endpoint. After fix: new session, requests route correctly to openai provider. No more 404 errors.

**Observed result after fix**: Gateway correctly routes gpt-5.5 model requests to the openai provider instead of ollama. Telegram session screenshot above shows successful completion. No more model_not_found fallback decisions in gateway logs.

**What was not tested**: Other call sites (codex-route-warnings.ts) that don't pass defaultModel — these use the original implicit fallback path which is unchanged.