### PR TITLE
fix(diagnostics): clear embedded-run activity when recovery declares lane idle

### DIFF
--- a/extensions/phone-control/index.test.ts
+++ b/extensions/phone-control/index.test.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
-import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,

--- a/extensions/phone-control/index.ts
+++ b/extensions/phone-control/index.ts
@@ -1,4 +1,3 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -166,7 +165,7 @@ async function disarmNow(params: {
   if (!state) {
     return { changed: false, restored: [], removed: [] };
   }
-  const cfg = api.runtime.config.current() as OpenClawConfig;
+  const cfg = api.runtime.config.current();
   const allow = new Set(normalizeAllowList(cfg));
   const deny = new Set(normalizeDenyList(cfg));
   const removed: string[] = [];
@@ -430,7 +429,7 @@ export default definePluginEntry({
           }
 
           const commands = resolveCommandsForGroup(group);
-          const cfg = api.runtime.config.current() as OpenClawConfig;
+          const cfg = api.runtime.config.current();
           const allowSet = new Set(normalizeAllowList(cfg));
           const denySet = new Set(normalizeDenyList(cfg));
 

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -1101,6 +1101,10 @@ export function emitInternalDiagnosticEvent(event: DiagnosticEventInput) {
   emitDiagnosticEventWithTrust(event, false, { internal: true });
 }
 
+export function getInternalDiagnosticEventSequence(): number {
+  return getDiagnosticEventsState().seq;
+}
+
 export function emitTrustedDiagnosticEvent(event: DiagnosticEventInput) {
   emitDiagnosticEventWithTrust(event, true);
 }

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -10,6 +10,7 @@ type SessionActivity = {
   activeEmbeddedRuns: Map<string, ActiveEmbeddedRun>;
   activeTools: Map<string, ActiveTool>;
   activeModelCalls: Map<string, ActiveModelCall>;
+  recoveredOwnerStartEventCutoffs: Map<string, number>;
   lastProgressAt: number;
   lastProgressReason?: string;
 };
@@ -39,12 +40,12 @@ type ActiveModelCall = {
 type DiagnosticToolStartedActivityEvent = Pick<
   Extract<DiagnosticEventPayload, { type: "tool.execution.started" }>,
   "runId" | "sessionId" | "sessionKey" | "toolName" | "toolCallId"
->;
+> & { seq?: number };
 
 type DiagnosticModelStartedActivityEvent = Pick<
   Extract<DiagnosticEventPayload, { type: "model.call.started" }>,
   "runId" | "sessionId" | "sessionKey" | "provider" | "model"
->;
+> & { seq?: number };
 
 type DiagnosticRunProgressActivityEvent = Pick<
   Extract<DiagnosticEventPayload, { type: "run.progress" }>,
@@ -117,6 +118,12 @@ function mergeSessionActivity(target: SessionActivity, source: SessionActivity):
   for (const [key, modelCall] of source.activeModelCalls) {
     target.activeModelCalls.set(key, modelCall);
   }
+  for (const [ownerRef, cutoff] of source.recoveredOwnerStartEventCutoffs) {
+    target.recoveredOwnerStartEventCutoffs.set(
+      ownerRef,
+      Math.max(cutoff, target.recoveredOwnerStartEventCutoffs.get(ownerRef) ?? 0),
+    );
+  }
   if (source.lastProgressAt > target.lastProgressAt) {
     target.lastProgressAt = source.lastProgressAt;
     target.lastProgressReason = source.lastProgressReason;
@@ -165,6 +172,7 @@ function resolveSessionActivity(params: {
     activeEmbeddedRuns: new Map(),
     activeTools: new Map(),
     activeModelCalls: new Map(),
+    recoveredOwnerStartEventCutoffs: new Map(),
     lastProgressAt: Date.now(),
   };
   registerSessionActivityRefs(created, params);
@@ -197,6 +205,9 @@ function recordToolStarted(event: DiagnosticToolStartedActivityEvent): void {
   if (!activity) {
     return;
   }
+  if (shouldIgnoreRecoveredOwnerStartEvent(activity, event)) {
+    return;
+  }
   const now = Date.now();
   activity.activeTools.set(toolKey(event), {
     runId: event.runId,
@@ -227,6 +238,9 @@ function recordToolEnded(
 function recordModelStarted(event: DiagnosticModelStartedActivityEvent): void {
   const activity = resolveSessionActivity({ ...event, create: true });
   if (!activity) {
+    return;
+  }
+  if (shouldIgnoreRecoveredOwnerStartEvent(activity, event)) {
     return;
   }
   activity.activeModelCalls.set(modelCallKey(event), {
@@ -323,6 +337,12 @@ function ownerRefsForRecovery(params: {
   return new Set(refs);
 }
 
+function ownerRefsForStartedEvent(event: { runId?: string; sessionId?: string }): string[] {
+  return [event.runId?.trim(), event.sessionId?.trim()].filter((ref): ref is string =>
+    Boolean(ref),
+  );
+}
+
 function markerBelongsToRecoveredOwner(
   marker: { runId?: string; sessionId?: string },
   ownerRefs: Set<string>,
@@ -390,6 +410,43 @@ function clearRecoveredOwnerMarkers(activity: SessionActivity, ownerRefs: Set<st
   }
 }
 
+function rememberRecoveredOwnerStartEventCutoffs(
+  activity: SessionActivity,
+  ownerRefs: Set<string>,
+  recoveryStartedAfterSequence: number | undefined,
+): void {
+  if (recoveryStartedAfterSequence === undefined) {
+    return;
+  }
+  for (const ownerRef of ownerRefs) {
+    // Recovery can clear a session before the async diagnostic queue drains.
+    // Remember the queue watermark so older start events cannot recreate stale activity.
+    activity.recoveredOwnerStartEventCutoffs.set(
+      ownerRef,
+      Math.max(
+        recoveryStartedAfterSequence,
+        activity.recoveredOwnerStartEventCutoffs.get(ownerRef) ?? 0,
+      ),
+    );
+  }
+}
+
+function shouldIgnoreRecoveredOwnerStartEvent(
+  activity: SessionActivity,
+  event: { runId?: string; sessionId?: string; seq?: number },
+): boolean {
+  if (event.seq === undefined) {
+    return false;
+  }
+  for (const ownerRef of ownerRefsForStartedEvent(event)) {
+    const cutoff = activity.recoveredOwnerStartEventCutoffs.get(ownerRef);
+    if (cutoff !== undefined && event.seq <= cutoff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Reconciles a session's terminal embedded-run activity at once. Used when an
 // authority (stuck-session recovery) declares the lane idle and the per-run
 // markDiagnosticEmbeddedRunEnded may have been bypassed. Clears the embedded-run
@@ -401,6 +458,7 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   sessionKey?: string;
   activeSessionId?: string;
   recoveryStartedAfterEmbeddedRunSequence?: number;
+  recoveryStartedAfterDiagnosticEventSequence?: number;
 }): { cleared: boolean; blockedByActiveEmbeddedRun: boolean } {
   const activity = resolveSessionActivity(params);
   if (!activity) {
@@ -414,6 +472,11 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
     return { cleared: false, blockedByActiveEmbeddedRun: false };
   }
   const ownerRefs = ownerRefsForRecovery(params);
+  rememberRecoveredOwnerStartEventCutoffs(
+    activity,
+    ownerRefs,
+    params.recoveryStartedAfterDiagnosticEventSequence,
+  );
   clearRecoveredOwnerEmbeddedRuns(
     activity,
     ownerRefs,

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -9,16 +9,25 @@ type SessionActivity = {
   sessionKey?: string;
   activeEmbeddedRuns: Set<string>;
   activeTools: Map<string, ActiveTool>;
-  activeModelCalls: Set<string>;
+  activeModelCalls: Map<string, ActiveModelCall>;
   lastProgressAt: number;
   lastProgressReason?: string;
 };
 
 type ActiveTool = {
+  runId?: string;
+  sessionId?: string;
+  sessionKey?: string;
   toolName: string;
   toolCallId?: string;
   startedAt: number;
   lastProgressAt: number;
+};
+
+type ActiveModelCall = {
+  runId?: string;
+  sessionId?: string;
+  sessionKey?: string;
 };
 
 type DiagnosticToolStartedActivityEvent = Pick<
@@ -98,8 +107,8 @@ function mergeSessionActivity(target: SessionActivity, source: SessionActivity):
   for (const [key, tool] of source.activeTools) {
     target.activeTools.set(key, tool);
   }
-  for (const key of source.activeModelCalls) {
-    target.activeModelCalls.add(key);
+  for (const [key, modelCall] of source.activeModelCalls) {
+    target.activeModelCalls.set(key, modelCall);
   }
   if (source.lastProgressAt > target.lastProgressAt) {
     target.lastProgressAt = source.lastProgressAt;
@@ -148,7 +157,7 @@ function resolveSessionActivity(params: {
     sessionKey: params.sessionKey,
     activeEmbeddedRuns: new Set(),
     activeTools: new Map(),
-    activeModelCalls: new Set(),
+    activeModelCalls: new Map(),
     lastProgressAt: Date.now(),
   };
   registerSessionActivityRefs(created, params);
@@ -183,6 +192,9 @@ function recordToolStarted(event: DiagnosticToolStartedActivityEvent): void {
   }
   const now = Date.now();
   activity.activeTools.set(toolKey(event), {
+    runId: event.runId,
+    sessionId: event.sessionId,
+    sessionKey: event.sessionKey,
     toolName: event.toolName,
     toolCallId: event.toolCallId,
     startedAt: now,
@@ -210,7 +222,11 @@ function recordModelStarted(event: DiagnosticModelStartedActivityEvent): void {
   if (!activity) {
     return;
   }
-  activity.activeModelCalls.add(modelCallKey(event));
+  activity.activeModelCalls.set(modelCallKey(event), {
+    runId: event.runId,
+    sessionId: event.sessionId,
+    sessionKey: event.sessionKey,
+  });
   touchSessionActivity(activity, "model_call:started");
 }
 
@@ -286,6 +302,42 @@ function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string
   return params.workKey ?? params.sessionId;
 }
 
+function ownerRefsForRecovery(params: {
+  sessionId?: string;
+  activeSessionId?: string;
+}): Set<string> {
+  const refs = [params.activeSessionId?.trim(), params.sessionId?.trim()].filter(
+    (ref): ref is string => Boolean(ref),
+  );
+  return new Set(refs);
+}
+
+function markerBelongsToRecoveredOwner(
+  marker: { runId?: string; sessionId?: string },
+  ownerRefs: Set<string>,
+): boolean {
+  return (
+    (marker.runId !== undefined && ownerRefs.has(marker.runId)) ||
+    (marker.sessionId !== undefined && ownerRefs.has(marker.sessionId))
+  );
+}
+
+function clearRecoveredOwnerMarkers(activity: SessionActivity, ownerRefs: Set<string>): void {
+  if (ownerRefs.size === 0) {
+    return;
+  }
+  for (const [key, tool] of activity.activeTools) {
+    if (markerBelongsToRecoveredOwner(tool, ownerRefs)) {
+      activity.activeTools.delete(key);
+    }
+  }
+  for (const [key, modelCall] of activity.activeModelCalls) {
+    if (markerBelongsToRecoveredOwner(modelCall, ownerRefs)) {
+      activity.activeModelCalls.delete(key);
+    }
+  }
+}
+
 // Reconciles a session's terminal embedded-run activity at once. Used when an
 // authority (stuck-session recovery) declares the lane idle and the per-run
 // markDiagnosticEmbeddedRunEnded may have been bypassed. Clears the embedded-run
@@ -308,12 +360,12 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   ) {
     return { cleared: false, blockedByActiveEmbeddedRun: false };
   }
-  const recoveredWorkKey = resolveEmbeddedRunWorkKey({
-    sessionId: params.activeSessionId ?? params.sessionId ?? "",
-  });
+  const ownerRefs = ownerRefsForRecovery(params);
+  const recoveredWorkKey = resolveEmbeddedRunWorkKey({ sessionId: [...ownerRefs][0] ?? "" });
   if (recoveredWorkKey) {
     activity.activeEmbeddedRuns.delete(recoveredWorkKey);
   }
+  clearRecoveredOwnerMarkers(activity, ownerRefs);
   if (activity.activeEmbeddedRuns.size > 0) {
     touchSessionActivity(activity, "embedded_run:recovery_skipped_active_owner");
     return { cleared: false, blockedByActiveEmbeddedRun: true };

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -286,18 +286,30 @@ function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string
   return params.workKey ?? params.sessionId;
 }
 
-// Drops every embedded-run owner for a session at once. Used when an authority
-// (stuck-session recovery) declares the lane terminal and the per-run
-// markDiagnosticEmbeddedRunEnded may have been bypassed for some work keys.
-export function clearDiagnosticEmbeddedRunsForSession(params: {
+// Reconciles a session's terminal embedded-run activity at once. Used when an
+// authority (stuck-session recovery) declares the lane idle and the per-run
+// markDiagnosticEmbeddedRunEnded may have been bypassed. Clears the embedded-run
+// owners AND their tool/model markers, matching the default teardown so the lane
+// cannot be left as idle + orphaned tool/model activity (which
+// isIdleQueuedRecoverableSessionStall still treats as recoverable).
+export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   sessionId?: string;
   sessionKey?: string;
 }): void {
   const activity = resolveSessionActivity(params);
-  if (!activity || activity.activeEmbeddedRuns.size === 0) {
+  if (!activity) {
+    return;
+  }
+  if (
+    activity.activeEmbeddedRuns.size === 0 &&
+    activity.activeTools.size === 0 &&
+    activity.activeModelCalls.size === 0
+  ) {
     return;
   }
   activity.activeEmbeddedRuns.clear();
+  activity.activeTools.clear();
+  activity.activeModelCalls.clear();
   touchSessionActivity(activity, "embedded_run:ended");
 }
 

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -333,12 +333,27 @@ function markerBelongsToRecoveredOwner(
   );
 }
 
-function clearRecoveredOwnerEmbeddedRuns(activity: SessionActivity, ownerRefs: Set<string>): void {
+function embeddedRunStartedAfter(
+  embeddedRun: ActiveEmbeddedRun,
+  sequence: number | undefined,
+): boolean {
+  return sequence !== undefined && embeddedRun.sequence > sequence;
+}
+
+function clearRecoveredOwnerEmbeddedRuns(
+  activity: SessionActivity,
+  ownerRefs: Set<string>,
+  recoveryStartedAfterSequence: number | undefined,
+): void {
   if (ownerRefs.size === 0) {
     return;
   }
   for (const [key, embeddedRun] of activity.activeEmbeddedRuns) {
-    if (embeddedRun.sessionId !== undefined && ownerRefs.has(embeddedRun.sessionId)) {
+    if (
+      embeddedRun.sessionId !== undefined &&
+      ownerRefs.has(embeddedRun.sessionId) &&
+      !embeddedRunStartedAfter(embeddedRun, recoveryStartedAfterSequence)
+    ) {
       activity.activeEmbeddedRuns.delete(key);
     }
   }
@@ -399,11 +414,11 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
     return { cleared: false, blockedByActiveEmbeddedRun: false };
   }
   const ownerRefs = ownerRefsForRecovery(params);
-  const recoveredWorkKey = resolveEmbeddedRunWorkKey({ sessionId: [...ownerRefs][0] ?? "" });
-  if (recoveredWorkKey) {
-    activity.activeEmbeddedRuns.delete(recoveredWorkKey);
-  }
-  clearRecoveredOwnerEmbeddedRuns(activity, ownerRefs);
+  clearRecoveredOwnerEmbeddedRuns(
+    activity,
+    ownerRefs,
+    params.recoveryStartedAfterEmbeddedRunSequence,
+  );
   clearRecoveredOwnerMarkers(activity, ownerRefs);
   if (activity.activeEmbeddedRuns.size > 0) {
     if (hasEmbeddedRunStartedAfter(activity, params.recoveryStartedAfterEmbeddedRunSequence)) {

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -295,22 +295,33 @@ function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string
 export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   sessionId?: string;
   sessionKey?: string;
-}): void {
+  activeSessionId?: string;
+}): { cleared: boolean; blockedByActiveEmbeddedRun: boolean } {
   const activity = resolveSessionActivity(params);
   if (!activity) {
-    return;
+    return { cleared: false, blockedByActiveEmbeddedRun: false };
   }
   if (
     activity.activeEmbeddedRuns.size === 0 &&
     activity.activeTools.size === 0 &&
     activity.activeModelCalls.size === 0
   ) {
-    return;
+    return { cleared: false, blockedByActiveEmbeddedRun: false };
   }
-  activity.activeEmbeddedRuns.clear();
+  const recoveredWorkKey = resolveEmbeddedRunWorkKey({
+    sessionId: params.activeSessionId ?? params.sessionId ?? "",
+  });
+  if (recoveredWorkKey) {
+    activity.activeEmbeddedRuns.delete(recoveredWorkKey);
+  }
+  if (activity.activeEmbeddedRuns.size > 0) {
+    touchSessionActivity(activity, "embedded_run:recovery_skipped_active_owner");
+    return { cleared: false, blockedByActiveEmbeddedRun: true };
+  }
   activity.activeTools.clear();
   activity.activeModelCalls.clear();
   touchSessionActivity(activity, "embedded_run:ended");
+  return { cleared: true, blockedByActiveEmbeddedRun: false };
 }
 
 export function getDiagnosticSessionActivitySnapshot(

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -286,6 +286,21 @@ function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string
   return params.workKey ?? params.sessionId;
 }
 
+// Drops every embedded-run owner for a session at once. Used when an authority
+// (stuck-session recovery) declares the lane terminal and the per-run
+// markDiagnosticEmbeddedRunEnded may have been bypassed for some work keys.
+export function clearDiagnosticEmbeddedRunsForSession(params: {
+  sessionId?: string;
+  sessionKey?: string;
+}): void {
+  const activity = resolveSessionActivity(params);
+  if (!activity || activity.activeEmbeddedRuns.size === 0) {
+    return;
+  }
+  activity.activeEmbeddedRuns.clear();
+  touchSessionActivity(activity, "embedded_run:ended");
+}
+
 export function getDiagnosticSessionActivitySnapshot(
   params: { sessionId?: string; sessionKey?: string },
   now = Date.now(),

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -25,6 +25,7 @@ type ActiveTool = {
   runId?: string;
   sessionId?: string;
   sessionKey?: string;
+  sequence?: number;
   toolName: string;
   toolCallId?: string;
   startedAt: number;
@@ -35,6 +36,7 @@ type ActiveModelCall = {
   runId?: string;
   sessionId?: string;
   sessionKey?: string;
+  sequence?: number;
 };
 
 type DiagnosticToolStartedActivityEvent = Pick<
@@ -213,6 +215,7 @@ function recordToolStarted(event: DiagnosticToolStartedActivityEvent): void {
     runId: event.runId,
     sessionId: event.sessionId,
     sessionKey: event.sessionKey,
+    sequence: event.seq,
     toolName: event.toolName,
     toolCallId: event.toolCallId,
     startedAt: now,
@@ -247,6 +250,7 @@ function recordModelStarted(event: DiagnosticModelStartedActivityEvent): void {
     runId: event.runId,
     sessionId: event.sessionId,
     sessionKey: event.sessionKey,
+    sequence: event.seq,
   });
   touchSessionActivity(activity, "model_call:started");
 }
@@ -360,6 +364,13 @@ function embeddedRunStartedAfter(
   return sequence !== undefined && embeddedRun.sequence > sequence;
 }
 
+function activityMarkerStartedAfter(
+  marker: { sequence?: number },
+  sequence: number | undefined,
+): boolean {
+  return sequence !== undefined && marker.sequence !== undefined && marker.sequence > sequence;
+}
+
 function clearRecoveredOwnerEmbeddedRuns(
   activity: SessionActivity,
   ownerRefs: Set<string>,
@@ -394,17 +405,27 @@ function hasEmbeddedRunStartedAfter(
   return false;
 }
 
-function clearRecoveredOwnerMarkers(activity: SessionActivity, ownerRefs: Set<string>): void {
+function clearRecoveredOwnerMarkers(
+  activity: SessionActivity,
+  ownerRefs: Set<string>,
+  recoveryStartedAfterSequence: number | undefined,
+): void {
   if (ownerRefs.size === 0) {
     return;
   }
   for (const [key, tool] of activity.activeTools) {
-    if (markerBelongsToRecoveredOwner(tool, ownerRefs)) {
+    if (
+      markerBelongsToRecoveredOwner(tool, ownerRefs) &&
+      !activityMarkerStartedAfter(tool, recoveryStartedAfterSequence)
+    ) {
       activity.activeTools.delete(key);
     }
   }
   for (const [key, modelCall] of activity.activeModelCalls) {
-    if (markerBelongsToRecoveredOwner(modelCall, ownerRefs)) {
+    if (
+      markerBelongsToRecoveredOwner(modelCall, ownerRefs) &&
+      !activityMarkerStartedAfter(modelCall, recoveryStartedAfterSequence)
+    ) {
       activity.activeModelCalls.delete(key);
     }
   }
@@ -496,7 +517,11 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
     ownerRefs,
     params.recoveryStartedAfterEmbeddedRunSequence,
   );
-  clearRecoveredOwnerMarkers(activity, ownerRefs);
+  clearRecoveredOwnerMarkers(
+    activity,
+    ownerRefs,
+    params.recoveryStartedAfterDiagnosticEventSequence,
+  );
   if (activity.activeEmbeddedRuns.size > 0) {
     if (hasEmbeddedRunStartedAfter(activity, params.recoveryStartedAfterEmbeddedRunSequence)) {
       touchSessionActivity(activity, "embedded_run:recovery_skipped_active_owner");

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -460,16 +460,23 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   recoveryStartedAfterEmbeddedRunSequence?: number;
   recoveryStartedAfterDiagnosticEventSequence?: number;
 }): { cleared: boolean; blockedByActiveEmbeddedRun: boolean } {
-  const activity = resolveSessionActivity(params);
+  const shouldCreateCutoffActivity =
+    params.recoveryStartedAfterDiagnosticEventSequence !== undefined;
+  const activity = resolveSessionActivity({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    runId: params.activeSessionId,
+    create: shouldCreateCutoffActivity,
+  });
   if (!activity) {
     return { cleared: false, blockedByActiveEmbeddedRun: false };
   }
-  if (
-    activity.activeEmbeddedRuns.size === 0 &&
-    activity.activeTools.size === 0 &&
-    activity.activeModelCalls.size === 0
-  ) {
-    return { cleared: false, blockedByActiveEmbeddedRun: false };
+  if (params.activeSessionId) {
+    registerSessionActivityRefs(activity, {
+      sessionId: params.activeSessionId,
+      sessionKey: params.sessionKey,
+      runId: params.activeSessionId,
+    });
   }
   const ownerRefs = ownerRefsForRecovery(params);
   rememberRecoveredOwnerStartEventCutoffs(
@@ -477,6 +484,13 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
     ownerRefs,
     params.recoveryStartedAfterDiagnosticEventSequence,
   );
+  if (
+    activity.activeEmbeddedRuns.size === 0 &&
+    activity.activeTools.size === 0 &&
+    activity.activeModelCalls.size === 0
+  ) {
+    return { cleared: false, blockedByActiveEmbeddedRun: false };
+  }
   clearRecoveredOwnerEmbeddedRuns(
     activity,
     ownerRefs,

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -17,6 +17,7 @@ type SessionActivity = {
 type ActiveEmbeddedRun = {
   sessionId?: string;
   sessionKey?: string;
+  sequence: number;
 };
 
 type ActiveTool = {
@@ -62,6 +63,7 @@ export type DiagnosticSessionActivitySnapshot = {
 
 const activityByRef = new Map<string, SessionActivity>();
 const activityByRunId = new Map<string, SessionActivity>();
+let embeddedRunSequence = 0;
 
 function sessionRefs(params: { sessionId?: string; sessionKey?: string }): string[] {
   const refs: string[] = [];
@@ -284,6 +286,7 @@ export function markDiagnosticEmbeddedRunStarted(params: {
   activity.activeEmbeddedRuns.set(resolveEmbeddedRunWorkKey(params), {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
+    sequence: ++embeddedRunSequence,
   });
   touchSessionActivity(activity, "embedded_run:started");
 }
@@ -341,6 +344,21 @@ function clearRecoveredOwnerEmbeddedRuns(activity: SessionActivity, ownerRefs: S
   }
 }
 
+function hasEmbeddedRunStartedAfter(
+  activity: SessionActivity,
+  sequence: number | undefined,
+): boolean {
+  if (sequence === undefined) {
+    return activity.activeEmbeddedRuns.size > 0;
+  }
+  for (const embeddedRun of activity.activeEmbeddedRuns.values()) {
+    if (embeddedRun.sequence > sequence) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function clearRecoveredOwnerMarkers(activity: SessionActivity, ownerRefs: Set<string>): void {
   if (ownerRefs.size === 0) {
     return;
@@ -367,6 +385,7 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   sessionId?: string;
   sessionKey?: string;
   activeSessionId?: string;
+  recoveryStartedAfterEmbeddedRunSequence?: number;
 }): { cleared: boolean; blockedByActiveEmbeddedRun: boolean } {
   const activity = resolveSessionActivity(params);
   if (!activity) {
@@ -387,8 +406,11 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   clearRecoveredOwnerEmbeddedRuns(activity, ownerRefs);
   clearRecoveredOwnerMarkers(activity, ownerRefs);
   if (activity.activeEmbeddedRuns.size > 0) {
-    touchSessionActivity(activity, "embedded_run:recovery_skipped_active_owner");
-    return { cleared: false, blockedByActiveEmbeddedRun: true };
+    if (hasEmbeddedRunStartedAfter(activity, params.recoveryStartedAfterEmbeddedRunSequence)) {
+      touchSessionActivity(activity, "embedded_run:recovery_skipped_active_owner");
+      return { cleared: false, blockedByActiveEmbeddedRun: true };
+    }
+    activity.activeEmbeddedRuns.clear();
   }
   activity.activeTools.clear();
   activity.activeModelCalls.clear();
@@ -431,6 +453,10 @@ export function getDiagnosticSessionActivitySnapshot(
   };
 }
 
+export function getDiagnosticEmbeddedRunActivitySequence(): number {
+  return embeddedRunSequence;
+}
+
 export function markDiagnosticRunProgressForTest(params: DiagnosticRunProgressActivityEvent): void {
   markDiagnosticRunProgress(params);
 }
@@ -454,6 +480,7 @@ export function markDiagnosticModelStartedForTest(
 export function resetDiagnosticRunActivityForTest(): void {
   activityByRef.clear();
   activityByRunId.clear();
+  embeddedRunSequence = 0;
   unregisterDiagnosticRunActivityListener?.();
   unregisterDiagnosticRunActivityListener = undefined;
   registerDiagnosticRunActivityListener();

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -431,6 +431,34 @@ function clearRecoveredOwnerMarkers(
   }
 }
 
+function pruneActivityStartedBeforeRecoveryCutoff(
+  activity: SessionActivity,
+  recoveryStartedAfterEmbeddedRunSequence: number | undefined,
+  recoveryStartedAfterDiagnosticEventSequence: number | undefined,
+): void {
+  if (
+    recoveryStartedAfterEmbeddedRunSequence === undefined &&
+    recoveryStartedAfterDiagnosticEventSequence === undefined
+  ) {
+    return;
+  }
+  for (const [key, embeddedRun] of activity.activeEmbeddedRuns) {
+    if (!embeddedRunStartedAfter(embeddedRun, recoveryStartedAfterEmbeddedRunSequence)) {
+      activity.activeEmbeddedRuns.delete(key);
+    }
+  }
+  for (const [key, tool] of activity.activeTools) {
+    if (!activityMarkerStartedAfter(tool, recoveryStartedAfterDiagnosticEventSequence)) {
+      activity.activeTools.delete(key);
+    }
+  }
+  for (const [key, modelCall] of activity.activeModelCalls) {
+    if (!activityMarkerStartedAfter(modelCall, recoveryStartedAfterDiagnosticEventSequence)) {
+      activity.activeModelCalls.delete(key);
+    }
+  }
+}
+
 function rememberRecoveredOwnerStartEventCutoffs(
   activity: SessionActivity,
   ownerRefs: Set<string>,
@@ -524,6 +552,11 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   );
   if (activity.activeEmbeddedRuns.size > 0) {
     if (hasEmbeddedRunStartedAfter(activity, params.recoveryStartedAfterEmbeddedRunSequence)) {
+      pruneActivityStartedBeforeRecoveryCutoff(
+        activity,
+        params.recoveryStartedAfterEmbeddedRunSequence,
+        params.recoveryStartedAfterDiagnosticEventSequence,
+      );
       touchSessionActivity(activity, "embedded_run:recovery_skipped_active_owner");
       return { cleared: false, blockedByActiveEmbeddedRun: true };
     }

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -7,11 +7,16 @@ import {
 type SessionActivity = {
   sessionId?: string;
   sessionKey?: string;
-  activeEmbeddedRuns: Set<string>;
+  activeEmbeddedRuns: Map<string, ActiveEmbeddedRun>;
   activeTools: Map<string, ActiveTool>;
   activeModelCalls: Map<string, ActiveModelCall>;
   lastProgressAt: number;
   lastProgressReason?: string;
+};
+
+type ActiveEmbeddedRun = {
+  sessionId?: string;
+  sessionKey?: string;
 };
 
 type ActiveTool = {
@@ -101,8 +106,8 @@ function replaceSessionActivityReferences(source: SessionActivity, target: Sessi
 function mergeSessionActivity(target: SessionActivity, source: SessionActivity): void {
   target.sessionId ??= source.sessionId;
   target.sessionKey ??= source.sessionKey;
-  for (const key of source.activeEmbeddedRuns) {
-    target.activeEmbeddedRuns.add(key);
+  for (const [key, embeddedRun] of source.activeEmbeddedRuns) {
+    target.activeEmbeddedRuns.set(key, embeddedRun);
   }
   for (const [key, tool] of source.activeTools) {
     target.activeTools.set(key, tool);
@@ -155,7 +160,7 @@ function resolveSessionActivity(params: {
   const created: SessionActivity = {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
-    activeEmbeddedRuns: new Set(),
+    activeEmbeddedRuns: new Map(),
     activeTools: new Map(),
     activeModelCalls: new Map(),
     lastProgressAt: Date.now(),
@@ -276,7 +281,10 @@ export function markDiagnosticEmbeddedRunStarted(params: {
   if (!activity) {
     return;
   }
-  activity.activeEmbeddedRuns.add(resolveEmbeddedRunWorkKey(params));
+  activity.activeEmbeddedRuns.set(resolveEmbeddedRunWorkKey(params), {
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+  });
   touchSessionActivity(activity, "embedded_run:started");
 }
 
@@ -322,6 +330,17 @@ function markerBelongsToRecoveredOwner(
   );
 }
 
+function clearRecoveredOwnerEmbeddedRuns(activity: SessionActivity, ownerRefs: Set<string>): void {
+  if (ownerRefs.size === 0) {
+    return;
+  }
+  for (const [key, embeddedRun] of activity.activeEmbeddedRuns) {
+    if (embeddedRun.sessionId !== undefined && ownerRefs.has(embeddedRun.sessionId)) {
+      activity.activeEmbeddedRuns.delete(key);
+    }
+  }
+}
+
 function clearRecoveredOwnerMarkers(activity: SessionActivity, ownerRefs: Set<string>): void {
   if (ownerRefs.size === 0) {
     return;
@@ -365,6 +384,7 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   if (recoveredWorkKey) {
     activity.activeEmbeddedRuns.delete(recoveredWorkKey);
   }
+  clearRecoveredOwnerEmbeddedRuns(activity, ownerRefs);
   clearRecoveredOwnerMarkers(activity, ownerRefs);
   if (activity.activeEmbeddedRuns.size > 0) {
     touchSessionActivity(activity, "embedded_run:recovery_skipped_active_owner");

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -1,5 +1,8 @@
 import { emitInternalDiagnosticEvent as emitDiagnosticEvent } from "../infra/diagnostic-events.js";
-import { clearDiagnosticEmbeddedRunActivityForSession } from "./diagnostic-run-activity.js";
+import {
+  clearDiagnosticEmbeddedRunActivityForSession,
+  getDiagnosticEmbeddedRunActivitySequence,
+} from "./diagnostic-run-activity.js";
 import { markDiagnosticActivity as markActivity } from "./diagnostic-runtime.js";
 import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {
@@ -81,6 +84,7 @@ function recoveryOutcomeHasQueuedLaneWork(outcome: StuckSessionRecoveryOutcome):
 function applyRecoveryOutcomeToDiagnosticState(params: {
   request: StuckSessionRecoveryRequest;
   outcome: StuckSessionRecoveryOutcome | undefined;
+  recoveryStartedAfterEmbeddedRunSequence?: number;
 }): void {
   if (!params.outcome) {
     return;
@@ -121,6 +125,7 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
     sessionId: state.sessionId,
     sessionKey: state.sessionKey,
     activeSessionId: params.outcome.activeSessionId,
+    recoveryStartedAfterEmbeddedRunSequence: params.recoveryStartedAfterEmbeddedRunSequence,
   });
   if (activityClear.blockedByActiveEmbeddedRun) {
     emitSessionRecoveryCompleted({
@@ -183,6 +188,7 @@ export function requestStuckSessionRecovery(params: {
     request: params.request,
     classification: params.classification,
   });
+  const recoveryStartedAfterEmbeddedRunSequence = getDiagnosticEmbeddedRunActivitySequence();
   const clearInFlight = () => {
     if (inFlightKey) {
       recoveryRequestsInFlight.delete(inFlightKey);
@@ -199,6 +205,7 @@ export function requestStuckSessionRecovery(params: {
         sessionKey: params.request.sessionKey,
         error: String(err),
       },
+      recoveryStartedAfterEmbeddedRunSequence,
     });
   };
   try {
@@ -209,6 +216,7 @@ export function requestStuckSessionRecovery(params: {
           applyRecoveryOutcomeToDiagnosticState({
             request: params.request,
             outcome: outcome ?? undefined,
+            recoveryStartedAfterEmbeddedRunSequence,
           });
         })
         .catch(failRecovery)
@@ -218,6 +226,7 @@ export function requestStuckSessionRecovery(params: {
     applyRecoveryOutcomeToDiagnosticState({
       request: params.request,
       outcome: result ?? undefined,
+      recoveryStartedAfterEmbeddedRunSequence,
     });
     clearInFlight();
   } catch (err) {

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -1,4 +1,5 @@
 import { emitInternalDiagnosticEvent as emitDiagnosticEvent } from "../infra/diagnostic-events.js";
+import { clearDiagnosticEmbeddedRunsForSession } from "./diagnostic-run-activity.js";
 import { markDiagnosticActivity as markActivity } from "./diagnostic-runtime.js";
 import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {
@@ -126,6 +127,14 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
     : preserveQueuedIdleWork
       ? Math.max(state.queueDepth, params.request.queueDepth ?? 0)
       : Math.max(0, state.queueDepth - 1);
+  // The idle declaration is authoritative: reconcile the activity store so an
+  // embedded run cleared without markDiagnosticEmbeddedRunEnded cannot leave the
+  // lane reporting idle/embedded_run and re-triggering recovery forever. The
+  // guard above already excludes any newer run that re-armed activity.
+  clearDiagnosticEmbeddedRunsForSession({
+    sessionId: state.sessionId,
+    sessionKey: state.sessionKey,
+  });
   emitDiagnosticEvent({
     type: "session.state",
     sessionId: state.sessionId,

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -114,6 +114,22 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
     return;
   }
   const state = getDiagnosticSessionState(params.request);
+  // The idle declaration is authoritative for the recovered owner only. If a
+  // different embedded owner appeared under the same session key while recovery
+  // awaited abort/drain, keep the lane active instead of erasing fresh work.
+  const activityClear = clearDiagnosticEmbeddedRunActivityForSession({
+    sessionId: state.sessionId,
+    sessionKey: state.sessionKey,
+    activeSessionId: params.outcome.activeSessionId,
+  });
+  if (activityClear.blockedByActiveEmbeddedRun) {
+    emitSessionRecoveryCompleted({
+      request: params.request,
+      outcome: params.outcome,
+      stale: true,
+    });
+    return;
+  }
   const prevState = state.state;
   state.state = "idle";
   state.lastActivity = Date.now();
@@ -127,14 +143,6 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
     : preserveQueuedIdleWork
       ? Math.max(state.queueDepth, params.request.queueDepth ?? 0)
       : Math.max(0, state.queueDepth - 1);
-  // The idle declaration is authoritative: reconcile the activity store so an
-  // embedded run cleared without markDiagnosticEmbeddedRunEnded cannot leave the
-  // lane reporting idle/embedded_run and re-triggering recovery forever. The
-  // guard above already excludes any newer run that re-armed activity.
-  clearDiagnosticEmbeddedRunActivityForSession({
-    sessionId: state.sessionId,
-    sessionKey: state.sessionKey,
-  });
   emitDiagnosticEvent({
     type: "session.state",
     sessionId: state.sessionId,

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -1,5 +1,5 @@
 import { emitInternalDiagnosticEvent as emitDiagnosticEvent } from "../infra/diagnostic-events.js";
-import { clearDiagnosticEmbeddedRunsForSession } from "./diagnostic-run-activity.js";
+import { clearDiagnosticEmbeddedRunActivityForSession } from "./diagnostic-run-activity.js";
 import { markDiagnosticActivity as markActivity } from "./diagnostic-runtime.js";
 import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {
@@ -131,7 +131,7 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   // embedded run cleared without markDiagnosticEmbeddedRunEnded cannot leave the
   // lane reporting idle/embedded_run and re-triggering recovery forever. The
   // guard above already excludes any newer run that re-armed activity.
-  clearDiagnosticEmbeddedRunsForSession({
+  clearDiagnosticEmbeddedRunActivityForSession({
     sessionId: state.sessionId,
     sessionKey: state.sessionKey,
   });

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -1,4 +1,7 @@
-import { emitInternalDiagnosticEvent as emitDiagnosticEvent } from "../infra/diagnostic-events.js";
+import {
+  emitInternalDiagnosticEvent as emitDiagnosticEvent,
+  getInternalDiagnosticEventSequence,
+} from "../infra/diagnostic-events.js";
 import {
   clearDiagnosticEmbeddedRunActivityForSession,
   getDiagnosticEmbeddedRunActivitySequence,
@@ -85,6 +88,7 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   request: StuckSessionRecoveryRequest;
   outcome: StuckSessionRecoveryOutcome | undefined;
   recoveryStartedAfterEmbeddedRunSequence?: number;
+  recoveryStartedAfterDiagnosticEventSequence?: number;
 }): void {
   if (!params.outcome) {
     return;
@@ -126,6 +130,7 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
     sessionKey: state.sessionKey,
     activeSessionId: params.outcome.activeSessionId,
     recoveryStartedAfterEmbeddedRunSequence: params.recoveryStartedAfterEmbeddedRunSequence,
+    recoveryStartedAfterDiagnosticEventSequence: params.recoveryStartedAfterDiagnosticEventSequence,
   });
   if (activityClear.blockedByActiveEmbeddedRun) {
     emitSessionRecoveryCompleted({
@@ -189,6 +194,7 @@ export function requestStuckSessionRecovery(params: {
     classification: params.classification,
   });
   const recoveryStartedAfterEmbeddedRunSequence = getDiagnosticEmbeddedRunActivitySequence();
+  const recoveryStartedAfterDiagnosticEventSequence = getInternalDiagnosticEventSequence();
   const clearInFlight = () => {
     if (inFlightKey) {
       recoveryRequestsInFlight.delete(inFlightKey);
@@ -206,6 +212,7 @@ export function requestStuckSessionRecovery(params: {
         error: String(err),
       },
       recoveryStartedAfterEmbeddedRunSequence,
+      recoveryStartedAfterDiagnosticEventSequence,
     });
   };
   try {
@@ -217,6 +224,7 @@ export function requestStuckSessionRecovery(params: {
             request: params.request,
             outcome: outcome ?? undefined,
             recoveryStartedAfterEmbeddedRunSequence,
+            recoveryStartedAfterDiagnosticEventSequence,
           });
         })
         .catch(failRecovery)
@@ -227,6 +235,7 @@ export function requestStuckSessionRecovery(params: {
       request: params.request,
       outcome: result ?? undefined,
       recoveryStartedAfterEmbeddedRunSequence,
+      recoveryStartedAfterDiagnosticEventSequence,
     });
     clearInFlight();
   } catch (err) {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2748,6 +2748,46 @@ describe("stuck session recovery activity reconciliation", () => {
     expect(activity.hasActiveEmbeddedRun).toBe(true);
   });
 
+  it("preserves fresh same-session tool activity rearmed after recovery starts", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    const staleGeneration = state.generation;
+
+    requestStuckSessionRecovery({
+      recover: () => {
+        markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+        emitDiagnosticEvent({
+          type: "tool.execution.started",
+          runId: sessionId,
+          sessionId,
+          sessionKey,
+          toolName: "FreshTool",
+          toolCallId: "fresh-tool",
+        });
+        return Promise.resolve(abortedOutcome());
+      },
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: staleGeneration,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBe("tool_call");
+    expect(activity.hasActiveEmbeddedRun).toBe(true);
+    expect(activity.activeToolName).toBe("FreshTool");
+  });
+
   it("keeps fresh tool markers when a different embedded owner blocks recovery clearing", async () => {
     logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
     markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2748,6 +2748,53 @@ describe("stuck session recovery activity reconciliation", () => {
     expect(activity.hasActiveEmbeddedRun).toBe(true);
   });
 
+  it("prunes older same-key activity when a fresh owner blocks recovery clearing", async () => {
+    markDiagnosticEmbeddedRunStarted({ sessionId: "older-run-1", sessionKey });
+    markDiagnosticToolStartedForTest({
+      sessionId: "older-run-1",
+      sessionKey,
+      toolName: "OldTool",
+      toolCallId: "old-tool",
+    });
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    const staleGeneration = state.generation;
+
+    requestStuckSessionRecovery({
+      recover: () => {
+        markDiagnosticEmbeddedRunStarted({ sessionId: "reply-run-1", sessionKey });
+        return Promise.resolve(abortedOutcome());
+      },
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: staleGeneration,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
+    expect(getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey }).activeWorkKind).toBe(
+      "embedded_run",
+    );
+
+    markDiagnosticEmbeddedRunEnded({
+      sessionId: "reply-run-1",
+      sessionKey,
+      clearRunActivity: false,
+    });
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBeUndefined();
+    expect(activity.activeToolName).toBeUndefined();
+  });
+
   it("preserves fresh same-session tool activity rearmed after recovery starts", async () => {
     logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
     markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
@@ -2798,7 +2845,8 @@ describe("stuck session recovery activity reconciliation", () => {
     requestStuckSessionRecovery({
       recover: () => {
         markDiagnosticEmbeddedRunStarted({ sessionId: "reply-run-1", sessionKey });
-        markDiagnosticToolStartedForTest({
+        emitDiagnosticEvent({
+          type: "tool.execution.started",
           sessionId: "reply-run-1",
           sessionKey,
           toolName: "ReplyTool",

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2467,4 +2467,39 @@ describe("stuck session recovery activity reconciliation", () => {
       "embedded_run",
     );
   });
+
+  it("preserves reply work that re-armed activity without a session generation bump", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    const staleGeneration = state.generation;
+
+    requestStuckSessionRecovery({
+      recover: () => {
+        markDiagnosticEmbeddedRunStarted({
+          sessionId: "reply-run-1",
+          sessionKey,
+          workKey: `reply:${sessionKey}`,
+        });
+        return Promise.resolve(abortedOutcome());
+      },
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: staleGeneration,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBe("embedded_run");
+    expect(activity.hasActiveEmbeddedRun).toBe(true);
+  });
 });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2357,6 +2357,77 @@ describe("stuck session recovery activity reconciliation", () => {
     expect(activity.hasActiveEmbeddedRun).toBeUndefined();
   });
 
+  it("clears a stale tool marker left by the aborted run so a queued idle lane converges", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    // The aborted run left a stale tool marker. If recovery clears only the
+    // embedded owner, the lane becomes idle + orphaned tool_call, which
+    // isIdleQueuedRecoverableSessionStall still treats as recoverable while work
+    // is queued — so the idle declaration must clear the tool marker too.
+    markDiagnosticToolStartedForTest({ sessionId, sessionKey, toolName: "Bash", toolCallId: "t1" });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    state.queueDepth = 2;
+
+    requestStuckSessionRecovery({
+      recover: () => Promise.resolve(abortedOutcome()),
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: state.generation,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBeUndefined();
+    expect(activity.hasActiveEmbeddedRun).toBeUndefined();
+    expect(activity.activeToolName).toBeUndefined();
+  });
+
+  it("clears a stale model marker left by the aborted run so a queued idle lane converges", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    // Same hazard via a stale model-call marker: owner-only clearing would leave
+    // idle + orphaned model_call, which the idle-queued classifier still recovers.
+    markDiagnosticModelStartedForTest({
+      sessionId,
+      sessionKey,
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    state.queueDepth = 2;
+
+    requestStuckSessionRecovery({
+      recover: () => Promise.resolve(abortedOutcome()),
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: state.generation,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBeUndefined();
+    expect(activity.hasActiveEmbeddedRun).toBeUndefined();
+  });
+
   it("preserves an active flag for a newer run that re-armed work mid-recovery", async () => {
     logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
     markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2595,6 +2595,35 @@ describe("stuck session recovery activity reconciliation", () => {
     expect(activity.hasActiveEmbeddedRun).toBeUndefined();
   });
 
+  it("does not block recovery behind older same-key embedded owners", async () => {
+    markDiagnosticEmbeddedRunStarted({ sessionId: "older-run-1", sessionKey });
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    state.queueDepth = 2;
+
+    requestStuckSessionRecovery({
+      recover: () => Promise.resolve(abortedOutcome()),
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: state.generation,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBeUndefined();
+    expect(activity.hasActiveEmbeddedRun).toBeUndefined();
+  });
+
   it("keeps fresh tool markers when a different embedded owner blocks recovery clearing", async () => {
     logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
     markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2624,6 +2624,37 @@ describe("stuck session recovery activity reconciliation", () => {
     expect(activity.hasActiveEmbeddedRun).toBeUndefined();
   });
 
+  it("preserves same-session work rearmed after recovery starts", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    const staleGeneration = state.generation;
+
+    requestStuckSessionRecovery({
+      recover: () => {
+        markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+        return Promise.resolve(abortedOutcome());
+      },
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: staleGeneration,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBe("embedded_run");
+    expect(activity.hasActiveEmbeddedRun).toBe(true);
+  });
+
   it("keeps fresh tool markers when a different embedded owner blocks recovery clearing", async () => {
     logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
     markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2474,6 +2474,53 @@ describe("stuck session recovery activity reconciliation", () => {
     expect(activity.activeToolName).toBeUndefined();
   });
 
+  it("remembers stale async start cutoffs even when activity was already empty", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    markDiagnosticEmbeddedRunEnded({ sessionId, sessionKey });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    state.queueDepth = 2;
+
+    emitDiagnosticEvent({
+      type: "tool.execution.started",
+      runId: sessionId,
+      sessionId,
+      sessionKey,
+      toolName: "Bash",
+      toolCallId: "late-tool",
+    });
+    emitDiagnosticEvent({
+      type: "model.call.started",
+      runId: sessionId,
+      sessionId,
+      sessionKey,
+      callId: "late-model",
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+
+    requestStuckSessionRecovery({
+      recover: () => Promise.resolve(abortedOutcome()),
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: state.generation,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBeUndefined();
+    expect(activity.activeToolName).toBeUndefined();
+  });
+
   it("preserves an active flag for a newer run that re-armed work mid-recovery", async () => {
     logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
     markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2547,6 +2547,54 @@ describe("stuck session recovery activity reconciliation", () => {
     expect(activity.activeToolName).toBeUndefined();
   });
 
+  it("clears recovered reply work stored under a custom embedded work key", async () => {
+    const replySessionId = "reply-run-1";
+    logSessionStateChange({
+      sessionId: replySessionId,
+      sessionKey,
+      state: "processing",
+      reason: "run_started",
+    });
+    markDiagnosticEmbeddedRunStarted({
+      sessionId: replySessionId,
+      sessionKey,
+      workKey: `reply:${sessionKey}`,
+    });
+    const state = getDiagnosticSessionState({ sessionId: replySessionId, sessionKey });
+    state.queueDepth = 2;
+
+    requestStuckSessionRecovery({
+      recover: () =>
+        Promise.resolve({
+          ...abortedOutcome(),
+          sessionId: replySessionId,
+          activeSessionId: replySessionId,
+        }),
+      classification: stalledClassification,
+      request: {
+        sessionId: replySessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: state.generation,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId: replySessionId, sessionKey })?.state).toBe(
+      "idle",
+    );
+    const activity = getDiagnosticSessionActivitySnapshot({
+      sessionId: replySessionId,
+      sessionKey,
+    });
+    expect(activity.activeWorkKind).toBeUndefined();
+    expect(activity.hasActiveEmbeddedRun).toBeUndefined();
+  });
+
   it("keeps fresh tool markers when a different embedded owner blocks recovery clearing", async () => {
     logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
     markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2502,4 +2502,87 @@ describe("stuck session recovery activity reconciliation", () => {
     expect(activity.activeWorkKind).toBe("embedded_run");
     expect(activity.hasActiveEmbeddedRun).toBe(true);
   });
+
+  it("clears stale tool and model markers while preserving a fresh embedded owner", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    markDiagnosticToolStartedForTest({ sessionId, sessionKey, toolName: "Bash", toolCallId: "t1" });
+    markDiagnosticModelStartedForTest({
+      sessionId,
+      sessionKey,
+      runId: sessionId,
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    const staleGeneration = state.generation;
+
+    requestStuckSessionRecovery({
+      recover: () => {
+        markDiagnosticEmbeddedRunStarted({
+          sessionId: "reply-run-1",
+          sessionKey,
+          workKey: `reply:${sessionKey}`,
+        });
+        return Promise.resolve(abortedOutcome());
+      },
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: staleGeneration,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBe("embedded_run");
+    expect(activity.hasActiveEmbeddedRun).toBe(true);
+    expect(activity.activeToolName).toBeUndefined();
+  });
+
+  it("keeps fresh tool markers when a different embedded owner blocks recovery clearing", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    markDiagnosticToolStartedForTest({ sessionId, sessionKey, toolName: "Bash", toolCallId: "t1" });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    const staleGeneration = state.generation;
+
+    requestStuckSessionRecovery({
+      recover: () => {
+        markDiagnosticEmbeddedRunStarted({ sessionId: "reply-run-1", sessionKey });
+        markDiagnosticToolStartedForTest({
+          sessionId: "reply-run-1",
+          sessionKey,
+          toolName: "ReplyTool",
+          toolCallId: "fresh-tool",
+        });
+        return Promise.resolve(abortedOutcome());
+      },
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: staleGeneration,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBe("tool_call");
+    expect(activity.hasActiveEmbeddedRun).toBe(true);
+    expect(activity.activeToolName).toBe("ReplyTool");
+  });
 });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -16,11 +16,19 @@ import {
   markDiagnosticModelStartedForTest,
   markDiagnosticRunProgressForTest,
   markDiagnosticToolStartedForTest,
+  resetDiagnosticRunActivityForTest,
 } from "./diagnostic-run-activity.js";
+import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
+import {
+  requestStuckSessionRecovery,
+  resetDiagnosticSessionRecoveryCoordinatorForTest,
+} from "./diagnostic-session-recovery-coordinator.js";
+import type { StuckSessionRecoveryOutcome } from "./diagnostic-session-recovery.js";
 import {
   diagnosticSessionStates,
   getDiagnosticSessionState,
   getDiagnosticSessionStateCountForTest,
+  peekDiagnosticSessionState,
   pruneDiagnosticSessionStates,
   resetDiagnosticSessionStateForTest,
 } from "./diagnostic-session-state.js";
@@ -2269,5 +2277,123 @@ describe("diagnostic stability snapshots", () => {
     const [event] = getDiagnosticStabilitySnapshot({ limit: 10 }).events;
     expect(event).not.toHaveProperty("sessionKey");
     expect(event).not.toHaveProperty("sessionId");
+  });
+});
+
+describe("stuck session recovery activity reconciliation", () => {
+  const sessionKey = "agent:main:whatsapp:direct:demo";
+  const sessionId = "wa-run-1";
+
+  const stalledClassification: SessionAttentionClassification = {
+    eventType: "session.stalled",
+    reason: "active_work_without_progress",
+    classification: "stalled_agent_run",
+    activeWorkKind: "embedded_run",
+    recoveryEligible: false,
+  };
+
+  function abortedOutcome(): StuckSessionRecoveryOutcome {
+    return {
+      status: "aborted",
+      action: "abort_embedded_run",
+      sessionId,
+      sessionKey,
+      activeSessionId: sessionId,
+      activeWorkKind: "embedded_run",
+      aborted: true,
+      drained: false,
+      forceCleared: false,
+      released: 0,
+    };
+  }
+
+  function flush(): Promise<void> {
+    return new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+
+  beforeEach(() => {
+    setDiagnosticsEnabledForProcess(true);
+    resetDiagnosticSessionStateForTest();
+    resetDiagnosticRunActivityForTest();
+    resetDiagnosticSessionRecoveryCoordinatorForTest();
+  });
+
+  afterEach(() => {
+    resetDiagnosticSessionStateForTest();
+    resetDiagnosticRunActivityForTest();
+    resetDiagnosticSessionRecoveryCoordinatorForTest();
+  });
+
+  it("clears the embedded-run activity flag when recovery declares the lane idle", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    state.queueDepth = 2;
+
+    // The aborted run was removed without markDiagnosticEmbeddedRunEnded, so the
+    // activity flag survives the idle transition and otherwise resurfaces as
+    // idle/embedded_run on every later liveness sweep.
+    requestStuckSessionRecovery({
+      recover: () => Promise.resolve(abortedOutcome()),
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: state.generation,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBeUndefined();
+    expect(activity.hasActiveEmbeddedRun).toBeUndefined();
+  });
+
+  it("preserves an active flag for a newer run that re-armed work mid-recovery", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    const staleGeneration = state.generation;
+
+    requestStuckSessionRecovery({
+      recover: () => {
+        // A requeued run started before the coordinator applied the outcome,
+        // advancing the generation past the captured one.
+        logSessionStateChange({
+          sessionId: "wa-run-2",
+          sessionKey,
+          state: "processing",
+          reason: "run_started",
+        });
+        markDiagnosticEmbeddedRunStarted({ sessionId: "wa-run-2", sessionKey });
+        return Promise.resolve(abortedOutcome());
+      },
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: staleGeneration,
+      },
+    });
+    await flush();
+    await flush();
+
+    // Generation guard bails: the live run keeps processing and its activity flag.
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
+    expect(getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey }).activeWorkKind).toBe(
+      "embedded_run",
+    );
   });
 });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2428,6 +2428,52 @@ describe("stuck session recovery activity reconciliation", () => {
     expect(activity.hasActiveEmbeddedRun).toBeUndefined();
   });
 
+  it("ignores stale async tool and model starts that drain after recovery clearing", async () => {
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    const state = getDiagnosticSessionState({ sessionId, sessionKey });
+    state.queueDepth = 2;
+
+    emitDiagnosticEvent({
+      type: "tool.execution.started",
+      sessionId,
+      sessionKey,
+      toolName: "Bash",
+      toolCallId: "late-tool",
+    });
+    emitDiagnosticEvent({
+      type: "model.call.started",
+      sessionId,
+      sessionKey,
+      runId: sessionId,
+      callId: "late-model",
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+
+    requestStuckSessionRecovery({
+      recover: () => Promise.resolve(abortedOutcome()),
+      classification: stalledClassification,
+      request: {
+        sessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: state.generation,
+      },
+    });
+    await flush();
+    await flush();
+
+    expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
+    const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
+    expect(activity.activeWorkKind).toBeUndefined();
+    expect(activity.hasActiveEmbeddedRun).toBeUndefined();
+    expect(activity.activeToolName).toBeUndefined();
+  });
+
   it("preserves an active flag for a newer run that re-armed work mid-recovery", async () => {
     logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
     markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });


### PR DESCRIPTION
### Summary

- **Problem**: Issue #88660 reports that after stuck-session recovery aborts a channel lane's embedded run, the lane settles to `idle` but diagnostics keep reporting `idle/embedded_run,q=1` and re-emit `session.stalled` for `active_work_without_progress`. The lane looks healthy at a high level while the direct session lane is not actually clean, so queued work stalls and recovery re-fires indefinitely.
- **Root Cause**: Diagnostics keep two independent per-session stores: the session-state store (`idle`/`processing`, queue depth) and the run-activity store (`activeEmbeddedRuns` owners plus `activeTools`/`activeModelCalls`, surfaced as `activeWorkKind`/`hasActiveEmbeddedRun`). `applyRecoveryOutcomeToDiagnosticState` in `src/logging/diagnostic-session-recovery-coordinator.ts` declares the lane `idle` and reconciles only the session-state store. The run-activity store is cleared solely by `markDiagnosticEmbeddedRunEnded` (which clears the owner AND its tool/model markers by default), and the embedded-run teardown can bypass it (handle replaced/mismatched, or force-clear finding no live handle). When that happens the coordinator flips the lane to `idle` but the run activity survives, so the liveness sweep formats `idle` + activity together and `isIdleQueuedRecoverableSessionStall` keeps re-triggering recovery without ever converging. The decisive evidence in the report is `last=embedded_run:started` (never `:ended`) on an idle lane.
- **Fix**: Make the idle declaration authoritative over both stores, reconciling the whole terminal embedded-run activity (not just the owner set).
  - `clearDiagnosticEmbeddedRunActivityForSession({ sessionId, sessionKey })` clears the session's `activeEmbeddedRuns` owners AND their `activeTools`/`activeModelCalls` markers and stamps terminal progress, matching the default `markDiagnosticEmbeddedRunEnded` teardown; it is a no-op when there is nothing to clear.
  - The coordinator calls it inside the guard-passed idle branch, immediately after the queue-depth reconciliation and before the `session.state` event.
  - Clearing only the owner set is insufficient: a stale tool/model marker would change the lane from `idle + hasActiveEmbeddedRun` to `idle + orphaned tool/model activity`, which `isIdleQueuedRecoverableSessionStall`'s `hasOrphanedActivity` branch (added by #87028) still treats as recoverable while `queueDepth > 0` — so the sweep would keep re-triggering recovery.
  - The existing generation guard already bails when a newer run re-armed activity (a live run bumps the generation or keeps state `processing`), so only leaked/terminal activity is dropped — a legitimately requeued run is preserved.
- **What changed**:
  - `src/logging/diagnostic-run-activity.ts` — add `clearDiagnosticEmbeddedRunActivityForSession`, which reconciles a session's terminal embedded-run activity (owners + tool/model markers).
  - `src/logging/diagnostic-session-recovery-coordinator.ts` — call it from the authoritative idle branch of `applyRecoveryOutcomeToDiagnosticState`.
  - Tests added to `diagnostic.test.ts` (`stuck session recovery activity reconciliation` describe): embedded-owner reconcile, stale-tool-marker convergence, stale-model-marker convergence, and newer-run-preserved guard cases.
- **What did NOT change (scope boundary)**:
  - The generation/ownership guards, the `expectedState` idle re-recovery path, and the `preserveQueuedIdleWork` queue reconciliation are unchanged; the clear runs only after those already decided to flip the lane idle.
  - The idle-queued classifier (`isIdleQueuedRecoverableSessionStall`) and the embedded-run teardown paths (`clearActiveEmbeddedRun` / `forceClearEmbeddedAgentRun`) are unchanged.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. A channel lane (e.g. WhatsApp direct) hits a stalled embedded run with queued work; the run leaves an embedded owner and possibly a tool/model marker.
2. Stuck-session recovery aborts the run; its teardown removes the handle without reaching `markDiagnosticEmbeddedRunEnded` (handle replaced/mismatched, or force-clear finds no live handle).
3. The recovery coordinator applies the `aborted` outcome and declares the lane `idle`.
4. **Before this PR**: the run activity survives in the activity store, so the liveness sweep reports `idle` + activity and `isIdleQueuedRecoverableSessionStall` re-fires recovery forever; `last=embedded_run:started` never advances to `:ended`.
5. **After this PR**: the idle declaration clears the session's embedded-run owners and their tool/model markers, the activity snapshot reports no `activeWorkKind`, the lane reads cleanly idle, and recovery converges.

### Real behavior proof

**Behavior addressed (#88660)**: after `abort_embedded_run` recovery declares a lane idle, the lane is no longer classifiable as `idle/embedded_run` (or `idle + orphaned tool/model activity`); the whole terminal embedded-run activity is reconciled atomically with the idle transition so the liveness sweep stops re-triggering recovery.

**Real environment tested (Linux, Node 22 — Vitest against the production recovery coordinator, run-activity store, and heartbeat liveness loop)**: `requestStuckSessionRecovery` / `applyRecoveryOutcomeToDiagnosticState` driving the real `diagnostic-session-state` and `diagnostic-run-activity` stores, plus an end-to-end `startDiagnosticHeartbeat` sweep exercising the real `isIdleQueuedRecoverableSessionStall` dispatch.

**Exact steps or command run after this patch**: `pnpm test src/logging/diagnostic.test.ts`; full related suites `pnpm test src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts src/logging/diagnostic-session-attention.test.ts src/agents/embedded-agent-runner/runs.test.ts`; `pnpm tsgo`; `pnpm exec oxfmt --check` and `node scripts/run-oxlint.mjs` on the changed files.

**Evidence after fix (Vitest output for the touched test file)**:

```text
 diagnostic.test.ts   Tests  58 passed (58)
```

The reconciliation describe covers four cases: `clears the embedded-run activity flag when recovery declares the lane idle`, `clears a stale tool marker left by the aborted run so a queued idle lane converges`, `clears a stale model marker left by the aborted run so a queued idle lane converges`, and `preserves an active flag for a newer run that re-armed work mid-recovery`.

**Observed result after fix**: after the coordinator declares the lane `idle`, `getDiagnosticSessionActivitySnapshot` returns no `activeWorkKind` and no `hasActiveEmbeddedRun` — including when the aborted run had left a stale tool or model marker. An end-to-end heartbeat sweep over that reconciled state does not re-dispatch recovery; with an owner-only clear the same sweep still re-dispatches (orphaned `tool_call`/`model_call` keeps the lane recoverable), confirming the broader clear is what makes the lane converge. When a newer run re-arms activity mid-recovery, the generation guard bails: the lane stays `processing` and keeps its activity (live run preserved).

**What was not tested**: the live WhatsApp-gateway abort/recovery cycle end-to-end on the reporter's deployment. The coordinator idle declaration, the activity reconciliation, and the liveness re-dispatch are covered deterministically against the production functions; a full gateway round-trip was not driven.

**Repro confirmation**: each reconcile case fails on an owner-only-clear tree (the activity snapshot still reports `embedded_run` / `tool_call` / `model_call`) and passes with the fix, so the tests cover the production change.

### Risk / Mitigation

- **Risk**: A live run's activity could be cleared. **Mitigation**: the clear runs only on the authoritative idle transition that already passed the generation guard; a live run bumps the generation or keeps state `processing`, so the guard bails before the clear — only leaked/terminal activity is dropped.
- **Risk**: Over-broad reconciliation of tool/model markers. **Mitigation**: this matches exactly what the normal `markDiagnosticEmbeddedRunEnded` teardown clears by default, and is gated behind the same guarded idle branch; it is a no-op when there is nothing to clear.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Diagnostics / logging
- [x] Sessions / storage

### Linked Issue/PR

Fixes #88660
