### PR TITLE
fix: repair red trunk CI lanes (voice-call test-types + task-registry allowlist)

### DIFF
--- a/extensions/voice-call/doctor-contract-api.test.ts
+++ b/extensions/voice-call/doctor-contract-api.test.ts
@@ -35,6 +35,9 @@ function installStateRuntime(): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
+      openChannelIngressQueue: (() => {
+        throw new Error("openChannelIngressQueue is not used by voice-call tests");
+      }) as never,
       openKeyedStore: (() => {
         throw new Error("openKeyedStore is not used by voice-call doctor tests");
       }) as never,

--- a/extensions/voice-call/src/manager.restore.test.ts
+++ b/extensions/voice-call/src/manager.restore.test.ts
@@ -19,6 +19,9 @@ function installStateRuntime(): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
+      openChannelIngressQueue: (() => {
+        throw new Error("openChannelIngressQueue is not used by voice-call tests");
+      }) as never,
       openKeyedStore: (() => {
         throw new Error("openKeyedStore is not used by voice-call restore tests");
       }) as never,

--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -84,6 +84,9 @@ export function installVoiceCallStateRuntimeForTests(): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
+      openChannelIngressQueue: (() => {
+        throw new Error("openChannelIngressQueue is not used by voice-call tests");
+      }) as never,
       openKeyedStore: (() => {
         throw new Error("openKeyedStore is not used by voice-call manager tests");
       }) as never,

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -21,6 +21,9 @@ function installStateRuntime(): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
+      openChannelIngressQueue: (() => {
+        throw new Error("openChannelIngressQueue is not used by voice-call tests");
+      }) as never,
       openKeyedStore: (() => {
         throw new Error("openKeyedStore is not used by voice-call event tests");
       }) as never,

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -24,6 +24,9 @@ function installStateRuntime(): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
+      openChannelIngressQueue: (() => {
+        throw new Error("openChannelIngressQueue is not used by voice-call tests");
+      }) as never,
       openKeyedStore: (() => {
         throw new Error("openKeyedStore is not used by voice-call store tests");
       }) as never,
@@ -82,6 +85,9 @@ describe("voice-call call record store", () => {
     setVoiceCallStateRuntime({
       state: {
         resolveStateDir: () => "",
+        openChannelIngressQueue: (() => {
+          throw new Error("openChannelIngressQueue is not used by voice-call tests");
+        }) as never,
         openKeyedStore: (() => {
           throw new Error("openKeyedStore is not used by voice-call store tests");
         }) as never,

--- a/extensions/voice-call/src/webhook.hangup-once.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.hangup-once.lifecycle.test.ts
@@ -16,6 +16,9 @@ function installStateRuntime(): void {
   setVoiceCallStateRuntime({
     state: {
       resolveStateDir: () => "",
+      openChannelIngressQueue: (() => {
+        throw new Error("openChannelIngressQueue is not used by voice-call tests");
+      }) as never,
       openKeyedStore: (() => {
         throw new Error("openKeyedStore is not used by voice-call webhook lifecycle tests");
       }) as never,

--- a/src/tasks/task-boundaries.test.ts
+++ b/src/tasks/task-boundaries.test.ts
@@ -35,6 +35,7 @@ const TASK_REGISTRY_ALLOWED_IMPORTERS = new Set([
   "tasks/runtime-internal.ts",
   "tasks/task-owner-access.ts",
   "tasks/task-status-access.ts",
+  "agents/embedded-agent-runner/run/attempt.async-tasks.ts",
 ]);
 
 let sources: TaskBoundarySource[] = [];


### PR DESCRIPTION
## Summary
`main` is currently red on several CI lanes (independent of any feature PR). This fixes the
**two** that have a clear, behavior-preserving repair. Reasoning is the point here, so it's spelled out.

### 1. `check-test-types` — `extensions/voice-call/**` (`TS2741: openChannelIngressQueue is missing`)
The plugin-state runtime contract (`src/plugins/runtime/types-core.ts`) gained `openChannelIngressQueue`
when the channel ingress-queue feature landed, so every `PluginState` value must now provide it. The
voice-call tests build the plugin state inline as throwaway mocks that predate the method, so
`tsgo:test` rejects them.
**Fix / why it works:** voice-call tests never exercise the ingress queue (only the keyed-store seam),
so the correct minimal repair is to satisfy the type contract without inventing behavior — add
`openChannelIngressQueue` as a throwing stub, mirroring the file's existing `openKeyedStore` stub. The
mocks now match the interface, typecheck, and still pass because the stub is never called.

### 2. `checks-node-core-fast` — `src/tasks/task-boundaries.test.ts` (allowlist drift)
This architecture guard asserts the *exact* set of production files importing `tasks/task-registry.js`
directly equals an allowlist. A new internal reader, `agents/embedded-agent-runner/run/attempt.async-tasks.ts`,
imports `findTaskByRunId`/`listTaskRecords` straight from the registry but landed without updating the
allowlist (4 actual vs 3 expected).
**Fix / why it works:** the import is a legitimate internal runtime read, and the allowlist is exactly
the mechanism for declaring approved direct importers. Adding the file realigns the guard with the
intended set. Routing through the `task-owner-access` seam would change runtime semantics (owner-scoped
lookups), so the allowlist update is the behavior-preserving fix.

## Verification
```
pnpm tsgo:test                                                  -> clean (voice-call TS2741 gone)
node scripts/run-vitest.mjs run src/tasks/task-boundaries.test.ts            -> pass
node scripts/run-vitest.mjs run extensions/voice-call/src/manager/store.test.ts \
  extensions/voice-call/src/manager/events.test.ts                          -> pass (compile + run)
oxfmt --check, oxlint                                           -> clean on touched files
```

## Not addressed (needs a maintainer API decision, not a guessed fix)
The other red lanes stem from the same ingress-queue landing: `check-additional-boundaries-bcd`
(`lint:plugins:no-extension-test-core-imports`) flags `telegram`/`whatsapp` **test** files deep-importing
core internals (`src/channels/message/ingress-queue.js`, `state-db`, `kysely-sync`). There is **no
plugin-sdk subpath** exposing those for tests, so the proper fix is to **create a focused
`openclaw/plugin-sdk/*` test/runtime subpath** and migrate the imports — a public-surface decision left
to the owners. `check-lint` / `check-additional-extension-bundled` carry related debt.

## Real behavior proof
Behavior addressed: trunk CI lanes `check-test-types` and `checks-node-core-fast` fail on `main` due to a test-mock missing a newly-required interface method and an out-of-date architecture allowlist.
Real environment tested: local repo checkout on the same toolchain CI uses (`tsgo`/Vitest), running the exact failing checks before and after the change.
Exact steps or command run after this patch:
```
pnpm tsgo:test
node scripts/run-vitest.mjs run src/tasks/task-boundaries.test.ts extensions/voice-call/src/manager/store.test.ts
```
Evidence after fix: console output of the checks — `tsgo:test` exits 0 with no `openChannelIngressQueue`/`TS2741` diagnostics, and the Vitest run reports the task-boundaries and voice-call suites passing.
Observed result after fix: the two formerly-red lanes pass locally; before this change `tsgo:test` reported `TS2741` across six voice-call test files and `task-boundaries.test.ts` failed its set assertion (4 vs 3).
What was not tested: the remaining red lanes (extension test core-import boundary, lint/extension-bundled) are intentionally out of scope here — they require creating a plugin-sdk test seam, a maintainer API decision.
