### PR TITLE
fix: normalise wiki lint targets

### DIFF
--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -387,6 +387,123 @@ describe("lintMemoryWikiVault", () => {
     );
   });
 
+  it("resolves title, slug, fragment, and imported source-path wikilinks", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-links-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "syntheses"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "bridge-alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.bridge.alpha",
+          title: "Imported Alpha Source",
+          sourceType: "memory-bridge",
+          sourcePath: "/workspace/research notes/Alpha System Overview.md",
+          bridgeRelativePath: "research notes/Alpha System Overview.md",
+          bridgeWorkspaceDir: "/workspace",
+        },
+        body: [
+          "# Imported Alpha Source",
+          "",
+          "[[Alpha Database#Evidence]]",
+          "[[alpha-database]]",
+          "[[syntheses/alpha-db#Details]]",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "alpha-db.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.alpha.db",
+          title: "Alpha Database",
+          sourceIds: ["source.bridge.alpha"],
+        },
+        body: [
+          "# Alpha Database",
+          "",
+          "[[research notes/Alpha System Overview#Quote]]",
+          "[[Alpha System Overview]]",
+          "[[alpha-system-overview]]",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.filter((issue) => issue.code === "broken-wikilink")).toEqual([]);
+  });
+
+  it("keeps path target matching case-sensitive", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-path-case-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "syntheses"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "bridge-alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.bridge.alpha",
+          title: "Bridge Alpha",
+          sourceType: "memory-bridge",
+          sourcePath: "/workspace/Alpha.md",
+          bridgeRelativePath: "Alpha.md",
+          bridgeWorkspaceDir: "/workspace",
+        },
+        body: [
+          "# Bridge Alpha",
+          "",
+          "[[Alpha Database]]",
+          "[[alpha-database]]",
+          "[[syntheses/Alpha-DB]]",
+          "[[Alpha-DB]]",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "alpha-db.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.alpha.db",
+          title: "Alpha Database",
+          sourceIds: ["source.bridge.alpha"],
+        },
+        body: "# Alpha Database\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+    const brokenTargets = result.issues
+      .filter((issue) => issue.code === "broken-wikilink")
+      .map((issue) => issue.message);
+
+    expect(brokenTargets).toEqual([
+      "Broken wikilink target `syntheses/Alpha-DB`.",
+      "Broken wikilink target `Alpha-DB`.",
+    ]);
+  });
+
   it("detects duplicate ids, provenance gaps, contradictions, and open questions", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-lint-",

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -5,6 +5,7 @@ import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   assessPageFreshness,
   buildClaimContradictionClusters,
@@ -17,6 +18,7 @@ import {
   isUnmanagedRawSourceSummary,
   parseWikiMarkdown,
   renderWikiMarkdown,
+  slugifyWikiSegment,
   type WikiPageSummary,
 } from "./markdown.js";
 import { readMemoryWikiSourceSyncState } from "./source-sync-state.js";
@@ -67,19 +69,106 @@ function isUnmanagedRawSourcePage(
   );
 }
 
