### PR TITLE
fix(doctor): respect explicit PI runtime policy

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1919,16 +1919,10 @@ importers:
       marked:
         specifier: 18.0.4
         version: 18.0.4
-      three:
-        specifier: 0.184.0
-        version: 0.184.0
     devDependencies:
       '@types/markdown-it':
         specifier: 14.1.2
         version: 14.1.2
-      '@types/three':
-        specifier: 0.184.1
-        version: 0.184.1
       '@vitest/browser-playwright':
         specifier: 4.1.7
         version: 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
@@ -2446,9 +2440,6 @@ packages:
 
   '@d-fischer/typed-event-emitter@3.3.3':
     resolution: {integrity: sha512-OvSEOa8icfdWDqcRtjSEZtgJTFOFNgTjje7zaL0+nAtu2/kZtRCSK5wUMrI/aXtCH8o0Qz2vA8UqkhWUTARFQQ==}
-
-  '@dimforge/rapier3d-compat@0.12.0':
-    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@discordjs/voice@0.19.2':
     resolution: {integrity: sha512-3yJ255e4ag3wfZu/DSxeOZK1UtnqNxnspmLaQetGT0pDkThNZoHs+Zg6dgZZ19JEVomXygvfHn9lNpICZuYtEA==}
@@ -4009,9 +4000,6 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@tweenjs/tween.js@23.1.3':
-    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
-
   '@twurple/api-call@8.1.4':
     resolution: {integrity: sha512-qh2TpdxxyiSkwadcCSes6uBHQB6l4Fz8sVfmzk+Brb12asemHMXTEyQAdrMJT7LlgtZq01nr+RASzWM3jmGtkw==}
 
@@ -4139,12 +4127,6 @@ packages:
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
-  '@types/stats.js@0.17.4':
-    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
-
-  '@types/three@0.184.1':
-    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
-
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -4153,9 +4135,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/webxr@0.5.24':
-    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -5077,9 +5056,6 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fflate@0.8.3:
-    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
-
   file-type@22.0.1:
     resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
     engines: {node: '>=22'}
@@ -5832,9 +5808,6 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  meshoptimizer@1.1.1:
-    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -6808,9 +6781,6 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
-
-  three@0.184.0:
-    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -8047,8 +8017,6 @@ snapshots:
   '@d-fischer/typed-event-emitter@3.3.3':
     dependencies:
       tslib: 2.8.1
-
-  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@discordjs/voice@0.19.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -9475,8 +9443,6 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tweenjs/tween.js@23.1.3': {}
-
   '@twurple/api-call@8.1.4':
     dependencies:
       '@d-fischer/shared-utils': 3.6.4
@@ -9649,24 +9615,11 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 25.9.1
 
-  '@types/stats.js@0.17.4': {}
-
-  '@types/three@0.184.1':
-    dependencies:
-      '@dimforge/rapier3d-compat': 0.12.0
-      '@tweenjs/tween.js': 23.1.3
-      '@types/stats.js': 0.17.4
-      '@types/webxr': 0.5.24
-      fflate: 0.8.3
-      meshoptimizer: 1.1.1
-
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/webxr@0.5.24': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -10609,8 +10562,6 @@ snapshots:
       node-domexception: '@nolyfill/domexception@1.0.28'
       web-streams-polyfill: 3.3.3
 
-  fflate@0.8.3: {}
-
   file-type@22.0.1:
     dependencies:
       '@tokenizer/inflate': 0.4.1
@@ -11506,8 +11457,6 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
-
-  meshoptimizer@1.1.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -12782,8 +12731,6 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
-
-  three@0.184.0: {}
 
   tinybench@2.9.0: {}
 

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -440,6 +440,7 @@ vi.mock("./model-selection.js", () => {
       allowAny: false,
     };
   };
