### PR TITLE
fix: persist ACP metadata in SQLite

### DIFF
--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -311,7 +311,8 @@ The branch already has a real shared SQLite base:
   `delivery_queue_entries`, `model_capability_cache`,
   `workspace_setup_state`, `native_hook_relay_bridges`,
   `current_conversation_bindings`, `plugin_binding_approvals`,
-  `tui_last_sessions`, `task_runs`, `task_delivery_state`, `flow_runs`,
+  `tui_last_sessions`, `acp_sessions`, `acp_replay_sessions`,
+  `acp_replay_events`, `task_runs`, `task_delivery_state`, `flow_runs`,
   `subagent_runs`, `migration_runs`, and `backup_runs`.
 - Arbitrary plugin-owned state does not get host-owned typed tables. Installed
   plugins use `plugin_state_entries` for versioned JSON payloads and
@@ -1669,6 +1670,8 @@ Move these into agent databases:
 - ACP replay ledger sessions. Done for runtime writes via
   `acp_replay_sessions` and `acp_replay_events`; legacy `acp/event-ledger.json`
   remains only as doctor input.
+- ACP session metadata. Done for runtime writes via `acp_sessions`; legacy
+  `entry.acp` blocks in `sessions.json` are doctor migration input only.
 - Trajectory sidecars when they are not explicit export files. Done for runtime
   writes: trajectory capture writes agent-database `trajectory_runtime_events`
   rows and mirrors run-scoped artifacts into SQLite. Legacy sidecars are doctor

--- a/extensions/feishu/src/doctor.ts
+++ b/extensions/feishu/src/doctor.ts
@@ -752,7 +752,6 @@ async function repairFeishuDoctorState(params: {
         },
         {
           skipMaintenance: true,
-          allowDropAcpMetaSessionKeys: [...keys],
         },
       );
       const removed = removedEntries.length;

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -560,7 +560,7 @@ export function createTelegramThreadBindingManager(params: {
       sessionEntry.entry.status === "failed" ||
       sessionEntry.entry.status === "killed" ||
       sessionEntry.entry.status === "timeout" ||
-      sessionEntry.entry.acp?.state === "error";
+      sessionEntry.acp?.state === "error";
     if (isStale) {
       staleSessionKeys.add(targetSessionKey);
     }

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1749,7 +1749,7 @@ export class AcpSessionManager {
         if (!entry) {
           return null;
         }
-        const base = current ?? entry.acp;
+        const base = current;
         if (!base) {
           return null;
         }
@@ -1895,7 +1895,7 @@ export class AcpSessionManager {
         if (!entry) {
           return null;
         }
-        const base = current ?? entry.acp;
+        const base = current;
         if (!base) {
           return null;
         }
@@ -1944,7 +1944,7 @@ export class AcpSessionManager {
         if (!entry) {
           return null;
         }
-        const base = current ?? entry.acp;
+        const base = current;
         if (!base) {
           return null;
         }
@@ -2055,7 +2055,7 @@ export class AcpSessionManager {
         if (!entry) {
           return null;
         }
-        const base = current ?? entry.acp;
+        const base = current;
         if (!base) {
           return null;
         }

--- a/src/acp/control-plane/manager.identity-reconcile.ts
+++ b/src/acp/control-plane/manager.identity-reconcile.ts
@@ -148,7 +148,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
       if (!entry) {
         return null;
       }
-      const base = current ?? entry.acp;
+      const base = current;
       if (!base) {
         return null;
       }

--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -1,10 +1,20 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
-import { createFileAcpEventLedger, createInMemoryAcpEventLedger } from "./event-ledger.js";
+import {
+  createFileAcpEventLedger,
+  createInMemoryAcpEventLedger,
+  createSqliteAcpEventLedger,
+  migrateFileAcpEventLedgerToSqlite,
+} from "./event-ledger.js";
 
 describe("ACP event ledger", () => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+  });
+
   it("records complete in-memory session updates in sequence", async () => {
     const ledger = createInMemoryAcpEventLedger({ now: () => 123 });
     await ledger.startSession({
@@ -139,6 +149,123 @@ describe("ACP event ledger", () => {
         content: { type: "text", text: "Thinking" },
       });
       await expect(fs.readFile(filePath, "utf8")).resolves.toContain('"version":1');
+    });
+  });
+
+  it("persists SQLite-backed replay state across ledger instances", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const databasePath = path.join(dir, "openclaw.sqlite");
+      const first = createSqliteAcpEventLedger({ path: databasePath, now: () => 1000 });
+      await first.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        cwd: "/work",
+        complete: true,
+      });
+      await first.recordUpdate({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        runId: "run-1",
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "Thinking" },
+        },
+      });
+
+      closeOpenClawStateDatabaseForTest();
+      const second = createSqliteAcpEventLedger({ path: databasePath });
+      const replay = await second.readReplay({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+      });
+
+      expect(replay.complete).toBe(true);
+      expect(replay.events).toHaveLength(1);
+      expect(replay.events[0]?.update).toEqual({
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "Thinking" },
+      });
+    });
+  });
+
+  it("imports legacy file-backed replay state into SQLite", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const filePath = path.join(dir, "acp", "event-ledger.json");
+      const databasePath = path.join(dir, "openclaw.sqlite");
+      const legacy = createFileAcpEventLedger({ filePath, now: () => 1000 });
+      await legacy.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        cwd: "/work",
+        complete: true,
+      });
+      await legacy.recordUpdate({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        runId: "run-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Answer" },
+        },
+      });
+
+      const migrated = await migrateFileAcpEventLedgerToSqlite({
+        filePath,
+        path: databasePath,
+        archiveSource: true,
+      });
+      const sqlite = createSqliteAcpEventLedger({ path: databasePath });
+      const replay = await sqlite.readReplay({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+      });
+
+      expect(migrated).toEqual({
+        importedSessions: 1,
+        importedEvents: 1,
+        archived: true,
+      });
+      expect(replay.complete).toBe(true);
+      expect(replay.events[0]?.update).toEqual({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Answer" },
+      });
+      await expect(fs.stat(`${filePath}.migrated`)).resolves.toBeTruthy();
+    });
+  });
+
+  it("marks SQLite-backed replay incomplete when event retention truncates history", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const ledger = createSqliteAcpEventLedger({
+        path: path.join(dir, "openclaw.sqlite"),
+        maxEventsPerSession: 1,
+      });
+      await ledger.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        cwd: "/work",
+        complete: true,
+      });
+      await ledger.recordUpdate({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "First" },
+        },
+      });
+      await ledger.recordUpdate({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Second" },
+        },
+      });
+
+      await expect(
+        ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
+      ).resolves.toEqual({ complete: false, events: [] });
     });
   });
 

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -1,10 +1,16 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import type { ContentBlock, SessionUpdate } from "@agentclientprotocol/sdk";
 import { resolveIntegerOption } from "@openclaw/acp-core/numeric-options";
 import { resolveStateDir } from "../config/paths.js";
 import { withFileLock } from "../infra/file-lock.js";
 import { readJsonFile, writeTextAtomic } from "../infra/json-files.js";
+import {
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabaseOptions,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
 import { isRecord } from "../utils.js";
 
 const LEDGER_VERSION = 1;
@@ -436,6 +442,15 @@ export function resolveDefaultAcpEventLedgerPath(env: NodeJS.ProcessEnv = proces
   return path.join(resolveStateDir(env), "acp", "event-ledger.json");
 }
 
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function createFileAcpEventLedger(
   params: { filePath: string } & LedgerOptions,
 ): AcpEventLedger {
@@ -485,4 +500,454 @@ export function createFileAcpEventLedger(
         });
       }),
   });
