### PR TITLE
fix(diagnostics): include sanitized input previews

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5029,11 +5029,13 @@ describe("dispatchReplyFromConfig", () => {
       }),
     );
     expect(diagnosticMocks.logMessageQueued).toHaveBeenCalledTimes(1);
-    expect(diagnosticMocks.logSessionStateChange).toHaveBeenCalledWith({
-      sessionKey: "agent:main:main",
-      state: "processing",
-      reason: "message_start",
-    });
+    expect(diagnosticMocks.logSessionStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        state: "processing",
+        reason: "message_start",
+      }),
+    );
     const processedEvent = firstMockArg(
       diagnosticMocks.logMessageProcessed,
       "message processed",
@@ -5041,6 +5043,56 @@ describe("dispatchReplyFromConfig", () => {
     expect(processedEvent?.channel).toBe("slack");
     expect(processedEvent?.outcome).toBe("completed");
     expect(processedEvent?.sessionKey).toBe("agent:main:main");
+  });
+
+  it("adds a sanitized user input preview to interactive diagnostic lifecycle events", async () => {
+    setNoAbort();
+    const cfg = { diagnostics: { enabled: true } } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      SessionKey: "agent:main:main",
+      CommandBody: "  Check   AgentWeave\ntraces now  ",
+      RawBody: "fallback body",
+      To: "telegram:123",
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(diagnosticMocks.logMessageQueued).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputPreview: "Check AgentWeave traces now",
+      }),
+    );
+    expect(diagnosticMocks.logSessionStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputPreview: "Check AgentWeave traces now",
+      }),
+    );
+  });
+
+  it("caps long diagnostic input previews", async () => {
+    setNoAbort();
+    const cfg = { diagnostics: { enabled: true } } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      SessionKey: "agent:main:main",
+      CommandBody: `  ${"x".repeat(1_100)}  `,
+      To: "telegram:123",
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    const queuedEvent = firstMockArg(diagnosticMocks.logMessageQueued, "message queued") as
+      | { inputPreview?: string }
+      | undefined;
+    expect(queuedEvent?.inputPreview).toHaveLength(1_000);
+    expect(queuedEvent?.inputPreview?.endsWith("…")).toBe(true);
   });
 
   it("marks diagnostic progress for real reply events but not reply start callbacks", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -823,6 +823,25 @@ function captureDeliveredSourceReplyTranscriptMirror(params: {
   return () => deliveredMetadata;
 }
 
+function buildDiagnosticInputPreview(ctx: FinalizedMsgContext): string | undefined {
+  const raw =
+    normalizeOptionalString(ctx.BodyForCommands) ??
+    normalizeOptionalString(ctx.CommandBody) ??
+    normalizeOptionalString(ctx.RawBody) ??
+    normalizeOptionalString(ctx.Body);
+  if (!raw) {
+    return undefined;
+  }
+  const normalized = raw.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return undefined;
+  }
+  const maxChars = 1000;
+  return normalized.length <= maxChars
+    ? normalized
+    : `${normalized.slice(0, maxChars - 1).trimEnd()}…`;
+}
+
 async function mirrorInternalSourceReplyAfterDispatcherDelivery(params: {
   dispatcher: ReplyDispatcher;
   before: { cancelled: number; failed: number };
@@ -1040,6 +1059,7 @@ export async function dispatchReplyFromConfig(
     chatId,
     messageId,
     sessionKey,
+    inputPreview: buildDiagnosticInputPreview(ctx),
     source: "dispatch",
     processingReason: "message_start",
     startedAtMs: startTime,

--- a/src/cron/isolated-agent/run.diagnostic-events.test.ts
+++ b/src/cron/isolated-agent/run.diagnostic-events.test.ts
@@ -47,6 +47,8 @@ type EventRecord = {
   source?: string;
   state?: string;
   outcome?: string;
+  inputPreview?: string;
+  taskLabel?: string;
 };
 
 describe("runCronIsolatedAgentTurn diagnostic events", () => {
@@ -86,9 +88,14 @@ describe("runCronIsolatedAgentTurn diagnostic events", () => {
     const ofType = (type: string) => events.filter((e) => e.type === type);
     expect(ofType("message.queued")).toHaveLength(1);
     expect(ofType("message.queued")[0]?.source).toBe("cron-isolated");
+    expect(ofType("message.queued")[0]?.inputPreview).toBe("run task");
 
     const stateEvents = ofType("session.state");
     expect(stateEvents.map((e) => e.state)).toEqual(["processing", "idle"]);
+    expect(stateEvents[0]?.inputPreview).toBe("run task");
+    expect(stateEvents[0]?.taskLabel).toBe("Diag Events");
+    expect(stateEvents[1]?.inputPreview).toBeUndefined();
+    expect(stateEvents[1]?.taskLabel).toBeUndefined();
 
     const processed = ofType("message.processed");
     expect(processed).toHaveLength(1);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -116,6 +116,24 @@ const runtimePluginsLoader = createLazyImportLoader(
   () => import("../../plugins/runtime-plugins.runtime.js"),
 );
 
+function buildCronDiagnosticInputPreview(job: CronJob): string | undefined {
+  const raw =
+    job.payload.kind === "agentTurn"
+      ? normalizeOptionalString(job.payload.message)
+      : normalizeOptionalString(job.name);
+  if (!raw) {
+    return undefined;
+  }
+  const normalized = raw.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return undefined;
+  }
+  const maxChars = 1000;
+  return normalized.length <= maxChars
+    ? normalized
+    : `${normalized.slice(0, maxChars - 1).trimEnd()}…`;
+}
+
 async function loadSessionStoreRuntime() {
   return await sessionStoreRuntimeLoader.load();
 }
@@ -1261,6 +1279,8 @@ export async function runCronIsolatedAgentTurn(params: {
     sessionKey: prepared.context.runSessionKey,
     channel: "cron",
     source: "cron-isolated",
+    inputPreview: buildCronDiagnosticInputPreview(params.job),
+    taskLabel: params.job.name,
     startedAtMs: turnStartedAtMs,
     trackSessionState: true,
   });

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -90,6 +90,7 @@ export type DiagnosticMessageQueuedEvent = DiagnosticBaseEvent & {
   channel?: string;
   source: string;
   queueDepth?: number;
+  inputPreview?: string;
 };
 
 export type DiagnosticMessageReceivedEvent = DiagnosticBaseEvent & {
@@ -182,6 +183,8 @@ export type DiagnosticSessionStateEvent = DiagnosticBaseEvent & {
   state: DiagnosticSessionState;
   reason?: string;
   queueDepth?: number;
+  inputPreview?: string;
+  taskLabel?: string;
 };
 
 export type DiagnosticSessionActiveWorkKind = "embedded_run" | "model_call" | "tool_call";

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -647,6 +647,7 @@ export function logMessageQueued(params: {
   sessionKey?: string;
   channel?: string;
   source: string;
+  inputPreview?: string;
 }) {
   if (!areDiagnosticsEnabledForProcess()) {
     return;
@@ -671,6 +672,7 @@ export function logMessageQueued(params: {
     channel: params.channel,
     source: params.source,
     queueDepth: state.queueDepth,
+    inputPreview: params.inputPreview,
   });
   markActivity();
 }
@@ -856,6 +858,8 @@ export function logSessionStateChange(
   params: SessionRef & {
     state: SessionStateValue;
     reason?: string;
+    inputPreview?: string;
+    taskLabel?: string;
   },
 ) {
   if (!areDiagnosticsEnabledForProcess()) {
@@ -893,6 +897,8 @@ export function logSessionStateChange(
     state: params.state,
     reason: params.reason,
     queueDepth: state.queueDepth,
+    inputPreview: params.inputPreview,
+    taskLabel: params.taskLabel,
   });
   markActivity();
 }

--- a/src/logging/message-lifecycle.test.ts
+++ b/src/logging/message-lifecycle.test.ts
@@ -43,6 +43,7 @@ describe("createDiagnosticMessageLifecycle", () => {
       sessionKey: "cron:job",
       channel: "cron",
       source: "cron-isolated",
+      inputPreview: undefined,
     });
     expect(diagnosticMocks.logSessionStateChange.mock.calls).toEqual([
       [
@@ -51,6 +52,8 @@ describe("createDiagnosticMessageLifecycle", () => {
           sessionKey: "cron:job",
           state: "processing",
           reason: undefined,
+          inputPreview: undefined,
+          taskLabel: undefined,
         },
       ],
       [
@@ -123,5 +126,31 @@ describe("createDiagnosticMessageLifecycle", () => {
     expect(diagnosticMocks.logMessageQueued).not.toHaveBeenCalled();
     expect(diagnosticMocks.logSessionStateChange).not.toHaveBeenCalled();
     expect(diagnosticMocks.logMessageProcessed).not.toHaveBeenCalled();
+  });
+
+  it("carries preview and task label on processing lifecycle events", () => {
+    const lifecycle = createDiagnosticMessageLifecycle({
+      enabled: true,
+      channel: "telegram",
+      source: "dispatch",
+      sessionKey: "agent:main:main",
+      inputPreview: "Summarize the latest deployment",
+      taskLabel: "deployment check",
+      trackSessionState: true,
+    });
+
+    lifecycle.markProcessing();
+
+    expect(diagnosticMocks.logMessageQueued).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputPreview: "Summarize the latest deployment",
+      }),
+    );
+    expect(diagnosticMocks.logSessionStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputPreview: "Summarize the latest deployment",
+        taskLabel: "deployment check",
+      }),
+    );
   });
 });

--- a/src/logging/message-lifecycle.ts
+++ b/src/logging/message-lifecycle.ts
@@ -20,6 +20,8 @@ export function createDiagnosticMessageLifecycle(
     source: string;
     chatId?: number | string;
     messageId?: number | string;
+    inputPreview?: string;
+    taskLabel?: string;
     processingReason?: string;
     startedAtMs?: number;
     trackSessionState: boolean;
@@ -48,12 +50,15 @@ export function createDiagnosticMessageLifecycle(
         sessionKey: ref.sessionKey,
         channel: params.channel,
         source: params.source,
+        inputPreview: params.inputPreview,
       });
       logSessionStateChange({
         sessionId: ref.sessionId,
         sessionKey: ref.sessionKey,
         state: "processing",
         reason: params.processingReason,
+        inputPreview: params.inputPreview,
+        taskLabel: params.taskLabel,
       });
     },
 


### PR DESCRIPTION
## Why

OpenClaw diagnostic lifecycle events tell plugins when a turn is queued/processing, but they currently do not include any safe representation of the user/task input that triggered the lifecycle. Observability plugins can see that a turn happened, but cannot populate a useful observation input without reaching back into raw channel/runtime state.

This leaves trace and observability UIs with blank input for OpenClaw turn/subagent observations even though the lifecycle event is the natural boundary for that metadata.

## Change

Add optional, sanitized input context to lifecycle diagnostics:

- `message.queued.inputPreview`
- `session.state.inputPreview`
- `session.state.taskLabel`

Interactive dispatch turns derive `inputPreview` from the finalized message context, preferring command/body fields already used by dispatch. Whitespace is normalized and previews are capped at 1000 chars.

Cron/isolated-agent turns derive `inputPreview` from the agent-turn message when available, otherwise from the job name, and also include `taskLabel: job.name` on the processing state event.

## Safety

The field is optional and additive. Existing consumers that ignore unknown fields keep working. The preview is normalized and capped, not a full raw transcript/message dump.

## Tests

Added/updated tests for:

- diagnostic lifecycle propagation of `inputPreview` / `taskLabel`
- interactive dispatch preview normalization
- interactive dispatch preview cap/truncation
- cron diagnostic lifecycle events carrying preview/label on processing only

Local validation:

- `git diff --check` passed
- Focused Vitest could not complete in this local shell because the clean worktree initially had only Node 18 on PATH, then the symlinked dependency setup spent minutes in Rolldown plugin startup. CI should run this in the normal repo environment.
- Full `tsc --noEmit` also hit a heap limit in this shell, so I did not treat local typecheck as conclusive.


## Real behavior proof

**Behavior or issue addressed:** OpenClaw interactive and cron lifecycle diagnostics previously emitted `message.queued` / `session.state` events without a safe input preview, so observability plugins could create turn/subagent spans but could not populate a useful observation input from the diagnostic event itself.

**Real environment tested:** A live OpenClaw gateway process built from this branch, with a diagnostics consumer enabled and exporting lifecycle events to an observability sink.

**Exact steps or command run after this patch:** Built the OpenClaw gateway from this branch, installed the rebuilt diagnostics consumer, restarted the gateway process, sent real interactive client turns through the gateway, and inspected the emitted lifecycle events plus downstream observability output.

**Evidence after fix:** Gateway logs showed the diagnostics consumer receiving live lifecycle events after restart:

```text
[diagnostics-consumer] event: message.queued sessionKey: agent:main:main source: dispatch inputPreview: <sanitized user-turn preview>
[diagnostics-consumer] event: session.state sessionKey: agent:main:main state: processing reason: message_start inputPreview: <sanitized user-turn preview>
[diagnostics-consumer] event: model.call.started sessionKey: agent:main:main
[diagnostics-consumer] event: model.call.completed sessionKey: agent:main:main
[diagnostics-consumer] event: model.usage sessionKey: agent:main:main
[diagnostics-consumer] event: message.processed sessionKey: agent:main:main
```

The downstream observability sink then showed OpenClaw turn/subagent observations with their input populated from the sanitized lifecycle preview instead of remaining blank.

**Observed result after fix:** OpenClaw diagnostic lifecycle events now provide the safe preview field needed by plugins to set observation input, while the gateway continued processing real interactive turns normally.



**What was not tested:** Full upstream CI remains in progress/partially failing on unrelated current-main checks. The live proof exercised interactive gateway diagnostics; cron preview behavior is covered by the new unit test and was not separately exercised on a live scheduled cron run.

