### PR TITLE
test(agents): fix mcp runtime lint

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1907,7 +1907,9 @@ process.stdin.on("end", () => {
         });
       });
 
-      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", () => resolve());
+      });
       const addr = server.address() as { port: number };
 
       try {


### PR DESCRIPTION
## Summary

- Fixes a current changed-gate lint failure in `src/agents/agent-bundle-mcp-runtime.test.ts` by making the `server.listen` Promise executor use a block body instead of returning the `Server` instance.
- Keeps the test behavior unchanged: the Promise still resolves only after the server starts listening.
- Intentionally out of scope: any MCP runtime behavior changes or broader agent test cleanup.
- Success means `check:changed` no longer fails the core test lint lane on this file.
- Review focus: confirm this is a mechanical lint-only correction.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Maintainer lane follow-up after a Mattermost changed gate exposed this current-main lint blocker.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `no-promise-executor-return` failure in `src/agents/agent-bundle-mcp-runtime.test.ts` during `check:changed`.
- Real environment tested: local macOS checkout plus delegated Blacksmith Testbox through Crabbox.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts`; `node scripts/run-oxlint.mjs src/agents/agent-bundle-mcp-runtime.test.ts`; Testbox `corepack pnpm check:changed`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): local Vitest passed 1 file / 30 tests; targeted oxlint exited 0; Testbox `tbx_01kt066qj1ahrffb00q3b6jzt7` exited 0.
- Observed result after fix: changed gate narrowed to `coreTests`, typechecked core tests, linted the changed file, and completed successfully.
- What was not tested: full repository CI beyond changed gate.
- Proof limitations or environment constraints: no runtime behavior change; this is a test lint fix.
- Before evidence (optional but encouraged): Testbox `tbx_01kt05kb41mcd8rb78hcntx5mc` failed `lint core` on `no-promise-executor-return` for this file.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts`
- `node scripts/run-oxlint.mjs src/agents/agent-bundle-mcp-runtime.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`

What regression coverage was added or updated?

No coverage added; existing agent MCP runtime test remains the coverage.

What failed before this fix, if known?

`check:changed` failed the core lint lane with `eslint(no-promise-executor-return)` on this test.

If no test was added, why not?

The existing test already covers the behavior; the patch only fixes lint syntax.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

Very low: accidental test timing change.

How is that risk mitigated?

The touched test passed locally after the callback change, and changed-gate type/lint passed remotely.

## Current review state

What is the next action?

Review and merge when CI is satisfied.

What is still waiting on author, maintainer, CI, or external proof?

Repository PR CI, if required by maintainers.

Which bot or reviewer comments were addressed?

Local autoreview reported no accepted/actionable findings.
