### PR TITLE
fix(codex): stream final answer partials

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -316,6 +316,29 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.replayMetadata.replaySafe).toBe(true);
   });
 
+  it("streams final-answer assistant deltas into partial replies", async () => {
+    const { onPartialReply, projector } = await createProjectorWithAssistantHooks();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "agentMessage",
+          id: "msg-final",
+          phase: "final_answer",
+          text: "",
+        },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("hel", "msg-final"));
+    await projector.handleNotification(agentMessageDelta("lo", "msg-final"));
+
+    expect(onPartialReply).toHaveBeenCalledTimes(2);
+    expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
+      { text: "hel", delta: "hel" },
+      { text: "hello", delta: "lo" },
+    ]);
+  });
+
   it("suppresses mirrored user prompt when the inbound message was already persisted", async () => {
     const params = await createParams();
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -447,6 +447,11 @@ export class CodexAppServerEventProjector {
     if (!delta) {
       return;
     }
+    this.rememberAssistantPhase(readItem(params.item));
+    const phase = readString(params, "phase");
+    if (phase) {
+      this.assistantPhaseByItem.set(itemId, phase);
+    }
     if (!this.assistantStarted) {
       this.assistantStarted = true;
       await this.params.onAssistantMessageStart?.();
@@ -456,10 +461,13 @@ export class CodexAppServerEventProjector {
     this.assistantTextByItem.set(itemId, text);
     if (this.isCommentaryAssistantItem(itemId)) {
       this.emitCommentaryProgress({ itemId, text });
+    } else if (this.shouldStreamAssistantPartial(itemId)) {
+      await this.params.onPartialReply?.({ text, delta });
     }
     // Codex app-server can emit multiple agentMessage items per turn, including
     // intermediate coordination/progress prose. Keep those deltas internal until
-    // turn completion chooses the last assistant item as the user-visible reply.
+    // their phase identifies terminal answer text or turn completion chooses the
+    // last assistant item as the user-visible reply.
   }
 
   private async handleReasoningDelta(
@@ -968,6 +976,10 @@ export class CodexAppServerEventProjector {
 
   private isCommentaryAssistantItem(itemId: string): boolean {
     return this.assistantPhaseByItem.get(itemId) === "commentary";
+  }
+
+  private shouldStreamAssistantPartial(itemId: string): boolean {
+    return this.assistantPhaseByItem.get(itemId) === "final_answer";
   }
 
   private emitCommentaryProgress(params: { itemId: string; text: string }): void {


### PR DESCRIPTION
## Summary

- Stream Codex app-server `final_answer` assistant deltas into `onPartialReply` so Telegram partial previews can receive live answer text before the final block.
- Keep commentary on the keyed progress lane and keep unphased agent-message deltas withheld until turn completion.
- Add a projector regression test for cumulative partial reply payloads.

Fixes #88405.

## Codex contract checked

Direct sibling source inspection before the code change:

- `../codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs`: `AgentMessageDeltaNotification` carries `thread_id`, `turn_id`, `item_id`, and `delta`; it does not carry phase.
- `../codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs`: `ThreadItem::AgentMessage` carries optional `phase`.
- `../codex/codex-rs/protocol/src/models.rs`: `MessagePhase` is `commentary` or `final_answer`, and `None` means phase unknown.
- `../codex/codex-rs/app-server-protocol/src/protocol/event_mapping.rs`: app-server delta notifications are mapped from `AgentMessageContentDeltaEvent` with only `item_id` and `delta`.

## Verification

Behavior addressed: Codex app-server final-answer text now reaches existing partial-reply consumers during the turn without leaking commentary or unknown-phase prose into answer previews.

Real environment tested: local OpenClaw source checkout on macOS plus Testbox changed checks.

Exact steps or command run after this patch:

```sh
.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the Codex app-server final_answer partial streaming patch for #88405. I directly checked sibling ../codex: AgentMessageDeltaNotification has thread_id/turn_id/item_id/delta only; ThreadItem::AgentMessage carries optional phase; MessagePhase is commentary/final_answer and None means unknown. The patch should stream only known final_answer deltas to onPartialReply and keep commentary/unphased deltas out of answer previews."
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts
./node_modules/.bin/oxfmt --check extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts
git diff --check
```

Evidence after fix:

```text
autoreview clean: no accepted/actionable findings reported
Test Files  1 passed (1)
Tests  77 passed (77)
All matched files use the correct format.
git diff --check passed
```

Observed result after fix: the new regression observes two `onPartialReply` calls for `phase: "final_answer"` deltas: `{ text: "hel", delta: "hel" }` and `{ text: "hello", delta: "lo" }`.

What was not tested: live Telegram Bot API plus live Codex OAuth. This patch is projector-level source proof for the callback bridge that Telegram already consumes.
