### PR TITLE
fix(ci): repair current main checks

### DIFF
--- a/extensions/microsoft-foundry/provider.ts
+++ b/extensions/microsoft-foundry/provider.ts
@@ -58,7 +58,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         const nextModel = Object.assign({}, model, {
           name: selectedModelCapabilities.modelName,
           api: selectedModelCapabilities.api,
-          reasoning: selectedModelCapabilities.reasoning || model.reasoning === true,
+          reasoning: selectedModelCapabilities.reasoning || model.reasoning,
           thinkingLevelMap: selectedModelCapabilities.thinkingLevelMap ?? model.thinkingLevelMap,
           input: selectedModelCapabilities.input,
         });
@@ -69,7 +69,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
               : undefined;
           const preserveExplicitReasoningEffort =
             !selectedModelCapabilities.reasoning &&
-            model.reasoning === true &&
+            model.reasoning &&
             explicitSupportsReasoningEffort !== false;
           const explicitMaxTokensField =
             typeof model.compat?.maxTokensField === "string"
@@ -78,7 +78,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
                 ? "max_completion_tokens"
                 : undefined;
           nextModel.compat = {
-            ...(model.compat ?? {}),
+            ...model.compat,
             ...selectedModelCapabilities.compat,
             ...(explicitSupportsReasoningEffort !== undefined
               ? { supportsReasoningEffort: explicitSupportsReasoningEffort }
@@ -138,7 +138,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         typeof model.compat?.supportsReasoningEffort === "boolean"
           ? model.compat.supportsReasoningEffort
           : undefined;
-      const preserveExplicitReasoningEffort = !capabilities.reasoning && model.reasoning === true;
+      const preserveExplicitReasoningEffort = !capabilities.reasoning && model.reasoning;
       const explicitMaxTokensField =
         typeof model.compat?.maxTokensField === "string"
           ? model.compat.maxTokensField
@@ -147,7 +147,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
             : undefined;
       const compat = capabilities.compat
         ? {
-            ...(model.compat ?? {}),
+            ...model.compat,
             ...capabilities.compat,
             ...(explicitSupportsReasoningEffort !== undefined
               ? { supportsReasoningEffort: explicitSupportsReasoningEffort }
@@ -161,7 +161,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         ...model,
         name: capabilities.modelName,
         api: capabilities.api,
-        reasoning: capabilities.reasoning || model.reasoning === true,
+        reasoning: capabilities.reasoning || model.reasoning,
         thinkingLevelMap: capabilities.thinkingLevelMap ?? model.thinkingLevelMap,
         input: capabilities.input,
         baseUrl: buildFoundryProviderBaseUrl(

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -5,12 +5,13 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { loadSessionStore, saveSessionStore, type SessionEntry } from "../config/sessions.js";
 import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { runAgentAttempt } from "./command/attempt-execution.runtime.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent.js";
 import type { loadManifestModelCatalog } from "./model-catalog.js";
 
 type ProviderModelNormalizationParams = { provider: string; context: { modelId: string } };
 type LoadManifestModelCatalogParams = Parameters<typeof loadManifestModelCatalog>[0];
-type RunAgentAttempt = typeof import("./command/attempt-execution.runtime.js").runAgentAttempt;
+type RunAgentAttempt = typeof runAgentAttempt;
 
 const state = vi.hoisted(() => ({
   cfg: undefined as OpenClawConfig | undefined,
@@ -137,7 +138,7 @@ vi.mock("./command/attempt-execution.runtime.js", async () => {
   );
   return {
     ...actual,
-    runAgentAttempt: (params: Parameters<RunAgentAttempt>[0]) => state.runAgentAttemptMock(params),
+    runAgentAttempt: (...args: Parameters<RunAgentAttempt>) => state.runAgentAttemptMock(...args),
   };
 });
 
@@ -207,7 +208,7 @@ function makeResult(params: {
       durationMs: 1,
       stopReason: "end_turn",
       executionTrace: {
-        runner: "embedded",
+        runner: "embedded" as const,
         fallbackUsed: false,
         winnerProvider: "openai",
         winnerModel: "gpt-5.5",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -488,9 +488,12 @@ function rememberSingleRowChildSessionCandidateCacheEntry(
 }
 
 function buildStoreChildSessionCandidateIndex(
-  store: Record<string, SessionEntry>,
+  store: Record<string, SessionEntry> | null | undefined,
 ): Map<string, string[]> {
   const childSessionsByKey = new Map<string, string[]>();
+  if (!store) {
+    return childSessionsByKey;
+  }
   for (const [key, entry] of Object.entries(store)) {
     if (!entry) {
       continue;
@@ -508,8 +511,11 @@ function buildStoreChildSessionCandidateIndex(
 
 function getSingleRowChildSessionCandidates(params: {
   storePath: string;
-  store: Record<string, SessionEntry>;
+  store: Record<string, SessionEntry> | null | undefined;
 }): Map<string, string[]> {
+  if (!params.store) {
+    return new Map();
+  }
   const storeVersion = getSessionStoreCacheVersion(params.storePath);
   const cached = singleRowChildSessionCandidateCache.get(params.storePath);
   if (cached && cached.store === params.store && cached.storeVersion === storeVersion) {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -473,6 +473,24 @@ function requireElement(container: Element, selector: string, label: string): El
   return element;
 }
 
+function getTalkSelectOptionValues(container: Element, name: string): string[] {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>(
+      `[data-talk-select="${name}"] [data-talk-select-option]`,
+    ),
+  ).map((option) => option.dataset.talkSelectOption ?? "");
+}
+
+function clickTalkSelectOption(container: Element, name: string, value: string): void {
+  const option = container.querySelector<HTMLButtonElement>(
+    `[data-talk-select="${name}"] [data-talk-select-option="${value}"]`,
+  );
+  if (option === null) {
+    throw new Error(`expected Talk ${name} option ${value}`);
+  }
+  option.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+}
+
 function renderChatView(overrides: Partial<Parameters<typeof renderChat>[0]> = {}) {
   const container = document.createElement("div");
   render(
@@ -845,26 +863,13 @@ describe("chat voice controls", () => {
     const model = container.querySelector<HTMLInputElement>(
       '.agent-chat__talk-options-primary input[placeholder="Auto"]',
     );
-    const voice = container.querySelector<HTMLElement>('[data-talk-select="voice"]');
-    const sensitivity = container.querySelector<HTMLElement>('[data-talk-select="sensitivity"]');
-    const voiceOptions = Array.from(
-      container.querySelectorAll<HTMLOptionElement>(
-        '[data-talk-select="voice"] [data-talk-select-option]',
-      ),
-    ).map((option) => option.dataset.talkSelectOption ?? "");
-    const reasoningOptions = Array.from(
-      container.querySelectorAll<HTMLOptionElement>(
-        '[data-talk-select="reasoning"] [data-talk-select-option]',
-      ),
-    ).map((option) => option.dataset.talkSelectOption ?? "");
+    const sensitivityLabel = requireElement(
+      container,
+      '[data-talk-select="sensitivity"] .agent-chat__talk-select-label',
+      "Talk sensitivity selected label",
+    );
 
-    if (voice === null) {
-      throw new Error("expected Talk voice select");
-    }
-    if (sensitivity === null) {
-      throw new Error("expected Talk sensitivity select");
-    }
-    expect(voiceOptions).toEqual([
+    expect(getTalkSelectOptionValues(container, "voice")).toEqual([
       "",
       "alloy",
       "ash",
@@ -877,15 +882,21 @@ describe("chat voice controls", () => {
       "marin",
       "cedar",
     ]);
-    expect(
-      sensitivity.querySelector<HTMLElement>('[aria-selected="true"]')?.dataset.talkSelectOption,
-    ).toBe("__custom");
-    expect(
-      Array.from(sensitivity.querySelectorAll<HTMLElement>("[data-talk-select-option]")).map(
-        (option) => option.dataset.talkSelectOption ?? "",
-      ),
-    ).toEqual(["", "0.65", "0.5", "0.35", "__custom"]);
-    expect(reasoningOptions).toEqual(["", "minimal", "low", "medium", "high"]);
+    expect(sensitivityLabel.textContent).toBe("Custom");
+    expect(getTalkSelectOptionValues(container, "sensitivity")).toEqual([
+      "",
+      "0.65",
+      "0.5",
+      "0.35",
+      "__custom",
+    ]);
+    expect(getTalkSelectOptionValues(container, "reasoning")).toEqual([
+      "",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
     expect(container.textContent).toContain("Sensitivity");
     expect(container.textContent).toContain("Advanced");
     expect(container.textContent).toContain("Pause before send");
@@ -894,19 +905,10 @@ describe("chat voice controls", () => {
     if (model === null) {
       throw new Error("expected Talk model input");
     }
-    const chooseOption = (root: HTMLElement, value: string) => {
-      const option = Array.from(
-        root.querySelectorAll<HTMLButtonElement>("[data-talk-select-option]"),
-      ).find((button) => button.dataset.talkSelectOption === value);
-      if (!option) {
-        throw new Error(`expected Talk option ${value}`);
-      }
-      option.click();
-    };
     model.value = "gpt-realtime-mini";
     model.dispatchEvent(new Event("input", { bubbles: true }));
-    chooseOption(sensitivity, "0.35");
-    chooseOption(sensitivity, "");
+    clickTalkSelectOption(container, "sensitivity", "0.35");
+    clickTalkSelectOption(container, "sensitivity", "");
 
     expect(onRealtimeTalkOptionsChange).toHaveBeenCalledWith({ model: "gpt-realtime-mini" });
     expect(onRealtimeTalkOptionsChange).toHaveBeenCalledWith({ vadThreshold: "0.35" });
@@ -926,18 +928,18 @@ describe("chat voice controls", () => {
       },
       onRealtimeTalkOptionsChange,
     });
-    const defaultSensitivity = defaultContainer.querySelector<HTMLElement>(
-      '[data-talk-select="sensitivity"]',
+    const defaultSensitivityLabel = requireElement(
+      defaultContainer,
+      '[data-talk-select="sensitivity"] .agent-chat__talk-select-label',
+      "default Talk sensitivity selected label",
     );
-    expect(
-      defaultSensitivity?.querySelector<HTMLElement>('[aria-selected="true"]')?.dataset
-        .talkSelectOption,
-    ).toBe("");
-    expect(
-      Array.from(
-        defaultSensitivity?.querySelectorAll<HTMLElement>("[data-talk-select-option]") ?? [],
-      ).map((option) => option.dataset.talkSelectOption ?? ""),
-    ).toEqual(["", "0.65", "0.5", "0.35"]);
+    expect(defaultSensitivityLabel.textContent).toBe("Default");
+    expect(getTalkSelectOptionValues(defaultContainer, "sensitivity")).toEqual([
+      "",
+      "0.65",
+      "0.5",
+      "0.35",
+    ]);
   });
 
   it("renders composer and Talk labels from the active locale", async () => {


### PR DESCRIPTION
## Summary

- tolerates missing session-store maps while building single-row child-session candidate indexes
- prevents `chat.history` / session-info paths from throwing when a caller has no loaded store but still asks for child-session metadata
- updates the stale Talk launch-options UI test to exercise the current custom Talk select controls instead of removed native `<select>` controls
- tightens the compaction-rotation attempt mock/result fixture types so the current core test typecheck passes
- fixes the current Microsoft Foundry provider lint drift on latest `main`

## Verification

- `node scripts/run-vitest.mjs src/agents/agent-command.compaction-rotation.test.ts src/gateway/session-utils.test.ts ui/src/ui/views/chat.test.ts --reporter=dot`: passed 3 shards / 178 tests after rebasing the repair branch
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/agent-command.compaction-rotation.test.ts src/gateway/session-utils.ts ui/src/ui/views/chat.test.ts extensions/microsoft-foundry/provider.ts`: passed
- `node scripts/run-oxlint.mjs extensions/microsoft-foundry/provider.ts`: passed
- `git diff --check`: passed
- AWS Crabbox exact remote-head proof: `node scripts/crabbox-wrapper.mjs run --provider aws --label main-ci-blockers-f962-check-changed --shell -- "pnpm check:changed"` (`provider=aws`, `lease=cbx_cb720cfb366a`, `slug=tidal-barnacle`, `run=run_84fbccfe9ad6`, head `f96270ed7e8`, exit 0)
- Earlier AWS Crabbox proof on the previous rebased local head also passed: `provider=aws`, `lease=cbx_c7fcfd9807db`, `slug=crimson-prawn`, `run=run_d442570edb10`, exit 0

## Real behavior proof

Behavior addressed: the gateway no longer throws `Cannot convert undefined or null to object` while building single-row child-session candidates for session-info paths that do not have a loaded store, current Talk launch-options and compaction-rotation tests no longer block CI, and the current Microsoft Foundry provider satisfies extension lint.

Real environment tested: focused local Vitest/formatter/lint proof in a linked OpenClaw worktree, plus AWS Crabbox Linux changed-gate proof on the exact pushed PR head.

Exact steps or command run after this patch: reran the focused session-utils regression file, compaction-rotation test, full chat view test file, formatter, targeted Foundry lint, diff check, and remote `pnpm check:changed`.

Evidence after fix: the focused gateway shard passed 104 tests; the compaction-rotation shard passed 3 tests; the chat view shard passed 71 tests including the previously failing Talk launch-options test; the exact-head AWS Crabbox changed gate selected `core`, `coreTests`, `extensions`, and `extensionTests`, including full extension lint, and exited 0.

Observed result after fix: missing stores produce an empty child-session candidate map instead of throwing, valid store callers keep the same candidate and context-token behavior, the Talk launch-options test now exercises the shipped custom select controls, the compaction-rotation fixture matches the runtime attempt/result types, and Foundry provider lint no longer fails current-main changed gates.

What was not tested: full repository suite locally.
