### PR TITLE
refactor: make Telegram message cache SQLite-only

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -729,11 +729,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `Sticker.fileUniqueId`
     - `Sticker.cachedDescription`
 
-    Sticker cache file:
-
-    - `~/.openclaw/telegram/sticker-cache.json`
-
-    Stickers are described once (when possible) and cached to reduce repeated vision calls.
+    Sticker descriptions are cached in OpenClaw SQLite plugin state to reduce repeated vision calls.
 
     Enable sticker actions:
 
@@ -866,7 +862,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `channels.telegram.timeoutSeconds` overrides Telegram API client timeout (if unset, grammY default applies). Bot clients clamp configured values below the 60-second outbound text/typing request guard so grammY does not abort visible reply delivery before OpenClaw's transport guard and fallback can run. Long polling still uses a 45-second `getUpdates` request guard so idle polls are not abandoned indefinitely.
     - `channels.telegram.pollingStallThresholdMs` defaults to `120000`; tune between `30000` and `600000` only for false-positive polling-stall restarts.
     - group context history uses `channels.telegram.historyLimit` or `messages.groupChat.historyLimit` (default 50); `0` disables.
-    - reply/quote/forward supplemental context is normalized into one selected conversation context window when the gateway has observed the parent messages; the observed-message cache is persisted beside the session store. Telegram only includes one shallow `reply_to_message` in updates, so chains older than the cache are limited to Telegram's current update payload.
+    - reply/quote/forward supplemental context is normalized into one selected conversation context window when the gateway has observed the parent messages; the observed-message cache lives in OpenClaw SQLite plugin state, and `openclaw doctor --fix` imports legacy sidecars. Telegram only includes one shallow `reply_to_message` in updates, so chains older than the cache are limited to Telegram's current update payload.
     - Telegram allowlists primarily gate who can trigger the agent, not a full supplemental-context redaction boundary.
     - DM history controls:
       - `channels.telegram.dmHistoryLimit`

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -123,7 +123,7 @@ import {
   buildTelegramConversationContext,
   buildTelegramReplyChain,
   createTelegramMessageCache,
-  resolveTelegramMessageCachePath,
+  resolveTelegramMessageCacheScope,
   type TelegramCachedMessageNode,
   type TelegramReplyChainEntry,
 } from "./message-cache.js";
