### PR TITLE
fix(auth): enforce canonical openai-codex OAuth owner

### DIFF
--- a/src/agents/auth-profiles/canonical-owner.ts
+++ b/src/agents/auth-profiles/canonical-owner.ts
@@ -1,0 +1,79 @@
+import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
+import { resolveAuthStorePath } from "./path-resolve.js";
+import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
+
+const CANONICAL_MAIN_OAUTH_PROVIDERS = new Set<string>(["openai-codex"]);
+
+export function hasCanonicalMainOAuthOwner(provider: string): boolean {
+  return CANONICAL_MAIN_OAUTH_PROVIDERS.has(resolveProviderIdForAuth(provider));
+}
+
+export function resolveCanonicalOAuthOwnerAgentDir(params: {
+  provider: string;
+  agentDir?: string;
+}): string | undefined {
+  if (!hasCanonicalMainOAuthOwner(params.provider)) {
+    return params.agentDir;
+  }
+  const requestedPath = resolveAuthStorePath(params.agentDir);
+  const mainPath = resolveAuthStorePath(undefined);
+  return requestedPath === mainPath ? params.agentDir : undefined;
+}
+
+export function isCanonicalOAuthOwnerAgentDir(params: {
+  provider: string;
+  agentDir?: string;
+}): boolean {
+  return (
+    resolveAuthStorePath(resolveCanonicalOAuthOwnerAgentDir(params)) ===
+    resolveAuthStorePath(params.agentDir)
+  );
+}
+
+export function shouldPersistCredentialInAgentStore(params: {
+  credential: AuthProfileCredential;
+  agentDir?: string;
+}): boolean {
+  if (params.credential.type !== "oauth") {
+    return true;
+  }
+  return isCanonicalOAuthOwnerAgentDir({
+    provider: params.credential.provider,
+    agentDir: params.agentDir,
+  });
+}
+
+export function stripNonOwnerCanonicalOAuthProfiles(params: {
+  store: AuthProfileStore;
+  agentDir?: string;
+}): AuthProfileStore {
+  const requestedPath = resolveAuthStorePath(params.agentDir);
+  const mainPath = resolveAuthStorePath(undefined);
+  if (!params.agentDir || requestedPath === mainPath) {
+    return params.store;
+  }
+
+  let changed = false;
+  const profiles = Object.fromEntries(
+    Object.entries(params.store.profiles).flatMap(([profileId, credential]) => {
+      if (
+        credential.type === "oauth" &&
+        hasCanonicalMainOAuthOwner(credential.provider) &&
+        !isCanonicalOAuthOwnerAgentDir({ provider: credential.provider, agentDir: params.agentDir })
+      ) {
+        changed = true;
+        return [];
+      }
+      return [[profileId, credential]];
+    }),
+  ) as AuthProfileStore["profiles"];
+
+  if (!changed) {
+    return params.store;
+  }
+
+  return {
+    ...params.store,
+    profiles,
+  };
+}

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -19,8 +19,10 @@ import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles,
+  loadAuthProfileStoreForSecretsRuntime,
   saveAuthProfileStore,
 } from "./store.js";
