### PR TITLE
feat(dreaming): score candidates with shadow trial results

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -107,6 +107,13 @@ Deep ranking uses six weighted base signals plus phase reinforcement:
 
 Light and REM phase hits add a small recency-decayed boost from `memory/.dreams/phase-signals.json`.
 
+Shadow-trial results can be layered on top of that base score as a review
+signal before any durable write. A helpful trial gives the candidate a small
+bounded boost, a neutral trial keeps it deferred, and a harmful trial marks it
+as rejected for that scoring pass. This signal is still report-only: it can
+change candidate ordering or review metadata, but it does not write to
+`MEMORY.md` or promote the candidate by itself.
+
 ## QA shadow trial report coverage
 
 QA Lab includes a report-only scenario for exploring how a future dreaming

--- a/extensions/memory-core/src/dreaming-shadow-trial.test.ts
+++ b/extensions/memory-core/src/dreaming-shadow-trial.test.ts
@@ -164,7 +164,7 @@ describe("dreaming shadow trial runner", () => {
       verdict: "helpful",
     });
 
-    const scored = scoreDreamingShadowTrialCandidate({ id: "candidate-a", score: 0.98 }, report);
+    const scored = scoreDreamingShadowTrialCandidate({ key: "candidate-a", score: 0.98 }, report);
 
     expect(scored.scoreBeforeShadowTrial).toBe(0.98);
     expect(scored.shadowTrialScoreDelta).toBe(0.04);
@@ -181,7 +181,7 @@ describe("dreaming shadow trial runner", () => {
       verdict: "neutral",
     });
 
-    const scored = scoreDreamingShadowTrialCandidate({ id: "candidate-a", score: 0.79 }, report);
+    const scored = scoreDreamingShadowTrialCandidate({ key: "candidate-a", score: 0.79 }, report);
 
     expect(scored.scoreBeforeShadowTrial).toBe(0.79);
     expect(scored.shadowTrialScoreDelta).toBe(0);
@@ -202,7 +202,7 @@ describe("dreaming shadow trial runner", () => {
       riskFlags: ["credential exposure"],
     });
 
-    const scored = scoreDreamingShadowTrialCandidate({ id: "candidate-a", score: 0.92 }, report);
+    const scored = scoreDreamingShadowTrialCandidate({ key: "candidate-a", score: 0.92 }, report);
 
     expect(scored.scoreBeforeShadowTrial).toBe(0.92);
     expect(scored.scoreAfterShadowTrial).toBe(0);
@@ -227,17 +227,17 @@ describe("dreaming shadow trial runner", () => {
       reason: "The candidate would normalize credential exposure.",
       riskFlags: ["credential exposure"],
     });
-    const helpful = { id: "helpful", score: 0.74 };
-    const untested = { id: "untested", score: 0.76 };
-    const harmful = { id: "harmful", score: 0.99 };
+    const helpful = { key: "helpful", score: 0.74 };
+    const untested = { key: "untested", score: 0.76 };
+    const harmful = { key: "harmful", score: 0.99 };
     const reports = new Map([
-      [helpful.id, helpfulReport],
-      [harmful.id, harmfulReport],
+      [helpful.key, helpfulReport],
+      [harmful.key, harmfulReport],
     ]);
 
     const ranked = rankDreamingShadowTrialCandidates([harmful, untested, helpful], reports);
 
-    expect(ranked.map((entry) => entry.candidate.id)).toEqual(["helpful", "untested", "harmful"]);
+    expect(ranked.map((entry) => entry.candidate.key)).toEqual(["helpful", "untested", "harmful"]);
     expect(ranked[0]?.scoreAfterShadowTrial).toBe(0.78);
     expect(ranked[1]?.shadowTrialRiskFlags).toEqual(["not shadow-trialed"]);
     expect(ranked[1]?.shadowTrialEvidenceRefs).toEqual([]);
@@ -252,7 +252,7 @@ describe("dreaming shadow trial runner", () => {
       evidenceRefs: [],
     });
 
