### PR TITLE
docs(imessage): document SSH wrapper TCC send failure

### DIFF
--- a/docs/channels/imessage-from-bluebubbles.md
+++ b/docs/channels/imessage-from-bluebubbles.md
@@ -65,7 +65,7 @@ Use this checklist when you already know your old BlueBubbles config and want th
    imsg rpc --help
    ```
 
-   Replace `42` with a real chat id from `imsg chats`. Sending requires Automation permission for Messages.app. If OpenClaw will run through SSH, run these commands through the same SSH wrapper or user context that OpenClaw will use.
+   Replace `42` with a real chat id from `imsg chats`. Sending requires Automation permission for Messages.app. If OpenClaw will run through SSH, run these commands through the same SSH wrapper or user context that OpenClaw will use. If reads/probes work but sends fail with AppleEvents `-1743`, check whether Automation landed on `/usr/libexec/sshd-keygen-wrapper`; see [SSH wrapper sends fail with AppleEvents -1743](/channels/imessage#ssh-wrapper-sends-fail-with-appleevents-1743).
 
 3. Enable the private API bridge when you need advanced actions:
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -151,6 +151,29 @@ imsg send <handle> "test"
 
 </Tip>
 
+<Accordion title="SSH wrapper sends fail with AppleEvents -1743">
+  A remote-SSH setup can read chats, pass `channels status --probe`, and process inbound messages while outbound sends still fail with an AppleEvents authorization error:
+
+```text
+Not authorized to send Apple events to Messages. (-1743)
+```
+
+Check the signed-in Mac user's TCC database or System Settings > Privacy & Security > Automation. If the Automation entry is recorded for `/usr/libexec/sshd-keygen-wrapper` instead of the `imsg` or local shell process, macOS may not expose a usable Messages toggle for that SSH server-side client:
+
+```text
+kTCCServiceAppleEvents | /usr/libexec/sshd-keygen-wrapper | auth_value=0 | com.apple.MobileSMS
+```
+
+In that state, repeating `tccutil reset AppleEvents` or rerunning `imsg send` through the same SSH wrapper may keep failing because the process context that needs Messages Automation is the SSH wrapper, not an app the UI can grant.
+
+Use one of the supported `imsg` process contexts instead:
+
+- Run the Gateway, or at least the `imsg` bridge, in the logged-in Messages user's local session.
+- Start the Gateway with a LaunchAgent for that user after granting Full Disk Access and Automation from the same session.
+- If you keep the two-user SSH topology, verify that a real outbound `imsg send` succeeds through the exact wrapper before enabling the channel. If it cannot be granted Automation, reconfigure to a single-user `imsg` setup instead of relying on the SSH wrapper for sends.
+
+</Accordion>
+
 ## Enabling the imsg private API
 
 `imsg` ships in two operational modes:

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -597,6 +597,8 @@ BlueBubbles support was removed. `channels.bluebubbles` is not a supported runti
 
 If the Gateway is not running on the signed-in Messages Mac, keep `channels.imessage.enabled=true` and set `channels.imessage.cliPath` to an SSH wrapper that runs `imsg "$@"` on that Mac. The default local `imsg` path is macOS-only.
 
+Before relying on an SSH wrapper for production sends, verify an outbound `imsg send` through that exact wrapper. Some macOS TCC states assign Messages Automation to `/usr/libexec/sshd-keygen-wrapper`, which can make reads and probes work while sends fail with AppleEvents `-1743`; see [SSH wrapper sends fail with AppleEvents -1743](/channels/imessage#ssh-wrapper-sends-fail-with-appleevents-1743).
+
 ```json5
 {
   channels: {


### PR DESCRIPTION
Fixes #79289.

## Summary

- document the iMessage SSH-wrapper state where reads/probes work but outbound sends fail with AppleEvents `-1743`
- call out the `/usr/libexec/sshd-keygen-wrapper` TCC record pattern
- point operators back to supported `imsg` process contexts instead of suggesting unsupported BlueBubbles fallback paths

## Real behavior proof

Behavior or issue addressed: The iMessage docs now tell operators how to recognize the SSH-wrapper TCC state, why repeated AppleEvents resets may not clear it, and which supported `imsg` process contexts avoid it.

Real environment tested: Local OpenClaw checkout on macOS at `/Users/andy/openclaw/openclaw-79289-imessage-docs`, branch `fix/imessage-ssh-tcc-docs-79289`, commit `86048b77a5`.

Exact steps or command run after the patch:

```text
pnpm docs:list
pnpm check:docs
git diff --check upstream/main..HEAD
rg -n "sshd-keygen-wrapper|-1743|AppleEvents|Remote Mac over SSH|Automation" docs/channels/imessage.md docs/gateway/config-channels.md docs/channels/imessage-from-bluebubbles.md
git log --format='%h %an <%ae> %s' upstream/main..HEAD
```

Evidence after fix: Terminal output from the patched checkout showed the docs checks and targeted content audit succeeding:

```text
Docs formatting clean (660 files).
Summary: 0 error(s)
Docs MDX check passed (675 files, 5279ms).
docs:check-i18n-glossary: no merge base found; skipping glossary coverage check.
checked_internal_links=4548
broken_links=0
565e24f127 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> docs(imessage): document SSH wrapper TCC send failure
docs/channels/imessage.md:154:<Accordion title="SSH wrapper sends fail with AppleEvents -1743">
docs/channels/imessage.md:164:kTCCServiceAppleEvents | /usr/libexec/sshd-keygen-wrapper | auth_value=0 | com.apple.MobileSMS
docs/gateway/config-channels.md:600:Before relying on an SSH wrapper for production sends, verify an outbound `imsg send` through that exact wrapper.
docs/channels/imessage-from-bluebubbles.md:68:If reads/probes work but sends fail with AppleEvents `-1743`, check whether Automation landed on `/usr/libexec/sshd-keygen-wrapper`.
```

Observed result after fix: The changed docs contain the SSH-wrapper `-1743` guidance in the iMessage setup page and link to it from gateway channel config and BlueBubbles migration docs.

Repo-process cleanup: Removed the manual `CHANGELOG.md` entry so release-owned changelog generation remains untouched.

What was not tested: I did not run a live Messages send on a remote Mac; this is a docs-only repair for the macOS TCC state reported in #79289.

