### PR TITLE
fix(gateway): gate cron on channel readiness

### DIFF
--- a/src/gateway/cron-channel-readiness.test.ts
+++ b/src/gateway/cron-channel-readiness.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
+import { waitForConfiguredChannelDeliveryReadiness } from "./cron-channel-readiness.js";
+import type { ChannelRuntimeSnapshot } from "./server-channel-runtime.types.js";
+
+describe("waitForConfiguredChannelDeliveryReadiness", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves immediately when configured channel accounts are connected", async () => {
+    const log = { warn: vi.fn() };
+
+    await waitForConfiguredChannelDeliveryReadiness({
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected: true,
+            },
+          },
+        }),
+      timeoutMs: 10,
+      pollIntervalMs: 1,
+      log,
+    });
+
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("waits until a configured channel account reports connected", async () => {
+    vi.useFakeTimers();
+    const log = { warn: vi.fn() };
+    let connected = false;
+
+    const wait = waitForConfiguredChannelDeliveryReadiness({
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected,
+            },
+          },
+        }),
+      timeoutMs: 50,
+      pollIntervalMs: 5,
+      log,
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    connected = true;
+    await vi.advanceTimersByTimeAsync(5);
+    await wait;
+
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns once and proceeds when configured channel accounts stay unconnected", async () => {
+    vi.useFakeTimers();
+    const log = { warn: vi.fn() };
+
+    const wait = waitForConfiguredChannelDeliveryReadiness({
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected: false,
+            },
+          },
+        }),
+      timeoutMs: 10,
+      pollIntervalMs: 5,
+      log,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await wait;
+
+    expect(log.warn).toHaveBeenCalledOnce();
+    expect(log.warn).toHaveBeenCalledWith(
+      "gateway cron starting before channel delivery readiness; unconnected channel accounts: discord/default",
+    );
+  });
+
+  it("skips unmanaged accounts and accounts without active transport readiness", async () => {
+    const log = { warn: vi.fn() };
+
+    await waitForConfiguredChannelDeliveryReadiness({
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            disabled: { accountId: "disabled", enabled: false, configured: true, connected: false },
+            stopped: {
+              accountId: "stopped",
+              enabled: true,
+              configured: true,
+              running: false,
+              connected: false,
+            },
+            unconfigured: {
+              accountId: "unconfigured",
+              enabled: true,
+              configured: false,
+              connected: false,
+            },
+          },
+          slack: {
+            default: { accountId: "default", enabled: true, configured: true },
+          },
+        }),
+      timeoutMs: 10,
+      pollIntervalMs: 1,
+      log,
+    });
+
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("aborts waiting when the gateway is closing", async () => {
+    const log = { warn: vi.fn() };
+
+    await waitForConfiguredChannelDeliveryReadiness({
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected: false,
+            },
+          },
+        }),
+      timeoutMs: 10,
+      pollIntervalMs: 1,
+      isClosing: () => true,
+      log,
+    });
+
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});
+
+function createRuntimeSnapshot(
+  channelAccounts: Partial<Record<string, Record<string, ChannelAccountSnapshot>>>,
+): ChannelRuntimeSnapshot {
+  return {
+    channels: {},
+    channelAccounts: channelAccounts as ChannelRuntimeSnapshot["channelAccounts"],
+  };
+}

--- a/src/gateway/cron-channel-readiness.ts
+++ b/src/gateway/cron-channel-readiness.ts
@@ -1,0 +1,77 @@
+import { DEFAULT_CHANNEL_CONNECT_GRACE_MS } from "./channel-health-policy.js";
+import type { ChannelRuntimeSnapshot } from "./server-channel-runtime.types.js";
+
+type ChannelDeliveryReadinessLogger = {
+  warn: (message: string) => void;
+};
+
+export type ChannelDeliveryReadinessWaitParams = {
+  getRuntimeSnapshot: () => ChannelRuntimeSnapshot;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  isClosing?: () => boolean;
+  log: ChannelDeliveryReadinessLogger;
+};
+
+const DEFAULT_CHANNEL_DELIVERY_READINESS_POLL_MS = 250;
+
+function listUnconnectedConfiguredAccounts(snapshot: ChannelRuntimeSnapshot): string[] {
+  const pending: string[] = [];
+  const channelEntries = Object.entries(snapshot.channelAccounts).toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  for (const [channelId, accounts] of channelEntries) {
+    const accountEntries = Object.entries(accounts ?? {}).toSorted(([left], [right]) =>
+      left.localeCompare(right),
+    );
+    for (const [accountId, account] of accountEntries) {
+      if (account.enabled === false || account.configured === false || account.running !== true) {
+        continue;
+      }
+      if (typeof account.connected !== "boolean") {
+        continue;
+      }
+      if (!account.connected) {
+        pending.push(`${channelId}/${accountId}`);
+      }
+    }
+  }
+  return pending;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
+export async function waitForConfiguredChannelDeliveryReadiness(
+  params: ChannelDeliveryReadinessWaitParams,
+): Promise<void> {
+  const timeoutMs = Math.max(0, params.timeoutMs ?? DEFAULT_CHANNEL_CONNECT_GRACE_MS);
+  const pollIntervalMs = Math.max(
+    1,
+    params.pollIntervalMs ?? DEFAULT_CHANNEL_DELIVERY_READINESS_POLL_MS,
+  );
+  const deadlineAt = Date.now() + timeoutMs;
+  let pending = listUnconnectedConfiguredAccounts(params.getRuntimeSnapshot());
+
+  while (pending.length > 0 && params.isClosing?.() !== true) {
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      break;
+    }
+    await sleep(Math.min(pollIntervalMs, remainingMs));
+    pending = listUnconnectedConfiguredAccounts(params.getRuntimeSnapshot());
+  }
+
+  if (pending.length === 0 || params.isClosing?.() === true) {
+    return;
+  }
+  params.log.warn(
+    `gateway cron starting before channel delivery readiness; unconnected channel accounts: ${pending.join(
+      ", ",
+    )}`,
+  );
+}

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
 import type { ConfigWriteNotification } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { consumeGatewaySigusr1RestartIntent } from "../infra/restart.js";
 import type { ChannelKind, GatewayReloadPlan } from "./config-reload-plan.js";
