### PR TITLE
fix: keep insecure Control UI auth disabled after onboarding

### DIFF
--- a/src/wizard/setup.gateway-config.test.ts
+++ b/src/wizard/setup.gateway-config.test.ts
@@ -200,6 +200,24 @@ describe("configureGatewayForSetup", () => {
     expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).toBe(false);
   });
 
+  it("preserves explicit insecure local control ui auth opt-in in quickstart", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+
+    const result = await runGatewayConfig({
+      flow: "quickstart",
+      textQueue: [],
+      nextConfig: {
+        gateway: {
+          controlUi: {
+            allowInsecureAuth: true,
+          },
+        },
+      },
+    });
+
+    expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).toBe(true);
+  });
+
   it("keeps insecure local control ui auth disabled when quickstart reuses an existing loopback config", async () => {
     mocks.randomToken.mockReturnValue("generated-token");
     const prompter = createPrompter({

--- a/src/wizard/setup.gateway-config.test.ts
+++ b/src/wizard/setup.gateway-config.test.ts
@@ -171,7 +171,7 @@ describe("configureGatewayForSetup", () => {
     }
   });
 
-  it("enables insecure local control ui auth for fresh quickstart loopback setups", async () => {
+  it("keeps insecure local control ui auth disabled for fresh quickstart loopback setups", async () => {
     mocks.randomToken.mockReturnValue("generated-token");
 
     const result = await runGatewayConfig({
@@ -179,7 +179,7 @@ describe("configureGatewayForSetup", () => {
       textQueue: [],
     });
 
-    expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).toBe(true);
+    expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).not.toBe(true);
   });
 
   it("preserves explicit control ui auth policy in quickstart", async () => {
@@ -200,7 +200,7 @@ describe("configureGatewayForSetup", () => {
     expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).toBe(false);
   });
 
-  it("enables insecure local control ui auth when quickstart reuses an existing loopback config", async () => {
+  it("keeps insecure local control ui auth disabled when quickstart reuses an existing loopback config", async () => {
     mocks.randomToken.mockReturnValue("generated-token");
     const prompter = createPrompter({
       selectQueue: [],
@@ -226,7 +226,7 @@ describe("configureGatewayForSetup", () => {
       runtime,
     });
 
-    expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).toBe(true);
+    expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).not.toBe(true);
   });
 
   it("does not set password to literal 'undefined' when prompt returns undefined", async () => {

--- a/src/wizard/setup.gateway-config.ts
+++ b/src/wizard/setup.gateway-config.ts
@@ -354,23 +354,6 @@ export async function configureGatewayForSetup(
     },
   };
 
-  if (
-    flow === "quickstart" &&
-    bind === "loopback" &&
-    nextConfig.gateway?.controlUi?.allowInsecureAuth === undefined
-  ) {
-    nextConfig = {
-      ...nextConfig,
-      gateway: {
-        ...nextConfig.gateway,
-        controlUi: {
-          ...nextConfig.gateway?.controlUi,
-          allowInsecureAuth: true,
-        },
-      },
-    };
-  }
-
   nextConfig = ensureControlUiAllowedOriginsForNonLoopbackBind(nextConfig, {
     requireControlUiEnabled: true,
   }).config;


### PR DESCRIPTION
## Summary

Fixes #78855.

The QuickStart setup path could leave `gateway.controlUi.allowInsecureAuth=true` in generated setup config for loopback Control UI compatibility. This keeps the post-onboarding default safe by no longer enabling `allowInsecureAuth` unless the user or an existing config sets it explicitly.

## Security impact

`gateway.controlUi.allowInsecureAuth` is already treated as an insecure/dangerous flag by `openclaw security audit`. New QuickStart setup should not write that warning-class flag by default.

This does not remove the compatibility flag. Users who intentionally need it can still configure it explicitly, and explicit `allowInsecureAuth=true` remains supported and audited.

## Compatibility note

There is a legitimate compatibility reason this flag may have been generated historically: it preserves local Control UI usability for localhost token/password flows when the browser cannot provide device identity in an insecure HTTP context.

This PR does not claim that `allowInsecureAuth` is a full remote auth bypass. The runtime policy still treats it as a local-only compatibility toggle, while `dangerouslyDisableDeviceAuth` remains the break-glass bypass.

The security issue is narrower: QuickStart silently persists a warning-class security downgrade into generated config. A user can complete normal onboarding and end up with `gateway.controlUi.allowInsecureAuth=true` without making an explicit security choice, and `openclaw security audit` later reports that generated state as insecure.

This PR keeps the compatibility mechanism intact for users who intentionally need it. It only removes the automatic QuickStart writer path. If localhost token-only compatibility should remain part of onboarding, it should be made explicit with a setup prompt, warning, or documented opt-in path instead of silently persisting the insecure flag.

The current PR head also adds explicit regression coverage proving that QuickStart still preserves an intentional `gateway.controlUi.allowInsecureAuth=true` opt-in from existing config.

## Real behavior proof

- Behavior or issue addressed: Interactive QuickStart/local onboarding should not leave `gateway.controlUi.allowInsecureAuth=true` in the generated config unless it was explicitly configured.
- Real environment tested: Local source checkout on Linux, Node via repo source runner, isolated `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH` under `/home/rev/tmp/openclaw-78855-interactive-quickstart-source`; validated PR HEAD `01f2bc3e0d0fb5807dd28472509e50dcc66d76d0`.
- Exact steps or command run after this patch: `script -qfec 'node -e "console.log(\"stdin isTTY:\", Boolean(process.stdin.isTTY)); console.log(\"stdout isTTY:\", Boolean(process.stdout.isTTY))"; node scripts/run-node.mjs onboard --flow quickstart --mode local --accept-risk --auth-choice skip --skip-channels --skip-skills --skip-search --skip-hooks --skip-daemon --skip-health --skip-ui' /dev/null`, then read `$OPENCLAW_CONFIG_PATH` and checked `gateway.controlUi.allowInsecureAuth`.
- Evidence after fix: terminal output from `/tmp/openclaw-pr78855-interactive-source-proof.log`:

```text
HEAD: 01f2bc3e0d0fb5807dd28472509e50dcc66d76d0
stdin isTTY: true
stdout isTTY: true
OpenClaw 2026.5.31 (01f2bc3)

OpenClaw setup
QuickStart
  Gateway port: 18789
  Gateway bind: Loopback (127.0.0.1)
  Gateway auth: Token (default)
  Tailscale exposure: Off
  Direct to chat channels.

Updated config: /home/rev/tmp/openclaw-78855-interactive-quickstart-source/config/openclaw.json
Workspace OK: $OPENCLAW_HOME/.openclaw/workspace
Sessions OK: /home/rev/tmp/openclaw-78855-interactive-quickstart-source/state/agents/main/sessions

Control UI
  Web UI: http://127.0.0.1:18789/
  Web UI (with token): <redacted tokenized local URL>
  Gateway WS: ws://127.0.0.1:18789
  Gateway: not detected (unauthorized: gateway token mismatch (provide gateway auth token))
  Docs: https://docs.openclaw.ai/web/control-ui

Onboarding complete. Use the dashboard link above to control OpenClaw.

CONFIG CHECK:
config: /home/rev/tmp/openclaw-78855-interactive-quickstart-source/config/openclaw.json
{}
OK: allowInsecureAuth is not true
```

- Observed result after fix: A TTY-backed interactive QuickStart/local setup through `runSetupWizard` and `configureGatewayForSetup` completed in the isolated config, and the final `gateway.controlUi` object was `{}`; `gateway.controlUi.allowInsecureAuth` was not `true`.
- What was not tested: Full daemon install and browser launch were not run; this PR is scoped to the shared QuickStart setup writer and generated config state. The Control UI summary path was exercised with `--skip-ui`, and the expected local Gateway probe reported not detected because no daemon was started in the isolated proof run.

## Additional proof details

Before patch, detached `origin/main` at `49e5091f180e3c1fd35d39b449c074d0f8670f60` still showed the QuickStart setup writer enabling the flag:

```text
COMMAND: node --import tsx --input-type=module <inline configureGatewayForSetup quickstart loopback>
{
  "allowInsecureAuth": true
}
VULNERABLE: allowInsecureAuth remains true after QuickStart setup writer
```

After patch, setup writer proof at validated head `01f2bc3e0d0fb5807dd28472509e50dcc66d76d0`:

```text
COMMAND: node --import tsx --input-type=module <inline configureGatewayForSetup quickstart loopback>
{}
OK: allowInsecureAuth is not true
```

Current PR head `04eac2dc034990a6c3862ca491518732d386b13d` adds test-only coverage for the explicit compatibility path:

```text
preserves explicit insecure local control ui auth opt-in in quickstart
```

Security audit still flags explicit insecure config:

```text
gateway.control_ui.insecure_auth Control UI insecure auth toggle enabled
config.insecure_or_dangerous_flags Insecure or dangerous config flag enabled
  Detected enabled flag: gateway.controlUi.allowInsecureAuth=true.
```

Safe generated config does not trigger the insecure-auth warning:

```text
{}
OK: safe onboarding audit did not report allowInsecureAuth
```

Note: local `openclaw security audit` printed an unrelated source-checkout warning about the WhatsApp persistedAuthState checker missing `@openclaw/normalization-core/string-coerce`; the audit still completed and produced the expected insecure-auth findings.

## Validation

Validation log: `/tmp/openclaw-pr78855-validation.log`
Proof logs: `/tmp/openclaw-pr78855-proof.log`, `/tmp/openclaw-pr78855-interactive-source-proof.log`

Validated head `01f2bc3e0d0fb5807dd28472509e50dcc66d76d0`:

- `env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.wizard.config.ts src/wizard/setup.gateway-config.test.ts` - 1 file, 11 tests passed
- `env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server/ws-connection/connect-policy.test.ts src/gateway/server.auth.control-ui.test.ts` - 2 files, 38 tests passed
- `env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/security/audit-gateway-exposure.test.ts` - 1 file, 15 tests passed
- `env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-startup-log.test.ts` - 1 file, 8 tests passed
- `pnpm -s exec oxfmt --check --threads=1 --config .oxfmtrc.jsonc src/wizard/setup.gateway-config.ts src/wizard/setup.gateway-config.test.ts` - passed
- `git diff --check` - passed
- `timeout 240s pnpm -s tsgo:core` - passed

Follow-up commit `04eac2dc034990a6c3862ca491518732d386b13d` is test-only and adds explicit opt-in preservation coverage. The targeted wizard command above should now report 12 tests when rerun at current head.

Not run: full `pnpm test` and full `pnpm lint`; this PR is intentionally scoped to the QuickStart setup writer and nearby gateway/security coverage above.