### PR TITLE
fix(plugin-sdk): isolate provider catalog projection failures

### DIFF
--- a/extensions/matrix/src/matrix/monitor/auto-join.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.ts
@@ -58,10 +58,19 @@ export function registerMatrixAutoJoin(params: {
     );
     return resolved.filter((roomId): roomId is string => Boolean(roomId));
   };
+  const runInviteTask = (roomId: string, task: () => Promise<void>) => {
+    void Promise.resolve()
+      .then(task)
+      .catch((err: unknown) => {
+        runtime.error?.(
+          `matrix: auto-join invite handler failed for room ${roomId}: ${String(err)}`,
+        );
+      });
+  };
 
   // Handle invites directly so both "always" and "allowlist" modes share the same path.
   client.on("room.invite", (roomId: string, _inviteEvent: unknown) => {
-    void (async () => {
+    runInviteTask(roomId, async () => {
       if (autoJoin === "allowlist") {
         const allowedAliasRoomIds = await resolveAllowedAliasRoomIds();
         const allowed =
@@ -81,6 +90,6 @@ export function registerMatrixAutoJoin(params: {
       } catch (err) {
         runtime.error?.(`matrix: failed to join room ${roomId}: ${String(err)}`);
       }
-    })();
+    });
   });
 }

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -238,7 +238,8 @@ describe("CronToolSchema", () => {
       | Record<string, { properties?: Record<string, { type?: unknown }> }>
       | undefined;
 
-    // Must be plain "array" — not ["array", "null"] — for provider compat.
+    // Provider-facing schemas must be plain "array" rather than JSON Schema
+    // unions so OpenAPI 3.0 subset validators accept them.
     expect(patchProps?.payload?.properties?.toolsAllow?.type).toBe("array");
   });
 
@@ -248,7 +249,7 @@ describe("CronToolSchema", () => {
     const json = JSON.stringify(providerSchemaRecord);
     // type arrays like ["string","null"] are not valid in OpenAPI 3.0
     expect(json).not.toMatch(/"type"\s*:\s*\[/);
-    // "not" composition keyword is not supported by OpenAPI 3.0
+    // The "not" composition keyword is not supported by OpenAPI 3.0.
     expect(json).not.toMatch(/"not"\s*:\s*\{/);
   });
 });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -481,21 +481,25 @@ describe("cron tool", () => {
       "string",
       "null",
     ]);
+    expect(patch?.properties?.agentId?.type).toBeUndefined();
     expect(patch?.properties?.agentId?.description).toContain("null to clear");
     expect(patch?.properties?.sessionKey?.anyOf?.map((entry) => entry.type)).toEqual([
       "string",
       "null",
     ]);
+    expect(patch?.properties?.sessionKey?.type).toBeUndefined();
     expect(patch?.properties?.sessionKey?.description).toContain("null to clear");
     expect(payload?.properties?.toolsAllow?.anyOf?.map((entry) => entry.type)).toEqual([
       "array",
       "null",
     ]);
+    expect(payload?.properties?.toolsAllow?.type).toBeUndefined();
     expect(payload?.properties?.toolsAllow?.description).toContain("null to clear");
     expect(delivery?.properties?.channel?.anyOf?.map((entry) => entry.type)).toEqual([
       "string",
       "null",
     ]);
+    expect(delivery?.properties?.channel?.type).toBeUndefined();
     expect(delivery?.properties?.channel?.description).toContain("null to clear");
     expect(delivery?.properties?.failureDestination?.anyOf?.map((entry) => entry.type)).toEqual([
       "object",

--- a/src/plugin-sdk/provider-entry.test.ts
+++ b/src/plugin-sdk/provider-entry.test.ts
@@ -238,6 +238,139 @@ describe("defineSingleProviderPluginEntry", () => {
     });
   });
 
+  it("skips unreadable provider catalog entries while preserving healthy siblings", async () => {
+    const providers = Object.defineProperty(
+      {
+        mockplugin: {
+          api: "openai-completions" as const,
+          baseUrl: "https://mockplugin.test/v1",
+          models: [createModel("mock-model", "Mock Model")],
+        },
+      },
+      "fuzzplugin",
+      {
+        enumerable: true,
+        get() {
+          throw new Error("fuzzplugin provider catalog entry read failed");
+        },
+      },
+    );
+    const entry = defineSingleProviderPluginEntry({
+      id: "mockplugin",
+      name: "Mock Provider",
+      description: "Synthetic provider plugin",
+      provider: {
+        label: "Mock",
+        docsPath: "/providers/mockplugin",
+        catalog: {
+          run: async () => ({ providers }),
+        },
+      },
+    });
+
+    const { unifiedCatalog } = await captureProviderEntry({ entry });
+    expect(unifiedCatalog).toEqual([
+      {
+        kind: "text",
+        provider: "mockplugin",
+        model: "mock-model",
+        label: "Mock Model",
+        source: "live",
+      },
+    ]);
+  });
+
+  it("skips unreadable provider catalog model rows while preserving healthy siblings", async () => {
+    const models = Object.defineProperty([createModel("mock-model", "Mock Model")], "1", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin provider model row read failed");
+      },
+    });
+    const entry = defineSingleProviderPluginEntry({
+      id: "mockplugin",
+      name: "Mock Provider",
+      description: "Synthetic provider plugin",
+      provider: {
+        label: "Mock",
+        docsPath: "/providers/mockplugin",
+        catalog: {
+          run: async () => ({
+            providers: {
+              mockplugin: {
+                api: "openai-completions" as const,
+                baseUrl: "https://mockplugin.test/v1",
+                models,
+              },
+            },
+          }),
+        },
+      },
+    });
+
+    const { unifiedCatalog } = await captureProviderEntry({ entry });
+    expect(unifiedCatalog).toEqual([
+      {
+        kind: "text",
+        provider: "mockplugin",
+        model: "mock-model",
+        label: "Mock Model",
+        source: "live",
+      },
+    ]);
+  });
+
+  it("skips unreadable provider auth option rows while preserving healthy entries", async () => {
+    const unreadableAuth = Object.defineProperty(
+      {
+        methodId: "fuzz-api-key",
+        label: "Fuzz API key",
+        optionKey: "fuzzApiKey",
+        flagName: "--fuzz-api-key" as const,
+        envVar: "FUZZ_API_KEY",
+        promptMessage: "Enter Fuzz API key",
+      },
+      "label",
+      {
+        enumerable: true,
+        get() {
+          throw new Error("fuzzplugin provider auth label read failed");
+        },
+      },
+    );
+    const entry = defineSingleProviderPluginEntry({
+      id: "mockplugin",
+      name: "Mock Provider",
+      description: "Synthetic provider plugin",
+      provider: {
+        label: "Mock",
+        docsPath: "/providers/mockplugin",
+        auth: [
+          unreadableAuth,
+          {
+            methodId: "mock-api-key",
+            label: "Mock API key",
+            optionKey: "mockApiKey",
+            flagName: "--mock-api-key",
+            envVar: "MOCK_API_KEY",
+            promptMessage: "Enter Mock API key",
+          },
+        ],
+        catalog: {
+          buildProvider: () => ({
+            api: "openai-completions",
+            baseUrl: "https://mockplugin.test/v1",
+            models: [],
+          }),
+        },
+      },
+    });
+
+    const { provider } = await captureProviderEntry({ entry });
+    expect(provider?.envVars).toEqual(["MOCK_API_KEY"]);
+    expect(provider?.auth.map((method) => method.id)).toEqual(["mock-api-key"]);
+  });
+
   it("registers extra non-api-key auth methods", async () => {
     const entry = defineSingleProviderPluginEntry({
       id: "demo",

--- a/src/plugin-sdk/provider-entry.ts
+++ b/src/plugin-sdk/provider-entry.ts
@@ -1,4 +1,8 @@
 import type { UnifiedModelCatalogEntry } from "@openclaw/model-catalog-core/model-catalog-types";
+import {
+  normalizeStringEntries,
+  uniqueStrings,
+} from "../../packages/normalization-core/src/string-normalization.js";
 import { createProviderApiKeyAuthMethod } from "../plugins/provider-api-key-auth.js";
 import { projectProviderCatalogResultToUnifiedTextRows } from "../plugins/provider-catalog-unified-text.js";
 import type {
@@ -10,7 +14,7 @@ import type {
   UnifiedModelCatalogProviderContext,
   ProviderPluginWizardSetup,
 } from "../plugins/types.js";
-import { normalizeStringEntries, uniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
+import { copyArrayEntries, isRecord, readRecordValue } from "../shared/safe-record.js";
 import { definePluginEntry } from "./plugin-entry.js";
 import type {
   OpenClawPluginApi,
@@ -99,13 +103,21 @@ function resolveWizardSetup(params: {
   };
 }
 
+function copyProviderAuthOptions(value: unknown): SingleProviderPluginApiKeyAuthOptions[] {
+  return copyArrayEntries(value).filter(isRecord) as SingleProviderPluginApiKeyAuthOptions[];
+}
+
+function copyProviderAuthMethods(value: unknown): ProviderAuthMethod[] {
+  return copyArrayEntries(value).filter(isRecord) as ProviderAuthMethod[];
+}
+
 function resolveEnvVars(params: {
-  envVars?: string[];
+  envVars?: unknown;
   auth?: SingleProviderPluginApiKeyAuthOptions[];
 }): string[] | undefined {
   const combined = normalizeStringEntries([
-    ...(params.envVars ?? []),
-    ...(params.auth ?? []).map((entry) => entry.envVar).filter(Boolean),
+    ...copyArrayEntries(params.envVars),
+    ...(params.auth ?? []).map((entry) => readRecordValue(entry, "envVar")).filter(Boolean),
   ]);
   return combined.length > 0 ? uniqueStrings(combined) : undefined;
 }
@@ -135,25 +147,33 @@ export function defineSingleProviderPluginEntry(options: SingleProviderPluginOpt
       const provider = options.provider;
       if (provider) {
         const providerId = provider.id ?? options.id;
+        const providerAuth = copyProviderAuthOptions(provider.auth);
+        const acceptedProviderAuth: SingleProviderPluginApiKeyAuthOptions[] = [];
+        const auth = providerAuth.flatMap((entry) => {
+          try {
+            const { wizard: _wizard, ...authParams } = entry;
+            const wizard = resolveWizardSetup({
+              providerId,
+              providerLabel: provider.label,
+              auth: entry,
+            });
+            const method = createProviderApiKeyAuthMethod({
+              ...authParams,
+              providerId,
+              expectedProviders: entry.expectedProviders ?? [providerId],
+              ...(wizard ? { wizard } : {}),
+            });
+            acceptedProviderAuth.push(entry);
+            return [method];
+          } catch {
+            return [];
+          }
+        });
         const envVars = resolveEnvVars({
           envVars: provider.envVars,
-          auth: provider.auth,
+          auth: acceptedProviderAuth,
         });
-        const auth = (provider.auth ?? []).map((entry) => {
-          const { wizard: _wizard, ...authParams } = entry;
-          const wizard = resolveWizardSetup({
-            providerId,
-            providerLabel: provider.label,
-            auth: entry,
-          });
-          return createProviderApiKeyAuthMethod({
-            ...authParams,
-            providerId,
-            expectedProviders: entry.expectedProviders ?? [providerId],
-            ...(wizard ? { wizard } : {}),
-          });
-        });
-        auth.push(...(provider.extraAuth ?? []));
+        auth.push(...copyProviderAuthMethods(provider.extraAuth));
         let catalog: ProviderPluginCatalog;
         if ("run" in provider.catalog) {
           const catalogRun = provider.catalog.run;

--- a/src/plugins/provider-catalog-result.ts
+++ b/src/plugins/provider-catalog-result.ts
@@ -92,11 +92,14 @@ function copyProviderCatalogModel(model: unknown): ModelDefinitionConfig | undef
   }
   const id = readRecordValue(model, "id");
   const name = readRecordValue(model, "name");
-  if (typeof id !== "string" || typeof name !== "string") {
+  if (typeof id !== "string") {
     return undefined;
   }
 
-  const copied: Partial<ModelDefinitionConfig> = { id, name };
+  const copied: Partial<ModelDefinitionConfig> = {
+    id,
+    name: typeof name === "string" ? name : id,
+  };
   for (const key of MODEL_DEFINITION_CONFIG_KEYS) {
     const value = readRecordValue(model, key);
     if (value !== undefined) {

--- a/src/plugins/provider-catalog-result.ts
+++ b/src/plugins/provider-catalog-result.ts
@@ -1,4 +1,4 @@
-import type { ModelProviderConfig } from "../config/types.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.js";
 import {
   copyArrayEntries,
   copyRecordEntries,
@@ -25,6 +25,24 @@ const MODEL_PROVIDER_CONFIG_KEYS = [
   "authHeader",
   "request",
 ] as const satisfies readonly (keyof ModelProviderConfig)[];
+
+const MODEL_DEFINITION_CONFIG_KEYS = [
+  "api",
+  "baseUrl",
+  "reasoning",
+  "input",
+  "cost",
+  "contextWindow",
+  "contextTokens",
+  "maxTokens",
+  "thinkingLevelMap",
+  "params",
+  "agentRuntime",
+  "headers",
+  "compat",
+  "mediaInput",
+  "metadataSource",
+] as const satisfies readonly (keyof ModelDefinitionConfig)[];
 
 export type ProviderCatalogResultProjection =
   | { kind: "provider"; provider: ModelProviderConfig }
@@ -62,9 +80,30 @@ export function copyProviderCatalogResultEntries(params: {
 export function copyProviderCatalogModels(
   providerConfig: ModelProviderConfig,
 ): ModelProviderConfig["models"] {
-  return copyArrayEntries(readRecordValue(providerConfig, "models")).filter(
-    (entry): entry is ModelProviderConfig["models"][number] => isRecord(entry),
-  );
+  return copyArrayEntries(readRecordValue(providerConfig, "models")).flatMap((entry) => {
+    const copied = copyProviderCatalogModel(entry);
+    return copied ? [copied] : [];
+  });
+}
+
+function copyProviderCatalogModel(model: unknown): ModelDefinitionConfig | undefined {
+  if (!isRecord(model)) {
+    return undefined;
+  }
+  const id = readRecordValue(model, "id");
+  const name = readRecordValue(model, "name");
+  if (typeof id !== "string" || typeof name !== "string") {
+    return undefined;
+  }
+
+  const copied: Partial<ModelDefinitionConfig> = { id, name };
+  for (const key of MODEL_DEFINITION_CONFIG_KEYS) {
+    const value = readRecordValue(model, key);
+    if (value !== undefined) {
+      (copied as Record<string, unknown>)[key] = value;
+    }
+  }
+  return copied as ModelDefinitionConfig;
 }
 
 export function copyProviderCatalogProviderConfig(

--- a/src/plugins/provider-catalog-result.ts
+++ b/src/plugins/provider-catalog-result.ts
@@ -1,0 +1,94 @@
+import type { ModelProviderConfig } from "../config/types.js";
+import {
+  copyArrayEntries,
+  copyRecordEntries,
+  isRecord,
+  readRecordValue,
+} from "../shared/safe-record.js";
+import type { ProviderCatalogResult } from "./types.js";
+
+const MODEL_PROVIDER_CONFIG_KEYS = [
+  "baseUrl",
+  "apiKey",
+  "auth",
+  "api",
+  "contextWindow",
+  "contextTokens",
+  "maxTokens",
+  "timeoutSeconds",
+  "region",
+  "injectNumCtxForOpenAICompat",
+  "params",
+  "agentRuntime",
+  "localService",
+  "headers",
+  "authHeader",
+  "request",
+] as const satisfies readonly (keyof ModelProviderConfig)[];
+
+export type ProviderCatalogResultProjection =
+  | { kind: "provider"; provider: ModelProviderConfig }
+  | { kind: "providers"; providers: Array<[string, ModelProviderConfig]> }
+  | { kind: "empty" };
+
+export function copyProviderCatalogResultProjection(
+  result: ProviderCatalogResult,
+): ProviderCatalogResultProjection {
+  const provider = copyProviderCatalogProviderConfig(readRecordValue(result, "provider"));
+  if (provider) {
+    return { kind: "provider", provider };
+  }
+
+  const providers = copyRecordEntries<ModelProviderConfig>(
+    readRecordValue(result, "providers"),
+  ).flatMap(([providerId, providerConfig]) => {
+    const copied = copyProviderCatalogProviderConfig(providerConfig);
+    return copied ? [[providerId, copied] as [string, ModelProviderConfig]] : [];
+  });
+  return providers.length > 0 ? { kind: "providers", providers } : { kind: "empty" };
+}
+
+export function copyProviderCatalogResultEntries(params: {
+  providerId: string;
+  result: ProviderCatalogResult;
+}): Array<[string, ModelProviderConfig]> {
+  const projection = copyProviderCatalogResultProjection(params.result);
+  if (projection.kind === "provider") {
+    return [[params.providerId, projection.provider]];
+  }
+  return projection.kind === "providers" ? projection.providers : [];
+}
+
+export function copyProviderCatalogModels(
+  providerConfig: ModelProviderConfig,
+): ModelProviderConfig["models"] {
+  return copyArrayEntries(readRecordValue(providerConfig, "models")).filter(
+    (entry): entry is ModelProviderConfig["models"][number] => isRecord(entry),
+  );
+}
+
+export function copyProviderCatalogProviderConfig(
+  providerConfig: unknown,
+): ModelProviderConfig | undefined {
+  if (!isRecord(providerConfig)) {
+    return undefined;
+  }
+
+  try {
+    return {
+      ...(providerConfig as ModelProviderConfig),
+      models: copyProviderCatalogModels(providerConfig as ModelProviderConfig),
+    };
+  } catch {
+    const copied: Partial<ModelProviderConfig> = {
+      models: copyProviderCatalogModels(providerConfig as ModelProviderConfig),
+    };
+    for (const key of MODEL_PROVIDER_CONFIG_KEYS) {
+      const value = readRecordValue(providerConfig, key);
+      if (value !== undefined) {
+        (copied as Record<string, unknown>)[key] = value;
+      }
+    }
+    return copied as ModelProviderConfig;
+  }
+}

--- a/src/plugins/provider-catalog-result.ts
+++ b/src/plugins/provider-catalog-result.ts
@@ -116,21 +116,23 @@ export function copyProviderCatalogProviderConfig(
     return undefined;
   }
 
-  try {
-    return {
-      ...(providerConfig as ModelProviderConfig),
-      models: copyProviderCatalogModels(providerConfig as ModelProviderConfig),
-    };
-  } catch {
-    const copied: Partial<ModelProviderConfig> = {
-      models: copyProviderCatalogModels(providerConfig as ModelProviderConfig),
-    };
-    for (const key of MODEL_PROVIDER_CONFIG_KEYS) {
-      const value = readRecordValue(providerConfig, key);
-      if (value !== undefined) {
-        (copied as Record<string, unknown>)[key] = value;
-      }
-    }
-    return copied as ModelProviderConfig;
+  const baseUrl = readRecordValue(providerConfig, "baseUrl");
+  if (typeof baseUrl !== "string") {
+    return undefined;
   }
+
+  const copied: Partial<ModelProviderConfig> = {
+    baseUrl,
+    models: copyProviderCatalogModels(providerConfig as ModelProviderConfig),
+  };
+  for (const key of MODEL_PROVIDER_CONFIG_KEYS) {
+    if (key === "baseUrl") {
+      continue;
+    }
+    const value = readRecordValue(providerConfig, key);
+    if (value !== undefined) {
+      (copied as Record<string, unknown>)[key] = value;
+    }
+  }
+  return copied as ModelProviderConfig;
 }

--- a/src/plugins/provider-catalog-unified-text.ts
+++ b/src/plugins/provider-catalog-unified-text.ts
@@ -1,29 +1,10 @@
 import type { UnifiedModelCatalogEntry } from "@openclaw/model-catalog-core/model-catalog-types";
-import type { ModelProviderConfig } from "../config/types.js";
+import { readRecordValue } from "../shared/safe-record.js";
 import {
-  copyArrayEntries,
-  copyRecordEntries,
-  isRecord,
-  readRecordValue,
-} from "../shared/safe-record.js";
+  copyProviderCatalogModels,
+  copyProviderCatalogResultEntries,
+} from "./provider-catalog-result.js";
 import type { ProviderCatalogResult } from "./types.js";
-
-function copyProviderCatalogResultEntries(params: {
-  providerId: string;
-  result: ProviderCatalogResult;
-}): Array<[string, ModelProviderConfig]> {
-  const provider = readRecordValue(params.result, "provider");
-  if (isRecord(provider)) {
-    return [[params.providerId, provider as ModelProviderConfig]];
-  }
-  return copyRecordEntries<ModelProviderConfig>(readRecordValue(params.result, "providers"));
-}
-
-function copyProviderModels(providerConfig: ModelProviderConfig): ModelProviderConfig["models"] {
-  return copyArrayEntries(readRecordValue(providerConfig, "models")).filter(
-    (entry): entry is ModelProviderConfig["models"][number] => isRecord(entry),
-  );
-}
 
 export function projectProviderCatalogResultToUnifiedTextRows(params: {
   providerId: string;
@@ -34,7 +15,7 @@ export function projectProviderCatalogResultToUnifiedTextRows(params: {
   // Runtime projection isolates unreadable catalog rows so one bad plugin-owned
   // provider/model entry cannot hide every healthy sibling from model selection.
   for (const [providerId, providerConfig] of copyProviderCatalogResultEntries(params)) {
-    for (const model of copyProviderModels(providerConfig)) {
+    for (const model of copyProviderCatalogModels(providerConfig)) {
       const modelId = readRecordValue(model, "id");
       if (typeof modelId !== "string") {
         continue;

--- a/src/plugins/provider-catalog-unified-text.ts
+++ b/src/plugins/provider-catalog-unified-text.ts
@@ -1,28 +1,50 @@
 import type { UnifiedModelCatalogEntry } from "@openclaw/model-catalog-core/model-catalog-types";
+import type { ModelProviderConfig } from "../config/types.js";
+import {
+  copyArrayEntries,
+  copyRecordEntries,
+  isRecord,
+  readRecordValue,
+} from "../shared/safe-record.js";
 import type { ProviderCatalogResult } from "./types.js";
+
+function copyProviderCatalogResultEntries(params: {
+  providerId: string;
+  result: ProviderCatalogResult;
+}): Array<[string, ModelProviderConfig]> {
+  const provider = readRecordValue(params.result, "provider");
+  if (isRecord(provider)) {
+    return [[params.providerId, provider as ModelProviderConfig]];
+  }
+  return copyRecordEntries<ModelProviderConfig>(readRecordValue(params.result, "providers"));
+}
+
+function copyProviderModels(providerConfig: ModelProviderConfig): ModelProviderConfig["models"] {
+  return copyArrayEntries(readRecordValue(providerConfig, "models")).filter(
+    (entry): entry is ModelProviderConfig["models"][number] => isRecord(entry),
+  );
+}
 
 export function projectProviderCatalogResultToUnifiedTextRows(params: {
   providerId: string;
   result: ProviderCatalogResult;
   source: UnifiedModelCatalogEntry["source"];
 }): UnifiedModelCatalogEntry[] {
-  if (!params.result) {
-    return [];
-  }
-  const providers =
-    "provider" in params.result
-      ? { [params.providerId]: params.result.provider }
-      : params.result.providers;
   const rows: UnifiedModelCatalogEntry[] = [];
-  // Doctor owns malformed plugin catalog diagnostics; runtime projection stays on
-  // the typed provider catalog contract instead of carrying fallback semantics.
-  for (const [providerId, providerConfig] of Object.entries(providers)) {
-    for (const model of providerConfig.models ?? []) {
+  // Runtime projection isolates unreadable catalog rows so one bad plugin-owned
+  // provider/model entry cannot hide every healthy sibling from model selection.
+  for (const [providerId, providerConfig] of copyProviderCatalogResultEntries(params)) {
+    for (const model of copyProviderModels(providerConfig)) {
+      const modelId = readRecordValue(model, "id");
+      if (typeof modelId !== "string") {
+        continue;
+      }
+      const modelName = readRecordValue(model, "name");
       rows.push({
         kind: "text",
         provider: providerId,
-        model: model.id,
-        ...(model.name ? { label: model.name } : {}),
+        model: modelId,
+        ...(typeof modelName === "string" && modelName ? { label: modelName } : {}),
         source: params.source,
       });
     }

--- a/src/plugins/provider-catalog.test.ts
+++ b/src/plugins/provider-catalog.test.ts
@@ -227,4 +227,30 @@ describe("buildSingleProviderApiKeyCatalog", () => {
       expected: createPairedCatalogProviders("secret-key"),
     });
   });
+
+  it("omits unreadable paired provider catalog entries", async () => {
+    const unreadableProvider = new Proxy(createProviderConfig(), {
+      ownKeys() {
+        throw new Error("mockplugin provider config keys failed");
+      },
+    });
+    const result = await buildPairedProviderApiKeyCatalog({
+      ctx: createCatalogContext({
+        apiKeys: { fuzzplugin: "secret-key" },
+      }),
+      providerId: "fuzzplugin",
+      buildProviders: async () =>
+        ({
+          readable: createProviderConfig({ baseUrl: "https://fuzzplugin.test/v1" }),
+          unreadable: unreadableProvider,
+        }) as Record<string, ModelProviderConfig>,
+    });
+
+    expectPairedCatalogProviders(result, {
+      readable: {
+        ...createProviderConfig({ baseUrl: "https://fuzzplugin.test/v1" }),
+        apiKey: "secret-key",
+      },
+    });
+  });
 });

--- a/src/plugins/provider-catalog.ts
+++ b/src/plugins/provider-catalog.ts
@@ -4,7 +4,19 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { ModelProviderConfig } from "../config/types.js";
+import { copyRecordEntries } from "../shared/safe-record.js";
 import type { ProviderCatalogContext, ProviderCatalogResult } from "./types.js";
+
+function addApiKeyToProvider(
+  provider: ModelProviderConfig,
+  apiKey: string,
+): (ModelProviderConfig & { apiKey: string }) | undefined {
+  try {
+    return { ...provider, apiKey };
+  } catch {
+    return undefined;
+  }
+}
 
 export function findCatalogTemplate(params: {
   entries: ReadonlyArray<{ provider: string; id: string }>;
@@ -66,7 +78,10 @@ export async function buildPairedProviderApiKeyCatalog(params: {
   const providers = await params.buildProviders();
   return {
     providers: Object.fromEntries(
-      Object.entries(providers).map(([id, provider]) => [id, { ...provider, apiKey }]),
+      copyRecordEntries<ModelProviderConfig>(providers).flatMap(([id, provider]) => {
+        const providerWithApiKey = addApiKeyToProvider(provider, apiKey);
+        return providerWithApiKey ? [[id, providerWithApiKey]] : [];
+      }),
     ),
   };
 }

--- a/src/plugins/provider-discovery.test.ts
+++ b/src/plugins/provider-discovery.test.ts
@@ -405,6 +405,37 @@ describe("normalizePluginDiscoveryResult", () => {
       },
     },
     {
+      name: "skips providers with unreadable required fields",
+      provider: makeProvider({ id: "ignored" }),
+      result: {
+        providers: {
+          broken: Object.defineProperty(
+            makeModelProviderConfig({
+              baseUrl: "http://broken.example/v1",
+              models: [makeModel("broken-model")],
+            }),
+            "baseUrl",
+            {
+              enumerable: true,
+              get() {
+                throw new Error("provider baseUrl read failed");
+              },
+            },
+          ),
+          healthy: makeModelProviderConfig({
+            baseUrl: "http://healthy.example/v1",
+            models: [makeModel("healthy-model")],
+          }),
+        },
+      },
+      expected: {
+        healthy: {
+          baseUrl: "http://healthy.example/v1",
+          models: [makeModel("healthy-model")],
+        },
+      },
+    },
+    {
       name: "skips unreadable model rows while preserving healthy siblings",
       provider: makeProvider({ id: "ignored" }),
       result: {

--- a/src/plugins/provider-discovery.test.ts
+++ b/src/plugins/provider-discovery.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import type { ModelProviderConfig } from "../config/types.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
   groupPluginDiscoveryProvidersByOrder,
@@ -87,6 +87,23 @@ function makeModelProviderConfig(overrides?: Partial<ModelProviderConfig>): Mode
     baseUrl: "http://127.0.0.1:8000/v1",
     models: [],
     ...overrides,
+  };
+}
+
+function makeModel(id: string): ModelDefinitionConfig {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"],
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: 128_000,
+    maxTokens: 8_192,
   };
 }
 
@@ -358,6 +375,55 @@ describe("normalizePluginDiscoveryResult", () => {
         safe: {
           baseUrl: "http://safe.example/v1",
           models: [],
+        },
+      },
+    },
+    {
+      name: "skips unreadable multi-provider entries while preserving healthy siblings",
+      provider: makeProvider({ id: "ignored" }),
+      result: {
+        providers: Object.defineProperty(
+          {
+            healthy: makeModelProviderConfig({
+              baseUrl: "http://healthy.example/v1",
+            }),
+          },
+          "broken",
+          {
+            enumerable: true,
+            get() {
+              throw new Error("provider row read failed");
+            },
+          },
+        ) as Record<string, ModelProviderConfig>,
+      },
+      expected: {
+        healthy: {
+          baseUrl: "http://healthy.example/v1",
+          models: [],
+        },
+      },
+    },
+    {
+      name: "skips unreadable model rows while preserving healthy siblings",
+      provider: makeProvider({ id: "ignored" }),
+      result: {
+        providers: {
+          healthy: makeModelProviderConfig({
+            baseUrl: "http://healthy.example/v1",
+            models: Object.defineProperty([makeModel("healthy-model")], "1", {
+              enumerable: true,
+              get() {
+                throw new Error("model row read failed");
+              },
+            }),
+          }),
+        },
+      },
+      expected: {
+        healthy: {
+          baseUrl: "http://healthy.example/v1",
+          models: [makeModel("healthy-model")],
         },
       },
     },

--- a/src/plugins/provider-discovery.test.ts
+++ b/src/plugins/provider-discovery.test.ts
@@ -427,6 +427,32 @@ describe("normalizePluginDiscoveryResult", () => {
         },
       },
     },
+    {
+      name: "skips model rows with unreadable required fields",
+      provider: makeProvider({ id: "ignored" }),
+      result: {
+        providers: {
+          healthy: makeModelProviderConfig({
+            baseUrl: "http://healthy.example/v1",
+            models: [
+              Object.defineProperty(makeModel("broken-model"), "id", {
+                enumerable: true,
+                get() {
+                  throw new Error("model id read failed");
+                },
+              }),
+              makeModel("healthy-model"),
+            ],
+          }),
+        },
+      },
+      expected: {
+        healthy: {
+          baseUrl: "http://healthy.example/v1",
+          models: [makeModel("healthy-model")],
+        },
+      },
+    },
   ];
 
   it.each(cases)("$name", ({ provider, result, expected }) => {

--- a/src/plugins/provider-discovery.test.ts
+++ b/src/plugins/provider-discovery.test.ts
@@ -453,6 +453,24 @@ describe("normalizePluginDiscoveryResult", () => {
         },
       },
     },
+    {
+      name: "keeps minimal model rows with id-only labels",
+      provider: makeProvider({ id: "ignored" }),
+      result: {
+        providers: {
+          healthy: makeModelProviderConfig({
+            baseUrl: "http://healthy.example/v1",
+            models: [{ id: "local-tiny" } as ModelDefinitionConfig],
+          }),
+        },
+      },
+      expected: {
+        healthy: {
+          baseUrl: "http://healthy.example/v1",
+          models: [{ id: "local-tiny", name: "local-tiny" }],
+        },
+      },
+    },
   ];
 
   it.each(cases)("$name", ({ provider, result, expected }) => {

--- a/src/plugins/provider-discovery.ts
+++ b/src/plugins/provider-discovery.ts
@@ -6,6 +6,7 @@ import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { listManifestProviderContributionIds } from "./manifest-contribution-ids.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
 import type { LoadPluginRegistryParams, PluginRegistrySnapshot } from "./plugin-registry.js";
+import { copyProviderCatalogResultProjection } from "./provider-catalog-result.js";
 import type { ProviderDiscoveryOrder, ProviderPlugin } from "./types.js";
 
 const DISCOVERY_ORDER: readonly ProviderDiscoveryOrder[] = ["simple", "profile", "paired", "late"];
@@ -110,7 +111,8 @@ export function normalizePluginDiscoveryResult(params: {
     return {};
   }
 
-  if ("provider" in result) {
+  const projection = copyProviderCatalogResultProjection(result);
+  if (projection.kind === "provider") {
     const normalized = createProviderConfigRecord();
     for (const providerId of [
       params.provider.id,
@@ -121,13 +123,16 @@ export function normalizePluginDiscoveryResult(params: {
       if (!isSafeProviderConfigKey(normalizedKey)) {
         continue;
       }
-      normalized[normalizedKey] = result.provider;
+      normalized[normalizedKey] = projection.provider;
     }
     return normalized;
   }
 
   const normalized = createProviderConfigRecord();
-  for (const [key, value] of Object.entries(result.providers)) {
+  if (projection.kind !== "providers") {
+    return normalized;
+  }
+  for (const [key, value] of projection.providers) {
     const normalizedKey = normalizeProviderId(key);
     if (!isSafeProviderConfigKey(normalizedKey) || !value) {
       continue;

--- a/src/shared/safe-record.ts
+++ b/src/shared/safe-record.ts
@@ -1,0 +1,70 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  try {
+    return Boolean(value && typeof value === "object" && !Array.isArray(value));
+  } catch {
+    return false;
+  }
+}
+
+export function readRecordValue(value: unknown, key: string): unknown {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  try {
+    return value[key];
+  } catch {
+    return undefined;
+  }
+}
+
+export function copyArrayEntries(value: unknown): unknown[] {
+  let isArray: boolean;
+  try {
+    isArray = Array.isArray(value);
+  } catch {
+    return [];
+  }
+  if (!isArray) {
+    return [];
+  }
+
+  const arrayValue = value as readonly unknown[];
+  let length: number;
+  try {
+    length = arrayValue.length;
+  } catch {
+    return [];
+  }
+
+  const entries: unknown[] = [];
+  for (let index = 0; index < length; index += 1) {
+    try {
+      entries.push(arrayValue[index]);
+    } catch {
+      continue;
+    }
+  }
+  return entries;
+}
+
+export function copyRecordEntries<T>(value: unknown): Array<[string, T]> {
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  let keys: string[];
+  try {
+    keys = Object.keys(value);
+  } catch {
+    return [];
+  }
+
+  const entries: Array<[string, T]> = [];
+  for (const key of keys) {
+    const entry = readRecordValue(value, key);
+    if (isRecord(entry)) {
+      entries.push([key, entry as T]);
+    }
+  }
+  return entries;
+}


### PR DESCRIPTION
## Summary

- isolates provider catalog projection so unreadable plugin-owned provider/model rows are skipped instead of hiding healthy siblings
- filters malformed provider auth entries before provider registration while preserving valid auth methods and env vars
- guards paired provider catalog API-key injection from throwing provider configs

## Verification

- `node scripts/run-vitest.mjs src/plugin-sdk/provider-entry.test.ts src/plugins/provider-catalog.test.ts --reporter=dot` passed 1 shard / 14 tests after final rebase
- `node_modules/.bin/oxfmt --check --threads=1 src/plugin-sdk/provider-entry.ts src/plugin-sdk/provider-entry.test.ts src/plugins/provider-catalog-unified-text.ts src/plugins/provider-catalog.ts src/plugins/provider-catalog.test.ts src/shared/safe-record.ts` passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/plugin-sdk/provider-entry.ts src/plugin-sdk/provider-entry.test.ts src/plugins/provider-catalog-unified-text.ts src/plugins/provider-catalog.ts src/plugins/provider-catalog.test.ts src/shared/safe-record.ts` passed
- `git diff --check origin/main...HEAD` passed after final rebase
- private reported-name scrub over the branch diff passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed clean, overall 0.84
- AWS Crabbox changed gate passed: provider `aws`, lease `cbx_508d1fb17e4f`, run `run_421055b8dbcb`, slug `harbor-crab`, command `pnpm check:changed`, selected lanes `core`, `coreTests`, `extensions`, `extensionTests`, exit 0
- Blacksmith Testbox proof was attempted first but local Blacksmith auth is missing; AWS Crabbox was used instead of running the broad gate locally

## Real behavior proof

Behavior addressed: hostile or malformed plugin provider catalog/auth rows no longer make provider projection fail before healthy sibling provider data can be used.

Real environment tested: linked OpenClaw gwt worktree rebased onto current `origin/main`, final head `1fcab057102b`.

Exact steps or command run after this patch: rebased the pruned provider-catalog slice onto current `origin/main`, reran focused provider-entry/provider-catalog tests, formatter, lint, diff check, private-name scrub, branch autoreview, and AWS Crabbox `pnpm check:changed`.

Evidence after fix: focused regressions pass for unreadable provider catalog entries, unreadable provider model rows, unreadable provider auth option rows, and unreadable paired provider catalog configs while preserving healthy siblings.

Observed result after fix: healthy provider catalog rows and auth methods remain registered/projected while only unreadable sibling rows are omitted.

What was not tested: full repo-wide test suite or a live external plugin process; this PR uses the existing provider/plugin SDK harness plus remote changed-gate proof to exercise the projection paths directly.