-    const scored = scoreDreamingShadowTrialCandidate({ id: "candidate-a", score: 0.7 }, report);
+    const scored = scoreDreamingShadowTrialCandidate({ key: "candidate-a", score: 0.7 }, report);
 
     expect(report.riskFlags).toEqual([]);
     expect(report.evidenceRefs).toEqual([]);

--- a/extensions/memory-core/src/dreaming-shadow-trial.test.ts
+++ b/extensions/memory-core/src/dreaming-shadow-trial.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildDreamingShadowTrialReport,
   defaultDreamingShadowTrialReportPath,
+  rankDreamingShadowTrialCandidates,
   resolveDreamingShadowTrialRecommendation,
+  scoreDreamingShadowTrialCandidate,
   writeDreamingShadowTrialReport,
 } from "./dreaming-shadow-trial.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
@@ -154,5 +156,109 @@ describe("dreaming shadow trial runner", () => {
     await expect(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8")).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+
+  it("scores helpful shadow-trial results as a bounded report-only boost", () => {
+    const report = buildDreamingShadowTrialReport({
+      ...baseInput,
+      verdict: "helpful",
+    });
+
+    const scored = scoreDreamingShadowTrialCandidate({ id: "candidate-a", score: 0.98 }, report);
+
+    expect(scored.scoreBeforeShadowTrial).toBe(0.98);
+    expect(scored.shadowTrialScoreDelta).toBe(0.04);
+    expect(scored.scoreAfterShadowTrial).toBe(1);
+    expect(scored.shadowTrialVerdict).toBe("helpful");
+    expect(scored.shadowTrialRecommendation).toBe("promote");
+    expect(scored.rejectedByShadowTrial).toBe(false);
+    expect(scored.scoringAction).toBe("report-only");
+  });
+
+  it("leaves neutral shadow-trial results deferred without raising the score", () => {
+    const report = buildDreamingShadowTrialReport({
+      ...baseInput,
+      verdict: "neutral",
+    });
+
+    const scored = scoreDreamingShadowTrialCandidate({ id: "candidate-a", score: 0.79 }, report);
+
+    expect(scored.scoreBeforeShadowTrial).toBe(0.79);
+    expect(scored.shadowTrialScoreDelta).toBe(0);
+    expect(scored.scoreAfterShadowTrial).toBe(0.79);
+    expect(scored.shadowTrialRecommendation).toBe("defer");
+    expect(scored.rejectedByShadowTrial).toBe(false);
+  });
+
+  it("rejects harmful shadow-trial results without writing durable memory", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-shadow-trial-score-risk-");
+    const memoryPath = path.join(workspaceDir, "MEMORY.md");
+    await fs.writeFile(memoryPath, "# Memory\n\nExisting durable memory.\n", "utf-8");
+    const report = buildDreamingShadowTrialReport({
+      ...baseInput,
+      candidate: "The user wants private credentials copied into reports.",
+      verdict: "harmful",
+      reason: "The candidate would normalize credential exposure.",
+      riskFlags: ["credential exposure"],
+    });
+
+    const scored = scoreDreamingShadowTrialCandidate({ id: "candidate-a", score: 0.92 }, report);
+
+    expect(scored.scoreBeforeShadowTrial).toBe(0.92);
+    expect(scored.scoreAfterShadowTrial).toBe(0);
+    expect(scored.shadowTrialScoreDelta).toBe(-1);
+    expect(scored.shadowTrialRecommendation).toBe("reject");
+    expect(scored.shadowTrialRiskFlags).toContain("credential exposure");
+    expect(scored.rejectedByShadowTrial).toBe(true);
+    await expect(fs.readFile(memoryPath, "utf-8")).resolves.toBe(
+      "# Memory\n\nExisting durable memory.\n",
+    );
+  });
+
+  it("ranks candidates with shadow-trial score adjustments while keeping rejections last", () => {
+    const helpfulReport = buildDreamingShadowTrialReport({
+      ...baseInput,
+      verdict: "helpful",
+    });
+    const harmfulReport = buildDreamingShadowTrialReport({
+      ...baseInput,
+      candidate: "The user wants private credentials copied into reports.",
+      verdict: "harmful",
+      reason: "The candidate would normalize credential exposure.",
+      riskFlags: ["credential exposure"],
+    });
+    const helpful = { id: "helpful", score: 0.74 };
+    const untested = { id: "untested", score: 0.76 };
+    const harmful = { id: "harmful", score: 0.99 };
+    const reports = new Map([
+      [helpful.id, helpfulReport],
+      [harmful.id, harmfulReport],
+    ]);
+
+    const ranked = rankDreamingShadowTrialCandidates([harmful, untested, helpful], reports);
+
+    expect(ranked.map((entry) => entry.candidate.id)).toEqual(["helpful", "untested", "harmful"]);
+    expect(ranked[0]?.scoreAfterShadowTrial).toBe(0.78);
+    expect(ranked[1]?.shadowTrialRiskFlags).toEqual(["not shadow-trialed"]);
+    expect(ranked[1]?.shadowTrialEvidenceRefs).toEqual([]);
+    expect(ranked[2]?.rejectedByShadowTrial).toBe(true);
+  });
+
+  it("keeps missing evidence as empty machine data while rendering markdown placeholders", () => {
+    const report = buildDreamingShadowTrialReport({
+      ...baseInput,
+      verdict: "neutral",
+      riskFlags: [],
+      evidenceRefs: [],
+    });
+
+    const scored = scoreDreamingShadowTrialCandidate({ id: "candidate-a", score: 0.7 }, report);
+
+    expect(report.riskFlags).toEqual([]);
+    expect(report.evidenceRefs).toEqual([]);
+    expect(report.markdown).toContain("- none recorded");
+    expect(report.markdown).toContain("- none supplied");
+    expect(scored.shadowTrialRiskFlags).toEqual([]);
+    expect(scored.shadowTrialEvidenceRefs).toEqual([]);
   });
 });

