### PR TITLE
[codex] Surface disabled Codex plugin routes in doctor lint

### DIFF
--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetCoreHealthChecksForTest } from "../flows/doctor-core-checks.js";
 import { clearHealthChecksForTest } from "../flows/health-check-registry.js";
 import { runDoctorLintCli } from "./doctor-lint.js";
@@ -136,6 +137,55 @@ describe("runDoctorLintCli", () => {
           },
         ],
       });
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
+  it("reports disabled Codex plugin routes through doctor lint", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: {
+              primary: "gpt-5.5",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      path: "/tmp/openclaw.json",
+    });
+
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const exitCode = await runDoctorLintCli(runtime, {
+        json: true,
+        onlyIds: ["core/doctor/codex-session-routes"],
+      });
+
+      expect(exitCode).toBe(1);
+      const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({
+        ok: false,
+        checksRun: 1,
+        findings: [
+          {
+            checkId: "core/doctor/codex-session-routes",
+            severity: "warning",
+            path: "agents.defaults.model.primary",
+            target: "openai/gpt-5.5",
+          },
+        ],
+      });
+      expect(payload.findings[0].message).toContain("Codex plugin is disabled by config");
+      expect(payload.findings[0].fixHint).toContain("openclaw doctor --fix");
     } finally {
       stdout.mockRestore();
     }

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -43,6 +43,12 @@ type DisabledCodexPluginRouteHit = {
   modelRef: string;
   canonicalModel: string;
 };
+export type DisabledCodexPluginRouteIssue = {
+  path: string;
+  modelRef: string;
+  canonicalModel: string;
+  blockedOutsideEntry: boolean;
+};
 type SharedDefaultCompactionOverrideConsumers = Record<CompactionOverrideKey, boolean>;
 
 type MutableRecord = Record<string, unknown>;
@@ -1171,6 +1177,18 @@ function collectDisabledCodexPluginRouteHits(cfg: OpenClawConfig): DisabledCodex
     hits.push({ path: ref.path, modelRef: ref.modelRef, canonicalModel });
   }
   return hits;