+  const normalizeProviderId = (provider: string) => provider.trim().toLowerCase();
 
   return {
     buildAllowedModelSet,

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -440,8 +440,6 @@ vi.mock("./model-selection.js", () => {
       allowAny: false,
     };
   };
-  const normalizeProviderId = (provider: string) => provider.trim().toLowerCase();
-
   return {
     buildAllowedModelSet,
     createModelVisibilityPolicy: (params: {

--- a/src/agents/openai-routing.test.ts
+++ b/src/agents/openai-routing.test.ts
@@ -43,6 +43,22 @@ describe("OpenAI runtime routing policy", () => {
     ).toBe("openai");
   });
 
+  it("normalizes OpenAI provider keys before checking custom base URLs", () => {
+    const config = {
+      models: {
+        providers: {
+          OpenAI: {
+            baseUrl: "https://example.test/v1",
+            models: [],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(openAIProviderUsesCodexRuntimeByDefault({ provider: "openai", config })).toBe(false);
+    expect(modelSelectionShouldEnsureCodexPlugin({ model: "openai/gpt-5.5", config })).toBe(false);
+  });
+
   it("uses canonical OpenAI context config under the Codex runtime", () => {
     expect(
       resolveContextConfigProviderForRuntime({

--- a/src/agents/openai-routing.ts
+++ b/src/agents/openai-routing.ts
@@ -23,8 +23,25 @@ function isOfficialOpenAIBaseUrl(baseUrl: unknown): boolean {
   }
 }
 
+function resolveOpenAIProviderConfig(config: OpenClawConfig | undefined) {
+  const providers = config?.models?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  const direct = providers.openai;
+  if (direct) {
+    return direct;
+  }
+  for (const [providerId, providerConfig] of Object.entries(providers)) {
+    if (normalizeProviderId(providerId) === OPENAI_PROVIDER_ID) {
+      return providerConfig;
+    }
+  }
+  return undefined;
+}
+
 function openAIProviderUsesCustomBaseUrl(config: OpenClawConfig | undefined): boolean {
-  return !isOfficialOpenAIBaseUrl(config?.models?.providers?.openai?.baseUrl);
+  return !isOfficialOpenAIBaseUrl(resolveOpenAIProviderConfig(config)?.baseUrl);
 }
 
 export function isOpenAIProvider(provider: string | undefined): boolean {

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -87,7 +87,7 @@ vi.mock("../agents/model-selection.js", () => {
   });
   const normalizeProviderId = (provider: string) => provider.trim().toLowerCase();
   const modelKey = (provider: string, model: string) =>
-    `${provider.trim().toLowerCase()}/${model.trim().toLowerCase()}`;
+    `${normalizeProviderId(provider)}/${model.trim().toLowerCase()}`;
   const isModelKeyAllowedBySet = (allowedKeys: ReadonlySet<string>, key: string) => {
     if (allowedKeys.has(key)) {
       return true;

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -3749,6 +3749,60 @@ describe("collectCodexRouteWarnings", () => {
     expect(store.other.agentHarnessId).toBe("codex");
   });
 
+  it("preserves explicit OpenClaw runtime pins while repairing legacy session routes", () => {
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "s1",
+        updatedAt: 1,
+        modelProvider: "openai-codex",
+        model: "gpt-5.5",
+        providerOverride: "openai-codex",
+        modelOverride: "openai-codex/gpt-5.4",
+        agentHarnessId: "pi",
+        agentRuntimeOverride: "pi",
+        authProfileOverride: "openai-codex:default",
+      },
+    };
+
+    const result = repairCodexSessionStoreRoutes({
+      store,
+      now: 123,
+    });
+
+    expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
+    expect(store.main.modelProvider).toBe("openai");
+    expect(store.main.model).toBe("gpt-5.5");
+    expect(store.main.providerOverride).toBe("openai");
+    expect(store.main.modelOverride).toBe("gpt-5.4");
+    expect(store.main.agentHarnessId).toBe("pi");
+    expect(store.main.agentRuntimeOverride).toBe("pi");
+    expect(store.main.authProfileOverride).toBe("openai-codex:default");
+  });
+
+  it("clears stale Codex overrides while preserving explicit OpenClaw session pins", () => {
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "s1",
+        updatedAt: 1,
+        modelProvider: "openai-codex",
+        model: "gpt-5.5",
+        agentHarnessId: "pi",
+        agentRuntimeOverride: "codex",
+      },
+    };
+
+    const result = repairCodexSessionStoreRoutes({
+      store,
+      now: 123,
+    });
+
+    expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
+    expect(store.main.modelProvider).toBe("openai");
+    expect(store.main.model).toBe("gpt-5.5");
+    expect(store.main.agentHarnessId).toBe("pi");
+    expect(store.main.agentRuntimeOverride).toBeUndefined();
+  });
+
   it("keeps Codex session auth pins while leaving runtime unpinned", () => {
     const store: Record<string, SessionEntry> = {
       main: {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -2914,12 +2914,14 @@ function clearStaleCodexFallbackNotice(entry: SessionEntry): boolean {
 }
 
 function clearStaleSessionRuntimePins(entry: SessionEntry): boolean {
+  const harnessRuntime = normalizeRuntimeString(entry.agentHarnessId);
+  const overrideRuntime = normalizeRuntimeString(entry.agentRuntimeOverride);
   let changed = false;
-  if (entry.agentHarnessId !== undefined) {
+  if (entry.agentHarnessId !== undefined && harnessRuntime !== "openclaw") {
     delete entry.agentHarnessId;
     changed = true;
   }
-  if (entry.agentRuntimeOverride !== undefined) {
+  if (entry.agentRuntimeOverride !== undefined && overrideRuntime !== "openclaw") {
     delete entry.agentRuntimeOverride;
     changed = true;
   }

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -432,6 +432,40 @@ describe("doctor stale plugin config helpers", () => {
     expect(maybeRepairStalePluginConfig(cfg)).toEqual({ config: cfg, changes: [] });
   });
 
+  it("keeps Codex entry diagnostics when OpenAI wildcard policy falls back to Codex", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+            agentRuntime: { id: "pi" },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          models: {
+            "openai/*": { agentRuntime: { id: "default" } },
+          },
+        },
+      },
+      plugins: {
+        entries: {
+          codex: {},
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(scanStalePluginConfig(cfg)).toEqual([
+      {
+        pluginId: "codex",
+        pathLabel: "plugins.entries.codex",
+        surface: "entries",
+      },
+    ]);
+  });
+
   it("still reports an explicitly enabled missing Codex plugin entry as stale", () => {
     const cfg = {
       models: {

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -380,6 +380,85 @@ describe("doctor stale plugin config helpers", () => {
     expect(warnings[2]).toContain("Auto-removal is paused");
   });
 
+  it("keeps an intentionally unavailable Codex plugin entry out of stale diagnostics", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+            agentRuntime: { id: "openclaw" },
+          },
+        },
+      },
+      plugins: {
+        allow: ["codex", "acpx"],
+        entries: {
+          codex: {},
+          acpx: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(scanStalePluginConfig(cfg)).toEqual([
+      {
+        pluginId: "codex",
+        pathLabel: "plugins.allow",
+        surface: "allow",
+      },
+      {
+        pluginId: "acpx",
+        pathLabel: "plugins.allow",
+        surface: "allow",
+      },
+      {
+        pluginId: "acpx",
+        pathLabel: "plugins.entries.acpx",
+        surface: "entries",
+      },
+    ]);
+  });
+
+  it("keeps an explicitly disabled Codex plugin entry out of stale diagnostics", () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          codex: { enabled: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(scanStalePluginConfig(cfg)).toEqual([]);
+    expect(maybeRepairStalePluginConfig(cfg)).toEqual({ config: cfg, changes: [] });
+  });
+
+  it("still reports an explicitly enabled missing Codex plugin entry as stale", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+            agentRuntime: { id: "pi" },
+          },
+        },
+      },
+      plugins: {
+        entries: {
+          codex: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(scanStalePluginConfig(cfg)).toEqual([
+      {
+        pluginId: "codex",
+        pathLabel: "plugins.entries.codex",
+        surface: "entries",
+      },
+    ]);
+  });
+
   it("treats legacy OpenAI Codex plugin ids as stale during scan and repair", () => {
     const cfg = {
       plugins: {

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -1,6 +1,7 @@
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../../agents/agent-scope.js";
 import { CHANNEL_IDS } from "../../../channels/ids.js";
+import { shouldSuppressMissingCodexPluginDiagnostics } from "../../../config/codex-plugin-diagnostics.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { normalizePluginId } from "../../../plugins/config-state.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "../../../plugins/installed-plugin-index-records.js";
@@ -146,6 +147,9 @@ function scanStalePluginConfigWithState(
     for (const rawPluginId of Object.keys(entries)) {
       const pluginId = normalizePluginId(rawPluginId);
       if (!pluginId || knownIds.has(pluginId) || registryState.knownChannelIds.has(pluginId)) {
+        continue;
+      }
+      if (pluginId === "codex" && shouldSuppressMissingCodexPluginDiagnostics(cfg)) {
         continue;
       }
       hits.push({

--- a/src/config/codex-plugin-diagnostics.ts
+++ b/src/config/codex-plugin-diagnostics.ts
@@ -1,9 +1,11 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
-  OPENCLAW_AGENT_RUNTIME_ID,
+  AUTO_AGENT_RUNTIME_ID,
   normalizeOptionalAgentRuntimeId,
 } from "../agents/agent-runtime-id.js";
+import { resolveModelRuntimePolicy } from "../agents/model-runtime-policy.js";
+import { openAIProviderUsesCodexRuntimeByDefault } from "../agents/openai-routing.js";
 import type { AgentModelEntryConfig } from "./types.agent-defaults.js";
 import type { AgentRuntimePolicyConfig } from "./types.agents-shared.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
@@ -15,12 +17,27 @@ function normalizeRuntimeId(raw?: string | null): string | undefined {
   return normalizeOptionalAgentRuntimeId(raw);
 }
 
-function isOpenClawRuntimeSelection(raw?: string | null): boolean {
-  return normalizeRuntimeId(raw) === OPENCLAW_AGENT_RUNTIME_ID;
-}
-
 function isCodexRuntimeSelection(raw?: string | null): boolean {
   return normalizeRuntimeId(raw) === CODEX_PLUGIN_ID;
+}
+
+function isOpenAiCodexDefaultRuntimeSelection(params: {
+  cfg: OpenClawConfig;
+  raw?: string | null;
+}): boolean {
+  const runtime = normalizeRuntimeId(params.raw);
+  if (runtime === CODEX_PLUGIN_ID) {
+    return true;
+  }
+  if (runtime !== AUTO_AGENT_RUNTIME_ID && runtime !== "default") {
+    return false;
+  }
+  // "auto"/"default" only means Codex for the official OpenAI route.
+  // Custom OpenAI-compatible base URLs stay on the OpenClaw runtime path.
+  return openAIProviderUsesCodexRuntimeByDefault({
+    provider: OPENAI_PROVIDER_ID,
+    config: params.cfg,
+  });
 }
 
 function parseProviderModelRef(raw: string): { provider: string; model: string } | null {
@@ -51,7 +68,36 @@ function openAiProviderRuntimePolicy(cfg: OpenClawConfig): AgentRuntimePolicyCon
   return undefined;
 }
 
-function openAiHasCodexRuntimePolicy(cfg: OpenClawConfig): boolean {
+function listConfiguredAgentIds(cfg: OpenClawConfig): Array<string | undefined> {
+  const ids: Array<string | undefined> = [undefined];
+  for (const agent of cfg.agents?.list ?? []) {
+    if (typeof agent.id === "string" && agent.id.trim()) {
+      ids.push(agent.id);
+    }
+  }
+  return ids;
+}
+
+function openAiProviderModelCanResolveToCodexDefault(params: {
+  cfg: OpenClawConfig;
+  modelId: string;
+}): boolean {
+  // Provider model rows are below exact agent model policies in runtime
+  // precedence, so inspect the resolved policy instead of the raw row.
+  return listConfiguredAgentIds(params.cfg).some((agentId) =>
+    isOpenAiCodexDefaultRuntimeSelection({
+      cfg: params.cfg,
+      raw: resolveModelRuntimePolicy({
+        config: params.cfg,
+        provider: OPENAI_PROVIDER_ID,
+        modelId: params.modelId,
+        agentId,
+      }).policy?.id,
+    }),
+  );
+}
+
+function openAiHasCodexDefaultRuntimePolicy(cfg: OpenClawConfig): boolean {
   for (const [providerId, providerConfig] of Object.entries(cfg.models?.providers ?? {})) {
     if (normalizeProviderId(providerId) !== OPENAI_PROVIDER_ID) {
       continue;
@@ -59,26 +105,40 @@ function openAiHasCodexRuntimePolicy(cfg: OpenClawConfig): boolean {
     if (isCodexRuntimeSelection(providerConfig?.agentRuntime?.id)) {
       return true;
     }
-    if (providerConfig?.models?.some((model) => isCodexRuntimeSelection(model.agentRuntime?.id))) {
+    // A model-scoped explicit "auto"/"default" overrides provider-wide PI/OpenClaw
+    // policy and falls back to the official OpenAI Codex runtime default.
+    if (
+      providerConfig?.models?.some(
+        (model) =>
+          model.agentRuntime?.id?.trim() &&
+          openAiProviderModelCanResolveToCodexDefault({ cfg, modelId: model.id }),
+      )
+    ) {
       return true;
     }
   }
-  if (agentModelsHaveCodexRuntimePolicy(cfg.agents?.defaults?.models)) {
+  if (agentModelsHaveCodexDefaultRuntimePolicy(cfg, cfg.agents?.defaults?.models)) {
     return true;
   }
   return (
-    cfg.agents?.list?.some((agent) => agentModelsHaveCodexRuntimePolicy(agent.models)) ?? false
+    cfg.agents?.list?.some((agent) =>
+      agentModelsHaveCodexDefaultRuntimePolicy(cfg, agent.models),
+    ) ?? false
   );
 }
 
-function agentModelsHaveCodexRuntimePolicy(
+function agentModelsHaveCodexDefaultRuntimePolicy(
+  cfg: OpenClawConfig,
   models: Record<string, AgentModelEntryConfig> | undefined,
 ): boolean {
   for (const [modelRef, modelConfig] of Object.entries(models ?? {})) {
     const parsed = parseProviderModelRef(modelRef);
     if (
       parsed?.provider === OPENAI_PROVIDER_ID &&
-      isCodexRuntimeSelection(modelConfig?.agentRuntime?.id)
+      isOpenAiCodexDefaultRuntimeSelection({
+        cfg,
+        raw: modelConfig?.agentRuntime?.id,
+      })
     ) {
       return true;
     }
@@ -102,19 +162,36 @@ function openAiWildcardRuntimePolicy(
   return undefined;
 }
 
-function openAiDefaultRouteRuntimePolicies(cfg: OpenClawConfig): AgentRuntimePolicyConfig[] {
-  return [
-    openAiWildcardRuntimePolicy(cfg.agents?.defaults?.models),
-    openAiProviderRuntimePolicy(cfg),
-  ].filter((policy): policy is AgentRuntimePolicyConfig => Boolean(policy));
+function openAiDefaultRouteRuntimePolicy(
+  cfg: OpenClawConfig,
+): AgentRuntimePolicyConfig | undefined {
+  // This mirrors the default-route slice of resolveModelRuntimePolicy: a global
+  // OpenAI wildcard policy is more specific than the provider-level policy.
+  return (
+    openAiWildcardRuntimePolicy(cfg.agents?.defaults?.models) ?? openAiProviderRuntimePolicy(cfg)
+  );
+}
+
+function openAiDefaultRouteKeepsCodexUnavailable(cfg: OpenClawConfig): boolean {
+  const policy = openAiDefaultRouteRuntimePolicy(cfg);
+  if (!policy?.id?.trim()) {
+    // With no explicit runtime policy, the OpenAI route only needs Codex on the
+    // official OpenAI endpoint. OpenAI-compatible proxies stay on OpenClaw.
+    return !openAIProviderUsesCodexRuntimeByDefault({
+      provider: OPENAI_PROVIDER_ID,
+      config: cfg,
+    });
+  }
+  // Any explicit default-route policy that does not resolve to Codex keeps the
+  // external Codex plugin optional, including custom OpenAI-compatible base URLs.
+  return !isOpenAiCodexDefaultRuntimeSelection({ cfg, raw: policy.id });
 }
 
 export function configExplicitlyKeepsCodexUnavailableForOpenAi(cfg: OpenClawConfig): boolean {
-  if (openAiHasCodexRuntimePolicy(cfg)) {
+  if (openAiHasCodexDefaultRuntimePolicy(cfg)) {
     return false;
   }
-  const policies = openAiDefaultRouteRuntimePolicies(cfg);
-  return policies.some((policy) => isOpenClawRuntimeSelection(policy.id));
+  return openAiDefaultRouteKeepsCodexUnavailable(cfg);
 }
 
 export function shouldSuppressMissingCodexPluginDiagnostics(cfg: OpenClawConfig): boolean {
@@ -122,5 +199,7 @@ export function shouldSuppressMissingCodexPluginDiagnostics(cfg: OpenClawConfig)
   if (entryEnabled === true) {
     return false;
   }
+  // A disabled entry is an explicit opt-out from the external Codex plugin.
+  // Route-specific Codex warnings still come from doctor when Codex is selected.
   return entryEnabled === false || configExplicitlyKeepsCodexUnavailableForOpenAi(cfg);
 }

--- a/src/config/codex-plugin-diagnostics.ts
+++ b/src/config/codex-plugin-diagnostics.ts
@@ -1,0 +1,126 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  OPENCLAW_AGENT_RUNTIME_ID,
+  normalizeOptionalAgentRuntimeId,
+} from "../agents/agent-runtime-id.js";
+import type { AgentModelEntryConfig } from "./types.agent-defaults.js";
+import type { AgentRuntimePolicyConfig } from "./types.agents-shared.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+const CODEX_PLUGIN_ID = "codex";
+const OPENAI_PROVIDER_ID = "openai";
+
+function normalizeRuntimeId(raw?: string | null): string | undefined {
+  return normalizeOptionalAgentRuntimeId(raw);
+}
+
+function isOpenClawRuntimeSelection(raw?: string | null): boolean {
+  return normalizeRuntimeId(raw) === OPENCLAW_AGENT_RUNTIME_ID;
+}
+
+function isCodexRuntimeSelection(raw?: string | null): boolean {
+  return normalizeRuntimeId(raw) === CODEX_PLUGIN_ID;
+}
+
+function parseProviderModelRef(raw: string): { provider: string; model: string } | null {
+  const slashIndex = raw.indexOf("/");
+  if (slashIndex <= 0 || slashIndex >= raw.length - 1) {
+    return null;
+  }
+  const provider = normalizeProviderId(raw.slice(0, slashIndex));
+  const model = raw.slice(slashIndex + 1).trim();
+  return provider && model ? { provider, model } : null;
+}
+
+function codexPluginEntryEnabled(cfg: OpenClawConfig): boolean | undefined {
+  for (const [pluginId, entry] of Object.entries(cfg.plugins?.entries ?? {})) {
+    if (normalizeLowercaseStringOrEmpty(pluginId) === CODEX_PLUGIN_ID) {
+      return entry?.enabled;
+    }
+  }
+  return undefined;
+}
+
+function openAiProviderRuntimePolicy(cfg: OpenClawConfig): AgentRuntimePolicyConfig | undefined {
+  for (const [providerId, providerConfig] of Object.entries(cfg.models?.providers ?? {})) {
+    if (normalizeProviderId(providerId) === OPENAI_PROVIDER_ID) {
+      return providerConfig?.agentRuntime?.id?.trim() ? providerConfig.agentRuntime : undefined;
+    }
+  }
+  return undefined;
+}
+
+function openAiHasCodexRuntimePolicy(cfg: OpenClawConfig): boolean {
+  for (const [providerId, providerConfig] of Object.entries(cfg.models?.providers ?? {})) {
+    if (normalizeProviderId(providerId) !== OPENAI_PROVIDER_ID) {
+      continue;
+    }
+    if (isCodexRuntimeSelection(providerConfig?.agentRuntime?.id)) {
+      return true;
+    }
+    if (providerConfig?.models?.some((model) => isCodexRuntimeSelection(model.agentRuntime?.id))) {
+      return true;
+    }
+  }
+  if (agentModelsHaveCodexRuntimePolicy(cfg.agents?.defaults?.models)) {
+    return true;
+  }
+  return (
+    cfg.agents?.list?.some((agent) => agentModelsHaveCodexRuntimePolicy(agent.models)) ?? false
+  );
+}
+
+function agentModelsHaveCodexRuntimePolicy(
+  models: Record<string, AgentModelEntryConfig> | undefined,
+): boolean {
+  for (const [modelRef, modelConfig] of Object.entries(models ?? {})) {
+    const parsed = parseProviderModelRef(modelRef);
+    if (
+      parsed?.provider === OPENAI_PROVIDER_ID &&
+      isCodexRuntimeSelection(modelConfig?.agentRuntime?.id)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function openAiWildcardRuntimePolicy(
+  models: Record<string, AgentModelEntryConfig> | undefined,
+): AgentRuntimePolicyConfig | undefined {
+  for (const [modelRef, modelConfig] of Object.entries(models ?? {})) {
+    const parsed = parseProviderModelRef(modelRef);
+    if (
+      parsed?.provider === OPENAI_PROVIDER_ID &&
+      parsed.model === "*" &&
+      modelConfig?.agentRuntime?.id?.trim()
+    ) {
+      return modelConfig.agentRuntime;
+    }
+  }
+  return undefined;
+}
+
+function openAiDefaultRouteRuntimePolicies(cfg: OpenClawConfig): AgentRuntimePolicyConfig[] {
+  return [
+    openAiWildcardRuntimePolicy(cfg.agents?.defaults?.models),
+    openAiProviderRuntimePolicy(cfg),
+  ].filter((policy): policy is AgentRuntimePolicyConfig => Boolean(policy));
+}
+
+export function configExplicitlyKeepsCodexUnavailableForOpenAi(cfg: OpenClawConfig): boolean {
+  if (openAiHasCodexRuntimePolicy(cfg)) {
+    return false;
+  }
+  const policies = openAiDefaultRouteRuntimePolicies(cfg);
+  return policies.some((policy) => isOpenClawRuntimeSelection(policy.id));
+}
+
+export function shouldSuppressMissingCodexPluginDiagnostics(cfg: OpenClawConfig): boolean {
+  const entryEnabled = codexPluginEntryEnabled(cfg);
+  if (entryEnabled === true) {
+    return false;
+  }
+  return entryEnabled === false || configExplicitlyKeepsCodexUnavailableForOpenAi(cfg);
+}

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -316,6 +316,208 @@ describe("config plugin validation", () => {
     }
   });
 
+  describe("missing Codex plugin diagnostics", () => {
+    const validateWithMissingCodexPlugin = (raw: Record<string, unknown>) =>
+      validateConfigObjectWithPlugins(
+        {
+          agents: { list: [{ id: "openclaw" }] },
+          ...raw,
+        },
+        {
+          env: suiteEnv(),
+          pluginMetadataSnapshot: {
+            manifestRegistry: {
+              plugins: [],
+              diagnostics: [],
+            },
+          },
+        },
+      );
+
+    const expectNoMissingCodexPluginWarning = (
+      warnings: readonly { path: string; message: string }[] | undefined,
+    ) => {
+      expect(warnings ?? []).not.toContainEqual(
+        expect.objectContaining({
+          path: "plugins.entries.codex",
+          message: expect.stringContaining("plugin not installed: codex"),
+        }),
+      );
+    };
+
+    const expectMissingCodexPluginWarning = (
+      warnings: readonly { path: string; message: string }[] | undefined,
+    ) => {
+      expect(warnings ?? []).toContainEqual(
+        expect.objectContaining({
+          path: "plugins.entries.codex",
+          message: expect.stringContaining("plugin not installed: codex"),
+        }),
+      );
+    };
+
+    it.each([
+      {
+        name: "provider-level PI runtime policy",
+        config: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                models: [],
+                agentRuntime: { id: "pi" },
+              },
+            },
+          },
+          plugins: { entries: { codex: {} } },
+        },
+      },
+      {
+        name: "agent wildcard PI runtime policy",
+        config: {
+          agents: {
+            list: [{ id: "openclaw" }],
+            defaults: {
+              models: {
+                "openai/*": { agentRuntime: { id: "pi" } },
+              },
+            },
+          },
+          plugins: { entries: { codex: {} } },
+        },
+      },
+      {
+        name: "explicitly disabled Codex plugin entry",
+        config: {
+          plugins: { entries: { codex: { enabled: false } } },
+        },
+      },
+    ])("does not warn when $name keeps Codex unavailable", ({ config }) => {
+      const res = validateWithMissingCodexPlugin(config);
+
+      expect(res.ok).toBe(true);
+      expectNoMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("still warns when only one provider model route is pinned to OpenClaw", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "GPT 5.5",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                  agentRuntime: { id: "openclaw" },
+                },
+              ],
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("still warns when only one agent model route is pinned to PI", () => {
+      const res = validateWithMissingCodexPlugin({
+        agents: {
+          list: [{ id: "openclaw" }],
+          defaults: {
+            models: {
+              "openai/gpt-5.5": { agentRuntime: { id: "pi" } },
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("still warns when the missing Codex plugin is explicitly enabled", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [],
+              agentRuntime: { id: "pi" },
+            },
+          },
+        },
+        plugins: { entries: { codex: { enabled: true } } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("still warns when a provider model route explicitly selects Codex", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              agentRuntime: { id: "pi" },
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "GPT 5.5",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                  agentRuntime: { id: "codex" },
+                },
+              ],
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("still warns when an agent model route explicitly selects Codex", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [],
+              agentRuntime: { id: "pi" },
+            },
+          },
+        },
+        agents: {
+          list: [{ id: "openclaw" }],
+          defaults: {
+            models: {
+              "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectMissingCodexPluginWarning(res.warnings);
+    });
+  });
+
   it("deduplicates catalog install hints for missing configured official external plugins", () => {
     const res = validateConfigObjectWithPlugins(
       {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -427,6 +427,188 @@ describe("config plugin validation", () => {
       expectMissingCodexPluginWarning(res.warnings);
     });
 
+    it("still warns when provider PI policy is overridden by an automatic OpenAI model route", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              agentRuntime: { id: "pi" },
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "GPT 5.5",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                  agentRuntime: { id: "auto" },
+                },
+              ],
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("does not warn when a custom OpenAI-compatible base URL uses automatic runtime policy", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://proxy.example.invalid/v1",
+              agentRuntime: { id: "pi" },
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "GPT 5.5",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                  agentRuntime: { id: "auto" },
+                },
+              ],
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectNoMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("does not warn when exact agent policy overrides an automatic OpenAI provider model route", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              agentRuntime: { id: "pi" },
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "GPT 5.5",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                  agentRuntime: { id: "auto" },
+                },
+              ],
+            },
+          },
+        },
+        agents: {
+          list: [{ id: "openclaw" }],
+          defaults: {
+            models: {
+              "openai/*": { agentRuntime: { id: "pi" } },
+              "openai/gpt-5.5": { agentRuntime: { id: "pi" } },
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectNoMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("does not warn when a custom OpenAI-compatible base URL uses implicit runtime policy", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://proxy.example.invalid/v1",
+              models: [],
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectNoMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("does not warn when a normalized custom OpenAI-compatible provider key uses implicit runtime policy", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            OpenAI: {
+              baseUrl: "https://proxy.example.invalid/v1",
+              models: [],
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectNoMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("still reports explicit Codex allowlist entries for custom OpenAI-compatible base URLs", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://proxy.example.invalid/v1",
+              models: [],
+            },
+          },
+        },
+        plugins: {
+          allow: ["codex"],
+          entries: { codex: {} },
+        },
+      });
+
+      expect(res.ok).toBe(true);
+      expectNoMissingCodexPluginWarning(res.warnings);
+      expect(res.warnings ?? []).toContainEqual(
+        expect.objectContaining({
+          path: "plugins.allow",
+          message: expect.stringContaining("plugin not installed: codex"),
+        }),
+      );
+    });
+
+    it("does not warn when a custom OpenAI-compatible base URL uses automatic wildcard policy", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://proxy.example.invalid/v1",
+              models: [],
+              agentRuntime: { id: "pi" },
+            },
+          },
+        },
+        agents: {
+          list: [{ id: "openclaw" }],
+          defaults: {
+            models: {
+              "openai/*": { agentRuntime: { id: "default" } },
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectNoMissingCodexPluginWarning(res.warnings);
+    });
+
     it("still warns when only one agent model route is pinned to PI", () => {
       const res = validateWithMissingCodexPlugin({
         agents: {
@@ -434,6 +616,32 @@ describe("config plugin validation", () => {
           defaults: {
             models: {
               "openai/gpt-5.5": { agentRuntime: { id: "pi" } },
+            },
+          },
+        },
+        plugins: { entries: { codex: {} } },
+      });
+
+      expect(res.ok).toBe(true);
+      expectMissingCodexPluginWarning(res.warnings);
+    });
+
+    it("still warns when a provider-wide PI policy is overridden by an OpenAI wildcard default", () => {
+      const res = validateWithMissingCodexPlugin({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [],
+              agentRuntime: { id: "pi" },
+            },
+          },
+        },
+        agents: {
+          list: [{ id: "openclaw" }],
+          defaults: {
+            models: {
+              "openai/*": { agentRuntime: { id: "default" } },
             },
           },
         },

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -5,6 +5,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
+import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
 import {
   normalizePluginsConfig,
   normalizePluginId,
@@ -1724,6 +1725,12 @@ function validateConfigObjectWithPluginsBase(
       } else {
         issues.push({ path: pathLocal, message });
       }
+      return;
+    }
+    if (
+      normalizePluginId(pluginId) === "codex" &&
+      shouldSuppressMissingCodexPluginDiagnostics(config)
+    ) {
       return;
     }
     if (optsLocal?.warnOnly && optsLocal.officialInstallHint !== false) {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -5,7 +5,6 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
-import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
 import {
   normalizePluginsConfig,
   normalizePluginId,
@@ -43,6 +42,7 @@ import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-di
 import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
 import { collectChannelSchemaMetadata } from "./channel-config-metadata.js";
+import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
 import { materializeRuntimeConfig } from "./materialize.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { coerceSecretRef } from "./types.secrets.js";
@@ -1729,6 +1729,7 @@ function validateConfigObjectWithPluginsBase(
     }
     if (
       normalizePluginId(pluginId) === "codex" &&
+      pathLocal === "plugins.entries.codex" &&
       shouldSuppressMissingCodexPluginDiagnostics(config)
     ) {
       return;

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,12 +19,10 @@
     "lit": "3.3.3",
     "markdown-it": "14.2.0",
     "markdown-it-task-lists": "2.1.1",
-    "marked": "18.0.4",
-    "three": "0.184.0"
+    "marked": "18.0.4"
   },
   "devDependencies": {
     "@types/markdown-it": "14.1.2",
-    "@types/three": "0.184.1",
     "@vitest/browser-playwright": "4.1.7",
     "jsdom": "29.1.1",
     "playwright": "1.60.0",


### PR DESCRIPTION
## Summary

Respect the resolved OpenAI runtime policy before warning that the Codex plugin is missing.

This keeps the OpenAI/Codex default behavior unchanged, but makes explicit PI/OpenClaw and OpenAI-compatible routing authoritative in the diagnostics path:

- config validation suppresses only intentional missing `plugins.entries.codex` noise when the resolved OpenAI route does not use Codex
- doctor stale-plugin diagnostics keep reporting real stale policy refs such as `plugins.allow` / `plugins.deny` and explicitly enabled missing Codex entries
- shared OpenAI routing now normalizes provider ids before checking custom `baseUrl`, so `OpenAI` and `openai` behave consistently
- model policy precedence now matches the runtime contract: exact agent/default policy beats provider model defaults, and custom OpenAI-compatible bases stay out of the Codex/plugin path

Refs #88706.

## Real behavior proof

Behavior addressed: intentional PI/OpenClaw runtime policy and custom OpenAI-compatible routes no longer produce missing `plugins.entries.codex` diagnostics, while true Codex references still warn.

Real environment tested: local OpenClaw source checkout at commit `c5a84de4caa`, isolated temp `OPENCLAW_HOME` configs, bundled plugins disabled with `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` to prove the missing-plugin diagnostic path.

Exact steps or command run after this patch: ran `pnpm openclaw --no-color doctor` against four isolated configs: explicit PI route with `plugins.entries.codex`, provider model `auto/default`, custom OpenAI-compatible route with both `plugins.entries.codex` and `plugins.allow`, and explicitly enabled missing Codex entry.

Evidence after fix:

```text
routewide:
  no codex warning lines

provider_model_auto_warns:
  plugins.entries.codex: stale plugin reference "codex" was found.

custom_base_entry_quiet_allow_warns:
  plugins.allow: plugin not installed: codex
  plugins.allow: stale plugin reference "codex" was found.
  no plugins.entries.codex warning lines

enabled_missing:
  plugins.entries.codex: plugin not installed: codex
  plugins.entries.codex: stale plugin reference "codex" was found.
```

Observed result after fix: diagnostics now follow the same resolved runtime policy as agent routing; intentional non-Codex routes are quiet, and explicit/stale Codex policy still reports actionable warnings.

What was not tested: full cross-OS CI and a real user credentialed home; the live proof used isolated local configs only.

## Tests

- `pnpm test -- --run src/agents/openai-routing.test.ts src/config/config.plugin-validation.test.ts src/commands/doctor/shared/stale-plugin-config.test.ts src/commands/doctor/shared/codex-route-warnings.test.ts src/commands/agent.test.ts src/agents/agent-command.live-model-switch.test.ts`
  - `src/agents/openai-routing.test.ts`: 13 passed
  - `src/config/config.plugin-validation.test.ts`: 54 passed
  - `src/commands/doctor/shared/stale-plugin-config.test.ts`: 16 passed
  - `src/commands/doctor/shared/codex-route-warnings.test.ts` and `src/commands/agent.test.ts`: 132 passed together in the commands shard
  - `src/agents/agent-command.live-model-switch.test.ts`: 40 passed
- `pnpm lint --threads=8`
- `pnpm check:test-types`
- `pnpm deadcode:dependencies && pnpm deadcode:unused-files && pnpm deadcode:report:ci:ts-unused`
- `pnpm deps:shrinkwrap:check`
- autoreview: clean, no accepted/actionable findings
