### PR TITLE
fix(telegram): silently skip empty-text sends

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -2,6 +2,10 @@
 import { type Bot, GrammyError } from "grammy";
 import type { Message } from "grammy/types";
 import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -367,6 +371,8 @@ async function deliverMediaReply(params: {
 }): Promise<{ firstDeliveredMessageId?: number; visibleFallbackText?: string }> {
   let firstDeliveredMessageId: number | undefined;
   let visibleFallbackText: string | undefined;
+  let firstDeliveredCaption: string | undefined;
+  const deliveredMediaMessageIds: string[] = [];
   let first = true;
   let pendingFollowUpText: string | undefined;
   const recordPromptContextMessage = async (message: Message, text?: string) => {
@@ -381,10 +387,9 @@ async function deliverMediaReply(params: {
     sender: TelegramOutboundMediaSender<Message>;
     requestParams: Record<string, unknown>;
     plainCaption?: string;
-    text?: string;
     shouldLog?: (err: unknown) => boolean;
   }) => {
-    const message = await sendTelegramCaptionedMediaWithFallback({
+    const delivery = await sendTelegramCaptionedMediaWithFallback({
       operation: options.sender.operation,
       requestParams: options.requestParams,
       plainCaption: options.plainCaption,
@@ -398,10 +403,25 @@ async function deliverMediaReply(params: {
           send: options.sender.send,
         }),
     });
+    const message = delivery.result;
     firstDeliveredMessageId ??= message.message_id;
+    firstDeliveredCaption ??= delivery.deliveredCaption;
+    if (delivery.captionRemoved) {
+      visibleFallbackText = "";
+    }
+    deliveredMediaMessageIds.push(String(message.message_id));
     params.recordMessageId(message.message_id);
-    await recordPromptContextMessage(message, options.text);
+    await recordPromptContextMessage(message, delivery.deliveredCaption);
     markDelivered(params.progress);
+  };
+  const throwMediaPartial = (error: unknown): never => {
+    const textMessageIds = isChannelPartialDeliveryError(error)
+      ? (error.deliveryResult.messageIds ?? [])
+      : [];
+    throw createChannelPartialDeliveryError(error, {
+      messageIds: [...new Set([...deliveredMediaMessageIds, ...textMessageIds])],
+      visibleReplySent: true,
+    });
   };
   const createVoiceFallbackProgress = (): DeliveryProgress => ({
     hasReplied: false,
@@ -470,7 +490,6 @@ async function deliverMediaReply(params: {
           sender: mediaSender,
           requestParams,
           plainCaption: hasCaption ? plainCaption : undefined,
-          text: hasCaption ? plainCaption : undefined,
           shouldLog,
         });
       };
@@ -526,6 +545,9 @@ async function deliverMediaReply(params: {
             replyToId: voiceFallbackReplyTo,
             includeQuote: true,
           });
+          if (fallbackMessageId === undefined) {
+            throw voiceErr;
+          }
           firstDeliveredMessageId ??= fallbackMessageId;
           visibleFallbackText = fallbackText;
           markReplyApplied(params.progress, voiceFallbackReplyTo);
@@ -542,8 +564,19 @@ async function deliverMediaReply(params: {
           await sendVoiceMedia(noCaptionParams);
           const fallbackText = resolveVoiceFallbackText(params.reply);
           if (fallbackText?.trim()) {
-            await sendVoiceFallbackText(fallbackText, { replyToMode: "first" });
-            visibleFallbackText = fallbackText;
+            try {
+              const fallbackMessageId = await sendVoiceFallbackText(fallbackText, {
+                replyToMode: "first",
+              });
+              if (fallbackMessageId !== undefined) {
+                visibleFallbackText = fallbackText;
+              }
+            } catch (fallbackError) {
+              if (!isTelegramEmptyContentError(fallbackError)) {
+                throw fallbackError;
+              }
+              visibleFallbackText = "";
+            }
           }
           markReplyApplied(params.progress, replyToMessageId);
           continue;
@@ -559,7 +592,6 @@ async function deliverMediaReply(params: {
             sender,
             requestParams: mediaParams,
             plainCaption,
-            text: plainCaption,
             ...(sender.label === "photo"
               ? { shouldLog: (error: unknown) => !isTelegramPhotoLimitError(error) }
               : {}),
@@ -568,23 +600,44 @@ async function deliverMediaReply(params: {
     }
     markReplyApplied(params.progress, replyToMessageId);
     if (pendingFollowUpText && isFirstMedia) {
-      await deliverTextReply({
-        bot: params.bot,
-        chatId: params.chatId,
-        runtime: params.runtime,
-        thread: params.thread,
-        chunkText: params.chunkText,
-        text: pendingFollowUpText,
-        replyMarkup: params.replyMarkup,
-        richMessages: params.richMessages,
-        tableMode: params.tableMode,
-        linkPreview: params.linkPreview,
-        silent: params.silent,
-        replyToId: params.replyToId,
-        replyToMode: params.replyToMode,
-        progress: params.progress,
-        recordMessageId: params.recordMessageId,
-      });
+      try {
+        const followUpMessageId = await deliverTextReply({
+          bot: params.bot,
+          chatId: params.chatId,
+          runtime: params.runtime,
+          thread: params.thread,
+          chunkText: params.chunkText,
+          text: pendingFollowUpText,
+          replyMarkup: params.replyMarkup,
+          richMessages: params.richMessages,
+          tableMode: params.tableMode,
+          linkPreview: params.linkPreview,
+          silent: params.silent,
+          replyToId: params.replyToId,
+          replyToMode: params.replyToMode,
+          progress: params.progress,
+          recordMessageId: params.recordMessageId,
+        });
+        if (followUpMessageId === undefined) {
+          visibleFallbackText = firstDeliveredCaption ?? "";
+        } else {
+          visibleFallbackText = undefined;
+        }
+      } catch (error) {
+        if (!isTelegramEmptyContentError(error)) {
+          throwMediaPartial(error);
+        }
+        visibleFallbackText = firstDeliveredCaption ?? "";
+        if (params.replyMarkup && firstDeliveredMessageId !== undefined) {
+          try {
+            await params.bot.api.editMessageReplyMarkup(params.chatId, firstDeliveredMessageId, {
+              reply_markup: params.replyMarkup,
+            });
+          } catch (keyboardError) {
+            throwMediaPartial(keyboardError);
+          }
+        }
+      }
       pendingFollowUpText = undefined;
     }
   }
@@ -945,7 +998,7 @@ export async function deliverReplies(params: {
           ...(params.textMode ? { textMode: params.textMode } : {}),
         });
         firstDeliveredMessageId = mediaDelivery.firstDeliveredMessageId;
-        if (mediaDelivery.visibleFallbackText) {
+        if (mediaDelivery.visibleFallbackText !== undefined) {
           contentForSentHook = mediaDelivery.visibleFallbackText;
         }
       }

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -55,6 +55,7 @@ import {
   TELEGRAM_RICH_TEXT_LIMIT,
   type TelegramInputRichMessage,
 } from "../rich-message.js";
+import { isTelegramEmptyContentError } from "../rich-plain-fallback.js";
 import { isTelegramPhotoLimitError } from "../send-error-predicates.js";
 import { buildInlineKeyboard, reactMessageTelegram } from "../send.js";
 import { recordSentMessage } from "../sent-message-cache.js";
@@ -178,7 +179,7 @@ function markDelivered(progress: DeliveryProgress): void {
 }
 
 function filterEmptyTelegramTextChunks<
-  T extends { text: string; richMessage?: TelegramInputRichMessage },
+  T extends { text: string; plainText?: string; richMessage?: TelegramInputRichMessage },
 >(chunks: readonly T[]): T[] {
   // Telegram rejects whitespace-only text payloads; drop them before sendMessage so
   // hook-mutated or model-emitted empty replies become a no-op instead of a 400.
@@ -186,7 +187,7 @@ function filterEmptyTelegramTextChunks<
   // can have an empty plain projection and must still send.
   return chunks.filter((chunk) =>
     chunk.richMessage
-      ? !isEmptyTelegramRichMessage(chunk.richMessage)
+      ? !isEmptyTelegramRichMessage(chunk.richMessage) || Boolean(chunk.plainText?.trim())
       : chunk.text.trim().length > 0,
   );
 }
@@ -267,6 +268,11 @@ async function deliverTextReply(params: {
     onRejected: (error) =>
       params.runtime.error?.(
         danger(`telegram reply chunk rejected; continuing: ${formatErrorMessage(error)}`),
+      ),
+    isSilentSkip: isTelegramEmptyContentError,
+    onSilentSkip: (error) =>
+      params.runtime.log?.(
+        `telegram reply chunk rendered empty; skipping: ${formatErrorMessage(error)}`,
       ),
     markDelivered,
     sendChunk: async ({ chunk, isFirstChunk, replyToMessageId, replyMarkup, replyQuoteText }) => {

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -24,6 +24,7 @@ import {
 } from "../rich-message.js";
 import {
   buildTelegramPlainFallbackPlan,
+  isTelegramEmptyContentError,
   isTelegramHtmlParseError,
   warnTelegramRichBlocksDegradations,
 } from "../rich-plain-fallback.js";
@@ -33,7 +34,6 @@ import type { TelegramThreadSpec } from "./helpers.js";
 
 export { buildTelegramSendParams } from "../reply-parameters.js";
 
-const EMPTY_TEXT_ERR_RE = /message text is empty/i;
 function createTelegramDeliverySendRetry() {
   return createChannelApiRetryRunner({
     shouldRetry: (err) => isSafeToRetrySendError(err) || isTelegramRateLimitError(err),
@@ -145,9 +145,7 @@ export async function sendTelegramText(
     });
     if (isEmptyTelegramRichMessage(richPlan.richMessage)) {
       if (!hasFallbackText) {
-        throw new Error(
-          "telegram sendRichMessage failed: empty rich text and empty plain fallback",
-        );
+        throw new Error("telegram text must be non-empty: rich and plain fallback rendered empty");
       }
       runtime.log?.("telegram sendRichMessage rendered empty; falling back to plain text");
       return await sendPlainFallback();
@@ -185,7 +183,9 @@ export async function sendTelegramText(
   // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
   if (!htmlText.trim()) {
     if (!hasFallbackText) {
-      throw new Error("telegram sendMessage failed: empty formatted text and empty plain fallback");
+      throw new Error(
+        "telegram text must be non-empty: formatted and plain fallback rendered empty",
+      );
     }
     return await sendPlainFallback();
   }
@@ -194,10 +194,7 @@ export async function sendTelegramText(
       operation: "sendMessage",
       runtime,
       requestParams: baseParams,
-      shouldLog: (err) => {
-        const errText = formatErrorMessage(err);
-        return !isTelegramHtmlParseError(err) && !EMPTY_TEXT_ERR_RE.test(errText);
-      },
+      shouldLog: (err) => !isTelegramHtmlParseError(err) && !isTelegramEmptyContentError(err),
       send: (effectiveParams) =>
         bot.api.sendMessage(chatId, htmlText, {
           parse_mode: "HTML",
@@ -210,7 +207,7 @@ export async function sendTelegramText(
     return res.message_id;
   } catch (err) {
     const errText = formatErrorMessage(err);
-    if (isTelegramHtmlParseError(err) || EMPTY_TEXT_ERR_RE.test(errText)) {
+    if (isTelegramHtmlParseError(err) || isTelegramEmptyContentError(err)) {
       if (!hasFallbackText) {
         throw err;
       }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -216,6 +216,16 @@ function createVoiceMessagesForbiddenError() {
   );
 }
 
+function createEmptyTextError() {
+  return new Error("Bad Request: text must be non-empty");
+}
+
+function createCaptionTooLongError() {
+  return new Error(
+    "GrammyError: Call to 'sendVoice' failed! (400: Bad Request: caption is too long)",
+  );
+}
+
 function createThreadNotFoundError(operation = "sendMessage") {
   return new Error(
     `GrammyError: Call to '${operation}' failed! (400: Bad Request: message thread not found)`,
@@ -1037,6 +1047,64 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("does not mirror media follow-up text that Telegram rejects as empty", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const invisibleText = "\u200B".repeat(1025);
+    const emptyError = createEmptyTextError();
+    const mediaUrl = "https://example.com/photo.jpg";
+    const sendPhoto = vi.fn().mockResolvedValueOnce({ message_id: 82, chat: { id: "123" } });
+    const sendMessage = vi.fn().mockRejectedValue(emptyError);
+    const transcriptMirror = vi.fn();
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    await expect(
+      deliverWith({
+        replies: [{ mediaUrl, text: invisibleText }],
+        runtime: createRuntime(),
+        bot: createBot({ sendPhoto, sendMessage }),
+        textMode: "html",
+        transcriptMirror,
+      }),
+    ).resolves.toEqual({ delivered: true });
+
+    expect(sendPhoto).toHaveBeenCalledOnce();
+    expect(mockCallArg(sendPhoto, 0, 2)).toHaveProperty("caption", undefined);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(recordSentMessage.mock.calls).toEqual([["123", 82, undefined]]);
+    expect(transcriptMirror).toHaveBeenCalledWith({ text: undefined, mediaUrls: [mediaUrl] });
+    expectRecordFields(mockCallArg(messageHookRunner.runMessageSent, 0, 0), {
+      success: true,
+      content: "",
+    });
+  });
+
+  it("retries media without a caption when Telegram renders it empty", async () => {
+    const invisibleText = "\u200B".repeat(1024);
+    const emptyError = createEmptyTextError();
+    const mediaUrl = "https://example.com/photo.jpg";
+    const sendPhoto = vi
+      .fn()
+      .mockRejectedValueOnce(emptyError)
+      .mockResolvedValueOnce({ message_id: 83, chat: { id: "123" } });
+    const transcriptMirror = vi.fn();
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    await expect(
+      deliverWith({
+        replies: [{ mediaUrl, text: invisibleText }],
+        runtime: createRuntime(),
+        bot: createBot({ sendPhoto }),
+        textMode: "html",
+        transcriptMirror,
+      }),
+    ).resolves.toEqual({ delivered: true });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(sendPhoto, 0, 2), { caption: invisibleText });
+    expect(mockCallArg(sendPhoto, 1, 2)).not.toHaveProperty("caption");
+    expect(transcriptMirror).toHaveBeenCalledWith({ text: undefined, mediaUrls: [mediaUrl] });
+  });
+
   it.each([
     {
       kind: "ordinary Markdown",
@@ -1484,7 +1552,7 @@ describe("deliverReplies", () => {
         bot: createBot({ sendMessage }),
         textMode: "html",
       }),
-    ).resolves.toEqual({ delivered: false });
+    ).rejects.toThrow("text must be non-empty");
 
     expect(sendMessage).toHaveBeenCalledOnce();
     expect(recordSentMessage).not.toHaveBeenCalled();
@@ -1923,6 +1991,69 @@ describe("deliverReplies", () => {
     if (firstMockCallArg(sendMessage, 2) === undefined) {
       throw new Error("Expected Telegram fallback text options");
     }
+  });
+
+  it("does not account for a voice fallback that Telegram rejects as empty", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const emptyError = createEmptyTextError();
+    const sendVoice = vi.fn().mockRejectedValue(createVoiceMessagesForbiddenError());
+    const sendMessage = vi.fn().mockRejectedValue(emptyError);
+    const transcriptMirror = vi.fn();
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await expect(
+      deliverWith({
+        replies: [
+          { mediaUrl: "https://example.com/note.ogg", text: "<i></i>", audioAsVoice: true },
+        ],
+        runtime: createRuntime(),
+        bot: createBot({ sendVoice, sendMessage }),
+        textMode: "html",
+        transcriptMirror,
+      }),
+    ).rejects.toBe(emptyError);
+
+    expect(sendVoice).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(recordSentMessage).not.toHaveBeenCalled();
+    expect(transcriptMirror).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(messageHookRunner.runMessageSent, 0, 0), {
+      success: false,
+      content: "<i></i>",
+    });
+  });
+
+  it("does not mirror caption text when the caption fallback is empty", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const invisibleText = "\u200B".repeat(1024);
+    const emptyError = createEmptyTextError();
+    const sendVoice = vi
+      .fn()
+      .mockRejectedValueOnce(createCaptionTooLongError())
+      .mockResolvedValueOnce({ message_id: 81, chat: { id: "123" } });
+    const sendMessage = vi.fn().mockRejectedValue(emptyError);
+    const transcriptMirror = vi.fn();
+    const mediaUrl = "https://example.com/note.ogg";
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await expect(
+      deliverWith({
+        replies: [{ mediaUrl, text: invisibleText, audioAsVoice: true }],
+        runtime: createRuntime(),
+        bot: createBot({ sendVoice, sendMessage }),
+        textMode: "html",
+        transcriptMirror,
+      }),
+    ).resolves.toEqual({ delivered: true });
+
+    expect(sendVoice).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(recordSentMessage.mock.calls).toEqual([["123", 81, undefined]]);
+    expect(transcriptMirror).toHaveBeenCalledWith({ text: undefined, mediaUrls: [mediaUrl] });
+    expectRecordFields(mockCallArg(messageHookRunner.runMessageSent, 0, 0), {
+      success: true,
+      content: "",
+    });
   });
 
   it("uses spokenText only after voice rejection", async () => {

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1472,6 +1472,28 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("records no delivery when Telegram rejects rendered-empty HTML", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockRejectedValue(new Error("Bad Request: text must be non-empty"));
+
+    await expect(
+      deliverWith({
+        replies: [{ text: "<i></i>" }],
+        runtime,
+        bot: createBot({ sendMessage }),
+        textMode: "html",
+      }),
+    ).resolves.toEqual({ delivered: false });
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(recordSentMessage).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(messageHookRunner.runMessageSent, 0, 0), {
+      success: false,
+      content: "<i></i>",
+    });
+  });
+
   it("uses reply_parameters when quote text is provided", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/bot/reply-threading.test.ts
+++ b/extensions/telegram/src/bot/reply-threading.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { isTelegramEmptyContentError } from "../rich-plain-fallback.js";
+import { sendChunkedTelegramReplyText } from "./reply-threading.js";
+
+describe("sendChunkedTelegramReplyText", () => {
+  it("carries first-send state past an empty skipped chunk", async () => {
+    const progress = { hasReplied: false, hasDelivered: false };
+    const replyMarkup = { inline_keyboard: [] };
+    const seenMarkup: Array<typeof replyMarkup | undefined> = [];
+    const recordChunk = vi.fn(async () => {});
+    const sendChunk = vi.fn(async (params: { replyMarkup?: typeof replyMarkup }) => {
+      seenMarkup.push(params.replyMarkup);
+      if (sendChunk.mock.calls.length === 1) {
+        throw new Error("Bad Request: text must be non-empty");
+      }
+      return 301;
+    });
+
+    await sendChunkedTelegramReplyText({
+      chunks: ["empty", "visible"],
+      progress,
+      replyToId: 555,
+      replyToMode: "all",
+      replyMarkup,
+      invalidate: vi.fn(),
+      onRejected: vi.fn(),
+      isSilentSkip: isTelegramEmptyContentError,
+      onSilentSkip: vi.fn(),
+      sendChunk,
+      recordChunk,
+    });
+
+    expect(seenMarkup).toEqual([replyMarkup, replyMarkup]);
+    expect(recordChunk).toHaveBeenCalledOnce();
+    expect(recordChunk).toHaveBeenCalledWith(301, "visible");
+    expect(progress).toEqual({ hasReplied: true, hasDelivered: true });
+  });
+});

--- a/extensions/telegram/src/bot/reply-threading.ts
+++ b/extensions/telegram/src/bot/reply-threading.ts
@@ -42,6 +42,8 @@ export async function sendChunkedTelegramReplyText<
   quoteOnlyOnFirstChunk?: boolean;
   invalidate: () => void;
   onRejected: (error: unknown) => void;
+  isSilentSkip?: (error: unknown) => boolean;
+  onSilentSkip?: (error: unknown) => void;
   markDelivered?: (progress: TProgress) => void;
   sendChunk: (opts: {
     chunk: TChunk;
@@ -57,6 +59,8 @@ export async function sendChunkedTelegramReplyText<
   const tracker = createTelegramChunkDeliveryTracker({
     invalidate: params.invalidate,
     onRejected: params.onRejected,
+    isSilentSkip: params.isSilentSkip,
+    onSilentSkip: params.onSilentSkip,
     partialDeliveryResult: () => ({ messageIds: [...messageIds], visibleReplySent: true }),
   });
   const suppressSingleUseReply =
@@ -97,7 +101,7 @@ export async function sendChunkedTelegramReplyText<
         return params.recordChunk(result, chunk);
       },
     );
-    if (!accepted) {
+    if (accepted !== "accepted") {
       continue;
     }
     hasAcceptedChunk = true;

--- a/extensions/telegram/src/chunk-delivery.test.ts
+++ b/extensions/telegram/src/chunk-delivery.test.ts
@@ -34,7 +34,7 @@ describe("Telegram chunk delivery", () => {
     }
   });
 
-  it("records empty content as a silent skip without invalidating delivery", async () => {
+  it("throws the original error when every chunk is silently skipped", async () => {
     const invalidate = vi.fn();
     const onRejected = vi.fn();
     const onSilentSkip = vi.fn();
@@ -55,10 +55,29 @@ describe("Telegram chunk delivery", () => {
         async () => {},
       ),
     ).resolves.toBe("silent-skip");
-    expect(() => tracker.finish()).not.toThrow();
+    expect(() => tracker.finish()).toThrow(emptyError);
     expect(onSilentSkip).toHaveBeenCalledWith(emptyError);
     expect(invalidate).not.toHaveBeenCalled();
     expect(onRejected).not.toHaveBeenCalled();
+  });
+
+  it("accepts a visible chunk after a silent skip", async () => {
+    const emptyError = telegramError(400, "text must be non-empty");
+    const record = vi.fn(async (_value: number) => {});
+    const tracker = createTelegramChunkDeliveryTracker({
+      invalidate: vi.fn(),
+      onRejected: vi.fn(),
+      isSilentSkip: (error) => error === emptyError,
+      partialDeliveryResult: () => ({ visibleReplySent: true }),
+    });
+
+    await tracker.attempt(async () => {
+      throw emptyError;
+    }, record);
+    await expect(tracker.attempt(async () => 7, record)).resolves.toBe("accepted");
+    expect(() => tracker.finish()).not.toThrow();
+    expect(record).toHaveBeenCalledOnce();
+    expect(record).toHaveBeenCalledWith(7);
   });
 
   it("drains skippable failures then reports accepted partial delivery", async () => {

--- a/extensions/telegram/src/chunk-delivery.test.ts
+++ b/extensions/telegram/src/chunk-delivery.test.ts
@@ -28,10 +28,37 @@ describe("Telegram chunk delivery", () => {
     );
 
     if (expected) {
-      await expect(attempt).resolves.toBe(false);
+      await expect(attempt).resolves.toBe("rejected");
     } else {
       await expect(attempt).rejects.toBe(error);
     }
+  });
+
+  it("records empty content as a silent skip without invalidating delivery", async () => {
+    const invalidate = vi.fn();
+    const onRejected = vi.fn();
+    const onSilentSkip = vi.fn();
+    const emptyError = telegramError(400, "text must be non-empty");
+    const tracker = createTelegramChunkDeliveryTracker({
+      invalidate,
+      onRejected,
+      isSilentSkip: (error) => error === emptyError,
+      onSilentSkip,
+      partialDeliveryResult: () => ({ visibleReplySent: true }),
+    });
+
+    await expect(
+      tracker.attempt(
+        async () => {
+          throw emptyError;
+        },
+        async () => {},
+      ),
+    ).resolves.toBe("silent-skip");
+    expect(() => tracker.finish()).not.toThrow();
+    expect(onSilentSkip).toHaveBeenCalledWith(emptyError);
+    expect(invalidate).not.toHaveBeenCalled();
+    expect(onRejected).not.toHaveBeenCalled();
   });
 
   it("drains skippable failures then reports accepted partial delivery", async () => {

--- a/extensions/telegram/src/chunk-delivery.ts
+++ b/extensions/telegram/src/chunk-delivery.ts
@@ -32,6 +32,7 @@ export function createTelegramChunkDeliveryTracker(params: {
 }) {
   let acceptedCount = 0;
   let firstRejectedError: unknown;
+  let firstSilentSkipError: unknown;
 
   const throwAfterAccepted = (error: unknown): never => {
     if (acceptedCount === 0 || isChannelPartialDeliveryError(error)) {
@@ -42,6 +43,7 @@ export function createTelegramChunkDeliveryTracker(params: {
 
   const reject = (error: unknown): "rejected" | "silent-skip" => {
     if (params.isSilentSkip?.(error)) {
+      firstSilentSkipError ??= error;
       params.onSilentSkip?.(error);
       return "silent-skip";
     }
@@ -80,6 +82,9 @@ export function createTelegramChunkDeliveryTracker(params: {
     finish() {
       if (firstRejectedError !== undefined) {
         throwAfterAccepted(firstRejectedError);
+      }
+      if (acceptedCount === 0 && firstSilentSkipError !== undefined) {
+        throwAfterAccepted(firstSilentSkipError);
       }
     },
   };

--- a/extensions/telegram/src/chunk-delivery.ts
+++ b/extensions/telegram/src/chunk-delivery.ts
@@ -26,6 +26,8 @@ function isTelegramSkippableChunkSendError(error: unknown): boolean {
 export function createTelegramChunkDeliveryTracker(params: {
   invalidate: () => void;
   onRejected: (error: unknown) => void;
+  isSilentSkip?: (error: unknown) => boolean;
+  onSilentSkip?: (error: unknown) => void;
   partialDeliveryResult: () => PartialDeliveryResult;
 }) {
   let acceptedCount = 0;
@@ -38,14 +40,18 @@ export function createTelegramChunkDeliveryTracker(params: {
     throw createChannelPartialDeliveryError(error, params.partialDeliveryResult());
   };
 
-  const reject = (error: unknown): false => {
+  const reject = (error: unknown): "rejected" | "silent-skip" => {
+    if (params.isSilentSkip?.(error)) {
+      params.onSilentSkip?.(error);
+      return "silent-skip";
+    }
     if (!isTelegramSkippableChunkSendError(error)) {
       throwAfterAccepted(error);
     }
     firstRejectedError ??= error;
     params.invalidate();
     params.onRejected(error);
-    return false;
+    return "rejected";
   };
 
   const recordAccepted = async <T>(result: T, record: (result: T) => Promise<void>) => {
@@ -66,10 +72,11 @@ export function createTelegramChunkDeliveryTracker(params: {
         return reject(error);
       }
       await recordAccepted(result, record);
-      return true;
+      return "accepted" as const;
     },
     recordAccepted,
     reject,
+    fail: throwAfterAccepted,
     finish() {
       if (firstRejectedError !== undefined) {
         throwAfterAccepted(firstRejectedError);

--- a/extensions/telegram/src/outbound-media.ts
+++ b/extensions/telegram/src/outbound-media.ts
@@ -8,7 +8,7 @@ import type { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { resolveTelegramPlainCaption, splitTelegramCaption } from "./caption.js";
 import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
 import type { TelegramOutboundPromptContextMessage } from "./outbound-message-context.js";
-import { isTelegramHtmlParseError } from "./rich-plain-fallback.js";
+import { isTelegramEmptyContentError, isTelegramHtmlParseError } from "./rich-plain-fallback.js";
 import type { TelegramApi } from "./send-context.js";
 import { isTelegramPhotoLimitError } from "./send-error-predicates.js";
 import { resolveTelegramVoiceSend } from "./voice.js";
@@ -200,17 +200,36 @@ export async function sendTelegramCaptionedMediaWithFallback<T>(params: {
     requestParams: Record<string, unknown>,
     shouldLog?: (err: unknown) => boolean,
   ) => Promise<T>;
-}): Promise<T> {
-  if (!params.plainCaption) {
-    return await params.send(params.requestParams, params.shouldLog);
-  }
+}): Promise<{ result: T; deliveredCaption?: string; captionRemoved?: true }> {
+  const requestCaption =
+    typeof params.requestParams.caption === "string" ? params.requestParams.caption : undefined;
+  const sendCaptionless = async () => {
+    const captionlessParams = { ...params.requestParams };
+    delete captionlessParams.caption;
+    delete captionlessParams.parse_mode;
+    return {
+      result: await params.send(captionlessParams, params.shouldLog),
+      ...(requestCaption !== undefined ? { captionRemoved: true as const } : {}),
+    };
+  };
   try {
-    return await params.send(
-      params.requestParams,
-      (err) => !isTelegramHtmlParseError(err) && (params.shouldLog?.(err) ?? true),
-    );
+    return {
+      result: await params.send(
+        params.requestParams,
+        (err) =>
+          !isTelegramHtmlParseError(err) &&
+          !isTelegramEmptyContentError(err) &&
+          (params.shouldLog?.(err) ?? true),
+      ),
+      ...(requestCaption !== undefined
+        ? { deliveredCaption: params.plainCaption ?? requestCaption }
+        : {}),
+    };
   } catch (err) {
-    if (!isTelegramHtmlParseError(err)) {
+    if (isTelegramEmptyContentError(err) && requestCaption !== undefined) {
+      return await sendCaptionless();
+    }
+    if (!isTelegramHtmlParseError(err) || !params.plainCaption) {
       throw err;
     }
     // Captions share the text-send contract: retain visible content after an
@@ -225,7 +244,21 @@ export async function sendTelegramCaptionedMediaWithFallback<T>(params: {
       caption: params.plainCaption,
     };
     delete plainParams.parse_mode;
-    return await params.send(plainParams, params.shouldLog);
+    try {
+      return {
+        result: await params.send(
+          plainParams,
+          (plainError) =>
+            !isTelegramEmptyContentError(plainError) && (params.shouldLog?.(plainError) ?? true),
+        ),
+        deliveredCaption: params.plainCaption,
+      };
+    } catch (plainError) {
+      if (!isTelegramEmptyContentError(plainError)) {
+        throw plainError;
+      }
+      return await sendCaptionless();
+    }
   }
 }
 

--- a/extensions/telegram/src/rich-plain-fallback.test.ts
+++ b/extensions/telegram/src/rich-plain-fallback.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildTelegramPlainFallbackPlan } from "./rich-plain-fallback.js";
+import {
+  buildTelegramPlainFallbackPlan,
+  isTelegramEmptyContentError,
+} from "./rich-plain-fallback.js";
 
 function planFor(message: string) {
   return buildTelegramPlainFallbackPlan({
@@ -32,5 +35,19 @@ describe("buildTelegramPlainFallbackPlan", () => {
 
   it("rethrows unrelated errors", () => {
     expect(planFor("Bad Request: chat not found")).toBeUndefined();
+  });
+});
+
+describe("isTelegramEmptyContentError", () => {
+  it.each([
+    "Bad Request: message text is empty",
+    "Bad Request: text must be non-empty",
+    "Bad Request: RICH_MESSAGE_CONTENT_REQUIRED",
+  ])("recognizes %s", (message) => {
+    expect(isTelegramEmptyContentError(new Error(message))).toBe(true);
+  });
+
+  it("does not hide unrelated bad requests", () => {
+    expect(isTelegramEmptyContentError(new Error("Bad Request: content rejected"))).toBe(false);
   });
 });

--- a/extensions/telegram/src/rich-plain-fallback.ts
+++ b/extensions/telegram/src/rich-plain-fallback.ts
@@ -8,6 +8,7 @@ import type { TelegramRichBlocksDegradationReason } from "./rich-block-model.js"
 // file, live-verified) is only knowable server-side.
 const RICH_ENTITY_INVALID_RE = /RICH_MESSAGE_[A-Z_]+_INVALID/i;
 const RICH_CONTENT_REQUIRED_RE = /RICH_MESSAGE_CONTENT_REQUIRED/i;
+const EMPTY_TEXT_RE = /message text is empty|text must be non-empty/i;
 // Structural-limit rejections, live-verified against Bot API 10.2 (2026-07-15):
 // >500 top-level blocks, >16 depth, oversized text, >50 media, >20 table cols.
 const RICH_STRUCTURE_INVALID_RE =
@@ -32,6 +33,11 @@ function isTelegramRichEntityInvalidError(err: unknown): boolean {
 
 export function isTelegramHtmlParseError(err: unknown): boolean {
   return PARSE_ERR_RE.test(formatErrorMessage(err));
+}
+
+export function isTelegramEmptyContentError(err: unknown): boolean {
+  const message = formatErrorMessage(err);
+  return EMPTY_TEXT_RE.test(message) || RICH_CONTENT_REQUIRED_RE.test(message);
 }
 
 function getTelegramPlainFallbackTrigger(err: unknown): TelegramPlainFallbackTrigger | undefined {

--- a/extensions/telegram/src/send-message-text.ts
+++ b/extensions/telegram/src/send-message-text.ts
@@ -48,6 +48,11 @@ import type {
 import type { OpenClawConfig } from "./send.runtime.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 
+type SendTextOptions = {
+  replyToAlreadyUsed?: boolean;
+  beforeFirstAccepted?: () => Promise<void>;
+};
+
 function buildTelegramTextSendReceipt(params: {
   messageIds: readonly string[];
   chatId: string;
@@ -226,7 +231,7 @@ export function createTelegramTextSender(config: {
       : undefined;
   };
 
-  const createTextDelivery = (context: string) => {
+  const createTextDelivery = (context: string, beforeFirstAccepted?: () => Promise<void>) => {
     type PendingChunk = {
       result: TelegramMessageLike;
       messageId: number;
@@ -234,6 +239,7 @@ export function createTelegramTextSender(config: {
       plainText: string;
       reportChatId: string | number;
       hasInlineKeyboard: boolean;
+      reported: boolean;
     };
 
     let lastMessageId = "";
@@ -248,16 +254,23 @@ export function createTelegramTextSender(config: {
     let pendingChunk: PendingChunk | undefined;
 
     const flushChunk = async (chunk: PendingChunk, finalPart: boolean) => {
+      let hasInlineKeyboard = chunk.hasInlineKeyboard;
+      let keyboardError: unknown;
       if (finalPart && replyMarkup && !chunk.hasInlineKeyboard) {
         try {
           await api.editMessageReplyMarkup(chunk.reportChatId, chunk.messageId, {
             reply_markup: replyMarkup,
           });
+          hasInlineKeyboard = true;
         } catch (error) {
-          sendLogger.warn(
-            `telegram ${context} final keyboard attachment failed: ${formatErrorMessage(error)}`,
-          );
+          keyboardError = error;
         }
+      }
+      if (!chunk.reported) {
+        await reportDelivery(chunk.messageId, chunk.reportChatId, {
+          telegramDeliveredText: chunk.plainText,
+          telegramHasInlineKeyboard: hasInlineKeyboard,
+        });
       }
       await recordDeliveredPromptContext(
         {
@@ -270,6 +283,14 @@ export function createTelegramTextSender(config: {
         },
         finalPart,
       );
+      if (keyboardError !== undefined) {
+        // finish() routes this through tracker.fail(), which preserves the
+        // accepted message IDs in a partial-delivery error.
+        if (keyboardError instanceof Error) {
+          throw keyboardError;
+        }
+        throw new Error(formatErrorMessage(keyboardError));
+      }
     };
 
     const flushPending = async (finalPart: boolean) => {
@@ -294,12 +315,18 @@ export function createTelegramTextSender(config: {
       lastAcceptedParams = params.acceptedParams;
       acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(params.acceptedParams);
       messageIds.push(lastMessageId);
+      if (sentChunkCount === 0) {
+        await beforeFirstAccepted?.();
+      }
       sentChunkCount += 1;
       recordSentMessage(chatId, messageId, cfg);
-      await reportDelivery(messageId, params.result?.chat?.id ?? chatId, {
-        telegramDeliveredText: params.plainText,
-        telegramHasInlineKeyboard: params.hasInlineKeyboard,
-      });
+      const reported = !replyMarkup;
+      if (reported) {
+        await reportDelivery(messageId, params.result?.chat?.id ?? chatId, {
+          telegramDeliveredText: params.plainText,
+          telegramHasInlineKeyboard: params.hasInlineKeyboard,
+        });
+      }
       const previousChunk = pendingChunk;
       pendingChunk = {
         result: params.result,
@@ -308,6 +335,7 @@ export function createTelegramTextSender(config: {
         plainText: params.plainText,
         reportChatId: params.result?.chat?.id ?? chatId,
         hasInlineKeyboard: params.hasInlineKeyboard,
+        reported,
       };
       if (previousChunk) {
         await flushChunk(previousChunk, false);
@@ -376,9 +404,9 @@ export function createTelegramTextSender(config: {
   const sendTelegramTextChunks = async (
     chunks: TelegramTextChunk[],
     context: string,
-    options: { replyToAlreadyUsed?: boolean } = {},
+    options: SendTextOptions = {},
   ): Promise<TelegramSendResult> => {
-    const delivery = createTextDelivery(context);
+    const delivery = createTextDelivery(context, options.beforeFirstAccepted);
     const tracker = createTelegramChunkDeliveryTracker({
       invalidate: () => opts.promptContextProjectionPlan?.cursor.invalidate(),
       onRejected: (error) =>
@@ -459,14 +487,16 @@ export function createTelegramTextSender(config: {
   const sendChunkedText = async (
     rawText: string,
     context: string,
-    options: { replyToAlreadyUsed?: boolean } = {},
+    options: SendTextOptions = {},
   ) => {
     try {
       return useRichMessages
         ? await sendTelegramRichTextChunks(buildRichTextPlan(rawText), context, options)
         : await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context, options);
     } catch (error) {
-      opts.promptContextProjectionPlan?.cursor.invalidate();
+      if (!isTelegramEmptyContentError(error)) {
+        opts.promptContextProjectionPlan?.cursor.invalidate();
+      }
       throw error;
     }
   };
@@ -489,10 +519,10 @@ export function createTelegramTextSender(config: {
   const sendTelegramRichTextChunks = async (
     chunks: TelegramRichTextChunk[],
     context: string,
-    options: { replyToAlreadyUsed?: boolean } = {},
+    options: SendTextOptions = {},
   ): Promise<TelegramSendResult> => {
     const richRawApi = getTelegramRichRawApi(api);
-    const delivery = createTextDelivery(context);
+    const delivery = createTextDelivery(context, options.beforeFirstAccepted);
     const tracker = createTelegramChunkDeliveryTracker({
       invalidate: () => opts.promptContextProjectionPlan?.cursor.invalidate(),
       onRejected: (error) =>

--- a/extensions/telegram/src/send-message-text.ts
+++ b/extensions/telegram/src/send-message-text.ts
@@ -25,6 +25,7 @@ import {
 } from "./rich-message.js";
 import {
   buildTelegramPlainFallbackPlan,
+  isTelegramEmptyContentError,
   splitTelegramPlainTextChunks,
   warnTelegramRichBlocksDegradations,
 } from "./rich-plain-fallback.js";
@@ -154,9 +155,12 @@ export function createTelegramTextSender(config: {
       });
     const requestPlain = (label: string) =>
       requestSendMessage(label, chunk.plainText, plainParams ?? {});
-    const result = !chunk.htmlText
-      ? await requestPlain("message")
-      : await withTelegramHtmlParseFallback({
+    let result: Awaited<ReturnType<typeof requestPlain>>;
+    if (!chunk.htmlText) {
+      result = await requestPlain("message");
+    } else {
+      try {
+        result = await withTelegramHtmlParseFallback({
           label: "message",
           verbose: opts.verbose,
           requestHtml: (label) =>
@@ -166,6 +170,13 @@ export function createTelegramTextSender(config: {
             }),
           requestPlain,
         });
+      } catch (error) {
+        if (!isTelegramEmptyContentError(error) || !chunk.plainText.trim()) {
+          throw error;
+        }
+        result = await requestPlain("message-empty-fallback");
+      }
+    }
     return {
       result: result.result,
       acceptedParams: toAcceptedThreadScopedParams(result.acceptedParams),
@@ -216,6 +227,15 @@ export function createTelegramTextSender(config: {
   };
 
   const createTextDelivery = (context: string) => {
+    type PendingChunk = {
+      result: TelegramMessageLike;
+      messageId: number;
+      acceptedParams?: TelegramThreadScopedParams | TelegramRichMessageContextParams;
+      plainText: string;
+      reportChatId: string | number;
+      hasInlineKeyboard: boolean;
+    };
+
     let lastMessageId = "";
     let lastChatId = chatId;
     let lastAcceptedParams:
@@ -225,12 +245,45 @@ export function createTelegramTextSender(config: {
     let acceptedReplyToMessageId: number | undefined;
     const messageIds: string[] = [];
     let sentChunkCount = 0;
+    let pendingChunk: PendingChunk | undefined;
+
+    const flushChunk = async (chunk: PendingChunk, finalPart: boolean) => {
+      if (finalPart && replyMarkup && !chunk.hasInlineKeyboard) {
+        try {
+          await api.editMessageReplyMarkup(chunk.reportChatId, chunk.messageId, {
+            reply_markup: replyMarkup,
+          });
+        } catch (error) {
+          sendLogger.warn(
+            `telegram ${context} final keyboard attachment failed: ${formatErrorMessage(error)}`,
+          );
+        }
+      }
+      await recordDeliveredPromptContext(
+        {
+          message: chunk.result,
+          messageId: chunk.messageId,
+          text: chunk.plainText,
+          ...(chunk.acceptedParams?.message_thread_id !== undefined
+            ? { messageThreadId: chunk.acceptedParams.message_thread_id }
+            : {}),
+        },
+        finalPart,
+      );
+    };
+
+    const flushPending = async (finalPart: boolean) => {
+      const chunk = pendingChunk;
+      pendingChunk = undefined;
+      if (chunk) {
+        await flushChunk(chunk, finalPart);
+      }
+    };
 
     const record = async (params: {
       result: TelegramMessageLike;
       acceptedParams?: TelegramThreadScopedParams | TelegramRichMessageContextParams;
       plainText: string;
-      finalPart: boolean;
       hasInlineKeyboard: boolean;
     }) => {
       const messageId = resolveTelegramMessageIdOrThrow(params.result, context);
@@ -247,20 +300,22 @@ export function createTelegramTextSender(config: {
         telegramDeliveredText: params.plainText,
         telegramHasInlineKeyboard: params.hasInlineKeyboard,
       });
-      await recordDeliveredPromptContext(
-        {
-          message: params.result,
-          messageId,
-          text: params.plainText,
-          ...(params.acceptedParams?.message_thread_id !== undefined
-            ? { messageThreadId: params.acceptedParams.message_thread_id }
-            : {}),
-        },
-        params.finalPart,
-      );
+      const previousChunk = pendingChunk;
+      pendingChunk = {
+        result: params.result,
+        messageId,
+        acceptedParams: params.acceptedParams,
+        plainText: params.plainText,
+        reportChatId: params.result?.chat?.id ?? chatId,
+        hasInlineKeyboard: params.hasInlineKeyboard,
+      };
+      if (previousChunk) {
+        await flushChunk(previousChunk, false);
+      }
     };
 
-    const finish = (operation: string): TelegramSendResult => {
+    const finish = async (operation: string): Promise<TelegramSendResult> => {
+      await flushPending(true);
       if (lastMessageId) {
         logTelegramOutboundSendOk({
           accountId: account.accountId,
@@ -301,7 +356,21 @@ export function createTelegramTextSender(config: {
       };
     };
 
-    return { record, finish, partialDeliveryResult };
+    const fail = async (
+      error: unknown,
+      throwAfterAccepted: (error: unknown) => never,
+    ): Promise<never> => {
+      try {
+        await flushPending(false);
+      } catch (flushError) {
+        sendLogger.warn(
+          `telegram ${context} delivery bookkeeping cleanup failed: ${formatErrorMessage(flushError)}`,
+        );
+      }
+      return throwAfterAccepted(error);
+    };
+
+    return { record, finish, fail, partialDeliveryResult };
   };
 
   const sendTelegramTextChunks = async (
@@ -316,32 +385,40 @@ export function createTelegramTextSender(config: {
         logVerbose(
           `telegram ${context} text chunk rejected; continuing: ${formatErrorMessage(error)}`,
         ),
+      isSilentSkip: isTelegramEmptyContentError,
+      onSilentSkip: (error) =>
+        logVerbose(
+          `telegram ${context} text chunk rendered empty; skipping: ${formatErrorMessage(error)}`,
+        ),
       partialDeliveryResult: delivery.partialDeliveryResult,
     });
-    for (let index = 0; index < chunks.length; index += 1) {
-      const chunk = chunks[index];
-      if (!chunk) {
-        continue;
+    try {
+      for (let index = 0; index < chunks.length; index += 1) {
+        const chunk = chunks[index];
+        if (!chunk) {
+          continue;
+        }
+        const finalPart = index === chunks.length - 1;
+        await tracker.attempt(
+          () =>
+            sendTelegramTextChunk(
+              chunk,
+              buildTextParams(index, chunks.length, finalPart, options.replyToAlreadyUsed === true),
+            ),
+          ({ result, acceptedParams }) =>
+            delivery.record({
+              result,
+              acceptedParams,
+              plainText: chunk.plainText,
+              hasInlineKeyboard: finalPart && Boolean(replyMarkup),
+            }),
+        );
       }
-      const finalPart = index === chunks.length - 1;
-      await tracker.attempt(
-        () =>
-          sendTelegramTextChunk(
-            chunk,
-            buildTextParams(index, chunks.length, finalPart, options.replyToAlreadyUsed === true),
-          ),
-        ({ result, acceptedParams }) =>
-          delivery.record({
-            result,
-            acceptedParams,
-            plainText: chunk.plainText,
-            finalPart,
-            hasInlineKeyboard: finalPart && Boolean(replyMarkup),
-          }),
-      );
+      tracker.finish();
+      return await delivery.finish("sendMessage");
+    } catch (error) {
+      return await delivery.fail(error, tracker.fail);
     }
-    tracker.finish();
-    return delivery.finish("sendMessage");
   };
 
   const buildChunkedTextPlan = (rawText: string, context: string): TelegramTextChunk[] => {
@@ -422,102 +499,139 @@ export function createTelegramTextSender(config: {
         logVerbose(
           `telegram ${context} rich chunk rejected; continuing: ${formatErrorMessage(error)}`,
         ),
+      isSilentSkip: isTelegramEmptyContentError,
+      onSilentSkip: (error) =>
+        logVerbose(
+          `telegram ${context} rich chunk rendered empty; skipping: ${formatErrorMessage(error)}`,
+        ),
       partialDeliveryResult: delivery.partialDeliveryResult,
     });
-    for (let index = 0; index < chunks.length; index += 1) {
-      const chunk = chunks[index];
-      if (!chunk) {
-        continue;
-      }
-      const acceptedParams = buildRichTextParams(
-        index,
-        chunks.length,
-        index === chunks.length - 1,
-        options.replyToAlreadyUsed === true,
-      );
-      let result: TelegramMessageLike;
-      let recordedParams: TelegramThreadScopedParams | TelegramRichMessageContextParams | undefined;
-      if (isEmptyTelegramRichMessage(chunk.richMessage)) {
-        // Gate on the rich payload only: valid rich content (media/divider HTML)
-        // can have an empty plain projection and must still send.
-        sendLogger.warn("telegram richMessage chunk rendered empty; skipping");
-        continue;
-      }
-      try {
-        warnTelegramRichBlocksDegradations({
-          context: "richMessage",
-          reasons: chunk.degradationReasons,
-          warn: (message) => sendLogger.warn(message),
-        });
-        const richResult = await withTelegramNativeQuoteFallback<TelegramMessageLike>({
-          label: "richMessage",
-          requestParams: acceptedParams ?? {},
-          removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
-          request: (effectiveParams, retryLabel) =>
-            requestWithChatNotFound(
-              () =>
-                richRawApi.sendRichMessage({
-                  chat_id: chatId,
-                  rich_message: chunk.richMessage,
-                  ...effectiveParams,
-                  ...(opts.silent === true ? { disable_notification: true } : {}),
-                }),
-              retryLabel,
-            ),
-        });
-        result = richResult.result;
-        recordedParams = toTelegramRichMessageContextParams(richResult.acceptedParams);
-      } catch (err) {
-        const fallbackPlan = buildTelegramPlainFallbackPlan({
-          plainText: chunk.plainText,
-          err,
-          context: "richMessage",
-          warn: (message) => sendLogger.warn(message),
-        });
-        if (!fallbackPlan) {
-          tracker.reject(err);
+    try {
+      for (let index = 0; index < chunks.length; index += 1) {
+        const chunk = chunks[index];
+        if (!chunk) {
           continue;
         }
-        const fallbackChunks = fallbackPlan.chunks;
-        const fallbackReplyChunkCount = Math.max(chunks.length, fallbackChunks.length);
-        for (let fallbackIndex = 0; fallbackIndex < fallbackChunks.length; fallbackIndex += 1) {
-          const fallbackText = fallbackChunks[fallbackIndex] ?? "";
-          const fallbackReplyIndex = chunks.length === 1 ? fallbackIndex : index;
-          const fallbackParams = buildTextParams(
-            fallbackReplyIndex,
-            fallbackReplyChunkCount,
-            index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1,
-            options.replyToAlreadyUsed === true,
-          );
-          const finalPart =
-            index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1;
+        const acceptedParams = buildRichTextParams(
+          index,
+          chunks.length,
+          index === chunks.length - 1,
+          options.replyToAlreadyUsed === true,
+        );
+        let result: TelegramMessageLike;
+        let recordedParams:
+          | TelegramThreadScopedParams
+          | TelegramRichMessageContextParams
+          | undefined;
+        if (isEmptyTelegramRichMessage(chunk.richMessage)) {
+          if (!chunk.plainText.trim()) {
+            sendLogger.warn(
+              "telegram richMessage chunk and plain fallback rendered empty; skipping",
+            );
+            continue;
+          }
+          const finalPart = index === chunks.length - 1;
           await tracker.attempt(
-            () => sendTelegramTextChunk({ plainText: fallbackText }, fallbackParams),
+            () =>
+              sendTelegramTextChunk(
+                { plainText: chunk.plainText },
+                buildTextParams(
+                  index,
+                  chunks.length,
+                  finalPart,
+                  options.replyToAlreadyUsed === true,
+                ),
+              ),
             ({ result: fallbackResult, acceptedParams: fallbackAcceptedParams }) =>
               delivery.record({
                 result: fallbackResult,
                 acceptedParams: fallbackAcceptedParams,
-                plainText: fallbackText,
-                finalPart,
+                plainText: chunk.plainText,
                 hasInlineKeyboard: finalPart && Boolean(replyMarkup),
               }),
           );
+          continue;
         }
-        continue;
+        try {
+          warnTelegramRichBlocksDegradations({
+            context: "richMessage",
+            reasons: chunk.degradationReasons,
+            warn: (message) => sendLogger.warn(message),
+          });
+          const richResult = await withTelegramNativeQuoteFallback<TelegramMessageLike>({
+            label: "richMessage",
+            requestParams: acceptedParams ?? {},
+            removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
+            request: (effectiveParams, retryLabel) =>
+              requestWithChatNotFound(
+                () =>
+                  richRawApi.sendRichMessage({
+                    chat_id: chatId,
+                    rich_message: chunk.richMessage,
+                    ...effectiveParams,
+                    ...(opts.silent === true ? { disable_notification: true } : {}),
+                  }),
+                retryLabel,
+              ),
+          });
+          result = richResult.result;
+          recordedParams = toTelegramRichMessageContextParams(richResult.acceptedParams);
+        } catch (err) {
+          const fallbackPlan = buildTelegramPlainFallbackPlan({
+            plainText: chunk.plainText,
+            err,
+            context: "richMessage",
+            warn: (message) => sendLogger.warn(message),
+          });
+          if (!fallbackPlan) {
+            tracker.reject(err);
+            continue;
+          }
+          const fallbackChunks = fallbackPlan.chunks;
+          if (fallbackChunks.length === 0) {
+            tracker.reject(err);
+            continue;
+          }
+          const fallbackReplyChunkCount = Math.max(chunks.length, fallbackChunks.length);
+          for (let fallbackIndex = 0; fallbackIndex < fallbackChunks.length; fallbackIndex += 1) {
+            const fallbackText = fallbackChunks[fallbackIndex] ?? "";
+            const fallbackReplyIndex = chunks.length === 1 ? fallbackIndex : index;
+            const fallbackParams = buildTextParams(
+              fallbackReplyIndex,
+              fallbackReplyChunkCount,
+              index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1,
+              options.replyToAlreadyUsed === true,
+            );
+            const finalPart =
+              index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1;
+            await tracker.attempt(
+              () => sendTelegramTextChunk({ plainText: fallbackText }, fallbackParams),
+              ({ result: fallbackResult, acceptedParams: fallbackAcceptedParams }) =>
+                delivery.record({
+                  result: fallbackResult,
+                  acceptedParams: fallbackAcceptedParams,
+                  plainText: fallbackText,
+                  hasInlineKeyboard: finalPart && Boolean(replyMarkup),
+                }),
+            );
+          }
+          continue;
+        }
+        const finalPart = index === chunks.length - 1;
+        await tracker.recordAccepted(result, (acceptedResult) =>
+          delivery.record({
+            result: acceptedResult,
+            acceptedParams: recordedParams,
+            plainText: chunk.plainText,
+            hasInlineKeyboard: finalPart && Boolean(replyMarkup),
+          }),
+        );
       }
-      const finalPart = index === chunks.length - 1;
-      await tracker.recordAccepted(result, (acceptedResult) =>
-        delivery.record({
-          result: acceptedResult,
-          acceptedParams: recordedParams,
-          plainText: chunk.plainText,
-          finalPart,
-          hasInlineKeyboard: finalPart && Boolean(replyMarkup),
-        }),
-      );
+      tracker.finish();
+      return await delivery.finish("sendRichMessage");
+    } catch (error) {
+      return await delivery.fail(error, tracker.fail);
     }
-    tracker.finish();
-    return delivery.finish("sendRichMessage");
   };
 
   return { sendChunkedText };

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -1,4 +1,8 @@
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -16,6 +20,7 @@ import {
   buildTelegramThreadReplyParams,
   resolveTelegramSendThreadSpec,
 } from "./reply-parameters.js";
+import { isTelegramEmptyContentError } from "./rich-plain-fallback.js";
 import {
   createRequestWithChatNotFound,
   createTelegramNonIdempotentRequestWithDiag,
@@ -251,7 +256,7 @@ async function sendMessageTelegramWithContext(
       asVoice: opts.asVoice,
       sendImageAsPhoto,
     });
-    const { caption, htmlCaption, plainCaption, followUpText } = mediaPlan;
+    const { htmlCaption, plainCaption, followUpText } = mediaPlan;
     // If text exceeds Telegram's caption limit, send media without caption
     // then send text as a separate follow-up message.
     const needsSeparateText = Boolean(followUpText);
@@ -298,15 +303,17 @@ async function sendMessageTelegramWithContext(
       });
     };
 
-    let mediaDelivery: Awaited<ReturnType<typeof sendMedia>>;
+    let mediaDelivery: Awaited<ReturnType<typeof sendMedia>>["result"];
     let deliveredMediaSender: typeof mediaSender;
+    let deliveredCaption: string | undefined;
     try {
       const delivery = await sendTelegramOutboundMediaWithPhotoFallback({
         sender: mediaSender,
         documentSender,
         send: (sender) => sendMedia(sender.label, sender.send),
       });
-      mediaDelivery = delivery.result;
+      mediaDelivery = delivery.result.result;
+      deliveredCaption = delivery.result.deliveredCaption;
       deliveredMediaSender = delivery.sender;
     } catch (error) {
       opts.promptContextProjectionPlan?.cursor.invalidate();
@@ -317,21 +324,34 @@ async function sendMessageTelegramWithContext(
     const mediaMessageId = resolveTelegramMessageIdOrThrow(result, "media send");
     const resolvedChatId = String(result?.chat?.id ?? chatId);
     recordSentMessage(chatId, mediaMessageId, cfg);
-    await reportDelivery(mediaMessageId, resolvedChatId, {
-      ...(caption ? { telegramDeliveredText: caption } : {}),
-      telegramHasInlineKeyboard: !needsSeparateText && Boolean(replyMarkup),
-    });
-    await recordDeliveredPromptContext(
-      {
-        message: result,
-        messageId: mediaMessageId,
-        ...(caption ? { text: caption } : {}),
-        ...(acceptedMediaParams?.message_thread_id !== undefined
-          ? { messageThreadId: acceptedMediaParams.message_thread_id }
-          : {}),
-      },
-      !needsSeparateText,
-    );
+    let mediaReported = false;
+    let mediaPromptRecorded = false;
+    const recordMediaDelivery = async (finalPart: boolean, hasInlineKeyboard: boolean) => {
+      if (!mediaReported) {
+        await reportDelivery(mediaMessageId, resolvedChatId, {
+          ...(deliveredCaption ? { telegramDeliveredText: deliveredCaption } : {}),
+          telegramHasInlineKeyboard: hasInlineKeyboard,
+        });
+        mediaReported = true;
+      }
+      if (!mediaPromptRecorded) {
+        await recordDeliveredPromptContext(
+          {
+            message: result,
+            messageId: mediaMessageId,
+            ...(deliveredCaption ? { text: deliveredCaption } : {}),
+            ...(acceptedMediaParams?.message_thread_id !== undefined
+              ? { messageThreadId: acceptedMediaParams.message_thread_id }
+              : {}),
+          },
+          finalPart,
+        );
+        mediaPromptRecorded = true;
+      }
+    };
+    if (!needsSeparateText) {
+      await recordMediaDelivery(true, Boolean(replyMarkup));
+    }
     logTelegramOutboundSendOk({
       accountId: account.accountId,
       chatId: resolvedChatId,
@@ -351,9 +371,44 @@ async function sendMessageTelegramWithContext(
     // If text was too long for a caption, send it as a separate follow-up message.
     // Use HTML conversion so markdown renders like captions.
     if (needsSeparateText && followUpText) {
-      const textResult = await sendChunkedText(followUpText, "text follow-up send", {
-        replyToAlreadyUsed: singleUseReplyTo && mediaUsedReplyTo,
-      });
+      let textResult: TelegramSendResult;
+      try {
+        textResult = await sendChunkedText(followUpText, "text follow-up send", {
+          replyToAlreadyUsed: singleUseReplyTo && mediaUsedReplyTo,
+          beforeFirstAccepted: () => recordMediaDelivery(false, false),
+        });
+      } catch (error) {
+        if (isTelegramEmptyContentError(error)) {
+          let hasInlineKeyboard = false;
+          let keyboardError: unknown;
+          if (replyMarkup) {
+            try {
+              await api.editMessageReplyMarkup(resolvedChatId, mediaMessageId, {
+                reply_markup: replyMarkup,
+              });
+              hasInlineKeyboard = true;
+            } catch (editError) {
+              keyboardError = editError;
+            }
+          }
+          await recordMediaDelivery(true, hasInlineKeyboard);
+          if (keyboardError !== undefined) {
+            throw createChannelPartialDeliveryError(keyboardError, {
+              messageIds: [String(mediaMessageId)],
+              visibleReplySent: true,
+            });
+          }
+          return { messageId: String(mediaMessageId), chatId: resolvedChatId };
+        }
+        await recordMediaDelivery(false, false);
+        const textMessageIds = isChannelPartialDeliveryError(error)
+          ? (error.deliveryResult.messageIds ?? [])
+          : [];
+        throw createChannelPartialDeliveryError(error, {
+          messageIds: [String(mediaMessageId), ...textMessageIds],
+          visibleReplySent: true,
+        });
+      }
       const mediaReplyToId = resolveAcceptedReplyToMessageId(acceptedMediaParams)?.toString();
       const receipt = createMessageReceiptFromOutboundResults({
         results: [{ messageId: String(mediaMessageId), chatId: resolvedChatId }, textResult],

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1877,7 +1877,7 @@ describe("sendMessageTelegram", () => {
     });
     expect(result.messageId).toBe("71");
     expect(onDeliveryResult).toHaveBeenCalledTimes(1);
-    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta?.telegramHasInlineKeyboard).toBe(false);
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta?.telegramHasInlineKeyboard).toBe(true);
     const cached = await createTelegramMessageCache({
       scope: resolveTelegramMessageCacheScope(storePath),
     }).get({ accountId: "default", chatId: "123", messageId: "71" });
@@ -1885,6 +1885,69 @@ describe("sendMessageTelegram", () => {
       kind: "valid",
       projection: { ...cursor.source, partIndex: 0, finalPart: true },
     });
+  });
+
+  it("reports partial delivery when the final keyboard retrofit fails", async () => {
+    const storePath = `/tmp/openclaw-telegram-empty-tail-keyboard-failure-${process.pid}-${Date.now()}.json`;
+    const cursor = createTelegramPromptContextProjectionCursor({
+      transcriptMessageId: "assistant-empty-tail-keyboard-failure",
+    });
+    const emptyError = new Error("Bad Request: text must be non-empty");
+    const retrofitError = new Error("keyboard retrofit failed");
+    const onDeliveryResult = vi.fn();
+    botApi.sendMessage
+      .mockResolvedValueOnce({ message_id: 72, chat: { id: "123" } })
+      .mockRejectedValueOnce(emptyError)
+      .mockRejectedValueOnce(emptyError);
+    botApi.editMessageReplyMarkup.mockRejectedValueOnce(retrofitError);
+
+    let observed: unknown;
+    try {
+      await sendMessageTelegram("123", `${"A".repeat(4000)}\u200B\u200B`, {
+        cfg: { session: { store: storePath } },
+        token: "tok",
+        textMode: "html",
+        buttons: [[{ text: "OK", callback_data: "ok" }]],
+        onDeliveryResult,
+        promptContextProjectionPlan: { cursor, finalPart: true },
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["72"]);
+    expect(botApi.editMessageReplyMarkup).toHaveBeenCalledWith("123", 72, {
+      reply_markup: { inline_keyboard: [[{ text: "OK", callback_data: "ok" }]] },
+    });
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.messageId).toBe("72");
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta?.telegramHasInlineKeyboard).toBe(false);
+    const cached = await createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    }).get({ accountId: "default", chatId: "123", messageId: "72" });
+    expect(cached?.promptContextProjectionMarker).toEqual({
+      kind: "valid",
+      projection: { ...cursor.source, partIndex: 0, finalPart: true },
+    });
+  });
+
+  it("fails when every Telegram chunk renders empty", async () => {
+    const emptyError = new Error("Bad Request: text must be non-empty");
+    botApi.sendMessage.mockRejectedValue(emptyError);
+
+    await expect(
+      sendMessageTelegram("123", "\u200B\u200B", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        textMode: "html",
+      }),
+    ).rejects.toBe(emptyError);
+
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(2);
   });
 
   it("fails when every Telegram chunk is rejected", async () => {
@@ -2333,6 +2396,44 @@ describe("sendMessageTelegram", () => {
       { platformMessageId: "70", kind: "media", index: 0 },
       { platformMessageId: "71", kind: "text", index: 1 },
     ]);
+  });
+
+  it("finalizes media when its separate text renders empty", async () => {
+    const storePath = `/tmp/openclaw-telegram-empty-media-follow-up-${process.pid}-${Date.now()}.json`;
+    const cursor = createTelegramPromptContextProjectionCursor({
+      transcriptMessageId: "assistant-empty-media-follow-up",
+    });
+    const emptyError = new Error("Bad Request: text must be non-empty");
+    const onDeliveryResult = vi.fn();
+    botApi.sendPhoto.mockResolvedValueOnce({ message_id: 70, chat: { id: "123" } });
+    botApi.sendMessage.mockRejectedValue(emptyError);
+    botApi.editMessageReplyMarkup.mockResolvedValueOnce({ message_id: 70 });
+    mockLoadedMedia({ contentType: "image/jpeg", fileName: "photo.jpg" });
+
+    const result = await sendMessageTelegram("123", "\u200B".repeat(1025), {
+      cfg: { session: { store: storePath } },
+      token: "tok",
+      textMode: "html",
+      mediaUrl: "https://example.com/photo.jpg",
+      buttons: [[{ text: "OK", callback_data: "ok" }]],
+      onDeliveryResult,
+      promptContextProjectionPlan: { cursor, finalPart: true },
+    });
+
+    expect(result).toEqual({ messageId: "70", chatId: "123" });
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(2);
+    expect(botApi.editMessageReplyMarkup).toHaveBeenCalledWith("123", 70, {
+      reply_markup: { inline_keyboard: [[{ text: "OK", callback_data: "ok" }]] },
+    });
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta?.telegramHasInlineKeyboard).toBe(true);
+    const cached = await createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    }).get({ accountId: "default", chatId: "123", messageId: "70" });
+    expect(cached?.promptContextProjectionMarker).toEqual({
+      kind: "valid",
+      projection: { ...cursor.source, partIndex: 0, finalPart: true },
+    });
   });
 
   it("reports delivered media before a caption follow-up fails", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1850,6 +1850,43 @@ describe("sendMessageTelegram", () => {
     expect(cursor.complete).toBe(false);
   });
 
+  it("finalizes the visible chunk when Telegram rejects an invisible tail", async () => {
+    const storePath = `/tmp/openclaw-telegram-empty-tail-${process.pid}-${Date.now()}.json`;
+    const cursor = createTelegramPromptContextProjectionCursor({
+      transcriptMessageId: "assistant-empty-tail",
+    });
+    const onDeliveryResult = vi.fn();
+    botApi.sendMessage
+      .mockResolvedValueOnce({ message_id: 71, chat: { id: "123" } })
+      .mockRejectedValueOnce(new Error("Bad Request: text must be non-empty"))
+      .mockRejectedValueOnce(new Error("Bad Request: text must be non-empty"));
+    botApi.editMessageReplyMarkup.mockResolvedValueOnce({ message_id: 71 });
+
+    const result = await sendMessageTelegram("123", `${"A".repeat(4000)}\u200B\u200B`, {
+      cfg: { session: { store: storePath } },
+      token: "tok",
+      textMode: "html",
+      buttons: [[{ text: "OK", callback_data: "ok" }]],
+      onDeliveryResult,
+      promptContextProjectionPlan: { cursor, finalPart: true },
+    });
+
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(3);
+    expect(botApi.editMessageReplyMarkup).toHaveBeenCalledWith("123", 71, {
+      reply_markup: { inline_keyboard: [[{ text: "OK", callback_data: "ok" }]] },
+    });
+    expect(result.messageId).toBe("71");
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta?.telegramHasInlineKeyboard).toBe(false);
+    const cached = await createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    }).get({ accountId: "default", chatId: "123", messageId: "71" });
+    expect(cached?.promptContextProjectionMarker).toEqual({
+      kind: "valid",
+      projection: { ...cursor.source, partIndex: 0, finalPart: true },
+    });
+  });
+
   it("fails when every Telegram chunk is rejected", async () => {
     const rejection = createChunkRejection();
     botApi.sendMessage.mockRejectedValue(rejection);


### PR DESCRIPTION
Supersedes #59725.

## What Problem This Solves

Telegram now rejects rendered-empty text with `400: Bad Request: text must be non-empty`. A visible answer followed by an invisible tail could therefore send the visible part, then report the whole reply as failed. Voice/media fallbacks could also claim text delivery when Telegram accepted nothing.

`NO_REPLY` is unchanged: it is still removed before channel delivery. This PR does not turn intentional suppression into an error.

## Root Cause

Telegram delivery tracked empty-content rejection as an unconditional successful skip. That was correct only when another text or media part had actually landed. With zero accepted parts, callers received a false success and could record phantom delivery state.

Final keyboard and prompt-context facts were also reported before the true last accepted Telegram message was known.

## Fix

- Record the first empty-content rejection in the shared Telegram chunk tracker.
- Succeed only when at least one chunk or media item actually landed; otherwise surface the original empty-content error.
- Keep ordinary rejection precedence and existing partial-delivery identities.
- Retry media without a caption when Telegram renders the caption empty.
- Count voice/media fallback text only after Telegram returns a real message id.
- Move a trailing inline keyboard to the actual last accepted message; keyboard-edit failure becomes partial delivery instead of silent success.
- Defer durable media projection/reporting until the separate text outcome is known, so metadata describes what Telegram accepted.

## Evidence

Exact head: `c9f126cc7793587e1e78265c783a8962ba640ff6`

- Focused Vitest: 5 files, 342/342 tests passed.
- Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/31006367049: repository guards, formatting, boundaries, dead-code scan, extension production tsgo, and extension test tsgo passed. Its final lint step found only two `only-throw-error` style violations; both were fixed, then exact-head targeted Oxlint passed.
- Autoreview P0/P1: clean; no accepted/actionable findings.
- Greybeard: no hot-path regression. New merge/allocation work is rejection-only; happy-path work remains constant per accepted message.
- Production LOC: +514/-204, net +310. Growth establishes one factual delivery owner across text, voice, media, keyboard, receipt, and prompt projection paths. Test LOC: +394/-2, net +392.

### Telegram real-behavior proof

`telegram-e2e-userbot` drove a dedicated real Telegram user in a DM through an ephemeral exact-head gateway and deterministic mock provider. Provider output was exactly 4,000 visible `A` characters plus two U+200B characters.

```json
{
  "verdict": "pass",
  "head": "c9f126cc7793587e1e78265c783a8962ba640ff6",
  "driver": "telegram-e2e-userbot",
  "providerRequests": 1,
  "telegramApiEmptyRejections": 2,
  "sutEvents": { "typing": 2, "message": 1, "edit": 0, "delete": 0 },
  "visibleMessageLength": 4000,
  "phantomTailMessages": 0,
  "visibleErrorMessages": 0
}
```

The Bot API rejected the formatted invisible tail and its plain retry. The user saw one 4,000-character answer and no failure text.

## ClawSweeper moves

- [x] Preserve the shared partial-delivery tracker in reply, default, and rich funnels.
- [x] Make all-empty delivery fail instead of returning phantom success.
- [x] Gate voice and caption fallback accounting on real Telegram message ids.
- [x] Preserve media-only success when separate empty text is rejected.
- [x] Report actual final keyboard and prompt-projection state.
- [x] Refresh exact-head tests, typechecks, lint, autoreview, and real Telegram proof.