+import * as storeModule from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
 
 function createCredential(overrides: Partial<OAuthCredential> = {}): OAuthCredential {
@@ -625,5 +627,151 @@ describe("createOAuthManager", () => {
       expect(surfacedCauseMessage).not.toContain("external-attempt-refresh");
       expect(surfacedCauseMessage).not.toContain("external-attempt-id-token");
     }
+  });
+
+  it("shares one in-flight refresh result across concurrent callers", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-singleflight-"));
+    tempDirs.push(tempRoot);
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    const mainAgentDir = path.join(tempRoot, "agents", "main", "agent");
+    process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+    process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+    await fs.mkdir(mainAgentDir, { recursive: true });
+
+    const profileId = "openai-codex:default";
+    const expiredCredential = createCredential({
+      provider: "openai-codex",
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-123",
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: expiredCredential,
+        },
+      },
+      mainAgentDir,
+      { filterExternalAuthProfiles: false },
+    );
+
+    let refreshCalls = 0;
+    let releaseRefresh!: () => void;
+    const refreshStarted = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const manager = createOAuthManager({
+      buildApiKey: async (_provider, credential) => credential.access,
+      refreshCredential: vi.fn(async () => {
+        refreshCalls += 1;
+        await refreshStarted;
+        return {
+          access: "shared-access",
+          refresh: "shared-refresh",
+          expires: Date.now() + 60_000,
+        };
+      }),
+      readBootstrapCredential: () => null,
+      isRefreshTokenReusedError: () => false,
+    });
+
+    const staleA = ensureAuthProfileStore(mainAgentDir).profiles[profileId] as OAuthCredential;
+    const first = manager.resolveOAuthAccess({
+      store: ensureAuthProfileStore(mainAgentDir),
+      profileId,
+      credential: staleA,
+      agentDir: mainAgentDir,
+    });
+    const staleB = loadAuthProfileStoreForSecretsRuntime(mainAgentDir).profiles[
+      profileId
+    ] as OAuthCredential;
+    const second = manager.resolveOAuthAccess({
+      store: ensureAuthProfileStore(mainAgentDir),
+      profileId,
+      credential: staleB,
+      agentDir: mainAgentDir,
+    });
+
+    releaseRefresh();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(refreshCalls).toBe(1);
+    expect(firstResult).toMatchObject({ apiKey: "shared-access" });
+    expect(secondResult).toMatchObject({ apiKey: "shared-access" });
+    const persisted = loadAuthProfileStoreForSecretsRuntime(mainAgentDir).profiles[
+      profileId
+    ] as OAuthCredential;
+    expect(persisted.access).toBe("shared-access");
+    expect(persisted.refresh).toBe("shared-refresh");
+  });
+
+  it("fails closed when refreshed credentials cannot be persisted", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-persist-fail-"));
+    tempDirs.push(tempRoot);
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    const mainAgentDir = path.join(tempRoot, "agents", "main", "agent");
+    process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+    process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+    await fs.mkdir(mainAgentDir, { recursive: true });
+
+    const profileId = "openai-codex:default";
+    const expiredCredential = createCredential({
+      provider: "openai-codex",
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-123",
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: expiredCredential,
+        },
+      },
+      mainAgentDir,
+      { filterExternalAuthProfiles: false },
+    );
+
+    const originalSave = storeModule.saveAuthProfileStore;
+    const saveSpy = vi
+      .spyOn(storeModule, "saveAuthProfileStore")
+      .mockImplementation((store, agentDir, options) => {
+        const profile = store.profiles[profileId];
+        if (profile?.type === "oauth" && profile.access === "broken-access") {
+          throw new Error("disk full");
+        }
+        return originalSave(store, agentDir, options);
+      });
+
+    const manager = createOAuthManager({
+      buildApiKey: async (_provider, credential) => credential.access,
+      refreshCredential: vi.fn(async () => ({
+        access: "broken-access",
+        refresh: "broken-refresh",
+        expires: Date.now() + 60_000,
+      })),
+      readBootstrapCredential: () => null,
+      isRefreshTokenReusedError: () => false,
+    });
+
+    await expect(
+      manager.resolveOAuthAccess({
+        store: ensureAuthProfileStore(mainAgentDir),
+        profileId,
+        credential: ensureAuthProfileStore(mainAgentDir).profiles[profileId] as OAuthCredential,
+        agentDir: mainAgentDir,
+      }),
+    ).rejects.toBeInstanceOf(OAuthManagerRefreshError);
+
+    saveSpy.mockRestore();
+
+    const persisted = loadAuthProfileStoreForSecretsRuntime(mainAgentDir).profiles[
+      profileId
+    ] as OAuthCredential;
+    expect(persisted.access).toBe("stale-access");
+    expect(persisted.refresh).toBe("stale-refresh");
   });
 });

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -5,6 +5,10 @@ import { withFileLock } from "../../infra/file-lock.js";
 import { redactSensitiveText } from "../../logging/redact.js";
 import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import {
+  isCanonicalOAuthOwnerAgentDir,
+  resolveCanonicalOAuthOwnerAgentDir,
+} from "./canonical-owner.js";
+import {
   AUTH_STORE_LOCK_OPTIONS,
   OAUTH_REFRESH_CALL_TIMEOUT_MS,
   OAUTH_REFRESH_LOCK_OPTIONS,
@@ -355,7 +359,10 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     return null;
   }
 