+import type { ChannelRuntimeSnapshot } from "./server-channel-runtime.types.js";
 import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
 import {
   createGatewayReloadHandlers,
@@ -24,28 +26,48 @@ type GmailWatcherRestartParams = {
 type StartGmailWatcherWithLogs = (params: GmailWatcherRestartParams) => Promise<void>;
 type StopGmailWatcher = () => Promise<void>;
 
-const hoisted = vi.hoisted(() => ({
-  startGmailWatcherWithLogs: vi.fn<StartGmailWatcherWithLogs>(async () => {}),
-  stopGmailWatcher: vi.fn<StopGmailWatcher>(async () => {}),
-  activeTaskCount: { value: 0 },
-  activeTaskBlockers: [] as Array<{
-    taskId: string;
-    status: "queued" | "running";
-    runtime: "subagent" | "acp" | "cli" | "cron";
-    runId?: string;
-    label?: string;
-    title?: string;
-  }>,
-  activeEmbeddedRunCount: { value: 0 },
-  activeEmbeddedRunSessionIds: [] as string[],
-  activeEmbeddedRunSessionKeys: [] as string[],
-  markRestartAbortedMainSessions: vi.fn(async (_params: unknown) => ({ marked: 1, skipped: 0 })),
-  runtimeConfig: { value: { session: { store: "/tmp/active-sessions.json" } } as OpenClawConfig },
-  reloadEvents: [] as string[],
-  resetModelCatalogCache: vi.fn(() => {}),
-  clearCurrentProviderAuthState: vi.fn(() => {}),
-  warmCurrentProviderAuthStateOffMainThread: vi.fn(async (_cfg: OpenClawConfig) => {}),
-  disposeAllSessionMcpRuntimes: vi.fn(async () => {}),
+const hoisted = vi.hoisted(() => {
+  const reloadEvents: string[] = [];
+  const builtCrons: Array<{ start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }> = [];
+  const buildGatewayCronService = vi.fn(() => {
+    const cron = {
+      start: vi.fn(async () => {
+        reloadEvents.push("cron-start");
+      }),
+      stop: vi.fn(),
+    };
+    builtCrons.push(cron);
+    return { cron, storePath: "/tmp/cron.json", cronEnabled: true };
+  });
+  return {
+    startGmailWatcherWithLogs: vi.fn<StartGmailWatcherWithLogs>(async () => {}),
+    stopGmailWatcher: vi.fn<StopGmailWatcher>(async () => {}),
+    activeTaskCount: { value: 0 },
+    activeTaskBlockers: [] as Array<{
+      taskId: string;
+      status: "queued" | "running";
+      runtime: "subagent" | "acp" | "cli" | "cron";
+      runId?: string;
+      label?: string;
+      title?: string;
+    }>,
+    activeEmbeddedRunCount: { value: 0 },
+    activeEmbeddedRunSessionIds: [] as string[],
+    activeEmbeddedRunSessionKeys: [] as string[],
+    markRestartAbortedMainSessions: vi.fn(async (_params: unknown) => ({ marked: 1, skipped: 0 })),
+    runtimeConfig: { value: { session: { store: "/tmp/active-sessions.json" } } as OpenClawConfig },
+    reloadEvents,
+    builtCrons,
+    buildGatewayCronService,
+    resetModelCatalogCache: vi.fn(() => {}),
+    clearCurrentProviderAuthState: vi.fn(() => {}),
+    warmCurrentProviderAuthStateOffMainThread: vi.fn(async (_cfg: OpenClawConfig) => {}),
+    disposeAllSessionMcpRuntimes: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("./server-cron.js", () => ({
+  buildGatewayCronService: hoisted.buildGatewayCronService,
 }));
 
 vi.mock("../hooks/gmail-watcher.js", () => ({
@@ -123,13 +145,18 @@ vi.mock("../agents/agent-bundle-mcp-tools.js", () => ({
   disposeAllSessionMcpRuntimes: hoisted.disposeAllSessionMcpRuntimes,
 }));
 
-function createReloadHandlersForTest(logReload = { info: vi.fn(), warn: vi.fn() }) {
+type ReloadHandlerParams = Parameters<typeof createGatewayReloadHandlers>[0];
+
+function createReloadHandlersForTest(
+  logReload = { info: vi.fn(), warn: vi.fn() },
+  overrides: Partial<ReloadHandlerParams> = {},
+) {
   const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
   const heartbeatRunner = {
     stop: vi.fn(),
     updateConfig: vi.fn(),
   };
-  return createGatewayReloadHandlers({
+  const params: ReloadHandlerParams = {
     deps: {} as never,
     broadcast: vi.fn(),
     getState: () => ({
@@ -154,7 +181,9 @@ function createReloadHandlersForTest(logReload = { info: vi.fn(), warn: vi.fn() 
     logCron: { error: vi.fn() },
     logReload,
     createHealthMonitor: () => null,
-  });
+    ...overrides,
+  };
+  return createGatewayReloadHandlers(params);
 }
 
 afterEach(() => {
@@ -169,11 +198,119 @@ afterEach(() => {
   hoisted.markRestartAbortedMainSessions.mockClear();
   hoisted.runtimeConfig.value = { session: { store: "/tmp/active-sessions.json" } };
   hoisted.reloadEvents.length = 0;
+  hoisted.builtCrons.length = 0;
+  hoisted.buildGatewayCronService.mockClear();
   hoisted.resetModelCatalogCache.mockClear();
   hoisted.clearCurrentProviderAuthState.mockClear();
   hoisted.warmCurrentProviderAuthStateOffMainThread.mockClear();
   hoisted.disposeAllSessionMcpRuntimes.mockClear();
   hoisted.disposeAllSessionMcpRuntimes.mockResolvedValue(undefined);
+});
+
+function createCronReloadPlan(overrides: Partial<GatewayReloadPlan> = {}): GatewayReloadPlan {
+  return {
+    changedPaths: ["cron.jobs"],
+    restartGateway: false,
+    restartReasons: [],
+    hotReasons: ["cron.jobs"],
+    reloadHooks: false,
+    restartGmailWatcher: false,
+    restartCron: true,
+    restartHeartbeat: false,
+    restartHealthMonitor: false,
+    reloadPlugins: false,
+    restartChannels: new Set(),
+    disposeMcpRuntimes: false,
+    noopPaths: [],
+    ...overrides,
+  };
+}
+
+describe("gateway cron hot reload handlers", () => {
+  it("waits for channel delivery readiness before starting restarted cron", async () => {
+    vi.useFakeTimers();
+    let connected = false;
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const oldCron = { start: vi.fn(async () => {}), stop: vi.fn() };
+    const { applyHotReload } = createReloadHandlersForTest(logReload, {
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: { cron: oldCron, storePath: "/tmp/cron.json", cronEnabled: false } as never,
+        channelHealthMonitor: null,
+      }),
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected,
+            },
+          },
+        }),
+      channelReadinessTimeoutMs: 50,
+      channelReadinessPollIntervalMs: 5,
+    });
+
+    const reload = applyHotReload(createCronReloadPlan(), {});
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(oldCron.stop).toHaveBeenCalledTimes(1);
+    expect(hoisted.buildGatewayCronService).toHaveBeenCalledTimes(1);
+    expect(hoisted.builtCrons[0]?.start).not.toHaveBeenCalled();
+
+    connected = true;
+    await vi.advanceTimersByTimeAsync(5);
+    await reload;
+
+    expect(hoisted.builtCrons[0]?.start).toHaveBeenCalledTimes(1);
+    expect(logReload.warn).not.toHaveBeenCalled();
+  });
+
+  it("starts restarted cron after channel readiness timeout", async () => {
+    vi.useFakeTimers();
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const { applyHotReload } = createReloadHandlersForTest(logReload, {
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected: false,
+            },
+          },
+        }),
+      channelReadinessTimeoutMs: 10,
+      channelReadinessPollIntervalMs: 5,
+    });
+
+    const reload = applyHotReload(createCronReloadPlan(), {});
+    await vi.advanceTimersByTimeAsync(10);
+    await reload;
+
+    expect(hoisted.builtCrons[0]?.start).toHaveBeenCalledTimes(1);
+    expect(logReload.warn).toHaveBeenCalledWith(
+      "gateway cron starting before channel delivery readiness; unconnected channel accounts: discord/default",
+    );
+  });
 });
 
 describe("gateway hot reload model state", () => {
@@ -807,6 +944,168 @@ describe("gateway channel hot reload handlers", () => {
       }
     }
   }
+
+  it("starts restarted cron after channel reload completes", async () => {
+    const setState = vi.fn();
+    const startChannel = vi.fn(async (_channel: ChannelKind) => {});
+    const stopChannel = vi.fn(async (_channel: ChannelKind) => {});
+    const { applyHotReload } = createReloadHandlersForTest(undefined, {
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState,
+      startChannel,
+      stopChannel,
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected: true,
+            },
+          },
+        }),
+      channelReadinessTimeoutMs: 50,
+      channelReadinessPollIntervalMs: 5,
+    });
+
+    await withChannelReloadsEnabled(async () => {
+      await applyHotReload(
+        createCronReloadPlan({
+          changedPaths: ["channels.discord.enabled", "cron.jobs"],
+          hotReasons: ["channels", "cron.jobs"],
+          restartChannels: new Set(["discord"]),
+        }),
+        {},
+      );
+    });
+
+    expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
+    expect(startChannel).toHaveBeenCalledWith("discord");
+    const [builtCron] = hoisted.builtCrons;
+    if (!builtCron) {
+      throw new Error("Expected cron service to be rebuilt");
+    }
+    expect(startChannel).toHaveBeenCalledBefore(builtCron.start);
+    expect(builtCron.start).toHaveBeenCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts restarted cron without readiness wait when channel reload is skipped", async () => {
+    const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
+    process.env.OPENCLAW_SKIP_CHANNELS = "1";
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const startChannel = vi.fn(async (_channel: ChannelKind) => {});
+    const { applyHotReload } = createReloadHandlersForTest(logReload, {
+      startChannel,
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected: false,
+            },
+          },
+        }),
+      channelReadinessTimeoutMs: 0,
+    });
+
+    try {
+      await applyHotReload(
+        createCronReloadPlan({
+          changedPaths: ["channels.discord.enabled", "cron.jobs"],
+          hotReasons: ["channels", "cron.jobs"],
+          restartChannels: new Set(["discord"]),
+        }),
+        {},
+      );
+    } finally {
+      if (previousSkipChannels === undefined) {
+        delete process.env.OPENCLAW_SKIP_CHANNELS;
+      } else {
+        process.env.OPENCLAW_SKIP_CHANNELS = previousSkipChannels;
+      }
+    }
+
+    expect(startChannel).not.toHaveBeenCalled();
+    expect(hoisted.builtCrons[0]?.start).toHaveBeenCalledTimes(1);
+    expect(logReload.warn).not.toHaveBeenCalled();
+  });
+
+  it("restores the old cron when channel reload failure aborts a cron restart", async () => {
+    const setState = vi.fn();
+    const logChannels = { info: vi.fn(), error: vi.fn() };
+    const oldCron = { start: vi.fn(async () => {}), stop: vi.fn() };
+    const stopChannel = vi.fn(async (_channel: ChannelKind) => {});
+    const startChannel = vi.fn(async (channel: ChannelKind) => {
+      if (channel === "telegram") {
+        throw new Error("start failed");
+      }
+    });
+    const { applyHotReload } = createReloadHandlersForTest(undefined, {
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: oldCron,
+          storePath: "/tmp/cron.json",
+          cronEnabled: true,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState,
+      startChannel,
+      stopChannel,
+      logChannels,
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          telegram: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected: true,
+            },
+          },
+        }),
+      channelReadinessTimeoutMs: 50,
+      channelReadinessPollIntervalMs: 5,
+    });
+
+    await withChannelReloadsEnabled(async () => {
+      await expect(
+        applyHotReload(
+          createCronReloadPlan({
+            changedPaths: ["channels.telegram.enabled", "cron.jobs"],
+            hotReasons: ["channels", "cron.jobs"],
+            restartChannels: new Set(["telegram"]),
+          }),
+          {},
+        ),
+      ).rejects.toThrow("failed to restart channels during hot reload: telegram");
+    });
+
+    expect(oldCron.stop).toHaveBeenCalledTimes(1);
+    expect(oldCron.start).toHaveBeenCalledTimes(1);
+    expect(hoisted.builtCrons[0]?.start).not.toHaveBeenCalled();
+    expect(setState).not.toHaveBeenCalled();
+  });
 
   it("continues restarting later channels after a hot-reload stop failure", async () => {
     const events: string[] = [];
@@ -1494,3 +1793,12 @@ describe("gateway plugin hot reload handlers", () => {
     expect(setState).toHaveBeenCalledTimes(1);
   });
 });
