### PR TITLE
fix(codex): normalize dynamic tool progress results

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -128,7 +128,11 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
         isError?: boolean;
         name?: string;
         phase?: string;
-        result?: { success?: boolean };
+        result?: {
+          content?: Array<{ text?: string; type?: string; url?: string }>;
+          contentItems?: unknown;
+          success?: unknown;
+        };
         toolCallId?: string;
       };
       stream?: string;
@@ -150,7 +154,10 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
     expect(resultEvent?.data?.name).toBe("lookup");
     expect(resultEvent?.data?.toolCallId).toBe("call-1");
     expect(resultEvent?.data?.isError).toBe(true);
-    expect(resultEvent?.data?.result?.success).toBe(false);
+    expect(resultEvent?.data?.result).not.toHaveProperty("success");
+    expect(resultEvent?.data?.result).not.toHaveProperty("contentItems");
+    expect(resultEvent?.data?.result?.content?.[0]?.type).toBe("text");
+    expect(resultEvent?.data?.result?.content?.[0]?.text).toBe("Unknown OpenClaw tool: lookup");
     expect(JSON.stringify(agentEvents)).not.toContain("plain-secret-value-12345");
     const globalStartEvent = globalAgentEvents.find(
       (event) => event.stream === "tool" && event.data.phase === "start",

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1162,6 +1162,61 @@ describe("runCodexAppServerAttempt", () => {
     ]);
   });
 
