### PR TITLE
fix(cli): make native hook relay resilient to stale bridges

### DIFF
--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -744,7 +744,7 @@ export function renderNativeHookRelayUnavailableResponse(params: {
   const adapter = getNativeHookRelayProviderAdapter(provider);
   const message = params.message?.trim() || "Native hook relay unavailable";
   if (event === "pre_tool_use") {
-    return adapter.renderPreToolUseBlockResponse(message);
+    return adapter.renderNoopResponse(event);
   }
   if (event === "permission_request") {
     return adapter.renderPermissionDecisionResponse("deny", message);

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -176,40 +176,13 @@ describe("native hook relay CLI", () => {
     );
   });
 
-  it.each([
-    {
-      event: "pre_tool_use",
-      stdout: {
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-          permissionDecision: "deny",
-          permissionDecisionReason: "Native hook relay unavailable",
-        },
-      },
-    },
-    {
-      event: "permission_request",
-      stdout: {
-        hookSpecificOutput: {
-          hookEventName: "PermissionRequest",
-          decision: {
-            behavior: "deny",
-            message: "Native hook relay unavailable",
-          },
-        },
-      },
-    },
-    {
-      event: "post_tool_use",
-      stdout: null,
-    },
-  ])(
-    "does not fall back to the gateway after a stale direct bridge error for $event",
-    async (testCase) => {
+  it.each(["pre_tool_use", "permission_request", "post_tool_use"])(
+    "falls back to the gateway after a stale direct bridge error for %s",
+    async (event) => {
       const invokeBridge = vi.fn(async () => {
         throw new Error("native hook relay bridge stale registration");
       });
-      const callGateway = vi.fn(async () => ({ stdout: "unexpected", stderr: "", exitCode: 0 }));
+      const callGateway = vi.fn(async () => ({ stdout: "gateway", stderr: "", exitCode: 0 }));
       const stdout = createWritableTextBuffer();
       const stderr = createWritableTextBuffer();
 
@@ -218,7 +191,7 @@ describe("native hook relay CLI", () => {
           provider: "codex",
           relayId: "relay-1",
           generation: "generation-1",
-          event: testCase.event,
+          event,
         },
         {
           stdin: createReadableTextStream("{}"),
@@ -230,14 +203,20 @@ describe("native hook relay CLI", () => {
       );
 
       expect(exitCode).toBe(0);
-      if (testCase.stdout) {
-        expect(JSON.parse(stdout.text())).toEqual(testCase.stdout);
-      } else {
-        expect(stdout.text()).toBe("");
-      }
-      expect(stderr.text()).toContain("native hook relay unavailable");
-      expect(stderr.text()).toContain("native hook relay bridge stale registration");
-      expect(callGateway).not.toHaveBeenCalled();
+      expect(stdout.text()).toBe("gateway");
+      expect(stderr.text()).toBe("");
+      expect(callGateway).toHaveBeenCalledWith({
+        method: "nativeHook.invoke",
+        params: {
+          provider: "codex",
+          relayId: "relay-1",
+          generation: "generation-1",
+          event,
+          rawPayload: {},
+        },
+        timeoutMs: 5_000,
+        scopes: ["operator.admin"],
+      });
     },
   );
 

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -137,7 +137,7 @@ describe("native hook relay CLI", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
-  it("renders unavailable output for legacy relay commands without a generation", async () => {
+  it("does not block PreToolUse for legacy relay commands without a generation", async () => {
     const invokeBridge = vi.fn(async () => {
       throw new Error("generation must be non-empty string");
     });
@@ -159,13 +159,7 @@ describe("native hook relay CLI", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout.text())).toEqual({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: "Native hook relay unavailable",
-      },
-    });
+    expect(stdout.text()).toBe("");
     expect(stderr.text()).toContain("native hook relay unavailable");
     expect(stderr.text()).toContain("generation must be non-empty string");
     expect(callGateway).toHaveBeenCalledWith(
@@ -256,7 +250,7 @@ describe("native hook relay CLI", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
-  it("fails closed for PreToolUse when the gateway relay is unavailable", async () => {
+  it("does not block PreToolUse when the gateway relay is unavailable", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error("gateway closed");
     });
@@ -274,13 +268,7 @@ describe("native hook relay CLI", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(JSON.parse(stdout.text())).toEqual({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: "Native hook relay unavailable",
-      },
-    });
+    expect(stdout.text()).toBe("");
     expect(stderr.text()).toContain("native hook relay unavailable");
   });
 

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -1,7 +1,6 @@
 import { Readable, Writable } from "node:stream";
 import {
   invokeNativeHookRelayBridge,
-  isNativeHookRelayBridgeStaleRegistrationError,
   renderNativeHookRelayUnavailableResponse,
   type NativeHookRelayProcessResponse,
 } from "../agents/harness/native-hook-relay.js";
@@ -71,19 +70,8 @@ export async function runNativeHookRelayCli(
     writeText(stderr, response.stderr);
     return response.exitCode;
   } catch (error) {
-    if (isNativeHookRelayBridgeStaleRegistrationError(error)) {
-      writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
-      const response = renderNativeHookRelayUnavailableResponse({
-        provider,
-        event,
-        message: "Native hook relay unavailable",
-      });
-      writeText(stdout, response.stdout);
-      writeText(stderr, response.stderr);
-      return response.exitCode;
-    }
     // Fall through to the gateway path for embedded/local gateway cases and
-    // older registrations that predate the direct relay bridge.
+    // direct bridge records that are missing, stale, or otherwise unusable.
   }
 
   try {


### PR DESCRIPTION
## Summary
- fall back from stale/unusable direct native hook bridge records to the gateway nativeHook.invoke path
- fail open for unavailable pre-tool relay events so tool execution is not blocked by relay outages
- keep permission_request unavailable handling fail-closed

## Verification
- pnpm exec vitest run src/cli/native-hook-relay-cli.test.ts
- TMPDIR="/var/folders/fh/106677c12vb2dpynx68j804c0000gn/T/tmp.KOtcmuzV9h" pnpm exec vitest run src/agents/harness/native-hook-relay.test.ts --testNamePattern "dead foreign|expired foreign|live unexpired foreign|stale direct bridge"