-  const refreshQueues = new Map<string, Promise<unknown>>();
+  const refreshQueues = new Map<
+    string,
+    { promise: Promise<ResolvedOAuthAccess | null>; waiters: number }
+  >();
 
   function refreshQueueKey(provider: string, profileId: string): string {
     return `${provider}\u0000${profileId}`;
@@ -430,7 +437,10 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     forceRefresh?: boolean;
     attemptedCredentials?: OAuthCredential[];
   }): Promise<ResolvedOAuthAccess | null> {
-    const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir(params);
+    const ownerAgentDir = resolveCanonicalOAuthOwnerAgentDir({
+      provider: params.provider,
+      agentDir: resolvePersistedAuthProfileOwnerAgentDir(params),
+    });
     const authPath = resolveAuthStorePath(ownerAgentDir);
     ensureAuthStoreFile(authPath);
     const globalRefreshLockPath = resolveOAuthRefreshLockPath(params.provider, params.profileId);
@@ -455,7 +465,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             };
           }
 
-          if (params.agentDir) {
+          if (params.agentDir && authPath !== resolveAuthStorePath(params.agentDir)) {
             try {
               const mainStore = loadStoredOAuthRefreshStore(undefined);
               const mainCred = mainStore.profiles[params.profileId];
@@ -466,12 +476,15 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                 !params.forceRefresh &&
                 isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
               ) {
-                store.profiles[params.profileId] = { ...mainCred };
-                log.info("adopted fresh OAuth credential from main store (under refresh lock)", {
-                  profileId: params.profileId,
-                  agentDir: params.agentDir,
-                  expires: new Date(mainCred.expires).toISOString(),
-                });
+                log.info(
+                  "adopted fresh OAuth credential from canonical main store (under refresh lock)",
+                  {
+                    profileId: params.profileId,
+                    agentDir: params.agentDir,
+                    ownerAgentDir,
+                    expires: new Date(mainCred.expires).toISOString(),
+                  },
+                );
                 return {
                   apiKey: await adapter.buildApiKey(mainCred.provider, mainCred, {
                     cfg: params.cfg,
@@ -560,14 +573,11 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           }
           store.profiles[params.profileId] = refreshedCredentials;
           saveAuthProfileStore(store, ownerAgentDir);
-          if (ownerAgentDir) {
-            const mainPath = resolveAuthStorePath(undefined);
-            if (mainPath !== authPath) {
-              await mirrorRefreshedCredentialIntoMainStore({
-                profileId: params.profileId,
-                refreshed: refreshedCredentials,
-              });
-            }
+          if (params.agentDir && authPath !== resolveAuthStorePath(undefined)) {
+            await mirrorRefreshedCredentialIntoMainStore({
+              profileId: params.profileId,
+              refreshed: refreshedCredentials,
+            });
           }
           return {
             apiKey: await adapter.buildApiKey(cred.provider, refreshedCredentials, {
@@ -599,21 +609,67 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     attemptedCredentials?: OAuthCredential[];
   }): Promise<ResolvedOAuthAccess | null> {
     const key = refreshQueueKey(params.provider, params.profileId);
-    const prev = refreshQueues.get(key) ?? Promise.resolve();
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    refreshQueues.set(key, gate);
-    try {
-      await prev;
-      return await doRefreshOAuthTokenWithLock(params);
-    } finally {
-      release();
-      if (refreshQueues.get(key) === gate) {
-        refreshQueues.delete(key);
-      }
+    const existing = refreshQueues.get(key);
+    if (existing) {
+      existing.waiters += 1;
+      log.info("joined in-flight OAuth refresh", {
+        profileId: params.profileId,
+        provider: params.provider,
+        agentDir: params.agentDir,
+        waiters: existing.waiters,
+        ownerAgentDir: resolveCanonicalOAuthOwnerAgentDir({
+          provider: params.provider,
+          agentDir: resolvePersistedAuthProfileOwnerAgentDir(params),
+        }),
+      });
+      return await existing.promise;
     }
+
+    const entry: { promise: Promise<ResolvedOAuthAccess | null>; waiters: number } = {
+      promise: Promise.resolve(null),
+      waiters: 0,
+    };
+    const ownerAgentDir = resolveCanonicalOAuthOwnerAgentDir({
+      provider: params.provider,
+      agentDir: resolvePersistedAuthProfileOwnerAgentDir(params),
+    });
+    const promise = (async () => {
+      log.info("starting OAuth refresh owner", {
+        profileId: params.profileId,
+        provider: params.provider,
+        agentDir: params.agentDir,
+        ownerAgentDir,
+      });
+      try {
+        const result = await doRefreshOAuthTokenWithLock(params);
+        log.info("completed OAuth refresh owner", {
+          profileId: params.profileId,
+          provider: params.provider,
+          agentDir: params.agentDir,
+          ownerAgentDir,
+          waiters: entry.waiters,
+          success: result !== null,
+        });
+        return result;
+      } catch (error) {
+        log.warn("OAuth refresh owner failed", {
+          profileId: params.profileId,
+          provider: params.provider,
+          agentDir: params.agentDir,
+          ownerAgentDir,
+          waiters: entry.waiters,
+          error: formatErrorMessage(error),
+        });
+        throw error;
+      } finally {
+        if (refreshQueues.get(key) === entry) {
+          refreshQueues.delete(key);
+        }
+      }
+    })();
+    entry.promise = promise;
+    refreshQueues.set(key, entry);
+    return await promise;
   }
 
   async function resolveOAuthAccess(params: {
@@ -734,11 +790,19 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             }) &&
             isSafeToAdoptMainStoreOAuthIdentity(params.credential, mainCred)
           ) {
-            refreshedStore.profiles[params.profileId] = { ...mainCred };
+            const persistedLocally = isCanonicalOAuthOwnerAgentDir({
+              provider: mainCred.provider,
+              agentDir: params.agentDir,
+            });
+            if (persistedLocally) {
+              refreshedStore.profiles[params.profileId] = { ...mainCred };
+              saveAuthProfileStore(refreshedStore, params.agentDir);
+            }
             log.info("inherited fresh OAuth credentials from main agent", {
               profileId: params.profileId,
               agentDir: params.agentDir,
               expires: new Date(mainCred.expires).toISOString(),
+              persistedLocally,
             });
             return {
               apiKey: await adapter.buildApiKey(mainCred.provider, mainCred, {

--- a/src/agents/auth-profiles/store.canonical-owner.test.ts
+++ b/src/agents/auth-profiles/store.canonical-owner.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureEnv } from "../../test-utils/env.js";
+import {
+  createOAuthMainAgentDir,
+  createOAuthTestTempRoot,
+  createExpiredOauthStore,
+  removeOAuthTestTempRoot,
+} from "./oauth-test-utils.js";
+import { AUTH_PROFILE_FILENAME, AUTH_STATE_FILENAME } from "./path-constants.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStore,
+  saveAuthProfileStore,
+} from "./store.js";
+
+describe("canonical OAuth owner reconciliation", () => {
+  const envSnapshot = captureEnv([
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_AGENT_DIR",
+    "PI_CODING_AGENT_DIR",
+  ]);
+  let tempRoot = "";
+  let mainAgentDir = "";
+
+  beforeEach(async () => {
+    clearRuntimeAuthProfileStoreSnapshots();
+    tempRoot = await createOAuthTestTempRoot("openclaw-auth-canonical-");
+    mainAgentDir = await createOAuthMainAgentDir(tempRoot);
+  });
+
+  afterEach(async () => {
+    envSnapshot.restore();
+    clearRuntimeAuthProfileStoreSnapshots();
+    await removeOAuthTestTempRoot(tempRoot);
+  });
+
+  it("reconciles duplicate openai-codex credentials out of non-owner agent stores", async () => {
+    const profileId = "openai-codex:default";
+    const subAgentDir = path.join(tempRoot, "agents", "orchestrator", "agent");
+    await fs.mkdir(subAgentDir, { recursive: true });
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        access: "main-access",
+        refresh: "main-refresh",
+        accountId: "acct-main",
+      }),
+      mainAgentDir,
+      { filterExternalAuthProfiles: false },
+    );
+
+    await fs.writeFile(
+      path.join(subAgentDir, AUTH_PROFILE_FILENAME),
+      JSON.stringify(
+        {
+          version: 1,
+          profiles: {
+            [profileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "orchestrator-access",
+              refresh: "orchestrator-refresh",
+              expires: Date.now() - 60_000,
+              accountId: "acct-main",
+            },
+            "anthropic:default": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "anthropic-key",
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await fs.writeFile(
+      path.join(subAgentDir, AUTH_STATE_FILENAME),
+      JSON.stringify(
+        {
+          version: 1,
+          order: {
+            "openai-codex": [profileId],
+            anthropic: ["anthropic:default"],
+          },
+          lastGood: {
+            "openai-codex": profileId,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const runtimeStore = ensureAuthProfileStore(subAgentDir);
+
+    expect(runtimeStore.profiles[profileId]).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "main-access",
+      refresh: "main-refresh",
+      accountId: "acct-main",
+    });
+    expect(runtimeStore.profiles["anthropic:default"]).toMatchObject({
+      type: "api_key",
+      provider: "anthropic",
+      key: "anthropic-key",
+    });
+
+    const persistedSubStore = JSON.parse(
+      await fs.readFile(path.join(subAgentDir, AUTH_PROFILE_FILENAME), "utf8"),
+    ) as {
+      profiles: Record<string, unknown>;
+    };
+    expect(persistedSubStore.profiles[profileId]).toBeUndefined();
+    expect(persistedSubStore.profiles["anthropic:default"]).toBeTruthy();
+
+    const persistedMainStore = JSON.parse(
+      await fs.readFile(path.join(mainAgentDir, AUTH_PROFILE_FILENAME), "utf8"),
+    ) as {
+      profiles: Record<string, unknown>;
+    };
+    expect(persistedMainStore.profiles[profileId]).toBeTruthy();
+
+    const persistedSubState = JSON.parse(
+      await fs.readFile(path.join(subAgentDir, AUTH_STATE_FILENAME), "utf8"),
+    ) as {
+      lastGood?: Record<string, string>;
+      order?: Record<string, string[]>;
+    };
+    expect(persistedSubState.lastGood?.["openai-codex"]).toBeUndefined();
+    expect(persistedSubState.order?.["openai-codex"]).toEqual([profileId]);
+  });
+});

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -6,6 +6,10 @@ import { withFileLock } from "../../infra/file-lock.js";
 import { loadJsonFile, repairJsonFilePermissions, saveJsonFile } from "../../infra/json-file.js";
 import { asDateTimestampMs } from "../../shared/number-coercion.js";
 import { isRecord } from "../../utils.js";
+import {
+  shouldPersistCredentialInAgentStore,
+  stripNonOwnerCanonicalOAuthProfiles,
+} from "./canonical-owner.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION, log } from "./constants.js";
 import {
@@ -437,6 +441,14 @@ function shouldKeepProfileInLocalStore(params: {
     return true;
   }
   if (
+    !shouldPersistCredentialInAgentStore({
+      credential: params.credential,
+      agentDir: params.agentDir,
+    })
+  ) {
+    return false;
+  }
+  if (
     isInheritedMainOAuthCredential({
       agentDir: params.agentDir,
       profileId: params.profileId,
@@ -471,6 +483,13 @@ function shouldKeepProfileInLocalStore(params: {
     credential: params.credential,
     profiles: params.externalProfiles(),
   });
+}
+
+function sanitizeLocalAuthProfileStore(params: {
+  store: AuthProfileStore;
+  agentDir?: string;
+}): AuthProfileStore {
+  return stripNonOwnerCanonicalOAuthProfiles(params);
 }
 
 function pruneAuthProfileStoreReferences(
@@ -841,15 +860,22 @@ function loadAuthProfileStoreForAgent(
       agentDir,
       options,
     });
-    if (!readOnly && synced.cacheable) {
+    const sanitized = sanitizeLocalAuthProfileStore({ store: synced.store, agentDir });
+    if (!readOnly && sanitized !== synced.store) {
+      saveAuthProfileStore(sanitized, agentDir, { filterExternalAuthProfiles: false });
+      log.info("reconciled canonical OAuth ownership in local auth store", {
+        agentDir,
+      });
+    }
+    if (!readOnly && (synced.cacheable || sanitized !== synced.store)) {
       writeCachedAuthProfileStore({
         authPath,
         authMtimeMs: readAuthStoreMtimeMs(authPath),
         stateMtimeMs: readAuthStoreMtimeMs(statePath),
-        store: synced.store,
+        store: sanitized,
       });
     }
-    return synced.store;
+    return sanitized;
   }
 
   const legacy = loadLegacyAuthProfileStore(agentDir);
@@ -890,16 +916,17 @@ function loadAuthProfileStoreForAgent(
     agentDir,
     options,
   });
+  const sanitized = sanitizeLocalAuthProfileStore({ store: synced.store, agentDir });
 
-  if (!readOnly && synced.cacheable) {
+  if (!readOnly && (synced.cacheable || sanitized !== synced.store)) {
     writeCachedAuthProfileStore({
       authPath,
       authMtimeMs: readAuthStoreMtimeMs(authPath),
       stateMtimeMs: readAuthStoreMtimeMs(statePath),
-      store: synced.store,
+      store: sanitized,
     });
   }
-  return synced.store;
+  return sanitized;
 }
 
 export function loadAuthProfileStoreForRuntime(


### PR DESCRIPTION
## Summary

- supersedes closed https://github.com/openclaw/openclaw/pull/78166 with a refreshed `origin/main` rebase
- keeps `openai-codex` OAuth credentials owned by the canonical main auth store instead of duplicating refresh-token material into sub-agent stores
- strips non-owner `openai-codex` OAuth credentials from local persisted stores while preserving local non-OAuth credentials and provider order state
- shares one in-flight OAuth refresh result across concurrent callers and fails closed if refreshed credentials cannot be persisted

Relates to https://github.com/openclaw/openclaw/issues/86599.

## Verification

Behavior addressed: `openai-codex` OAuth refresh no longer has multiple persisted owners that can race refresh-token rotation across agents/lanes.

Real environment tested: focused local Vitest wrapper, format/diff checks, and AWS Crabbox Linux changed gate. Blacksmith Testbox proof is still blocked locally by missing Blacksmith auth, so the broad remote gate used direct AWS Crabbox.

Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-manager.test.ts src/agents/auth-profiles/store.canonical-owner.test.ts --reporter=dot
node_modules/.bin/oxfmt --check --threads=1 src/agents/auth-profiles/canonical-owner.ts src/agents/auth-profiles/oauth-manager.ts src/agents/auth-profiles/oauth-manager.test.ts src/agents/auth-profiles/store.ts src/agents/auth-profiles/store.canonical-owner.test.ts
git diff --check origin/main...HEAD
node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"
```

Evidence after fix: refreshed head `bfd9f704a65d`; focused auth-profile tests passed `22/22`; formatting and diff checks passed. AWS Crabbox `pnpm check:changed` passed with provider `aws`, lease `cbx_e3b40cc95f0e`, slug `tidal-hermit`, run `run_fd68beacbb3c`, machine `c7a.8xlarge`, exit `0`, `leaseStopped=true`, selected lanes `core` and `coreTests`.

Observed result after fix: canonical `openai-codex` credentials persist only in the main owner store, duplicate non-owner persisted OAuth material is reconciled away, concurrent refresh callers share the same result, and a persist failure returns an OAuth refresh error instead of handing out unpersisted rotated credentials.

What was not tested: live OpenAI/Codex OAuth refresh was not rerun from this environment; available local auth profile inventory did not include usable OpenAI/Codex OAuth credentials.
