### PR TITLE
fix(agents): harden runtime tool schema quarantine

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -179,6 +179,32 @@ describe("Codex app-server dynamic tool build", () => {
     expect(resolveCodexDynamicToolsLoading({}, privateQaCodexEnv)).toBe("direct");
   });
 
+  it("quarantines unreadable tool entries before Codex-specific filtering", async () => {
+    const messageTool = createRuntimeDynamicTool("message");
+    const sourceTools = new Proxy([messageTool] as RuntimeDynamicToolForTest[], {
+      get(target, property, receiver) {
+        if (property === "0") {
+          throw new Error("fuzzplugin tool entry getter exploded");
+        }
+        if (property === "1") {
+          return messageTool;
+        }
+        if (property === "length") {
+          return 2;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    setOpenClawCodingToolsFactoryForTests(() => sourceTools);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+
+    await expect(buildDynamicToolsForTest(params, workspaceDir)).resolves.toEqual([messageTool]);
+  });
+
   it("limits Codex memory flush runs to managed read and write tools", async () => {
     const factoryOptions: unknown[] = [];
     setOpenClawCodingToolsFactoryForTests((options) => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -2,6 +2,7 @@ import {
   buildAgentHookContextChannelFields,
   buildEmbeddedAttemptToolRunContext,
   embeddedAgentLog,
+  filterProviderNormalizableTools,
   isSubagentSessionKey,
   normalizeAgentRuntimeTools,
   resolveAttemptSpawnWorkspaceDir,
@@ -9,6 +10,7 @@ import {
   resolveSandboxContext,
   supportsModelTools,
   type EmbeddedRunAttemptParams,
+  type RuntimeToolSchemaDiagnostic,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
@@ -265,15 +267,19 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     },
   });
   toolBuildStages.mark("create-openclaw-coding-tools");
+  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
+  const readableAllToolProjection = filterProviderNormalizableTools(allTools);
+  preNormalizationDiagnostics.push(...readableAllToolProjection.diagnostics);
+  const readableAllTools = [...readableAllToolProjection.tools];
   const codexFilteredTools = addNodeShellDynamicToolsIfNeeded(
     addSandboxShellDynamicToolsIfAvailable(
       isCodexMemoryFlushRun(params)
-        ? filterCodexMemoryFlushDynamicTools(allTools)
-        : filterCodexDynamicTools(allTools, input.pluginConfig),
-      allTools,
+        ? filterCodexMemoryFlushDynamicTools(readableAllTools)
+        : filterCodexDynamicTools(readableAllTools, input.pluginConfig),
+      readableAllTools,
       input,
     ),
-    allTools,
+    readableAllTools,
     input,
   );
   toolBuildStages.mark("codex-filtering");
@@ -295,8 +301,25 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelId: params.modelId,
     modelApi: params.model.api,
     model: params.model,
+    onPreNormalizationSchemaDiagnostics: (diagnostics) =>
+      preNormalizationDiagnostics.push(...diagnostics),
   });
   toolBuildStages.mark("runtime-normalization");
+  if (preNormalizationDiagnostics.length > 0) {
+    embeddedAgentLog.warn(
+      `codex app-server quarantined ${preNormalizationDiagnostics.length} unsupported runtime tool schema${preNormalizationDiagnostics.length === 1 ? "" : "s"} before dynamic tool registration`,
+      {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        diagnostics: preNormalizationDiagnostics.map((diagnostic) => ({
+          index: diagnostic.toolIndex,
+          tool: diagnostic.toolName,
+          violations: diagnostic.violations.slice(0, 12),
+          violationCount: diagnostic.violations.length,
+        })),
+      },
+    );
+  }
   const summary = toolBuildStages.snapshot();
   if (shouldWarnCodexDynamicToolBuildStageSummary(summary)) {
     const phase = input.forceHeartbeatTool ? "registered-tools" : "runtime-tools";
@@ -308,7 +331,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         phase,
         totalMs: summary.totalMs,
         stages: summary.stages,
-        allToolCount: allTools.length,
+        allToolCount: readableAllTools.length,
         codexFilteredToolCount: codexFilteredTools.length,
         visionFilteredToolCount: visionFilteredTools.length,
         filteredToolCount: filteredTools.length,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -111,7 +111,10 @@ import {
 } from "../session-write-lock.js";
 import { createAgentSession, estimateTokens, SessionManager } from "../sessions/index.js";
 import { detectRuntimeShell } from "../shell-utils.js";
-import { filterRuntimeCompatibleTools } from "../tool-schema-projection.js";
+import {
+  filterProviderNormalizableTools,
+  filterRuntimeCompatibleTools,
+} from "../tool-schema-projection.js";
 import { logRuntimeToolSchemaQuarantine } from "../tool-schema-quarantine.js";
 import {
   classifyCompactionReason,
@@ -827,8 +830,18 @@ async function compactEmbeddedAgentSessionDirectOnce(
       modelApi: model.api,
       model,
     };
-    const tools = runtimePlan.tools.normalize(
+    const normalizableToolProjection = filterProviderNormalizableTools(
       toolsEnabled ? toolsRaw : [],
+    );
+    logRuntimeToolSchemaQuarantine({
+      diagnostics: normalizableToolProjection.diagnostics,
+      tools: toolsEnabled ? toolsRaw : [],
+      runId,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+    });
+    const tools = runtimePlan.tools.normalize(
+      [...normalizableToolProjection.tools],
       runtimePlanModelContext,
     );
     const bundleMcpRuntime = toolsEnabled
@@ -873,9 +886,22 @@ async function compactEmbeddedAgentSessionDirectOnce(
       senderE164: params.senderE164,
       warn: (message) => log.warn(message),
     });
+    const normalizableBundledToolProjection = filterProviderNormalizableTools(filteredBundledTools);
+    if (normalizableBundledToolProjection.diagnostics.length > 0) {
+      logRuntimeToolSchemaQuarantine({
+        diagnostics: normalizableBundledToolProjection.diagnostics,
+        tools: filteredBundledTools,
+        runId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+      });
+    }
     const normalizedBundledTools =
       filteredBundledTools.length > 0
-        ? runtimePlan.tools.normalize(filteredBundledTools, runtimePlanModelContext)
+        ? runtimePlan.tools.normalize(
+            [...normalizableBundledToolProjection.tools],
+            runtimePlanModelContext,
+          )
         : filteredBundledTools;
     const projectedEffectiveTools = [...tools, ...normalizedBundledTools];
     const toolSchemaProjection = filterRuntimeCompatibleTools(projectedEffectiveTools);

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1413,6 +1413,14 @@ export async function runEmbeddedAttempt(
       modelApi: params.model.api,
       model: params.model,
       runtimeHandle: getProviderRuntimeHandle(),
+      onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
+        logRuntimeToolSchemaQuarantine({
+          diagnostics,
+          tools: sourceTools,
+          runId: params.runId,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+        }),
     });
     const clientTools = toolsEnabled && !isRawModelRun ? params.clientTools : undefined;
     const bundleMcpEnabled = shouldCreateBundleMcpRuntimeForAttempt({
@@ -1501,6 +1509,14 @@ export async function runEmbeddedAttempt(
             modelApi: params.model.api,
             model: params.model,
             runtimeHandle: getProviderRuntimeHandle(),
+            onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
+              logRuntimeToolSchemaQuarantine({
+                diagnostics,
+                tools: sourceTools,
+                runId: params.runId,
+                sessionKey: params.sessionKey,
+                sessionId: params.sessionId,
+              }),
           })
         : filteredBundledTools;
     const projectedUncompactedEffectiveTools = filterLocalModelLeanTools({

--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getPluginToolMeta, setPluginToolMeta } from "../../plugins/tools.js";
+import type { RuntimeToolSchemaDiagnostic } from "../tool-schema-projection.js";
 import { logAgentRuntimeToolDiagnostics, normalizeAgentRuntimeTools } from "./tools.js";
 import type { AgentRuntimePlan } from "./types.js";
 
@@ -53,6 +54,82 @@ describe("AgentRuntimePlan tool policy helpers", () => {
       modelApi: "openai-responses",
       model,
     });
+  });
+
+  it("quarantines unreadable tools before RuntimePlan normalization", () => {
+    const healthy = { ...createParameterFreeTool(), name: "healthy" } as AgentTool;
+    const unreadable = { ...createParameterFreeTool(), name: "fuzzplugin_unreadable" } as AgentTool;
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin parameters getter exploded");
+      },
+    });
+    const tools = [unreadable, healthy];
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    const normalize = vi.fn((entries: AgentTool[]) => entries);
+    const runtimePlan = {
+      tools: {
+        normalize,
+        logDiagnostics: vi.fn(),
+      },
+    } as unknown as AgentRuntimePlan;
+
+    expect(
+      normalizeAgentRuntimeTools({
+        runtimePlan,
+        tools,
+        provider: "openai",
+        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+      }),
+    ).toEqual([healthy]);
+    expect(normalize).toHaveBeenCalledWith([healthy], {
+      workspaceDir: undefined,
+      modelApi: undefined,
+      model: undefined,
+    });
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "fuzzplugin_unreadable",
+          toolIndex: 0,
+          violations: ["fuzzplugin_unreadable.parameters is unreadable"],
+        },
+      ],
+    ]);
+  });
+
+  it("quarantines non-object schemas before provider schema normalization", () => {
+    const healthy = { ...createParameterFreeTool(), name: "healthy" } as AgentTool;
+    const arraySchema = {
+      ...createParameterFreeTool("fuzzplugin_array_root"),
+      parameters: { type: "array", items: { type: "number" } },
+    } as unknown as AgentTool;
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    mocks.normalizeProviderToolSchemas.mockImplementationOnce(({ tools: entries }) => entries);
+
+    expect(
+      normalizeAgentRuntimeTools({
+        tools: [arraySchema, healthy],
+        provider: "openai",
+        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+      }),
+    ).toEqual([healthy]);
+    expect(mocks.normalizeProviderToolSchemas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: [healthy],
+        provider: "openai",
+      }),
+    );
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "fuzzplugin_array_root",
+          toolIndex: 0,
+          violations: ['fuzzplugin_array_root.parameters.type must be "object"'],
+        },
+      ],
+    ]);
   });
 
   it("accepts legacy optional model fields while normalizing RuntimePlan context", () => {
@@ -143,6 +220,96 @@ describe("AgentRuntimePlan tool policy helpers", () => {
         toolName: "lookup_note",
       },
     });
+  });
+
+  it("does not reread quarantined tools while preserving normalized metadata", () => {
+    const unreadableName = {
+      ...createParameterFreeTool("fuzzplugin_unreadable_name"),
+    } as AgentTool;
+    Object.defineProperty(unreadableName, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin name getter exploded");
+      },
+    });
+    const healthy = createParameterFreeTool("fixture__lookup_note") as AgentTool;
+    setPluginToolMeta(healthy, {
+      pluginId: "bundle-mcp",
+      optional: false,
+      mcp: {
+        serverName: "fixture",
+        safeServerName: "fixture",
+        toolName: "lookup_note",
+        operation: "tool",
+      },
+    });
+    const normalized = {
+      ...healthy,
+      parameters: normalizedParameterFreeSchema(),
+    };
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    mocks.normalizeProviderToolSchemas.mockReturnValueOnce([normalized]);
+
+    const result = normalizeAgentRuntimeTools({
+      tools: [unreadableName, healthy],
+      provider: "openai",
+      onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+    });
+
+    expect(result).toEqual([normalized]);
+    expect(getPluginToolMeta(result[0])).toMatchObject({
+      pluginId: "bundle-mcp",
+      mcp: {
+        serverName: "fixture",
+        toolName: "lookup_note",
+      },
+    });
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["tool[0].name is unreadable"],
+        },
+      ],
+    ]);
+  });
+
+  it("quarantines unreadable tools before provider schema normalization", () => {
+    const healthy = { ...createParameterFreeTool(), name: "healthy" } as AgentTool;
+    const unreadable = { ...createParameterFreeTool(), name: "fuzzplugin_unreadable" } as AgentTool;
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin parameters getter exploded");
+      },
+    });
+    const tools = [unreadable, healthy];
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    mocks.normalizeProviderToolSchemas.mockImplementationOnce(({ tools: entries }) => entries);
+
+    expect(
+      normalizeAgentRuntimeTools({
+        tools,
+        provider: "openai",
+        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+      }),
+    ).toEqual([healthy]);
+    expect(mocks.normalizeProviderToolSchemas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: [healthy],
+        provider: "openai",
+      }),
+    );
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "fuzzplugin_unreadable",
+          toolIndex: 0,
+          violations: ["fuzzplugin_unreadable.parameters is unreadable"],
+        },
+      ],
+    ]);
   });
 
   it("can normalize without cold-loading provider runtime plugins", () => {

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -9,6 +9,10 @@ import {
   normalizeProviderToolSchemas,
 } from "../embedded-agent-runner/tool-schema-runtime.js";
 import type { AgentTool } from "../runtime/index.js";
+import {
+  filterProviderNormalizableTools,
+  type RuntimeToolSchemaDiagnostic,
+} from "../tool-schema-projection.js";
 import type { AgentRuntimePlan } from "./types.js";
 
 type AgentRuntimeToolPolicyParams<TSchemaType extends TSchema = TSchema, TResult = unknown> = {
@@ -23,6 +27,10 @@ type AgentRuntimeToolPolicyParams<TSchemaType extends TSchema = TSchema, TResult
   model?: ProviderRuntimeModel;
   runtimeHandle?: ProviderRuntimePluginHandle;
   allowProviderRuntimePluginLoad?: boolean;
+  onPreNormalizationSchemaDiagnostics?: (
+    diagnostics: readonly RuntimeToolSchemaDiagnostic[],
+    tools: readonly AgentTool<TSchemaType, TResult>[],
+  ) => void;
 };
 
 function runtimePlanToolContext(params: {
@@ -78,10 +86,21 @@ export function normalizeAgentRuntimeTools<
   TResult = unknown,
 >(params: AgentRuntimeToolPolicyParams<TSchemaType, TResult>): AgentTool<TSchemaType, TResult>[] {
   const planContext = runtimePlanToolContext(params);
+  const normalizableToolProjection = filterProviderNormalizableTools(params.tools);
+  if (normalizableToolProjection.diagnostics.length > 0) {
+    params.onPreNormalizationSchemaDiagnostics?.(
+      normalizableToolProjection.diagnostics,
+      params.tools,
+    );
+  }
+  const normalizableTools = [...normalizableToolProjection.tools] as AgentTool<
+    TSchemaType,
+    TResult
+  >[];
   const normalized =
-    params.runtimePlan?.tools.normalize(params.tools, planContext) ??
+    params.runtimePlan?.tools.normalize(normalizableTools, planContext) ??
     normalizeProviderToolSchemas({
-      tools: params.tools,
+      tools: normalizableTools,
       provider: params.provider,
       config: params.config,
       workspaceDir: params.workspaceDir,
@@ -92,8 +111,8 @@ export function normalizeAgentRuntimeTools<
       runtimeHandle: params.runtimeHandle,
       allowRuntimePluginLoad: params.allowProviderRuntimePluginLoad,
     });
-  const normalizedTools = Array.isArray(normalized) ? normalized : params.tools;
-  return preserveRuntimeToolMetadata(params.tools, normalizedTools);
+  const normalizedTools = Array.isArray(normalized) ? normalized : normalizableTools;
+  return preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
 }
 
 export function logAgentRuntimeToolDiagnostics(params: AgentRuntimeToolPolicyParams): void {

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  filterProviderNormalizableTools,
   filterRuntimeCompatibleTools,
   inspectRuntimeToolInputSchemas,
   projectRuntimeToolInputSchema,
 } from "./tool-schema-projection.js";
+import type { AnyAgentTool } from "./tools/common.js";
 
 describe("runtime tool input schema projection", () => {
   it("accepts JSON object input schemas", () => {
@@ -29,15 +31,15 @@ describe("runtime tool input schema projection", () => {
     expect(
       inspectRuntimeToolInputSchemas([
         {
-          name: "dofbot_move_angles",
+          name: "fuzzplugin_move_angles",
           parameters: { type: "array", items: { type: "number" } },
         },
       ] as never),
     ).toEqual([
       {
-        toolName: "dofbot_move_angles",
+        toolName: "fuzzplugin_move_angles",
         toolIndex: 0,
-        violations: ['dofbot_move_angles.parameters.type must be "object"'],
+        violations: ['fuzzplugin_move_angles.parameters.type must be "object"'],
       },
     ]);
   });
@@ -86,7 +88,7 @@ describe("runtime tool input schema projection", () => {
       parameters: { type: "object", properties: {} },
     };
     const broken = {
-      name: "dofbot_move_angles",
+      name: "fuzzplugin_move_angles",
       parameters: { type: "array", items: { type: "number" } },
     };
 
@@ -94,9 +96,114 @@ describe("runtime tool input schema projection", () => {
       tools: [healthy],
       diagnostics: [
         {
-          toolName: "dofbot_move_angles",
+          toolName: "fuzzplugin_move_angles",
           toolIndex: 1,
-          violations: ['dofbot_move_angles.parameters.type must be "object"'],
+          violations: ['fuzzplugin_move_angles.parameters.type must be "object"'],
+        },
+      ],
+    });
+  });
+
+  it("quarantines unreadable runtime tool entries before field projection", () => {
+    const healthy = {
+      name: "healthy",
+      parameters: { type: "object", properties: {} },
+    };
+    const tools = [healthy] as Array<typeof healthy>;
+    const proxy = new Proxy(tools, {
+      get(target, property, receiver) {
+        if (property === "1") {
+          throw new Error("fuzzplugin tool entry getter exploded");
+        }
+        if (property === "length") {
+          return 2;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(filterRuntimeCompatibleTools(proxy)).toEqual({
+      tools: [healthy],
+      diagnostics: [
+        {
+          toolName: "tool[1]",
+          toolIndex: 1,
+          violations: ["tool[1] is unreadable"],
+        },
+      ],
+    });
+  });
+
+  it("quarantines unreadable runtime tool fields without dropping healthy siblings", () => {
+    const unreadable = {
+      name: "fuzzplugin_unreadable",
+      parameters: { type: "object", properties: {} },
+    };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin parameters getter exploded");
+      },
+    });
+    const healthy = {
+      name: "healthy",
+      parameters: { type: "object", properties: {} },
+    };
+
+    expect(filterRuntimeCompatibleTools([unreadable, healthy])).toEqual({
+      tools: [healthy],
+      diagnostics: [
+        {
+          toolName: "fuzzplugin_unreadable",
+          toolIndex: 0,
+          violations: ["fuzzplugin_unreadable.parameters is unreadable"],
+        },
+      ],
+    });
+  });
+
+  it("keeps provider-normalizable object schemas for provider-specific cleanup", () => {
+    const dynamicSchema = {
+      name: "fuzzplugin_dynamic_ref",
+      parameters: {
+        type: "object",
+        properties: {
+          target: { $dynamicRef: "#target" },
+        },
+      },
+    };
+
+    expect(filterProviderNormalizableTools([dynamicSchema])).toEqual({
+      tools: [dynamicSchema],
+      diagnostics: [],
+    });
+  });
+
+  it("keeps missing parameter schemas for provider-specific normalization", () => {
+    const parameterFree = {
+      name: "fuzzplugin_parameter_free",
+      parameters: undefined,
+    } as unknown as Pick<AnyAgentTool, "name" | "parameters">;
+
+    expect(filterProviderNormalizableTools([parameterFree])).toEqual({
+      tools: [parameterFree],
+      diagnostics: [],
+    });
+  });
+
+  it("quarantines non-object schemas before provider normalization", () => {
+    const arraySchema = {
+      name: "fuzzplugin_array_root",
+      parameters: { type: "array", items: { type: "number" } },
+    };
+
+    expect(filterProviderNormalizableTools([arraySchema])).toEqual({
+      tools: [],
+      diagnostics: [
+        {
+          toolName: "fuzzplugin_array_root",
+          toolIndex: 0,
+          violations: ['fuzzplugin_array_root.parameters.type must be "object"'],
         },
       ],
     });

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -24,6 +24,65 @@ export type RuntimeToolSchemaInspection<TTool extends Pick<AnyAgentTool, "name" 
   readonly diagnostics: readonly RuntimeToolSchemaDiagnostic[];
 };
 
+type RuntimeToolEntryRead<TTool extends Pick<AnyAgentTool, "name" | "parameters">> =
+  | {
+      readonly ok: true;
+      readonly tool: TTool;
+      readonly toolIndex: number;
+    }
+  | {
+      readonly ok: false;
+      readonly diagnostic: RuntimeToolSchemaDiagnostic;
+    };
+
+type ToolSchemaInspectionMode = "runtime" | "provider-normalizable";
+
+function unreadableRuntimeToolEntry(
+  toolIndex: number,
+): RuntimeToolEntryRead<Pick<AnyAgentTool, "name" | "parameters">> {
+  return {
+    ok: false,
+    diagnostic: {
+      toolName: `tool[${toolIndex}]`,
+      toolIndex,
+      violations: [`tool[${toolIndex}] is unreadable`],
+    },
+  };
+}
+
+function readRuntimeToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
+  tools: readonly TTool[],
+): RuntimeToolEntryRead<TTool>[] {
+  let length: number;
+  try {
+    length = tools.length;
+  } catch {
+    return [unreadableRuntimeToolEntry(0) as RuntimeToolEntryRead<TTool>];
+  }
+  const entries: RuntimeToolEntryRead<TTool>[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    try {
+      entries.push({ ok: true, tool: tools[toolIndex], toolIndex });
+    } catch {
+      entries.push(unreadableRuntimeToolEntry(toolIndex) as RuntimeToolEntryRead<TTool>);
+    }
+  }
+  return entries;
+}
+
+function readToolProjectionField<TField extends "name" | "parameters">(
+  tool: Pick<AnyAgentTool, "name" | "parameters">,
+  field: TField,
+):
+  | { readable: true; value: Pick<AnyAgentTool, "name" | "parameters">[TField] }
+  | { readable: false } {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
 function isJsonValue(value: unknown): value is RuntimeToolInputSchemaJson {
   if (value === null) {
     return true;
@@ -140,29 +199,82 @@ export function projectRuntimeToolInputSchema(
   };
 }
 
+function inspectToolSchema(
+  tool: Pick<AnyAgentTool, "name" | "parameters">,
+  toolIndex: number,
+  mode: ToolSchemaInspectionMode,
+): RuntimeToolSchemaDiagnostic | undefined {
+  const nameRead = readToolProjectionField(tool, "name");
+  const toolName =
+    nameRead.readable && typeof nameRead.value === "string" && nameRead.value
+      ? nameRead.value
+      : `tool[${toolIndex}]`;
+  const descriptorViolations = nameRead.readable ? [] : [`${toolName}.name is unreadable`];
+  const parametersRead = readToolProjectionField(tool, "parameters");
+  if (!parametersRead.readable) {
+    return {
+      toolName,
+      toolIndex,
+      violations: [...descriptorViolations, `${toolName}.parameters is unreadable`],
+    };
+  }
+  if (mode === "provider-normalizable" && parametersRead.value === undefined) {
+    return descriptorViolations.length > 0
+      ? { toolName, toolIndex, violations: descriptorViolations }
+      : undefined;
+  }
+
+  const schemaPath = `${toolName}.parameters`;
+  const projection = projectRuntimeToolInputSchema(parametersRead.value, schemaPath);
+  const projectionViolations =
+    mode === "runtime"
+      ? projection.violations
+      : projection.violations.filter(
+          (violation) =>
+            violation !== `${schemaPath}.$dynamicRef` &&
+            violation !== `${schemaPath}.$dynamicAnchor` &&
+            !violation.endsWith(".$dynamicRef") &&
+            !violation.endsWith(".$dynamicAnchor"),
+        );
+  const violations = [...descriptorViolations, ...projectionViolations];
+  return violations.length > 0 ? { toolName, toolIndex, violations } : undefined;
+}
+
+function inspectToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
+  entries: readonly RuntimeToolEntryRead<TTool>[],
+  mode: ToolSchemaInspectionMode,
+): RuntimeToolSchemaInspection<TTool> {
+  const diagnostics: RuntimeToolSchemaDiagnostic[] = [];
+  const compatibleTools: TTool[] = [];
+  for (const entry of entries) {
+    if (!entry.ok) {
+      diagnostics.push(entry.diagnostic);
+      continue;
+    }
+    const diagnostic = inspectToolSchema(entry.tool, entry.toolIndex, mode);
+    if (diagnostic) {
+      diagnostics.push(diagnostic);
+      continue;
+    }
+    compatibleTools.push(entry.tool);
+  }
+  return { tools: compatibleTools, diagnostics };
+}
+
 export function inspectRuntimeToolInputSchemas(
   tools: readonly Pick<AnyAgentTool, "name" | "parameters">[],
 ): RuntimeToolSchemaDiagnostic[] {
-  return tools.flatMap((tool, toolIndex) => {
-    const toolName = tool.name || `tool[${toolIndex}]`;
-    const projection = projectRuntimeToolInputSchema(tool.parameters, `${toolName}.parameters`);
-    if (projection.violations.length === 0) {
-      return [];
-    }
-    return [{ toolName, toolIndex, violations: projection.violations }];
-  });
+  return [...inspectToolEntries(readRuntimeToolEntries(tools), "runtime").diagnostics];
 }
 
 export function filterRuntimeCompatibleTools<
   TTool extends Pick<AnyAgentTool, "name" | "parameters">,
 >(tools: readonly TTool[]): RuntimeToolSchemaInspection<TTool> {
-  const diagnostics = inspectRuntimeToolInputSchemas(tools);
-  if (diagnostics.length === 0) {
-    return { tools, diagnostics };
-  }
-  const blockedIndexes = new Set(diagnostics.map((diagnostic) => diagnostic.toolIndex));
-  return {
-    tools: tools.filter((_tool, index) => !blockedIndexes.has(index)),
-    diagnostics,
-  };
+  return inspectToolEntries(readRuntimeToolEntries(tools), "runtime");
+}
+
+export function filterProviderNormalizableTools<
+  TTool extends Pick<AnyAgentTool, "name" | "parameters">,
+>(tools: readonly TTool[]): RuntimeToolSchemaInspection<TTool> {
+  return inspectToolEntries(readRuntimeToolEntries(tools), "provider-normalizable");
 }

--- a/src/agents/tool-schema-quarantine.test.ts
+++ b/src/agents/tool-schema-quarantine.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { logRuntimeToolSchemaQuarantine } from "./tool-schema-quarantine.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+describe("runtime tool schema quarantine logging", () => {
+  it("does not re-read unreadable tool entries while logging diagnostics", () => {
+    const tools = new Proxy([] as AnyAgentTool[], {
+      get(target, property, receiver) {
+        if (property === "0") {
+          throw new Error("fuzzplugin tool entry getter exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(() =>
+      logRuntimeToolSchemaQuarantine({
+        diagnostics: [
+          {
+            toolName: "tool[0]",
+            toolIndex: 0,
+            violations: ["tool[0] is unreadable"],
+          },
+        ],
+        tools,
+        runId: "run-fuzzplugin-unreadable-tool",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -6,6 +6,18 @@ import type { AnyAgentTool } from "./tools/common.js";
 
 const log = createSubsystemLogger("agents/tools");
 
+function readDiagnosticPluginId(params: {
+  tools: readonly AnyAgentTool[];
+  diagnostic: RuntimeToolSchemaDiagnostic;
+}): string | undefined {
+  try {
+    const tool = params.tools[params.diagnostic.toolIndex];
+    return tool ? getPluginToolMeta(tool)?.pluginId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function logRuntimeToolSchemaQuarantine(params: {
   diagnostics: readonly RuntimeToolSchemaDiagnostic[];
   tools: readonly AnyAgentTool[];
@@ -18,8 +30,7 @@ export function logRuntimeToolSchemaQuarantine(params: {
   }
   const summary = params.diagnostics
     .map((diagnostic) => {
-      const tool = params.tools[diagnostic.toolIndex];
-      const pluginId = tool ? getPluginToolMeta(tool)?.pluginId : undefined;
+      const pluginId = readDiagnosticPluginId({ tools: params.tools, diagnostic });
       const owner = pluginId ? ` plugin=${pluginId}` : "";
       emitTrustedDiagnosticEvent({
         type: "tool.execution.blocked",

--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -11,6 +11,7 @@ import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import { summarizeToolDescriptionText } from "./tool-description-summary.js";
 import { resolveToolDisplay } from "./tool-display.js";
 import {
+  filterProviderNormalizableTools,
   filterRuntimeCompatibleTools,
   type RuntimeToolSchemaDiagnostic,
 } from "./tool-schema-projection.js";
@@ -74,8 +75,9 @@ function buildUnsupportedToolSchemaNotice(params: {
   tool: AnyAgentTool | undefined;
   fallbackTool: AnyAgentTool | undefined;
 }): EffectiveToolInventoryNotice {
-  const source = params.tool
-    ? resolveEffectiveToolSource(params.tool, params.fallbackTool)
+  const sourceTool = params.tool ?? params.fallbackTool;
+  const source = sourceTool
+    ? resolveEffectiveToolSource(sourceTool, params.fallbackTool)
     : { source: "core" as const };
   const owner =
     source.source === "plugin" && source.pluginId
@@ -98,10 +100,43 @@ function buildUnsupportedToolSchemaNotices(params: {
   return params.diagnostics.map((diagnostic) =>
     buildUnsupportedToolSchemaNotice({
       diagnostic,
-      tool: params.tools[diagnostic.toolIndex],
+      tool: readMatchingTool(params.tools, diagnostic),
       fallbackTool: params.rawToolsByName.get(diagnostic.toolName),
     }),
   );
+}
+
+function readMatchingTool(
+  tools: readonly AnyAgentTool[],
+  diagnostic: RuntimeToolSchemaDiagnostic,
+): AnyAgentTool | undefined {
+  try {
+    const tool = tools[diagnostic.toolIndex];
+    return tool?.name === diagnostic.toolName ? tool : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildReadableRawToolsByName(
+  tools: readonly AnyAgentTool[],
+): ReadonlyMap<string, AnyAgentTool> {
+  const toolsByName = new Map<string, AnyAgentTool>();
+  let toolCount: number;
+  try {
+    toolCount = tools.length;
+  } catch {
+    return toolsByName;
+  }
+  for (let index = 0; index < toolCount; index += 1) {
+    try {
+      const tool = tools[index];
+      toolsByName.set(tool.name, tool);
+    } catch {
+      // Unreadable entries are reported by the schema projection diagnostics.
+    }
+  }
+  return toolsByName;
 }
 
 function disambiguateLabels(entries: EffectiveToolInventoryEntry[]): EffectiveToolInventoryEntry[] {
@@ -171,23 +206,30 @@ export function buildRuntimeCompatibleToolInventory(params: {
   entries: EffectiveToolInventoryEntry[];
   notices: EffectiveToolInventoryNotice[];
 } {
-  const rawToolsByName = new Map(params.tools.map((tool) => [tool.name, tool]));
+  const rawToolsByName = buildReadableRawToolsByName(params.tools);
+  const preNormalizationProjection = filterProviderNormalizableTools(params.tools);
+  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [
+    ...preNormalizationProjection.diagnostics,
+  ];
   const normalizedTools = normalizeAgentRuntimeTools({
     // Schema normalization can replace tool definitions, so hand the runtime
     // policy a mutable copy while keeping this inventory API readonly.
-    tools: [...params.tools],
+    tools: [...preNormalizationProjection.tools],
     provider: params.modelProvider ?? "",
     config: params.cfg,
     workspaceDir: params.workspaceDir,
     modelId: params.modelId,
     modelApi: params.modelApi ?? undefined,
     model: params.runtimeModel,
+    onPreNormalizationSchemaDiagnostics: (diagnostics) =>
+      preNormalizationDiagnostics.push(...diagnostics),
   });
   const projection = filterRuntimeCompatibleTools(normalizedTools);
+  const diagnostics = [...preNormalizationDiagnostics, ...projection.diagnostics];
   return {
     entries: buildEffectiveToolInventoryEntries(projection.tools, rawToolsByName),
     notices: buildUnsupportedToolSchemaNotices({
-      diagnostics: projection.diagnostics,
+      diagnostics,
       tools: normalizedTools,
       rawToolsByName,
     }),

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -348,6 +348,66 @@ describe("resolveEffectiveToolInventory", () => {
     ]);
   });
 
+  it("preserves plugin ownership for pre-normalization schema quarantines", async () => {
+    const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal12 } =
+      await loadHarness({
+        tools: [
+          mockTool({ name: "exec", label: "Exec", description: "Run shell commands" }),
+          mockTool({
+            name: "fuzzplugin_move_angles",
+            label: "Fuzzplugin Move Angles",
+            description: "Move fixture joints",
+            parameters: { type: "array", items: { type: "number" } },
+          }),
+        ],
+        pluginMeta: { fuzzplugin_move_angles: { pluginId: "fuzzplugin" } },
+      });
+
+    const result = resolveEffectiveToolInventoryLocal12({ cfg: {} });
+
+    expect(result.groups.flatMap((group) => group.tools.map((tool) => tool.id))).toEqual(["exec"]);
+    expect(result.notices).toEqual([
+      {
+        id: "unsupported-tool-schema:fuzzplugin_move_angles",
+        severity: "warning",
+        message:
+          'Tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has an unsupported runtime input schema (fuzzplugin_move_angles.parameters.type must be "object") and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
+      },
+    ]);
+  });
+
+  it("reports unreadable inventory tool entries without crashing", async () => {
+    const healthy = mockTool({ name: "exec", label: "Exec", description: "Run shell commands" });
+    const tools = new Proxy([healthy] as AnyAgentTool[], {
+      get(target, property, receiver) {
+        if (property === "0") {
+          throw new Error("fuzzplugin inventory entry getter exploded");
+        }
+        if (property === "1") {
+          return healthy;
+        }
+        if (property === "length") {
+          return 2;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal13 } =
+      await loadHarness({ tools });
+
+    const result = resolveEffectiveToolInventoryLocal13({ cfg: {} });
+
+    expect(result.groups.flatMap((group) => group.tools.map((tool) => tool.id))).toEqual(["exec"]);
+    expect(result.notices).toEqual([
+      {
+        id: "unsupported-tool-schema:tool[0]",
+        severity: "warning",
+        message:
+          'Tool "tool[0]" has an unsupported runtime input schema (tool[0] is unreadable) and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
+      },
+    ]);
+  });
+
   it("validates normalized runtime schemas before quarantining effective tools", async () => {
     const normalizeToolsMock = vi.fn((options: { tools: AnyAgentTool[] }) =>
       options.tools.map((entry) =>

--- a/src/agents/tools-effective-mcp-inventory.ts
+++ b/src/agents/tools-effective-mcp-inventory.ts
@@ -8,6 +8,7 @@ import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import { summarizeToolDescriptionText } from "./tool-description-summary.js";
 import { resolveToolDisplay } from "./tool-display.js";
 import {
+  filterProviderNormalizableTools,
   filterRuntimeCompatibleTools,
   type RuntimeToolSchemaDiagnostic,
 } from "./tool-schema-projection.js";
@@ -96,8 +97,12 @@ export function buildRuntimeCompatibleMcpToolInventory(params: {
   entries: EffectiveToolInventoryEntry[];
   notices: EffectiveToolInventoryNotice[];
 } {
+  const preNormalizationProjection = filterProviderNormalizableTools(params.tools);
+  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [
+    ...preNormalizationProjection.diagnostics,
+  ];
   const normalizedTools = normalizeAgentRuntimeTools({
-    tools: [...params.tools],
+    tools: [...preNormalizationProjection.tools],
     provider: params.modelProvider ?? "",
     config: params.cfg,
     workspaceDir: params.workspaceDir,
@@ -105,10 +110,13 @@ export function buildRuntimeCompatibleMcpToolInventory(params: {
     modelApi: params.modelApi ?? undefined,
     model: params.runtimeModel,
     allowProviderRuntimePluginLoad: false,
+    onPreNormalizationSchemaDiagnostics: (diagnostics) =>
+      preNormalizationDiagnostics.push(...diagnostics),
   });
   const projection = filterRuntimeCompatibleTools(normalizedTools);
+  const diagnostics = [...preNormalizationDiagnostics, ...projection.diagnostics];
   return {
     entries: buildMcpToolInventoryEntries(projection.tools),
-    notices: projection.diagnostics.map(buildMcpUnsupportedToolSchemaNotice),
+    notices: diagnostics.map(buildMcpUnsupportedToolSchemaNotice),
   };
 }

--- a/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
@@ -105,6 +105,33 @@ describe("active tool schema doctor warnings", () => {
     ]);
   });
 
+  it("warns about unreadable active tool entries without crashing", () => {
+    const healthy = tool("message", { type: "object", properties: {} });
+    toolState.tools = new Proxy([healthy] as AnyAgentTool[], {
+      get(target, property, receiver) {
+        if (property === "0") {
+          throw new Error("fuzzplugin tool entry getter exploded");
+        }
+        if (property === "1") {
+          return healthy;
+        }
+        if (property === "length") {
+          return 2;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(
+      collectActiveToolSchemaProjectionWarnings({
+        cfg: {},
+        env: { HOME: "/tmp/openclaw-test" },
+      }),
+    ).toEqual([
+      '- agents.main: active tool "tool[0]" has unsupported runtime input schema (tool[0] is unreadable). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
+    ]);
+  });
+
   it("does not validate disabled plugin mode", () => {
     toolState.tools = [tool("dofbot_move_angles", { type: "array", items: { type: "number" } })];
     toolState.pluginIds = { dofbot_move_angles: "dofbot" };

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -14,6 +14,7 @@ import {
   filterRuntimeCompatibleTools,
   type RuntimeToolSchemaDiagnostic,
 } from "../../../agents/tool-schema-projection.js";
+import type { AnyAgentTool } from "../../../agents/tools/common.js";
 import { resolveAgentModelPrimaryValue } from "../../../config/model-input.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
@@ -76,6 +77,43 @@ function formatDiagnostic(params: {
   );
 }
 
+function buildReadableToolsByName(
+  tools: readonly AnyAgentTool[],
+): ReadonlyMap<string, AnyAgentTool> {
+  const toolsByName = new Map<string, AnyAgentTool>();
+  let toolCount: number;
+  try {
+    toolCount = tools.length;
+  } catch {
+    return toolsByName;
+  }
+  for (let index = 0; index < toolCount; index += 1) {
+    try {
+      const tool = tools[index];
+      toolsByName.set(tool.name, tool);
+    } catch {
+      // Unreadable names are surfaced as schema projection diagnostics.
+    }
+  }
+  return toolsByName;
+}
+
+function readToolByIndex(tools: readonly AnyAgentTool[], index: number): AnyAgentTool | undefined {
+  try {
+    return tools[index];
+  } catch {
+    return undefined;
+  }
+}
+
+function readPluginId(tool: AnyAgentTool | undefined): string | undefined {
+  try {
+    return tool ? getPluginToolMeta(tool)?.pluginId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function collectActiveToolSchemaProjectionWarnings(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -130,7 +168,8 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
       continue;
     }
 
-    const rawToolsByName = new Map(tools.map((tool) => [tool.name, tool]));
+    const rawToolsByName = buildReadableToolsByName(tools);
+    const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
     let normalizedTools: typeof tools;
     try {
       normalizedTools = normalizeAgentRuntimeTools({
@@ -142,6 +181,8 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
         modelId: modelRef.model,
         modelApi: runtimeModelContext.modelApi,
         model: runtimeModelContext.model,
+        onPreNormalizationSchemaDiagnostics: (diagnostics) =>
+          preNormalizationDiagnostics.push(...diagnostics),
       });
     } catch (error) {
       warnings.push(
@@ -151,13 +192,22 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
       );
       continue;
     }
+    for (const diagnostic of preNormalizationDiagnostics) {
+      const rawTool = rawToolsByName.get(diagnostic.toolName);
+      const pluginId = readPluginId(rawTool);
+      warnings.push(
+        formatDiagnostic({
+          agentId,
+          diagnostic,
+          ...(pluginId ? { pluginId } : {}),
+        }),
+      );
+    }
     const projection = filterRuntimeCompatibleTools(normalizedTools);
     for (const diagnostic of projection.diagnostics) {
-      const tool = normalizedTools[diagnostic.toolIndex];
+      const tool = readToolByIndex(normalizedTools, diagnostic.toolIndex);
       const rawTool = rawToolsByName.get(diagnostic.toolName);
-      const pluginId =
-        (tool ? getPluginToolMeta(tool)?.pluginId : undefined) ??
-        (rawTool ? getPluginToolMeta(rawTool)?.pluginId : undefined);
+      const pluginId = readPluginId(tool) ?? readPluginId(rawTool);
       warnings.push(
         formatDiagnostic({
           agentId,

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -547,7 +547,12 @@ function toolSchemaDiagnosticToFinding(params: {
   tools: readonly AnyAgentTool[];
   diagnostic: RuntimeToolSchemaDiagnostic;
 }): HealthFinding {
-  const tool = params.tools[params.diagnostic.toolIndex];
+  let tool: AnyAgentTool | undefined;
+  try {
+    tool = params.tools[params.diagnostic.toolIndex];
+  } catch {
+    tool = undefined;
+  }
   const pluginId = tool ? getPluginToolMeta(tool)?.pluginId : undefined;
   const owner = pluginId ? ` from plugin ${pluginId}` : "";
   const agent = `Agent ${params.agentId} `;
@@ -601,6 +606,7 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
     modelId: params.modelRef.model,
     warn: () => {},
   });
+  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
   const normalizedTools = normalizeAgentRuntimeTools({
     tools: activeBundleTools,
     provider: params.modelRef.provider,
@@ -610,11 +616,22 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
     modelId: params.modelRef.model,
     modelApi: params.model.api,
     model: params.model,
+    onPreNormalizationSchemaDiagnostics: (diagnostics) =>
+      preNormalizationDiagnostics.push(...diagnostics),
   });
-  return collectToolSchemaFindings({
-    agentId: params.agentId,
-    tools: normalizedTools,
-  });
+  return [
+    ...preNormalizationDiagnostics.map((diagnostic) =>
+      toolSchemaDiagnosticToFinding({
+        agentId: params.agentId,
+        tools: activeBundleTools,
+        diagnostic,
+      }),
+    ),
+    ...collectToolSchemaFindings({
+      agentId: params.agentId,
+      tools: normalizedTools,
+    }),
+  ];
 }
 
 function bundleMcpRuntimeLoadFailureFinding(error: unknown): HealthFinding {
@@ -797,6 +814,7 @@ export async function collectRuntimeToolSchemaFindings(
         allowGatewaySubagentBinding: true,
         emitBeforeToolCallDiagnostics: false,
       });
+      const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
       const normalizedTools = normalizeAgentRuntimeTools({
         tools,
         provider: modelRef.provider,
@@ -806,8 +824,17 @@ export async function collectRuntimeToolSchemaFindings(
         modelId: modelRef.model,
         modelApi: model.api,
         model,
+        onPreNormalizationSchemaDiagnostics: (diagnostics) =>
+          preNormalizationDiagnostics.push(...diagnostics),
       });
       findings.push(
+        ...preNormalizationDiagnostics.map((diagnostic) =>
+          toolSchemaDiagnosticToFinding({
+            agentId,
+            tools,
+            diagnostic,
+          }),
+        ),
         ...collectToolSchemaFindings({
           agentId,
           tools: normalizedTools,

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -171,6 +171,7 @@ export {
   normalizeAgentRuntimeTools,
 } from "../agents/runtime-plan/tools.js";
 export {
+  filterProviderNormalizableTools,
   inspectRuntimeToolInputSchemas,
   projectRuntimeToolInputSchema,
   type RuntimeToolInputSchemaJson,


### PR DESCRIPTION
## Summary

- quarantines unreadable, non-object, malformed, or non-serializable runtime tool schemas before RuntimePlan/provider normalization can crash assistant turns, compaction, doctor, or Codex dynamic tool build paths
- keeps provider-normalizable parameter-free tools on the normalization path, while rejecting array/root-invalid schemas early enough that one bad plugin tool cannot poison the whole runtime set
- surfaces pre-normalization diagnostics through runtime logging, doctor warnings/findings, Codex dynamic tool build logging, and minimal `tools.effective` inventory notices with plugin ownership preserved when the raw fallback tool is readable

This is the pruned critical hardening PR. The older stacked doctor/reporting work should stay parked unless a smaller follow-up still has a concrete missing CLI/reporting behavior after this lands.

## Verification

- `node scripts/run-vitest.mjs src/agents/tool-schema-projection.test.ts src/agents/tools-effective-inventory.test.ts src/gateway/server-methods/tools-effective.test.ts src/agents/runtime-plan/tools.test.ts src/agents/agent-bundle-mcp-runtime.test.ts --reporter=verbose` passed after the final full rebase: 3 shards / 87 tests
- after the `check-test-types` CI fix, `node scripts/run-vitest.mjs src/agents/tool-schema-projection.test.ts --reporter=verbose` passed: 1 shard / 10 tests
- after the `check-lint` CI fix, `node scripts/run-vitest.mjs src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/agents/tool-schema-projection.test.ts --reporter=verbose` passed: 2 shards / 17 tests
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/agents/tool-schema-projection.ts src/agents/tool-schema-projection.test.ts src/agents/runtime-plan/tools.test.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-mcp-inventory.ts src/agents/tools-effective-inventory.test.ts src/gateway/server-methods/tools-effective.test.ts src/agents/agent-bundle-mcp-runtime.test.ts` passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/commands/doctor/shared/active-tool-schema-warnings.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/agents/tool-schema-projection.test.ts src/agents/tool-schema-projection.ts` passed after the `check-lint` fix
- `git diff --check` passed
- GitHub CI on head `8fe3c081f415337a93c591f043676234ca69431a`: 134 success, 22 skipped, 1 neutral, 0 failed at final poll
- autoreview clean after the CI follow-up fixes: no accepted/actionable findings, overall `patch is correct (0.86)`

Remote changed-gate note: local full `check:test-types` cannot run in this sparse worktree because `test/tsconfig/tsconfig.core.test.json` requires missing tracked project inputs under `ui/config`; GitHub CI provided the full-checkout proof for the pushed SHA. Fresh Testbox `pnpm check:changed` is also not claimed because Blacksmith Testbox is not authenticated locally (`blacksmith testbox list` reports `not authenticated`).

## Real behavior proof

Behavior addressed: unsupported or unreadable active runtime tool schemas are quarantined before runtime/provider normalization can crash an assistant turn, compaction, doctor, Codex dynamic tool build, or effective tool inventory path.

Real environment tested: local targeted runtime, gateway, inventory, MCP-runtime, and Codex/doctor-adjacent unit coverage on PR branch `runtime-tool-schema-quarantine-20260531`, with CI follow-up fixes pushed as head `8fe3c081f415337a93c591f043676234ca69431a`.

Exact steps or command run after this patch: ran the focused Vitest commands, targeted oxlint commands, `git diff --check`, `blacksmith testbox list`, and autoreview command listed above; GitHub CI passed all required/relevant checks on the current head.

Evidence after fix: focused tests passed, oxlint/diff checks passed, fixture-name scrub found no newly added private reported tool/plugin name, CI type/lint/full selected checks passed, and autoreview returned no actionable findings after verifying the pre-normalization and inventory owner-attribution fixes.

Observed result after fix: bad or unreadable tool entries are removed before provider normalization and name-based Codex filtering; doctor, runtime logging, and effective inventory reporting use guarded reads so broken entries produce diagnostics instead of crashing the reporting path.

What was not tested: local full `check:test-types` and Testbox `pnpm check:changed` on the final SHA for the environment reasons above.
