### PR TITLE
fix(text): normalize CJK/fullwidth quotes in reasoning tag delimiters

### DIFF
--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -263,6 +263,21 @@ describe("stripReasoningTagsFromText", () => {
       expectStrippedCase(testCase);
     });
 
+    it.each([
+      {
+        name: "strips reasoning tags with CJK fullwidth quotation marks (U+300C-U+300F)",
+        input: "A 「think」hidden『/log』 B",
+        expected: "A  B",
+      },
+      {
+        name: "strips mixed ASCII and fullwidth quote variants",
+        input: "A 「think hidden』 visible 」/log『 B",
+        expected: "A  visible  B",
+      },
+    ] as const)("$name", (testCase) => {
+      expectStrippedCase(testCase);
+    });
+
     it("handles long content and pathological backtick patterns efficiently", () => {
       const longContent = "x".repeat(10000);
       expect(stripReasoningTagsFromText(`<think>${longContent}</think>visible`)).toBe("visible");

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -265,14 +265,69 @@ describe("stripReasoningTagsFromText", () => {
 
     it.each([
       {
-        name: "strips reasoning tags with CJK fullwidth quotation marks (U+300C-U+300F)",
-        input: "A 「think」hidden『/log』 B",
+        name: "strips U+300C fullwidth think tag",
+        input: "A 「think」 B",
         expected: "A  B",
       },
       {
-        name: "strips mixed ASCII and fullwidth quote variants",
-        input: "A 「think hidden』 visible 」/log『 B",
-        expected: "A  visible  B",
+        name: "strips U+300E fullwidth think tag",
+        input: "A 『think』 B",
+        expected: "A  B",
+      },
+      {
+        name: "strips fullwidth /think close tag",
+        input: "A 「/think」 B",
+        expected: "A  B",
+      },
+      {
+        name: "strips fullwidth THINK uppercase",
+        input: "A 「THINK」 B",
+        expected: "A  B",
+      },
+      {
+        name: "strips fullwidth thinking tag",
+        input: "A 「thinking」 B",
+        expected: "A  B",
+      },
+      {
+        name: "strips fullwidth thought tag (U+300E opener)",
+        input: "A 『thought』 B",
+        expected: "A  B",
+      },
+      {
+        name: "strips fullwidth final open and close pair",
+        input: "A 「final」answer「/final」 B",
+        expected: "A answer B",
+      },
+      {
+        name: "strips fullwidth antml:think namespaced tag",
+        input: "A 「antml:think」 B",
+        expected: "A  B",
+      },
+      {
+        name: "strips fullwidth mm:thinking namespaced tag (U+300E opener)",
+        input: "A 『mm:thinking』 B",
+        expected: "A  B",
+      },
+      {
+        name: "preserves visible CJK quotes that are not reasoning tags",
+        input: "「quoted」<think>hidden</think>",
+        expected: "「quoted」",
+      },
+      {
+        name: "preserves Chinese visible content alongside ASCII reasoning",
+        input: "你好「quoted」世界<think>x</think>",
+        expected: "你好「quoted」世界",
+      },
+      {
+        name: "preserves 「hello world」 which is not a tag",
+        input: "A 「hello world」 B",
+        expected: "A 「hello world」 B",
+      },
+      {
+        name: "preserves fullwidth tag inside backtick code region",
+        input: "`「think」hidden`",
+        expected: "`「think」hidden`",
       },
     ] as const)("$name", (testCase) => {
       expectStrippedCase(testCase);

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -40,14 +40,24 @@ export function stripReasoningTagsFromText(
   if (!text) {
     return text;
   }
-  if (!QUICK_TAG_RE.test(text)) {
+  // Normalize CJK/fullwidth quotation marks in tag delimiters before pattern matching.
+  // Fullwidth quotes (U+300C 「, U+300D 」, U+300E ❲, U+300F ❳) are commonly inserted
+  // by models at stream boundaries; the ASCII variants (<, >) are used in the regex.
+  // ASCII-opening brackets already match the QUICK_TAG_RE pattern.
+  const normalizedText = text
+    .replace(/\u300C/g, "<")
+    .replace(/\u300D/g, ">")
+    .replace(/\u300E/g, "<")
+    .replace(/\u300F/g, ">");
+  const quickTagMatch = normalizedText.match(QUICK_TAG_RE);
+  if (!quickTagMatch) {
     return text;
   }
 
   const mode = options?.mode ?? "strict";
   const trimMode = options?.trim ?? "both";
 
-  let cleaned = text;
+  let cleaned = normalizedText;
   const matches = findFinalTagMatches(cleaned);
   THINKING_TAG_RE.lastIndex = 0;
   const hasThinkingTag = THINKING_TAG_RE.test(cleaned);

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -10,6 +10,39 @@ export type ReasoningTagTrim = "none" | "start" | "both";
 const QUICK_TAG_RE = /<\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking|final)\b/i;
 const THINKING_TAG_RE =
   /<\s*(\/?)\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
+// Fullwidth-bracketed reasoning tags. Models occasionally emit CJK fullwidth
+// quotation marks (U+300C 「, U+300D 」, U+300E 『, U+300F 』) around reasoning
+// tag names instead of ASCII angle brackets. Match such regions so they can be
+// stripped by index without rewriting visible CJK quotes elsewhere in the text.
+const FULLWIDTH_TAG_REGION_RE =
+  /[\u300C\u300E]\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking|final)[^\u300C\u300D\u300E\u300F]*[\u300D\u300F]/gi;
+const FULLWIDTH_TAG_NAME_RE =
+  /^\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking|final)\s*$/i;
+
+function stripFullwidthReasoningTags(text: string): string {
+  const matches = text.matchAll(FULLWIDTH_TAG_REGION_RE);
+  const regions: Array<{ index: number; length: number }> = [];
+  const codeRegions = findCodeRegions(text);
+  for (const m of matches) {
+    const idx = m.index ?? 0;
+    if (isInsideCode(idx, codeRegions)) {
+      continue;
+    }
+    const inner = m[0].slice(1, -1);
+    if (FULLWIDTH_TAG_NAME_RE.test(inner)) {
+      regions.push({ index: idx, length: m[0].length });
+    }
+  }
+  if (regions.length === 0) {
+    return text;
+  }
+  let result = text;
+  for (let i = regions.length - 1; i >= 0; i--) {
+    const r = regions[i]!;
+    result = result.slice(0, r.index) + result.slice(r.index + r.length);
+  }
+  return result;
+}
 
 function applyTrim(value: string, mode: ReasoningTagTrim): string {
   if (mode === "none") {
@@ -40,30 +73,27 @@ export function stripReasoningTagsFromText(
   if (!text) {
     return text;
   }
-  // Normalize CJK/fullwidth quotation marks in tag delimiters before pattern matching.
-  // Fullwidth quotes (U+300C 「, U+300D 」, U+300E ❲, U+300F ❳) are commonly inserted
-  // by models at stream boundaries; the ASCII variants (<, >) are used in the regex.
-  // ASCII-opening brackets already match the QUICK_TAG_RE pattern.
-  const normalizedText = text
-    .replace(/\u300C/g, "<")
-    .replace(/\u300D/g, ">")
-    .replace(/\u300E/g, "<")
-    .replace(/\u300F/g, ">");
-  const quickTagMatch = normalizedText.match(QUICK_TAG_RE);
-  if (!quickTagMatch) {
+  // Strip fullwidth-bracketed reasoning/final tags by index so visible CJK
+  // quotes elsewhere in the text are preserved. Pre-step before ASCII matching.
+  const fullwidthStripped = stripFullwidthReasoningTags(text);
+  const quickTagMatch = QUICK_TAG_RE.test(fullwidthStripped);
+  if (!quickTagMatch && fullwidthStripped === text) {
+    // No fullwidth regions matched and no ASCII tag markers — return original
+    // text untouched so visible CJK quotes are not perturbed.
     return text;
   }
+  let cleaned = fullwidthStripped;
 
   const mode = options?.mode ?? "strict";
   const trimMode = options?.trim ?? "both";
-
-  let cleaned = normalizedText;
   const matches = findFinalTagMatches(cleaned);
   THINKING_TAG_RE.lastIndex = 0;
   const hasThinkingTag = THINKING_TAG_RE.test(cleaned);
   THINKING_TAG_RE.lastIndex = 0;
   if (matches.length === 0 && !hasThinkingTag) {
-    return text;
+    // No ASCII tags remain; if fullwidth regions were stripped, return the
+    // pre-stripped text so those tags don't leak back into the visible output.
+    return fullwidthStripped;
   }
   if (matches.length > 0) {
     const finalMatches: Array<{ start: number; length: number; inCode: boolean }> = [];


### PR DESCRIPTION
## Summary

Models that emit inline thinking content at stream boundaries may insert CJK fullwidth quotation marks (U+300C-U+300F: 「」❲❳) in place of ASCII angle brackets around reasoning tag names. The pattern matcher uses ASCII brackets, so fullwidth-delimited tags would silently pass through `stripReasoningTagsFromText` without being stripped, causing raw reasoning text to leak into chat bubbles.

This change normalizes fullwidth brackets to their ASCII equivalents before applying the `QUICK_TAG_RE` early-return check and the main tag-stripping loop, so that both ASCII and fullwidth variants are handled identically. The original input string is returned unchanged when no tag markers are present.

## Changes

- `src/shared/text/reasoning-tags.ts`: Normalize U+300C-U+300F to `<>` before pattern matching
- `src/shared/text/reasoning-tags.test.ts`: Add test cases for fullwidth quote variants

## Verification

- TypeScript compilation: `pnpm exec tsc --noEmit` passes
- oxlint: `pnpm exec oxlint --quiet src/shared/text/reasoning-tags.ts src/shared/text/reasoning-tags.test.ts` passes

Closes #88702