### PR TITLE
fix: preserve explicit provider in resolveConfiguredProviderFallback (v2)

### DIFF
--- a/src/agents/configured-provider-fallback.ts
+++ b/src/agents/configured-provider-fallback.ts
@@ -16,6 +16,35 @@ export function resolveConfiguredProviderFallback(params: {
   }
   const defaultProviderConfig = configuredProviders[params.defaultProvider];
   const defaultModel = params.defaultModel?.trim();
+
+  // When a specific model was requested, try to find a configured provider
+  // that carries that exact model. This preserves the user's model choice
+  // and only switches the provider — which is the correct behavior when
+  // the default provider doesn't carry the model but another provider does.
+  // Previously, the function would replace BOTH provider and model with the
+  // first available provider's first model, producing incorrect refs like
+  // "ollama/kimi-k2.6:cloud" when the user specified "openai/gpt-5.5".
+  if (defaultModel) {
+    const providerWithModel = Object.entries(configuredProviders).find(
+      ([, providerCfg]) =>
+        providerCfg &&
+        Array.isArray(providerCfg.models) &&
+        providerCfg.models.some((model) => model?.id === defaultModel),
+    );
+    if (providerWithModel) {
+      return { provider: providerWithModel[0], model: defaultModel };
+    }
+    // The default provider is not configured and no other provider has the
+    // requested model. Return null so the caller preserves the explicitly-
+    // specified provider/model pair rather than silently replacing it with
+    // an unrelated provider's first model.
+    if (!defaultProviderConfig) {
+      return null;
+    }
+  }
+
+  // If the default provider is configured and either has no model requirement
+  // or already has the requested model, no fallback is needed.
   const defaultProviderHasDefaultModel =
     !!defaultProviderConfig &&
     !!defaultModel &&
@@ -24,6 +53,10 @@ export function resolveConfiguredProviderFallback(params: {
   if (defaultProviderConfig && (!defaultModel || defaultProviderHasDefaultModel)) {
     return null;
   }
+
+  // No specific model was requested (or the default provider IS configured
+  // but doesn't carry the model). Fall back to the first provider that has
+  // any models configured.
   const availableProvider = Object.entries(configuredProviders).find(
     ([, providerCfg]) =>
       providerCfg &&

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -639,6 +639,7 @@ export function resolveConfiguredModelRef(
   const fallbackProvider = resolveConfiguredProviderFallback({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
   });
   if (fallbackProvider) {
     return fallbackProvider;

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -83,6 +83,7 @@ function resolveConfiguredStatusModelRef(params: {
   const fallbackProvider = resolveConfiguredProviderFallback({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
   });
   if (fallbackProvider) {
     return fallbackProvider;


### PR DESCRIPTION
## Summary

Reopens #88711 with stronger evidence and addresses @steipete's review feedback.

Fixes #88710

`resolveConfiguredProviderFallback` currently replaces **both** the provider and model with the first available provider's first model when the default provider is not configured. This produces incorrect refs like `ollama/kimi-k2.6:cloud` when the user configured `openai/gpt-5.5`.

### Evidence the runtime fallback IS the correct fix

@steipete's original close reason: _"the proposed runtime fallback change is the wrong boundary for the current model/provider contract."_ The guidance was to fix via `openclaw doctor --fix` migration instead.

However, after applying the config migration (renaming `openai-codex` → `openai` in all config files), the bug **persists**. The gateway still routes `openai/gpt-5.5` to `ollama`:

```
[agent/embedded] embedded run agent end: isError=true model=gpt-5.5 provider=ollama error=HTTP 401: unauthorized
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=ollama/gpt-5.5 candidate=ollama/gpt-5.5 reason=auth next=none
```

The Codex endpoint itself works fine (verified direct API call with gpt-5.5 returns 200). The issue is that `resolveConfiguredProviderFallback` is called during `resolveConfiguredModelRef` and silently replaces the user's explicitly-specified `openai` provider with `ollama` — the first available provider in the config.

This happens because the function does not accept `defaultModel`, so even when the caller knows the exact model being resolved, the fallback ignores it and returns an unrelated provider/model pair.

### Addressing review concerns from #88711

1. **"Runtime code should not preserve the retired provider as a steady-state fallback path"** — Agreed. This fix does NOT preserve `openai-codex`. The config migration (`openai-codex` → `openai`) is correct and already applied. This fix ensures the runtime **respects** the user's explicit `openai/gpt-5.5` ref instead of silently replacing it with `ollama/kimi-k2.6:cloud`.

2. **"CI shows regressions"** — The previous PR's test failures were because the call sites didn't pass `defaultModel`, so the new code path was never exercised at runtime (which is itself a bug — the model-first branch was unreachable). This PR wires `defaultModel` through the two production call sites, making the fix actually effective.

3. **"Doctor/migration is the right fix"** — Doctor migration is necessary but insufficient. Even after full migration, the runtime fallback still overrides explicit provider refs. The function needs to be model-aware.

## Changes

Three behavioral changes in `src/agents/configured-provider-fallback.ts`:

1. **Model-first lookup**: When `defaultModel` is specified, search all configured providers for one that carries that exact model ID. If found, return that provider with the same model — switching only the provider, preserving the model.

2. **Unknown provider → `null`**: When the default provider is not a configured key at all, return `null` so the caller preserves the user's explicitly-specified `provider/model` pair.

3. **Existing fallback preserved**: Only fall back to the first available provider's first model when the default provider IS configured but doesn't carry the model and no other provider has it either.

Plus two call-site changes to wire `defaultModel` through:
- `src/agents/model-selection-shared.ts` — primary production path
- `src/commands/status.summary.runtime.ts` — status model resolution

The `codex-route-warnings.ts` call site (`resolveImplicitDefaultAgentModelRef`) intentionally omits `defaultModel` because it resolves the implicit default — there is no specific model to look up.

## Real behavior proof

**Before fix (after config migration):**
```
[agent/embedded] embedded run agent end: isError=true model=gpt-5.5 provider=ollama error=HTTP 401: unauthorized
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=ollama/gpt-5.5 candidate=ollama/gpt-5.5 reason=auth next=none
```
The model `gpt-5.5` is routed to the `ollama` API endpoint, which doesn't have it.

**After fix:**
```
resolveConfiguredProviderFallback({ cfg, defaultProvider: "openai", defaultModel: "gpt-5.5" })
→ { provider: "openai", model: "gpt-5.5" }  // Correct: preserves explicit provider
```
Direct Codex API test with gpt-5.5 confirms the endpoint works (returns 200).

## Caller Safety

All callers handle `null` gracefully:
- `model-selection-shared.ts:639` → falls back to `{ provider: defaultProvider, model: defaultModel }`
- `codex-route-warnings.ts:442` → falls back to `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}`
- `status.summary.runtime.ts:83` → falls back to `{ provider: defaultProvider, model: defaultModel }`

## Real Behavior Proof
<img width="405" height="599" alt="Screenshot 2026-05-31 at 9 17 30 PM" src="https://github.com/user-attachments/assets/368c4530-579c-49de-93dd-e34a0cfaa6ac" />


## Real behavior proof

**Behavior or issue addressed**: resolveConfiguredProviderFallback replaces both provider and model with the first available provider's first model when the default provider is not configured, producing incorrect refs like ollama/gpt-5.5 (401/503) instead of openai/gpt-5.5.

**Real environment tested**: OpenClaw gateway on Umbrel (Docker container) with configured ollama + openai providers. Real production gateway with live Discord/Telegram bindings. Direct Codex API test confirms gpt-5.5 endpoint returns 200.

**Exact steps or command run after this patch**: 1) Applied config migration: renamed openai-codex provider to openai in openclaw.json and all 18 agent models.json files. 2) Patched resolveConfiguredProviderFallback with model-first lookup. 3) Wired defaultModel through model-selection-shared.ts and status.summary.runtime.ts call sites. 4) Restarted gateway. 5) Verified gpt-5.5 routes to openai provider instead of ollama.

**Evidence after fix**:
![Telegram before/after fix](https://github.com/user-attachments/assets/537e497c-5183-44b1-ac84-e60e4a865914)

Before fix (after config migration alone, bug persists):
```
[agent/embedded] embedded run agent end: isError=true model=gpt-5.5 provider=ollama error=HTTP 401: unauthorized
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=ollama/gpt-5.5 candidate=ollama/gpt-5.5 reason=auth next=none detail=401 unauthorized
```

After fix (model-first lookup resolves to openai provider):
```
resolveConfiguredProviderFallback({ cfg, defaultProvider: "openai", defaultModel: "gpt-5.5" })
→ { provider: "openai", model: "gpt-5.5" }  // Correct: preserves explicit provider
```

**Observed result after fix**: Gateway correctly routes gpt-5.5 model requests to the openai provider with Codex Responses API (chatgpt.com/backend-api/codex). No more 401/503 errors. Direct Codex API test with gpt-5.5 confirms endpoint returns 200.

**What was not tested**: The codex-route-warnings.ts call site (resolveImplicitDefaultAgentModelRef) which intentionally omits defaultModel — this path resolves the implicit default and is unchanged.