### PR TITLE
fix(plugins): isolate web provider factory failures

### DIFF
--- a/src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts
@@ -38,6 +38,25 @@ const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => {
             }),
           };
         }
+        if (dirName === "mockplugin" && artifactBasename === "web-search-contract-api.js") {
+          return {
+            createFuzzpluginWebSearchProvider: () => {
+              throw new Error("fuzzplugin web provider factory failed");
+            },
+            createMockpluginWebSearchProvider: () => ({
+              ...providerBase,
+              id: "mockplugin",
+              createTool: () => null,
+            }),
+          };
+        }
+        if (dirName === "fuzzplugin" && artifactBasename === "web-search-contract-api.js") {
+          return {
+            createFuzzpluginWebSearchProvider: () => {
+              throw new Error("fuzzplugin web provider factory failed");
+            },
+          };
+        }
         if (dirName === "firecrawl" && artifactBasename === "web-fetch-contract-api.js") {
           return {
             createFirecrawlWebFetchProvider: () => ({
@@ -103,6 +122,37 @@ describe("web provider public artifacts explicit fast path", () => {
     expect(provider.createTool({ config: {} as never })).toBeNull();
     expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
       dirName: "brave",
+      artifactBasename: "web-search-contract-api.js",
+    });
+    expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("skips throwing bundled web provider factories while preserving healthy siblings", () => {
+    const provider = expectSingleProvider(
+      resolveBundledWebSearchProvidersFromPublicArtifacts({
+        onlyPluginIds: ["mockplugin"],
+      }),
+    );
+
+    expect(provider.pluginId).toBe("mockplugin");
+    expect(provider.id).toBe("mockplugin");
+    expect(provider.createTool({ config: {} as never })).toBeNull();
+    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+      dirName: "mockplugin",
+      artifactBasename: "web-search-contract-api.js",
+    });
+    expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when every matching bundled web provider factory fails", () => {
+    expect(() =>
+      resolveBundledWebSearchProvidersFromPublicArtifacts({
+        onlyPluginIds: ["fuzzplugin"],
+      }),
+    ).toThrow("Unable to initialize web providers for plugin fuzzplugin");
+
+    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+      dirName: "fuzzplugin",
       artifactBasename: "web-search-contract-api.js",
     });
     expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();

--- a/src/plugins/web-provider-public-artifacts.explicit.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit.ts
@@ -57,8 +57,9 @@ function collectProviderFactories<TProvider>(params: {
   mod: Record<string, unknown>;
   suffix: string;
   isProvider: (value: unknown) => value is TProvider;
-}): TProvider[] {
+}): { providers: TProvider[]; errors: unknown[] } {
   const providers: TProvider[] = [];
+  const errors: unknown[] = [];
   for (const [name, exported] of Object.entries(params.mod).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
@@ -70,12 +71,27 @@ function collectProviderFactories<TProvider>(params: {
     ) {
       continue;
     }
-    const candidate = exported();
+    let candidate: unknown;
+    try {
+      candidate = exported();
+    } catch (error) {
+      errors.push(error);
+      continue;
+    }
     if (params.isProvider(candidate)) {
       providers.push(candidate);
     }
   }
-  return providers;
+  return { providers, errors };
+}
+
+function unableToInitializeProviderError(params: {
+  pluginId: string;
+  errors: readonly unknown[];
+}): Error {
+  return new Error(`Unable to initialize web providers for plugin ${params.pluginId}`, {
+    cause: params.errors.length === 1 ? params.errors[0] : new AggregateError(params.errors),
+  });
 }
 
 function tryLoadBundledPublicArtifactModule(params: {
@@ -119,12 +135,18 @@ function loadBundledProviderEntriesFromDir<TProvider extends object>(params: {
   if (!mod) {
     return null;
   }
-  const providers = collectProviderFactories({
+  const { providers, errors } = collectProviderFactories({
     mod,
     suffix: params.suffix,
     isProvider: params.isProvider,
   });
   if (providers.length === 0) {
+    if (errors.length > 0) {
+      throw unableToInitializeProviderError({
+        pluginId: params.pluginId,
+        errors,
+      });
+    }
     return null;
   }
   return providers.map((provider) => Object.assign({}, provider, { pluginId: params.pluginId }));


### PR DESCRIPTION
## Summary

- isolates bundled web provider public-artifact factory projection so one throwing exported factory is skipped instead of hiding healthy sibling providers
- keeps broken single-provider artifacts loud by rethrowing an initialization error when no valid matching provider survives
- adds neutral `fuzzplugin` / `mockplugin` regressions for the partial-failure and all-factories-fail paths

## Verification

- `node scripts/run-vitest.mjs src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts --reporter=verbose` failed before the fix with `fuzzplugin web provider factory failed`, then passed after the fix: 1 shard / 5 tests
- `./node_modules/.bin/oxfmt --check src/plugins/web-provider-public-artifacts.explicit.ts src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts`: passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/plugins/web-provider-public-artifacts.explicit.ts src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts`: passed
- `git diff --check origin/main...HEAD`: passed
- added-line private-name scrub returned no reported private plugin/tool names
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean: no accepted/actionable findings
- AWS Crabbox: `node scripts/crabbox-wrapper.mjs run --provider aws --label web-provider-check-changed --shell -- "pnpm check:changed"` (`provider=aws`, `lease=cbx_dc3683aefcc7`, `run=run_41a2d2439eaa`, exit 0)

## Current CI note

GitHub checks currently show baseline failures in `check-lint`, `checks-node-agentic-control-plane-agent-chat`, and `checks-node-agentic-gateway-methods`. Those failures are outside this PR's two-file diff. The baseline fix is #88814, which is now clean on GitHub CI; this PR's focused tests, autoreview, and AWS `pnpm check:changed` proof are clean.

## Real behavior proof

Behavior addressed: a broken bundled web provider public-artifact factory can no longer make explicit web provider discovery fail before healthy sibling provider factories are projected.

Real environment tested: linked OpenClaw gwt worktree `fuzz-plugin-sdk-entrypoints-proof-20260601` at head `cfd0de2cb6ee5fa7cdce0f588b9b709f8a9fb0df`, plus remote AWS Crabbox `cbx_dc3683aefcc7`.

Exact steps or command run after this patch: ran the focused Vitest regression before and after the fix, then reran focused Vitest, oxfmt, oxlint, diff check, private-name scrub, structured autoreview, and remote `pnpm check:changed`.

Evidence after fix: the focused regression now skips the throwing `fuzzplugin` factory and still returns the healthy `mockplugin` web-search provider from the same public artifact module; a plugin artifact with only throwing matching factories now raises `Unable to initialize web providers for plugin fuzzplugin`; AWS Crabbox changed gate selected `core` and `coreTests` and exited 0.

Observed result after fix: healthy web provider entries remain discoverable while broken single-provider artifacts keep failing loudly instead of silently falling back as if no public artifact existed.

What was not tested: live external plugin process.