+}
+
+export async function migrateFileAcpEventLedgerToSqlite(
+  params: { filePath: string; archiveSource?: boolean } & OpenClawStateDatabaseOptions,
+): Promise<{ importedSessions: number; importedEvents: number; archived?: boolean }> {
+  if (!(await fileExists(params.filePath))) {
+    return { importedSessions: 0, importedEvents: 0 };
+  }
+
+  const legacy = await withFileLock(params.filePath, FILE_LEDGER_LOCK_OPTIONS, async () =>
+    normalizeStore(await readJsonFile(params.filePath)),
+  );
+  const sessions = Object.values(legacy.sessions);
+  if (sessions.length === 0) {
+    return { importedSessions: 0, importedEvents: 0 };
+  }
+
+  let importedSessions = 0;
+  let importedEvents = 0;
+  runOpenClawStateWriteTransaction((database) => {
+    const sessionExists = database.db.prepare(
+      "SELECT 1 FROM acp_replay_sessions WHERE session_id = ?",
+    );
+    const insertSession = database.db.prepare(
+      `INSERT INTO acp_replay_sessions (
+         session_id, session_key, cwd, complete, created_at, updated_at, next_seq
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const insertEvent = database.db.prepare(
+      `INSERT OR IGNORE INTO acp_replay_events (
+         session_id, seq, at, session_key, run_id, update_json
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+    for (const session of sessions) {
+      if (sessionExists.get(session.sessionId)) {
+        continue;
+      }
+      insertSession.run(
+        session.sessionId,
+        session.sessionKey,
+        session.cwd,
+        session.complete ? 1 : 0,
+        session.createdAt,
+        session.updatedAt,
+        session.nextSeq,
+      );
+      importedSessions++;
+      for (const event of session.events) {
+        const result = insertEvent.run(
+          event.sessionId,
+          event.seq,
+          event.at,
+          event.sessionKey,
+          event.runId ?? null,
+          JSON.stringify(event.update),
+        );
+        importedEvents += Number(result.changes);
+      }
+    }
+  }, params);
+
+  if (params.archiveSource !== true || importedSessions === 0) {
+    return { importedSessions, importedEvents };
+  }
+  const archivePath = `${params.filePath}.migrated`;
+  try {
+    if (!(await fileExists(archivePath))) {
+      await fs.rename(params.filePath, archivePath);
+      return { importedSessions, importedEvents, archived: true };
+    }
+  } catch {
+    // The SQLite import succeeded; archiving is a best-effort cleanup.
+  }
+  return { importedSessions, importedEvents };
+}
+
+function normalizeSqliteInteger(value: number | bigint | null): number {
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  return typeof value === "number" ? value : 0;
+}
+
+type AcpReplaySessionRow = {
+  session_id: string;
+  session_key: string;
+  cwd: string;
+  complete: number | bigint;
+  created_at: number | bigint;
+  updated_at: number | bigint;
+  next_seq: number | bigint;
+};
+
+type AcpReplayEventRow = {
+  session_id: string;
+  seq: number | bigint;
+  at: number | bigint;
+  session_key: string;
+  run_id: string | null;
+  update_json: string;
+};
+
+function sqliteRowToLedgerSession(db: DatabaseSync, row: AcpReplaySessionRow): LedgerSession {
+  const events = db
+    .prepare(
+      `SELECT session_id, seq, at, session_key, run_id, update_json
+         FROM acp_replay_events
+        WHERE session_id = ?
+        ORDER BY seq ASC`,
+    )
+    .all(row.session_id)
+    .flatMap((eventRow) => {
+      const normalized = sqliteRowToLedgerEvent(eventRow as AcpReplayEventRow);
+      return normalized ? [normalized] : [];
+    });
+  return {
+    sessionId: row.session_id,
+    sessionKey: row.session_key,
+    cwd: row.cwd,
+    complete: normalizeSqliteInteger(row.complete) === 1,
+    createdAt: normalizeSqliteInteger(row.created_at),
+    updatedAt: normalizeSqliteInteger(row.updated_at),
+    nextSeq: normalizeSqliteInteger(row.next_seq),
+    events,
+  };
+}
+
+function sqliteRowToLedgerEvent(row: AcpReplayEventRow): AcpEventLedgerEntry | undefined {
+  let update: unknown;
+  try {
+    update = JSON.parse(row.update_json) as unknown;
+  } catch {
+    return undefined;
+  }
+  return normalizeEvent({
+    seq: normalizeSqliteInteger(row.seq),
+    at: normalizeSqliteInteger(row.at),
+    sessionId: row.session_id,
+    sessionKey: row.session_key,
+    ...(row.run_id ? { runId: row.run_id } : {}),
+    update,
+  });
+}
+
+function readSqliteSessionById(db: DatabaseSync, sessionId: string): LedgerSession | undefined {
+  const row = db
+    .prepare(
+      `SELECT session_id, session_key, cwd, complete, created_at, updated_at, next_seq
+         FROM acp_replay_sessions
+        WHERE session_id = ?`,
+    )
+    .get(sessionId) as AcpReplaySessionRow | undefined;
+  return row ? sqliteRowToLedgerSession(db, row) : undefined;
+}
+
+function readLatestCompleteSqliteSessionByKey(
+  db: DatabaseSync,
+  sessionKey: string,
+): LedgerSession | undefined {
+  const row = db
+    .prepare(
+      `SELECT session_id, session_key, cwd, complete, created_at, updated_at, next_seq
+         FROM acp_replay_sessions
+        WHERE session_key = ? AND complete = 1
+        ORDER BY updated_at DESC, session_id ASC
+        LIMIT 1`,
+    )
+    .get(sessionKey) as AcpReplaySessionRow | undefined;
+  return row ? sqliteRowToLedgerSession(db, row) : undefined;
+}
+
+function upsertSqliteSession(
+  db: DatabaseSync,
+  state: Pick<MutableLedgerState, "now">,
+  params: {
+    sessionId: string;
+    sessionKey: string;
+    cwd: string;
+    complete: boolean;
+    reset?: boolean;
+  },
+): LedgerSession {
+  const now = state.now();
+  const existing = readSqliteSessionById(db, params.sessionId);
+  if (!params.reset && existing) {
+    const cwd = params.cwd || existing.cwd;
+    const complete = existing.complete || params.complete ? 1 : 0;
+    db.prepare(
+      `UPDATE acp_replay_sessions
+          SET session_key = ?, cwd = ?, complete = ?, updated_at = ?
+        WHERE session_id = ?`,
+    ).run(params.sessionKey, cwd, complete, now, params.sessionId);
+    return {
+      ...existing,
+      sessionKey: params.sessionKey,
+      cwd,
+      complete: complete === 1,
+      updatedAt: now,
+    };
+  }
+
+  if (params.reset) {
+    db.prepare("DELETE FROM acp_replay_events WHERE session_id = ?").run(params.sessionId);
+  }
+  db.prepare(
+    `INSERT INTO acp_replay_sessions (
+       session_id, session_key, cwd, complete, created_at, updated_at, next_seq
+     ) VALUES (?, ?, ?, ?, ?, ?, 1)
+     ON CONFLICT(session_id) DO UPDATE SET
+       session_key = excluded.session_key,
+       cwd = excluded.cwd,
+       complete = excluded.complete,
+       updated_at = excluded.updated_at,
+       next_seq = excluded.next_seq`,
+  ).run(params.sessionId, params.sessionKey, params.cwd, params.complete ? 1 : 0, now, now);
+  return {
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    cwd: params.cwd,
+    complete: params.complete,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+    nextSeq: 1,
+    events: [],
+  };
+}
+
+function estimateSqliteLedgerBytes(db: DatabaseSync): number {
+  const row = db
+    .prepare(
+      `SELECT
+         COALESCE(SUM(length(session_id) + length(session_key) + length(cwd) + 32), 0) AS sessions,
+         (SELECT COALESCE(SUM(length(session_id) + length(session_key) + length(update_json) + COALESCE(length(run_id), 0) + 32), 0)
+            FROM acp_replay_events) AS events
+       FROM acp_replay_sessions`,
+    )
+    .get() as { sessions?: number | bigint; events?: number | bigint } | undefined;
+  return normalizeSqliteInteger(row?.sessions ?? 0) + normalizeSqliteInteger(row?.events ?? 0);
+}
+
+function trimSqliteLedger(
+  db: DatabaseSync,
+  state: Pick<MutableLedgerState, "maxEventsPerSession" | "maxSessions" | "maxSerializedBytes">,
+): void {
+  const sessionsWithCounts = db
+    .prepare(
+      `SELECT s.session_id AS session_id, COUNT(e.seq) AS event_count
+         FROM acp_replay_sessions s
+         LEFT JOIN acp_replay_events e ON e.session_id = s.session_id
+        GROUP BY s.session_id`,
+    )
+    .all() as Array<{ session_id: string; event_count: number | bigint }>;
+  for (const row of sessionsWithCounts) {
+    const overage = normalizeSqliteInteger(row.event_count) - state.maxEventsPerSession;
+    if (overage <= 0) {
+      continue;
+    }
+    const oldEvents = db
+      .prepare(
+        `SELECT seq
+           FROM acp_replay_events
+          WHERE session_id = ?
+          ORDER BY seq ASC
+          LIMIT ?`,
+      )
+      .all(row.session_id, overage) as Array<{ seq: number | bigint }>;
+    const deleteEvent = db.prepare(
+      "DELETE FROM acp_replay_events WHERE session_id = ? AND seq = ?",
+    );
+    for (const event of oldEvents) {
+      deleteEvent.run(row.session_id, normalizeSqliteInteger(event.seq));
+    }
+    db.prepare("UPDATE acp_replay_sessions SET complete = 0 WHERE session_id = ?").run(
+      row.session_id,
+    );
+  }
+
+  const oldSessions = db
+    .prepare(
+      `SELECT session_id
+         FROM acp_replay_sessions
+        ORDER BY updated_at DESC, session_id ASC
+        LIMIT -1 OFFSET ?`,
+    )
+    .all(state.maxSessions) as Array<{ session_id: string }>;
+  for (const session of oldSessions) {
+    db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
+  }
+
+  let serializedBytes = estimateSqliteLedgerBytes(db);
+  while (serializedBytes > state.maxSerializedBytes) {
+    const event = db
+      .prepare(
+        `SELECT e.session_id AS session_id, e.seq AS seq
+           FROM acp_replay_events e
+           JOIN acp_replay_sessions s ON s.session_id = e.session_id
+          ORDER BY s.updated_at ASC, e.seq ASC
+          LIMIT 1`,
+      )
+      .get() as { session_id: string; seq: number | bigint } | undefined;
+    if (!event) {
+      break;
+    }
+    db.prepare("DELETE FROM acp_replay_events WHERE session_id = ? AND seq = ?").run(
+      event.session_id,
+      normalizeSqliteInteger(event.seq),
+    );
+    db.prepare("UPDATE acp_replay_sessions SET complete = 0 WHERE session_id = ?").run(
+      event.session_id,
+    );
+    serializedBytes = estimateSqliteLedgerBytes(db);
+  }
+
+  while (serializedBytes > state.maxSerializedBytes) {
+    const session = db
+      .prepare(
+        `SELECT session_id
+           FROM acp_replay_sessions
+          ORDER BY updated_at ASC, session_id ASC
+          LIMIT 1`,
+      )
+      .get() as { session_id: string } | undefined;
+    if (!session) {
+      break;
+    }
+    db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
+    serializedBytes = estimateSqliteLedgerBytes(db);
+  }
+}
+
+function appendSqliteUpdate(
+  db: DatabaseSync,
+  state: Pick<
+    MutableLedgerState,
+    "now" | "maxEventsPerSession" | "maxSessions" | "maxSerializedBytes"
+  >,
+  params: {
+    sessionId: string;
+    sessionKey: string;
+    runId?: string;
+    update: SessionUpdate;
+  },
+): void {
+  const session = upsertSqliteSession(db, state, {
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    cwd: "",
+    complete: false,
+  });
+  const now = state.now();
+  db.prepare(
+    `INSERT INTO acp_replay_events (session_id, seq, at, session_key, run_id, update_json)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    params.sessionId,
+    session.nextSeq,
+    now,
+    params.sessionKey,
+    params.runId ?? null,
+    JSON.stringify(cloneJsonValue(params.update)),
+  );
+  db.prepare(
+    `UPDATE acp_replay_sessions
+        SET session_key = ?, updated_at = ?, next_seq = ?
+      WHERE session_id = ?`,
+  ).run(params.sessionKey, now, session.nextSeq + 1, params.sessionId);
+  trimSqliteLedger(db, state);
+}
+
+function buildSqliteReplay(session: LedgerSession | undefined): AcpEventLedgerReplay {
+  if (!session?.complete) {
+    return { complete: false, events: [] };
+  }
+  return {
+    complete: true,
+    sessionId: session.sessionId,
+    sessionKey: session.sessionKey,
+    events: session.events.map((event) => cloneJsonValue(event)),
+  };
+}
+
+export function createSqliteAcpEventLedger(
+  params: OpenClawStateDatabaseOptions & LedgerOptions = {},
+): AcpEventLedger {
+  const normalized = normalizeLedgerOptions(params);
+  const dbOptions = { env: params.env, path: params.path };
+  const state = {
+    ...normalized,
+  };
+  const mutate = (fn: (db: DatabaseSync) => void) =>
+    runOpenClawStateWriteTransaction((database) => fn(database.db), dbOptions);
+  const read = <T>(fn: (db: DatabaseSync) => T): T => fn(openOpenClawStateDatabase(dbOptions).db);
+
+  return {
+    async startSession(sessionParams) {
+      mutate((db) => {
+        upsertSqliteSession(db, state, sessionParams);
+        trimSqliteLedger(db, state);
+      });
+    },
+
+    async recordUserPrompt(promptParams) {
+      mutate((db) => {
+        for (const update of createUserPromptUpdates(promptParams.prompt)) {
+          appendSqliteUpdate(db, state, {
+            sessionId: promptParams.sessionId,
+            sessionKey: promptParams.sessionKey,
+            runId: promptParams.runId,
+            update,
+          });
+        }
+      });
+    },
+
+    async recordUpdate(updateParams) {
+      mutate((db) => {
+        appendSqliteUpdate(db, state, updateParams);
+      });
+    },
+
+    async markIncomplete(markParams) {
+      mutate((db) => {
+        db.prepare(
+          `UPDATE acp_replay_sessions
+              SET complete = 0, updated_at = ?
+            WHERE session_id = ? AND session_key = ?`,
+        ).run(state.now(), markParams.sessionId, markParams.sessionKey);
+      });
+    },
+
+    async readReplay(replayParams) {
+      return read((db) => {
+        const session = readSqliteSessionById(db, replayParams.sessionId);
+        if (session?.sessionKey !== replayParams.sessionKey) {
+          return { complete: false, events: [] };
+        }
+        return buildSqliteReplay(session);
+      });
+    },
+
+    async readReplayBySessionId(replayParams) {
+      return read((db) => buildSqliteReplay(readSqliteSessionById(db, replayParams.sessionId)));
+    },
+
+    async readReplayBySessionKey(replayParams) {
+      return read((db) =>
+        buildSqliteReplay(readLatestCompleteSqliteSessionByKey(db, replayParams.sessionKey)),
+      );
+    },
+  };
 }

--- a/src/acp/runtime/session-meta.test.ts
+++ b/src/acp/runtime/session-meta.test.ts
@@ -1,90 +1,319 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { loadSessionStore } from "../../config/sessions/store-load.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withTempDir } from "../../test-helpers/temp-dir.js";
+import {
+  listAcpSessionEntries,
+  readAcpSessionEntry,
+  upsertAcpSessionMeta,
+  writeAcpSessionMetaForMigration,
+} from "./session-meta.js";
 
-const hoisted = vi.hoisted(() => {
-  const resolveAllAgentSessionStoreTargetsMock = vi.fn();
-  const loadSessionStoreMock = vi.fn();
-  return {
-    resolveAllAgentSessionStoreTargetsMock,
-    loadSessionStoreMock,
-  };
-});
-
-vi.mock("../../config/sessions/store-load.js", () => ({
-  loadSessionStore: (storePath: string, opts?: unknown) =>
-    hoisted.loadSessionStoreMock(storePath, opts),
-}));
-
-vi.mock("../../config/sessions/targets.js", () => ({
-  resolveAllAgentSessionStoreTargets: (cfg: OpenClawConfig, opts: unknown) =>
-    hoisted.resolveAllAgentSessionStoreTargetsMock(cfg, opts),
-}));
-let listAcpSessionEntries: typeof import("./session-meta.js").listAcpSessionEntries;
-
-describe("listAcpSessionEntries", () => {
-  beforeAll(async () => {
-    ({ listAcpSessionEntries } = await import("./session-meta.js"));
+describe("ACP session metadata SQLite store", () => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
   });
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  it("persists ACP metadata in SQLite without writing sessions.json acp blocks", async () => {
+    await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const databasePath = path.join(dir, "state", "openclaw.sqlite");
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const sessionKey = "agent:codex:acp:binding:discord:default:feedface";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sess-acp",
+            updatedAt: 100,
+          },
+        }),
+        "utf8",
+      );
 
-  it("reads ACP sessions from resolved configured store targets", async () => {
-    const cfg = {
-      session: {
-        store: "/custom/sessions/{agentId}.json",
-      },
-    } as OpenClawConfig;
-    hoisted.resolveAllAgentSessionStoreTargetsMock.mockResolvedValue([
-      {
-        agentId: "ops",
-        storePath: "/custom/sessions/ops.json",
-      },
-    ]);
-    const storedEntry = {
-      updatedAt: 123,
-      acp: {
+      const result = await upsertAcpSessionMeta({
+        cfg,
+        databasePath,
+        sessionKey,
+        now: () => 200,
+        mutate: () => ({
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "codex-discord",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 123,
+          cwd: "/repo",
+        }),
+      });
+
+      expect(result?.acp?.runtimeSessionName).toBe("codex-discord");
+      expect(loadSessionStore(storePath)[sessionKey]?.acp).toBeUndefined();
+      expect(
+        readAcpSessionEntry({
+          cfg,
+          databasePath,
+          sessionKey,
+        })?.acp,
+      ).toMatchObject({
         backend: "acpx",
-        agent: "ops",
+        agent: "codex",
+        runtimeSessionName: "codex-discord",
         mode: "persistent",
         state: "idle",
-      },
-    };
-    hoisted.loadSessionStoreMock.mockReturnValue({
-      "agent:ops:acp:s1": storedEntry,
+        cwd: "/repo",
+      });
     });
-
-    const entries = await listAcpSessionEntries({ cfg });
-
-    expect(hoisted.resolveAllAgentSessionStoreTargetsMock).toHaveBeenCalledWith(cfg, undefined);
-    expect(hoisted.loadSessionStoreMock).toHaveBeenCalledWith(
-      "/custom/sessions/ops.json",
-      undefined,
-    );
-    expect(entries).toEqual([
-      {
-        acp: storedEntry.acp,
-        cfg,
-        entry: storedEntry,
-        storePath: "/custom/sessions/ops.json",
-        sessionKey: "agent:ops:acp:s1",
-        storeSessionKey: "agent:ops:acp:s1",
-      },
-    ]);
   });
 
-  it("can skip cloning for maintenance callers that only inspect ACP entries", async () => {
-    const cfg = { session: { store: "/custom/sessions/{agentId}.json" } } as OpenClawConfig;
-    hoisted.resolveAllAgentSessionStoreTargetsMock.mockResolvedValue([
-      { agentId: "ops", storePath: "/custom/sessions/ops.json" },
-    ]);
-    hoisted.loadSessionStoreMock.mockReturnValue({});
+  it("creates a session-store row for new SQLite ACP sessions without embedding ACP metadata", async () => {
+    await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const databasePath = path.join(dir, "state", "openclaw.sqlite");
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const sessionKey = "agent:codex:acp:new-session";
 
-    await listAcpSessionEntries({ cfg, clone: false });
+      const result = await upsertAcpSessionMeta({
+        cfg,
+        databasePath,
+        sessionKey,
+        now: () => 200,
+        mutate: () => ({
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "codex-new",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 123,
+        }),
+      });
 
-    expect(hoisted.loadSessionStoreMock).toHaveBeenCalledWith("/custom/sessions/ops.json", {
-      clone: false,
+      expect(result?.sessionId).toEqual(expect.any(String));
+      expect(result?.acp?.runtimeSessionName).toBe("codex-new");
+      const storedEntry = loadSessionStore(storePath)[sessionKey];
+      expect(storedEntry?.sessionId).toEqual(expect.any(String));
+      expect(storedEntry?.updatedAt).toEqual(expect.any(Number));
+      expect(storedEntry?.acp).toBeUndefined();
+    });
+  });
+
+  it("normalizes ACP metadata lookups and writes to the resolved session-store key", async () => {
+    await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const databasePath = path.join(dir, "state", "openclaw.sqlite");
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const storeSessionKey = "agent:codex:acp:binding:discord:default:feedface";
+      const rawSessionKey = storeSessionKey.toUpperCase();
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [storeSessionKey]: {
+            sessionId: "sess-acp",
+            updatedAt: 100,
+          },
+        }),
+        "utf8",
+      );
+
+      await upsertAcpSessionMeta({
+        cfg,
+        databasePath,
+        sessionKey: rawSessionKey,
+        now: () => 200,
+        mutate: () => ({
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "codex-normalized",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 123,
+        }),
+      });
+
+      expect(
+        readAcpSessionEntry({
+          cfg,
+          databasePath,
+          sessionKey: rawSessionKey,
+        })?.acp?.runtimeSessionName,
+      ).toBe("codex-normalized");
+      expect(
+        readAcpSessionEntry({
+          cfg,
+          databasePath,
+          sessionKey: storeSessionKey,
+        })?.acp?.runtimeSessionName,
+      ).toBe("codex-normalized");
+      expect(loadSessionStore(storePath)[storeSessionKey]?.acp).toBeUndefined();
+
+      await upsertAcpSessionMeta({
+        cfg,
+        databasePath,
+        sessionKey: rawSessionKey,
+        mutate: (current) => {
+          expect(current?.runtimeSessionName).toBe("codex-normalized");
+          return null;
+        },
+      });
+
+      expect(
+        readAcpSessionEntry({
+          cfg,
+          databasePath,
+          sessionKey: storeSessionKey,
+        })?.acp,
+      ).toBeUndefined();
+    });
+  });
+
+  it("ignores SQLite ACP metadata rows for replaced session ids", async () => {
+    await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const databasePath = path.join(dir, "state", "openclaw.sqlite");
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const sessionKey = "agent:codex:acp:binding:discord:default:feedface";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sess-new",
+            updatedAt: 100,
+          },
+        }),
+        "utf8",
+      );
+
+      writeAcpSessionMetaForMigration({
+        databasePath,
+        sessionKey,
+        sessionId: "sess-old",
+        meta: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "codex-stale",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 123,
+        },
+      });
+
+      expect(readAcpSessionEntry({ cfg, databasePath, sessionKey })?.acp).toBeUndefined();
+      expect(await listAcpSessionEntries({ cfg, databasePath })).toHaveLength(0);
+
+      writeAcpSessionMetaForMigration({
+        databasePath,
+        sessionKey,
+        sessionId: "sess-new",
+        meta: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "codex-current",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 124,
+        },
+      });
+
+      expect(readAcpSessionEntry({ cfg, databasePath, sessionKey })?.acp?.runtimeSessionName).toBe(
+        "codex-current",
+      );
+      expect(await listAcpSessionEntries({ cfg, databasePath })).toHaveLength(1);
+    });
+  });
+
+  it("lists SQLite ACP rows while joining current session-store entries", async () => {
+    await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions", "codex.json");
+      const databasePath = path.join(dir, "state", "openclaw.sqlite");
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const sessionKey = "agent:codex:acp:s1";
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sess-acp",
+            updatedAt: 100,
+            model: "gpt-5.5",
+          },
+        }),
+        "utf8",
+      );
+      await upsertAcpSessionMeta({
+        cfg,
+        databasePath,
+        sessionKey,
+        mutate: () => ({
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "codex-s1",
+          mode: "oneshot",
+          state: "running",
+          lastActivityAt: 321,
+        }),
+      });
+
+      const entries = await listAcpSessionEntries({ cfg, databasePath, clone: false });
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        cfg,
+        storePath,
+        sessionKey,
+        storeSessionKey: sessionKey,
+        entry: {
+          sessionId: "sess-acp",
+          model: "gpt-5.5",
+        },
+        acp: {
+          backend: "acpx",
+          runtimeSessionName: "codex-s1",
+          mode: "oneshot",
+          state: "running",
+        },
+      });
+    });
+  });
+
+  it("honors OPENCLAW_STATE_DIR when joining listed SQLite rows to session stores", async () => {
+    await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: dir } as NodeJS.ProcessEnv;
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:codex:acp:s1";
+      const storePath = path.join(dir, "agents", "codex", "sessions", "sessions.json");
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sess-acp",
+            updatedAt: 100,
+          },
+        }),
+        "utf8",
+      );
+      await upsertAcpSessionMeta({
+        cfg,
+        env,
+        sessionKey,
+        mutate: () => ({
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "codex-s1",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 321,
+        }),
+      });
+
+      const entries = await listAcpSessionEntries({ cfg, env });
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.storePath).toBe(storePath);
+      expect(entries[0]?.entry?.sessionId).toBe("sess-acp");
     });
   });
 });

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -1,24 +1,30 @@
+import type { DatabaseSync } from "node:sqlite";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { Insertable, Selectable } from "kysely";
 import { getRuntimeConfig } from "../../config/config.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import { loadSessionStore } from "../../config/sessions/store-load.js";
-import { resolveAllAgentSessionStoreTargets } from "../../config/sessions/targets.js";
 import {
   mergeSessionEntry,
+  type AcpSessionRuntimeOptions,
+  type SessionAcpIdentity,
   type SessionAcpMeta,
   type SessionEntry,
 } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
-
-let sessionStoreRuntimePromise:
-  | Promise<typeof import("../../config/sessions/store.runtime.js")>
-  | undefined;
-
-function loadSessionStoreRuntime() {
-  sessionStoreRuntimePromise ??= import("../../config/sessions/store.runtime.js");
-  return sessionStoreRuntimePromise;
-}
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabaseOptions,
+  runOpenClawStateWriteTransaction,
+} from "../../state/openclaw-state-db.js";
+import { isRecord } from "../../utils.js";
 
 export type AcpSessionStoreEntry = {
   cfg: OpenClawConfig;
@@ -29,6 +35,19 @@ export type AcpSessionStoreEntry = {
   acp?: SessionAcpMeta;
   storeReadFailed?: boolean;
 };
+
+type AcpSessionsTable = OpenClawStateKyselyDatabase["acp_sessions"];
+type AcpSessionMetaDatabase = Pick<OpenClawStateKyselyDatabase, "acp_sessions">;
+type AcpSessionRow = Selectable<AcpSessionsTable>;
+
+let sessionStoreRuntimePromise:
+  | Promise<typeof import("../../config/sessions/store.runtime.js")>
+  | undefined;
+
+function loadSessionStoreRuntime() {
+  sessionStoreRuntimePromise ??= import("../../config/sessions/store.runtime.js");
+  return sessionStoreRuntimePromise;
+}
 
 function resolveStoreSessionKey(store: Record<string, SessionEntry>, sessionKey: string): string {
   const normalized = sessionKey.trim();
@@ -53,46 +72,263 @@ function resolveStoreSessionKey(store: Record<string, SessionEntry>, sessionKey:
 export function resolveSessionStorePathForAcp(params: {
   sessionKey: string;
   cfg?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
 }): { cfg: OpenClawConfig; storePath: string } {
   const cfg = params.cfg ?? getRuntimeConfig();
   const parsed = parseAgentSessionKey(params.sessionKey);
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: parsed?.agentId,
+    env: params.env,
   });
   return { cfg, storePath };
+}
+
+function getAcpSessionKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<AcpSessionMetaDatabase>(db);
+}
+
+function parseOptionalJsonRecord(raw: string | null): Record<string, unknown> | undefined {
+  if (raw == null || raw === "") {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function rowToAcpSessionMeta(row: AcpSessionRow): SessionAcpMeta {
+  const identity = parseOptionalJsonRecord(row.identity_json) as SessionAcpIdentity | undefined;
+  const runtimeOptions = parseOptionalJsonRecord(row.runtime_options_json) as
+    | AcpSessionRuntimeOptions
+    | undefined;
+  return {
+    backend: row.backend,
+    agent: row.agent,
+    runtimeSessionName: row.runtime_session_name,
+    ...(identity ? { identity } : {}),
+    mode: row.mode === "oneshot" ? "oneshot" : "persistent",
+    ...(runtimeOptions ? { runtimeOptions } : {}),
+    ...(row.cwd != null ? { cwd: row.cwd } : {}),
+    state: row.state === "running" || row.state === "error" ? row.state : "idle",
+    lastActivityAt: row.last_activity_at,
+    ...(row.last_error != null ? { lastError: row.last_error } : {}),
+  };
+}
+
+function bindAcpSessionMeta(params: {
+  sessionKey: string;
+  sessionId?: string;
+  meta: SessionAcpMeta;
+  updatedAt: number;
+}): Insertable<AcpSessionsTable> {
+  return {
+    session_key: params.sessionKey,
+    session_id: params.sessionId ?? null,
+    backend: params.meta.backend,
+    agent: params.meta.agent,
+    runtime_session_name: params.meta.runtimeSessionName,
+    identity_json: params.meta.identity ? JSON.stringify(params.meta.identity) : null,
+    mode: params.meta.mode,
+    runtime_options_json: params.meta.runtimeOptions
+      ? JSON.stringify(params.meta.runtimeOptions)
+      : null,
+    cwd: params.meta.cwd ?? null,
+    state: params.meta.state,
+    last_activity_at: params.meta.lastActivityAt,
+    last_error: params.meta.lastError ?? null,
+    updated_at: params.updatedAt,
+  };
+}
+
+function selectAcpSessionRow(db: DatabaseSync, sessionKey: string): AcpSessionRow | undefined {
+  return executeSqliteQueryTakeFirstSync(
+    db,
+    getAcpSessionKysely(db)
+      .selectFrom("acp_sessions")
+      .selectAll()
+      .where("session_key", "=", sessionKey),
+  );
+}
+
+function acpSessionRowMatchesEntry(row: AcpSessionRow, entry: SessionEntry | undefined): boolean {
+  return row.session_id == null || row.session_id === entry?.sessionId;
+}
+
+export function readAcpSessionMeta(params: {
+  sessionKey: string;
+  cfg?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
+}): SessionAcpMeta | undefined {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const storeEntry = readSessionEntryFromStore({
+    sessionKey,
+    cfg: params.cfg,
+    env: params.env,
+    clone: false,
+  });
+  const database = openOpenClawStateDatabase({
+    env: params.env,
+    path: params.databasePath,
+  });
+  const row = selectAcpSessionRow(database.db, storeEntry.storeSessionKey);
+  if (!row || !acpSessionRowMatchesEntry(row, storeEntry.entry)) {
+    return undefined;
+  }
+  return rowToAcpSessionMeta(row);
+}
+
+export function readAcpSessionMetaForEntry(params: {
+  sessionKey: string;
+  entry: SessionEntry | undefined;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
+}): SessionAcpMeta | undefined {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const database = openOpenClawStateDatabase({
+    env: params.env,
+    path: params.databasePath,
+  });
+  const row = selectAcpSessionRow(database.db, sessionKey);
+  if (!row || !acpSessionRowMatchesEntry(row, params.entry)) {
+    return undefined;
+  }
+  return rowToAcpSessionMeta(row);
+}
+
+function selectAcpSessionRows(options: OpenClawStateDatabaseOptions = {}): AcpSessionRow[] {
+  const database = openOpenClawStateDatabase(options);
+  return executeSqliteQuerySync(
+    database.db,
+    getAcpSessionKysely(database.db)
+      .selectFrom("acp_sessions")
+      .selectAll()
+      .orderBy("last_activity_at", "desc")
+      .orderBy("session_key", "asc"),
+  ).rows;
+}
+
+export function writeAcpSessionMetaForMigration(params: {
+  sessionKey: string;
+  sessionId?: string;
+  meta: SessionAcpMeta;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
+  now?: () => number;
+}): void {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return;
+  }
+  const row = bindAcpSessionMeta({
+    sessionKey,
+    sessionId: params.sessionId,
+    meta: params.meta,
+    updatedAt: params.now?.() ?? Date.now(),
+  });
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      upsertAcpSessionMetaRow(database.db, row);
+    },
+    { env: params.env, path: params.databasePath },
+  );
+}
+
+function upsertAcpSessionMetaRow(db: DatabaseSync, row: Insertable<AcpSessionsTable>): void {
+  executeSqliteQuerySync(
+    db,
+    getAcpSessionKysely(db)
+      .insertInto("acp_sessions")
+      .values(row)
+      .onConflict((conflict) =>
+        conflict.column("session_key").doUpdateSet({
+          session_id: (eb) => eb.ref("excluded.session_id"),
+          backend: (eb) => eb.ref("excluded.backend"),
+          agent: (eb) => eb.ref("excluded.agent"),
+          runtime_session_name: (eb) => eb.ref("excluded.runtime_session_name"),
+          identity_json: (eb) => eb.ref("excluded.identity_json"),
+          mode: (eb) => eb.ref("excluded.mode"),
+          runtime_options_json: (eb) => eb.ref("excluded.runtime_options_json"),
+          cwd: (eb) => eb.ref("excluded.cwd"),
+          state: (eb) => eb.ref("excluded.state"),
+          last_activity_at: (eb) => eb.ref("excluded.last_activity_at"),
+          last_error: (eb) => eb.ref("excluded.last_error"),
+          updated_at: (eb) => eb.ref("excluded.updated_at"),
+        }),
+      ),
+  );
+}
+
+function readSessionEntryFromStore(params: {
+  sessionKey: string;
+  cfg?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  clone?: boolean;
+}): {
+  cfg: OpenClawConfig;
+  storePath: string;
+  storeSessionKey: string;
+  entry?: SessionEntry;
+  storeReadFailed?: boolean;
+} {
+  const { cfg, storePath } = resolveSessionStorePathForAcp({
+    sessionKey: params.sessionKey,
+    cfg: params.cfg,
+    env: params.env,
+  });
+  try {
+    const store = loadSessionStore(
+      storePath,
+      params.clone === false ? { clone: false } : undefined,
+    );
+    const storeSessionKey = resolveStoreSessionKey(store, params.sessionKey);
+    return { cfg, storePath, storeSessionKey, entry: store[storeSessionKey] };
+  } catch {
+    return {
+      cfg,
+      storePath,
+      storeSessionKey: normalizeLowercaseStringOrEmpty(params.sessionKey),
+      storeReadFailed: true,
+    };
+  }
 }
 
 export function readAcpSessionEntry(params: {
   sessionKey: string;
   cfg?: OpenClawConfig;
   clone?: boolean;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
 }): AcpSessionStoreEntry | null {
   const sessionKey = params.sessionKey.trim();
   if (!sessionKey) {
     return null;
   }
-  const { cfg, storePath } = resolveSessionStorePathForAcp({
-    sessionKey,
-    cfg: params.cfg,
+  const storeEntry = readSessionEntryFromStore(params);
+  const database = openOpenClawStateDatabase({
+    env: params.env,
+    path: params.databasePath,
   });
-  let store: Record<string, SessionEntry>;
-  let storeReadFailed = false;
-  try {
-    store = loadSessionStore(storePath, params.clone === false ? { clone: false } : undefined);
-  } catch {
-    storeReadFailed = true;
-    store = {};
-  }
-  const storeSessionKey = resolveStoreSessionKey(store, sessionKey);
-  const entry = store[storeSessionKey];
+  const row = selectAcpSessionRow(database.db, storeEntry.storeSessionKey);
+  const acp =
+    row && acpSessionRowMatchesEntry(row, storeEntry.entry) ? rowToAcpSessionMeta(row) : undefined;
   return {
-    cfg,
-    storePath,
+    cfg: storeEntry.cfg,
+    storePath: storeEntry.storePath,
     sessionKey,
-    storeSessionKey,
-    entry,
-    acp: entry?.acp,
-    storeReadFailed,
+    storeSessionKey: storeEntry.storeSessionKey,
+    entry: storeEntry.entry,
+    acp,
+    storeReadFailed: storeEntry.storeReadFailed,
   };
 }
 
@@ -100,43 +336,68 @@ export async function listAcpSessionEntries(params: {
   cfg?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   clone?: boolean;
+  databasePath?: string;
 }): Promise<AcpSessionStoreEntry[]> {
   const cfg = params.cfg ?? getRuntimeConfig();
-  const storeTargets = await resolveAllAgentSessionStoreTargets(
-    cfg,
-    params.env ? { env: params.env } : undefined,
-  );
+  const rows = selectAcpSessionRows({
+    env: params.env,
+    path: params.databasePath,
+  });
   const entries: AcpSessionStoreEntry[] = [];
 
-  for (const target of storeTargets) {
-    const storePath = target.storePath;
+  for (const row of rows) {
+    const sessionKey = row.session_key;
+    const { storePath } = resolveSessionStorePathForAcp({
+      sessionKey,
+      cfg,
+      env: params.env,
+    });
     let store: Record<string, SessionEntry>;
     try {
       store = loadSessionStore(storePath, params.clone === false ? { clone: false } : undefined);
     } catch {
       continue;
     }
-    for (const [sessionKey, entry] of Object.entries(store)) {
-      if (!entry?.acp) {
-        continue;
-      }
-      entries.push({
-        cfg,
-        storePath,
-        sessionKey,
-        storeSessionKey: sessionKey,
-        entry,
-        acp: entry.acp,
-      });
+    const storeSessionKey = resolveStoreSessionKey(store, sessionKey);
+    const entry = store[storeSessionKey];
+    if (!entry || !acpSessionRowMatchesEntry(row, entry)) {
+      continue;
     }
+    entries.push({
+      cfg,
+      storePath,
+      sessionKey,
+      storeSessionKey,
+      entry,
+      acp: rowToAcpSessionMeta(row),
+    });
   }
 
   return entries;
 }
 
+function mergeAcpForReturn(entry: SessionEntry | undefined, acp: SessionAcpMeta): SessionEntry {
+  return mergeSessionEntry(entry, { acp });
+}
+
+function sessionStoreUpdateOptions(params: {
+  sessionKey: string;
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+}) {
+  return {
+    activeSessionKey: normalizeLowercaseStringOrEmpty(params.sessionKey),
+    ...(params.skipMaintenance === true ? { skipMaintenance: true } : {}),
+    ...(params.takeCacheOwnership === true ? { takeCacheOwnership: true } : {}),
+  };
+}
+
 export async function upsertAcpSessionMeta(params: {
   sessionKey: string;
   cfg?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
+  now?: () => number;
   skipMaintenance?: boolean;
   takeCacheOwnership?: boolean;
   mutate: (
@@ -148,38 +409,87 @@ export async function upsertAcpSessionMeta(params: {
   if (!sessionKey) {
     return null;
   }
-  const { storePath } = resolveSessionStorePathForAcp({
+  const storeEntry = readSessionEntryFromStore({
     sessionKey,
     cfg: params.cfg,
+    env: params.env,
+    clone: false,
   });
-  const { updateSessionStore } = await loadSessionStoreRuntime();
-  return await updateSessionStore(
-    storePath,
-    (store) => {
-      const storeSessionKey = resolveStoreSessionKey(store, sessionKey);
-      const currentEntry = store[storeSessionKey];
-      const nextMeta = params.mutate(currentEntry?.acp, currentEntry);
-      if (nextMeta === undefined) {
-        return currentEntry ?? null;
-      }
-      if (nextMeta === null && !currentEntry) {
-        return null;
-      }
-
-      const nextEntry = mergeSessionEntry(currentEntry, {
-        acp: nextMeta ?? undefined,
-      });
+  const { entry } = storeEntry;
+  const storageSessionKey = storeEntry.storeSessionKey;
+  let current: SessionAcpMeta | undefined;
+  let nextMeta: SessionAcpMeta | null | undefined;
+  let preparedEntry: SessionEntry | undefined;
+  const updatedAt = params.now?.() ?? Date.now();
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      const currentRow = selectAcpSessionRow(database.db, storageSessionKey);
+      current =
+        currentRow && acpSessionRowMatchesEntry(currentRow, entry)
+          ? rowToAcpSessionMeta(currentRow)
+          : undefined;
+      preparedEntry = mergeSessionEntry(entry, { updatedAt });
+      nextMeta = params.mutate(
+        current,
+        current ? mergeAcpForReturn(preparedEntry, current) : entry,
+      );
       if (nextMeta === null) {
-        delete nextEntry.acp;
+        executeSqliteQuerySync(
+          database.db,
+          getAcpSessionKysely(database.db)
+            .deleteFrom("acp_sessions")
+            .where("session_key", "=", storageSessionKey),
+        );
+        return;
       }
-      store[storeSessionKey] = nextEntry;
-      return nextEntry;
+      if (nextMeta !== undefined) {
+        upsertAcpSessionMetaRow(
+          database.db,
+          bindAcpSessionMeta({
+            sessionKey: storageSessionKey,
+            sessionId: preparedEntry.sessionId,
+            meta: nextMeta,
+            updatedAt,
+          }),
+        );
+      }
     },
-    {
-      activeSessionKey: normalizeLowercaseStringOrEmpty(sessionKey),
-      allowDropAcpMetaSessionKeys: [sessionKey],
-      ...(params.skipMaintenance === true ? { skipMaintenance: true } : {}),
-      ...(params.takeCacheOwnership === true ? { takeCacheOwnership: true } : {}),
-    },
+    { env: params.env, path: params.databasePath },
   );
+  if (nextMeta === undefined) {
+    return current ? mergeAcpForReturn(entry, current) : (entry ?? null);
+  }
+  if (nextMeta === null) {
+    if (!entry) {
+      return null;
+    }
+    const { updateSessionStore } = await loadSessionStoreRuntime();
+    return await updateSessionStore(
+      storeEntry.storePath,
+      (store) => {
+        const storeSessionKey = resolveStoreSessionKey(store, storageSessionKey);
+        const next = { ...(store[storeSessionKey] ?? entry) };
+        delete next.acp;
+        store[storeSessionKey] = next;
+        return next;
+      },
+      sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
+    );
+  }
+  const { updateSessionStore } = await loadSessionStoreRuntime();
+  const persisted = await updateSessionStore(
+    storeEntry.storePath,
+    (store) => {
+      const storeSessionKey = resolveStoreSessionKey(store, storageSessionKey);
+      const next = mergeSessionEntry(store[storeSessionKey], {
+        sessionId: preparedEntry?.sessionId,
+        updatedAt,
+      });
+      delete next.acp;
+      store[storeSessionKey] = next;
+      return next;
+    },
+    sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
+  );
+  return mergeAcpForReturn(persisted, nextMeta);
 }

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -14,7 +14,11 @@ import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-re
 import { GatewayClient } from "../gateway/client.js";
 import { isMainModule } from "../infra/is-main.js";
 import { routeLogsToStderr } from "../logging/console.js";
-import { createFileAcpEventLedger, resolveDefaultAcpEventLedgerPath } from "./event-ledger.js";
+import {
+  createSqliteAcpEventLedger,
+  migrateFileAcpEventLedgerToSqlite,
+  resolveDefaultAcpEventLedgerPath,
+} from "./event-ledger.js";
 import { readSecretFromFile } from "./secret-file.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { normalizeAcpProvenanceMode, type AcpServerOptions } from "./types.js";
@@ -127,9 +131,11 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   const input = Writable.toWeb(process.stdout);
   const output = Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>;
   const stream = ndJsonStream(input, output);
-  const eventLedger = createFileAcpEventLedger({
+  await migrateFileAcpEventLedgerToSqlite({
     filePath: resolveDefaultAcpEventLedgerPath(process.env),
+    archiveSource: true,
   });
+  const eventLedger = createSqliteAcpEventLedger();
 
   void new AgentSideConnection((conn: AgentSideConnection) => {
     agent = new AcpGatewayAgent(conn, gateway, { ...opts, eventLedger });

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -55,6 +55,7 @@ const hoisted = vi.hoisted(() => {
   const startAcpSpawnParentStreamRelayMock = vi.fn();
   const resolveAcpSpawnStreamLogPathMock = vi.fn();
   const loadSessionStoreMock = vi.fn();
+  const readAcpSessionMetaMock = vi.fn();
   const resolveStorePathMock = vi.fn();
   const resolveSessionTranscriptFileMock = vi.fn();
   const areHeartbeatsEnabledMock = vi.fn();
@@ -84,6 +85,7 @@ const hoisted = vi.hoisted(() => {
     startAcpSpawnParentStreamRelayMock,
     resolveAcpSpawnStreamLogPathMock,
     loadSessionStoreMock,
+    readAcpSessionMetaMock,
     resolveStorePathMock,
     resolveSessionTranscriptFileMock,
     areHeartbeatsEnabledMock,
@@ -105,6 +107,10 @@ vi.mock("../acp/control-plane/manager.js", () => ({
 
 vi.mock("../acp/control-plane/spawn.js", () => ({
   cleanupFailedAcpSpawn: hoisted.cleanupFailedAcpSpawnMock,
+}));
+
+vi.mock("../acp/runtime/session-meta.js", () => ({
+  readAcpSessionMeta: (params: unknown) => hoisted.readAcpSessionMetaMock(params),
 }));
 
 vi.mock("../channels/plugins/index.js", () => ({
@@ -723,6 +729,7 @@ describe("spawnAcpDirect", () => {
       .mockReset()
       .mockReturnValue("/tmp/sess-main.acp-stream.jsonl");
     hoisted.resolveStorePathMock.mockReset().mockReturnValue("/tmp/codex-sessions.json");
+    hoisted.readAcpSessionMetaMock.mockReset().mockReturnValue(undefined);
     hoisted.loadSessionStoreMock.mockReset().mockImplementation(() => {
       const store: Record<string, { sessionId: string; updatedAt: number }> = {};
       return new Proxy(store, {
@@ -824,27 +831,33 @@ describe("spawnAcpDirect", () => {
 
   it("allows ACP resume IDs recorded for the requester session", async () => {
     const resumeSessionId = "codex-inner-resume";
+    const ownedSessionKey = "agent:codex:acp:owned";
     hoisted.loadSessionStoreMock.mockReturnValue({
-      "agent:codex:acp:owned": {
+      [ownedSessionKey]: {
         sessionId: "sess-owned",
         updatedAt: Date.now(),
         spawnedBy: "agent:main:main",
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "codex",
-          identity: {
-            state: "resolved",
-            source: "ensure",
-            agentSessionId: resumeSessionId,
-            acpxSessionId: "acpx-owned",
-            lastUpdatedAt: Date.now(),
-          },
-          mode: "oneshot",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
       } satisfies SessionEntry,
+    });
+    hoisted.readAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string };
+      return params.sessionKey === ownedSessionKey
+        ? {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: "codex",
+            identity: {
+              state: "resolved",
+              source: "ensure",
+              agentSessionId: resumeSessionId,
+              acpxSessionId: "acpx-owned",
+              lastUpdatedAt: Date.now(),
+            },
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: Date.now(),
+          }
+        : undefined;
     });
 
     const result = await spawnAcpDirect(
@@ -863,27 +876,33 @@ describe("spawnAcpDirect", () => {
   });
 
   it("rejects ACP resume IDs not recorded for the requester session", async () => {
+    const otherSessionKey = "agent:codex:acp:other";
     hoisted.loadSessionStoreMock.mockReturnValue({
-      "agent:codex:acp:other": {
+      [otherSessionKey]: {
         sessionId: "sess-other",
         updatedAt: Date.now(),
         spawnedBy: "agent:other:main",
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "codex",
-          identity: {
-            state: "resolved",
-            source: "ensure",
-            agentSessionId: "codex-inner-other",
-            acpxSessionId: "acpx-other",
-            lastUpdatedAt: Date.now(),
-          },
-          mode: "oneshot",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
       } satisfies SessionEntry,
+    });
+    hoisted.readAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string };
+      return params.sessionKey === otherSessionKey
+        ? {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: "codex",
+            identity: {
+              state: "resolved",
+              source: "ensure",
+              agentSessionId: "codex-inner-other",
+              acpxSessionId: "acpx-other",
+              lastUpdatedAt: Date.now(),
+            },
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: Date.now(),
+          }
+        : undefined;
     });
 
     const result = await spawnAcpDirect(

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -16,6 +16,7 @@ import {
   type AcpSpawnRuntimeCloseHandle,
 } from "../acp/control-plane/spawn.js";
 import { isAcpEnabledByPolicy, resolveAcpAgentPolicyError } from "../acp/policy.js";
+import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { DEFAULT_HEARTBEAT_EVERY } from "../auto-reply/heartbeat.js";
 import { formatThinkingLevels } from "../auto-reply/thinking.js";
 import {
@@ -43,7 +44,7 @@ import { getRuntimeConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
-import type { SessionEntry } from "../config/sessions/types.js";
+import type { SessionAcpMeta, SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -922,10 +923,10 @@ function resolveAcpSpawnStreamPlan(params: {
 }
 
 function sessionEntryMatchesAcpResumeSessionId(
-  entry: SessionEntry | undefined,
+  acp: SessionAcpMeta | undefined,
   resumeSessionId: string,
 ): boolean {
-  const identity = entry?.acp?.identity;
+  const identity = acp?.identity;
   return (
     normalizeOptionalString(identity?.agentSessionId) === resumeSessionId ||
     normalizeOptionalString(identity?.acpxSessionId) === resumeSessionId
@@ -965,7 +966,8 @@ function validateAcpResumeSessionOwnership(params: {
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
   const sessionStore = loadSessionStore(storePath);
   for (const [sessionKey, entry] of Object.entries(sessionStore)) {
-    if (!sessionEntryMatchesAcpResumeSessionId(entry, resumeSessionId)) {
+    const acp = readAcpSessionMeta({ sessionKey });
+    if (!sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)) {
       continue;
     }
     if (

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -3,6 +3,7 @@ import { isRequesterParentOfBackgroundAcpSession } from "@openclaw/acp-core/sess
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { Type } from "typebox";
+import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -167,10 +168,16 @@ type SessionsSendRouteEntry = Pick<SessionEntry, "acp" | "parentSessionKey" | "s
 
 function isRequesterParentOfNativeSubagentSession(params: {
   entry: SessionsSendRouteEntry | null | undefined;
+  acpMeta?: unknown;
   requesterSessionKey: string | null | undefined;
   targetSessionKey: string;
 }): boolean {
-  if (!params.entry || params.entry.acp || !isSubagentSessionKey(params.targetSessionKey)) {
+  if (
+    !params.entry ||
+    params.acpMeta ||
+    params.entry.acp ||
+    !isSubagentSessionKey(params.targetSessionKey)
+  ) {
     return false;
   }
   const requester = normalizeOptionalString(params.requesterSessionKey);
@@ -574,14 +581,20 @@ export function createSessionsSendTool(opts?: {
       // `tools.sessions.visibility=all`) must still go through the normal A2A
       // path so it actually receives a follow-up delivery.
       const targetSessionEntry = loadSessionEntryByKey(resolvedKey);
+      const targetAcpMeta = readAcpSessionMeta({ sessionKey: resolvedKey });
+      const targetSessionEntryWithAcp =
+        targetAcpMeta && targetSessionEntry
+          ? { ...targetSessionEntry, acp: targetAcpMeta }
+          : targetSessionEntry;
       const skipAcpA2AFlow = isRequesterParentOfBackgroundAcpSession(
-        targetSessionEntry,
+        targetSessionEntryWithAcp,
         effectiveRequesterKey,
       );
       const skipNativeParentA2AFlow =
         timeoutSeconds !== 0 &&
         isRequesterParentOfNativeSubagentSession({
           entry: targetSessionEntry,
+          acpMeta: targetAcpMeta,
           requesterSessionKey: effectiveRequesterKey,
           targetSessionKey: resolvedKey,
         });

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -556,6 +556,11 @@ function createAcpSessionEntry(options?: {
   return {
     sessionKey,
     storeSessionKey: sessionKey,
+    entry: {
+      sessionId: "sess-acp",
+      updatedAt: Date.now(),
+      label: "codex-main",
+    },
     acp: {
       backend: "acpx",
       agent: "codex",
@@ -1799,25 +1804,7 @@ describe("/acp command", () => {
     hoisted.sessionBindingListBySessionMock.mockImplementation((key: string) =>
       key === defaultAcpSessionKey ? [createBoundThreadSession(key) as SessionBindingRecord] : [],
     );
-    hoisted.loadSessionStoreMock.mockReturnValue({
-      [defaultAcpSessionKey]: {
-        sessionId: "sess-1",
-        updatedAt: Date.now(),
-        label: "codex-main",
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "runtime-1",
-          mode: "persistent",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
-      },
-      "agent:main:main": {
-        sessionId: "sess-main",
-        updatedAt: Date.now(),
-      },
-    });
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([createAcpSessionEntry()]);
 
     const result = await runDiscordAcpCommand("/acp sessions", baseCfg);
 

--- a/src/auto-reply/reply/commands-acp/diagnostics.ts
+++ b/src/auto-reply/reply/commands-acp/diagnostics.ts
@@ -6,9 +6,9 @@ import {
 import { getAcpSessionManager } from "../../../acp/control-plane/manager.js";
 import { toAcpRuntimeError } from "../../../acp/runtime/errors.js";
 import { getAcpRuntimeBackend, requireAcpRuntimeBackend } from "../../../acp/runtime/registry.js";
-import { resolveSessionStorePathForAcp } from "../../../acp/runtime/session-meta.js";
-import { loadSessionStore } from "../../../config/sessions.js";
+import { listAcpSessionEntries } from "../../../acp/runtime/session-meta.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
+import type { SessionAcpMeta } from "../../../config/sessions/types.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import type { CommandHandlerResult, HandleCommandsParams } from "../commands-types.js";
 import { resolveAcpCommandBindingContext } from "./context.js";
@@ -161,23 +161,21 @@ export function handleAcpInstallAction(
 function formatAcpSessionLine(params: {
   key: string;
   entry: SessionEntry;
+  acp: SessionAcpMeta;
   currentSessionKey?: string;
   threadId?: string;
 }): string {
-  const acp = params.entry.acp;
-  if (!acp) {
-    return "";
-  }
+  const acp = params.acp;
   const marker = params.currentSessionKey === params.key ? "*" : " ";
   const label = normalizeOptionalString(params.entry.label) || acp.agent;
   const threadText = params.threadId ? `, thread:${params.threadId}` : "";
   return `${marker} ${label} (${acp.mode}, ${acp.state}, backend:${acp.backend}${threadText}) -> ${params.key}`;
 }
 
-export function handleAcpSessionsAction(
+export async function handleAcpSessionsAction(
   params: HandleCommandsParams,
   restTokens: string[],
-): CommandHandlerResult {
+): Promise<CommandHandlerResult> {
   if (restTokens.length > 0) {
     return stopWithText(ACP_SESSIONS_USAGE);
   }
@@ -187,38 +185,30 @@ export function handleAcpSessionsAction(
     return stopWithText("⚠️ Missing session key.");
   }
 
-  const { storePath } = resolveSessionStorePathForAcp({
-    cfg: params.cfg,
-    sessionKey: currentSessionKey,
-  });
-
-  let store: Record<string, SessionEntry>;
-  try {
-    store = loadSessionStore(storePath);
-  } catch {
-    store = {};
-  }
-
   const bindingContext = resolveAcpCommandBindingContext(params);
   const normalizedChannel = bindingContext.channel;
   const normalizedAccountId = bindingContext.accountId || undefined;
   const bindingService = getSessionBindingService();
+  const entries = await listAcpSessionEntries({ cfg: params.cfg });
 
-  const rows = Object.entries(store)
-    .filter(([, entry]) => Boolean(entry?.acp))
-    .toSorted(([, a], [, b]) => (b?.updatedAt ?? 0) - (a?.updatedAt ?? 0))
+  const rows = entries
+    .toSorted((a, b) => (b.entry?.updatedAt ?? 0) - (a.entry?.updatedAt ?? 0))
     .slice(0, 20)
-    .map(([key, entry]) => {
+    .map(({ storeSessionKey, entry, acp }) => {
+      if (!entry || !acp) {
+        return "";
+      }
       const bindingThreadId = bindingService
-        .listBySession(key)
+        .listBySession(storeSessionKey)
         .find(
           (binding) =>
             (!normalizedChannel || binding.conversation.channel === normalizedChannel) &&
             (!normalizedAccountId || binding.conversation.accountId === normalizedAccountId),
         )?.conversation.conversationId;
       return formatAcpSessionLine({
-        key,
+        key: storeSessionKey,
         entry,
+        acp,
         currentSessionKey,
         threadId: bindingThreadId,
       });

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -62,6 +62,9 @@ const acpMocks = vi.hoisted(() => ({
   readAcpSessionEntry: vi.fn<(params: { sessionKey: string; cfg?: OpenClawConfig }) => unknown>(
     () => null,
   ),
+  readAcpSessionMeta: vi.fn<(params: { sessionKey: string; cfg?: OpenClawConfig }) => unknown>(
+    () => null,
+  ),
   getAcpRuntimeBackend: vi.fn<() => unknown>(() => null),
   upsertAcpSessionMeta: vi.fn<
     (params: {
@@ -226,6 +229,7 @@ vi.mock("../../plugins/hook-runner-global.js", () => ({
 vi.mock("../../acp/runtime/session-meta.js", () => ({
   listAcpSessionEntries: acpMocks.listAcpSessionEntries,
   readAcpSessionEntry: acpMocks.readAcpSessionEntry,
+  readAcpSessionMeta: acpMocks.readAcpSessionMeta,
   upsertAcpSessionMeta: acpMocks.upsertAcpSessionMeta,
 }));
 vi.mock("../../acp/runtime/registry.js", () => ({

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -87,6 +87,9 @@ const acpMocks = vi.hoisted(() => ({
   readAcpSessionEntry: vi.fn<(params: { sessionKey: string; cfg?: OpenClawConfig }) => unknown>(
     () => null,
   ),
+  readAcpSessionMeta: vi.fn<(params: { sessionKey: string; cfg?: OpenClawConfig }) => unknown>(
+    () => null,
+  ),
   getAcpRuntimeBackend: vi.fn<() => unknown>(() => null),
   upsertAcpSessionMeta: vi.fn<
     (params: {
@@ -420,6 +423,7 @@ vi.mock("../../plugins/hook-runner-global.js", () => ({
 vi.mock("../../acp/runtime/session-meta.js", () => ({
   listAcpSessionEntries: acpMocks.listAcpSessionEntries,
   readAcpSessionEntry: acpMocks.readAcpSessionEntry,
+  readAcpSessionMeta: acpMocks.readAcpSessionMeta,
   upsertAcpSessionMeta: acpMocks.upsertAcpSessionMeta,
 }));
 vi.mock("../../acp/runtime/registry.js", () => ({
@@ -965,6 +969,8 @@ describe("dispatchReplyFromConfig", () => {
     internalHookMocks.triggerInternalHook.mockClear();
     acpMocks.readAcpSessionEntry.mockReset();
     acpMocks.readAcpSessionEntry.mockReturnValue(null);
+    acpMocks.readAcpSessionMeta.mockReset();
+    acpMocks.readAcpSessionMeta.mockReturnValue(null);
     acpMocks.upsertAcpSessionMeta.mockReset();
     acpMocks.upsertAcpSessionMeta.mockResolvedValue(null);
     acpMocks.getAcpRuntimeBackend.mockReset();
@@ -7055,164 +7061,165 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
-  it.each(
-    [
-      {
-        name: "handled without a plugin reply",
-        bindingId: "binding-message-tool-only",
-        conversation: {
-          channel: "telegram",
-          accountId: "default",
-          conversationId: "-1001234567890:topic:11",
-          parentConversationId: "-1001234567890",
-        },
-        ctx: {
-          Provider: "telegram",
-          Surface: "telegram",
-          OriginatingChannel: "telegram",
-          OriginatingTo: "telegram:-1001234567890",
-          To: "telegram:-1001234567890",
-          AccountId: "default",
-          MessageThreadId: 11,
-          ChatType: "group",
-          GroupSubject: "Dev",
-          Body: "observed message",
-        },
-        cfg: emptyConfig,
-        replyOptions: {
-          sourceReplyDeliveryMode: "message_tool_only" as const,
-        },
-        expectedClaim: { channel: "telegram", threadId: 11 },
+  it.each([
+    {
+      name: "handled without a plugin reply",
+      bindingId: "binding-message-tool-only",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-1001234567890:topic:11",
+        parentConversationId: "-1001234567890",
       },
-      {
-        name: "handled with a plugin reply",
-        bindingId: "binding-message-tool-reply",
-        conversation: {
-          channel: "discord",
-          accountId: "default",
-          conversationId: "channel:reply-test",
-        },
-        ctx: {
-          Provider: "discord",
-          Surface: "discord",
-          OriginatingChannel: "discord",
-          OriginatingTo: "discord:channel:reply-test",
-          To: "discord:channel:reply-test",
-          AccountId: "default",
-          ChatType: "channel",
-          Body: "observed message",
-          SessionKey: "agent:main:discord:channel:reply-test",
-        },
-        cfg: {
-          messages: {
-            groupChat: { visibleReplies: "message_tool" },
-          },
-        } as OpenClawConfig,
-        expectedClaim: { channel: "discord" },
-        pluginReply: { text: "Codex native reply" },
-        expectPluginReplyDelivered: true,
+      ctx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:-1001234567890",
+        To: "telegram:-1001234567890",
+        AccountId: "default",
+        MessageThreadId: 11,
+        ChatType: "group",
+        GroupSubject: "Dev",
+        Body: "observed message",
       },
-      {
-        name: "suppresses ambient room_event plugin reply",
-        bindingId: "binding-message-tool-room-event",
-        conversation: {
-          channel: "discord",
-          accountId: "default",
-          conversationId: "channel:room-event-test",
-        },
-        ctx: {
-          Provider: "discord",
-          Surface: "discord",
-          OriginatingChannel: "discord",
-          OriginatingTo: "discord:channel:room-event-test",
-          To: "discord:channel:room-event-test",
-          AccountId: "default",
-          ChatType: "group",
-          InboundEventKind: "room_event",
-          Body: "observed message",
-          SessionKey: "agent:main:discord:channel:room-event-test",
-        },
-        cfg: emptyConfig,
-        expectedClaim: { channel: "discord" },
-        pluginReply: { text: "Codex ambient room event reply" },
-        expectPluginReplyDelivered: false,
+      cfg: emptyConfig,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only" as const,
       },
-    ] satisfies Array<{
-      name: string;
-      bindingId: string;
-      conversation: SessionBindingRecord["conversation"];
-      ctx: Partial<MsgContext>;
-      cfg: OpenClawConfig;
-      replyOptions?: { sourceReplyDeliveryMode: "message_tool_only" };
-      expectedClaim: Record<string, unknown>;
-      pluginReply?: ReplyPayload;
-      expectPluginReplyDelivered?: boolean;
-    }>,
-  )("routes plugin-owned bindings under message-tool-only source delivery: $name", async (params) => {
-    setNoAbort();
-    hookMocks.runner.hasHooks.mockImplementation(
-      ((hookName?: string) =>
-        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
-    );
-    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
-    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
-      status: "handled",
-      result: params.pluginReply
-        ? { handled: true, reply: params.pluginReply }
-        : { handled: true },
-    });
-    sessionBindingMocks.resolveByConversation.mockReturnValue({
-      bindingId: params.bindingId,
-      targetSessionKey: "plugin-binding:codex:abc123",
-      targetKind: "session",
-      conversation: params.conversation,
-      status: "active",
-      boundAt: 1710000000000,
-      metadata: {
-        pluginBindingOwner: "plugin",
-        pluginId: "openclaw-codex-app-server",
-        pluginRoot: "/tmp/plugin",
+      expectedClaim: { channel: "telegram", threadId: 11 },
+    },
+    {
+      name: "handled with a plugin reply",
+      bindingId: "binding-message-tool-reply",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:reply-test",
       },
-    } satisfies SessionBindingRecord);
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
-    const dispatcher = createDispatcher();
-    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "discord:channel:reply-test",
+        To: "discord:channel:reply-test",
+        AccountId: "default",
+        ChatType: "channel",
+        Body: "observed message",
+        SessionKey: "agent:main:discord:channel:reply-test",
+      },
+      cfg: {
+        messages: {
+          groupChat: { visibleReplies: "message_tool" },
+        },
+      } as OpenClawConfig,
+      expectedClaim: { channel: "discord" },
+      pluginReply: { text: "Codex native reply" },
+      expectPluginReplyDelivered: true,
+    },
+    {
+      name: "suppresses ambient room_event plugin reply",
+      bindingId: "binding-message-tool-room-event",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:room-event-test",
+      },
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "discord:channel:room-event-test",
+        To: "discord:channel:room-event-test",
+        AccountId: "default",
+        ChatType: "group",
+        InboundEventKind: "room_event",
+        Body: "observed message",
+        SessionKey: "agent:main:discord:channel:room-event-test",
+      },
+      cfg: emptyConfig,
+      expectedClaim: { channel: "discord" },
+      pluginReply: { text: "Codex ambient room event reply" },
+      expectPluginReplyDelivered: false,
+    },
+  ] satisfies Array<{
+    name: string;
+    bindingId: string;
+    conversation: SessionBindingRecord["conversation"];
+    ctx: Partial<MsgContext>;
+    cfg: OpenClawConfig;
+    replyOptions?: { sourceReplyDeliveryMode: "message_tool_only" };
+    expectedClaim: Record<string, unknown>;
+    pluginReply?: ReplyPayload;
+    expectPluginReplyDelivered?: boolean;
+  }>)(
+    "routes plugin-owned bindings under message-tool-only source delivery: $name",
+    async (params) => {
+      setNoAbort();
+      hookMocks.runner.hasHooks.mockImplementation(
+        ((hookName?: string) =>
+          hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+      );
+      hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+      hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+        status: "handled",
+        result: params.pluginReply
+          ? { handled: true, reply: params.pluginReply }
+          : { handled: true },
+      });
+      sessionBindingMocks.resolveByConversation.mockReturnValue({
+        bindingId: params.bindingId,
+        targetSessionKey: "plugin-binding:codex:abc123",
+        targetKind: "session",
+        conversation: params.conversation,
+        status: "active",
+        boundAt: 1710000000000,
+        metadata: {
+          pluginBindingOwner: "plugin",
+          pluginId: "openclaw-codex-app-server",
+          pluginRoot: "/tmp/plugin",
+        },
+      } satisfies SessionBindingRecord);
+      sessionStoreMocks.currentEntry = {
+        sessionId: "s1",
+        updatedAt: 0,
+        sendPolicy: "allow",
+      };
+      const dispatcher = createDispatcher();
+      const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
 
-    const result = await dispatchReplyFromConfig({
-      ctx: buildTestCtx(params.ctx),
-      cfg: params.cfg,
-      dispatcher,
-      replyResolver,
-      replyOptions: params.replyOptions,
-    });
+      const result = await dispatchReplyFromConfig({
+        ctx: buildTestCtx(params.ctx),
+        cfg: params.cfg,
+        dispatcher,
+        replyResolver,
+        replyOptions: params.replyOptions,
+      });
 
-    expect(result).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
-    expect(sessionBindingMocks.touch).toHaveBeenCalledWith(params.bindingId);
-    expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
-      "openclaw-codex-app-server",
-      expect.objectContaining({
-        content: "observed message",
-        ...params.expectedClaim,
-      }),
-      expect.objectContaining({
-        pluginBinding: expect.objectContaining({ bindingId: params.bindingId }),
-      }),
-    );
-    expect(replyResolver).not.toHaveBeenCalled();
-    if (params.expectPluginReplyDelivered) {
-      expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(params.pluginReply);
-    } else {
-      expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
-    }
-  });
+      expect(result).toEqual({
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+        sourceReplyDeliveryMode: "message_tool_only",
+      });
+      expect(sessionBindingMocks.touch).toHaveBeenCalledWith(params.bindingId);
+      expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
+        "openclaw-codex-app-server",
+        expect.objectContaining({
+          content: "observed message",
+          ...params.expectedClaim,
+        }),
+        expect.objectContaining({
+          pluginBinding: expect.objectContaining({ bindingId: params.bindingId }),
+        }),
+      );
+      expect(replyResolver).not.toHaveBeenCalled();
+      if (params.expectPluginReplyDelivered) {
+        expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(params.pluginReply);
+      } else {
+        expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("keeps unmentioned plugin-bound fallback from ordinary group agent dispatch", async () => {
     setNoAbort();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -9,6 +9,7 @@ import {
   hasOutboundReplyContent,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
+import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import {
   resolveAgentConfig,
   resolveAgentWorkspaceDir,
@@ -1373,7 +1374,14 @@ export async function dispatchReplyFromConfig(
   // flow when the provider handles its own messages.
   //
   // Debug: `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts`
-  const suppressAcpChildUserDelivery = isParentOwnedBackgroundAcpSession(sessionStoreEntry.entry);
+  const sessionAcpMeta = sessionStoreEntry.sessionKey
+    ? readAcpSessionMeta({ sessionKey: sessionStoreEntry.sessionKey })
+    : undefined;
+  const sessionEntryWithAcp =
+    sessionAcpMeta && sessionStoreEntry.entry
+      ? { ...sessionStoreEntry.entry, acp: sessionAcpMeta }
+      : sessionStoreEntry.entry;
+  const suppressAcpChildUserDelivery = isParentOwnedBackgroundAcpSession(sessionEntryWithAcp);
   const normalizedRouteReplyChannel = normalizeMessageChannel(replyRoute.channel);
   const normalizedProviderChannel = normalizeMessageChannel(ctx.Provider);
   const normalizedSurfaceChannel = normalizeMessageChannel(ctx.Surface);

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   createPluginStateKeyedStore,
@@ -10,6 +11,7 @@ import {
   setMaxPluginStateEntriesPerPluginForTests,
 } from "../plugin-state/plugin-state-store.js";
 import { seedPluginStateEntriesForTests } from "../plugin-state/plugin-state-store.test-helpers.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { loadTaskFlowRegistryStateFromSqlite } from "../tasks/task-flow-registry.store.sqlite.js";
 import { loadTaskRegistryStateFromSqlite } from "../tasks/task-registry.store.sqlite.js";
 import {
@@ -236,6 +238,7 @@ async function runTelegramAllowFromMigration(params: { root: string; cfg: OpenCl
 afterEach(async () => {
   resetAutoMigrateLegacyStateForTest();
   resetAutoMigrateLegacyStateDirForTest();
+  closeOpenClawStateDatabaseForTest();
   setMaxPluginStateEntriesPerPluginForTests();
   resetPluginStateStoreForTests();
   mockedChannelMigrationPlans.plans = [];
@@ -252,7 +255,7 @@ function writeJson5(filePath: string, value: unknown) {
 
 function writeLegacySessionsFixture(params: {
   root: string;
-  sessions: Record<string, { sessionId: string; updatedAt: number }>;
+  sessions: Record<string, Record<string, unknown> & { sessionId: string; updatedAt: number }>;
   transcripts?: Record<string, string>;
 }) {
   const legacySessionsDir = path.join(params.root, "sessions");
@@ -588,6 +591,79 @@ describe("doctor legacy state migrations", () => {
     expect(store["agent:main:slack:channel:c123"]?.sessionId).toBe("c");
     expect(store["agent:main:unknown:group:abc"]?.sessionId).toBe("d");
     expect(store["agent:main:subagent:xyz"]?.sessionId).toBe("e");
+  });
+
+  it("migrates legacy ACP metadata from sessions.json into shared SQLite", async () => {
+    const root = await makeTempRoot();
+    const cfg: OpenClawConfig = {};
+    const legacySessionKey = "acp:binding:discord:default:feedface";
+    const sessionKey = "agent:main:acp:binding:discord:default:feedface";
+    writeLegacySessionsFixture({
+      root,
+      sessions: {
+        [legacySessionKey]: {
+          sessionId: "sess-acp",
+          updatedAt: 100,
+          acp: {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: "codex-discord",
+            mode: "persistent",
+            state: "idle",
+            lastActivityAt: 123,
+          },
+        },
+      },
+    });
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({
+      detected,
+      config: cfg,
+      now: () => 456,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes.some((change) => change.includes("ACP session metadata"))).toBe(true);
+    const storePath = path.join(root, "agents", "main", "sessions", "sessions.json");
+    const store = JSON.parse(fs.readFileSync(storePath, "utf8")) as Record<string, SessionEntry>;
+    expect(store[legacySessionKey]?.acp).toBeUndefined();
+
+    const sqlite = requireNodeSqlite();
+    const db = new sqlite.DatabaseSync(path.join(root, "state", "openclaw.sqlite"));
+    try {
+      const row = db
+        .prepare(
+          "SELECT backend, agent, runtime_session_name, mode, state, last_activity_at FROM acp_sessions WHERE session_key = ?",
+        )
+        .get(sessionKey) as
+        | {
+            backend: string;
+            agent: string;
+            runtime_session_name: string;
+            mode: string;
+            state: string;
+            last_activity_at: number | bigint;
+          }
+        | undefined;
+      expect(row).toMatchObject({
+        backend: "acpx",
+        agent: "codex",
+        runtime_session_name: "codex-discord",
+        mode: "persistent",
+        state: "idle",
+      });
+      expect(Number(row?.last_activity_at)).toBe(123);
+      const legacyRow = db
+        .prepare("SELECT session_key FROM acp_sessions WHERE session_key = ?")
+        .get(legacySessionKey);
+      expect(legacyRow).toBeUndefined();
+    } finally {
+      db.close();
+    }
   });
 
   it("keeps shipped WhatsApp legacy group keys channel-qualified during migration", async () => {

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { loadSessionStore } from "../config/sessions.js";
 import { resolveSessionFilePath } from "../config/sessions/paths.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import { resolveStoredSessionKeyForAgentStore } from "../gateway/session-store-key.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -317,8 +319,16 @@ function readFollowFileState(filePath: string): FollowFileState | null {
   }
 }
 
-function isRunningSession(entry: SessionEntry): boolean {
-  return entry.status === "running" || entry.acp?.state === "running";
+function isRunningSession(selection: TailSelection): boolean {
+  const cfg = getRuntimeConfig();
+  const acpMeta = readAcpSessionMeta({
+    sessionKey: resolveStoredSessionKeyForAgentStore({
+      cfg,
+      agentId: selection.agentId,
+      sessionKey: selection.key,
+    }),
+  });
+  return selection.entry.status === "running" || acpMeta?.state === "running";
 }
 
 function compareSelectionsByUpdatedAt(a: TailSelection, b: TailSelection): number {
@@ -360,7 +370,7 @@ function selectSessionsToTail(selections: TailSelection[], sessionKey?: string):
     return selections.filter((selection) => selection.key === requested);
   }
 
-  const running = selections.filter((selection) => isRunningSession(selection.entry));
+  const running = selections.filter((selection) => isRunningSession(selection));
   if (running.length > 0) {
     return running.toSorted(compareSelectionsByUpdatedAt);
   }

--- a/src/commands/sessions.acp-model-display.test.ts
+++ b/src/commands/sessions.acp-model-display.test.ts
@@ -1,5 +1,10 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   mockSessionsConfig,
   resetMockSessionsConfig,
@@ -26,12 +31,12 @@ import {
  * default. It never inspects the session key or the persisted ACP metadata.
  *
  * Decided fix shape (catalog #20, mirrors #18): SENTINEL OVERLAY at the call
- * site, gated on BOTH key shape AND persisted `entry.acp` metadata. Key shape
+ * site, gated on BOTH key shape AND persisted SQLite ACP metadata. Key shape
  * alone is not sufficient because ACP bridge sessions (translator.ts) also use
  * ACP-shaped keys without ever writing `SessionAcpMeta` — those sessions run
  * the normal configured model and must not receive the sentinel.
  *
- * When `isAcpSessionKey(row.key)` is true AND `entry.acp != null`, the
+ * When `isAcpSessionKey(row.key)` is true AND SQLite ACP metadata exists, the
  * JSON-emit path overlays `{ provider: "acpx", model: "<agentId>-acp" }` on
  * top of the resolver result. The resolver itself stays pure.
  *
@@ -60,6 +65,31 @@ const NON_ACP_SESSION_KEY = "agent:copilot:main";
 const AGENT_CONFIGURED_MODEL = "gpt-5.3-codex";
 const AGENT_CONFIGURED_PROVIDER = "microsoft-foundry";
 
+let originalStateDir: string | undefined;
+let tempStateDirs: string[] = [];
+
+function useTempStateDir(): string {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-acp-sessions-state-"));
+  tempStateDirs.push(stateDir);
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  return stateDir;
+}
+
+function writeAcpRuntimeMeta(sessionKey: string): void {
+  writeAcpSessionMetaForMigration({
+    sessionKey,
+    sessionId: "acp-bridge-session-id",
+    meta: {
+      backend: "copilot",
+      agent: "copilot",
+      runtimeSessionName: "acp-runtime-session-1",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: Date.now() - 2 * 60_000,
+    },
+  });
+}
+
 /**
  * Mock config with a `copilot` agent whose configured model is
  * `microsoft-foundry/gpt-5.3-codex` (the deployed scenario from the catalog).
@@ -86,35 +116,11 @@ function mockAgentConfigWithCopilotModel(): void {
 }
 
 /**
- * ACP control-plane session entry: includes `entry.acp` as persisted by
- * `src/acp/control-plane/manager.core.ts:365` during acpx child init. The
- * presence of `entry.acp` is the discriminator the overlay uses to distinguish
- * real ACP child-runtime sessions from ACP bridge sessions.
- *
- * No `model` / `modelProvider` set on the entry — the listing falls through
- * to the agent's configured default, which is the buggy path for ACP keys.
- */
-function buildAcpSessionEntry(): SessionEntry {
-  return {
-    sessionId: "acp-session-id",
-    updatedAt: Date.now() - 2 * 60_000,
-    acp: {
-      backend: "copilot",
-      agent: "copilot",
-      runtimeSessionName: "acp-runtime-session-1",
-      mode: "persistent",
-      state: "idle",
-      lastActivityAt: Date.now() - 2 * 60_000,
-    },
-  };
-}
-
-/**
- * ACP bridge session entry: ACP-shaped key but no `entry.acp`. The ACP bridge
+ * ACP bridge session entry: ACP-shaped key but no ACP metadata. The ACP bridge
  * (translator.ts) uses an in-memory-only session store and never writes
  * `SessionAcpMeta` to disk. If a bridge client passes an explicit ACP-shaped
  * key (e.g. `agent:copilot:acp:session-1`) and the Gateway persists the
- * session, it will have an ACP key without `entry.acp`. The overlay must NOT
+ * session, it will have an ACP key without ACP metadata. The overlay must NOT
  * fire for these sessions — they ran the configured model.
  */
 function buildAcpBridgeSessionEntry(): SessionEntry {
@@ -142,26 +148,39 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2025-12-06T00:00:00Z"));
+    originalStateDir = process.env.OPENCLAW_STATE_DIR;
     mockAgentConfigWithCopilotModel();
   });
 
   afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    for (const stateDir of tempStateDirs) {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+    tempStateDirs = [];
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
     resetMockSessionsConfig();
     vi.useRealTimers();
   });
 
   it("RED: ACP control-plane session must NOT report the agent-configured model", async () => {
     // RED before fix. The session is a real ACP control-plane session
-    // (key has the `:acp:` segment AND entry.acp is present), but
+    // (key has the `:acp:` segment AND SQLite ACP metadata is present), but
     // `resolveSessionDisplayModelRef` ignores both and returns the agent
     // default. Operators relying on `sessions --json` model fields see the
     // model the openclaw-agent-driven flow would have used, NOT what copilot
     // actually selected internally when it ran via ACP.
     //
     // The discriminator the fix uses: `isAcpSessionKey(row.key)` AND
-    // `entry.acp != null` (persisted by the ACP control plane manager).
+    // SQLite ACP metadata (persisted by the ACP control plane manager).
+    useTempStateDir();
+    writeAcpRuntimeMeta(ACP_SESSION_KEY);
     const store = writeStore(
-      { [ACP_SESSION_KEY]: buildAcpSessionEntry() },
+      { [ACP_SESSION_KEY]: buildAcpBridgeSessionEntry() },
       "sessions-acp-model-display-red",
     );
 
@@ -178,13 +197,13 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
         `model (${AGENT_CONFIGURED_MODEL}), not what copilot actually used inside ACP. ` +
         `resolveSessionDisplayModelRef (src/commands/sessions-display-model.ts:123) has zero ` +
         `ACP-awareness; the call site at src/commands/sessions.ts should consult ` +
-        `isAcpSessionKey(row.key) AND entry.acp != null, then overlay an ACP-runtime sentinel.`,
+        `isAcpSessionKey(row.key) AND SQLite ACP metadata exists, then overlay an ACP-runtime sentinel.`,
     ).not.toBe(AGENT_CONFIGURED_MODEL);
     expect(
       row?.modelProvider,
       `ACP session ${ACP_SESSION_KEY} reports modelProvider="${row?.modelProvider}" — the ` +
         `agent-configured provider (${AGENT_CONFIGURED_PROVIDER}), not the ACP runtime. ` +
-        `Same fix site as above; the overlay must gate on entry.acp presence.`,
+        `Same fix site as above; the overlay must gate on persisted ACP metadata.`,
     ).not.toBe(AGENT_CONFIGURED_PROVIDER);
   });
 
@@ -192,13 +211,15 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
     // RED before fix; GREEN once the catalog-#20 sentinel-overlay fix lands.
     //
     // The catalog's chosen fix shape: when `isAcpSessionKey(row.key)` is true
-    // AND `entry.acp != null`, overlay `{ provider: "acpx", model: "<agentId>-acp" }`.
+    // AND persisted ACP metadata exists, overlay `{ provider: "acpx", model: "<agentId>-acp" }`.
     // This trades model-name accuracy for "this is ACP control-plane, not the
     // agent default" clarity. Plumbing the actual copilot-side model selection
     // into the openclaw record would require capturing ACP `session.model_change`
     // events (catalog notes this as deferrable).
+    useTempStateDir();
+    writeAcpRuntimeMeta(ACP_SESSION_KEY);
     const store = writeStore(
-      { [ACP_SESSION_KEY]: buildAcpSessionEntry() },
+      { [ACP_SESSION_KEY]: buildAcpBridgeSessionEntry() },
       "sessions-acp-model-display-fix-shape",
     );
 
@@ -209,7 +230,7 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
     expect(
       row?.model,
       `ACP session ${ACP_SESSION_KEY} should resolve model to "copilot-acp" (the catalog-chosen ` +
-        `sentinel). Got "${row?.model}". Fix gates on isAcpSessionKey(row.key) AND entry.acp != null ` +
+        `sentinel). Got "${row?.model}". Fix gates on isAcpSessionKey(row.key) and persisted ACP metadata ` +
         `and overlays { provider: "acpx", model: "copilot-acp" }. Keeps resolveSessionDisplayModelRef pure.`,
     ).toBe("copilot-acp");
     expect(
@@ -220,9 +241,43 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
     ).toBe("acpx");
   });
 
-  it("GREEN control: ACP bridge session (ACP key, no entry.acp) reports the configured model", async () => {
+  it("reads ACP runtime metadata from SQLite for the display overlay", async () => {
+    useTempStateDir();
+    const store = writeStore(
+      { [ACP_SESSION_KEY]: buildAcpBridgeSessionEntry() },
+      "sessions-acp-model-display-sqlite",
+    );
+    writeAcpRuntimeMeta(ACP_SESSION_KEY);
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === ACP_SESSION_KEY);
+
+    expect(row).toBeDefined();
+    expect(row?.model).toBe("copilot-acp");
+    expect(row?.modelProvider).toBe("acpx");
+  });
+
+  it("canonicalizes raw ACP store keys before reading SQLite metadata", async () => {
+    useTempStateDir();
+    const rawStoreKey = "acp:binding:discord:default:feedface";
+    const canonicalAcpKey = "agent:copilot:acp:binding:discord:default:feedface";
+    const store = writeStore(
+      { [rawStoreKey]: buildAcpBridgeSessionEntry() },
+      "sessions-acp-model-display-canonical",
+    );
+    writeAcpRuntimeMeta(canonicalAcpKey);
+
+    const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+    const row = payload.sessions?.find((entry) => entry.key === rawStoreKey);
+
+    expect(row).toBeDefined();
+    expect(row?.model).toBe("copilot-acp");
+    expect(row?.modelProvider).toBe("acpx");
+  });
+
+  it("GREEN control: ACP bridge session (ACP key, no ACP metadata) reports the configured model", async () => {
     // ACP bridge sessions (translator.ts) use ACP-shaped keys but never
-    // persist SessionAcpMeta to disk. They run the normal configured model
+    // persist SessionAcpMeta. They run the normal configured model
     // and must NOT receive the acpx sentinel. This guards against a regression
     // where key-shape-only detection would misreport bridge sessions.
     const ACP_BRIDGE_SESSION_KEY = "agent:copilot:acp:bridge-session-1";
@@ -237,9 +292,9 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
     expect(row).toBeDefined();
     expect(
       row?.model,
-      `ACP bridge session ${ACP_BRIDGE_SESSION_KEY} has an ACP-shaped key but no entry.acp — ` +
+      `ACP bridge session ${ACP_BRIDGE_SESSION_KEY} has an ACP-shaped key but no ACP metadata — ` +
         `it ran the configured model. Got model="${row?.model}"; expected "${AGENT_CONFIGURED_MODEL}". ` +
-        `The overlay must gate on entry.acp != null, not key shape alone.`,
+        `The overlay must gate on persisted ACP metadata, not key shape alone.`,
     ).toBe(AGENT_CONFIGURED_MODEL);
     expect(
       row?.modelProvider,
@@ -258,7 +313,7 @@ describe("sessionsCommand model/modelProvider display for ACP sessions (catalog 
     //   2. The configured-model branch of resolveSessionDisplayModelRef
     //      remains correct for non-ACP keys; the proposed sentinel overlay
     //      must NOT break this case (it should only fire when both
-    //      isAcpSessionKey(row.key) is true AND entry.acp is present).
+    //      isAcpSessionKey(row.key) is true AND ACP metadata is present).
     const store = writeStore(
       { [NON_ACP_SESSION_KEY]: buildNonAcpSessionEntry() },
       "sessions-acp-model-display-green-control",

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -3,6 +3,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
+import { readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { resolveRuntimePolicySessionKey } from "../auto-reply/reply/runtime-policy-session-key.js";
@@ -11,6 +12,7 @@ import { getRuntimeConfig } from "../config/config.js";
 import { loadSessionStore, resolveSessionTotalTokens } from "../config/sessions.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveStoredSessionKeyForAgentStore } from "../gateway/session-store-key.js";
 import { info } from "../globals.js";
 import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
@@ -42,11 +44,10 @@ type SessionRow = SessionDisplayRow & {
   agentRuntime: ReturnType<typeof resolveModelAgentRuntimeMetadata>;
   runtimeLabel: string;
   /**
-   * True only when the session entry has persisted ACP runtime metadata
-   * (`entry.acp` is present). Key-shape alone is not sufficient because ACP
-   * bridge sessions (translator.ts) may use ACP-shaped keys without ever
-   * writing `SessionAcpMeta` — those use the normal configured model and must
-   * not be overlaid with the acpx sentinel.
+   * True only when the session has persisted ACP runtime metadata. Key-shape
+   * alone is not sufficient because ACP bridge sessions (translator.ts) may
+   * use ACP-shaped keys without ever writing `SessionAcpMeta` — those use the
+   * normal configured model and must not be overlaid with the acpx sentinel.
    */
   acpRuntime: boolean;
 };
@@ -65,7 +66,7 @@ const formatKTokens = (value: number) => `${(value / 1000).toFixed(value >= 10_0
  * Inline ACP model overlay — catalog #20.
  *
  * When a session ran via the ACP control plane (e.g. key =
- * `agent:copilot:acp:<uuid>` AND `entry.acp` is present), the agent's
+ * `agent:copilot:acp:<uuid>` AND ACP metadata is persisted), the agent's
  * configured model is irrelevant: the actual model is selected inside the ACP
  * child process. We overlay a sentinel `{ provider: "acpx",
  * model: "<agentId>-acp" }` so the listing clearly signals "ACP runtime" and
@@ -74,7 +75,7 @@ const formatKTokens = (value: number) => `${(value / 1000).toFixed(value >= 10_0
  * Key-shape alone is not sufficient: ACP bridge sessions (translator.ts) also
  * use ACP-shaped keys but never persist `SessionAcpMeta` — they run the
  * normal configured model and must not receive the sentinel. The `acpRuntime`
- * flag is set at row-construction time from `entry.acp != null`.
+ * flag is set at row-construction time from SQLite metadata.
  *
  * The resolver (`resolveSessionDisplayModelRef`) stays pure; this overlay
  * applies only at the emit sites in this file.
@@ -358,10 +359,19 @@ export async function sessionsCommand(
       .map(([key, entry]) => {
         const row = toSessionDisplayRow(key, entry);
         const agentId = parseAgentSessionKey(row.key)?.agentId ?? target.agentId;
-        const acpRuntime = entry?.acp != null;
+        const acpSessionKey = resolveStoredSessionKeyForAgentStore({
+          cfg,
+          agentId,
+          sessionKey: row.key,
+        });
+        const acpMeta = readAcpSessionMetaForEntry({
+          sessionKey: acpSessionKey,
+          entry,
+        });
+        const acpRuntime = acpMeta != null;
         const modelRef = applyAcpModelOverlayIfNeeded(
           resolveSessionDisplayModelRef(cfg, row),
-          row.key,
+          acpSessionKey,
           acpRuntime,
         );
         const agentRuntime = resolveModelAgentRuntimeMetadata({
@@ -369,9 +379,9 @@ export async function sessionsCommand(
           agentId,
           provider: modelRef.provider,
           model: modelRef.model,
-          sessionKey: row.key,
+          sessionKey: acpSessionKey,
           acpRuntime,
-          acpBackend: entry?.acp?.backend,
+          acpBackend: acpMeta?.backend,
         });
         return Object.assign({}, row, {
           agentId,
@@ -421,7 +431,11 @@ export async function sessionsCommand(
           const r = toJsonSessionRow(row);
           const modelRef = applyAcpModelOverlayIfNeeded(
             resolveSessionDisplayModelRef(cfg, r),
-            r.key,
+            resolveStoredSessionKeyForAgentStore({
+              cfg,
+              agentId: row.agentId,
+              sessionKey: r.key,
+            }),
             row.acpRuntime,
           );
           return {
@@ -484,7 +498,11 @@ export async function sessionsCommand(
   for (const row of rows) {
     const model = applyAcpModelOverlayIfNeeded(
       resolveSessionDisplayModelRef(cfg, row),
-      row.key,
+      resolveStoredSessionKeyForAgentStore({
+        cfg,
+        agentId: row.agentId,
+        sessionKey: row.key,
+      }),
       row.acpRuntime,
     ).model;
     const contextTokens =

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
+import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveConfiguredProviderFallback } from "../agents/configured-provider-fallback.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
@@ -11,6 +12,7 @@ import { parseModelRef, resolvePersistedSelectedModelRef } from "../agents/model
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { resolveStoredSessionKeyForAgentStore } from "../gateway/session-store-key.js";
 import { classifySessionKind } from "../sessions/classify-session-kind.js";
 import { resolveAgentRuntimeLabel } from "../status/agent-runtime-label.js";
 
@@ -158,14 +160,22 @@ function resolveSessionRuntimeLabel(params: {
   agentId?: string;
   sessionKey: string;
 }): string {
+  const acpSessionKey = params.agentId
+    ? resolveStoredSessionKeyForAgentStore({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      })
+    : params.sessionKey;
+  const acpMeta = readAcpSessionMeta({ sessionKey: acpSessionKey });
   const runtime = resolveModelAgentRuntimeMetadata({
     cfg: params.cfg,
     agentId: params.agentId ?? "",
     provider: params.provider,
     model: params.model,
-    sessionKey: params.sessionKey,
-    acpRuntime: params.entry?.acp != null,
-    acpBackend: params.entry?.acp?.backend,
+    sessionKey: acpSessionKey,
+    acpRuntime: acpMeta != null,
+    acpBackend: acpMeta?.backend,
   });
   const id = normalizeOptionalLowercaseString(runtime.id);
   const resolvedHarness = id && id !== "openclaw" && id !== "auto" ? id : undefined;

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -688,7 +688,7 @@ describe("sessions", () => {
     expect(store[sessionKey]?.modelProvider).toBeUndefined();
   });
 
-  it("upsertSessionEntry preserves existing ACP metadata by default", async () => {
+  it("upsertSessionEntry drops legacy embedded ACP metadata", async () => {
     const sessionKey = "agent:main:main";
     const acp = {
       backend: "codex",
@@ -720,7 +720,7 @@ describe("sessions", () => {
 
     const store = loadSessionStore(storePath);
     expect(store[sessionKey]?.sessionId).toBe("sess-2");
-    expect(store[sessionKey]?.acp).toStrictEqual(acp);
+    expect(store[sessionKey]?.acp).toBeUndefined();
   });
 
   it("updateSessionStore preserves concurrent additions", async () => {

--- a/src/config/sessions/runtime-types.ts
+++ b/src/config/sessions/runtime-types.ts
@@ -40,7 +40,6 @@ export type SessionMaintenanceApplyReportRuntime = {
 export type SaveSessionStoreOptions = {
   skipMaintenance?: boolean;
   activeSessionKey?: string;
-  allowDropAcpMetaSessionKeys?: string[];
   onWarn?: (warning: SessionMaintenanceWarningRuntime) => void | Promise<void>;
   onMaintenanceApplied?: (report: SessionMaintenanceApplyReportRuntime) => void | Promise<void>;
   maintenanceOverride?: Partial<ResolvedSessionMaintenanceConfigRuntime>;

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -947,7 +947,7 @@ describe("session store writer queue", () => {
     expect(store[key]?.model).toBeUndefined();
   });
 
-  it("preserves ACP metadata when replacing a session entry wholesale", async () => {
+  it("does not preserve legacy ACP metadata when replacing a session entry wholesale", async () => {
     const key = "agent:codex:acp:binding:discord:default:feedface";
     const acp = {
       backend: "acpx",
@@ -975,12 +975,12 @@ describe("session store writer queue", () => {
     });
 
     const store = loadSessionStore(storePath);
-    expect(store[key]?.acp).toEqual(acp);
+    expect(store[key]?.acp).toBeUndefined();
     expect(store[key]?.modelProvider).toBe("openai");
     expect(store[key]?.model).toBe("gpt-5.4");
   });
 
-  it("allows explicit ACP metadata removal through the ACP session helper", async () => {
+  it("removes legacy ACP metadata when the SQLite metadata row is cleared", async () => {
     const key = "agent:codex:acp:binding:discord:default:deadbeef";
     const { storePath } = await makeTmpStore({
       [key]: {

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -170,7 +170,7 @@ describe("session store key normalization", () => {
     const store = loadSessionStore(storePath, { skipCache: true });
     expect(Object.keys(store)).toEqual([CANONICAL_KEY]);
     expect(store[CANONICAL_KEY]?.sessionId).toBe("canonical-session");
-    expect(store[CANONICAL_KEY]?.acp?.runtimeSessionName).toBe("runtime-1");
+    expect(store[CANONICAL_KEY]?.acp).toBeUndefined();
   });
 
   it("preserves updatedAt when recording inbound metadata for an existing session", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -37,7 +37,7 @@ import {
   takeMutableSessionStoreCache,
   writeSessionStoreCache,
 } from "./store-cache.js";
-import { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
+import { resolveSessionStoreEntry } from "./store-entry.js";
 import {
   loadSessionStore,
   normalizeSessionStore,
@@ -156,12 +156,6 @@ type SaveSessionStoreOptions = {
   takeCacheOwnership?: boolean;
   /** Active session key for warn-only maintenance. */
   activeSessionKey?: string;
-  /**
-   * Session keys that are allowed to drop persisted ACP metadata during this update.
-   * All other updates preserve existing `entry.acp` blocks when callers replace the
-   * whole session entry without carrying ACP state forward.
-   */
-  allowDropAcpMetaSessionKeys?: string[];
   /** Optional callback for warn-only maintenance. */
   onWarn?: (warning: SessionMaintenanceWarning) => void | Promise<void>;
   /** Optional callback with maintenance stats after a save. */
@@ -502,64 +496,6 @@ function sessionEntriesHaveSameSerializedForm(
   return previous !== undefined && JSON.stringify(previous) === JSON.stringify(next);
 }
 
-function resolveMutableSessionStoreKey(
-  store: Record<string, SessionEntry>,
-  sessionKey: string,
-): string | undefined {
-  const trimmed = sessionKey.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  if (Object.hasOwn(store, trimmed)) {
-    return trimmed;
-  }
-  const normalized = normalizeStoreSessionKey(trimmed);
-  if (Object.hasOwn(store, normalized)) {
-    return normalized;
-  }
-  return Object.keys(store).find((key) => normalizeStoreSessionKey(key) === normalized);
-}
-
-function collectAcpMetadataSnapshot(
-  store: Record<string, SessionEntry>,
-): Map<string, NonNullable<SessionEntry["acp"]>> {
-  const snapshot = new Map<string, NonNullable<SessionEntry["acp"]>>();
-  for (const [sessionKey, entry] of Object.entries(store)) {
-    if (entry?.acp) {
-      snapshot.set(sessionKey, entry.acp);
-    }
-  }
-  return snapshot;
-}
-
-function preserveExistingAcpMetadata(params: {
-  previousAcpByKey: Map<string, NonNullable<SessionEntry["acp"]>>;
-  nextStore: Record<string, SessionEntry>;
-  allowDropSessionKeys?: string[];
-}): void {
-  const allowDrop = new Set(
-    (params.allowDropSessionKeys ?? []).map((key) => normalizeStoreSessionKey(key)),
-  );
-  for (const [previousKey, previousAcp] of params.previousAcpByKey.entries()) {
-    const normalizedKey = normalizeStoreSessionKey(previousKey);
-    if (allowDrop.has(normalizedKey)) {
-      continue;
-    }
-    const nextKey = resolveMutableSessionStoreKey(params.nextStore, previousKey);
-    if (!nextKey) {
-      continue;
-    }
-    const nextEntry = params.nextStore[nextKey];
-    if (!nextEntry || nextEntry.acp) {
-      continue;
-    }
-    params.nextStore[nextKey] = {
-      ...nextEntry,
-      acp: previousAcp,
-    };
-  }
-}
-
 async function saveSessionStoreUnlocked(
   storePath: string,
   store: Record<string, SessionEntry>,
@@ -857,17 +793,11 @@ export async function updateSessionStore<T>(
 ): Promise<T> {
   return await runExclusiveSessionStoreWrite(storePath, async () => {
     const store = loadMutableSessionStoreForWriter(storePath);
-    const previousAcpByKey = collectAcpMetadataSnapshot(store);
     const result = await mutator(store);
     if (opts?.skipSaveWhenResult?.(result)) {
       restoreUnchangedSessionStoreCache(storePath, store);
       return result;
     }
-    preserveExistingAcpMetadata({
-      previousAcpByKey,
-      nextStore: store,
-      allowDropSessionKeys: opts?.allowDropAcpMetaSessionKeys,
-    });
     await saveSessionStoreUnlocked(storePath, store, {
       ...opts,
       singleEntryPersistence: opts?.resolveSingleEntryPersistence?.(result) ?? undefined,
@@ -979,7 +909,6 @@ async function persistResolvedSessionEntry(params: {
   store: Record<string, SessionEntry>;
   resolved: ReturnType<typeof resolveSessionStoreEntry>;
   next: SessionEntry;
-  previousAcpByKey?: Map<string, NonNullable<SessionEntry["acp"]>>;
   skipMaintenance?: boolean;
   takeCacheOwnership?: boolean;
   returnDetached?: boolean;
@@ -991,12 +920,6 @@ async function persistResolvedSessionEntry(params: {
   params.store[params.resolved.normalizedKey] = next;
   for (const legacyKey of params.resolved.legacyKeys) {
     delete params.store[legacyKey];
-  }
-  if (params.previousAcpByKey) {
-    preserveExistingAcpMetadata({
-      previousAcpByKey: params.previousAcpByKey,
-      nextStore: params.store,
-    });
   }
   await saveSessionStoreUnlocked(params.storePath, params.store, {
     activeSessionKey: params.resolved.normalizedKey,
@@ -1116,7 +1039,6 @@ export async function upsertSessionEntry(
   params: SessionEntryWorkflowOptions & {
     sessionKey: string;
     entry: SessionEntry;
-    allowDropAcpMeta?: boolean;
   },
 ): Promise<void> {
   const storePath = resolveSessionWorkflowStorePath(params);
@@ -1124,9 +1046,6 @@ export async function upsertSessionEntry(
     const store = loadMutableSessionStoreForWriter(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
     const next = cloneSessionEntry(params.entry);
-    if (!params.allowDropAcpMeta && resolved.existing?.acp && !next.acp) {
-      next.acp = resolved.existing.acp;
-    }
     await persistResolvedSessionEntry({
       storePath,
       store,
@@ -1148,7 +1067,6 @@ export async function recordSessionMetaFromInbound(params: {
   const createIfMissing = params.createIfMissing ?? true;
   return await runExclusiveSessionStoreWrite(storePath, async () => {
     const store = loadMutableSessionStoreForWriter(storePath);
-    const previousAcpByKey = collectAcpMetadataSnapshot(store);
     const resolved = resolveSessionStoreEntry({ store, sessionKey });
     const existing = resolved.existing;
     const patch = deriveSessionMetaPatch({
@@ -1164,7 +1082,6 @@ export async function recordSessionMetaFromInbound(params: {
           store,
           resolved,
           next: existing,
-          previousAcpByKey,
           takeCacheOwnership: true,
           returnDetached: true,
         });
@@ -1192,7 +1109,6 @@ export async function recordSessionMetaFromInbound(params: {
       store,
       resolved,
       next,
-      previousAcpByKey,
       takeCacheOwnership: true,
       returnDetached: true,
     });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -21,6 +21,7 @@ import {
   validateAgentParams,
   validateAgentWaitParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import { listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { resolveTrustedGroupId } from "../../agents/agent-tools.policy.js";
 import {
@@ -1296,7 +1297,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       if (normalizedAttachments.length > 0) {
         let baseProvider: string | undefined;
         let baseModel: string | undefined;
-        let requestedSessionEntry: SessionEntry | undefined;
+        let requestedAcpMeta: ReturnType<typeof readAcpSessionMeta>;
         if (requestedSessionKeyRaw) {
           const {
             cfg: sessCfg,
@@ -1306,7 +1307,6 @@ export const agentHandlers: GatewayRequestHandlers = {
             ...(agentId ? { agentId } : {}),
             clone: false,
           });
-          requestedSessionEntry = sessEntry;
           const sessionAgentId =
             sessCanonicalKey === "global" && agentId
               ? agentId
@@ -1314,13 +1314,14 @@ export const agentHandlers: GatewayRequestHandlers = {
           const modelRef = resolveSessionModelRef(sessCfg, sessEntry, sessionAgentId);
           baseProvider = modelRef.provider;
           baseModel = modelRef.model;
+          requestedAcpMeta = readAcpSessionMeta({ sessionKey: sessCanonicalKey });
         }
         const effectiveProvider = providerOverride || baseProvider;
         const effectiveModel = modelOverride || baseModel;
         const isConfirmedAcpSession =
           request.acpTurnSource === "manual_spawn" &&
           isAcpSessionKey(requestedSessionKeyRaw) &&
-          requestedSessionEntry?.acp != null;
+          requestedAcpMeta != null;
         const supportsInlineImages = isConfirmedAcpSession
           ? true
           : await resolveGatewayModelSupportsImages({

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -31,6 +31,7 @@ import {
   validateSessionsResolveParams,
   validateSessionsSendParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../../agents/agent-runtime-metadata.js";
 import {
   listAgentIds,
@@ -2330,14 +2331,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       provider: resolved.provider,
       model: resolved.model,
     });
+    const acpMeta = readAcpSessionMeta({ sessionKey: target.canonicalKey ?? key });
     const agentRuntime = resolveModelAgentRuntimeMetadata({
       cfg,
       agentId,
       provider: resolvedDisplayModel.provider,
       model: resolvedDisplayModel.model,
       sessionKey: target.canonicalKey ?? key,
-      acpRuntime: applied.entry?.acp != null,
-      acpBackend: applied.entry?.acp?.backend,
+      acpRuntime: acpMeta != null,
+      acpBackend: acpMeta?.backend,
     });
     const result: SessionsPatchResult = {
       ok: true,

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { expect, test } from "vitest";
+import { afterEach, expect, test } from "vitest";
+import {
+  readAcpSessionMeta,
+  writeAcpSessionMetaForMigration,
+} from "../acp/runtime/session-meta.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { embeddedRunMock, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
@@ -18,6 +23,10 @@ import {
 } from "./test/server-sessions.test-helpers.js";
 
 const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
 
 function expectObject(value: unknown) {
   if (!value || typeof value !== "object") {
@@ -209,16 +218,18 @@ test("sessions.delete closes ACP runtime handles before removing ACP sessions", 
   await writeSessionStore({
     entries: {
       main: sessionStoreEntry("sess-main"),
-      "discord:group:dev": sessionStoreEntry("sess-acp", {
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "runtime:delete",
-          mode: "persistent",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
-      }),
+      "discord:group:dev": sessionStoreEntry("sess-acp"),
+    },
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:discord:group:dev",
+    meta: {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "runtime:delete",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: Date.now(),
     },
   });
   const deleted = await directSessionReq<{ ok: true; deleted: boolean }>("sessions.delete", {
@@ -257,6 +268,7 @@ test("sessions.delete closes ACP runtime handles before removing ACP sessions", 
   expectObject(cancelSessionCall?.cfg);
   expect(cancelSessionCall?.reason).toBe("session-delete");
   expect(cancelSessionCall?.sessionKey).toBe("agent:main:discord:group:dev");
+  expect(readAcpSessionMeta({ sessionKey: "agent:main:discord:group:dev" })).toBeUndefined();
 });
 
 test("sessions.delete closes child ACP runtimes spawned from the deleted parent", async () => {
@@ -277,12 +289,19 @@ test("sessions.delete closes child ACP runtimes spawned from the deleted parent"
   await writeSessionStore({
     entries: {
       main: sessionStoreEntry("sess-main"),
-      "acp-parent": sessionStoreEntry("sess-parent", { acp: acpMeta("agent:main:acp-parent") }),
+      "acp-parent": sessionStoreEntry("sess-parent"),
       "acp-child": sessionStoreEntry("sess-child", {
         spawnedBy: "agent:main:acp-parent",
-        acp: acpMeta("agent:main:acp-child"),
       }),
     },
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:acp-parent",
+    meta: acpMeta("agent:main:acp-parent"),
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:acp-child",
+    meta: acpMeta("agent:main:acp-child"),
   });
 
   const deleted = await directSessionReq<{ ok: true; deleted: boolean }>("sessions.delete", {
@@ -298,6 +317,8 @@ test("sessions.delete closes child ACP runtimes spawned from the deleted parent"
   ).map((call) => call[0]?.sessionKey);
   expect(closedKeys).toContain("agent:main:acp-parent");
   expect(closedKeys).toContain("agent:main:acp-child");
+  expect(readAcpSessionMeta({ sessionKey: "agent:main:acp-parent" })).toBeUndefined();
+  expect(readAcpSessionMeta({ sessionKey: "agent:main:acp-child" })).toBeUndefined();
 });
 
 test("sessions.delete emits session_end with deleted reason and no replacement", async () => {

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -1,8 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { expect, test, vi } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  readAcpSessionMeta,
+  writeAcpSessionMetaForMigration,
+} from "../acp/runtime/session-meta.js";
 import type { SessionAcpMeta } from "../config/sessions/types.js";
 import { enqueueSystemEvent, peekSystemEvents } from "../infra/system-events.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { embeddedRunMock, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
@@ -21,6 +26,10 @@ import {
 } from "./test/server-sessions.test-helpers.js";
 
 const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsTestHarness();
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
 
 function expectResetAcpState(
   acp:
@@ -167,57 +176,42 @@ test("sessions.reset closes ACP runtime handles for ACP sessions", async () => {
 
   await writeSessionStore({
     entries: {
-      main: sessionStoreEntry("sess-main", {
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "runtime:reset",
-          identity: {
-            state: "resolved",
-            acpxRecordId: "agent:main:main",
-            acpxSessionId: "backend-session-1",
-            source: "status",
-            lastUpdatedAt: Date.now(),
-          },
-          mode: "persistent",
-          runtimeOptions: {
-            runtimeMode: "auto",
-            timeoutSeconds: 30,
-          },
-          cwd: "/tmp/acp-session",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
-      }),
+      main: sessionStoreEntry("sess-main"),
+    },
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:main",
+    meta: {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "runtime:reset",
+      identity: {
+        state: "resolved",
+        acpxRecordId: "agent:main:main",
+        acpxSessionId: "backend-session-1",
+        source: "status",
+        lastUpdatedAt: Date.now(),
+      },
+      mode: "persistent",
+      runtimeOptions: {
+        runtimeMode: "auto",
+        timeoutSeconds: 30,
+      },
+      cwd: "/tmp/acp-session",
+      state: "idle",
+      lastActivityAt: Date.now(),
     },
   });
   const reset = await directSessionReq<{
     ok: true;
     key: string;
-    entry: {
-      acp?: {
-        backend?: string;
-        agent?: string;
-        runtimeSessionName?: string;
-        identity?: {
-          state?: string;
-          acpxRecordId?: string;
-          acpxSessionId?: string;
-        };
-        mode?: string;
-        runtimeOptions?: {
-          runtimeMode?: string;
-          timeoutSeconds?: number;
-        };
-        cwd?: string;
-        state?: string;
-      };
-    };
+    entry: Record<string, unknown>;
   }>("sessions.reset", {
     key: "main",
   });
   expect(reset.ok).toBe(true);
-  expectResetAcpState(reset.payload?.entry.acp);
+  expect(reset.payload?.entry).not.toHaveProperty("acp");
+  expectResetAcpState(readAcpSessionMeta({ sessionKey: "agent:main:main" }));
   expect(acpManagerMocks.closeSession).toHaveBeenCalledTimes(1);
   const closeSessionCall = acpManagerMocks.closeSession.mock.calls.at(0) as unknown as
     | [
@@ -274,7 +268,8 @@ test("sessions.reset closes ACP runtime handles for ACP sessions", async () => {
       };
     }
   >;
-  expectResetAcpState(store["agent:main:main"]?.acp);
+  expect(store["agent:main:main"]).not.toHaveProperty("acp");
+  expectResetAcpState(readAcpSessionMeta({ sessionKey: "agent:main:main" }));
 });
 
 test("sessions.reset closes child ACP runtime handles spawned from the parent", async () => {
@@ -290,58 +285,66 @@ test("sessions.reset closes child ACP runtime handles spawned from the parent", 
 
   await writeSessionStore({
     entries: {
-      main: sessionStoreEntry("sess-main", {
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "runtime:reset",
-          identity: {
-            state: "resolved",
-            acpxRecordId: "agent:main:main",
-            acpxSessionId: "backend-session-main",
-            source: "status",
-            lastUpdatedAt: Date.now(),
-          },
-          mode: "persistent",
-          cwd: "/tmp/acp-session",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
-      }),
+      main: sessionStoreEntry("sess-main"),
       "acp-child-1": sessionStoreEntry("sess-child-1", {
         spawnedBy: "agent:main:main",
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "runtime:child-1",
-          identity: {
-            state: "resolved",
-            acpxRecordId: "agent:main:acp-child-1",
-            acpxSessionId: "backend-session-child-1",
-            source: "status",
-            lastUpdatedAt: Date.now(),
-          },
-          mode: "oneshot",
-          cwd: "/tmp/acp-session",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
       }),
       "not-acp-child": sessionStoreEntry("sess-not-acp-child", {
         spawnedBy: "agent:main:main",
       }),
       "unrelated-acp-child": sessionStoreEntry("sess-unrelated-acp-child", {
         spawnedBy: "agent:main:other",
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "runtime:unrelated",
-          mode: "oneshot",
-          cwd: "/tmp/acp-session",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
       }),
+    },
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:main",
+    meta: {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "runtime:reset",
+      identity: {
+        state: "resolved",
+        acpxRecordId: "agent:main:main",
+        acpxSessionId: "backend-session-main",
+        source: "status",
+        lastUpdatedAt: Date.now(),
+      },
+      mode: "persistent",
+      cwd: "/tmp/acp-session",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    },
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:acp-child-1",
+    meta: {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "runtime:child-1",
+      identity: {
+        state: "resolved",
+        acpxRecordId: "agent:main:acp-child-1",
+        acpxSessionId: "backend-session-child-1",
+        source: "status",
+        lastUpdatedAt: Date.now(),
+      },
+      mode: "oneshot",
+      cwd: "/tmp/acp-session",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    },
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:unrelated-acp-child",
+    meta: {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "runtime:unrelated",
+      mode: "oneshot",
+      cwd: "/tmp/acp-session",
+      state: "idle",
+      lastActivityAt: Date.now(),
     },
   });
 
@@ -381,14 +384,6 @@ test("sessions.reset closes a spawned ACP child that lives in a different agent 
       main: {
         sessionId: "sess-main",
         updatedAt: Date.now(),
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "runtime:main",
-          mode: "persistent",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
       },
     }),
     "utf-8",
@@ -400,18 +395,32 @@ test("sessions.reset closes a spawned ACP child that lives in a different agent 
         sessionId: "sess-codex-child",
         updatedAt: Date.now(),
         spawnedBy: "agent:main:main",
-        acp: {
-          backend: "acpx",
-          agent: "codex",
-          runtimeSessionName: "runtime:codex-child",
-          mode: "oneshot",
-          state: "idle",
-          lastActivityAt: Date.now(),
-        },
       },
     }),
     "utf-8",
   );
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:main",
+    meta: {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "runtime:main",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    },
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:codex:acp:cross-store-child",
+    meta: {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "runtime:codex-child",
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    },
+  });
 
   const reset = await directSessionReq<{ ok: true }>("sessions.reset", { key: "main" });
   expect(reset.ok).toBe(true);
@@ -451,23 +460,31 @@ test("sessions.reset closes child ACP runtimes concurrently so stuck children do
 
   await writeSessionStore({
     entries: {
-      main: sessionStoreEntry("sess-main", { acp: childAcp("agent:main:main") }),
+      main: sessionStoreEntry("sess-main"),
       // Mix the two real lineage fields: ACP spawns record `spawnedBy`,
       // subagent spawns record `parentSessionKey`; both must be cleaned up.
       "acp-child-1": sessionStoreEntry("sess-c1", {
         spawnedBy: "agent:main:main",
-        acp: childAcp("agent:main:acp-child-1"),
       }),
       "acp-child-2": sessionStoreEntry("sess-c2", {
         spawnedBy: "agent:main:main",
-        acp: childAcp("agent:main:acp-child-2"),
       }),
       "acp-child-3": sessionStoreEntry("sess-c3", {
         parentSessionKey: "agent:main:main",
-        acp: childAcp("agent:main:acp-child-3"),
       }),
     },
   });
+  for (const sessionKey of [
+    "agent:main:main",
+    "agent:main:acp-child-1",
+    "agent:main:acp-child-2",
+    "agent:main:acp-child-3",
+  ]) {
+    writeAcpSessionMetaForMigration({
+      sessionKey,
+      meta: childAcp(sessionKey),
+    });
+  }
 
   // Parent cancel resolves immediately; child cancels hang until released. With
   // sequential cleanup only the first child would dispatch; concurrent cleanup

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { ErrorCodes, errorShape } from "../../packages/gateway-protocol/src/index.js";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { getAcpRuntimeBackend } from "../acp/runtime/registry.js";
-import { readAcpSessionEntry, upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
+import {
+  readAcpSessionMeta,
+  upsertAcpSessionMeta,
+  writeAcpSessionMetaForMigration,
+} from "../acp/runtime/session-meta.js";
 import { retireSessionMcpRuntime } from "../agents/agent-bundle-mcp-tools.js";
 import {
   listAgentIds,
@@ -437,10 +441,27 @@ async function runAcpCleanupStep(params: {
 async function closeAcpRuntimeForSession(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
-  entry?: SessionEntry;
+  fallbackSessionKeys?: Array<string | undefined>;
   reason: "session-reset" | "session-delete";
+  onResetMeta?: (params: { sessionKey: string; meta: SessionAcpMeta }) => void;
 }) {
-  if (!params.entry?.acp) {
+  const sessionKeys = Array.from(
+    new Set(
+      [params.sessionKey, ...(params.fallbackSessionKeys ?? [])]
+        .map((key) => (typeof key === "string" ? key.trim() : ""))
+        .filter(Boolean),
+    ),
+  );
+  let acpMeta: SessionAcpMeta | undefined;
+  let acpSessionKey = params.sessionKey;
+  for (const sessionKey of sessionKeys) {
+    acpMeta = readAcpSessionMeta({ sessionKey });
+    if (acpMeta) {
+      acpSessionKey = sessionKey;
+      break;
+    }
+  }
+  if (!acpMeta) {
     return undefined;
   }
   const acpManager = getAcpSessionManager();
@@ -448,7 +469,7 @@ async function closeAcpRuntimeForSession(params: {
     op: async () => {
       await acpManager.cancelSession({
         cfg: params.cfg,
-        sessionKey: params.sessionKey,
+        sessionKey: acpSessionKey,
         reason: params.reason,
       });
     },
@@ -469,7 +490,7 @@ async function closeAcpRuntimeForSession(params: {
     op: async () => {
       await acpManager.closeSession({
         cfg: params.cfg,
-        sessionKey: params.sessionKey,
+        sessionKey: acpSessionKey,
         reason: params.reason,
         discardPersistentState: true,
         requireAcpSession: false,
@@ -488,12 +509,23 @@ async function closeAcpRuntimeForSession(params: {
       `sessions.${params.reason}: ACP runtime close failed for ${params.sessionKey}: ${String(closeOutcome.error)}`,
     );
   }
-  await ensureFreshAcpResetState({
-    cfg: params.cfg,
-    sessionKey: params.sessionKey,
-    reason: params.reason,
-    entry: params.entry,
-  });
+  if (params.reason === "session-delete") {
+    await upsertAcpSessionMeta({
+      cfg: params.cfg,
+      sessionKey: acpSessionKey,
+      mutate: () => null,
+    });
+  } else {
+    const resetMeta = await ensureFreshAcpResetState({
+      cfg: params.cfg,
+      sessionKey: acpSessionKey,
+      reason: params.reason,
+      acpMeta,
+    });
+    if (resetMeta) {
+      params.onResetMeta?.({ sessionKey: acpSessionKey, meta: resetMeta });
+    }
+  }
   return undefined;
 }
 
@@ -524,21 +556,21 @@ async function ensureFreshAcpResetState(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   reason: "session-reset" | "session-delete";
-  entry?: SessionEntry;
-}): Promise<void> {
-  if (params.reason !== "session-reset" || !params.entry?.acp) {
-    return;
+  acpMeta: SessionAcpMeta;
+}): Promise<SessionAcpMeta | undefined> {
+  if (params.reason !== "session-reset") {
+    return undefined;
   }
-  const latestMeta = readAcpSessionEntry({
-    cfg: params.cfg,
-    sessionKey: params.sessionKey,
-  })?.acp;
+  const latestMeta =
+    readAcpSessionMeta({
+      sessionKey: params.sessionKey,
+    }) ?? params.acpMeta;
   if (
     !latestMeta?.identity ||
     latestMeta.identity.state !== "resolved" ||
     (!latestMeta.identity.acpxSessionId && !latestMeta.identity.agentSessionId)
   ) {
-    return;
+    return undefined;
   }
 
   const backendId = (latestMeta.backend || params.cfg.acp?.backend || "").trim() || undefined;
@@ -553,17 +585,16 @@ async function ensureFreshAcpResetState(params: {
   }
 
   const now = Date.now();
+  let resetMeta: SessionAcpMeta | undefined;
   await upsertAcpSessionMeta({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
-    mutate: (current, entry) => {
-      const base = current ?? entry?.acp;
-      if (!base) {
-        return null;
-      }
-      return buildPendingAcpMeta(base, now);
+    mutate: (current) => {
+      resetMeta = buildPendingAcpMeta(current ?? latestMeta, now);
+      return resetMeta;
     },
   });
+  return resetMeta;
 }
 
 async function closeChildAcpRuntimesForParent(params: {
@@ -577,12 +608,15 @@ async function closeChildAcpRuntimesForParent(params: {
   // parent's under the default per-agent layout. The combined gateway store
   // aggregates all agent stores under canonical keys (same source the dashboard
   // session list uses).
-  let children: Array<{ sessionKey: string; entry: SessionEntry }>;
+  let children: Array<{ sessionKey: string }>;
   try {
     children = findDirectChildSessionsForParent({
       cfg: params.cfg,
       parentKey: params.parentKey,
-    }).filter(({ entry }) => entry.acp);
+    }).flatMap(({ sessionKey }) => {
+      const acpMeta = readAcpSessionMeta({ sessionKey });
+      return acpMeta ? [{ sessionKey }] : [];
+    });
   } catch (error) {
     logVerbose(
       `sessions.${params.reason}: failed to enumerate sessions for child ACP cleanup: ${String(error)}`,
@@ -597,11 +631,10 @@ async function closeChildAcpRuntimesForParent(params: {
   // children; per-child failures are logged best-effort and never propagated,
   // so a stuck child cannot block or fail the parent mutation.
   await Promise.allSettled(
-    children.map(({ sessionKey, entry }) =>
+    children.map(({ sessionKey }) =>
       closeAcpRuntimeForSession({
         cfg: params.cfg,
         sessionKey,
-        entry,
         reason: params.reason,
       }).then((childError) => {
         if (childError) {
@@ -620,6 +653,7 @@ export async function cleanupSessionBeforeMutation(params: {
   legacyKey?: string;
   canonicalKey?: string;
   reason: "session-reset" | "session-delete";
+  onAcpResetMeta?: (params: { sessionKey: string; meta: SessionAcpMeta }) => void;
 }) {
   const cleanupError = await ensureSessionRuntimeCleanup({
     cfg: params.cfg,
@@ -641,11 +675,13 @@ export async function cleanupSessionBeforeMutation(params: {
       `plugin host cleanup failed for ${failure.pluginId}/${failure.hookId}: ${String(failure.error)}`,
     );
   }
+  const parentSessionKey = params.target.canonicalKey ?? params.canonicalKey ?? params.key;
   const parentAcpError = await closeAcpRuntimeForSession({
     cfg: params.cfg,
-    sessionKey: params.legacyKey ?? params.canonicalKey ?? params.target.canonicalKey ?? params.key,
-    entry: params.entry,
+    sessionKey: parentSessionKey,
+    fallbackSessionKeys: [params.canonicalKey, params.legacyKey, params.key],
     reason: params.reason,
+    onResetMeta: params.onAcpResetMeta,
   });
   await closeChildAcpRuntimesForParent({
     cfg: params.cfg,
@@ -760,6 +796,7 @@ export async function performGatewaySessionReset(params: {
   const hadExistingEntry = Boolean(entry);
   const agentId = normalizeAgentId(target.agentId ?? resolveDefaultAgentId(cfg));
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+  let pendingAcpResetMeta: { sessionKey: string; meta: SessionAcpMeta } | undefined;
   const hookEvent = createInternalHookEvent(
     "command",
     params.reason,
@@ -781,6 +818,9 @@ export async function performGatewaySessionReset(params: {
     legacyKey,
     canonicalKey,
     reason: "session-reset",
+    onAcpResetMeta: (meta) => {
+      pendingAcpResetMeta = meta;
+    },
   });
   if (mutationCleanupError) {
     return { ok: false, error: mutationCleanupError };
@@ -888,7 +928,6 @@ export async function performGatewaySessionReset(params: {
       // sessions (Signal DMs/groups in particular) otherwise keep advertising a
       // stale <available_skills> block even after reset/restart, because the
       // skills snapshot version is runtime-local and may reset to 0.
-      acp: currentEntry?.acp,
       inputTokens: 0,
       outputTokens: 0,
       totalTokens: 0,
@@ -906,6 +945,13 @@ export async function performGatewaySessionReset(params: {
     store[primaryKey] = nextEntry;
     return nextEntry;
   });
+  if (pendingAcpResetMeta) {
+    writeAcpSessionMetaForMigration({
+      sessionKey: pendingAcpResetMeta.sessionKey,
+      sessionId: next.sessionId,
+      meta: pendingAcpResetMeta.meta,
+    });
+  }
   await emitGatewayBeforeResetPluginHook({
     cfg,
     key: params.key,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -7,6 +7,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
+import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import {
   listAgentIds,
@@ -2037,14 +2038,20 @@ export function buildGatewaySessionRow(params: {
       });
   const rowModelProvider = rowModelIdentity.provider;
   const rowModel = rowModelIdentity.model;
+  const acpSessionKey = resolveStoredSessionKeyForAgentStore({
+    cfg,
+    agentId: sessionAgentId,
+    sessionKey: key,
+  });
+  const acpMeta = readAcpSessionMeta({ sessionKey: acpSessionKey });
   const agentRuntime = resolveModelAgentRuntimeMetadata({
     cfg,
     agentId: sessionAgentId,
     provider: rowModelProvider,
     model: rowModel,
-    sessionKey: key,
-    acpRuntime: entry?.acp != null,
-    acpBackend: entry?.acp?.backend,
+    sessionKey: acpSessionKey,
+    acpRuntime: acpMeta != null,
+    acpBackend: acpMeta?.backend,
   });
   const estimatedCostUsd = lightweight
     ? resolveNonNegativeNumber(entry?.estimatedCostUsd)

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { writeAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   listBundledChannelLegacySessionSurfaces,
@@ -18,6 +19,7 @@ import {
 import type { SessionEntry } from "../config/sessions.js";
 import { saveSessionStore } from "../config/sessions.js";
 import { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
+import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 import type { SessionScope } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -2342,6 +2344,11 @@ export async function runLegacyStateMigrations(params: {
   const sessions = await migrateLegacySessions(detected, now, {
     recoverCorruptTargetStore: params.recoverCorruptTargetStore,
   });
+  const acpSessionMetadata = await migrateLegacyAcpSessionMetadata({
+    cfg: params.config ?? ({} as OpenClawConfig),
+    env: { ...process.env, OPENCLAW_STATE_DIR: detected.stateDir },
+    now,
+  });
   const agentDir = await migrateLegacyAgentDir(detected, now);
   const channelPlans = await runLegacyMigrationPlans(
     detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
@@ -2353,6 +2360,7 @@ export async function runLegacyStateMigrations(params: {
       ...preSessionChannelPlans.changes,
       ...pluginPlans.changes,
       ...sessions.changes,
+      ...acpSessionMetadata.changes,
       ...agentDir.changes,
       ...channelPlans.changes,
     ],
@@ -2362,6 +2370,7 @@ export async function runLegacyStateMigrations(params: {
       ...preSessionChannelPlans.warnings,
       ...pluginPlans.warnings,
       ...sessions.warnings,
+      ...acpSessionMetadata.warnings,
       ...agentDir.warnings,
       ...channelPlans.warnings,
     ],
@@ -2527,6 +2536,80 @@ export async function migrateOrphanedSessionKeys(params: {
   return { changes, warnings };
 }
 
+async function migrateLegacyAcpSessionMetadata(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  now?: () => number;
+}): Promise<{ changes: string[]; warnings: string[] }> {
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const env = params.env ?? process.env;
+  const now = params.now ?? (() => Date.now());
+  const targets = resolveAllAgentSessionStoreTargetsSync(params.cfg, { env });
+  const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
+  const scope = params.cfg.session?.scope as SessionScope | undefined;
+  const seenStorePaths = new Set<string>();
+
+  for (const target of targets) {
+    const storePath = target.storePath;
+    if (seenStorePaths.has(storePath) || !fileExists(storePath)) {
+      continue;
+    }
+    seenStorePaths.add(storePath);
+    let parsed: ReturnType<typeof readSessionStoreJson5>;
+    try {
+      parsed = readSessionStoreJson5(storePath);
+    } catch (err) {
+      warnings.push(`Could not read ${storePath}: ${String(err)}`);
+      continue;
+    }
+    if (!parsed.ok) {
+      continue;
+    }
+
+    const normalized: Record<string, SessionEntry> = {};
+    let migrated = 0;
+    for (const [sessionKey, entry] of Object.entries(parsed.store)) {
+      const normalizedEntry = normalizeSessionEntry(entry);
+      if (!normalizedEntry) {
+        continue;
+      }
+      if (normalizedEntry.acp) {
+        const canonicalSessionKey = canonicalizeSessionKeyForAgent({
+          key: sessionKey,
+          agentId: target.agentId,
+          mainKey,
+          scope,
+          skipCrossAgentRemap: true,
+        });
+        writeAcpSessionMetaForMigration({
+          sessionKey: canonicalSessionKey,
+          sessionId: normalizedEntry.sessionId,
+          meta: normalizedEntry.acp,
+          env,
+          now,
+        });
+        delete normalizedEntry.acp;
+        migrated++;
+      }
+      normalized[sessionKey] = normalizedEntry;
+    }
+    if (migrated === 0) {
+      continue;
+    }
+    try {
+      await saveSessionStore(storePath, normalized, { skipMaintenance: true });
+      changes.push(
+        `Migrated ${migrated} ACP session metadata ${migrated === 1 ? "row" : "rows"} → shared SQLite state`,
+      );
+    } catch (err) {
+      warnings.push(`Failed to write ACP metadata migration source ${storePath}: ${String(err)}`);
+    }
+  }
+
+  return { changes, warnings };
+}
+
 function resolveStorePathFromTemplate(
   template: string,
   agentId: string,
@@ -2572,6 +2655,11 @@ export async function autoMigrateLegacyState(params: {
     cfg: params.cfg,
     env,
   });
+  const acpSessionMetadata = await migrateLegacyAcpSessionMetadata({
+    cfg: params.cfg,
+    env,
+    now: params.now,
+  });
 
   const logMigrationResults = (changes: string[], warnings: string[]) => {
     const logger = params.log ?? createSubsystemLogger("state-migrations");
@@ -2610,6 +2698,7 @@ export async function autoMigrateLegacyState(params: {
     const changes = [
       ...stateDirResult.changes,
       ...orphanKeys.changes,
+      ...acpSessionMetadata.changes,
       ...pluginStateSidecar.changes,
       ...taskStateSidecars.changes,
       ...preSessionChannelPlans.changes,
@@ -2618,6 +2707,7 @@ export async function autoMigrateLegacyState(params: {
     const warnings = [
       ...stateDirResult.warnings,
       ...orphanKeys.warnings,
+      ...acpSessionMetadata.warnings,
       ...pluginStateSidecar.warnings,
       ...taskStateSidecars.warnings,
       ...preSessionChannelPlans.warnings,
@@ -2628,6 +2718,7 @@ export async function autoMigrateLegacyState(params: {
       migrated:
         stateDirResult.migrated ||
         orphanKeys.changes.length > 0 ||
+        acpSessionMetadata.changes.length > 0 ||
         pluginStateSidecar.changes.length > 0 ||
         taskStateSidecars.changes.length > 0 ||
         preSessionChannelPlans.changes.length > 0 ||
@@ -2645,11 +2736,22 @@ export async function autoMigrateLegacyState(params: {
     !detected.pluginStateSidecar.hasLegacy &&
     !detected.taskStateSidecars.hasLegacy
   ) {
-    const changes = [...stateDirResult.changes, ...orphanKeys.changes];
-    const warnings = [...stateDirResult.warnings, ...orphanKeys.warnings];
+    const changes = [
+      ...stateDirResult.changes,
+      ...orphanKeys.changes,
+      ...acpSessionMetadata.changes,
+    ];
+    const warnings = [
+      ...stateDirResult.warnings,
+      ...orphanKeys.warnings,
+      ...acpSessionMetadata.warnings,
+    ];
     logMigrationResults(changes, warnings);
     return {
-      migrated: stateDirResult.migrated || orphanKeys.changes.length > 0,
+      migrated:
+        stateDirResult.migrated ||
+        orphanKeys.changes.length > 0 ||
+        acpSessionMetadata.changes.length > 0,
       skipped: false,
       changes,
       warnings,
@@ -2673,6 +2775,11 @@ export async function autoMigrateLegacyState(params: {
   const sessions = await migrateLegacySessions(detected, now, {
     recoverCorruptTargetStore: params.recoverCorruptTargetStore,
   });
+  const postSessionAcpMetadata = await migrateLegacyAcpSessionMetadata({
+    cfg: params.cfg,
+    env,
+    now,
+  });
   const agentDir = await migrateLegacyAgentDir(detected, now);
   const channelPlans = await runLegacyMigrationPlans(
     detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
@@ -2680,22 +2787,26 @@ export async function autoMigrateLegacyState(params: {
   const changes = [
     ...stateDirResult.changes,
     ...orphanKeys.changes,
+    ...acpSessionMetadata.changes,
     ...pluginStateSidecar.changes,
     ...taskStateSidecars.changes,
     ...preSessionChannelPlans.changes,
     ...pluginPlans.changes,
     ...sessions.changes,
+    ...postSessionAcpMetadata.changes,
     ...agentDir.changes,
     ...channelPlans.changes,
   ];
   const warnings = [
     ...stateDirResult.warnings,
     ...orphanKeys.warnings,
+    ...acpSessionMetadata.warnings,
     ...pluginStateSidecar.warnings,
     ...taskStateSidecars.warnings,
     ...preSessionChannelPlans.warnings,
     ...pluginPlans.warnings,
     ...sessions.warnings,
+    ...postSessionAcpMetadata.warnings,
     ...agentDir.warnings,
     ...channelPlans.warnings,
   ];

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -29,6 +29,22 @@ export interface AcpReplaySessions {
   updated_at: number;
 }
 
+export interface AcpSessions {
+  agent: string;
+  backend: string;
+  cwd: string | null;
+  identity_json: string | null;
+  last_activity_at: number;
+  last_error: string | null;
+  mode: string;
+  runtime_options_json: string | null;
+  runtime_session_name: string;
+  session_id: string | null;
+  session_key: string;
+  state: string;
+  updated_at: number;
+}
+
 export interface AgentDatabases {
   agent_id: string;
   last_seen_at: number;
@@ -902,6 +918,7 @@ export interface WorkspaceSetupState {
 export interface DB {
   acp_replay_events: AcpReplayEvents;
   acp_replay_sessions: AcpReplaySessions;
+  acp_sessions: AcpSessions;
   agent_databases: AgentDatabases;
   agent_model_catalogs: AgentModelCatalogs;
   android_notification_recent_packages: AndroidNotificationRecentPackages;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -529,6 +529,28 @@ CREATE TABLE IF NOT EXISTS gateway_restart_handoff (
 CREATE INDEX IF NOT EXISTS idx_gateway_restart_handoff_expiry
   ON gateway_restart_handoff(expires_at, pid);
 
+CREATE TABLE IF NOT EXISTS acp_sessions (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT,
+  backend TEXT NOT NULL,
+  agent TEXT NOT NULL,
+  runtime_session_name TEXT NOT NULL,
+  identity_json TEXT,
+  mode TEXT NOT NULL,
+  runtime_options_json TEXT,
+  cwd TEXT,
+  state TEXT NOT NULL,
+  last_activity_at INTEGER NOT NULL,
+  last_error TEXT,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_state_activity
+  ON acp_sessions(state, last_activity_at DESC, session_key);
+
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_agent_activity
+  ON acp_sessions(agent, last_activity_at DESC, session_key);
+
 CREATE TABLE IF NOT EXISTS acp_replay_sessions (
   session_id TEXT NOT NULL PRIMARY KEY,
   session_key TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -524,6 +524,28 @@ CREATE TABLE IF NOT EXISTS gateway_restart_handoff (
 CREATE INDEX IF NOT EXISTS idx_gateway_restart_handoff_expiry
   ON gateway_restart_handoff(expires_at, pid);
 
+CREATE TABLE IF NOT EXISTS acp_sessions (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT,
+  backend TEXT NOT NULL,
+  agent TEXT NOT NULL,
+  runtime_session_name TEXT NOT NULL,
+  identity_json TEXT,
+  mode TEXT NOT NULL,
+  runtime_options_json TEXT,
+  cwd TEXT,
+  state TEXT NOT NULL,
+  last_activity_at INTEGER NOT NULL,
+  last_error TEXT,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_state_activity
+  ON acp_sessions(state, last_activity_at DESC, session_key);
+
+CREATE INDEX IF NOT EXISTS idx_acp_sessions_agent_activity
+  ON acp_sessions(agent, last_activity_at DESC, session_key);
+
 CREATE TABLE IF NOT EXISTS acp_replay_sessions (
   session_id TEXT NOT NULL PRIMARY KEY,
   session_key TEXT NOT NULL,


### PR DESCRIPTION
## Summary

- Move ACP session metadata and the ACP replay/event ledger into OpenClaw SQLite state.
- Migrate legacy `sessions.json` ACP metadata and file-backed ACP event ledgers into SQLite, then keep session-store rows discoverable without embedded `acp` blocks.
- Update reset/delete/list/status/tail/dispatch/session-spawn/Telegram/gateway paths to read ACP metadata from SQLite with canonical session-key and session-id checks.

## Verification

- `node scripts/run-vitest.mjs src/acp/runtime/session-meta.test.ts src/acp/control-plane/manager.test.ts src/gateway/session-utils.subagent.test.ts src/gateway/server.sessions.reset-cleanup.test.ts src/gateway/server.sessions.delete-lifecycle.test.ts src/commands/sessions.acp-model-display.test.ts src/commands/status.test.ts src/commands/sessions-tail.test.ts extensions/telegram/src/thread-bindings.test.ts src/acp/event-ledger.test.ts src/commands/doctor-state-migrations.test.ts src/config/sessions/sessions.test.ts src/auto-reply/reply/commands-acp.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts src/gateway/server.sessions-send.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/acp-spawn.test.ts src/auto-reply/reply/routing-policy.test.ts src/auto-reply/reply/dispatch-acp-delivery.test.ts` passed, 9 shards / 636 tests.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` passed.
- `node scripts/run-oxlint.mjs ...` on touched ACP/session/gateway/dispatch surfaces passed.
- `pnpm db:kysely:check` passed.
- `git diff --check` passed.
- Autoreview clean: no accepted/actionable findings reported.
- Remote changed proof: `pnpm check:changed` delegated to Blacksmith Testbox `tbx_01kszgt2yn9ydp0z67tzv7eew8`, exit 0. GitHub Actions run: https://github.com/openclaw/openclaw/actions/runs/26719270163

## Real behavior proof

Behavior addressed: ACP metadata and ACP replay/event ledgers now survive restart/update paths through SQLite state instead of session-store JSON or file sidecars.

Real environment tested: Blacksmith Testbox via Crabbox, plus focused local Vitest and type/lint/schema checks in this checkout.

Exact steps or command run after this patch: `pnpm check:changed` through the repository wrapper, which delegated to Blacksmith Testbox and ran the selected core, coreTests, extensions, extensionTests, and docs lanes.

Evidence after fix: Testbox lease `tbx_01kszgt2yn9ydp0z67tzv7eew8` completed with exit 0; local focused Vitest suite passed 9 shards / 636 tests.

Observed result after fix: ACP metadata reads join SQLite rows to the current session entry and session id, reset/delete cleanup finds canonical metadata for raw legacy keys, ACP session listings work for explicit stores, and legacy JSON/file ACP state migrates into SQLite.

What was not tested: A manual Discord ACP end-to-end run was not performed in this PR; coverage is from unit/integration tests plus the remote changed lane.
