### PR TITLE
Add Vertex API key model config regression coverage

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
@@ -47,6 +50,24 @@ function createImplicitOpenAiProvider(overrides: Partial<ProviderConfig> = {}): 
       },
     ],
     ...overrides,
+  };
+}
+
+function createImplicitGoogleVertexProvider(): ProviderConfig {
+  return {
+    baseUrl: "https://{location}-aiplatform.googleapis.com",
+    api: "google-vertex",
+    models: [
+      {
+        id: "gemini-2.5-pro",
+        name: "Gemini 2.5 Pro",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_048_576,
+        maxTokens: 65_536,
+      },
+    ],
   };
 }
 
@@ -401,6 +422,72 @@ describe("models-config", () => {
     expect(parsed.providers?.google?.models?.map((model) => model.id)).toEqual([
       "gemini-3.1-pro-preview",
     ]);
+  });
+
+  it("keeps google-vertex static catalog rows when an auth profile supplies the API key", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-models-"));
+    try {
+      await fs.writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "google-vertex:default": {
+                type: "api_key",
+                provider: "google-vertex",
+                keyRef: { source: "env", provider: "default", id: "GOOGLE_CLOUD_API_KEY" },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const plan = await planOpenClawModelsJsonWithDeps(
+        {
+          cfg: {
+            agents: {
+              defaults: {
+                models: {
+                  "google-vertex/gemini-2.5-pro": {},
+                },
+                model: { primary: "google-vertex/gemini-2.5-pro" },
+              },
+            },
+            models: { providers: {} },
+          },
+          agentDir,
+          env: {},
+          existingRaw: "",
+          existingParsed: null,
+        },
+        {
+          resolveImplicitProviders: async () => ({
+            "google-vertex": createImplicitGoogleVertexProvider(),
+          }),
+        },
+      );
+
+      expect(plan.action).toBe("write");
+      if (plan.action !== "write") {
+        throw new Error("Expected models.json write plan");
+      }
+      const parsed = JSON.parse(plan.contents) as {
+        providers?: Record<
+          string,
+          { apiKey?: string; api?: string; models?: Array<{ id?: string }> }
+        >;
+      };
+      expect(parsed.providers?.["google-vertex"]?.api).toBe("google-vertex");
+      expect(parsed.providers?.["google-vertex"]?.apiKey).toBe("GOOGLE_CLOUD_API_KEY");
+      expect(parsed.providers?.["google-vertex"]?.models?.map((model) => model.id)).toEqual([
+        "gemini-2.5-pro",
+      ]);
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
   });
 
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {


### PR DESCRIPTION
## Summary
- Add regression coverage for the Google Vertex Express API-key/profile path from #88816.
- Verify models.json planning preserves `google-vertex/gemini-2.5-pro` provider rows when `agents.defaults.models` selects Vertex and the credential comes from an auth profile rather than `models.providers`.
- Builds on current `main`'s Vertex static catalog rows so the reported `model_not_found` hint does not return for the profile-backed config shape.

## Real behavior proof
- **Behavior addressed:** Google Vertex model config generation keeps `google-vertex` catalog rows for profile-backed API key auth, so `agents.defaults.models["google-vertex/gemini-2.5-pro"]` has a matching `models.providers["google-vertex"].models[]` row.
- **Real environment tested:** Local checkout `/Users/andy/openclaw` on branch `codex/google-vertex-express-catalog`, using the actual Google static catalog builder and models.json planner against a temp agent auth-profile setup.
- **Exact steps or command run after this patch:** Ran a `node --import tsx` one-shot script that wrote `auth-profiles.json` with `google-vertex:default`, loaded `buildGoogleVertexStaticCatalogProvider()`, ran `planOpenClawModelsJsonWithDeps(...)`, and inspected the generated provider row.
- **Evidence after fix:** Terminal output from the local OpenClaw setup:

```text
agentDir=/var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/openclaw-vertex-proof-i6CI6m
planAction=write
providerKeys=google-vertex
googleVertexApi=google-vertex
googleVertexApiKey=GOOGLE_CLOUD_API_KEY
googleVertexHasGemini25Pro=true
```

- **Observed result after fix:** The generated provider config contains the `google-vertex` provider row, preserves the API-key marker from the profile, and includes the `gemini-2.5-pro` model row needed by the reported `agents.defaults.models` selection.
- **What was not tested:** No live Vertex Express network request was run because no Vertex Express credentials were available in this checkout.

## Additional verification
- `node scripts/run-vitest.mjs extensions/google/provider-models.test.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts src/agents/models-config.applies-config-env-vars.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/models-config.applies-config-env-vars.test.ts`
- `git diff --check`
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD`

Refs #88816
