### PR TITLE
test(agents): cover nonfatal trajectory flush timeout

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-flush-cleanup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-flush-cleanup.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flush-cleanup.js";
+
+describe("embedded attempt trajectory flush cleanup", () => {
+  const log = {
+    warn: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    log.warn.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("times out a stalled trajectory flush without rejecting attempt cleanup", async () => {
+    const flush = vi.fn(async () => new Promise<never>(() => {}));
+    const describeFlushState = vi.fn(
+      () => "pendingWrites=1 queuedBytes=704 activeOperation=file-append",
+    );
+
+    const result = flushEmbeddedAttemptTrajectoryRecorder({
+      runId: "run-trajectory",
+      sessionId: "session-trajectory",
+      trajectoryRecorder: {
+        describeFlushState,
+        flush,
+      },
+      log,
+      timeoutMs: 5,
+    });
+
+    await vi.advanceTimersByTimeAsync(4);
+    expect(log.warn).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toBeUndefined();
+
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(describeFlushState).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      "agent cleanup timed out: runId=run-trajectory sessionId=session-trajectory step=openclaw-trajectory-flush timeoutMs=5 details=pendingWrites=1 queuedBytes=704 activeOperation=file-append",
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-flush-cleanup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-flush-cleanup.ts
@@ -1,0 +1,30 @@
+import { runAgentCleanupStep } from "../../run-cleanup-timeout.js";
+
+export type EmbeddedAttemptTrajectoryRecorder = {
+  describeFlushState: () => string | undefined;
+  flush: () => Promise<void>;
+};
+
+export async function flushEmbeddedAttemptTrajectoryRecorder(params: {
+  runId: string;
+  sessionId: string;
+  trajectoryRecorder: EmbeddedAttemptTrajectoryRecorder | null;
+  log: {
+    warn: (message: string) => void;
+  };
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}): Promise<void> {
+  await runAgentCleanupStep({
+    runId: params.runId,
+    sessionId: params.sessionId,
+    step: "openclaw-trajectory-flush",
+    log: params.log,
+    env: params.env,
+    timeoutMs: params.timeoutMs,
+    getTimeoutDetails: () => params.trajectoryRecorder?.describeFlushState(),
+    cleanup: async () => {
+      await params.trajectoryRecorder?.flush();
+    },
+  });
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -162,7 +162,6 @@ import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "../../prompt-surface.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
-import { runAgentCleanupStep } from "../../run-cleanup-timeout.js";
 import { collectRuntimeChannelCapabilities } from "../../runtime-capabilities.js";
 import {
   logAgentRuntimeToolDiagnostics,
@@ -327,6 +326,7 @@ import {
   shouldWarnEmbeddedRunStageSummary,
 } from "./attempt-stage-timing.js";
 import { buildAttemptSystemPrompt } from "./attempt-system-prompt.js";
+import { flushEmbeddedAttemptTrajectoryRecorder } from "./attempt-trajectory-flush-cleanup.js";
 import {
   assembleAttemptContextEngine,
   buildLoopPromptCacheInfo,
@@ -5031,15 +5031,11 @@ export async function runEmbeddedAttempt(
           promptError: promptError ? formatErrorMessage(promptError) : undefined,
         });
       }
-      await runAgentCleanupStep({
+      await flushEmbeddedAttemptTrajectoryRecorder({
         runId: params.runId,
         sessionId: params.sessionId,
-        step: "openclaw-trajectory-flush",
         log,
-        getTimeoutDetails: () => trajectoryRecorder?.describeFlushState(),
-        cleanup: async () => {
-          await trajectoryRecorder?.flush();
-        },
+        trajectoryRecorder,
       });
       // Always tear down the session (and release the lock) before we leave this attempt.
       //


### PR DESCRIPTION
Fixes #88520.

## Summary

- Current `upstream/main` already makes trajectory flush cleanup nonfatal via `runAgentCleanupStep`.
- Extract the embedded-attempt flush boundary into a small helper.
- Add regression coverage proving a stalled trajectory recorder flush resolves after timeout and logs pending write details instead of rejecting cleanup.

## Real behavior proof

Behavior or issue addressed: The issue reported that a `pi-trajectory-flush` timeout could abort the agent run. Current `upstream/main` already uses the nonfatal cleanup timeout helper for `openclaw-trajectory-flush`; this patch locks that behavior at the embedded-attempt call boundary.

Real environment tested: Local OpenClaw checkout at `/Users/andy/openclaw-88520`, branch `fix/trajectory-flush-nonfatal-88520`, commit `6acb2ff7de`.

Exact steps or command run after the patch:

```text
node scripts/test-projects.mjs src/agents/embedded-agent-runner/run/attempt-trajectory-flush-cleanup.test.ts src/agents/run-cleanup-timeout.test.ts
node --import tsx --input-type=module <runtime-timeout-proof>
git log --format='%h %an <%ae> %s' upstream/main..HEAD
```

Evidence after fix:

```text
Test Files  2 passed (2)
Tests  12 passed (12)
[test] passed 1 Vitest shard in 6.35s

cleanup_resolved=true
elapsed_ms=12
warnings=["agent cleanup timed out: runId=proof-run sessionId=proof-session step=openclaw-trajectory-flush timeoutMs=<ms> details=pendingWrites=1 queuedBytes=42"]

6acb2ff7de Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> test: cover nonfatal trajectory flush timeout
```

Observed result after fix: A stalled trajectory recorder `flush()` resolves from the cleanup wrapper after the timeout, logs `agent cleanup timed out` with pending write details, and does not reject the attempt cleanup path.

What was not tested: I did not reproduce the reporter's macOS I/O pressure event; the regression uses fake timers and the runtime proof uses a stalled recorder promise with a short timeout to cover the reported failure mode deterministically.

## Notes

- Maintainer can modify: enabled.