### PR TITLE
fix(agents): keep inline <think> reasoning out of OpenAI-compatible visible text

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1257,6 +1257,104 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("keeps inline <think> reasoning out of visible text parts on the completions stream", async () => {
+    const chunks = [
+      { delta: { role: "assistant", content: "<think>" } },
+      { delta: { content: "User wants thrillers. ", reasoning_content: "User wants thrillers. " } },
+      { delta: { content: "Recommend three.</think>", reasoning_content: "Recommend three." } },
+      { delta: { content: "Here are three great thrillers." } },
+      { delta: {}, finish_reason: "stop" },
+    ];
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        const created = Math.floor(Date.now() / 1000);
+        for (const chunk of chunks) {
+          res.write(
+            `data: ${JSON.stringify({
+              id: "chatcmpl-think-leak",
+              object: "chat.completion.chunk",
+              created,
+              model: "minimax/MiniMax-M2.7",
+              choices: [{ index: 0, finish_reason: null, ...chunk }],
+            })}\n\n`,
+          );
+        }
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = {
+        id: "minimax/MiniMax-M2.7",
+        name: "MiniMax M2.7",
+        api: "openai-completions",
+        provider: "minimax",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">;
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        model,
+        {
+          systemPrompt: "system",
+          messages: [
+            { role: "user", content: "Best thriller movies right now", timestamp: Date.now() },
+          ],
+          tools: [],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      let text = "";
+      let thinking = "";
+      let doneMessage: { content: Array<{ type: string; text?: string }> } | undefined;
+      for await (const event of stream as AsyncIterable<{
+        type: string;
+        delta?: string;
+        message?: { content: Array<{ type: string; text?: string }> };
+      }>) {
+        if (event.type === "text_delta") {
+          text += event.delta ?? "";
+        }
+        if (event.type === "thinking_delta") {
+          thinking += event.delta ?? "";
+        }
+        if (event.type === "done") {
+          doneMessage = event.message;
+        }
+      }
+
+      expect(text).toBe("Here are three great thrillers.");
+      expect(text).not.toContain("<think>");
+      expect(text).not.toContain("User wants thrillers.");
+      expect(thinking).toBe("User wants thrillers. Recommend three.");
+      const visibleTextParts = (doneMessage?.content ?? [])
+        .filter((part) => part.type === "text")
+        .map((part) => part.text ?? "")
+        .join("");
+      expect(visibleTextParts).toBe("Here are three great thrillers.");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("preserves OpenAI-compatible error metadata on failed chat requests", async () => {
     const server = createServer((req, res) => {
       req.resume();

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -29,6 +29,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { resolveProviderTransportTurnStateWithPlugin } from "../plugins/provider-runtime.js";
 import { isGemma4ModelId } from "../shared/google-models.js";
+import { createReasoningTagTextFilter } from "../shared/text/reasoning-tags.js";
 import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../utils/cjk-chars.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { createDeepSeekTextFilter } from "./deepseek-text-filter.js";
@@ -2526,6 +2527,7 @@ async function processOpenAICompletionsStream(
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat)
     ? createDeepSeekTextFilter()
     : null;
+  const reasoningTagTextFilter = createReasoningTagTextFilter();
   type ToolCallBlock = {
     type: "toolCall";
     id: string;
@@ -2656,18 +2658,22 @@ async function processOpenAICompletionsStream(
     }
   };
   const appendFilteredVisibleTextDelta = (text: string) => {
-    const parts = deepSeekTextFilter?.push(text) ?? [text];
-    for (const part of parts) {
-      appendVisibleTextDelta(part);
+    const dsmlParts = deepSeekTextFilter?.push(text) ?? [text];
+    for (const part of dsmlParts) {
+      for (const visible of reasoningTagTextFilter.push(part)) {
+        appendVisibleTextDelta(visible);
+      }
     }
   };
-  const flushDeepSeekTextFilterAtEnd = () => {
-    const parts = deepSeekTextFilter?.flush();
-    if (!parts) {
-      return;
+  const flushVisibleTextFiltersAtEnd = () => {
+    const dsmlParts = deepSeekTextFilter?.flush() ?? [];
+    for (const part of dsmlParts) {
+      for (const visible of reasoningTagTextFilter.push(part)) {
+        appendVisibleTextDelta(visible);
+      }
     }
-    for (const part of parts) {
-      appendVisibleTextDelta(part);
+    for (const visible of reasoningTagTextFilter.flush()) {
+      appendVisibleTextDelta(visible);
     }
   };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
@@ -2803,7 +2809,7 @@ async function processOpenAICompletionsStream(
     flushPendingPostToolCallDeltas();
     await cooperativeScheduler.afterEvent();
   }
-  flushDeepSeekTextFilterAtEnd();
+  flushVisibleTextFiltersAtEnd();
   finishAllToolCallBlocks();
   currentBlock = null;
   flushPendingPostToolCallDeltas();

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -214,3 +214,67 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(result.content.filter((b) => b.type === "toolCall")).toStrictEqual([]);
   });
 });
+
+describe("openai-completions inline reasoning-tag routing", () => {
+  function makeContentChunk(content: string, reasoningContent?: string) {
+    const delta: { role: "assistant"; content: string; reasoning_content?: string } = {
+      role: "assistant",
+      content,
+    };
+    if (reasoningContent) {
+      delta.reasoning_content = reasoningContent;
+    }
+    return {
+      id: "chatcmpl-test",
+      choices: [{ index: 0, delta }],
+    } satisfies DeepPartial<ChatCompletionChunk>;
+  }
+
+  it("keeps inline <think> reasoning out of the visible text block", async () => {
+    mockChunksRef.chunks = [
+      makeContentChunk("<think>"),
+      makeContentChunk("User wants thrillers. ", "User wants thrillers. "),
+      makeContentChunk("Recommend three.</think>", "Recommend three."),
+      makeContentChunk("Here are three great thrillers."),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    const text = result.content
+      .filter((block) => block.type === "text")
+      .map((block) => (block as { text: string }).text)
+      .join("");
+    const thinking = result.content
+      .filter((block) => block.type === "thinking")
+      .map((block) => (block as { thinking: string }).thinking)
+      .join("");
+
+    expect(text).toBe("Here are three great thrillers.");
+    expect(text).not.toContain("<think>");
+    expect(text).not.toContain("User wants thrillers.");
+    expect(thinking).toBe("User wants thrillers. Recommend three.");
+  });
+
+  it("preserves literal <think> examples inside fenced and inline code", async () => {
+    mockChunksRef.chunks = [
+      makeContentChunk("Models can emit a "),
+      makeContentChunk("`<think>` tag. Example:\n```html\n<think>hi</think>\n```\n"),
+      makeContentChunk("Use it carefully."),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    const text = result.content
+      .filter((block) => block.type === "text")
+      .map((block) => (block as { text: string }).text)
+      .join("");
+
+    expect(text).toBe(
+      "Models can emit a `<think>` tag. Example:\n```html\n<think>hi</think>\n```\nUse it carefully.",
+    );
+  });
+});

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -10,6 +10,7 @@ import type {
   ChatCompletionSystemMessageParam,
   ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
+import { createReasoningTagTextFilter } from "../../shared/text/reasoning-tags.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
@@ -179,6 +180,20 @@ export const streamOpenAICompletions: StreamFunction<
       let textBlock: TextContent | null = null;
       let thinkingBlock: ThinkingContent | null = null;
       let hasFinishReason = false;
+      const reasoningTagTextFilter = createReasoningTagTextFilter();
+      const appendVisibleText = (visible: string) => {
+        if (!visible) {
+          return;
+        }
+        const block = ensureTextBlock();
+        block.text += visible;
+        stream.push({
+          type: "text_delta",
+          contentIndex: getContentIndex(block),
+          delta: visible,
+          partial: output,
+        });
+      };
       const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
       const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
       const blocks = output.content as StreamingBlock[];
@@ -326,14 +341,9 @@ export const streamOpenAICompletions: StreamFunction<
             choice.delta.content !== undefined &&
             choice.delta.content.length > 0
           ) {
-            const block = ensureTextBlock();
-            block.text += choice.delta.content;
-            stream.push({
-              type: "text_delta",
-              contentIndex: getContentIndex(block),
-              delta: choice.delta.content,
-              partial: output,
-            });
+            for (const visible of reasoningTagTextFilter.push(choice.delta.content)) {
+              appendVisibleText(visible);
+            }
           }
 
           // Some endpoints return reasoning in reasoning_content (llama.cpp),
@@ -412,6 +422,9 @@ export const streamOpenAICompletions: StreamFunction<
         }
       }
 
+      for (const visible of reasoningTagTextFilter.flush()) {
+        appendVisibleText(visible);
+      }
       for (const block of blocks) {
         finishBlock(block);
       }

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { stripReasoningTagsFromText } from "./reasoning-tags.js";
+import { createReasoningTagTextFilter, stripReasoningTagsFromText } from "./reasoning-tags.js";
 
 describe("stripReasoningTagsFromText", () => {
   function expectStrippedCase(params: {
@@ -327,5 +327,125 @@ describe("stripReasoningTagsFromText", () => {
     { input: "E <think>x</think> F", expected: "E  F" },
   ] as const)("does not leak regex state across repeated calls: %j", (testCase) => {
     expectStrippedCase(testCase);
+  });
+});
+
+describe("createReasoningTagTextFilter", () => {
+  function runFilter(chunks: readonly string[]): string {
+    const filter = createReasoningTagTextFilter();
+    const parts: string[] = [];
+    for (const chunk of chunks) {
+      parts.push(...filter.push(chunk));
+    }
+    parts.push(...filter.flush());
+    return parts.join("");
+  }
+
+  it.each([
+    { name: "single buffered span", chunks: ["before <think>reason</think> after"] },
+    { name: "tag split across chunks", chunks: ["before <thi", "nk>reason</thi", "nk> after"] },
+    { name: "body split across chunks", chunks: ["before <think>rea", "son</think> aft", "er"] },
+    {
+      name: "leading think then answer",
+      chunks: ["<think>", "User wants thrillers. ", "Recommend three.</think>", "after"],
+      expected: "after",
+    },
+  ] as const)("strips inline reasoning spans: $name", ({ chunks, expected }) => {
+    expect(runFilter(chunks)).toBe(expected ?? "before  after");
+  });
+
+  it.each([
+    { name: "thinking", open: "<thinking>", close: "</thinking>" },
+    { name: "thought", open: "<thought>", close: "</thought>" },
+    { name: "antml thinking", open: "<thinking>", close: "</thinking>" },
+    { name: "whitespace + close slash", open: "< think >", close: "</ think >" },
+  ] as const)("recognizes $name tags", ({ open, close }) => {
+    expect(runFilter([`a${open}secret${close}b`])).toBe("ab");
+  });
+
+  it("recovers answer text when the reasoning tag is never closed", () => {
+    expect(runFilter(["<think>orphaned answer with no close tag"])).toBe(
+      "orphaned answer with no close tag",
+    );
+  });
+
+  it("keeps unclosed reasoning hidden when visible text already streamed", () => {
+    expect(runFilter(["Visible prefix <think>private reasoning"])).toBe("Visible prefix ");
+    expect(runFilter(["Visible ", "prefix <thi", "nk>private reasoning"])).toBe("Visible prefix ");
+  });
+
+  it.each([
+    { name: "single chunk", chunks: ["private </think>answer"] },
+    { name: "split across chunks", chunks: ["private </thi", "nk>answer"] },
+  ] as const)(
+    "preserves orphan close boundaries for the delivery sanitizer: $name",
+    ({ chunks }) => {
+      expect(runFilter(chunks)).toBe("private </think>answer");
+      expect(stripReasoningTagsFromText("private </think>answer", { trim: "none" })).toBe("answer");
+    },
+  );
+
+  it("passes through literal angle brackets that are not reasoning tags", () => {
+    expect(runFilter(["if a < b && c > d, then "])).toBe("if a < b && c > d, then ");
+    expect(runFilter(["see <table> and ", "</table> markup"])).toBe(
+      "see <table> and </table> markup",
+    );
+  });
+
+  it("keeps text emitted before a still-pending partial tag", () => {
+    const filter = createReasoningTagTextFilter();
+    expect(filter.push("answer<")).toEqual(["answer"]);
+    expect(filter.push("think>hidden")).toEqual([]);
+    expect(filter.push("</think>done")).toEqual(["done"]);
+    expect(filter.flush()).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: "inline code keeps literal tag",
+      input: "Use the `<think>` tag to reason.",
+    },
+    {
+      name: "inline code split across chunks",
+      input: ["Use the `<thi", "nk>` tag to reason."],
+      expected: "Use the `<think>` tag to reason.",
+    },
+    {
+      name: "fenced block keeps literal tags",
+      input: "Example:\n```html\n<think>reasoning</think>\n```\ndone",
+    },
+    {
+      name: "tilde fence keeps literal tags",
+      input: "Example:\n~~~\n<think>reasoning</think>\n~~~\ndone",
+    },
+    {
+      name: "fence split across chunks",
+      input: ["Example:\n```\n<thi", "nk>x</think>\n```\nend"],
+      expected: "Example:\n```\n<think>x</think>\n```\nend",
+    },
+    {
+      name: "reasoning before a code example is still stripped",
+      input: "<think>plan it</think>Use the `<think>` tag.",
+      expected: "Use the `<think>` tag.",
+    },
+  ] as const)("preserves reasoning tags inside code: $name", ({ input, expected }) => {
+    const chunks: readonly string[] = typeof input === "string" ? [input] : input;
+    const joined = chunks.join("");
+    expect(runFilter(chunks)).toBe(expected ?? joined);
+  });
+
+  it.each([
+    "before <think>reason</think> after",
+    "<think>plan</think>answer",
+    "Use the `<think>` tag.",
+    "Example:\n```\n<think>x</think>\n```\ndone",
+    "leading <thinking>secret</thinking> middle <thought>more</thought> end",
+    "no reasoning tags at all, just text",
+    "Start `unclosed <think>hidden</think> end",
+    "Use ``code`` with <think>hidden</think> text",
+    "Example:\n~~~\n<think>reasoning</think>\n~~~\nDone!",
+    "Before\n```\ncode\n```\nAfter with <think>hidden</think>",
+  ])("matches stripReasoningTagsFromText (trim none) on fully buffered input: %j", (input) => {
+    expect(runFilter([input])).toBe(stripReasoningTagsFromText(input, { trim: "none" }));
   });
 });

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -7,6 +7,18 @@ const QUICK_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthink
 const THINKING_TAG_RE =
   /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 
+const REASONING_TAG_ANCHORED_RE =
+  /^<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/i;
+const REASONING_TAG_KEYWORDS = [
+  "antml:thinking",
+  "antml:thought",
+  "antml:think",
+  "antthinking",
+  "thinking",
+  "thought",
+  "think",
+] as const;
+
 function applyTrim(value: string, mode: ReasoningTagTrim): string {
   if (mode === "none") {
     return value;
@@ -129,4 +141,224 @@ export function stripReasoningTagsFromText(
   }
 
   return trimmedResult;
+}
+
+export interface ReasoningTagTextFilter {
+  push(chunk: string): string[];
+  flush(): string[];
+}
+
+function reasoningTagPartialAtTail(buffer: string): boolean {
+  const head = /^<\s*\/?\s*/.exec(buffer);
+  if (!head) {
+    return false;
+  }
+  const rest = buffer.slice(head[0].length);
+  if (rest.length === 0) {
+    return true;
+  }
+  if (/[<>]/.test(rest)) {
+    return false;
+  }
+  const restLower = rest.toLowerCase();
+  for (const keyword of REASONING_TAG_KEYWORDS) {
+    if (keyword.startsWith(restLower)) {
+      return true;
+    }
+    if (restLower.startsWith(keyword)) {
+      const after = rest.slice(keyword.length);
+      if (after.length === 0 || /^[^A-Za-z0-9_]/.test(after)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function runLengthAt(buffer: string, index: number, marker: string): number {
+  let length = 0;
+  while (buffer[index + length] === marker) {
+    length += 1;
+  }
+  return length;
+}
+
+function trailingPrefixLength(buffer: string, token: string): number {
+  const maxLength = Math.min(buffer.length, token.length - 1);
+  for (let length = maxLength; length > 0; length--) {
+    if (token.startsWith(buffer.slice(buffer.length - length))) {
+      return length;
+    }
+  }
+  return 0;
+}
+
+export function createReasoningTagTextFilter(): ReasoningTagTextFilter {
+  let buffer = "";
+  let thinkingDepth = 0;
+  let droppedThinking = "";
+  let fenceMarker = "";
+  let atLineStart = true;
+  let keptVisible = false;
+
+  const consume = (final: boolean): string[] => {
+    const output: string[] = [];
+    const keep = (text: string) => {
+      if (text) {
+        output.push(text);
+      }
+    };
+    const drop = (text: string) => {
+      droppedThinking += text;
+    };
+    const keepVisible = (text: string) => {
+      if (text) {
+        keep(text);
+        atLineStart = text.endsWith("\n");
+        if (text.trim()) {
+          keptVisible = true;
+        }
+      }
+    };
+
+    while (buffer.length > 0) {
+      if (fenceMarker) {
+        const closeToken = `\n${fenceMarker}`;
+        const close = buffer.indexOf(closeToken);
+        if (close >= 0) {
+          const end = close + closeToken.length;
+          keep(buffer.slice(0, end));
+          buffer = buffer.slice(end);
+          fenceMarker = "";
+          atLineStart = false;
+          continue;
+        }
+        if (final) {
+          keep(buffer);
+          buffer = "";
+          fenceMarker = "";
+          break;
+        }
+        const hold = trailingPrefixLength(buffer, closeToken);
+        keep(buffer.slice(0, buffer.length - hold));
+        buffer = buffer.slice(buffer.length - hold);
+        return output;
+      }
+
+      if (thinkingDepth > 0) {
+        const open = buffer.indexOf("<");
+        if (open === -1) {
+          drop(buffer);
+          buffer = "";
+          break;
+        }
+        if (open > 0) {
+          drop(buffer.slice(0, open));
+          buffer = buffer.slice(open);
+          continue;
+        }
+        const tag = REASONING_TAG_ANCHORED_RE.exec(buffer);
+        if (tag) {
+          if (tag[1] === "/") {
+            thinkingDepth -= 1;
+            if (thinkingDepth === 0) {
+              droppedThinking = "";
+            }
+          } else {
+            thinkingDepth += 1;
+          }
+          buffer = buffer.slice(tag[0].length);
+          continue;
+        }
+        if (!final && reasoningTagPartialAtTail(buffer)) {
+          return output;
+        }
+        drop(buffer.slice(0, 1));
+        buffer = buffer.slice(1);
+        continue;
+      }
+
+      const special = buffer.search(/[<`~]/);
+      if (special === -1) {
+        keepVisible(buffer);
+        buffer = "";
+        break;
+      }
+      if (special > 0) {
+        keepVisible(buffer.slice(0, special));
+        buffer = buffer.slice(special);
+        continue;
+      }
+
+      const ch = buffer[0];
+      if (ch === "`" || ch === "~") {
+        const run = runLengthAt(buffer, 0, ch);
+        if (!final && run === buffer.length) {
+          return output;
+        }
+        if (atLineStart && run >= 3) {
+          keepVisible(buffer.slice(0, run));
+          buffer = buffer.slice(run);
+          fenceMarker = ch.repeat(3);
+          atLineStart = false;
+          continue;
+        }
+        if (ch === "~") {
+          keepVisible(buffer.slice(0, run));
+          buffer = buffer.slice(run);
+          atLineStart = false;
+          continue;
+        }
+        const close = buffer.indexOf("`", run);
+        if (close === -1) {
+          if (!final) {
+            return output;
+          }
+          keepVisible(buffer.slice(0, run));
+          buffer = buffer.slice(run);
+          atLineStart = false;
+          continue;
+        }
+        const closeEnd = close + runLengthAt(buffer, close, "`");
+        keepVisible(buffer.slice(0, closeEnd));
+        buffer = buffer.slice(closeEnd);
+        atLineStart = false;
+        continue;
+      }
+
+      const tag = REASONING_TAG_ANCHORED_RE.exec(buffer);
+      if (tag) {
+        if (tag[1] === "/") {
+          keepVisible(buffer.slice(0, tag[0].length));
+        } else {
+          thinkingDepth += 1;
+        }
+        buffer = buffer.slice(tag[0].length);
+        atLineStart = false;
+        continue;
+      }
+      if (!final && reasoningTagPartialAtTail(buffer)) {
+        return output;
+      }
+      keepVisible(buffer.slice(0, 1));
+      buffer = buffer.slice(1);
+    }
+
+    if (final && thinkingDepth > 0 && droppedThinking && !keptVisible) {
+      keep(droppedThinking);
+      droppedThinking = "";
+      thinkingDepth = 0;
+    }
+    return output;
+  };
+
+  return {
+    push(chunk: string) {
+      buffer += chunk;
+      return consume(false);
+    },
+    flush() {
+      return consume(true);
+    },
+  };
 }


### PR DESCRIPTION
## Summary

Fixes #88741.

When a model streams inline `<think>…</think>` reasoning in `delta.content` over the OpenAI-compatible streaming path (e.g. `minimax/MiniMax-M2.7`), the parsers routed the raw `delta.content` string straight into a **visible text** content part. Combined with the provider mirroring the same reasoning into `reasoning_content` (which becomes a `thinking` part), the assistant message ended up with the chain-of-thought in *both* the text part and the thinking part — and channel renderers (Telegram, Discord) show the text part, leaking the CoT verbatim before the answer. The leak is also persisted into the session content parts.

This adds a stateful streaming reasoning-tag text filter (`createReasoningTagTextFilter`) — a direct sibling of the existing `createDeepSeekTextFilter` — that strips inline `<think>/<thinking>/<thought>/antthinking` spans from the **visible text** stream at the parser boundary, using the exact same tag vocabulary as the already-shipped delivery-time `stripReasoningTagsFromText` sanitizer. It is wired into both OpenAI-compatible parsers:

- `src/agents/openai-transport-stream.ts` (active transport-stream path) — chained after the DSML filter in the visible-text path.
- `src/llm/providers/openai-completions.ts` (legacy `openai-completions` provider path) — content routed through the filter before being appended to the text block.

Reasoning still reaches the thinking channel via the existing `reasoning_content` / structured-thinking paths, so the reported case (reasoning mirrored into both `delta.content` and `reasoning_content`) now produces clean visible text **and a single thinking part — with no new duplication into thinking**. An unclosed-`<think>` recovery flush ensures a malformed stream never drops the answer. This sits in front of the delivery-time sanitizer, which remains as defense-in-depth.

The filter is **code-region aware**, matching the `stripReasoningTagsFromText` contract: literal `<think>` examples inside inline (`` `…` ``) and fenced (```` ``` ````/`~~~`) code are preserved, while a real reasoning span after an *unclosed* backtick is still stripped (inline code is only honored when it actually closes).

### Review follow-up

Addresses the ClawSweeper review on this PR:
- **P1 (preserve literal tag examples):** the filter now tracks fenced/inline code state, so documentation that shows `<think>` inside code keeps it verbatim.
- **P1 (regression coverage):** added filter unit tests for inline/fenced/tilde code (including split-across-chunk cases) plus parity assertions against `stripReasoningTagsFromText`, and a legacy-parser integration test for a fenced/inline `<think>` example.
- **P1 (real behavior proof):** the runtime capture below replaces the earlier source-only evidence.

## Real behavior proof

- **Behavior addressed:** Inline `<think>…</think>` reasoning streamed in `delta.content` (with mirrored `reasoning_content`) no longer leaks into the channel-visible text content part on either OpenAI-compatible parser; the reasoning is present only in the hidden thinking part.
- **Real environment tested:** The actual OpenClaw runtime stream path, exercised end-to-end through the production `createOpenAICompletionsTransportStreamFn` entrypoint against a real loopback HTTP server streaming OpenAI-compatible SSE chunks that emulate `minimax/MiniMax-M2.7` (inline `<think>` in `delta.content`, mirrored in `reasoning_content`). Run on Node 22.19.0 via `tsx`. This drives the real provider/runtime code path and real SSE parsing — no live MiniMax API key was available in this environment, so a hosted MiniMax credential was substituted with a faithful local SSE emulation of its stream shape.
- **Exact steps or command run after this patch:**
  - After the patch (clean): `tsx tmp-repro-think.ts`
  - Before the patch (leak), for comparison: `git checkout HEAD~1 -- src/agents/openai-transport-stream.ts src/llm/providers/openai-completions.ts src/shared/text/reasoning-tags.ts && tsx tmp-repro-think.ts` (then restored to `HEAD`).
- **Evidence after fix:** Captured terminal output from the real runtime run.

  Before the patch — the chain-of-thought leaks into the channel-visible text, and the persisted parts duplicate it into both `text` and `thinking` (matching the report):

  ```
  MODEL: minimax/MiniMax-M2.7 over OpenAI-compatible stream (real runtime, loopback SSE)
  CHANNEL-VISIBLE TEXT (what Telegram/Discord renders):
    "<think>User wants thrillers. Recommend three.</think>Here are three great thrillers."
  THINKING (hidden reasoning channel):
    "User wants thrillers. Recommend three."
  PERSISTED ASSISTANT CONTENT PARTS:
    [text] "<think>User wants thrillers. "
    [thinking] "User wants thrillers. "
    [text] "Recommend three.</think>"
    [thinking] "Recommend three."
    [text] "Here are three great thrillers."
  CoT LEAKED INTO VISIBLE TEXT: YES (BUG)
  ```

  After the patch — the visible text carries only the answer; reasoning remains solely in the hidden thinking part:

  ```
  MODEL: minimax/MiniMax-M2.7 over OpenAI-compatible stream (real runtime, loopback SSE)
  CHANNEL-VISIBLE TEXT (what Telegram/Discord renders):
    "Here are three great thrillers."
  THINKING (hidden reasoning channel):
    "User wants thrillers. Recommend three."
  PERSISTED ASSISTANT CONTENT PARTS:
    [thinking] "User wants thrillers. Recommend three."
    [text] "Here are three great thrillers."
  CoT LEAKED INTO VISIBLE TEXT: NO (clean)
  ```
- **Observed result after fix:** The channel-visible text equals only the answer (`"Here are three great thrillers."`) and contains neither `<think>` nor the reasoning prose; the reasoning appears only in the hidden thinking part (`"User wants thrillers. Recommend three."`), as a single part with no duplication.
- **What was not tested:** A live `minimax/MiniMax-M2.7` run against a real hosted MiniMax endpoint over a real Telegram/Discord channel (no provider API key was available in this environment).

## Verification

Beyond the runtime capture above, automated coverage was added and run green (supplemental):

- Streaming-filter unit tests incl. code-region preservation and `stripReasoningTagsFromText` parity: `src/shared/text/reasoning-tags.test.ts` (84 passing).
- Parser integration tests: `src/agents/openai-transport-stream.test.ts` (214 passing) and `src/llm/providers/openai-completions.test.ts` (8 passing, incl. a fenced/inline `<think>` example). The active-parser leak case fails on `HEAD~1` and passes on this branch.
- Prod typecheck (`tsgo:core`), `oxfmt --check`, and `oxlint` on the changed files all pass.