-function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[] {
-  const validTargets = new Set<string>();
-  for (const page of pages) {
-    const withoutExtension = page.relativePath.replace(/\.md$/i, "");
-    validTargets.add(page.relativePath);
-    validTargets.add(withoutExtension);
-    validTargets.add(path.basename(withoutExtension));
+type WikiLinkTargetIndex = {
+  pathTargets: Set<string>;
+  aliasTargets: Set<string>;
+};
+
+function normalizeLintPathTarget(value: string): string {
+  const withoutFragment = value.trim().replace(/\\/g, "/").split("#")[0] ?? "";
+  const withoutQuery = withoutFragment.split("?")[0] ?? "";
+  return withoutQuery
+    .replace(/\.md$/i, "")
+    .replace(/^\.\/+/, "")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .trim();
+}
+
+function normalizeLintAliasTarget(value: string): string {
+  return normalizeLowercaseStringOrEmpty(normalizeLintPathTarget(value));
+}
+
+function addPathTarget(index: WikiLinkTargetIndex, raw: string | undefined) {
+  const normalized = raw ? normalizeLintPathTarget(raw) : "";
+  if (!normalized) {
+    return;
   }
+  index.pathTargets.add(normalized);
+  index.pathTargets.add(path.posix.basename(normalized));
+}
+
+function addAliasTarget(index: WikiLinkTargetIndex, raw: string | undefined) {
+  const normalized = raw ? normalizeLintAliasTarget(raw) : "";
+  if (normalized) {
+    index.aliasTargets.add(normalized);
+  }
+}
+
+function addSlugAliasTarget(index: WikiLinkTargetIndex, raw: string | undefined) {
+  const normalized = raw ? normalizeLintPathTarget(raw) : "";
+  if (normalized) {
+    index.aliasTargets.add(slugifyWikiSegment(normalized));
+  }
+}
+
+function addTitleTarget(index: WikiLinkTargetIndex, raw: string | undefined) {
+  addAliasTarget(index, raw);
+  addSlugAliasTarget(index, raw);
+}
+
+function addPathSuffixTargets(index: WikiLinkTargetIndex, raw: string | undefined) {
+  const normalized = raw ? normalizeLintPathTarget(raw) : "";
+  if (!normalized) {
+    return;
+  }
+  const parts = normalized.split("/").filter(Boolean);
+  for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+    const suffix = parts.slice(partIndex).join("/");
+    addPathTarget(index, suffix);
+    addSlugAliasTarget(index, suffix);
+  }
+}
+
+function buildWikiLinkTargetIndex(pages: WikiPageSummary[]): WikiLinkTargetIndex {
+  const index: WikiLinkTargetIndex = {
+    pathTargets: new Set(),
+    aliasTargets: new Set(),
+  };
+  for (const page of pages) {
+    addPathTarget(index, page.relativePath);
+    addTitleTarget(index, page.title);
+    addPathSuffixTargets(index, page.sourcePath);
+    addPathSuffixTargets(index, page.bridgeRelativePath);
+    addPathSuffixTargets(index, page.unsafeLocalRelativePath);
+  }
+  return index;
+}
+
+function hasValidWikiLinkTarget(index: WikiLinkTargetIndex, rawTarget: string): boolean {
+  const pathTarget = normalizeLintPathTarget(rawTarget);
+  if (!pathTarget) {
+    return true;
+  }
+  if (index.pathTargets.has(pathTarget)) {
+    return true;
+  }
+  if (pathTarget.includes("/")) {
+    return false;
+  }
+  return (
+    index.aliasTargets.has(normalizeLintAliasTarget(pathTarget)) ||
+    index.aliasTargets.has(slugifyWikiSegment(pathTarget))
+  );
+}
+
+function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[] {
+  const validTargets = buildWikiLinkTargetIndex(pages);
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
     for (const linkTarget of page.linkTargets) {
-      if (!validTargets.has(linkTarget)) {
+      if (!hasValidWikiLinkTarget(validTargets, linkTarget)) {
         issues.push({
           severity: "warning",
           category: "links",


### PR DESCRIPTION
## Summary

- Problem: `openclaw wiki lint` can report valid imported wiki links as `broken-wikilink` when they use page titles, slug variants, fragments, or imported source-path suffixes.
- Why it matters: imported evidence should not need provenance-damaging rewrites just to satisfy lint.
- What changed: memory-wiki lint now builds separate case-sensitive path targets and case-insensitive alias targets, including titles, title slugs, source-path suffixes, and fragment/query-stripped targets.
- What did NOT change (scope boundary): wiki compile, ingest, page rendering, markdown link extraction, and startup behaviour remain unchanged.

## What Problem This Solves

Imported memory-wiki pages can preserve source-authored Obsidian links that are semantically valid but do not exactly match generated file names. Today, links like `[[Alpha Database#Evidence]]`, `[[alpha-database]]`, or `[[research notes/Alpha System Overview#Quote]]` can be reported as `broken-wikilink` even when the target page exists. That creates noisy lint output and pressures users to rewrite source-preserving imported evidence just to satisfy the linter.

This PR fixes that specific resolver gap while keeping path-style links strict. Title, slug, fragment-stripped, and imported source-path suffix links can resolve to existing pages; path targets containing `/` remain case-sensitive, so a case-mismatched path such as `[[syntheses/Alpha-DB]]` still warns. The validation added in `extensions/memory-wiki/src/lint.test.ts` covers both the accepted imported-link forms and the rejected case-mismatched path form.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73574
- Related #73722
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: memory-wiki lint compared raw link targets against only exact extensionless relative paths and basenames.
- Missing detection / guardrail: regression coverage did not cover title-style, slug-style, fragment-bearing, source-path suffix, or path-case link variants.
- Contributing context (if known): imported evidence can preserve source-authored link forms that differ from generated wiki filenames.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-wiki/src/lint.test.ts`
- Scenario the test should lock in: existing pages linked by title, slug, fragment-stripped path, and imported source-path suffix do not produce `broken-wikilink` issues.
- Why this is the smallest reliable guardrail: the bug is isolated to lint target indexing and resolution.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw wiki lint` should produce fewer false-positive `broken-wikilink` warnings for imported wiki pages whose links already resolve by title, slug, fragment-stripped path, or imported source-path suffix. Path-style targets remain case-sensitive, so case-mismatched path links still warn.

## Diagram (if applicable)

```text
Before:
[[Alpha Database#Evidence]] -> raw target check -> false broken-wikilink

After:
[[Alpha Database#Evidence]] -> alias lookup -> existing page match
[[syntheses/Alpha-DB]] -> path lookup -> broken-wikilink when case differs
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout
- Model/provider: N/A
- Integration/channel (if any): memory-wiki
- Relevant config (redacted): N/A

### Steps

1. Create a memory-wiki vault containing links such as `[[Alpha Database#Evidence]]`, `[[alpha-database]]`, `[[research notes/Alpha System Overview#Quote]]`, and a case-mismatched path such as `[[syntheses/Alpha-DB]]`.
2. Run memory-wiki lint.
3. Inspect `broken-wikilink` results.

### Expected

- Title, slug, fragment-stripped, and source-path suffix links to existing pages do not warn.
- Case-mismatched path-style links still warn.

### Actual

- Current main only compares raw targets against exact extensionless relative paths and basenames, so valid imported links can be reported as broken.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local command evidence from the 2026-07-04 branch refresh:

- `git diff --check upstream/main...HEAD` passed.
- `rg -n 'text-runtime|<<<<<<<|>>>>>>>' extensions/memory-wiki/src/lint.ts extensions/memory-wiki/src/lint.test.ts` returned no matches.
- `pnpm test extensions/memory-wiki/src/lint.test.ts` was attempted locally and with elevated network permissions, but Corepack timed out downloading pinned `pnpm 11.2.2` from the npm registry.
- `curl -I https://registry.npmjs.org/pnpm/-/pnpm-11.2.2.tgz` also timed out, confirming local registry access is blocked rather than a test failure.
- Focused formatter and Vitest proof are deferred to PR CI until package-manager access works locally or a maintainer Testbox run is available.

## Human Verification (required)

- Verified scenarios: source-level review confirms lint now separates case-sensitive path matching from case-insensitive alias matching, and indexes titles, title slugs, relative paths, basenames, and imported source-path suffixes.
- Edge cases checked: the new regression keeps case-mismatched path targets warning, addressing the blocker that closed #73722.
- What you did **not** verify: local formatter or Vitest execution, because this machine cannot fetch the required package-manager and dependency tarballs from the npm registry.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: alias matching could suppress warnings for ambiguous non-path titles or slugs.
  - Mitigation: this only suppresses broken-link warnings when a normalised alias matches an existing page key; path-style targets containing `/` remain case-sensitive.
