### PR TITLE
refactor: extract ACP translator session updates

### DIFF
--- a/src/acp/translator.session-updates.ts
+++ b/src/acp/translator.session-updates.ts
@@ -1,0 +1,179 @@
+import type {
+  AgentSideConnection,
+  AvailableCommand,
+  PromptRequest,
+  SessionUpdate,
+} from "@agentclientprotocol/sdk";
+import type { AcpEventLedger, AcpEventLedgerReplay } from "./event-ledger.js";
+
+export type AcpTranslatorSessionRef = {
+  sessionId: string;
+  sessionKey: string;
+  ledgerSessionId?: string;
+};
+
+type AcpTranslatorLedgerSessionRef = AcpTranslatorSessionRef & {
+  cwd: string;
+};
+
+type AcpTranslatorSessionUpdatesOptions = {
+  connection: Pick<AgentSideConnection, "sessionUpdate">;
+  eventLedger: AcpEventLedger;
+  getAvailableCommands: () => Promise<AvailableCommand[]>;
+  log: (message: string) => void;
+};
+
+function resolveLedgerSessionId(session: { sessionId: string; ledgerSessionId?: string }): string {
+  return session.ledgerSessionId ?? session.sessionId;
+}
+
+export class AcpTranslatorSessionUpdates {
+  constructor(private options: AcpTranslatorSessionUpdatesOptions) {}
+
+  async startLedgerSession(
+    session: AcpTranslatorLedgerSessionRef,
+    options: { complete: boolean; reset?: boolean },
+  ): Promise<void> {
+    try {
+      await this.options.eventLedger.startSession({
+        sessionId: resolveLedgerSessionId(session),
+        sessionKey: session.sessionKey,
+        cwd: session.cwd,
+        complete: options.complete,
+        ...(options.reset ? { reset: true } : {}),
+      });
+    } catch (err) {
+      this.options.log(
+        `event ledger session start failed for ${session.sessionId}: ${String(err)}`,
+      );
+    }
+  }
+
+  async readLedgerReplay(params: {
+    sessionId: string;
+    sessionKey: string;
+  }): Promise<AcpEventLedgerReplay> {
+    try {
+      return await this.options.eventLedger.readReplay(params);
+    } catch (err) {
+      this.options.log(`event ledger replay fallback for ${params.sessionId}: ${String(err)}`);
+      return { complete: false, events: [] };
+    }
+  }
+
+  async readLedgerReplayBySessionId(sessionId: string): Promise<AcpEventLedgerReplay> {
+    try {
+      return await this.options.eventLedger.readReplayBySessionId({ sessionId });
+    } catch (err) {
+      this.options.log(`event ledger exact replay fallback for ${sessionId}: ${String(err)}`);
+      return { complete: false, events: [] };
+    }
+  }
+
+  async readLedgerReplayBySessionKey(sessionKey: string): Promise<AcpEventLedgerReplay> {
+    try {
+      return await this.options.eventLedger.readReplayBySessionKey({ sessionKey });
+    } catch (err) {
+      this.options.log(
+        `event ledger session-key replay fallback for ${sessionKey}: ${String(err)}`,
+      );
+      return { complete: false, events: [] };
+    }
+  }
+
+  async recordUserPrompt(
+    session: AcpTranslatorSessionRef,
+    runId: string,
+    prompt: PromptRequest["prompt"],
+  ): Promise<void> {
+    try {
+      await this.options.eventLedger.recordUserPrompt({
+        sessionId: resolveLedgerSessionId(session),
+        sessionKey: session.sessionKey,
+        runId,
+        prompt,
+      });
+    } catch (err) {
+      this.options.log(
+        `event ledger prompt record failed for ${session.sessionId}: ${String(err)}`,
+      );
+      await this.markLedgerIncomplete(session);
+    }
+  }
+
+  async emit(params: {
+    sessionId: string;
+    sessionKey?: string;
+    ledgerSessionId?: string;
+    runId?: string;
+    update: SessionUpdate;
+    record?: boolean;
+  }): Promise<void> {
+    await this.options.connection.sessionUpdate({
+      sessionId: params.sessionId,
+      update: params.update,
+    });
+    if (params.record && params.sessionKey) {
+      await this.recordLedgerUpdate({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
+        ...(params.runId ? { runId: params.runId } : {}),
+        update: params.update,
+      });
+    }
+  }
+
+  async sendAvailableCommands(
+    session: AcpTranslatorSessionRef,
+    options: { record: boolean },
+  ): Promise<void> {
+    await this.emit({
+      sessionId: session.sessionId,
+      sessionKey: session.sessionKey,
+      ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
+      record: options.record,
+      update: {
+        sessionUpdate: "available_commands_update",
+        availableCommands: await this.options.getAvailableCommands(),
+      },
+    });
+  }
+
+  private async recordLedgerUpdate(params: {
+    sessionId: string;
+    sessionKey: string;
+    ledgerSessionId?: string;
+    runId?: string;
+    update: SessionUpdate;
+  }): Promise<void> {
+    try {
+      await this.options.eventLedger.recordUpdate({
+        sessionId: params.ledgerSessionId ?? params.sessionId,
+        sessionKey: params.sessionKey,
+        ...(params.runId ? { runId: params.runId } : {}),
+        update: params.update,
+      });
+    } catch (err) {
+      this.options.log(`event ledger update record failed for ${params.sessionId}: ${String(err)}`);
+      await this.markLedgerIncomplete({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
+      });
+    }
+  }
+
+  private async markLedgerIncomplete(session: AcpTranslatorSessionRef): Promise<void> {
+    try {
+      await this.options.eventLedger.markIncomplete({
+        sessionId: resolveLedgerSessionId(session),
+        sessionKey: session.sessionKey,
+      });
+    } catch (err) {
+      this.options.log(
+        `event ledger incomplete mark failed for ${session.sessionId}: ${String(err)}`,
+      );
+    }
+  }
+}

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -21,7 +21,6 @@ import type {
   ResumeSessionRequest,
   ResumeSessionResponse,
   SessionInfo,
-  SessionUpdate,
   SetSessionConfigOptionRequest,
   SetSessionConfigOptionResponse,
   SetSessionModeRequest,
@@ -97,6 +96,7 @@ import {
   encodeListSessionsCursor,
   resolveListSessionsPageSize,
 } from "./translator.session-list.js";
+import { AcpTranslatorSessionUpdates } from "./translator.session-updates.js";
 import { ACP_AGENT_INFO, type AcpServerOptions } from "./types.js";
 
 // Maximum allowed prompt size (2MB) to prevent DoS via memory exhaustion (CWE-400, GHSA-cxpw-2g23-2vgw)
@@ -222,17 +222,13 @@ function hasExplicitSessionRouting(
   );
 }
 