@@ -206,9 +206,7 @@ export const registerTelegramHandlers = ({
   const mediaGroupBuffer = new Map<string, BufferedMediaGroupEntry>();
   const mediaGroupProcessingByKey = new Map<string, Promise<void>>();
   const messageCache = createTelegramMessageCache({
-    persistedPath: resolveTelegramMessageCachePath(
-      telegramDeps.resolveStorePath(cfg.session?.store),
-    ),
+    scope: resolveTelegramMessageCacheScope(telegramDeps.resolveStorePath(cfg.session?.store)),
   });
   const messageDispatchReplayGuard = createTelegramMessageDispatchReplayGuard({
     storePath: telegramDeps.resolveStorePath(cfg.session?.store),

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1,6 +1,10 @@
-import fs from "node:fs";
 import type { Bot } from "grammy";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPluginStateKeyedStoreForTests,
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAutoTopicLabelConfig as resolveAutoTopicLabelConfigRuntime } from "./auto-topic-label-config.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {
@@ -11,9 +15,11 @@ import { notifyTelegramInboundEventOutboundSuccess } from "./inbound-event-deliv
 import {
   buildTelegramConversationContext,
   createTelegramMessageCache,
-  resolveTelegramMessageCachePath,
+  resolveTelegramMessageCacheScope,
 } from "./message-cache.js";
 import { recordOutboundMessageForPromptContext as recordOutboundMessageForPromptContextActual } from "./outbound-message-context.js";
+import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
+import type { TelegramRuntime } from "./runtime.types.js";
 
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
@@ -170,6 +176,24 @@ vi.mock("./sticker-cache.js", () => ({
 let dispatchTelegramMessage: typeof import("./bot-message-dispatch.js").dispatchTelegramMessage;
 let resetTelegramReplyFenceForTests: typeof import("./bot-message-dispatch.js").resetTelegramReplyFenceForTests;
 
+function installTelegramStateRuntimeForTest(): void {
+  setTelegramRuntime({
+    state: {
+      openKeyedStore: ((options) =>
+        createPluginStateKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openKeyedStore"],
+      openSyncKeyedStore: ((options) =>
+        createPluginStateSyncKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openSyncKeyedStore"],
+    },
+    channel: {},
+  } as TelegramRuntime);
+}
+
 const telegramDepsForTest: TelegramBotDeps = {
   getRuntimeConfig: loadConfig as TelegramBotDeps["getRuntimeConfig"],
   resolveStorePath: resolveStorePath as TelegramBotDeps["resolveStorePath"],
@@ -210,6 +234,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   beforeEach(() => {
+    resetPluginStateStoreForTests({ closeDatabase: false });
+    installTelegramStateRuntimeForTest();
     resetTelegramReplyFenceForTests();
     createTelegramDraftStream.mockReset();
     createNativeTelegramToolProgressDraft.mockReset();
@@ -305,6 +331,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
       provider: "openai",
       model: "gpt-test",
     });
+  });
+
+  afterEach(() => {
+    clearTelegramRuntime();
+    resetPluginStateStoreForTests();
   });
 
   const createDraftStream = (messageId?: number) => createTestDraftStream({ messageId });
@@ -1312,59 +1343,56 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
   it("records streamed final replies into the prompt context cache", async () => {
     const storePath = `/tmp/openclaw-telegram-stream-context-${process.pid}-${Date.now()}.json`;
-    const persistedPath = resolveTelegramMessageCachePath(storePath);
-    try {
-      setupDraftStreams({ answerMessageId: 1497 });
-      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-        await dispatcherOptions.deliver(
-          { text: "Done already: timeoutSeconds is now 7200s." },
-          { kind: "final" },
-        );
-        return { queuedFinal: true };
-      });
-
-      await dispatchWithContext({
-        context: createContext(),
-        cfg: { session: { store: storePath } },
-        telegramDeps: {
-          ...telegramDepsForTest,
-          recordOutboundMessageForPromptContext: recordOutboundMessageForPromptContextActual,
-        },
-      });
-
-      const cache = createTelegramMessageCache({ persistedPath });
-      await cache.record({
-        accountId: "default",
-        chatId: "123",
-        threadId: 777,
-        msg: {
-          chat: { id: 123, type: "private", first_name: "Keshav" },
-          message_thread_id: 777,
-          message_id: 1521,
-          date: 1_779_425_460,
-          text: "Did all Amazon crons run fine",
-          from: { id: 5185575566, is_bot: false, first_name: "Keshav" },
-        },
-      });
-
-      const context = await buildTelegramConversationContext({
-        cache,
-        accountId: "default",
-        chatId: "123",
-        threadId: 777,
-        messageId: "1521",
-        replyChainNodes: [],
-        recentLimit: 10,
-        replyTargetWindowSize: 2,
-      });
-
-      expect(context.map((entry) => entry.node.messageId)).toContain("1497");
-      expect(context.map((entry) => entry.node.body)).toContain(
-        "Done already: timeoutSeconds is now 7200s.",
+    setupDraftStreams({ answerMessageId: 1497 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "Done already: timeoutSeconds is now 7200s." },
+        { kind: "final" },
       );
-    } finally {
-      fs.rmSync(persistedPath, { force: true });
-    }
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      cfg: { session: { store: storePath } },
+      telegramDeps: {
+        ...telegramDepsForTest,
+        recordOutboundMessageForPromptContext: recordOutboundMessageForPromptContextActual,
+      },
+    });
+
+    const cache = createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    });
+    await cache.record({
+      accountId: "default",
+      chatId: "123",
+      threadId: 777,
+      msg: {
+        chat: { id: 123, type: "private", first_name: "Keshav" },
+        message_thread_id: 777,
+        message_id: 1521,
+        date: 1_779_425_460,
+        text: "Did all Amazon crons run fine",
+        from: { id: 5185575566, is_bot: false, first_name: "Keshav" },
+      },
+    });
+
+    const context = await buildTelegramConversationContext({
+      cache,
+      accountId: "default",
+      chatId: "123",
+      threadId: 777,
+      messageId: "1521",
+      replyChainNodes: [],
+      recentLimit: 10,
+      replyTargetWindowSize: 2,
+    });
+
+    expect(context.map((entry) => entry.node.messageId)).toContain("1497");
+    expect(context.map((entry) => entry.node.body)).toContain(
+      "Done already: timeoutSeconds is now 7200s.",
+    );
   });
 
   it("suppresses text-only tool payloads delivered after the final answer", async () => {

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -1,10 +1,11 @@
-import { readFile, rm, writeFile } from "node:fs/promises";
+import { rm, writeFile } from "node:fs/promises";
 import type { Message } from "grammy/types";
 import { describe, expect, it } from "vitest";
 import {
   buildTelegramConversationContext,
   buildTelegramReplyChain,
   createTelegramMessageCache,
+  listTelegramLegacyMessageCacheEntries,
   resetTelegramMessageCacheBucketsForTest,
   resolveTelegramMessageCachePath,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
@@ -68,21 +69,31 @@ function persistedCacheEntry(messageId: number, text: string): PersistedCacheEnt
   };
 }
 
-function unscopedPersistentKeys(entries: Map<string, PersistedCacheValue>): string[] {
-  return Array.from(entries.keys(), (key) => key.split(":").slice(-3).join(":")).toSorted();
-}
-
 describe("telegram message cache", () => {
   it("hydrates reply chains from persisted cached messages", async () => {
-    const storePath = `/tmp/openclaw-telegram-message-cache-${process.pid}-${Date.now()}.json`;
-    const persistedPath = resolveTelegramMessageCachePath(storePath);
-    await rm(persistedPath, { force: true });
-    try {
-      const firstCache = createTelegramMessageCache({ persistedPath });
-      await firstCache.record({
-        accountId: "default",
-        chatId: 7,
-        msg: {
+    const { bucketKey, store } = createMemoryPersistentStore();
+    const firstCache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    await firstCache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat: { id: 7, type: "private", first_name: "Kesava" },
+        message_id: 9000,
+        date: 1736380700,
+        from: { id: 1, is_bot: false, first_name: "Kesava" },
+        photo: [{ file_id: "photo-1", file_unique_id: "photo-unique-1", width: 640, height: 480 }],
+      } as Message,
+    });
+    await firstCache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat: { id: 7, type: "private", first_name: "Ada" },
+        message_id: 9001,
+        date: 1736380750,
+        text: "The cache warmer is the piece I meant",
+        from: { id: 2, is_bot: false, first_name: "Ada" },
+        reply_to_message: {
           chat: { id: 7, type: "private", first_name: "Kesava" },
           message_id: 9000,
           date: 1736380700,
@@ -90,12 +101,40 @@ describe("telegram message cache", () => {
           photo: [
             { file_id: "photo-1", file_unique_id: "photo-unique-1", width: 640, height: 480 },
           ],
-        } as Message,
-      });
-      await firstCache.record({
-        accountId: "default",
-        chatId: 7,
-        msg: {
+        } as Message["reply_to_message"],
+      } as Message,
+    });
+
+    resetTelegramMessageCacheBucketsForTest();
+    const secondCache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    const chain = await buildTelegramReplyChain({
+      cache: secondCache,
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat: { id: 7, type: "private", first_name: "Grace" },
+        message_id: 9002,
+        text: "Please explain what this reply was about",
+        from: { id: 3, is_bot: false, first_name: "Grace" },
+        reply_to_message: {
+          chat: { id: 7, type: "private", first_name: "Ada" },
+          message_id: 9001,
+          date: 1736380750,
+          text: "The cache warmer is the piece I meant",
+          from: { id: 2, is_bot: false, first_name: "Ada" },
+        } as Message["reply_to_message"],
+      } as Message,
+    });
+
+    expect(chain).toEqual([
+      {
+        messageId: "9001",
+        sender: "Ada",
+        senderId: "2",
+        timestamp: 1736380750000,
+        body: "The cache warmer is the piece I meant",
+        replyToId: "9000",
+        sourceMessage: {
           chat: { id: 7, type: "private", first_name: "Ada" },
           message_id: 9001,
           date: 1736380750,
@@ -109,157 +148,101 @@ describe("telegram message cache", () => {
             photo: [
               { file_id: "photo-1", file_unique_id: "photo-unique-1", width: 640, height: 480 },
             ],
-          } as Message["reply_to_message"],
-        } as Message,
-      });
-
-      resetTelegramMessageCacheBucketsForTest();
-      const secondCache = createTelegramMessageCache({ persistedPath });
-      const chain = await buildTelegramReplyChain({
-        cache: secondCache,
-        accountId: "default",
-        chatId: 7,
-        msg: {
-          chat: { id: 7, type: "private", first_name: "Grace" },
-          message_id: 9002,
-          text: "Please explain what this reply was about",
-          from: { id: 3, is_bot: false, first_name: "Grace" },
-          reply_to_message: {
-            chat: { id: 7, type: "private", first_name: "Ada" },
-            message_id: 9001,
-            date: 1736380750,
-            text: "The cache warmer is the piece I meant",
-            from: { id: 2, is_bot: false, first_name: "Ada" },
-          } as Message["reply_to_message"],
-        } as Message,
-      });
-
-      expect(chain).toEqual([
-        {
-          messageId: "9001",
-          sender: "Ada",
-          senderId: "2",
-          timestamp: 1736380750000,
-          body: "The cache warmer is the piece I meant",
-          replyToId: "9000",
-          sourceMessage: {
-            chat: { id: 7, type: "private", first_name: "Ada" },
-            message_id: 9001,
-            date: 1736380750,
-            text: "The cache warmer is the piece I meant",
-            from: { id: 2, is_bot: false, first_name: "Ada" },
-            reply_to_message: {
-              chat: { id: 7, type: "private", first_name: "Kesava" },
-              message_id: 9000,
-              date: 1736380700,
-              from: { id: 1, is_bot: false, first_name: "Kesava" },
-              photo: [
-                { file_id: "photo-1", file_unique_id: "photo-unique-1", width: 640, height: 480 },
-              ],
-            },
           },
         },
-        {
-          messageId: "9000",
-          sender: "Kesava",
-          senderId: "1",
-          timestamp: 1736380700000,
-          mediaRef: "telegram:file/photo-1",
-          mediaType: "image",
-          body: "<media:image>",
-          sourceMessage: {
-            chat: { id: 7, type: "private", first_name: "Kesava" },
-            message_id: 9000,
-            date: 1736380700,
-            from: { id: 1, is_bot: false, first_name: "Kesava" },
-            photo: [
-              { file_id: "photo-1", file_unique_id: "photo-unique-1", width: 640, height: 480 },
-            ],
-          },
+      },
+      {
+        messageId: "9000",
+        sender: "Kesava",
+        senderId: "1",
+        timestamp: 1736380700000,
+        mediaRef: "telegram:file/photo-1",
+        mediaType: "image",
+        body: "<media:image>",
+        sourceMessage: {
+          chat: { id: 7, type: "private", first_name: "Kesava" },
+          message_id: 9000,
+          date: 1736380700,
+          from: { id: 1, is_bot: false, first_name: "Kesava" },
+          photo: [
+            { file_id: "photo-1", file_unique_id: "photo-unique-1", width: 640, height: 480 },
+          ],
         },
-      ]);
-    } finally {
-      await rm(persistedPath, { force: true });
-    }
+      },
+    ]);
   });
 
   it("records embedded reply targets as normal cached messages", async () => {
-    const storePath = `/tmp/openclaw-telegram-message-cache-reply-target-${process.pid}-${Date.now()}.json`;
-    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    const { bucketKey, store } = createMemoryPersistentStore();
     const chat = { id: 7, type: "group", title: "Ops" } as const;
-    await rm(persistedPath, { force: true });
-    try {
-      const firstCache = createTelegramMessageCache({ persistedPath });
-      await firstCache.record({
-        accountId: "default",
-        chatId: 7,
-        msg: {
-          chat,
-          message_id: 102,
-          date: 1736380750,
-          text: "Why is there a 4th person?",
-          from: { id: 2, is_bot: false, first_name: "UserB" },
-          reply_to_message: {
-            chat,
-            message_id: 101,
-            date: 1736380700,
-            text: "Done, here is the image",
-            from: { id: 999, is_bot: true, first_name: "Bot" },
-            photo: [
-              {
-                file_id: "generated-photo-1",
-                file_unique_id: "generated-photo-unique-1",
-                width: 640,
-                height: 480,
-              },
-            ],
-          } as Message["reply_to_message"],
-        } as Message,
-      });
-
-      resetTelegramMessageCacheBucketsForTest();
-      const secondCache = createTelegramMessageCache({ persistedPath });
-      const current = {
+    const firstCache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    await firstCache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
         chat,
-        message_id: 103,
-        date: 1736380800,
-        text: "Explain what went wrong",
-        from: { id: 1, is_bot: false, first_name: "UserA" },
+        message_id: 102,
+        date: 1736380750,
+        text: "Why is there a 4th person?",
+        from: { id: 2, is_bot: false, first_name: "UserB" },
         reply_to_message: {
           chat,
-          message_id: 102,
-          date: 1736380750,
-          text: "Why is there a 4th person?",
-          from: { id: 2, is_bot: false, first_name: "UserB" },
+          message_id: 101,
+          date: 1736380700,
+          text: "Done, here is the image",
+          from: { id: 999, is_bot: true, first_name: "Bot" },
+          photo: [
+            {
+              file_id: "generated-photo-1",
+              file_unique_id: "generated-photo-unique-1",
+              width: 640,
+              height: 480,
+            },
+          ],
         } as Message["reply_to_message"],
-      } as Message;
-      const chain = await buildTelegramReplyChain({
-        cache: secondCache,
-        accountId: "default",
-        chatId: 7,
-        msg: current,
-      });
-      const context = await buildTelegramConversationContext({
-        cache: secondCache,
-        accountId: "default",
-        chatId: 7,
-        messageId: "103",
-        replyChainNodes: chain,
-        recentLimit: 10,
-        replyTargetWindowSize: 2,
-      });
+      } as Message,
+    });
 
-      expect(chain.map((entry) => entry.messageId)).toEqual(["102", "101"]);
-      expect(chain[1]).toMatchObject({
-        sender: "Bot",
-        body: "Done, here is the image",
-        mediaRef: "telegram:file/generated-photo-1",
-      });
-      expect(context.map((entry) => entry.node.messageId)).toEqual(["101", "102"]);
-      expect(context.find((entry) => entry.node.messageId === "101")?.isReplyTarget).toBe(true);
-    } finally {
-      await rm(persistedPath, { force: true });
-    }
+    resetTelegramMessageCacheBucketsForTest();
+    const secondCache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    const current = {
+      chat,
+      message_id: 103,
+      date: 1736380800,
+      text: "Explain what went wrong",
+      from: { id: 1, is_bot: false, first_name: "UserA" },
+      reply_to_message: {
+        chat,
+        message_id: 102,
+        date: 1736380750,
+        text: "Why is there a 4th person?",
+        from: { id: 2, is_bot: false, first_name: "UserB" },
+      } as Message["reply_to_message"],
+    } as Message;
+    const chain = await buildTelegramReplyChain({
+      cache: secondCache,
+      accountId: "default",
+      chatId: 7,
+      msg: current,
+    });
+    const context = await buildTelegramConversationContext({
+      cache: secondCache,
+      accountId: "default",
+      chatId: 7,
+      messageId: "103",
+      replyChainNodes: chain,
+      recentLimit: 10,
+      replyTargetWindowSize: 2,
+    });
+
+    expect(chain.map((entry) => entry.messageId)).toEqual(["102", "101"]);
+    expect(chain[1]).toMatchObject({
+      sender: "Bot",
+      body: "Done, here is the image",
+      mediaRef: "telegram:file/generated-photo-1",
+    });
+    expect(context.map((entry) => entry.node.messageId)).toEqual(["101", "102"]);
+    expect(context.find((entry) => entry.node.messageId === "101")?.isReplyTarget).toBe(true);
   });
 
   it("replaces authoritative edited message fields without stale caption carryover", async () => {
@@ -314,66 +297,60 @@ describe("telegram message cache", () => {
   });
 
   it("shares one persisted bucket across live cache instances", async () => {
-    const storePath = `/tmp/openclaw-telegram-message-cache-shared-${process.pid}-${Date.now()}.json`;
-    const persistedPath = resolveTelegramMessageCachePath(storePath);
-    await rm(persistedPath, { force: true });
-    try {
-      const firstCache = createTelegramMessageCache({ persistedPath });
-      const secondCache = createTelegramMessageCache({ persistedPath });
-      await firstCache.record({
-        accountId: "default",
-        chatId: 7,
-        msg: {
+    const { bucketKey, store } = createMemoryPersistentStore();
+    const firstCache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    const secondCache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    await firstCache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat: { id: 7, type: "private", first_name: "Nora" },
+        message_id: 9100,
+        date: 1736380700,
+        text: "Architecture sketch for the cache warmer",
+        from: { id: 1, is_bot: false, first_name: "Nora" },
+      } as Message,
+    });
+    await secondCache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat: { id: 7, type: "private", first_name: "Ira" },
+        message_id: 9101,
+        date: 1736380750,
+        text: "The cache warmer is the piece I meant",
+        from: { id: 2, is_bot: false, first_name: "Ira" },
+        reply_to_message: {
           chat: { id: 7, type: "private", first_name: "Nora" },
           message_id: 9100,
           date: 1736380700,
           text: "Architecture sketch for the cache warmer",
           from: { id: 1, is_bot: false, first_name: "Nora" },
-        } as Message,
-      });
-      await secondCache.record({
-        accountId: "default",
-        chatId: 7,
-        msg: {
+        } as Message["reply_to_message"],
+      } as Message,
+    });
+
+    const reloadedCache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    const chain = await buildTelegramReplyChain({
+      cache: reloadedCache,
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat: { id: 7, type: "private", first_name: "Mina" },
+        message_id: 9102,
+        text: "Please explain what this reply was about",
+        from: { id: 3, is_bot: false, first_name: "Mina" },
+        reply_to_message: {
           chat: { id: 7, type: "private", first_name: "Ira" },
           message_id: 9101,
           date: 1736380750,
           text: "The cache warmer is the piece I meant",
           from: { id: 2, is_bot: false, first_name: "Ira" },
-          reply_to_message: {
-            chat: { id: 7, type: "private", first_name: "Nora" },
-            message_id: 9100,
-            date: 1736380700,
-            text: "Architecture sketch for the cache warmer",
-            from: { id: 1, is_bot: false, first_name: "Nora" },
-          } as Message["reply_to_message"],
-        } as Message,
-      });
+        } as Message["reply_to_message"],
+      } as Message,
+    });
 