+
+function createRuntimeSnapshot(
+  channelAccounts: Partial<Record<string, Record<string, ChannelAccountSnapshot>>>,
+): ChannelRuntimeSnapshot {
+  return {
+    channels: {},
+    channelAccounts: channelAccounts as ChannelRuntimeSnapshot["channelAccounts"],
+  };
+}

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -37,6 +37,7 @@ import {
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import type { ChannelKind } from "./config-reload-plan.js";
 import { startGatewayConfigReloader, type GatewayReloadPlan } from "./config-reload.js";
+import { waitForConfiguredChannelDeliveryReadiness } from "./cron-channel-readiness.js";
 import { resolveHooksConfig } from "./hooks.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
 import { applyGatewayLaneConcurrency } from "./server-lanes.js";
@@ -158,6 +159,10 @@ type GatewayReloadHandlerParams = {
   logCron: { error: (msg: string) => void };
   logReload: GatewayReloadLog;
   createHealthMonitor: (config: OpenClawConfig) => ChannelHealthMonitor | null;
+  getRuntimeSnapshot?: GatewayChannelManager["getRuntimeSnapshot"];
+  channelReadinessTimeoutMs?: number;
+  channelReadinessPollIntervalMs?: number;
+  isClosing?: () => boolean;
   createGmailRestartAbortController?: () => GatewayGmailRestartAbortController;
   clearGmailRestartAbortController?: (controller: GatewayGmailRestartAbortController) => void;
   onCronRestart?: () => void;
@@ -165,7 +170,7 @@ type GatewayReloadHandlerParams = {
 
 type ManagedGatewayConfigReloaderParams = Omit<
   GatewayReloadHandlerParams,
-  "createHealthMonitor" | "logReload"
+  "createHealthMonitor" | "getRuntimeSnapshot" | "isClosing" | "logReload"
 > & {
   minimalTestGateway: boolean;
   initialConfig: OpenClawConfig;
@@ -332,6 +337,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     const channelsToRestart = new Set(plan.restartChannels);
     const channelsStoppedBeforePluginReload = new Set<ChannelKind>();
     let activePluginChannelsAfterReload: ReadonlySet<ChannelKind> | null = null;
+    let startRebuiltCron: (() => Promise<void>) | null = null;
     const shouldSkipChannelRestart = () =>
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
@@ -409,10 +415,32 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         deps: params.deps,
         broadcast: params.broadcast,
       });
-      startGatewayCronWithLogging({
-        cron: nextState.cronState.cron,
-        logCron: params.logCron,
-      });
+      startRebuiltCron = async () => {
+        if (params.getRuntimeSnapshot && !shouldSkipChannelRestart()) {
+          await waitForConfiguredChannelDeliveryReadiness({
+            getRuntimeSnapshot: params.getRuntimeSnapshot,
+            ...(params.channelReadinessTimeoutMs !== undefined
+              ? { timeoutMs: params.channelReadinessTimeoutMs }
+              : {}),
+            ...(params.channelReadinessPollIntervalMs !== undefined
+              ? { pollIntervalMs: params.channelReadinessPollIntervalMs }
+              : {}),
+            ...(params.isClosing ? { isClosing: params.isClosing } : {}),
+            log: params.logReload,
+          });
+        }
+        if (params.isClosing?.() === true) {
+          return;
+        }
+        startGatewayCronWithLogging({
+          cron: nextState.cronState.cron,
+          logCron: params.logCron,
+        });
+      };
+      if (channelsToRestart.size === 0) {
+        await startRebuiltCron();
+        startRebuiltCron = null;
+      }
     }
 
     if (plan.restartHealthMonitor) {
@@ -491,11 +519,21 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
           },
         });
         if (restartFailures.length > 0) {
+          if (startRebuiltCron) {
+            startGatewayCronWithLogging({
+              cron: state.cronState.cron,
+              logCron: params.logCron,
+            });
+          }
           throw new Error(
             `failed to restart channels during hot reload: ${restartFailures.join(", ")}`,
           );
         }
       }
