### PR TITLE
feat(feeds): add native feed search defaults

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -38,6 +38,8 @@ openclaw plugins list --json
 openclaw plugins search <query>
 openclaw plugins search <query> --limit 20
 openclaw plugins search <query> --json
+openclaw plugins search <query> --catalog-feeds
+openclaw plugins search <query> --catalog-feeds --feed-source approved
 openclaw plugins install <path-or-spec>
 openclaw plugins inspect <id>
 openclaw plugins inspect <id> --runtime
@@ -103,6 +105,7 @@ rewriting files.
 
 ```bash
 openclaw plugins search "calendar"                   # search ClawHub plugins
+openclaw plugins search "calendar" --catalog-feeds   # search configured feed plugins
 openclaw plugins install <package>                      # source auto-detection
 openclaw plugins install clawhub:<package>              # ClawHub only
 openclaw plugins install npm:<package>                  # npm only
@@ -126,9 +129,13 @@ sources with guarded environment variables. See
 Bare package names install from npm by default during the launch cutover, unless they match an official plugin id. Raw `@openclaw/*` package specs that match bundled plugins use the bundled copy that shipped with the current OpenClaw build. Use `npm:<package>` when you deliberately want an external npm package instead. Use `clawhub:<package>` for ClawHub. Treat plugin installs like running code. Prefer pinned versions.
 </Warning>
 
-`plugins search` queries ClawHub for installable plugin packages and prints
-install-ready package names. It searches code-plugin and bundle-plugin packages,
-not skills. Use `openclaw skills search` for ClawHub skills.
+`plugins search` queries ClawHub for installable plugin packages by default,
+or configured catalog feeds when you pass `--catalog-feeds`, pass
+`--feed-source <id>`, or enable the Feeds plugin search default in config.
+ClawHub search prints install-ready package names and searches code-plugin and
+bundle-plugin packages, not skills. Feed search prints matching feed plugin
+entries with source/feed provenance and install hints when the feed advertises
+install metadata. Use `openclaw skills search` for skills.
 
 <Note>
 ClawHub is the primary distribution and discovery surface for most plugins. Npm
@@ -305,10 +312,12 @@ does not import plugin runtime code, run a package manager, or repair missing
 dependencies.
 </Note>
 
-`plugins search` is a remote ClawHub catalog lookup. It does not inspect local
-state, mutate config, install packages, or load plugin runtime code. Search
-results include the ClawHub package name, family, channel, version, summary, and
-an install hint such as `openclaw plugins install clawhub:<package>`.
+`plugins search` is a remote ClawHub catalog lookup unless catalog-feed search
+is explicitly requested or enabled as the Feeds plugin search default. It does not
+mutate config, install packages, or load plugin runtime code. ClawHub results
+include the package name, family, channel, version, summary, and an install hint
+such as `openclaw plugins install clawhub:<package>`. Feed results include the
+feed source id, feed id, entry metadata, and an install hint when advertised.
 
 For bundled plugin work inside a packaged Docker image, bind-mount the plugin
 source directory over the matching packaged source path, such as

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -122,6 +122,10 @@ file posture, and tool metadata looks like this:
       "requirePinned": true,
       "allowUnsigned": false,
     },
+    "search": {
+      "requireDefault": true,
+      "requireSources": ["company-approved"],
+    },
   },
   "agents": {
     "workspace": {
@@ -382,13 +386,16 @@ Every scope present in `policy.jsonc` must be valid and enforceable.
 
 #### Feed catalog sources
 
-| Policy field                  | Observed state                                   | Use when                                                       |
-| ----------------------------- | ------------------------------------------------ | -------------------------------------------------------------- |
-| `feeds.sources.require`       | `plugins.entries.feeds.config.sources[].id`      | Require specific feed source ids to be configured and enabled. |
-| `feeds.sources.requirePinned` | Feed source `trust` and `integrity` declarations | Set to `true` to require enabled feed sources to be pinned.    |
-| `feeds.sources.allowUnsigned` | Feed source `trust` declarations                 | Set to `false` to reject enabled sources using unsigned trust. |
+| Policy field                  | Observed state                                   | Use when                                                            |
+| ----------------------------- | ------------------------------------------------ | ------------------------------------------------------------------- |
+| `feeds.sources.require`       | `plugins.entries.feeds.config.sources[].id`      | Require specific feed source ids to be configured and enabled.      |
+| `feeds.sources.requirePinned` | Feed source `trust` and `integrity` declarations | Set to `true` to require enabled feed sources to be pinned.         |
+| `feeds.sources.allowUnsigned` | Feed source `trust` declarations                 | Set to `false` to reject enabled sources using unsigned trust.      |
+| `feeds.search.requireDefault` | `plugins.entries.feeds.config.search.default`    | Set to `true` to require native skills/plugins search to use feeds. |
+| `feeds.search.requireSources` | `plugins.entries.feeds.config.search.sources[]`  | Require default native feed search to use selected source ids.      |
 
-Feed policy observes only configured source declarations. It does not fetch
+Feed policy observes only configured source declarations and native search
+configuration. It does not fetch
 feed documents, install entries, or enforce install decisions at runtime.
 
 #### Agent workspace
@@ -847,6 +854,8 @@ Policy currently verifies:
 | `policy/feeds-required-source-missing`                   | A required feed source id is not configured and enabled.                          |
 | `policy/feeds-source-unpinned`                           | An enabled feed source is not pinned when policy requires pinned feeds.           |
 | `policy/feeds-source-unsigned`                           | An enabled feed source uses unsigned trust when policy denies unsigned feeds.     |
+| `policy/feeds-search-default-missing`                    | Native skills/plugins search is not configured to use feeds by default.           |
+| `policy/feeds-search-source-missing`                     | Native feed search does not require a policy-required source id.                  |
 | `policy/agents-workspace-access-denied`                  | Agent sandbox mode or workspace access is outside the policy allowlist.           |
 | `policy/agents-tool-not-denied`                          | An agent or default config does not deny a tool required by policy.               |
 | `policy/tools-profile-unapproved`                        | A configured global or per-agent tool profile is outside the allowlist.           |

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -2,7 +2,7 @@
 summary: "CLI reference for `openclaw skills` (search/install/update/verify/list/info/check/workshop)"
 read_when:
   - You want to see which skills are available and ready to run
-  - You want to search ClawHub or install skills from ClawHub, Git, or local directories
+  - You want to search ClawHub or configured catalog feeds, or install skills from ClawHub, Git, or local directories
   - You want to verify a ClawHub skill with ClawHub
   - You want to debug missing binaries/env/config for skills
 title: "Skills"
@@ -10,8 +10,9 @@ title: "Skills"
 
 # `openclaw skills`
 
-Inspect local skills, search ClawHub, install skills from ClawHub/Git/local
-directories, verify ClawHub skills, and update ClawHub-tracked installs.
+Inspect local skills, search ClawHub or configured catalog feeds, install skills
+from ClawHub/Git/local directories, verify ClawHub skills, and update
+ClawHub-tracked installs.
 
 Related:
 
@@ -25,6 +26,8 @@ Related:
 ```bash
 openclaw skills search "calendar"
 openclaw skills search --limit 20 --json
+openclaw skills search "calendar" --catalog-feeds
+openclaw skills search "calendar" --catalog-feeds --feed-source approved
 openclaw skills install <slug>
 openclaw skills install <slug> --version <version>
 openclaw skills install git:owner/repo
@@ -64,12 +67,14 @@ openclaw skills workshop reject <proposal-id> --reason "Not reusable"
 openclaw skills workshop quarantine <proposal-id> --reason "Needs security review"
 ```
 
-`search`, `update`, and `verify` use ClawHub directly. `install <slug>` installs
-a ClawHub skill, `install git:owner/repo[@ref]` clones a Git skill, and
-`install ./path` copies a local skill directory. By default, `install`, `update`,
-and `verify` target the active workspace `skills/` directory; with `--global`,
-they target the shared managed skills directory. `list`/`info`/`check` still
-inspect the local skills visible to the current workspace and config.
+`search` uses ClawHub by default, or configured catalog feeds when you pass
+`--catalog-feeds`, pass `--feed-source <id>`, or enable the Feeds plugin search
+default in config. `update` and `verify` use ClawHub directly. `install <slug>`
+installs a ClawHub skill, `install git:owner/repo[@ref]` clones a Git skill,
+and `install ./path` copies a local skill directory. By default, `install`,
+`update`, and `verify` target the active workspace `skills/` directory; with
+`--global`, they target the shared managed skills directory. `list`/`info`/`check`
+still inspect the local skills visible to the current workspace and config.
 Workspace-backed commands resolve the target workspace from `--agent <id>`, then
 the current working directory when it is inside a configured agent workspace,
 then the default agent.
@@ -86,8 +91,11 @@ settings use the separate `skills.install` request path instead.
 Notes:
 
 - `search [query...]` accepts an optional query; omit it to browse the default
-  ClawHub search feed.
+  ClawHub search feed, or the configured feed default when Feeds search is enabled.
 - `search --limit <n>` caps returned results.
+- `search --catalog-feeds` searches configured feed entries instead of ClawHub.
+- `search --feed-source <id>` searches one configured feed source id; repeat it or
+  pass comma-separated ids to search multiple sources.
 - `install git:owner/repo[@ref]` installs a Git skill. Branch refs may contain
   slashes, such as `git:owner/repo@feature/foo`.
 - `install ./path/to/skill` installs a local directory whose root contains

--- a/docs/plugins/reference/feeds.md
+++ b/docs/plugins/reference/feeds.md
@@ -38,13 +38,13 @@ integrity.
               "id": "company-approved",
               "url": "https://feeds.example.com/openclaw/feed.json",
               "trust": "pinned",
-              "integrity": "sha256:..."
-            }
-          ]
-        }
-      }
-    }
-  }
+              "integrity": "sha256:...",
+            },
+          ],
+        },
+      },
+    },
+  },
 }
 ```
 
@@ -84,18 +84,18 @@ Use `--dry-run` to print the underlying install command without running it. Use
         "config": {
           "installPolicy": {
             "mode": "enforce",
-            "requireApproval": true
+            "requireApproval": true,
           },
           "sources": [
             {
               "id": "company-approved",
-              "url": "file:///opt/openclaw/feeds/company.json"
-            }
-          ]
-        }
-      }
-    }
-  }
+              "url": "file:///opt/openclaw/feeds/company.json",
+            },
+          ],
+        },
+      },
+    },
+  },
 }
 ```
 
@@ -129,20 +129,20 @@ To make native search use feeds by default, configure the bundled Feeds plugin:
         "config": {
           "search": {
             "default": true,
-            "sources": ["company-approved"]
+            "sources": ["company-approved"],
           },
           "sources": [
             {
               "id": "company-approved",
               "url": "https://feeds.example.com/openclaw/feed.json",
               "trust": "pinned",
-              "integrity": "sha256:..."
-            }
-          ]
-        }
-      }
-    }
-  }
+              "integrity": "sha256:...",
+            },
+          ],
+        },
+      },
+    },
+  },
 }
 ```
 

--- a/docs/plugins/reference/feeds.md
+++ b/docs/plugins/reference/feeds.md
@@ -7,7 +7,9 @@ title: "Feeds plugin"
 
 # Feeds plugin
 
-Adds configured catalog feed source validation for skills and plugins.
+Adds configured catalog feed source validation, search, install handoff,
+lifecycle tooling, and optional native `skills search` / `plugins search` feed
+integration.
 
 ## Distribution
 
@@ -36,13 +38,13 @@ integrity.
               "id": "company-approved",
               "url": "https://feeds.example.com/openclaw/feed.json",
               "trust": "pinned",
-              "integrity": "sha256:...",
-            },
-          ],
-        },
-      },
-    },
-  },
+              "integrity": "sha256:..."
+            }
+          ]
+        }
+      }
+    }
+  }
 }
 ```
 
@@ -82,18 +84,18 @@ Use `--dry-run` to print the underlying install command without running it. Use
         "config": {
           "installPolicy": {
             "mode": "enforce",
-            "requireApproval": true,
+            "requireApproval": true
           },
           "sources": [
             {
               "id": "company-approved",
-              "url": "file:///opt/openclaw/feeds/company.json",
-            },
-          ],
-        },
-      },
-    },
-  },
+              "url": "file:///opt/openclaw/feeds/company.json"
+            }
+          ]
+        }
+      }
+    }
+  }
 }
 ```
 
@@ -105,3 +107,43 @@ Use `--dry-run` to print the underlying install command without running it. Use
 If `requireApproval` is `true` and `mode` is omitted, OpenClaw treats the policy
 as enforce. If `mode` is `enforce` and `requireApproval` is omitted, approval is
 required.
+
+## Native search
+
+`openclaw skills search` and `openclaw plugins search` continue to use ClawHub by
+default. Operators can opt into configured feeds explicitly:
+
+```bash
+openclaw skills search calendar --catalog-feeds
+openclaw plugins search calendar --feed-source company-approved
+```
+
+To make native search use feeds by default, configure the bundled Feeds plugin:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "feeds": {
+        "enabled": true,
+        "config": {
+          "search": {
+            "default": true,
+            "sources": ["company-approved"]
+          },
+          "sources": [
+            {
+              "id": "company-approved",
+              "url": "https://feeds.example.com/openclaw/feed.json",
+              "trust": "pinned",
+              "integrity": "sha256:..."
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Omit `search.sources` to search all enabled configured feed sources.

--- a/extensions/feeds/api.ts
+++ b/extensions/feeds/api.ts
@@ -1,1 +1,7 @@
 export { registerFeedsDoctorChecks } from "./src/doctor/register.js";
+export {
+  formatFeedInstallCommand,
+  searchConfiguredFeedEntries,
+  type FeedEntryResult,
+} from "./src/cli.js";
+export { type FeedEntryType } from "./src/feed-document.js";

--- a/extensions/feeds/openclaw.plugin.json
+++ b/extensions/feeds/openclaw.plugin.json
@@ -4,9 +4,17 @@
   "description": "Adds configured catalog feed source validation for skills and plugins.",
   "activation": {
     "onStartup": false,
-    "onCommands": ["doctor", "feeds"]
+    "onCommands": [
+      "doctor",
+      "feeds"
+    ]
   },
-  "commandAliases": [{ "name": "feeds", "kind": "cli" }],
+  "commandAliases": [
+    {
+      "name": "feeds",
+      "kind": "cli"
+    }
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -22,12 +30,34 @@
         "properties": {
           "mode": {
             "type": "string",
-            "enum": ["off", "warn", "enforce"],
+            "enum": [
+              "off",
+              "warn",
+              "enforce"
+            ],
             "description": "Install policy mode. Defaults to off."
           },
           "requireApproval": {
             "type": "boolean",
             "description": "Require feed entries to declare approval.status=approved before install."
+          }
+        }
+      },
+      "search": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Optional native skills/plugins search integration for configured feeds.",
+        "properties": {
+          "default": {
+            "type": "boolean",
+            "description": "Use configured feeds for native skills/plugins search when no CLI feed option is supplied."
+          },
+          "sources": {
+            "type": "array",
+            "description": "Optional source ids used by default native search. Omit to search all enabled sources.",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -37,7 +67,10 @@
         "items": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["id", "url"],
+          "required": [
+            "id",
+            "url"
+          ],
           "properties": {
             "id": {
               "type": "string",
@@ -53,7 +86,10 @@
             },
             "trust": {
               "type": "string",
-              "enum": ["unsigned", "pinned"],
+              "enum": [
+                "unsigned",
+                "pinned"
+              ],
               "description": "Whether this source is accepted unsigned or pinned by integrity hash."
             },
             "integrity": {

--- a/extensions/feeds/src/cli.test.ts
+++ b/extensions/feeds/src/cli.test.ts
@@ -15,6 +15,8 @@ import {
   feedsHashCommand,
   feedsSearchCommand,
   feedsSourcesCommand,
+  readConfiguredFeedSearchConfig,
+  searchConfiguredFeedEntries,
   feedsUpdatesCommand,
   feedsValidateCommand,
   type FeedsCommandRuntime,
@@ -152,6 +154,59 @@ describe("Feeds CLI", () => {
         " bytes.",
     );
     expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("searches configured feed entries for native search", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [
+        { type: "skill", id: "excel-review", tags: ["m365"] },
+        { type: "plugin", id: "calendar-helper", tags: ["outlook"] },
+      ],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const entries = await searchConfiguredFeedEntries(
+      { query: "outlook", type: "plugin", sourceIds: ["approved"] },
+      runtime,
+    );
+
+    expect(entries).toEqual([expect.objectContaining({ id: "calendar-helper" })]);
+  });
+
+  it("does not widen native search when source ids are explicitly empty", async () => {
+    const feed = JSON.stringify({
+      schemaVersion: 1,
+      id: "company-approved",
+      entries: [{ type: "plugin", id: "calendar-helper", tags: ["outlook"] }],
+    });
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      files: { "/feeds/company.json": feed },
+    });
+
+    const entries = await searchConfiguredFeedEntries(
+      { query: "outlook", type: "plugin", sourceIds: [] },
+      runtime,
+    );
+
+    expect(entries).toEqual([]);
+  });
+
+  it("reads configured native search defaults", async () => {
+    const runtime = createRuntime({
+      sources: [{ id: "approved", url: "file:///feeds/company.json" }],
+      search: { default: true, sources: ["approved"] },
+    });
+
+    await expect(readConfiguredFeedSearchConfig(runtime)).resolves.toEqual({
+      default: true,
+      sources: ["approved"],
+    });
   });
 
   it("checks pinned feed integrity while loading entries", async () => {
@@ -928,6 +983,7 @@ function createRuntime(params: {
   readonly files?: Readonly<Record<string, string>>;
   readonly fetch?: FeedsCommandRuntime["fetch"];
   readonly installPolicy?: Record<string, unknown>;
+  readonly search?: Record<string, unknown>;
 }): FeedsCommandRuntime & {
   stdout: string;
   stderr: string;
@@ -968,7 +1024,11 @@ function createRuntime(params: {
             entries: {
               feeds: {
                 enabled: true,
-                config: { sources: params.sources, installPolicy: params.installPolicy },
+                config: {
+                  sources: params.sources,
+                  installPolicy: params.installPolicy,
+                  search: params.search,
+                },
               },
             },
           },

--- a/extensions/feeds/src/cli.ts
+++ b/extensions/feeds/src/cli.ts
@@ -67,6 +67,11 @@ export type FeedInstallPolicy = {
   readonly requireApproval: boolean;
 };
 
+export type FeedSearchConfig = {
+  readonly default: boolean;
+  readonly sources?: readonly string[];
+};
+
 export type FeedsInstallOptions = FeedsCommandOptions & {
   readonly dryRun?: boolean;
   readonly force?: boolean;
@@ -75,6 +80,7 @@ export type FeedsInstallOptions = FeedsCommandOptions & {
 type ConfiguredFeeds = {
   readonly sources: readonly FeedSourceConfig[];
   readonly installPolicy: FeedInstallPolicy;
+  readonly search: FeedSearchConfig;
 };
 
 export type FeedInstalledEntry = {
@@ -104,6 +110,13 @@ export type FeedUpdateNotice = {
 export type FeedEntryResult = FeedEntry & {
   readonly sourceId: string;
   readonly feedId: string;
+};
+
+export type FeedNativeSearchOptions = {
+  readonly query?: string;
+  readonly type?: FeedEntryType;
+  readonly sourceIds?: readonly string[];
+  readonly limit?: number;
 };
 
 export type FeedBuildRules = {
@@ -287,6 +300,28 @@ export async function feedsSearchCommand(
     runtime.error(err instanceof Error ? err.message : String(err));
     return 2;
   }
+}
+
+export async function searchConfiguredFeedEntries(
+  options: FeedNativeSearchOptions,
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<readonly FeedEntryResult[]> {
+  const config = await readConfiguredFeedsConfig(runtime);
+  const loaded = await loadFeedDocuments(config.sources, { type: options.type }, runtime, {
+    sourceIds: options.sourceIds,
+  });
+  const query = options.query?.trim() ?? "";
+  const entries = filterEntriesByType(
+    flattenFeedEntries(loaded).filter((entry) => feedEntryMatchesQuery(entry, query)),
+    options.type,
+  );
+  return entries.slice(0, clampNativeSearchLimit(options.limit));
+}
+
+export async function readConfiguredFeedSearchConfig(
+  runtime: FeedsCommandRuntime = defaultRuntime,
+): Promise<FeedSearchConfig> {
+  return (await readConfiguredFeedsConfig(runtime)).search;
 }
 
 export async function feedsUpdatesCommand(
@@ -881,9 +916,10 @@ async function loadFeedDocuments(
   configuredSources: readonly FeedSourceConfig[],
   options: FeedsCommandOptions,
   runtime: FeedsCommandRuntime,
+  selection?: { readonly sourceIds?: readonly string[] },
 ): Promise<readonly LoadedFeedDocument[]> {
   const sources = configuredSources.filter((source) => source.enabled);
-  const selected = selectSources(sources, options.source);
+  const selected = selectSources(sources, options.source, selection?.sourceIds);
   return Promise.all(selected.map((source) => loadFeedDocument(source, runtime)));
 }
 
@@ -902,13 +938,21 @@ async function readConfiguredFeedsConfig(runtime: FeedsCommandRuntime): Promise<
   }
   const config = snapshot.config.plugins?.entries?.feeds?.config;
   if (config === undefined) {
-    return { sources: [], installPolicy: { mode: "off", requireApproval: false } };
+    return {
+      sources: [],
+      installPolicy: { mode: "off", requireApproval: false },
+      search: { default: false },
+    };
   }
   if (!isRecord(config)) {
     throw new Error("plugins.entries.feeds.config must be an object.");
   }
   if (config.sources === undefined) {
-    return { sources: [], installPolicy: parseInstallPolicy(config.installPolicy) };
+    return {
+      sources: [],
+      installPolicy: parseInstallPolicy(config.installPolicy),
+      search: parseSearchConfig(config.search),
+    };
   }
   if (!Array.isArray(config.sources)) {
     throw new Error("plugins.entries.feeds.config.sources must be an array.");
@@ -916,6 +960,29 @@ async function readConfiguredFeedsConfig(runtime: FeedsCommandRuntime): Promise<
   return {
     sources: config.sources.map((source, index) => parseSourceConfig(source, index)),
     installPolicy: parseInstallPolicy(config.installPolicy),
+    search: parseSearchConfig(config.search),
+  };
+}
+
+function parseSearchConfig(value: unknown): FeedSearchConfig {
+  if (value === undefined) {
+    return { default: false };
+  }
+  if (!isRecord(value)) {
+    throw new Error("plugins.entries.feeds.config.search must be an object.");
+  }
+  if (value.default !== undefined && typeof value.default !== "boolean") {
+    throw new Error("feeds search.default must be a boolean.");
+  }
+  if (
+    value.sources !== undefined &&
+    (!Array.isArray(value.sources) || !value.sources.every((source) => typeof source === "string"))
+  ) {
+    throw new Error("feeds search.sources must be an array of source ids.");
+  }
+  return {
+    default: value.default === true,
+    ...(Array.isArray(value.sources) ? { sources: value.sources } : {}),
   };
 }
 
@@ -967,15 +1034,35 @@ function parseSourceConfig(value: unknown, index: number): FeedSourceConfig {
 function selectSources(
   sources: readonly FeedSourceConfig[],
   selectedId: string | undefined,
+  selectedIds?: readonly string[],
 ): readonly FeedSourceConfig[] {
   if (selectedId === undefined) {
-    return sources;
+    if (selectedIds === undefined) {
+      return sources;
+    }
+    if (selectedIds.length === 0) {
+      return [];
+    }
+    const selectedIdSet = new Set(selectedIds);
+    const selected = sources.filter((source) => selectedIdSet.has(source.id));
+    const missing = selectedIds.find((id) => !selected.some((source) => source.id === id));
+    if (missing !== undefined) {
+      throw new Error(`No enabled feed source found for '${missing}'.`);
+    }
+    return selected;
   }
   const selected = sources.filter((source) => source.id === selectedId);
   if (selected.length === 0) {
     throw new Error(`No enabled feed source found for '${selectedId}'.`);
   }
   return selected;
+}
+
+function clampNativeSearchLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit) || !limit || limit <= 0) {
+    return 20;
+  }
+  return Math.min(Math.max(Math.trunc(limit), 1), 100);
 }
 
 function flattenFeedEntries(loaded: readonly LoadedFeedDocument[]): readonly FeedEntryResult[] {
@@ -1038,7 +1125,7 @@ type FeedInstallCommand = {
   readonly label: string;
 };
 
-function formatFeedInstallCommand(entry: FeedEntry): string | undefined {
+export function formatFeedInstallCommand(entry: FeedEntry): string | undefined {
   return buildFeedInstallCommand(entry)?.label;
 }
 

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -584,6 +584,8 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/feeds-required-source-missing",
       "policy/feeds-source-unpinned",
       "policy/feeds-source-unsigned",
+      "policy/feeds-search-default-missing",
+      "policy/feeds-search-source-missing",
       "policy/agents-workspace-access-denied",
       "policy/agents-tool-not-denied",
       "policy/tools-profile-unapproved",
@@ -660,6 +662,270 @@ describe("registerPolicyDoctorChecks", () => {
         expect.objectContaining({
           checkId: "policy/feeds-required-source-missing",
           requirement: "oc://policy.jsonc/feeds/sources/require",
+        }),
+      ]),
+    );
+  });
+
+  it("reports native feed search policy conformance findings", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          search: {
+            requireDefault: true,
+            requireSources: ["company-approved"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: true,
+              config: {
+                search: {
+                  default: false,
+                  sources: ["partner"],
+                },
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-search-default-missing",
+          requirement: "oc://policy.jsonc/feeds/search/requireDefault",
+        }),
+        expect.objectContaining({
+          checkId: "policy/feeds-search-source-missing",
+          requirement: "oc://policy.jsonc/feeds/search/requireSources",
+        }),
+      ]),
+    );
+  });
+
+  it("accepts omitted native feed search sources as all enabled sources", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          search: {
+            requireDefault: true,
+            requireSources: ["company-approved"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: true,
+              config: {
+                search: {
+                  default: true,
+                },
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-search-source-missing",
+        }),
+      ]),
+    );
+  });
+
+  it("does not accept feed search sources when native feed search is not default", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          search: {
+            requireSources: ["company-approved"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: true,
+              config: {
+                search: {
+                  default: false,
+                  sources: ["company-approved"],
+                },
+                sources: [
+                  {
+                    id: "company-approved",
+                    url: "https://feeds.example.com/company.json",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-search-source-missing",
+        }),
+      ]),
+    );
+  });
+
+  it("does not accept disabled feed search sources as policy evidence", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          search: {
+            requireSources: ["company-approved"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: true,
+              config: {
+                search: {
+                  sources: ["company-approved"],
+                },
+                sources: [
+                  {
+                    id: "company-approved",
+                    enabled: false,
+                    url: "https://feeds.example.com/company.json",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-search-source-missing",
+        }),
+      ]),
+    );
+  });
+
+  it("does not accept disabled feed search config as policy evidence", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          search: {
+            requireDefault: true,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              enabled: false,
+              config: {
+                search: {
+                  default: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-search-default-missing",
         }),
       ]),
     );
@@ -832,7 +1098,7 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
-  it("does not satisfy required feed sources from an inactive Feeds plugin", async () => {
+  it("satisfies required feed sources from a default-enabled Feeds config", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
@@ -874,7 +1140,7 @@ describe("registerPolicyDoctorChecks", () => {
       }),
     );
 
-    expect(result.findings).toEqual(
+    expect(result.findings).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           checkId: "policy/feeds-required-source-missing",

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -885,6 +885,51 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
+  it("accepts default feed search config without an explicit Feeds plugin enabled flag", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        feeds: {
+          search: {
+            requireDefault: true,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyChecks(
+      ctx(configPath, {
+        ...cfgWithPolicy(),
+        plugins: {
+          entries: {
+            policy: {
+              enabled: true,
+              config: { enabled: true },
+            },
+            feeds: {
+              config: {
+                search: {
+                  default: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/feeds-search-default-missing",
+        }),
+      ]),
+    );
+  });
+
   it("does not accept disabled feed search config as policy evidence", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     await fs.writeFile(configPath, "{}", "utf-8");

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -21,6 +21,7 @@ import {
   type PolicyEvidence,
   type PolicyExecApprovalEvidence,
   type PolicyFeedSourceEvidence,
+  type PolicyFeedSearchEvidence,
   type PolicyIngressEvidence,
   type PolicySandboxPostureEvidence,
   type PolicyToolPostureEvidence,
@@ -60,6 +61,8 @@ const CHECK_IDS = {
   policyFeedsRequiredSourceMissing: "policy/feeds-required-source-missing",
   policyFeedsSourceUnpinned: "policy/feeds-source-unpinned",
   policyFeedsSourceUnsigned: "policy/feeds-source-unsigned",
+  policyFeedsSearchDefaultMissing: "policy/feeds-search-default-missing",
+  policyFeedsSearchSourceMissing: "policy/feeds-search-source-missing",
   policyAgentsWorkspaceAccessDenied: "policy/agents-workspace-access-denied",
   policyAgentsToolNotDenied: "policy/agents-tool-not-denied",
   policyToolsElevatedEnabled: "policy/tools-elevated-enabled",
@@ -131,6 +134,8 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyFeedsRequiredSourceMissing,
   CHECK_IDS.policyFeedsSourceUnpinned,
   CHECK_IDS.policyFeedsSourceUnsigned,
+  CHECK_IDS.policyFeedsSearchDefaultMissing,
+  CHECK_IDS.policyFeedsSearchSourceMissing,
   CHECK_IDS.policyAgentsWorkspaceAccessDenied,
   CHECK_IDS.policyAgentsToolNotDenied,
   CHECK_IDS.policyToolsProfileUnapproved,
@@ -684,6 +689,8 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyFeedsRequiredSourceMissingCheck);
   registerHealthCheck(policyFeedsSourceUnpinnedCheck);
   registerHealthCheck(policyFeedsSourceUnsignedCheck);
+  registerHealthCheck(policyFeedsSearchDefaultMissingCheck);
+  registerHealthCheck(policyFeedsSearchSourceMissingCheck);
   registerHealthCheck(policyAgentsWorkspaceAccessDeniedCheck);
   registerHealthCheck(policyAgentsToolNotDeniedCheck);
   registerHealthCheck(policyToolsProfileUnapprovedCheck);
@@ -1017,6 +1024,26 @@ const policyFeedsSourceUnsignedCheck: HealthCheck = {
   source: "policy",
   async detect(ctx) {
     return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyFeedsSourceUnsigned);
+  },
+};
+
+const policyFeedsSearchDefaultMissingCheck: HealthCheck = {
+  id: CHECK_IDS.policyFeedsSearchDefaultMissing,
+  kind: "plugin",
+  description: "Native skills/plugins search uses feeds by default when policy requires it.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyFeedsSearchDefaultMissing);
+  },
+};
+
+const policyFeedsSearchSourceMissingCheck: HealthCheck = {
+  id: CHECK_IDS.policyFeedsSearchSourceMissing,
+  kind: "plugin",
+  description: "Native skills/plugins search includes required feed sources.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyFeedsSearchSourceMissing);
   },
 };
 
@@ -2207,6 +2234,33 @@ function feedsPolicyShapeFinding(
       `${params.policyPath} feeds must be an object.`,
       `Fix ${params.policyPath} so feeds is an object.`,
     );
+  }
+  if (value.search !== undefined && !isRecord(value.search)) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/feeds/search`,
+      `${params.policyPath} feeds.search must be an object.`,
+      `Fix ${params.policyPath} so feeds.search is an object.`,
+    );
+  }
+  const search = isRecord(value.search) ? value.search : {};
+  if (search.requireDefault !== undefined && typeof search.requireDefault !== "boolean") {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/feeds/search/requireDefault`,
+      `${params.policyPath} feeds.search.requireDefault must be a boolean.`,
+      `Set feeds.search.requireDefault to true or false.`,
+    );
+  }
+  const requireSourcesFinding = policyStringArrayPropertyShapeFinding(search.requireSources, {
+    policyDocName: params.policyDocName,
+    policyPath: params.policyPath,
+    property: "feeds.search.requireSources",
+    target: "feeds/search/requireSources",
+    valueName: "feed source id",
+  });
+  if (requireSourcesFinding !== undefined) {
+    return requireSourcesFinding;
   }
   if (value.sources !== undefined && !isRecord(value.sources)) {
     return policyShapeFinding(
@@ -4322,13 +4376,31 @@ function feedSourceFindings(
   const required = readStringList(policy, ["feeds", "sources", "require"], { lowercase: false });
   const requirePinned = readPolicyBoolean(policy, ["feeds", "sources", "requirePinned"]) === true;
   const allowUnsigned = readPolicyBoolean(policy, ["feeds", "sources", "allowUnsigned"]) !== false;
-  if (required.length === 0 && !requirePinned && allowUnsigned) {
+  const requireSearchDefault =
+    readPolicyBoolean(policy, ["feeds", "search", "requireDefault"]) === true;
+  const requiredSearchSources = readStringList(policy, ["feeds", "search", "requireSources"]);
+  if (
+    required.length === 0 &&
+    !requirePinned &&
+    allowUnsigned &&
+    !requireSearchDefault &&
+    requiredSearchSources.length === 0
+  ) {
     return [];
   }
 
   const enabledSources = (evidence.feeds ?? []).filter((source) => source.enabled !== false);
   const enabledById = new Map(enabledSources.map((source) => [source.id, source]));
   const findings: HealthFinding[] = [];
+  findings.push(
+    ...feedSearchFindings({
+      policyDocName,
+      requireDefault: requireSearchDefault,
+      requireSources: requiredSearchSources,
+      evidence: evidence.feedSearch,
+      enabledSourceIds: [...enabledById.keys()],
+    }),
+  );
 
   for (const sourceId of required) {
     const source = enabledById.get(sourceId);
@@ -4370,6 +4442,54 @@ function feedSourceFindings(
         }),
       );
     }
+  }
+  return findings;
+}
+
+function feedSearchFindings(params: {
+  readonly policyDocName: string;
+  readonly requireDefault: boolean;
+  readonly requireSources: readonly string[];
+  readonly evidence?: PolicyFeedSearchEvidence;
+  readonly enabledSourceIds: readonly string[];
+}): readonly HealthFinding[] {
+  const findings: HealthFinding[] = [];
+  if (params.requireDefault && params.evidence?.default !== true) {
+    findings.push({
+      checkId: CHECK_IDS.policyFeedsSearchDefaultMissing,
+      severity: "error",
+      message: "Native skills/plugins search is not configured to use feeds by default.",
+      source: "policy",
+      path: "openclaw config",
+      target: "oc://openclaw.config/plugins/entries/feeds/config/search/default",
+      requirement: `oc://${params.policyDocName}/feeds/search/requireDefault`,
+      fixHint:
+        "Set plugins.entries.feeds.config.search.default to true or update policy after review.",
+    });
+  }
+  const enabled = new Set(params.enabledSourceIds);
+  const configured = new Set(
+    params.evidence?.default !== true
+      ? []
+      : params.evidence.sourceIds === undefined
+        ? params.enabledSourceIds
+        : params.evidence.sourceIds.filter((sourceId) => enabled.has(sourceId)),
+  );
+  for (const sourceId of params.requireSources) {
+    if (configured.has(sourceId)) {
+      continue;
+    }
+    findings.push({
+      checkId: CHECK_IDS.policyFeedsSearchSourceMissing,
+      severity: "error",
+      message: `Native feed search does not require source '${sourceId}'.`,
+      source: "policy",
+      path: "openclaw config",
+      target: "oc://openclaw.config/plugins/entries/feeds/config/search/sources",
+      requirement: `oc://${params.policyDocName}/feeds/search/requireSources`,
+      fixHint:
+        "Add the source id to plugins.entries.feeds.config.search.sources or update policy after review.",
+    });
   }
   return findings;
 }
@@ -6381,13 +6501,18 @@ function policyHasGatewayRules(policy: unknown): boolean {
 }
 
 function policyHasFeedRules(policy: unknown): boolean {
+  if (!isRecord(policy) || !isRecord(policy.feeds)) {
+    return false;
+  }
+
   return (
-    isRecord(policy) &&
-    isRecord(policy.feeds) &&
-    isRecord(policy.feeds.sources) &&
-    (policy.feeds.sources.require !== undefined ||
-      policy.feeds.sources.requirePinned !== undefined ||
-      policy.feeds.sources.allowUnsigned !== undefined)
+    (isRecord(policy.feeds.sources) &&
+      (policy.feeds.sources.require !== undefined ||
+        policy.feeds.sources.requirePinned !== undefined ||
+        policy.feeds.sources.allowUnsigned !== undefined)) ||
+    (isRecord(policy.feeds.search) &&
+      (policy.feeds.search.requireDefault !== undefined ||
+        policy.feeds.search.requireSources !== undefined))
   );
 }
 

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -3154,7 +3154,7 @@ function feedPluginEnabledForPolicy(
   const deny = readStringArray(plugins.deny);
   return (
     plugins.enabled !== false &&
-    feeds.enabled === true &&
+    feeds.enabled !== false &&
     !deny.includes("feeds") &&
     (allow.length === 0 || allow.includes("feeds"))
   );

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -51,6 +51,7 @@ export type PolicyEvidence = {
   readonly ingress?: readonly PolicyIngressEvidence[];
   readonly gatewayExposure?: readonly PolicyGatewayExposureEvidence[];
   readonly feeds?: readonly PolicyFeedSourceEvidence[];
+  readonly feedSearch?: PolicyFeedSearchEvidence;
   readonly agentWorkspace?: readonly PolicyAgentWorkspaceEvidence[];
   readonly dataHandling?: readonly PolicyDataHandlingEvidence[];
   readonly secrets?: readonly PolicySecretEvidence[];
@@ -166,6 +167,12 @@ export type PolicyFeedSourceEvidence = {
   readonly url?: string;
   readonly trust?: string;
   readonly integrityPresent?: boolean;
+};
+
+export type PolicyFeedSearchEvidence = {
+  readonly source: string;
+  readonly default?: boolean;
+  readonly sourceIds?: readonly string[];
 };
 
 export type PolicyGatewayExposureEvidence = {
@@ -378,7 +385,9 @@ export function collectPolicyEvidence(
     ...(options.includeGatewayExposure === false
       ? {}
       : { gatewayExposure: scanPolicyGatewayExposure(cfg) }),
-    ...(options.includeFeeds === false ? {} : { feeds: scanPolicyFeeds(cfg) }),
+    ...(options.includeFeeds === false
+      ? {}
+      : { feeds: scanPolicyFeeds(cfg), feedSearch: scanPolicyFeedSearch(cfg) }),
     ...(options.includeAgentWorkspace === false
       ? {}
       : { agentWorkspace: scanPolicyAgentWorkspace(cfg) }),
@@ -851,14 +860,7 @@ export function scanPolicyFeeds(cfg: Record<string, unknown>): readonly PolicyFe
   const entries = isRecord(plugins.entries) ? plugins.entries : {};
   const feeds = isRecord(entries.feeds) ? entries.feeds : {};
   const config = isRecord(feeds.config) ? feeds.config : {};
-  const allow = readStringArray(plugins.allow);
-  const deny = readStringArray(plugins.deny);
-  if (
-    plugins.enabled === false ||
-    feeds.enabled !== true ||
-    deny.includes("feeds") ||
-    (allow.length > 0 && !allow.includes("feeds"))
-  ) {
+  if (!feedPluginEnabledForPolicy(plugins, feeds)) {
     return [];
   }
   const sources = Array.isArray(config.sources) ? config.sources : [];
@@ -901,6 +903,36 @@ export function scanPolicyFeeds(cfg: Record<string, unknown>): readonly PolicyFe
     })
     .filter((entry): entry is PolicyFeedSourceEvidence => entry !== undefined)
     .toSorted((a, b) => a.id.localeCompare(b.id) || a.source.localeCompare(b.source));
+}
+
+export function scanPolicyFeedSearch(
+  cfg: Record<string, unknown>,
+): PolicyFeedSearchEvidence | undefined {
+  const plugins = isRecord(cfg.plugins) ? cfg.plugins : {};
+  const entries = isRecord(plugins.entries) ? plugins.entries : {};
+  const feeds = isRecord(entries.feeds) ? entries.feeds : {};
+  const config = isRecord(feeds.config) ? feeds.config : {};
+  if (!feedPluginEnabledForPolicy(plugins, feeds)) {
+    return undefined;
+  }
+  const search = isRecord(config.search) ? config.search : undefined;
+  if (search === undefined) {
+    return undefined;
+  }
+  const evidence: {
+    source: string;
+    default?: boolean;
+    sourceIds?: readonly string[];
+  } = {
+    source: "oc://openclaw.config/plugins/entries/feeds/config/search",
+  };
+  if (typeof search.default === "boolean") {
+    evidence.default = search.default;
+  }
+  if (Array.isArray(search.sources)) {
+    evidence.sourceIds = search.sources.filter((id): id is string => typeof id === "string");
+  }
+  return evidence;
 }
 
 export function scanPolicyGatewayExposure(
@@ -3112,4 +3144,18 @@ function stableJson(value: unknown): string {
       .join(",")}}`;
   }
   return JSON.stringify(value);
+}
+
+function feedPluginEnabledForPolicy(
+  plugins: Record<string, unknown>,
+  feeds: Record<string, unknown>,
+): boolean {
+  const allow = readStringArray(plugins.allow);
+  const deny = readStringArray(plugins.deny);
+  return (
+    plugins.enabled !== false &&
+    feeds.enabled === true &&
+    !deny.includes("feeds") &&
+    (allow.length === 0 || allow.includes("feeds"))
+  );
 }

--- a/src/cli/feed-search-options.test.ts
+++ b/src/cli/feed-search-options.test.ts
@@ -77,7 +77,7 @@ describe("feed search CLI options", () => {
     });
   });
 
-  it("keeps explicit feed search disabled when the Feeds plugin is disabled", async () => {
+  it("fails explicit feed search when the Feeds plugin is disabled", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValueOnce({
       valid: true,
       config: {
@@ -94,9 +94,17 @@ describe("feed search CLI options", () => {
       },
     });
 
-    await expect(resolveCatalogFeedSearchOptions({ catalogFeeds: true })).resolves.toEqual({
-      enabled: false,
-    });
+    await expect(resolveCatalogFeedSearchOptions({ catalogFeeds: true })).rejects.toThrow(
+      "Catalog feed search requires the Feeds plugin to be enabled and allowed in config.",
+    );
+  });
+
+  it("fails explicit feed search when feed search config cannot be read", async () => {
+    mocks.readConfigFileSnapshot.mockRejectedValueOnce(new Error("bad feeds config"));
+
+    await expect(resolveCatalogFeedSearchOptions({ catalogFeeds: true })).rejects.toThrow(
+      "Catalog feed search requires the Feeds plugin to be enabled and allowed in config.",
+    );
   });
 
   it("keeps default search disabled when the Feeds plugin is disabled", async () => {

--- a/src/cli/feed-search-options.test.ts
+++ b/src/cli/feed-search-options.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  readConfigFileSnapshot: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+}));
+
+const { formatFeedSearchEntry, resolveCatalogFeedSearchOptions } =
+  await import("./feed-search-options.js");
+
+describe("feed search CLI options", () => {
+  beforeEach(() => {
+    mocks.readConfigFileSnapshot.mockReset();
+  });
+
+  it("quotes feed install specs in native search hints", () => {
+    const formatted = formatFeedSearchEntry({
+      id: "calendar-helper",
+      type: "plugin",
+      sourceId: "company-approved",
+      feedId: "company-feed",
+      install: {
+        source: "clawhub",
+        spec: "safe-package && curl example.invalid",
+      },
+    });
+
+    expect(formatted).toContain(
+      "Install: openclaw plugins install 'clawhub:safe-package && curl example.invalid'",
+    );
+  });
+
+  it("uses npm install specs in native search hints", () => {
+    const formatted = formatFeedSearchEntry({
+      id: "calendar-helper",
+      type: "plugin",
+      sourceId: "company-approved",
+      feedId: "company-feed",
+      install: {
+        source: "npm",
+        npmSpec: "@company/calendar-helper@1.2.3",
+      },
+    });
+
+    expect(formatted).toContain("Install: openclaw plugins install @company/calendar-helper@1.2.3");
+  });
+
+  it("keeps default search disabled when feed search config cannot be read", async () => {
+    mocks.readConfigFileSnapshot.mockRejectedValueOnce(new Error("bad feeds config"));
+
+    await expect(resolveCatalogFeedSearchOptions({})).resolves.toEqual({ enabled: false });
+  });
+
+  it("preserves an explicit empty default feed source list", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValueOnce({
+      valid: true,
+      config: {
+        plugins: {
+          entries: {
+            feeds: {
+              enabled: true,
+              config: {
+                search: { default: true, sources: [] },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await expect(resolveCatalogFeedSearchOptions({})).resolves.toEqual({
+      enabled: true,
+      sourceIds: [],
+    });
+  });
+
+  it("keeps explicit feed search disabled when the Feeds plugin is disabled", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValueOnce({
+      valid: true,
+      config: {
+        plugins: {
+          entries: {
+            feeds: {
+              enabled: false,
+              config: {
+                search: { default: true },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await expect(resolveCatalogFeedSearchOptions({ catalogFeeds: true })).resolves.toEqual({
+      enabled: false,
+    });
+  });
+
+  it("keeps default search disabled when the Feeds plugin is disabled", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValueOnce({
+      valid: true,
+      config: {
+        plugins: {
+          entries: {
+            feeds: {
+              enabled: false,
+              config: {
+                search: { default: true },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await expect(resolveCatalogFeedSearchOptions({})).resolves.toEqual({ enabled: false });
+  });
+});

--- a/src/cli/feed-search-options.ts
+++ b/src/cli/feed-search-options.ts
@@ -1,8 +1,29 @@
-import type { FeedEntryResult, FeedEntryType } from "../../extensions/feeds/api.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { isRecord } from "../shared/record-coerce.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { theme } from "../terminal/theme.js";
+
+type FeedEntryType = "skill" | "plugin";
+
+type FeedEntryResult = {
+  readonly type: FeedEntryType;
+  readonly id: string;
+  readonly sourceId: string;
+  readonly feedId: string;
+  readonly name?: string;
+  readonly description?: string;
+  readonly version?: string;
+  readonly install?: unknown;
+};
+
+type FeedSearchApi = {
+  readonly searchConfiguredFeedEntries: (options: {
+    readonly query?: string;
+    readonly type?: FeedEntryType;
+    readonly sourceIds?: readonly string[];
+    readonly limit?: number;
+  }) => Promise<readonly FeedEntryResult[]>;
+};
 
 export type CatalogFeedSearchCliOptions = {
   catalogFeeds?: boolean;
@@ -54,7 +75,12 @@ export async function searchCatalogFeedEntriesForCli(params: {
   if (!searchOptions.enabled) {
     return [];
   }
-  const { searchConfiguredFeedEntries } = await import("../../extensions/feeds/api.js");
+  const { loadBundledPluginPublicArtifactModuleSync } =
+    await import("../plugins/public-surface-loader.js");
+  const { searchConfiguredFeedEntries } = loadBundledPluginPublicArtifactModuleSync<FeedSearchApi>({
+    dirName: "feeds",
+    artifactBasename: "api.js",
+  });
   return searchConfiguredFeedEntries({
     query: normalizeOptionalString(
       Array.isArray(params.queryParts) ? params.queryParts.join(" ") : params.queryParts,

--- a/src/cli/feed-search-options.ts
+++ b/src/cli/feed-search-options.ts
@@ -38,9 +38,12 @@ export async function resolveCatalogFeedSearchOptions(opts: CatalogFeedSearchCli
 }> {
   const cliSourceIds = splitFeedSourceIds(opts.feedSource);
   if (opts.catalogFeeds === true || cliSourceIds !== undefined) {
-    return (await readFeedPluginEnabledForSearch())
-      ? { enabled: true, sourceIds: cliSourceIds }
-      : { enabled: false };
+    if (!(await readFeedPluginEnabledForSearch())) {
+      throw new Error(
+        "Catalog feed search requires the Feeds plugin to be enabled and allowed in config.",
+      );
+    }
+    return { enabled: true, sourceIds: cliSourceIds };
   }
   return readDefaultCatalogFeedSearchOptions();
 }

--- a/src/cli/feed-search-options.ts
+++ b/src/cli/feed-search-options.ts
@@ -1,8 +1,4 @@
-import {
-  formatFeedInstallCommand,
-  type FeedEntryResult,
-  type FeedEntryType,
-} from "../../extensions/feeds/api.js";
+import type { FeedEntryResult, FeedEntryType } from "../../extensions/feeds/api.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { isRecord } from "../shared/record-coerce.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -78,8 +74,47 @@ export function formatFeedSearchEntry(entry: FeedEntryResult): string {
 }
 
 function feedInstallHint(entry: FeedEntryResult): string {
-  const command = formatFeedInstallCommand(entry);
+  const command = formatFeedInstallCommandForSearch(entry);
   return command === undefined ? "" : `\n  ${theme.muted(`Install: ${command}`)}`;
+}
+
+function formatFeedInstallCommandForSearch(entry: FeedEntryResult): string | undefined {
+  const install = isRecord(entry.install) ? entry.install : {};
+  const source = typeof install.source === "string" ? install.source : undefined;
+  const spec = typeof install.spec === "string" ? install.spec.trim() : "";
+  const clawhubSpec = typeof install.clawhubSpec === "string" ? install.clawhubSpec.trim() : "";
+  const npmSpec = typeof install.npmSpec === "string" ? install.npmSpec.trim() : "";
+  const slug = typeof install.slug === "string" ? install.slug.trim() : "";
+  if (entry.type === "plugin") {
+    const resolvedSpec =
+      clawhubSpec ||
+      (source === "clawhub" && spec ? normalizeClawHubSpec(spec) : "") ||
+      npmSpec ||
+      ((source === "npm" || source === "path" || source === "git") && spec ? spec : "");
+    return resolvedSpec ? formatOpenClawCommand(["plugins", "install", resolvedSpec]) : undefined;
+  }
+  if (entry.type === "skill") {
+    const resolvedSpec =
+      slug ||
+      (source === "clawhub" && spec ? spec.replace(/^clawhub:/u, "") : "") ||
+      ((source === "git" || source === "path" || source === "local") && spec ? spec : "");
+    return resolvedSpec ? formatOpenClawCommand(["skills", "install", resolvedSpec]) : undefined;
+  }
+  return undefined;
+}
+
+function normalizeClawHubSpec(value: string): string {
+  return value.startsWith("clawhub:") ? value : `clawhub:${value}`;
+}
+
+function formatOpenClawCommand(argv: readonly string[]): string {
+  return ["openclaw", ...argv].map(quoteCliArg).join(" ");
+}
+
+function quoteCliArg(value: string): string {
+  return /^[A-Za-z0-9_/:=.,@%+-]+$/u.test(value)
+    ? value
+    : "'" + value.replaceAll("'", "'\\''") + "'";
 }
 
 async function readFeedPluginEnabledForSearch(): Promise<boolean> {

--- a/src/cli/feed-search-options.ts
+++ b/src/cli/feed-search-options.ts
@@ -1,7 +1,7 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { theme } from "../../packages/terminal-core/src/theme.js";
 import { readConfigFileSnapshot } from "../config/config.js";
-import { isRecord } from "../shared/record-coerce.js";
-import { normalizeOptionalString } from "../shared/string-coerce.js";
-import { theme } from "../terminal/theme.js";
 
 type FeedEntryType = "skill" | "plugin";
 

--- a/src/cli/feed-search-options.ts
+++ b/src/cli/feed-search-options.ts
@@ -1,0 +1,152 @@
+import {
+  formatFeedInstallCommand,
+  type FeedEntryResult,
+  type FeedEntryType,
+} from "../../extensions/feeds/api.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import { isRecord } from "../shared/record-coerce.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { theme } from "../terminal/theme.js";
+
+export type CatalogFeedSearchCliOptions = {
+  catalogFeeds?: boolean;
+  feedSource?: string[];
+};
+
+export function splitFeedSourceIds(values: string[] | undefined): string[] | undefined {
+  if (values === undefined) {
+    return undefined;
+  }
+  const ids = values.flatMap((value) =>
+    value
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean),
+  );
+  return ids.length === 0 ? undefined : [...new Set(ids)];
+}
+
+export async function shouldSearchCatalogFeeds(
+  opts: CatalogFeedSearchCliOptions,
+): Promise<boolean> {
+  return (await resolveCatalogFeedSearchOptions(opts)).enabled;
+}
+
+export async function resolveCatalogFeedSearchOptions(opts: CatalogFeedSearchCliOptions): Promise<{
+  enabled: boolean;
+  sourceIds?: string[];
+}> {
+  const cliSourceIds = splitFeedSourceIds(opts.feedSource);
+  if (opts.catalogFeeds === true || cliSourceIds !== undefined) {
+    return (await readFeedPluginEnabledForSearch())
+      ? { enabled: true, sourceIds: cliSourceIds }
+      : { enabled: false };
+  }
+  return readDefaultCatalogFeedSearchOptions();
+}
+
+export async function searchCatalogFeedEntriesForCli(params: {
+  queryParts: string[] | string;
+  type: FeedEntryType;
+  limit?: number;
+  opts: CatalogFeedSearchCliOptions;
+}): Promise<readonly FeedEntryResult[]> {
+  const searchOptions = await resolveCatalogFeedSearchOptions(params.opts);
+  if (!searchOptions.enabled) {
+    return [];
+  }
+  const { searchConfiguredFeedEntries } = await import("../../extensions/feeds/api.js");
+  return searchConfiguredFeedEntries({
+    query: normalizeOptionalString(
+      Array.isArray(params.queryParts) ? params.queryParts.join(" ") : params.queryParts,
+    ),
+    type: params.type,
+    sourceIds: searchOptions.sourceIds,
+    limit: params.limit,
+  });
+}
+
+export function formatFeedSearchEntry(entry: FeedEntryResult): string {
+  const version = entry.version === undefined ? "" : ` v${entry.version}`;
+  const name = entry.name === undefined ? entry.id : entry.name;
+  const summary = entry.description === undefined ? "" : theme.muted(` - ${entry.description}`);
+  const install = feedInstallHint(entry);
+  return `${entry.id}${version}  ${name}${summary}\n  ${theme.muted(`Feed: ${entry.sourceId}/${entry.feedId}`)}${install}`;
+}
+
+function feedInstallHint(entry: FeedEntryResult): string {
+  const command = formatFeedInstallCommand(entry);
+  return command === undefined ? "" : `\n  ${theme.muted(`Install: ${command}`)}`;
+}
+
+async function readFeedPluginEnabledForSearch(): Promise<boolean> {
+  try {
+    const snapshot = await readConfigFileSnapshot();
+    if (!snapshot.valid) {
+      return false;
+    }
+    const plugins = isRecord(snapshot.config.plugins) ? snapshot.config.plugins : {};
+    const entries = isRecord(plugins.entries) ? plugins.entries : {};
+    const feeds = isRecord(entries.feeds) ? entries.feeds : {};
+    const config = isRecord(feeds.config) ? feeds.config : {};
+    return feedPluginEnabledForDefaultSearch(plugins, feeds, config);
+  } catch {
+    return false;
+  }
+}
+
+async function readDefaultCatalogFeedSearchOptions(): Promise<{
+  enabled: boolean;
+  sourceIds?: string[];
+}> {
+  try {
+    const snapshot = await readConfigFileSnapshot();
+    if (!snapshot.valid) {
+      return { enabled: false };
+    }
+    const plugins = isRecord(snapshot.config.plugins) ? snapshot.config.plugins : {};
+    const entries = isRecord(plugins.entries) ? plugins.entries : {};
+    const feeds = isRecord(entries.feeds) ? entries.feeds : {};
+    const config = isRecord(feeds.config) ? feeds.config : {};
+    if (!feedPluginEnabledForDefaultSearch(plugins, feeds, config)) {
+      return { enabled: false };
+    }
+    const search = isRecord(config.search) ? config.search : {};
+    if (search.default !== true) {
+      return { enabled: false };
+    }
+    if (search.sources !== undefined && !Array.isArray(search.sources)) {
+      return { enabled: false };
+    }
+    return {
+      enabled: true,
+      sourceIds: Array.isArray(search.sources)
+        ? search.sources.filter((id): id is string => typeof id === "string")
+        : undefined,
+    };
+  } catch {
+    return { enabled: false };
+  }
+}
+
+function feedPluginEnabledForDefaultSearch(
+  plugins: Record<string, unknown>,
+  feeds: Record<string, unknown>,
+  config: Record<string, unknown>,
+): boolean {
+  const allow = readStringArray(plugins.allow);
+  const deny = readStringArray(plugins.deny);
+  return (
+    plugins.enabled !== false &&
+    feeds.enabled !== false &&
+    config.enabled !== false &&
+    !deny.includes("feeds") &&
+    (allow.length === 0 || allow.includes("feeds"))
+  );
+}
+
+function readStringArray(value: unknown): readonly string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -20,6 +20,8 @@ export type PluginMarketplaceListOptions = {
 export type PluginSearchOptions = {
   json?: boolean;
   limit?: number;
+  catalogFeeds?: boolean;
+  feedSource?: string[];
 };
 
 export type PluginUninstallOptions = {
@@ -63,6 +65,10 @@ const loadPluginsAuthoringCommands = createModuleLoader(
   () => import("./plugins-authoring-command.js"),
 );
 
+function collectFeedSource(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
 export function registerPluginsCli(program: Command) {
   const plugins = program
     .command("plugins")
@@ -90,6 +96,8 @@ export function registerPluginsCli(program: Command) {
     .argument("[query...]", "Search query")
     .option("--limit <n>", "Max results", (value) => parseStrictPositiveIntOption(value, "--limit"))
     .option("--json", "Print JSON", false)
+    .option("--catalog-feeds", "Search configured catalog feeds instead of ClawHub", false)
+    .option("--feed-source <id>", "Search one configured feed source id", collectFeedSource, [])
     .action(async (queryParts: string[], opts: PluginSearchOptions) => {
       const { runPluginsSearchCommand } = await import("./plugins-search-command.js");
       await runPluginsSearchCommand(queryParts, opts);

--- a/src/cli/plugins-search-command.test.ts
+++ b/src/cli/plugins-search-command.test.ts
@@ -23,6 +23,9 @@ const mocks = vi.hoisted(() => {
     errors,
     runtime,
     searchClawHubPackages: vi.fn(),
+    shouldSearchCatalogFeeds: vi.fn(() => false),
+    searchCatalogFeedEntriesForCli: vi.fn(),
+    formatFeedSearchEntry: vi.fn((entry: { id: string }) => `feed:${entry.id}`),
   };
 });
 
@@ -34,6 +37,12 @@ vi.mock("../runtime.js", () => ({
 
 vi.mock("../infra/clawhub.js", () => ({
   searchClawHubPackages: mocks.searchClawHubPackages,
+}));
+
+vi.mock("./feed-search-options.js", () => ({
+  shouldSearchCatalogFeeds: mocks.shouldSearchCatalogFeeds,
+  searchCatalogFeedEntriesForCli: mocks.searchCatalogFeedEntriesForCli,
+  formatFeedSearchEntry: mocks.formatFeedSearchEntry,
 }));
 
 const { runPluginsSearchCommand } = await import("./plugins-search-command.js");
@@ -48,6 +57,10 @@ describe("plugins search command", () => {
     mocks.runtime.writeJson.mockClear();
     mocks.runtime.exit.mockClear();
     mocks.searchClawHubPackages.mockReset();
+    mocks.shouldSearchCatalogFeeds.mockReset();
+    mocks.shouldSearchCatalogFeeds.mockReturnValue(false);
+    mocks.searchCatalogFeedEntriesForCli.mockReset();
+    mocks.formatFeedSearchEntry.mockClear();
   });
 
   it("searches ClawHub code and bundle plugin families", async () => {
@@ -101,6 +114,22 @@ describe("plugins search command", () => {
     expect(mocks.logs.join("\n")).toContain(
       "Install: openclaw plugins install clawhub:openclaw-calendar",
     );
+  });
+
+  it("searches catalog feed plugins when requested", async () => {
+    mocks.shouldSearchCatalogFeeds.mockResolvedValueOnce(true);
+    mocks.searchCatalogFeedEntriesForCli.mockResolvedValueOnce([{ id: "calendar-helper" }]);
+
+    await runPluginsSearchCommand(["calendar"], { catalogFeeds: true, limit: 5 }, mocks.runtime);
+
+    expect(mocks.searchCatalogFeedEntriesForCli).toHaveBeenCalledWith({
+      queryParts: ["calendar"],
+      type: "plugin",
+      limit: 5,
+      opts: { catalogFeeds: true, limit: 5 },
+    });
+    expect(mocks.searchClawHubPackages).not.toHaveBeenCalled();
+    expect(mocks.logs.join("\n")).toContain("feed:calendar-helper");
   });
 
   it("writes JSON results when requested", async () => {

--- a/src/cli/plugins-search-command.ts
+++ b/src/cli/plugins-search-command.ts
@@ -8,11 +8,18 @@ import {
 } from "../infra/clawhub.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
+import {
+  formatFeedSearchEntry,
+  searchCatalogFeedEntriesForCli,
+  shouldSearchCatalogFeeds,
+} from "./feed-search-options.js";
 
 /** Options accepted by `openclaw plugins search`. */
 export type PluginsSearchOptions = {
   json?: boolean;
   limit?: number;
+  catalogFeeds?: boolean;
+  feedSource?: string[];
 };
 
 const INSTALLABLE_PLUGIN_FAMILIES: ClawHubPackageFamily[] = ["code-plugin", "bundle-plugin"];
