### PR TITLE
fix: restore backgrounded in-flight runs on TUI switch-back via gateway snapshot

### DIFF
--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -505,6 +505,26 @@ describe("resolveInFlightRunSnapshot", () => {
     ).toEqual({ runId: "run-a", text: "main agent global text" });
   });
 
+  it("resolves bare global history snapshots to the default agent", () => {
+    const controllers = new Map<string, ChatAbortControllerEntry>([
+      ["run-main", inFlightEntry("global", { agentId: "main", startedAtMs: 1_000 })],
+      ["run-work", inFlightEntry("global", { agentId: "work", startedAtMs: 2_000 })],
+    ]);
+    const buffers = new Map([
+      ["run-main", "main default text"],
+      ["run-work", "work global text"],
+    ]);
+
+    expect(
+      snap({
+        chatAbortControllers: controllers,
+        chatRunBuffers: buffers,
+        sessionKey: "global",
+        defaultAgentId: "main",
+      }),
+    ).toEqual({ runId: "run-main", text: "main default text" });
+  });
+
   it("prefers the newest startedAtMs when several runs match the same session+agent", () => {
     // A fast restart/retry/stale-controller race can leave two active entries for
     // the same key; selection must not depend on Map insertion order. Insert the

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -360,6 +360,7 @@ describe("resolveInFlightRunSnapshot", () => {
       aborted?: boolean;
       projectSessionActive?: boolean;
       startedAtMs?: number;
+      kind?: ChatAbortControllerEntry["kind"];
     },
   ): ChatAbortControllerEntry => {
     const now = Date.now();
@@ -376,6 +377,7 @@ describe("resolveInFlightRunSnapshot", () => {
       startedAtMs,
       expiresAtMs: startedAtMs + 10_000,
       projectSessionActive: opts?.projectSessionActive ?? true,
+      kind: opts?.kind,
     };
   };
 
@@ -444,6 +446,18 @@ describe("resolveInFlightRunSnapshot", () => {
         }),
       ).toBeUndefined();
     }
+  });
+
+  it("ignores hidden agent runs that are not visible chat sends", () => {
+    expect(
+      snap({
+        chatAbortControllers: new Map([
+          ["run-agent", inFlightEntry("agent:main:s", { kind: "agent" })],
+        ]),
+        chatRunBuffers: new Map([["run-agent", "hidden partial"]]),
+        sessionKey: "agent:main:s",
+      }),
+    ).toBeUndefined();
   });
 
   it("treats an entry with undefined projectSessionActive as active (sessions.list contract)", () => {

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -8,6 +8,7 @@ import {
   resolveChatRunExpiresAtMs,
   type ChatAbortOps,
   type ChatAbortControllerEntry,
+  resolveInFlightRunSnapshot,
   updateChatRunProvider,
 } from "./chat-abort.js";
 
@@ -347,5 +348,200 @@ describe("abortChatRunsForProvider", () => {
         stopReason: "auth-revoked",
       }),
     );
+  });
+});
+
+describe("resolveInFlightRunSnapshot", () => {
+  const inFlightEntry = (
+    sessionKey: string,
+    opts?: {
+      agentId?: string;
+      aborted?: boolean;
+      projectSessionActive?: boolean;
+      startedAtMs?: number;
+    },
+  ): ChatAbortControllerEntry => {
+    const now = Date.now();
+    const controller = new AbortController();
+    if (opts?.aborted) {
+      controller.abort();
+    }
+    const startedAtMs = opts?.startedAtMs ?? now;
+    return {
+      controller,
+      sessionId: "sess-1",
+      sessionKey,
+      agentId: opts?.agentId,
+      startedAtMs,
+      expiresAtMs: startedAtMs + 10_000,
+      projectSessionActive: opts?.projectSessionActive ?? true,
+    };
+  };
+
+  // Most cases request with requestedKey === canonicalKey; default canonical to
+  // the requested key unless a case exercises the requested/canonical split.
+  const snap = (p: {
+    chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+    chatRunBuffers: Map<string, string>;
+    sessionKey: string;
+    canonicalSessionKey?: string;
+    agentId?: string;
+    defaultAgentId?: string;
+  }) =>
+    resolveInFlightRunSnapshot({
+      chatAbortControllers: p.chatAbortControllers,
+      chatRunBuffers: p.chatRunBuffers,
+      requestedSessionKey: p.sessionKey,
+      canonicalSessionKey: p.canonicalSessionKey ?? p.sessionKey,
+      agentId: p.agentId,
+      defaultAgentId: p.defaultAgentId,
+    });
+
+  it("returns the live assistant text of a matching active run", () => {
+    const result = snap({
+      chatAbortControllers: new Map([["run-1", inFlightEntry("agent:main:tui-x")]]),
+      chatRunBuffers: new Map([["run-1", "partial answer so far"]]),
+      sessionKey: "agent:main:tui-x",
+    });
+    expect(result).toEqual({ runId: "run-1", text: "partial answer so far" });
+  });
+
+  it("is a no-op when chatAbortControllers is not a Map (unpopulated context)", () => {
+    expect(
+      snap({
+        chatAbortControllers: undefined as never,
+        chatRunBuffers: undefined as never,
+        sessionKey: "agent:main:s",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("matches a run stored under the canonical key when requested with a different key", () => {
+    // Abort entry holds the canonical store key; the client requests history with
+    // a different (requested) key for the same logical session.
+    const result = snap({
+      chatAbortControllers: new Map([["run-1", inFlightEntry("agent:main:main")]]),
+      chatRunBuffers: new Map([["run-1", "partial"]]),
+      sessionKey: "main",
+      canonicalSessionKey: "agent:main:main",
+    });
+    expect(result).toEqual({ runId: "run-1", text: "partial" });
+  });
+
+  it("ignores aborted, completed (not projected active), and other-session runs", () => {
+    const variants: ChatAbortControllerEntry[] = [
+      inFlightEntry("agent:main:s", { aborted: true }),
+      inFlightEntry("agent:main:s", { projectSessionActive: false }),
+      inFlightEntry("agent:main:other"),
+    ];
+    for (const entry of variants) {
+      expect(
+        snap({
+          chatAbortControllers: new Map([["run", entry]]),
+          chatRunBuffers: new Map([["run", "text"]]),
+          sessionKey: "agent:main:s",
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("treats an entry with undefined projectSessionActive as active (sessions.list contract)", () => {
+    const entry = inFlightEntry("agent:main:s");
+    delete (entry as { projectSessionActive?: boolean }).projectSessionActive;
+    expect(
+      snap({
+        chatAbortControllers: new Map([["run", entry]]),
+        chatRunBuffers: new Map([["run", "live partial"]]),
+        sessionKey: "agent:main:s",
+      }),
+    ).toEqual({ runId: "run", text: "live partial" });
+  });
+
+  it("returns an active run with empty text (Codex streams no incremental text mid-run)", () => {
+    expect(
+      snap({
+        chatAbortControllers: new Map([["run", inFlightEntry("agent:main:s")]]),
+        chatRunBuffers: new Map(),
+        sessionKey: "agent:main:s",
+      }),
+    ).toEqual({ runId: "run", text: "" });
+  });
+
+  it("scopes the shared global session by agent so one agent's run is not restored into another", () => {
+    const controllers = new Map<string, ChatAbortControllerEntry>([
+      ["run-a", inFlightEntry("global", { agentId: "main" })],
+      ["run-b", inFlightEntry("global", { agentId: "work" })],
+    ]);
+    const buffers = new Map([
+      ["run-a", "main agent global text"],
+      ["run-b", "work agent global text"],
+    ]);
+    expect(
+      snap({
+        chatAbortControllers: controllers,
+        chatRunBuffers: buffers,
+        sessionKey: "global",
+        agentId: "work",
+      }),
+    ).toEqual({ runId: "run-b", text: "work agent global text" });
+    expect(
+      snap({
+        chatAbortControllers: controllers,
+        chatRunBuffers: buffers,
+        sessionKey: "global",
+        agentId: "main",
+      }),
+    ).toEqual({ runId: "run-a", text: "main agent global text" });
+  });
+
+  it("prefers the newest startedAtMs when several runs match the same session+agent", () => {
+    // A fast restart/retry/stale-controller race can leave two active entries for
+    // the same key; selection must not depend on Map insertion order. Insert the
+    // older run first so a first-match selector would return the wrong one.
+    const controllers = new Map<string, ChatAbortControllerEntry>([
+      ["run-old", inFlightEntry("agent:main:s", { startedAtMs: 1_000 })],
+      ["run-new", inFlightEntry("agent:main:s", { startedAtMs: 2_000 })],
+    ]);
+    const buffers = new Map([
+      ["run-old", "stale partial"],
+      ["run-new", "current partial"],
+    ]);
+    expect(
+      snap({
+        chatAbortControllers: controllers,
+        chatRunBuffers: buffers,
+        sessionKey: "agent:main:s",
+      }),
+    ).toEqual({ runId: "run-new", text: "current partial" });
+  });
+
+  it("breaks startedAtMs ties deterministically by runId regardless of insertion order", () => {
+    const buffers = new Map([
+      ["run-a", "a"],
+      ["run-b", "b"],
+    ]);
+    const ascending = new Map<string, ChatAbortControllerEntry>([
+      ["run-a", inFlightEntry("agent:main:s", { startedAtMs: 5_000 })],
+      ["run-b", inFlightEntry("agent:main:s", { startedAtMs: 5_000 })],
+    ]);
+    const descending = new Map<string, ChatAbortControllerEntry>([
+      ["run-b", inFlightEntry("agent:main:s", { startedAtMs: 5_000 })],
+      ["run-a", inFlightEntry("agent:main:s", { startedAtMs: 5_000 })],
+    ]);
+    // Same winner ("run-b" > "run-a") no matter which order the map was built in.
+    expect(
+      snap({
+        chatAbortControllers: ascending,
+        chatRunBuffers: buffers,
+        sessionKey: "agent:main:s",
+      }),
+    ).toEqual({ runId: "run-b", text: "b" });
+    expect(
+      snap({
+        chatAbortControllers: descending,
+        chatRunBuffers: buffers,
+        sessionKey: "agent:main:s",
+      }),
+    ).toEqual({ runId: "run-b", text: "b" });
   });
 });

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   abortChatRunById,
   abortChatRunsForProvider,
+  boundInFlightRunSnapshotForChatHistory,
   isChatStopCommandText,
   registerChatAbortController,
   resolveAgentRunExpiresAtMs,
@@ -543,5 +544,25 @@ describe("resolveInFlightRunSnapshot", () => {
         sessionKey: "agent:main:s",
       }),
     ).toEqual({ runId: "run-b", text: "b" });
+  });
+
+  it("keeps in-flight text when it fits the chat history budget", () => {
+    expect(
+      boundInFlightRunSnapshotForChatHistory({
+        snapshot: { runId: "run-1", text: "partial" },
+        messages: [],
+        maxBytes: 1_000,
+      }),
+    ).toEqual({ runId: "run-1", text: "partial" });
+  });
+
+  it("drops oversized in-flight text but keeps the run id for adoption", () => {
+    expect(
+      boundInFlightRunSnapshotForChatHistory({
+        snapshot: { runId: "run-1", text: "x".repeat(1_000) },
+        messages: [],
+        maxBytes: 100,
+      }),
+    ).toEqual({ runId: "run-1", text: "" });
   });
 });

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -468,6 +468,16 @@ describe("resolveInFlightRunSnapshot", () => {
     ).toEqual({ runId: "run", text: "" });
   });
 
+  it("does not surface suppressed control-token lead fragments from the live buffer", () => {
+    expect(
+      snap({
+        chatAbortControllers: new Map([["run", inFlightEntry("agent:main:s")]]),
+        chatRunBuffers: new Map([["run", "NO_"]]),
+        sessionKey: "agent:main:s",
+      }),
+    ).toEqual({ runId: "run", text: "" });
+  });
+
   it("scopes the shared global session by agent so one agent's run is not restored into another", () => {
     const controllers = new Map<string, ChatAbortControllerEntry>([
       ["run-a", inFlightEntry("global", { agentId: "main" })],

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -162,6 +162,81 @@ function normalizeActiveAgentId(agentId: string | undefined): string | undefined
   return trimmed || undefined;
 }
 
+/**
+ * Snapshot the live assistant text of any in-flight run for a session+agent. Used
+ * by chat.history so a run that kept streaming while the client was switched away
+ * — whose deltas the gateway delivered to a delivery key this client is no longer
+ * subscribed to — is restored on switch-back.
+ *
+ * Matches a run the same way sessions.list's active-run projection does: an abort
+ * entry can hold the requested key while chat run state holds the canonical store
+ * key, so accept a match on EITHER `requestedSessionKey` or `canonicalSessionKey`,
+ * scoping the shared "global" session by agent. Only runs still projected active
+ * (`projectSessionActive !== false`, matching sessions.list; the terminal lifecycle
+ * flips it to false) and not aborted are returned, so a finalized run — already in
+ * persisted history — is not duplicated and a stale run cannot leave the client
+ * stuck in `streaming`.
+ */
+export function resolveInFlightRunSnapshot(params: {
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  chatRunBuffers: Map<string, string>;
+  requestedSessionKey: string;
+  canonicalSessionKey: string;
+  agentId?: string;
+  defaultAgentId?: string;
+}): { runId: string; text: string } | undefined {
+  const matchesKey = (entry: ChatAbortControllerEntry, key: string): boolean => {
+    if (entry.sessionKey !== key) {
+      return false;
+    }
+    if (key !== "global" || params.agentId === undefined) {
+      return true;
+    }
+    const runAgentId =
+      normalizeActiveAgentId(entry.agentId) ?? normalizeActiveAgentId(params.defaultAgentId);
+    return runAgentId === normalizeActiveAgentId(params.agentId);
+  };
+  // Some callers/tests run without populated run state; guard like
+  // collectTrackedActiveSessionRuns so a missing map is a no-op, not a throw.
+  if (!(params.chatAbortControllers instanceof Map)) {
+    return undefined;
+  }
+  // Pick the newest matching run rather than the first iterated. If a fast
+  // restart/retry/stale-controller race leaves two active entries for the same
+  // (sessionKey, agentId), Map insertion order is not a meaningful selector;
+  // the latest `startedAtMs` is the run a switching-back client wants, and the
+  // runId tie-break keeps the choice deterministic when timestamps collide.
+  let best: { runId: string; startedAtMs: number } | undefined;
+  for (const [runId, entry] of params.chatAbortControllers) {
+    // Active unless explicitly projected inactive — mirrors sessions.list's
+    // collectTrackedActiveSessionRuns (`projectSessionActive !== false`), so a run
+    // that indicator shows active is never silently dropped here.
+    if (entry.projectSessionActive === false || entry.controller.signal.aborted) {
+      continue;
+    }
+    if (
+      !matchesKey(entry, params.requestedSessionKey) &&
+      !matchesKey(entry, params.canonicalSessionKey)
+    ) {
+      continue;
+    }
+    const newer = best === undefined || entry.startedAtMs > best.startedAtMs;
+    const tie = best !== undefined && entry.startedAtMs === best.startedAtMs && runId > best.runId;
+    if (newer || tie) {
+      best = { runId, startedAtMs: entry.startedAtMs };
+    }
+  }
+  if (best === undefined) {
+    return undefined;
+  }
+  // Adopt the run even when no assistant text is buffered yet. Some runtimes
+  // (e.g. Codex) do not stream incremental assistant text — the result exists
+  // only at completion — so there is nothing to show mid-run, but the client
+  // should still adopt the run and show a `streaming` status (not idle) and
+  // render the result cleanly when it lands.
+  return { runId: best.runId, text: params.chatRunBuffers?.get(best.runId) ?? "" };
+}
+
 export type ChatAbortOps = {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatRunBuffers: Map<string, string>;

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -7,6 +7,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 
 const DEFAULT_CHAT_RUN_ABORT_GRACE_MS = 60_000;
 
@@ -235,6 +236,25 @@ export function resolveInFlightRunSnapshot(params: {
   // should still adopt the run and show a `streaming` status (not idle) and
   // render the result cleanly when it lands.
   return { runId: best.runId, text: params.chatRunBuffers?.get(best.runId) ?? "" };
+}
+
+export function boundInFlightRunSnapshotForChatHistory(params: {
+  snapshot: { runId: string; text: string } | undefined;
+  messages: unknown[];
+  maxBytes: number;
+}): { runId: string; text: string } | undefined {
+  if (!params.snapshot?.text) {
+    return params.snapshot;
+  }
+  const messagesBytes = jsonUtf8Bytes(params.messages);
+  const snapshotBytes = jsonUtf8Bytes(params.snapshot);
+  if (messagesBytes + snapshotBytes <= params.maxBytes) {
+    return params.snapshot;
+  }
+  // The run id is the recovery contract; buffered partial text is opportunistic.
+  // If it would break the history payload budget, keep adoption and wait for the
+  // next live delta/final instead of sending an oversized chat.history response.
+  return { runId: params.snapshot.runId, text: "" };
 }
 
 export type ChatAbortOps = {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -191,12 +191,17 @@ export function resolveInFlightRunSnapshot(params: {
     if (entry.sessionKey !== key) {
       return false;
     }
-    if (key !== "global" || params.agentId === undefined) {
+    if (key !== "global") {
       return true;
+    }
+    const requestedAgentId =
+      normalizeActiveAgentId(params.agentId) ?? normalizeActiveAgentId(params.defaultAgentId);
+    if (!requestedAgentId) {
+      return false;
     }
     const runAgentId =
       normalizeActiveAgentId(entry.agentId) ?? normalizeActiveAgentId(params.defaultAgentId);
-    return runAgentId === normalizeActiveAgentId(params.agentId);
+    return runAgentId === requestedAgentId;
   };
   // Some callers/tests run without populated run state; guard like
   // collectTrackedActiveSessionRuns so a missing map is a no-op, not a throw.

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -8,6 +8,7 @@ import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
 
 const DEFAULT_CHAT_RUN_ABORT_GRACE_MS = 60_000;
 
@@ -235,7 +236,11 @@ export function resolveInFlightRunSnapshot(params: {
   // only at completion — so there is nothing to show mid-run, but the client
   // should still adopt the run and show a `streaming` status (not idle) and
   // render the result cleanly when it lands.
-  return { runId: best.runId, text: params.chatRunBuffers?.get(best.runId) ?? "" };
+  const bufferedText = params.chatRunBuffers?.get(best.runId) ?? "";
+  const projected = projectLiveAssistantBufferedText(bufferedText, {
+    suppressLeadFragments: true,
+  });
+  return { runId: best.runId, text: projected.suppress ? "" : projected.text };
 }
 
 export function boundInFlightRunSnapshotForChatHistory(params: {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -175,9 +175,10 @@ function normalizeActiveAgentId(agentId: string | undefined): string | undefined
  * key, so accept a match on EITHER `requestedSessionKey` or `canonicalSessionKey`,
  * scoping the shared "global" session by agent. Only runs still projected active
  * (`projectSessionActive !== false`, matching sessions.list; the terminal lifecycle
- * flips it to false) and not aborted are returned, so a finalized run — already in
- * persisted history — is not duplicated and a stale run cannot leave the client
- * stuck in `streaming`.
+ * flips it to false), not aborted, and visible chat-send runs are returned, so a
+ * finalized run — already in persisted history — is not duplicated and hidden
+ * agent runs cannot be adopted by chat clients that will not receive their final
+ * events.
  */
 export function resolveInFlightRunSnapshot(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
@@ -218,7 +219,11 @@ export function resolveInFlightRunSnapshot(params: {
     // Active unless explicitly projected inactive — mirrors sessions.list's
     // collectTrackedActiveSessionRuns (`projectSessionActive !== false`), so a run
     // that indicator shows active is never silently dropped here.
-    if (entry.projectSessionActive === false || entry.controller.signal.aborted) {
+    if (
+      entry.projectSessionActive === false ||
+      entry.controller.signal.aborted ||
+      entry.kind === "agent"
+    ) {
       continue;
     }
     if (

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -103,6 +103,7 @@ import {
   type ChatAbortOps,
   isChatStopCommandText,
   registerChatAbortController,
+  resolveInFlightRunSnapshot,
   updateChatRunProvider,
 } from "../chat-abort.js";
 import {
@@ -2544,6 +2545,17 @@ export const chatHandlers: GatewayRequestHandlers = {
     const thinkingLevel = sessionInfo.thinkingLevel ?? sessionInfo.thinkingDefault;
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
     sessionInfo.verboseLevel = verboseLevel;
+    // Surface any run still streaming for this session+agent so a client that
+    // switched away (and stopped receiving the run's per-agent-delivered events)
+    // can restore the in-flight assistant text on switch-back.
+    const inFlightRun = resolveInFlightRunSnapshot({
+      chatAbortControllers: context.chatAbortControllers,
+      chatRunBuffers: context.chatRunBuffers,
+      requestedSessionKey: sessionKey,
+      canonicalSessionKey: resolveSessionStoreKey({ cfg, sessionKey }),
+      agentId: requestedAgentId,
+      defaultAgentId: resolveDefaultAgentId(cfg),
+    });
     respond(true, {
       sessionKey,
       sessionId,
@@ -2553,6 +2565,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       thinkingLevel,
       fastMode: entry?.fastMode,
       verboseLevel,
+      ...(inFlightRun ? { inFlightRun } : {}),
     });
   },
   "chat.message.get": async ({ params, respond, context }) => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2533,14 +2533,15 @@ export const chatHandlers: GatewayRequestHandlers = {
       agentId: selectedAgent.agentId,
       modelCatalog,
     });
+    const defaultAgentId = resolveDefaultAgentId(cfg);
+    const activeRunAgentId =
+      canonicalKey === "global" ? (selectedAgent.agentId ?? defaultAgentId) : selectedAgent.agentId;
     sessionInfo.hasActiveRun = hasTrackedActiveSessionRun({
       context,
       requestedKey: sessionKey,
       canonicalKey,
-      ...(canonicalKey === "global" && selectedAgent.agentId
-        ? { agentId: selectedAgent.agentId }
-        : {}),
-      defaultAgentId: resolveDefaultAgentId(cfg),
+      ...(activeRunAgentId ? { agentId: activeRunAgentId } : {}),
+      defaultAgentId,
     });
     const defaults = getSessionDefaults(cfg, modelCatalog, { allowPluginNormalization: false });
     const thinkingLevel = sessionInfo.thinkingLevel ?? sessionInfo.thinkingDefault;
@@ -2554,8 +2555,8 @@ export const chatHandlers: GatewayRequestHandlers = {
       chatRunBuffers: context.chatRunBuffers,
       requestedSessionKey: sessionKey,
       canonicalSessionKey: resolveSessionStoreKey({ cfg, sessionKey }),
-      agentId: requestedAgentId,
-      defaultAgentId: resolveDefaultAgentId(cfg),
+      agentId: activeRunAgentId,
+      defaultAgentId,
     });
     const boundedInFlightRun = boundInFlightRunSnapshotForChatHistory({
       snapshot: inFlightRun,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -99,6 +99,7 @@ import {
 } from "../../utils/message-channel.js";
 import {
   abortChatRunById,
+  boundInFlightRunSnapshotForChatHistory,
   type ChatAbortControllerEntry,
   type ChatAbortOps,
   isChatStopCommandText,
@@ -2556,6 +2557,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       agentId: requestedAgentId,
       defaultAgentId: resolveDefaultAgentId(cfg),
     });
+    const boundedInFlightRun = boundInFlightRunSnapshotForChatHistory({
+      snapshot: inFlightRun,
+      messages: bounded.messages,
+      maxBytes: maxHistoryBytes,
+    });
     respond(true, {
       sessionKey,
       sessionId,
@@ -2565,7 +2571,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       thinkingLevel,
       fastMode: entry?.fastMode,
       verboseLevel,
-      ...(inFlightRun ? { inFlightRun } : {}),
+      ...(boundedInFlightRun ? { inFlightRun: boundedInFlightRun } : {}),
     });
   },
   "chat.message.get": async ({ params, respond, context }) => {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -489,6 +489,99 @@ describe("tui session actions", () => {
     expect(listSessions).not.toHaveBeenCalled();
   });
 
+  it("restores an in-flight run reported by chat.history on switch-back", async () => {
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-bg",
+      messages: [],
+      inFlightRun: { runId: "run-bg", text: "still working in the background" },
+    });
+    const updateAssistant = vi.fn();
+    const setActivityStatus = vi.fn();
+    const chatLog = {
+      addSystem: vi.fn(),
+      clearAll: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      updateAssistant,
+      startTool: vi.fn(),
+    } as unknown as import("./components/chat-log.js").ChatLog;
+    const state = createBaseState({ currentSessionKey: "agent:main:other" });
+
+    const { setSession } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog,
+      state,
+      setActivityStatus,
+    });
+
+    await setSession("agent:main:main");
+
+    expect(updateAssistant).toHaveBeenCalledWith("still working in the background", "run-bg");
+    expect(state.activeChatRunId).toBe("run-bg");
+    expect(setActivityStatus).toHaveBeenLastCalledWith("streaming");
+  });
+
+  it("adopts an in-flight run with no buffered text (Codex) and shows streaming", async () => {
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-bg",
+      messages: [],
+      inFlightRun: { runId: "run-bg", text: "" },
+    });
+    const updateAssistant = vi.fn();
+    const setActivityStatus = vi.fn();
+    const chatLog = {
+      addSystem: vi.fn(),
+      clearAll: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      updateAssistant,
+      startTool: vi.fn(),
+    } as unknown as import("./components/chat-log.js").ChatLog;
+    const state = createBaseState({ currentSessionKey: "agent:main:other" });
+
+    const { setSession } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog,
+      state,
+      setActivityStatus,
+    });
+
+    await setSession("agent:main:main");
+
+    // No partial bubble (none exists), but the run is adopted and shows streaming.
+    expect(updateAssistant).not.toHaveBeenCalled();
+    expect(state.activeChatRunId).toBe("run-bg");
+    expect(setActivityStatus).toHaveBeenLastCalledWith("streaming");
+  });
+
+  it("stays idle when chat.history reports no in-flight run", async () => {
+    const loadHistory = vi.fn().mockResolvedValue({ sessionId: "session-x", messages: [] });
+    const updateAssistant = vi.fn();
+    const setActivityStatus = vi.fn();
+    const chatLog = {
+      addSystem: vi.fn(),
+      clearAll: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      updateAssistant,
+      startTool: vi.fn(),
+    } as unknown as import("./components/chat-log.js").ChatLog;
+    const state = createBaseState({ currentSessionKey: "agent:main:other" });
+
+    const { setSession } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog,
+      state,
+      setActivityStatus,
+    });
+
+    await setSession("agent:main:main");
+
+    expect(updateAssistant).not.toHaveBeenCalled();
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
+  });
+
   it("applies default model info when the current session has no persisted entry yet", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -421,6 +421,7 @@ export function createSessionActions(context: SessionActionContext) {
         fastMode?: boolean;
         verboseLevel?: string;
         traceLevel?: string;
+        inFlightRun?: { runId?: unknown; text?: unknown };
       };
       const sessionInfo = record.sessionInfo;
       if (sessionInfo?.key && sessionInfo.key !== state.currentSessionKey) {
@@ -504,6 +505,24 @@ export function createSessionActions(context: SessionActionContext) {
             { isError: Boolean(message.isError) },
           );
         }
+      }
+      // Restore a run still streaming for this session+agent that the gateway
+      // reports as in-flight. Its live deltas were delivered to a per-agent key
+      // we stopped watching after switching away, so the persisted history above
+      // does not contain it; render the partial and re-adopt the run so further
+      // deltas (now that this session is active again) continue it.
+      const inFlight = record.inFlightRun;
+      const inFlightRunId = asString(inFlight?.runId, "");
+      const inFlightText = asString(inFlight?.text, "");
+      if (inFlightRunId) {
+        // Render any buffered partial (embedded runtimes); Codex has none mid-run.
+        if (inFlightText) {
+          chatLog.updateAssistant(inFlightText, inFlightRunId);
+        }
+        // Adopt the run regardless so its status shows `streaming` (not idle) and
+        // its completion is handled here instead of an unowned error path.
+        state.activeChatRunId = inFlightRunId;
+        setActivityStatus("streaming");
       }
       state.historyLoaded = true;
       void rememberSessionKey?.(state.currentSessionKey);


### PR DESCRIPTION
## Summary
- Restores a **backgrounded in-flight run** on terminal-TUI session/agent switch-back. Switching agents while a run was streaming left the TUI blank/idle on return — the result never surfaced.
- **Root cause (delivery scoping, not rendering):** global-session runs are delivered per agent (`src/gateway/server-chat.ts` `resolveSessionDeliveryKey` → `agent:<id>:global`), so once the client switches to another agent it stops receiving the backgrounded run's events entirely. `chat.history` rebuilds only from **persisted** messages, and an in-flight run's text isn't persisted yet — so switch-back shows neither the live run nor a result.
- **Fix (gateway-sourced snapshot; additive, no protocol break):** `chat.history` returns an additive `inFlightRun` ({ runId, text }) for any active run on the requested session+agent, read from the authoritative gateway state (`chatAbortControllers` + `chatRunBuffers`). The TUI adopts it on switch-back: renders any buffered partial, shows `streaming`, and re-adopts `activeChatRunId` so the run's completion is owned by the client. Works across runtimes (Codex/embedded) and for `/agent` + `/session` switches, because the run state comes from the gateway on return rather than client event capture.
- The run match mirrors `sessions.list`'s active-run projection (`isTrackedActiveSessionRunForKey`): match on the **requested OR canonical** session key, scope the shared `global` session by agent, and include only `projectSessionActive !== false`, non-aborted runs (so a finalized run already in history is not duplicated and a stale run can't get stuck in `streaming`).
- Supersedes an earlier **client-side live-run-store** attempt that real-gateway testing proved inert — the backgrounded run's events are never delivered to the switched-away client, so there was nothing for a client store to retain.
- **Codex adversarial review:** 3 rounds, ended clean (matching, lifecycle/race, TUI adoption, empty-text adoption, and compatibility with other `chat.history` callers all checked; final verdict: no remaining substantiated bug).

## Verification
```
node scripts/run-vitest.mjs run src/gateway/chat-abort.test.ts src/tui/tui-session-actions.test.ts
  -> passing (incl. requested-or-canonical key match, global agent scoping, undefined
     projectSessionActive == active, empty-text Codex adoption, TUI render + adopt)
node scripts/run-vitest.mjs run src/gateway/server-methods/server-methods.test.ts \
  src/gateway/server.chat.gateway-server-chat.test.ts
  -> chat.history coverage passing
node scripts/run-tsgo.mjs -p tsconfig.core.json   -> no errors in touched files
oxfmt --check  and  oxlint                          -> clean on touched files
```

## Real behavior proof
Behavior addressed: switching agents (`/agent`) while a task was running left the terminal TUI blank/idle on switch-back — the backgrounded run's result never appeared. Originally observed on `gpt-5.4-mini` (Codex runtime).
Real environment tested: a real Dockerized OpenClaw gateway (the `openclaw:williamliu` image rebuilt from this branch) with the `openai-codex` provider (`gpt-5.x`), driving the terminal TUI against the live gateway over its real transport.
Exact steps or command run after this patch:
```
OPENCLAW_IMAGE=openclaw:williamliu docker compose build && docker compose up -d
# in the TUI: start a task on an agent; /agent switch away while it runs; /agent switch back
```
Evidence after fix: proof-of-fix screen recording captured on the live Dockerized gateway running a patched build — https://github.com/user-attachments/assets/8922a5d7-3967-4abb-a81c-4fab5f753100 . The recording shows the patched TUI (it carries diagnostic markers not present in this PR), the agent's session remaining in the `streaming` state after switching to a different agent and a different session and back, and the content rendering correctly at the end of the run. (Observed directly in the live TUI terminal/console output.)
Observed result after fix: the previously-lost backgrounded run is restored on switch-back (status `streaming`, result rendered on completion). Before the fix, the returned session was blank/idle and the result never surfaced. A gateway trace during diagnosis confirmed the run was active for the session but its in-flight text was empty mid-run (Codex emits the answer only at completion), which the fix now adopts as `streaming` rather than dropping.
What was not tested: a captured screenshot/recording is not attached inline (verified interactively on the live gateway); the WebChat surface was not separately exercised; the embedded (non-Codex) runtime relies on the same `inFlightRun` path, covered by unit tests rather than a separate live capture.
