### PR TITLE
refactor: extract ACP runtime resume state

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -15,7 +15,6 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import { formatErrorMessage } from "../../infra/errors.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { isAcpSessionKey } from "../../sessions/session-key-utils.js";
 import {
@@ -47,6 +46,12 @@ import {
 } from "./manager.runtime-controls.js";
 import { ManagerRuntimeHandleCache } from "./manager.runtime-handle-cache.js";
 import { ensureManagerRuntimeHandle } from "./manager.runtime-handle-ensure.js";
+import {
+  discardPersistedManagerRuntimeState,
+  isRecoverableManagerAcpxExitError,
+  prepareFreshManagerRuntimeHandleRetry,
+  tryPrepareFreshManagerRuntimeSession,
+} from "./manager.runtime-resume-state.js";
 import { consumeAcpTurnStream } from "./manager.turn-stream.js";
 import {
   awaitTurnWithTimeout,
@@ -912,7 +917,7 @@ export class AcpSessionManager {
                     ? "ACP turn failed before completion."
                     : "Could not initialize ACP session runtime.",
                 });
-                retryFreshHandle = await this.prepareFreshHandleRetry({
+                retryFreshHandle = await prepareFreshManagerRuntimeHandleRetry({
                   attempt,
                   cfg: input.cfg,
                   sessionKey,
@@ -920,6 +925,8 @@ export class AcpSessionManager {
                   sawTurnOutput,
                   runtime,
                   meta,
+                  runtimeHandles: this.runtimeHandles,
+                  writeSessionMeta: async (writeParams) => await this.writeSessionMeta(writeParams),
                 });
                 if (retryFreshHandle) {
                   continue;
@@ -1103,18 +1110,13 @@ export class AcpSessionManager {
       let runtimeNotice: string | undefined;
       if (shouldSkipRuntimeClose) {
         if (input.discardPersistentState) {
-          const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
-          try {
-            await this.deps
-              .getRuntimeBackend(configuredBackend || undefined)
-              ?.runtime.prepareFreshSession?.({
-                sessionKey,
-              });
-          } catch (error) {
-            logVerbose(
-              `acp close fast-reset: unable to prepare fresh session for ${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
-            );
-          }
+          await tryPrepareFreshManagerRuntimeSession({
+            deps: this.deps,
+            cfg: input.cfg,
+            meta,
+            sessionKey,
+            logPrefix: "acp close fast-reset",
+          });
         }
         this.runtimeHandles.clear(sessionKey);
       } else {
@@ -1149,23 +1151,17 @@ export class AcpSessionManager {
               (input.discardPersistentState && acpError.code === "ACP_SESSION_INIT_FAILED") ||
               (input.discardPersistentState &&
                 acpError.code === "ACP_BACKEND_UNSUPPORTED_CONTROL") ||
-              this.isRecoverableAcpxExitError(acpError.message))
+              isRecoverableManagerAcpxExitError(acpError.message))
           ) {
             if (input.discardPersistentState) {
-              const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
-              try {
-                const runtimeBackend = this.deps.getRuntimeBackend(configuredBackend || undefined);
-                if (!runtimeBackend) {
-                  throw acpError;
-                }
-                await runtimeBackend.runtime.prepareFreshSession?.({
-                  sessionKey,
-                });
-              } catch (recoveryError) {
-                logVerbose(
-                  `acp close recovery: unable to prepare fresh session for ${sessionKey}: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
-                );
-              }
+              await tryPrepareFreshManagerRuntimeSession({
+                deps: this.deps,
+                cfg: input.cfg,
+                meta,
+                sessionKey,
+                logPrefix: "acp close recovery",
+                missingBackendError: acpError,
+              });
             }
             // Treat unavailable backends as terminal for this cached handle so it
             // cannot continue counting against maxConcurrentSessions.
@@ -1179,9 +1175,10 @@ export class AcpSessionManager {
 
       let metaCleared = false;
       if (input.discardPersistentState && !input.clearMeta) {
-        await this.discardPersistedRuntimeState({
+        await discardPersistedManagerRuntimeState({
           cfg: input.cfg,
           sessionKey,
+          writeSessionMeta: async (writeParams) => await this.writeSessionMeta(writeParams),
         });
       }
 
@@ -1303,163 +1300,6 @@ export class AcpSessionManager {
   private recordErrorCode(code: string): void {
     const normalized = normalizeAcpErrorCode(code);
     this.errorCountsByCode.set(normalized, (this.errorCountsByCode.get(normalized) ?? 0) + 1);
-  }
-
-  private async prepareFreshHandleRetry(params: {
-    attempt: number;
-    cfg: OpenClawConfig;
-    sessionKey: string;
-    error: AcpRuntimeError;
-    sawTurnOutput: boolean;
-    runtime?: AcpRuntime;
-    meta?: SessionAcpMeta;
-  }): Promise<boolean> {
-    if (params.attempt > 0 || params.sawTurnOutput) {
-      return false;
-    }
-    if (this.isRecoverableAcpxExitError(params.error.message)) {
-      this.runtimeHandles.clear(params.sessionKey);
-      logVerbose(
-        `acp-manager: retrying ${params.sessionKey} with a fresh runtime handle after early turn failure: ${params.error.message}`,
-      );
-      return true;
-    }
-    if (
-      !params.runtime ||
-      !params.meta ||
-      params.meta.mode !== "persistent" ||
-      !this.isRecoverableMissingPersistentSessionError(params.error.message)
-    ) {
-      return false;
-    }
-    const cleared = await this.clearPersistedRuntimeResumeState({
-      cfg: params.cfg,
-      sessionKey: params.sessionKey,
-    });
-    if (!cleared) {
-      return false;
-    }
-    if (params.runtime.prepareFreshSession) {
-      try {
-        await params.runtime.prepareFreshSession({
-          sessionKey: params.sessionKey,
-        });
-      } catch (error) {
-        logVerbose(
-          `acp-manager: failed preparing a fresh persistent session for ${params.sessionKey}: ${formatErrorMessage(error)}`,
-        );
-        return false;
-      }
-    }
-    this.runtimeHandles.clear(params.sessionKey);
-    logVerbose(
-      `acp-manager: retrying ${params.sessionKey} with a fresh persistent session after missing backend resume target: ${params.error.message}`,
-    );
-    return true;
-  }
-
-  private isRecoverableAcpxExitError(message: string): boolean {
-    return /^acpx exited with (code \d+|signal [a-z0-9]+)/i.test(message.trim());
-  }
-
-  private isRecoverableMissingPersistentSessionError(message: string): boolean {
-    const normalized = message.trim();
-    return (
-      /persistent acp session .* could not be resumed/i.test(normalized) &&
-      /(resource not found|no matching session)/i.test(normalized)
-    );
-  }
-
-  private async clearPersistedRuntimeResumeState(params: {
-    cfg: OpenClawConfig;
-    sessionKey: string;
-  }): Promise<boolean> {
-    const now = Date.now();
-    const updated = await this.writeSessionMeta({
-      cfg: params.cfg,
-      sessionKey: params.sessionKey,
-      mutate: (current, entry) => {
-        if (!entry) {
-          return null;
-        }
-        const base = current;
-        if (!base) {
-          return null;
-        }
-        const currentIdentity = resolveSessionIdentityFromMeta(base);
-        if (!currentIdentity?.acpxSessionId && !currentIdentity?.agentSessionId) {
-          return base;
-        }
-        const nextIdentity = {
-          state: "pending" as const,
-          ...(currentIdentity.acpxRecordId ? { acpxRecordId: currentIdentity.acpxRecordId } : {}),
-          source: currentIdentity.source,
-          lastUpdatedAt: now,
-        };
-        return {
-          backend: base.backend,
-          agent: base.agent,
-          runtimeSessionName: base.runtimeSessionName,
-          identity: nextIdentity,
-          mode: base.mode,
-          ...(base.runtimeOptions ? { runtimeOptions: base.runtimeOptions } : {}),
-          ...(base.cwd ? { cwd: base.cwd } : {}),
-          state: base.state,
-          lastActivityAt: now,
-          ...(base.lastError ? { lastError: base.lastError } : {}),
-        };
-      },
-    });
-    if (!updated) {
-      logVerbose(
-        `acp-manager: unable to clear persisted runtime resume state for ${params.sessionKey}`,
-      );
-      return false;
-    }
-    return true;
-  }
-
-  private async discardPersistedRuntimeState(params: {
-    cfg: OpenClawConfig;
-    sessionKey: string;
-  }): Promise<void> {
-    const now = Date.now();
-    await this.writeSessionMeta({
-      cfg: params.cfg,
-      sessionKey: params.sessionKey,
-      mutate: (current, entry) => {
-        if (!entry) {
-          return null;
-        }
-        const base = current;
-        if (!base) {
-          return null;
-        }
-        const currentIdentity = resolveSessionIdentityFromMeta(base);
-        const nextIdentity = currentIdentity
-          ? {
-              state: "pending" as const,
-              ...(currentIdentity.acpxRecordId
-                ? { acpxRecordId: currentIdentity.acpxRecordId }
-                : {}),
-              source: currentIdentity.source,
-              lastUpdatedAt: now,
-            }
-          : undefined;
-        return {
-          backend: base.backend,
-          agent: base.agent,
-          runtimeSessionName: base.runtimeSessionName,
-          ...(nextIdentity ? { identity: nextIdentity } : {}),
-          mode: base.mode,
-          ...(base.runtimeOptions ? { runtimeOptions: base.runtimeOptions } : {}),
-          ...(base.cwd ? { cwd: base.cwd } : {}),
-          state: "idle",
-          lastActivityAt: now,
-        };
-      },
-      failOnError: true,
-    });
   }
 
   private async resolveRuntimeCapabilities(params: {

--- a/src/acp/control-plane/manager.runtime-handle-ensure.ts
+++ b/src/acp/control-plane/manager.runtime-handle-ensure.ts
@@ -13,7 +13,11 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { toAcpRuntimeError, withAcpRuntimeErrorBoundary } from "../runtime/errors.js";
 import type { ManagerRuntimeHandleCache } from "./manager.runtime-handle-cache.js";
-import type { AcpSessionManagerDeps, SessionAcpMeta, SessionEntry } from "./manager.types.js";
+import type {
+  AcpSessionManagerDeps,
+  SessionAcpMeta,
+  WriteManagerSessionMeta,
+} from "./manager.types.js";
 import { hasLegacyAcpIdentityProjection, resolveAcpAgentFromSessionKey } from "./manager.utils.js";
 import {
   normalizeRuntimeOptions,
@@ -22,18 +26,6 @@ import {
   runtimeOptionsEqual,
 } from "./runtime-options.js";
 
-type WriteSessionMeta = (params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  mutate: (
-    current: SessionAcpMeta | undefined,
-    entry: SessionEntry | undefined,
-  ) => SessionAcpMeta | null | undefined;
-  failOnError?: boolean;
-  skipMaintenance?: boolean;
-  takeCacheOwnership?: boolean;
-}) => Promise<SessionEntry | null>;
-
 export async function ensureManagerRuntimeHandle(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -41,7 +33,7 @@ export async function ensureManagerRuntimeHandle(params: {
   deps: Pick<AcpSessionManagerDeps, "requireRuntimeBackend">;
   runtimeHandles: ManagerRuntimeHandleCache;
   enforceConcurrentSessionLimit: (params: { cfg: OpenClawConfig; sessionKey: string }) => void;
-  writeSessionMeta: WriteSessionMeta;
+  writeSessionMeta: WriteManagerSessionMeta;
 }): Promise<{ runtime: AcpRuntime; handle: AcpRuntimeHandle; meta: SessionAcpMeta }> {
   const agent =
     normalizeText(params.meta.agent) || resolveAcpAgentFromSessionKey(params.sessionKey, "main");

--- a/src/acp/control-plane/manager.runtime-resume-state.ts
+++ b/src/acp/control-plane/manager.runtime-resume-state.ts
@@ -1,0 +1,199 @@
+import { resolveSessionIdentityFromMeta } from "@openclaw/acp-core/runtime/session-identity";
+import type { AcpRuntime } from "@openclaw/acp-core/runtime/types";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { logVerbose } from "../../globals.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import type { AcpRuntimeError } from "../runtime/errors.js";
+import type { ManagerRuntimeHandleCache } from "./manager.runtime-handle-cache.js";
+import type {
+  AcpSessionManagerDeps,
+  SessionAcpMeta,
+  WriteManagerSessionMeta,
+} from "./manager.types.js";
+
+export function isRecoverableManagerAcpxExitError(message: string): boolean {
+  return /^acpx exited with (code \d+|signal [a-z0-9]+)/i.test(message.trim());
+}
+
+function isRecoverableMissingManagerPersistentSessionError(message: string): boolean {
+  const normalized = message.trim();
+  return (
+    /persistent acp session .* could not be resumed/i.test(normalized) &&
+    /(resource not found|no matching session)/i.test(normalized)
+  );
+}
+
+export async function prepareFreshManagerRuntimeHandleRetry(params: {
+  attempt: number;
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  error: AcpRuntimeError;
+  sawTurnOutput: boolean;
+  runtime?: AcpRuntime;
+  meta?: SessionAcpMeta;
+  runtimeHandles: ManagerRuntimeHandleCache;
+  writeSessionMeta: WriteManagerSessionMeta;
+}): Promise<boolean> {
+  if (params.attempt > 0 || params.sawTurnOutput) {
+    return false;
+  }
+  if (isRecoverableManagerAcpxExitError(params.error.message)) {
+    params.runtimeHandles.clear(params.sessionKey);
+    logVerbose(
+      `acp-manager: retrying ${params.sessionKey} with a fresh runtime handle after early turn failure: ${params.error.message}`,
+    );
+    return true;
+  }
+  if (
+    !params.runtime ||
+    !params.meta ||
+    params.meta.mode !== "persistent" ||
+    !isRecoverableMissingManagerPersistentSessionError(params.error.message)
+  ) {
+    return false;
+  }
+  const cleared = await clearPersistedRuntimeResumeState({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    writeSessionMeta: params.writeSessionMeta,
+  });
+  if (!cleared) {
+    return false;
+  }
+  if (params.runtime.prepareFreshSession) {
+    try {
+      await params.runtime.prepareFreshSession({
+        sessionKey: params.sessionKey,
+      });
+    } catch (error) {
+      logVerbose(
+        `acp-manager: failed preparing a fresh persistent session for ${params.sessionKey}: ${formatErrorMessage(error)}`,
+      );
+      return false;
+    }
+  }
+  params.runtimeHandles.clear(params.sessionKey);
+  logVerbose(
+    `acp-manager: retrying ${params.sessionKey} with a fresh persistent session after missing backend resume target: ${params.error.message}`,
+  );
+  return true;
+}
+
+async function clearPersistedRuntimeResumeState(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  writeSessionMeta: WriteManagerSessionMeta;
+}): Promise<boolean> {
+  const now = Date.now();
+  const updated = await params.writeSessionMeta({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    mutate: (current, entry) => {
+      if (!entry) {
+        return null;
+      }
+      const base = current;
+      if (!base) {
+        return null;
+      }
+      const currentIdentity = resolveSessionIdentityFromMeta(base);
+      if (!currentIdentity?.acpxSessionId && !currentIdentity?.agentSessionId) {
+        return base;
+      }
+      const nextIdentity = {
+        state: "pending" as const,
+        ...(currentIdentity.acpxRecordId ? { acpxRecordId: currentIdentity.acpxRecordId } : {}),
+        source: currentIdentity.source,
+        lastUpdatedAt: now,
+      };
+      return {
+        backend: base.backend,
+        agent: base.agent,
+        runtimeSessionName: base.runtimeSessionName,
+        identity: nextIdentity,
+        mode: base.mode,
+        ...(base.runtimeOptions ? { runtimeOptions: base.runtimeOptions } : {}),
+        ...(base.cwd ? { cwd: base.cwd } : {}),
+        state: base.state,
+        lastActivityAt: now,
+        ...(base.lastError ? { lastError: base.lastError } : {}),
+      };
+    },
+  });
+  if (!updated) {
+    logVerbose(
+      `acp-manager: unable to clear persisted runtime resume state for ${params.sessionKey}`,
+    );
+    return false;
+  }
+  return true;
+}
+
+export async function discardPersistedManagerRuntimeState(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  writeSessionMeta: WriteManagerSessionMeta;
+}): Promise<void> {
+  const now = Date.now();
+  await params.writeSessionMeta({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    mutate: (current, entry) => {
+      if (!entry) {
+        return null;
+      }
+      const base = current;
+      if (!base) {
+        return null;
+      }
+      const currentIdentity = resolveSessionIdentityFromMeta(base);
+      const nextIdentity = currentIdentity
+        ? {
+            state: "pending" as const,
+            ...(currentIdentity.acpxRecordId ? { acpxRecordId: currentIdentity.acpxRecordId } : {}),
+            source: currentIdentity.source,
+            lastUpdatedAt: now,
+          }
+        : undefined;
+      return {
+        backend: base.backend,
+        agent: base.agent,
+        runtimeSessionName: base.runtimeSessionName,
+        ...(nextIdentity ? { identity: nextIdentity } : {}),
+        mode: base.mode,
+        ...(base.runtimeOptions ? { runtimeOptions: base.runtimeOptions } : {}),
+        ...(base.cwd ? { cwd: base.cwd } : {}),
+        state: "idle",
+        lastActivityAt: now,
+      };
+    },
+    failOnError: true,
+  });
+}
+
+export async function tryPrepareFreshManagerRuntimeSession(params: {
+  deps: Pick<AcpSessionManagerDeps, "getRuntimeBackend">;
+  cfg: OpenClawConfig;
+  meta: SessionAcpMeta;
+  sessionKey: string;
+  logPrefix: string;
+  missingBackendError?: unknown;
+}): Promise<void> {
+  const configuredBackend = (params.meta.backend || params.cfg.acp?.backend || "").trim();
+  try {
+    const backend = params.deps.getRuntimeBackend(configuredBackend || undefined);
+    if (!backend) {
+      if (params.missingBackendError) {
+        throw params.missingBackendError;
+      }
+      return;
+    }
+    await backend.runtime.prepareFreshSession?.({
+      sessionKey: params.sessionKey,
+    });
+  } catch (error) {
+    logVerbose(
+      `${params.logPrefix}: unable to prepare fresh session for ${params.sessionKey}: ${formatErrorMessage(error)}`,
+    );
+  }
+}

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -147,6 +147,18 @@ export type AcpSessionManagerDeps = {
   requireRuntimeBackend: typeof requireAcpRuntimeBackend;
 };
 
+export type WriteManagerSessionMeta = (params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  mutate: (
+    current: SessionAcpMeta | undefined,
+    entry: SessionEntry | undefined,
+  ) => SessionAcpMeta | null | undefined;
+  failOnError?: boolean;
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+}) => Promise<SessionEntry | null>;
+
 export const DEFAULT_DEPS: AcpSessionManagerDeps = {
   listAcpSessions: listAcpSessionEntries,
   readSessionEntry: readAcpSessionEntry,


### PR DESCRIPTION
## Summary
- extract ACP runtime resume/discard recovery helpers from `AcpSessionManager`
- keep close-time fresh-session recovery and early-turn retry behavior in a dedicated resume-state module
- move the shared manager session-meta writer callback type into `manager.types.ts`

## Verification
- `pnpm test src/acp/control-plane/manager.runtime-handles.test.ts src/acp/control-plane/manager.runtime-config.test.ts src/acp/control-plane/manager.turn-results.test.ts`
- `pnpm tsgo:prod`
- `pnpm check:test-types`
- `node scripts/run-oxlint.mjs src/acp/control-plane/manager.core.ts src/acp/control-plane/manager.runtime-resume-state.ts src/acp/control-plane/manager.runtime-handle-ensure.ts src/acp/control-plane/manager.types.ts`
- `pnpm format:check src/acp/control-plane/manager.core.ts src/acp/control-plane/manager.runtime-resume-state.ts src/acp/control-plane/manager.runtime-handle-ensure.ts src/acp/control-plane/manager.types.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof
Behavior addressed: ACP runtime resume-state repair/discard ownership moved out of `AcpSessionManager` without changing runtime behavior.
Real environment tested: Local OpenClaw checkout, Node/pnpm repo toolchain.
Exact steps or command run after this patch: Focused ACP manager tests, prod/test type checks, narrow oxlint, format check, diff check, autoreview local.
Evidence after fix: All listed local commands passed; autoreview reported no accepted/actionable findings.
Observed result after fix: `manager.core.ts` dropped from 1655 LOC to 1495 LOC while resume-state handling lives in `manager.runtime-resume-state.ts`.
What was not tested: Live ACP backend process recovery against a real external ACP provider.
