### PR TITLE
fix(feishu): preserve long streaming replies

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -162,6 +162,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
           resolveMarkdownTableMode: vi.fn(() => "preserve"),
           convertMarkdownTables: vi.fn((text) => text),
           chunkTextWithMode: vi.fn((text) => [text]),
+          chunkMarkdownTextWithMode: vi.fn((text) => [text]),
         },
         reply: {
           createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
@@ -431,13 +432,15 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   it("keeps oversized auto mode markdown final text on the chunked card path", async () => {
     const runtime = getFeishuRuntimeMock();
     runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
-    runtime.channel.text.chunkTextWithMode.mockReturnValue(["```ts\nx\n```", "tail"]);
+    runtime.channel.text.chunkMarkdownTextWithMode.mockReturnValue(["```ts\nx\n```", "tail"]);
 
     const { options } = createDispatcherHarness({ runtime: createRuntimeLogger() });
     await options.deliver({ text: "```ts\nconst x = 1\n```\ntail" }, { kind: "final" });
     await options.onIdle?.();
 
     expect(streamingInstances).toHaveLength(0);
+    expect(runtime.channel.text.chunkMarkdownTextWithMode).toHaveBeenCalledTimes(1);
+    expect(runtime.channel.text.chunkTextWithMode).not.toHaveBeenCalled();
     expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(2);
     expectMockArgFields(sendStructuredCardFeishuMock, "first card send params", {
       text: "```ts\nx\n```",

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -837,6 +837,33 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("skips oversized late final text after streaming card close", async () => {
+    const runtime = getFeishuRuntimeMock();
+    runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
+    runtime.channel.text.chunkTextWithMode.mockReturnValue(["oversized ", "late final"]);
+
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.deliver({ text: "First" }, { kind: "final" });
+    await options.onIdle?.();
+    await options.deliver(
+      { text: "oversized late final", mediaUrl: "https://example.com/a.png" },
+      { kind: "final" },
+    );
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(sendMediaFeishuMock, "media send params", {
+      mediaUrl: "https://example.com/a.png",
+    });
+  });
+
   it("suppresses duplicate final text while still sending media", async () => {
     const options = setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "plain final" }, { kind: "final" });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -403,6 +403,83 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("keeps oversized auto mode plain final text on the chunked message path", async () => {
+    const runtime = getFeishuRuntimeMock();
+    runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
+    runtime.channel.text.chunkTextWithMode.mockReturnValue(["0123456789", "abcdefghij"]);
+
+    const { options } = createDispatcherHarness();
+    await options.deliver({ text: "0123456789abcdefghij" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expectMockArgFields(sendMessageFeishuMock, "first message send params", {
+      text: "0123456789",
+    });
+    expectMockArgFields(
+      sendMessageFeishuMock,
+      "second message send params",
+      {
+        text: "abcdefghij",
+      },
+      1,
+    );
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps oversized auto mode markdown final text on the chunked card path", async () => {
+    const runtime = getFeishuRuntimeMock();
+    runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
+    runtime.channel.text.chunkTextWithMode.mockReturnValue(["```ts\nx\n```", "tail"]);
+
+    const { options } = createDispatcherHarness({ runtime: createRuntimeLogger() });
+    await options.deliver({ text: "```ts\nconst x = 1\n```\ntail" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(2);
+    expectMockArgFields(sendStructuredCardFeishuMock, "first card send params", {
+      text: "```ts\nx\n```",
+    });
+    expectMockArgFields(
+      sendStructuredCardFeishuMock,
+      "second card send params",
+      {
+        text: "tail",
+      },
+      1,
+    );
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("discards partial streaming preview before oversized final text fallback", async () => {
+    const runtime = getFeishuRuntimeMock();
+    runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
+    runtime.channel.text.chunkTextWithMode.mockReturnValue(["final text", " overflow"]);
+
+    const { result, options } = createDispatcherHarness({ runtime: createRuntimeLogger() });
+    result.replyOptions.onPartialReply?.({ text: "partial" });
+    await options.deliver({ text: "final text overflow" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].discard).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expectMockArgFields(sendMessageFeishuMock, "first message send params", {
+      text: "final text",
+    });
+    expectMockArgFields(
+      sendMessageFeishuMock,
+      "second message send params",
+      {
+        text: " overflow",
+      },
+      1,
+    );
+  });
+
   it("keeps auto mode plain tool text on the message path when streaming is enabled", async () => {
     const { options } = createDispatcherHarness();
     await options.deliver({ text: "tool summary" }, { kind: "tool" });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -463,9 +463,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     const chunkSource = paramsLocal.useCard
       ? paramsLocal.text
       : core.channel.text.convertMarkdownTables(paramsLocal.text, tableMode);
+    const chunkText = paramsLocal.useCard
+      ? core.channel.text.chunkMarkdownTextWithMode
+      : core.channel.text.chunkTextWithMode;
     const chunks = resolveTextChunksWithFallback(
       chunkSource,
-      core.channel.text.chunkTextWithMode(chunkSource, textChunkLimit, chunkMode),
+      chunkText(chunkSource, textChunkLimit, chunkMode),
     );
     for (const [index, chunk] of chunks.entries()) {
       await paramsLocal.sendChunk({

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -629,13 +629,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               ...(payload.audioAsVoice === true ? { audioAsVoice: true } : {}),
             }),
           );
-        const streamingCardEnabledForReplyKind = streamingEnabled && info?.kind === "final";
-        const useCard =
+        const finalTextExceedsStreamingLimit =
+          info?.kind === "final" && hasText && text.length > textChunkLimit;
+        const useStaticCard =
           hasText &&
-          (streamingCardEnabledForReplyKind ||
-            renderMode === "card" ||
+          (renderMode === "card" ||
             (info?.kind === "block" && coreBlockStreamingEnabled && renderMode !== "raw") ||
             (renderMode === "auto" && shouldUseCard(text)));
+        const useStreamingCard =
+          hasText &&
+          streamingEnabled &&
+          !finalTextExceedsStreamingLimit &&
+          (info?.kind === "final" || useStaticCard);
+        const useCard = useStaticCard || useStreamingCard;
         const skipTextForDuplicateFinal =
           info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
         const skipTextForClosedStreamingFinal =
@@ -643,8 +649,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           hasText &&
           streamingClosedForReply &&
           !streamingCloseErroredForReply &&
-          streamingEnabled &&
-          useCard;
+          useStreamingCard;
         const shouldDeliverText =
           hasText &&
           !hasVoiceMedia &&
@@ -652,8 +657,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           !skipTextForClosedStreamingFinal;
         const shouldDiscardStreamingPreview =
           info?.kind === "final" &&
-          hasMedia &&
-          ((hasVoiceMedia && !shouldDeliverText) || skipTextForDuplicateFinal);
+          (finalTextExceedsStreamingLimit ||
+            (hasMedia && ((hasVoiceMedia && !shouldDeliverText) || skipTextForDuplicateFinal)));
 
         if (!shouldDeliverText && !hasMedia) {
           return;
@@ -667,7 +672,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           if (info?.kind === "block") {
             // Drop internal block chunks unless we can safely consume them as
             // streaming-card fallback content.
-            if (!(streamingEnabled && useCard)) {
+            if (!useStreamingCard) {
               return;
             }
             startStreaming();
@@ -676,7 +681,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
           }
 
-          if (info?.kind === "final" && streamingEnabled && useCard) {
+          if (info?.kind === "final" && useStreamingCard) {
             startStreaming();
             if (streamingStartPromise) {
               await streamingStartPromise;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -641,6 +641,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           streamingEnabled &&
           !finalTextExceedsStreamingLimit &&
           (info?.kind === "final" || useStaticCard);
+        const finalTextWouldUseStreamingCard =
+          info?.kind === "final" && hasText && streamingEnabled;
         const useCard = useStaticCard || useStreamingCard;
         const skipTextForDuplicateFinal =
           info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
@@ -649,7 +651,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           hasText &&
           streamingClosedForReply &&
           !streamingCloseErroredForReply &&
-          useStreamingCard;
+          finalTextWouldUseStreamingCard;
         const shouldDeliverText =
           hasText &&
           !hasVoiceMedia &&


### PR DESCRIPTION
## Summary

- Keep oversized Feishu final replies off the streaming-card path when they exceed the configured text chunk limit, including auto-mode markdown/code-block/table replies.
- Discard any active streaming preview before delivering oversized final replies through the existing chunked message/static-card send path.
- Add focused coverage for oversized plain and markdown final replies plus partial-preview cleanup.

Fixes #88631.

## Verification

- `node scripts/run-vitest.mjs extensions/feishu/src/reply-dispatcher.test.ts` (66 tests)
- `node_modules/.bin/oxfmt --check extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts`
- `git diff --check origin/main`
- One-shot local Feishu-compatible HTTP proof harness using the real dispatcher, real chunker, real `sendMessageFeishu`/`sendStructuredCardFeishu`, and the real Lark SDK `Client.im.message.create` request path.

## Real behavior proof

Behavior addressed: Feishu streaming no longer routes oversized plain or auto markdown/table/code-block final replies into streaming CardKit content that can exceed CardKit element limits.

Real environment tested: Local OpenClaw source checkout with a one-shot Feishu-compatible HTTP endpoint. The proof exercised `extensions/feishu/src/reply-dispatcher.ts`, `extensions/feishu/src/send.ts`, `extensions/feishu/src/client.ts`, `extensions/feishu/src/streaming-card.ts`, and the installed `@larksuiteoapi/node-sdk` client request path. This is real OpenClaw/Lark SDK code-path proof, not a mocked unit test and not a live Feishu tenant.

Exact steps or command run after this patch: Ran the one-shot Node proof harness after the predicate fix, then reran the focused Vitest file and formatting/diff checks listed above.

Evidence after fix: Plain oversized final with no partial preview produced 3 post chunks (`10,10,3`) and `cardkit_calls=0`. Plain oversized final after an active partial preview logged streaming start, `DELETE /open-apis/im/v1/messages/om_3`, then the same three post chunks. Oversized markdown/code-block final with no partial preview produced `interactive_create_calls=8` static card sends and `cardkit_calls=0`.

Observed result after fix: Oversized plain final text is delivered as chunked Feishu post messages, while oversized markdown/code-block final text is delivered as chunked static interactive cards. Neither path closes the final answer through a streaming CardKit card; existing partial previews are explicitly discarded before final chunked delivery.

What was not tested: A live Feishu tenant/CardKit API call was not run; this checkout has no configured Feishu/Lark app credentials or target, and repo search found no Feishu secret-backed live lane.