-function resolveLedgerSessionId(session: { sessionId: string; ledgerSessionId?: string }): string {
-  return session.ledgerSessionId ?? session.sessionId;
-}
-
 export class AcpGatewayAgent implements Agent {
   private connection: AgentSideConnection;
   private gateway: GatewayClient;
   private opts: AcpGatewayAgentOptions;
   private log: (msg: string) => void;
   private sessionStore: AcpSessionStore;
-  private eventLedger: AcpEventLedger;
+  private sessionUpdates: AcpTranslatorSessionUpdates;
   private sessionCreateRateLimiter: FixedWindowRateLimiter;
   private pendingPrompts = new Map<string, PendingPrompt>();
   private approvalRelays = new Map<string, PendingApprovalRelay>();
@@ -260,7 +256,12 @@ export class AcpGatewayAgent implements Agent {
     this.opts = opts;
     this.log = opts.verbose ? (msg: string) => process.stderr.write(`[acp] ${msg}\n`) : () => {};
     this.sessionStore = opts.sessionStore ?? defaultAcpSessionStore;
-    this.eventLedger = opts.eventLedger ?? createInMemoryAcpEventLedger();
+    this.sessionUpdates = new AcpTranslatorSessionUpdates({
+      connection,
+      eventLedger: opts.eventLedger ?? createInMemoryAcpEventLedger(),
+      getAvailableCommands: getAvailableCommandsForAcp,
+      log: this.log,
+    });
     this.sessionCreateRateLimiter = createFixedWindowRateLimiter({
       maxRequests: resolveFixedWindowRateLimitInteger(
         opts.sessionCreateRateLimit?.maxRequests,
@@ -379,14 +380,14 @@ export class AcpGatewayAgent implements Agent {
       sessionKey,
       cwd: params.cwd,
     });
-    await this.startLedgerSession(session, { complete: true, reset: true });
+    await this.sessionUpdates.startLedgerSession(session, { complete: true, reset: true });
     this.log(`newSession: ${session.sessionId} -> ${session.sessionKey}`);
     const sessionSnapshot = await this.getSessionSnapshot(session.sessionKey);
     await this.sendSessionSnapshotUpdate(session, sessionSnapshot, {
       includeControls: false,
       record: true,
     });
-    await this.sendAvailableCommands(session, { record: true });
+    await this.sessionUpdates.sendAvailableCommands(session, { record: true });
     const { configOptions, modes } = sessionSnapshot;
     return {
       sessionId: session.sessionId,
@@ -405,10 +406,10 @@ export class AcpGatewayAgent implements Agent {
     const hasExplicitRouting = hasExplicitSessionRouting(meta, this.opts);
     const exactLedgerReplay: AcpEventLedgerReplay = hasExplicitRouting
       ? { complete: false, events: [] }
-      : await this.readLedgerReplayBySessionId(params.sessionId);
+      : await this.sessionUpdates.readLedgerReplayBySessionId(params.sessionId);
     const listedLedgerReplay: AcpEventLedgerReplay =
       !hasExplicitRouting && !exactLedgerReplay.complete
-        ? await this.readLedgerReplayBySessionKey(params.sessionId)
+        ? await this.sessionUpdates.readLedgerReplayBySessionKey(params.sessionId)
         : { complete: false, events: [] };
     const routedLedgerReplay = exactLedgerReplay.complete ? exactLedgerReplay : listedLedgerReplay;
     const sessionKey = await this.resolveSessionKeyFromMeta({
@@ -420,7 +421,7 @@ export class AcpGatewayAgent implements Agent {
         ? exactLedgerReplay
         : listedLedgerReplay.complete && listedLedgerReplay.sessionKey === sessionKey
           ? listedLedgerReplay
-          : await this.readLedgerReplay({
+          : await this.sessionUpdates.readLedgerReplay({
               sessionId: params.sessionId,
               sessionKey,
             });
@@ -431,7 +432,7 @@ export class AcpGatewayAgent implements Agent {
       ...(ledgerReplay.sessionId ? { ledgerSessionId: ledgerReplay.sessionId } : {}),
       cwd: params.cwd,
     });
-    await this.startLedgerSession(session, { complete: ledgerReplay.complete });
+    await this.sessionUpdates.startLedgerSession(session, { complete: ledgerReplay.complete });
     this.log(`loadSession: ${session.sessionId} -> ${session.sessionKey}`);
     const [sessionSnapshot, transcript] = await Promise.all([
       this.getSessionSnapshot(session.sessionKey),
@@ -451,7 +452,7 @@ export class AcpGatewayAgent implements Agent {
       includeControls: false,
       record: false,
     });
-    await this.sendAvailableCommands(session, { record: false });
+    await this.sessionUpdates.sendAvailableCommands(session, { record: false });
     const { configOptions, modes } = sessionSnapshot;
     return { configOptions, modes };
   }
@@ -540,13 +541,13 @@ export class AcpGatewayAgent implements Agent {
       sessionKey,
       cwd: params.cwd,
     });
-    await this.startLedgerSession(session, { complete: false });
+    await this.sessionUpdates.startLedgerSession(session, { complete: false });
     this.log(`resumeSession: ${session.sessionId} -> ${session.sessionKey}`);
     await this.sendSessionSnapshotUpdate(session, sessionSnapshot, {
       includeControls: false,
       record: false,
     });
-    await this.sendAvailableCommands(session, { record: false });
+    await this.sessionUpdates.sendAvailableCommands(session, { record: false });
     const { configOptions, modes } = sessionSnapshot;
     return { configOptions, modes };
   }
@@ -710,7 +711,7 @@ export class AcpGatewayAgent implements Agent {
             { timeoutMs: null },
           );
           markSendAccepted();
-          await this.recordUserPrompt(session, runId, params.prompt);
+          await this.sessionUpdates.recordUserPrompt(session, runId, params.prompt);
         } catch (err) {
           if (
             (systemInputProvenance || systemProvenanceReceipt) &&
@@ -718,7 +719,7 @@ export class AcpGatewayAgent implements Agent {
           ) {
             await this.gateway.request("chat.send", requestParams, { timeoutMs: null });
             markSendAccepted();
-            await this.recordUserPrompt(session, runId, params.prompt);
+            await this.sessionUpdates.recordUserPrompt(session, runId, params.prompt);
             return;
           }
           throw err;
@@ -817,7 +818,7 @@ export class AcpGatewayAgent implements Agent {
         rawInput: args,
         locations,
       });
-      await this.emitSessionUpdate({
+      await this.sessionUpdates.emit({
         sessionId: pending.sessionId,
         sessionKey: pending.sessionKey,
         ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
@@ -839,7 +840,7 @@ export class AcpGatewayAgent implements Agent {
     if (phase === "update") {
       const toolState = pending.toolCalls?.get(toolCallId);
       const partialResult = data.partialResult;
-      await this.emitSessionUpdate({
+      await this.sessionUpdates.emit({
         sessionId: pending.sessionId,
         sessionKey: pending.sessionKey,
         ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
@@ -861,7 +862,7 @@ export class AcpGatewayAgent implements Agent {
       const isError = Boolean(data.isError);
       const toolState = pending.toolCalls?.get(toolCallId);
       pending.toolCalls?.delete(toolCallId);
-      await this.emitSessionUpdate({
+      await this.sessionUpdates.emit({
         sessionId: pending.sessionId,
         sessionKey: pending.sessionKey,
         ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
@@ -1103,7 +1104,7 @@ export class AcpGatewayAgent implements Agent {
       const newThought = fullThought.slice(sentThoughtSoFar);
       pending.sentThoughtLength = fullThought.length;
       pending.sentThought = fullThought;
-      await this.emitSessionUpdate({
+      await this.sessionUpdates.emit({
         sessionId,
         sessionKey: pending.sessionKey,
         ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
@@ -1129,7 +1130,7 @@ export class AcpGatewayAgent implements Agent {
     const newText = fullText.slice(sentSoFar);
     pending.sentTextLength = fullText.length;
     pending.sentText = fullText;
-    await this.emitSessionUpdate({
+    await this.sessionUpdates.emit({
       sessionId,
       sessionKey: pending.sessionKey,
       ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
@@ -1376,149 +1377,6 @@ export class AcpGatewayAgent implements Agent {
     return true;
   }
 
-  private async startLedgerSession(
-    session: { sessionId: string; sessionKey: string; ledgerSessionId?: string; cwd: string },
-    options: { complete: boolean; reset?: boolean },
-  ): Promise<void> {
-    try {
-      await this.eventLedger.startSession({
-        sessionId: resolveLedgerSessionId(session),
-        sessionKey: session.sessionKey,
-        cwd: session.cwd,
-        complete: options.complete,
-        ...(options.reset ? { reset: true } : {}),
-      });
-    } catch (err) {
-      this.log(`event ledger session start failed for ${session.sessionId}: ${String(err)}`);
-    }
-  }
-
-  private async readLedgerReplay(params: {
-    sessionId: string;
-    sessionKey: string;
-  }): Promise<AcpEventLedgerReplay> {
-    try {
-      return await this.eventLedger.readReplay(params);
-    } catch (err) {
-      this.log(`event ledger replay fallback for ${params.sessionId}: ${String(err)}`);
-      return { complete: false, events: [] };
-    }
-  }
-
-  private async readLedgerReplayBySessionId(sessionId: string): Promise<AcpEventLedgerReplay> {
-    try {
-      return await this.eventLedger.readReplayBySessionId({ sessionId });
-    } catch (err) {
-      this.log(`event ledger exact replay fallback for ${sessionId}: ${String(err)}`);
-      return { complete: false, events: [] };
-    }
-  }
-
-  private async readLedgerReplayBySessionKey(sessionKey: string): Promise<AcpEventLedgerReplay> {
-    try {
-      return await this.eventLedger.readReplayBySessionKey({ sessionKey });
-    } catch (err) {
-      this.log(`event ledger session-key replay fallback for ${sessionKey}: ${String(err)}`);
-      return { complete: false, events: [] };
-    }
-  }
-
-  private async recordUserPrompt(
-    session: { sessionId: string; sessionKey: string; ledgerSessionId?: string },
-    runId: string,
-    prompt: PromptRequest["prompt"],
-  ): Promise<void> {
-    try {
-      await this.eventLedger.recordUserPrompt({
-        sessionId: resolveLedgerSessionId(session),
-        sessionKey: session.sessionKey,
-        runId,
-        prompt,
-      });
-    } catch (err) {
-      this.log(`event ledger prompt record failed for ${session.sessionId}: ${String(err)}`);
-      await this.markLedgerIncomplete(session);
-    }
-  }
-
-  private async recordLedgerUpdate(params: {
-    sessionId: string;
-    sessionKey: string;
-    ledgerSessionId?: string;
-    runId?: string;
-    update: SessionUpdate;
-  }): Promise<void> {
-    try {
-      await this.eventLedger.recordUpdate({
-        sessionId: params.ledgerSessionId ?? params.sessionId,
-        sessionKey: params.sessionKey,
-        ...(params.runId ? { runId: params.runId } : {}),
-        update: params.update,
-      });
-    } catch (err) {
-      this.log(`event ledger update record failed for ${params.sessionId}: ${String(err)}`);
-      await this.markLedgerIncomplete({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
-      });
-    }
-  }
-
-  private async markLedgerIncomplete(session: {
-    sessionId: string;
-    sessionKey: string;
-    ledgerSessionId?: string;
-  }): Promise<void> {
-    try {
-      await this.eventLedger.markIncomplete({
-        sessionId: resolveLedgerSessionId(session),
-        sessionKey: session.sessionKey,
-      });
-    } catch (err) {
-      this.log(`event ledger incomplete mark failed for ${session.sessionId}: ${String(err)}`);
-    }
-  }
-
-  private async emitSessionUpdate(params: {
-    sessionId: string;
-    sessionKey?: string;
-    ledgerSessionId?: string;
-    runId?: string;
-    update: SessionUpdate;
-    record?: boolean;
-  }): Promise<void> {
-    await this.connection.sessionUpdate({
-      sessionId: params.sessionId,
-      update: params.update,
-    });
-    if (params.record && params.sessionKey) {
-      await this.recordLedgerUpdate({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
-        ...(params.runId ? { runId: params.runId } : {}),
-        update: params.update,
-      });
-    }
-  }
-
-  private async sendAvailableCommands(
-    session: { sessionId: string; sessionKey: string; ledgerSessionId?: string },
-    options: { record: boolean },
-  ): Promise<void> {
-    await this.emitSessionUpdate({
-      sessionId: session.sessionId,
-      sessionKey: session.sessionKey,
-      ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
-      record: options.record,
-      update: {
-        sessionUpdate: "available_commands_update",
-        availableCommands: await getAvailableCommandsForAcp(),
-      },
-    });
-  }
-
   private async getSessionSnapshot(
     sessionKey: string,
     overrides?: Partial<GatewaySessionPresentationRow>,
@@ -1722,7 +1580,7 @@ export class AcpGatewayAgent implements Agent {
     for (const message of transcript) {
       const replayChunks = extractReplayChunks(message);
       for (const chunk of replayChunks) {
-        await this.emitSessionUpdate({
+        await this.sessionUpdates.emit({
           sessionId,
           update: {
             sessionUpdate: chunk.sessionUpdate,
@@ -1738,7 +1596,7 @@ export class AcpGatewayAgent implements Agent {
     ledgerReplay: AcpEventLedgerReplay,
   ): Promise<void> {
     for (const event of ledgerReplay.events) {
-      await this.emitSessionUpdate({
+      await this.sessionUpdates.emit({
         sessionId,
         update: event.update,
         record: false,
@@ -1752,7 +1610,7 @@ export class AcpGatewayAgent implements Agent {
     options: { includeControls: boolean; record: boolean; runId?: string },
   ): Promise<void> {
     if (options.includeControls) {
-      await this.emitSessionUpdate({
+      await this.sessionUpdates.emit({
         sessionId: session.sessionId,
         sessionKey: session.sessionKey,
         ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
@@ -1763,7 +1621,7 @@ export class AcpGatewayAgent implements Agent {
           currentModeId: sessionSnapshot.modes.currentModeId,
         },
       });
-      await this.emitSessionUpdate({
+      await this.sessionUpdates.emit({
         sessionId: session.sessionId,
         sessionKey: session.sessionKey,
         ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
@@ -1776,7 +1634,7 @@ export class AcpGatewayAgent implements Agent {
       });
     }
     if (sessionSnapshot.metadata) {
-      await this.emitSessionUpdate({
+      await this.sessionUpdates.emit({
         sessionId: session.sessionId,
         sessionKey: session.sessionKey,
         ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
@@ -1789,7 +1647,7 @@ export class AcpGatewayAgent implements Agent {
       });
     }
     if (sessionSnapshot.usage) {
-      await this.emitSessionUpdate({
+      await this.sessionUpdates.emit({
         sessionId: session.sessionId,
         sessionKey: session.sessionKey,
         ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),


### PR DESCRIPTION
## Summary

- Extract ACP translator session-update and event-ledger emission into `AcpTranslatorSessionUpdates`
- Keep translator focused on ACP/Gateway orchestration while preserving ledger replay, recording, and fallback behavior
- Reduce `src/acp/translator.ts` by moving the local bridge logic into a dedicated ACP helper

## Verification

Behavior addressed: internal ACP translator refactor only; no protocol or user-visible behavior change intended.
Real environment tested: local macOS checkout, Node/pnpm repo tooling.
Exact steps or command run after this patch:
- `pnpm test src/acp/translator.event-ledger.test.ts src/acp/translator.session-setup.test.ts src/acp/translator.tool-streaming.test.ts src/acp/translator.final-snapshots.test.ts`
- `node scripts/run-oxlint.mjs src/acp/translator.ts src/acp/translator.session-updates.ts`
- `pnpm check:test-types`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
Evidence after fix: focused ACP translator replay/setup/streaming tests passed; narrow oxlint passed; test types passed; autoreview reported no accepted/actionable findings.
Observed result after fix: session updates still emit before optional ledger recording, ledger session-id resolution remains preserved, and replay fallback behavior is unchanged.
What was not tested: full CI before PR creation.
