### PR TITLE
fix(agents): preserve stop-finished OpenAI tool calls

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -6984,7 +6984,134 @@ describe("openai transport stream", () => {
     });
   });
 
-  it("strips tool call blocks when provider signals finish_reason stop", async () => {
+  it("promotes silent tool calls when provider signals finish_reason stop", async () => {
+    const model = {
+      id: "qwen3.6-27b",
+      name: "Qwen 3.6 27B",
+      api: "openai-completions",
+      provider: "vllm",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131072,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const output = createAssistantOutput(model);
+    const stream = { push: () => {} };
+
+    const mockChunks = [
+      {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "qwen3.6-27b",
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant" as const, content: "" },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "qwen3.6-27b",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_legit",
+                  function: { name: "bash", arguments: '{"cmd":"echo hi"}' },
+                },
+              ],
+            },
+            logprobs: null,
+            finish_reason: "stop",
+          },
+        ],
+      },
+    ] as const;
+
+    async function* mockStream() {
+      for (const chunk of mockChunks) {
+        yield chunk as never;
+      }
+    }
+
+    await testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
+
+    expect(output.stopReason).toBe("toolUse");
+    const toolCalls = output.content.filter(
+      (block) => (block as { type?: string }).type === "toolCall",
+    );
+    expect(toolCalls).toHaveLength(1);
+  });
+
+  it("does not promote tool calls when provider omits final finish_reason", async () => {
+    const model = {
+      id: "qwen3.6-27b",
+      name: "Qwen 3.6 27B",
+      api: "openai-completions",
+      provider: "vllm",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131072,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const output = createAssistantOutput(model);
+    const stream = { push: () => {} };
+
+    const mockChunks = [
+      {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "qwen3.6-27b",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_unfinished",
+                  function: { name: "bash", arguments: '{"cmd":"echo hi"}' },
+                },
+              ],
+            },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+    ] as const;
+
+    async function* mockStream() {
+      for (const chunk of mockChunks) {
+        yield chunk as never;
+      }
+    }
+
+    await testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
+
+    expect(output.stopReason).toBe("stop");
+    expect(
+      output.content.filter((block) => (block as { type?: string }).type === "toolCall"),
+    ).toStrictEqual([]);
+  });
+
+  it("strips tool call blocks when provider signals finish_reason stop after visible text", async () => {
     const model = {
       id: "llama-3.3-70b",
       name: "Llama 3.3 70B",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2545,6 +2545,7 @@ async function processOpenAICompletionsStream(
   const toolCallBlocksByIndex = new Map<number, ToolCallBlock>();
   const toolCallBlocksById = new Map<string, ToolCallBlock>();
   const toolCallBlockBytes = new WeakMap<ToolCallBlock, number>();
+  let sawStopFinishReason = false;
   const blockIndex = () => output.content.length - 1;
   const measureUtf8Bytes = (text: string) => Buffer.byteLength(text, "utf8");
   const finishCurrentBlock = () => {
@@ -2693,6 +2694,9 @@ async function processOpenAICompletionsStream(
     if (choice.finish_reason) {
       const finishReasonResult = mapStopReason(choice.finish_reason);
       output.stopReason = finishReasonResult.stopReason;
+      if (finishReasonResult.stopReason === "stop") {
+        sawStopFinishReason = true;
+      }
       if (finishReasonResult.errorMessage) {
         output.errorMessage = finishReasonResult.errorMessage;
       }
@@ -2804,8 +2808,14 @@ async function processOpenAICompletionsStream(
   currentBlock = null;
   flushPendingPostToolCallDeltas();
   const hasToolCalls = output.content.some((block) => block.type === "toolCall");
+  const hasVisibleText = output.content.some(
+    (block) => block.type === "text" && block.text.trim().length > 0,
+  );
   if (output.stopReason === "toolUse" && !hasToolCalls) {
     output.stopReason = "stop";
+  }
+  if (sawStopFinishReason && output.stopReason === "stop" && hasToolCalls && !hasVisibleText) {
+    output.stopReason = "toolUse";
   }
   if (hasToolCalls && output.stopReason !== "toolUse") {
     output.content = output.content.filter((block) => block.type !== "toolCall");

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2809,7 +2809,8 @@ async function processOpenAICompletionsStream(
   flushPendingPostToolCallDeltas();
   const hasToolCalls = output.content.some((block) => block.type === "toolCall");
   const hasVisibleText = output.content.some(
-    (block) => block.type === "text" && block.text.trim().length > 0,
+    (block) =>
+      block.type === "text" && typeof block.text === "string" && block.text.trim().length > 0,
   );
   if (output.stopReason === "toolUse" && !hasToolCalls) {
     output.stopReason = "stop";

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -138,7 +138,23 @@ describe("OpenAI-compatible completions params", () => {
 });
 
 describe("openai-completions stop-reason tool-call guard", () => {
-  it("strips toolCall blocks when finish_reason is stop but tool_calls were accumulated", async () => {
+  it("promotes silent tool_calls with finish_reason stop to toolUse", async () => {
+    mockChunksRef.chunks = [
+      makeToolCallChunk("call_1", "bash", '{"cmd":"ls"}'),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("toolUse");
+    const toolCalls = result.content.filter((b) => b.type === "toolCall");
+    expect(toolCalls).toHaveLength(1);
+  });
+
+  it("strips toolCall blocks when finish_reason is stop after visible text", async () => {
     mockChunksRef.chunks = [
       makeTextChunk("Hello"),
       makeToolCallChunk("call_1", "bash", '{"cmd":"ls"}'),

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -430,8 +430,14 @@ export const streamOpenAICompletions: StreamFunction<
       }
 
       const hasToolCalls = output.content.some((block) => block.type === "toolCall");
+      const hasVisibleText = output.content.some(
+        (block) => block.type === "text" && block.text.trim().length > 0,
+      );
       if (output.stopReason === "toolUse" && !hasToolCalls) {
         output.stopReason = "stop";
+      }
+      if (output.stopReason === "stop" && hasToolCalls && !hasVisibleText) {
+        output.stopReason = "toolUse";
       }
       if (hasToolCalls && output.stopReason !== "toolUse") {
         output.content = output.content.filter((block) => block.type !== "toolCall");


### PR DESCRIPTION
Fixes #88791

## Summary

- Preserve silent structured OpenAI-compatible tool calls when providers stream `tool_calls` but finish with `finish_reason: stop`.
- Keep stripping tool calls for visible-text `stop` responses, `length`/error completions, and transport streams that never emitted a final finish reason.
- Cover both the transport stream assembler and the legacy `openai-completions` provider path.

## Verification

- `pnpm format -- src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts`
- `node scripts/run-vitest.mjs src/llm/providers/openai-completions.test.ts src/agents/openai-transport-stream.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: structured `tool_calls` paired with `finish_reason: stop` no longer get stripped into a silent terminal assistant turn when there is no visible assistant text.

Real environment tested: local OpenClaw worktree running the actual OpenAI-compatible transport stream function against a loopback OpenAI-compatible SSE endpoint, with no provider credentials. Proof run timestamp: 2026-05-31 15:27 PDT.

Exact steps or command run after this patch: `node --import tsx /private/tmp/openclaw-real-proof-88791.mjs`

Evidence after fix: terminal output copied from the after-fix runtime proof:

```text
local OpenAI-compatible SSE endpoint: http://127.0.0.1:57954/v1
silent-stop-tool-call -> stopReason=toolUse; content=[toolCall:bash:{"cmd":"echo after-fix"}]
visible-stop-tool-call -> stopReason=stop; content=[text:"Visible answer."]
missing-finish-tool-call -> stopReason=stop; content=[]
```

Observed result after fix: the OpenClaw runtime preserved the silent structured tool call as `toolUse`, kept the visible-text `stop` response deliverable as text, and dropped the unfinished tool call when the stream ended without a final finish reason.

What was not tested: external vLLM/Qwen provider behavior and broad CI.