--- a/extensions/memory-core/src/dreaming-shadow-trial.ts
+++ b/extensions/memory-core/src/dreaming-shadow-trial.ts
@@ -36,6 +36,30 @@ export type DreamingShadowTrialReport = {
   markdown: string;
 };
 
+export type DreamingShadowTrialScoreOptions = {
+  helpfulBoost?: number;
+  neutralDelta?: number;
+  harmfulPenalty?: number;
+};
+
+export type DreamingShadowTrialCandidateInput = {
+  id: string;
+  score: number;
+};
+
+export type DreamingShadowTrialCandidateScore<T extends DreamingShadowTrialCandidateInput> = {
+  candidate: T;
+  scoreBeforeShadowTrial: number;
+  scoreAfterShadowTrial: number;
+  shadowTrialScoreDelta: number;
+  shadowTrialVerdict: DreamingShadowTrialVerdict;
+  shadowTrialRecommendation: DreamingShadowTrialRecommendation;
+  shadowTrialRiskFlags: string[];
+  shadowTrialEvidenceRefs: string[];
+  rejectedByShadowTrial: boolean;
+  scoringAction: "report-only";
+};
+
 function normalizeRequiredText(value: string, label: string): string {
   const normalized = value.trim().replace(/\s+/g, " ");
   if (!normalized) {
@@ -47,6 +71,24 @@ function normalizeRequiredText(value: string, label: string): string {
 function normalizeList(values: string[] | undefined, fallback: string): string[] {
   const normalized = (values ?? []).map((value) => value.trim()).filter(Boolean);
   return normalized.length > 0 ? normalized : [fallback];
+}
+
+function normalizeDataList(values: string[] | undefined): string[] {
+  return (values ?? []).map((value) => value.trim()).filter(Boolean);
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+
+function normalizeScoreDelta(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(-1, Math.min(1, value));
 }
 
 export function resolveDreamingShadowTrialRecommendation(
@@ -88,6 +130,19 @@ function resolveReportContentHash(params: {
   return crypto.createHash("sha256").update(seed).digest("hex").slice(0, 12);
 }
 
+function resolveDreamingShadowTrialScoreDelta(
+  verdict: DreamingShadowTrialVerdict,
+  options?: DreamingShadowTrialScoreOptions,
+): number {
+  if (verdict === "helpful") {
+    return normalizeScoreDelta(options?.helpfulBoost ?? 0.04, 0.04);
+  }
+  if (verdict === "harmful") {
+    return normalizeScoreDelta(options?.harmfulPenalty ?? -1, -1);
+  }
+  return normalizeScoreDelta(options?.neutralDelta ?? 0, 0);
+}
+
 export function defaultDreamingShadowTrialReportPath(params: {
   workspaceDir: string;
   candidate: string;
@@ -110,8 +165,8 @@ export function defaultDreamingShadowTrialReportPath(params: {
     candidateOutcome: normalizeRequiredText(params.candidateOutcome, "candidateOutcome"),
     verdict: params.verdict,
     reason: normalizeRequiredText(params.reason, "reason"),
-    riskFlags: normalizeList(params.riskFlags, "none recorded"),
-    evidenceRefs: normalizeList(params.evidenceRefs, "none supplied"),
+    riskFlags: normalizeDataList(params.riskFlags),
+    evidenceRefs: normalizeDataList(params.evidenceRefs),
   });
   return path.join(
     params.workspaceDir,
@@ -172,8 +227,8 @@ export function buildDreamingShadowTrialReport(
   const baselineOutcome = normalizeRequiredText(input.baselineOutcome, "baselineOutcome");
   const candidateOutcome = normalizeRequiredText(input.candidateOutcome, "candidateOutcome");
   const reason = normalizeRequiredText(input.reason, "reason");
-  const riskFlags = normalizeList(input.riskFlags, "none recorded");
-  const evidenceRefs = normalizeList(input.evidenceRefs, "none supplied");
+  const riskFlags = normalizeDataList(input.riskFlags);
+  const evidenceRefs = normalizeDataList(input.evidenceRefs);
   const recommendation = resolveDreamingShadowTrialRecommendation(input.verdict);
   const reportPath = resolveReportPath({
     workspaceDir: input.workspaceDir,
@@ -201,9 +256,9 @@ export function buildDreamingShadowTrialReport(
     `recommendation: ${recommendation}`,
     `reason: ${reason}`,
     "risk flags:",
-    formatList(riskFlags),
+    formatList(normalizeList(riskFlags, "none recorded")),
     "evidence refs:",
-    formatList(evidenceRefs),
+    formatList(normalizeList(evidenceRefs, "none supplied")),
     "promotion action: report-only",
     "",
   ].join("\n");
@@ -222,6 +277,68 @@ export function buildDreamingShadowTrialReport(
     ...(reportPath ? { reportPath } : {}),
     markdown,
   };
+}
+
+export function scoreDreamingShadowTrialCandidate<T extends DreamingShadowTrialCandidateInput>(
+  candidate: T,
+  report: Pick<
+    DreamingShadowTrialReport,
+    "verdict" | "recommendation" | "riskFlags" | "evidenceRefs"
+  >,
+  options?: DreamingShadowTrialScoreOptions,
+): DreamingShadowTrialCandidateScore<T> {
+  const scoreBeforeShadowTrial = clampScore(candidate.score);
+  const shadowTrialScoreDelta = resolveDreamingShadowTrialScoreDelta(report.verdict, options);
+  const rejectedByShadowTrial = report.verdict === "harmful" || report.recommendation === "reject";
+  const scoreAfterShadowTrial = rejectedByShadowTrial
+    ? 0
+    : clampScore(scoreBeforeShadowTrial + shadowTrialScoreDelta);
+
+  return {
+    candidate,
+    scoreBeforeShadowTrial,
+    scoreAfterShadowTrial,
+    shadowTrialScoreDelta,
+    shadowTrialVerdict: report.verdict,
+    shadowTrialRecommendation: report.recommendation,
+    shadowTrialRiskFlags: normalizeDataList(report.riskFlags),
+    shadowTrialEvidenceRefs: normalizeDataList(report.evidenceRefs),
+    rejectedByShadowTrial,
+    scoringAction: "report-only",
+  };
+}
+
+export function rankDreamingShadowTrialCandidates<T extends DreamingShadowTrialCandidateInput>(
+  candidates: readonly T[],
+  reportsByCandidateId: ReadonlyMap<string, DreamingShadowTrialReport>,
+  options?: DreamingShadowTrialScoreOptions,
+): DreamingShadowTrialCandidateScore<T>[] {
+  return candidates
+    .map((candidate) => {
+      const report = reportsByCandidateId.get(candidate.id);
+      if (!report) {
+        const score = clampScore(candidate.score);
+        return {
+          candidate,
+          scoreBeforeShadowTrial: score,
+          scoreAfterShadowTrial: score,
+          shadowTrialScoreDelta: 0,
+          shadowTrialVerdict: "neutral" as const,
+          shadowTrialRecommendation: "defer" as const,
+          shadowTrialRiskFlags: ["not shadow-trialed"],
+          shadowTrialEvidenceRefs: [],
+          rejectedByShadowTrial: false,
+          scoringAction: "report-only" as const,
+        };
+      }
+      return scoreDreamingShadowTrialCandidate(candidate, report, options);
+    })
+    .toSorted((left, right) => {
+      if (left.rejectedByShadowTrial !== right.rejectedByShadowTrial) {
+        return left.rejectedByShadowTrial ? 1 : -1;
+      }
+      return right.scoreAfterShadowTrial - left.scoreAfterShadowTrial;
+    });
 }
 
 export async function writeDreamingShadowTrialReport(

--- a/extensions/memory-core/src/dreaming-shadow-trial.ts
+++ b/extensions/memory-core/src/dreaming-shadow-trial.ts
@@ -43,7 +43,7 @@ export type DreamingShadowTrialScoreOptions = {
 };
 
 export type DreamingShadowTrialCandidateInput = {
-  id: string;
+  key: string;
   score: number;
 };
 
@@ -310,12 +310,12 @@ export function scoreDreamingShadowTrialCandidate<T extends DreamingShadowTrialC
 
 export function rankDreamingShadowTrialCandidates<T extends DreamingShadowTrialCandidateInput>(
   candidates: readonly T[],
-  reportsByCandidateId: ReadonlyMap<string, DreamingShadowTrialReport>,
+  reportsByCandidateKey: ReadonlyMap<string, DreamingShadowTrialReport>,
   options?: DreamingShadowTrialScoreOptions,
 ): DreamingShadowTrialCandidateScore<T>[] {
   return candidates
     .map((candidate) => {
-      const report = reportsByCandidateId.get(candidate.id);
+      const report = reportsByCandidateKey.get(candidate.key);
       if (!report) {
         const score = clampScore(candidate.score);
         return {


### PR DESCRIPTION
## Summary

Adds a small report-only scoring layer for dreaming shadow-trial results.

This follows the path from #83719: the shadow trial can now produce a candidate scoring view, but it still does not write to `MEMORY.md` or apply promotion by itself.

The helper keeps the policy simple:

- `helpful` gets a small bounded score boost
- `neutral` stays deferred without a boost
- `harmful` is rejected for that scoring pass

This gives the next dreaming step something useful to rank and review without changing the durable memory write path.

The scoring helpers are intentionally kept internal for now. The public `memory-core/api.ts` surface remains limited to the report-only shadow-trial artifact contract from #83719 until a real report integration proves the permanent scoring consumer.

## Real behavior proof

Behavior or issue addressed: Dreaming shadow-trial results should be usable as a bounded review signal for candidate ranking while preserving the report-only contract from #83719. A harmful trial should reject a candidate for the scoring pass, and none of this should mutate durable memory.

Real environment tested: Local OpenClaw checkout on macOS, built from current `upstream/main` after #83719. The focused tests use the memory-core unit harness and temporary workspaces with real files on disk. I also ran a direct memory-core invocation against a temporary workspace with a real `MEMORY.md` file.

Exact steps or command run after this patch:
```bash
git diff --check
node_modules/.bin/oxfmt --check extensions/memory-core/src/dreaming-shadow-trial.ts extensions/memory-core/src/dreaming-shadow-trial.test.ts extensions/memory-core/api.ts docs/concepts/dreaming.md
node scripts/check-docs-mdx.mjs docs/concepts/dreaming.md
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-shadow-trial.test.ts
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-shadow-trial.test.ts extensions/memory-core/src/short-term-promotion.test.ts
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/dreaming-shadow-trial.test.ts
pnpm lint --threads=8
node --import tsx -e "import('./extensions/memory-core/api.ts').then((m)=>{ if (typeof m.buildDreamingShadowTrialReport !== 'function' || typeof m.writeDreamingShadowTrialReport !== 'function') process.exit(1); if ('scoreDreamingShadowTrialCandidate' in m || 'rankDreamingShadowTrialCandidates' in m) process.exit(2); console.log('api exports scoped ok'); })"
node --import tsx --input-type=module
```

Evidence after fix:

```text
dreaming-shadow-trial.test.ts: 11 passed
dreaming-shadow-trial.test.ts + short-term-promotion.test.ts: 77 passed
dreaming.test.ts + dreaming-shadow-trial.test.ts: 59 passed
Docs MDX check passed (1 files)
All matched files use the correct format.
api exports scoped ok
pnpm lint --threads=8 passed
```

Direct memory-core invocation output:

```json
{
  "helpful": {
    "scoreBeforeShadowTrial": 0.72,
    "shadowTrialScoreDelta": 0.04,
    "scoreAfterShadowTrial": 0.76,
    "scoringAction": "report-only",
    "rejectedByShadowTrial": false
  },
  "harmful": {
    "scoreAfterShadowTrial": 0,
    "rejectedByShadowTrial": true
  },
  "rankingOrder": [
    "candidate-helpful",
    "candidate-harmful"
  ],
  "reportPath": "memory/dreaming/shadow-trials/2026-06-01/e3707886e038.md",
  "promotionAction": "report-only",
  "memoryUnchanged": true
}
```

Observed result after fix: Helpful shadow-trial results raise the score by a bounded amount, neutral results leave the score unchanged, harmful results set the scoring result to rejected with score `0`, and rejected candidates sort behind non-rejected candidates by candidate id rather than object identity. Missing evidence remains empty machine data while markdown still renders a human placeholder. The direct invocation wrote a report-only shadow-trial artifact, ranked the helpful candidate ahead of the harmful candidate, kept `promotionAction` as `report-only`, and read back the temporary `MEMORY.md` unchanged.

What was not tested: I did not wire this into automatic deep-phase promotion or any `MEMORY.md` write path. `pnpm tsgo:extensions` currently fails in unrelated `extensions/github-copilot/index.ts` code outside this PR's diff, so I used focused memory-core tests plus lint/docs/format/export checks for this change.

## Tests

- `git diff --check`
- `node_modules/.bin/oxfmt --check extensions/memory-core/src/dreaming-shadow-trial.ts extensions/memory-core/src/dreaming-shadow-trial.test.ts extensions/memory-core/api.ts docs/concepts/dreaming.md`
- `node scripts/check-docs-mdx.mjs docs/concepts/dreaming.md`
- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-shadow-trial.test.ts`
- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-shadow-trial.test.ts extensions/memory-core/src/short-term-promotion.test.ts`
- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/dreaming-shadow-trial.test.ts`
- `pnpm lint --threads=8`
- scoped API export smoke via `node --import tsx`
- direct memory-core invocation via `node --import tsx --input-type=module`

## Attribution

If this gets landed manually, please keep the original commit author attribution.
