### PR TITLE
fix #71992: [Bug]: Control UI webchat duplicates every assistant reply on 2026.4.21 — regression from #5964/#39469

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -82,6 +82,28 @@ function createActiveStreamingState() {
   });
 }
 
+function trackChatMessagesAssignments(state: ChatState) {
+  let chatMessages = state.chatMessages;
+  const assignments: Array<{
+    chatRunId: string | null;
+    chatStream: string | null;
+    messages: unknown[];
+  }> = [];
+  Object.defineProperty(state, "chatMessages", {
+    configurable: true,
+    get: () => chatMessages,
+    set: (messages: unknown[]) => {
+      assignments.push({
+        chatRunId: state.chatRunId,
+        chatStream: state.chatStream,
+        messages,
+      });
+      chatMessages = messages;
+    },
+  });
+  return assignments;
+}
+
 function createOtherRunSilentFinalPayload(text: string): ChatEventPayload {
   return {
     runId: "run-announce",
@@ -733,7 +755,10 @@ describe("handleChatEvent", () => {
       sessionKey: "main",
       state: "final",
     };
+    const assignments = trackChatMessagesAssignments(state);
+
     expect(handleChatEvent(state, payload)).toBe("final");
+    expect(assignments).toMatchObject([{ chatRunId: null, chatStream: null }]);
     expect(state.chatRunId).toBe(null);
     expect(state.chatStream).toBe(null);
     expect(state.chatStreamStartedAt).toBe(null);
@@ -799,7 +824,7 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe(null);
   });
 
-  it("appends final payload message from own run before clearing stream state", () => {
+  it("appends final payload message from own run after clearing stream state", () => {
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-1",
@@ -816,7 +841,10 @@ describe("handleChatEvent", () => {
         timestamp: 101,
       },
     };
+    const assignments = trackChatMessagesAssignments(state);
+
     expect(handleChatEvent(state, payload)).toBe("final");
+    expect(assignments).toMatchObject([{ chatRunId: null, chatStream: null }]);
     expect(state.chatMessages).toEqual([payload.message]);
     expect(state.chatRunId).toBe(null);
     expect(state.chatStream).toBe(null);
@@ -847,8 +875,10 @@ describe("handleChatEvent", () => {
       state: "aborted",
       message: partialMessage,
     };
+    const assignments = trackChatMessagesAssignments(state);
 
     expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(assignments).toMatchObject([{ chatRunId: null, chatStream: null }]);
     expect(state.chatRunId).toBe(null);
     expect(state.chatStream).toBe(null);
     expect(state.chatStreamStartedAt).toBe(null);

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1138,45 +1138,50 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
-    if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
-      state.chatMessages = [...state.chatMessages, finalMessage];
-    } else if (
-      state.chatStream?.trim() &&
-      !isSilentReplyStream(state.chatStream) &&
-      !isHeartbeatAckStream(state.chatStream)
-    ) {
-      state.chatMessages = [
-        ...state.chatMessages,
-        {
-          role: "assistant",
-          content: [{ type: "text", text: state.chatStream }],
-          timestamp: Date.now(),
-        },
-      ];
-    }
-    reconcileTerminalRun("done", "done");
-  } else if (payload.state === "aborted") {
-    const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
-    if (normalizedMessage && !shouldHideAssistantChatMessage(normalizedMessage)) {
-      state.chatMessages = [...state.chatMessages, normalizedMessage];
-    } else {
-      const streamedText = state.chatStream ?? "";
-      if (
-        streamedText.trim() &&
-        !isSilentReplyStream(streamedText) &&
-        !isHeartbeatAckStream(streamedText)
-      ) {
-        state.chatMessages = [
-          ...state.chatMessages,
-          {
+    const visibleFinalMessage =
+      finalMessage && !shouldHideAssistantChatMessage(finalMessage) ? finalMessage : null;
+    const streamedText = state.chatStream ?? "";
+    const fallbackMessage =
+      !visibleFinalMessage &&
+      streamedText.trim() &&
+      !isSilentReplyStream(streamedText) &&
+      !isHeartbeatAckStream(streamedText)
+        ? {
             role: "assistant",
             content: [{ type: "text", text: streamedText }],
             timestamp: Date.now(),
-          },
-        ];
-      }
+          }
+        : null;
+    reconcileTerminalRun("done", "done");
+    if (visibleFinalMessage) {
+      state.chatMessages = [...state.chatMessages, visibleFinalMessage];
+    } else if (fallbackMessage) {
+      state.chatMessages = [...state.chatMessages, fallbackMessage];
     }
+  } else if (payload.state === "aborted") {
+    const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
+    const visibleAbortedMessage =
+      normalizedMessage && !shouldHideAssistantChatMessage(normalizedMessage)
+        ? normalizedMessage
+        : null;
+    const streamedText = state.chatStream ?? "";
+    const fallbackMessage =
+      !visibleAbortedMessage &&
+      streamedText.trim() &&
+      !isSilentReplyStream(streamedText) &&
+      !isHeartbeatAckStream(streamedText)
+        ? {
+            role: "assistant",
+            content: [{ type: "text", text: streamedText }],
+            timestamp: Date.now(),
+          }
+        : null;
     reconcileTerminalRun("interrupted", "killed");
+    if (visibleAbortedMessage) {
+      state.chatMessages = [...state.chatMessages, visibleAbortedMessage];
+    } else if (fallbackMessage) {
+      state.chatMessages = [...state.chatMessages, fallbackMessage];
+    }
   } else if (payload.state === "error") {
     const errorMessage = hadActiveRunBeforeEvent ? buildErrorAssistantMessage(payload) : null;
     if (errorMessage) {


### PR DESCRIPTION
## Summary

- Fixes #71992 by clearing active Control UI WebChat stream/run state before committing terminal assistant messages.
- Preserves final and aborted fallback text behavior by snapshotting the live stream before lifecycle reconciliation.
- Adds regression assertions that final and aborted terminal commits happen only after `chatStream` and `chatRunId` are cleared.

## Root Cause

- **Root cause:** Terminal `final` / `aborted` events could append an assistant message into `chatMessages` while the same assistant content still existed in the live `chatStream` / `chatRunId` state. Because the Control UI renders committed history and the live stream item separately, Lit batching could briefly render the completed assistant reply twice.
- **Why this is root-cause fix:** The terminal path now snapshots any fallback stream text, reconciles the run lifecycle first, and only then commits the assistant message. That removes the overlapping committed-message + live-stream render state instead of hiding duplicate DOM output after the fact.
- **Fix classification:** Minimal root-cause UI state-ordering fix for the Control UI WebChat renderer.
- **Patch quality notes:** The diff is limited to WebChat terminal event handling and focused regression coverage; no protocol, schema, provider, or persisted transcript format changes are included.

## Real behavior proof

- **Behavior or issue addressed:** Control UI WebChat should render a completed assistant reply exactly once after a send completes, with no leftover streaming bubble for the same assistant turn.
- **Real environment tested:** Local OpenClaw gateway serving the real Control UI from this PR head (`095b9b496f1e320b9ff61617c2b2b4eb0f92e186`) on loopback, driven by Playwright in Chromium. The gateway used the repo's deterministic `qa mock-openai` provider so the proof exercises a real browser WebChat send without depending on external model billing/auth.
- **Exact steps or command run after this patch:**
  - Started `pnpm openclaw qa mock-openai --host 127.0.0.1 --port 44180`.
  - Started `node scripts/run-node.mjs gateway run` with `OPENCLAW_CONFIG_PATH=/tmp/openclaw-dev-pr88786-mock-proof/.openclaw-dev/openclaw.json` and gateway port `19190`.
  - Ran `node /media/vdc/code/ai/aispace/openclaw-pr-88786-evidence/control-ui-send-proof-after-sync.mjs` with `OPENCLAW_PROOF_SESSION=dailyfix-88786-mock-proof` and `OPENCLAW_EXPECTED_REPLY=daily-fix-88786-proof`.
- **Evidence after fix:** Copied proof result from `/media/vdc/code/ai/aispace/openclaw-pr-88786-evidence/control-ui-send-proof-after-sync.json` plus screenshot artifact `/media/vdc/code/ai/aispace/openclaw-pr-88786-evidence/control-ui-after-one-reply-after-sync.png` (`sha256:05db04780c0b9b707d78920c714fae19b34d9586ddc448d0a40cbeb755eadc14`).

  ```json
  {
    "url": "http://127.0.0.1:19190/chat?session=dailyfix-88786-mock-proof#token=<redacted>",
    "prompt": "reply exactly `daily-fix-88786-proof`",
    "expectedReply": "daily-fix-88786-proof",
    "before": {
      "messageCount": 0,
      "userCount": 0,
      "assistantCount": 0,
      "chatRunId": null,
      "chatStream": null,
      "liveStreamingBubbleCount": 0
    },
    "after": {
      "messageCount": 2,
      "userCount": 1,
      "assistantCount": 1,
      "messageSummaries": [
        { "role": "user", "text": "reply exactly `daily-fix-88786-proof`" },
        { "role": "assistant", "text": "daily-fix-88786-proof" }
      ],
      "assistantGroups": [
        { "text": "daily-fix-88786-proof Assistant 2026年6月3日 0:45", "bubbleCount": 1, "streamingBubbleCount": 0 }
      ],
      "chatRunId": null,
      "chatStream": null,
      "liveStreamingBubbleCount": 0
    },
    "result": {
      "newUserMessages": 1,
      "newAssistantMessages": 1,
      "newAssistantTexts": ["daily-fix-88786-proof"],
      "chatRunIdCleared": true,
      "chatStreamCleared": true,
      "liveStreamingBubbleCount": 0,
      "completedAssistantReply": true,
      "exactlyOneCompletedAssistantReply": true
    }
  }
  ```
- **Observed result after fix:** One WebChat send added exactly one user message and exactly one completed assistant message. The completed assistant text was `daily-fix-88786-proof`; `chatRunId` and `chatStream` were both `null`; `.chat-bubble.streaming` count was `0`; the rendered assistant group had one bubble.
- **What was not tested:** This proof does not claim to fix the separate persisted-transcript structural duplicate shape described in #39469. It also does not depend on a third-party live model response; model-provider billing/auth behavior is outside this UI rendering fix.

## Review findings addressed

- RF-001 / RF-002 / RF-003: Added an after-fix real Control UI WebChat send proof with copied JSON, runtime log, and screenshot artifact showing one completed assistant reply and no live streaming duplicate.
- RF-004: Explicitly out of scope: persisted transcript structural duplicates from #39469 are a separate backend/history shape and are not treated as fixed by this PR.
- RF-005: No further code change was needed after review; the missing item was contributor-supplied WebChat behavior proof, now recorded against current head.

## Regression Test Plan

- **Target test file:** `ui/src/ui/controllers/chat.test.ts`.
- Ran `node scripts/run-vitest.mjs ui/src/ui/controllers/chat.test.ts`.
- Ran `pnpm tsgo:test:ui`.
- Ran `git diff --check`.
- Ran the Control UI WebChat Playwright proof described above against the current PR head.

## Merge risk

- **Why it matters / User impact:** Users sending messages in Control UI WebChat should not see every assistant response duplicated after the terminal event lands.
- **Risk labels considered:** `app: web-ui`, `size: S`, `impact:session-state`, `impact:message-loss`.
- **Risk explanation:** The change touches only terminal event ordering in Control UI chat state. The main risk is losing fallback text when a terminal payload does not include a visible assistant message; the implementation snapshots fallback text before clearing stream state to preserve that behavior.
- **Why acceptable:** Unit coverage asserts final and aborted terminal commits happen after stream/run clearing, and the browser proof shows a real WebChat send completing with one rendered assistant reply and no streaming duplicate.
- **Maintainer-ready confidence:** High for the client-side duplicate visible reply in #71992; separate persisted transcript duplicates remain out of scope as documented above.