+}
+
+export function collectDisabledCodexPluginRouteIssues(
+  cfg: OpenClawConfig,
+): DisabledCodexPluginRouteIssue[] {
+  const blockedOutsideEntry = codexPluginIsBlockedOutsideEntry(cfg);
+  return collectDisabledCodexPluginRouteHits(cfg).map((hit) => ({
+    path: hit.path,
+    modelRef: hit.modelRef,
+    canonicalModel: hit.canonicalModel,
+    blockedOutsideEntry,
+  }));
 }
 
 function enableCodexPluginForRequiredRoutes(params: {

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -327,6 +327,45 @@ describe("registerCoreHealthChecks", () => {
     );
   });
 
+  it("reports disabled Codex plugin routes as core health findings", async () => {
+    const check = getCheck(
+      createCoreHealthChecks(createDeps()),
+      "core/doctor/codex-session-routes",
+    );
+
+    const findings = await check.detect({
+      mode: "lint",
+      runtime,
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: {
+              primary: "gpt-5.5",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(findings).toStrictEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/codex-session-routes",
+        severity: "warning",
+        path: "agents.defaults.model.primary",
+        target: "openai/gpt-5.5",
+        requirement: "Codex plugin enabled for routes that use the Codex runtime.",
+        fixHint:
+          "Run `openclaw doctor --fix`: it enables plugins.entries.codex, or set the affected OpenAI models to an OpenClaw runtime policy.",
+      }),
+    ]);
+    expect(findings[0]?.message).toContain("Codex plugin is disabled by config");
+  });
+
   it("uses the read-only model catalog for hooks.gmail.model checks", async () => {
     const cfg: OpenClawConfig = {
       hooks: {

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -18,6 +18,7 @@ import {
   uiProtocolFreshnessIssueToHealthFinding,
   uiProtocolFreshnessIssueToRepairEffects,
 } from "../commands/doctor-ui.js";
+import { collectDisabledCodexPluginRouteIssues } from "../commands/doctor/shared/codex-route-warnings.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { hasAmbiguousGatewayAuthModeConfig } from "../gateway/auth-mode-policy.js";
@@ -29,6 +30,7 @@ import { registerHealthCheck } from "./health-check-registry.js";
 import type { HealthCheck, HealthCheckContext, HealthFinding } from "./health-checks.js";
 
 const BROWSER_CLAWD_PROFILE_RESIDUE_CHECK_ID = "core/doctor/browser-clawd-profile-residue";
+const CODEX_SESSION_ROUTES_CHECK_ID = "core/doctor/codex-session-routes";
 const FINAL_CONFIG_VALIDATION_CHECK_ID = "core/doctor/final-config-validation";
 
 const loadDoctorCoreChecksRuntimeModule = async () =>
@@ -616,6 +618,37 @@ const legacyWhatsAppCrontabCheck: HealthCheck = {
   },
 };
 
+const codexSessionRoutesCheck: HealthCheck = {
+  id: CODEX_SESSION_ROUTES_CHECK_ID,
+  kind: "core",
+  description: "Codex runtime routes have a registered Codex plugin harness before sessions run.",
+  source: "doctor",
+  async detect(ctx) {
+    return collectDisabledCodexPluginRouteIssues(ctx.cfg).map(
+      (issue): HealthFinding => ({
+        checkId: CODEX_SESSION_ROUTES_CHECK_ID,
+        severity: "warning",
+        message: [
+          `${issue.path} routes ${issue.modelRef} to ${issue.canonicalModel}`,
+          "with Codex runtime, but the Codex plugin is disabled by config.",
+        ].join(" "),
+        path: issue.path,
+        target: issue.canonicalModel,
+        requirement: "Codex plugin enabled for routes that use the Codex runtime.",
+        fixHint: issue.blockedOutsideEntry
+          ? [
+              "Enable plugin loading and remove codex from plugins.deny,",
+              "or set the affected OpenAI models to an OpenClaw runtime policy.",
+            ].join(" ")
+          : [
+              "Run `openclaw doctor --fix`: it enables plugins.entries.codex,",
+              "or set the affected OpenAI models to an OpenClaw runtime policy.",
+            ].join(" "),
+      }),
+    );
+  },
+};
+
 const gatewayPlatformNotesCheck: HealthCheck = {
   id: "core/doctor/gateway-services/platform-notes",
   kind: "core",
@@ -913,6 +946,7 @@ function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly Heal
     gatewayAuthCheck,
     legacyStateCheck,
     legacyWhatsAppCrontabCheck,
+    codexSessionRoutesCheck,
     shellCompletionCheck,
     uiProtocolFreshnessCheck,
     gatewayPlatformNotesCheck,


### PR DESCRIPTION
Closes #88751.

## Summary
- Adds a structured `core/doctor/codex-session-routes` health check so `openclaw doctor --lint` reports OpenAI/Codex-runtime routes when the Codex plugin is disabled.
- Reuses the existing disabled-Codex-plugin route detector and keeps the repair path in the existing `doctor --fix` route repair flow.
- Adds focused CLI/core tests proving lint now returns a warning instead of reporting a clean run for this config mismatch.

## Verification
- `pnpm install --frozen-lockfile --store-dir C:\oc-work\.pnpm-store`
- `pnpm exec oxfmt --check --threads=1 src/commands/doctor-lint.test.ts src/commands/doctor/shared/codex-route-warnings.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-core-checks.ts`
- `git diff --check`
- `pnpm exec oxlint src/commands/doctor/shared/codex-route-warnings.ts src/flows/doctor-core-checks.ts src/commands/doctor-lint.test.ts src/flows/doctor-core-checks.test.ts`
- `node scripts/run-vitest.mjs src/commands/doctor-lint.test.ts src/commands/doctor/shared/codex-route-warnings.test.ts src/flows/doctor-core-checks.test.ts`
- `OPENCLAW_CONFIG_PATH=.artifacts/issue-88751-openclaw.jsonc node scripts/run-node.mjs doctor --lint --json --only core/doctor/codex-session-routes` exited 1 as expected because the new lint finding is present.

## Real Behavior Proof
- Behavior addressed: `doctor --lint` missed configs where agent routes resolve to the Codex runtime while `plugins.entries.codex.enabled` is false, leaving cron/session runs to fail later with `MissingAgentHarnessError`.
- Real environment tested: local Windows desktop worktree `C:\oc-work\oc-88751`, rebased on `origin/main` at `92b9cd21ec`, running the real OpenClaw CLI from this branch against a temporary OpenClaw config file.
- Exact steps or command run after this patch:
  1. Created a temporary OpenClaw config with `plugins.entries.codex.enabled=false` and `agents.defaults.model.primary="gpt-5.5"`.
  2. Ran `OPENCLAW_CONFIG_PATH=.artifacts/issue-88751-openclaw.jsonc node scripts/run-node.mjs doctor --lint --json --only core/doctor/codex-session-routes`.
- Evidence after fix: console output from the real OpenClaw CLI was:

```json
{"ok":false,"checksRun":1,"checksSkipped":21,"findings":[{"checkId":"core/doctor/codex-session-routes","severity":"warning","message":"agents.defaults.model.primary routes gpt-5.5 to openai/gpt-5.5 with Codex runtime, but the Codex plugin is disabled by config.","path":"agents.defaults.model.primary","target":"openai/gpt-5.5","requirement":"Codex plugin enabled for routes that use the Codex runtime.","fixHint":"Run `openclaw doctor --fix`: it enables plugins.entries.codex, or set the affected OpenAI models to an OpenClaw runtime policy."}]}
```

- Observed result after fix: `doctor --lint` no longer reports a clean run for the disabled-Codex-plugin/native-Codex-runtime mismatch; it returns a warning finding and non-zero lint exit before cron/session execution reaches `MissingAgentHarnessError`.
- What was not tested: live VPS config mutation from this PR. The issue has live beta failure evidence, and this patch only changes lint detection; the existing `doctor --fix` repair path was intentionally left in place.

## Supplemental Proof
- Focused Vitest suite passed post-rebase: 15 doctor-lint tests, 110 combined Codex-route/core-check tests, 2 Vitest shards passed.