### PR TITLE
docs: document cli command path helpers

### DIFF
--- a/src/auto-reply/command-status-builders.ts
+++ b/src/auto-reply/command-status-builders.ts
@@ -51,6 +51,7 @@ function groupCommandsByCategory(
   return grouped;
 }
 
+/** Builds the compact slash-command help text shown by `/help`. */
 export function buildHelpMessage(cfg?: OpenClawConfig): string {
   const lines = ["ℹ️ Help", ""];
 
@@ -90,12 +91,14 @@ export function buildHelpMessage(cfg?: OpenClawConfig): string {
 
 const COMMANDS_PER_PAGE = 8;
 
+/** Options for rendering `/commands` output for a specific channel surface. */
 export type CommandsMessageOptions = {
   page?: number;
   surface?: string;
   forcePaginatedList?: boolean;
 };
 
+/** Rendered `/commands` text plus pagination metadata for channel-native lists. */
 export type CommandsMessageResult = {
   text: string;
   totalPages: number;
@@ -181,6 +184,7 @@ function formatCommandList(items: CommandsListItem[]): string {
   return lines.join("\n");
 }
 
+/** Builds `/commands` text, returning only the rendered message body. */
 export function buildCommandsMessage(
   cfg?: OpenClawConfig,
   skillCommands?: SkillCommandSpec[],
@@ -190,6 +194,7 @@ export function buildCommandsMessage(
   return result.text;
 }
 
+/** Builds `/commands` text and pagination metadata for surfaces with native list controls. */
 export function buildCommandsMessagePaginated(
   cfg?: OpenClawConfig,
   skillCommands?: SkillCommandSpec[],
@@ -197,6 +202,7 @@ export function buildCommandsMessagePaginated(
 ): CommandsMessageResult {
   const page = Math.max(1, options?.page ?? 1);
   const surface = normalizeOptionalLowercaseString(options?.surface);
+  // Surfaces with native command-list UI need page metadata; plain text surfaces get one full list.
   const prefersPaginatedList =
     options?.forcePaginatedList === true ||
     Boolean(surface && getChannelPlugin(surface)?.commands?.buildCommandsListChannelData);

--- a/src/channels/message/adapter.ts
+++ b/src/channels/message/adapter.ts
@@ -16,6 +16,7 @@ type ChannelMessageAdapterWithDefaultReceive<TAdapter extends ChannelMessageAdap
       : NonNullable<TAdapter["receive"]>;
   };
 
+/** Defines a message adapter while defaulting receive acknowledgement to manual. */
 export function defineChannelMessageAdapter<const TAdapter extends ChannelMessageAdapterShape>(
   adapter: TAdapter,
 ): ChannelMessageAdapter<ChannelMessageAdapterWithDefaultReceive<TAdapter>> {

--- a/src/channels/message/capabilities.ts
+++ b/src/channels/message/capabilities.ts
@@ -26,6 +26,7 @@ function setRequired(
   }
 }
 
+/** Derives the adapter capabilities core needs before it can require durable final delivery. */
 export function deriveDurableFinalDeliveryRequirements(
   params: DeriveDurableFinalDeliveryRequirementsParams,
 ): DurableFinalDeliveryRequirementMap {

--- a/src/channels/message/durable-receive.ts
+++ b/src/channels/message/durable-receive.ts
@@ -1,6 +1,7 @@
 import type { PluginStateKeyedStore } from "../../plugin-state/plugin-state-store.types.js";
 import type { ChannelIngressQueue, ChannelIngressQueuePruneOptions } from "./ingress-queue.js";
 
+/** Pending inbound receive record kept until agent dispatch or durable send completes. */
 export type DurableInboundReceivePendingRecord<TPayload, TMetadata = unknown> = {
   id: string;
   payload: TPayload;
@@ -12,12 +13,14 @@ export type DurableInboundReceivePendingRecord<TPayload, TMetadata = unknown> = 
   lastError?: string;
 };
 
+/** Completed inbound receive tombstone used to detect duplicate platform events. */
 export type DurableInboundReceiveCompletedRecord<TMetadata = unknown> = {
   id: string;
   completedAt: number;
   metadata?: TMetadata;
 };
 
+/** Accept result for a new or duplicate inbound platform event. */
 export type DurableInboundReceiveAcceptResult<TPayload, TMetadata, TCompletedMetadata> =
   | {
       kind: "accepted";
@@ -35,6 +38,7 @@ export type DurableInboundReceiveAcceptResult<TPayload, TMetadata, TCompletedMet
       record: DurableInboundReceiveCompletedRecord<TCompletedMetadata>;
     };
 
+/** Store-backed durable receive journal options. */
 export type DurableInboundReceiveJournalOptions<TPayload, TMetadata, TCompletedMetadata> = {
   pendingStore: PluginStateKeyedStore<DurableInboundReceivePendingRecord<TPayload, TMetadata>>;
   completedStore: PluginStateKeyedStore<DurableInboundReceiveCompletedRecord<TCompletedMetadata>>;
@@ -43,21 +47,25 @@ export type DurableInboundReceiveJournalOptions<TPayload, TMetadata, TCompletedM
   completedTtlMs?: number;
 };
 
+/** Options recorded when accepting a pending inbound event. */
 export type DurableInboundReceiveAcceptOptions<TMetadata> = {
   metadata?: TMetadata;
   receivedAt?: number;
 };
 
+/** Options recorded when marking an inbound event complete. */
 export type DurableInboundReceiveCompleteOptions<TCompletedMetadata> = {
   metadata?: TCompletedMetadata;
   completedAt?: number;
 };
 
+/** Options recorded when releasing an inbound event for retry. */
 export type DurableInboundReceiveReleaseOptions = {
   lastError?: string;
   releasedAt?: number;
 };
 
+/** Durable receive journal facade used by channel receive pipelines. */
 export type DurableInboundReceiveJournal<TPayload, TMetadata, TCompletedMetadata> = {
   accept(
     id: string,
@@ -73,6 +81,7 @@ export type DurableInboundReceiveJournal<TPayload, TMetadata, TCompletedMetadata
   deletePending(id: string): Promise<boolean>;
 };
 
+/** Queue-backed durable receive journal options with optional retention pruning. */
 export type DurableInboundReceiveQueueJournalOptions<TPayload, TMetadata, TCompletedMetadata> = {
   queue: ChannelIngressQueue<TPayload, TMetadata, TCompletedMetadata>;
   retention?: ChannelIngressQueuePruneOptions;
@@ -92,6 +101,7 @@ function sortPendingRecords<TPayload, TMetadata>(
   return records.toSorted((a, b) => a.receivedAt - b.receivedAt || a.id.localeCompare(b.id));
 }
 
+/** Creates a store-backed journal for accepting, completing, and retrying inbound events. */
 export function createDurableInboundReceiveJournal<
   TPayload,
   TMetadata = unknown,
@@ -127,6 +137,7 @@ export function createDurableInboundReceiveJournal<
     const acceptInsertedRecord = async (): Promise<
       DurableInboundReceiveAcceptResult<TPayload, TMetadata, TCompletedMetadata>
     > => {
+      // Completion can win the register race; remove the pending copy before reporting duplicate.
       const completedAfterInsertRace = await options.completedStore.lookup(key);
       if (completedAfterInsertRace) {
         await options.pendingStore.delete(key);
@@ -229,6 +240,7 @@ export function createDurableInboundReceiveJournal<
   };
 }
 
+/** Adapts the shared channel ingress queue to the durable receive journal API. */
 export function createDurableInboundReceiveJournalFromQueue<
   TPayload,
   TMetadata = unknown,

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -15,6 +15,7 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
 
+/** Pending or retryable inbound channel event stored in the durable ingress queue. */
 export type ChannelIngressQueueRecord<TPayload, TMetadata = unknown> = {
   id: string;
   channelId: string;
@@ -30,6 +31,7 @@ export type ChannelIngressQueueRecord<TPayload, TMetadata = unknown> = {
   lastError?: string;
 };
 
+/** Pending ingress event currently claimed by a worker. */
 export type ChannelIngressQueueClaim<TPayload, TMetadata = unknown> = ChannelIngressQueueRecord<
   TPayload,
   TMetadata
@@ -41,6 +43,7 @@ export type ChannelIngressQueueClaim<TPayload, TMetadata = unknown> = ChannelIng
   };
 };
 
+/** Minimal claim reference used to guard completion/release/failure with a claim token. */
 export type ChannelIngressQueueClaimRef = {
   id: string;
   claim: {
@@ -48,6 +51,7 @@ export type ChannelIngressQueueClaimRef = {
   };
 };
 
+/** Completed ingress event tombstone retained for duplicate detection. */
 export type ChannelIngressQueueCompletedRecord<TCompletedMetadata = unknown> = {
   id: string;
   channelId: string;
@@ -57,6 +61,7 @@ export type ChannelIngressQueueCompletedRecord<TCompletedMetadata = unknown> = {
   metadata?: TCompletedMetadata;
 };
 
+/** Failed ingress event tombstone retained for duplicate detection and diagnostics. */
 export type ChannelIngressQueueFailedRecord = {
   id: string;
   channelId: string;
@@ -67,6 +72,7 @@ export type ChannelIngressQueueFailedRecord = {
   message?: string;
 };
 
+/** Retention options for pending, completed, and failed ingress queue rows. */
 export type ChannelIngressQueuePruneOptions = {
   pendingTtlMs?: number;
   completedTtlMs?: number;
@@ -78,6 +84,7 @@ export type ChannelIngressQueuePruneOptions = {
   now?: number;
 };
 
+/** Result of enqueueing a possibly duplicate ingress event id. */
 export type ChannelIngressQueueEnqueueResult<TPayload, TMetadata, TCompletedMetadata> =
   | {
       kind: "accepted";
@@ -105,6 +112,7 @@ export type ChannelIngressQueueEnqueueResult<TPayload, TMetadata, TCompletedMeta
       record: ChannelIngressQueueFailedRecord;
     };
 
+/** Durable FIFO-ish ingress queue with claims, duplicate detection, and retention pruning. */
 export type ChannelIngressQueue<TPayload, TMetadata = unknown, TCompletedMetadata = unknown> = {
   enqueue(
     id: string,
@@ -157,6 +165,7 @@ export type ChannelIngressQueue<TPayload, TMetadata = unknown, TCompletedMetadat
   prune(options?: ChannelIngressQueuePruneOptions): Promise<number>;
 };
 
+/** Construction options for a channel/account-scoped ingress queue. */
 export type CreateChannelIngressQueueOptions = {
   channelId: string;
   accountId?: string;
@@ -303,9 +312,11 @@ function normalizedProtectedIds(ids: Iterable<string> | undefined): string[] {
 }
 
 function queueNameForParts(channelId: string, accountId: string): string {
+  // JSON tuple encoding keeps channel/account scopes unambiguous even when ids contain separators.
   return JSON.stringify([channelId, accountId]);
 }
 
+/** Creates a durable channel/account-scoped ingress queue backed by the OpenClaw state database. */
 export function createChannelIngressQueue<
   TPayload,
   TMetadata = unknown,

--- a/src/channels/message/live.ts
+++ b/src/channels/message/live.ts
@@ -1,6 +1,7 @@
 import type { LiveMessageState, MessageReceipt, RenderedMessageBatch } from "./types.js";
 export type { LiveMessagePhase, LiveMessageState } from "./types.js";
 
+/** Mutable draft preview handle used before a live message is finalized or discarded. */
 export type LivePreviewFinalizerDraft<TId> = {
   flush: () => Promise<void>;
   id: () => TId | undefined;
@@ -9,17 +10,20 @@ export type LivePreviewFinalizerDraft<TId> = {
   clear: () => Promise<void>;
 };
 
+/** Outcome kind returned after attempting to finalize or fall back from a live preview. */
 export type LivePreviewFinalizerResultKind =
   | "normal-delivered"
   | "normal-skipped"
   | "preview-finalized"
   | "preview-retained";
 
+/** Result of a live preview finalization attempt plus the latest live state. */
 export type LivePreviewFinalizerResult<TPayload> = {
   kind: LivePreviewFinalizerResultKind;
   liveState?: LiveMessageState<TPayload>;
 };
 
+/** Adapter contract for channels that can edit a draft preview into the final message. */
 export type FinalizableLivePreviewAdapter<TPayload, TId, TEdit> = {
   draft?: LivePreviewFinalizerDraft<TId>;
   buildFinalEdit: (payload: TPayload) => TEdit | undefined;
@@ -43,12 +47,14 @@ export type FinalizableLivePreviewAdapter<TPayload, TId, TEdit> = {
   logPreviewEditFailure?: (error: unknown) => void;
 };
 
+/** Defines a finalizable live-preview adapter while preserving its generic payload/id/edit types. */
 export function defineFinalizableLivePreviewAdapter<TPayload, TId, TEdit>(
   adapter: FinalizableLivePreviewAdapter<TPayload, TId, TEdit>,
 ): FinalizableLivePreviewAdapter<TPayload, TId, TEdit> {
   return adapter;
 }
 
+/** Creates the initial live-message state, optionally seeded with an existing preview receipt. */
 export function createLiveMessageState<TPayload = unknown>(params?: {
   receipt?: MessageReceipt;
   lastRendered?: RenderedMessageBatch<TPayload>;
@@ -62,6 +68,7 @@ export function createLiveMessageState<TPayload = unknown>(params?: {
   };
 }
 
+/** Marks a live message as finalized and disables further in-place preview edits. */
 export function markLiveMessageFinalized<TPayload>(
   state: LiveMessageState<TPayload>,
   receipt: MessageReceipt,
@@ -74,6 +81,7 @@ export function markLiveMessageFinalized<TPayload>(
   };
 }
 
+/** Creates a receipt for a draft/preview platform message. */
 export function createPreviewMessageReceipt(params: {
   id: unknown;
   threadId?: string;
@@ -101,6 +109,7 @@ export function createPreviewMessageReceipt(params: {
   };
 }
 
+/** Finalizes a live preview in place when possible, otherwise falls back to normal delivery. */
 export async function deliverFinalizableLivePreview<TPayload, TId, TEdit>(params: {
   kind: "tool" | "block" | "final";
   payload: TPayload;
@@ -153,6 +162,7 @@ export async function deliverFinalizableLivePreview<TPayload, TId, TEdit>(params
         editSucceeded = true;
       } catch (err) {
         params.logPreviewEditFailure?.(err);
+        // Ambiguous preview edit failures can keep the preview as the visible final state.
         const decision =
           (await params.handlePreviewEditError?.({
             error: err,
@@ -214,6 +224,7 @@ export async function deliverFinalizableLivePreview<TPayload, TId, TEdit>(params
   return { kind: delivered ? "normal-delivered" : "normal-skipped", liveState };
 }
 
+/** Runs live-preview finalization through an optional adapter, falling back to normal delivery. */
 export async function deliverWithFinalizableLivePreviewAdapter<TPayload, TId, TEdit>(params: {
   kind: "tool" | "block" | "final";
   payload: TPayload;
@@ -265,6 +276,7 @@ export async function deliverWithFinalizableLivePreviewAdapter<TPayload, TId, TE
   });
 }
 
+/** Records the latest rendered preview batch and moves the live message into previewing state. */
 export function markLiveMessagePreviewUpdated<TPayload>(
   state: LiveMessageState<TPayload>,
   rendered: RenderedMessageBatch<TPayload>,
@@ -276,6 +288,7 @@ export function markLiveMessagePreviewUpdated<TPayload>(
   };
 }
 
+/** Marks a live message cancelled and prevents later in-place finalization. */
 export function markLiveMessageCancelled<TPayload>(
   state: LiveMessageState<TPayload>,
 ): LiveMessageState<TPayload> {

--- a/src/channels/message/outbound-bridge.ts
+++ b/src/channels/message/outbound-bridge.ts
@@ -19,11 +19,13 @@ const defaultManualReceiveAdapter = {
   supportedAckPolicies: ["manual"],
 } as const satisfies ChannelMessageReceiveAdapterShape;
 
+/** Send result accepted from legacy outbound bridge methods before receipt normalization. */
 export type ChannelMessageOutboundBridgeResult = MessageReceiptSourceResult & {
   receipt?: MessageReceipt;
   messageId?: string;
 };
 
+/** Legacy outbound adapter shape bridged into the channel message adapter contract. */
 export type ChannelMessageOutboundBridgeAdapter<TConfig = unknown> = {
   deliveryCapabilities?: {
     durableFinal?: DurableFinalDeliveryRequirementMap;
@@ -42,6 +44,7 @@ export type ChannelMessageOutboundBridgeAdapter<TConfig = unknown> = {
   ) => Promise<ChannelMessageOutboundBridgeResult>;
 };
 
+/** Options for building a message adapter from legacy outbound send functions. */
 export type CreateChannelMessageAdapterFromOutboundParams<TConfig = unknown> = {
   id?: string;
   outbound: ChannelMessageOutboundBridgeAdapter<TConfig>;
@@ -117,6 +120,7 @@ function resolvePayloadReceiptKind(
   return "unknown";
 }
 
+/** Converts legacy outbound send methods into a typed channel message adapter. */
 export function createChannelMessageAdapterFromOutbound<TConfig = unknown>(
   params: CreateChannelMessageAdapterFromOutboundParams<TConfig>,
 ): ChannelMessageAdapterShape<TConfig> {

--- a/src/channels/message/receipt.ts
+++ b/src/channels/message/receipt.ts
@@ -37,6 +37,7 @@ function appendUnique(values: string[], value: string | undefined): void {
   }
 }
 
+/** Builds one normalized receipt from platform send results or nested adapter receipts. */
 export function createMessageReceiptFromOutboundResults(params: {
   results: readonly MessageReceiptInputResult[];
   kind?: MessageReceiptPartKind;
@@ -46,6 +47,7 @@ export function createMessageReceiptFromOutboundResults(params: {
 }): MessageReceipt {
   const parts = params.results.flatMap((result, resultIndex) => {
     if (hasNestedReceiptData(result.receipt)) {
+      // Preserve adapter-supplied receipt parts first; only fill missing thread/reply metadata.
       return result.receipt.parts.length > 0
         ? result.receipt.parts.map((part, partIndex) => ({
             ...part,
@@ -108,10 +110,12 @@ export function createMessageReceiptFromOutboundResults(params: {
   };
 }
 
+/** Lists unique platform message ids in receipt order. */
 export function listMessageReceiptPlatformIds(receipt: MessageReceipt): string[] {
   return normalizeUniqueStringEntries(receipt.platformMessageIds);
 }
 
+/** Resolves the explicit primary platform id, falling back to the first unique receipt id. */
 export function resolveMessageReceiptPrimaryId(receipt: MessageReceipt): string | undefined {
   const primary = receipt.primaryPlatformMessageId?.trim();
   if (primary) {

--- a/src/channels/message/receive.ts
+++ b/src/channels/message/receive.ts
@@ -1,11 +1,15 @@
 import type { ChannelMessageReceiveAckPolicy } from "./types.js";
 
+/** Public alias for channel receive acknowledgement policy names. */
 export type MessageAckPolicy = ChannelMessageReceiveAckPolicy;
 
+/** Processing stage where a durable inbound message may be acknowledged. */
 export type MessageAckStage = "receive_record" | "agent_dispatch" | "durable_send" | "manual";
 
+/** Current acknowledgement state for one inbound message context. */
 export type MessageAckState = "pending" | "acked" | "nacked";
 
+/** Mutable receive context passed through durable inbound message processing. */
 export type MessageReceiveContext<TMessage = unknown> = {
   id: string;
   channel: string;
@@ -24,6 +28,7 @@ export type MessageReceiveContext<TMessage = unknown> = {
 
 const neverAbortedSignal = new AbortController().signal;
 
+/** Returns whether an ack policy should acknowledge at the supplied processing stage. */
 export function shouldAckMessageAfterStage(
   policy: MessageAckPolicy,
   stage: MessageAckStage,
@@ -45,6 +50,7 @@ function normalizeAckErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/** Creates a receive context with idempotent ack and explicit nack state transitions. */
 export function createMessageReceiveContext<TMessage>(params: {
   id: string;
   channel: string;
@@ -67,6 +73,7 @@ export function createMessageReceiveContext<TMessage>(params: {
     signal: params.signal ?? neverAbortedSignal,
     shouldAckAfter: (stage) => shouldAckMessageAfterStage(ctx.ackPolicy, stage),
     ack: async () => {
+      // Ack callbacks must be idempotent because receive pipelines may revisit completed stages.
       if (ctx.ackState === "acked") {
         return;
       }

--- a/src/channels/message/rendered-batch.ts
+++ b/src/channels/message/rendered-batch.ts
@@ -51,6 +51,7 @@ function createRenderedMessageBatchPlanItem(
   };
 }
 
+/** Summarizes rendered reply payloads so delivery can choose adapter paths and recovery metadata. */
 export function createRenderedMessageBatchPlan(
   payloads: readonly ReplyPayload[],
 ): RenderedMessageBatchPlan {
@@ -83,6 +84,7 @@ export function createRenderedMessageBatchPlan(
   );
 }
 
+/** Pairs reply payloads with their render plan for durable send and live-preview flows. */
 export function createRenderedMessageBatch(
   payloads: ReplyPayload[],
 ): RenderedMessageBatch<ReplyPayload> {

--- a/src/channels/message/reply-pipeline.ts
+++ b/src/channels/message/reply-pipeline.ts
@@ -25,6 +25,7 @@ export type { CreateTypingCallbacksParams, TypingCallbacks };
 export { createReplyPrefixContext, createReplyPrefixOptions, createTypingCallbacks };
 export type { SourceReplyDeliveryMode };
 
+/** Resolves whether a channel reply should use source delivery, message tools, or direct sending. */
 export function resolveChannelSourceReplyDeliveryMode(params: {
   cfg: OpenClawConfig;
   ctx: SourceReplyDeliveryModeContext;
@@ -34,11 +35,13 @@ export function resolveChannelSourceReplyDeliveryMode(params: {
   return resolveSourceReplyDeliveryMode(params);
 }
 
+/** Reply pipeline options shared by core channel turns and plugin SDK callers. */
 export type ChannelReplyPipeline = ReplyPrefixOptions & {
   typingCallbacks?: TypingCallbacks;
   transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
 };
 
+/** Parameters for building a channel reply pipeline with prefix, typing, and payload transforms. */
 export type CreateChannelReplyPipelineParams = {
   cfg: Parameters<typeof createReplyPrefixOptions>[0]["cfg"];
   agentId: string;
@@ -49,6 +52,7 @@ export type CreateChannelReplyPipelineParams = {
   transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
 };
 
+/** Builds the reply pipeline used by channel turns and plugin SDK reply helpers. */
 export function createChannelReplyPipeline(
   params: CreateChannelReplyPipelineParams,
 ): ChannelReplyPipeline {
@@ -58,6 +62,7 @@ export function createChannelReplyPipeline(
   let plugin: ReturnType<typeof getLoadedChannelPluginForRead> | undefined;
   let pluginTransformResolved = false;
   const resolvePluginTransform = () => {
+    // Load the channel plugin lazily so reply-pipeline construction stays cheap for hot turn paths.
     if (pluginTransformResolved) {
       return plugin?.messaging?.transformReplyPayload;
     }

--- a/src/channels/message/state.ts
+++ b/src/channels/message/state.ts
@@ -1,5 +1,6 @@
 import type { DurableMessageSendIntent, MessageReceipt } from "./types.js";
 
+/** Durable send state stored for recovery and operator-visible delivery status. */
 export type DurableMessageSendState =
   | "pending"
   | "sent"
@@ -7,6 +8,7 @@ export type DurableMessageSendState =
   | "failed"
   | "unknown_after_send";
 
+/** Recovery record for one durable outbound message intent. */
 export type DurableMessageStateRecord = {
   intent: DurableMessageSendIntent;
   state: DurableMessageSendState;
@@ -15,6 +17,7 @@ export type DurableMessageStateRecord = {
   errorMessage?: string;
 };
 
+/** Creates a durable message recovery record from intent, receipt, and optional error state. */
 export function createDurableMessageStateRecord(params: {
   intent: DurableMessageSendIntent;
   state?: DurableMessageSendState;
@@ -31,6 +34,7 @@ export function createDurableMessageStateRecord(params: {
   };
 }
 
+/** Classifies recovery state from persisted intent/receipt facts after a send interruption. */
 export function classifyDurableSendRecoveryState(params: {
   hasIntent: boolean;
   hasReceipt: boolean;

--- a/src/channels/message/types.ts
+++ b/src/channels/message/types.ts
@@ -5,8 +5,10 @@ import type { OutboundSendDeps } from "../../infra/outbound/send-deps.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import type { PollInput } from "../../polls.js";
 
+/** Delivery durability requested by core when a channel sends agent output. */
 export type MessageDurabilityPolicy = "required" | "best_effort" | "disabled";
 
+/** Capability names a channel must advertise before core can rely on durable final delivery. */
 export const durableFinalDeliveryCapabilities = [
   "text",
   "media",
@@ -23,12 +25,15 @@ export const durableFinalDeliveryCapabilities = [
   "afterCommit",
 ] as const;
 
+/** Durable final delivery capability key understood by message-channel adapters. */
 export type DurableFinalDeliveryCapability = (typeof durableFinalDeliveryCapabilities)[number];
 
+/** Capability map used by adapters to declare which final-send guarantees they support. */
 export type DurableFinalDeliveryRequirementMap = Partial<
   Record<DurableFinalDeliveryCapability, boolean>
 >;
 
+/** Minimal payload facts used to derive required durable-delivery capabilities. */
 export type DurableFinalDeliveryPayloadShape = {
   text?: string | null;
   replyToId?: string | null;
@@ -36,6 +41,7 @@ export type DurableFinalDeliveryPayloadShape = {
   mediaUrls?: readonly (string | null | undefined)[] | null;
 };
 
+/** Raw platform result shape normalized into a message receipt. */
 export type MessageReceiptSourceResult = {
   channel?: string;
   messageId?: string;
@@ -49,6 +55,7 @@ export type MessageReceiptSourceResult = {
   meta?: Record<string, unknown>;
 };
 
+/** Logical part kind for multi-part rendered messages. */
 export type MessageReceiptPartKind =
   | "text"
   | "media"
@@ -58,6 +65,7 @@ export type MessageReceiptPartKind =
   | "preview"
   | "unknown";
 
+/** One platform message produced by a logical outbound send. */
 export type MessageReceiptPart = {
   platformMessageId: string;
   kind: MessageReceiptPartKind;
@@ -67,6 +75,7 @@ export type MessageReceiptPart = {
   raw?: MessageReceiptSourceResult;
 };
 
+/** Normalized receipt for all platform messages that make up a logical send. */
 export type MessageReceipt = {
   primaryPlatformMessageId?: string;
   platformMessageIds: string[];
@@ -79,6 +88,7 @@ export type MessageReceipt = {
   raw?: readonly MessageReceiptSourceResult[];
 };
 
+/** Render-plan item category used before adapter-specific send execution. */
 export type RenderedMessageBatchPlanKind =
   | "text"
   | "media"
@@ -88,6 +98,7 @@ export type RenderedMessageBatchPlanKind =
   | "channelData"
   | "empty";
 
+/** Render plan for a single reply payload after text/media/presentation splitting. */
 export type RenderedMessageBatchPlanItem = {
   index: number;
   kinds: readonly RenderedMessageBatchPlanKind[];
@@ -99,6 +110,7 @@ export type RenderedMessageBatchPlanItem = {
   hasChannelData?: boolean;
 };
 
+/** Aggregate render plan for a batch of reply payloads. */
 export type RenderedMessageBatchPlan = {
   payloadCount: number;
   textCount: number;
@@ -110,13 +122,16 @@ export type RenderedMessageBatchPlan = {
   items: readonly RenderedMessageBatchPlanItem[];
 };
 
+/** Rendered payload batch paired with the plan core uses for send routing and recovery. */
 export type RenderedMessageBatch<TPayload = unknown> = {
   payloads: TPayload[];
   plan: RenderedMessageBatchPlan;
 };
 
+/** Lifecycle phase for a live preview or streaming message send. */
 export type LiveMessagePhase = "idle" | "previewing" | "finalizing" | "finalized" | "cancelled";
 
+/** Mutable state snapshot for live preview/finalization flows. */
 export type LiveMessageState<TPayload = unknown> = {
   phase: LiveMessagePhase;
   canFinalizeInPlace: boolean;
@@ -124,6 +139,7 @@ export type LiveMessageState<TPayload = unknown> = {
   lastRendered?: RenderedMessageBatch<TPayload>;
 };
 
+/** Durable send context passed through render, preview, send, edit, commit, and failure steps. */
 export type MessageSendContext<TPayload = unknown, TSendResult = unknown> = {
   id: string;
   channel: string;
@@ -144,6 +160,7 @@ export type MessageSendContext<TPayload = unknown, TSendResult = unknown> = {
   fail(error: unknown): Promise<void>;
 };
 
+/** Common text-send context shared by text, media, payload, and poll adapter calls. */
 export type ChannelMessageSendTextContext<TConfig = OpenClawConfig> = {
   cfg: TConfig;
   to: string;
@@ -159,6 +176,7 @@ export type ChannelMessageSendTextContext<TConfig = OpenClawConfig> = {
   gatewayClientScopes?: readonly string[];
 };
 
+/** Media send context with validated access hooks and media presentation hints. */
 export type ChannelMessageSendMediaContext<TConfig = OpenClawConfig> =
   ChannelMessageSendTextContext<TConfig> & {
     mediaUrl: string;
@@ -170,6 +188,7 @@ export type ChannelMessageSendMediaContext<TConfig = OpenClawConfig> =
     forceDocument?: boolean;
   };
 
+/** Rich reply payload send context used when adapters can consume structured payloads. */
 export type ChannelMessageSendPayloadContext<TConfig = OpenClawConfig> =
   ChannelMessageSendTextContext<TConfig> & {
     payload: ReplyPayload;
@@ -182,6 +201,7 @@ export type ChannelMessageSendPayloadContext<TConfig = OpenClawConfig> =
     forceDocument?: boolean;
   };
 
+/** Poll send context; thread ids stay string-like because poll APIs do not accept numeric ids. */
 export type ChannelMessageSendPollContext<TConfig = OpenClawConfig> = Omit<
   ChannelMessageSendTextContext<TConfig>,
   "text" | "threadId"
@@ -191,19 +211,23 @@ export type ChannelMessageSendPollContext<TConfig = OpenClawConfig> = Omit<
   isAnonymous?: boolean;
 };
 
+/** Adapter send result normalized to a receipt plus optional legacy message id. */
 export type ChannelMessageSendResult = {
   receipt: MessageReceipt;
   messageId?: string;
 };
 
+/** Discriminator for lifecycle hooks around a concrete adapter send attempt. */
 export type ChannelMessageSendAttemptKind = "text" | "media" | "payload" | "poll";
 
+/** Send-attempt context tagged with the adapter method core is about to call. */
 export type ChannelMessageSendAttemptContext<TConfig = OpenClawConfig> =
   | (ChannelMessageSendTextContext<TConfig> & { kind: "text" })
   | (ChannelMessageSendMediaContext<TConfig> & { kind: "media" })
   | (ChannelMessageSendPayloadContext<TConfig> & { kind: "payload" })
   | (ChannelMessageSendPollContext<TConfig> & { kind: "poll" });
 
+/** Lifecycle context emitted after an adapter send succeeds but before commit finishes. */
 export type ChannelMessageSendSuccessContext<
   TConfig = OpenClawConfig,
   TSendResult extends ChannelMessageSendResult = ChannelMessageSendResult,
@@ -212,17 +236,20 @@ export type ChannelMessageSendSuccessContext<
   attemptToken?: unknown;
 };
 
+/** Lifecycle context emitted after an adapter send throws or rejects. */
 export type ChannelMessageSendFailureContext<TConfig = OpenClawConfig> =
   ChannelMessageSendAttemptContext<TConfig> & {
     error: unknown;
     attemptToken?: unknown;
   };
 
+/** Lifecycle context emitted when a successful send is being durably committed. */
 export type ChannelMessageSendCommitContext<
   TConfig = OpenClawConfig,
   TSendResult extends ChannelMessageSendResult = ChannelMessageSendResult,
 > = ChannelMessageSendSuccessContext<TConfig, TSendResult>;
 
+/** Durable queue context used to reconcile a send whose platform state is unknown. */
 export type ChannelMessageUnknownSendContext<TConfig = OpenClawConfig> = {
   cfg: TConfig;
   queueId: string;
@@ -240,6 +267,7 @@ export type ChannelMessageUnknownSendContext<TConfig = OpenClawConfig> = {
   silent?: boolean;
 };
 
+/** Adapter verdict for whether an unknown queued send reached the platform. */
 export type ChannelMessageUnknownSendReconciliationResult =
   | {
       status: "sent";
@@ -255,6 +283,7 @@ export type ChannelMessageUnknownSendReconciliationResult =
       retryable?: boolean;
     };
 
+/** Optional hooks around adapter send attempts, platform success/failure, and commit. */
 export type ChannelMessageSendLifecycleAdapter<
   TConfig = OpenClawConfig,
   TSendResult extends ChannelMessageSendResult = ChannelMessageSendResult,
@@ -269,6 +298,7 @@ export type ChannelMessageSendLifecycleAdapter<
   ) => Promise<void> | void;
 };
 
+/** Adapter methods a message channel can implement for outbound text/media/payload/poll sends. */
 export type ChannelMessageSendAdapter<
   TConfig = OpenClawConfig,
   TSendResult extends ChannelMessageSendResult = ChannelMessageSendResult,
@@ -280,6 +310,7 @@ export type ChannelMessageSendAdapter<
   lifecycle?: ChannelMessageSendLifecycleAdapter<TConfig, TSendResult>;
 };
 
+/** Durable final-delivery extension for queue reconciliation and capability declaration. */
 export type ChannelMessageDurableFinalAdapter = {
   capabilities?: DurableFinalDeliveryRequirementMap;
   reconcileUnknownSend?: (
@@ -290,6 +321,7 @@ export type ChannelMessageDurableFinalAdapter = {
     | null;
 };
 
+/** Live-message feature key declared by adapters that support preview or streaming behavior. */
 export type ChannelMessageLiveCapability =
   | "draftPreview"
   | "previewFinalization"
@@ -297,6 +329,7 @@ export type ChannelMessageLiveCapability =
   | "nativeStreaming"
   | "quietFinalization";
 
+/** Canonical ordered list of live-message feature keys. */
 export const channelMessageLiveCapabilities = [
   "draftPreview",
   "previewFinalization",
@@ -305,6 +338,7 @@ export const channelMessageLiveCapabilities = [
   "quietFinalization",
 ] as const satisfies readonly ChannelMessageLiveCapability[];
 
+/** Capability keys for turning a preview into a final platform message. */
 export const livePreviewFinalizerCapabilities = [
   "finalEdit",
   "normalFallback",
@@ -313,27 +347,33 @@ export const livePreviewFinalizerCapabilities = [
   "retainOnAmbiguousFailure",
 ] as const;
 
+/** Finalizer capability key understood by live-message adapters. */
 export type LivePreviewFinalizerCapability = (typeof livePreviewFinalizerCapabilities)[number];
 
+/** Capability map for preview finalization behavior. */
 export type LivePreviewFinalizerCapabilityMap = Partial<
   Record<LivePreviewFinalizerCapability, boolean>
 >;
 
+/** Adapter shape for finalizing live previews. */
 export type ChannelMessageLiveFinalizerAdapterShape = {
   capabilities?: LivePreviewFinalizerCapabilityMap;
 };
 
+/** Adapter shape for live preview and streaming message features. */
 export type ChannelMessageLiveAdapterShape = {
   capabilities?: Partial<Record<ChannelMessageLiveCapability, boolean>>;
   finalizer?: ChannelMessageLiveFinalizerAdapterShape;
 };
 
+/** Receive acknowledgement timing policy for durable inbound message records. */
 export type ChannelMessageReceiveAckPolicy =
   | "after_receive_record"
   | "after_agent_dispatch"
   | "after_durable_send"
   | "manual";
 
+/** Canonical ordered list of receive acknowledgement policies. */
 export const channelMessageReceiveAckPolicies = [
   "after_receive_record",
   "after_agent_dispatch",
@@ -341,11 +381,13 @@ export const channelMessageReceiveAckPolicies = [
   "manual",
 ] as const satisfies readonly ChannelMessageReceiveAckPolicy[];
 
+/** Adapter receive shape for default and supported inbound acknowledgement policies. */
 export type ChannelMessageReceiveAdapterShape = {
   defaultAckPolicy?: ChannelMessageReceiveAckPolicy;
   supportedAckPolicies?: readonly ChannelMessageReceiveAckPolicy[];
 };
 
+/** Full message adapter shape composed from send, durable-final, live, and receive facets. */
 export type ChannelMessageAdapterShape<
   TConfig = OpenClawConfig,
   TSendResult extends ChannelMessageSendResult = ChannelMessageSendResult,
@@ -357,12 +399,15 @@ export type ChannelMessageAdapterShape<
   receive?: ChannelMessageReceiveAdapterShape;
 };
 
+/** Concrete message adapter type, preserving channel-specific adapter refinements. */
 export type ChannelMessageAdapter<
   TAdapter extends ChannelMessageAdapterShape = ChannelMessageAdapterShape,
 > = TAdapter;
 
+/** Back-compat alias for callers that derive extra durable final requirements. */
 export type DurableFinalRequirementExtras = DurableFinalDeliveryRequirementMap;
 
+/** Inputs used to derive durable final-delivery requirements for a planned send. */
 export type DeriveDurableFinalDeliveryRequirementsParams = {
   payload: DurableFinalDeliveryPayloadShape;
   replyToId?: string | null;
@@ -377,6 +422,7 @@ export type DeriveDurableFinalDeliveryRequirementsParams = {
   extraCapabilities?: DurableFinalRequirementExtras;
 };
 
+/** Stable intent record for a durable outbound message send. */
 export type DurableMessageSendIntent<TPayload = unknown> = {
   id: string;
   channel: string;

--- a/src/channels/turn/bot-loop-protection.ts
+++ b/src/channels/turn/bot-loop-protection.ts
@@ -6,6 +6,7 @@ import {
   type PairLoopGuardSnapshotEntry,
 } from "../../plugin-sdk/pair-loop-guard-runtime.js";
 
+/** Facts used to detect repeated bot-to-bot channel reply loops. */
 export type ChannelBotLoopProtectionFacts = {
   scopeId: string;
   conversationId: string;
@@ -19,6 +20,7 @@ export type ChannelBotLoopProtectionFacts = {
 
 const channelBotPairLoopGuard = createPairLoopGuard({ pruneIntervalMs: 60_000 });
 
+/** Records a bot pair interaction and returns whether the loop guard should suppress it. */
 export function recordChannelBotPairLoopAndCheckSuppression(
   params: ChannelBotLoopProtectionFacts,
 ): PairLoopGuardResult {
@@ -36,10 +38,12 @@ export function recordChannelBotPairLoopAndCheckSuppression(
   });
 }
 
+/** Clears channel bot-loop state for isolated tests. */
 export function clearChannelBotPairLoopGuardForTests(): void {
   channelBotPairLoopGuard.clear();
 }
 
+/** Lists tracked bot-loop pairs for isolated tests. */
 export function listTrackedChannelBotPairsForTests(): PairLoopGuardSnapshotEntry[] {
   return channelBotPairLoopGuard.snapshot();
 }

--- a/src/channels/turn/delivery-result.ts
+++ b/src/channels/turn/delivery-result.ts
@@ -2,6 +2,7 @@ import { listMessageReceiptPlatformIds } from "../message/receipt.js";
 import type { MessageReceipt } from "../message/types.js";
 import type { ChannelDeliveryIntent, ChannelDeliveryResult } from "./types.js";
 
+/** Converts a normalized message receipt into the delivery result shape used by channel turns. */
 export function createChannelDeliveryResultFromReceipt(params: {
   receipt: MessageReceipt;
   threadId?: string;

--- a/src/channels/turn/dispatch-result.ts
+++ b/src/channels/turn/dispatch-result.ts
@@ -1,5 +1,6 @@
 import type { ReplyDispatchKind } from "../../auto-reply/reply/reply-dispatcher.types.js";
 
+/** Minimal dispatch result shape needed to count visible channel deliveries. */
 export type ChannelTurnDispatchResultLike =
   | {
       queuedFinal?: boolean;
@@ -8,18 +9,21 @@ export type ChannelTurnDispatchResultLike =
   | null
   | undefined;
 
+/** Extra delivery signals observed outside the normal dispatch count payload. */
 export type ChannelTurnVisibleDeliverySignals = {
   observedReplyDelivery?: boolean;
   fallbackDelivered?: boolean;
   deliverySummaryDelivered?: boolean;
 };
 
+/** Zero-filled reply dispatch count map used before merging optional provider counts. */
 export const EMPTY_CHANNEL_TURN_DISPATCH_COUNTS: Record<ReplyDispatchKind, number> = {
   tool: 0,
   block: 0,
   final: 0,
 };
 
+/** Resolves dispatch counts with missing reply kinds filled as zero. */
 export function resolveChannelTurnDispatchCounts(
   result: ChannelTurnDispatchResultLike,
 ): Record<ReplyDispatchKind, number> {
@@ -29,11 +33,13 @@ export function resolveChannelTurnDispatchCounts(
   };
 }
 
+/** Returns whether a turn produced any visible reply delivery signal. */
 export function hasVisibleChannelTurnDispatch(
   result: ChannelTurnDispatchResultLike,
   signals: ChannelTurnVisibleDeliverySignals = {},
 ): boolean {
   const counts = resolveChannelTurnDispatchCounts(result);
+  // Non-count signals cover delivery paths that bypass the buffered reply dispatcher.
   return (
     signals.observedReplyDelivery === true ||
     signals.fallbackDelivered === true ||
@@ -45,6 +51,7 @@ export function hasVisibleChannelTurnDispatch(
   );
 }
 
+/** Returns whether a turn produced a final reply, fallback, summary, or queued final payload. */
 export function hasFinalChannelTurnDispatch(
   result: ChannelTurnDispatchResultLike,
   signals: Pick<

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -16,6 +16,7 @@ import { sendDurableMessageBatch } from "../message/send.js";
 import { createChannelDeliveryResultFromReceipt } from "./delivery-result.js";
 import type { ChannelDeliveryInfo, ChannelDeliveryResult } from "./types.js";
 
+/** Options controlling durable final delivery for inbound channel replies. */
 export type DurableInboundReplyDeliveryOptions = Pick<
   DeliverOutboundPayloadsParams,
   "deps" | "formatting" | "identity" | "mediaAccess" | "replyToMode" | "silent" | "threadId"
@@ -25,6 +26,7 @@ export type DurableInboundReplyDeliveryOptions = Pick<
   requiredCapabilities?: DurableFinalDeliveryRequirements;
 };
 
+/** Full context required to deliver one inbound final reply through durable message sending. */
 export type DurableInboundReplyDeliveryParams = DurableInboundReplyDeliveryOptions & {
   cfg: OpenClawConfig;
   channel: string;
@@ -35,6 +37,7 @@ export type DurableInboundReplyDeliveryParams = DurableInboundReplyDeliveryOptio
   info: ChannelDeliveryInfo;
 };
 
+/** Outcome of attempting durable final delivery for an inbound reply payload. */
 export type DurableInboundReplyDeliveryResult =
   | { status: "not_applicable"; reason: "non_final" }
   | {
@@ -61,6 +64,7 @@ function resolveDeliveryTarget(params: DurableInboundReplyDeliveryParams): strin
 export function resolveDurableInboundReplyToId(
   params: Pick<DurableInboundReplyDeliveryParams, "ctxPayload" | "payload" | "replyToId">,
 ): string | null | undefined {
+  // Explicit null means "do not reply to a source message"; do not fall back to context ids.
   if (params.replyToId === null || params.payload.replyToId === null) {
     return null;
   }
@@ -93,6 +97,7 @@ function toDeliveryIntent(intent: OutboundDeliveryIntent): ChannelDeliveryResult
   };
 }
 
+/** Narrows durable delivery results that handled the payload without caller fallback. */
 export function isDurableInboundReplyDeliveryHandled(
   result: DurableInboundReplyDeliveryResult,
 ): result is Extract<
@@ -102,6 +107,7 @@ export function isDurableInboundReplyDeliveryHandled(
   return result.status === "handled_visible" || result.status === "handled_no_send";
 }
 
+/** Throws failed durable delivery results, preserving visible-send metadata when applicable. */
 export function throwIfDurableInboundReplyDeliveryFailed(
   result: DurableInboundReplyDeliveryResult,
 ): void {
@@ -113,6 +119,7 @@ export function throwIfDurableInboundReplyDeliveryFailed(
 }
 
 function markDurableInboundReplyDeliveryErrorVisible(error: unknown): unknown {
+  // Partial durable sends must suppress duplicate fallback delivery while still surfacing failure.
   if (typeof error === "object" && error !== null && Object.isExtensible(error)) {
     Object.assign(error, { sentBeforeError: true, visibleReplySent: true });
     return error;
@@ -123,6 +130,7 @@ function markDurableInboundReplyDeliveryErrorVisible(error: unknown): unknown {
   return visibleError;
 }
 
+/** Delivers final inbound replies through the durable message-send context when supported. */
 export async function deliverInboundReplyWithMessageSendContext(
   params: DurableInboundReplyDeliveryParams,
 ): Promise<DurableInboundReplyDeliveryResult> {

--- a/src/channels/turn/history-window.ts
+++ b/src/channels/turn/history-window.ts
@@ -9,6 +9,7 @@ import type { HistoryEntry, HistoryMediaEntry } from "../../auto-reply/reply/his
 
 type MaybePromise<T> = T | Promise<T>;
 
+/** Windowed channel history facade used by turn adapters to record and render recent context. */
 export type ChannelHistoryWindow<T extends HistoryEntry = HistoryEntry> = {
   record: (params: { historyKey: string; entry?: T | null; limit: number }) => T[];
   recordWithMedia: (params: {
@@ -37,6 +38,7 @@ export type ChannelHistoryWindow<T extends HistoryEntry = HistoryEntry> = {
   clear: (params: { historyKey: string; limit: number }) => void;
 };
 
+/** Creates a bounded channel history window over a caller-owned history map. */
 export function createChannelHistoryWindow<T extends HistoryEntry = HistoryEntry>(params: {
   historyMap: Map<string, T[]>;
 }): ChannelHistoryWindow<T> {

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -23,18 +23,21 @@ import type { ChannelBotLoopProtectionFacts } from "./bot-loop-protection.js";
 
 export type { InboundEventKind } from "../inbound-event/kind.js";
 
+/** Admission decision for an inbound channel event before agent dispatch. */
 export type ChannelTurnAdmission =
   | { kind: "dispatch"; reason?: string }
   | { kind: "observeOnly"; reason: string }
   | { kind: "handled"; reason: string }
   | { kind: "drop"; reason: string; recordHistory?: boolean };
 
+/** Coarse event classification used to decide whether an event can start an agent turn. */
 export type ChannelEventClass = {
   kind: "message" | "command" | "interaction" | "reaction" | "lifecycle" | "unknown";
   canStartAgentTurn: boolean;
   requiresImmediateAck?: boolean;
 };
 
+/** Normalized inbound event text and raw payload after channel-specific ingestion. */
 export type NormalizedTurnInput = {
   id: string;
   timestamp?: number;
@@ -44,6 +47,7 @@ export type NormalizedTurnInput = {
   raw?: unknown;
 };
 
+/** Sender identity facts projected into channel access, routing, and prompt context. */
 export type SenderFacts = {
   id?: string;
   name?: string;
@@ -55,6 +59,7 @@ export type SenderFacts = {
   displayLabel?: string;
 };
 
+/** Conversation identity and threading facts for a channel turn. */
 export type ConversationFacts = {
   kind: "direct" | "group" | "channel";
   id: string;
@@ -69,6 +74,7 @@ export type ConversationFacts = {
   };
 };
 
+/** Session routing facts derived before dispatch. */
 export type RouteFacts = {
   agentId: string;
   accountId?: string;
@@ -81,6 +87,7 @@ export type RouteFacts = {
   createIfMissing?: boolean;
 };
 
+/** Reply target and source-delivery facts for a channel turn. */
 export type ReplyPlanFacts = {
   to: string;
   originatingTo?: string;
@@ -94,6 +101,7 @@ export type ReplyPlanFacts = {
   sourceReplyDeliveryMode?: "thread" | "reply" | "channel" | "direct" | "none";
 };
 
+/** Allowlist projection used by access checks without exposing raw configured entries. */
 export type ProjectedAllowlistAccessFacts = {
   configured: boolean;
   matched: boolean;
@@ -110,6 +118,7 @@ export type ProjectedAllowlistAccessFacts = {
   };
 };
 
+/** Event-level access projection for commands, reactions, buttons, and native events. */
 export type ProjectedEventAccessFacts = {
   kind:
     | "message"
@@ -127,6 +136,7 @@ export type ProjectedEventAccessFacts = {
   originSubjectMatched: boolean;
 };
 
+/** Access decisions for DMs, groups, commands, events, and mention gating. */
 export type AccessFacts = {
   dm?: {
     decision: "allow" | "pairing" | "deny";
@@ -177,6 +187,7 @@ export type AccessFacts = {
   };
 };
 
+/** Message text/history facts passed into templating and dispatch. */
 export type MessageFacts = {
   inboundEventKind?: InboundEventKind;
   body?: string;
@@ -189,6 +200,7 @@ export type MessageFacts = {
   inboundHistory?: HistoryEntry[];
 };
 
+/** Parsed command facts for command-like channel turns. */
 export type CommandFacts = {
   kind: CommandTurnKind;
   body?: string;
@@ -196,6 +208,7 @@ export type CommandFacts = {
   authorized?: boolean;
 };
 
+/** Quoted, forwarded, thread, and untrusted context facts attached to an inbound turn. */
 export type SupplementalContextFacts = {
   quote?: {
     id?: string;
@@ -228,6 +241,7 @@ export type SupplementalContextFacts = {
   untrustedGroupSystemPrompt?: string;
 };
 
+/** Inbound media facts supplied to the agent context. */
 export type InboundMediaFacts = {
   path?: string;
   url?: string;
@@ -239,6 +253,7 @@ export type InboundMediaFacts = {
 
 type MaybePromise<T> = T | Promise<T>;
 
+/** Adapter preflight output assembled before turn resolution. */
 export type PreflightFacts = {
   admission?: ChannelTurnAdmission;
   command?: CommandFacts;
@@ -252,16 +267,19 @@ export type PreflightFacts = {
   history?: ChannelTurnDroppedHistoryOptions;
 };
 
+/** Delivery metadata for one reply payload dispatch. */
 export type ChannelDeliveryInfo = {
   kind: ReplyDispatchKind;
 };
 
+/** Durable delivery queue intent recorded when a reply is deferred. */
 export type ChannelDeliveryIntent = {
   id: string;
   kind: "outbound_queue";
   queuePolicy: OutboundDeliveryQueuePolicy;
 };
 
+/** Result returned after delivering one channel reply payload. */
 export type ChannelDeliveryResult = {
   messageIds?: string[];
   receipt?: MessageReceipt;
@@ -271,6 +289,7 @@ export type ChannelDeliveryResult = {
   deliveryIntent?: ChannelDeliveryIntent;
 };
 
+/** Durable outbound delivery options available to channel turn delivery adapters. */
 export type ChannelTurnDurableDeliveryOptions = Pick<
   DeliverOutboundPayloadsParams,
   "deps" | "formatting" | "identity" | "mediaAccess" | "replyToMode" | "silent" | "threadId"
@@ -280,6 +299,7 @@ export type ChannelTurnDurableDeliveryOptions = Pick<
   requiredCapabilities?: DurableFinalDeliveryRequirements;
 };
 
+/** Delivery adapter used by channel turns to send reply payloads. */
 export type ChannelEventDeliveryAdapter = {
   preparePayload?: (
     payload: ReplyPayload,
@@ -307,6 +327,7 @@ export type ChannelEventDeliveryAdapter = {
   onError?: (err: unknown, info: { kind: string }) => void;
 };
 
+/** Options for recording inbound session route state around a turn. */
 export type ChannelTurnRecordOptions = {
   groupResolution?: GroupKeyResolution | null;
   createIfMissing?: boolean;
@@ -315,6 +336,7 @@ export type ChannelTurnRecordOptions = {
   trackSessionMetaTask?: (task: Promise<unknown>) => void;
 };
 
+/** Options for finalizing visible conversation history after dispatch. */
 export type ChannelTurnHistoryFinalizeOptions = {
   isGroup?: boolean;
   historyKey?: string;
@@ -322,6 +344,7 @@ export type ChannelTurnHistoryFinalizeOptions = {
   limit?: number;
 };
 
+/** Options for recording history when an inbound event is dropped before dispatch. */
 export type ChannelTurnDroppedHistoryOptions = {
   key: string;
   limit: number;
@@ -331,16 +354,19 @@ export type ChannelTurnDroppedHistoryOptions = {
   shouldRecord?: () => boolean;
 };
 
+/** Dispatcher options excluding delivery hooks owned by the channel turn adapter. */
 export type ChannelTurnDispatcherOptions = Omit<
   ReplyDispatcherWithTypingOptions,
   "deliver" | "onError"
 >;
 
+/** Reply pipeline options excluding cfg/agent/channel identity supplied by the turn. */
 export type ChannelTurnReplyPipelineOptions = Omit<
   CreateChannelReplyPipelineParams,
   "cfg" | "agentId" | "channel" | "accountId"
 >;
 
+/** Fully assembled channel turn ready to build the dispatch runner. */
 export type AssembledChannelTurn = {
   cfg: OpenClawConfig;
   channel: string;
@@ -364,6 +390,7 @@ export type AssembledChannelTurn = {
   messageId?: string;
 };
 
+/** Channel turn with dispatch runner already prepared. */
 export type PreparedChannelTurn<TDispatchResult = DispatchFromConfigResult> = {
   channel: string;
   accountId?: string;
@@ -382,6 +409,7 @@ export type PreparedChannelTurn<TDispatchResult = DispatchFromConfigResult> = {
   messageId?: string;
 };
 
+/** Resolved turn shape returned by adapters before final run/dispatch handling. */
 export type ChannelTurnResolved<TDispatchResult = DispatchFromConfigResult> =
   | (AssembledChannelTurn & {
       admission?: Extract<ChannelTurnAdmission, { kind: "dispatch" | "observeOnly" }>;
@@ -390,6 +418,7 @@ export type ChannelTurnResolved<TDispatchResult = DispatchFromConfigResult> =
       admission?: Extract<ChannelTurnAdmission, { kind: "dispatch" | "observeOnly" }>;
     });
 
+/** Ordered lifecycle stage names emitted to channel turn log hooks. */
 export type ChannelTurnStage =
   | "ingest"
   | "classify"
@@ -401,6 +430,7 @@ export type ChannelTurnStage =
   | "dispatch"
   | "finalize";
 
+/** Structured channel turn log event. */
 export type ChannelTurnLogEvent = {
   stage: ChannelTurnStage;
   event: "start" | "done" | "drop" | "handled" | "error";
@@ -413,6 +443,7 @@ export type ChannelTurnLogEvent = {
   error?: unknown;
 };
 
+/** Final result for a channel turn, dispatched or admitted without dispatch. */
 export type ChannelTurnResult<TDispatchResult = DispatchFromConfigResult> =
   | DispatchedChannelTurnResult<TDispatchResult>
   | {
@@ -422,6 +453,7 @@ export type ChannelTurnResult<TDispatchResult = DispatchFromConfigResult> =
       routeSessionKey?: string;
     };
 
+/** Successful dispatch result for a channel turn. */
 export type DispatchedChannelTurnResult<TDispatchResult = DispatchFromConfigResult> = {
   admission: Extract<ChannelTurnAdmission, { kind: "dispatch" | "observeOnly" }>;
   dispatched: true;
@@ -430,6 +462,7 @@ export type DispatchedChannelTurnResult<TDispatchResult = DispatchFromConfigResu
   dispatchResult: TDispatchResult;
 };
 
+/** Adapter contract for ingesting, classifying, resolving, and finalizing raw channel events. */
 export type ChannelTurnAdapter<TRaw, TDispatchResult = DispatchFromConfigResult> = {
   ingest: (raw: TRaw) => Promise<NormalizedTurnInput | null> | NormalizedTurnInput | null;
   classify?: (input: NormalizedTurnInput) => Promise<ChannelEventClass> | ChannelEventClass;
@@ -450,6 +483,7 @@ export type ChannelTurnAdapter<TRaw, TDispatchResult = DispatchFromConfigResult>
   onFinalize?: (result: ChannelTurnResult<TDispatchResult>) => Promise<void> | void;
 };
 
+/** Parameters for running one raw channel event through the turn kernel. */
 export type RunChannelTurnParams<TRaw, TDispatchResult = DispatchFromConfigResult> = {
   channel: string;
   accountId?: string;

--- a/src/cli/command-path-matches.ts
+++ b/src/cli/command-path-matches.ts
@@ -23,6 +23,7 @@ function normalizeCommandPathMatchRule(rule: CommandPathMatchRule): NormalizedCo
   return { pattern: rule.pattern, exact: rule.exact ?? false };
 }
 
+/** Matches a command path prefix, or the full path when `exact` is requested. */
 export function matchesCommandPath(
   commandPath: string[],
   pattern: readonly string[],
@@ -34,6 +35,7 @@ export function matchesCommandPath(
   return !params?.exact || commandPath.length === pattern.length;
 }
 
+/** Applies the shared command-path rule shape used by startup and help policies. */
 export function matchesCommandPathRule(commandPath: string[], rule: CommandPathMatchRule): boolean {
   const normalizedRule = normalizeCommandPathMatchRule(rule);
   return matchesCommandPath(commandPath, normalizedRule.pattern, {
@@ -41,6 +43,7 @@ export function matchesCommandPathRule(commandPath: string[], rule: CommandPathM
   });
 }
 
+/** Returns whether any configured command-path rule matches the parsed command path. */
 export function matchesAnyCommandPath(
   commandPath: string[],
   rules: readonly CommandPathMatchRule[],

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -12,6 +12,7 @@ export const COMPLETION_SHELLS = ["zsh", "bash", "powershell", "fish"] as const;
 export type CompletionShell = (typeof COMPLETION_SHELLS)[number];
 export const COMPLETION_SKIP_PLUGIN_COMMANDS_ENV = "OPENCLAW_COMPLETION_SKIP_PLUGIN_COMMANDS";
 
+/** Narrows an arbitrary shell label to a completion shell supported by installer logic. */
 export function isCompletionShell(value: string): value is CompletionShell {
   return COMPLETION_SHELLS.includes(value as CompletionShell);
 }
@@ -27,6 +28,7 @@ function resolveShellBasename(
   return normalizeLowercaseStringOrEmpty(basename.replace(/\.(?:exe|cmd|bat)$/i, ""));
 }
 
+/** Resolves the active shell from environment paths, defaulting to zsh for unknown shells. */
 export function resolveShellFromEnv(env: NodeJS.ProcessEnv = process.env): CompletionShell {
   const shellPath = normalizeOptionalString(env.SHELL) ?? "";
   const shellName = shellPath ? resolveShellBasename(shellPath) : "";
@@ -58,6 +60,7 @@ function resolveCompletionCacheDir(env: NodeJS.ProcessEnv = process.env): string
   return path.join(stateDir, "completions");
 }
 
+/** Returns the per-shell cached completion script path for a sanitized CLI binary name. */
 export function resolveCompletionCachePath(shell: CompletionShell, binName: string): string {
   const basename = sanitizeCompletionBasename(binName);
   const extension =
@@ -78,6 +81,7 @@ function escapePowerShellSingleQuotedString(value: string): string {
   return value.replace(/'/g, "''");
 }
 
+/** Formats the profile line that sources the cached completion script for a shell. */
 export function formatCompletionSourceLine(
   shell: CompletionShell,
   _binName: string,
@@ -92,6 +96,7 @@ export function formatCompletionSourceLine(
   return `[ -f "${cachePath}" ] && source "${cachePath}"`;
 }
 
+/** Formats the command users can run to reload the shell profile after installation. */
 export function formatCompletionReloadCommand(shell: CompletionShell, profilePath: string): string {
   if (shell === "powershell") {
     return `. '${escapePowerShellSingleQuotedString(profilePath)}'`;
@@ -151,6 +156,7 @@ function updateCompletionProfile(
   return { next, changed: next !== content, hadExisting };
 }
 
+/** Resolves the shell startup profile path that should contain the OpenClaw completion block. */
 export function resolveCompletionProfilePath(
   shell: CompletionShell,
   options: {
@@ -186,6 +192,7 @@ export function resolveCompletionProfilePath(
   return path.join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
 }
 
+/** Returns whether a shell profile already contains an OpenClaw completion block or source line. */
 export async function isCompletionInstalled(
   shell: CompletionShell,
   binName = "openclaw",

--- a/src/cli/json-output-mode.ts
+++ b/src/cli/json-output-mode.ts
@@ -1,5 +1,6 @@
 import { loggingState } from "../logging/state.js";
 
+/** Detects CLI JSON mode before Commander parses options, stopping at the argv sentinel. */
 export function hasJsonOutputFlag(argv: readonly string[]): boolean {
   for (const arg of argv) {
     if (arg === "--") {
@@ -12,6 +13,7 @@ export function hasJsonOutputFlag(argv: readonly string[]): boolean {
   return false;
 }
 
+/** Keeps structured JSON stdout clean by routing incidental console logs to stderr. */
 export async function withConsoleLogsRoutedToStderrForJson<T>(
   argv: readonly string[],
   run: () => Promise<T>,
@@ -24,6 +26,7 @@ export async function withConsoleLogsRoutedToStderrForJson<T>(
   try {
     return await run();
   } finally {
+    // Restore the process-wide logging switch so nested/serial CLI calls keep their own output mode.
     loggingState.forceConsoleToStderr = previousForceStderr;
   }
 }

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -3,6 +3,7 @@ import readline from "node:readline/promises";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isVerbose, isYes } from "../globals.js";
 
+/** Signals that an interactive prompt lost stdin before a complete answer arrived. */
 export class PromptInputClosedError extends Error {
   constructor() {
     super("Prompt input closed before an answer was received.");
@@ -25,6 +26,7 @@ function questionUntilClose(rl: ReadlineInterface, question: string): Promise<st
     };
     const onClose = () => finish(() => reject(new PromptInputClosedError()));
 
+    // readline.question does not reject on interface close, so race it with the close event.
     rl.once("close", onClose);
     void rl.question(question).then(
       (answer) => finish(() => resolve(answer)),
@@ -33,11 +35,11 @@ function questionUntilClose(rl: ReadlineInterface, question: string): Promise<st
   });
 }
 
+/** Prompts for yes/no input, honoring global `--yes` before opening stdin. */
 export async function promptYesNo(question: string, defaultYes = false): Promise<boolean> {
-  // Simple Y/N prompt honoring global --yes and verbosity flags.
   if (isVerbose() && isYes()) {
     return true;
-  } // redundant guard when both flags set
+  }
   if (isYes()) {
     return true;
   }

--- a/src/cli/respawn-policy.ts
+++ b/src/cli/respawn-policy.ts
@@ -37,9 +37,12 @@ function isForegroundGatewayRunArgv(argv: string[]): boolean {
   if (!positionals) {
     return false;
   }
+  // Foreground gateway owns the terminal/process environment itself; respawning would
+  // add an extra parent process around the long-lived server.
   return positionals.length === 0 || (positionals.length === 1 && positionals[0] === "run");
 }
 
+/** Returns whether CLI startup should avoid the general respawn wrapper for this argv. */
 export function shouldSkipRespawnForArgv(argv: string[]): boolean {
   const invocation = resolveCliArgvInvocation(argv);
   return (
@@ -49,6 +52,7 @@ export function shouldSkipRespawnForArgv(argv: string[]): boolean {
   );
 }
 
+/** Returns whether startup-environment respawn should be skipped without suppressing TUI respawn policy. */
 export function shouldSkipStartupEnvironmentRespawnForArgv(argv: string[]): boolean {
   const invocation = resolveCliArgvInvocation(argv);
   return (

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -7,11 +7,14 @@ type CronActiveJobState = {
 const CRON_ACTIVE_JOB_STATE_KEY = Symbol.for("openclaw.cron.activeJobs");
 
 function getCronActiveJobState(): CronActiveJobState {
+  // Cron runs can cross module reload boundaries in tests and dev watch; keep
+  // the in-flight job set process-global so duplicate-run guards share state.
   return resolveGlobalSingleton<CronActiveJobState>(CRON_ACTIVE_JOB_STATE_KEY, () => ({
     activeJobIds: new Set<string>(),
   }));
 }
 
+/** Marks a cron job id as currently executing for duplicate-run suppression. */
 export function markCronJobActive(jobId: string) {
   if (!jobId) {
     return;
@@ -19,6 +22,7 @@ export function markCronJobActive(jobId: string) {
   getCronActiveJobState().activeJobIds.add(jobId);
 }
 
+/** Clears the active marker when a cron run exits or is abandoned. */
 export function clearCronJobActive(jobId: string) {
   if (!jobId) {
     return;
@@ -26,6 +30,7 @@ export function clearCronJobActive(jobId: string) {
   getCronActiveJobState().activeJobIds.delete(jobId);
 }
 
+/** Returns whether the given cron job id is currently executing in this process. */
 export function isCronJobActive(jobId: string) {
   if (!jobId) {
     return false;
@@ -33,10 +38,12 @@ export function isCronJobActive(jobId: string) {
   return getCronActiveJobState().activeJobIds.has(jobId);
 }
 
+/** Returns whether any cron run is active in this process. */
 export function hasActiveCronJobs() {
   return getCronActiveJobState().activeJobIds.size > 0;
 }
 
+/** Clears process-global cron active-job state between tests. */
 export function resetCronActiveJobsForTests() {
   getCronActiveJobState().activeJobIds.clear();
 }

--- a/src/cron/delivery-context.ts
+++ b/src/cron/delivery-context.ts
@@ -6,6 +6,7 @@ import {
 } from "../utils/delivery-context.shared.js";
 import type { CronDelivery, CronMessageChannel } from "./types.js";
 
+/** Converts an active delivery context into cron announce delivery config. */
 export function cronDeliveryFromContext(context?: DeliveryContext): CronDelivery | null {
   const normalized = normalizeDeliveryContext(context);
   if (!normalized?.to) {
@@ -27,6 +28,7 @@ export function cronDeliveryFromContext(context?: DeliveryContext): CronDelivery
   return delivery;
 }
 
+/** Recovers delivery context from a stored session key captured when the cron job was created. */
 export function resolveCronStoredDeliveryContext(params: {
   cfg: OpenClawConfig;
   sessionKey?: string;
@@ -37,11 +39,13 @@ export function resolveCronStoredDeliveryContext(params: {
   }
   const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey, { cfg: params.cfg });
   if (deliveryContext && threadId) {
+    // Parsed session-key thread ids are canonical; replace any stale thread value in stored context.
     return { ...deliveryContext, threadId };
   }
   return deliveryContext;
 }
 
+/** Resolves initial cron delivery, preferring the live context before falling back to session storage. */
 export function resolveCronCreationDelivery(params: {
   cfg: OpenClawConfig;
   currentDeliveryContext?: DeliveryContext;

--- a/src/cron/delivery-field-schemas.ts
+++ b/src/cron/delivery-field-schemas.ts
@@ -10,21 +10,25 @@ const DeliveryModeFieldSchema = z
   .preprocess(trimLowercaseStringPreprocess, z.enum(["deliver", "announce", "none", "webhook"]))
   .transform((value) => (value === "deliver" ? "announce" : value));
 
+/** Accepts non-empty string fields after trimming and lowercasing user-provided delivery input. */
 export const LowercaseNonEmptyStringFieldSchema = z.preprocess(
   trimLowercaseStringPreprocess,
   z.string().min(1),
 );
 
+/** Accepts non-empty string fields after trimming delivery input without changing case. */
 export const TrimmedNonEmptyStringFieldSchema = z.preprocess(
   trimStringPreprocess,
   z.string().min(1),
 );
 
+/** Accepts delivery thread identifiers as either trimmed strings or finite numeric ids. */
 export const DeliveryThreadIdFieldSchema = z.union([
   TrimmedNonEmptyStringFieldSchema,
   z.number().finite(),
 ]);
 
+/** Accepts non-negative finite timeout seconds from cron delivery payloads. */
 export const TimeoutSecondsFieldSchema = z.number().finite().nonnegative();
 
 type ParsedDeliveryInput = {
@@ -35,6 +39,7 @@ type ParsedDeliveryInput = {
   accountId?: string;
 };
 
+/** Parses optional cron delivery fields while dropping invalid values instead of throwing. */
 export function parseDeliveryInput(input: Record<string, unknown>): ParsedDeliveryInput {
   return {
     mode: parseOptionalField(DeliveryModeFieldSchema, input.mode),
@@ -45,6 +50,7 @@ export function parseDeliveryInput(input: Record<string, unknown>): ParsedDelive
   };
 }
 
+/** Returns a parsed field value only when the supplied schema accepts it. */
 export function parseOptionalField<T>(schema: ZodType<T>, value: unknown): T | undefined {
   const parsed = schema.safeParse(value);
   return parsed.success ? parsed.data : undefined;

--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -8,6 +8,7 @@ import type { CronFailureDestinationConfig } from "../config/types.cron.js";
 import { resolveTargetPrefixedChannel } from "../infra/outbound/channel-target-prefix.js";
 import type { CronDelivery, CronDeliveryMode, CronJob, CronMessageChannel } from "./types.js";
 
+/** Normalized routing plan for a cron job's primary delivery behavior. */
 export type CronDeliveryPlan = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
@@ -19,6 +20,7 @@ export type CronDeliveryPlan = {
   requested: boolean;
 };
 
+/** Returns whether a delivery plan names a concrete channel, recipient, thread, or account. */
 export function hasExplicitCronDeliveryTarget(plan: CronDeliveryPlan): boolean {
   return Boolean(
     (plan.channel && plan.channel !== "last") || plan.to || plan.threadId != null || plan.accountId,
@@ -47,6 +49,7 @@ function resolveAnnounceChannel(params: {
   );
 }
 
+/** Resolves primary delivery config into the runtime mode/channel/target plan. */
 export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   const delivery = job.delivery;
   const hasDelivery = delivery && typeof delivery === "object";
@@ -110,6 +113,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   };
 }
 
+/** Normalized destination for notifying about cron execution failures. */
 export type CronFailureDeliveryPlan = {
   mode: "announce" | "webhook";
   channel?: CronMessageChannel;
@@ -117,6 +121,7 @@ export type CronFailureDeliveryPlan = {
   accountId?: string;
 };
 
+/** Job-level failure destination override fields before global defaults are merged. */
 export type CronFailureDestinationInput = {
   channel?: CronMessageChannel;
   to?: string;
@@ -132,6 +137,7 @@ function normalizeFailureMode(value: unknown): "announce" | "webhook" | undefine
   return undefined;
 }
 
+/** Resolves job-level failure notification routing layered over global defaults. */
 export function resolveFailureDestination(
   job: CronJob,
   globalConfig?: CronFailureDestinationConfig,
@@ -175,6 +181,7 @@ export function resolveFailureDestination(
     if (jobMode !== undefined) {
       const globalMode = globalConfig?.mode ?? "announce";
       if (!jobToExplicitValue && globalMode !== jobMode) {
+        // Do not carry an inherited target across modes; an announce chat is not a webhook URL.
         to = undefined;
       }
       mode = jobMode;

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -34,6 +34,7 @@ function formatDeliveryDetail(params: {
   return params.resolved ? "explicit" : (params.error ?? "unresolved");
 }
 
+/** Builds the user-visible cron delivery preview for one job without sending anything. */
 export async function resolveCronDeliveryPreview(params: {
   cfg: OpenClawConfig;
   defaultAgentId?: string;
@@ -65,6 +66,8 @@ export async function resolveCronDeliveryPreview(params: {
     { dryRun: true },
   );
   if (!resolved.ok) {
+    // Preview mirrors runtime fail-closed behavior for "last" delivery so the
+    // UI can show unresolved routes before the cron job actually runs.
     return {
       label: `${plan.mode} -> ${formatTarget(requestedChannel, plan.to ?? null)}`,
       detail:
@@ -88,6 +91,7 @@ export async function resolveCronDeliveryPreview(params: {
   };
 }
 
+/** Builds cron delivery previews keyed by job id. */
 export async function resolveCronDeliveryPreviews(params: {
   cfg: OpenClawConfig;
   defaultAgentId?: string;

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -112,6 +112,7 @@ async function deliverCronAnnouncePayload(params: {
   }
 }
 
+/** Sends a cron announce payload and throws if target resolution or delivery fails. */
 export async function sendCronAnnouncePayloadStrict(params: {
   deps: CliDeps;
   cfg: OpenClawConfig;
@@ -134,6 +135,7 @@ export async function sendCronAnnouncePayloadStrict(params: {
   });
 }
 
+/** Sends a best-effort cron failure notification, logging resolution/send failures. */
 export async function sendFailureNotificationAnnounce(
   deps: CliDeps,
   cfg: OpenClawConfig,
@@ -145,6 +147,7 @@ export async function sendFailureNotificationAnnounce(
   const delivery = await resolveCronAnnounceDelivery({ cfg, agentId, jobId, target });
 
   if (!delivery.ok) {
+    // Failure alerts must not mask the original cron run failure.
     cronDeliveryLogger.warn(
       { error: delivery.error.message },
       "cron: failed to resolve failure destination target",

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -31,6 +31,7 @@ export {
 const FAILURE_NOTIFICATION_TIMEOUT_MS = 30_000;
 const cronDeliveryLogger = getChildLogger({ subsystem: "cron-delivery" });
 
+/** Channel target metadata used for cron announcements and failure notifications. */
 export type CronAnnounceTarget = {
   channel?: string;
   to?: string;
@@ -157,6 +158,8 @@ export async function sendFailureNotificationAnnounce(
 
   const abortController = new AbortController();
   const timeout = setTimeout(() => {
+    // Failure notifications are secondary; timeout prevents a stuck channel send
+    // from extending an already-failed cron run.
     abortController.abort();
   }, FAILURE_NOTIFICATION_TIMEOUT_MS);
 

--- a/src/cron/heartbeat-policy.ts
+++ b/src/cron/heartbeat-policy.ts
@@ -10,6 +10,7 @@ type HeartbeatDeliveryPayload = {
   channelData?: unknown;
 };
 
+/** Returns whether delivery output contains only heartbeat acknowledgement text. */
 export function shouldSkipHeartbeatOnlyDelivery(
   payloads: HeartbeatDeliveryPayload[],
   ackMaxChars: number,
@@ -32,6 +33,7 @@ export function shouldSkipHeartbeatOnlyDelivery(
   });
 }
 
+/** Returns whether an undelivered cron main-summary system event should be queued. */
 export function shouldEnqueueCronMainSummary(params: {
   summaryText: string | undefined;
   deliveryRequested: boolean;

--- a/src/cron/isolated-agent/channel-output-policy.ts
+++ b/src/cron/isolated-agent/channel-output-policy.ts
@@ -11,6 +11,7 @@ async function loadChannelPluginRuntime() {
   return await channelPluginRuntimeLoader.load();
 }
 
+/** Resolves channel-specific cron output preferences from loaded channel plugins. */
 export async function resolveCronChannelOutputPolicy(channel: string | undefined): Promise<{
   preferFinalAssistantVisibleText: boolean;
 }> {
@@ -25,6 +26,7 @@ export async function resolveCronChannelOutputPolicy(channel: string | undefined
   };
 }
 
+/** Resolves the provider-specific current-thread target for a delivery address. */
 export async function resolveCurrentChannelTarget(params: {
   channel?: string;
   to?: string;

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -86,6 +86,7 @@ function normalizeSilentReplyText(text: string | undefined): NormalizedSilentRep
   return { text: next, strippedTrailingSilentToken };
 }
 
+/** Returns whether cron delivery should tolerate per-payload send failures. */
 export function resolveCronDeliveryBestEffort(job: CronJob): boolean {
   return job.delivery?.bestEffort === true;
 }
@@ -241,6 +242,7 @@ async function logCronDeliveryError(message: string): Promise<void> {
   logError(message);
 }
 
+/** Deletes or retires ephemeral direct-delivery cron sessions for delete-after-run jobs. */
 export async function cleanupDirectCronSession(params: {
   job: CronJob;
   agentSessionKey: string;
@@ -680,10 +682,12 @@ async function appendDirectCronDeliveryTranscriptMirror(params: {
   }
 }
 
+/** Clears the direct-delivery idempotency cache for deterministic tests. */
 export function resetCompletedDirectCronDeliveriesForTests() {
   COMPLETED_DIRECT_CRON_DELIVERIES.clear();
 }
 
+/** Returns the direct-delivery idempotency cache size for tests. */
 export function getCompletedDirectCronDeliveriesCountForTests(): number {
   return COMPLETED_DIRECT_CRON_DELIVERIES.size;
 }
@@ -749,6 +753,7 @@ async function retryTransientDirectCronDelivery<T>(params: {
   return await params.run();
 }
 
+/** Dispatches cron run output through verified message-tool or direct delivery paths. */
 export async function dispatchCronDelivery(
   params: DispatchCronDeliveryParams,
 ): Promise<DispatchCronDeliveryState> {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -91,6 +91,7 @@ export function resolveCronDeliveryBestEffort(job: CronJob): boolean {
   return job.delivery?.bestEffort === true;
 }
 
+/** Successful delivery-target resolution consumed by announce/direct delivery dispatch. */
 export type SuccessfulDeliveryTarget = Extract<DeliveryTargetResolution, { ok: true }>;
 
 type DispatchCronDeliveryParams = {
@@ -125,6 +126,7 @@ type DispatchCronDeliveryParams = {
   ) => RunCronAgentTurnResult;
 };
 
+/** Mutable delivery-dispatch accumulator returned to the isolated cron runner. */
 export type DispatchCronDeliveryState = {
   result?: RunCronAgentTurnResult;
   delivered: boolean;

--- a/src/cron/isolated-agent/delivery-target.runtime.ts
+++ b/src/cron/isolated-agent/delivery-target.runtime.ts
@@ -13,6 +13,7 @@ export { getLoadedChannelPluginForRead } from "../../channels/plugins/registry-l
 export { mapAllowFromEntries } from "../../plugin-sdk/channel-config-helpers.js";
 export { resolveFirstBoundAccountId } from "../../routing/bound-account-read.js";
 
+/** Resolves a cron delivery target through channel plugins with bootstrap allowed. */
 export async function resolveChannelTargetForDelivery(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -40,6 +41,7 @@ export async function resolveChannelTargetForDelivery(params: {
   }
 }
 
+/** Resolves the outbound session route used for cron delivery threading and mirrors. */
 export async function resolveOutboundSessionRouteForDelivery(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -58,6 +60,7 @@ export async function resolveOutboundSessionRouteForDelivery(params: {
   return await resolveOutboundSessionRoute(params);
 }
 
+/** Returns whether a channel can canonicalize outbound cron delivery sessions. */
 export function channelCanResolveOutboundSessionRoute(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -19,6 +19,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveCronStoredDeliveryContext } from "../delivery-context.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 
+/** Result of resolving a cron job delivery request into a sendable outbound channel target. */
 export type DeliveryTargetResolution =
   | {
       ok: true;
@@ -108,6 +109,8 @@ function shouldCarrySessionThread(params: {
       params.resolved.to === params.resolved.lastTo
     );
   }
+  // Explicit targets may reuse a stored thread only when both targets resolve
+  // to the same channel peer; otherwise cron could reply into a stale thread.
   return routesSharePeer(params.route, params.lastRoute);
 }
 

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -127,6 +127,7 @@ function shouldStripResolvedTargetProviderPrefix(target: ResolvedMessagingTarget
   return target.resolutionSource === "normalized";
 }
 
+/** Resolves cron delivery config into a concrete channel target and optional thread/account. */
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
   agentId: string,
@@ -275,6 +276,8 @@ export async function resolveDeliveryTarget(
     effectiveAllowFrom = allowFromOverride;
 
     if (toCandidate && allowFromOverride.length > 0) {
+      // Implicit delivery must stay within channel allow-from policy; if the
+      // remembered target is outside that set, fall back to the first allowed peer.
       const currentTargetResolution = await resolveOutboundTargetWithRuntime({
         channel,
         to: toCandidate,

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -11,6 +11,7 @@ type DeliveryPayload = Pick<
   "text" | "mediaUrl" | "mediaUrls" | "presentation" | "interactive" | "channelData" | "isError"
 >;
 
+/** Normalized cron run payload state used for summaries, delivery, and failure classification. */
 export type CronPayloadOutcome = {
   summary?: string;
   outputText?: string;
@@ -296,6 +297,8 @@ export function resolveCronPayloadOutcome(params: {
     !hasPendingPresentationWarning &&
     !hasNonTerminalToolErrorWarning &&
     !hasRecoveredToolWarning;
+  // Fatal structured errors own the final delivery payload unless later output
+  // proves recovery; otherwise cron would announce stale partial success text.
   // Keep structured/media announce payloads intact. Only collapse purely textual
   // cron announce output to the final assistant-visible answer.
   // A final assistant answer can replace textual warning payloads, but never

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -77,6 +77,7 @@ function formatCronRunLevelError(error: unknown): string | undefined {
   return "cron isolated run failed";
 }
 
+/** Picks a bounded cron run summary from plain text output. */
 export function pickSummaryFromOutput(text: string | undefined) {
   const clean = (text ?? "").trim();
   if (!clean) {
@@ -86,6 +87,7 @@ export function pickSummaryFromOutput(text: string | undefined) {
   return clean.length > limit ? `${truncateUtf16Safe(clean, limit)}…` : clean;
 }
 
+/** Picks the last non-error payload text suitable for cron run summaries. */
 export function pickSummaryFromPayloads(
   payloads: Array<{ text?: string | undefined; isError?: boolean }>,
 ) {
@@ -110,6 +112,7 @@ export function pickSummaryFromPayloads(
   return undefined;
 }
 
+/** Picks the last non-empty payload text while ignoring terminal error payloads first. */
 export function pickLastNonEmptyTextFromPayloads(
   payloads: Array<{ text?: string | undefined; isError?: boolean }>,
 ) {
@@ -154,6 +157,7 @@ function payloadHasStructuredDeliveryContent(payload: DeliveryPayload | null | u
   );
 }
 
+/** Picks the last payload with deliverable outbound content, preferring non-error payloads. */
 export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
   for (let i = payloads.length - 1; i >= 0; i--) {
     if (payloads[i]?.isError) {
@@ -171,6 +175,7 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
   return undefined;
 }
 
+/** Selects deliverable cron payloads while preserving multi-payload successful responses. */
 export function pickDeliverablePayloads(payloads: DeliveryPayload[]): DeliveryPayload[] {
   const successfulDeliverablePayloads = payloads.filter(
     (payload) => payload != null && payload.isError !== true && isDeliverablePayload(payload),
@@ -190,6 +195,7 @@ export function isHeartbeatOnlyResponse(payloads: DeliveryPayload[], ackMaxChars
   return shouldSkipHeartbeatOnlyDelivery(payloads, ackMaxChars);
 }
 
+/** Resolves the non-negative heartbeat ack length used for heartbeat-only filtering. */
 export function resolveHeartbeatAckMaxChars(agentCfg?: { heartbeat?: { ackMaxChars?: number } }) {
   const raw = agentCfg?.heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
   return Math.max(0, raw);
@@ -218,6 +224,7 @@ function isSuccessfulCronPayload(payload: DeliveryPayload | undefined): boolean 
   );
 }
 
+/** Resolves summary, output text, delivery payloads, and fatal-error state from cron run output. */
 export function resolveCronPayloadOutcome(params: {
   payloads: DeliveryPayload[];
   runLevelError?: unknown;
@@ -259,6 +266,8 @@ export function resolveCronPayloadOutcome(params: {
     normalizedFinalAssistantVisibleText !== undefined ||
     hasSuccessfulPayloadAfterLastError ||
     hasSuccessfulPayloadBeforeLastError;
+  // Some tools emit warning/error payloads before a final answer. Treat those
+  // as non-terminal only when later visible output proves the run recovered.
   const hasNonTerminalToolErrorWarning =
     !params.runLevelError &&
     params.failureSignal?.fatalForCron !== true &&
@@ -289,6 +298,8 @@ export function resolveCronPayloadOutcome(params: {
     !hasRecoveredToolWarning;
   // Keep structured/media announce payloads intact. Only collapse purely textual
   // cron announce output to the final assistant-visible answer.
+  // A final assistant answer can replace textual warning payloads, but never
+  // structured/media payloads that carry the actual delivery content.
   const shouldUseFinalAssistantVisibleText =
     params.preferFinalAssistantVisibleText === true &&
     normalizedFinalAssistantVisibleText !== undefined &&

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -10,6 +10,7 @@ const PREFLIGHT_TIMEOUT_MS = 2_500;
 
 type PreflightApi = "ollama" | "openai-completions";
 
+/** Local provider reachability result used to skip cron runs before runner startup. */
 export type CronModelProviderPreflightResult =
   | { status: "available" }
   | {

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -174,6 +174,7 @@ async function probeLocalProviderEndpoint(params: {
   }
 }
 
+/** Checks local model-provider reachability before a scheduled cron run starts. */
 export async function preflightCronModelProvider(params: {
   cfg: OpenClawConfig;
   provider: string;
@@ -194,6 +195,8 @@ export async function preflightCronModelProvider(params: {
   const cacheKey = `${api}\0${baseUrl}`;
   const cached = preflightCache.get(cacheKey);
   if (cached && nowMs - cached.checkedAtMs < PREFLIGHT_CACHE_TTL_MS) {
+    // Cache by endpoint, not model: this probe only verifies local server
+    // reachability, while model availability is handled by the runner.
     if (cached.result.status === "available") {
       return { status: "available" };
     }
@@ -224,6 +227,7 @@ export async function preflightCronModelProvider(params: {
   });
 }
 
+/** Clears the local-provider preflight cache for deterministic tests. */
 export function resetCronModelProviderPreflightCacheForTest(): void {
   preflightCache.clear();
 }

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -63,6 +63,7 @@ function formatCronPayloadModelRejection(params: {
   return `cron payload.model '${modelOverride}' rejected: ${error}`;
 }
 
+/** Resolves the effective model for an isolated cron run across defaults, agents, hooks, payload, and session state. */
 export async function resolveCronModelSelection(
   params: ResolveCronModelSelectionParams,
 ): Promise<ResolveCronModelSelectionResult> {
@@ -92,6 +93,8 @@ export async function resolveCronModelSelection(
   const subagentModelSource: CronModelSelectionSource =
     subagentModelConfigSelection?.source === "agent" ? "agent" : "subagent";
   if (subagentModelRaw) {
+    // Subagent/agent model config is advisory here: invalid refs fall back to
+    // defaults so an agent config typo does not prevent unrelated cron runs.
     const resolvedSubagent = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,
       catalog: await loadCatalogOnce(),
@@ -157,6 +160,8 @@ export async function resolveCronModelSelection(
   if (!modelOverride && !hooksGmailModelApplied) {
     const sessionModelOverride = params.sessionEntry.modelOverride?.trim();
     if (sessionModelOverride) {
+      // Stored session overrides are lowest precedence so explicit cron payload
+      // and hook-specific models can intentionally move a run away from history.
       const sessionProviderOverride =
         params.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;
       const resolvedSessionOverride = resolveAllowedModelRef({

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -20,6 +20,7 @@ type CronSessionModelOverrides = {
 
 type CronModelSelectionSource = "default" | "subagent" | "agent" | "hook" | "payload" | "session";
 
+/** Inputs used to resolve the model for one isolated cron run. */
 export type ResolveCronModelSelectionParams = {
   cfg: OpenClawConfig;
   cfgWithAgentDefaults: OpenClawConfig;
@@ -30,6 +31,7 @@ export type ResolveCronModelSelectionParams = {
   agentId?: string;
 };
 
+/** Resolved provider/model pair plus the precedence source that selected it. */
 export type ResolveCronModelSelectionResult =
   | {
       ok: true;

--- a/src/cron/isolated-agent/run-config.ts
+++ b/src/cron/isolated-agent/run-config.ts
@@ -32,6 +32,7 @@ function mergeCronAgentModelOverride(params: {
   return nextDefaults;
 }
 
+/** Builds the agent defaults snapshot used by isolated cron runs. */
 export function buildCronAgentDefaultsConfig(params: {
   defaults?: AgentDefaultsConfig;
   agentConfigOverride?: ResolvedAgentConfig;

--- a/src/cron/isolated-agent/run-execution.runtime.ts
+++ b/src/cron/isolated-agent/run-execution.runtime.ts
@@ -22,6 +22,7 @@ async function loadCronExecutionCliRuntime() {
   return await cronExecutionCliRuntimeLoader.load();
 }
 
+/** Lazily resolves CLI session ids without loading the cron CLI runner at module import time. */
 export async function getCliSessionId(
   ...args: Parameters<typeof import("../../agents/cli-session.js").getCliSessionId>
 ): Promise<ReturnType<typeof import("../../agents/cli-session.js").getCliSessionId>> {
@@ -29,6 +30,7 @@ export async function getCliSessionId(
   return runtime.getCliSessionId(...args);
 }
 
+/** Lazily runs the CLI-backed agent path used by isolated cron execution. */
 export async function runCliAgent(
   ...args: Parameters<typeof import("../../agents/cli-runner.js").runCliAgent>
 ): ReturnType<typeof import("../../agents/cli-runner.js").runCliAgent> {

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -84,6 +84,7 @@ function resolveIsolatedCronPromptCacheKey(params: {
   return `openclaw-cron-${digest}`;
 }
 
+/** Detects single-line cron prompts that look like shell commands or command invocations. */
 export function isCommandStyleCronMessage(message: string): boolean {
   const trimmed = message.trim();
   if (!trimmed || trimmed.includes("\n")) {
@@ -104,6 +105,7 @@ function resolveCronBootstrapContextMode(
   return isCommandStyleCronMessage(payload?.message ?? "") ? "lightweight" : undefined;
 }
 
+/** Result envelope returned after an isolated cron prompt completes. */
 export type CronExecutionResult = {
   runResult: CronPromptRunResult;
   fallbackProvider: string;
@@ -113,6 +115,7 @@ export type CronExecutionResult = {
   liveSelection: CronLiveSelection;
 };
 
+/** Creates the model-fallback executor for one isolated cron prompt run. */
 export function createCronPromptExecutor(params: {
   cfg: OpenClawConfig;
   cfgWithAgentDefaults: OpenClawConfig;
@@ -212,6 +215,8 @@ export function createCronPromptExecutor(params: {
           }) ?? providerOverride;
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
+        // CLI providers can resume provider-native sessions; embedded providers
+        // use OpenClaw's transcript/session file plus prompt-cache affinity.
         if (isCliProvider(executionProvider, params.cfgWithAgentDefaults)) {
           const cliSessionId = params.cronSession.isNewSession
             ? undefined
@@ -349,6 +354,7 @@ export function createCronPromptExecutor(params: {
   };
 }
 
+/** Executes an isolated cron prompt, including live model-switch and interim-ack retries. */
 export async function executeCronRun(params: {
   cfg: OpenClawConfig;
   cfgWithAgentDefaults: OpenClawConfig;
@@ -457,6 +463,8 @@ export async function executeCronRun(params: {
         liveSelection: params.liveSelection,
       });
       try {
+        // Persist the switched model before retrying so later delivery/session
+        // metadata agrees with the model that actually handled the run.
         await params.persistSessionEntry();
       } catch (persistErr) {
         logWarn(
@@ -510,6 +518,8 @@ export async function executeCronRun(params: {
     }
 
     if (shouldRetryInterimAck && !hasFreshDescendants && !hasActiveDescendants) {
+      // Retry a bare acknowledgement only when no descendant subagent was
+      // spawned; otherwise delivery waits for the subagent follow-up path.
       const continuationPrompt = [
         "Your previous response was only an acknowledgement and did not complete this cron task.",
         "Complete the original task now.",

--- a/src/cron/isolated-agent/run-fallback-policy.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.ts
@@ -7,6 +7,7 @@ import {
   resolveSubagentModelFallbacksOverride,
 } from "./run-execution.runtime.js";
 
+/** Resolves cron model fallbacks, giving explicit payload fallbacks precedence over subagent/default policy. */
 export function resolveCronFallbacksOverride(params: {
   cfg: OpenClawConfig;
   job: CronJob;
@@ -21,6 +22,8 @@ export function resolveCronFallbacksOverride(params: {
     return payloadFallbacks;
   }
   if (params.useSubagentFallbacks === true && !hasCronPayloadModelOverride) {
+    // A payload model override owns its full candidate chain; otherwise the
+    // selected subagent can contribute its configured fallback policy.
     const subagentFallbacksOverride = resolveSubagentModelFallbacksOverride(
       params.cfg,
       params.agentId,
@@ -37,6 +40,7 @@ export function resolveCronFallbacksOverride(params: {
   });
 }
 
+/** Builds the ordered model candidates used by cron preflight checks. */
 export function resolveCronPreflightCandidates(params: {
   cfg: OpenClawConfig;
   job: CronJob;

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -7,11 +7,14 @@ import type { resolveCronSession } from "./session.js";
 
 type MutableSessionStore = Record<string, SessionEntry>;
 
+/** Mutable cron session entry updated by an isolated run before persistence. */
 export type MutableCronSessionEntry = SessionEntry;
+/** Resolved cron session plus its mutable backing store and active entry. */
 export type MutableCronSession = ReturnType<typeof resolveCronSession> & {
   store: MutableSessionStore;
   sessionEntry: MutableCronSessionEntry;
 };
+/** Live provider/model/auth-profile selection reported by the running session. */
 export type CronLiveSelection = LiveSessionModelSelection;
 
 type UpdateSessionStore = (
@@ -19,6 +22,7 @@ type UpdateSessionStore = (
   update: (store: MutableSessionStore) => void,
 ) => Promise<void>;
 
+/** Persists the currently selected mutable cron session entry to the session store. */
 export type PersistCronSessionEntry = () => Promise<void>;
 
 function cronTranscriptExists(entry: SessionEntry): boolean {

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -33,6 +33,8 @@ function normalizeSessionField(value: string | undefined): string | undefined {
 
 function toNonResumableCronSessionEntry(entry: SessionEntry): SessionEntry {
   const next = { ...entry } as Partial<SessionEntry>;
+  // If the transcript never materialized, do not persist stale resume handles
+  // that would make the next cron run believe a resumable CLI session exists.
   delete next.sessionId;
   delete next.sessionFile;
   delete next.sessionStartedAt;
@@ -43,6 +45,7 @@ function toNonResumableCronSessionEntry(entry: SessionEntry): SessionEntry {
   return next as SessionEntry;
 }
 
+/** Creates the persistence callback that stores cron session metadata after a run. */
 export function createPersistCronSessionEntry(params: {
   isFastTestEnv: boolean;
   cronSession: MutableCronSession;
@@ -66,6 +69,7 @@ export function createPersistCronSessionEntry(params: {
   };
 }
 
+/** Adopts the session id/file produced by a run and preserves usage-family lineage. */
 export function adoptCronRunSessionMetadata(params: {
   entry: MutableCronSessionEntry;
   sessionKey: string;
@@ -103,6 +107,7 @@ export function adoptCronRunSessionMetadata(params: {
   return changed;
 }
 
+/** Persists a changed skills snapshot onto the cron session entry outside fast tests. */
 export async function persistCronSkillsSnapshotIfChanged(params: {
   isFastTestEnv: boolean;
   cronSession: MutableCronSession;
@@ -124,6 +129,7 @@ export async function persistCronSkillsSnapshotIfChanged(params: {
   await params.persistSessionEntry();
 }
 
+/** Records the selected provider/model before a cron run starts. */
 export function markCronSessionPreRun(params: {
   entry: MutableCronSessionEntry;
   provider: string;
@@ -134,6 +140,7 @@ export function markCronSessionPreRun(params: {
   params.entry.systemSent = true;
 }
 
+/** Syncs live model/auth-profile changes from a running cron session back to storage. */
 export function syncCronSessionLiveSelection(params: {
   entry: MutableCronSessionEntry;
   liveSelection: CronLiveSelection;
@@ -144,6 +151,8 @@ export function syncCronSessionLiveSelection(params: {
     params.entry.authProfileOverride = params.liveSelection.authProfileId;
     params.entry.authProfileOverrideSource = params.liveSelection.authProfileIdSource;
     if (params.liveSelection.authProfileIdSource === "auto") {
+      // Auto-selected profiles are tied to the compaction generation that
+      // resolved them; manual overrides should survive later compactions.
       params.entry.authProfileOverrideCompactionCount = params.entry.compactionCount ?? 0;
     } else {
       delete params.entry.authProfileOverrideCompactionCount;

--- a/src/cron/isolated-agent/run-timeout.ts
+++ b/src/cron/isolated-agent/run-timeout.ts
@@ -1,5 +1,6 @@
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 
+/** Converts explicit cron payload timeoutSeconds into a timer-safe millisecond override signal. */
 export function resolveCronRunTimeoutOverrideMs(timeoutSeconds: unknown): number | undefined {
   return finiteSecondsToTimerSafeMilliseconds(timeoutSeconds);
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1203,6 +1203,7 @@ async function disposeCronRunContext(params: {
   (params.cronSession as { store?: unknown }).store = undefined;
 }
 
+/** Runs one isolated cron agent turn, including setup, execution, delivery, and persistence. */
 export async function runCronIsolatedAgentTurn(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;

--- a/src/cron/isolated-agent/run.types.ts
+++ b/src/cron/isolated-agent/run.types.ts
@@ -1,5 +1,6 @@
 import type { CronDeliveryTrace, CronRunOutcome, CronRunTelemetry } from "../types.js";
 
+/** Final isolated cron turn result merged into service state and run logs. */
 export type RunCronAgentTurnResult = {
   /** Last non-empty agent text output (not truncated). */
   outputText?: string;

--- a/src/cron/isolated-agent/session-key.ts
+++ b/src/cron/isolated-agent/session-key.ts
@@ -2,6 +2,7 @@ import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session
 import type { SessionScope } from "../../config/sessions/types.js";
 import { toAgentStoreSessionKey } from "../../routing/session-key.js";
 
+/** Resolves a cron session key into the canonical agent-scoped session-store key. */
 export function resolveCronAgentSessionKey(params: {
   sessionKey: string;
   agentId: string;

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -103,6 +103,7 @@ function sanitizeFreshCronSessionEntry(
   return next;
 }
 
+/** Resolves or rolls over the cron session entry for one isolated-agent run. */
 export function resolveCronSession(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -118,14 +119,13 @@ export function resolveCronSession(params: {
   const store = params.store ?? loadSessionStore(storePath);
   const entry = store[params.sessionKey];
 
-  // Check if we can reuse an existing session
   let sessionId: string;
   let isNewSession: boolean;
   let systemSent: boolean;
 
   if (!params.forceNew && entry?.sessionId) {
-    // Evaluate freshness using the configured reset policy
-    // Cron/webhook sessions use "direct" reset type (1:1 conversation style)
+    // Cron/webhook sessions follow the direct reset policy so scheduled turns
+    // roll over like 1:1 conversations rather than long-lived group contexts.
     const resetPolicy = resolveSessionResetPolicy({
       sessionCfg,
       resetType: "direct",
@@ -142,18 +142,15 @@ export function resolveCronSession(params: {
     });
 
     if (freshness.fresh) {
-      // Reuse existing session
       sessionId = entry.sessionId;
       isNewSession = false;
       systemSent = entry.systemSent ?? false;
     } else {
-      // Session expired, create new
       sessionId = crypto.randomUUID();
       isNewSession = true;
       systemSent = false;
     }
   } else {
-    // No existing session or forced new
     sessionId = crypto.randomUUID();
     isNewSession = true;
     systemSent = false;
@@ -172,9 +169,9 @@ export function resolveCronSession(params: {
     : undefined;
 
   const sessionEntry: SessionEntry = {
-    // Preserve existing per-session overrides even when rolling to a new sessionId.
+    // Fresh cron sessions keep user preference/auth overrides but drop resume
+    // handles and auto-fallback model overrides that belong to the old run.
     ...baseEntry,
-    // Always update these core fields
     sessionId,
     updatedAt: params.nowMs,
     sessionStartedAt: isNewSession

--- a/src/cron/isolated-agent/subagent-followup-hints.ts
+++ b/src/cron/isolated-agent/subagent-followup-hints.ts
@@ -30,6 +30,7 @@ function normalizeHintText(value: string): string {
   return normalizeLowercaseStringOrEmpty(value).replace(/\s+/g, " ");
 }
 
+/** Detects short cron replies that probably announce work continuing elsewhere. */
 export function isLikelyInterimCronMessage(value: string): boolean {
   const normalized = normalizeHintText(value);
   if (!normalized) {
@@ -42,6 +43,7 @@ export function isLikelyInterimCronMessage(value: string): boolean {
   return words <= 45 && INTERIM_CRON_HINTS.some((hint) => normalized.includes(hint));
 }
 
+/** Detects cron replies that explicitly promise a subagent follow-up message. */
 export function expectsSubagentFollowup(value: string): boolean {
   const normalized = normalizeHintText(value);
   return Boolean(normalized && SUBAGENT_FOLLOWUP_HINTS.some((hint) => normalized.includes(hint)));

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -12,6 +12,7 @@ function resolveCronSubagentTimings() {
   };
 }
 
+/** Reads completed descendant subagent replies when the orchestrator only emitted interim text. */
 export async function readDescendantSubagentFallbackReply(params: {
   sessionKey: string;
   runStartedAt: number;

--- a/src/cron/normalize-job-identity.ts
+++ b/src/cron/normalize-job-identity.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
+/** Normalizes mutable cron job rows from old `jobId` storage into the canonical `id` field. */
 export function normalizeCronJobIdentityFields(raw: Record<string, unknown>): {
   mutated: boolean;
   legacyJobIdIssue: boolean;

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -27,7 +27,7 @@ type UnknownRecord = Record<string, unknown>;
 
 type NormalizeOptions = {
   applyDefaults?: boolean;
-  /** Session context for resolving "current" sessionTarget or auto-binding when not specified */
+  /** Session context used to resolve "current" sessionTarget during create-time defaulting. */
   sessionContext?: { sessionKey?: string };
 };
 
@@ -93,6 +93,8 @@ function coerceSchedule(schedule: UnknownRecord) {
   }
 
   if (next.kind === "at") {
+    // Keep each schedule variant canonical so persisted jobs do not carry stale
+    // fields from a previous kind after CLI/API normalization.
     delete next.everyMs;
     delete next.anchorMs;
     delete next.expr;
@@ -261,7 +263,8 @@ function normalizeSessionTarget(raw: unknown) {
   if (lower === "main" || lower === "isolated" || lower === "current") {
     return lower;
   }
-  // Support custom session IDs with "session:" prefix
+  // Custom session targets must still pass the same session-id safety gate used
+  // by runtime session resolution.
   if (lower.startsWith("session:")) {
     return `session:${assertSafeCronSessionTargetId(trimmed.slice(8))}`;
   }
@@ -279,6 +282,7 @@ function normalizeWakeMode(raw: unknown) {
   return undefined;
 }
 
+/** Normalizes raw cron job input without deciding whether create-time defaults apply. */
 export function normalizeCronJobInput(
   raw: unknown,
   options: NormalizeOptions = DEFAULT_OPTIONS,
@@ -386,10 +390,8 @@ export function normalizeCronJobInput(
     }
     if (!next.sessionTarget && isRecord(next.payload)) {
       const kind = typeof next.payload.kind === "string" ? next.payload.kind : "";
-      // Keep default behavior unchanged for backward compatibility:
-      // - systemEvent defaults to "main"
-      // - agentTurn defaults to "isolated" (NOT "current", to avoid token accumulation)
-      // Users must explicitly specify "current" or "session:xxx" for custom session binding
+      // Keep create-time defaults explicit: system events join main, while agent
+      // turns isolate by default to avoid unbounded token accumulation.
       if (kind === "systemEvent") {
         next.sessionTarget = "main";
       } else if (kind === "agentTurn") {
@@ -430,7 +432,8 @@ export function normalizeCronJobInput(
     const payload = isRecord(next.payload) ? next.payload : null;
     const payloadKind = payload && typeof payload.kind === "string" ? payload.kind : "";
     const sessionTarget = typeof next.sessionTarget === "string" ? next.sessionTarget : "";
-    // Support "isolated", custom session IDs (session:xxx), and resolved "current" as isolated-like targets
+    // Resolved "current" and custom session ids still use isolated-agent
+    // delivery semantics, so they get the same default announce behavior.
     const isIsolatedAgentTurn =
       sessionTarget === "isolated" ||
       sessionTarget === "current" ||
@@ -445,6 +448,7 @@ export function normalizeCronJobInput(
   return next;
 }
 
+/** Normalizes a raw cron create request and applies create-time defaults. */
 export function normalizeCronJobCreate(
   raw: unknown,
   options?: Omit<NormalizeOptions, "applyDefaults">,
@@ -455,6 +459,7 @@ export function normalizeCronJobCreate(
   }) as CronJobCreate | null;
 }
 
+/** Normalizes a raw cron patch request without filling omitted fields. */
 export function normalizeCronJobPatch(
   raw: unknown,
   options?: NormalizeOptions,

--- a/src/cron/parse.ts
+++ b/src/cron/parse.ts
@@ -17,6 +17,7 @@ function normalizeUtcIso(raw: string) {
   return raw;
 }
 
+/** Parses absolute cron timestamps from epoch milliseconds or ISO-like strings normalized to UTC. */
 export function parseAbsoluteTimeMs(input: string): number | null {
   const raw = input.trim();
   if (!raw) {

--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -7,6 +7,7 @@ export type InvalidPersistedCronJobReason =
   | "missing-payload"
   | "invalid-payload";
 
+/** Returns the first structural reason a persisted cron job cannot be loaded safely. */
 export function getInvalidPersistedCronJobReason(
   candidate: Record<string, unknown>,
 ): InvalidPersistedCronJobReason | null {
@@ -19,6 +20,8 @@ export function getInvalidPersistedCronJobReason(
     return "missing-schedule";
   }
   if (typeof schedule === "string") {
+    // Legacy shorthand schedules are normalized later by the full cron parser;
+    // this guard only rejects shapes that cannot be persisted or quarantined.
     return null;
   }
   if (typeof schedule !== "object") {

--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -1,5 +1,6 @@
 import { parseAbsoluteTimeMs } from "./parse.js";
 
+/** Structural rejection code for persisted cron jobs that cannot be loaded safely. */
 export type InvalidPersistedCronJobReason =
   | "missing-id"
   | "missing-schedule"

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -1,5 +1,6 @@
 import type { CronRetryOn } from "../config/types.cron.js";
 
+/** Cron retry classifier output consumed by scheduler retry policy. */
 export type CronRetryHint = {
   retryable: boolean;
   category?: CronRetryOn;
@@ -16,6 +17,7 @@ const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   server_error: /\b5\d{2}\b/,
 };
 
+/** Classifies cron execution errors against the configured retryable transient categories. */
 export function resolveCronExecutionRetryHint(
   error: string | undefined,
   retryOn?: CronRetryOn[],
@@ -27,6 +29,7 @@ export function resolveCronExecutionRetryHint(
   const keys = retryOn?.length ? retryOn : (Object.keys(TRANSIENT_PATTERNS) as CronRetryOn[]);
   const classified = classifiedReason ?? undefined;
   if (classified && keys.includes(classified as CronRetryOn)) {
+    // Structured provider classifications win over brittle message regexes when allowed.
     return { retryable: true, category: classified as CronRetryOn };
   }
   for (const key of keys) {

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -105,6 +105,7 @@ export function summarizeCronRunDiagnostics(
   return trimSummary(diagnostics.summary ?? diagnostics.entries[0]?.message);
 }
 
+/** Normalizes untrusted cron diagnostic payloads into bounded, redacted entries. */
 export function normalizeCronRunDiagnostics(
   value: unknown,
   opts?: { nowMs?: () => number },
@@ -141,6 +142,8 @@ export function normalizeCronRunDiagnostics(
       ...(entry.truncated === true || normalized.truncated ? { truncated: true } : {}),
     });
     if (entries.length > MAX_ENTRIES) {
+      // Keep the latest diagnostics because late tool/exec failures usually
+      // explain the final cron result better than setup noise.
       entries.shift();
     }
   }
@@ -155,6 +158,7 @@ export function normalizeCronRunDiagnostics(
   return { ...(summary ? { summary } : {}), entries };
 }
 
+/** Merges cron diagnostics while choosing the highest-severity latest summary. */
 export function mergeCronRunDiagnostics(
   ...values: Array<CronRunDiagnostics | undefined>
 ): CronRunDiagnostics | undefined {
@@ -174,6 +178,8 @@ export function mergeCronRunDiagnostics(
       const severity =
         entryCandidate?.severity === "error" ? 2 : entryCandidate?.severity === "warn" ? 1 : 0;
       const order = entries.length + normalized.entries.length;
+      // Summary text is operator-facing; prefer severe diagnostics, then the
+      // newest diagnostic at the same severity so retries surface current cause.
       if (
         !summaryCandidate ||
         severity > summaryCandidate.severity ||
@@ -190,6 +196,7 @@ export function mergeCronRunDiagnostics(
   });
 }
 
+/** Converts an arbitrary thrown cron error into a redacted diagnostic entry. */
 export function createCronRunDiagnosticsFromError(
   source: CronRunDiagnosticSource,
   error: unknown,
@@ -219,6 +226,7 @@ export function createCronRunDiagnosticsFromError(
   );
 }
 
+/** Extracts failed exec details from tool metadata into cron diagnostics. */
 export function createCronRunDiagnosticsFromExecDetails(
   details: unknown,
   opts?: {
@@ -260,6 +268,7 @@ export function createCronRunDiagnosticsFromExecDetails(
   );
 }
 
+/** Extracts tool-call failure diagnostics from an agent reply payload. */
 export function createCronRunDiagnosticsFromToolPayload(
   payload: unknown,
   opts?: { nowMs?: () => number; finalStatus?: "ok" | "error" | "skipped" },
@@ -289,6 +298,7 @@ export function createCronRunDiagnosticsFromToolPayload(
   return mergeCronRunDiagnostics(detailsDiagnostics, textDiagnostics);
 }
 
+/** Extracts cron run diagnostics from agent result payloads and metadata. */
 export function createCronRunDiagnosticsFromAgentResult(
   result: unknown,
   opts?: { nowMs?: () => number; finalStatus?: "ok" | "error" | "skipped" },

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -67,6 +67,8 @@ function tailText(value: string, maxChars: number): string {
   if (value.length <= maxChars) {
     return value;
   }
+  // Exec output often ends with the actionable failure; keep the tail when
+  // bounding diagnostic text for run logs and control surfaces.
   return value.slice(value.length - maxChars);
 }
 
@@ -96,6 +98,7 @@ function trimSummary(value: string | undefined): string | undefined {
   return `${normalized.slice(0, MAX_SUMMARY_CHARS - 1)}…`;
 }
 
+/** Returns the operator-facing summary for persisted cron diagnostics. */
 export function summarizeCronRunDiagnostics(
   diagnostics: CronRunDiagnostics | undefined,
 ): string | undefined {

--- a/src/cron/run-id.ts
+++ b/src/cron/run-id.ts
@@ -1,3 +1,4 @@
+/** Builds the stable diagnostic/session execution id for a single cron run. */
 export function createCronExecutionId(jobId: string, startedAt: number): string {
   return `cron:${jobId}:${startedAt}`;
 }

--- a/src/cron/run-log-jsonl.ts
+++ b/src/cron/run-log-jsonl.ts
@@ -1,6 +1,7 @@
 import type { CronRunLogEntry } from "./run-log-types.js";
 import { parseCronRunLogEntryObject } from "./run-log/entry-codec.js";
 
+/** Parses legacy cron run-log JSONL, skipping malformed or non-matching rows. */
 export function parseCronRunLogEntriesFromJsonl(
   raw: string,
   opts?: { jobId?: string },

--- a/src/cron/run-log-types.ts
+++ b/src/cron/run-log-types.ts
@@ -8,6 +8,7 @@ import type {
   CronRunTelemetry,
 } from "./types.js";
 
+/** Append-only run-log record for a completed cron job execution. */
 export type CronRunLogEntry = {
   ts: number;
   jobId: string;

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -71,6 +71,7 @@ function assertSafeCronRunLogJobId(jobId: string): string {
   return trimmed;
 }
 
+/** Returns whether an error came from cron run-log job id validation. */
 export function isInvalidCronRunLogJobIdError(err: unknown): boolean {
   return err instanceof Error && err.message === INVALID_CRON_RUN_LOG_JOB_ID_MESSAGE;
 }
@@ -80,6 +81,7 @@ const writesByTarget = new Map<string, Promise<void>>();
 export const DEFAULT_CRON_RUN_LOG_MAX_BYTES = 2_000_000;
 export const DEFAULT_CRON_RUN_LOG_KEEP_LINES = 2_000;
 
+/** Resolves configured run-log pruning limits while preserving legacy maxBytes parsing. */
 export function resolveCronRunLogPruneOptions(cfg?: CronConfig["runLog"]): {
   maxBytes: number;
   keepLines: number;
@@ -106,6 +108,7 @@ export function resolveCronRunLogPruneOptions(cfg?: CronConfig["runLog"]): {
   return { maxBytes, keepLines };
 }
 
+/** Exposes the in-process async write queue size for run-log concurrency tests. */
 export function getPendingCronRunLogWriteCountForTests() {
   return writesByTarget.size;
 }
@@ -126,6 +129,7 @@ async function drainPendingWrite(storePath: string, jobId?: string): Promise<voi
   await Promise.all(pending);
 }
 
+/** Appends a cron run-log row and serializes writes per store/job before pruning old rows. */
 export async function appendCronRunLog(params: {
   storePath: string;
   entry: CronRunLogEntry;
@@ -134,6 +138,7 @@ export async function appendCronRunLog(params: {
   const storeKey = cronStoreKey(params.storePath);
   const writeKey = cronRunLogWriteKey(params.storePath, params.entry.jobId);
   const prev = writesByTarget.get(writeKey) ?? Promise.resolve();
+  // Keep writes for the same store/job ordered so prune-by-count cannot race a later insert.
   const next = prev
     .catch(() => undefined)
     .then(async () => {
@@ -159,6 +164,7 @@ export async function appendCronRunLog(params: {
   }
 }
 
+/** Reads recent run-log entries in chronological order after draining pending async writes. */
 export async function readCronRunLogEntries(params: {
   storePath: string;
   jobId?: string;
@@ -177,6 +183,7 @@ export async function readCronRunLogEntries(params: {
   return page.entries.toReversed();
 }
 
+/** Reads recent run-log entries synchronously for startup/task reconciliation paths. */
 export function readCronRunLogEntriesSync(params: {
   storePath: string;
   jobId?: string;
@@ -281,6 +288,7 @@ function filterRunLogEntries(
   });
 }
 
+/** Reads a bounded, filterable run-log page for CLI and UI list views. */
 export async function readCronRunLogEntriesPage(
   opts: ReadCronRunLogPageOptions & { storePath: string; jobNameById?: Record<string, string> },
 ): Promise<CronRunLogPageResult> {
@@ -395,6 +403,7 @@ export async function readCronRunLogEntriesPage(
   };
 }
 
+/** Reads a run-log page across all jobs for a specific cron store. */
 export async function readCronRunLogEntriesPageAll(
   opts: ReadCronRunLogAllPageOptions,
 ): Promise<CronRunLogPageResult> {

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -78,7 +78,9 @@ export function isInvalidCronRunLogJobIdError(err: unknown): boolean {
 
 const writesByTarget = new Map<string, Promise<void>>();
 
+/** Legacy byte cap kept for config parsing compatibility with older file-backed run logs. */
 export const DEFAULT_CRON_RUN_LOG_MAX_BYTES = 2_000_000;
+/** Default SQLite row retention per cron job when no explicit keepLines value is configured. */
 export const DEFAULT_CRON_RUN_LOG_KEEP_LINES = 2_000;
 
 /** Resolves configured run-log pruning limits while preserving legacy maxBytes parsing. */

--- a/src/cron/run-log/entry-codec.ts
+++ b/src/cron/run-log/entry-codec.ts
@@ -28,6 +28,7 @@ function normalizeCronRunLogErrorReason(value: unknown): FailoverReason | undefi
     : undefined;
 }
 
+/** Parses a persisted cron run-log entry object and drops invalid or wrong-job rows. */
 export function parseCronRunLogEntryObject(
   obj: unknown,
   opts?: { jobId?: string },

--- a/src/cron/run-log/sqlite-store.ts
+++ b/src/cron/run-log/sqlite-store.ts
@@ -74,6 +74,7 @@ function bindCronRunLogRow(params: {
   };
 }
 
+/** Rehydrates a cron run-log row, preferring indexed SQLite columns over JSON payload values. */
 export function parseStoredRunLogEntry(row: CronRunLogRow): CronRunLogEntry | null {
   let rawEntry: unknown;
   try {
@@ -106,6 +107,7 @@ export function parseStoredRunLogEntry(row: CronRunLogRow): CronRunLogEntry | nu
   };
 }
 
+/** Reads run-log rows for one store, optionally scoped to one job, in chronological order. */
 export function readCronRunLogRows(
   db: DatabaseSync,
   storeKey: string,
@@ -136,6 +138,8 @@ function applyRunLogFilters<Output>(
     next = next.where((eb) =>
       eb.or(
         params.deliveryStatuses!.map((status) =>
+          // Older rows stored an omitted delivery status as SQL NULL; keep
+          // not-requested filters compatible with both representations.
           status === "not-requested"
             ? eb.or([eb("delivery_status", "is", null), eb("delivery_status", "=", status)])
             : eb("delivery_status", "=", status),
@@ -150,6 +154,7 @@ function applyRunLogFilters<Output>(
   return next;
 }
 
+/** Counts run-log rows after applying the same filters used by paged reads. */
 export function countCronRunLogRows(params: {
   db: DatabaseSync;
   storeKey: string;
@@ -170,6 +175,7 @@ export function countCronRunLogRows(params: {
   return normalizeNumber(row?.count ?? null) ?? 0;
 }
 
+/** Reads a sorted, filtered page of cron run-log rows. */
 export function readCronRunLogRowsPage(params: {
   db: DatabaseSync;
   storeKey: string;
@@ -205,6 +211,7 @@ function nextCronRunLogSeq(db: DatabaseSync, storeKey: string, jobId: string): n
   return (normalizeNumber(row?.seq ?? null) ?? 0) + 1;
 }
 
+/** Appends a cron run-log entry with a per-job monotonic sequence number. */
 export function insertCronRunLogEntry(
   db: DatabaseSync,
   storeKey: string,
@@ -219,6 +226,7 @@ export function insertCronRunLogEntry(
   );
 }
 
+/** Prunes old cron run-log rows for one job, retaining the newest keepLines rows. */
 export function pruneCronRunLogRows(
   db: DatabaseSync,
   storeKey: string,

--- a/src/cron/schedule-identity.ts
+++ b/src/cron/schedule-identity.ts
@@ -65,6 +65,7 @@ function resolveSchedulePayload(
   return undefined;
 }
 
+/** Builds a stable scheduling identity for deciding whether stored timer state is still valid. */
 export function tryCronScheduleIdentity(job: CronScheduleIdentityInput): string | undefined {
   const schedule = resolveSchedulePayload(job);
   if (!schedule) {
@@ -77,6 +78,7 @@ export function tryCronScheduleIdentity(job: CronScheduleIdentityInput): string 
   });
 }
 
+/** Compares two cron jobs by the normalized inputs that affect next-run computation. */
 export function cronSchedulingInputsEqual(
   previous: CronScheduleIdentityInput,
   next: CronScheduleIdentityInput,

--- a/src/cron/schedule-number.ts
+++ b/src/cron/schedule-number.ts
@@ -1,5 +1,6 @@
 import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 
+/** Coerces schedule numeric fields without accepting partial or non-finite numbers. */
 export function coerceFiniteScheduleNumber(value: unknown): number | undefined {
   return parseStrictFiniteNumber(value);
 }

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -21,7 +21,7 @@ function resolveCachedCron(expr: string, timezone: string): Cron {
   const key = `${timezone}\u0000${expr}`;
   const cached = cronEvalCache.get(key);
   if (cached) {
-    // Move to end of Map iteration order for LRU eviction
+    // Move to the end of Map iteration order so the bounded cache behaves as LRU.
     cronEvalCache.delete(key);
     cronEvalCache.set(key, cached);
     return cached;
@@ -48,6 +48,7 @@ function resolveCronFromSchedule(schedule: { tz?: string; expr?: unknown }): Cro
   return resolveCachedCron(expr, resolveCronTimezone(schedule.tz));
 }
 
+/** Computes the next scheduled run timestamp after now for at/every/cron schedules. */
 export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): number | undefined {
   if (schedule.kind === "at") {
     const atMs = parseAbsoluteTimeMs(schedule.at);
@@ -114,6 +115,7 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
   return nextMs;
 }
 
+/** Computes the previous cron-expression run timestamp before now. */
 export function computePreviousRunAtMs(schedule: CronSchedule, nowMs: number): number | undefined {
   if (schedule.kind !== "cron") {
     return undefined;
@@ -137,18 +139,22 @@ export function computePreviousRunAtMs(schedule: CronSchedule, nowMs: number): n
   return previousMs;
 }
 
+/** Clears the Croner expression cache for deterministic tests. */
 export function clearCronScheduleCacheForTest(): void {
   cronEvalCache.clear();
 }
 
+/** Returns the Croner expression cache size for tests. */
 export function getCronScheduleCacheSizeForTest(): number {
   return cronEvalCache.size;
 }
 
+/** Returns the Croner expression cache capacity for tests. */
 export function getCronScheduleCacheMaxForTest(): number {
   return CRON_EVAL_CACHE_MAX;
 }
 
+/** Returns whether an expression/timezone pair is present in the Croner cache for tests. */
 export function hasCronInCacheForTest(expr: string, tz: string): boolean {
   return cronEvalCache.has(`${tz}\u0000${expr}`);
 }

--- a/src/cron/service-contract.ts
+++ b/src/cron/service-contract.ts
@@ -15,8 +15,10 @@ import type { CronJob } from "./types.js";
 
 type CronWakeResult = { ok: true } | { ok: false; reason?: "unwakeable-session-key" };
 
+/** Result shape for direct/queued cron runs, including invalid persisted specs. */
 export type CronServiceRunResult = CronRunResult | { ok: true; ran: false; reason: "invalid-spec" };
 
+/** Public cron service facade used by gateway, plugin SDK, and tests. */
 export interface CronServiceContract {
   start(): Promise<void>;
   stop(): void;

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -10,8 +10,10 @@ import type { CronJob, CronJobCreate, CronJobPatch } from "./types.js";
 
 export type { CronEvent, CronServiceDeps } from "./service/state.js";
 
+/** Public cron service facade that owns mutable scheduler state and delegates to locked ops. */
 export class CronService implements CronServiceContract {
   private readonly state;
+
   constructor(deps: CronServiceDeps) {
     this.state = createCronServiceState(deps);
   }
@@ -55,6 +57,8 @@ export class CronService implements CronServiceContract {
   async enqueueRun(id: string, mode?: "due" | "force"): Promise<CronServiceRunResult> {
     const result = await ops.enqueueRun(this.state, id, mode);
     if (result.ok && "runnable" in result) {
+      // ops.enqueueRun resolves runnable dispositions before crossing the
+      // public facade; leaking one would expose an internal scheduler detail.
       throw new Error("cron enqueueRun returned unresolved runnable disposition");
     }
     return result;

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -25,6 +25,8 @@ type CronAgentWatchdogState =
 
 type CronAgentPhaseWatchdogStage = "pre_execution" | "execution";
 
+// Phase ordering is not strictly monotonic during fallback attempts, so each
+// emitted phase is mapped to the watchdog bucket that should keep timing it.
 const CRON_AGENT_PHASE_WATCHDOG_STAGE = {
   runner_entered: "pre_execution",
   workspace: "pre_execution",
@@ -42,6 +44,7 @@ const CRON_AGENT_PHASE_WATCHDOG_STAGE = {
   model_call_started: "execution",
 } as const satisfies Record<CronAgentExecutionPhase, CronAgentPhaseWatchdogStage>;
 
+/** Handle for feeding isolated-agent progress into cron timeout watchdogs. */
 export type CronAgentWatchdog = {
   start: () => void;
   noteRunnerStarted: (info?: CronAgentExecutionStarted) => void;

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -50,6 +50,7 @@ export type CronAgentWatchdog = {
   dispose: () => void;
 };
 
+/** Tracks isolated-agent setup/execution progress and fires the correct cron timeout reason. */
 export function createCronAgentWatchdog(params: {
   deferUntilRunner: boolean;
   jobTimeoutMs: number;
@@ -112,6 +113,8 @@ export function createCronAgentWatchdog(params: {
       previousPhase === "before_agent_reply" &&
       stage === "pre_execution"
     ) {
+      // Model fallback can move from an execution phase back into setup-like
+      // phases; restart the pre-execution watchdog so fallback stalls are seen.
       state = "waiting_for_execution";
       startPreExecutionTimeout();
       return;
@@ -164,6 +167,7 @@ export function createCronAgentWatchdog(params: {
   };
 }
 
+/** Runs timeout cleanup with a guard so stuck cleanup cannot block the cron lane. */
 export async function cleanupTimedOutCronAgentRun(
   state: CronServiceState,
   job: CronJob,

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -5,6 +5,7 @@ function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): s
   return formatEmbeddedAgentExecutionPhase(execution?.phase);
 }
 
+/** Formats the generic cron execution timeout message with last-known phase context when available. */
 export function timeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
   const phase = formatCronAgentExecutionPhase(execution);
   if (!phase) {
@@ -13,6 +14,7 @@ export function timeoutErrorMessage(execution?: CronAgentExecutionStarted): stri
   return `cron: job execution timed out (last phase: ${phase})`;
 }
 
+/** Formats timeout text for runs that stalled before the isolated runner started. */
 export function setupTimeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
   const phase = formatCronAgentExecutionPhase(execution);
   if (!phase) {
@@ -21,6 +23,7 @@ export function setupTimeoutErrorMessage(execution?: CronAgentExecutionStarted):
   return `cron: isolated agent setup timed out before runner start (last phase: ${phase})`;
 }
 
+/** Formats timeout text for runs that stalled after setup but before execution start. */
 export function preExecutionTimeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
   const phase = formatCronAgentExecutionPhase(execution);
   if (!phase) {
@@ -29,6 +32,7 @@ export function preExecutionTimeoutErrorMessage(execution?: CronAgentExecutionSt
   return `cron: isolated agent run stalled before execution start (last phase: ${phase})`;
 }
 
+/** Extracts a human timeout/abort reason, falling back to the canonical cron timeout text. */
 export function abortErrorMessage(signal?: AbortSignal): string {
   const reason = signal?.reason;
   if (typeof reason === "string" && reason.trim()) {
@@ -44,6 +48,7 @@ function isAbortError(err: unknown): boolean {
   return err.name === "AbortError" || err.message === timeoutErrorMessage();
 }
 
+/** Normalizes thrown cron run failures into stable log/run-log text. */
 export function normalizeCronRunErrorText(err: unknown): string {
   if (isAbortError(err)) {
     return timeoutErrorMessage();

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -16,6 +16,7 @@ type ResolvedFailureAlert = {
   includeSkipped: boolean;
 };
 
+/** Returns the last failure-notification delivery trace persisted on a cron job. */
 export function failureNotificationDeliveryFromJobState(
   job: CronJob,
 ): CronFailureNotificationDelivery | undefined {
@@ -59,6 +60,7 @@ function clampNonNegativeInt(value: unknown, fallback: number): number {
   return floored >= 0 ? floored : fallback;
 }
 
+/** Resolves effective failure-alert policy from job config, delivery defaults, and global cron config. */
 export function resolveFailureAlert(
   state: CronServiceState,
   job: CronJob,
@@ -113,6 +115,8 @@ function emitFailureAlert(
     params.status === "error" && typeof params.error === "string"
       ? (resolveFailoverReasonFromError(params.error, params.provider) ?? undefined)
       : undefined;
+  // Keep alert bodies compact because they may route through chat channels
+  // with notification previews and provider-specific message limits.
   const statusVerb = params.status === "skipped" ? "skipped" : "failed";
   const detailLabel = params.status === "skipped" ? "Skip reason" : "Last error";
   const text = [
@@ -150,6 +154,7 @@ function emitFailureAlert(
   }
 }
 
+/** Emits a failure alert when threshold, best-effort, and cooldown policy allow it. */
 export function maybeEmitFailureAlert(
   state: CronServiceState,
   params: {
@@ -170,6 +175,8 @@ export function maybeEmitFailureAlert(
   }
   const now = state.deps.nowMs();
   const lastAlert = params.job.state.lastFailureAlertAtMs;
+  // Cooldown is stored on job state so process restarts and service reloads do
+  // not spam operators with repeated alerts for the same failing job.
   const inCooldown =
     typeof lastAlert === "number" && now - lastAlert < Math.max(0, params.alertConfig.cooldownMs);
   if (inCooldown) {

--- a/src/cron/service/initial-delivery.ts
+++ b/src/cron/service/initial-delivery.ts
@@ -1,5 +1,6 @@
 import type { CronDelivery, CronJobCreate } from "../types.js";
 
+/** Resolves default cron delivery for new jobs when callers omit explicit delivery config. */
 export function resolveInitialCronDelivery(input: CronJobCreate): CronDelivery | undefined {
   if (input.delivery) {
     return input.delivery;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -54,6 +54,7 @@ export function hasScheduledNextRunAtMs(value: unknown): value is number {
   return isFiniteTimestamp(value) && value > 0;
 }
 
+/** Resolves the retry backoff delay for a one-based consecutive error count. */
 export function errorBackoffMs(
   consecutiveErrors: number,
   scheduleMs = DEFAULT_ERROR_BACKOFF_SCHEDULE_MS,
@@ -62,6 +63,7 @@ export function errorBackoffMs(
   return scheduleMs[Math.max(0, idx)] ?? DEFAULT_ERROR_BACKOFF_SCHEDULE_MS[0];
 }
 
+/** Returns the earliest retry timestamp after a failed cron run and its runtime duration. */
 export function resolveJobErrorBackoffUntilMs(
   job: CronJob,
   scheduleMs = DEFAULT_ERROR_BACKOFF_SCHEDULE_MS,
@@ -94,6 +96,8 @@ function resolveStableCronOffsetMs(jobId: string, staggerMs: number) {
   const digest = crypto.createHash("sha256").update(jobId).digest();
   const offset = digest.readUInt32BE(0) % staggerMs;
   if (staggerOffsetCache.size >= STAGGER_OFFSET_CACHE_MAX) {
+    // The offset is deterministic, so the cache can evict oldest entries
+    // without changing scheduling semantics for future lookups.
     const first = staggerOffsetCache.keys().next();
     if (!first.done) {
       staggerOffsetCache.delete(first.value);
@@ -256,6 +260,7 @@ function resolveEveryAnchorMs(params: {
   return 0;
 }
 
+/** Validates that session target and payload kind form a supported cron job shape. */
 export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "payload">) {
   if (typeof job.sessionTarget !== "string") {
     throw new Error(
@@ -362,6 +367,7 @@ function assertFailureDestinationSupport(job: Pick<CronJob, "sessionTarget" | "d
   }
 }
 
+/** Finds an in-memory cron job or throws the public unknown-id error. */
 export function findJobOrThrow(state: CronServiceState, id: string) {
   const job = state.store?.jobs.find((j) => j.id === id);
   if (!job) {
@@ -370,10 +376,12 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
   return job;
 }
 
+/** Returns the effective enabled flag, defaulting missing values to enabled. */
 export function isJobEnabled(job: Pick<CronJob, "enabled">): boolean {
   return job.enabled ?? true;
 }
 
+/** Computes the next run timestamp for enabled jobs across every/at/cron schedules. */
 export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | undefined {
   if (!isJobEnabled(job)) {
     return undefined;
@@ -419,6 +427,7 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
   return isFiniteTimestamp(next) ? next : undefined;
 }
 
+/** Computes the previous effective cron timestamp, including per-job staggering. */
 export function computeJobPreviousRunAtMs(job: CronJob, nowMs: number): number | undefined {
   if (!isJobEnabled(job) || job.schedule.kind !== "cron") {
     return undefined;
@@ -430,6 +439,7 @@ export function computeJobPreviousRunAtMs(job: CronJob, nowMs: number): number |
 /** Maximum consecutive schedule errors before auto-disabling a job. */
 const MAX_SCHEDULE_ERRORS = 3;
 
+/** Records a schedule-computation failure and auto-disables after repeated errors. */
 export function recordScheduleComputeError(params: {
   state: CronServiceState;
   job: CronJob;
@@ -593,6 +603,7 @@ function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob
   return changed;
 }
 
+/** Recomputes missing, due, or repairable next-run timestamps for all schedulable jobs. */
 export function recomputeNextRuns(state: CronServiceState): boolean {
   return walkSchedulableJobs(state, ({ job, nowMs: now }) => {
     let changed = false;
@@ -668,6 +679,7 @@ export function recomputeNextRunsForMaintenance(
   );
 }
 
+/** Returns the next enabled wake timestamp from the in-memory cron store. */
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
   const enabled = jobs.filter((j) => j.enabled && hasScheduledNextRunAtMs(j.state.nextRunAtMs));
@@ -684,6 +696,7 @@ export function nextWakeAtMs(state: CronServiceState) {
   }, first);
 }
 
+/** Creates a normalized cron job row from public add input and computes its initial schedule. */
 export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {
   const now = state.deps.nowMs();
   const id = crypto.randomUUID();
@@ -743,6 +756,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
   return job;
 }
 
+/** Applies a public cron patch in-place, preserving omitted nested fields and validating the result. */
 export function applyJobPatch(
   job: CronJob,
   patch: CronJobPatch,
@@ -766,6 +780,8 @@ export function applyJobPatch(
       if (explicitStaggerMs !== undefined) {
         job.schedule = { ...patch.schedule, staggerMs: explicitStaggerMs };
       } else if (job.schedule.kind === "cron") {
+        // Preserve an existing explicit stagger when editing only the cron
+        // expression; otherwise a patch could silently change fire timing.
         job.schedule = { ...patch.schedule, staggerMs: job.schedule.staggerMs };
       } else {
         const defaultStaggerMs = resolveDefaultCronStaggerMs(patch.schedule.expr);
@@ -1032,6 +1048,7 @@ function mergeCronFailureAlert(
   return next;
 }
 
+/** Returns whether a cron job should execute at `nowMs`, honoring force mode and active runs. */
 export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean }) {
   if (!job.state) {
     job.state = {};
@@ -1049,6 +1066,7 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
   );
 }
 
+/** Returns main-session queue text for system-event jobs, or undefined when empty/unsupported. */
 export function resolveJobPayloadTextForMain(job: CronJob): string | undefined {
   if (job.payload.kind !== "systemEvent") {
     return undefined;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -38,6 +38,8 @@ import type { CronServiceState } from "./state.js";
 const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
 const STAGGER_OFFSET_CACHE_MAX = 4096;
 const staggerOffsetCache = new Map<string, number>();
+
+/** Default retry delays applied after consecutive cron execution errors. */
 export const DEFAULT_ERROR_BACKOFF_SCHEDULE_MS = [
   30_000,
   60_000,
@@ -50,6 +52,7 @@ function isFiniteTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+/** Returns whether a stored next-run timestamp is finite and schedulable. */
 export function hasScheduledNextRunAtMs(value: unknown): value is number {
   return isFiniteTimestamp(value) && value > 0;
 }
@@ -928,6 +931,8 @@ function mergeCronDelivery(
     const previousMode = next.mode;
     next.mode = (patch.mode as string) === "deliver" ? "announce" : patch.mode;
     if (previousMode !== next.mode && (previousMode === "webhook" || next.mode === "webhook")) {
+      // `to` has different meaning for channel targets and webhook URLs; clear
+      // it when crossing that boundary so stale destinations do not leak.
       next.to = undefined;
     }
     if (next.mode === "webhook") {

--- a/src/cron/service/list-page-types.ts
+++ b/src/cron/service/list-page-types.ts
@@ -1,11 +1,21 @@
 import type { CronJob, CronRunStatus } from "../types.js";
 
+/** Enabled-state filter accepted by paginated cron listing. */
 export type CronJobsEnabledFilter = "all" | "enabled" | "disabled";
+
+/** Schedule-kind filter accepted by paginated cron listing. */
 export type CronJobsScheduleKindFilter = "all" | "at" | "every" | "cron";
+
+/** Last-run status filter, including jobs that have not produced a status yet. */
 export type CronJobsLastRunStatusFilter = "all" | CronRunStatus | "unknown";
+
+/** Stable sort keys supported by paginated cron listing. */
 export type CronJobsSortBy = "nextRunAtMs" | "updatedAtMs" | "name";
+
+/** Sort direction for paginated cron listing. */
 export type CronSortDir = "asc" | "desc";
 
+/** Input contract for filtered, sorted, offset-based cron job pages. */
 export type CronListPageOptions = {
   includeDisabled?: boolean;
   limit?: number;
@@ -19,6 +29,7 @@ export type CronListPageOptions = {
   agentId?: string;
 };
 
+/** Offset-page result returned by cron listPage callers. */
 export type CronListPageResult<TJobs extends readonly CronJob[] = CronJob[]> = {
   jobs: TJobs;
   total: number;

--- a/src/cron/service/locked.ts
+++ b/src/cron/service/locked.ts
@@ -8,12 +8,14 @@ const resolveChain = (promise: Promise<unknown>) =>
     () => undefined,
   );
 
+/** Serializes cron operations per store path while preserving state-local operation ordering. */
 export async function locked<T>(state: CronServiceState, fn: () => Promise<T>): Promise<T> {
   const storePath = state.deps.storePath;
   const storeOp = storeLocks.get(storePath) ?? Promise.resolve();
   const next = Promise.all([resolveChain(state.op), resolveChain(storeOp)]).then(fn);
 
-  // Keep the chain alive even when the operation fails.
+  // Store locks are process-local; keep the chain alive after failures so the
+  // next operation for this store still waits for the failed one to settle.
   const keepAlive = resolveChain(next);
   state.op = keepAlive;
   storeLocks.set(storePath, keepAlive);

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -3,6 +3,7 @@ import { normalizeAgentId } from "../../routing/session-key.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { CronPayload } from "../types.js";
 
+/** Normalizes a required cron job name and throws the public validation error when absent. */
 export function normalizeRequiredName(raw: unknown) {
   if (typeof raw !== "string") {
     throw new Error("cron job name is required");
@@ -21,6 +22,7 @@ function truncateText(input: string, maxLen: number) {
   return `${truncateUtf16Safe(input, Math.max(0, maxLen - 1)).trimEnd()}…`;
 }
 
+/** Normalizes optional cron agent ids through the canonical session-key agent id rules. */
 export function normalizeOptionalAgentId(raw: unknown) {
   const trimmed = normalizeOptionalString(raw);
   if (!trimmed) {
@@ -29,6 +31,7 @@ export function normalizeOptionalAgentId(raw: unknown) {
   return normalizeAgentId(trimmed);
 }
 
+/** Infers a compact cron job name from payload text first, then schedule shape. */
 export function inferCronJobName(job: {
   schedule?: { kind?: unknown; everyMs?: unknown; expr?: unknown };
   payload?: { kind?: unknown; text?: unknown; message?: unknown };
@@ -45,6 +48,8 @@ export function inferCronJobName(job: {
       .map((l) => l.trim())
       .find(Boolean) ?? "";
   if (firstLine) {
+    // Names appear in CLI lists and alerts; keep them single-line and UTF-16
+    // safe so emoji/surrogate pairs are not split by truncation.
     return truncateText(firstLine, 60);
   }
 
@@ -61,6 +66,7 @@ export function inferCronJobName(job: {
   return "Cron job";
 }
 
+/** Extracts the executable text from cron payload variants for main-session queueing. */
 export function normalizePayloadToSystemText(payload: CronPayload) {
   if (payload.kind === "systemEvent") {
     return typeof payload.text === "string" ? payload.text.trim() : "";

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -163,6 +163,7 @@ async function ensureLoadedForRead(state: CronServiceState) {
   }
 }
 
+/** Starts the cron service, recovers interrupted runs, catches up missed jobs, and arms the timer. */
 export async function start(state: CronServiceState) {
   if (!state.deps.cronEnabled) {
     state.deps.log.info({ enabled: false }, "cron: disabled");
@@ -238,10 +239,12 @@ export async function start(state: CronServiceState) {
   });
 }
 
+/** Stops the cron service timer without mutating persisted job state. */
 export function stop(state: CronServiceState) {
   stopTimer(state);
 }
 
+/** Returns cron service status after a read-only maintenance pass. */
 export async function status(state: CronServiceState) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);
@@ -254,6 +257,7 @@ export async function status(state: CronServiceState) {
   });
 }
 
+/** Lists cron jobs sorted by next run time, excluding disabled jobs unless requested. */
 export async function list(state: CronServiceState, opts?: { includeDisabled?: boolean }) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);
@@ -263,6 +267,7 @@ export async function list(state: CronServiceState, opts?: { includeDisabled?: b
   });
 }
 
+/** Reads one cron job by id without advancing due schedules. */
 export async function readJob(state: CronServiceState, id: string) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);
@@ -346,6 +351,7 @@ function resolveEffectiveJobAgentId(job: CronJob, defaultAgentId: string | undef
   );
 }
 
+/** Lists a filtered, sorted, bounded page of cron jobs for CLI/RPC callers. */
 export async function listPage(state: CronServiceState, opts?: CronListPageOptions) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);
@@ -402,6 +408,7 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
   });
 }
 
+/** Adds a cron job, recomputes scheduler state, persists, and re-arms the timer. */
 export async function add(state: CronServiceState, input: CronJobCreate) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
@@ -437,6 +444,7 @@ export async function add(state: CronServiceState, input: CronJobCreate) {
   });
 }
 
+/** Updates a cron job patch in-place, recomputes affected schedule state, and persists it. */
 export async function update(state: CronServiceState, id: string, patch: CronJobPatch) {
   return await locked(state, async () => {
     warnIfDisabled(state, "update");
@@ -499,6 +507,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
   });
 }
 
+/** Removes a cron job by id and re-arms the timer when the in-memory store changes. */
 export async function remove(state: CronServiceState, id: string) {
   return await locked(state, async () => {
     warnIfDisabled(state, "remove");
@@ -722,6 +731,8 @@ async function inspectManualRunDisposition(
   id: string,
   mode?: "due" | "force",
 ): Promise<ManualRunDisposition | { ok: false }> {
+  // Queue callers need a cheap eligibility check before entering the command
+  // lane; the real reservation happens later under lock in prepareManualRun.
   const result = await inspectManualRunPreflight(state, id, mode);
   if (!result.ok) {
     return result;
@@ -768,6 +779,8 @@ async function prepareManualRun(
       startedAt: preflight.now,
     });
     markCronJobActive(job.id);
+    // Execute against a snapshot so later reload/merge can preserve delivery
+    // target writeback from disk without mutating the running object.
     const executionJob = structuredClone(job);
     return {
       ok: true,
@@ -886,6 +899,7 @@ async function finishPreparedManualRun(
   }
 }
 
+/** Runs a cron job manually, reserving it under lock before executing outside the lock. */
 export async function run(
   state: CronServiceState,
   id: string,
@@ -900,6 +914,7 @@ export async function run(
   return { ok: true, ran: true } as const;
 }
 
+/** Queues a manual cron run behind the cron command lane and returns an immediate run id. */
 export async function enqueueRun(state: CronServiceState, id: string, mode?: "due" | "force") {
   const disposition = await inspectManualRunDisposition(state, id, mode);
   if (!disposition.ok || !("runnable" in disposition && disposition.runnable)) {
@@ -937,6 +952,7 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
   return { ok: true, enqueued: true, runId } as const;
 }
 
+/** Enqueues manual wake text through the cron wake API. */
 export function wakeNow(
   state: CronServiceState,
   opts: { mode: CronWakeMode; text: string; sessionKey?: string },

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -19,6 +19,7 @@ import type {
   CronStoreFile,
 } from "../types.js";
 
+/** Event payload emitted for cron lifecycle changes and completed runs. */
 export type CronEvent = {
   jobId: string;
   action: "added" | "updated" | "removed" | "started" | "finished";
@@ -41,6 +42,7 @@ export type CronEvent = {
   nextRunAtMs?: number;
 } & CronRunTelemetry;
 
+/** Logger contract consumed by cron service internals. */
 export type Logger = {
   debug: (obj: unknown, msg?: string) => void;
   info: (obj: unknown, msg?: string) => void;
@@ -48,6 +50,7 @@ export type Logger = {
   error: (obj: unknown, msg?: string) => void;
 };
 
+/** Dependency injection surface for the cron service runtime. */
 export type CronServiceDeps = {
   nowMs?: () => number;
   log: Logger;
@@ -147,15 +150,18 @@ export type CronServiceDeps = {
   onEvent?: (evt: CronEvent) => void;
 };
 
+/** Cron deps after optional defaults have been made concrete. */
 export type CronServiceDepsInternal = Omit<CronServiceDeps, "nowMs"> & {
   nowMs: () => number;
 };
 
+/** Mutable cron service state shared across store, job, timer, and ops helpers. */
 export type CronServiceState = {
   deps: CronServiceDepsInternal;
   store: CronStoreFile | null;
   timer: NodeJS.Timeout | null;
   running: boolean;
+  /** Serializes mutating service operations so store writes and timers stay ordered. */
   op: Promise<unknown>;
   warnedDisabled: boolean;
   /**
@@ -184,9 +190,13 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
   };
 }
 
+/** Direct-run mode: respect due time or force execution. */
 export type CronRunMode = "due" | "force";
+
+/** Main-session wake strategy used after enqueuing cron text. */
 export type CronWakeMode = "now" | "next-heartbeat";
 
+/** Lightweight service status returned to gateway/control surfaces. */
 export type CronStatusSummary = {
   enabled: boolean;
   storePath: string;
@@ -194,6 +204,7 @@ export type CronStatusSummary = {
   nextWakeAtMs: number | null;
 };
 
+/** Result shape for immediate or queued cron run requests. */
 export type CronRunResult =
   | { ok: true; ran: true }
   | { ok: true; enqueued: true; runId: string }
@@ -201,6 +212,7 @@ export type CronRunResult =
   | { ok: true; ran: false; reason: "already-running" }
   | { ok: false };
 
+/** Remove result that distinguishes missing jobs from failed removal. */
 export type CronRemoveResult = { ok: true; removed: boolean } | { ok: false; removed: false };
 
 export type CronAddResult = CronJob;

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -215,9 +215,14 @@ export type CronRunResult =
 /** Remove result that distinguishes missing jobs from failed removal. */
 export type CronRemoveResult = { ok: true; removed: boolean } | { ok: false; removed: false };
 
+/** Created cron job returned by service mutation calls. */
 export type CronAddResult = CronJob;
+/** Updated cron job returned by service mutation calls. */
 export type CronUpdateResult = CronJob;
 
+/** Chronological job list returned by service read calls. */
 export type CronListResult = CronJob[];
+/** Normalized create input accepted by the cron service. */
 export type CronAddInput = CronJobCreate;
+/** Normalized patch input accepted by cron service updates. */
 export type CronUpdateInput = CronJobPatch;

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -168,6 +168,7 @@ export type CronServiceState = {
   storeLoadedAtMs: number | null;
 };
 
+/** Creates mutable cron service state with a concrete clock dependency. */
 export function createCronServiceState(deps: CronServiceDeps): CronServiceState {
   return {
     deps: { ...deps, nowMs: deps.nowMs ?? (() => Date.now()) },

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -81,6 +81,7 @@ async function flushPendingQuarantine(
   }
 }
 
+/** Loads and normalizes the cron store, quarantining invalid persisted rows before runtime use. */
 export async function ensureLoaded(
   state: CronServiceState,
   opts?: {
@@ -109,6 +110,8 @@ export async function ensureLoaded(
     const raw = decodedRaw;
     const sourceIndex = loaded.configJobIndexes[index] ?? index;
     const runtimeEntry = loaded.configJobRuntimeEntries[index];
+    // Accept old `jobId` rows at the raw boundary only; the in-memory store
+    // uses canonical `id` before validation and scheduling.
     normalizeCronJobIdentityFields(raw);
     let normalized: Record<string, unknown> | null;
     try {
@@ -136,6 +139,8 @@ export async function ensureLoaded(
       };
       const runtimeState = runtimeEntry?.state ?? raw.state;
       if (runtimeState && typeof runtimeState === "object" && !Array.isArray(runtimeState)) {
+        // Preserve runtime state with the quarantined config so doctor can
+        // repair shape without losing last/next run information.
         quarantineEntry.state = structuredClone(runtimeState as Record<string, unknown>);
       }
       const updatedAtMs = runtimeEntry?.updatedAtMs ?? raw.updatedAtMs;
@@ -189,6 +194,7 @@ export async function ensureLoaded(
   }
 }
 
+/** Emits the cron-disabled warning once per service state. */
 export function warnIfDisabled(state: CronServiceState, action: string) {
   if (state.deps.cronEnabled) {
     return;
@@ -203,6 +209,7 @@ export function warnIfDisabled(state: CronServiceState, action: string) {
   );
 }
 
+/** Persists the in-memory cron store, flushing pending quarantine records first. */
 export async function persist(state: CronServiceState, opts?: { stateOnly?: boolean }) {
   if (!state.store) {
     return;

--- a/src/cron/service/task-ledger.ts
+++ b/src/cron/service/task-ledger.ts
@@ -1,1 +1,2 @@
+/** Progress summary shown while a detached task ledger row represents an active cron run. */
 export const CRON_TASK_RUNNING_PROGRESS_SUMMARY = "Running cron job.";

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -16,6 +16,7 @@ import { normalizeCronRunErrorText, timeoutErrorMessage } from "./execution-erro
 import type { CronServiceState } from "./state.js";
 import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
 
+/** Converts cron ids into bounded session-key path segments with a fallback for empty input. */
 export function normalizeCronLaneSegment(value: string | undefined, fallback: string): string {
   const normalized = normalizeOptionalLowercaseString(value)
     ?.replace(/[^a-z0-9_-]+/g, "-")
@@ -24,6 +25,7 @@ export function normalizeCronLaneSegment(value: string | undefined, fallback: st
   return normalized || fallback;
 }
 
+/** Builds the main-session child key used to isolate one cron run's task transcript. */
 export function resolveMainSessionCronRunSessionKey(job: CronJob, startedAt: number): string {
   const explicitAgentId = job.agentId?.trim();
   const agentId = normalizeAgentId(explicitAgentId || resolveAgentIdFromSessionKey(job.sessionKey));
@@ -53,6 +55,7 @@ function resolveCronTaskChildSessionKey(params: {
   });
 }
 
+/** Creates a best-effort detached task ledger row for a cron run. */
 export function tryCreateCronTaskRun(params: {
   state: CronServiceState;
   job: CronJob;
@@ -93,6 +96,7 @@ export function tryCreateCronTaskRun(params: {
   }
 }
 
+/** Completes or fails the detached task ledger row for a cron run when one exists. */
 export function tryFinishCronTaskRun(
   state: CronServiceState,
   result: {

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -44,6 +44,8 @@ function resolveCronTaskChildSessionKey(params: {
   }
   const explicitSessionKey = params.job.sessionKey?.trim();
   if (explicitSessionKey) {
+    // Explicit session bindings must win over generated cron session keys so
+    // task drill-down opens the same transcript the cron run actually used.
     return explicitSessionKey;
   }
   if (params.job.sessionTarget !== "isolated") {

--- a/src/cron/service/timeout-policy.ts
+++ b/src/cron/service/timeout-policy.ts
@@ -14,6 +14,7 @@ export const DEFAULT_JOB_TIMEOUT_MS = 10 * 60_000; // 10 minutes
  */
 export const AGENT_TURN_SAFETY_TIMEOUT_MS = 60 * 60_000; // 60 minutes
 
+/** Resolves the wall-clock timeout for a cron job, including explicit agent-turn overrides. */
 export function resolveCronJobTimeoutMs(job: CronJob): number | undefined {
   const configuredTimeoutMs =
     job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -115,6 +115,7 @@ type StartupCatchupPlan = {
   deferredJobs: StartupDeferredJob[];
 };
 
+/** Executes cron job core logic with the configured wall-clock timeout and watchdog cleanup. */
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
@@ -132,6 +133,8 @@ export async function executeJobCoreWithTimeout(
     resolveTimeout = resolve;
   });
 
+  // Detached agent runs report setup phases separately; defer the wall-clock
+  // timeout until the runner starts so cold setup gets a clearer failure reason.
   const deferTimeoutUntilExecutionStart =
     job.sessionTarget !== "main" && job.payload.kind === "agentTurn";
   const triggerTimeout = (reason: string) => {
@@ -371,11 +374,7 @@ function resolveDeliveryState(params: {
   return { status: "unknown", failureNotification: { status: "not-requested" } };
 }
 
-/**
- * Apply the result of a job execution to the job's state.
- * Handles consecutive error tracking, exponential backoff, one-shot disable,
- * and nextRunAtMs computation. Returns `true` if the job should be deleted.
- */
+/** Applies run outcome state, delivery state, backoff/next-run scheduling, and delete-after-run policy. */
 export function applyJobResult(
   state: CronServiceState,
   job: CronJob,
@@ -703,6 +702,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
   }
 }
 
+/** Arms the cron timer for the next wake or a maintenance recheck. */
 export function armTimer(state: CronServiceState) {
   if (state.timer) {
     clearTimeout(state.timer);
@@ -772,6 +772,7 @@ function armRunningRecheckTimer(state: CronServiceState) {
   }, MAX_TIMER_DELAY_MS);
 }
 
+/** Handles one cron timer tick: load due jobs, reserve them, execute, persist, and re-arm. */
 export async function onTimer(state: CronServiceState) {
   if (state.running) {
     // Re-arm the timer so the scheduler keeps ticking even when a job is
@@ -1098,6 +1099,7 @@ function deferPendingBackoffMissedCronSlots(
   return changed;
 }
 
+/** Runs or defers missed startup jobs using restart catch-up limits. */
 export async function runMissedJobs(
   state: CronServiceState,
   opts?: { skipJobIds?: ReadonlySet<string>; deferAgentTurnJobs?: boolean },
@@ -1156,6 +1158,8 @@ async function planStartupCatchup(
       state.deps.startupDeferredMissedAgentJobDelayMs ??
         DEFAULT_STARTUP_DEFERRED_MISSED_AGENT_JOB_DELAY_MS,
     );
+    // Agent-turn startup catch-up is deferred by default so gateway/channel
+    // startup is not blocked by model/tool bootstrap work.
     const deferred: StartupDeferredJob[] = [
       ...deferredOverflow.map((job) => ({ jobId: job.id })),
       ...deferredAgentJobs.map((job) => ({ jobId: job.id, delayMs: deferredAgentDelayMs })),
@@ -1307,6 +1311,7 @@ async function applyStartupCatchupOutcomes(
   });
 }
 
+/** Executes a cron job without mutating persisted job state. */
 export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
@@ -1558,10 +1563,7 @@ async function executeDetachedCronJob(
   };
 }
 
-/**
- * Execute a job. This version is used by the `run` command and other
- * places that need the full execution with state updates.
- */
+/** Executes a cron job and applies the resulting state transitions in memory. */
 export async function executeJob(
   state: CronServiceState,
   job: CronJob,
@@ -1644,6 +1646,7 @@ function emitJobFinished(
   });
 }
 
+/** Clears the currently armed cron timer. */
 export function stopTimer(state: CronServiceState) {
   if (state.timer) {
     clearTimeout(state.timer);
@@ -1651,6 +1654,7 @@ export function stopTimer(state: CronServiceState) {
   state.timer = null;
 }
 
+/** Dispatches a cron event to the optional subscriber without letting subscriber errors escape. */
 export function emit(state: CronServiceState, evt: CronEvent) {
   try {
     state.deps.onEvent?.(evt);

--- a/src/cron/service/wake.ts
+++ b/src/cron/service/wake.ts
@@ -1,6 +1,7 @@
 import { isSubagentSessionKey } from "../../routing/session-key.js";
 import type { CronServiceState } from "./state.js";
 
+/** Enqueues a manual cron wake event and optionally pokes the targeted heartbeat loop. */
 export function wake(
   state: CronServiceState,
   opts: { mode: "now" | "next-heartbeat"; text: string; sessionKey?: string },

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -1,11 +1,3 @@
-/**
- * Cron session reaper — prunes completed isolated cron run sessions
- * from the session store after a configurable retention period.
- *
- * Pattern: sessions keyed as `...:cron:<jobId>:run:<uuid>` are ephemeral
- * run records. The base session (`...:cron:<jobId>`) is kept as-is.
- */
-
 import { parseDurationMs } from "../cli/parse-duration.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
 import { archiveRemovedSessionTranscripts, updateSessionStore } from "../config/sessions/store.js";
@@ -21,6 +13,7 @@ const MIN_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
 
 const lastSweepAtMsByStore = new Map<string, number>();
 
+/** Resolves cron run-session retention; `false` disables pruning, bad strings fall back safely. */
 export function resolveRetentionMs(cronConfig?: CronConfig): number | null {
   if (cronConfig?.sessionRetention === false) {
     return null; // pruning disabled
@@ -42,14 +35,10 @@ type ReaperResult = {
 };
 
 /**
- * Sweep the session store and prune expired cron run sessions.
- * Designed to be called from the cron timer tick — self-throttles via
- * MIN_SWEEP_INTERVAL_MS to avoid excessive I/O.
+ * Sweeps completed isolated cron run sessions while preserving base cron sessions.
  *
- * Lock ordering: this function acquires the session-store file lock via
- * `updateSessionStore`. It must be called OUTSIDE of the cron service's
- * own `locked()` section to avoid lock-order inversions. The cron timer
- * calls this after all `locked()` sections have been released.
+ * Must run outside the cron service `locked()` section because this acquires
+ * the session-store file lock; reversing that order can deadlock timer ticks.
  */
 export async function sweepCronRunSessions(params: {
   cronConfig?: CronConfig;
@@ -64,7 +53,8 @@ export async function sweepCronRunSessions(params: {
   const storePath = params.sessionStorePath;
   const lastSweepAtMs = lastSweepAtMsByStore.get(storePath) ?? 0;
 
-  // Throttle: don't sweep more often than every 5 minutes.
+  // Timer ticks can be frequent; throttle per store path to avoid repeated
+  // session-store I/O while preserving a force path for deterministic tests.
   if (!params.force && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
     return { swept: false, pruned: 0 };
   }
@@ -108,6 +98,8 @@ export async function sweepCronRunSessions(params: {
   if (prunedSessions.size > 0) {
     try {
       const store = loadSessionStore(storePath, { skipCache: true });
+      // Archive only transcripts that no remaining session references; base
+      // cron sessions intentionally keep their transcript history.
       const referencedSessionIds = new Set(
         Object.values(store)
           .map((entry) => entry?.sessionId)
@@ -143,7 +135,7 @@ export async function sweepCronRunSessions(params: {
   return { swept: true, pruned };
 }
 
-/** Reset the throttle timer (for tests). */
+/** Resets per-store reaper throttles between tests. */
 export function resetReaperThrottle(): void {
   lastSweepAtMsByStore.clear();
 }

--- a/src/cron/session-target.ts
+++ b/src/cron/session-target.ts
@@ -1,9 +1,11 @@
 const INVALID_CRON_SESSION_TARGET_ID_ERROR = "invalid cron sessionTarget session id";
 
+/** Returns whether an error came from cron session target id validation. */
 export function isInvalidCronSessionTargetIdError(error: unknown): boolean {
   return error instanceof Error && error.message === INVALID_CRON_SESSION_TARGET_ID_ERROR;
 }
 
+/** Validates the opaque session id portion of a `session:` cron target. */
 export function assertSafeCronSessionTargetId(sessionId: string): string {
   const trimmed = sessionId.trim();
   if (!trimmed) {
@@ -15,6 +17,7 @@ export function assertSafeCronSessionTargetId(sessionId: string): string {
   return trimmed;
 }
 
+/** Extracts the persistent session key from a `session:` cron target, if present. */
 export function resolveCronSessionTargetSessionKey(
   sessionTarget?: string | null,
 ): string | undefined {
@@ -24,6 +27,7 @@ export function resolveCronSessionTargetSessionKey(
   return assertSafeCronSessionTargetId(sessionTarget.slice(8));
 }
 
+/** Resolves `current` at creation time so scheduled jobs do not depend on future active UI state. */
 export function resolveCronCurrentSessionTarget(params: {
   sessionTarget?: string | null;
   sessionKey?: string | null;
@@ -35,6 +39,7 @@ export function resolveCronCurrentSessionTarget(params: {
   return sessionKey ? `session:${assertSafeCronSessionTargetId(sessionKey)}` : "isolated";
 }
 
+/** Chooses the session key used for cron delivery, preferring explicit persistent targets. */
 export function resolveCronDeliverySessionKey(job: {
   sessionTarget?: string | null;
   sessionKey?: string | null;
@@ -48,6 +53,7 @@ export function resolveCronDeliverySessionKey(job: {
     : undefined;
 }
 
+/** Returns the notification session key, falling back to a stable per-job failure session. */
 export function resolveCronNotificationSessionKey(params: {
   jobId: string;
   sessionKey?: string | null;
@@ -57,6 +63,7 @@ export function resolveCronNotificationSessionKey(params: {
     : `cron:${params.jobId}:failure`;
 }
 
+/** Resolves the session key used to deliver failure notifications for a cron job. */
 export function resolveCronFailureNotificationSessionKey(job: {
   id: string;
   sessionTarget?: string | null;

--- a/src/cron/stagger.ts
+++ b/src/cron/stagger.ts
@@ -1,6 +1,7 @@
 import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
 import type { CronSchedule } from "./types.js";
 
+/** Default jitter window applied to recurring top-of-hour cron schedules. */
 export const DEFAULT_TOP_OF_HOUR_STAGGER_MS = 5 * 60 * 1000;
 
 function parseCronFields(expr: string) {

--- a/src/cron/stagger.ts
+++ b/src/cron/stagger.ts
@@ -7,6 +7,7 @@ function parseCronFields(expr: string) {
   return expr.trim().split(/\s+/).filter(Boolean);
 }
 
+/** Returns whether a cron expression fires recurring jobs exactly at the top of an hour. */
 export function isRecurringTopOfHourCronExpr(expr: string) {
   const fields = parseCronFields(expr);
   if (fields.length === 5) {
@@ -20,6 +21,7 @@ export function isRecurringTopOfHourCronExpr(expr: string) {
   return false;
 }
 
+/** Normalizes explicit stagger values from config, preserving zero as "run exactly on schedule". */
 export function normalizeCronStaggerMs(raw: unknown): number | undefined {
   const numeric =
     typeof raw === "number"
@@ -33,10 +35,12 @@ export function normalizeCronStaggerMs(raw: unknown): number | undefined {
   return Math.max(0, Math.floor(numeric));
 }
 
+/** Returns the default anti-thundering-herd stagger for top-of-hour recurring schedules. */
 export function resolveDefaultCronStaggerMs(expr: string): number | undefined {
   return isRecurringTopOfHourCronExpr(expr) ? DEFAULT_TOP_OF_HOUR_STAGGER_MS : undefined;
 }
 
+/** Resolves the effective stagger for a cron schedule, preferring explicit values over defaults. */
 export function resolveCronStaggerMs(schedule: Extract<CronSchedule, { kind: "cron" }>): number {
   const explicit = normalizeCronStaggerMs(schedule.staggerMs);
   if (explicit !== undefined) {

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -39,6 +39,7 @@ function resolveDefaultCronStorePath(): string {
   return path.join(resolveDefaultCronDir(), "jobs.json");
 }
 
+/** Resolves the sidecar quarantine path used for invalid cron config rows. */
 export function resolveCronQuarantinePath(storePath: string): string {
   if (storePath.endsWith(".json")) {
     return storePath.replace(/\.json$/, "-quarantine.json");
@@ -46,6 +47,7 @@ export function resolveCronQuarantinePath(storePath: string): string {
   return `${storePath}-quarantine.json`;
 }
 
+/** Resolves the cron jobs store path, expanding home-relative user input. */
 export function resolveCronJobsStorePath(storePath?: string) {
   if (storePath?.trim()) {
     const raw = storePath.trim();
@@ -57,6 +59,7 @@ export function resolveCronJobsStorePath(storePath?: string) {
   return resolveDefaultCronStorePath();
 }
 
+/** Loads cron jobs plus config/runtime sidecars from the SQLite-backed store. */
 export async function loadCronJobsStoreWithConfigJobs(storePath: string): Promise<LoadedCronStore> {
   const resolvedStorePath = path.resolve(storePath);
   const storeKey = cronStoreKey(resolvedStorePath);
@@ -74,10 +77,12 @@ export async function loadCronJobsStoreWithConfigJobs(storePath: string): Promis
   };
 }
 
+/** Loads only the persisted cron job store payload. */
 export async function loadCronJobsStore(storePath: string): Promise<CronStoreFile> {
   return (await loadCronJobsStoreWithConfigJobs(storePath)).store;
 }
 
+/** Synchronously loads only the persisted cron job store payload. */
 export function loadCronJobsStoreSync(storePath: string): CronStoreFile {
   const resolvedStorePath = path.resolve(storePath);
   const storeKey = cronStoreKey(resolvedStorePath);
@@ -105,6 +110,7 @@ async function atomicWrite(filePath: string, content: string, dirMode = 0o700): 
   });
 }
 
+/** Persists cron jobs, or only mutable runtime state when stateOnly is set. */
 export async function saveCronJobsStore(
   storePath: string,
   store: CronStoreFile,
@@ -125,18 +131,22 @@ export async function saveCronJobsStore(
 }
 
 // Public plugin SDK seam; core callers use the SQLite-backed cron-jobs names above.
+/** Resolves the public plugin-SDK cron store path. */
 export function resolveCronStorePath(storePath?: string) {
   return resolveCronJobsStorePath(storePath);
 }
 
+/** Plugin-SDK alias for loading the cron store. */
 export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
   return await loadCronJobsStore(storePath);
 }
 
+/** Plugin-SDK alias for synchronously loading the cron store. */
 export function loadCronStoreSync(storePath: string): CronStoreFile {
   return loadCronJobsStoreSync(storePath);
 }
 
+/** Plugin-SDK alias for saving the cron store. */
 export async function saveCronStore(
   storePath: string,
   store: CronStoreFile,
@@ -145,6 +155,7 @@ export async function saveCronStore(
   await saveCronJobsStore(storePath, store, opts);
 }
 
+/** Loads the cron quarantine sidecar, validating its persisted v1 shape. */
 export async function loadCronQuarantineFile(pathLocal: string): Promise<CronQuarantineFile> {
   try {
     const raw = await fs.promises.readFile(pathLocal, "utf-8");
@@ -212,6 +223,7 @@ function quarantineEntryKey(entry: QuarantinedCronConfigJob): string {
   });
 }
 
+/** Appends new invalid cron config rows to the quarantine sidecar without duplicating entries. */
 export async function saveCronQuarantineFile(params: {
   storePath: string;
   entries: QuarantinedCronConfigJob[];
@@ -230,6 +242,8 @@ export async function saveCronQuarantineFile(params: {
     if (seen.has(key)) {
       continue;
     }
+    // Deduplicate by the original invalid row shape so repeated loads do not
+    // keep appending the same quarantined config job.
     seen.add(key);
     appended = true;
     nextJobs.push({

--- a/src/cron/store/delivery-codec.ts
+++ b/src/cron/store/delivery-codec.ts
@@ -2,6 +2,7 @@ import type { CronDelivery } from "../types.js";
 import { booleanToInteger, integerToBoolean } from "./scalar-codec.js";
 import type { CronJobInsert, CronJobRow } from "./schema.js";
 
+/** Maps cron delivery config into normalized SQLite columns. */
 export function bindDeliveryColumns(
   delivery: CronDelivery | undefined,
 ): Pick<
@@ -42,6 +43,7 @@ function cronDeliveryModeFromValue(value: unknown): CronDelivery["mode"] | undef
   return value === "none" || value === "announce" || value === "webhook" ? value : undefined;
 }
 
+/** Reconstructs delivery config from split SQLite columns, preserving legacy partial rows. */
 export function deliveryFromRow(row: CronJobRow): CronDelivery | undefined {
   const rowMode = cronDeliveryModeFromValue(row.delivery_mode);
   const hasDeliveryColumns =
@@ -85,6 +87,8 @@ export function deliveryFromRow(row: CronJobRow): CronDelivery | undefined {
   if (!rowMode && !hasDeliveryColumns) {
     return undefined;
   }
+  // Old rows may have destination columns without a mode; announce matches the
+  // historical default for configured channel delivery.
   return {
     mode: rowMode ?? "announce",
     ...(row.delivery_channel ? { channel: row.delivery_channel as CronDelivery["channel"] } : {}),

--- a/src/cron/store/failure-alert-codec.ts
+++ b/src/cron/store/failure-alert-codec.ts
@@ -2,6 +2,7 @@ import type { CronFailureAlert } from "../types.js";
 import { booleanToInteger, integerToBoolean, normalizeNumber } from "./scalar-codec.js";
 import type { CronJobInsert, CronJobRow } from "./schema.js";
 
+/** Maps cron failure-alert config into normalized SQLite columns. */
 export function bindFailureAlertColumns(
   failureAlert: CronFailureAlert | false | undefined,
 ): Pick<
@@ -39,6 +40,7 @@ export function bindFailureAlertColumns(
   };
 }
 
+/** Reconstructs failure-alert config, distinguishing disabled from omitted config. */
 export function failureAlertFromRow(row: CronJobRow): CronFailureAlert | false | undefined {
   if (row.failure_alert_disabled === 1) {
     return false;

--- a/src/cron/store/key.ts
+++ b/src/cron/store/key.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 
+/** Returns the canonical per-file SQLite partition key for cron store rows. */
 export function cronStoreKey(storePath: string): string {
   return path.resolve(storePath);
 }

--- a/src/cron/store/payload-codec.ts
+++ b/src/cron/store/payload-codec.ts
@@ -14,6 +14,7 @@ function parseExternalContentSource(raw: string | null): "gmail" | "webhook" | u
   return parsed === "gmail" || parsed === "webhook" ? parsed : undefined;
 }
 
+/** Maps cron payload variants into normalized SQLite columns. */
 export function bindPayloadColumns(
   payload: CronPayload,
 ): Pick<
@@ -57,6 +58,7 @@ export function bindPayloadColumns(
   };
 }
 
+/** Reconstructs cron payload variants from SQLite columns, returning null for invalid rows. */
 export function payloadFromRow(row: CronJobRow): CronPayload | null {
   if (row.payload_kind === "systemEvent") {
     return row.payload_message == null ? null : { kind: "systemEvent", text: row.payload_message };

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -100,6 +100,8 @@ function normalizeCronJobForSqlite(job: CronStoreFile["jobs"][number]): CronJob 
     return null;
   }
   if (!hadDeleteAfterRun) {
+    // Legacy rows omitted deleteAfterRun entirely; avoid writing the default
+    // back into job_json so config round-trips stay byte-light.
     delete normalized.deleteAfterRun;
   }
   const createdAtMs =
@@ -122,6 +124,7 @@ function countUnpersistableCronJobs(store: CronStoreFile): number {
   return store.jobs.reduce((count, job) => count + (normalizeCronJobForSqlite(job) ? 0 : 1), 0);
 }
 
+/** Fails before replacing SQLite rows when any config job cannot round-trip. */
 export function assertCronStoreCanPersist(store: CronStoreFile): void {
   const invalidJobs = countUnpersistableCronJobs(store);
   if (invalidJobs > 0) {
@@ -183,6 +186,7 @@ function rowToCronJob(row: CronJobRow): CronJob | null {
   };
 }
 
+/** Loads cron rows in config order with deterministic fallbacks for old rows. */
 export function loadCronRows(db: DatabaseSync, storeKey: string): CronJobRow[] {
   return executeSqliteQuerySync(
     db,
@@ -196,6 +200,7 @@ export function loadCronRows(db: DatabaseSync, storeKey: string): CronJobRow[] {
   ).rows;
 }
 
+/** Replaces all persisted cron rows for one store key from the config store snapshot. */
 export function replaceCronRows(db: DatabaseSync, storeKey: string, store: CronStoreFile): void {
   executeSqliteQuerySync(
     db,
@@ -215,6 +220,7 @@ export function replaceCronRows(db: DatabaseSync, storeKey: string, store: CronS
   }
 }
 
+/** Updates only mutable runtime columns without rewriting full job config JSON. */
 export function updateCronRuntimeRows(
   db: DatabaseSync,
   storeKey: string,
@@ -237,6 +243,7 @@ export function updateCronRuntimeRows(
   }
 }
 
+/** Reconstructs loaded cron store data and config-runtime sidecars from SQLite rows. */
 export function loadedCronStoreFromRows(rows: CronJobRow[]): LoadedCronStore {
   const parsedJobs = rows.map(rowToCronJob);
   const jobs = parsedJobs.filter((job): job is CronJob => job !== null);

--- a/src/cron/store/scalar-codec.ts
+++ b/src/cron/store/scalar-codec.ts
@@ -1,3 +1,4 @@
+/** Parses a JSON object column, returning the fallback for malformed or non-object values. */
 export function parseJsonObject<T>(raw: string, fallback: T): T {
   try {
     const parsed = JSON.parse(raw) as unknown;
@@ -7,6 +8,7 @@ export function parseJsonObject<T>(raw: string, fallback: T): T {
   }
 }
 
+/** Parses a JSON column without shape validation, returning the fallback only on parse failure. */
 export function parseJsonValue<T>(raw: string, fallback: T): T {
   try {
     return JSON.parse(raw) as T;
@@ -15,6 +17,7 @@ export function parseJsonValue<T>(raw: string, fallback: T): T {
   }
 }
 
+/** Normalizes SQLite number/bigint columns into JavaScript numbers. */
 export function normalizeNumber(value: number | bigint | null): number | undefined {
   if (typeof value === "bigint") {
     return Number(value);
@@ -22,19 +25,23 @@ export function normalizeNumber(value: number | bigint | null): number | undefin
   return typeof value === "number" ? value : undefined;
 }
 
+/** Converts optional booleans into nullable SQLite integer flags. */
 export function booleanToInteger(value: boolean | undefined): number | null {
   return typeof value === "boolean" ? (value ? 1 : 0) : null;
 }
 
+/** Converts SQLite integer flags into booleans while preserving missing columns as undefined. */
 export function integerToBoolean(value: number | bigint | null): boolean | undefined {
   const normalized = normalizeNumber(value);
   return normalized == null ? undefined : normalized !== 0;
 }
 
+/** Serializes optional structured values for JSON columns. */
 export function serializeJson(value: unknown): string | null {
   return value == null ? null : JSON.stringify(value);
 }
 
+/** Parses a JSON string-array column and drops non-string entries from legacy data. */
 export function parseJsonArray(raw: string | null): string[] | undefined {
   if (!raw) {
     return undefined;

--- a/src/cron/store/schema.ts
+++ b/src/cron/store/schema.ts
@@ -6,7 +6,10 @@ import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-sta
 type CronJobsTable = OpenClawStateKyselyDatabase["cron_jobs"];
 type CronStoreDatabase = Pick<OpenClawStateKyselyDatabase, "cron_jobs">;
 
+/** Read shape for rows in the cron_jobs SQLite table. */
 export type CronJobRow = Selectable<CronJobsTable>;
+
+/** Insert/update shape for rows in the cron_jobs SQLite table. */
 export type CronJobInsert = Insertable<CronJobsTable>;
 
 /** Creates the Kysely facade scoped to cron_jobs for synchronous SQLite access. */

--- a/src/cron/store/schema.ts
+++ b/src/cron/store/schema.ts
@@ -9,6 +9,7 @@ type CronStoreDatabase = Pick<OpenClawStateKyselyDatabase, "cron_jobs">;
 export type CronJobRow = Selectable<CronJobsTable>;
 export type CronJobInsert = Insertable<CronJobsTable>;
 
+/** Creates the Kysely facade scoped to cron_jobs for synchronous SQLite access. */
 export function getCronStoreKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<CronStoreDatabase>(db);
 }

--- a/src/cron/store/state-codec.ts
+++ b/src/cron/store/state-codec.ts
@@ -7,6 +7,7 @@ import {
 } from "./scalar-codec.js";
 import type { CronJobInsert, CronJobRow } from "./schema.js";
 
+/** Maps mutable cron runtime state into normalized SQLite columns. */
 export function bindStateColumns(
   state: CronJobState,
 ): Pick<
@@ -42,8 +43,11 @@ export function bindStateColumns(
   };
 }
 
+/** Reconstructs cron runtime state from JSON plus split indexed columns. */
 export function stateFromRow(row: CronJobRow): CronJobState {
   return {
+    // Keep unknown runtime fields from state_json while letting indexed columns
+    // win for fields that SQLite updates independently during hot-path writes.
     ...parseJsonObject<CronJobState>(row.state_json, {}),
     ...(row.next_run_at_ms != null ? { nextRunAtMs: normalizeNumber(row.next_run_at_ms) } : {}),
     ...(row.running_at_ms != null ? { runningAtMs: normalizeNumber(row.running_at_ms) } : {}),

--- a/src/cron/store/types.ts
+++ b/src/cron/store/types.ts
@@ -1,5 +1,6 @@
 import type { CronStoreFile } from "../types.js";
 
+/** Invalid config-backed cron job captured for quarantine instead of runtime load. */
 export type QuarantinedCronConfigJob = {
   sourceIndex: number;
   reason: string;
@@ -10,17 +11,20 @@ export type QuarantinedCronConfigJob = {
   scheduleIdentity?: string;
 };
 
+/** Sidecar file that records config jobs skipped during cron store loading. */
 export type CronQuarantineFile = {
   version: 1;
   jobs: Array<QuarantinedCronConfigJob & { quarantinedAtMs: number }>;
 };
 
+/** Runtime state retained for config-sourced jobs that are not persisted as canonical jobs. */
 export type CronConfigJobRuntimeEntry = {
   updatedAtMs?: number;
   scheduleIdentity?: string;
   state?: Record<string, unknown>;
 };
 
+/** Combined cron store load result with canonical jobs and config-backed metadata. */
 export type LoadedCronStore = {
   store: CronStoreFile;
   configJobs: Array<Record<string, unknown>>;

--- a/src/cron/types-shared.ts
+++ b/src/cron/types-shared.ts
@@ -1,3 +1,4 @@
+/** Shared persisted cron job envelope used by runtime and external config shapes. */
 export type CronJobBase<TSchedule, TSessionTarget, TWakeMode, TPayload, TDelivery, TFailureAlert> =
   {
     id: string;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -155,6 +155,7 @@ export type CronRunDiagnostics = {
   entries: CronRunDiagnostic[];
 };
 
+/** Execution result persisted on cron state, run logs, and isolated turn results. */
 export type CronRunOutcome = {
   status: CronRunStatus;
   error?: string;
@@ -166,6 +167,7 @@ export type CronRunOutcome = {
   diagnostics?: CronRunDiagnostics;
 };
 
+/** Embedded-agent execution phase names surfaced to cron watchdog progress. */
 export type CronAgentExecutionPhase = EmbeddedAgentExecutionPhase;
 
 /** Watchdog-visible execution metadata for an in-flight cron agent run. */

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -22,6 +22,7 @@ export type CronSessionTarget = "main" | "isolated" | "current" | `session:${str
 /** Wake policy for main-session jobs waiting on heartbeat/user activity. */
 export type CronWakeMode = "next-heartbeat" | "now";
 
+/** Messaging channel id accepted by cron delivery settings. */
 export type CronMessageChannel = ChannelId;
 
 /** Delivery mode for job completion output. */
@@ -43,6 +44,7 @@ export type CronDelivery = {
   failureDestination?: CronFailureDestination;
 };
 
+/** Webhook completion destination used alongside chat delivery. */
 export type CronCompletionDestination = {
   mode: "webhook";
   to?: string;
@@ -56,6 +58,7 @@ export type CronFailureDestination = {
   mode?: "announce" | "webhook";
 };
 
+/** Partial delivery update shape; null clears the nested completion destination. */
 export type CronDeliveryPatch = Partial<Omit<CronDelivery, "completionDestination">> & {
   completionDestination?: CronCompletionDestination | null;
 };
@@ -66,6 +69,7 @@ export type CronRunStatus = "ok" | "error" | "skipped";
 /** Delivery outcome for completion or failure-notification sends. */
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
 
+/** Delivery target snapshot recorded for audit/debug output. */
 export type CronDeliveryTraceTarget = {
   channel?: string;
   to?: string | null;
@@ -74,6 +78,7 @@ export type CronDeliveryTraceTarget = {
   source?: "explicit" | "last";
 };
 
+/** Message-tool target that already sent to the cron delivery destination. */
 export type CronDeliveryTraceMessageTarget = {
   channel: string;
   to?: string;
@@ -81,6 +86,7 @@ export type CronDeliveryTraceMessageTarget = {
   threadId?: string;
 };
 
+/** Trace of intended, resolved, and already-sent delivery decisions for one run. */
 export type CronDeliveryTrace = {
   intended?: CronDeliveryTraceTarget;
   resolved?: CronDeliveryTraceTarget & { ok: boolean; error?: string };
@@ -97,11 +103,13 @@ export type CronFailureNotificationDelivery = {
   error?: string;
 };
 
+/** Human-readable delivery target preview for list/detail surfaces. */
 export type CronDeliveryPreview = {
   label: string;
   detail: string;
 };
 
+/** Token usage summary copied from the agent runner when available. */
 export type CronUsageSummary = {
   input_tokens?: number;
   output_tokens?: number;
@@ -110,14 +118,17 @@ export type CronUsageSummary = {
   cache_write_tokens?: number;
 };
 
+/** Model/provider/usage telemetry attached to cron run results and logs. */
 export type CronRunTelemetry = {
   model?: string;
   provider?: string;
   usage?: CronUsageSummary;
 };
 
+/** Severity level for persisted cron run diagnostics. */
 export type CronRunDiagnosticSeverity = "info" | "warn" | "error";
 
+/** Subsystem that produced a cron run diagnostic entry. */
 export type CronRunDiagnosticSource =
   | "cron-preflight"
   | "cron-setup"
@@ -127,6 +138,7 @@ export type CronRunDiagnosticSource =
   | "exec"
   | "delivery";
 
+/** Timestamped diagnostic entry preserved for cron run troubleshooting. */
 export type CronRunDiagnostic = {
   ts: number;
   source: CronRunDiagnosticSource;
@@ -137,6 +149,7 @@ export type CronRunDiagnostic = {
   truncated?: boolean;
 };
 
+/** Bounded diagnostic bundle stored on the run outcome. */
 export type CronRunDiagnostics = {
   summary?: string;
   entries: CronRunDiagnostic[];
@@ -173,10 +186,12 @@ export type CronAgentExecutionStarted = {
   firstModelCallStarted?: boolean;
 };
 
+/** Watchdog update that requires the new execution phase. */
 export type CronAgentExecutionPhaseUpdate = CronAgentExecutionStarted & {
   phase: CronAgentExecutionPhase;
 };
 
+/** Failure alert policy persisted on a cron job. */
 export type CronFailureAlert = {
   after?: number;
   channel?: CronMessageChannel;
@@ -193,6 +208,7 @@ export type CronFailureAlert = {
 /** Payload variants cron can execute in main-session or isolated-agent modes. */
 export type CronPayload = { kind: "systemEvent"; text: string } | CronAgentTurnPayload;
 
+/** Partial payload update shape used by cron patch/edit flows. */
 export type CronPayloadPatch = { kind: "systemEvent"; text?: string } | CronAgentTurnPayloadPatch;
 
 type CronAgentTurnPayloadFields = {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -4,6 +4,7 @@ import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { HookExternalContentSource } from "../security/external-content.js";
 import type { CronJobBase } from "./types-shared.js";
 
+/** Supported schedule forms persisted in cron job specs. */
 export type CronSchedule =
   | { kind: "at"; at: string }
   | { kind: "every"; everyMs: number; anchorMs?: number }
@@ -15,13 +16,18 @@ export type CronSchedule =
       staggerMs?: number;
     };
 
+/** Runtime target that decides whether a job joins main, isolated, or a named session. */
 export type CronSessionTarget = "main" | "isolated" | "current" | `session:${string}`;
+
+/** Wake policy for main-session jobs waiting on heartbeat/user activity. */
 export type CronWakeMode = "next-heartbeat" | "now";
 
 export type CronMessageChannel = ChannelId;
 
+/** Delivery mode for job completion output. */
 export type CronDeliveryMode = "none" | "announce" | "webhook";
 
+/** Completion delivery configuration for cron job output. */
 export type CronDelivery = {
   mode: CronDeliveryMode;
   channel?: CronMessageChannel;
@@ -42,6 +48,7 @@ export type CronCompletionDestination = {
   to?: string;
 };
 
+/** Destination override for failed-run notifications. */
 export type CronFailureDestination = {
   channel?: CronMessageChannel;
   to?: string;
@@ -53,7 +60,10 @@ export type CronDeliveryPatch = Partial<Omit<CronDelivery, "completionDestinatio
   completionDestination?: CronCompletionDestination | null;
 };
 
+/** Execution outcome, separate from delivery outcome. */
 export type CronRunStatus = "ok" | "error" | "skipped";
+
+/** Delivery outcome for completion or failure-notification sends. */
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
 
 export type CronDeliveryTraceTarget = {
@@ -79,6 +89,7 @@ export type CronDeliveryTrace = {
   delivered?: boolean;
 };
 
+/** Last failed-run notification delivery state stored on job state and run logs. */
 export type CronFailureNotificationDelivery = {
   /** Whether the last failed run's failure notification reached the target channel. */
   delivered?: boolean;
@@ -144,6 +155,7 @@ export type CronRunOutcome = {
 
 export type CronAgentExecutionPhase = EmbeddedAgentExecutionPhase;
 
+/** Watchdog-visible execution metadata for an in-flight cron agent run. */
 export type CronAgentExecutionStarted = {
   jobId: string;
   agentId?: string;
@@ -178,6 +190,7 @@ export type CronFailureAlert = {
   accountId?: string;
 };
 
+/** Payload variants cron can execute in main-session or isolated-agent modes. */
 export type CronPayload = { kind: "systemEvent"; text: string } | CronAgentTurnPayload;
 
 export type CronPayloadPatch = { kind: "systemEvent"; text?: string } | CronAgentTurnPayloadPatch;
@@ -208,6 +221,7 @@ type CronAgentTurnPayloadPatch = {
 } & Partial<Omit<CronAgentTurnPayloadFields, "toolsAllow">> & {
     toolsAllow?: string[] | null;
   };
+/** Mutable runtime state persisted beside the immutable cron job spec. */
 export type CronJobState = {
   nextRunAtMs?: number;
   runningAtMs?: number;
@@ -244,6 +258,7 @@ export type CronJobState = {
   lastFailureNotificationDeliveryError?: string;
 };
 
+/** Fully persisted cron job with spec fields and mutable run state. */
 export type CronJob = CronJobBase<
   CronSchedule,
   CronSessionTarget,
@@ -255,15 +270,18 @@ export type CronJob = CronJobBase<
   state: CronJobState;
 };
 
+/** Versioned cron store file shape. */
 export type CronStoreFile = {
   version: 1;
   jobs: CronJob[];
 };
 
+/** Create input accepted by cron APIs before id/timestamps/state are assigned. */
 export type CronJobCreate = Omit<CronJob, "id" | "createdAtMs" | "updatedAtMs" | "state"> & {
   state?: Partial<CronJobState>;
 };
 
+/** Patch input accepted by cron APIs without allowing immutable identity fields. */
 export type CronJobPatch = Partial<
   Omit<CronJob, "id" | "createdAtMs" | "state" | "payload" | "delivery">
 > & {

--- a/src/cron/validate-timestamp.ts
+++ b/src/cron/validate-timestamp.ts
@@ -21,10 +21,7 @@ type TimestampValidationSuccess = {
 type TimestampValidationResult = TimestampValidationSuccess | TimestampValidationError;
 
 /**
- * Validates at timestamps in cron schedules.
- * Rejects timestamps that are:
- * - More than 1 minute in the past
- * - More than 10 years in the future
+ * Validates one-shot cron timestamps with a small past grace window and far-future cap.
  */
 export function validateScheduleTimestamp(
   schedule: CronSchedule,
@@ -47,7 +44,8 @@ export function validateScheduleTimestamp(
   const referenceNowMs = asDateTimestampMs(nowMs) ?? asDateTimestampMs(Date.now()) ?? 0;
   const diffMs = atMs - referenceNowMs;
 
-  // Check if timestamp is in the past (allow 1 minute grace period)
+  // Allow a one-minute grace window so creation and validation races do not
+  // reject freshly submitted one-shot jobs.
   if (diffMs < -ONE_MINUTE_MS) {
     const nowDate = resolveTimestampMsToIsoString(referenceNowMs);
     const atDate = resolveTimestampMsToIsoString(atMs);
@@ -58,7 +56,7 @@ export function validateScheduleTimestamp(
     };
   }
 
-  // Check if timestamp is too far in the future
+  // Bound far-future one-shot jobs so mistyped years do not persist forever.
   if (diffMs > TEN_YEARS_MS) {
     const atDate = resolveTimestampMsToIsoString(atMs);
     const yearsAhead = Math.floor(diffMs / (365.25 * 24 * 60 * 60 * 1000));

--- a/src/cron/webhook-url.ts
+++ b/src/cron/webhook-url.ts
@@ -2,6 +2,7 @@ function isAllowedWebhookProtocol(protocol: string) {
   return protocol === "http:" || protocol === "https:";
 }
 
+/** Normalizes cron webhook URLs while rejecting empty, malformed, and non-HTTP(S) values. */
 export function normalizeHttpWebhookUrl(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;

--- a/src/infra/outbound/abort.ts
+++ b/src/infra/outbound/abort.ts
@@ -1,8 +1,4 @@
 /**
- * Utility for checking AbortSignal state and throwing a standard AbortError.
- */
-
-/**
  * Throws an AbortError if the given signal has been aborted.
  * Use at async checkpoints to support cancellation.
  */

--- a/src/infra/outbound/account-scoped-conversation-bindings.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.ts
@@ -13,6 +13,7 @@ import {
   type SessionBindingRecord,
 } from "./session-binding-service.js";
 
+/** In-memory binding record scoped to one channel account and conversation id. */
 export type AccountScopedConversationBindingRecord<TKind extends string = string> = {
   accountId: string;
   conversationId: string;
@@ -25,6 +26,7 @@ export type AccountScopedConversationBindingRecord<TKind extends string = string
   lastActivityAt: number;
 };
 
+/** Account-local binding manager exposed by channel-specific conversation stores. */
 export type AccountScopedConversationBindingManager<TKind extends string = string> = {
   accountId: string;
   getByConversationId: (
@@ -115,6 +117,7 @@ function toSessionBindingRecord<TKind extends string>(params: {
   };
 }
 
+/** Creates a channel/account binding manager and registers it as a session-binding adapter. */
 export function createAccountScopedConversationBindingManager<TKind extends string>(params: {
   channel: string;
   cfg: OpenClawConfig;
@@ -338,6 +341,7 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
   return manager;
 }
 
+/** Stops registered managers and clears account-scoped binding state for one test key. */
 export function resetAccountScopedConversationBindingsForTests(params: { stateKey: symbol }) {
   const state = getState(params.stateKey);
   for (const manager of state.managersByAccountId.values()) {

--- a/src/infra/outbound/base-session-key.ts
+++ b/src/infra/outbound/base-session-key.ts
@@ -1,6 +1,12 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { buildAgentSessionKey, type RoutePeer } from "../../routing/resolve-route.js";
 
+/**
+ * Builds the canonical outbound base-session key for a resolved route peer.
+ *
+ * Mirrors the routing layer's session-scope rules so outbound-only sends and
+ * inbound route resolution keep the same `dmScope` and identity-link behavior.
+ */
 export function buildOutboundBaseSessionKey(params: {
   cfg: OpenClawConfig;
   agentId: string;

--- a/src/infra/outbound/best-effort-delivery.ts
+++ b/src/infra/outbound/best-effort-delivery.ts
@@ -6,6 +6,7 @@ import {
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 
+/** Optional external destination for best-effort delivery from session-only flows. */
 export type ExternalBestEffortDeliveryTarget = {
   deliver: boolean;
   channel?: string;
@@ -14,6 +15,7 @@ export type ExternalBestEffortDeliveryTarget = {
   threadId?: string;
 };
 
+/** Normalizes an optional best-effort destination into a deliver/no-deliver decision. */
 export function resolveExternalBestEffortDeliveryTarget(params: {
   channel?: string | null;
   to?: string | null;
@@ -39,6 +41,7 @@ export function resolveExternalBestEffortDeliveryTarget(params: {
   };
 }
 
+/** Detects best-effort sends that should stay session-only on the internal channel. */
 export function shouldDowngradeDeliveryToSessionOnly(params: {
   wantsDelivery: boolean;
   bestEffortDeliver: boolean;

--- a/src/infra/outbound/bound-delivery-router.ts
+++ b/src/infra/outbound/bound-delivery-router.ts
@@ -58,6 +58,7 @@ function resolveBindingForRequester(
   return null;
 }
 
+/** Creates a router that resolves task-completion delivery through active session bindings. */
 export function createBoundDeliveryRouter(
   service: SessionBindingService = getSessionBindingService(),
 ): BoundDeliveryRouter {

--- a/src/infra/outbound/bound-delivery-router.ts
+++ b/src/infra/outbound/bound-delivery-router.ts
@@ -6,6 +6,7 @@ import {
   type SessionBindingService,
 } from "./session-binding-service.js";
 
+/** Session-bound delivery lookup input for routing task completion messages. */
 export type BoundDeliveryRouterInput = {
   eventKind: "task_completion";
   targetSessionKey: string;
@@ -13,12 +14,14 @@ export type BoundDeliveryRouterInput = {
   failClosed: boolean;
 };
 
+/** Resolved session binding or the fallback reason used by delivery callers. */
 export type BoundDeliveryRouterResult = {
   binding: SessionBindingRecord | null;
   mode: "bound" | "fallback";
   reason: string;
 };
 
+/** Router facade that maps a target session/requester pair to a bound conversation. */
 export type BoundDeliveryRouter = {
   resolveDestination: (input: BoundDeliveryRouterInput) => BoundDeliveryRouterResult;
 };
@@ -93,6 +96,8 @@ export function createBoundDeliveryRouter(
             reason: "single-active-binding",
           };
         }
+        // Without requester context, multiple active bindings are ambiguous;
+        // fallback avoids leaking one session's completion into another chat.
         return {
           binding: null,
           mode: "fallback",

--- a/src/infra/outbound/channel-bootstrap.runtime.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.ts
@@ -11,6 +11,7 @@ import type { DeliverableMessageChannel } from "../../utils/message-channel.js";
 
 const bootstrapAttempts = new Set<string>();
 
+/** Clears the per-registry channel bootstrap retry guard for isolated tests. */
 export function resetOutboundChannelBootstrapStateForTests(): void {
   bootstrapAttempts.clear();
 }
@@ -19,6 +20,7 @@ function channelEntryCanSend(entry: PluginChannelRegistration | undefined): bool
   return Boolean(entry?.plugin?.outbound?.sendText ?? entry?.plugin?.message?.send?.text);
 }
 
+/** Loads runtime plugins on demand when a selected outbound channel has only a setup shell. */
 export function bootstrapOutboundChannelPlugin(params: {
   channel: DeliverableMessageChannel;
   cfg?: OpenClawConfig;

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -32,6 +32,7 @@ import {
 
 type ChannelTargetResolver = NonNullable<ChannelMessagingAdapter["targetResolver"]>;
 
+/** Prompt-facing channel capabilities exposed to outbound/runtime callers. */
 export type ChannelPromptRuntime = {
   messageToolHints?: ChannelAgentPromptAdapter["messageToolHints"];
   messageToolCapabilities?: ChannelAgentPromptAdapter["messageToolCapabilities"];
@@ -39,6 +40,7 @@ export type ChannelPromptRuntime = {
   hasNativeApprovalPromptUi?: boolean;
 };
 
+/** Read-only channel runtime facade assembled from a channel plugin. */
 export type OutboundChannelRuntime = {
   id: string;
   label: string;
@@ -84,10 +86,12 @@ export type OutboundChannelRuntime = {
   blockStreamingCoalesceDefaults?: ChannelStreamingAdapter["blockStreamingCoalesceDefaults"];
 };
 
+/** Resets outbound channel bootstrap/resolution state for isolated tests. */
 export function resetOutboundChannelResolutionStateForTest(): void {
   resetOutboundChannelBootstrapStateForTests();
 }
 
+/** Normalizes a raw channel id and rejects non-deliverable/internal channels. */
 export function normalizeDeliverableOutboundChannel(
   raw?: string | null,
 ): DeliverableMessageChannel | undefined {
@@ -171,6 +175,7 @@ function toOutboundChannelRuntime(plugin: ChannelPlugin): OutboundChannelRuntime
   };
 }
 
+/** Resolves a deliverable outbound channel plugin, optionally bootstrapping it. */
 export function resolveOutboundChannelPlugin(params: {
   channel: string;
   cfg?: OpenClawConfig;
@@ -205,6 +210,7 @@ export function resolveOutboundChannelPlugin(params: {
   return resolveLoaded() ?? resolveDirectFromActiveRegistry(normalized) ?? resolve();
 }
 
+/** Resolves the message adapter for a deliverable outbound channel. */
 export function resolveOutboundChannelMessageAdapter(params: {
   channel: string;
   cfg?: OpenClawConfig;
@@ -213,6 +219,7 @@ export function resolveOutboundChannelMessageAdapter(params: {
   return resolveOutboundChannelPlugin(params)?.message;
 }
 
+/** Resolves a channel plugin for read-only metadata paths. */
 export function resolveOutboundChannelPluginForRead(params: {
   channel: string;
   cfg?: OpenClawConfig;
@@ -242,6 +249,7 @@ export function resolveOutboundChannelPluginForRead(params: {
   return getChannelPlugin(channelId);
 }
 
+/** Resolves the read-only outbound runtime facade for a channel. */
 export function resolveOutboundChannelRuntime(params: {
   channel: string;
   cfg?: OpenClawConfig;
@@ -250,6 +258,7 @@ export function resolveOutboundChannelRuntime(params: {
   return plugin ? toOutboundChannelRuntime(plugin) : undefined;
 }
 
+/** Reads an already-loaded channel plugin without bootstrapping. */
 export function resolveLoadedOutboundChannelPluginForRead(params: {
   channel: string;
 }): ChannelPlugin | undefined {

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -15,7 +15,9 @@ import {
 import { formatErrorMessage } from "../errors.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 
+/** Deliverable message channel id that can be selected for message actions. */
 export type MessageChannelId = DeliverableMessageChannel;
+/** Source that explains how message channel selection chose its result. */
 export type MessageChannelSelectionSource =
   | "explicit"
   | "tool-context-fallback"
@@ -67,6 +69,7 @@ function resolveAvailableKnownChannel(params: {
     : undefined;
 }
 
+/** Checks whether a channel has a non-disabled config entry. */
 export function isConfiguredChannel(cfg: OpenClawConfig, channelId: string): boolean {
   const channels = cfg.channels;
   if (!channels || typeof channels !== "object" || Array.isArray(channels)) {
@@ -202,6 +205,7 @@ async function isPluginConfigured(plugin: ChannelPlugin, cfg: OpenClawConfig): P
   return false;
 }
 
+/** Lists deliverable channels with at least one enabled, configured account. */
 export async function listConfiguredMessageChannels(
   cfg: OpenClawConfig,
 ): Promise<MessageChannelId[]> {
@@ -217,6 +221,7 @@ export async function listConfiguredMessageChannels(
   return channels;
 }
 
+/** Resolves the message action channel from explicit input, context fallback, or config. */
 export async function resolveMessageChannelSelection(params: {
   cfg: OpenClawConfig;
   channel?: string | null;

--- a/src/infra/outbound/channel-target-prefix.ts
+++ b/src/infra/outbound/channel-target-prefix.ts
@@ -12,6 +12,7 @@ const TARGET_KIND_PREFIXES = new Set([
   "user",
 ]);
 
+/** Removes a selected channel/provider prefix from an outbound target string. */
 export function stripTargetProviderPrefix(raw: string, ...providers: string[]): string {
   const trimmed = raw.trim();
   const lower = normalizeOptionalLowercaseString(trimmed) ?? "";
@@ -24,6 +25,7 @@ export function stripTargetProviderPrefix(raw: string, ...providers: string[]): 
   return trimmed;
 }
 
+/** Removes generic target-kind prefixes such as room:, thread:, or user:. */
 export function stripTargetKindPrefix(
   raw: string,
   kinds: readonly string[] = ["channel", "conversation", "dm", "group", "room", "thread", "user"],
@@ -35,6 +37,7 @@ export function stripTargetKindPrefix(
   return kindPattern ? raw.replace(new RegExp(`^(${kindPattern}):`, "i"), "").trim() : raw.trim();
 }
 
+/** Strips plugin topic suffixes while preserving ordinary colon-containing targets. */
 export function stripTargetTopicSuffix(
   raw: string,
   options: { allowNumericShorthand?: boolean } = {},
@@ -47,6 +50,7 @@ export function stripTargetTopicSuffix(
   return trimmed.replace(/:topic:.*$/i, "").trim();
 }
 
+/** Parsed provider prefix and the channel that owns it. */
 export type ChannelTargetProviderPrefix = {
   prefix: string;
   channel: string;
@@ -86,10 +90,12 @@ function resolveChannelTargetProviderPrefix(
   return channel ? { prefix, channel } : undefined;
 }
 
+/** Resolves the channel implied by a plugin-owned target prefix, if any. */
 export function resolveTargetPrefixedChannel(raw?: string | null): string | undefined {
   return resolveChannelTargetProviderPrefix(raw)?.channel;
 }
 
+/** Rejects targets whose plugin-owned prefix belongs to a different selected channel. */
 export function validateTargetProviderPrefix(params: {
   channel: string;
   to?: string | null;

--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -4,14 +4,18 @@ import {
 } from "../../../packages/normalization-core/src/string-coerce.js";
 import { MESSAGE_ACTION_TARGET_MODE } from "./message-action-spec.js";
 
+/** Shared non-empty string guard for message-action target params. */
 export const hasNonEmptyString = sharedHasNonEmptyString;
 
+/** Human-readable description for a single message-action destination. */
 export const CHANNEL_TARGET_DESCRIPTION =
   "Recipient/channel: E.164 for WhatsApp/Signal, Telegram chat id/@username, Discord/Slack/Mattermost <channelId|user:ID|channel:ID>, or iMessage handle/chat_id";
 
+/** Human-readable description for repeated message-action destinations. */
 export const CHANNEL_TARGETS_DESCRIPTION =
   "Recipient/channel targets (same format as --target); accepts ids or names when the directory is available.";
 
+/** Maps canonical `target` into the legacy field required by the action implementation. */
 export function applyTargetToParams(params: {
   action: string;
   args: Record<string, unknown>;

--- a/src/infra/outbound/conversation-id.ts
+++ b/src/infra/outbound/conversation-id.ts
@@ -35,6 +35,8 @@ export function resolveConversationIdFromTargets(params: {
       return explicitConversationId;
     }
     if (target.includes(":") && explicitConversationId === undefined) {
+      // Colon targets are usually provider-native ids. Only explicit target
+      // prefixes above are safe to collapse into a portable conversation id.
       continue;
     }
     const mentionMatch = target.match(/^<#(\d+)>$/);

--- a/src/infra/outbound/conversation-id.ts
+++ b/src/infra/outbound/conversation-id.ts
@@ -13,6 +13,9 @@ function resolveExplicitConversationTargetId(target: string): string | undefined
   return undefined;
 }
 
+/**
+ * Chooses the best conversation id from an explicit thread id or outbound targets.
+ */
 export function resolveConversationIdFromTargets(params: {
   threadId?: string | number;
   targets: Array<string | undefined | null>;

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -145,6 +145,7 @@ function resolveChannelSupportsCurrentConversationBinding(channel: string): bool
   return false;
 }
 
+/** Reports generic current-conversation binding support for plugin-owned channels. */
 export function getGenericCurrentConversationBindingCapabilities(params: {
   channel: string;
   accountId: string;
@@ -161,6 +162,7 @@ export function getGenericCurrentConversationBindingCapabilities(params: {
   };
 }
 
+/** Stores or replaces the current-conversation binding for a normalized conversation ref. */
 export async function bindGenericCurrentConversation(
   input: SessionBindingBindInput,
 ): Promise<SessionBindingRecord | null> {
@@ -209,12 +211,14 @@ export async function bindGenericCurrentConversation(
   return record;
 }
 
+/** Resolves a current-conversation binding and prunes it if its TTL has expired. */
 export function resolveGenericCurrentConversationBinding(
   ref: ConversationRef,
 ): SessionBindingRecord | null {
   return pruneExpiredBinding(buildConversationKey(ref));
 }
 
+/** Lists non-expired current-conversation bindings owned by one target session. */
 export function listGenericCurrentConversationBindingsBySession(
   targetSessionKey: string,
 ): SessionBindingRecord[] {
@@ -230,6 +234,7 @@ export function listGenericCurrentConversationBindingsBySession(
   return results;
 }
 
+/** Persists last-activity metadata for an existing generic current-conversation binding. */
 export function touchGenericCurrentConversationBinding(bindingId: string, at = Date.now()): void {
   loadBindingsIntoMemory();
   if (!bindingId.startsWith(CURRENT_BINDINGS_ID_PREFIX)) {
@@ -250,6 +255,7 @@ export function touchGenericCurrentConversationBinding(bindingId: string, at = D
   persistBindingsToDisk();
 }
 
+/** Removes generic current-conversation bindings by binding id or target session key. */
 export async function unbindGenericCurrentConversationBindings(
   input: SessionBindingUnbindInput,
 ): Promise<SessionBindingRecord[]> {

--- a/src/infra/outbound/deliver-types.ts
+++ b/src/infra/outbound/deliver-types.ts
@@ -1,6 +1,7 @@
 import type { MessageReceipt } from "../../channels/message/types.js";
 import type { ChannelId } from "../../channels/plugins/channel-id.types.js";
 
+/** Successful channel send result normalized for core delivery accounting. */
 export type OutboundDeliveryResult = {
   channel: Exclude<ChannelId, "none">;
   messageId: string;
@@ -16,6 +17,7 @@ export type OutboundDeliveryResult = {
   meta?: Record<string, unknown>;
 };
 
+/** Reason a payload was intentionally not sent after normalization or hooks. */
 export type OutboundPayloadDeliverySuppressionReason =
   | "cancelled_by_message_sending_hook"
   | "cancelled_by_reply_payload_sending_hook"
@@ -24,8 +26,10 @@ export type OutboundPayloadDeliverySuppressionReason =
   | "no_visible_payload"
   | "adapter_returned_no_identity";
 
+/** Delivery phase where a failure occurred. */
 export type OutboundDeliveryFailureStage = "platform_send" | "queue" | "unknown";
 
+/** Per-payload delivery status emitted to callers and channel send summaries. */
 export type OutboundPayloadDeliveryOutcome =
   | {
       index: number;
@@ -49,6 +53,7 @@ export type OutboundPayloadDeliveryOutcome =
       stage: OutboundDeliveryFailureStage;
     };
 
+/** Error carrying partial delivery results when an outbound send fails mid-batch. */
 export class OutboundDeliveryError extends Error {
   readonly results: OutboundDeliveryResult[];
   readonly payloadOutcomes: OutboundPayloadDeliveryOutcome[];
@@ -73,6 +78,7 @@ export class OutboundDeliveryError extends Error {
   }
 }
 
+/** Narrows unknown failures to outbound delivery errors with partial-send metadata. */
 export function isOutboundDeliveryError(error: unknown): error is OutboundDeliveryError {
   return error instanceof OutboundDeliveryError;
 }

--- a/src/infra/outbound/delivery-commit-hooks.ts
+++ b/src/infra/outbound/delivery-commit-hooks.ts
@@ -2,6 +2,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { formatErrorMessage } from "../errors.js";
 import type { OutboundDeliveryResult } from "./deliver-types.js";
 
+/** Callback attached to a delivery result and run after durable send commit. */
 export type OutboundDeliveryCommitHook = () => Promise<void>;
 
 const log = createSubsystemLogger("outbound/deliver");
@@ -10,6 +11,7 @@ const outboundDeliveryCommitHooks = new WeakMap<
   OutboundDeliveryCommitHook[]
 >();
 
+/** Attaches an after-commit hook without changing the delivery result shape. */
 export function attachOutboundDeliveryCommitHook<T extends OutboundDeliveryResult>(
   result: T,
   hook?: OutboundDeliveryCommitHook,
@@ -23,6 +25,7 @@ export function attachOutboundDeliveryCommitHook<T extends OutboundDeliveryResul
   return result;
 }
 
+/** Runs after-commit hooks for delivered results while isolating hook failures. */
 export async function runOutboundDeliveryCommitHooks(
   results: readonly OutboundDeliveryResult[],
 ): Promise<void> {
@@ -31,6 +34,8 @@ export async function runOutboundDeliveryCommitHooks(
       try {
         await hook();
       } catch (err) {
+        // Commit hooks are side effects after successful send; failures are
+        // logged but must not turn the already-committed delivery into failure.
         log.warn("Plugin message adapter after-commit hook failed.", {
           channel: result.channel,
           messageId: result.messageId,
@@ -41,6 +46,7 @@ export async function runOutboundDeliveryCommitHooks(
   }
 }
 
+/** Type guard for batched outbound delivery results crossing loose boundaries. */
 export function isOutboundDeliveryResultArray(value: unknown): value is OutboundDeliveryResult[] {
   return Array.isArray(value);
 }

--- a/src/infra/outbound/directory-cache.ts
+++ b/src/infra/outbound/directory-cache.ts
@@ -7,6 +7,9 @@ type CacheEntry<T> = {
   fetchedAt: number;
 };
 
+/**
+ * Stable dimensions that partition channel-directory cache entries.
+ */
 export type DirectoryCacheKey = {
   channel: ChannelId;
   accountId?: string | null;
@@ -15,11 +18,17 @@ export type DirectoryCacheKey = {
   signature?: string | null;
 };
 
+/**
+ * Serializes channel-directory lookup dimensions into a cache key.
+ */
 export function buildDirectoryCacheKey(key: DirectoryCacheKey): string {
   const signature = key.signature ?? "default";
   return `${key.channel}:${key.accountId ?? "default"}:${key.kind}:${key.source}:${signature}`;
 }
 
+/**
+ * Small TTL cache for channel directory lookups tied to a config object reference.
+ */
 export class DirectoryCache<T> {
   private readonly cache = new Map<string, CacheEntry<T>>();
   private lastConfigRef: OpenClawConfig | null = null;
@@ -31,6 +40,9 @@ export class DirectoryCache<T> {
     this.maxSize = Math.max(1, resolveNonNegativeIntegerOption(maxSize, 2000));
   }
 
+  /**
+   * Returns a cached value after applying config, TTL, and capacity invalidation.
+   */
   get(key: string, cfg: OpenClawConfig): T | undefined {
     this.resetIfConfigChanged(cfg);
     this.pruneExpired(Date.now());
@@ -41,6 +53,9 @@ export class DirectoryCache<T> {
     return entry.value;
   }
 
+  /**
+   * Stores a value and refreshes its recency for bounded-size eviction.
+   */
   set(key: string, value: T, cfg: OpenClawConfig): void {
     this.resetIfConfigChanged(cfg);
     const now = Date.now();
@@ -53,6 +68,9 @@ export class DirectoryCache<T> {
     this.evictToMaxSize();
   }
 
+  /**
+   * Clears matching entries without disturbing unrelated cached lookups.
+   */
   clearMatching(match: (key: string) => boolean): void {
     for (const key of this.cache.keys()) {
       if (match(key)) {
@@ -61,6 +79,9 @@ export class DirectoryCache<T> {
     }
   }
 
+  /**
+   * Drops all cached entries and optionally adopts the current config reference.
+   */
   clear(cfg?: OpenClawConfig): void {
     this.cache.clear();
     if (cfg) {
@@ -69,6 +90,7 @@ export class DirectoryCache<T> {
   }
 
   private resetIfConfigChanged(cfg: OpenClawConfig): void {
+    // Directory availability can change with config snapshots; ref changes must not leak stale entries.
     if (this.lastConfigRef && this.lastConfigRef !== cfg) {
       this.cache.clear();
     }

--- a/src/infra/outbound/envelope.ts
+++ b/src/infra/outbound/envelope.ts
@@ -2,6 +2,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OutboundDeliveryJson } from "./format.js";
 import { normalizeOutboundPayloadsForJson, type OutboundPayloadJson } from "./payloads.js";
 
+/** Structured result returned by outbound helpers when payloads/meta wrap delivery data. */
 export type OutboundResultEnvelope = {
   payloads?: OutboundPayloadJson[];
   meta?: unknown;
@@ -19,6 +20,7 @@ const isOutboundPayloadJson = (
   payload: ReplyPayload | OutboundPayloadJson,
 ): payload is OutboundPayloadJson => "mediaUrl" in payload;
 
+/** Builds the outbound result envelope, flattening plain delivery-only results by default. */
 export function buildOutboundResultEnvelope(
   params: BuildEnvelopeParams,
 ): OutboundResultEnvelope | OutboundDeliveryJson {

--- a/src/infra/outbound/format.ts
+++ b/src/infra/outbound/format.ts
@@ -4,6 +4,9 @@ import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { normalizeChatChannelId } from "../../channels/registry.js";
 import type { OutboundDeliveryResult } from "./deliver.js";
 
+/**
+ * Machine-readable delivery result emitted by outbound send commands.
+ */
 export type OutboundDeliveryJson = {
   channel: string;
   via: "direct" | "gateway";
@@ -35,6 +38,7 @@ const resolveChannelLabel = (channel: string) => {
   if (pluginLabel) {
     return pluginLabel;
   }
+  // Some legacy chat channels are not plugins; keep their human labels for CLI output.
   const normalized = normalizeChatChannelId(channel);
   if (normalized) {
     return getChatChannelMeta(normalized).label;
@@ -42,6 +46,9 @@ const resolveChannelLabel = (channel: string) => {
   return channel;
 };
 
+/**
+ * Formats the human-readable direct delivery summary for CLI output.
+ */
 export function formatOutboundDeliverySummary(
   channel: string,
   result?: OutboundDeliveryResult,
@@ -68,6 +75,9 @@ export function formatOutboundDeliverySummary(
   return base;
 }
 
+/**
+ * Builds the JSON delivery payload returned by direct or gateway sends.
+ */
 export function buildOutboundDeliveryJson(params: {
   channel: string;
   to: string;
@@ -110,6 +120,9 @@ export function buildOutboundDeliveryJson(params: {
   return payload;
 }
 
+/**
+ * Formats the human-readable gateway delivery summary for CLI output.
+ */
 export function formatGatewaySummary(params: {
   action?: string;
   channel?: string;

--- a/src/infra/outbound/formatting.ts
+++ b/src/infra/outbound/formatting.ts
@@ -1,6 +1,9 @@
 import type { ChunkMode } from "../../auto-reply/chunk.js";
 import type { MarkdownTableMode } from "../../config/types.js";
 
+/**
+ * Formatting and chunking hints carried through outbound delivery planning.
+ */
 export type OutboundDeliveryFormattingOptions = {
   textLimit?: number;
   maxLinesPerMessage?: number;

--- a/src/infra/outbound/identity-types.ts
+++ b/src/infra/outbound/identity-types.ts
@@ -1,3 +1,4 @@
+/** Agent identity metadata that outbound channels can render with a message. */
 export type OutboundIdentity = {
   name?: string;
   avatarUrl?: string;

--- a/src/infra/outbound/identity.ts
+++ b/src/infra/outbound/identity.ts
@@ -6,6 +6,7 @@ import type { OutboundIdentity } from "./identity-types.js";
 
 export type { OutboundIdentity } from "./identity-types.js";
 
+/** Trims outbound identity fields and drops empty identity payloads. */
 export function normalizeOutboundIdentity(
   identity?: OutboundIdentity | null,
 ): OutboundIdentity | undefined {
@@ -22,6 +23,7 @@ export function normalizeOutboundIdentity(
   return { name, avatarUrl, emoji, theme };
 }
 
+/** Resolves an agent's configured identity into channel-safe outbound metadata. */
 export function resolveAgentOutboundIdentity(
   cfg: OpenClawConfig,
   agentId: string,

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -10,6 +10,7 @@ import {
 import { applyTargetToParams } from "./channel-target.js";
 import { actionHasTarget, actionRequiresTarget } from "./message-action-spec.js";
 
+/** Normalizes message-action args before target validation and dispatch. */
 export function normalizeMessageActionInput(params: {
   action: ChannelMessageActionName;
   args: Record<string, unknown>;
@@ -29,6 +30,7 @@ export function normalizeMessageActionInput(params: {
     (normalizeOptionalString(normalizedArgs.channelId) ?? "").length > 0;
 
   if (explicitTarget && hasLegacyTargetFields) {
+    // Canonical `target` wins over old `to`/`channelId` aliases before validation.
     delete normalizedArgs.to;
     delete normalizedArgs.channelId;
   }

--- a/src/infra/outbound/message-action-param-keys.ts
+++ b/src/infra/outbound/message-action-param-keys.ts
@@ -42,6 +42,9 @@ const STANDARD_MESSAGE_ACTION_PARAM_KEYS = new Set([
   "to",
 ]);
 
+/**
+ * Detects non-standard message action params that may need plugin-owned handling.
+ */
 export function hasPotentialPluginActionParam(params: Record<string, unknown>): boolean {
   return Object.entries(params).some(([key, value]) => {
     if (STANDARD_MESSAGE_ACTION_PARAM_KEYS.has(key)) {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -21,6 +21,7 @@ import { resolveSnakeCaseParamKey } from "../../param-key.js";
 import { readBooleanParam as readBooleanParamShared } from "../../plugin-sdk/boolean-param.js";
 import { hasPotentialPluginActionParam } from "./message-action-param-keys.js";
 
+/** Shared boolean param reader used by message-action argument normalization. */
 export const readBooleanParam = readBooleanParamShared;
 
 const BASE_ACTION_MEDIA_SOURCE_PARAM_KEYS = [
@@ -140,6 +141,7 @@ function buildActionMediaSourceParamKeys(extraParamKeys?: readonly string[]): st
   return Array.from(keys);
 }
 
+/** Resolves plugin-declared media source param aliases for a message action. */
 export function resolveExtraActionMediaSourceParamKeys(params: {
   cfg: OpenClawConfig;
   action?: ChannelMessageActionName;
@@ -168,6 +170,7 @@ export function resolveExtraActionMediaSourceParamKeys(params: {
   });
 }
 
+/** Collects candidate media source strings from message-action args. */
 export function collectActionMediaSourceHints(
   args: Record<string, unknown>,
   extraParamKeys?: readonly string[],
@@ -248,6 +251,7 @@ function normalizeBase64Payload(params: { base64?: string; contentType?: string 
   };
 }
 
+/** Media access policy used when hydrating attachment action parameters. */
 export type AttachmentMediaPolicy =
   | {
       mode: "sandbox";
@@ -260,6 +264,7 @@ export type AttachmentMediaPolicy =
       mediaReadFile?: OutboundMediaReadFile;
     };
 
+/** Chooses sandbox or host media loading policy for attachment hydration. */
 export function resolveAttachmentMediaPolicy(params: {
   sandboxRoot?: string;
   mediaAccess?: OutboundMediaAccess;
@@ -391,6 +396,7 @@ async function hydrateAttachmentPayload(params: {
   }
 }
 
+/** Rewrites action media params to sandbox-safe paths and rejects data URLs. */
 export async function normalizeSandboxMediaParams(params: {
   args: Record<string, unknown>;
   mediaPolicy: AttachmentMediaPolicy;
@@ -437,6 +443,7 @@ export async function normalizeSandboxMediaParams(params: {
   }
 }
 
+/** Normalizes a list of media hints against an optional sandbox root. */
 export async function normalizeSandboxMediaList(params: {
   values: string[];
   sandboxRoot?: string;
@@ -511,6 +518,7 @@ async function hydrateAttachmentActionPayload(params: {
   });
 }
 
+/** Hydrates attachment-bearing message actions with base64 buffers and metadata. */
 export async function hydrateAttachmentParamsForAction(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -551,6 +559,7 @@ export async function hydrateAttachmentParamsForAction(params: {
   });
 }
 
+/** Parses a named string param as JSON for structured message action fields. */
 export function parseJsonMessageParam(params: Record<string, unknown>, key: string): void {
   const raw = params[key];
   if (typeof raw !== "string") {
@@ -568,6 +577,7 @@ export function parseJsonMessageParam(params: Record<string, unknown>, key: stri
   }
 }
 
+/** Parses the interactive message action param as JSON when provided as a string. */
 export function parseInteractiveParam(params: Record<string, unknown>): void {
   const raw = params.interactive;
   if (typeof raw !== "string") {

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -6,8 +6,14 @@ import { getBootstrapChannelPlugin } from "../../channels/plugins/bootstrap-regi
 import type { ChannelMessageActionName } from "../../channels/plugins/types.public.js";
 import { hasPotentialPluginActionParam } from "./message-action-param-keys.js";
 
+/**
+ * Canonical parameter shape used by an outbound message action target.
+ */
 export type MessageActionTargetMode = "to" | "channelId" | "none";
 
+/**
+ * Target-parameter policy for each supported channel message action.
+ */
 export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, MessageActionTargetMode> =
   {
     send: "to",
@@ -97,6 +103,7 @@ function listActionTargetAliasSpecs(
   if (!normalizedChannel || !hasPotentialPluginActionParam(params)) {
     return specs;
   }
+  // Plugin aliases are only checked after cheap param-shape screening to avoid bootstrap reads.
   const plugin = getBootstrapChannelPlugin(normalizedChannel);
   const channelSpec = plugin?.actions?.messageActionTargetAliases?.[action];
   if (channelSpec) {
@@ -105,10 +112,16 @@ function listActionTargetAliasSpecs(
   return specs;
 }
 
+/**
+ * Reports whether an action normally needs a destination target.
+ */
 export function actionRequiresTarget(action: ChannelMessageActionName): boolean {
   return MESSAGE_ACTION_TARGET_MODE[action] !== "none";
 }
 
+/**
+ * Detects whether an action invocation already carries a usable target.
+ */
 export function actionHasTarget(
   action: ChannelMessageActionName,
   params: Record<string, unknown>,

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -17,6 +17,7 @@ function suppressesImplicitThreading(actionParams: Record<string, unknown>): boo
   return actionParams.topLevel === true || actionParams.threadId === null;
 }
 
+/** Resolves and writes the outbound thread id used by message-action sends. */
 export function resolveAndApplyOutboundThreadId(
   actionParams: Record<string, unknown>,
   context: {
@@ -28,6 +29,7 @@ export function resolveAndApplyOutboundThreadId(
   },
 ): string | undefined {
   const threadId = readStringParam(actionParams, "threadId");
+  // `topLevel` and explicit null thread ids are caller opt-outs from inherited threading.
   if (!threadId && suppressesImplicitThreading(actionParams)) {
     return undefined;
   }
@@ -69,6 +71,7 @@ function isSameConversationTarget(
   return explicitTarget.trim() === currentChannelId;
 }
 
+/** Resolves and writes reply-to metadata for same-conversation message-action sends. */
 export function resolveAndApplyOutboundReplyToId(
   actionParams: Record<string, unknown>,
   context: {
@@ -108,6 +111,7 @@ export function resolveAndApplyOutboundReplyToId(
     if (hasRepliedRef?.value) {
       return undefined;
     }
+    // First-reply mode consumes the current inbound message once across batched sends.
     if (hasRepliedRef) {
       hasRepliedRef.value = true;
     }
@@ -122,6 +126,7 @@ export function resolveAndApplyOutboundReplyToId(
   return resolvedReplyToId;
 }
 
+/** Prepares outbound session mirroring metadata for message-action sends. */
 export async function prepareOutboundMirrorRoute(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;

--- a/src/infra/outbound/message-action-tts.ts
+++ b/src/infra/outbound/message-action-tts.ts
@@ -11,10 +11,12 @@ import { shouldAttemptTtsPayload } from "../../tts/tts-config.js";
 let ttsRuntimePromise: Promise<typeof import("../../tts/tts.runtime.js")> | null = null;
 
 function loadMessageActionTtsRuntime() {
+  // Keep the TTS runtime lazy so ordinary message sends do not pay the provider import cost.
   ttsRuntimePromise ??= import("../../tts/tts.runtime.js");
   return ttsRuntimePromise;
 }
 
+/** Reads the session-level TTS auto mode for a message-action send. */
 export function resolveMessageActionSessionTtsAuto(params: {
   cfg: OpenClawConfig;
   sessionKey?: string;
@@ -29,10 +31,12 @@ export function resolveMessageActionSessionTtsAuto(params: {
     const store = loadSessionStore(storePath);
     return resolveSessionStoreEntry({ store, sessionKey }).existing?.ttsAuto;
   } catch {
+    // Missing or unreadable session stores should not block message delivery.
     return undefined;
   }
 }
 
+/** Applies automatic TTS to a message-action send payload when config/session policy allows it. */
 export async function maybeApplyTtsToMessageActionSendPayload(params: {
   payload: ReplyPayload;
   cfg: OpenClawConfig;

--- a/src/infra/outbound/message-gateway-options.ts
+++ b/src/infra/outbound/message-gateway-options.ts
@@ -6,6 +6,7 @@ import {
   type GatewayClientName,
 } from "../../utils/message-channel.js";
 
+/** Raw gateway options accepted by outbound message senders. */
 export type OutboundMessageGatewayOptionsInput = {
   url?: string;
   token?: string;
@@ -15,9 +16,11 @@ export type OutboundMessageGatewayOptionsInput = {
   mode?: GatewayClientMode;
 };
 
+/** Normalizes outbound gateway options and fills CLI defaults. */
 export function resolveOutboundMessageGatewayOptions(gateway?: OutboundMessageGatewayOptionsInput) {
   const clientName = gateway?.clientName ?? GATEWAY_CLIENT_NAMES.CLI;
   const mode = gateway?.mode ?? GATEWAY_CLIENT_MODES.CLI;
+  // Backend-mode callers and gateway clients use the managed transport endpoint.
   const url =
     mode === GATEWAY_CLIENT_MODES.BACKEND || clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT
       ? undefined

--- a/src/infra/outbound/message-plan.ts
+++ b/src/infra/outbound/message-plan.ts
@@ -6,6 +6,9 @@ import {
 import type { OutboundDeliveryFormattingOptions } from "./formatting.js";
 import type { ReplyToOverride } from "./reply-policy.js";
 
+/**
+ * Per-send overrides carried from outbound planning into channel delivery.
+ */
 export type OutboundMessageSendOverrides = ReplyToOverride & {
   threadId?: string | number | null;
   audioAsVoice?: boolean;
@@ -13,6 +16,9 @@ export type OutboundMessageSendOverrides = ReplyToOverride & {
   formatting?: OutboundDeliveryFormattingOptions;
 };
 
+/**
+ * Planned outbound delivery unit after text chunking or media expansion.
+ */
 export type OutboundMessageUnit =
   | {
       kind: "text";
@@ -26,6 +32,9 @@ export type OutboundMessageUnit =
       overrides: OutboundMessageSendOverrides;
     };
 
+/**
+ * Splits outbound text with optional formatting-aware context.
+ */
 export type OutboundMessageChunker = (
   text: string,
   limit: number,
@@ -38,6 +47,7 @@ function withPlannedReplyTo(
   overrides: OutboundMessageSendOverrides,
   consumeReplyTo?: PlanReplyToConsumption,
 ): OutboundMessageSendOverrides {
+  // Reply-to policies can be single-use; clone overrides before consuming the implicit slot.
   return consumeReplyTo ? consumeReplyTo({ ...overrides }) : { ...overrides };
 }
 
@@ -61,6 +71,9 @@ function chunkTextForPlan(params: {
     : params.chunker(params.text, params.limit);
 }
 
+/**
+ * Plans text sends, preserving reply-to policy across chunked delivery units.
+ */
 export function planOutboundTextMessageUnits(params: {
   text: string;
   overrides: OutboundMessageSendOverrides;
@@ -125,6 +138,9 @@ export function planOutboundTextMessageUnits(params: {
   }).map(planChunkedTextUnit);
 }
 
+/**
+ * Plans media sends with a caption only on the leading media unit.
+ */
 export function planOutboundMediaMessageUnits(params: {
   caption: string;
   mediaUrls: readonly string[];

--- a/src/infra/outbound/mirror.ts
+++ b/src/infra/outbound/mirror.ts
@@ -1,3 +1,6 @@
+/**
+ * Transcript append data emitted after an outbound send completes.
+ */
 export type OutboundMirror = {
   sessionKey: string;
   agentId?: string;
@@ -6,6 +9,9 @@ export type OutboundMirror = {
   idempotencyKey?: string;
 };
 
+/**
+ * Delivery-layer mirror data with optional group/channel correlation metadata.
+ */
 export type DeliveryMirror = OutboundMirror & {
   /** Whether this message is being sent in a group/channel context */
   isGroup?: boolean;

--- a/src/infra/outbound/outbound-policy.ts
+++ b/src/infra/outbound/outbound-policy.ts
@@ -11,8 +11,14 @@ import type { MessagePresentation } from "../../interactive/payload.js";
 import { normalizeTargetForProvider } from "./target-normalization.js";
 import { formatTargetDisplay, lookupDirectoryDisplay } from "./target-resolver.js";
 
+/**
+ * Builds a channel-native presentation for forwarded cross-context text.
+ */
 export type CrossContextPresentationBuilder = (message: string) => MessagePresentation;
 
+/**
+ * Text and optional rich-presentation wrapper for cross-context outbound sends.
+ */
 export type CrossContextDecoration = {
   prefix: string;
   suffix: string;
@@ -104,6 +110,7 @@ function resolveAgentMessageToolsConfig(
   if (!agentConfig) {
     return globalConfig;
   }
+  // Agent message-tool policy is an override layer; nested policy groups must merge independently.
   return {
     ...globalConfig,
     ...agentConfig,
@@ -138,6 +145,9 @@ function resolveAgentMessageToolsConfig(
   };
 }
 
+/**
+ * Resolves the message-tool policy after applying any agent-specific overrides.
+ */
 export function resolveEffectiveMessageToolsConfig(params: {
   cfg: OpenClawConfig;
   agentId?: string | null;
@@ -145,6 +155,9 @@ export function resolveEffectiveMessageToolsConfig(params: {
   return resolveAgentMessageToolsConfig(params.cfg, params.agentId);
 }
 
+/**
+ * Returns the normalized allowed message actions for an agent or the global policy.
+ */
 export function resolveAllowedMessageActions(params: {
   cfg: OpenClawConfig;
   agentId?: string | null;
@@ -157,6 +170,9 @@ export function resolveAllowedMessageActions(params: {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+/**
+ * Rejects disabled message actions before channel-specific send handling runs.
+ */
 export function enforceMessageActionAllowlist(params: {
   cfg: OpenClawConfig;
   agentId?: string | null;
@@ -169,6 +185,9 @@ export function enforceMessageActionAllowlist(params: {
   throw new Error(`Message action "${params.action}" is disabled for this agent.`);
 }
 
+/**
+ * Enforces cross-context message-send policy for a bound channel/thread context.
+ */
 export function enforceCrossContextPolicy(params: {
   channel: ChannelId;
   action: ChannelMessageActionName;
@@ -197,6 +216,7 @@ export function enforceCrossContextPolicy(params: {
   const allowWithinProvider = messageConfig?.crossContext?.allowWithinProvider !== false;
   const allowAcrossProviders = messageConfig?.crossContext?.allowAcrossProviders === true;
 
+  // Provider mismatch is stronger than target mismatch; normalize targets only within one provider.
   if (currentProvider && currentProvider !== params.channel) {
     if (!allowAcrossProviders) {
       throw new Error(
@@ -224,6 +244,9 @@ export function enforceCrossContextPolicy(params: {
   );
 }
 
+/**
+ * Builds cross-context marker text or a channel-native presentation for forwarded sends.
+ */
 export async function buildCrossContextDecoration(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -235,7 +258,7 @@ export async function buildCrossContextDecoration(params: {
   if (!params.toolContext?.currentChannelId) {
     return null;
   }
-  // Skip decoration for direct tool sends (agent composing, not forwarding)
+  // Direct tool sends are authored for their destination, not forwarded from a bound context.
   if (params.toolContext.skipCrossContextDecoration) {
     return null;
   }
@@ -284,10 +307,16 @@ export async function buildCrossContextDecoration(params: {
   return { prefix, suffix, presentationBuilder };
 }
 
+/**
+ * Reports whether an action can carry a cross-context marker in outbound payloads.
+ */
 export function shouldApplyCrossContextMarker(action: ChannelMessageActionName): boolean {
   return CONTEXT_MARKER_ACTIONS.has(action);
 }
 
+/**
+ * Applies text markers or a preferred rich presentation to a cross-context message.
+ */
 export function applyCrossContextDecoration(params: {
   message: string;
   decoration: CrossContextDecoration;

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -20,6 +20,7 @@ import { sendMessage, sendPoll } from "./message.js";
 import type { OutboundMirror } from "./mirror.js";
 import { extractToolPayload } from "./tool-payload.js";
 
+/** Gateway connection settings forwarded to outbound send helpers. */
 export type OutboundGatewayContext = {
   url?: string;
   token?: string;
@@ -29,6 +30,7 @@ export type OutboundGatewayContext = {
   mode: GatewayClientMode;
 };
 
+/** Shared execution context for message-tool send and poll actions. */
 export type OutboundSendContext = {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -234,6 +236,7 @@ async function tryPreparePluginSendPayload(params: {
   );
 }
 
+/** Executes a message-tool send through plugin handlers or the core outbound path. */
 export async function executeSendAction(params: {
   ctx: OutboundSendContext;
   to: string;
@@ -270,6 +273,7 @@ export async function executeSendAction(params: {
   });
   if (preparedPayload) {
     throwIfAborted(params.ctx.abortSignal);
+    // Prepared plugin payloads still use core delivery so queueing, hooks, and mirrors stay uniform.
     const result = await sendCoreMessage({
       ...params,
       queuePolicy,
@@ -322,6 +326,7 @@ export async function executeSendAction(params: {
   };
 }
 
+/** Executes a message-tool poll through plugin handlers or the core poll path. */
 export async function executePollAction(params: {
   ctx: OutboundSendContext;
   resolveCorePoll: () => {

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -14,6 +14,7 @@ import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { buildOutboundBaseSessionKey } from "./base-session-key.js";
 import type { ResolvedMessagingTarget } from "./target-resolver.js";
 
+/** Session route produced for an outbound message target. */
 export type OutboundSessionRoute = {
   sessionKey: string;
   baseSessionKey: string;
@@ -24,6 +25,7 @@ export type OutboundSessionRoute = {
   threadId?: string | number;
 };
 
+/** Inputs required to resolve an outbound target into a session route. */
 export type ResolveOutboundSessionRouteParams = {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -177,6 +179,7 @@ function resolveFallbackSession(
   };
 }
 
+/** Resolves the session route used to mirror outbound delivery into conversation state. */
 export async function resolveOutboundSessionRoute(
   params: ResolveOutboundSessionRouteParams,
 ): Promise<OutboundSessionRoute | null> {
@@ -188,11 +191,13 @@ export async function resolveOutboundSessionRoute(
   const resolver = resolveOutboundChannelPlugin(params.channel)?.messaging
     ?.resolveOutboundSessionRoute;
   if (resolver) {
+    // Channel plugins can provide richer route semantics than the generic target parser.
     return await resolver(nextParams);
   }
   return resolveFallbackSession(nextParams);
 }
 
+/** Persists best-effort session metadata for an outbound-only route. */
 export async function ensureOutboundSessionEntry(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -21,6 +21,7 @@ import {
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
 import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citation-control-markers.js";
 
+/** Runtime-ready outbound payload after text/media/rich-content normalization. */
 export type NormalizedOutboundPayload = {
   text: string;
   mediaUrls: string[];
@@ -33,6 +34,7 @@ export type NormalizedOutboundPayload = {
   hookContent?: string;
 };
 
+/** JSON-safe outbound payload projection used for envelopes and diagnostics. */
 export type OutboundPayloadJson = {
   text: string;
   mediaUrl: string | null;
@@ -44,6 +46,7 @@ export type OutboundPayloadJson = {
   channelData?: Record<string, unknown>;
 };
 
+/** Prepared payload entry that keeps source indexing plus reusable projections. */
 export type OutboundPayloadPlan = {
   sourceIndex: number;
   payload: ReplyPayload;
@@ -61,6 +64,7 @@ type OutboundPayloadPlanContext = {
   extractMarkdownImages?: boolean;
 };
 
+/** Text/media projection used to mirror outbound replies into session state. */
 export type OutboundPayloadMirror = {
   text: string;
   mediaUrls: string[];
@@ -247,6 +251,7 @@ function createOutboundPayloadPlanEntry(
   };
 }
 
+/** Builds the canonical outbound payload plan shared by delivery projections. */
 export function createOutboundPayloadPlan(
   payloads: readonly ReplyPayload[],
   context: OutboundPayloadPlanContext = {},
@@ -281,12 +286,14 @@ export function createOutboundPayloadPlan(
   return plan;
 }
 
+/** Projects a payload plan back to normalized reply payloads for delivery. */
 export function projectOutboundPayloadPlanForDelivery(
   plan: readonly OutboundPayloadPlan[],
 ): ReplyPayload[] {
   return plan.map((entry) => entry.payload);
 }
 
+/** Projects a payload plan into runtime transport payload summaries. */
 export function projectOutboundPayloadPlanForOutbound(
   plan: readonly OutboundPayloadPlan[],
 ): NormalizedOutboundPayload[] {
@@ -315,6 +322,7 @@ export function projectOutboundPayloadPlanForOutbound(
   return normalizedPayloads;
 }
 
+/** Projects a payload plan into JSON-safe envelope/debug payloads. */
 export function projectOutboundPayloadPlanForJson(
   plan: readonly OutboundPayloadPlan[],
 ): OutboundPayloadJson[] {
@@ -335,6 +343,7 @@ export function projectOutboundPayloadPlanForJson(
   return normalized;
 }
 
+/** Projects a payload plan into text/media content for session mirroring. */
 export function projectOutboundPayloadPlanForMirror(
   plan: readonly OutboundPayloadPlan[],
 ): OutboundPayloadMirror {
@@ -347,6 +356,7 @@ export function projectOutboundPayloadPlanForMirror(
   };
 }
 
+/** Summarizes one reply payload for channel transport and hook processing. */
 export function summarizeOutboundPayloadForTransport(
   payload: ReplyPayload,
 ): NormalizedOutboundPayload {
@@ -369,24 +379,28 @@ export function summarizeOutboundPayloadForTransport(
   };
 }
 
+/** Normalizes reply payloads for direct delivery using the shared plan. */
 export function normalizeReplyPayloadsForDelivery(
   payloads: readonly ReplyPayload[],
 ): ReplyPayload[] {
   return projectOutboundPayloadPlanForDelivery(createOutboundPayloadPlan(payloads));
 }
 
+/** Normalizes reply payloads into runtime outbound transport payloads. */
 export function normalizeOutboundPayloads(
   payloads: readonly ReplyPayload[],
 ): NormalizedOutboundPayload[] {
   return projectOutboundPayloadPlanForOutbound(createOutboundPayloadPlan(payloads));
 }
 
+/** Normalizes reply payloads into JSON-safe outbound envelope payloads. */
 export function normalizeOutboundPayloadsForJson(
   payloads: readonly ReplyPayload[],
 ): OutboundPayloadJson[] {
   return projectOutboundPayloadPlanForJson(createOutboundPayloadPlan(payloads));
 }
 
+/** Formats normalized outbound payload text and attachments for logs. */
 export function formatOutboundPayloadLog(
   payload: Pick<NormalizedOutboundPayload, "text" | "channelData"> & {
     mediaUrls: readonly string[];

--- a/src/infra/outbound/reply-payload-normalize.ts
+++ b/src/infra/outbound/reply-payload-normalize.ts
@@ -1,6 +1,9 @@
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload as InternalReplyPayload } from "../../auto-reply/reply-payload.js";
 
+/**
+ * Outbound-facing subset of reply payload fields accepted from loose producers.
+ */
 export type OutboundReplyPayload = {
   text?: string;
   mediaUrls?: string[];

--- a/src/infra/outbound/reply-policy.ts
+++ b/src/infra/outbound/reply-policy.ts
@@ -2,16 +2,19 @@ import { isSingleUseReplyToMode } from "../../auto-reply/reply/reply-reference.j
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ReplyToMode } from "../../config/types.js";
 
+/** Per-payload reply target override passed to outbound channel adapters. */
 export type ReplyToOverride = {
   replyToId?: string | null | undefined;
   replyToIdSource?: ReplyToResolution["source"] | undefined;
 };
 
+/** Resolved reply target plus whether it came from payload or ambient context. */
 export type ReplyToResolution = {
   replyToId?: string;
   source?: "explicit" | "implicit";
 };
 
+/** Creates a reply-to supplier that consumes implicit single-use reply ids once. */
 export function createReplyToFanout(params: {
   replyToId?: string | null;
   replyToMode?: ReplyToMode;
@@ -36,6 +39,7 @@ export function createReplyToFanout(params: {
   };
 }
 
+/** Builds per-payload reply routing policy for outbound delivery batches. */
 export function createReplyToDeliveryPolicy(params: {
   replyToId?: string | null;
   replyToMode?: ReplyToMode;
@@ -71,6 +75,8 @@ export function createReplyToDeliveryPolicy(params: {
       return overrides;
     }
     if (replyToConsumed) {
+      // Single-use implicit reply targets apply to the first delivered payload only;
+      // later payloads must not accidentally thread into the same source message.
       return { ...overrides, replyToId: undefined };
     }
     replyToConsumed = true;

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -1,16 +1,3 @@
-/**
- * Sanitize model output for plain-text messaging surfaces.
- *
- * LLMs occasionally produce HTML tags (`<br>`, `<b>`, `<i>`, etc.) that render
- * correctly on web but appear as literal text on WhatsApp, Signal, SMS, and IRC.
- *
- * Converts common inline HTML to lightweight-markup equivalents used by
- * WhatsApp/Signal/Telegram and strips any remaining tags.
- *
- * @see https://github.com/openclaw/openclaw/issues/31884
- * @see https://github.com/openclaw/openclaw/issues/18558
- */
-
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
 
 const INTERNAL_RUNTIME_SCAFFOLDING_TAGS = ["system-reminder", "previous_response"] as const;
@@ -102,6 +89,7 @@ function unwrapPromptDataWrapperLines(text: string): string {
   return changed ? output.join("\n") : text;
 }
 
+/** Removes prompt/runtime scaffolding that must never leak to plain-text channels. */
 export function stripInternalRuntimeScaffolding(text: string): string {
   let stripped = unwrapPromptDataWrapperLines(text)
     .replace(INTERNAL_RUNTIME_SCAFFOLDING_BLOCK_RE, "")

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -47,6 +47,8 @@ function stripDelimitedRuntimeBlock(text: string, begin: string, end: string): s
     `${standaloneLinePattern(begin)}[\\s\\S]*?${standaloneLinePattern(end)}`,
     "g",
   );
+  // If the closing delimiter is missing, drop the rest rather than leaking
+  // internal runtime context to user-visible outbound text.
   const unmatchedBeginRe = new RegExp(`${standaloneLinePattern(begin)}[\\s\\S]*$`, "g");
   return stripStandaloneMarkerLine(
     text.replace(closedBlockRe, "").replace(unmatchedBeginRe, ""),

--- a/src/infra/outbound/send-deps.ts
+++ b/src/infra/outbound/send-deps.ts
@@ -5,6 +5,9 @@
  */
 export type OutboundSendDeps = { [channelId: string]: unknown };
 
+/**
+ * Builds historical dependency keys for channel send functions.
+ */
 export function resolveLegacyOutboundSendDepKeys(channelId: string): string[] {
   const compact = channelId.replace(/[^a-z0-9]+/gi, "");
   if (!compact) {
@@ -22,10 +25,16 @@ export function resolveLegacyOutboundSendDepKeys(channelId: string): string[] {
   return [...keys];
 }
 
+/**
+ * Extra historical keys to try after the normalized channel-derived keys.
+ */
 export type ResolveOutboundSendDepOptions = {
   legacyKeys?: readonly string[];
 };
 
+/**
+ * Resolves a channel send dependency from modern channel IDs or legacy helper keys.
+ */
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Channel-specific dependency lookup returns caller-typed values.
 export function resolveOutboundSendDep<T>(
   deps: OutboundSendDeps | null | undefined,

--- a/src/infra/outbound/session-binding-normalization.ts
+++ b/src/infra/outbound/session-binding-normalization.ts
@@ -4,6 +4,9 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeAccountId } from "../../routing/session-key.js";
 
+/**
+ * Minimal conversation shape normalized before binding lookup or storage.
+ */
 export type ConversationRefShape = {
   channel: string;
   accountId: string;
@@ -16,6 +19,9 @@ type ConversationTargetRefShape = {
   parentConversationId?: string | null;
 };
 
+/**
+ * Normalizes conversation ids and drops self-referential parent ids.
+ */
 export function normalizeConversationTargetRef<T extends ConversationTargetRefShape>(ref: T): T {
   const conversationId = normalizeOptionalString(ref.conversationId) ?? "";
   const parentConversationId = normalizeOptionalString(ref.parentConversationId);
@@ -29,6 +35,9 @@ export function normalizeConversationTargetRef<T extends ConversationTargetRefSh
   } as T;
 }
 
+/**
+ * Normalizes a full conversation reference for stable binding keys.
+ */
 export function normalizeConversationRef<T extends ConversationRefShape>(ref: T): T {
   const normalizedTarget = normalizeConversationTargetRef(ref);
   return {
@@ -38,6 +47,9 @@ export function normalizeConversationRef<T extends ConversationRefShape>(ref: T)
   };
 }
 
+/**
+ * Builds the adapter registry key shared by channel/account scoped bindings.
+ */
 export function buildChannelAccountKey(params: { channel: string; accountId: string }): string {
   return `${normalizeLowercaseStringOrEmpty(params.channel)}:${normalizeAccountId(params.accountId)}`;
 }

--- a/src/infra/outbound/session-binding.types.ts
+++ b/src/infra/outbound/session-binding.types.ts
@@ -1,11 +1,29 @@
+/**
+ * Runtime destination a conversation binding points at.
+ */
 export type BindingTargetKind = "subagent" | "session";
+
+/**
+ * Lifecycle state for a registered session binding.
+ */
 export type BindingStatus = "active" | "ending" | "ended";
+
+/**
+ * Placement requested when binding a child/current session to a conversation.
+ */
 export type SessionBindingPlacement = "current" | "child";
+
+/**
+ * Stable error codes emitted by session-binding service failures.
+ */
 export type SessionBindingErrorCode =
   | "BINDING_ADAPTER_UNAVAILABLE"
   | "BINDING_CAPABILITY_UNSUPPORTED"
   | "BINDING_CREATE_FAILED";
 
+/**
+ * Channel/account/conversation tuple used to resolve a bound delivery route.
+ */
 export type ConversationRef = {
   channel: string;
   accountId: string;
@@ -13,6 +31,9 @@ export type ConversationRef = {
   parentConversationId?: string;
 };
 
+/**
+ * Persistable record that connects one conversation to one target session.
+ */
 export type SessionBindingRecord = {
   bindingId: string;
   targetSessionKey: string;
@@ -24,6 +45,9 @@ export type SessionBindingRecord = {
   metadata?: Record<string, unknown>;
 };
 
+/**
+ * Request to create or refresh a session binding for a conversation.
+ */
 export type SessionBindingBindInput = {
   targetSessionKey: string;
   targetKind: BindingTargetKind;
@@ -33,12 +57,18 @@ export type SessionBindingBindInput = {
   ttlMs?: number;
 };
 
+/**
+ * Request to remove bindings by id or target session.
+ */
 export type SessionBindingUnbindInput = {
   bindingId?: string;
   targetSessionKey?: string;
   reason: string;
 };
 
+/**
+ * Capability summary exposed by the active binding adapter for a conversation scope.
+ */
 export type SessionBindingCapabilities = {
   adapterAvailable: boolean;
   bindSupported: boolean;

--- a/src/infra/outbound/session-context.ts
+++ b/src/infra/outbound/session-context.ts
@@ -47,6 +47,7 @@ export type OutboundSessionContext = {
   requesterSenderE164?: string;
 };
 
+/** Builds the outbound delivery session context, omitting empty policy fields. */
 export function buildOutboundSessionContext(params: {
   cfg: OpenClawConfig;
   sessionKey?: string | null;
@@ -82,6 +83,8 @@ export function buildOutboundSessionContext(params: {
   const derivedAgentId = key
     ? resolveSessionAgentId({ sessionKey: key, config: params.cfg })
     : undefined;
+  // Prefer explicit caller ownership, but derive from the canonical session key
+  // so redirected deliveries still get workspace-scoped media policy.
   const agentId = explicitAgentId ?? derivedAgentId;
   if (
     !key &&

--- a/src/infra/outbound/source-delivery-plan.ts
+++ b/src/infra/outbound/source-delivery-plan.ts
@@ -106,6 +106,8 @@ function deliveryTargetsMatch(channel: string, targetTo: string, deliveryTo: str
     targetKind === deliveryKind &&
     ["channel", "conversation", "group", "user"].includes(targetKind)
   ) {
+    // Some provider-owned ids are case-sensitive while Slack/Discord ids are
+    // compared case-insensitively; decide that before generic target normalization.
     const targetId = targetPrefixed?.[2]?.trim();
     const deliveryId = deliveryPrefixed?.[2]?.trim();
     if (caseSensitivePrefixedTargetProviders.has(channel)) {

--- a/src/infra/outbound/source-delivery-plan.ts
+++ b/src/infra/outbound/source-delivery-plan.ts
@@ -2,6 +2,7 @@ import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { normalizeTargetForProvider } from "./target-normalization.js";
 
+/** Owner responsible for making source delivery visible to the user. */
 export type SourceVisibleDeliveryOwner =
   | "automatic_source"
   | "message_tool"
@@ -9,6 +10,7 @@ export type SourceVisibleDeliveryOwner =
   | "direct_fallback"
   | "none";
 
+/** Reason code explaining why source delivery policy took this shape. */
 export type SourceDeliveryPlanReason =
   | "config"
   | "room_event"
@@ -18,6 +20,7 @@ export type SourceDeliveryPlanReason =
   | "media_completion"
   | "subagent_completion";
 
+/** Configured or inferred destination source delivery must satisfy. */
 export type SourceDeliveryTarget = {
   channel?: string;
   to?: string;
@@ -25,6 +28,7 @@ export type SourceDeliveryTarget = {
   threadId?: string | number;
 };
 
+/** Message-tool destination observed during a run. */
 export type SourceDeliveryMessageToolTarget = {
   tool?: string;
   provider?: string;
@@ -37,12 +41,14 @@ export type SourceDeliveryMessageToolTarget = {
   mediaUrls?: string[];
 };
 
+/** Visible message-tool delivery with target verification state. */
 export type SourceDeliveryVisibleDelivery = {
   via: "message_tool";
   target: SourceDeliveryMessageToolTarget;
   verifiedTarget: boolean;
 };
 
+/** Resolved source-delivery satisfaction result after a run. */
 export type SourceDeliveryOutcome = {
   visibleDeliveries: SourceDeliveryVisibleDelivery[];
   verifiedMessageToolDelivery: boolean;
@@ -50,6 +56,7 @@ export type SourceDeliveryOutcome = {
   unverifiedMessageToolDelivery: boolean;
 };
 
+/** Policy contract that decides message-tool ownership and fallback delivery. */
 export type SourceDeliveryPlan = {
   owner: SourceVisibleDeliveryOwner;
   reason: SourceDeliveryPlanReason;
@@ -122,6 +129,7 @@ function extractTopicThreadId(targetTo: string): string | undefined {
   return targetTo.match(/:topic:(\d+)$/i)?.[1];
 }
 
+/** Compares a message-tool target with the required source delivery target. */
 export function sourceDeliveryTargetsMatch(
   target: SourceDeliveryMessageToolTarget,
   delivery: SourceDeliveryTarget,
@@ -154,6 +162,7 @@ export function sourceDeliveryTargetsMatch(
   return deliveryThreadId === targetThreadId;
 }
 
+/** Builds a source delivery plan from ownership and fallback inputs. */
 export function createSourceDeliveryPlan(params: {
   owner: SourceVisibleDeliveryOwner;
   reason: SourceDeliveryPlanReason;
@@ -216,6 +225,7 @@ function resolveImplicitMessageToolDeliveryTarget(
   };
 }
 
+/** Evaluates whether observed message-tool sends satisfy the source delivery plan. */
 export function resolveSourceDeliveryOutcome(
   plan: SourceDeliveryPlan,
   params: {
@@ -225,6 +235,7 @@ export function resolveSourceDeliveryOutcome(
 ): SourceDeliveryOutcome {
   const didSendViaMessageTool = params.didSendViaMessageTool === true;
   const explicitTargets = params.messageToolSentTargets ?? [];
+  // A send without explicit target metadata still counts when the plan has a default target.
   const sentTargets =
     explicitTargets.length > 0
       ? explicitTargets

--- a/src/infra/outbound/target-errors.ts
+++ b/src/infra/outbound/target-errors.ts
@@ -1,23 +1,41 @@
+/**
+ * Formats the user-facing error shown when no target is available.
+ */
 export function missingTargetMessage(provider: string, hint?: string): string {
   return `Delivering to ${provider} requires target${formatTargetHint(hint)}`;
 }
 
+/**
+ * Builds an Error for missing outbound target failures.
+ */
 export function missingTargetError(provider: string, hint?: string): Error {
   return new Error(missingTargetMessage(provider, hint));
 }
 
+/**
+ * Formats the user-facing error shown when a target name resolves ambiguously.
+ */
 export function ambiguousTargetMessage(provider: string, raw: string, hint?: string): string {
   return `Ambiguous target "${raw}" for ${provider}. Provide a unique name or an explicit id.${formatTargetHint(hint, true)}`;
 }
 
+/**
+ * Builds an Error for ambiguous outbound target failures.
+ */
 export function ambiguousTargetError(provider: string, raw: string, hint?: string): Error {
   return new Error(ambiguousTargetMessage(provider, raw, hint));
 }
 
+/**
+ * Formats the user-facing error shown when no target matches the input.
+ */
 export function unknownTargetMessage(provider: string, raw: string, hint?: string): string {
   return `Unknown target "${raw}" for ${provider}.${formatTargetHint(hint, true)}`;
 }
 
+/**
+ * Builds an Error for unknown outbound target failures.
+ */
 export function unknownTargetError(provider: string, raw: string, hint?: string): Error {
   return new Error(unknownTargetMessage(provider, raw, hint));
 }

--- a/src/infra/outbound/target-id-resolution.ts
+++ b/src/infra/outbound/target-id-resolution.ts
@@ -2,6 +2,7 @@ import type { ChannelDirectoryEntryKind, ChannelId } from "../../channels/plugin
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { maybeResolvePluginMessagingTarget } from "./target-normalization.js";
 
+/** Plugin-resolved destination for a channel target that already looks id-like. */
 export type ResolvedIdLikeTarget = {
   to: string;
   kind: ChannelDirectoryEntryKind | "channel";
@@ -10,6 +11,7 @@ export type ResolvedIdLikeTarget = {
   resolutionSource: "plugin";
 };
 
+/** Resolves an id-like outbound target through the channel plugin directory. */
 export async function maybeResolveIdLikeTarget(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;

--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -9,6 +9,9 @@ import type { ChannelDirectoryEntryKind, ChannelId } from "../../channels/plugin
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getActivePluginChannelRegistryVersion } from "../../plugins/runtime.js";
 
+/**
+ * Normalizes raw user/channel target input before provider-specific parsing.
+ */
 export function normalizeChannelTargetInput(raw: string): string {
   return raw.trim();
 }
@@ -39,6 +42,7 @@ function resolveTargetNormalizer(channelId: ChannelId): TargetNormalizer {
   if (cached && cached.version === version) {
     return cached.normalizer;
   }
+  // Plugin channel metadata is process-stable between registry version bumps.
   const plugin = resolveChannelPluginForTargetRead(channelId);
   const normalizer = plugin?.messaging?.normalizeTarget;
   targetNormalizerCacheByChannelId.set(channelId, {
@@ -48,6 +52,9 @@ function resolveTargetNormalizer(channelId: ChannelId): TargetNormalizer {
   return normalizer;
 }
 
+/**
+ * Applies a channel plugin normalizer and falls back to trimmed input.
+ */
 export function normalizeTargetForProvider(provider: string, raw?: string): string | undefined {
   if (!raw) {
     return undefined;
@@ -61,8 +68,14 @@ export function normalizeTargetForProvider(provider: string, raw?: string): stri
   return normalizeOptionalString(normalizer?.(raw) ?? fallback);
 }
 
+/**
+ * Directory target kinds accepted by plugin-backed target resolution.
+ */
 export type TargetResolveKindLike = ChannelDirectoryEntryKind | "channel";
 
+/**
+ * Resolved outbound target returned by a channel plugin target resolver.
+ */
 export type ResolvedPluginMessagingTarget = {
   to: string;
   kind: TargetResolveKindLike;
@@ -71,6 +84,9 @@ export type ResolvedPluginMessagingTarget = {
   resolutionSource: "plugin";
 };
 
+/**
+ * Produces raw and provider-normalized forms of a nonblank target input.
+ */
 export function resolveNormalizedTargetInput(
   provider: string,
   raw?: string,
@@ -85,6 +101,9 @@ export function resolveNormalizedTargetInput(
   };
 }
 
+/**
+ * Detects whether input is specific enough to invoke plugin target resolution.
+ */
 export function looksLikeTargetId(params: {
   channel: ChannelId;
   raw: string;
@@ -112,6 +131,9 @@ export function looksLikeTargetId(params: {
   return /^(conversation|user):/i.test(params.raw);
 }
 
+/**
+ * Resolves a normalized target through the channel plugin when a resolver is available.
+ */
 export async function maybeResolvePluginMessagingTarget(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -157,11 +179,15 @@ export async function maybeResolvePluginMessagingTarget(params: {
   };
 }
 
+/**
+ * Builds a cache signature for target-resolution behavior exposed by a channel plugin.
+ */
 export function buildTargetResolverSignature(channel: ChannelId): string {
   const plugin = resolveChannelPluginForTargetRead(channel);
   const resolver = plugin?.messaging?.targetResolver;
   const hint = resolver?.hint ?? "";
   const looksLike = resolver?.looksLikeId;
+  // Function source is only a cheap invalidation hint; resolver behavior still belongs to the plugin.
   const source = looksLike ? looksLike.toString() : "";
   return hashSignature(`${hint}|${source}`);
 }

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -19,10 +19,13 @@ import {
   resolveNormalizedTargetInput,
 } from "./target-normalization.js";
 
+/** Directory-backed destination kind used by outbound target resolution. */
 export type TargetResolveKind = ChannelDirectoryEntryKind | "channel";
 
+/** Strategy for resolving multiple matching directory entries. */
 export type ResolveAmbiguousMode = "error" | "best" | "first";
 
+/** Canonical outbound target produced by plugin, directory, or normalized fallback resolution. */
 export type ResolvedMessagingTarget = {
   to: string;
   kind: TargetResolveKind;
@@ -31,6 +34,7 @@ export type ResolvedMessagingTarget = {
   resolutionSource: "plugin" | "directory" | "normalized";
 };
 
+/** Result of resolving a user-supplied outbound target. */
 export type ResolveMessagingTargetResult =
   | { ok: true; target: ResolvedMessagingTarget }
   | { ok: false; error: Error; candidates?: ChannelDirectoryEntry[] };
@@ -43,6 +47,7 @@ function asResolvedMessagingTarget(
 
 export { maybeResolveIdLikeTarget } from "./target-id-resolution.js";
 
+/** Resolves a channel target using the shared outbound target resolver. */
 export async function resolveChannelTarget(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -59,6 +64,7 @@ export async function resolveChannelTarget(params: {
 const CACHE_TTL_MS = 30 * 60 * 1000;
 const directoryCache = new DirectoryCache<ChannelDirectoryEntry[]>(CACHE_TTL_MS);
 
+/** Clears cached directory entries for all channels or one channel/account scope. */
 export function resetDirectoryCache(params?: { channel?: ChannelId; accountId?: string | null }) {
   if (!params?.channel) {
     directoryCache.clear();
@@ -88,6 +94,7 @@ function stripTargetPrefixes(value: string): string {
     .trim();
 }
 
+/** Formats a resolved target for user-facing summaries. */
 export function formatTargetDisplay(params: {
   channel: ChannelId;
   target: string;
@@ -339,6 +346,7 @@ function pickAmbiguousMatch(
   return best ?? entries[0] ?? null;
 }
 
+/** Resolves a user target through id-like, directory, plugin, and normalized fallback paths. */
 export async function resolveMessagingTarget(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -461,6 +469,7 @@ export async function resolveMessagingTarget(params: {
   };
 }
 
+/** Looks up a display label for a resolved target id from cached/live directory entries. */
 export async function lookupDirectoryDisplay(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;

--- a/src/infra/outbound/targets-loaded.ts
+++ b/src/infra/outbound/targets-loaded.ts
@@ -18,6 +18,7 @@ function resolveLoadedOutboundChannelPlugin(channel: string): ChannelPlugin | un
   return getLoadedChannelPluginForRead(normalized);
 }
 
+/** Resolves targets through an already-loaded channel plugin without bootstrap discovery. */
 export function tryResolveLoadedOutboundTarget(params: {
   channel: GatewayMessageChannel;
   to?: string;

--- a/src/infra/outbound/targets-resolve-shared.ts
+++ b/src/infra/outbound/targets-resolve-shared.ts
@@ -8,8 +8,14 @@ import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { validateTargetProviderPrefix } from "./channel-target-prefix.js";
 import { missingTargetError } from "./target-errors.js";
 
+/**
+ * Result of resolving a concrete outbound target for a channel send.
+ */
 export type OutboundTargetResolution = { ok: true; to: string } | { ok: false; error: Error };
 
+/**
+ * Inputs shared by direct and heartbeat outbound target resolution.
+ */
 export type ResolveOutboundTargetParams = {
   channel: GatewayMessageChannel;
   to?: string;
@@ -25,6 +31,9 @@ function buildWebChatDeliveryError(): Error {
   );
 }
 
+/**
+ * Resolves a target through a channel plugin or the generic fallback path.
+ */
 export function resolveOutboundTargetWithPlugin(params: {
   plugin: ChannelPlugin | undefined;
   target: ResolveOutboundTargetParams;
@@ -42,6 +51,7 @@ export function resolveOutboundTargetWithPlugin(params: {
     return params.onMissingPlugin?.();
   }
 
+  // Plugin defaults and allowlists can be account-scoped; resolve them before target validation.
   const allowFromRaw =
     params.target.allowFrom ??
     (params.target.cfg && plugin.config.resolveAllowFrom

--- a/src/infra/outbound/targets-session.ts
+++ b/src/infra/outbound/targets-session.ts
@@ -18,6 +18,9 @@ import type {
 } from "../../utils/message-channel-normalize.js";
 import { resolveTargetPrefixedChannel } from "./channel-target-prefix.js";
 
+/**
+ * Resolved delivery destination derived from session history, turn source, or explicit input.
+ */
 export type SessionDeliveryTarget = {
   channel?: DeliverableMessageChannel;
   to?: string;
@@ -56,6 +59,9 @@ function resolveParsedRouteTarget(params: {
   };
 }
 
+/**
+ * Resolves the effective outbound target for a session-scoped delivery request.
+ */
 export function resolveSessionDeliveryTarget(params: {
   entry?: SessionEntry;
   requestedChannel?: GatewayMessageChannel;
@@ -109,6 +115,8 @@ export function resolveSessionDeliveryTarget(params: {
         left: parsedTurnSourceTarget,
         right: parsedSessionTarget,
       }));
+  // Shared sessions can receive cross-channel updates mid-turn; only inherit session threads
+  // when the turn source still identifies the same conversation.
   const lastThreadId = hasTurnSourceThreadId
     ? parsedTurnSourceTarget?.threadId
     : hasTurnSourceChannel &&

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -30,10 +30,13 @@ import {
   type OutboundTargetResolution,
 } from "./targets-resolve-shared.js";
 
+/** Deliverable channel id accepted by outbound target resolution. */
 export type OutboundChannel = DeliverableMessageChannel;
 
+/** Heartbeat target channel id from agent/default heartbeat config. */
 export type HeartbeatTarget = OutboundChannel;
 
+/** Resolved outbound delivery destination and routing hints. */
 export type OutboundTarget = {
   channel: OutboundChannel;
   to?: string;
@@ -45,6 +48,7 @@ export type OutboundTarget = {
   lastAccountId?: string;
 };
 
+/** Sender identity context used when a heartbeat needs channel-compatible metadata. */
 export type HeartbeatSenderContext = {
   sender: string;
   provider?: DeliverableMessageChannel;
@@ -55,7 +59,7 @@ export type { OutboundTargetResolution } from "./targets-resolve-shared.js";
 export { resolveSessionDeliveryTarget, type SessionDeliveryTarget } from "./targets-session.js";
 import { resolveSessionDeliveryTarget, type SessionDeliveryTarget } from "./targets-session.js";
 
-// Channel docking: prefer plugin.outbound.resolveTarget + allowFrom to normalize destinations.
+/** Resolves a user-supplied outbound destination through the channel plugin. */
 export function resolveOutboundTarget(params: {
   channel: GatewayMessageChannel;
   to?: string;
@@ -87,6 +91,7 @@ export function resolveOutboundTarget(params: {
   );
 }
 
+/** Resolves the heartbeat delivery destination from config, session state, and turn source. */
 export function resolveHeartbeatDeliveryTarget(params: {
   cfg: OpenClawConfig;
   entry?: SessionEntry;
@@ -266,6 +271,7 @@ function buildNoHeartbeatDeliveryTarget(params: {
   };
 }
 
+/** Resolves heartbeat delivery and lets plugins refine the outbound session route. */
 export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -298,6 +304,7 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
         unknownTargetMode: "normalized",
       });
     } catch {
+      // Target normalization failure should not suppress an otherwise deliverable heartbeat.
       return null;
     }
   })();
@@ -436,6 +443,7 @@ function resolveHeartbeatSenderId(params: {
   return candidates[0] ?? "heartbeat";
 }
 
+/** Resolves the sender id/allow-list context used for heartbeat sends. */
 export function resolveHeartbeatSenderContext(params: {
   cfg: OpenClawConfig;
   entry?: SessionEntry;

--- a/src/infra/outbound/thread-id.ts
+++ b/src/infra/outbound/thread-id.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalStringifiedId } from "@openclaw/normalization-core/string-coerce";
 
+/** Normalizes channel thread/topic ids before outbound payload construction. */
 export function normalizeOutboundThreadId(value?: string | number | null): string | undefined {
   return normalizeOptionalStringifiedId(value);
 }

--- a/src/plugin-sdk/access-groups.ts
+++ b/src/plugin-sdk/access-groups.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 export { ACCESS_GROUP_ALLOW_FROM_PREFIX, parseAccessGroupAllowFromEntry };
 
+/** Resolves membership for an access group using the full OpenClaw config. */
 export type AccessGroupMembershipResolver = (params: {
   cfg: OpenClawConfig;
   name: string;
@@ -18,6 +19,7 @@ export type AccessGroupMembershipResolver = (params: {
   senderId: string;
 }) => boolean | Promise<boolean>;
 
+/** Resolves membership for one access group when the caller already selected the config group. */
 export type AccessGroupMembershipLookup = (params: {
   name: string;
   group: AccessGroupConfig;
@@ -26,6 +28,7 @@ export type AccessGroupMembershipLookup = (params: {
   senderId: string;
 }) => boolean | Promise<boolean>;
 
+/** Reports how access-group allowlist entries resolved for a channel sender. */
 export type ResolvedAccessGroupAllowFromState = {
   referenced: string[];
   matched: string[];
@@ -47,6 +50,7 @@ function resolveMessageSenderGroupEntries(params: {
   return [...(params.group.members["*"] ?? []), ...(params.group.members[params.channel] ?? [])];
 }
 
+/** Resolves `accessGroup:<name>` allowlist entries without changing the original allowlist. */
 export async function resolveAccessGroupAllowFromState(params: {
   accessGroups?: Record<string, AccessGroupConfig>;
   allowFrom: Array<string | number> | null | undefined;
@@ -124,6 +128,7 @@ export async function resolveAccessGroupAllowFromState(params: {
   return state;
 }
 
+/** Returns the matched `accessGroup:<name>` allowlist entries for a sender. */
 export async function resolveAccessGroupAllowFromMatches(params: {
   cfg?: OpenClawConfig;
   allowFrom: Array<string | number> | null | undefined;
@@ -154,6 +159,7 @@ export async function resolveAccessGroupAllowFromMatches(params: {
   return state.matchedAllowFromEntries;
 }
 
+/** Expands a matching access-group allowlist with the concrete sender entry. */
 export async function expandAllowFromWithAccessGroups(params: {
   cfg?: OpenClawConfig;
   allowFrom: Array<string | number> | null | undefined;
@@ -178,5 +184,6 @@ export async function expandAllowFromWithAccessGroups(params: {
     return allowFrom;
   }
   const senderEntry = params.senderAllowEntry ?? params.senderId;
+  // Downstream legacy sender checks still expect a concrete allowlist entry after a group match.
   return uniqueStrings([...allowFrom, senderEntry]);
 }

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -74,15 +74,18 @@ type DefineBundledChannelSetupEntryOptions = {
   features?: BundledChannelSetupEntryFeatures;
 };
 
+/** Feature flags exposed by bundled setup entries for optional migration/session surfaces. */
 export type BundledChannelSetupEntryFeatures = {
   legacyStateMigrations?: boolean;
   legacySessionSurfaces?: boolean;
 };
 
+/** Feature flags exposed by full bundled channel entries. */
 export type BundledChannelEntryFeatures = {
   accountInspect?: boolean;
 };
 
+/** Legacy session helpers used while bundled channels migrate old session key formats. */
 export type BundledChannelLegacySessionSurface = {
   isLegacyGroupSessionKey?: (key: string) => boolean;
   canonicalizeLegacySessionKey?: (params: {
@@ -91,6 +94,7 @@ export type BundledChannelLegacySessionSurface = {
   }) => string | null | undefined;
 };
 
+/** Detects channel-owned state migrations needed before a bundled channel starts. */
 export type BundledChannelLegacyStateMigrationDetector = (params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -102,6 +106,7 @@ export type BundledChannelLegacyStateMigrationDetector = (params: {
   | null
   | undefined;
 
+/** Runtime contract returned by a bundled channel's main entrypoint definition. */
 export type BundledChannelEntryContract<TPlugin = ChannelPlugin> = {
   kind: "bundled-channel-entry";
   id: string;
@@ -123,6 +128,7 @@ export type BundledChannelEntryContract<TPlugin = ChannelPlugin> = {
   setChannelRuntime?: (runtime: PluginRuntime) => void;
 };
 
+/** Runtime contract returned by a bundled channel's setup-only entrypoint definition. */
 export type BundledChannelSetupEntryContract<TPlugin = ChannelPlugin> = {
   kind: "bundled-channel-setup-entry";
   loadSetupPlugin: (options?: BundledEntryModuleLoadOptions) => TPlugin;
@@ -140,6 +146,7 @@ export type BundledChannelSetupEntryContract<TPlugin = ChannelPlugin> = {
   features?: BundledChannelSetupEntryFeatures;
 };
 
+/** Test hook for swapping the source-module loader used by bundled entry imports. */
 export type BundledEntryModuleLoadOptions = {
   createLoaderForTest?: PluginModuleLoaderFactory;
 };
@@ -261,6 +268,8 @@ function resolveBundledEntryModuleCandidates(
     return candidates;
   }
 
+  // Published bundles resolve from dist first, then fall back to source so local dev checkouts
+  // can exercise bundled entries without requiring a fresh package build.
   addBundledEntryCandidates(
     candidates,
     path.resolve(sourcePluginRoot, specifier),
@@ -457,6 +466,7 @@ function loadBundledEntryModuleSync(
 }
 
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic entry export loaders use caller-supplied export types.
+/** Loads one export from a bundled channel sidecar module through the guarded entry boundary. */
 export function loadBundledEntryExportSync<T>(
   importMetaUrl: string,
   reference: BundledEntryModuleRef,
@@ -479,6 +489,7 @@ export function loadBundledEntryExportSync<T>(
   return record[reference.exportName] as T;
 }
 
+/** Defines the full bundled channel entry contract used by core plugin registration. */
 export function defineBundledChannelEntry<TPlugin = ChannelPlugin>({
   id,
   name,
@@ -577,6 +588,7 @@ export function defineBundledChannelEntry<TPlugin = ChannelPlugin>({
   };
 }
 
+/** Defines the setup-only bundled channel entry contract for onboarding and migration surfaces. */
 export function defineBundledChannelSetupEntry<TPlugin = ChannelPlugin>({
   importMetaUrl,
   plugin,

--- a/src/plugin-sdk/channel-inbound.ts
+++ b/src/plugin-sdk/channel-inbound.ts
@@ -1,4 +1,3 @@
-// Shared inbound parsing helpers for channel plugins.
 import {
   buildChannelInboundEventContext,
   finalizeChannelInboundContext,
@@ -101,7 +100,11 @@ export type {
   FinalizeChannelInboundContextParams,
   FinalizeChannelInboundContextResult,
 };
-/** @deprecated Use `BuildChannelInboundEventContextParams`. */
+/**
+ * Deprecated turn-context input alias that still accepts the old `inboundTurnKind` name.
+ *
+ * @deprecated Use `BuildChannelInboundEventContextParams`.
+ */
 export type BuildChannelTurnContextParams = Omit<
   BuildChannelInboundEventContextParams,
   "message"
@@ -110,12 +113,20 @@ export type BuildChannelTurnContextParams = Omit<
     inboundTurnKind?: InboundEventKind;
   };
 };
-/** @deprecated Use `BuiltChannelInboundEventContext`. */
+/**
+ * Deprecated turn-context result alias with the historical `InboundTurnKind` field.
+ *
+ * @deprecated Use `BuiltChannelInboundEventContext`.
+ */
 export type BuiltChannelTurnContext = BuiltChannelInboundEventContext & {
   InboundTurnKind: InboundEventKind;
 };
 
-/** @deprecated Use `buildChannelInboundEventContext`. */
+/**
+ * Builds inbound-event context for callers still passing `inboundTurnKind`.
+ *
+ * @deprecated Use `buildChannelInboundEventContext`.
+ */
 export function buildChannelTurnContext(
   params: BuildChannelTurnContextParams,
 ): BuiltChannelTurnContext {
@@ -133,7 +144,11 @@ export function buildChannelTurnContext(
   };
 }
 
-/** @deprecated Use `filterChannelInboundSupplementalContext`. */
+/**
+ * Deprecated supplemental-context filter alias retained for channel SDK compatibility.
+ *
+ * @deprecated Use `filterChannelInboundSupplementalContext`.
+ */
 export const filterChannelTurnSupplementalContext = filterChannelInboundSupplementalContext;
 export {
   runChannelInboundEvent,

--- a/src/plugin-sdk/channel-outbound.ts
+++ b/src/plugin-sdk/channel-outbound.ts
@@ -1,4 +1,3 @@
-// Shared outbound/message lifecycle helpers for channel plugins.
 import type {
   DurableMessageBatchSendResult,
   DurableMessageSendContext,
@@ -10,6 +9,8 @@ type ChannelMessageRuntimeModule = typeof import("../channels/message/runtime.js
 let channelMessageRuntimeModulePromise: Promise<ChannelMessageRuntimeModule> | null = null;
 
 const loadChannelMessageRuntimeModule = async () => {
+  // Share one lazy import across SDK helper calls so plugin barrels do not eagerly pull
+  // message runtime internals into registration/discovery-only paths.
   channelMessageRuntimeModulePromise ??= import("../channels/message/runtime.js");
   return await channelMessageRuntimeModulePromise;
 };
@@ -196,12 +197,14 @@ export type {
   RenderedMessageBatchPlanKind,
 } from "../channels/message/index.js";
 
+/** Lazily forwards inbound reply delivery through the channel turn kernel. */
 export const deliverInboundReplyWithMessageSendContext: ChannelInboundKernelModule["deliverInboundReplyWithMessageSendContext"] =
   async (...args) => {
     const mod = await import("../channels/turn/kernel.js");
     return await mod.deliverInboundReplyWithMessageSendContext(...args);
   };
 
+/** Sends a durable message batch without eager-loading channel message runtime internals. */
 export async function sendDurableMessageBatch(
   params: DurableMessageSendContextParams,
 ): Promise<DurableMessageBatchSendResult> {
@@ -209,6 +212,7 @@ export async function sendDurableMessageBatch(
   return await mod.sendDurableMessageBatch(params);
 }
 
+/** Runs work inside a durable message send context loaded through the SDK lazy boundary. */
 export async function withDurableMessageSendContext<T>(
   params: DurableMessageSendContextParams,
   run: (ctx: DurableMessageSendContext) => Promise<T>,

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -62,6 +62,7 @@ export {
 } from "./group-access.js";
 export { createAllowlistProviderRestrictSendersWarningCollector };
 
+/** Normalizes allowFrom entries into trimmed unique string identifiers. */
 export function normalizeAllowFromList(list: Array<string | number> | undefined | null): string[] {
   if (!Array.isArray(list)) {
     return [];
@@ -69,6 +70,7 @@ export function normalizeAllowFromList(list: Array<string | number> | undefined 
   return normalizeStringEntries(list);
 }
 
+/** Coerces native feature settings to the supported boolean/auto shape. */
 export function coerceNativeSetting(value: unknown): boolean | "auto" | undefined {
   if (value === true || value === false || value === "auto") {
     return value;
@@ -76,6 +78,7 @@ export function coerceNativeSetting(value: unknown): boolean | "auto" | undefine
   return undefined;
 }
 
+/** Candidate mutable allowlist path inspected for dangerous name-matching warnings. */
 export type ChannelMutableAllowlistCandidate = {
   pathLabel: string;
   list: unknown;
@@ -97,6 +100,7 @@ function collectMutableAllowlistWarningLines(
   const exampleLines = hits
     .slice(0, 8)
     .map((hit) => `- ${sanitizeForLog(hit.path)}: ${sanitizeForLog(hit.entry)}`);
+  // Keep doctor output actionable without dumping large allowlists into logs.
   const remaining =
     hits.length > 8 ? `- +${hits.length - 8} more mutable allowlist entries.` : null;
   const flagPaths = uniqueStrings(hits.map((hit) => hit.dangerousFlagPath));
@@ -113,6 +117,7 @@ function collectMutableAllowlistWarningLines(
   ];
 }
 
+/** Creates a warning collector for mutable name/email/nick allowlists when matching is disabled. */
 export function createDangerousNameMatchingMutableAllowlistWarningCollector(params: {
   channel: string;
   detector: (entry: string) => boolean;

--- a/src/plugin-sdk/channel-route.ts
+++ b/src/plugin-sdk/channel-route.ts
@@ -5,12 +5,16 @@ import {
 } from "../../packages/normalization-core/src/string-coerce.js";
 import { normalizeOptionalAccountId } from "../routing/account-id.js";
 
+/** Coarse chat shape used when a channel can distinguish direct, group, and broadcast targets. */
 export type ChannelRouteChatType = "direct" | "group" | "channel";
 
+/** Provider-specific thread kind carried with normalized channel routes. */
 export type ChannelRouteThreadKind = "topic" | "thread" | "reply";
 
+/** Describes which runtime surface supplied a channel route thread id. */
 export type ChannelRouteThreadSource = "explicit" | "target" | "session" | "turn";
 
+/** Normalized channel route used for comparison, binding, and dedupe helpers. */
 export type ChannelRouteRef = {
   channel?: string;
   accountId?: string;
@@ -26,6 +30,7 @@ export type ChannelRouteRef = {
   };
 };
 
+/** Loose route input accepted at SDK boundaries before normalization. */
 export type ChannelRouteRefInput = {
   channel?: unknown;
   accountId?: unknown;
@@ -37,11 +42,13 @@ export type ChannelRouteRefInput = {
   threadSource?: ChannelRouteThreadSource;
 };
 
+/** Raw outbound target input shape used by helpers that do not need thread metadata source. */
 export type ChannelRouteTargetInput = Pick<
   ChannelRouteRefInput,
   "channel" | "accountId" | "to" | "rawTo" | "chatType" | "threadId"
 >;
 
+/** Route input accepted by compact-key helpers after legacy and normalized callers converge. */
 export type ChannelRouteKeyInput = ChannelRouteRef | ChannelRouteTargetInput;
 
 /** @deprecated Use `messaging.resolveOutboundSessionRoute` for provider-specific target grammar. */
@@ -57,15 +64,18 @@ export type ChannelRouteExplicitTargetParser = (
   rawTarget: string,
 ) => ChannelRouteExplicitTarget | null;
 
+/** Normalizes a route thread id while preserving provider string ids. */
 export function normalizeRouteThreadId(value: unknown): string | number | undefined {
   return normalizeOptionalThreadValue(value);
 }
 
+/** Stringifies a normalized thread id for stable route keys and comparisons. */
 export function stringifyRouteThreadId(value: unknown): string | undefined {
   const normalized = normalizeRouteThreadId(value);
   return normalized == null ? undefined : String(normalized);
 }
 
+/** Converts loose channel/account/target/thread input into a normalized route reference. */
 export function normalizeChannelRouteRef(
   input?: ChannelRouteRefInput,
 ): ChannelRouteRef | undefined {
@@ -105,20 +115,24 @@ export function normalizeChannelRouteRef(
   };
 }
 
+/** Returns the normalized destination id for a route reference. */
 export function channelRouteTarget(route?: ChannelRouteRef): string | undefined {
   return route?.target?.to;
 }
 
+/** Returns the normalized thread id for a route reference. */
 export function channelRouteThreadId(route?: ChannelRouteRef): string | number | undefined {
   return route?.thread?.id;
 }
 
+/** Normalizes raw target-only route input. */
 export function normalizeChannelRouteTarget(
   input?: ChannelRouteTargetInput | null,
 ): ChannelRouteRef | undefined {
   return input ? normalizeChannelRouteRef(input) : undefined;
 }
 
+/** Parsed target shape retained for deprecated explicit-target parser adapters. */
 export type ChannelRouteParsedTarget = ChannelRouteTargetInput & {
   channel: string;
   rawTo: string;
@@ -150,6 +164,7 @@ export function resolveChannelRouteTargetWithParser(params: {
   };
 }
 
+/** Builds a JSON route dedupe key that remains unambiguous when route parts contain separators. */
 export function channelRouteDedupeKey(input?: ChannelRouteTargetInput | null): string {
   const route = normalizeChannelRouteTarget(input);
   return JSON.stringify([
@@ -187,6 +202,7 @@ export function channelRoutesMatchExact(params: {
   if (!left || !right) {
     return false;
   }
+  // Exact route equality treats a missing account differently from an explicit account.
   return (
     left.channel === right.channel &&
     left.target?.to === right.target?.to &&
@@ -195,6 +211,7 @@ export function channelRoutesMatchExact(params: {
   );
 }
 
+/** Checks whether two normalized routes point at the same conversation or parent route. */
 export function channelRoutesShareConversation(params: {
   left?: ChannelRouteRef | null;
   right?: ChannelRouteRef | null;
@@ -211,11 +228,13 @@ export function channelRoutesShareConversation(params: {
     return false;
   }
   if (left.thread?.id == null || right.thread?.id == null) {
+    // Parent route matches any child thread once channel, target, and compatible account match.
     return true;
   }
   return threadIdsEqual(left.thread.id, right.thread.id);
 }
 
+/** Exact route comparison for loose target input. */
 export function channelRouteTargetsMatchExact(params: {
   left?: ChannelRouteTargetInput | null;
   right?: ChannelRouteTargetInput | null;
@@ -226,6 +245,7 @@ export function channelRouteTargetsMatchExact(params: {
   });
 }
 
+/** Conversation-level route comparison for loose target input. */
 export function channelRouteTargetsShareConversation(params: {
   left?: ChannelRouteTargetInput | null;
   right?: ChannelRouteTargetInput | null;
@@ -256,6 +276,7 @@ function normalizeChannelRouteKeyInput(
     : normalizeChannelRouteTarget(route);
 }
 
+/** Builds a compact human-readable route key when channel and target are both present. */
 export function channelRouteCompactKey(route?: ChannelRouteKeyInput | null): string | undefined {
   const normalized = normalizeChannelRouteKeyInput(route);
   if (!normalized?.channel || !normalized.target?.to) {

--- a/src/plugin-sdk/channel-send-result.ts
+++ b/src/plugin-sdk/channel-send-result.ts
@@ -4,12 +4,15 @@ import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 
 export type { ChannelOutboundAdapter } from "../channels/plugins/outbound.types.js";
 export type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
+
+/** Legacy raw send result shape accepted from channel SDK adapters. */
 export type ChannelSendRawResult = {
   ok: boolean;
   messageId?: string | null;
   error?: string | null;
 };
 
+/** Attaches the channel id to a single outbound send result. */
 export function attachChannelToResult<T extends object>(channel: string, result: T) {
   return {
     channel,
@@ -17,16 +20,19 @@ export function attachChannelToResult<T extends object>(channel: string, result:
   };
 }
 
+/** Attaches the channel id to each outbound send result in order. */
 export function attachChannelToResults<T extends object>(channel: string, results: readonly T[]) {
   return results.map((result) => attachChannelToResult(channel, result));
 }
 
+/** Creates an empty outbound delivery result for send paths that produced no platform id. */
 export function createEmptyChannelResult(
   channel: string,
   result: Partial<Omit<OutboundDeliveryResult, "channel" | "messageId">> & {
     messageId?: string;
   } = {},
 ): OutboundDeliveryResult {
+  // Empty message ids are the legacy "no platform id" sentinel expected by outbound callers.
   return attachChannelToResult(channel, {
     messageId: "",
     ...result,
@@ -38,6 +44,7 @@ type SendTextParams = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>
 type SendMediaParams = Parameters<NonNullable<ChannelOutboundAdapter["sendMedia"]>>[0];
 type SendPollParams = Parameters<NonNullable<ChannelOutboundAdapter["sendPoll"]>>[0];
 
+/** Wraps outbound send methods that already return delivery-shaped results without channel ids. */
 export function createAttachedChannelResultAdapter(params: {
   channel: string;
   sendText?: (ctx: SendTextParams) => MaybePromise<Omit<OutboundDeliveryResult, "channel">>;
@@ -57,6 +64,7 @@ export function createAttachedChannelResultAdapter(params: {
   };
 }
 
+/** Wraps legacy raw text/media send methods and normalizes their results. */
 export function createRawChannelSendResultAdapter(params: {
   channel: string;
   sendText?: (ctx: SendTextParams) => MaybePromise<ChannelSendRawResult>;

--- a/src/plugin-sdk/pair-loop-guard-runtime.ts
+++ b/src/plugin-sdk/pair-loop-guard-runtime.ts
@@ -1,3 +1,4 @@
+/** Resolved pair-loop guard settings in milliseconds for runtime checks. */
 export type PairLoopGuardSettings = {
   enabled: boolean;
   maxEventsPerWindow: number;
@@ -5,6 +6,7 @@ export type PairLoopGuardSettings = {
   cooldownMs: number;
 };
 
+/** User-facing pair-loop guard config accepted by channel plugins. */
 export type PairLoopGuardConfig = {
   enabled?: boolean;
   maxEventsPerWindow?: number;
@@ -19,10 +21,12 @@ const PAIR_LOOP_GUARD_CONFIG_KEYS = [
   "cooldownSeconds",
 ] as const satisfies ReadonlyArray<keyof PairLoopGuardConfig>;
 
+/** Result of recording one pair interaction against the loop guard. */
 export type PairLoopGuardResult =
   | { suppressed: false }
   | { suppressed: true; cooldownUntilMs: number };
 
+/** Snapshot entry for observability and tests. */
 export type PairLoopGuardSnapshotEntry = {
   key: string;
   recentCount: number;
@@ -36,6 +40,7 @@ type PairLoopGuardEntry = {
   cooldownUntilMs: number;
 };
 
+/** In-memory guard for suppressing repeated bidirectional bot pair loops. */
 export type PairLoopGuard = {
   recordAndCheck: (params: {
     scopeId: string;
@@ -52,6 +57,7 @@ export type PairLoopGuard = {
 const DEFAULT_PRUNE_INTERVAL_MS = 60_000;
 const KEY_SEPARATOR = "\u0001";
 
+/** Default plugin-facing loop guard config before per-channel overrides. */
 export const DEFAULT_PAIR_LOOP_GUARD_CONFIG: Required<PairLoopGuardConfig> = {
   enabled: true,
   maxEventsPerWindow: 20,
@@ -59,6 +65,7 @@ export const DEFAULT_PAIR_LOOP_GUARD_CONFIG: Required<PairLoopGuardConfig> = {
   cooldownSeconds: 60,
 };
 
+/** Default runtime loop guard settings derived from the default config. */
 export const DEFAULT_PAIR_LOOP_GUARD_SETTINGS: PairLoopGuardSettings = {
   enabled: DEFAULT_PAIR_LOOP_GUARD_CONFIG.enabled,
   maxEventsPerWindow: DEFAULT_PAIR_LOOP_GUARD_CONFIG.maxEventsPerWindow,
@@ -66,6 +73,7 @@ export const DEFAULT_PAIR_LOOP_GUARD_SETTINGS: PairLoopGuardSettings = {
   cooldownMs: DEFAULT_PAIR_LOOP_GUARD_CONFIG.cooldownSeconds * 1000,
 };
 
+/** Merges pair-loop configs from broad defaults to narrow overrides, ignoring undefined values. */
 export function mergePairLoopGuardConfig(
   ...configs: Array<PairLoopGuardConfig | undefined>
 ): PairLoopGuardConfig | undefined {
@@ -104,6 +112,7 @@ function positiveInteger(value: unknown): number | undefined {
     : undefined;
 }
 
+/** Resolves runtime loop guard settings from config/defaults and the channel default-enabled gate. */
 export function resolvePairLoopGuardSettings(params: {
   config?: PairLoopGuardConfig;
   defaultsConfig?: PairLoopGuardConfig;
@@ -142,6 +151,7 @@ function buildPairKey(params: {
   senderId: string;
   receiverId: string;
 }): string {
+  // Sort sender/receiver so A->B and B->A count as the same bot loop pair.
   const lhs = params.senderId < params.receiverId ? params.senderId : params.receiverId;
   const rhs = params.senderId < params.receiverId ? params.receiverId : params.senderId;
   return [params.scopeId, params.conversationId, lhs, rhs].join(KEY_SEPARATOR);
@@ -156,6 +166,7 @@ function countCurrentWindowEvents(entry: PairLoopGuardEntry, nowMs: number): num
   return entry.recentMs.filter((timestampMs) => timestampMs <= nowMs).length;
 }
 
+/** Creates an in-memory pair-loop guard with bounded periodic pruning. */
 export function createPairLoopGuard(params?: { pruneIntervalMs?: number }): PairLoopGuard {
   const tracked = new Map<string, PairLoopGuardEntry>();
   const pruneIntervalMs = params?.pruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS;
@@ -223,6 +234,7 @@ export function createPairLoopGuard(params?: { pruneIntervalMs?: number }): Pair
     if (countCurrentWindowEvents(entry, nowMs) > maxEventsPerWindow) {
       entry.cooldownStartedAtMs = nowMs;
       entry.cooldownUntilMs = nowMs + cooldownMs;
+      // Keep only future records during cooldown; past events should not extend suppression.
       entry.recentMs = entry.recentMs.filter((timestampMs) => timestampMs > nowMs);
       return { suppressed: true, cooldownUntilMs: entry.cooldownUntilMs };
     }

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -1,3 +1,4 @@
+/** Splits text into bounded chunks using caller-owned soft-break selection. */
 export function chunkTextByBreakResolver(
   text: string,
   limit: number,
@@ -14,6 +15,7 @@ export function chunkTextByBreakResolver(
   while (remaining.length > limit) {
     const window = remaining.slice(0, limit);
     const candidateBreak = resolveBreakIndex(window);
+    // Invalid or zero-width soft breaks would stall the loop, so fall back to the hard limit.
     const breakIdx =
       Number.isFinite(candidateBreak) && candidateBreak > 0 && candidateBreak <= limit
         ? candidateBreak
@@ -23,6 +25,7 @@ export function chunkTextByBreakResolver(
     if (chunk.length > 0) {
       chunks.push(chunk);
     }
+    // If the break lands before whitespace, consume one separator and trim the rest for the next chunk.
     const brokeOnSeparator = breakIdx < remaining.length && /\s/.test(remaining[breakIdx]);
     const nextStart = Math.min(remaining.length, breakIdx + (brokeOnSeparator ? 1 : 0));
     remaining = remaining.slice(nextStart).trimStart();

--- a/src/utils/boolean.ts
+++ b/src/utils/boolean.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 
+/** Accepted string literals for boolean parsing beyond actual booleans. */
 export type BooleanParseOptions = {
   truthy?: string[];
   falsy?: string[];
@@ -10,10 +11,12 @@ const DEFAULT_FALSY = ["false", "0", "no", "off"] as const;
 const DEFAULT_TRUTHY_SET = new Set<string>(DEFAULT_TRUTHY);
 const DEFAULT_FALSY_SET = new Set<string>(DEFAULT_FALSY);
 
+/** Returns only real boolean values and leaves boolean-like strings for explicit parsing. */
 export function asBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
 
+/** Parses booleans and configured string literals, returning undefined for ambiguous input. */
 export function parseBooleanValue(
   value: unknown,
   options: BooleanParseOptions = {},
@@ -31,6 +34,7 @@ export function parseBooleanValue(
   }
   const truthy = options.truthy ?? DEFAULT_TRUTHY;
   const falsy = options.falsy ?? DEFAULT_FALSY;
+  // Reuse default sets on hot paths; custom literals get per-call sets to keep caller state immutable.
   const truthySet = truthy === DEFAULT_TRUTHY ? DEFAULT_TRUTHY_SET : new Set(truthy);
   const falsySet = falsy === DEFAULT_FALSY ? DEFAULT_FALSY_SET : new Set(falsy);
   if (truthySet.has(normalized)) {

--- a/src/utils/chunk-items.ts
+++ b/src/utils/chunk-items.ts
@@ -1,3 +1,4 @@
+/** Splits items into fixed-size chunks, preserving order and returning one row for non-positive sizes. */
 export function chunkItems<T>(items: readonly T[], size: number): T[][] {
   if (size <= 0) {
     return [Array.from(items)];

--- a/src/utils/shell-argv.ts
+++ b/src/utils/shell-argv.ts
@@ -4,6 +4,7 @@ function isDoubleQuoteEscape(next: string | undefined): next is string {
   return Boolean(next && DOUBLE_QUOTE_ESCAPES.has(next));
 }
 
+/** Splits a shell-like argv string into tokens, returning null for unterminated quotes or escapes. */
 export function splitShellArgs(raw: string): string[] | null {
   const tokens: string[] = [];
   let buf = "";
@@ -39,6 +40,7 @@ export function splitShellArgs(raw: string): string[] | null {
     }
     if (inDouble) {
       const next = raw[i + 1];
+      // Inside double quotes, only POSIX-recognized escapes consume the backslash.
       if (ch === "\\" && isDoubleQuoteEscape(next)) {
         buf += next;
         i += 1;

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { asBoolean, parseBooleanValue } from "./boolean.js";
+import { chunkItems } from "./chunk-items.js";
 import { splitShellArgs } from "./shell-argv.js";
 
 describe("asBoolean", () => {
@@ -70,5 +71,15 @@ describe("splitShellArgs", () => {
     expect(splitShellArgs(`echo hi # comment && whoami`)).toEqual(["echo", "hi"]);
     expect(splitShellArgs(`echo "hi # still-literal"`)).toEqual(["echo", "hi # still-literal"]);
     expect(splitShellArgs(`echo hi#tail`)).toEqual(["echo", "hi#tail"]);
+  });
+});
+
+describe("chunkItems", () => {
+  it("splits items into fixed-size chunks", () => {
+    expect(chunkItems([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("keeps one row when the requested size is not positive", () => {
+    expect(chunkItems([1, 2, 3], 0)).toEqual([[1, 2, 3]]);
   });
 });


### PR DESCRIPTION
## Summary
- Documents exported CLI command-path matching helpers.
- Documents CLI JSON output helpers for pre-parse flag detection and stderr routing restoration.
- Documents CLI respawn policy helpers and the foreground gateway no-respawn invariant.
- Documents CLI prompt helpers for stdin close handling and global `--yes` behavior.
- Documents CLI completion runtime helpers for shell detection, cache/profile paths, and profile command formatting.
- Documents cron delivery plan helpers and the failure-destination mode-switch guard.
- Documents cron session target helpers for persistent/current targets, delivery routing, and failure notification fallback sessions.
- Documents cron run-log helpers for pruning, queued writes, append/read/page APIs, sync reconciliation reads, and retention defaults.
- Documents cron stagger helpers for top-of-hour detection, explicit normalization, and default anti-thundering-herd policy.
- Documents cron schedule identity helpers for timer reconciliation.
- Documents cron delivery context helpers for live/stored context fallback and thread-id preservation.
- Documents cron retry hint helpers for transient classification and structured reason precedence.
- Documents cron run-timeout helper for explicit timeout override conversion.
- Documents cron utility helpers for active-job state, identity normalization, absolute-time parsing, and delivery field parsing.
- Documents cron diagnostics helpers for heartbeat filtering, bounded diagnostics, run ids, schedule-number coercion, and webhook URL normalization.
- Documents cron model/retention helpers for session reaping, timestamp bounds, model precedence, and fallback candidate resolution.
- Documents cron service policy helpers for manual wake routing, timeout/error text policy, and failure alert cooldown behavior.
- Documents cron service runtime helpers for normalization, mutable state construction, task-ledger records, and watchdog cleanup.
- Documents cron service store helpers for initial delivery defaults, store locking, quarantine, and persistence.
- Documents cron service job helpers for backoff, schedule recompute, creation/patching, due checks, and payload extraction.
- Documents cron service ops helpers for lifecycle, read, mutation, manual run, queued run, and wake APIs.
- Documents cron service timer helpers for timeout wrapping, result application, timer ticks, startup catch-up, execution, and event dispatch.
- Documents cron normalization helpers for input/create/patch normalization, canonical schedule field pruning, session-target safety, and isolated-agent default-delivery semantics.
- Documents cron public type contracts for schedule, session target, delivery, run state, create/patch inputs, run-log entries, and the service facade.
- Documents cron service state contracts for lifecycle events, logger/dependency injection, mutable state, run results, and operation serialization.
- Documents cron list-page contracts for enabled/schedule/status filters, sort options, request options, and offset-page results.
- Documents cron persisted parsing contracts for legacy run-log JSONL rows and structural rejection reasons.
- Documents cron task-ledger contracts for active-run progress text and explicit session drill-down precedence.
- Documents cron store type contracts for quarantine sidecars, config-job runtime metadata, loaded stores, and SQLite row shapes.
- Documents cron job scheduling helpers for default error backoff, schedulable timestamps, and webhook/channel destination clearing.
- Documents cron delivery target contracts for announcement/failure-notification routing and timeout-bounded best-effort failure sends.
- Documents cron isolated-agent delivery target resolution contracts and stale-thread carry-over guard.
- Documents cron isolated-agent payload outcome contracts and fatal structured-error precedence.
- Documents cron isolated-agent model-selection and local-provider preflight result contracts.
- Documents cron isolated-agent mutable session-state contracts.
- Documents cron isolated-agent delivery dispatch and final turn-result contracts.
- Documents cron public telemetry, diagnostics, delivery trace, failure-alert, and patch contracts.
- Documents cron service add/update/list input and result alias contracts.
- Documents cron isolated-agent run entrypoint and top-of-hour stagger default contracts.
- Documents outbound reply-to policy contracts and single-use implicit reply consumption.
- Documents session-bound delivery router contracts and requesterless ambiguity fallback.
- Documents outbound thread-id normalization and delivery commit hook contracts.
- Documents outbound target provider/kind/topic prefix helpers and cross-channel validation.
- Documents outbound session context builder and agent-id derivation policy.
- Documents outbound transcript mirror payloads and delivery-layer group/channel correlation metadata.
- Documents outbound directory cache key, TTL, capacity, and config-reference invalidation contracts.
- Documents outbound message-tool allowlist, cross-context policy, marker decoration, and rich-presentation contracts.
- Documents outbound target normalization, plugin target resolution, id-like heuristics, and resolver signature contracts.
- Documents outbound send dependency legacy-key derivation and channel send dependency lookup contracts.
- Documents outbound message action target modes and target-presence detection contracts.
- Documents outbound session-binding target/status/placement/error, conversation ref, binding record, bind/unbind input, and capability contracts.
- Documents outbound message planning overrides, text/media units, chunking, reply-to consumption, and media caption contracts.
- Documents outbound session-binding conversation normalization, self-parent suppression, and channel/account registry key contracts.
- Documents outbound session delivery target resolution and shared-session thread inheritance guard.
- Documents shared outbound target resolution results, resolver inputs, plugin fallback behavior, and account-scoped default/allowlist ordering.
- Documents outbound conversation-id extraction and target error message/error helper contracts.
- Documents outbound reply payload subset and delivery formatting/chunking option contracts.
- Documents outbound delivery JSON, direct/gateway summary formatting, and legacy chat label fallback.
- Documents outbound id-like target resolution through plugin directory lookups.
- Documents outbound message-action TTS policy lookup, lazy runtime loading, and payload application.
- Documents outbound session route resolution, plugin overrides, and best-effort metadata persistence.
- Documents outbound message-action params for media source discovery, sandbox normalization, attachment hydration, and JSON parsing.
- Documents outbound gateway option defaults and managed-endpoint URL suppression.
- Documents outbound best-effort delivery decisions and result envelope flattening.
- Documents outbound channel resolution runtime facades, channel normalization, plugin resolution, and read-only metadata lookup.
- Documents outbound identity metadata normalization and agent identity resolution.
- Documents the outbound conversation-id guard for provider-native colon targets.
- Documents source-delivery target prefix comparison across case-sensitive and case-normalized providers.
- Documents account-scoped conversation binding manager and session-binding adapter registration contracts.
- Documents the bound-delivery router factory for active session-binding resolution.
- Documents outbound message channel selection ids, sources, and config resolution contracts.
- Documents outbound channel bootstrap and retry-guard reset contracts.
- Documents public message channel durability, receipt, render-plan, send lifecycle, live, receive, adapter, and durable intent contracts.
- Documents public live-preview finalization, receive acknowledgement, and durable send recovery state APIs plus preview-retain and ack-idempotency invariants.
- Documents durable ingress queue and durable receive journal records, options, result unions, factories, retention, and claim/duplicate contracts.
- Documents channel turn admission, event/access facts, delivery adapters/results, record/history options, resolved/prepared turn shapes, log events, adapters, and run params.
- Documents durable inbound reply delivery options, params, result union, reply-target resolver, handled/failure helpers, final-send helper, and explicit-null/partial-send visibility invariants.
- Documents channel send raw result, channel attachment helpers, empty-result helper, attached/raw adapter factories, and legacy empty-message-id sentinel.
- Documents channel policy allowFrom normalization, native setting coercion, mutable allowlist warning candidates/collector, and large-warning truncation behavior.
- Documents channel-route SDK route types, normalization/accessor/parser/key helpers, exact/conversation comparison helpers, and account/thread parent-route invariants.
- Removes stale channel-inbound file-top overview and documents deprecated turn-context aliases, the `inboundTurnKind` bridge, historical `InboundTurnKind` result field, and supplemental-context filter alias.
- Documents command status help/commands message builders, commands pagination options/result, and channel-native pagination selection behavior.
- Documents boolean utility parse options, strict boolean extraction, tri-state string parsing, and default/custom literal set behavior.
- Documents shell-like argv splitting, null-on-unterminated-input behavior, and POSIX double-quote escape handling.
- Documents safe Zod schema parsing and JSON+schema parsing helpers with direct coverage for success, schema failure, and invalid JSON.
- Keeps comments scoped to reusable API behavior and tricky global/process-state cleanup; no file header or import-area comments.

## Verification
- `git diff --check`
- `pnpm test src/cli/command-path-matches.test.ts`
- `pnpm test src/cli/json-output-mode.test.ts`
- `pnpm test src/cli/cli-utils.test.ts`
- `pnpm test src/cli/prompt.test.ts`
- `pnpm test src/cli/completion-runtime.test.ts`
- `pnpm test src/cron/delivery-plan.test.ts src/cron/delivery.test.ts`
- `pnpm test src/cron/session-target.test.ts`
- `pnpm test src/cron/run-log.test.ts`
- `pnpm test src/cron/stagger.test.ts`
- `pnpm test src/cron/schedule-identity.test.ts`
- `pnpm test src/cron/delivery-context.test.ts`
- `pnpm test src/cron/retry-hint.test.ts`
- `pnpm test src/cron/isolated-agent.run-timeout-override.test.ts`
- `pnpm test src/cron/active-jobs-manual-run.test.ts src/cron/normalize-job-identity.test.ts src/cron/parse.test.ts src/cron/delivery-plan.test.ts src/cron/delivery.test.ts`
- `pnpm test src/cron/heartbeat-policy.test.ts src/cron/run-diagnostics.test.ts src/cron/schedule.test.ts src/cron/delivery-plan.test.ts src/cron/delivery.test.ts`
- `pnpm test src/cron/session-reaper.test.ts src/cron/service.session-reaper-in-finally.test.ts src/cron/validate-timestamp.test.ts src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent.hook-content-wrapping.test.ts src/cron/isolated-agent/run-fallback-policy.test.ts`
- `pnpm test src/cron/service/wake.test.ts src/cron/service/timeout-policy.test.ts src/cron/service.failure-alert.test.ts src/cron/delivery.failure-notify.test.ts src/cron/run-log.error-reason.test.ts`
- `pnpm test src/cron/normalize.test.ts src/cron/service/state.test.ts src/cron/service/ops.regression.test.ts src/cron/service/timer.regression.test.ts`
- `pnpm test src/cron/service/store.test.ts src/cron/service/ops.test.ts src/cron/service/jobs.apply-patch.test.ts src/cron/service/store.load-missing-session-target.test.ts`
- `pnpm test src/cron/service.jobs.test.ts src/cron/service/jobs.apply-patch.test.ts src/cron/service.jobs.top-of-hour-stagger.test.ts src/cron/service.issue-13992-regression.test.ts src/cron/service.issue-17852-daily-skip.test.ts src/cron/service.issue-19676-at-reschedule.test.ts src/cron/service.issue-22895-every-next-run.test.ts src/cron/service/jobs.schedule-error-isolation.test.ts`
- `pnpm test src/cron/service/ops.test.ts src/cron/service/ops.regression.test.ts src/cron/service.read-ops-nonblocking.test.ts src/cron/service.list-page-sort-guards.test.ts src/cron/service.issue-regressions.test.ts`
- `pnpm test src/cron/service/timer.test.ts src/cron/service/timer.regression.test.ts src/cron/service.armtimer-tight-loop.test.ts src/cron/service.rearm-timer-when-running.test.ts src/cron/service.restart-catchup.test.ts src/cron/service.issue-66019-unresolved-next-run.test.ts src/cron/service.session-reaper-in-finally.test.ts`
- `pnpm test src/cron/normalize.test.ts src/cron/normalize-job-identity.test.ts src/cron/isolated-agent.session-identity.test.ts`
- `pnpm test src/cron/run-log.test.ts src/cron/service/ops.test.ts src/cron/normalize.test.ts`
- `pnpm test src/cron/service/state.test.ts src/cron/service/ops.test.ts src/cron/service/timer.test.ts`
- `pnpm test src/cron/service.list-page-sort-guards.test.ts src/cron/service/ops.test.ts`
- `pnpm test src/cron/delivery.test.ts src/cron/delivery.failure-notify.test.ts src/cron/delivery-plan.test.ts`
- `pnpm test src/cron/run-log.test.ts src/cron/store.test.ts src/cron/service/ops.test.ts`
- `pnpm test src/cron/isolated-agent/delivery-target.test.ts src/cron/delivery.test.ts src/cron/delivery-preview.test.ts`
- `pnpm test src/cron/isolated-agent/helpers.test.ts src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts`
- `pnpm test src/cron/isolated-agent.model-overrides.test.ts src/cron/isolated-agent/model-preflight.runtime.test.ts src/cron/isolated-agent.model-preflight.test.ts`
- `pnpm test src/cron/isolated-agent/run-session-state.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts src/cron/isolated-agent/run.meta-error-status.test.ts`
- `pnpm test src/cron/delivery-preview.test.ts src/cron/service/jobs.apply-patch.test.ts src/cron/run-diagnostics.test.ts src/cron/service.jobs.test.ts`
- `pnpm test src/cron/service/state.test.ts src/cron/service/ops.test.ts src/cron/service.get-job.test.ts`
- `pnpm test src/cron/stagger.test.ts src/cron/isolated-agent/run.session-key.test.ts src/cron/isolated-agent/run.meta-error-status.test.ts`
- `pnpm test src/infra/outbound/reply-policy.test.ts src/infra/outbound/message-plan.test.ts`
- `pnpm test src/infra/outbound/bound-delivery-router.test.ts`
- `pnpm test src/infra/outbound/thread-id.test.ts src/infra/outbound/delivery-queue.recovery.test.ts`
- `pnpm test src/infra/outbound/channel-target-prefix.test.ts src/cron/isolated-agent/delivery-target.test.ts`
- `pnpm test src/infra/outbound/session-context.test.ts src/infra/outbound/deliver.test.ts`
- `pnpm test src/infra/outbound/message.test.ts src/infra/outbound/deliver.test.ts src/infra/outbound/outbound-send-service.test.ts src/infra/outbound/delivery-queue.storage.test.ts src/infra/outbound/delivery-queue.recovery.test.ts`
- `pnpm test src/infra/outbound/directory-cache.test.ts src/infra/outbound/outbound.test.ts src/infra/outbound/target-resolver.test.ts`
- `pnpm test src/infra/outbound/outbound-policy.test.ts src/infra/outbound/message-plan.test.ts src/infra/outbound/message-action-runner.threading.test.ts`
- `pnpm test src/infra/outbound/target-normalization.test.ts src/infra/outbound/target-resolver.test.ts src/infra/outbound/outbound-policy.test.ts`
- `pnpm test src/cron/isolated-agent.direct-delivery-core-channels.test.ts src/cron/delivery.failure-notify.test.ts`
- `pnpm test src/infra/outbound/message-action-spec.test.ts src/infra/outbound/message-action-runner.threading.test.ts`
- `pnpm test src/infra/outbound/session-binding-service.test.ts src/infra/outbound/current-conversation-bindings.test.ts src/infra/outbound/bound-delivery-router.test.ts`
- `pnpm test src/infra/outbound/message-plan.test.ts src/infra/outbound/message.test.ts`
- `pnpm test src/infra/outbound/targets.test.ts src/infra/outbound/agent-delivery.test.ts`
- `pnpm test src/infra/outbound/conversation-id.test.ts src/infra/outbound/target-errors.test.ts`
- `pnpm test src/infra/outbound/deliver.test.ts src/infra/outbound/message-plan.test.ts src/infra/outbound/delivery-queue.recovery.test.ts`
- `pnpm test src/infra/outbound/format.test.ts src/infra/outbound/envelope.test.ts`
- `pnpm test src/cron/isolated-agent/delivery-target.test.ts src/infra/outbound/target-normalization.test.ts`
- `pnpm test src/infra/outbound/message-action-runner.core-send.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/tts/tts-config.test.ts`
- `pnpm test src/infra/outbound/outbound-session.test.ts src/infra/outbound/message-action-runner.threading.test.ts src/infra/outbound/targets.test.ts`
- `pnpm test src/infra/outbound/message-action-params.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/message-action-runner.send-validation.test.ts`
- `pnpm test src/infra/outbound/message-gateway-options.test.ts src/infra/outbound/message.test.ts`
- `pnpm test src/infra/outbound/best-effort-delivery.test.ts src/infra/outbound/envelope.test.ts src/cron/delivery-plan.test.ts`
- `pnpm test src/infra/outbound/channel-resolution.test.ts src/infra/outbound/channel-selection.test.ts`
- `pnpm test src/infra/outbound/identity.test.ts`
- `pnpm test src/infra/outbound/conversation-id.test.ts`
- `pnpm test src/infra/outbound/source-delivery-plan.test.ts`
- `pnpm test src/infra/outbound/session-binding-service.test.ts src/infra/outbound/current-conversation-bindings.test.ts`
- `pnpm test src/infra/outbound/bound-delivery-router.test.ts src/infra/outbound/session-binding-service.test.ts`
- `pnpm test src/infra/outbound/channel-selection.test.ts src/infra/outbound/channel-resolution.test.ts`
- `pnpm test src/infra/outbound/channel-bootstrap.runtime.test.ts src/infra/outbound/channel-resolution.test.ts`
- `pnpm test src/channels/message/contracts.test.ts src/channels/message/capabilities.test.ts src/channels/message/send.test.ts`
- `pnpm test src/channels/message/lifecycle.test.ts`
- `pnpm test src/channels/message/ingress-queue.test.ts src/channels/message/durable-receive.test.ts`
- `pnpm test src/channels/turn/kernel.test.ts src/channels/turn/history-window.test.ts src/channels/turn/delivery-result.test.ts`
- `pnpm test src/channels/turn/durable-delivery.test.ts src/channels/turn/kernel.test.ts`
- `pnpm test src/plugin-sdk/channel-send-result.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `pnpm test src/plugin-sdk/channel-policy.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `pnpm test src/plugin-sdk/channel-route.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `pnpm test src/plugin-sdk/channel-inbound.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `pnpm test src/plugin-sdk/command-auth.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `pnpm test src/utils/utils-misc.test.ts src/cli/nodes-media-utils.test.ts`
- `pnpm test src/utils/utils-misc.test.ts`

## Real behavior proof
Behavior addressed: helper docs now state command-path prefix/exact/rule contracts, sentinel-aware JSON flag detection, console stderr routing cleanup, foreground gateway respawn policy, prompt stdin-close/global-yes behavior, completion shell/profile/cache contracts, cron delivery/failure routing contracts, cron session-target/failure-notification contracts, cron run-log read/write/prune/retention-default contracts, cron stagger/defaulting policy, cron schedule identity reconciliation contracts, cron delivery-context creation contracts, cron retry classification contracts, cron run-timeout override contracts, cron utility contracts for active-job state, legacy identity normalization, absolute-time parsing, and delivery field parsing, cron diagnostics/heartbeat/run-id/schedule-number/webhook URL contracts, cron retention/model selection/fallback contracts, cron service policy contracts for wake routing, timeout/error text, and failure alerts, cron service runtime contracts for normalization, state construction, task ledgers, and watchdog cleanup, cron service store contracts for locking, quarantine, and persistence, cron service job contracts for backoff, recompute, creation/patching, due checks, and payload extraction, and cron service ops contracts for lifecycle, read, mutation, manual run, queued run, and wake APIs, plus cron service timer contracts for timeout wrapping, result application, timer ticks, startup catch-up, execution, and event dispatch, cron normalization contracts for input/create/patch normalization, canonical schedule field pruning, session-target safety, and isolated-agent default-delivery semantics, and cron public type contracts for schedule, session target, delivery, run state, create/patch inputs, run-log entries, and the service facade, cron service state contracts for lifecycle events, logger/dependency injection, mutable state, run results, and operation serialization, and cron list-page contracts for filters, sort options, request options, and offset-page results, cron delivery target contracts for announcement/failure-notification routing and timeout-bounded best-effort failure sends, and cron run-log retention default contracts, cron isolated-agent delivery target resolution contracts plus the stale-thread carry-over guard, and cron isolated-agent payload outcome contracts plus fatal structured-error precedence, cron isolated-agent model-selection/local-provider preflight contracts, and cron isolated-agent mutable session-state contracts, plus outbound message-tool allowlist/cross-context marker policy/rich-presentation contracts, plus outbound send dependency legacy-key/channel lookup contracts, plus outbound session-binding target/status/placement/error/conversation/bind/unbind/capability contracts, plus outbound session-binding conversation normalization/self-parent suppression/channel-account key contracts, plus shared outbound target resolver result/input/plugin-fallback/account-default ordering contracts, plus outbound reply payload subset and delivery formatting/chunking contracts, plus outbound delivery JSON/direct summary/gateway summary/legacy label contracts, plus outbound id-like target resolution contracts, plus outbound message-action TTS policy/lazy-runtime/payload contracts, plus outbound session route resolution/plugin override/metadata persistence contracts, plus outbound message-action media-param/sandbox/hydration/JSON parsing contracts, plus outbound gateway option defaulting/managed-endpoint contracts, plus outbound best-effort delivery/envelope flattening contracts, plus outbound channel resolution/runtime facade/plugin lookup contracts, plus outbound identity metadata normalization, plus outbound conversation-id colon-target safety, plus source-delivery provider-specific target prefix comparison, plus account-scoped conversation binding manager contracts, plus bound-delivery router session-binding resolution, plus outbound message channel selection contracts, plus outbound channel bootstrap retry guard contracts, plus public message channel adapter and send lifecycle contracts, plus channel message live-preview, receive-ack, and durable recovery contracts, plus channel ingress queue and durable receive journal contracts, plus channel turn type and adapter contracts, plus durable inbound reply delivery contracts and visibility invariants, plus channel send-result SDK contracts and legacy empty-id sentinel, plus channel policy SDK helper contracts and warning truncation invariant, plus channel-route SDK helper maintainability, plus channel-inbound SDK compatibility docs, plus command status builder docs, plus boolean utility docs, plus shell argv utility docs, plus zod parse utility docs.
Real environment tested: local macOS checkout on current `main` after PR #88554 was already merged upstream.
Exact steps or command run after this patch: `git diff --check`; `pnpm test src/cli/command-path-matches.test.ts`; `pnpm test src/cli/json-output-mode.test.ts`; `pnpm test src/cli/cli-utils.test.ts`; `pnpm test src/cli/prompt.test.ts`; `pnpm test src/cli/completion-runtime.test.ts`; `pnpm test src/cron/delivery-plan.test.ts src/cron/delivery.test.ts`; `pnpm test src/cron/session-target.test.ts`; `pnpm test src/cron/run-log.test.ts`; `pnpm test src/cron/stagger.test.ts`; `pnpm test src/cron/schedule-identity.test.ts`; `pnpm test src/cron/delivery-context.test.ts`; `pnpm test src/cron/retry-hint.test.ts`; `pnpm test src/cron/isolated-agent.run-timeout-override.test.ts`; `pnpm test src/cron/active-jobs-manual-run.test.ts src/cron/normalize-job-identity.test.ts src/cron/parse.test.ts src/cron/delivery-plan.test.ts src/cron/delivery.test.ts`; `pnpm test src/cron/heartbeat-policy.test.ts src/cron/run-diagnostics.test.ts src/cron/schedule.test.ts src/cron/delivery-plan.test.ts src/cron/delivery.test.ts`; `pnpm test src/cron/session-reaper.test.ts src/cron/service.session-reaper-in-finally.test.ts src/cron/validate-timestamp.test.ts src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent.hook-content-wrapping.test.ts src/cron/isolated-agent/run-fallback-policy.test.ts`; `pnpm test src/cron/service/wake.test.ts src/cron/service/timeout-policy.test.ts src/cron/service.failure-alert.test.ts src/cron/delivery.failure-notify.test.ts src/cron/run-log.error-reason.test.ts`; `pnpm test src/cron/normalize.test.ts src/cron/service/state.test.ts src/cron/service/ops.regression.test.ts src/cron/service/timer.regression.test.ts`; `pnpm test src/cron/service/store.test.ts src/cron/service/ops.test.ts src/cron/service/jobs.apply-patch.test.ts src/cron/service/store.load-missing-session-target.test.ts`; `pnpm test src/cron/service.jobs.test.ts src/cron/service/jobs.apply-patch.test.ts src/cron/service.jobs.top-of-hour-stagger.test.ts src/cron/service.issue-13992-regression.test.ts src/cron/service.issue-17852-daily-skip.test.ts src/cron/service.issue-19676-at-reschedule.test.ts src/cron/service.issue-22895-every-next-run.test.ts src/cron/service/jobs.schedule-error-isolation.test.ts`; `pnpm test src/cron/service/ops.test.ts src/cron/service/ops.regression.test.ts src/cron/service.read-ops-nonblocking.test.ts src/cron/service.list-page-sort-guards.test.ts src/cron/service.issue-regressions.test.ts`; `pnpm test src/cron/service/timer.test.ts src/cron/service/timer.regression.test.ts src/cron/service.armtimer-tight-loop.test.ts src/cron/service.rearm-timer-when-running.test.ts src/cron/service.restart-catchup.test.ts src/cron/service.issue-66019-unresolved-next-run.test.ts src/cron/service.session-reaper-in-finally.test.ts`; `pnpm test src/cron/normalize.test.ts src/cron/normalize-job-identity.test.ts src/cron/isolated-agent.session-identity.test.ts`; `pnpm test src/cron/run-log.test.ts src/cron/service/ops.test.ts src/cron/normalize.test.ts`; `pnpm test src/cron/service/state.test.ts src/cron/service/ops.test.ts src/cron/service/timer.test.ts`; `pnpm test src/cron/service.list-page-sort-guards.test.ts src/cron/service/ops.test.ts`; `pnpm test src/cron/delivery.test.ts src/cron/delivery.failure-notify.test.ts src/cron/delivery-plan.test.ts`; `pnpm test src/cron/run-log.test.ts src/cron/store.test.ts src/cron/service/ops.test.ts`; `pnpm test src/cron/isolated-agent/delivery-target.test.ts src/cron/delivery.test.ts src/cron/delivery-preview.test.ts`; `pnpm test src/cron/isolated-agent/helpers.test.ts src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts`; `pnpm test src/cron/isolated-agent.model-overrides.test.ts src/cron/isolated-agent/model-preflight.runtime.test.ts src/cron/isolated-agent.model-preflight.test.ts`; `pnpm test src/cron/isolated-agent/run-session-state.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`; `pnpm test src/infra/outbound/message.test.ts src/infra/outbound/deliver.test.ts src/infra/outbound/outbound-send-service.test.ts src/infra/outbound/delivery-queue.storage.test.ts src/infra/outbound/delivery-queue.recovery.test.ts`; `pnpm test src/infra/outbound/outbound-policy.test.ts src/infra/outbound/message-plan.test.ts src/infra/outbound/message-action-runner.threading.test.ts`; `pnpm test src/cron/isolated-agent.direct-delivery-core-channels.test.ts src/cron/delivery.failure-notify.test.ts`; `pnpm test src/infra/outbound/session-binding-service.test.ts src/infra/outbound/current-conversation-bindings.test.ts src/infra/outbound/bound-delivery-router.test.ts`; `pnpm test src/infra/outbound/targets.test.ts src/infra/outbound/agent-delivery.test.ts`; `pnpm test src/infra/outbound/deliver.test.ts src/infra/outbound/message-plan.test.ts src/infra/outbound/delivery-queue.recovery.test.ts`; `pnpm test src/infra/outbound/format.test.ts src/infra/outbound/envelope.test.ts`; `pnpm test src/cron/isolated-agent/delivery-target.test.ts src/infra/outbound/target-normalization.test.ts`; `pnpm test src/infra/outbound/message-action-runner.core-send.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/tts/tts-config.test.ts`; `pnpm test src/infra/outbound/outbound-session.test.ts src/infra/outbound/message-action-runner.threading.test.ts src/infra/outbound/targets.test.ts`; `pnpm test src/infra/outbound/message-action-params.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/message-action-runner.send-validation.test.ts`; `pnpm test src/infra/outbound/message-gateway-options.test.ts src/infra/outbound/message.test.ts`; `pnpm test src/infra/outbound/best-effort-delivery.test.ts src/infra/outbound/envelope.test.ts src/cron/delivery-plan.test.ts`; `pnpm test src/infra/outbound/channel-resolution.test.ts src/infra/outbound/channel-selection.test.ts`; `pnpm test src/infra/outbound/identity.test.ts`; `pnpm test src/infra/outbound/conversation-id.test.ts`; `pnpm test src/infra/outbound/source-delivery-plan.test.ts`; `pnpm test src/infra/outbound/session-binding-service.test.ts src/infra/outbound/current-conversation-bindings.test.ts`; `pnpm test src/infra/outbound/bound-delivery-router.test.ts src/infra/outbound/session-binding-service.test.ts`; `pnpm test src/infra/outbound/channel-selection.test.ts src/infra/outbound/channel-resolution.test.ts`; `pnpm test src/infra/outbound/channel-bootstrap.runtime.test.ts src/infra/outbound/channel-resolution.test.ts`; `pnpm test src/channels/message/contracts.test.ts src/channels/message/capabilities.test.ts src/channels/message/send.test.ts`; `pnpm test src/channels/message/lifecycle.test.ts`; `pnpm test src/channels/message/ingress-queue.test.ts src/channels/message/durable-receive.test.ts`; `pnpm test src/channels/turn/kernel.test.ts src/channels/turn/history-window.test.ts src/channels/turn/delivery-result.test.ts`; `pnpm test src/channels/turn/durable-delivery.test.ts src/channels/turn/kernel.test.ts`; `pnpm test src/plugin-sdk/channel-send-result.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`; `pnpm test src/plugin-sdk/channel-policy.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`; `pnpm test src/plugin-sdk/channel-route.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`; `pnpm test src/plugin-sdk/channel-inbound.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`; `pnpm test src/plugin-sdk/command-auth.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`; `pnpm test src/utils/utils-misc.test.ts src/cli/nodes-media-utils.test.ts`; `pnpm test src/utils/utils-misc.test.ts`.
Evidence after fix: zod parse utility docs targeted tests passed locally (1 file / 13 tests); shell argv utility docs targeted tests passed locally (1 file / 11 tests); boolean utility docs targeted tests passed locally (2 files / 11 tests); command status builder docs targeted tests passed locally (2 files / 23 tests); channel-inbound SDK compatibility docs targeted tests passed locally (2 files / 19 tests); channel-route SDK docs targeted tests passed locally (2 files / 28 tests); channel policy SDK helpers (2 files / 25 tests); channel send-result SDK helpers (2 files / 23 tests); durable inbound reply delivery helpers (2 files / 34 tests); channel turn type helpers (3 files / 31 tests); channel ingress queue/journal helpers (2 files / 15 tests); channel message lifecycle helpers (1 file / 16 tests); channel message public contract helpers (3 files / 32 tests); outbound channel bootstrap helpers (2 files / 14 tests); outbound channel selection helpers (2 files / 31 tests); outbound bound-delivery router helpers (2 files / 18 tests); outbound account-scoped conversation binding helpers (2 files / 21 tests); outbound source delivery plan helper (1 file / 10 tests); outbound conversation-id helper (1 file / 14 tests); outbound identity helpers (1 file / 5 tests); outbound channel resolution helpers (2 files / 31 tests); outbound best-effort/envelope helpers (3 files / 11 tests); outbound gateway option helpers (2 files / 13 tests); outbound message-action params helpers (3 files / 78 tests); outbound session route helpers (3 files / 114 tests); outbound message-action TTS helpers (3 files / 34 tests); outbound target id resolution helpers (2 files / 75 tests); outbound format helpers (2 files / 18 tests); outbound payload formatting helpers (3 files / 119 tests); shared outbound target resolver helpers (2 files / 79 tests); outbound session binding normalization helpers (3 files / 28 tests); outbound session binding type contracts (3 files / 28 tests); outbound send dependency helpers (2 files / 18 tests); outbound policy helpers (3 files / 30 tests); outbound mirror delivery helpers (5 files / 159 tests); focused Vitest shards passed command-path matching (1 file / 4 tests), JSON output mode (1 file / 3 tests), CLI utils/respawn coverage (1 file / 43 tests), prompt helpers (1 file / 3 tests), completion runtime (1 file / 5 tests), cron delivery planning (2 files / 19 tests), cron session targets (1 file / 8 tests), cron run log (1 file / 15 tests), cron stagger (1 file / 4 tests), cron schedule identity (1 file / 2 tests), cron delivery context (1 file / 5 tests), cron retry hints (1 file / 3 tests), cron run timeout (1 file / 4 tests), cron utility helpers (5 files / 27 tests), cron diagnostics helpers (5 files / 57 tests), cron model/retention helpers (6 files / 73 tests), cron service policy helpers (5 files / 31 tests), cron service runtime helpers (4 files / 98 tests), and cron service store helpers (4 files / 24 tests), and cron service job helpers (8 files / 100 tests), cron service ops helpers (5 files / 37 tests), and cron service timer helpers (7 files / 72 tests), cron normalization helpers (3 files / 60 tests), and cron public contract helpers (3 files / 73 tests), cron service state helpers (3 files / 19 tests), and cron list-page helpers (2 files / 20 tests), cron delivery target helpers (3 files / 23 tests), and cron run-log retention defaults (3 files / 61 tests), cron isolated delivery target resolution (3 files / 74 tests), and cron payload outcome helpers (3 files / 58 tests), cron model selection/preflight contracts (3 files / 16 tests), and cron session-state contracts (2 files / 44 tests); whitespace check passed.
Observed result after fix: exported helper behavior remains unchanged; comments clarify existing contracts only.
What was not tested: broader CI not run locally for this docs-only slice.























































