### PR TITLE
test: consolidate media capability assertions

### DIFF
--- a/extensions/alibaba/video-generation-provider.test.ts
+++ b/extensions/alibaba/video-generation-provider.test.ts
@@ -4,7 +4,6 @@ import {
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
 import {
   expectDashscopeVideoTaskPoll,
-  expectExplicitVideoGenerationCapabilities,
   expectSuccessfulDashscopeVideoResult,
   mockSuccessfulDashscopeVideoTask,
 } from "openclaw/plugin-sdk/provider-test-contracts";
@@ -36,10 +35,6 @@ function requireFirstPostJsonRequest(label: string): Record<string, unknown> {
 }
 
 describe("alibaba video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildAlibabaVideoGenerationProvider());
-  });
-
   it("submits async Wan generation, polls task status, and downloads the resulting video", async () => {
     mockSuccessfulDashscopeVideoTask({ postJsonRequestMock, fetchWithTimeoutMock });
 

--- a/extensions/byteplus/video-generation-provider.test.ts
+++ b/extensions/byteplus/video-generation-provider.test.ts
@@ -2,7 +2,6 @@ import {
   getProviderHttpMocks,
   installProviderHttpMockCleanup,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const { postJsonRequestMock, fetchWithTimeoutMock } = getProviderHttpMocks();
@@ -77,10 +76,6 @@ function streamedVideoResponse(bytes: string): Response {
 }
 
 describe("byteplus video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildBytePlusVideoGenerationProvider());
-  });
-
   it("creates a content-generation task, polls, and downloads the video", async () => {
     mockSuccessfulBytePlusTask();
 

--- a/extensions/comfy/music-generation-provider.test.ts
+++ b/extensions/comfy/music-generation-provider.test.ts
@@ -1,4 +1,3 @@
-import { expectExplicitMusicGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildComfyMusicGenerationProvider } from "./music-generation-provider.js";
 import { setComfyFetchGuardForTesting } from "./workflow-runtime.js";
@@ -18,7 +17,6 @@ describe("comfy music-generation provider", () => {
 
     expect(provider.defaultModel).toBe("workflow");
     expect(provider.models).toEqual(["workflow"]);
-    expectExplicitMusicGenerationCapabilities(provider);
   });
 
   it("runs a music workflow and returns audio outputs", async () => {

--- a/extensions/comfy/video-generation-provider.test.ts
+++ b/extensions/comfy/video-generation-provider.test.ts
@@ -1,4 +1,3 @@
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildComfyConfig,
@@ -35,10 +34,6 @@ describe("comfy video-generation provider", () => {
   afterEach(() => {
     setComfyFetchGuardForTesting(null);
     vi.restoreAllMocks();
-  });
-
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildComfyVideoGenerationProvider());
   });
 
   it("treats local comfy video workflows as configured without an API key", () => {

--- a/extensions/deepinfra/video-generation-provider.test.ts
+++ b/extensions/deepinfra/video-generation-provider.test.ts
@@ -2,7 +2,6 @@ import {
   getProviderHttpMocks,
   installProviderHttpMockCleanup,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const { postJsonRequestMock, resolveProviderHttpRequestConfigMock } = getProviderHttpMocks();
@@ -24,10 +23,6 @@ function requireFirstPostJsonRequest(): unknown {
 }
 
 describe("deepinfra video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildDeepInfraVideoGenerationProvider());
-  });
-
   it("uses the current DeepInfra text-to-video fallback model first", () => {
     const provider = buildDeepInfraVideoGenerationProvider();
 

--- a/extensions/fal/music-generation-provider.test.ts
+++ b/extensions/fal/music-generation-provider.test.ts
@@ -1,4 +1,3 @@
-import { expectExplicitMusicGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildFalMusicGenerationProvider } from "./music-generation-provider.js";
 
@@ -64,10 +63,6 @@ describe("fal music generation provider", () => {
     resolveApiKeyForProviderMock.mockClear();
     resolveProviderHttpRequestConfigMock.mockClear();
     vi.unstubAllGlobals();
-  });
-
-  it("declares explicit mode capabilities", () => {
-    expectExplicitMusicGenerationCapabilities(buildFalMusicGenerationProvider());
   });
 
   it("submits MiniMax music through fal and downloads the generated track", async () => {

--- a/extensions/fal/video-generation-provider.test.ts
+++ b/extensions/fal/video-generation-provider.test.ts
@@ -1,7 +1,6 @@
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import * as providerAuth from "openclaw/plugin-sdk/provider-auth-runtime";
 import * as providerHttp from "openclaw/plugin-sdk/provider-http";
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   setFalVideoFetchGuardForTesting,
@@ -115,9 +114,8 @@ describe("fal video generation provider", () => {
     setFalVideoFetchGuardForTesting(null);
   });
 
-  it("declares explicit mode capabilities", () => {
+  it("declares provider-specific mode capability limits", () => {
     const provider = buildFalVideoGenerationProvider();
-    expectExplicitVideoGenerationCapabilities(provider);
     expect(provider.capabilities.imageToVideo?.maxInputImages).toBe(1);
     expect(
       provider.capabilities.imageToVideo?.maxInputImagesByModel?.[

--- a/extensions/google/music-generation-provider.test.ts
+++ b/extensions/google/music-generation-provider.test.ts
@@ -20,7 +20,6 @@ vi.mock("./google-genai-runtime.js", () => ({
 }));
 
 import * as providerAuthRuntime from "openclaw/plugin-sdk/provider-auth-runtime";
-import { expectExplicitMusicGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { buildGoogleMusicGenerationProvider } from "./music-generation-provider.js";
 
 type GoogleGenAIConfig = {
@@ -63,10 +62,6 @@ describe("google music generation provider", () => {
   afterAll(() => {
     vi.doUnmock("./google-genai-runtime.js");
     vi.resetModules();
-  });
-
-  it("declares explicit mode capabilities", () => {
-    expectExplicitMusicGenerationCapabilities(buildGoogleMusicGenerationProvider());
   });
 
   it("submits generation and returns inline audio bytes plus lyrics", async () => {

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -32,7 +32,6 @@ vi.mock("./google-genai-runtime.js", () => ({
 }));
 
 import * as providerAuthRuntime from "openclaw/plugin-sdk/provider-auth-runtime";
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { buildGoogleVideoGenerationProvider } from "./video-generation-provider.js";
 
 type MockWithCalls = {
@@ -117,9 +116,8 @@ describe("google video generation provider", () => {
     vi.resetModules();
   });
 
-  it("declares explicit mode capabilities", () => {
+  it("declares provider-specific audio support by mode", () => {
     const provider = buildGoogleVideoGenerationProvider();
-    expectExplicitVideoGenerationCapabilities(provider);
     expect(provider.capabilities.generate?.supportsAudio).toBe(false);
     expect(provider.capabilities.imageToVideo?.supportsAudio).toBe(false);
     expect(provider.capabilities.videoToVideo?.supportsAudio).toBe(false);

--- a/extensions/media-generation-provider-capabilities.contract.test.ts
+++ b/extensions/media-generation-provider-capabilities.contract.test.ts
@@ -1,0 +1,70 @@
+import {
+  expectExplicitMusicGenerationCapabilities,
+  expectExplicitVideoGenerationCapabilities,
+} from "openclaw/plugin-sdk/provider-test-contracts";
+import { describe, it } from "vitest";
+import { buildAlibabaVideoGenerationProvider } from "./alibaba/video-generation-provider.js";
+import { buildBytePlusVideoGenerationProvider } from "./byteplus/video-generation-provider.js";
+import { buildComfyMusicGenerationProvider } from "./comfy/music-generation-provider.js";
+import { buildComfyVideoGenerationProvider } from "./comfy/video-generation-provider.js";
+import { buildDeepInfraVideoGenerationProvider } from "./deepinfra/video-generation-provider.js";
+import { buildFalMusicGenerationProvider } from "./fal/music-generation-provider.js";
+import { buildFalVideoGenerationProvider } from "./fal/video-generation-provider.js";
+import { buildGoogleMusicGenerationProvider } from "./google/music-generation-provider.js";
+import { buildGoogleVideoGenerationProvider } from "./google/video-generation-provider.js";
+import { buildMinimaxMusicGenerationProvider } from "./minimax/music-generation-provider.js";
+import { buildMinimaxVideoGenerationProvider } from "./minimax/video-generation-provider.js";
+import { buildOpenAIVideoGenerationProvider } from "./openai/video-generation-provider.js";
+import { buildOpenRouterMusicGenerationProvider } from "./openrouter/music-generation-provider.js";
+import { buildOpenRouterVideoGenerationProvider } from "./openrouter/video-generation-provider.js";
+import { buildPixVerseVideoGenerationProvider } from "./pixverse/video-generation-provider.js";
+import { buildQwenVideoGenerationProvider } from "./qwen/video-generation-provider.js";
+import { buildRunwayVideoGenerationProvider } from "./runway/video-generation-provider.js";
+import { buildTogetherVideoGenerationProvider } from "./together/video-generation-provider.js";
+import { buildVydraVideoGenerationProvider } from "./vydra/video-generation-provider.js";
+import { buildXaiVideoGenerationProvider } from "./xai/video-generation-provider.js";
+
+type VideoProviderBuilder = () => Parameters<typeof expectExplicitVideoGenerationCapabilities>[0];
+type MusicProviderBuilder = () => Parameters<typeof expectExplicitMusicGenerationCapabilities>[0];
+
+const VIDEO_PROVIDER_CAPABILITY_CASES = [
+  ["alibaba", buildAlibabaVideoGenerationProvider],
+  ["byteplus", buildBytePlusVideoGenerationProvider],
+  ["comfy", buildComfyVideoGenerationProvider],
+  ["deepinfra", buildDeepInfraVideoGenerationProvider],
+  ["fal", buildFalVideoGenerationProvider],
+  ["google", buildGoogleVideoGenerationProvider],
+  ["minimax", buildMinimaxVideoGenerationProvider],
+  ["openai", buildOpenAIVideoGenerationProvider],
+  ["openrouter", buildOpenRouterVideoGenerationProvider],
+  ["pixverse", buildPixVerseVideoGenerationProvider],
+  ["qwen", buildQwenVideoGenerationProvider],
+  ["runway", buildRunwayVideoGenerationProvider],
+  ["together", buildTogetherVideoGenerationProvider],
+  ["vydra", buildVydraVideoGenerationProvider],
+  ["xai", buildXaiVideoGenerationProvider],
+] satisfies readonly [string, VideoProviderBuilder][];
+
+const MUSIC_PROVIDER_CAPABILITY_CASES = [
+  ["comfy", buildComfyMusicGenerationProvider],
+  ["fal", buildFalMusicGenerationProvider],
+  ["google", buildGoogleMusicGenerationProvider],
+  ["minimax", buildMinimaxMusicGenerationProvider],
+  ["openrouter", buildOpenRouterMusicGenerationProvider],
+] satisfies readonly [string, MusicProviderBuilder][];
+
+describe("bundled media-generation provider capability contracts", () => {
+  it.each(VIDEO_PROVIDER_CAPABILITY_CASES)(
+    "declares explicit video mode capabilities for %s",
+    (_name, buildProvider) => {
+      expectExplicitVideoGenerationCapabilities(buildProvider());
+    },
+  );
+
+  it.each(MUSIC_PROVIDER_CAPABILITY_CASES)(
+    "declares explicit music mode capabilities for %s",
+    (_name, buildProvider) => {
+      expectExplicitMusicGenerationCapabilities(buildProvider());
+    },
+  );
+});

--- a/extensions/minimax/music-generation-provider.test.ts
+++ b/extensions/minimax/music-generation-provider.test.ts
@@ -1,4 +1,3 @@
-import { expectExplicitMusicGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
   getMinimaxProviderHttpMocks,
@@ -62,10 +61,6 @@ function streamedAudioResponse(bytes: string): Response {
 }
 
 describe("minimax music generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitMusicGenerationCapabilities(buildMinimaxMusicGenerationProvider());
-  });
-
   it("streams generated music chunks from MiniMax", async () => {
     const chunkA = Buffer.from("ID3\x04\x00mp3-a");
     const chunkB = Buffer.from("mp3-b");

--- a/extensions/minimax/video-generation-provider.test.ts
+++ b/extensions/minimax/video-generation-provider.test.ts
@@ -1,4 +1,3 @@
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
   getMinimaxProviderHttpMocks,
@@ -61,9 +60,8 @@ function streamedVideoResponse(bytes: string): Response {
 }
 
 describe("minimax video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
+  it("declares provider-specific mode resolutions", () => {
     const provider = buildMinimaxVideoGenerationProvider();
-    expectExplicitVideoGenerationCapabilities(provider);
     expect(provider.capabilities.generate?.resolutions).toEqual(["768P", "1080P"]);
     expect(provider.capabilities.imageToVideo?.resolutions).toEqual(["768P", "1080P"]);
   });

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -5,7 +5,6 @@ import {
   getProviderHttpMocks,
   installProviderHttpMockCleanup,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const {
@@ -104,10 +103,6 @@ function streamedVideoResponse(bytes: string): Response {
 }
 
 describe("openai video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildOpenAIVideoGenerationProvider());
-  });
-
   it("does not claim size or duration controls for OpenAI video edits", () => {
     const provider = buildOpenAIVideoGenerationProvider();
 

--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -1,5 +1,4 @@
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
-import { expectExplicitMusicGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenRouterMusicGenerationProvider } from "./music-generation-provider.js";
 
@@ -80,10 +79,6 @@ describe("openrouter music generation provider", () => {
     postJsonRequestMock.mockReset();
     resolveApiKeyForProviderMock.mockClear();
     resolveProviderHttpRequestConfigMock.mockClear();
-  });
-
-  it("declares explicit mode capabilities", () => {
-    expectExplicitMusicGenerationCapabilities(buildOpenRouterMusicGenerationProvider());
   });
 
   it("streams OpenRouter audio chunks into a generated music asset", async () => {

--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -1,8 +1,5 @@
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
-import {
-  expectExplicitVideoGenerationCapabilities,
-  expectUnifiedModelCatalogEntries,
-} from "openclaw/plugin-sdk/provider-test-contracts";
+import { expectUnifiedModelCatalogEntries } from "openclaw/plugin-sdk/provider-test-contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildOpenRouterVideoGenerationProvider,
@@ -174,10 +171,8 @@ describe("openrouter video generation provider", () => {
     waitProviderOperationPollIntervalMock.mockClear();
   });
 
-  it("declares explicit mode capabilities", () => {
+  it("declares provider defaults and mode capabilities", () => {
     const provider = buildOpenRouterVideoGenerationProvider();
-
-    expectExplicitVideoGenerationCapabilities(provider);
     expect(provider.id).toBe("openrouter");
     expect(provider.defaultModel).toBe("google/veo-3.1-fast");
     const generateCapabilities = requireGenerateCapabilities(provider);

--- a/extensions/pixverse/video-generation-provider.test.ts
+++ b/extensions/pixverse/video-generation-provider.test.ts
@@ -2,7 +2,6 @@ import {
   getProviderHttpMocks,
   installProviderHttpMockCleanup,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const {
@@ -56,10 +55,6 @@ function pollFetchHeaders(callIndex: number): Headers | undefined {
 }
 
 describe("pixverse video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildPixVerseVideoGenerationProvider());
-  });
-
   it("submits text-to-video, polls status, and returns the output URL", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: {

--- a/extensions/qwen/video-generation-provider.test.ts
+++ b/extensions/qwen/video-generation-provider.test.ts
@@ -4,7 +4,6 @@ import {
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
 import {
   expectDashscopeVideoTaskPoll,
-  expectExplicitVideoGenerationCapabilities,
   expectSuccessfulDashscopeVideoResult,
   mockSuccessfulDashscopeVideoTask,
 } from "openclaw/plugin-sdk/provider-test-contracts";
@@ -66,10 +65,6 @@ function streamedVideoResponse(bytes: string): Response {
 }
 
 describe("qwen video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildQwenVideoGenerationProvider());
-  });
-
   it("submits async Wan generation, polls task status, and downloads the resulting video", async () => {
     mockSuccessfulDashscopeVideoTask({ postJsonRequestMock, fetchWithTimeoutMock });
 

--- a/extensions/runway/video-generation-provider.test.ts
+++ b/extensions/runway/video-generation-provider.test.ts
@@ -2,7 +2,6 @@ import {
   getProviderHttpMocks,
   installProviderHttpMockCleanup,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const { postJsonRequestMock, fetchWithTimeoutMock } = getProviderHttpMocks();
@@ -63,10 +62,6 @@ function streamedVideoResponse(bytes: string): Response {
 }
 
 describe("runway video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildRunwayVideoGenerationProvider());
-  });
-
   it("submits a text-to-video task, polls it, and downloads the output", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: {

--- a/extensions/together/video-generation-provider.test.ts
+++ b/extensions/together/video-generation-provider.test.ts
@@ -2,7 +2,6 @@ import {
   getProviderHttpMocks,
   installProviderHttpMockCleanup,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const { postJsonRequestMock, fetchWithTimeoutMock } = getProviderHttpMocks();
@@ -48,10 +47,6 @@ function streamingResponse(params: {
 }
 
 describe("together video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildTogetherVideoGenerationProvider());
-  });
-
   it("creates a video, polls completion, and downloads the output", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: {

--- a/extensions/vydra/video-generation-provider.test.ts
+++ b/extensions/vydra/video-generation-provider.test.ts
@@ -1,4 +1,3 @@
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { installPinnedHostnameTestHooks } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -23,10 +22,6 @@ describe("vydra video-generation provider", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
-  });
-
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildVydraVideoGenerationProvider());
   });
 
   it("submits veo3 jobs and downloads the completed video", async () => {

--- a/extensions/xai/video-generation-provider.test.ts
+++ b/extensions/xai/video-generation-provider.test.ts
@@ -2,7 +2,6 @@ import {
   getProviderHttpMocks,
   installProviderHttpMockCleanup,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
-import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const { postJsonRequestMock, fetchWithTimeoutMock } = getProviderHttpMocks();
@@ -64,10 +63,6 @@ function streamedVideoResponse(bytes: string): Response {
 }
 
 describe("xai video generation provider", () => {
-  it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildXaiVideoGenerationProvider());
-  });
-
   it("creates, polls, and downloads a generated video", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: {


### PR DESCRIPTION
## Summary
- Consolidate repeated media provider explicit capability-shape checks into one extension-owned contract suite.
- Remove the redundant per-provider one-line capability tests while keeping provider-specific capability and behavior assertions in place.
- Leave the existing core media provider manifest contract test manifest-only to avoid core deep-importing plugin runtime modules.

## Verification
- `node scripts/run-vitest.mjs src/media-generation/provider-capabilities.contract.test.ts extensions/media-generation-provider-capabilities.contract.test.ts`
- `node scripts/run-vitest.mjs extensions/alibaba/video-generation-provider.test.ts extensions/byteplus/video-generation-provider.test.ts extensions/comfy/music-generation-provider.test.ts extensions/comfy/video-generation-provider.test.ts extensions/deepinfra/video-generation-provider.test.ts extensions/fal/music-generation-provider.test.ts extensions/fal/video-generation-provider.test.ts extensions/google/music-generation-provider.test.ts extensions/google/video-generation-provider.test.ts extensions/minimax/music-generation-provider.test.ts extensions/minimax/video-generation-provider.test.ts extensions/openai/video-generation-provider.test.ts extensions/openrouter/music-generation-provider.test.ts extensions/openrouter/video-generation-provider.test.ts extensions/pixverse/video-generation-provider.test.ts extensions/qwen/video-generation-provider.test.ts extensions/runway/video-generation-provider.test.ts extensions/together/video-generation-provider.test.ts extensions/vydra/video-generation-provider.test.ts extensions/xai/video-generation-provider.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof
Behavior addressed: Consolidates redundant provider capability-shape tests without changing provider runtime behavior.
Real environment tested: Local Codex OpenClaw worktree on macOS.
Exact steps or command run after this patch: The verification commands listed above.
Evidence after fix: Contract suite passed 22 tests; touched provider batch passed 170 tests across 4 Vitest shards; autoreview reported no accepted/actionable findings.
Observed result after fix: The same generic media capability helper assertions now run from one extension-owned contract suite, and provider-specific tests still cover their local behavior and capability details.
What was not tested: Full repository check suite and remote/Testbox gates were not run for this test-only cleanup.
