### PR TITLE
fix(codex): quarantine unreadable dynamic tools

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -371,6 +371,84 @@ describe("createCodexDynamicToolBridge", () => {
     expect(badExecute).not.toHaveBeenCalled();
   });
 
+  it("quarantines unreadable dynamic tool entries before Codex registration", () => {
+    const message = createTool({ name: "message" });
+    const tools = [message] as AnyAgentTool[];
+    const proxy = new Proxy(tools, {
+      get(target, property, receiver) {
+        if (property === "1") {
+          throw new Error("fuzzplugin dynamic tool entry getter exploded");
+        }
+        if (property === "length") {
+          return 2;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const bridge = createCodexDynamicToolBridge({
+      tools: proxy,
+      signal: new AbortController().signal,
+    });
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.specs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.telemetry.quarantinedTools).toEqual([
+      {
+        tool: "tool[1]",
+        violations: ["tool[1] is unreadable"],
+      },
+    ]);
+  });
+
+  it("quarantines unreadable dynamic tool fields before Codex registration", () => {
+    const unreadable = createTool({ name: "fuzzplugin_unreadable" });
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin dynamic tool parameters getter exploded");
+      },
+    });
+
+    const bridge = createCodexDynamicToolBridge({
+      tools: [unreadable, createTool({ name: "message" })],
+      signal: new AbortController().signal,
+    });
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.specs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.telemetry.quarantinedTools).toEqual([
+      {
+        tool: "fuzzplugin_unreadable",
+        violations: ["fuzzplugin_unreadable.inputSchema is unreadable"],
+      },
+    ]);
+  });
+
+  it("quarantines unreadable dynamic tool descriptions before Codex registration", () => {
+    const unreadable = createTool({ name: "fuzzplugin_unreadable_description" });
+    Object.defineProperty(unreadable, "description", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin dynamic tool description getter exploded");
+      },
+    });
+
+    const bridge = createCodexDynamicToolBridge({
+      tools: [unreadable, createTool({ name: "message" })],
+      signal: new AbortController().signal,
+    });
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.specs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.telemetry.quarantinedTools).toEqual([
+      {
+        tool: "fuzzplugin_unreadable_description",
+        violations: ["fuzzplugin_unreadable_description.description is unreadable"],
+      },
+    ]);
+  });
+
   it("can expose all dynamic tools directly for compatibility", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [createTool({ name: "web_search" }), createTool({ name: "message" })],

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -51,6 +51,8 @@ type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
 
 type ProjectedCodexDynamicTool = {
   tool: AnyAgentTool;
+  toolName: string;
+  description: string;
   inputSchema: JsonValue;
 };
 
@@ -58,6 +60,17 @@ type CodexDynamicToolSchemaQuarantine = {
   tool: string;
   violations: readonly string[];
 };
+
+type CodexDynamicToolEntryRead =
+  | {
+      readonly ok: true;
+      readonly tool: AnyAgentTool;
+      readonly toolIndex: number;
+    }
+  | {
+      readonly ok: false;
+      readonly quarantine: CodexDynamicToolSchemaQuarantine;
+    };
 
 export type CodexDynamicToolBridge = {
   availableSpecs: CodexDynamicToolSpec[];
@@ -101,19 +114,22 @@ export function createCodexDynamicToolBridge(params: {
   const registeredProjection = params.registeredTools
     ? projectCodexDynamicTools(params.registeredTools)
     : availableProjection;
-  const availableTools = availableProjection.tools.map(({ tool, inputSchema }) => {
-    if (isToolWrappedWithBeforeToolCallHook(tool)) {
-      setBeforeToolCallDiagnosticsEnabled(tool, false);
-      return { tool, inputSchema };
-    }
-    return {
-      tool: wrapToolWithBeforeToolCallHook(tool, params.hookContext, { emitDiagnostics: false }),
-      inputSchema,
-    };
-  });
-  const toolMap = new Map(availableTools.map(({ tool }) => [tool.name, tool]));
-  const registeredTools = registeredProjection.tools.map(({ tool }) => tool);
-  const registeredToolNames = new Set(registeredTools.map((tool) => tool.name));
+  const availableTools = availableProjection.tools.map(
+    ({ tool, toolName, description, inputSchema }) => {
+      if (isToolWrappedWithBeforeToolCallHook(tool)) {
+        setBeforeToolCallDiagnosticsEnabled(tool, false);
+        return { tool, toolName, description, inputSchema };
+      }
+      return {
+        tool: wrapToolWithBeforeToolCallHook(tool, params.hookContext, { emitDiagnostics: false }),
+        toolName,
+        description,
+        inputSchema,
+      };
+    },
+  );
+  const toolMap = new Map(availableTools.map(({ toolName, tool }) => [toolName, tool]));
+  const registeredToolNames = new Set(registeredProjection.tools.map((tool) => tool.toolName));
   const quarantinedTools = dedupeQuarantinedDynamicTools([
     ...availableProjection.quarantinedTools,
     ...registeredProjection.quarantinedTools,
@@ -142,17 +158,19 @@ export function createCodexDynamicToolBridge(params: {
   ]);
 
   return {
-    availableSpecs: availableTools.map(({ tool, inputSchema }) =>
+    availableSpecs: availableTools.map(({ toolName, description, inputSchema }) =>
       createCodexDynamicToolSpec({
-        tool,
+        toolName,
+        description,
         inputSchema,
         loading: params.loading ?? "searchable",
         directToolNames,
       }),
     ),
-    specs: registeredProjection.tools.map(({ tool, inputSchema }) =>
+    specs: registeredProjection.tools.map(({ toolName, description, inputSchema }) =>
       createCodexDynamicToolSpec({
-        tool,
+        toolName,
+        description,
         inputSchema,
         loading: params.loading ?? "searchable",
         directToolNames,
@@ -286,17 +304,18 @@ export function createCodexDynamicToolBridge(params: {
 }
 
 function createCodexDynamicToolSpec(params: {
-  tool: AnyAgentTool;
+  toolName: string;
+  description: string;
   inputSchema: JsonValue;
   loading: CodexDynamicToolsLoading;
   directToolNames: ReadonlySet<string>;
 }): CodexDynamicToolSpec {
   const base = {
-    name: params.tool.name,
-    description: params.tool.description,
+    name: params.toolName,
+    description: params.description,
     inputSchema: params.inputSchema,
   };
-  if (params.loading === "direct" || params.directToolNames.has(params.tool.name)) {
+  if (params.loading === "direct" || params.directToolNames.has(params.toolName)) {
     return base;
   }
   return {
@@ -312,15 +331,94 @@ function projectCodexDynamicTools(tools: readonly AnyAgentTool[]): {
 } {
   const projectedTools: ProjectedCodexDynamicTool[] = [];
   const quarantinedTools: CodexDynamicToolSchemaQuarantine[] = [];
-  for (const tool of tools) {
-    const projection = projectRuntimeToolInputSchema(tool.parameters, `${tool.name}.inputSchema`);
-    if (projection.violations.length > 0) {
-      quarantinedTools.push({ tool: tool.name, violations: projection.violations });
+  for (const entry of readCodexDynamicToolEntries(tools)) {
+    if (!entry.ok) {
+      quarantinedTools.push(entry.quarantine);
       continue;
     }
-    projectedTools.push({ tool, inputSchema: projection.schema as JsonValue });
+
+    const nameRead = readCodexDynamicToolField(entry.tool, "name");
+    if (!nameRead.readable) {
+      const diagnosticToolName = `tool[${entry.toolIndex}]`;
+      quarantinedTools.push({
+        tool: diagnosticToolName,
+        violations: [`${diagnosticToolName}.name is unreadable`],
+      });
+      continue;
+    }
+    const diagnosticToolName = nameRead.value;
+    const descriptionRead = readCodexDynamicToolField(entry.tool, "description");
+    if (!descriptionRead.readable) {
+      quarantinedTools.push({
+        tool: diagnosticToolName,
+        violations: [`${diagnosticToolName}.description is unreadable`],
+      });
+      continue;
+    }
+    const parametersRead = readCodexDynamicToolField(entry.tool, "parameters");
+    if (!parametersRead.readable) {
+      quarantinedTools.push({
+        tool: diagnosticToolName,
+        violations: [`${diagnosticToolName}.inputSchema is unreadable`],
+      });
+      continue;
+    }
+
+    const projection = projectRuntimeToolInputSchema(
+      parametersRead.value,
+      `${diagnosticToolName}.inputSchema`,
+    );
+    if (projection.violations.length > 0) {
+      quarantinedTools.push({ tool: diagnosticToolName, violations: projection.violations });
+      continue;
+    }
+    projectedTools.push({
+      tool: entry.tool,
+      toolName: diagnosticToolName,
+      description: typeof descriptionRead.value === "string" ? descriptionRead.value : "",
+      inputSchema: projection.schema as JsonValue,
+    });
   }
   return { tools: projectedTools, quarantinedTools };
+}
+
+function readCodexDynamicToolEntries(tools: readonly AnyAgentTool[]): CodexDynamicToolEntryRead[] {
+  let length: number;
+  try {
+    length = tools.length;
+  } catch {
+    return [unreadableCodexDynamicToolEntry(0)];
+  }
+  const entries: CodexDynamicToolEntryRead[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    try {
+      entries.push({ ok: true, tool: tools[toolIndex], toolIndex });
+    } catch {
+      entries.push(unreadableCodexDynamicToolEntry(toolIndex));
+    }
+  }
+  return entries;
+}
+
+function unreadableCodexDynamicToolEntry(toolIndex: number): CodexDynamicToolEntryRead {
+  return {
+    ok: false,
+    quarantine: {
+      tool: `tool[${toolIndex}]`,
+      violations: [`tool[${toolIndex}] is unreadable`],
+    },
+  };
+}
+
+function readCodexDynamicToolField<TField extends "name" | "description" | "parameters">(
+  tool: AnyAgentTool,
+  field: TField,
+): { readable: true; value: AnyAgentTool[TField] } | { readable: false } {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
 }
 
 function warnQuarantinedDynamicTools(tools: readonly CodexDynamicToolSchemaQuarantine[]): void {


### PR DESCRIPTION
## Summary

- quarantine unreadable Codex dynamic tool entries before registration so one malformed plugin tool does not poison the whole dynamic tool list
- preserve healthy dynamic tools when a neighboring entry, name, description, or schema is unreadable
- keep the provider-schema hardening in the stacked base PR; this PR only contains the Codex app-server quarantine surface

Stacked on: https://github.com/openclaw/openclaw/pull/88880

## Verification

Stack base: `8aeaadf963a`  
Head: `946ea6a7347`

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts --reporter=dot` - passed 1 shard / 39 tests
- `node --import tsx scripts/generate-prompt-snapshots.ts --check` - passed, `Prompt snapshots are current (7 files).`
- `node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/dynamic-tools.ts extensions/codex/src/app-server/dynamic-tools.test.ts` - passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/dynamic-tools.ts extensions/codex/src/app-server/dynamic-tools.test.ts` - passed
- `git diff --check origin/cron-schema-main-repro-20260601...HEAD` - passed
- private reported-name scrub across spec and changed Codex files - clean
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/cron-schema-main-repro-20260601 --prompt 'Review the pruned Codex dynamic-tool quarantine branch stacked on the provider schema PR. Focus on unreadable or unsupported dynamic tool schemas, keeping healthy tools active, diagnostic clarity, test coverage, and avoiding duplicated provider projection work.'` - clean, no accepted/actionable findings, `overall: patch is correct (0.78)`

## Real behavior proof

Behavior addressed: Codex dynamic-tool registration now skips unreadable malformed dynamic tool entries and keeps healthy tools available instead of failing the whole tool registration path.

Real environment tested: Local OpenClaw Codex/gwt worktree on macOS with shared repo `node_modules`, using the repo Vitest wrapper plus snapshot, format, lint, diff, scrub, and autoreview gates.

Exact steps or command run after this patch: The focused Vitest, prompt snapshot, oxfmt, oxlint, diff-check, private-name scrub, and autoreview commands listed above were run after restacking onto #88880.

Evidence after fix: Codex dynamic-tools tests passed 1 shard / 39 tests; prompt snapshots were current; oxfmt, oxlint, and diff-check passed; autoreview reported no accepted/actionable findings.

Observed result after fix: Unreadable dynamic tool data is quarantined before Codex registration while valid dynamic tools remain registered and usable.

What was not tested: A live Codex provider turn and full `pnpm check:changed` were not run for this narrow stacked PR; GitHub CI is expected to validate the pushed branch.
