### PR TITLE
fix(models): keep generated secret refs out of plaintext

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -348,7 +348,7 @@ Custom providers in `models.providers` are written into `models.json` under the 
 
     - Non-empty `baseUrl` already present in the agent `models.json` wins.
     - Non-empty `apiKey` in the agent `models.json` wins only when that provider is not SecretRef-managed in current config/auth-profile context.
-    - SecretRef-managed provider `apiKey` values are refreshed from source markers (`ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs) instead of persisting resolved secrets.
+    - SecretRef-managed provider `apiKey` values are refreshed from source markers (`secretref-env:ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs) instead of persisting resolved secrets.
     - SecretRef-managed provider header values are refreshed from source markers (`secretref-env:ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs).
     - Empty or missing agent `apiKey`/`baseUrl` fall back to config `models.providers`.
     - Other provider fields are refreshed from config and normalized catalog data.

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -515,7 +515,7 @@ Configuring a custom/local provider `baseUrl` is also the narrow network trust d
     - Merge precedence for matching provider IDs:
       - Non-empty agent `models.json` `baseUrl` values win.
       - Non-empty agent `apiKey` values win only when that provider is not SecretRef-managed in current config/auth-profile context.
-      - SecretRef-managed provider `apiKey` values are refreshed from source markers (`ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs) instead of persisting resolved secrets.
+      - SecretRef-managed provider `apiKey` values are refreshed from source markers (`secretref-env:ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs) instead of persisting resolved secrets.
       - SecretRef-managed provider header values are refreshed from source markers (`secretref-env:ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs).
       - Empty or missing agent `apiKey`/`baseUrl` fall back to `models.providers` in config.
       - Matching model `contextWindow`/`maxTokens` use the higher value between explicit config and implicit catalog values.

--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -27,6 +27,7 @@ export const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
 export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
 /** Prefix for secret-ref header markers that name an env-backed source. */
 export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
