### PR TITLE
fix(agents): publish owned announcement session writes

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -922,6 +922,75 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releases).toEqual(["release", "release", "release"]);
   });
 
+  it("allows prompt-stream announcement writes from another controller but still rejects external edits", async () => {
+    const sessionFile = await createTempSessionFile();
+    const acquireSessionWriteLockAnnouncement = vi.fn(async () => ({ release: vi.fn() }));
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockAnnouncement,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    const sessionKey = "agent:main:imessage:requester";
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockAnnouncement,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const forwardedOptions: Array<{ publishOwnedWrite?: boolean } | undefined> = [];
+    const announceSession = {
+      agent: {
+        streamFn: vi.fn(async () => {
+          await runWithOwnedSessionTranscriptWritePublication(
+            { sessionFile, sessionKey },
+            async () => {
+              await fs.appendFile(
+                sessionFile,
+                '{"type":"message","id":"announcement-complete"}\n',
+                "utf8",
+              );
+            },
+          );
+        }),
+      },
+    };
+
+    installPromptSubmissionLockRelease({
+      session: announceSession,
+      waitForSessionEvents: (sessionToDrain) =>
+        secondController.waitForSessionEvents(sessionToDrain),
+      releaseForPrompt: () => secondController.releaseForPrompt(),
+      reacquireAfterPrompt: () => secondController.reacquireAfterPrompt(),
+      sessionFile,
+      sessionKey,
+      withSessionWriteLock: (run, options) => {
+        forwardedOptions.push(options);
+        return secondController.withSessionWriteLock(run, options);
+      },
+    });
+
+    await announceSession.agent.streamFn();
+    await expect(
+      firstController.withSessionWriteLock(async () => {
+        await fs.appendFile(sessionFile, '{"type":"message","id":"post-announcement"}\n', "utf8");
+        return "post-announcement";
+      }),
+    ).resolves.toBe("post-announcement");
+    expect(firstController.hasSessionTakeover()).toBe(false);
+
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","id":"external-after-announcement"}\n',
+      "utf8",
+    );
+    await expect(firstController.withSessionWriteLock(() => "late")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+
+    expect(firstController.hasSessionTakeover()).toBe(true);
+    expect(forwardedOptions).toContainEqual({ publishOwnedWrite: true });
+  });
+
   it("rejects external edits interleaved while another controller holds cleanup lock", async () => {
     const sessionFile = await createTempSessionFile();
     const releases: string[] = [];

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3812,7 +3812,8 @@ export async function runEmbeddedAttempt(
               reacquireAfterPrompt: () => sessionLockController.reacquireAfterPrompt(),
               sessionKey: params.sessionKey,
               sessionFile: params.sessionFile,
-              withSessionWriteLock: (run) => sessionLockController.withSessionWriteLock(run),
+              withSessionWriteLock: (run, options) =>
+                sessionLockController.withSessionWriteLock(run, options),
             });
           }
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- Fixes a session-lock publication gap where prompt-submission owned writes could lose the `publishOwnedWrite` option before reaching the session lock controller.
- This lets legitimate same-process announcement/completion writes be recognized by the original attempt fence while keeping external edit takeover protection intact.

Why does this matter now?
- #88703 reports `EmbeddedAttemptSessionTakeoverError` after a yielded media completion falls back to an announce run that writes the same requester session.

What is the intended outcome?
- The prompt-lock wrapper forwards write-lock options, so owned transcript-write publication reaches the fence logic.

What is intentionally out of scope?
- This does not implement a broader yielded-run resume/wake mechanism.
- This does not relax takeover detection for unowned external edits.

What does success look like?
- Same-process announcement writes published through the prompt context are accepted on reacquire; plain external edits still throw `EmbeddedAttemptSessionTakeoverError`.

What should reviewers focus on?
- Whether option forwarding is limited to the intended prompt-lock wrapper and whether the regression preserves the external-edit guard.

## Linked context

Which issue does this close?

Closes #88703

Which issues, PRs, or discussions are related?

Related issue comments on #88703 report adjacent non-media cron failures with the same exception, but this PR targets the source-repro media/announcement publication path from the issue review.

Was this requested by a maintainer or owner?

No maintainer request observed; this follows the ClawSweeper-reviewed source-repro issue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: owned announcement writes during the prompt lock release window were not published to the original session fence because the wrapper dropped `publishOwnedWrite`.
- Real environment tested: Local development checkout on branch `fix/announce-owned-write-88703`, rebased on `upstream/main` at `92b9cd21ec`.
- Exact steps or command run after this patch:
  - Ran a local runtime proof script with `node --import tsx` that creates real temp session transcript state, installs `installPromptSubmissionLockRelease`, simulates a yielded media-completion announcement through `runWithOwnedSessionTranscriptWritePublication`, then checks the requester session fence.
  - Re-ran focused checks: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts src/agents/embedded-agent-runner/runs.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/tools/media-generate-background-shared.test.ts test/scripts/plugin-prerelease-test-plan.test.ts`, `pnpm check:test-types`, and `git diff --check`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "forwardedOptions": [
    {
      "publishOwnedWrite": true
    }
  ],
  "postAnnouncementResult": "accepted",
  "takeoverAfterOwnedAnnouncement": false,
  "externalEditRejected": true,
  "takeoverAfterExternalEdit": true,
  "transcriptLines": [
    "{"type":"session"}",
    "{"type":"message","id":"media-completion-announced"}",
    "{"type":"message","id":"post-announcement"}",
    "{"type":"message","id":"external-after-announcement"}"
  ]
}
```

- Observed result after fix: the prompt wrapper forwarded `{ publishOwnedWrite: true }`, the original requester controller accepted the post-announcement write with no takeover after the owned completion announcement, and a later unowned external edit was still rejected as `EmbeddedAttemptSessionTakeoverError`.
- What was not tested: I did not run a live image-generation provider completion against external provider credentials.
- Proof limitations or environment constraints: The proof exercises the actual local prompt-wrapper/session-fence code path with a simulated media-completion transcript write; live provider image generation would require configured media provider credentials and a longer end-to-end channel run.
- Before evidence (optional but encouraged): ClawSweeper review on #88703 identified the prompt submission wrapper as dropping the owned-write publication option before it reached the session lock controller.


## Tests and validation

Which commands did you run?

`node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts src/agents/embedded-agent-runner/runs.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/tools/media-generate-background-shared.test.ts`

`git diff --check`

What regression coverage was added or updated?

`attempt.session-lock.test.ts` now covers a prompt-stream announcement write from another controller that is published and accepted, followed by an unowned external edit that is still rejected.

What failed before this fix, if known?

The prompt submission wrapper passed only the operation into `withSessionWriteLock`, dropping the options object that carries `publishOwnedWrite`.

If no test was added, why not?

A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The session takeover fence, because it protects against real external edits.

How is that risk mitigated?

The fix only forwards existing options, and the regression explicitly verifies that a later unowned external edit still throws takeover protection.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI and optional maintainer/live media-completion confirmation.

Which bot or reviewer comments were addressed?

Initial implementation for #88703.