-      const reloadedCache = createTelegramMessageCache({ persistedPath });
-      const chain = await buildTelegramReplyChain({
-        cache: reloadedCache,
-        accountId: "default",
-        chatId: 7,
-        msg: {
-          chat: { id: 7, type: "private", first_name: "Mina" },
-          message_id: 9102,
-          text: "Please explain what this reply was about",
-          from: { id: 3, is_bot: false, first_name: "Mina" },
-          reply_to_message: {
-            chat: { id: 7, type: "private", first_name: "Ira" },
-            message_id: 9101,
-            date: 1736380750,
-            text: "The cache warmer is the piece I meant",
-            from: { id: 2, is_bot: false, first_name: "Ira" },
-          } as Message["reply_to_message"],
-        } as Message,
-      });
-
-      expect(chain.map((entry) => entry.messageId)).toEqual(["9101", "9100"]);
-    } finally {
-      await rm(persistedPath, { force: true });
-    }
+    expect(chain.map((entry) => entry.messageId)).toEqual(["9101", "9100"]);
   });
 
   it("persists cached records through the plugin state store", async () => {
@@ -509,263 +486,7 @@ describe("telegram message cache", () => {
     expect(recent).toEqual([]);
   });
 
-  it("reads legacy sidecar records as a persistent-store fallback", async () => {
-    const storePath = `/tmp/openclaw-telegram-message-cache-state-migrate-${process.pid}-${Date.now()}.json`;
-    const persistedPath = resolveTelegramMessageCachePath(storePath);
-    const { bucketKey, entries, store } = createMemoryPersistentStore();
-    await rm(persistedPath, { force: true });
-    try {
-      const legacyEntries = [
-        persistedCacheEntry(9130, "legacy one"),
-        persistedCacheEntry(9131, "legacy two"),
-        persistedCacheEntry(9132, "legacy three"),
-      ];
-      await writeFile(persistedPath, JSON.stringify(legacyEntries));
-
-      const cache = createTelegramMessageCache({
-        bucketKey,
-        legacyPersistedPath: persistedPath,
-        persistentStore: store,
-      });
-      const nearby = await cache.around({
-        accountId: "default",
-        chatId: 7,
-        messageId: "9131",
-        before: 1,
-        after: 1,
-      });
-
-      expect(nearby.map((entry) => entry.messageId)).toEqual(["9130", "9131", "9132"]);
-      expect(unscopedPersistentKeys(entries)).toEqual([]);
-
-      resetTelegramMessageCacheBucketsForTest();
-      const reloadedCache = createTelegramMessageCache({
-        bucketKey,
-        legacyPersistedPath: persistedPath,
-        persistentStore: store,
-      });
-      expect(
-        (
-          await reloadedCache.get({
-            accountId: "default",
-            chatId: 7,
-            messageId: "9132",
-          })
-        )?.body,
-      ).toBe("legacy three");
-      expect((await readFile(persistedPath, "utf-8")).startsWith("[")).toBe(true);
-    } finally {
-      await rm(persistedPath, { force: true });
-    }
-  });
-
-  it("keeps plugin state authoritative over legacy sidecar fallback", async () => {
-    const storePath = `/tmp/openclaw-telegram-message-cache-state-authoritative-${process.pid}-${Date.now()}.json`;
-    const persistedPath = resolveTelegramMessageCachePath(storePath);
-    const { bucketKey, entries, store } = createMemoryPersistentStore();
-    await rm(persistedPath, { force: true });
-    try {
-      const initialCache = createTelegramMessageCache({
-        bucketKey,
-        legacyPersistedPath: persistedPath,
-        persistentStore: store,
-      });
-      await initialCache.record({
-        accountId: "default",
-        chatId: 7,
-        msg: {
-          chat: { id: 7, type: "group", title: "Ops" },
-          message_id: 9141,
-          date: 1736389141,
-          text: "new sqlite value",
-          from: { id: 9141, is_bot: false, first_name: "State" },
-        } as Message,
-      });
-      await initialCache.record({
-        accountId: "default",
-        chatId: 7,
-        msg: {
-          chat: { id: 7, type: "group", title: "Ops" },
-          message_id: 9142,
-          date: 1736389142,
-          text: "bot reply kept only in sqlite",
-          from: { id: 0, is_bot: true, first_name: "OpenClaw" },
-        } as Message,
-      });
-      resetTelegramMessageCacheBucketsForTest();
-      await writeFile(
-        persistedPath,
-        JSON.stringify([
-          persistedCacheEntry(9140, "old sidecar only"),
-          persistedCacheEntry(9141, "stale sidecar value"),
-        ]),
-      );
-
-      const cache = createTelegramMessageCache({
-        bucketKey,
-        legacyPersistedPath: persistedPath,
-        persistentStore: store,
-      });
-
-      expect(
-        (
-          await cache.get({
-            accountId: "default",
-            chatId: 7,
-            messageId: "9140",
-          })
-        )?.body,
-      ).toBe("old sidecar only");
-      expect(
-        (
-          await cache.get({
-            accountId: "default",
-            chatId: 7,
-            messageId: "9141",
-          })
-        )?.body,
-      ).toBe("new sqlite value");
-      expect(
-        (
-          await cache.get({
-            accountId: "default",
-            chatId: 7,
-            messageId: "9142",
-          })
-        )?.body,
-      ).toBe("bot reply kept only in sqlite");
-      expect(unscopedPersistentKeys(entries)).toEqual(["default:7:9141", "default:7:9142"]);
-    } finally {
-      await rm(persistedPath, { force: true });
-    }
-  });
-
-  it("loads a legacy sidecar fallback when another plugin-state scope already has entries", async () => {
-    const firstStorePath = `/tmp/openclaw-telegram-message-cache-state-scope-a-${process.pid}-${Date.now()}.json`;
-    const secondStorePath = `/tmp/openclaw-telegram-message-cache-state-scope-b-${process.pid}-${Date.now()}.json`;
-    const firstPersistedPath = resolveTelegramMessageCachePath(firstStorePath);
-    const secondPersistedPath = resolveTelegramMessageCachePath(secondStorePath);
-    const { bucketKey, entries, store } = createMemoryPersistentStore();
-    await rm(firstPersistedPath, { force: true });
-    await rm(secondPersistedPath, { force: true });
-    try {
-      const firstCache = createTelegramMessageCache({
-        bucketKey: `${bucketKey}:first`,
-        legacyPersistedPath: firstPersistedPath,
-        persistentStore: store,
-      });
-      await firstCache.record({
-        accountId: "default",
-        chatId: 7,
-        msg: {
-          chat: { id: 7, type: "group", title: "Ops" },
-          message_id: 9150,
-          date: 1736389150,
-          text: "first store scope",
-          from: { id: 9150, is_bot: false, first_name: "First" },
-        } as Message,
-      });
-      resetTelegramMessageCacheBucketsForTest();
-      await writeFile(
-        secondPersistedPath,
-        JSON.stringify([persistedCacheEntry(9151, "second legacy scope")]),
-      );
-
-      const secondCache = createTelegramMessageCache({
-        bucketKey: `${bucketKey}:second`,
-        legacyPersistedPath: secondPersistedPath,
-        persistentStore: store,
-      });
-
-      expect(
-        (
-          await secondCache.get({
-            accountId: "default",
-            chatId: 7,
-            messageId: "9151",
-          })
-        )?.body,
-      ).toBe("second legacy scope");
-      expect(unscopedPersistentKeys(entries)).toEqual(["default:7:9150"]);
-    } finally {
-      await rm(firstPersistedPath, { force: true });
-      await rm(secondPersistedPath, { force: true });
-    }
-  });
-
-  it("appends cached records between compactions and reloads the bounded cache window", async () => {
-    const storePath = `/tmp/openclaw-telegram-message-cache-append-${process.pid}-${Date.now()}.json`;
-    const persistedPath = resolveTelegramMessageCachePath(storePath);
-    await rm(persistedPath, { force: true });
-    try {
-      const cache = createTelegramMessageCache({ persistedPath, maxMessages: 4 });
-      for (let index = 0; index < 5; index++) {
-        await cache.record({
-          accountId: "default",
-          chatId: 7,
-          msg: {
-            chat: { id: 7, type: "private", first_name: "Nora" },
-            message_id: 9150 + index,
-            date: 1736380700 + index,
-            text: `Message ${index}`,
-            from: { id: 1, is_bot: false, first_name: "Nora" },
-          } as Message,
-        });
-      }
-
-      const lines = (await readFile(persistedPath, "utf-8")).trim().split("\n");
-      expect(lines).toHaveLength(5);
-
-      resetTelegramMessageCacheBucketsForTest();
-      const reloadedCache = createTelegramMessageCache({ persistedPath, maxMessages: 4 });
-      expect(
-        await reloadedCache.get({ accountId: "default", chatId: 7, messageId: "9150" }),
-      ).toBeNull();
-      expect(
-        (await reloadedCache.get({ accountId: "default", chatId: 7, messageId: "9151" }))
-          ?.messageId,
-      ).toBe("9151");
-    } finally {
-      await rm(persistedPath, { force: true });
-    }
-  });
-
-  it("keeps the persisted log bounded by compacting cached records", async () => {
-    const storePath = `/tmp/openclaw-telegram-message-cache-compact-${process.pid}-${Date.now()}.json`;
-    const persistedPath = resolveTelegramMessageCachePath(storePath);
-    await rm(persistedPath, { force: true });
-    try {
-      const cache = createTelegramMessageCache({ persistedPath, maxMessages: 3 });
-      for (let index = 0; index < 7; index++) {
-        await cache.record({
-          accountId: "default",
-          chatId: 7,
-          msg: {
-            chat: { id: 7, type: "private", first_name: "Nora" },
-            message_id: 9200 + index,
-            date: 1736380700 + index,
-            text: `Message ${index}`,
-            from: { id: 1, is_bot: false, first_name: "Nora" },
-          } as Message,
-        });
-      }
-
-      const lines = (await readFile(persistedPath, "utf-8")).trim().split("\n");
-      expect(lines).toHaveLength(3);
-      expect(
-        lines.map((line) => {
-          const entry = JSON.parse(line) as {
-            node: { sourceMessage: { message_id: number } };
-          };
-          return entry.node.sourceMessage.message_id;
-        }),
-      ).toEqual([9204, 9205, 9206]);
-    } finally {
-      await rm(persistedPath, { force: true });
-    }
-  });
-
-  it("loads mixed legacy array caches and rewrites them as line-delimited entries", async () => {
+  it("parses legacy sidecar records for doctor migration only", async () => {
     const storePath = `/tmp/openclaw-telegram-message-cache-legacy-${process.pid}-${Date.now()}.json`;
     const persistedPath = resolveTelegramMessageCachePath(storePath);
     await rm(persistedPath, { force: true });
@@ -784,32 +505,10 @@ describe("telegram message cache", () => {
         `${JSON.stringify(legacyEntries)}${appendedEntries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
       );
 
-      const cache = createTelegramMessageCache({ persistedPath });
-
-      const nearby = await cache.around({
-        accountId: "default",
-        chatId: 7,
-        messageId: "35035",
-        before: 2,
-        after: 2,
-      });
-      expect(nearby.map((entry) => entry.messageId)).toEqual([
-        "35033",
-        "35034",
-        "35035",
-        "35036",
-        "35037",
-      ]);
-
-      const canonical = await readFile(persistedPath, "utf-8");
-      expect(canonical.startsWith("[")).toBe(false);
-      const lines = canonical.trim().split("\n");
-      expect(lines).toHaveLength(5);
       expect(
-        lines.map((line) => {
-          const entry = JSON.parse(line) as PersistedCacheEntry;
-          return entry.node.sourceMessage.message_id;
-        }),
+        listTelegramLegacyMessageCacheEntries({ persistedPath }).map(
+          (entry) => entry.value.sourceMessage.message_id,
+        ),
       ).toEqual([35033, 35034, 35035, 35036, 35037]);
     } finally {
       await rm(persistedPath, { force: true });

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -5,7 +5,6 @@ import { formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { appendRegularFileSync, replaceFileAtomicSync } from "openclaw/plugin-sdk/security-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveTelegramPrimaryMedia } from "./bot/body-helpers.js";
 import {
@@ -61,17 +60,13 @@ type MessageWithExternalReply = Message & { external_reply?: Message };
 
 type TelegramMessageCacheBucket = {
   messages: Map<string, TelegramCachedMessageNode>;
-  persistedEntryCount: number;
   hydrated: boolean;
   hydratePromise?: Promise<void>;
-  legacyPersistedPath?: string;
   persistentStore?: TelegramMessageCachePersistentStore;
 };
 
 type PersistedMessageReadResult = {
   messages: Map<string, TelegramCachedMessageNode>;
-  persistedEntryCount: number;
-  needsRewrite: boolean;
 };
 
 type TelegramMessageObservationMode = "authoritative" | "partial";
@@ -87,7 +82,6 @@ const DEFAULT_MAX_MESSAGES = 5000;
 export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES = 3000;
 export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE = "telegram.message-cache";
 const PERSISTENT_BUCKET_KEY = `plugin-state:${TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE}`;
-const COMPACT_THRESHOLD_RATIO = 2;
 const persistedMessageCacheBuckets = new Map<string, TelegramMessageCacheBucket>();
 
 export type PersistedTelegramMessageCacheValue = {
@@ -125,6 +119,10 @@ function telegramMessageCacheKeyPrefix(params: {
 
 export function resolveTelegramMessageCachePath(storePath: string): string {
   return `${storePath}.telegram-messages.json`;
+}
+
+export function resolveTelegramMessageCacheScope(storePath: string): string {
+  return resolveTelegramMessageCachePath(storePath);
 }
 
 function resolveReplyMessage(msg: Message): Message | undefined {
@@ -348,9 +346,8 @@ function findJsonArrayEnd(text: string): number {
   return -1;
 }
 
-function readPersistedEntryValues(raw: string): { values: unknown[]; needsRewrite: boolean } {
+function readPersistedEntryValues(raw: string): unknown[] {
   const values: unknown[] = [];
-  let needsRewrite = false;
   const readLines = (text: string) => {
     for (const line of text.split("\n")) {
       if (!line.trim()) {
@@ -360,7 +357,8 @@ function readPersistedEntryValues(raw: string): { values: unknown[]; needsRewrit
         const value: unknown = JSON.parse(line);
         values.push(value);
       } catch {
-        needsRewrite = true;
+        // Legacy cache files were best-effort append logs. Doctor imports every
+        // valid row and ignores torn/corrupt entries instead of keeping runtime fallback.
       }
     }
   };
@@ -369,20 +367,18 @@ function readPersistedEntryValues(raw: string): { values: unknown[]; needsRewrit
     const startOffset = raw.length - trimmedStart.length;
     const arrayEnd = findJsonArrayEnd(raw.slice(startOffset));
     if (arrayEnd === -1) {
-      needsRewrite = true;
       readLines(raw);
-      return { values, needsRewrite };
+      return values;
     }
     const legacyValue: unknown = JSON.parse(raw.slice(startOffset, startOffset + arrayEnd));
     if (Array.isArray(legacyValue)) {
       values.push(...legacyValue);
     }
-    needsRewrite = true;
     readLines(raw.slice(startOffset + arrayEnd));
-    return { values, needsRewrite };
+    return values;
   }
   readLines(raw);
-  return { values, needsRewrite };
+  return values;
 }
 
 function trimMessages(messages: Map<string, TelegramCachedMessageNode>, maxMessages: number): void {
@@ -451,17 +447,12 @@ function upsertCachedMessageNode(params: {
 
 function readPersistedMessages(filePath: string, maxMessages: number): PersistedMessageReadResult {
   const messages = new Map<string, TelegramCachedMessageNode>();
-  let persistedEntryCount = 0;
-  let needsRewrite = false;
   if (!fs.existsSync(filePath)) {
-    return { messages, persistedEntryCount, needsRewrite };
+    return { messages };
   }
   try {
-    const persisted = readPersistedEntryValues(fs.readFileSync(filePath, "utf-8"));
-    needsRewrite = persisted.needsRewrite;
-    for (const value of persisted.values) {
+    for (const value of readPersistedEntryValues(fs.readFileSync(filePath, "utf-8"))) {
       for (const entry of parsePersistedEntry(value)) {
-        persistedEntryCount++;
         upsertCachedMessageNode({
           messages,
           key: entry.key,
@@ -473,9 +464,8 @@ function readPersistedMessages(filePath: string, maxMessages: number): Persisted
     }
   } catch (error) {
     logVerbose(`telegram: failed to read message cache: ${String(error)}`);
-    needsRewrite = true;
   }
-  return { messages, persistedEntryCount, needsRewrite };
+  return { messages };
 }
 
 function toPersistedCacheValue(
@@ -485,52 +475,6 @@ function toPersistedCacheValue(
     sourceMessage: node.sourceMessage,
     ...(node.threadId ? { threadId: node.threadId } : {}),
   };
-}
-
-function serializePersistedEntry(key: string, node: TelegramCachedMessageNode): string {
-  return `${JSON.stringify({
-    key,
-    node: toPersistedCacheValue(node),
-  })}\n`;
-}
-
-function replaceLegacyPersistedMessages(params: {
-  messages: Map<string, TelegramCachedMessageNode>;
-  persistedPath?: string;
-}): number {
-  const { persistedPath, messages } = params;
-  if (!persistedPath) {
-    return messages.size;
-  }
-  if (messages.size === 0) {
-    fs.rmSync(persistedPath, { force: true });
-    return 0;
-  }
-  const serialized = Array.from(messages, ([key, node]) => serializePersistedEntry(key, node)).join(
-    "",
-  );
-  replaceFileAtomicSync({
-    filePath: persistedPath,
-    content: serialized,
-    tempPrefix: ".telegram-message-cache",
-  });
-  return messages.size;
-}
-
-function appendLegacyPersistedMessage(params: {
-  key: string;
-  node: TelegramCachedMessageNode;
-  persistedPath?: string;
-}): number {
-  const { persistedPath } = params;
-  if (!persistedPath) {
-    return 0;
-  }
-  appendRegularFileSync({
-    filePath: persistedPath,
-    content: serializePersistedEntry(params.key, params.node),
-  });
-  return 1;
 }
 
 function resolvePersistentScopeKey(scope: string): string {
@@ -573,7 +517,6 @@ function resolveDefaultPersistentStore(): TelegramMessageCachePersistentStore | 
 
 function resolveMessageCacheBucket(params: {
   bucketKey?: string;
-  legacyPersistedPath?: string;
   maxMessages: number;
   persistentStore?: TelegramMessageCachePersistentStore;
 }): TelegramMessageCacheBucket {
@@ -581,21 +524,17 @@ function resolveMessageCacheBucket(params: {
   if (!bucketKey) {
     return {
       messages: new Map<string, TelegramCachedMessageNode>(),
-      persistedEntryCount: 0,
       hydrated: true,
     };
   }
   const existing = persistedMessageCacheBuckets.get(bucketKey);
   if (existing) {
     existing.persistentStore = params.persistentStore ?? existing.persistentStore;
-    existing.legacyPersistedPath = params.legacyPersistedPath ?? existing.legacyPersistedPath;
     return existing;
   }
   const bucket = {
     messages: new Map<string, TelegramCachedMessageNode>(),
-    persistedEntryCount: 0,
     hydrated: false,
-    ...(params.legacyPersistedPath ? { legacyPersistedPath: params.legacyPersistedPath } : {}),
     ...(params.persistentStore ? { persistentStore: params.persistentStore } : {}),
   };
   persistedMessageCacheBuckets.set(bucketKey, bucket);
@@ -625,35 +564,8 @@ async function hydrateMessageCacheBucket(
       ? storeEntries.filter(({ key }) => key.startsWith(`${scopeKey}:`))
       : storeEntries;
 
-    const legacyPath = bucket.legacyPersistedPath;
-    if (legacyPath) {
-      const legacy = readPersistedMessages(legacyPath, maxMessages);
-      if (legacy.messages.size > 0) {
-        for (const [key, node] of legacy.messages) {
-          const cacheKey = bucket.persistentStore && scopeKey ? `${scopeKey}:${key}` : key;
-          upsertCachedMessageNode({
-            messages: bucket.messages,
-            key: cacheKey,
-            node,
-            mode: "authoritative",
-          });
-          trimMessages(bucket.messages, maxMessages);
-        }
-      }
-      if (!bucket.persistentStore && legacy.needsRewrite) {
-        try {
-          bucket.persistedEntryCount = replaceLegacyPersistedMessages({
-            messages: bucket.messages,
-            persistedPath: legacyPath,
-          });
-        } catch (error) {
-          logVerbose(`telegram: failed to compact message cache: ${String(error)}`);
-        }
-      }
-    }
     for (const { key, value } of scopedStoreEntries) {
       for (const entry of parsePersistedEntry(persistedValueToEntry(key, value))) {
-        bucket.persistedEntryCount++;
         upsertCachedMessageNode({
           messages: bucket.messages,
           key: entry.key,
@@ -673,31 +585,14 @@ async function hydrateMessageCacheBucket(
 async function persistCachedNode(params: {
   bucket: TelegramMessageCacheBucket;
   key: string;
-  maxMessages: number;
   node: TelegramCachedMessageNode;
 }): Promise<void> {
   const { persistentStore } = params.bucket;
   if (!persistentStore) {
-    try {
-      params.bucket.persistedEntryCount += appendLegacyPersistedMessage({
-        key: params.key,
-        node: params.node,
-        persistedPath: params.bucket.legacyPersistedPath,
-      });
-      if (params.bucket.persistedEntryCount > params.maxMessages * COMPACT_THRESHOLD_RATIO) {
-        params.bucket.persistedEntryCount = replaceLegacyPersistedMessages({
-          messages: params.bucket.messages,
-          persistedPath: params.bucket.legacyPersistedPath,
-        });
-      }
-    } catch (error) {
-      logVerbose(`telegram: failed to persist message cache: ${String(error)}`);
-    }
     return;
   }
   try {
     await persistentStore.register(params.key, toPersistedCacheValue(params.node));
-    params.bucket.persistedEntryCount++;
   } catch (error) {
     logVerbose(`telegram: failed to persist message cache: ${String(error)}`);
   }
@@ -705,8 +600,7 @@ async function persistCachedNode(params: {
 
 export function createTelegramMessageCache(params?: {
   maxMessages?: number;
-  legacyPersistedPath?: string;
-  persistedPath?: string;
+  scope?: string;
   persistentStore?: TelegramMessageCachePersistentStore;
   bucketKey?: string;
 }): TelegramMessageCache {
@@ -714,20 +608,13 @@ export function createTelegramMessageCache(params?: {
   const maxMessages =
     params?.maxMessages ??
     (persistentStore ? TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES : DEFAULT_MAX_MESSAGES);
-  const legacyPersistedPath = params?.legacyPersistedPath ?? params?.persistedPath;
   const scopeKey = persistentStore
-    ? resolvePersistentScopeKey(legacyPersistedPath ?? params?.bucketKey ?? "default")
+    ? resolvePersistentScopeKey(params?.scope ?? "default")
     : undefined;
   const bucketKey =
-    params?.bucketKey ??
-    (persistentStore
-      ? `${PERSISTENT_BUCKET_KEY}:${scopeKey}`
-      : legacyPersistedPath
-        ? `legacy:${legacyPersistedPath}`
-        : undefined);
+    params?.bucketKey ?? (persistentStore ? `${PERSISTENT_BUCKET_KEY}:${scopeKey}` : undefined);
   const bucket = resolveMessageCacheBucket({
     bucketKey,
-    legacyPersistedPath,
     maxMessages,
     ...(persistentStore ? { persistentStore } : {}),
   });
@@ -791,7 +678,7 @@ export function createTelegramMessageCache(params?: {
           recordedEntry = cachedNode;
         }
         trimMessages(messages, maxMessages);
-        await persistCachedNode({ bucket, key, maxMessages, node: cachedNode });
+        await persistCachedNode({ bucket, key, node: cachedNode });
       }
       return recordedEntry ?? currentObservation.node;
     },

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -2,7 +2,7 @@ import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
-import { createTelegramMessageCache, resolveTelegramMessageCachePath } from "./message-cache.js";
+import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
 
 export type TelegramOutboundPromptContextMessage = {
   message_id?: number;
@@ -67,9 +67,7 @@ export async function recordOutboundMessageForPromptContext(params: {
 }): Promise<void> {
   try {
     const cache = createTelegramMessageCache({
-      legacyPersistedPath: resolveTelegramMessageCachePath(
-        resolveStorePath(params.cfg.session?.store),
-      ),
+      scope: resolveTelegramMessageCacheScope(resolveStorePath(params.cfg.session?.store)),
     });
     await cache.record({
       accountId: params.account.accountId,

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import type { Bot } from "grammy";
 import {
+  createPluginStateKeyedStoreForTests,
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
@@ -9,9 +10,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildTelegramConversationContext,
   createTelegramMessageCache,
-  resolveTelegramMessageCachePath,
+  resolveTelegramMessageCacheScope,
   resetTelegramMessageCacheBucketsForTest,
 } from "./message-cache.js";
+import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
+import type { TelegramRuntime } from "./runtime.types.js";
 import {
   getTelegramSendTestMocks,
   importTelegramSendModule,
@@ -62,6 +65,7 @@ let sentMessageStore: NonNullable<Parameters<typeof setTelegramSentMessageStoreF
 
 beforeEach(() => {
   resetPluginStateStoreForTests({ closeDatabase: false });
+  installTelegramStateRuntimeForTest();
   sentMessageStore = createPluginStateSyncKeyedStoreForTests("telegram", {
     namespace: TELEGRAM_SENT_MESSAGE_CACHE_NAMESPACE,
     maxEntries: TELEGRAM_SENT_MESSAGE_CACHE_MAX_ENTRIES,
@@ -69,6 +73,24 @@ beforeEach(() => {
   sentMessageStore.clear();
   setTelegramSentMessageStoreForTest(sentMessageStore);
 });
+
+function installTelegramStateRuntimeForTest(): void {
+  setTelegramRuntime({
+    state: {
+      openKeyedStore: ((options) =>
+        createPluginStateKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openKeyedStore"],
+      openSyncKeyedStore: ((options) =>
+        createPluginStateSyncKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openSyncKeyedStore"],
+    },
+    channel: {},
+  } as TelegramRuntime);
+}
 
 async function expectChatNotFoundWithChatId(
   action: Promise<unknown>,
@@ -204,6 +226,7 @@ function capturedLogText(logFile: string): string {
 }
 
 afterEach(() => {
+  clearTelegramRuntime();
   clearSentMessageCache();
   setTelegramSentMessageStoreForTest(undefined);
   resetPluginStateStoreForTests();
@@ -698,66 +721,62 @@ describe("sendMessageTelegram", () => {
 
   it("records sent text messages into the Telegram prompt context cache", async () => {
     const storePath = `/tmp/openclaw-telegram-send-context-${process.pid}-${Date.now()}.json`;
-    const persistedPath = resolveTelegramMessageCachePath(storePath);
     const cfg = { session: { store: storePath } };
-    try {
-      botApi.sendMessage.mockResolvedValueOnce({
-        message_id: 1497,
-        date: 1_779_394_740,
+    botApi.sendMessage.mockResolvedValueOnce({
+      message_id: 1497,
+      date: 1_779_394_740,
+      chat: {
+        id: "-1003966283270",
+        type: "supergroup",
+        title: "Keshav and Kelaw - Keshav's Bot",
+      },
+      from: { id: 42, is_bot: true, first_name: "Kelaw", username: "keshavbotagent" },
+      text: "Done already: timeoutSeconds is now 7200s.",
+      message_thread_id: 1154,
+    });
+
+    await sendMessageTelegram("-1003966283270", "Done already: timeoutSeconds is now 7200s.", {
+      cfg,
+      token: "tok",
+      messageThreadId: 1154,
+    });
+
+    const cache = createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    });
+    await cache.record({
+      accountId: "default",
+      chatId: "-1003966283270",
+      threadId: 1154,
+      msg: {
         chat: {
-          id: "-1003966283270",
+          id: -1003966283270,
           type: "supergroup",
           title: "Keshav and Kelaw - Keshav's Bot",
         },
-        from: { id: 42, is_bot: true, first_name: "Kelaw", username: "keshavbotagent" },
-        text: "Done already: timeoutSeconds is now 7200s.",
         message_thread_id: 1154,
-      });
+        message_id: 1521,
+        date: 1_779_425_460,
+        text: "Did all Amazon crons run fine",
+        from: { id: 5185575566, is_bot: false, first_name: "Keshav" },
+      },
+    });
 
-      await sendMessageTelegram("-1003966283270", "Done already: timeoutSeconds is now 7200s.", {
-        cfg,
-        token: "tok",
-        messageThreadId: 1154,
-      });
+    const context = await buildTelegramConversationContext({
+      cache,
+      accountId: "default",
+      chatId: "-1003966283270",
+      threadId: 1154,
+      messageId: "1521",
+      replyChainNodes: [],
+      recentLimit: 10,
+      replyTargetWindowSize: 2,
+    });
 
-      const cache = createTelegramMessageCache({ persistedPath });
-      await cache.record({
-        accountId: "default",
-        chatId: "-1003966283270",
-        threadId: 1154,
-        msg: {
-          chat: {
-            id: -1003966283270,
-            type: "supergroup",
-            title: "Keshav and Kelaw - Keshav's Bot",
-          },
-          message_thread_id: 1154,
-          message_id: 1521,
-          date: 1_779_425_460,
-          text: "Did all Amazon crons run fine",
-          from: { id: 5185575566, is_bot: false, first_name: "Keshav" },
-        },
-      });
-
-      const context = await buildTelegramConversationContext({
-        cache,
-        accountId: "default",
-        chatId: "-1003966283270",
-        threadId: 1154,
-        messageId: "1521",
-        replyChainNodes: [],
-        recentLimit: 10,
-        replyTargetWindowSize: 2,
-      });
-
-      expect(context.map((entry) => entry.node.messageId)).toContain("1497");
-      expect(context.map((entry) => entry.node.body)).toContain(
-        "Done already: timeoutSeconds is now 7200s.",
-      );
-    } finally {
-      fs.rmSync(persistedPath, { force: true });
-      fs.rmSync(`${storePath}.telegram-sent-messages.json`, { force: true });
-    }
+    expect(context.map((entry) => entry.node.messageId)).toContain("1497");
+    expect(context.map((entry) => entry.node.body)).toContain(
+      "Done already: timeoutSeconds is now 7200s.",
+    );
   });
 
   it("falls back to plain text when Telegram rejects HTML and preserves send params", async () => {


### PR DESCRIPTION
## Summary

- Remove runtime read/write fallback for Telegram message-cache JSON sidecars.
- Keep legacy sidecar parsing only for doctor migration import into SQLite plugin state.
- Update Telegram prompt-context call sites, tests, and docs to use SQLite plugin-state scope.

## Verification

- `pnpm test extensions/telegram/src/message-cache.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/state-migrations.test.ts -- --reporter=dot`
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/message-cache.ts extensions/telegram/src/message-cache.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/outbound-message-context.ts docs/channels/telegram.md`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: Telegram prompt-context message cache no longer reads or writes legacy JSON sidecars at runtime; doctor remains the migration path into SQLite plugin state.
Real environment tested: local OpenClaw source checkout on branch `refactor/telegram-sqlite-state-runtime` at `e9269680c34d`.
Exact steps or command run after this patch: focused Telegram Vitest suite, changed gate for extensions/extensionTests/docs, oxfmt check, diff whitespace check, and autoreview.
Evidence after fix: focused Telegram suite passed 4 files / 223 tests; changed gate passed lanes `extensions`, `extensionTests`, and `docs`; autoreview reported no accepted/actionable findings.
Observed result after fix: Telegram message-cache persistence uses plugin state, legacy sidecar rows are still parsed for doctor migration tests, and docs now point operators to SQLite plugin state plus `openclaw doctor --fix`.
What was not tested: default `pnpm check:changed` Testbox delegation from this machine because the local Crabbox binary is 0.15.0 and the Testbox provider requires >=0.22.0; the same changed gate was run locally in remote-child mode instead.
