### PR TITLE
fix(agents): return schema lookup misses in-band

### DIFF
--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import { testing as restartTesting } from "../infra/restart.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
@@ -724,5 +725,30 @@ describe("gateway tool", () => {
     const schema = (result.details as { result?: { schema?: { properties?: unknown } } }).result
       ?.schema;
     expect(schema?.properties).toBeUndefined();
+  });
+
+  it("returns an in-band schema lookup miss for unknown paths", async () => {
+    vi.mocked(callGatewayTool).mockRejectedValueOnce(
+      new GatewayClientRequestError({
+        code: "INVALID_REQUEST",
+        message: "config schema path not found",
+      }),
+    );
+    const tool = requireGatewayTool();
+
+    const result = await tool.execute("call6", {
+      action: "config.schema.lookup",
+      path: "agents.main.authorizedSenders",
+    });
+
+    expect(gatewayCall("config.schema.lookup")[2]).toEqual({
+      path: "agents.main.authorizedSenders",
+    });
+    expect(result.details).toEqual({
+      ok: false,
+      code: "schema_path_not_found",
+      path: "agents.main.authorizedSenders",
+      message: "config schema path not found",
+    });
   });
 });

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -10,6 +10,7 @@ import { parseConfigJson5, resolveConfigSnapshotHash } from "../../config/io.js"
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { GatewayClientRequestError } from "../../gateway/client.js";
 import {
   buildRestartSuccessContinuation,
   formatDoctorNonInteractiveHint,
@@ -33,6 +34,7 @@ import { callGatewayTool, readGatewayCallOptions } from "./gateway.js";
 const log = createSubsystemLogger("gateway-tool");
 
 const DEFAULT_UPDATE_TIMEOUT_MS = 20 * 60_000;
+const CONFIG_SCHEMA_PATH_NOT_FOUND_MESSAGE = "config schema path not found";
 // Per SECURITY.md the model/agent itself is not a trusted principal.
 // `assertGatewayConfigMutationAllowed` is the explicit model -> operator
 // trust-boundary control on `config.apply`/`config.patch`, so the runtime tool
@@ -112,6 +114,14 @@ function stripConfigWriteResultPayload(result: unknown): unknown {
   const stripped = { ...result };
   delete stripped.config;
   return stripped;
+}
+
+function isConfigSchemaPathNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof GatewayClientRequestError &&
+    error.gatewayCode === "INVALID_REQUEST" &&
+    error.message.includes(CONFIG_SCHEMA_PATH_NOT_FOUND_MESSAGE)
+  );
 }
 
 function parseGatewayConfigMutationRaw(
@@ -475,8 +485,20 @@ export function createGatewayTool(opts?: {
           required: true,
           label: "path",
         });
-        const result = await callGatewayTool("config.schema.lookup", gatewayOpts, { path });
-        return jsonResult({ ok: true, result });
+        try {
+          const result = await callGatewayTool("config.schema.lookup", gatewayOpts, { path });
+          return jsonResult({ ok: true, result });
+        } catch (error) {
+          if (isConfigSchemaPathNotFoundError(error)) {
+            return jsonResult({
+              ok: false,
+              code: "schema_path_not_found",
+              path,
+              message: CONFIG_SCHEMA_PATH_NOT_FOUND_MESSAGE,
+            });
+          }
+          throw error;
+        }
       }
       if (action === "config.apply") {
         const { raw, baseHash, snapshotConfig, sessionKey, note, restartDelayMs } =


### PR DESCRIPTION
## Summary

- Convert `config.schema.lookup` "path not found" gateway errors into an in-band gateway tool result: `{ ok: false, code: "schema_path_not_found", path, message }`.
- Keep the direct gateway RPC miss behavior unchanged while preventing the agent-facing tool path from throwing into channel warning surfaces.
- Add regression coverage for unknown schema paths in the gateway tool.

Closes #88813

## Real behavior proof

- **Behavior or issue addressed:** An agent-facing `gateway` tool call for `config.schema.lookup` with an unknown path should return a structured in-band miss instead of throwing the gateway RPC error into warning/chip handling.
- **Real environment tested:** macOS local source checkout at `9c8cead19d`, Node via `node --import tsx`, local OpenClaw Gateway started on loopback with token auth and channel/provider sidecars skipped.
- **Exact steps or command run after this patch:** Started a real local Gateway from the patched source, then executed the production `createGatewayTool(...).execute(...)` path against `config.schema.lookup` for `agents.main.authorizedSenders`.

  ```bash
  node --import tsx --input-type=module <<'EOF_SCRIPT'
  import fs from "node:fs/promises";
  import os from "node:os";
  import path from "node:path";
  import net from "node:net";

  async function getFreePort() {
    return await new Promise((resolve, reject) => {
      const server = net.createServer();
      server.listen(0, "127.0.0.1", () => {
        const address = server.address();
        const port = typeof address === "object" && address ? address.port : undefined;
        server.close(() => (port ? resolve(port) : reject(new Error("no free port"))));
      });
      server.on("error", reject);
    });
  }

  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pr88817-proof-"));
  const stateDir = path.join(tempRoot, "state");
  const configPath = path.join(stateDir, "openclaw.json");
  const token = "proof-token-88817";
  await fs.mkdir(stateDir, { recursive: true });
  await fs.writeFile(configPath, JSON.stringify({ gateway: { auth: { token } }, agents: { list: [{ id: "main", default: true }] }, channels: {}, plugins: { allow: [] } }, null, 2) + "\n", "utf8");

  process.env.HOME = tempRoot;
  process.env.OPENCLAW_STATE_DIR = stateDir;
  process.env.OPENCLAW_CONFIG_PATH = configPath;
  process.env.OPENCLAW_GATEWAY_TOKEN = token;
  process.env.OPENCLAW_SKIP_CHANNELS = "1";
  process.env.OPENCLAW_SKIP_PROVIDERS = "1";
  process.env.OPENCLAW_SKIP_CRON = "1";
  process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
  process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER = "1";
  process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS = "1";

  const { startGatewayServer } = await import("./src/gateway/server.ts");
  const { createGatewayTool } = await import("./src/agents/tools/gateway-tool.ts");
  const port = await getFreePort();
  const server = await startGatewayServer(port, { bind: "loopback", auth: { mode: "token", token }, controlUiEnabled: false });

  try {
    const tool = createGatewayTool({ config: { commands: { restart: false } } });
    const result = await tool.execute("proof-88817", {
      action: "config.schema.lookup",
      path: "agents.main.authorizedSenders",
      gatewayUrl: `ws://127.0.0.1:${port}`,
      gatewayToken: token,
      timeoutMs: 10000,
    });
    console.log("agent gateway tool returned details:");
    console.log(JSON.stringify(result.details, null, 2));
    console.log("agent gateway tool threw: no");
  } finally {
    await server.close({ reason: "PR #88817 proof complete" });
    await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5 });
  }
  EOF_SCRIPT
  ```

- **Evidence after fix:** Terminal output from the local Gateway + agent gateway tool run:

  ```console
  [gateway] starting HTTP server...
  [gateway] ready
  [gateway] http server listening (0 plugins)
  [ws] ⇄ res ✗ config.schema.lookup 960ms errorCode=INVALID_REQUEST errorMessage=config schema path not found conn=4dedaa02…741f id=0b04306e…b322
  agent gateway tool returned details:
  {
    "ok": false,
    "code": "schema_path_not_found",
    "path": "agents.main.authorizedSenders",
    "message": "config schema path not found"
  }
  agent gateway tool threw: no
  [shutdown] completed cleanly in 16ms
  ```

- **Observed result after fix:** The direct gateway RPC still reports `INVALID_REQUEST`, preserving existing RPC semantics, but the agent-facing `gateway` tool returns the structured `schema_path_not_found` result and does not throw. Since the tool call returns normally (`agent gateway tool threw: no`), it does not enter the agent tool-error path that feeds channel warning chips.
- **What was not tested:** A live Slack workspace message transcript. The proof covers the local gateway + agent gateway tool boundary where the thrown error was converted before channel warning surfaces can observe it.

## Testing

- `node scripts/run-vitest.mjs src/agents/openclaw-gateway-tool.test.ts src/gateway/server.config-patch.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/tools/gateway-tool.ts src/agents/openclaw-gateway-tool.test.ts`
- `node scripts/run-oxlint.mjs src/agents/tools/gateway-tool.ts src/agents/openclaw-gateway-tool.test.ts`
- `git diff --check`