+    }
+
+    if (startRebuiltCron) {
+      await startRebuiltCron();
     }
 
     applyGatewayLaneConcurrency(nextConfig);
@@ -643,6 +681,8 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
       }
     },
     ...(params.onCronRestart ? { onCronRestart: params.onCronRestart } : {}),
+    getRuntimeSnapshot: params.channelManager.getRuntimeSnapshot,
+    isClosing: () => stopped,
     createHealthMonitor: (config) =>
       startGatewayChannelHealthMonitor({
         cfg: config,

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
+import type { ChannelRuntimeSnapshot } from "./server-channel-runtime.types.js";
 
 const hoisted = vi.hoisted(() => {
   const heartbeatRunner = {
@@ -251,6 +253,120 @@ describe("server-runtime-services", () => {
     expect(recordPostReadyMemory).toHaveBeenCalledTimes(1);
   });
 
+  it("defers post-ready cron startup until configured channels are connected", async () => {
+    vi.useFakeTimers();
+    const cron = { start: vi.fn(async () => undefined) };
+    const log = createLog();
+    let connected = false;
+
+    const run = runGatewayPostReadyMaintenance({
+      startMaintenance: vi.fn(async () => null),
+      applyMaintenance: vi.fn(),
+      shouldStartCron: () => true,
+      markCronStartHandled: vi.fn(),
+      cron,
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected,
+            },
+          },
+        }),
+      channelReadinessTimeoutMs: 50,
+      channelReadinessPollIntervalMs: 5,
+      logCron: { error: vi.fn() },
+      log,
+      recordPostReadyMemory: vi.fn(),
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    expect(cron.start).not.toHaveBeenCalled();
+    connected = true;
+    await vi.advanceTimersByTimeAsync(5);
+    await run;
+
+    expect(cron.start).toHaveBeenCalledTimes(1);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("starts post-ready cron after channel readiness timeout", async () => {
+    vi.useFakeTimers();
+    const cron = { start: vi.fn(async () => undefined) };
+    const log = createLog();
+
+    const run = runGatewayPostReadyMaintenance({
+      startMaintenance: vi.fn(async () => null),
+      applyMaintenance: vi.fn(),
+      shouldStartCron: () => true,
+      markCronStartHandled: vi.fn(),
+      cron,
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected: false,
+            },
+          },
+        }),
+      channelReadinessTimeoutMs: 10,
+      channelReadinessPollIntervalMs: 5,
+      logCron: { error: vi.fn() },
+      log,
+      recordPostReadyMemory: vi.fn(),
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await run;
+
+    expect(cron.start).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      "gateway cron starting before channel delivery readiness; unconnected channel accounts: discord/default",
+    );
+  });
+
+  it("starts post-ready cron without waiting when channel readiness is skipped", async () => {
+    const cron = { start: vi.fn(async () => undefined) };
+    const log = createLog();
+
+    await runGatewayPostReadyMaintenance({
+      startMaintenance: vi.fn(async () => null),
+      applyMaintenance: vi.fn(),
+      shouldStartCron: () => true,
+      markCronStartHandled: vi.fn(),
+      cron,
+      getRuntimeSnapshot: () =>
+        createRuntimeSnapshot({
+          discord: {
+            default: {
+              accountId: "default",
+              enabled: true,
+              configured: true,
+              running: true,
+              connected: false,
+            },
+          },
+        }),
+      shouldSkipChannelReadiness: () => true,
+      channelReadinessTimeoutMs: 10,
+      channelReadinessPollIntervalMs: 5,
+      logCron: { error: vi.fn() },
+      log,
+      recordPostReadyMemory: vi.fn(),
+    });
+
+    expect(cron.start).toHaveBeenCalledTimes(1);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
   it("returns a cancellable post-ready maintenance timer", async () => {
     vi.useFakeTimers();
     const startMaintenance = vi.fn(async () => null);
@@ -378,5 +494,14 @@ function createMaintenanceHandles() {
     healthInterval: setInterval(() => undefined, 60_000),
     dedupeCleanup: setInterval(() => undefined, 60_000),
     mediaCleanup: setInterval(() => undefined, 60_000),
+  };
+}
+
+function createRuntimeSnapshot(
+  channelAccounts: Partial<Record<string, Record<string, ChannelAccountSnapshot>>>,
+): ChannelRuntimeSnapshot {
+  return {
+    channels: {},
+    channelAccounts: channelAccounts as ChannelRuntimeSnapshot["channelAccounts"],
   };
 }

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -2,7 +2,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isVitestRuntimeEnv } from "../infra/env.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { PluginMetadataRegistryView } from "../plugins/plugin-metadata-snapshot.types.js";
+import { waitForConfiguredChannelDeliveryReadiness } from "./cron-channel-readiness.js";
 import { isGatewayModelPricingEnabled } from "./model-pricing-config.js";
+import type { ChannelRuntimeSnapshot } from "./server-channel-runtime.types.js";
 import type { startGatewayMaintenanceTimers } from "./server-maintenance.js";
 export {
   startGatewayChannelHealthMonitor,
@@ -59,6 +61,11 @@ export async function runGatewayPostReadyMaintenance(params: {
   shouldStartCron: () => boolean;
   markCronStartHandled: () => void;
   cron: { start: () => Promise<void> };
+  getRuntimeSnapshot?: () => ChannelRuntimeSnapshot;
+  shouldSkipChannelReadiness?: () => boolean;
+  channelReadinessTimeoutMs?: number;
+  channelReadinessPollIntervalMs?: number;
+  isClosing?: () => boolean;
   logCron: { error: (message: string) => void };
   log: GatewayPostReadyLogger;
   recordPostReadyMemory: () => void;
@@ -72,6 +79,23 @@ export async function runGatewayPostReadyMaintenance(params: {
     params.log.warn(`gateway post-ready maintenance startup failed: ${String(err)}`);
   }
   if (params.shouldStartCron()) {
+    if (params.getRuntimeSnapshot && params.shouldSkipChannelReadiness?.() !== true) {
+      await waitForConfiguredChannelDeliveryReadiness({
+        getRuntimeSnapshot: params.getRuntimeSnapshot,
+        ...(params.channelReadinessTimeoutMs !== undefined
+          ? { timeoutMs: params.channelReadinessTimeoutMs }
+          : {}),
+        ...(params.channelReadinessPollIntervalMs !== undefined
+          ? { pollIntervalMs: params.channelReadinessPollIntervalMs }
+          : {}),
+        ...(params.isClosing ? { isClosing: params.isClosing } : {}),
+        log: params.log,
+      });
+    }
+    if (!params.shouldStartCron()) {
+      params.recordPostReadyMemory();
+      return;
+    }
     params.markCronStartHandled();
     startGatewayCronWithLogging({
       cron: params.cron,
@@ -91,6 +115,10 @@ export function scheduleGatewayPostReadyMaintenance(params: {
   shouldStartCron: () => boolean;
   markCronStartHandled: () => void;
   cron: { start: () => Promise<void> };
+  getRuntimeSnapshot?: () => ChannelRuntimeSnapshot;
+  shouldSkipChannelReadiness?: () => boolean;
+  channelReadinessTimeoutMs?: number;
+  channelReadinessPollIntervalMs?: number;
   logCron: { error: (message: string) => void };
   log: GatewayPostReadyLogger;
   recordPostReadyMemory: () => void;
@@ -124,6 +152,17 @@ export function scheduleGatewayPostReadyMaintenance(params: {
       shouldStartCron: () => !params.isClosing() && params.shouldStartCron(),
       markCronStartHandled: params.markCronStartHandled,
       cron: params.cron,
+      ...(params.getRuntimeSnapshot ? { getRuntimeSnapshot: params.getRuntimeSnapshot } : {}),
+      ...(params.shouldSkipChannelReadiness
+        ? { shouldSkipChannelReadiness: params.shouldSkipChannelReadiness }
+        : {}),
+      ...(params.channelReadinessTimeoutMs !== undefined
+        ? { channelReadinessTimeoutMs: params.channelReadinessTimeoutMs }
+        : {}),
+      ...(params.channelReadinessPollIntervalMs !== undefined
+        ? { channelReadinessPollIntervalMs: params.channelReadinessPollIntervalMs }
+        : {}),
+      isClosing: params.isClosing,
       logCron: params.logCron,
       log: params.log,
       recordPostReadyMemory: () => {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -859,15 +859,16 @@ export async function startGatewayServer(
   });
   const deferStartupSidecars = opts.deferStartupSidecars === true;
   const isGatewayStartupPending = () => !startupSidecarsReady && !deferStartupSidecars;
+  const shouldSkipChannelReadiness = () =>
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
   const getReadiness = createReadinessChecker({
     channelManager,
     startedAt: serverStartedAt,
     getStartupPending: isGatewayStartupPending,
     getStartupPendingReason: () => startupPendingReason,
     getEventLoopHealth: readinessEventLoopHealth.snapshot,
-    shouldSkipChannelReadiness: () =>
-      isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
-      isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS),
+    shouldSkipChannelReadiness,
   });
   log.info("starting HTTP server...");
   let currentPluginRegistryGatewayContext: GatewayRequestContext | undefined;
@@ -1743,6 +1744,8 @@ export async function startGatewayServer(
           gatewayCronStartHandled = true;
         },
         cron: runtimeState.cronState.cron,
+        getRuntimeSnapshot: () => channelManager.getRuntimeSnapshot(),
+        shouldSkipChannelReadiness,
         logCron,
         log,
         recordPostReadyMemory: () => {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Prevent gateway cron from starting delivery work before configured channel transports report ready during startup and hot reload.

Why does this matter now?

- Cron catch-up can immediately deliver notifications after gateway startup or config reload; Discord can be running before it is connected.

What is the intended outcome?

- Cron waits for running configured channel accounts with explicit `connected` state, then fail-opens after the existing channel connect grace timeout with a warning.
- Hot reload restarts cron after channel restart completes, and restores the old cron if channel restart fails after the old cron was stopped.

What is intentionally out of scope?

- No plugin changes, config changes, migrations, or delivery retry policy changes.

What does success look like?

- Startup and hot-reload cron paths do not race known channel readiness, without blocking disabled, unconfigured, stopped, skipped, or closing gateways.

What should reviewers focus on?

- `src/gateway/server-runtime-services.ts` and `src/gateway/server-reload-handlers.ts` lifecycle ordering around cron start, channel readiness, skipped channels, and rollback on channel restart failure.

## Linked context

Which issue does this close?

Closes #62891

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Maintainer-requested local fix pass.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: gateway cron startup and hot-reload cron restart now wait for running configured channel accounts with explicit `connected` state before starting cron, with timeout fail-open and skipped-channel bypasses.
- Real environment tested: local OpenClaw source checkout on macOS, Node runtime executing the gateway startup and hot-reload paths from this branch.
- Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs src/gateway/cron-channel-readiness.test.ts src/gateway/server-runtime-services.test.ts src/gateway/server-reload-handlers.test.ts
node scripts/run-vitest.mjs src/gateway/server-cron.test.ts src/cron/service.restart-catchup.test.ts src/gateway/server-import-boundary.test.ts
node_modules/.bin/oxfmt --check --threads=1 src/gateway/cron-channel-readiness.ts src/gateway/cron-channel-readiness.test.ts src/gateway/server-runtime-services.ts src/gateway/server-runtime-services.test.ts src/gateway/server-reload-handlers.ts src/gateway/server-reload-handlers.test.ts src/gateway/server.impl.ts
node_modules/.bin/oxlint src/gateway/cron-channel-readiness.ts src/gateway/cron-channel-readiness.test.ts src/gateway/server-runtime-services.ts src/gateway/server-runtime-services.test.ts src/gateway/server-reload-handlers.ts src/gateway/server-reload-handlers.test.ts src/gateway/server.impl.ts
git diff --check
node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit --pretty false
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[test] passed 1 Vitest shard in 3.30s
Test Files  3 passed (3)
Tests  39 passed (39)

[test] passed 2 Vitest shards in 6.16s
Test Files  2 passed (2)
Tests  23 passed (23)
Test Files  1 passed (1)
Tests  12 passed (12)

Checking formatting...
All matched files use the correct format.
Finished in 7ms on 7 files using 1 threads.

oxlint changed files: exit 0

git diff --check: no output
tsgo core: exit 0
```

- Observed result after fix: post-ready cron waits until a running configured channel becomes connected; hot-reload cron starts after channel restart; skipped channel/provider envs bypass the wait; stopped accounts do not block; channel restart failure restores the old cron instead of leaving cron stopped.
- What was not tested: no live Discord gateway/SIGUSR1 timing reproduction was run.
- Proof limitations or environment constraints: focused local runtime coverage only; `test/tsconfig/tsconfig.core.test.json` remains blocked by pre-existing `src/agents/agent-command.compaction-rotation.test.ts:60` type error unrelated to this diff, and broad Testbox proof was not run because `node scripts/crabbox-wrapper.mjs --help` failed local binary sanity checks.
- Before evidence (optional but encouraged): source review showed startup cron was scheduled after startup readiness but before channel delivery readiness, and hot reload previously restarted cron before channel restart completion.

## Tests and validation

Which commands did you run?

```text
node scripts/run-vitest.mjs src/gateway/cron-channel-readiness.test.ts src/gateway/server-runtime-services.test.ts src/gateway/server-reload-handlers.test.ts
node scripts/run-vitest.mjs src/gateway/server-cron.test.ts src/cron/service.restart-catchup.test.ts src/gateway/server-import-boundary.test.ts
node_modules/.bin/oxfmt --check --threads=1 src/gateway/cron-channel-readiness.ts src/gateway/cron-channel-readiness.test.ts src/gateway/server-runtime-services.ts src/gateway/server-runtime-services.test.ts src/gateway/server-reload-handlers.ts src/gateway/server-reload-handlers.test.ts src/gateway/server.impl.ts
node_modules/.bin/oxlint src/gateway/cron-channel-readiness.ts src/gateway/cron-channel-readiness.test.ts src/gateway/server-runtime-services.ts src/gateway/server-runtime-services.test.ts src/gateway/server-reload-handlers.ts src/gateway/server-reload-handlers.test.ts src/gateway/server.impl.ts
git diff --check
node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit --pretty false
```

What regression coverage was added or updated?

- Added `cron-channel-readiness` coverage for connected, delayed connected, timeout fail-open, stopped/disabled/unconfigured/no-connected accounts, and closing gateways.
- Added post-ready cron coverage for readiness wait, timeout start, and skipped-channel bypass.
- Added hot-reload coverage for cron-after-channel ordering, skipped-channel bypass, and old-cron restore on channel restart failure.

What failed before this fix, if known?

- The new ordering and rollback regression cases would fail against the previous hot-reload/startup cron behavior.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

- Startup or reload cron could be delayed when a running configured channel never reports connected.

How is that risk mitigated?

- The wait uses the existing channel connect grace timeout, fail-opens with a warning, skips disabled/unconfigured/stopped/no-readiness accounts, bypasses explicit channel/provider skip envs, and exits on gateway close.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Live Discord/SIGUSR1 timing proof was not run locally; CI is pending.

Which bot or reviewer comments were addressed?

Pre-ship round 1 MUST-FIX findings were addressed: stopped accounts no longer block readiness, skipped channel/provider envs bypass readiness, and hot-reload channel restart failure restores the old cron.


