### PR TITLE
perf(plugins): avoid duplicate provider hook load probes

### DIFF
--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -202,28 +202,15 @@ export function resolveProviderPluginsForHooks(params: {
 }): ProviderPlugin[] {
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
-  if (
-    isPluginProvidersLoadInFlight({
-      ...params,
-      workspaceDir,
-      env,
-      activate: false,
-      applyAutoEnable: params.applyAutoEnable,
-      bundledProviderVitestCompat: params.bundledProviderVitestCompat ?? true,
-      pluginMetadataSnapshot: params.pluginMetadataSnapshot,
-    })
-  ) {
-    return [];
-  }
-  const resolved = resolvePluginProviders({
+  return resolvePluginProviders({
     ...params,
     workspaceDir,
     env,
     activate: false,
     applyAutoEnable: params.applyAutoEnable,
     bundledProviderVitestCompat: params.bundledProviderVitestCompat ?? true,
+    skipIfLoadInFlight: true,
   });
-  return resolved;
 }
 
 export function resolveProviderRuntimePlugin(

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -336,6 +336,7 @@ export function resolvePluginProviders(params: {
   mode?: "runtime" | "setup";
   includeUntrustedWorkspacePlugins?: boolean;
   pluginMetadataSnapshot?: PluginMetadataRegistryView;
+  skipIfLoadInFlight?: boolean;
 }): ProviderPlugin[] {
   const { env, workspaceDir, snapshot } = resolveProviderMetadataLookup(params);
   const base = resolvePluginProviderLoadBase({ ...params, workspaceDir, env }, snapshot);
@@ -344,12 +345,18 @@ export function resolvePluginProviders(params: {
     if (!loadState) {
       return [];
     }
+    if (params.skipIfLoadInFlight && isPluginRegistryLoadInFlight(loadState.loadOptions)) {
+      return [];
+    }
     const registry = loadOpenClawPlugins(loadState.loadOptions);
     return registry.providers.map((entry) =>
       Object.assign({}, entry.provider, { pluginId: entry.pluginId }),
     );
   }
   const loadState = resolveRuntimeProviderPluginLoadState(params, base, snapshot);
+  if (params.skipIfLoadInFlight && isPluginRegistryLoadInFlight(loadState.loadOptions)) {
+    return [];
+  }
   const registry =
     loadState.loadOptions.onlyPluginIds?.length === 0
       ? undefined


### PR DESCRIPTION
## Summary
- avoid a duplicate provider load in-flight probe for direct provider hook-list resolution
- keep `resolveProviderRuntimePlugin`'s explicit in-flight/reentrant guard intact, since existing tests prove it prevents cached misses and nested provider-load recursion
- add the opt-in skip at `resolvePluginProviders` so normal direct callers keep their current load behavior

## Verification
- `node scripts/run-vitest.mjs src/plugins/providers.runtime.consult-current-snapshot.test.ts`
- `node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts`
- `node scripts/run-vitest.mjs src/plugins/providers.test.ts`
- `pnpm exec oxfmt --check src/plugins/providers.runtime.ts src/plugins/provider-hook-runtime.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `autoreview --mode local --prompt-file /tmp/provider-hotpath-cleanup-review.md` -> clean

## Live / E2E
- `OpenClaw Live And E2E Checks (Reusable)` with `live_suite_filter=native-live-src-gateway-profiles-openai` against `c71bd375b05818465ff1076f68c5d0d48848283d`: https://github.com/openclaw/openclaw/actions/runs/26718818705
- Focused live shard `validate_live_provider_suites (native-live-src-gateway-profiles-openai)` passed in 3m18s.