+export const SECRETREF_ENV_API_KEY_MARKER_PREFIX = SECRETREF_ENV_HEADER_MARKER_PREFIX;
 
 const AWS_SDK_ENV_MARKERS = new Set([
   "AWS_BEARER_TOKEN_BEDROCK",
@@ -100,6 +101,11 @@ export function isOAuthApiKeyMarker(value: string): boolean {
 /** Resolve the API-key placeholder for a non-env secret-ref source. */
 export function resolveNonEnvSecretRefApiKeyMarker(_source: SecretRefSource): string {
   return NON_ENV_SECRETREF_MARKER;
+}
+
+/** Resolve the API-key placeholder for an env-backed secret-ref source. */
+export function resolveEnvSecretRefApiKeyMarker(envVarName: string): string {
+  return `${SECRETREF_ENV_API_KEY_MARKER_PREFIX}${envVarName.trim()}`;
 }
 
 /** Resolve the header-value placeholder for a non-env secret-ref source. */

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -7,7 +7,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { saveAuthProfileStore } from "./auth-profiles/store.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  saveAuthProfileStore,
+} from "./auth-profiles/store.js";
 import { unsetEnv, withTempEnv } from "./models-config.e2e-harness.js";
 import {
   planOpenClawModelsJsonWithDeps,
@@ -407,6 +410,74 @@ describe("models-config", () => {
     expect(parsed.providers?.openai?.apiKey).toBe("OPENAI_API_KEY");
   });
 
+  it("writes auth-profile env apiKey refs as non-plaintext markers", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-models-auth-ref-"));
+    try {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "tensorix:default": {
+              type: "api_key",
+              provider: "tensorix",
+              keyRef: {
+                source: "env",
+                provider: "default",
+                id: "TENSORIX_API_KEY",
+              },
+            },
+          },
+        },
+        agentDir,
+        { filterExternalAuthProfiles: false, syncExternalCli: false },
+      );
+      clearRuntimeAuthProfileStoreSnapshots();
+
+      const plan = await planOpenClawModelsJsonWithDeps(
+        {
+          cfg: {
+            models: {
+              providers: {
+                tensorix: {
+                  baseUrl: "https://api.tensorix.ai/v1",
+                  api: "openai-completions",
+                  models: [
+                    {
+                      id: "tensorix/deepseek/deepseek-v4-pro",
+                      name: "DeepSeek V4 Pro",
+                      reasoning: false,
+                      input: ["text"],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 64_000,
+                      maxTokens: 8_192,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          agentDir,
+          env: {},
+          existingRaw: "",
+          existingParsed: null,
+        },
+        {
+          resolveImplicitProviders: async () => ({}),
+        },
+      );
+
+      expect(plan.action).toBe("write");
+      const parsed = JSON.parse(plan.action === "write" ? plan.contents : "{}") as {
+        providers?: Record<string, { apiKey?: string }>;
+      };
+      expect(parsed.providers?.tensorix?.apiKey).toBe("secretref-env:TENSORIX_API_KEY"); // pragma: allowlist secret
+      expect(parsed.providers?.tensorix?.apiKey).not.toBe("TENSORIX_API_KEY"); // pragma: allowlist secret
+    } finally {
+      clearRuntimeAuthProfileStoreSnapshots();
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("normalizes retired Gemini ids preserved from existing models.json rows", async () => {
     const plan = await planOpenClawModelsJsonWithDeps(
       {
@@ -519,11 +590,14 @@ describe("models-config", () => {
         >;
       };
       expect(parsed.providers?.["google-vertex"]?.api).toBe("google-vertex");
-      expect(parsed.providers?.["google-vertex"]?.apiKey).toBe("GOOGLE_CLOUD_API_KEY");
+      expect(parsed.providers?.["google-vertex"]?.apiKey).toBe(
+        "secretref-env:GOOGLE_CLOUD_API_KEY",
+      );
       expect(parsed.providers?.["google-vertex"]?.models?.map((model) => model.id)).toEqual([
         "gemini-2.5-pro",
       ]);
     } finally {
+      clearRuntimeAuthProfileStoreSnapshots();
       await fs.rm(agentDir, { recursive: true, force: true });
     }
   });

--- a/src/agents/models-config.providers.auth-aliases.test.ts
+++ b/src/agents/models-config.providers.auth-aliases.test.ts
@@ -140,13 +140,13 @@ describe("provider auth aliases", () => {
     });
 
     expectAuthResult(resolveAuth("fixture-provider"), {
-      apiKey: "FIXTURE_PROVIDER_API_KEY",
+      apiKey: "secretref-env:FIXTURE_PROVIDER_API_KEY",
       mode: "api_key",
       source: "profile",
       profileId: "fixture-provider:default",
     });
     expectAuthResult(resolveAuth("fixture-provider-plan"), {
-      apiKey: "FIXTURE_PROVIDER_API_KEY",
+      apiKey: "secretref-env:FIXTURE_PROVIDER_API_KEY",
       mode: "api_key",
       source: "profile",
       profileId: "fixture-provider:default",

--- a/src/agents/models-config.providers.auth-provenance.test.ts
+++ b/src/agents/models-config.providers.auth-provenance.test.ts
@@ -80,9 +80,9 @@ describe("models-config provider auth provenance", () => {
       })?.apiKey;
       const volcengineProviders = buildPairedApiKeyProviders(volcengineApiKey ?? "");
 
-      expect(volcengineProviders.provider.apiKey).toBe("VOLCANO_ENGINE_API_KEY");
-      expect(volcengineProviders.paired.apiKey).toBe("VOLCANO_ENGINE_API_KEY");
-      expect(togetherApiKey).toBe("TOGETHER_API_KEY");
+      expect(volcengineProviders.provider.apiKey).toBe("secretref-env:VOLCANO_ENGINE_API_KEY");
+      expect(volcengineProviders.paired.apiKey).toBe("secretref-env:VOLCANO_ENGINE_API_KEY");
+      expect(togetherApiKey).toBe("secretref-env:TOGETHER_API_KEY");
     } finally {
       envSnapshot.restore();
     }
@@ -137,7 +137,7 @@ describe("models-config provider auth provenance", () => {
     );
 
     expect(auth("openai")).toEqual({
-      apiKey: "OPENAI_PROFILE_KEY",
+      apiKey: "secretref-env:OPENAI_PROFILE_KEY",
       discoveryApiKey: undefined,
       mode: "api_key",
       source: "profile",

--- a/src/agents/models-config.providers.cloudflare-ai-gateway.test.ts
+++ b/src/agents/models-config.providers.cloudflare-ai-gateway.test.ts
@@ -55,7 +55,7 @@ describe("cloudflare-ai-gateway profile provenance", () => {
           },
         },
       });
-      expect(provider?.apiKey).toBe("CLOUDFLARE_AI_GATEWAY_API_KEY");
+      expect(provider?.apiKey).toBe("secretref-env:CLOUDFLARE_AI_GATEWAY_API_KEY");
     } finally {
       envSnapshot.restore();
     }

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -271,7 +271,7 @@ describe("normalizeProviders", () => {
         secretRefManagedProviders,
       });
 
-      expect(normalized?.custom?.apiKey).toBe("CUSTOM_PROVIDER_API_KEY"); // pragma: allowlist secret
+      expect(normalized?.custom?.apiKey).toBe("secretref-env:CUSTOM_PROVIDER_API_KEY"); // pragma: allowlist secret
       expect(secretRefManagedProviders.has("custom")).toBe(true);
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
@@ -315,7 +315,7 @@ describe("normalizeProviders", () => {
         env: process.env,
       });
 
-      expect(resolved?.apiKey).toBe("MINIMAX_API_KEY"); // pragma: allowlist secret
+      expect(resolved?.apiKey).toBe("secretref-env:MINIMAX_API_KEY"); // pragma: allowlist secret
       expect(resolved?.source).toBe("env-ref");
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
@@ -380,7 +380,7 @@ describe("normalizeProviders", () => {
       sourceProviders,
     });
     expect((enforced as Record<string, unknown>).openai).toBeNull();
-    expect(enforced?.moonshot?.apiKey).toBe("MOONSHOT_API_KEY"); // pragma: allowlist secret
+    expect(enforced?.moonshot?.apiKey).toBe("secretref-env:MOONSHOT_API_KEY"); // pragma: allowlist secret
   });
 
   it("canonicalizes LM Studio baseUrl after merge-style explicit overwrite", async () => {

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -9,6 +9,7 @@ import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveEnvApiKey, type EnvApiKeyLookupOptions } from "./model-auth-env.js";
 import {
   isNonSecretApiKeyMarker,
+  resolveEnvSecretRefApiKeyMarker,
   resolveEnvSecretRefHeaderValueMarker,
   resolveNonEnvSecretRefApiKeyMarker,
   resolveNonEnvSecretRefHeaderValueMarker,
@@ -157,7 +158,7 @@ export function resolveApiKeyFromCredential(
       if (keyRef.source === "env") {
         const envVar = keyRef.id.trim();
         return {
-          apiKey: envVar,
+          apiKey: resolveEnvSecretRefApiKeyMarker(envVar),
           source: "env-ref",
           discoveryApiKey: toDiscoveryApiKey(env[envVar]),
         };
@@ -182,7 +183,7 @@ export function resolveApiKeyFromCredential(
       if (tokenRef.source === "env") {
         const envVar = tokenRef.id.trim();
         return {
-          apiKey: envVar,
+          apiKey: resolveEnvSecretRefApiKeyMarker(envVar),
           source: "env-ref",
           discoveryApiKey: toDiscoveryApiKey(env[envVar]),
         };
@@ -245,7 +246,7 @@ export function normalizeConfiguredProviderApiKey(params: {
     // Non-env secret refs intentionally become markers; loaders can route without exposing values.
     const marker =
       configuredApiKeyRef.source === "env"
-        ? configuredApiKeyRef.id.trim()
+        ? resolveEnvSecretRefApiKeyMarker(configuredApiKeyRef.id)
         : resolveNonEnvSecretRefApiKeyMarker(configuredApiKeyRef.source);
     params.secretRefManagedProviders?.add(params.providerKey);
     if (params.provider.apiKey === marker) {

--- a/src/agents/models-config.providers.source-managed.ts
+++ b/src/agents/models-config.providers.source-managed.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { isRecord } from "../utils.js";
 import {
+  resolveEnvSecretRefApiKeyMarker,
   resolveNonEnvSecretRefApiKeyMarker,
   resolveNonEnvSecretRefHeaderValueMarker,
   resolveEnvSecretRefHeaderValueMarker,
@@ -48,7 +49,7 @@ function resolveSourceManagedApiKeyMarker(params: {
     return undefined;
   }
   return sourceApiKeyRef.source === "env"
-    ? sourceApiKeyRef.id.trim()
+    ? resolveEnvSecretRefApiKeyMarker(sourceApiKeyRef.id)
     : resolveNonEnvSecretRefApiKeyMarker(sourceApiKeyRef.source);
 }
 

--- a/src/agents/models-config.providers.vercel-ai-gateway.test.ts
+++ b/src/agents/models-config.providers.vercel-ai-gateway.test.ts
@@ -50,7 +50,7 @@ describe("vercel-ai-gateway provider resolution", () => {
 
     const auth = resolveAuth("vercel-ai-gateway");
     // Persist the env marker, not the resolved plaintext profile key.
-    expect(auth.apiKey).toBe("AI_GATEWAY_API_KEY");
+    expect(auth.apiKey).toBe("secretref-env:AI_GATEWAY_API_KEY");
     expect(auth.mode).toBe("api_key");
     expect(auth.source).toBe("profile");
     expect(auth.profileId).toBe("vercel-ai-gateway:default");

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -292,7 +292,7 @@ describe("models-config runtime source snapshot", () => {
       providers: runtimeConfig.models!.providers!,
       sourceProviders: sourceConfig.models!.providers,
     })!;
-    expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+    expect(providers.openai?.apiKey).toBe("secretref-env:OPENAI_API_KEY"); // pragma: allowlist secret
     expect(providers.moonshot?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
   });
 
@@ -314,7 +314,7 @@ describe("models-config runtime source snapshot", () => {
       try {
         setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
         await ensureOpenClawModelsJson(clonedRuntimeConfig, agentDir);
-        await expectGeneratedProviderApiKey(agentDir, "openai", "OPENAI_API_KEY"); // pragma: allowlist secret
+        await expectGeneratedProviderApiKey(agentDir, "openai", "secretref-env:OPENAI_API_KEY"); // pragma: allowlist secret
       } finally {
         clearRuntimeConfigSnapshot();
         clearConfigCache();
@@ -332,7 +332,11 @@ describe("models-config runtime source snapshot", () => {
       try {
         setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
         await ensureOpenClawModelsJson(runtimeConfig, agentDir);
-        await expectGeneratedProviderApiKey(agentDir, "litellm", "OPENCLAW_MODEL_LITELLM_API_KEY"); // pragma: allowlist secret
+        await expectGeneratedProviderApiKey(
+          agentDir,
+          "litellm",
+          "secretref-env:OPENCLAW_MODEL_LITELLM_API_KEY", // pragma: allowlist secret
+        );
       } finally {
         clearRuntimeConfigSnapshot();
         clearConfigCache();
@@ -385,7 +389,7 @@ describe("models-config runtime source snapshot", () => {
           >;
         }>(agentDir);
         expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
-        expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+        expect(parsed.providers.openai?.apiKey).toBe("secretref-env:OPENAI_API_KEY"); // pragma: allowlist secret
         expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("one");
 
         // Header changes still rewrite models.json, but merge mode preserves the existing baseUrl.
@@ -397,7 +401,7 @@ describe("models-config runtime source snapshot", () => {
           >;
         }>(agentDir);
         expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
-        expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+        expect(parsed.providers.openai?.apiKey).toBe("secretref-env:OPENAI_API_KEY"); // pragma: allowlist secret
         expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("two");
       } finally {
         clearRuntimeConfigSnapshot();
@@ -419,7 +423,7 @@ describe("models-config runtime source snapshot", () => {
       config: createOpenAiRuntimeConfigWithHeadersAndApiKey(),
       sourceConfigForSecrets: withGatewayTokenMode(createOpenAiSourceConfigWithHeadersAndApiKey()),
     });
-    expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+    expect(providers.openai?.apiKey).toBe("secretref-env:OPENAI_API_KEY"); // pragma: allowlist secret
     expectOpenAiHeaderMarkers(providers);
   });
 });

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -218,7 +218,7 @@ describe("models-config", () => {
     );
 
     expect(auth("github-copilot")).toEqual({
-      apiKey: "COPILOT_REF_TOKEN",
+      apiKey: "secretref-env:COPILOT_REF_TOKEN",
       discoveryApiKey: "token-from-ref-env",
       mode: "token",
       source: "profile",

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -178,6 +178,40 @@ describe("ModelRegistry models.json auth", () => {
     });
   });
 
+  it("resolves models.json env SecretRef apiKey markers from process env", async () => {
+    const previous = process.env.TENSORIX_API_KEY;
+    process.env.TENSORIX_API_KEY = "sk-tensorix-runtime"; // pragma: allowlist secret
+    try {
+      const modelsPath = writeModelsJson({
+        providers: {
+          tensorix: {
+            baseUrl: "https://api.tensorix.ai/v1",
+            api: "openai-completions",
+            apiKey: "secretref-env:TENSORIX_API_KEY",
+            models: [{ id: "tensorix/deepseek/deepseek-v4-pro" }],
+          },
+        },
+      });
+
+      const registry = ModelRegistry.create(AuthStorage.inMemory(), modelsPath);
+      const model = registry.find("tensorix", "tensorix/deepseek/deepseek-v4-pro");
+
+      expect(registry.getError()).toBeUndefined();
+      expect(model).toBeDefined();
+      await expect(registry.getApiKeyAndHeaders(model!)).resolves.toEqual({
+        ok: true,
+        apiKey: "sk-tensorix-runtime",
+        headers: undefined,
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.TENSORIX_API_KEY;
+      } else {
+        process.env.TENSORIX_API_KEY = previous;
+      }
+    }
+  });
+
   it("ignores non-generated plugin catalog files", () => {
     // Plugin catalog shards are codegen artifacts; hand-written lookalikes must
     // not extend the provider registry.

--- a/src/agents/sessions/resolve-config-value.ts
+++ b/src/agents/sessions/resolve-config-value.ts
@@ -4,6 +4,7 @@
  */
 
 import { execSync, spawnSync } from "node:child_process";
+import { coerceSecretRef } from "../../config/types.secrets.js";
 import { getBashShellConfig } from "../shell-utils.js";
 
 // Cache for shell command results (persists for process lifetime)
@@ -15,6 +16,10 @@ const commandResultCache = new Map<string, string | undefined>();
  * - Otherwise checks environment variable first, then treats as literal (not cached)
  */
 export function resolveConfigValue(config: string): string | undefined {
+  const secretRef = coerceSecretRef(config);
+  if (secretRef) {
+    return secretRef.source === "env" ? process.env[secretRef.id] : undefined;
+  }
   if (config.startsWith("!")) {
     return executeCommand(config);
   }
@@ -94,6 +99,10 @@ function executeCommand(commandConfig: string): string | undefined {
  * Resolve all header values using the same resolution logic as API keys.
  */
 export function resolveConfigValueUncached(config: string): string | undefined {
+  const secretRef = coerceSecretRef(config);
+  if (secretRef) {
+    return secretRef.source === "env" ? process.env[secretRef.id] : undefined;
+  }
   if (config.startsWith("!")) {
     return executeCommandUncached(config);
   }

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -518,6 +518,102 @@ describe("secrets audit", () => {
     });
   });
 
+  it("does not flag stale bare env apiKey markers for current SecretRef-managed providers", async () => {
+    await fs.writeFile(fixture.envPath, "", "utf8");
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          tensorix: {
+            baseUrl: "https://api.tensorix.ai/v1",
+            api: "openai-completions",
+            models: [{ id: "tensorix/deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro" }],
+          },
+        },
+      },
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {
+        "tensorix:default": {
+          type: "api_key",
+          provider: "tensorix",
+          keyRef: { source: "env", provider: "default", id: "TENSORIX_API_KEY" },
+        },
+      },
+    });
+    await writeJsonFile(fixture.modelsPath, {
+      providers: {
+        tensorix: {
+          baseUrl: "https://api.tensorix.ai/v1",
+          api: "openai-completions",
+          apiKey: "TENSORIX_API_KEY",
+          models: [{ id: "tensorix/deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro" }],
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({
+      env: {
+        ...fixture.env,
+        TENSORIX_API_KEY: "env-tensorix-key", // pragma: allowlist secret
+      },
+    });
+
+    expectModelsFinding(report, {
+      code: "PLAINTEXT_FOUND",
+      jsonPath: "providers.tensorix.apiKey",
+      present: false,
+    });
+    expect(report.summary.plaintextCount).toBe(0);
+  });
+
+  it("still flags stale bare env apiKey markers that do not match current provider refs", async () => {
+    await fs.writeFile(fixture.envPath, "", "utf8");
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          tensorix: {
+            baseUrl: "https://api.tensorix.ai/v1",
+            api: "openai-completions",
+            models: [{ id: "tensorix/deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro" }],
+          },
+        },
+      },
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {
+        "tensorix:default": {
+          type: "api_key",
+          provider: "tensorix",
+          keyRef: { source: "env", provider: "default", id: "TENSORIX_API_KEY" },
+        },
+      },
+    });
+    await writeJsonFile(fixture.modelsPath, {
+      providers: {
+        tensorix: {
+          baseUrl: "https://api.tensorix.ai/v1",
+          api: "openai-completions",
+          apiKey: "OTHER_TENSORIX_API_KEY",
+          models: [{ id: "tensorix/deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro" }],
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({
+      env: {
+        ...fixture.env,
+        TENSORIX_API_KEY: "env-tensorix-key", // pragma: allowlist secret
+      },
+    });
+
+    expectModelsFinding(report, {
+      code: "PLAINTEXT_FOUND",
+      jsonPath: "providers.tensorix.apiKey",
+    });
+  });
+
   it("does not flag models.json header marker values as plaintext", async () => {
     await writeModelsProvider({
       headers: {

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -492,6 +492,22 @@ describe("secrets audit", () => {
     });
   });
 
+  it("does not flag models.json env SecretRef apiKey markers as plaintext", async () => {
+    await writeModelsProvider({ apiKey: "secretref-env:TENSORIX_API_KEY" }); // pragma: allowlist secret
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expectModelsFinding(report, {
+      code: "PLAINTEXT_FOUND",
+      jsonPath: "providers.openai.apiKey",
+      present: false,
+    });
+    expectModelsFinding(report, {
+      code: "REF_UNRESOLVED",
+      jsonPath: "providers.openai.apiKey",
+      present: false,
+    });
+  });
+
   it("flags arbitrary all-caps models.json apiKey values as plaintext", async () => {
     await writeModelsProvider({ apiKey: "ALLCAPS_SAMPLE" }); // pragma: allowlist secret
 

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -369,15 +369,18 @@ function collectModelsJsonSecrets(params: {
       continue;
     }
     const apiKey = providerValue.apiKey;
-    if (coerceSecretRef(apiKey)) {
-      addFinding(params.collector, {
-        code: "REF_UNRESOLVED",
-        severity: "error",
-        file: params.modelsJsonPath,
-        jsonPath: `providers.${providerId}.apiKey`,
-        message: "models.json contains an unresolved SecretRef object; regenerate models.json.",
-        provider: providerId,
-      });
+    const apiKeyRef = coerceSecretRef(apiKey);
+    if (apiKeyRef) {
+      if (typeof apiKey !== "string") {
+        addFinding(params.collector, {
+          code: "REF_UNRESOLVED",
+          severity: "error",
+          file: params.modelsJsonPath,
+          jsonPath: `providers.${providerId}.apiKey`,
+          message: "models.json contains an unresolved SecretRef object; regenerate models.json.",
+          provider: providerId,
+        });
+      }
     } else if (isNonEmptyString(apiKey) && !isNonSecretApiKeyMarker(apiKey)) {
       addFinding(params.collector, {
         code: "PLAINTEXT_FOUND",

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -109,6 +109,7 @@ type AuditCollector = {
   findings: SecretsAuditFinding[];
   refAssignments: RefAssignment[];
   configProviderRefPaths: Map<string, string[]>;
+  providerEnvRefMarkers: Map<string, Set<string>>;
   authProviderState: Map<string, ProviderAuthState>;
   filesScanned: Set<string>;
 };
@@ -131,6 +132,23 @@ function collectProviderRefPath(
     return;
   }
   collector.configProviderRefPaths.set(key, [configPath]);
+}
+
+function trackProviderEnvRefMarker(
+  collector: AuditCollector,
+  providerId: string | undefined,
+  ref: SecretRef,
+): void {
+  if (!providerId || ref.source !== "env" || !isNonEmptyString(ref.id)) {
+    return;
+  }
+  const key = normalizeProviderId(providerId);
+  let markers = collector.providerEnvRefMarkers.get(key);
+  if (!markers) {
+    markers = new Set<string>();
+    collector.providerEnvRefMarkers.set(key, markers);
+  }
+  markers.add(ref.id.trim());
 }
 
 function trackAuthProviderState(
@@ -208,6 +226,7 @@ function collectConfigSecrets(params: {
       if (target.entry.trackProviderShadowing && target.providerId) {
         collectProviderRefPath(params.collector, target.providerId, target.path);
       }
+      trackProviderEnvRefMarker(params.collector, target.providerId, ref);
       continue;
     }
 
@@ -265,6 +284,7 @@ function collectAuthStoreSecrets(params: {
           expected: "string",
           provider: entry.provider,
         });
+        trackProviderEnvRefMarker(params.collector, entry.provider, ref);
         trackAuthProviderState(params.collector, entry.provider, entry.kind);
       }
       if (authoredValueRef) {
@@ -381,7 +401,11 @@ function collectModelsJsonSecrets(params: {
           provider: providerId,
         });
       }
-    } else if (isNonEmptyString(apiKey) && !isNonSecretApiKeyMarker(apiKey)) {
+    } else if (
+      isNonEmptyString(apiKey) &&
+      !isNonSecretApiKeyMarker(apiKey) &&
+      !isCurrentProviderEnvRefMarker(params.collector, providerId, apiKey)
+    ) {
       addFinding(params.collector, {
         code: "PLAINTEXT_FOUND",
         severity: "warn",
@@ -429,6 +453,15 @@ function collectModelsJsonSecrets(params: {
       });
     }
   }
+}
+
+function isCurrentProviderEnvRefMarker(
+  collector: AuditCollector,
+  providerId: string,
+  value: string,
+): boolean {
+  const markers = collector.providerEnvRefMarkers.get(normalizeProviderId(providerId));
+  return markers?.has(value.trim()) ?? false;
 }
 
 async function collectUnresolvedRefFindings(params: {
@@ -630,6 +663,7 @@ export async function runSecretsAudit(
     findings: [],
     refAssignments: [],
     configProviderRefPaths: new Map(),
+    providerEnvRefMarkers: new Map(),
     authProviderState: new Map(),
     filesScanned: new Set([configPath]),
   };


### PR DESCRIPTION
Fixes #88562.

## Summary

- Persist generated env-backed SecretRef provider auth as `secretref-env:<NAME>` instead of a bare env var name.
- Resolve that marker through `process.env` at model registry request time.
- Treat string SecretRef markers as audit-safe while still flagging unresolved object SecretRefs and true plaintext strings.

## Real behavior proof

Behavior or issue addressed: Per-agent `models.json` generation could persist auth-profile env `keyRef` values as bare strings such as `TENSORIX_API_KEY`, which looked like plaintext to the deep security audit and produced false-positive `PLAINTEXT_FOUND` findings. The repair now covers both newly generated env-backed markers and stale existing `models.json` files when the current provider context has the matching env SecretRef.

Real environment tested: Local OpenClaw checkout at `/Users/andy/openclaw-88562`, branch `fix/models-json-secret-ref-88562`, commit `c6b55274f84698828a925b3c7a00fca96017ad30`.

Exact steps or command run after the rebase/conflict resolution:

```text
node scripts/run-vitest.mjs src/agents/sessions/model-registry.test.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.providers.normalize-keys.test.ts src/agents/models-config.providers.auth-provenance.test.ts src/agents/models-config.runtime-source-snapshot.test.ts src/secrets/audit.test.ts
git diff --check upstream/main..HEAD
git log --format='%h %an <%ae> %s' upstream/main..HEAD
```

Evidence after fix on the current head:

```text
node scripts/run-vitest.mjs ...
# passed: 2 Vitest shards, 6 files / 77 tests

git diff --check upstream/main..HEAD
# passed

git log --format='%h %an <%ae> %s' upstream/main..HEAD
# c6b55274f8 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> Fix stale models json secret ref audit markers
# 6b41cefd43 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> Fix models json secret ref api keys
```

Observed result after fix: The generated-provider coverage in `src/agents/models-config.applies-config-env-vars.test.ts` verifies a provider backed by an auth-profile env `keyRef` gets `apiKey: "secretref-env:TENSORIX_API_KEY"`, not the bare env var name. The model-registry coverage in `src/agents/sessions/model-registry.test.ts` verifies that marker resolves through `process.env.TENSORIX_API_KEY` at request time. The security-audit coverage in `src/secrets/audit.test.ts` verifies `secretref-env:TENSORIX_API_KEY` is not reported as `PLAINTEXT_FOUND`, a stale existing `models.json` value of `TENSORIX_API_KEY` is clean when Tensorix is currently managed by that exact env SecretRef, and a mismatched bare value such as `OTHER_TENSORIX_API_KEY` is still reported as `PLAINTEXT_FOUND`.

What was not tested: The source-tree CLI wrapper requires built `dist/entry.(m)js`, so the proof uses the patched generator, model registry, and security audit runtime through the focused test files rather than `node openclaw.mjs security audit --json`.

## Notes

- Maintainer can modify: enabled.