@@ -84,6 +91,25 @@ export async function runPluginsSearchCommand(
 
   const limit = clampSearchLimit(opts.limit);
   try {
+    if (await shouldSearchCatalogFeeds(opts)) {
+      const results = await searchCatalogFeedEntriesForCli({
+        queryParts,
+        type: "plugin",
+        limit,
+        opts,
+      });
+      if (opts.json) {
+        writeRuntimeJson(runtime, { results });
+        return;
+      }
+      if (results.length === 0) {
+        runtime.log("No catalog feed plugins found.");
+        return;
+      }
+      runtime.log(`${theme.heading("Catalog feed plugins")} ${theme.muted(`(${results.length})`)}`);
+      runtime.log(results.map(formatFeedSearchEntry).join("\n"));
+      return;
+    }
     const groups = await Promise.all(
       INSTALLABLE_PLUGIN_FAMILIES.map((family) =>
         searchClawHubPackages({

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -81,6 +81,9 @@ const mocks = vi.hoisted(() => {
       (_configForTest: unknown, _agentId: string) => "/tmp/workspace",
     ),
     searchSkillsFromClawHubMock: vi.fn(),
+    shouldSearchCatalogFeedsMock: vi.fn(() => false),
+    searchCatalogFeedEntriesForCliMock: vi.fn(),
+    formatFeedSearchEntryMock: vi.fn((entry: { id: string }) => `feed:${entry.id}`),
     installSkillFromClawHubMock: vi.fn(),
     installSkillFromSourceMock: vi.fn(),
     updateSkillsFromClawHubMock: vi.fn(),
@@ -107,6 +110,9 @@ const {
   resolveAgentIdByWorkspacePathMock,
   resolveAgentWorkspaceDirMock,
   searchSkillsFromClawHubMock,
+  shouldSearchCatalogFeedsMock,
+  searchCatalogFeedEntriesForCliMock,
+  formatFeedSearchEntryMock,
   installSkillFromClawHubMock,
   installSkillFromSourceMock,
   updateSkillsFromClawHubMock,
@@ -187,6 +193,12 @@ vi.mock("../agents/agent-scope.js", () => ({
     mocks.resolveAgentWorkspaceDirMock(config, agentId),
 }));
 
+vi.mock("./feed-search-options.js", () => ({
+  shouldSearchCatalogFeeds: mocks.shouldSearchCatalogFeedsMock,
+  searchCatalogFeedEntriesForCli: mocks.searchCatalogFeedEntriesForCliMock,
+  formatFeedSearchEntry: mocks.formatFeedSearchEntryMock,
+}));
+
 vi.mock("../skills/lifecycle/clawhub.js", () => ({
   searchSkillsFromClawHub: (...args: unknown[]) => mocks.searchSkillsFromClawHubMock(...args),
   installSkillFromClawHub: (...args: unknown[]) => mocks.installSkillFromClawHubMock(...args),
@@ -255,6 +267,9 @@ describe("skills cli commands", () => {
     resolveAgentIdByWorkspacePathMock.mockReset();
     resolveAgentWorkspaceDirMock.mockReset();
     searchSkillsFromClawHubMock.mockReset();
+    shouldSearchCatalogFeedsMock.mockReset();
+    searchCatalogFeedEntriesForCliMock.mockReset();
+    formatFeedSearchEntryMock.mockClear();
     installSkillFromClawHubMock.mockReset();
     installSkillFromSourceMock.mockReset();
     updateSkillsFromClawHubMock.mockReset();
@@ -273,6 +288,7 @@ describe("skills cli commands", () => {
     resolveAgentIdByWorkspacePathMock.mockReturnValue(undefined);
     resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     searchSkillsFromClawHubMock.mockResolvedValue([]);
+    shouldSearchCatalogFeedsMock.mockResolvedValue(false);
     installSkillFromClawHubMock.mockResolvedValue({
       ok: false,
       error: "install disabled in test",
@@ -365,6 +381,22 @@ describe("skills cli commands", () => {
       runtimeLogs.some((line) => line.includes("calendar v1.2.3  Calendar")),
       "search result log",
     ).toBe(true);
+  });
+
+  it("searches catalog feed skills when requested", async () => {
+    mocks.shouldSearchCatalogFeedsMock.mockResolvedValueOnce(true);
+    mocks.searchCatalogFeedEntriesForCliMock.mockResolvedValueOnce([{ id: "excel-review" }]);
+
+    await runCommand(["skills", "search", "excel", "--catalog-feeds"]);
+
+    expect(mocks.searchCatalogFeedEntriesForCliMock).toHaveBeenCalledWith({
+      queryParts: ["excel"],
+      type: "skill",
+      limit: undefined,
+      opts: { catalogFeeds: true, feedSource: [], json: false },
+    });
+    expect(searchSkillsFromClawHubMock).not.toHaveBeenCalled();
+    expect(runtimeLogs.join("\n")).toContain("feed:excel-review");
   });
 
   it("rejects partial numeric search limits", async () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -46,6 +46,11 @@ import type {
 } from "../skills/workshop/types.js";
 import { CONFIG_DIR } from "../utils.js";
 import { resolveOptionFromCommand } from "./cli-utils.js";
+import {
+  formatFeedSearchEntry,
+  searchCatalogFeedEntriesForCli,
+  shouldSearchCatalogFeeds,
+} from "./feed-search-options.js";
 import { parseStrictPositiveIntOption } from "./program/helpers.js";
 import { formatSkillInfo, formatSkillsCheck, formatSkillsList } from "./skills-cli.format.js";
 
@@ -239,6 +244,10 @@ async function readSkillProposalInput(options: {
   return { content: await readSkillProposalDraftFile(proposal!) };
 }
 
+function collectFeedSource(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
 /**
  * Register the skills CLI commands
  */
@@ -259,30 +268,57 @@ export function registerSkillsCli(program: Command) {
     .argument("[query...]", "Optional search query")
     .option("--limit <n>", "Max results", (value) => parseStrictPositiveIntOption(value, "--limit"))
     .option("--json", "Output as JSON", false)
-    .action(async (queryParts: string[], opts: { limit?: number; json?: boolean }) => {
-      try {
-        const results = await searchSkillsFromClawHub({
-          query: normalizeOptionalString(queryParts.join(" ")),
-          limit: opts.limit,
-        });
-        if (opts.json) {
-          defaultRuntime.writeJson({ results });
-          return;
+    .option("--catalog-feeds", "Search configured catalog feeds instead of ClawHub", false)
+    .option("--feed-source <id>", "Search one configured feed source id", collectFeedSource, [])
+    .action(
+      async (
+        queryParts: string[],
+        opts: { limit?: number; json?: boolean; catalogFeeds?: boolean; feedSource?: string[] },
+      ) => {
+        try {
+          if (await shouldSearchCatalogFeeds(opts)) {
+            const results = await searchCatalogFeedEntriesForCli({
+              queryParts,
+              type: "skill",
+              limit: opts.limit,
+              opts,
+            });
+            if (opts.json) {
+              defaultRuntime.writeJson({ results });
+              return;
+            }
+            if (results.length === 0) {
+              defaultRuntime.log("No catalog feed skills found.");
+              return;
+            }
+            for (const entry of results) {
+              defaultRuntime.log(formatFeedSearchEntry(entry));
+            }
+            return;
+          }
+          const results = await searchSkillsFromClawHub({
+            query: normalizeOptionalString(queryParts.join(" ")),
+            limit: opts.limit,
+          });
+          if (opts.json) {
+            defaultRuntime.writeJson({ results });
+            return;
+          }
+          if (results.length === 0) {
+            defaultRuntime.log("No ClawHub skills found.");
+            return;
+          }
+          for (const entry of results) {
+            const version = entry.version ? ` v${entry.version}` : "";
+            const summary = entry.summary ? `  ${entry.summary}` : "";
+            defaultRuntime.log(`${entry.slug}${version}  ${entry.displayName}${summary}`);
+          }
+        } catch (err) {
+          defaultRuntime.error(String(err));
+          defaultRuntime.exit(1);
         }
-        if (results.length === 0) {
-          defaultRuntime.log("No ClawHub skills found.");
-          return;
-        }
-        for (const entry of results) {
-          const version = entry.version ? ` v${entry.version}` : "";
-          const summary = entry.summary ? `  ${entry.summary}` : "";
-          defaultRuntime.log(`${entry.slug}${version}  ${entry.displayName}${summary}`);
-        }
-      } catch (err) {
-        defaultRuntime.error(String(err));
-        defaultRuntime.exit(1);
-      }
-    });
+      },
+    );
 
   skills
     .command("install")


### PR DESCRIPTION
## Summary

Adds the opt-in path for native `openclaw skills search` and `openclaw plugins search` to use configured catalog feeds.

This PR keeps the rollout explicit:

- `--catalog-feeds` searches configured feed sources for one command.
- `--feed-source <id>` narrows native search to specific configured source ids.
- `plugins.entries.feeds.config.search.default: true` makes native skill/plugin search use feeds by default.
- `plugins.entries.feeds.config.search.sources` optionally narrows the default feed source set; omitted means all enabled sources, and an explicit empty list means no sources.
- Policy can require native feed search defaults with `feeds.search.requireDefault` and `feeds.search.requireSources`.

## Policy syntax

```jsonc
{
  "feeds": {
    "search": {
      "requireDefault": true,
      "requireSources": ["company-approved"],
    },
  },
}
```

## Config syntax

```jsonc
{
  "plugins": {
    "entries": {
      "feeds": {
        "enabled": true,
        "config": {
          "search": {
            "default": true,
            "sources": ["company-approved"],
          },
          "sources": [
            {
              "id": "company-approved",
              "url": "https://feeds.example.com/company.json",
              "trust": "pinned",
              "integrity": "sha256:...",
            },
          ],
        },
      },
    },
  },
}
```

## Stack

1. #87824 - read-only feed discovery
2. #87825 - approved feed installs
3. #87826 - feed catalog policy conformance
4. #87827 - feed lifecycle tooling
5. This PR - native search defaults and policy checks

## Real behavior proof

Behavior or issue addressed:
Native `openclaw skills search` and `openclaw plugins search` can search configured catalog feeds explicitly with `--catalog-feeds` / `--feed-source`, and use feeds by default when the Feeds plugin search default is enabled.

Real environment tested:
WSL Ubuntu 24.04, source checkout `/root/src/openclaw-feeds-88732` at `c487721eafb27b0226e3cdfed5a54d8ddef2d12f`, source CLI via `node scripts/run-node.mjs`, temporary OpenClaw config/state/home, and one pinned local `file://` feed source. No ClawHub or external network service was contacted by the proof search commands.

Exact steps or command run after this patch:
1. `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/feed-search-options.test.ts src/cli/plugins-search-command.test.ts src/cli/skills-cli.commands.test.ts extensions/feeds/src/cli.test.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts src/flows/bundled-health-checks.test.ts --reporter=dot`
2. `pnpm exec oxlint --tsconfig ./tsconfig.json src/cli/feed-search-options.ts src/cli/feed-search-options.test.ts src/cli/plugins-cli.ts src/cli/plugins-search-command.ts src/cli/plugins-search-command.test.ts src/cli/skills-cli.ts src/cli/skills-cli.commands.test.ts extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/policy-state.ts`
3. `pnpm exec oxfmt --check --threads=1 docs/cli/plugins.md docs/cli/skills.md docs/cli/policy.md docs/plugins/reference/feeds.md src/cli/feed-search-options.ts src/cli/feed-search-options.test.ts src/cli/plugins-cli.ts src/cli/plugins-search-command.ts src/cli/plugins-search-command.test.ts src/cli/skills-cli.ts src/cli/skills-cli.commands.test.ts extensions/feeds/api.ts extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/policy-state.ts && git diff --check`
4. `pnpm tsgo:extensions`
5. `pnpm tsgo:core`
6. `node scripts/run-node.mjs skills search spreadsheet --catalog-feeds --feed-source approved --json`
7. `node scripts/run-node.mjs plugins search calendar --catalog-feeds --feed-source approved --json`
8. `node scripts/run-node.mjs skills search spreadsheet --json`
9. `node scripts/run-node.mjs plugins search calendar --json`

Evidence after fix:
Validation passed: focused Vitest passed 3 shards with 8, 64, and 371 tests; oxlint passed with 0 warnings/errors; scoped oxfmt plus `git diff --check` passed; `pnpm tsgo:extensions` passed; `pnpm tsgo:core` passed.

Source CLI proof transcript:

```text
PROOF_ROOT=/tmp/openclaw-feeds-88732-proof.sEIwUD
FEED_INTEGRITY=sha256:478b4a157e66822becaf8884665aeba82e4c50cca495d0ddafb7e1c30cee321e

## skills explicit
{
  "results": [
    {
      "type": "skill",
      "id": "excel-review",
      "version": "1.2.0",
      "name": "Excel Review",
      "description": "Review spreadsheets",
      "sourceId": "approved",
      "feedId": "company-approved"
    }
  ]
}

## plugins explicit
{
  "results": [
    {
      "type": "plugin",
      "id": "calendar-helper",
      "version": "0.3.0",
      "name": "Calendar Helper",
      "description": "Calendar automation",
      "sourceId": "approved",
      "feedId": "company-approved"
    }
  ]
}

## skills default
{
  "results": [
    {
      "type": "skill",
      "id": "excel-review",
      "sourceId": "approved",
      "feedId": "company-approved"
    }
  ]
}

## plugins default
{
  "results": [
    {
      "type": "plugin",
      "id": "calendar-helper",
      "sourceId": "approved",
      "feedId": "company-approved"
    }
  ]
}
```

Observed result after fix:
Explicit feed-backed `skills search` returned only the feed skill entry, explicit feed-backed `plugins search` returned only the feed plugin entry, and the same two commands used the configured feed by default when `plugins.entries.feeds.config.search.default` was true with `sources: ["approved"]`.

What was not tested:
No live external HTTPS feed endpoint or ClawHub service was contacted in the source CLI proof; the proof uses an isolated pinned local `file://` feed, and HTTPS feed loading is covered by the lower feed stack tests.

## Validation

- `codex review --commit HEAD`
- `node node_modules/vitest/vitest.mjs run extensions/feeds/src/cli.test.ts src/cli/feed-search-options.test.ts src/cli/plugins-search-command.test.ts src/cli/skills-cli.commands.test.ts extensions/policy/src/doctor/register.test.ts --reporter=dot`
- `node node_modules/oxlint/bin/oxlint extensions/feeds/api.ts extensions/feeds/src/cli.ts extensions/feeds/src/cli.test.ts src/cli/feed-search-options.ts src/cli/feed-search-options.test.ts src/cli/plugins-search-command.test.ts src/cli/skills-cli.commands.test.ts extensions/policy/src/policy-state.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts --tsconfig tsconfig.json`
- `git diff --check`

## Feed PR stack

1. openclaw/openclaw#87824 - read-only feed discovery
2. openclaw/openclaw#87825 - approved feed installs
3. openclaw/openclaw#87826 - feed catalog policy conformance
4. openclaw/openclaw#87827 - feed lifecycle tooling
5. openclaw/openclaw#88732 - native feed search defaults and policy checks
6. openclaw/clawhub#2460 - ClawHub root feed lanes

The stack keeps OpenClaw as a feed consumer. ClawHub root feeds are producer infrastructure; enterprise or tenant feeds can be produced elsewhere using the same schema.

RFC draft: https://github.com/giodl73-repo/rfcs/blob/feeds-rfc-draft/rfcs/0004-feeds.md

