### PR TITLE
fix: repair providerless Codex session overrides

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -3776,6 +3776,80 @@ describe("collectCodexRouteWarnings", () => {
     expect(store.main.agentRuntimeOverride).toBeUndefined();
   });
 
+  it("repairs providerless auto Codex session overrides", () => {
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "s1",
+        updatedAt: 1,
+        modelProvider: "ollama",
+        model: "gpt-5.5",
+        modelOverride: "gpt-5.5",
+        modelOverrideSource: "auto",
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+        contextTokens: 64_000,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "ollama",
+          model: "gpt-5.5",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 1_000,
+          contextTokenBudget: 64_000,
+          promptBudgetBeforeReserve: 62_000,
+          reserveTokens: 2_000,
+          effectiveReserveTokens: 2_000,
+          remainingPromptBudgetTokens: 61_000,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 1,
+          unwindowedMessageCount: 1,
+        },
+      },
+    };
+
+    const result = repairCodexSessionStoreRoutes({
+      store,
+      now: 123,
+    });
+
+    expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
+    expect(store.main.updatedAt).toBe(123);
+    expect(store.main.providerOverride).toBe("openai");
+    expect(store.main.modelOverride).toBe("gpt-5.5");
+    expect(store.main.modelOverrideSource).toBe("auto");
+    expect(store.main.authProfileOverride).toBe("openai-codex:default");
+    expect(store.main.authProfileOverrideSource).toBe("auto");
+    expect(store.main.modelProvider).toBeUndefined();
+    expect(store.main.model).toBeUndefined();
+    expect(store.main.contextTokens).toBeUndefined();
+    expect(store.main.contextBudgetStatus).toBeUndefined();
+  });
+
+  it("preserves legacy providerless overrides with Codex auth pins", () => {
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "s1",
+        updatedAt: 1,
+        modelOverride: "gpt-5.5",
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      },
+    };
+
+    const result = repairCodexSessionStoreRoutes({
+      store,
+      now: 123,
+    });
+
+    expect(result).toEqual({ changed: false, sessionKeys: [] });
+    expect(store.main.updatedAt).toBe(1);
+    expect(store.main.providerOverride).toBeUndefined();
+    expect(store.main.modelOverride).toBe("gpt-5.5");
+  });
+
   it("preserves canonical OpenAI sessions that are explicitly pinned to OpenClaw", () => {
     const store: Record<string, SessionEntry> = {
       main: {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -85,6 +85,15 @@ function isOpenAICodexModelRef(model: string | undefined): model is string {
   return normalizeString(model)?.startsWith("openai-codex/") === true;
 }
 
+function isOpenAICodexAuthProfileRef(profile: unknown): boolean {
+  return normalizeString(profile)?.startsWith("openai-codex:") === true;
+}
+
+function isProviderlessModelRef(model: unknown): model is string {
+  const normalized = normalizeString(model);
+  return Boolean(normalized && !normalized.includes("/"));
+}
+
 function toCanonicalOpenAIModelRef(model: string): string | undefined {
   if (!isOpenAICodexModelRef(model)) {
     return undefined;
@@ -2900,6 +2909,31 @@ function clearStaleSessionRuntimePins(entry: SessionEntry): boolean {
   return changed;
 }
 
+function repairProviderlessCodexSessionOverride(entry: SessionEntry): boolean {
+  if (
+    !isProviderlessModelRef(entry.modelOverride) ||
+    !isOpenAICodexAuthProfileRef(entry.authProfileOverride) ||
+    entry.authProfileOverrideSource !== "auto" ||
+    entry.modelOverrideSource !== "auto" ||
+    normalizeString(entry.providerOverride)
+  ) {
+    return false;
+  }
+
+  entry.providerOverride = "openai";
+  if (entry.model !== undefined || entry.modelProvider !== undefined) {
+    delete entry.model;
+    delete entry.modelProvider;
+  }
+  if (entry.contextTokens !== undefined) {
+    delete entry.contextTokens;
+  }
+  if (entry.contextBudgetStatus !== undefined) {
+    delete entry.contextBudgetStatus;
+  }
+  return true;
+}
+
 export function repairCodexSessionStoreRoutes(params: {
   store: Record<string, SessionEntry>;
   now?: number;
@@ -2920,7 +2954,9 @@ export function repairCodexSessionStoreRoutes(params: {
       providerKey: "providerOverride",
       modelKey: "modelOverride",
     });
-    const changedModelRoute = changedRuntimeModelRoute || changedOverrideModelRoute;
+    const changedProviderlessOverride = repairProviderlessCodexSessionOverride(entry);
+    const changedModelRoute =
+      changedRuntimeModelRoute || changedOverrideModelRoute || changedProviderlessOverride;
     const changedFallbackNotice = clearStaleCodexFallbackNotice(entry);
     const changedRuntimePins =
       changedModelRoute || changedFallbackNotice ? clearStaleSessionRuntimePins(entry) : false;
@@ -2946,6 +2982,11 @@ function scanCodexSessionStoreRoutes(store: Record<string, SessionEntry>): strin
       normalizeString(entry.providerOverride) === "openai-codex" ||
       isOpenAICodexModelRef(entry.model) ||
       isOpenAICodexModelRef(entry.modelOverride) ||
+      (isProviderlessModelRef(entry.modelOverride) &&
+        isOpenAICodexAuthProfileRef(entry.authProfileOverride) &&
+        entry.authProfileOverrideSource === "auto" &&
+        entry.modelOverrideSource === "auto" &&
+        !normalizeString(entry.providerOverride)) ||
       isOpenAICodexModelRef(entry.fallbackNoticeSelectedModel) ||
       isOpenAICodexModelRef(entry.fallbackNoticeActiveModel);
     return hasLegacyRoute ? [sessionKey] : [];


### PR DESCRIPTION
## Summary

Supersedes #88745 and addresses the stale route shape behind #88710 without changing steady-state model-selection fallback behavior.

`resolveConfiguredProviderFallback` remains the implicit default-provider fallback only. The fix is in doctor session-route repair: providerless auto session overrides with legacy `openai-codex:*` auth provenance are repaired to canonical `openai` provider overrides, and stale runtime/context budget fields are cleared so the next run does not resolve `gpt-5.5` against an unrelated inferred provider such as `ollama`.

Contributor credit preserved via `Co-authored-by: Earl Vanze <earlvanze@gmail.com>`.

## Verification

- `pnpm test src/commands/doctor/shared/codex-route-warnings.test.ts src/agents/model-selection.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