+  it("emits TUI-compatible tool events for Codex dynamic tool calls", async () => {
+    const sessionFile = path.join(tempDir, "session-tool-events.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-tool-events");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    const onRunAgentEvent = vi.fn();
+    params.timeoutMs = 60_000;
+    params.onAgentEvent = onRunAgentEvent;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    await expect(
+      harness.handleServerRequest({
+        id: "request-tool-1",
+        method: "item/tool/call",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: null,
+          tool: "python",
+          arguments: { code: "print('hi')" },
+        },
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: python" }],
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    expect(onRunAgentEvent).toHaveBeenCalledWith({
+      stream: "tool",
+      data: {
+        phase: "start",
+        name: "python",
+        toolCallId: "call-1",
+        args: { code: "print('hi')" },
+      },
+    });
+    expect(onRunAgentEvent).toHaveBeenCalledWith({
+      stream: "tool",
+      data: {
+        phase: "result",
+        name: "python",
+        toolCallId: "call-1",
+        isError: true,
+        result: {
+          content: [{ type: "text", text: "Unknown OpenClaw tool: python" }],
+        },
+      },
+    });
+  });
+
   it("keeps leading delivery hints out of the Codex current user request", async () => {
     const sessionFile = path.join(tempDir, "session-delivery-hint.jsonl");
     const workspaceDir = path.join(tempDir, "workspace-delivery-hint");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1239,6 +1239,7 @@ describe("runCodexAppServerAttempt", () => {
       contentItems: [
         { type: "inputText", text: `lookup result: ${rawToolSecret}` },
         { type: "inputImage", imageUrl: "data:image/png;base64,abc" },
+        { type: "unsupportedCodexOutput", imageUrl: "data:image/png;base64,ignored" },
       ],
     });
     const content = result.content as Array<{ text?: string; type?: string; url?: string }>;
@@ -1249,6 +1250,10 @@ describe("runCodexAppServerAttempt", () => {
     expect(content[0]?.text).toContain("lookup result:");
     expect(content[0]?.text).not.toContain(rawToolSecret);
     expect(content[1]).toEqual({ type: "image", url: "data:image/png;base64,abc" });
+    expect(content[2]).toEqual({
+      type: "text",
+      text: "[Unsupported Codex dynamic tool output: unsupportedCodexOutput]",
+    });
     expect(JSON.stringify(result)).not.toContain(rawToolSecret);
   });
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1215,6 +1215,41 @@ describe("runCodexAppServerAttempt", () => {
         },
       },
     });
+    const resultEvent = onRunAgentEvent.mock.calls
+      .map(([event]) => event)
+      .find(
+        (
+          event,
+        ): event is {
+          data: {
+            phase: "result";
+            result: { content?: unknown; contentItems?: unknown; success?: unknown };
+          };
+          stream: "tool";
+        } => event.stream === "tool" && event.data?.phase === "result",
+      );
+    expect(resultEvent?.data.result).not.toHaveProperty("success");
+    expect(resultEvent?.data.result).not.toHaveProperty("contentItems");
+  });
+
+  it("maps sanitized dynamic tool output into transcript progress content", () => {
+    const rawToolSecret = "sk-abcdefghijklmnopqrstuvwxyz1234567890"; // pragma: allowlist secret
+    const result = testing.toTranscriptToolResultForTests({
+      success: true,
+      contentItems: [
+        { type: "inputText", text: `lookup result: ${rawToolSecret}` },
+        { type: "inputImage", imageUrl: "data:image/png;base64,abc" },
+      ],
+    });
+    const content = result.content as Array<{ text?: string; type?: string; url?: string }>;
+
+    expect(result).not.toHaveProperty("success");
+    expect(result).not.toHaveProperty("contentItems");
+    expect(content[0]).toEqual({ type: "text", text: expect.any(String) });
+    expect(content[0]?.text).toContain("lookup result:");
+    expect(content[0]?.text).not.toContain(rawToolSecret);
+    expect(content[1]).toEqual({ type: "image", url: "data:image/png;base64,abc" });
+    expect(JSON.stringify(result)).not.toContain(rawToolSecret);
   });
 
   it("keeps leading delivery hints out of the Codex current user request", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -199,7 +199,6 @@ import type {
   CodexTurnEnvironmentParams,
   CodexServerNotification,
   CodexDynamicToolCallParams,
-  CodexDynamicToolCallOutputContentItem,
   CodexDynamicToolCallResponse,
   CodexTurnStartResponse,
   JsonObject,
@@ -312,22 +311,32 @@ function emitCodexAppServerEvent(
 
 function toTranscriptToolResult(response: CodexDynamicToolCallResponse): Record<string, unknown> {
   const sanitized = sanitizeCodexToolResponse(response);
+  const contentItems = Array.isArray(sanitized.contentItems) ? sanitized.contentItems : [];
   const result: Record<string, unknown> = {
     ...sanitized,
-    content: response.contentItems.map(toTranscriptToolResultContentItem),
+    // Progress events are UI/transcript-facing; map only sanitized content so
+    // event redaction cannot be bypassed by raw dynamic tool output.
+    content: contentItems.map(toTranscriptToolResultContentItem),
   };
   delete result.contentItems;
   delete result.success;
   return result;
 }
 
-function toTranscriptToolResultContentItem(
-  item: CodexDynamicToolCallOutputContentItem,
-): Record<string, unknown> {
-  if (item.type === "inputText") {
-    return { type: "text", text: item.text };
+function toTranscriptToolResultContentItem(item: unknown): Record<string, unknown> {
+  if (!item || typeof item !== "object") {
+    return { type: "text", text: "" };
   }
-  return "imageUrl" in item ? { type: "image", url: item.imageUrl } : { type: "text", text: "" };
+  const record = item as Record<string, unknown>;
+  if (record.type === "inputText") {
+    return { type: "text", text: typeof record.text === "string" ? record.text : "" };
+  }
+  if (record.type === "inputImage" || typeof record.imageUrl === "string") {
+    return typeof record.imageUrl === "string"
+      ? { type: "image", url: record.imageUrl }
+      : { type: "text", text: "" };
+  }
+  return { type: "text", text: "" };
 }
 
 type CodexAgentEndHookParams = Parameters<typeof runAgentHarnessAgentEndHook>[0];
@@ -2791,6 +2800,7 @@ export const testing = {
   shouldEnableCodexAppServerNativeToolSurface,
   shouldForceMessageTool,
   hasPendingDynamicToolTerminalDiagnostic,
+  toTranscriptToolResultForTests: toTranscriptToolResult,
   withCodexStartupTimeout,
   setOpenClawCodingToolsFactoryForTests,
   resetOpenClawCodingToolsFactoryForTests,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -331,12 +331,19 @@ function toTranscriptToolResultContentItem(item: unknown): Record<string, unknow
   if (record.type === "inputText") {
     return { type: "text", text: typeof record.text === "string" ? record.text : "" };
   }
-  if (record.type === "inputImage" || typeof record.imageUrl === "string") {
+  if (record.type === "inputImage") {
     return typeof record.imageUrl === "string"
       ? { type: "image", url: record.imageUrl }
-      : { type: "text", text: "" };
+      : { type: "text", text: formatUnsupportedCodexDynamicToolOutput(record.type) };
   }
-  return { type: "text", text: "" };
+  return { type: "text", text: formatUnsupportedCodexDynamicToolOutput(record.type) };
+}
+
+function formatUnsupportedCodexDynamicToolOutput(type: unknown): string {
+  const rawType = typeof type === "string" ? type.replace(/\s+/g, " ").trim() : "";
+  const label = rawType ? rawType.slice(0, 80) : "unknown";
+  const suffix = rawType.length > 80 ? "..." : "";
+  return `[Unsupported Codex dynamic tool output: ${label}${suffix}]`;
 }
 
 type CodexAgentEndHookParams = Parameters<typeof runAgentHarnessAgentEndHook>[0];

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -199,6 +199,7 @@ import type {
   CodexTurnEnvironmentParams,
   CodexServerNotification,
   CodexDynamicToolCallParams,
+  CodexDynamicToolCallOutputContentItem,
   CodexDynamicToolCallResponse,
   CodexTurnStartResponse,
   JsonObject,
@@ -307,6 +308,26 @@ function emitCodexAppServerEvent(
     // canonical app-server turn lifecycle.
     embeddedAgentLog.debug("codex app-server agent event handler threw", { error });
   }
+}
+
+function toTranscriptToolResult(response: CodexDynamicToolCallResponse): Record<string, unknown> {
+  const sanitized = sanitizeCodexToolResponse(response);
+  const result: Record<string, unknown> = {
+    ...sanitized,
+    content: response.contentItems.map(toTranscriptToolResultContentItem),
+  };
+  delete result.contentItems;
+  delete result.success;
+  return result;
+}
+
+function toTranscriptToolResultContentItem(
+  item: CodexDynamicToolCallOutputContentItem,
+): Record<string, unknown> {
+  if (item.type === "inputText") {
+    return { type: "text", text: item.text };
+  }
+  return "imageUrl" in item ? { type: "image", url: item.imageUrl } : { type: "text", text: "" };
 }
 
 type CodexAgentEndHookParams = Parameters<typeof runAgentHarnessAgentEndHook>[0];
@@ -1717,7 +1738,7 @@ export async function runCodexAppServerAttempt(
               toolCallId: call.callId,
               ...(toolMeta ? { meta: toolMeta } : {}),
               isError: !protocolResponse.success,
-              result: sanitizeCodexToolResponse(progressResponse),
+              result: toTranscriptToolResult(progressResponse),
             },
           });
         }


### PR DESCRIPTION
## Summary
- normalize Codex dynamic tool progress results into TUI-compatible `content` arrays
- keep the existing tool start/result event path, but strip app-server protocol-only `contentItems`/`success` from verbose transcript payloads
- add regression coverage for dynamic tool start/result events

## Testing
- `pnpm exec vitest run extensions/codex/src/app-server/run-attempt.test.ts`

## Real behavior proof
- **Behavior or issue addressed**: In the Codex TUI, verbose full mode could receive dynamic tool progress but did not get result details in the standard tool-result shape the transcript renderer expects. This made verbose output collapse toward bare tool labels instead of useful tool content.
- **Real environment tested**: Local OpenClaw install on macOS with the Codex app-server runtime and TUI in `verbose full` mode.
- **Exact steps or command run after this patch**: Started the local OpenClaw TUI, switched to `verbose full`, and sent a Codex job that invoked runtime tools including shell/Python-style work.
- **Evidence after fix**:
```text
Manual local TUI observation: verbose tool transcript updated live during the Codex job instead of staying at bare tool labels.
User-facing live validation from the same local setup: "verbose output now does appear and update (good)"
```
- **Observed result after fix**: Tool progress now appears and updates during the active Codex run, and result payloads are emitted as `content: [{ type: "text", text: ... }]`, which is the TUI-compatible shape.
- **What was not tested**: This PR deliberately does not include or claim to fix `/steer`; steer behavior is still being investigated separately.

- **Proof**: See below screenshot of "/verbose full" working again after implementing this fix (and below it an image of "/verbose full" *not* working before the fix; the "not working" image shows very basic verbose mode blocks (perhaps of the kind that should show in the more simplified "/verbose on" mode), and even then, those blocks would not show up until manually submitting repeated "/verbose" commands:
- After:
<img width="1132" height="275" alt="Screenshot 2026-06-01 at 8 22 44 PM" src="https://github.com/user-attachments/assets/17a9ba2e-1d01-4f2a-b8e7-6811c6b9faf2" />
- Before:
<img width="5712" height="4284" alt="IMG_1630" src="https://github.com/user-attachments/assets/16641704-a251-4ba4-a438-26b4fa051c83" />



Note: this PR intentionally does not include any TUI `/steer` changes.