### PR TITLE
perf: hydrate chat history session metadata

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -133,11 +133,12 @@ import { resolveSessionHistoryTailReadOptions } from "../session-history-state.j
 import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
 import {
   capArrayByJsonBytes,
+  buildGatewaySessionInfo,
+  getSessionDefaults,
   loadSessionEntry,
   readSessionMessageByIdAsync,
   readSessionMessagesAsync,
   resolveGatewayModelSupportsImages,
-  resolveGatewaySessionThinkingDefault,
   resolveDeletedAgentIdFromSessionKey,
   readRecentSessionMessagesAsync,
   resolveSessionModelRef,
@@ -156,6 +157,7 @@ import {
   buildWebchatAssistantMessageFromReplyPayloads,
   buildWebchatAudioContentBlocksFromReplyPayloads,
 } from "./chat-webchat-media.js";
+import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandlerOptions,
@@ -2418,7 +2420,10 @@ export const chatHandlers: GatewayRequestHandlers = {
       agentId: agentIdOverride,
     });
     const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
-    const { cfg, storePath, entry } = loadSessionEntry(sessionKey, sessionLoadOptions);
+    const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(
+      sessionKey,
+      sessionLoadOptions,
+    );
     const selectedAgent = validateChatSelectedAgent({
       cfg,
       requestedSessionKey: sessionKey,
@@ -2508,20 +2513,34 @@ export const chatHandlers: GatewayRequestHandlers = {
         `chat.history omitted oversized payloads placeholders=${placeholderCount} total=${chatHistoryPlaceholderEmitCount}`,
       );
     }
-    let thinkingLevel = entry?.thinkingLevel;
-    if (!thinkingLevel) {
-      thinkingLevel = resolveGatewaySessionThinkingDefault({
-        cfg,
-        agentId: sessionAgentId,
-        provider: resolvedSessionModel.provider,
-        model: resolvedSessionModel.model,
-      });
-    }
+    const sessionInfo = buildGatewaySessionInfo({
+      cfg,
+      storePath,
+      store,
+      key: canonicalKey,
+      entry,
+      agentId: selectedAgent.agentId,
+    });
+    sessionInfo.hasActiveRun = hasTrackedActiveSessionRun({
+      context,
+      requestedKey: sessionKey,
+      canonicalKey,
+      ...(canonicalKey === "global" && selectedAgent.agentId
+        ? { agentId: selectedAgent.agentId }
+        : {}),
+      defaultAgentId: resolveDefaultAgentId(cfg),
+    });
+    const defaults = getSessionDefaults(cfg, undefined, { allowPluginNormalization: false });
+    const thinkingLevel = sessionInfo.thinkingLevel ?? sessionInfo.thinkingDefault;
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
+    sessionInfo.thinkingLevel = thinkingLevel;
+    sessionInfo.verboseLevel = verboseLevel;
     respond(true, {
       sessionKey,
       sessionId,
       messages: bounded.messages,
+      defaults,
+      sessionInfo,
       thinkingLevel,
       fastMode: entry?.fastMode,
       verboseLevel,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2543,7 +2543,6 @@ export const chatHandlers: GatewayRequestHandlers = {
     const defaults = getSessionDefaults(cfg, modelCatalog, { allowPluginNormalization: false });
     const thinkingLevel = sessionInfo.thinkingLevel ?? sessionInfo.thinkingDefault;
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
-    sessionInfo.thinkingLevel = thinkingLevel;
     sessionInfo.verboseLevel = verboseLevel;
     respond(true, {
       sessionKey,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -158,6 +158,7 @@ import {
   buildWebchatAudioContentBlocksFromReplyPayloads,
 } from "./chat-webchat-media.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
+import { loadOptionalSessionMetadataModelCatalog } from "./session-model-catalog.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandlerOptions,
@@ -2513,6 +2514,14 @@ export const chatHandlers: GatewayRequestHandlers = {
         `chat.history omitted oversized payloads placeholders=${placeholderCount} total=${chatHistoryPlaceholderEmitCount}`,
       );
     }
+    const modelCatalog = await measureDiagnosticsTimelineSpan(
+      "gateway.chat.history.model_catalog",
+      () => loadOptionalSessionMetadataModelCatalog(context, "chat.history"),
+      {
+        config: cfg,
+        phase: "chat.history",
+      },
+    );
     const sessionInfo = buildGatewaySessionInfo({
       cfg,
       storePath,
@@ -2520,6 +2529,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       key: canonicalKey,
       entry,
       agentId: selectedAgent.agentId,
+      modelCatalog,
     });
     sessionInfo.hasActiveRun = hasTrackedActiveSessionRun({
       context,
@@ -2530,7 +2540,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         : {}),
       defaultAgentId: resolveDefaultAgentId(cfg),
     });
-    const defaults = getSessionDefaults(cfg, undefined, { allowPluginNormalization: false });
+    const defaults = getSessionDefaults(cfg, modelCatalog, { allowPluginNormalization: false });
     const thinkingLevel = sessionInfo.thinkingLevel ?? sessionInfo.thinkingDefault;
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
     sessionInfo.thinkingLevel = thinkingLevel;

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -1,0 +1,70 @@
+import { normalizeAgentId } from "../../routing/session-key.js";
+import type { GatewayRequestContext } from "./types.js";
+
+type TrackedActiveSessionRun = {
+  sessionKey: string;
+  agentId?: string;
+};
+
+function collectTrackedActiveSessionRuns(
+  context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>,
+): TrackedActiveSessionRun[] {
+  const runs: TrackedActiveSessionRun[] = [];
+  if (!(context.chatAbortControllers instanceof Map)) {
+    return runs;
+  }
+  for (const active of context.chatAbortControllers.values()) {
+    if (
+      active.projectSessionActive !== false &&
+      typeof active.sessionKey === "string" &&
+      active.sessionKey.trim()
+    ) {
+      runs.push({
+        sessionKey: active.sessionKey,
+        agentId: typeof active.agentId === "string" ? normalizeAgentId(active.agentId) : undefined,
+      });
+    }
+  }
+  return runs;
+}
+
+function isTrackedActiveSessionRunForKey(
+  active: TrackedActiveSessionRun,
+  key: string,
+  agentId?: string,
+  defaultAgentId?: string,
+): boolean {
+  if (active.sessionKey !== key) {
+    return false;
+  }
+  if (key !== "global" || agentId === undefined) {
+    return true;
+  }
+  const activeAgentId = active.agentId ?? defaultAgentId;
+  return activeAgentId ? normalizeAgentId(activeAgentId) === normalizeAgentId(agentId) : false;
+}
+
+export function hasTrackedActiveSessionRun(params: {
+  context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>;
+  requestedKey: string;
+  canonicalKey: string;
+  agentId?: string;
+  defaultAgentId?: string;
+}): boolean {
+  const activeRuns = collectTrackedActiveSessionRuns(params.context);
+  return activeRuns.some(
+    (active) =>
+      isTrackedActiveSessionRunForKey(
+        active,
+        params.canonicalKey,
+        params.agentId,
+        params.defaultAgentId,
+      ) ||
+      isTrackedActiveSessionRunForKey(
+        active,
+        params.requestedKey,
+        params.agentId,
+        params.defaultAgentId,
+      ),
+  );
+}

--- a/src/gateway/server-methods/session-model-catalog.ts
+++ b/src/gateway/server-methods/session-model-catalog.ts
@@ -1,0 +1,38 @@
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import type { GatewayRequestContext } from "./types.js";
+
+const SESSION_METADATA_MODEL_CATALOG_TIMEOUT_MS = 750;
+
+let loggedSlowSessionMetadataCatalog = false;
+
+export async function loadOptionalSessionMetadataModelCatalog(
+  context: GatewayRequestContext,
+  surface: string,
+): Promise<ModelCatalogEntry[] | undefined> {
+  let timeout: NodeJS.Timeout | undefined;
+  const timedOut = Symbol("session-metadata-model-catalog-timeout");
+  const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
+    timeout = setTimeout(() => resolve(timedOut), SESSION_METADATA_MODEL_CATALOG_TIMEOUT_MS);
+    timeout.unref?.();
+  });
+  try {
+    const result = await Promise.race([
+      context.loadGatewayModelCatalog().catch(() => undefined),
+      timeoutPromise,
+    ]);
+    if (result === timedOut) {
+      if (!loggedSlowSessionMetadataCatalog) {
+        loggedSlowSessionMetadataCatalog = true;
+        context.logGateway.debug(
+          `${surface} continuing without model catalog after ${SESSION_METADATA_MODEL_CATALOG_TIMEOUT_MS}ms`,
+        );
+      }
+      return undefined;
+    }
+    return Array.isArray(result) ? result : undefined;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -120,6 +120,7 @@ import { applySessionsPatchToStore } from "../sessions-patch.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { chatHandlers } from "./chat.js";
+import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
 import type {
   GatewayClient,
   GatewayRequestContext,
@@ -723,74 +724,6 @@ function resolveScopedAbortKey(params: {
   });
 }
 
-type TrackedActiveSessionRun = {
-  sessionKey: string;
-  agentId?: string;
-};
-
-function collectTrackedActiveSessionRuns(
-  context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>,
-): TrackedActiveSessionRun[] {
-  const runs: TrackedActiveSessionRun[] = [];
-  if (!(context.chatAbortControllers instanceof Map)) {
-    return runs;
-  }
-  for (const active of context.chatAbortControllers.values()) {
-    if (
-      active.projectSessionActive !== false &&
-      typeof active.sessionKey === "string" &&
-      active.sessionKey.trim()
-    ) {
-      runs.push({
-        sessionKey: active.sessionKey,
-        agentId: typeof active.agentId === "string" ? normalizeAgentId(active.agentId) : undefined,
-      });
-    }
-  }
-  return runs;
-}
-
-function isTrackedActiveSessionRunForKey(
-  active: TrackedActiveSessionRun,
-  key: string,
-  agentId?: string,
-  defaultAgentId?: string,
-): boolean {
-  if (active.sessionKey !== key) {
-    return false;
-  }
-  if (key !== "global" || agentId === undefined) {
-    return true;
-  }
-  const activeAgentId = active.agentId ?? defaultAgentId;
-  return activeAgentId ? normalizeAgentId(activeAgentId) === normalizeAgentId(agentId) : false;
-}
-
-function hasTrackedActiveSessionRun(params: {
-  context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>;
-  requestedKey: string;
-  canonicalKey: string;
-  agentId?: string;
-  defaultAgentId?: string;
-}): boolean {
-  const activeRuns = collectTrackedActiveSessionRuns(params.context);
-  return activeRuns.some(
-    (active) =>
-      isTrackedActiveSessionRunForKey(
-        active,
-        params.canonicalKey,
-        params.agentId,
-        params.defaultAgentId,
-      ) ||
-      isTrackedActiveSessionRunForKey(
-        active,
-        params.requestedKey,
-        params.agentId,
-        params.defaultAgentId,
-      ),
-  );
-}
-
 function resolveSessionMessageSubscriptionKey(params: {
   canonicalKey: string;
   agentId?: string;
@@ -1169,17 +1102,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         const sessions = measureDiagnosticsTimelineSpanSync(
           "gateway.sessions.list.active_run_flags",
           () => {
-            const activeRuns = collectTrackedActiveSessionRuns(context);
             return result.sessions.map((session) =>
               Object.assign({}, session, {
-                hasActiveRun: activeRuns.some((active) =>
-                  isTrackedActiveSessionRunForKey(
-                    active,
-                    session.key,
-                    session.key === "global" ? p.agentId : undefined,
-                    resolveDefaultAgentId(cfg),
-                  ),
-                ),
+                hasActiveRun: hasTrackedActiveSessionRun({
+                  context,
+                  requestedKey: session.key,
+                  canonicalKey: session.key,
+                  ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
+                  defaultAgentId: resolveDefaultAgentId(cfg),
+                }),
               }),
             );
           },

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -121,6 +121,7 @@ import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { chatHandlers } from "./chat.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
+import { loadOptionalSessionMetadataModelCatalog } from "./session-model-catalog.js";
 import type {
   GatewayClient,
   GatewayRequestContext,
@@ -198,44 +199,10 @@ function inheritSessionRuntimeSelection(
 type SessionsRuntimeModule = typeof import("./sessions.runtime.js");
 
 let sessionsRuntimeModulePromise: Promise<SessionsRuntimeModule> | undefined;
-let loggedSlowSessionsListCatalog = false;
-
-const SESSIONS_LIST_MODEL_CATALOG_TIMEOUT_MS = 750;
 
 function loadSessionsRuntimeModule(): Promise<SessionsRuntimeModule> {
   sessionsRuntimeModulePromise ??= import("./sessions.runtime.js");
   return sessionsRuntimeModulePromise;
-}
-
-async function loadOptionalSessionsListModelCatalog(
-  context: GatewayRequestContext,
-): Promise<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>> | undefined> {
-  let timeout: NodeJS.Timeout | undefined;
-  const timedOut = Symbol("sessions-list-model-catalog-timeout");
-  const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
-    timeout = setTimeout(() => resolve(timedOut), SESSIONS_LIST_MODEL_CATALOG_TIMEOUT_MS);
-    timeout.unref?.();
-  });
-  try {
-    const result = await Promise.race([
-      context.loadGatewayModelCatalog().catch(() => undefined),
-      timeoutPromise,
-    ]);
-    if (result === timedOut) {
-      if (!loggedSlowSessionsListCatalog) {
-        loggedSlowSessionsListCatalog = true;
-        context.logGateway.debug(
-          `sessions.list continuing without model catalog after ${SESSIONS_LIST_MODEL_CATALOG_TIMEOUT_MS}ms`,
-        );
-      }
-      return undefined;
-    }
-    return Array.isArray(result) ? result : undefined;
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  }
 }
 
 function requireSessionKey(key: unknown, respond: RespondFn): string | null {
@@ -1075,7 +1042,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           : store;
         const modelCatalog = await measureDiagnosticsTimelineSpan(
           "gateway.sessions.list.model_catalog",
-          () => loadOptionalSessionsListModelCatalog(context),
+          () => loadOptionalSessionMetadataModelCatalog(context, "sessions.list"),
           {
             config: cfg,
             phase: "sessions.list",

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -245,10 +245,28 @@ describe("gateway server chat", () => {
       expect(responses).toHaveLength(1);
       expect(responses[0]?.ok).toBe(true);
       const payload = responses[0]?.payload as
-        | { sessionKey?: string; sessionId?: string; messages?: unknown }
+        | {
+            sessionKey?: string;
+            sessionId?: string;
+            messages?: unknown;
+            defaults?: { modelProvider?: string | null };
+            sessionInfo?: {
+              key?: string;
+              sessionId?: string;
+              modelProvider?: string;
+              model?: string;
+            };
+          }
         | undefined;
       expect(payload?.sessionKey).toBe("main");
       expect(payload?.sessionId).toBe("sess-main");
+      expect(payload?.defaults?.modelProvider).toBe("test-provider");
+      expect(payload?.sessionInfo).toMatchObject({
+        key: "agent:main:main",
+        sessionId: "sess-main",
+        modelProvider: "test-provider",
+        model: "slow-catalog-model",
+      });
       expect(Array.isArray(payload?.messages)).toBe(true);
     } finally {
       clearConfigCache();

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -192,30 +192,36 @@ async function prepareMainHistoryHarness(params: {
 }
 
 describe("gateway server chat", () => {
-  test("chat.history does not wait for model catalog discovery to return history", async () => {
+  test("chat.history returns catalog-backed session metadata with history", async () => {
     const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       testState.agentConfig = {
-        model: { primary: "test-provider/slow-catalog-model" },
+        model: { primary: "test-provider/catalog-model" },
       };
       await writeSessionStore({
         entries: {
           main: {
             sessionId: "sess-main",
             modelProvider: "test-provider",
-            model: "slow-catalog-model",
+            model: "catalog-model",
             updatedAt: Date.now(),
           },
         },
       });
       const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
       const context = {
-        loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(
-          async () => {
-            throw new Error("model catalog should not load for chat.history");
-          },
-        ),
+        loadGatewayModelCatalog: vi
+          .fn<GatewayRequestContext["loadGatewayModelCatalog"]>()
+          .mockResolvedValue([
+            {
+              provider: "test-provider",
+              id: "catalog-model",
+              name: "Catalog Model",
+              reasoning: true,
+              compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
+            },
+          ]),
         logGateway: {
           info: vi.fn(),
           warn: vi.fn(),
@@ -241,7 +247,7 @@ describe("gateway server chat", () => {
         context,
       });
 
-      expect(context.loadGatewayModelCatalog).not.toHaveBeenCalled();
+      expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
       expect(responses).toHaveLength(1);
       expect(responses[0]?.ok).toBe(true);
       const payload = responses[0]?.payload as
@@ -249,24 +255,30 @@ describe("gateway server chat", () => {
             sessionKey?: string;
             sessionId?: string;
             messages?: unknown;
-            defaults?: { modelProvider?: string | null };
+            defaults?: {
+              modelProvider?: string | null;
+              thinkingLevels?: Array<{ id?: string }>;
+            };
             sessionInfo?: {
               key?: string;
               sessionId?: string;
               modelProvider?: string;
               model?: string;
+              thinkingLevels?: Array<{ id?: string }>;
             };
           }
         | undefined;
       expect(payload?.sessionKey).toBe("main");
       expect(payload?.sessionId).toBe("sess-main");
       expect(payload?.defaults?.modelProvider).toBe("test-provider");
+      expect(payload?.defaults?.thinkingLevels?.map((level) => level.id)).toContain("xhigh");
       expect(payload?.sessionInfo).toMatchObject({
         key: "agent:main:main",
         sessionId: "sess-main",
         modelProvider: "test-provider",
-        model: "slow-catalog-model",
+        model: "catalog-model",
       });
+      expect(payload?.sessionInfo?.thinkingLevels?.map((level) => level.id)).toContain("xhigh");
       expect(Array.isArray(payload?.messages)).toBe(true);
     } finally {
       clearConfigCache();

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -1328,12 +1328,14 @@ describe("gateway server chat", () => {
         },
       });
 
-      const historyRes = await rpcReq<{ thinkingLevel?: string }>(ws, "chat.history", {
-        sessionKey: "agent:alpha:main",
-      });
+      const historyRes = await rpcReq<{
+        thinkingLevel?: string;
+        sessionInfo?: { thinkingLevel?: string };
+      }>(ws, "chat.history", { sessionKey: "agent:alpha:main" });
 
       expect(historyRes.ok).toBe(true);
       expect(historyRes.payload?.thinkingLevel).toBe("minimal");
+      expect(historyRes.payload?.sessionInfo?.thinkingLevel).toBeUndefined();
     } finally {
       testState.agentConfig = undefined;
       testState.agentsConfig = undefined;

--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -9,7 +9,7 @@ import {
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/agent-events.js";
-import { listSessionsFromStore } from "./session-utils.js";
+import { buildGatewaySessionInfo, listSessionsFromStore } from "./session-utils.js";
 
 function createModelDefaultsConfig(params: {
   primary: string;
@@ -541,6 +541,47 @@ describe("listSessionsFromStore search", () => {
         expect(result.sessions[0]?.totalTokensFresh).toBe(true);
         expect(result.sessions[0]?.contextTokens).toBe(1_048_576);
         expect(result.sessions[0]?.estimatedCostUsd).toBeCloseTo(0.007725, 8);
+      },
+    });
+  });
+
+  test("chat history session metadata keeps model-derived contextTokens without transcript usage", () => {
+    withTranscriptStoreFixture({
+      prefix: "openclaw-session-info-context-",
+      transcriptId: "sess-main",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      input: 2_000,
+      output: 500,
+      cacheRead: 1_200,
+      costTotal: 0.007725,
+      run: ({ storePath, now }) => {
+        const row = buildGatewaySessionInfo({
+          cfg: {
+            models: {
+              providers: {
+                "local-test": {
+                  models: [{ id: "test-model", contextTokens: 123_456 }],
+                },
+              },
+            },
+          } as unknown as OpenClawConfig,
+          storePath,
+          key: "agent:main:main",
+          store: {
+            "agent:main:main": {
+              sessionId: "sess-main",
+              updatedAt: now,
+              modelProvider: "local-test",
+              model: "test-model",
+            } as SessionEntry,
+          },
+        });
+
+        expect(row.totalTokens).toBeUndefined();
+        expect(row.totalTokensFresh).toBe(false);
+        expect(row.estimatedCostUsd).toBeUndefined();
+        expect(row.contextTokens).toBe(123_456);
       },
     });
   });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -2076,7 +2076,15 @@ export function buildGatewaySessionRow(params: {
         rowContext: params.rowContext,
       }) ?? resolveNonNegativeNumber(transcriptUsage?.estimatedCostUsd));
   const contextTokens = lightweight
-    ? resolvePositiveNumber(entry?.contextTokens)
+    ? (resolvePositiveNumber(entry?.contextTokens) ??
+      resolvePositiveNumber(
+        resolveContextTokensForModel({
+          cfg,
+          provider: rowModelProvider,
+          model: rowModel,
+          allowAsyncLoad: false,
+        }),
+      ))
     : (resolvePositiveNumber(entry?.contextTokens) ??
       resolvePositiveNumber(transcriptUsage?.contextTokens) ??
       resolvePositiveNumber(
@@ -2337,6 +2345,38 @@ export function loadGatewaySessionRow(
     transcriptUsageMaxBytes: options?.transcriptUsageMaxBytes,
     storeChildSessionsByKey,
     ...(options?.agentId ? { agentId: options.agentId } : {}),
+  });
+}
+
+export function buildGatewaySessionInfo(params: {
+  cfg: OpenClawConfig;
+  storePath: string;
+  store: Record<string, SessionEntry>;
+  key: string;
+  entry?: SessionEntry;
+  agentId?: string;
+  now?: number;
+  modelCatalog?: ModelCatalogEntry[];
+}): GatewaySessionRow {
+  const now = params.now ?? Date.now();
+  const storeChildSessionsByKey = buildSingleRowStoreChildSessionsByKey({
+    storePath: params.storePath,
+    store: params.store,
+    key: params.key,
+    now,
+  });
+  return buildGatewaySessionRow({
+    cfg: params.cfg,
+    storePath: params.storePath,
+    store: params.store,
+    key: params.key,
+    entry: params.entry,
+    agentId: params.agentId,
+    modelCatalog: params.modelCatalog,
+    now,
+    storeChildSessionsByKey,
+    skipTranscriptUsageFallback: true,
+    lightweightListRow: true,
   });
 }
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -12,6 +12,20 @@ const updateSessionGoalStatusMock = vi.fn();
 const listSessionsFromStoreAsyncMock = vi.fn(
   async (_options?: unknown): Promise<{ sessions: unknown[] }> => ({ sessions: [] }),
 );
+const buildGatewaySessionInfoMock = vi.fn(
+  (params: { key: string; entry?: { sessionId?: string; thinkingLevel?: string } }) => ({
+    key: params.key,
+    kind: "direct",
+    updatedAt: null,
+    sessionId: params.entry?.sessionId,
+    thinkingLevel: params.entry?.thinkingLevel,
+  }),
+);
+const getSessionDefaultsMock = vi.fn(() => ({
+  modelProvider: null,
+  model: null,
+  contextTokens: null,
+}));
 const loadCombinedSessionStoreForGatewayMock = vi.fn((_options?: unknown) => ({
   storePath: "/tmp/openclaw-sessions.json",
   store: {},
@@ -24,12 +38,15 @@ type LoadSessionEntryMockResult = {
   cfg: Record<string, unknown>;
   canonicalKey: string;
   storePath?: string;
+  store?: Record<string, unknown>;
   entry?: Record<string, unknown>;
 };
 const loadSessionEntryMock = vi.fn(
   (sessionKey: string, _opts?: { agentId?: string }): LoadSessionEntryMockResult => ({
     cfg: {},
     canonicalKey: sessionKey,
+    storePath: "/tmp/openclaw-sessions.json",
+    store: {},
     entry: {},
   }),
 );
@@ -122,6 +139,9 @@ vi.mock("../gateway/server-methods/chat.js", () => ({
 }));
 
 vi.mock("../gateway/session-utils.js", () => ({
+  buildGatewaySessionInfo: (params: Parameters<typeof buildGatewaySessionInfoMock>[0]) =>
+    buildGatewaySessionInfoMock(params),
+  getSessionDefaults: () => getSessionDefaultsMock(),
   listAgentsForGateway: () => [],
   listSessionsFromStoreAsync: (...args: unknown[]) => listSessionsFromStoreAsyncMock(...args),
   loadCombinedSessionStoreForGateway: (...args: unknown[]) =>
@@ -225,8 +245,12 @@ describe("EmbeddedTuiBackend", () => {
     loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
       cfg: {},
       canonicalKey: sessionKey,
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
       entry: {},
     }));
+    buildGatewaySessionInfoMock.mockClear();
+    getSessionDefaultsMock.mockClear();
     registeredListener = undefined;
     setEmbeddedMode(false);
     defaultRuntime.log = originalRuntimeLog;

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -48,6 +48,8 @@ import { loadGatewayModelCatalog } from "../gateway/server-model-catalog.js";
 import { performGatewaySessionReset } from "../gateway/session-reset-service.js";
 import { capArrayByJsonBytes } from "../gateway/session-utils.fs.js";
 import {
+  buildGatewaySessionInfo,
+  getSessionDefaults,
   listAgentsForGateway,
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
@@ -405,7 +407,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   async loadHistory(opts: { sessionKey: string; agentId?: string; limit?: number }) {
     const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
-    const { cfg, storePath, entry } = loadSessionEntry(opts.sessionKey, loadOptions);
+    const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(
+      opts.sessionKey,
+      loadOptions,
+    );
     const sessionId = entry?.sessionId;
     const sessionAgentId = resolveSessionAgentId({
       sessionKey: opts.sessionKey,
@@ -455,13 +460,27 @@ export class EmbeddedTuiBackend implements TuiBackend {
       });
     }
 
+    const defaults = getSessionDefaults(cfg, undefined, { allowPluginNormalization: false });
+    const sessionInfo = buildGatewaySessionInfo({
+      cfg,
+      storePath,
+      store,
+      key: canonicalKey,
+      entry,
+      agentId: opts.agentId,
+    });
+    sessionInfo.thinkingLevel = thinkingLevel;
+    sessionInfo.verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
+
     return {
       sessionKey: opts.sessionKey,
       sessionId,
       messages,
+      defaults,
+      sessionInfo,
       thinkingLevel,
       fastMode: entry?.fastMode,
-      verboseLevel: entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault,
+      verboseLevel: sessionInfo.verboseLevel,
     };
   }
 

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -396,6 +396,13 @@ describe("tui session actions", () => {
     });
     const loadHistory = vi.fn().mockResolvedValue({
       sessionId: "session-2",
+      sessionInfo: {
+        key: "agent:main:other",
+        sessionId: "session-2",
+        model: "session-model",
+        modelProvider: "openai",
+        updatedAt: 50,
+      },
       messages: [],
     });
     const btw = createBtwPresenter();
@@ -431,6 +438,7 @@ describe("tui session actions", () => {
     expect(state.sessionInfo.model).toBe("session-model");
     expect(state.sessionInfo.modelProvider).toBe("openai");
     expect(state.sessionInfo.updatedAt).toBe(50);
+    expect(listSessions).not.toHaveBeenCalled();
     expect(btw.clear).toHaveBeenCalled();
   });
 
@@ -526,6 +534,7 @@ describe("tui session actions", () => {
 
     expect(setActivityStatus).toHaveBeenCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
+    expect(listSessions).toHaveBeenCalled();
   });
 
   it("clears optimistic pending state when switching sessions", async () => {
@@ -947,6 +956,44 @@ describe("tui session actions", () => {
 
     expect(state.currentSessionId).toBe("session-main");
     expect(rememberSessionKey).toHaveBeenCalledWith("agent:main:main");
+  });
+
+  it("hydrates session info from chat history without listing sessions", async () => {
+    const listSessions = vi.fn();
+    const loadHistory = vi.fn().mockResolvedValue({
+      messages: [],
+      sessionInfo: {
+        key: "agent:main:main",
+        sessionId: "session-main",
+        modelProvider: "openai",
+        model: "gpt-5",
+        contextTokens: 120_000,
+        thinkingLevel: "medium",
+        updatedAt: 200,
+      },
+      defaults: {
+        modelProvider: "openai",
+        model: "gpt-5",
+        contextTokens: 120_000,
+      },
+    });
+    const state = createBaseState();
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as TuiBackend,
+      state,
+    });
+
+    await runLoadHistory();
+
+    expect(listSessions).not.toHaveBeenCalled();
+    expect(state.currentSessionId).toBe("session-main");
+    expect(state.sessionInfo.model).toBe("gpt-5");
+    expect(state.sessionInfo.contextTokens).toBe(120_000);
+    expect(state.sessionInfo.thinkingLevel).toBe("medium");
   });
 
   it("loads selected-agent global history with the selected agent id", async () => {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -996,6 +996,37 @@ describe("tui session actions", () => {
     expect(state.sessionInfo.thinkingLevel).toBe("medium");
   });
 
+  it("uses top-level chat history thinking level when session info inherits it", async () => {
+    const listSessions = vi.fn();
+    const loadHistory = vi.fn().mockResolvedValue({
+      messages: [],
+      thinkingLevel: "medium",
+      sessionInfo: {
+        key: "agent:main:main",
+        sessionId: "session-main",
+        modelProvider: "openai",
+        model: "gpt-5",
+        contextTokens: 120_000,
+        thinkingDefault: "medium",
+        updatedAt: 200,
+      },
+    });
+    const state = createBaseState();
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as TuiBackend,
+      state,
+    });
+
+    await runLoadHistory();
+
+    expect(listSessions).not.toHaveBeenCalled();
+    expect(state.sessionInfo.thinkingLevel).toBe("medium");
+  });
+
   it("loads selected-agent global history with the selected agent id", async () => {
     const loadHistory = vi.fn().mockResolvedValue({
       sessionId: "session-work-global",

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -442,6 +442,45 @@ describe("tui session actions", () => {
     expect(btw.clear).toHaveBeenCalled();
   });
 
+  it("clears stale token counts when history supplies lightweight session metadata", async () => {
+    const listSessions = vi.fn().mockResolvedValue({ sessions: [] });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-2",
+      sessionInfo: {
+        key: "agent:main:other",
+        sessionId: "session-2",
+        model: "session-model",
+        modelProvider: "openai",
+        updatedAt: 50,
+      },
+      messages: [],
+    });
+    const state = createBaseState({
+      historyLoaded: true,
+      sessionInfo: {
+        inputTokens: 1,
+        outputTokens: 2,
+        totalTokens: 3,
+        updatedAt: 500,
+      },
+    });
+
+    const { setSession } = createTestSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as TuiBackend,
+      state,
+    });
+
+    await setSession("agent:main:other");
+
+    expect(state.sessionInfo.inputTokens).toBeNull();
+    expect(state.sessionInfo.outputTokens).toBeNull();
+    expect(state.sessionInfo.totalTokens).toBeNull();
+    expect(listSessions).not.toHaveBeenCalled();
+  });
+
   it("applies default model info when the current session has no persisted entry yet", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -45,6 +45,8 @@ type SessionInfoDefaults = {
 };
 
 type SessionInfoEntry = SessionInfo & {
+  key?: string;
+  sessionId?: string;
   modelOverride?: string;
   providerOverride?: string;
 };
@@ -401,16 +403,38 @@ export function createSessionActions(context: SessionActionContext) {
       const record = history as {
         messages?: unknown[];
         sessionId?: string;
+        sessionInfo?: SessionInfoEntry;
+        defaults?: SessionInfoDefaults;
         thinkingLevel?: string;
         fastMode?: boolean;
         verboseLevel?: string;
         traceLevel?: string;
       };
-      state.currentSessionId = typeof record.sessionId === "string" ? record.sessionId : null;
-      state.sessionInfo.thinkingLevel = record.thinkingLevel ?? state.sessionInfo.thinkingLevel;
-      state.sessionInfo.fastMode = record.fastMode ?? state.sessionInfo.fastMode;
-      state.sessionInfo.verboseLevel = record.verboseLevel ?? state.sessionInfo.verboseLevel;
-      state.sessionInfo.traceLevel = record.traceLevel ?? state.sessionInfo.traceLevel;
+      const sessionInfo = record.sessionInfo;
+      if (sessionInfo?.key && sessionInfo.key !== state.currentSessionKey) {
+        updateAgentFromSessionKey(sessionInfo.key);
+        state.currentSessionKey = sessionInfo.key;
+        updateHeader();
+      }
+      state.currentSessionId =
+        typeof sessionInfo?.sessionId === "string"
+          ? sessionInfo.sessionId
+          : typeof record.sessionId === "string"
+            ? record.sessionId
+            : null;
+      applySessionInfo({
+        entry: sessionInfo ?? {
+          sessionId: record.sessionId,
+          thinkingLevel: record.thinkingLevel,
+          fastMode: record.fastMode,
+          verboseLevel: record.verboseLevel,
+          traceLevel: record.traceLevel,
+        },
+        defaults: record.defaults,
+      });
+      if (!sessionInfo) {
+        await refreshSessionInfo();
+      }
       const showTools = (state.sessionInfo.verboseLevel ?? "off") !== "off";
       chatLog.clearAll();
       btw.clear();
@@ -469,7 +493,6 @@ export function createSessionActions(context: SessionActionContext) {
     } catch (err) {
       chatLog.addSystem(`history failed: ${String(err)}`);
     }
-    await refreshSessionInfo();
     tui.requestRender();
   };
 

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -416,6 +416,10 @@ export function createSessionActions(context: SessionActionContext) {
         state.currentSessionKey = sessionInfo.key;
         updateHeader();
       }
+      const historySessionInfo =
+        sessionInfo && sessionInfo.thinkingLevel === undefined && record.thinkingLevel !== undefined
+          ? { ...sessionInfo, thinkingLevel: record.thinkingLevel }
+          : sessionInfo;
       state.currentSessionId =
         typeof sessionInfo?.sessionId === "string"
           ? sessionInfo.sessionId
@@ -423,7 +427,7 @@ export function createSessionActions(context: SessionActionContext) {
             ? record.sessionId
             : null;
       applySessionInfo({
-        entry: sessionInfo ?? {
+        entry: historySessionInfo ?? {
           sessionId: record.sessionId,
           thinkingLevel: record.thinkingLevel,
           fastMode: record.fastMode,

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -188,6 +188,7 @@ export function createSessionActions(context: SessionActionContext) {
     entry?: SessionInfoEntry | null;
     defaults?: SessionInfoDefaults | null;
     force?: boolean;
+    clearMissingUsage?: boolean;
   }) => {
     const hasEntryUpdate = "entry" in params;
     const entry = params.entry ?? undefined;
@@ -244,6 +245,17 @@ export function createSessionActions(context: SessionActionContext) {
     }
     if (entry?.totalTokens !== undefined) {
       next.totalTokens = entry.totalTokens;
+    }
+    if (params.clearMissingUsage) {
+      if (entry?.inputTokens === undefined) {
+        next.inputTokens = null;
+      }
+      if (entry?.outputTokens === undefined) {
+        next.outputTokens = null;
+      }
+      if (entry?.totalTokens === undefined) {
+        next.totalTokens = null;
+      }
     }
     if (hasEntryUpdate) {
       next.goal = entry?.goal;
@@ -435,6 +447,7 @@ export function createSessionActions(context: SessionActionContext) {
           traceLevel: record.traceLevel,
         },
         defaults: record.defaults,
+        clearMissingUsage: Boolean(historySessionInfo),
       });
       if (!sessionInfo) {
         await refreshSessionInfo();

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -242,16 +242,7 @@ describe("refreshChat", () => {
       limit: 100,
     });
     expect(request).not.toHaveBeenCalledWith("models.list", { view: "configured" });
-    const sessionsListPayload = findRequestPayload(
-      request as unknown as MockCallSource,
-      "sessions.list",
-      "sessions list payload",
-    );
-    expect(sessionsListPayload).not.toHaveProperty("activeMinutes");
-    expect(sessionsListPayload.agentId).toBe("main");
-    expect(sessionsListPayload.includeGlobal).toBe(true);
-    expect(sessionsListPayload.includeUnknown).toBe(true);
-    expect(sessionsListPayload.limit).toBe(50);
+    expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
     expect(request).not.toHaveBeenCalledWith("commands.list", {
       agentId: "main",
       includeArgs: true,
@@ -286,13 +277,7 @@ describe("refreshChat", () => {
       agentId: "work",
       limit: 100,
     });
-    const sessionsListPayload = findRequestPayload(
-      request as unknown as MockCallSource,
-      "sessions.list",
-      "global sessions list payload",
-    );
-    expect(sessionsListPayload.agentId).toBe("work");
-    expect(sessionsListPayload.includeGlobal).toBe(true);
+    expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
     await vi.waitFor(() =>
       expect(request).toHaveBeenCalledWith("commands.list", {
         agentId: "work",
@@ -319,13 +304,7 @@ describe("refreshChat", () => {
       agentId: "work",
       limit: 100,
     });
-    const sessionsListPayload = findRequestPayload(
-      request as unknown as MockCallSource,
-      "sessions.list",
-      "global alias sessions list payload",
-    );
-    expect(sessionsListPayload.agentId).toBe("work");
-    expect(sessionsListPayload.includeGlobal).toBe(true);
+    expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
 
   it("scopes agent session refresh rows before the list limit", async () => {
@@ -340,14 +319,12 @@ describe("refreshChat", () => {
     const outcome = await raceWithMacrotask(refresh);
 
     expect(outcome).toBe("resolved");
-    const sessionsListPayload = findRequestPayload(
-      request as unknown as MockCallSource,
-      "sessions.list",
-      "agent direct sessions list payload",
-    );
-    expect(sessionsListPayload.agentId).toBe("work");
-    expect(sessionsListPayload.limit).toBe(50);
-    expect(sessionsListPayload.includeGlobal).toBe(true);
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "agent:work:dashboard",
+      limit: 100,
+      maxChars: 4000,
+    });
+    expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
 
   it("uses hello default for global chat refresh before agents list loads", async () => {
@@ -372,12 +349,7 @@ describe("refreshChat", () => {
       agentId: "ops",
       limit: 100,
     });
-    const sessionsListPayload = findRequestPayload(
-      request as unknown as MockCallSource,
-      "sessions.list",
-      "hello-default global sessions list payload",
-    );
-    expect(sessionsListPayload.agentId).toBe("ops");
+    expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
 
   it("keeps unknown chat refresh session rows unscoped", async () => {
@@ -397,13 +369,7 @@ describe("refreshChat", () => {
       sessionKey: "unknown",
       limit: 100,
     });
-    const sessionsListPayload = findRequestPayload(
-      request as unknown as MockCallSource,
-      "sessions.list",
-      "unknown sessions list payload",
-    );
-    expect(sessionsListPayload).not.toHaveProperty("agentId");
-    expect(sessionsListPayload.includeUnknown).toBe(true);
+    expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
 
   it("can wait for history without waiting for secondary metadata refreshes", async () => {
@@ -443,10 +409,10 @@ describe("refreshChat", () => {
   it("drains a restored queue after refresh proves the selected session is idle", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "chat.history") {
-        return { messages: [] };
-      }
-      if (method === "sessions.list") {
-        return createSessionsResult([row("main", { hasActiveRun: false, status: "done" })]);
+        return {
+          messages: [],
+          sessionInfo: row("main", { hasActiveRun: false, status: "done" }),
+        };
       }
       return {};
     });
@@ -469,13 +435,81 @@ describe("refreshChat", () => {
     expect(host.chatQueue).toEqual([]);
   });
 
+  it("drains a restored queue from history metadata when the visible list is scoped elsewhere", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.history") {
+        return {
+          messages: [],
+          sessionInfo: row("agent:work:dashboard", {
+            hasActiveRun: false,
+            status: "done",
+          }),
+        };
+      }
+      return {};
+    });
+    const previousSessionsResult = createSessionsResult([
+      row("agent:main:main", { hasActiveRun: false, status: "done" }),
+    ]);
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "agent:work:dashboard",
+      sessionsResult: previousSessionsResult,
+      chatQueue: [{ id: "queued-1", text: "after scoped reload", createdAt: 1 }],
+    });
+    (host as ChatHost & { sessionsResultAgentId: string }).sessionsResultAgentId = "main";
+
+    await refreshChat(host, { scheduleScroll: false });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(host.sessionsResult).toBe(previousSessionsResult);
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({
+        sessionKey: "agent:work:dashboard",
+        message: "after scoped reload",
+      }),
+    );
+    expect(host.chatQueue).toEqual([]);
+  });
+
+  it("drains a restored queue from fresh history metadata despite stale sessions errors", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.history") {
+        return {
+          messages: [],
+          sessionInfo: row("main", { hasActiveRun: false, status: "done" }),
+        };
+      }
+      return {};
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "main",
+      sessionsError: "old sessions.list failure",
+      chatQueue: [{ id: "queued-1", text: "after stale error", createdAt: 1 }],
+    });
+
+    await refreshChat(host, { scheduleScroll: false });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({
+        sessionKey: "main",
+        message: "after stale error",
+      }),
+    );
+    expect(host.chatQueue).toEqual([]);
+  });
+
   it("keeps a restored queue while the selected session is still active", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "chat.history") {
-        return { messages: [] };
-      }
-      if (method === "sessions.list") {
-        return createSessionsResult([row("main", { hasActiveRun: true, status: "running" })]);
+        return {
+          messages: [],
+          sessionInfo: row("main", { hasActiveRun: true, status: "running" }),
+        };
       }
       return {};
     });
@@ -494,13 +528,10 @@ describe("refreshChat", () => {
     expect(host.chatRunId).toBeNull();
   });
 
-  it("keeps a restored queue when idle proof is stale after sessions refresh fails", async () => {
+  it("keeps a restored queue when history has no selected-session metadata", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "chat.history") {
         return { messages: [] };
-      }
-      if (method === "sessions.list") {
-        throw new Error("sessions unavailable");
       }
       return {};
     });
@@ -517,7 +548,7 @@ describe("refreshChat", () => {
 
     expect(request).not.toHaveBeenCalledWith("chat.send", expect.anything());
     expect(host.chatQueue).toEqual(restoredQueue);
-    expect(host.sessionsError).toContain("sessions unavailable");
+    expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
 });
 
@@ -883,16 +914,7 @@ describe("refreshChat", () => {
       expect(host.chatMessages).toEqual([
         { role: "assistant", content: [{ type: "text", text: "ready" }] },
       ]);
-      const sessionsListPayload = findRequestPayload(
-        request as unknown as MockCallSource,
-        "sessions.list",
-        "sessions list payload",
-      );
-      expect(sessionsListPayload).not.toHaveProperty("activeMinutes");
-      expect(sessionsListPayload.agentId).toBe("main");
-      expect(sessionsListPayload.includeGlobal).toBe(true);
-      expect(sessionsListPayload.includeUnknown).toBe(true);
-      expect(sessionsListPayload.limit).toBe(50);
+      expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
       await vi.waitFor(() =>
         expect(request).toHaveBeenCalledWith("models.list", { view: "configured" }),
       );

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -322,7 +322,6 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "agent:work:dashboard",
       limit: 100,
-      maxChars: 4000,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -472,6 +472,46 @@ describe("refreshChat", () => {
     expect(host.chatQueue).toEqual([]);
   });
 
+  it("drains a restored queue when global history metadata answers an agent main alias", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.history") {
+        return {
+          messages: [],
+          sessionInfo: row("global", {
+            kind: "global",
+            hasActiveRun: false,
+            status: "done",
+          }),
+        };
+      }
+      return {};
+    });
+    const previousSessionsResult = createSessionsResult([
+      row("agent:main:main", { hasActiveRun: false, status: "done" }),
+    ]);
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "agent:work:main",
+      agentsList: { defaultId: "main", mainKey: "main" },
+      sessionsResult: previousSessionsResult,
+      chatQueue: [{ id: "queued-1", text: "after global alias reload", createdAt: 1 }],
+    });
+    (host as ChatHost & { sessionsResultAgentId: string }).sessionsResultAgentId = "main";
+
+    await refreshChat(host, { scheduleScroll: false });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({
+        sessionKey: "agent:work:main",
+        message: "after global alias reload",
+      }),
+    );
+    expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
+    expect(host.chatQueue).toEqual([]);
+  });
+
   it("drains a restored queue from fresh history metadata despite stale sessions errors", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "chat.history") {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -567,6 +567,47 @@ describe("refreshChat", () => {
     expect(host.chatRunId).toBeNull();
   });
 
+  it("keeps a restored queue when stale history says a newer active row is idle", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.history") {
+        return {
+          messages: [],
+          sessionInfo: row("main", {
+            hasActiveRun: false,
+            status: "done",
+            updatedAt: 5,
+          }),
+        };
+      }
+      return {};
+    });
+    const restoredQueue = [{ id: "queued-1", text: "after active run", createdAt: 1 }];
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "main",
+      chatQueue: restoredQueue,
+      sessionsResult: createSessionsResult([
+        row("main", {
+          hasActiveRun: true,
+          status: "running",
+          updatedAt: 10,
+          startedAt: 9,
+        }),
+      ]),
+    });
+
+    await refreshChat(host, { scheduleScroll: false });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(request).not.toHaveBeenCalledWith("chat.send", expect.anything());
+    expect(host.chatQueue).toEqual(restoredQueue);
+    expect(host.sessionsResult?.sessions[0]).toMatchObject({
+      hasActiveRun: true,
+      status: "running",
+      updatedAt: 10,
+    });
+  });
+
   it("keeps a restored queue when history has no selected-session metadata", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "chat.history") {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -30,10 +30,12 @@ import {
   requestChatSend,
   sendDetachedChatMessage,
   sendSteerChatMessage,
+  type ChatHistoryResult,
   type ChatState,
 } from "./controllers/chat.ts";
 import { loadModels } from "./controllers/models.ts";
 import {
+  applyChatHistorySessionInfo,
   loadSessions,
   type LoadSessionsOverrides,
   type SessionsState,
@@ -977,7 +979,7 @@ function isSelectedSessionKnownIdle(
 function flushChatQueueAfterIdleSessionReconciliation(
   host: ChatHost,
   sessionKey: string,
-  historyRefresh: Promise<unknown>,
+  historyRefresh: Promise<ChatHistoryResult | undefined>,
   sessionsRefresh: Promise<unknown>,
   previousSessionsResult: SessionsListResult | null | undefined,
 ) {
@@ -985,16 +987,29 @@ function flushChatQueueAfterIdleSessionReconciliation(
     return;
   }
   void Promise.allSettled([historyRefresh, sessionsRefresh]).then((results) => {
+    const historyRefreshSettled = results[0];
     const sessionsRefreshSettled = results[1];
     const freshSessionsResult = host.sessionsResult;
+    const historySessionInfo =
+      historyRefreshSettled.status === "fulfilled"
+        ? historyRefreshSettled.value?.sessionInfo
+        : null;
+    const historySessionKnownIdle = Boolean(
+      historySessionInfo &&
+      areUiSessionKeysEquivalent(historySessionInfo.key, sessionKey) &&
+      !isSessionRunActive(historySessionInfo),
+    );
+    const sessionsResultKnownIdle = freshSessionsResult
+      ? isSelectedSessionKnownIdle(freshSessionsResult, sessionKey)
+      : false;
     if (
       sessionsRefreshSettled.status !== "fulfilled" ||
       host.chatQueue.length === 0 ||
       !areUiSessionKeysEquivalent(host.sessionKey, sessionKey) ||
-      !freshSessionsResult ||
-      freshSessionsResult === previousSessionsResult ||
-      host.sessionsError ||
-      !isSelectedSessionKnownIdle(freshSessionsResult, sessionKey)
+      (!freshSessionsResult && !historySessionKnownIdle) ||
+      (freshSessionsResult === previousSessionsResult && !historySessionKnownIdle) ||
+      (host.sessionsError && !historySessionKnownIdle) ||
+      !(historySessionKnownIdle || sessionsResultKnownIdle)
     ) {
       return;
     }
@@ -1379,15 +1394,21 @@ export async function refreshChat(
   const refreshedSessionKey = host.sessionKey;
   const requestUpdate = () => host.requestUpdate?.();
   const previousSessionsResult = host.sessionsResult;
-  const historyRefresh = loadChatHistory(host as unknown as ChatState).finally(() => {
+  const historyLoad = loadChatHistory(host as unknown as ChatState);
+  const historyRefresh = historyLoad.finally(() => {
     if (opts?.scheduleScroll !== false) {
       scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
     }
     requestUpdate();
   });
-  const sessionsRefresh = loadSessions(host as unknown as SessionsState, {
-    ...createChatSessionsLoadOverrides(host),
-    ...scopedAgentListParamsForSession(host, refreshedSessionKey),
+  const sessionsRefresh = historyLoad.then((history) => {
+    if (history?.sessionInfo) {
+      applyChatHistorySessionInfo(
+        host as unknown as SessionsState,
+        history.sessionInfo,
+        history.defaults,
+      );
+    }
   });
   flushChatQueueAfterIdleSessionReconciliation(
     host,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -50,7 +50,7 @@ import {
 } from "./session-key.ts";
 import { isSessionRunActive } from "./session-run-state.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
-import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
+import type { ChatModelOverride, GatewaySessionRow, ModelCatalogEntry } from "./types.ts";
 import type { SessionsListResult } from "./types.ts";
 import type { ChatAttachment, ChatQueueItem, ChatSessionRefreshTarget } from "./ui-types.ts";
 import { generateUUID } from "./uuid.ts";
@@ -249,7 +249,7 @@ function resolveGlobalAliasAgentId(
   const configuredMainKey = normalizeLowercaseStringOrEmpty(
     host.agentsList?.mainKey ?? readHelloMainKey(host) ?? "main",
   );
-  return rest === "main" || rest === configuredMainKey
+  return rest === "global" || rest === "main" || rest === configuredMainKey
     ? normalizeAgentId(parsed.agentId)
     : undefined;
 }
@@ -991,6 +991,47 @@ function isHistorySessionInfoForRequestedSession(
   );
 }
 
+function findSelectedSessionRow(
+  host: ChatHost,
+  sessionsResult: SessionsListResult | null | undefined,
+  sessionKey: string,
+  historySessionKey: string | undefined,
+): GatewaySessionRow | undefined {
+  const requestedGlobalAgentId =
+    historySessionKey && isGlobalSessionKey(historySessionKey)
+      ? resolveGlobalAliasAgentId(host, sessionKey)
+      : undefined;
+  return sessionsResult?.sessions.find((session) => {
+    if (areUiSessionKeysEquivalent(session.key, sessionKey)) {
+      return true;
+    }
+    return (
+      requestedGlobalAgentId != null &&
+      resolveGlobalAliasAgentId(host, session.key) === requestedGlobalAgentId
+    );
+  });
+}
+
+function historyIdleProofIsStaleForSelectedRow(
+  historySessionInfo: GatewaySessionRow,
+  selectedRow: GatewaySessionRow | undefined,
+): boolean {
+  if (!selectedRow || !isSessionRunActive(selectedRow) || isSessionRunActive(historySessionInfo)) {
+    return false;
+  }
+  const historyUpdatedAt =
+    typeof historySessionInfo.updatedAt === "number" ? historySessionInfo.updatedAt : null;
+  if (historyUpdatedAt == null) {
+    return true;
+  }
+  const selectedUpdatedAt = typeof selectedRow.updatedAt === "number" ? selectedRow.updatedAt : 0;
+  if (selectedUpdatedAt >= historyUpdatedAt) {
+    return true;
+  }
+  const selectedStartedAt = typeof selectedRow.startedAt === "number" ? selectedRow.startedAt : 0;
+  return selectedStartedAt >= historyUpdatedAt;
+}
+
 function flushChatQueueAfterIdleSessionReconciliation(
   host: ChatHost,
   sessionKey: string,
@@ -1009,10 +1050,17 @@ function flushChatQueueAfterIdleSessionReconciliation(
       historyRefreshSettled.status === "fulfilled"
         ? historyRefreshSettled.value?.sessionInfo
         : null;
+    const selectedSessionRow = findSelectedSessionRow(
+      host,
+      freshSessionsResult,
+      sessionKey,
+      historySessionInfo?.key,
+    );
     const historySessionKnownIdle = Boolean(
       historySessionInfo &&
       isHistorySessionInfoForRequestedSession(host, historySessionInfo.key, sessionKey) &&
-      !isSessionRunActive(historySessionInfo),
+      !isSessionRunActive(historySessionInfo) &&
+      !historyIdleProofIsStaleForSelectedRow(historySessionInfo, selectedSessionRow),
     );
     const sessionsResultKnownIdle = freshSessionsResult
       ? isSelectedSessionKnownIdle(freshSessionsResult, sessionKey)

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -976,6 +976,21 @@ function isSelectedSessionKnownIdle(
   return Boolean(row && !isSessionRunActive(row));
 }
 
+function isHistorySessionInfoForRequestedSession(
+  host: ChatHost,
+  historySessionKey: string | undefined,
+  requestedSessionKey: string,
+): boolean {
+  if (areUiSessionKeysEquivalent(historySessionKey, requestedSessionKey)) {
+    return true;
+  }
+  return Boolean(
+    historySessionKey &&
+    isGlobalSessionKey(historySessionKey) &&
+    resolveGlobalAliasAgentId(host, requestedSessionKey),
+  );
+}
+
 function flushChatQueueAfterIdleSessionReconciliation(
   host: ChatHost,
   sessionKey: string,
@@ -996,7 +1011,7 @@ function flushChatQueueAfterIdleSessionReconciliation(
         : null;
     const historySessionKnownIdle = Boolean(
       historySessionInfo &&
-      areUiSessionKeysEquivalent(historySessionInfo.key, sessionKey) &&
+      isHistorySessionInfoForRequestedSession(host, historySessionInfo.key, sessionKey) &&
       !isSessionRunActive(historySessionInfo),
     );
     const sessionsResultKnownIdle = freshSessionsResult

--- a/ui/src/ui/chat/run-lifecycle.test.ts
+++ b/ui/src/ui/chat/run-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { isSessionRunActive } from "../session-run-state.ts";
 import type { SessionsListResult } from "../types.ts";
 import {
   reconcileChatRunFromCurrentSessionRow,
+  reconcileChatRunFromSessionRow,
   reconcileChatRunLifecycle,
   STALE_ACTIVE_ROW_RECONCILE_WINDOW_MS,
 } from "./run-lifecycle.ts";
@@ -142,6 +143,27 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
     expect(rowActive(host)).toBe(true);
     expect(host.lastLocalTerminalReconcile).toBeNull();
+  });
+
+  it("clears selected agent-main alias runs from canonical global history rows", () => {
+    const host = makeHost({
+      sessionKey: "agent:work:main",
+      chatRunId: "run-global",
+      chatStream: "streaming",
+      sessionsResult: makeSessionsResult([
+        { key: "agent:work:main", hasActiveRun: true, status: "running" },
+      ]),
+    });
+
+    const reconciled = reconcileChatRunFromSessionRow(
+      host,
+      { key: "global", kind: "global", updatedAt: 1, hasActiveRun: false, status: "done" },
+      { publishRunStatus: false },
+    );
+
+    expect(reconciled).toBe(true);
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatStream).toBeNull();
   });
 
   it("arms suppression on a completed turn, then suppresses the racing refresh", () => {

--- a/ui/src/ui/chat/run-lifecycle.test.ts
+++ b/ui/src/ui/chat/run-lifecycle.test.ts
@@ -166,6 +166,27 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     expect(host.chatStream).toBeNull();
   });
 
+  it("clears selected agent-global alias runs from canonical global history rows", () => {
+    const host = makeHost({
+      sessionKey: "agent:work:global",
+      chatRunId: "run-global",
+      chatStream: "streaming",
+      sessionsResult: makeSessionsResult([
+        { key: "agent:work:global", hasActiveRun: true, status: "running" },
+      ]),
+    });
+
+    const reconciled = reconcileChatRunFromSessionRow(
+      host,
+      { key: "global", kind: "global", updatedAt: 1, hasActiveRun: false, status: "done" },
+      { publishRunStatus: false },
+    );
+
+    expect(reconciled).toBe(true);
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatStream).toBeNull();
+  });
+
   it("clears configured agent-main alias runs from canonical global history rows", () => {
     const host = makeHost({
       sessionKey: "agent:work:inbox",

--- a/ui/src/ui/chat/run-lifecycle.test.ts
+++ b/ui/src/ui/chat/run-lifecycle.test.ts
@@ -166,6 +166,28 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     expect(host.chatStream).toBeNull();
   });
 
+  it("clears configured agent-main alias runs from canonical global history rows", () => {
+    const host = makeHost({
+      sessionKey: "agent:work:inbox",
+      agentsList: { mainKey: "inbox" },
+      chatRunId: "run-global",
+      chatStream: "streaming",
+      sessionsResult: makeSessionsResult([
+        { key: "agent:work:inbox", hasActiveRun: true, status: "running" },
+      ]),
+    });
+
+    const reconciled = reconcileChatRunFromSessionRow(
+      host,
+      { key: "global", kind: "global", updatedAt: 1, hasActiveRun: false, status: "done" },
+      { publishRunStatus: false },
+    );
+
+    expect(reconciled).toBe(true);
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatStream).toBeNull();
+  });
+
   it("arms suppression on a completed turn, then suppresses the racing refresh", () => {
     const host = makeHost({
       chatRunId: "r1",

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -1,6 +1,7 @@
 import { resetToolStream, type CompactionStatus, type FallbackStatus } from "../app-tool-stream.ts";
+import { areUiSessionKeysEquivalent } from "../session-key.ts";
 import { isSessionRunActive } from "../session-run-state.ts";
-import type { SessionRunStatus, SessionsListResult } from "../types.ts";
+import type { GatewaySessionRow, SessionRunStatus, SessionsListResult } from "../types.ts";
 
 export const CHAT_RUN_STATUS_TOAST_DURATION_MS = 5_000;
 
@@ -270,6 +271,20 @@ export function reconcileChatRunFromCurrentSessionRow(
   if (!row) {
     return false;
   }
+  return reconcileChatRunFromSessionRow(host, row, options);
+}
+
+export function reconcileChatRunFromSessionRow(
+  host: RunLifecycleHost,
+  row: GatewaySessionRow,
+  options: { publishRunStatus?: boolean } = {},
+): boolean {
+  if (!areUiSessionKeysEquivalent(row.key, host.sessionKey)) {
+    return false;
+  }
+  if (!host.chatRunId && host.chatStream == null) {
+    return false;
+  }
   if (isSessionRunActive(row)) {
     return false;
   }
@@ -282,6 +297,7 @@ export function reconcileChatRunFromCurrentSessionRow(
     sessionStatus: row.status === "done" ? "done" : (row.status ?? "killed"),
     runId: host.chatRunId,
     sessionKey: host.sessionKey,
+    sessionKeys: [row.key],
     clearLocalRun: true,
     clearChatStream: true,
     publishRunStatus: options.publishRunStatus,

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -1,5 +1,9 @@
 import { resetToolStream, type CompactionStatus, type FallbackStatus } from "../app-tool-stream.ts";
-import { areUiSessionKeysEquivalent } from "../session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  DEFAULT_MAIN_KEY,
+  parseAgentSessionKey,
+} from "../session-key.ts";
 import { isSessionRunActive } from "../session-run-state.ts";
 import type { GatewaySessionRow, SessionRunStatus, SessionsListResult } from "../types.ts";
 
@@ -274,12 +278,23 @@ export function reconcileChatRunFromCurrentSessionRow(
   return reconcileChatRunFromSessionRow(host, row, options);
 }
 
+function isSessionRowForSelectedChat(rowKey: string, sessionKey: string): boolean {
+  if (areUiSessionKeysEquivalent(rowKey, sessionKey)) {
+    return true;
+  }
+  if (rowKey !== "global") {
+    return false;
+  }
+  const parsed = parseAgentSessionKey(sessionKey);
+  return parsed?.rest === DEFAULT_MAIN_KEY;
+}
+
 export function reconcileChatRunFromSessionRow(
   host: RunLifecycleHost,
   row: GatewaySessionRow,
   options: { publishRunStatus?: boolean } = {},
 ): boolean {
-  if (!areUiSessionKeysEquivalent(row.key, host.sessionKey)) {
+  if (!isSessionRowForSelectedChat(row.key, host.sessionKey)) {
     return false;
   }
   if (!host.chatRunId && host.chatStream == null) {

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -304,7 +304,11 @@ function isSessionRowForSelectedChat(
     return false;
   }
   const parsed = parseAgentSessionKey(sessionKey);
-  return parsed?.rest === DEFAULT_MAIN_KEY || parsed?.rest === configuredMainKey(host);
+  return (
+    parsed?.rest === "global" ||
+    parsed?.rest === DEFAULT_MAIN_KEY ||
+    parsed?.rest === configuredMainKey(host)
+  );
 }
 
 export function reconcileChatRunFromSessionRow(

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -34,6 +34,8 @@ type TimerHandle = ReturnType<typeof globalThis.setTimeout>;
 
 type RunLifecycleHost = Omit<Partial<Parameters<typeof resetToolStream>[0]>, "hello"> & {
   sessionKey: string;
+  agentsList?: { mainKey?: string | null } | null;
+  hello?: { snapshot?: unknown } | null;
   chatRunId?: string | null;
   chatStream?: string | null;
   chatStreamStartedAt?: number | null;
@@ -278,7 +280,23 @@ export function reconcileChatRunFromCurrentSessionRow(
   return reconcileChatRunFromSessionRow(host, row, options);
 }
 
-function isSessionRowForSelectedChat(rowKey: string, sessionKey: string): boolean {
+function configuredMainKey(host: RunLifecycleHost): string {
+  const snapshot =
+    host.hello?.snapshot && typeof host.hello.snapshot === "object"
+      ? (host.hello.snapshot as { sessionDefaults?: { mainKey?: string | null } })
+      : undefined;
+  return (
+    host.agentsList?.mainKey?.trim() ||
+    snapshot?.sessionDefaults?.mainKey?.trim() ||
+    DEFAULT_MAIN_KEY
+  ).toLowerCase();
+}
+
+function isSessionRowForSelectedChat(
+  host: RunLifecycleHost,
+  rowKey: string,
+  sessionKey: string,
+): boolean {
   if (areUiSessionKeysEquivalent(rowKey, sessionKey)) {
     return true;
   }
@@ -286,7 +304,7 @@ function isSessionRowForSelectedChat(rowKey: string, sessionKey: string): boolea
     return false;
   }
   const parsed = parseAgentSessionKey(sessionKey);
-  return parsed?.rest === DEFAULT_MAIN_KEY;
+  return parsed?.rest === DEFAULT_MAIN_KEY || parsed?.rest === configuredMainKey(host);
 }
 
 export function reconcileChatRunFromSessionRow(
@@ -294,7 +312,7 @@ export function reconcileChatRunFromSessionRow(
   row: GatewaySessionRow,
   options: { publishRunStatus?: boolean } = {},
 ): boolean {
-  if (!isSessionRowForSelectedChat(row.key, host.sessionKey)) {
+  if (!isSessionRowForSelectedChat(host, row.key, host.sessionKey)) {
     return false;
   }
   if (!host.chatRunId && host.chatStream == null) {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1161,6 +1161,32 @@ describe("loadChatHistory filtering", () => {
     expect(state.chatMessages).toEqual(messages);
   });
 
+  it("applies current session metadata from chat history", async () => {
+    const request = vi.fn().mockResolvedValue({
+      messages: [],
+      sessionId: "legacy-session",
+      thinkingLevel: "low",
+      sessionInfo: {
+        key: "main",
+        sessionId: "session-main",
+        thinkingLevel: "medium",
+        modelProvider: "openai",
+        model: "gpt-5",
+        updatedAt: 123,
+      },
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    const result = await loadChatHistory(state);
+
+    expect(result?.sessionInfo?.sessionId).toBe("session-main");
+    expect(state.currentSessionId).toBe("session-main");
+    expect(state.chatThinkingLevel).toBe("medium");
+  });
+
   it("omits literal global agentId until selected/default agent is known", async () => {
     const request = vi.fn().mockResolvedValue({ messages: [] });
     const state = createState({

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -17,6 +17,7 @@ import {
   parseAgentSessionKey,
 } from "../session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
+import type { GatewaySessionRow, GatewaySessionsDefaults } from "../types.ts";
 import type { ChatAttachment } from "../ui-types.ts";
 import { generateUUID } from "../uuid.ts";
 import {
@@ -293,6 +294,14 @@ export type ChatState = {
   hello?: GatewayHelloOk | null;
 };
 
+export type ChatHistoryResult = {
+  messages?: Array<unknown>;
+  sessionId?: string;
+  thinkingLevel?: string;
+  defaults?: GatewaySessionsDefaults;
+  sessionInfo?: GatewaySessionRow;
+};
+
 export type ChatEventPayload = {
   runId?: string;
   sessionKey: string;
@@ -403,14 +412,14 @@ type InFlightChatHistoryRequest = {
   client: NonNullable<ChatState["client"]>;
   key: string;
   messages: unknown[];
-  promise: Promise<void>;
+  promise: Promise<ChatHistoryResult | undefined>;
 };
 
 const inFlightChatHistoryRequests = new WeakMap<ChatState, InFlightChatHistoryRequest>();
 
-export async function loadChatHistory(state: ChatState) {
+export async function loadChatHistory(state: ChatState): Promise<ChatHistoryResult | undefined> {
   if (!state.client || !state.connected) {
-    return;
+    return undefined;
   }
   const sessionKey = state.sessionKey;
   const requestAgentId = isSelectedGlobalEventSessionKey(sessionKey)
@@ -446,7 +455,7 @@ async function loadChatHistoryUncached(
   client: NonNullable<ChatState["client"]>,
   sessionKey: string,
   requestAgentId: string | undefined,
-) {
+): Promise<ChatHistoryResult | undefined> {
   const requestVersion = beginChatHistoryRequest(state);
   const startedAt = Date.now();
   const previousMessages = state.chatMessages;
@@ -455,14 +464,10 @@ async function loadChatHistoryUncached(
   state.chatLoading = true;
   setChatError(state, null);
   try {
-    let res: { messages?: Array<unknown>; sessionId?: string; thinkingLevel?: string };
+    let res: ChatHistoryResult;
     for (;;) {
       try {
-        res = await client.request<{
-          messages?: Array<unknown>;
-          sessionId?: string;
-          thinkingLevel?: string;
-        }>("chat.history", {
+        res = await client.request<ChatHistoryResult>("chat.history", {
           sessionKey,
           ...(requestAgentId ? { agentId: requestAgentId } : {}),
           limit: CHAT_HISTORY_REQUEST_LIMIT,
@@ -470,14 +475,14 @@ async function loadChatHistoryUncached(
         break;
       } catch (err) {
         if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey, requestAgentId)) {
-          return;
+          return undefined;
         }
         const withinStartupRetryWindow =
           Date.now() - startedAt < STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS;
         if (withinStartupRetryWindow && isRetryableStartupUnavailable(err, "chat.history")) {
           await sleep(resolveStartupRetryDelayMs(err));
           if (!state.client || !state.connected) {
-            return;
+            return undefined;
           }
           continue;
         }
@@ -485,22 +490,27 @@ async function loadChatHistoryUncached(
       }
     }
     if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey, requestAgentId)) {
-      return;
+      return undefined;
     }
     const messages = Array.isArray(res.messages) ? res.messages : [];
     const visibleMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
     state.chatMessages = preserveOptimisticTailMessages(visibleMessages, previousMessages);
     state.currentSessionId =
-      typeof res.sessionId === "string" && res.sessionId.trim() ? res.sessionId : null;
-    state.chatThinkingLevel = res.thinkingLevel ?? null;
+      typeof res.sessionInfo?.sessionId === "string" && res.sessionInfo.sessionId.trim()
+        ? res.sessionInfo.sessionId
+        : typeof res.sessionId === "string" && res.sessionId.trim()
+          ? res.sessionId
+          : null;
+    state.chatThinkingLevel = res.sessionInfo?.thinkingLevel ?? res.thinkingLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
     maybeResetToolStream(state);
     state.chatStream = null;
     state.chatStreamStartedAt = null;
+    return res;
   } catch (err) {
     if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey, requestAgentId)) {
-      return;
+      return undefined;
     }
     if (isMissingOperatorReadScopeError(err)) {
       state.chatMessages = [];
@@ -514,6 +524,7 @@ async function loadChatHistoryUncached(
       state.chatLoading = false;
     }
   }
+  return undefined;
 }
 
 function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string } | null {

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { isSessionRunActive } from "../session-run-state.ts";
 import {
+  applyChatHistorySessionInfo,
   applySessionsChangedEvent,
   branchSessionFromCheckpoint,
   createSessionAndRefresh,
@@ -2041,6 +2042,196 @@ describe("applySessionsChangedEvent", () => {
     expect(state.sessionsResult?.sessions[0]?.totalTokens).toBeUndefined();
     expect(state.sessionsResult?.sessions[0]?.totalTokensFresh).toBe(false);
     expect(state.sessionsResult?.sessions[0]?.contextTokens).toBe(200_000);
+  });
+
+  it("keeps richer token metadata when applying lightweight chat history session info", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: "openai", model: "gpt-5.4", contextTokens: 200_000 },
+        sessions: [
+          {
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 1,
+            totalTokens: 190_000,
+            totalTokensFresh: true,
+            contextTokens: 200_000,
+          },
+        ],
+      },
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "agent:main:main",
+      kind: "direct",
+      updatedAt: 2,
+      totalTokens: undefined,
+      totalTokensFresh: false,
+      contextTokens: undefined,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions[0]).toMatchObject({
+      key: "agent:main:main",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+      totalTokens: 190_000,
+      totalTokensFresh: true,
+      contextTokens: 200_000,
+    });
+  });
+
+  it("applies chat history session info for the selected non-default global agent", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "global",
+      assistantAgentId: "work",
+      agentsList: { defaultId: "main" },
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "global", kind: "global", updatedAt: 1, status: "running" }],
+      },
+      chatRunId: "run-work",
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "global",
+      kind: "global",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions[0]).toMatchObject({
+      key: "global",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+    expect(state.chatRunId).toBeNull();
+  });
+
+  it("clears current runs from canonical chat history rows outside the visible list", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "main",
+      sessionsResultAgentId: "work",
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:work:main", kind: "direct", updatedAt: 1, status: "done" }],
+      },
+      chatRunId: "run-main",
+      chatStream: "streaming",
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "agent:main:main",
+      kind: "direct",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions.map((row) => row.key)).toEqual(["agent:work:main"]);
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+  });
+
+  it("clears alias-selected runs from first-load canonical chat history rows", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "main",
+      sessionsResult: null,
+      chatRunId: "run-main",
+      chatStream: "streaming",
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "agent:main:main",
+      kind: "direct",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions[0]?.key).toBe("agent:main:main");
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+  });
+
+  it("merges canonical chat history rows into visible legacy alias rows", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "main",
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "main", kind: "direct", updatedAt: 1, status: "running" }],
+      },
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "agent:main:main",
+      kind: "direct",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.count).toBe(1);
+    expect(state.sessionsResult?.sessions).toEqual([
+      expect.objectContaining({
+        key: "main",
+        updatedAt: 2,
+        status: "done",
+        hasActiveRun: false,
+      }),
+    ]);
+  });
+
+  it("clears current global runs even when the visible list is scoped elsewhere", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "global",
+      assistantAgentId: "work",
+      agentsList: { defaultId: "main" },
+      sessionsResultAgentId: "main",
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: 1, status: "done" }],
+      },
+      chatRunId: "run-work-global",
+      chatStream: "streaming",
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "global",
+      kind: "global",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions.map((row) => row.key)).toEqual(["agent:main:main"]);
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
   });
 
   it("keeps updated existing rows sorted like sessions.list", () => {

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -2087,6 +2087,82 @@ describe("applySessionsChangedEvent", () => {
     });
   });
 
+  it("updates catalog-backed thinking metadata from chat history session info", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: {
+          modelProvider: "custom",
+          model: "catalog-model",
+          contextTokens: 200_000,
+          thinkingLevels: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+          ],
+          thinkingOptions: ["Low", "Medium", "High"],
+          thinkingDefault: "medium",
+        },
+        sessions: [
+          {
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 1,
+            thinkingLevels: [
+              { id: "low", label: "Low" },
+              { id: "medium", label: "Medium" },
+              { id: "high", label: "High" },
+            ],
+            thinkingOptions: ["Low", "Medium", "High"],
+            thinkingDefault: "medium",
+          },
+        ],
+      },
+    });
+
+    const catalogThinkingLevels = [
+      { id: "low", label: "Low" },
+      { id: "medium", label: "Medium" },
+      { id: "high", label: "High" },
+      { id: "xhigh", label: "Extra high" },
+    ];
+    const applied = applyChatHistorySessionInfo(
+      state,
+      {
+        key: "agent:main:main",
+        kind: "direct",
+        updatedAt: 2,
+        thinkingLevels: catalogThinkingLevels,
+        thinkingOptions: ["Low", "Medium", "High", "Extra high"],
+        thinkingDefault: "medium",
+      },
+      {
+        modelProvider: "custom",
+        model: "catalog-model",
+        contextTokens: 200_000,
+        thinkingLevels: catalogThinkingLevels,
+        thinkingOptions: ["Low", "Medium", "High", "Extra high"],
+        thinkingDefault: "medium",
+      },
+    );
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions[0]?.thinkingLevels?.map((level) => level.id)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(state.sessionsResult?.defaults.thinkingLevels?.map((level) => level.id)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
   it("applies chat history session info for the selected non-default global agent", () => {
     const state = createState(async () => undefined, {
       sessionKey: "global",

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -2163,6 +2163,82 @@ describe("applySessionsChangedEvent", () => {
     ]);
   });
 
+  it("keeps richer catalog-backed thinking metadata when chat history is lightweight", () => {
+    const catalogThinkingLevels = [
+      { id: "low", label: "Low" },
+      { id: "medium", label: "Medium" },
+      { id: "high", label: "High" },
+      { id: "xhigh", label: "Extra high" },
+    ];
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: {
+          modelProvider: "custom",
+          model: "catalog-model",
+          contextTokens: 200_000,
+          thinkingLevels: catalogThinkingLevels,
+          thinkingOptions: ["Low", "Medium", "High", "Extra high"],
+          thinkingDefault: "medium",
+        },
+        sessions: [
+          {
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 1,
+            thinkingLevels: catalogThinkingLevels,
+            thinkingOptions: ["Low", "Medium", "High", "Extra high"],
+            thinkingDefault: "medium",
+          },
+        ],
+      },
+    });
+
+    const applied = applyChatHistorySessionInfo(
+      state,
+      {
+        key: "agent:main:main",
+        kind: "direct",
+        updatedAt: 2,
+        thinkingLevels: [
+          { id: "low", label: "Low" },
+          { id: "medium", label: "Medium" },
+          { id: "high", label: "High" },
+        ],
+        thinkingOptions: ["Low", "Medium", "High"],
+        thinkingDefault: "medium",
+      },
+      {
+        modelProvider: "custom",
+        model: "catalog-model",
+        contextTokens: 200_000,
+        thinkingLevels: [
+          { id: "low", label: "Low" },
+          { id: "medium", label: "Medium" },
+          { id: "high", label: "High" },
+        ],
+        thinkingOptions: ["Low", "Medium", "High"],
+        thinkingDefault: "medium",
+      },
+    );
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions[0]?.thinkingLevels?.map((level) => level.id)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(state.sessionsResult?.defaults.thinkingLevels?.map((level) => level.id)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
   it("applies chat history session info for the selected non-default global agent", () => {
     const state = createState(async () => undefined, {
       sessionKey: "global",

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -2087,6 +2087,23 @@ describe("applySessionsChangedEvent", () => {
     });
   });
 
+  it("does not create visible rows from synthetic chat history session info", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: null,
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "agent:main:missing",
+      kind: "direct",
+      updatedAt: null,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(false);
+    expect(state.sessionsResult).toBeNull();
+  });
+
   it("updates catalog-backed thinking metadata from chat history session info", () => {
     const state = createState(async () => undefined, {
       sessionsResult: {

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -2517,6 +2517,39 @@ describe("applySessionsChangedEvent", () => {
     ]);
   });
 
+  it("merges canonical global chat history rows into selected global alias rows", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "agent:work:main",
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:work:main", kind: "global", updatedAt: 1, status: "running" }],
+      },
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "global",
+      kind: "global",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.count).toBe(1);
+    expect(state.sessionsResult?.sessions).toEqual([
+      expect.objectContaining({
+        key: "agent:work:main",
+        kind: "global",
+        updatedAt: 2,
+        status: "done",
+        hasActiveRun: false,
+      }),
+    ]);
+  });
+
   it("clears current global runs even when the visible list is scoped elsewhere", () => {
     const state = createState(async () => undefined, {
       sessionKey: "global",

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -2550,6 +2550,40 @@ describe("applySessionsChangedEvent", () => {
     ]);
   });
 
+  it("merges canonical global chat history rows into configured main-key alias rows", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "agent:work:inbox",
+      agentsList: { defaultId: "main", mainKey: "inbox" },
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:work:inbox", kind: "global", updatedAt: 1, status: "running" }],
+      },
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "global",
+      kind: "global",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.count).toBe(1);
+    expect(state.sessionsResult?.sessions).toEqual([
+      expect.objectContaining({
+        key: "agent:work:inbox",
+        kind: "global",
+        updatedAt: 2,
+        status: "done",
+        hasActiveRun: false,
+      }),
+    ]);
+  });
+
   it("clears current global runs even when the visible list is scoped elsewhere", () => {
     const state = createState(async () => undefined, {
       sessionKey: "global",

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -2104,6 +2104,42 @@ describe("applySessionsChangedEvent", () => {
     expect(state.sessionsResult).toBeNull();
   });
 
+  it("keeps history defaults when ignoring synthetic chat history session rows", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: null,
+    });
+
+    const applied = applyChatHistorySessionInfo(
+      state,
+      {
+        key: "agent:main:missing",
+        kind: "direct",
+        updatedAt: null,
+        status: "done",
+        hasActiveRun: false,
+      },
+      {
+        modelProvider: "openai",
+        model: "gpt-5.4",
+        contextTokens: 200_000,
+        thinkingLevels: [{ id: "medium", label: "Medium" }],
+        thinkingDefault: "medium",
+      },
+    );
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult).toMatchObject({
+      count: 0,
+      sessions: [],
+      defaults: {
+        modelProvider: "openai",
+        model: "gpt-5.4",
+        contextTokens: 200_000,
+        thinkingDefault: "medium",
+      },
+    });
+  });
+
   it("updates catalog-backed thinking metadata from chat history session info", () => {
     const state = createState(async () => undefined, {
       sessionsResult: {
@@ -2388,6 +2424,47 @@ describe("applySessionsChangedEvent", () => {
       key: "agent:main:main",
       kind: "direct",
       updatedAt: 50,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.chatRunId).toBe("run-active");
+    expect(state.chatStream).toBe("streaming");
+    expect(state.sessionsResult?.sessions[0]).toMatchObject({
+      updatedAt: 100,
+      status: "running",
+      hasActiveRun: true,
+    });
+  });
+
+  it("does not clear equal-timestamp active runs from stale chat history session info", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "agent:main:main",
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 100,
+            startedAt: 100,
+            status: "running",
+            hasActiveRun: true,
+          },
+        ],
+      },
+      chatRunId: "run-active",
+      chatStream: "streaming",
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "agent:main:main",
+      kind: "direct",
+      updatedAt: 100,
       status: "done",
       hasActiveRun: false,
     });

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -2239,6 +2239,78 @@ describe("applySessionsChangedEvent", () => {
     ]);
   });
 
+  it("uses incoming thinking metadata when chat history changes models", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: {
+          modelProvider: "custom",
+          model: "extended-model",
+          contextTokens: 200_000,
+          thinkingLevels: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+            { id: "xhigh", label: "Extra high" },
+          ],
+          thinkingOptions: ["Low", "Medium", "High", "Extra high"],
+          thinkingDefault: "medium",
+        },
+        sessions: [
+          {
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 1,
+            modelProvider: "custom",
+            model: "extended-model",
+            thinkingLevels: [
+              { id: "low", label: "Low" },
+              { id: "medium", label: "Medium" },
+              { id: "high", label: "High" },
+              { id: "xhigh", label: "Extra high" },
+            ],
+            thinkingOptions: ["Low", "Medium", "High", "Extra high"],
+            thinkingDefault: "medium",
+          },
+        ],
+      },
+    });
+
+    const applied = applyChatHistorySessionInfo(
+      state,
+      {
+        key: "agent:main:main",
+        kind: "direct",
+        updatedAt: 2,
+        modelProvider: "custom",
+        model: "basic-model",
+        thinkingLevels: [{ id: "off", label: "Off" }],
+        thinkingOptions: ["Off"],
+        thinkingDefault: "off",
+      },
+      {
+        modelProvider: "custom",
+        model: "basic-model",
+        contextTokens: 200_000,
+        thinkingLevels: [{ id: "off", label: "Off" }],
+        thinkingOptions: ["Off"],
+        thinkingDefault: "off",
+      },
+    );
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions[0]).toMatchObject({
+      model: "basic-model",
+      thinkingLevels: [{ id: "off", label: "Off" }],
+      thinkingOptions: ["Off"],
+    });
+    expect(state.sessionsResult?.defaults.thinkingLevels?.map((level) => level.id)).toEqual([
+      "off",
+    ]);
+  });
+
   it("applies chat history session info for the selected non-default global agent", () => {
     const state = createState(async () => undefined, {
       sessionKey: "global",
@@ -2270,6 +2342,47 @@ describe("applySessionsChangedEvent", () => {
       hasActiveRun: false,
     });
     expect(state.chatRunId).toBeNull();
+  });
+
+  it("does not clear newer active runs from stale chat history session info", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "agent:main:main",
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 100,
+            startedAt: 90,
+            status: "running",
+            hasActiveRun: true,
+          },
+        ],
+      },
+      chatRunId: "run-active",
+      chatStream: "streaming",
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "agent:main:main",
+      kind: "direct",
+      updatedAt: 50,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.chatRunId).toBe("run-active");
+    expect(state.chatStream).toBe("streaming");
+    expect(state.sessionsResult?.sessions[0]).toMatchObject({
+      updatedAt: 100,
+      status: "running",
+      hasActiveRun: true,
+    });
   });
 
   it("clears current runs from canonical chat history rows outside the visible list", () => {

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -2247,6 +2247,55 @@ describe("applySessionsChangedEvent", () => {
     expect(state.chatStream).toBeNull();
   });
 
+  it("preserves first-load chat history scope for selected global agent rows", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "agent:work:global",
+      sessionsResult: null,
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "global",
+      kind: "global",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResultAgentId).toBe("work");
+
+    const crossAgentApplied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      session: {
+        key: "agent:main:main",
+        kind: "direct",
+        updatedAt: 3,
+      },
+    });
+
+    expect(crossAgentApplied).toEqual({ applied: true, change: "inserted" });
+    expect(state.sessionsResult?.sessions.map((row) => row.key)).toEqual(["global"]);
+  });
+
+  it("preserves first-load chat history scope for canonical agent rows", () => {
+    const state = createState(async () => undefined, {
+      sessionKey: "agent:work:main",
+      sessionsResult: null,
+    });
+
+    const applied = applyChatHistorySessionInfo(state, {
+      key: "agent:work:main",
+      kind: "direct",
+      updatedAt: 2,
+      status: "done",
+      hasActiveRun: false,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResultAgentId).toBe("work");
+  });
+
   it("merges canonical chat history rows into visible legacy alias rows", () => {
     const state = createState(async () => undefined, {
       sessionKey: "main",

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -1,9 +1,15 @@
 import {
   reconcileChatRunFromCurrentSessionRow,
+  reconcileChatRunFromSessionRow,
   type ChatRunUiStatus,
 } from "../chat/run-lifecycle.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../gateway.ts";
-import { isSubagentSessionKey, normalizeAgentId, parseAgentSessionKey } from "../session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  isSubagentSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../session-key.ts";
 import type {
   GatewaySessionRow,
   SessionCompactionCheckpoint,
@@ -366,6 +372,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function hasOwn(record: Record<string, unknown>, key: string): boolean {
   return Object.hasOwn(record, key);
+}
+
+function sanitizeChatHistorySessionRow(row: GatewaySessionRow): GatewaySessionRow {
+  const next: Partial<GatewaySessionRow> = {};
+  for (const [key, value] of Object.entries(row) as Array<[keyof GatewaySessionRow, unknown]>) {
+    if (value === undefined) {
+      continue;
+    }
+    if (key === "totalTokensFresh" && value === false && row.totalTokens === undefined) {
+      continue;
+    }
+    next[key] = value as never;
+  }
+  return next as GatewaySessionRow;
 }
 
 export function parseSessionsFilterInteger(value: string): number {
@@ -775,6 +795,71 @@ export function applySessionsChangedEvent(
         }
       : {}),
   };
+}
+
+export function applyChatHistorySessionInfo(
+  state: SessionsState,
+  row: GatewaySessionRow | undefined,
+  defaults?: SessionsListResult["defaults"],
+): boolean {
+  if (!row?.key) {
+    return false;
+  }
+  const session = sanitizeChatHistorySessionRow(row);
+  if (!state.sessionsResult) {
+    const sessions = state.sessionsShowArchived || !isArchivedSessionRow(session) ? [session] : [];
+    state.sessionsResult = {
+      ts: Date.now(),
+      path: "",
+      count: sessions.length,
+      defaults: defaults ?? {
+        modelProvider: null,
+        model: null,
+        contextTokens: null,
+      },
+      sessions,
+    };
+    upsertCachedChatAgentSessionRow(state, session);
+    if (hasCurrentChatSession(state)) {
+      const reconciled = reconcileChatRunFromSessionRow(state, session, { publishRunStatus: true });
+      if (!reconciled) {
+        reconcileChatRunFromCurrentSessionRow(state, { publishRunStatus: true });
+      }
+    }
+    return true;
+  }
+  const visibleKey =
+    state.sessionsResult.sessions.find((existing) =>
+      areUiSessionKeysEquivalent(existing.key, session.key),
+    )?.key ?? session.key;
+  const visibleSession = visibleKey === session.key ? session : { ...session, key: visibleKey };
+  const applied = applySessionsChangedEvent(state, {
+    session: visibleSession,
+    sessionKey: visibleSession.key,
+    ...(isGlobalSessionKey(visibleSession.key)
+      ? { agentId: resolveSelectedGlobalAgentId(state) }
+      : {}),
+  });
+  if (applied.applied) {
+    upsertCachedChatAgentSessionRow(state, visibleSession);
+    if (hasCurrentChatSession(state)) {
+      const reconciled = reconcileChatRunFromSessionRow(state, visibleSession, {
+        publishRunStatus: true,
+      });
+      if (!reconciled) {
+        reconcileChatRunFromCurrentSessionRow(state, { publishRunStatus: true });
+      }
+    }
+    return true;
+  }
+  const cached = upsertCachedChatAgentSessionRow(state, visibleSession);
+  if (hasCurrentChatSession(state)) {
+    const reconciled =
+      reconcileChatRunFromSessionRow(state, visibleSession, { publishRunStatus: true }) ||
+      (cached && reconcileChatRunFromCurrentSessionRow(state, { publishRunStatus: true }));
+    return cached || reconciled;
+  }
+  return cached;
 }
 
 export async function subscribeSessions(state: SessionsState) {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -555,11 +555,11 @@ function historyRowIsStaleForActiveSession(
   }
   const existingUpdatedAt = existing.updatedAt ?? 0;
   const incomingUpdatedAt = incoming.updatedAt ?? 0;
-  if (existingUpdatedAt > incomingUpdatedAt) {
+  if (existingUpdatedAt >= incomingUpdatedAt) {
     return true;
   }
   const existingStartedAt = typeof existing.startedAt === "number" ? existing.startedAt : 0;
-  return existingStartedAt > incomingUpdatedAt;
+  return existingStartedAt >= incomingUpdatedAt;
 }
 
 function isPersistedChatHistorySessionRow(row: GatewaySessionRow): boolean {
@@ -917,7 +917,17 @@ export function applyChatHistorySessionInfo(
   const session = sanitizeChatHistorySessionRow(row);
   if (!state.sessionsResult) {
     if (!isPersistedChatHistorySessionRow(session)) {
-      return false;
+      if (!defaults) {
+        return false;
+      }
+      state.sessionsResult = {
+        ts: Date.now(),
+        path: "",
+        count: 0,
+        defaults,
+        sessions: [],
+      };
+      return true;
     }
     const sessions = state.sessionsShowArchived || !isArchivedSessionRow(session) ? [session] : [];
     state.sessionsResult = {
@@ -945,6 +955,13 @@ export function applyChatHistorySessionInfo(
     sessionRowMatchesChatHistoryRow(state, existing, session),
   );
   if (!existingVisibleSession && !isPersistedChatHistorySessionRow(session)) {
+    if (defaults) {
+      state.sessionsResult = {
+        ...state.sessionsResult,
+        defaults: preserveRicherThinkingMetadata(defaults, state.sessionsResult.defaults),
+      };
+      return true;
+    }
     return false;
   }
   if (defaults) {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -484,6 +484,35 @@ function compareSessionRowsByUpdatedAt(a: GatewaySessionRow, b: GatewaySessionRo
   return (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
 }
 
+type ThinkingMetadataCarrier = {
+  thinkingLevels?: Array<{ id: string; label: string }>;
+  thinkingOptions?: string[];
+  thinkingDefault?: string;
+};
+
+function preserveRicherThinkingMetadata<T extends ThinkingMetadataCarrier>(
+  incoming: T,
+  existing: ThinkingMetadataCarrier | undefined,
+): T {
+  const existingLevels = existing?.thinkingLevels;
+  if (!existingLevels?.length) {
+    return incoming;
+  }
+  const incomingLevels = incoming.thinkingLevels;
+  if (incomingLevels && incomingLevels.length >= existingLevels.length) {
+    return incoming;
+  }
+  const existingThinkingDefault = existing?.thinkingDefault;
+  return {
+    ...incoming,
+    thinkingLevels: existingLevels,
+    ...(existing?.thinkingOptions ? { thinkingOptions: existing.thinkingOptions } : {}),
+    ...(incoming.thinkingDefault === undefined && existingThinkingDefault !== undefined
+      ? { thinkingDefault: existingThinkingDefault }
+      : {}),
+  };
+}
+
 function checkpointSummarySignature(
   row:
     | {
@@ -841,17 +870,22 @@ export function applyChatHistorySessionInfo(
     }
     return true;
   }
+  const existingVisibleSession = state.sessionsResult.sessions.find((existing) =>
+    areUiSessionKeysEquivalent(existing.key, session.key),
+  );
   if (defaults) {
     state.sessionsResult = {
       ...state.sessionsResult,
-      defaults,
+      defaults: preserveRicherThinkingMetadata(defaults, state.sessionsResult.defaults),
     };
   }
-  const visibleKey =
-    state.sessionsResult.sessions.find((existing) =>
-      areUiSessionKeysEquivalent(existing.key, session.key),
-    )?.key ?? session.key;
-  const visibleSession = visibleKey === session.key ? session : { ...session, key: visibleKey };
+  const visibleKey = existingVisibleSession?.key ?? session.key;
+  const keyedVisibleSession =
+    visibleKey === session.key ? session : { ...session, key: visibleKey };
+  const visibleSession = preserveRicherThinkingMetadata(
+    keyedVisibleSession,
+    existingVisibleSession,
+  );
   const applied = applySessionsChangedEvent(state, {
     session: visibleSession,
     sessionKey: visibleSession.key,

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -341,6 +341,7 @@ const SESSION_EVENT_ROW_FIELDS = [
   "systemSent",
   "thinkingDefault",
   "thinkingLevel",
+  "thinkingLevels",
   "thinkingOptions",
   "totalTokens",
   "totalTokensFresh",
@@ -827,6 +828,12 @@ export function applyChatHistorySessionInfo(
       }
     }
     return true;
+  }
+  if (defaults) {
+    state.sessionsResult = {
+      ...state.sessionsResult,
+      defaults,
+    };
   }
   const visibleKey =
     state.sessionsResult.sessions.find((existing) =>

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -549,6 +549,20 @@ function historyRowIsStaleForActiveSession(
   return existingStartedAt > incomingUpdatedAt;
 }
 
+function sessionRowMatchesChatHistoryRow(
+  state: SessionsState,
+  existing: GatewaySessionRow,
+  incoming: GatewaySessionRow,
+): boolean {
+  if (areUiSessionKeysEquivalent(existing.key, incoming.key)) {
+    return true;
+  }
+  return (
+    isGlobalSessionKey(incoming.key) &&
+    resolveSelectedGlobalAliasAgentId(state, existing.key) === resolveSelectedGlobalAgentId(state)
+  );
+}
+
 function checkpointSummarySignature(
   row:
     | {
@@ -907,7 +921,7 @@ export function applyChatHistorySessionInfo(
     return true;
   }
   const existingVisibleSession = state.sessionsResult.sessions.find((existing) =>
-    areUiSessionKeysEquivalent(existing.key, session.key),
+    sessionRowMatchesChatHistoryRow(state, existing, session),
   );
   if (defaults) {
     state.sessionsResult = {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -10,6 +10,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../session-key.ts";
+import { isSessionRunActive } from "../session-run-state.ts";
 import type {
   GatewaySessionRow,
   SessionCompactionCheckpoint,
@@ -485,15 +486,34 @@ function compareSessionRowsByUpdatedAt(a: GatewaySessionRow, b: GatewaySessionRo
 }
 
 type ThinkingMetadataCarrier = {
+  modelProvider?: string | null;
+  model?: string | null;
   thinkingLevels?: Array<{ id: string; label: string }>;
   thinkingOptions?: string[];
   thinkingDefault?: string;
 };
 
+function thinkingMetadataModelMatches(
+  incoming: ThinkingMetadataCarrier,
+  existing: ThinkingMetadataCarrier,
+): boolean {
+  const incomingProvider = incoming.modelProvider;
+  const existingProvider = existing.modelProvider;
+  if (incomingProvider && existingProvider && incomingProvider !== existingProvider) {
+    return false;
+  }
+  const incomingModel = incoming.model;
+  const existingModel = existing.model;
+  return !(incomingModel && existingModel && incomingModel !== existingModel);
+}
+
 function preserveRicherThinkingMetadata<T extends ThinkingMetadataCarrier>(
   incoming: T,
   existing: ThinkingMetadataCarrier | undefined,
 ): T {
+  if (existing && !thinkingMetadataModelMatches(incoming, existing)) {
+    return incoming;
+  }
   const existingLevels = existing?.thinkingLevels;
   if (!existingLevels?.length) {
     return incoming;
@@ -511,6 +531,22 @@ function preserveRicherThinkingMetadata<T extends ThinkingMetadataCarrier>(
       ? { thinkingDefault: existingThinkingDefault }
       : {}),
   };
+}
+
+function historyRowIsStaleForActiveSession(
+  incoming: GatewaySessionRow,
+  existing: GatewaySessionRow | undefined,
+): boolean {
+  if (!existing || !isSessionRunActive(existing) || isSessionRunActive(incoming)) {
+    return false;
+  }
+  const existingUpdatedAt = existing.updatedAt ?? 0;
+  const incomingUpdatedAt = incoming.updatedAt ?? 0;
+  if (existingUpdatedAt > incomingUpdatedAt) {
+    return true;
+  }
+  const existingStartedAt = typeof existing.startedAt === "number" ? existing.startedAt : 0;
+  return existingStartedAt > incomingUpdatedAt;
 }
 
 function checkpointSummarySignature(
@@ -886,6 +922,9 @@ export function applyChatHistorySessionInfo(
     keyedVisibleSession,
     existingVisibleSession,
   );
+  if (historyRowIsStaleForActiveSession(visibleSession, existingVisibleSession)) {
+    return true;
+  }
   const applied = applySessionsChangedEvent(state, {
     session: visibleSession,
     sessionKey: visibleSession.key,

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -54,7 +54,7 @@ export type SessionsState = SessionsChatRunState & {
   chatSessionMessageSubscriptionRequestedKey?: string | null;
   chatSessionMessageSubscriptionAgentId?: string | null;
   assistantAgentId?: string | null;
-  agentsList?: { defaultId?: string | null } | null;
+  agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
   hello?: GatewayHelloOk | null;
 };
 
@@ -108,6 +108,18 @@ function isGlobalSessionKey(value: string | null | undefined): boolean {
   return (value ?? "").trim().toLowerCase() === "global";
 }
 
+function resolveConfiguredMainKey(state: SessionsState): string {
+  const snapshot = state.hello?.snapshot as { sessionDefaults?: { mainKey?: string } } | undefined;
+  const mainKey =
+    typeof state.agentsList?.mainKey === "string" && state.agentsList.mainKey.trim()
+      ? state.agentsList.mainKey
+      : typeof snapshot?.sessionDefaults?.mainKey === "string" &&
+          snapshot.sessionDefaults.mainKey.trim()
+        ? snapshot.sessionDefaults.mainKey
+        : "main";
+  return mainKey.trim().toLowerCase();
+}
+
 function resolveSelectedGlobalAliasAgentId(
   state: SessionsState,
   key: string | null | undefined,
@@ -120,7 +132,8 @@ function resolveSelectedGlobalAliasAgentId(
   if (rest === "global") {
     return normalizeAgentId(parsed.agentId);
   }
-  if (rest !== "main") {
+  const configuredMainKey = resolveConfiguredMainKey(state);
+  if (rest !== "main" && rest !== configuredMainKey) {
     return null;
   }
   const row = state.sessionsResult?.sessions.find((session) => session.key === key);

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -562,6 +562,11 @@ function historyRowIsStaleForActiveSession(
   return existingStartedAt > incomingUpdatedAt;
 }
 
+function isPersistedChatHistorySessionRow(row: GatewaySessionRow): boolean {
+  const sessionId = typeof row.sessionId === "string" ? row.sessionId.trim() : "";
+  return Boolean(sessionId || typeof row.updatedAt === "number");
+}
+
 function sessionRowMatchesChatHistoryRow(
   state: SessionsState,
   existing: GatewaySessionRow,
@@ -911,6 +916,9 @@ export function applyChatHistorySessionInfo(
   }
   const session = sanitizeChatHistorySessionRow(row);
   if (!state.sessionsResult) {
+    if (!isPersistedChatHistorySessionRow(session)) {
+      return false;
+    }
     const sessions = state.sessionsShowArchived || !isArchivedSessionRow(session) ? [session] : [];
     state.sessionsResult = {
       ts: Date.now(),
@@ -936,6 +944,9 @@ export function applyChatHistorySessionInfo(
   const existingVisibleSession = state.sessionsResult.sessions.find((existing) =>
     sessionRowMatchesChatHistoryRow(state, existing, session),
   );
+  if (!existingVisibleSession && !isPersistedChatHistorySessionRow(session)) {
+    return false;
+  }
   if (defaults) {
     state.sessionsResult = {
       ...state.sessionsResult,

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -160,6 +160,17 @@ function resolveSelectedGlobalAgentId(state: SessionsState): string {
   return normalizeAgentId(assistantAgentId ?? defaultAgentId ?? helloDefaultAgentId ?? "main");
 }
 
+function resolveChatHistorySessionResultAgentId(
+  state: SessionsState,
+  row: GatewaySessionRow,
+): string | null {
+  const parsed = parseAgentSessionKey(row.key);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId);
+  }
+  return isGlobalSessionKey(row.key) ? resolveSelectedGlobalAgentId(state) : null;
+}
+
 function resolveDefaultGlobalAgentId(state: SessionsState): string {
   const snapshot = state.hello?.snapshot as
     | { sessionDefaults?: { defaultAgentId?: string } }
@@ -820,6 +831,7 @@ export function applyChatHistorySessionInfo(
       },
       sessions,
     };
+    state.sessionsResultAgentId = resolveChatHistorySessionResultAgentId(state, session);
     upsertCachedChatAgentSessionRow(state, session);
     if (hasCurrentChatSession(state)) {
       const reconciled = reconcileChatRunFromSessionRow(state, session, { publishRunStatus: true });


### PR DESCRIPTION
## Summary

- Make chat.history return selected session metadata/defaults so TUI and web can hydrate startup state without a follow-up sessions.list.
- Reuse the history metadata in web chat refresh and TUI history loading, including run state, model/thinking defaults, global aliases, and blank-chat defaults.
- Add guards for stale active rows, synthetic history rows, configured main-key aliases, and lightweight TUI token metadata.

## Verification

- node scripts/run-vitest.mjs ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/chat/run-lifecycle.test.ts src/tui/tui-session-actions.test.ts
- node scripts/run-vitest.mjs ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/chat/run-lifecycle.test.ts src/tui/tui-session-actions.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts
- node scripts/run-tsgo.mjs -b tsconfig.projects.json
- pnpm build
- pnpm check:changed: Testbox tbx_01kt022hb9pze9vy3sgfq5tg5f, GitHub Actions https://github.com/openclaw/openclaw/actions/runs/26726171494, exit 0
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main: clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: TUI and web chat startup/refresh can hydrate current session metadata from chat.history and avoid the extra sessions.list call.

Real environment tested: Local built dist gateway on loopback, local TUI in tmux, Chrome DevTools automation against the web UI.

Exact steps or command run after this patch: Started gateway in tmux with node dist/entry.js gateway run --dev --allow-unconfigured --auth none --bind loopback --port 18789 --force --ws-log compact; started TUI in tmux with node dist/entry.js tui --url ws://127.0.0.1:18789 --token proof-token --session live-proof-pr-tui --history-limit 1; sent /new; opened http://127.0.0.1:18789/chat?session=live-proof-pr-web via chrome-devtools.new_page; evaluated page title/body via chrome-devtools.evaluate_script; counted gateway methods from the proof log.

Evidence after fix: TUI /new created tui-07c8bae9-4202-44a1-a529-f75f3295f370 and stayed idle with hydrated model/defaults. Chrome rendered OpenClaw Control for live-proof-pr-web and showed Ready to chat. Gateway proof log showed chat.history count 3 and sessions.list count 0.

Observed result after fix: Both TUI and web loaded usable chat views from chat.history metadata, and the web startup proof did not call sessions.list.

What was not tested: Cross-platform packaged app smoke; this PR was verified locally, in browser/TUI live proof, focused Vitest suites, build, autoreview, and Testbox changed gate.
