### PR TITLE
fix(telegram): slow polling restart storms

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -19,7 +19,9 @@ import type { TelegramIngressWorkerMessage } from "./telegram-ingress-worker.js"
 const runMock = vi.hoisted(() => vi.fn());
 const createTelegramBotMock = vi.hoisted(() => vi.fn());
 const isRecoverableTelegramNetworkErrorMock = vi.hoisted(() => vi.fn(() => true));
-const computeBackoffMock = vi.hoisted(() => vi.fn(() => 0));
+const computeBackoffMock = vi.hoisted(() =>
+  vi.fn((_policy: { initialMs: number }, _attempt: number) => 0),
+);
 const sleepWithAbortMock = vi.hoisted(() => vi.fn(async () => undefined));
 const drainPendingDeliveriesMock = vi.hoisted(() => vi.fn(async (_opts: unknown) => undefined));
 
@@ -190,10 +192,27 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
   });
   const realSetTimeout = globalThis.setTimeout;
   const realClearTimeout = globalThis.clearTimeout;
+  const watchdogs: Array<() => void> = [];
+  const watchdogWaiters: Array<{
+    count: number;
+    resolve: (fn: () => void) => void;
+    reject: (err: Error) => void;
+    timeout: ReturnType<typeof realSetTimeout>;
+  }> = [];
   const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((fn, delay) => {
     if (delay === POLLING_TEST_WATCHDOG_INTERVAL_MS) {
       watchdog = fn as () => void;
+      watchdogs.push(watchdog);
       resolveWatchdog?.(watchdog);
+      for (let index = watchdogWaiters.length - 1; index >= 0; index -= 1) {
+        const waiter = watchdogWaiters[index];
+        if (watchdogs.length < waiter.count) {
+          continue;
+        }
+        realClearTimeout(waiter.timeout);
+        watchdogWaiters.splice(index, 1);
+        waiter.resolve(watchdogs[waiter.count - 1]);
+      }
     }
     return 1 as unknown as ReturnType<typeof setInterval>;
   });
@@ -228,6 +247,18 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
             reject(toLintErrorObject(error, "Non-Error rejection"));
           },
         );
+      });
+    },
+    async waitForWatchdogRegistration(count: number) {
+      const registered = watchdogs[count - 1];
+      if (registered) {
+        return registered;
+      }
+      return await new Promise<() => void>((resolve, reject) => {
+        const timeout = realSetTimeout(() => {
+          reject(new Error(`Timed out waiting for polling watchdog registration ${count}`));
+        }, 5_000);
+        watchdogWaiters.push({ count, resolve, reject, timeout });
       });
     },
     setNow(now: number) {
@@ -662,7 +693,29 @@ describe("TelegramPollingSession", () => {
       mockObjectArg(createTelegramBotMock, "createTelegramBot").minimumClientTimeoutSeconds,
     ).toBe(45);
     expect(computeBackoffMock).toHaveBeenCalledTimes(1);
+    expect(computeBackoffMock).toHaveBeenCalledWith(
+      {
+        initialMs: 30_000,
+        maxMs: 600_000,
+        factor: 2,
+        jitter: 0.2,
+      },
+      1,
+    );
     expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets restart backoff after a healthy polling cycle", () => {
+    const state = pollingSessionTesting.createTelegramRestartBackoffState();
+    pollingSessionTesting.resolveTelegramRestartDelayMs(state, { stopTimedOut: true });
+    pollingSessionTesting.resolveTelegramRestartDelayMs(state, { stopTimedOut: true });
+    pollingSessionTesting.resetTelegramRestartBackoffState(state);
+    pollingSessionTesting.resolveTelegramRestartDelayMs(state);
+
+    expect(computeBackoffMock.mock.calls.map((call) => call[1])).toEqual([1, 2, 1, 1]);
+    expect(
+      computeBackoffMock.mock.calls.map((call) => (call[0] as { initialMs: number }).initialMs),
+    ).toEqual([30_000, 30_000, 120_000, 30_000]);
   });
 
   it("does not call getUpdates for offset confirmation (avoiding 409 conflicts)", async () => {
@@ -961,6 +1014,63 @@ describe("TelegramPollingSession", () => {
     await runPromise;
   });
 
+  it("resets restart backoff after isolated ingress reports poll success", async () => {
+    const abort = new AbortController();
+    const init = vi.fn(async () => undefined);
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init,
+      handleUpdate: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+    sleepWithAbortMock.mockImplementation(async () => {
+      if (sleepWithAbortMock.mock.calls.length >= 2) {
+        abort.abort();
+      }
+    });
+
+    let cycle = 0;
+    const createWorker = vi.fn(() => {
+      let onMessage: WorkerPollSuccessListener | undefined;
+      cycle += 1;
+      return {
+        onMessage: vi.fn((handler) => {
+          onMessage = handler;
+          return () => undefined;
+        }),
+        stop: vi.fn(async () => undefined),
+        task: vi.fn(async () => {
+          if (cycle === 2) {
+            onMessage?.({
+              type: "poll-success",
+              offset: null,
+              finishedAt: Date.now(),
+              count: 0,
+            });
+          }
+        }),
+      };
+    });
+
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      isolatedIngress: {
+        enabled: true,
+        createWorker,
+        drainIntervalMs: 10,
+      },
+    });
+
+    await session.runUntilAbort();
+
+    expect(createWorker).toHaveBeenCalledTimes(2);
+    expect(computeBackoffMock.mock.calls.map((call) => call[1])).toEqual([1, 1]);
+  });
+
   it("restarts isolated ingress when worker liveness stalls", async () => {
     const abort = new AbortController();
     const log = vi.fn();
@@ -1026,6 +1136,97 @@ describe("TelegramPollingSession", () => {
 
       expectLogIncludes(log, "Polling stall detected");
       expectLogIncludes(log, "isolated polling ingress finished reason=polling stall detected");
+    } finally {
+      watchdogHarness.restore();
+      abort.abort();
+    }
+  });
+
+  it("applies stop-timeout cooldown to isolated ingress forced restarts", async () => {
+    const abort = new AbortController();
+    const log = vi.fn();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+    computeBackoffMock.mockImplementation((policy: { initialMs: number }, attempt: number) => {
+      if (policy.initialMs === 120_000) {
+        return attempt * 100_000;
+      }
+      return attempt * 1_000;
+    });
+
+    const finishStoppedWorkers: Array<() => void> = [];
+    let workerCycle = 0;
+    const createWorker = vi.fn(() => {
+      workerCycle += 1;
+      if (workerCycle <= 2) {
+        let finishTask: (() => void) | undefined;
+        const task = new Promise<void>((resolve) => {
+          finishTask = resolve;
+        });
+        let finishStop: (() => void) | undefined;
+        const stop = new Promise<void>((resolve) => {
+          finishStop = resolve;
+        });
+        finishStoppedWorkers.push(() => {
+          finishStop?.();
+          finishTask?.();
+        });
+        return {
+          onMessage: vi.fn(() => () => undefined),
+          stop: vi.fn(() => stop),
+          task: vi.fn(async () => {
+            await task;
+          }),
+        };
+      }
+      return {
+        onMessage: vi.fn(() => () => undefined),
+        stop: vi.fn(async () => undefined),
+        task: vi.fn(async () => {
+          abort.abort();
+        }),
+      };
+    });
+    const watchdogHarness = installPollingStallWatchdogHarness([0]);
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      stallThresholdMs: 30_000,
+      isolatedIngress: {
+        enabled: true,
+        createWorker,
+        drainIntervalMs: 500,
+      },
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      const firstWatchdog = await watchdogHarness.waitForWatchdog();
+      watchdogHarness.setNow(31_000);
+      firstWatchdog?.();
+      await vi.waitFor(() => expectLogIncludes(log, "Isolated polling ingress stop timed out"));
+      finishStoppedWorkers.shift()?.();
+      await vi.waitFor(() => expect(createWorker).toHaveBeenCalledTimes(2));
+
+      const secondWatchdog = await watchdogHarness.waitForWatchdogRegistration(2);
+      watchdogHarness.setNow(62_000);
+      secondWatchdog?.();
+      await vi.waitFor(() => expectLogIncludes(log, "Stop timeout burst=2; applying cooldown."));
+      finishStoppedWorkers.shift()?.();
+      await runPromise;
+
+      const stopCooldownCalls = computeBackoffMock.mock.calls.filter(
+        ([policy]) => (policy as { initialMs: number }).initialMs === 120_000,
+      );
+      expect(stopCooldownCalls.map((call) => call[1])).toEqual([1]);
     } finally {
       watchdogHarness.restore();
       abort.abort();
@@ -2762,6 +2963,7 @@ describe("TelegramPollingSession", () => {
   it("forces a restart when polling stalls without getUpdates activity", async () => {
     const abort = new AbortController();
     const botStop = vi.fn(async () => undefined);
+    const secondBotStop = vi.fn(async () => undefined);
     const firstRunnerStop = vi.fn(async () => undefined);
     const secondRunnerStop = vi.fn(async () => undefined);
     const bot = {
@@ -2772,7 +2974,10 @@ describe("TelegramPollingSession", () => {
       },
       stop: botStop,
     };
-    createTelegramBotMock.mockReturnValue(bot);
+    createTelegramBotMock.mockReturnValueOnce(bot).mockReturnValueOnce({
+      ...bot,
+      stop: secondBotStop,
+    });
 
     let firstTaskResolve: (() => void) | undefined;
     const firstTask = new Promise<void>((resolve) => {
@@ -2826,12 +3031,43 @@ describe("TelegramPollingSession", () => {
 
       expect(runMock).toHaveBeenCalledTimes(2);
       expect(firstRunnerStop).toHaveBeenCalledTimes(1);
-      expect(botStop).toHaveBeenCalled();
+      expect(botStop).toHaveBeenCalledTimes(1);
       expectLogIncludes(log, "Polling stall detected");
       expectLogIncludes(log, "polling stall detected");
     } finally {
       watchdogHarness.restore();
     }
+  });
+
+  it("cools down repeated stop-timeout restart bursts", () => {
+    computeBackoffMock.mockImplementation((policy: { initialMs: number }, attempt: number) => {
+      if (policy.initialMs === 120_000) {
+        return attempt * 100_000;
+      }
+      return attempt * 1_000;
+    });
+
+    const state = pollingSessionTesting.createTelegramRestartBackoffState();
+    expect(
+      pollingSessionTesting.resolveTelegramRestartDelayMs(state, { stopTimedOut: true }),
+    ).toEqual({ delayMs: 1_000, stopTimeoutSuffix: "" });
+    expect(
+      pollingSessionTesting.resolveTelegramRestartDelayMs(state, { stopTimedOut: true }),
+    ).toEqual({
+      delayMs: 100_000,
+      stopTimeoutSuffix: " Stop timeout burst=2; applying cooldown.",
+    });
+    expect(
+      pollingSessionTesting.resolveTelegramRestartDelayMs(state, { stopTimedOut: true }),
+    ).toEqual({
+      delayMs: 200_000,
+      stopTimeoutSuffix: " Stop timeout burst=3; applying cooldown.",
+    });
+
+    const stopCooldownCalls = computeBackoffMock.mock.calls.filter(
+      ([policy]) => (policy as { initialMs: number }).initialMs === 120_000,
+    );
+    expect(stopCooldownCalls.map((call) => call[1])).toEqual([1, 2]);
   });
 
   it("forces a restart when the runner task is pending but reports not running", async () => {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -217,11 +217,12 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
     return 1 as unknown as ReturnType<typeof setInterval>;
   });
   const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
-  const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((fn) => {
-    void Promise.resolve().then(() => (fn as () => void)());
-    return 1 as unknown as ReturnType<typeof setTimeout>;
+  const setTimeoutSpy = vi
+    .spyOn(globalThis, "setTimeout")
+    .mockImplementation((fn) => realSetTimeout(fn as () => void, 0));
+  const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation((timeoutId) => {
+    realClearTimeout(timeoutId);
   });
-  const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => {});
   const dateNowSpy = vi.spyOn(Date, "now");
   for (const value of dateNowSequence) {
     dateNowSpy.mockImplementationOnce(() => value);
@@ -1136,6 +1137,7 @@ describe("TelegramPollingSession", () => {
 
       expectLogIncludes(log, "Polling stall detected");
       expectLogIncludes(log, "isolated polling ingress finished reason=polling stall detected");
+      expectLogExcludes(log, "Isolated polling ingress stop timed out");
     } finally {
       watchdogHarness.restore();
       abort.abort();
@@ -3034,6 +3036,7 @@ describe("TelegramPollingSession", () => {
       expect(botStop).toHaveBeenCalledTimes(1);
       expectLogIncludes(log, "Polling stall detected");
       expectLogIncludes(log, "polling stall detected");
+      expectLogExcludes(log, "Polling runner stop timed out");
     } finally {
       watchdogHarness.restore();
     }

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -803,9 +803,7 @@ export class TelegramPollingSession {
     const stopWorker = () => {
       stopWorkerPromise ??= Promise.resolve(worker.stop())
         .then(() => undefined)
-        .catch(() => {
-          // Worker may already be stopped by restart/abort paths.
-        });
+        .catch(() => undefined);
       return stopWorkerPromise;
     };
     this.opts.log(`[telegram][diag] isolated polling ingress started spool=${spoolDir}`);
@@ -904,9 +902,26 @@ export class TelegramPollingSession {
     const stopBot = () => {
       return Promise.resolve(bot.stop())
         .then(() => undefined)
-        .catch(() => {
-          // Bot may already be stopped by shutdown paths.
-        });
+        .catch(() => undefined);
+    };
+    const requestStopForRestart = () => {
+      if (restartRequested) {
+        return;
+      }
+      restartRequested = true;
+      void stopWorker();
+      if (!forceCycleTimer) {
+        forceCycleTimer = setTimeout(() => {
+          if (this.opts.abortSignal?.aborted) {
+            return;
+          }
+          this.opts.log(
+            `[telegram] Isolated polling ingress stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
+          );
+          stopTimedOut = true;
+          forceCycleResolve?.();
+        }, POLL_STOP_GRACE_MS);
+      }
     };
     const drainOnce = async () => {
       if (restartRequested || drainActive || this.opts.abortSignal?.aborted) {
@@ -936,8 +951,7 @@ export class TelegramPollingSession {
         }
         const timedOutRecovery = await this.#recoverTimedOutSpooledHandler(drain.blockedByLane);
         if (timedOutRecovery?.restart) {
-          restartRequested = true;
-          void stopWorker();
+          requestStopForRestart();
         } else if (timedOutRecovery) {
           stalledBacklogKeys.add(timedOutRecovery.handlerKey);
         }
@@ -967,22 +981,9 @@ export class TelegramPollingSession {
       }
       this.#transportState.markDirty();
       stalledRestart = true;
-      restartRequested = true;
       this.opts.log(`[telegram] ${stall.message}`);
       this.#status.notePollingError(stall.message);
-      void stopWorker();
-      if (!forceCycleTimer) {
-        forceCycleTimer = setTimeout(() => {
-          if (this.opts.abortSignal?.aborted) {
-            return;
-          }
-          this.opts.log(
-            `[telegram] Isolated polling ingress stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
-          );
-          stopTimedOut = true;
-          forceCycleResolve?.();
-        }, POLL_STOP_GRACE_MS);
-      }
+      requestStopForRestart();
     }, POLL_WATCHDOG_INTERVAL_MS);
     watchdog.unref?.();
     try {
@@ -1095,18 +1096,14 @@ export class TelegramPollingSession {
       fetchAbortController?.abort();
       stopPromise ??= Promise.resolve(runner.stop())
         .then(() => undefined)
-        .catch(() => {
-          // Runner may already be stopped by abort/retry paths.
-        });
+        .catch(() => undefined);
       return stopPromise;
     };
     let stopBotPromise: Promise<void> | undefined;
     const stopBot = () => {
       stopBotPromise ??= Promise.resolve(bot.stop())
         .then(() => undefined)
-        .catch(() => {
-          // Bot may already be stopped by runner stop/abort paths.
-        });
+        .catch(() => undefined);
       return stopBotPromise;
     };
     const stopOnAbort = () => {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -904,6 +904,13 @@ export class TelegramPollingSession {
         .then(() => undefined)
         .catch(() => undefined);
     };
+    const clearForceCycleTimer = () => {
+      if (!forceCycleTimer) {
+        return;
+      }
+      clearTimeout(forceCycleTimer);
+      forceCycleTimer = undefined;
+    };
     const requestStopForRestart = () => {
       if (restartRequested) {
         return;
@@ -989,6 +996,7 @@ export class TelegramPollingSession {
     try {
       try {
         await Promise.race([worker.task(), forceCyclePromise]);
+        clearForceCycleTimer();
       } catch (err) {
         if (this.opts.abortSignal?.aborted) {
           return "exit";
@@ -1003,6 +1011,7 @@ export class TelegramPollingSession {
         const message = formatErrorMessage(err);
         this.opts.log(`[telegram][diag] isolated polling ingress failed: ${message}`);
         this.#status.notePollingError(message);
+        clearForceCycleTimer();
         const shouldRestart = await this.#waitBeforeRestart(
           (delay) => `Telegram isolated polling ingress failed; restarting in ${delay}.`,
         );
@@ -1034,9 +1043,7 @@ export class TelegramPollingSession {
     } finally {
       clearInterval(watchdog);
       clearInterval(drainTimer);
-      if (forceCycleTimer) {
-        clearTimeout(forceCycleTimer);
-      }
+      clearForceCycleTimer();
       unsubscribe();
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
       await stopWorker();
@@ -1092,6 +1099,13 @@ export class TelegramPollingSession {
     const forceCyclePromise = new Promise<void>((resolve) => {
       forceCycleResolve = resolve;
     });
+    const clearForceCycleTimer = () => {
+      if (!forceCycleTimer) {
+        return;
+      }
+      clearTimeout(forceCycleTimer);
+      forceCycleTimer = undefined;
+    };
     const stopRunner = () => {
       fetchAbortController?.abort();
       stopPromise ??= Promise.resolve(runner.stop())
@@ -1154,6 +1168,7 @@ export class TelegramPollingSession {
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
     try {
       await Promise.race([runner.task(), forceCyclePromise]);
+      clearForceCycleTimer();
       if (this.opts.abortSignal?.aborted) {
         return "exit";
       }
@@ -1200,15 +1215,14 @@ export class TelegramPollingSession {
       this.opts.log(
         `[telegram][diag] polling cycle error reason=${reason} ${liveness.formatDiagnosticFields("lastGetUpdatesError")} err=${errMsg}${conflictHint}`,
       );
+      clearForceCycleTimer();
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram ${reason}: ${errMsg};${conflictHint} retrying in ${delay}.`,
       );
       return shouldRestart ? "continue" : "exit";
     } finally {
       clearInterval(watchdog);
-      if (forceCycleTimer) {
-        clearTimeout(forceCycleTimer);
-      }
+      clearForceCycleTimer();
       this.opts.abortSignal?.removeEventListener("abort", abortFetch);
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
       await waitForGracefulStop(stopRunner);

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -50,11 +50,64 @@ import {
 } from "./telegram-reply-fence.js";
 
 const TELEGRAM_POLL_RESTART_POLICY = {
-  initialMs: 2000,
-  maxMs: 30_000,
-  factor: 1.8,
-  jitter: 0.25,
+  initialMs: 30_000,
+  maxMs: 600_000,
+  factor: 2,
+  jitter: 0.2,
 };
+
+const TELEGRAM_POLL_STOP_TIMEOUT_COOLDOWN_POLICY = {
+  initialMs: 120_000,
+  maxMs: 600_000,
+  factor: 2,
+  jitter: 0.2,
+};
+const TELEGRAM_POLL_STOP_TIMEOUT_BURST_LIMIT = 2;
+
+type TelegramRestartBackoffState = {
+  restartAttempts: number;
+  stopTimeoutBurst: number;
+  stopTimeoutCooldownAttempts: number;
+};
+
+function createTelegramRestartBackoffState(): TelegramRestartBackoffState {
+  return {
+    restartAttempts: 0,
+    stopTimeoutBurst: 0,
+    stopTimeoutCooldownAttempts: 0,
+  };
+}
+
+function resetTelegramRestartBackoffState(state: TelegramRestartBackoffState): void {
+  state.restartAttempts = 0;
+  state.stopTimeoutBurst = 0;
+  state.stopTimeoutCooldownAttempts = 0;
+}
+
+function resolveTelegramRestartDelayMs(
+  state: TelegramRestartBackoffState,
+  opts: { stopTimedOut?: boolean } = {},
+): { delayMs: number; stopTimeoutSuffix: string } {
+  state.restartAttempts += 1;
+  let delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, state.restartAttempts);
+  let stopTimeoutSuffix = "";
+  if (opts.stopTimedOut) {
+    state.stopTimeoutBurst += 1;
+    if (state.stopTimeoutBurst >= TELEGRAM_POLL_STOP_TIMEOUT_BURST_LIMIT) {
+      state.stopTimeoutCooldownAttempts += 1;
+      const cooldownMs = computeBackoff(
+        TELEGRAM_POLL_STOP_TIMEOUT_COOLDOWN_POLICY,
+        state.stopTimeoutCooldownAttempts,
+      );
+      delayMs = Math.max(delayMs, cooldownMs);
+      stopTimeoutSuffix = ` Stop timeout burst=${state.stopTimeoutBurst}; applying cooldown.`;
+    }
+  } else {
+    state.stopTimeoutBurst = 0;
+    state.stopTimeoutCooldownAttempts = 0;
+  }
+  return { delayMs, stopTimeoutSuffix };
+}
 
 const DEFAULT_POLL_STALL_THRESHOLD_MS = 120_000;
 const MIN_POLL_STALL_THRESHOLD_MS = 30_000;
@@ -239,7 +292,7 @@ function isSpooledUpdateHandlerKeyForSpool(handlerKey: string, spoolDir: string)
 }
 
 export class TelegramPollingSession {
-  #restartAttempts = 0;
+  #restartBackoffState = createTelegramRestartBackoffState();
   #webhookCleared = false;
   #forceRestarted = false;
   #activeRunner: ReturnType<typeof run> | undefined;
@@ -321,11 +374,20 @@ export class TelegramPollingSession {
     }
   }
 
-  async #waitBeforeRestart(buildLine: (delay: string) => string): Promise<boolean> {
-    this.#restartAttempts += 1;
-    const delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, this.#restartAttempts);
+  #noteHealthyPollingCycle() {
+    resetTelegramRestartBackoffState(this.#restartBackoffState);
+  }
+
+  async #waitBeforeRestart(
+    buildLine: (delay: string) => string,
+    opts: { stopTimedOut?: boolean } = {},
+  ): Promise<boolean> {
+    const { delayMs, stopTimeoutSuffix } = resolveTelegramRestartDelayMs(
+      this.#restartBackoffState,
+      opts,
+    );
     const delay = formatDurationPrecise(delayMs);
-    this.opts.log(buildLine(delay));
+    this.opts.log(`${buildLine(delay)}${stopTimeoutSuffix}`);
     try {
       await sleepWithAbort(delayMs, this.opts.abortSignal);
     } catch (sleepErr) {
@@ -761,6 +823,7 @@ export class TelegramPollingSession {
     let consecutiveDrainFailures = 0;
     let restartRequested = false;
     let stalledRestart = false;
+    let stopTimedOut = false;
     let forceCycleTimer: ReturnType<typeof setTimeout> | undefined;
     let forceCycleResolve: (() => void) | undefined;
     const forceCyclePromise = new Promise<void>((resolve) => {
@@ -796,6 +859,7 @@ export class TelegramPollingSession {
       if (message.type === "poll-success") {
         liveness.noteGetUpdatesSuccessCount(message.count, message.finishedAt);
         liveness.noteGetUpdatesFinished();
+        this.#noteHealthyPollingCycle();
         if (!restartRequested && stalledBacklogKeys.size === 0) {
           this.#status.notePollSuccess(message.finishedAt);
         }
@@ -915,6 +979,7 @@ export class TelegramPollingSession {
           this.opts.log(
             `[telegram] Isolated polling ingress stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
           );
+          stopTimedOut = true;
           forceCycleResolve?.();
         }, POLL_STOP_GRACE_MS);
       }
@@ -951,7 +1016,11 @@ export class TelegramPollingSession {
             `[telegram][diag] isolated polling ingress finished reason=polling stall detected ${liveness.formatDiagnosticFields("error")}`,
           );
         }
-        return "continue";
+        const shouldRestart = await this.#waitBeforeRestart(
+          (delay) => `Telegram isolated polling ingress restart requested; restarting in ${delay}.`,
+          { stopTimedOut },
+        );
+        return shouldRestart ? "continue" : "exit";
       }
       const errorText = pollState.error ? ` error=${pollState.error}` : "";
       this.opts.log(
@@ -981,6 +1050,7 @@ export class TelegramPollingSession {
   async #runPollingCycle(bot: TelegramBot): Promise<"continue" | "exit"> {
     const liveness = new TelegramPollingLivenessTracker({
       onPollSuccess: (finishedAt) => {
+        this.#noteHealthyPollingCycle();
         this.#status.notePollSuccess(finishedAt);
         this.#drainPendingDeliveriesAfterReconnect();
       },
@@ -1030,12 +1100,14 @@ export class TelegramPollingSession {
         });
       return stopPromise;
     };
+    let stopBotPromise: Promise<void> | undefined;
     const stopBot = () => {
-      return Promise.resolve(bot.stop())
+      stopBotPromise ??= Promise.resolve(bot.stop())
         .then(() => undefined)
         .catch(() => {
           // Bot may already be stopped by runner stop/abort paths.
         });
+      return stopBotPromise;
     };
     const stopOnAbort = () => {
       if (this.opts.abortSignal?.aborted) {
@@ -1043,8 +1115,31 @@ export class TelegramPollingSession {
       }
     };
 
+    let restartRequested = false;
+    let stopTimedOut = false;
+    const requestStopForRestart = () => {
+      if (restartRequested) {
+        return;
+      }
+      restartRequested = true;
+      void stopRunner();
+      void stopBot();
+      if (!forceCycleTimer) {
+        forceCycleTimer = setTimeout(() => {
+          if (this.opts.abortSignal?.aborted) {
+            return;
+          }
+          this.opts.log(
+            `[telegram] Polling runner stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
+          );
+          stopTimedOut = true;
+          forceCycleResolve?.();
+        }, POLL_STOP_GRACE_MS);
+      }
+    };
+
     const watchdog = setInterval(() => {
-      if (this.opts.abortSignal?.aborted) {
+      if (this.opts.abortSignal?.aborted || restartRequested) {
         return;
       }
 
@@ -1055,19 +1150,7 @@ export class TelegramPollingSession {
         this.#transportState.markDirty();
         stalledRestart = true;
         this.opts.log(`[telegram] ${stall.message}`);
-        void stopRunner();
-        void stopBot();
-        if (!forceCycleTimer) {
-          forceCycleTimer = setTimeout(() => {
-            if (this.opts.abortSignal?.aborted) {
-              return;
-            }
-            this.opts.log(
-              `[telegram] Polling runner stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
-            );
-            forceCycleResolve?.();
-          }, POLL_STOP_GRACE_MS);
-        }
+        requestStopForRestart();
       }
     }, POLL_WATCHDOG_INTERVAL_MS);
 
@@ -1088,6 +1171,7 @@ export class TelegramPollingSession {
       );
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
+        { stopTimedOut },
       );
       return shouldRestart ? "continue" : "exit";
     } catch (err) {
@@ -1166,6 +1250,9 @@ export const testing = {
   resetActiveSpooledUpdateHandlersForTests: (): void => {
     activeSpooledUpdateHandlersByLane.clear();
   },
+  createTelegramRestartBackoffState,
+  resetTelegramRestartBackoffState,
+  resolveTelegramRestartDelayMs,
   resolveSpooledUpdateHandlerAbortGraceMs: (valueMs: unknown): number =>
     resolvePositiveTimerTimeoutMs(valueMs, TELEGRAM_SPOOLED_HANDLER_ABORT_GRACE_MS),
 };


### PR DESCRIPTION
## Summary
- Increase Telegram polling restart backoff from the tight 2s/30s policy to a bounded 30s/10m exponential policy.
- Deduplicate runner/bot stop calls per polling restart cycle so watchdog restarts do not stack repeated stop requests.
- Add stop-timeout burst cooldown and reset restart state after healthy normal and isolated-ingress polling cycles, including isolated forced-restart stop timeouts.

## Real behavior proof
- **Behavior addressed:** Consecutive Telegram polling stop timeouts no longer restart on the same short 30s ceiling. The second stop-timeout burst applies a separate cooldown, while a healthy normal or isolated polling cycle resets restart attempts back to the first-delay path.
- **Real environment tested:** Isolated PR-head worktree `/private/tmp/openclaw-pr88832-proof` at `0579b14240079e4c791646a5b09e4bf39f8bff15`, running the actual `TelegramPollingSession` isolated-ingress restart loop, actual wall-clock timers, actual restart/backoff helper, and a real grammY `Bot` instance pointed at a refused local Telegram API endpoint (`127.0.0.1:9`) with a redacted dummy token. The ingress worker was production-like but local: it emitted a real `poll-start`, held the in-flight getUpdates open, and resolved `stop()` only after the 15s stop grace so the session exercised the forced stop-timeout path without using production credentials.
- **Exact steps or command run after this patch:** Ran the stop-timeout/network-flap proof below through `node --import tsx proof-telegram-stop-timeout.mjs`, ran the helper proof below through `node --import tsx`, then ran focused Vitest cases against `extensions/telegram/src/polling-session.test.ts` that exercise normal restart backoff, isolated `poll-success` reset, and two consecutive isolated forced stop-timeout restarts reaching the cooldown policy.
- **Evidence after fix:** Helper output from the local OpenClaw checkout:

```text
firstStopTimeoutDelayMs=33000
firstStopTimeoutSuffix=""
secondStopTimeoutDelayMs=132000
secondStopTimeoutSuffix=" Stop timeout burst=2; applying cooldown."
afterHealthyDelayMs=33000
afterHealthySuffix=""
```

- **Production-like stop-timeout/network-flap proof from PR head:**

```text
$ node --import tsx proof-telegram-stop-timeout.mjs

+30.1s [telegram] Polling stall detected (active getUpdates stuck for 60.98s); forcing restart. [diag inFlight=1 outcome=started startedAt=<redacted> finishedAt=n/a durationMs=n/a offset=n/a]
+45.1s [telegram] Isolated polling ingress stop timed out after 15s; forcing restart cycle.
+45.1s Telegram isolated polling ingress restart requested; restarting in 33.53s.
+108.7s [telegram] Polling stall detected (active getUpdates stuck for 60.98s); forcing restart. [diag inFlight=1 outcome=started startedAt=<redacted> finishedAt=n/a durationMs=n/a offset=n/a]
+123.7s [telegram] Isolated polling ingress stop timed out after 15s; forcing restart cycle.
+123.7s Telegram isolated polling ingress restart requested; restarting in 124.2s. Stop timeout burst=2; applying cooldown.
PROOF_SUMMARY_START
head=0579b14240079e4c791646a5b09e4bf39f8bff15
workerCycles=2
containsStopTimeoutCooldown=true
elapsedMs=124702
PROOF_SUMMARY_END
```

- **Production-like isolated polling focused test proof:**

```text
$ node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/polling-session.test.ts -t "drains Telegram delivery queue after isolated ingress reports poll success|resets restart backoff after isolated ingress reports poll success|applies stop-timeout cooldown to isolated ingress forced restarts|uses backoff helpers|resets restart backoff|cools down repeated|forces a restart when polling stalls without getUpdates activity|forces a restart when the runner task is pending" --reporter=dot --testTimeout=30000 --hookTimeout=30000

 RUN  v4.1.7 /private/tmp/openclaw-pr88832-proof

··----··-·-------------------------···---------------

 Test Files  1 passed (1)
      Tests  8 passed | 45 skipped (53)
   Start at  18:42:52
   Duration  6.63s (transform 5.09s, setup 193ms, import 166ms, tests 6.19s, environment 0ms)
```

- **Observed result after fix:** The first stop timeout uses the normal 30s-class restart policy, the second consecutive stop timeout is raised by the stop-timeout cooldown path, the normal healthy cycle resets to the first-attempt delay, isolated-ingress `poll-success` resets the real session backoff state, and isolated forced stop-timeout restarts now wait through the same cooldown/backoff path instead of immediately continuing.
- **What was not tested:** No production Telegram bot token was used and no message was sent. The production-like proof intentionally used a local refused Telegram API endpoint and a redacted dummy token to avoid credential exposure or disturbing the running gateway. The full local `polling-session.test.ts` file also hits an existing `upstream/main` hang in `keeps active spooled lanes blocked across isolated ingress restarts`; this was reproduced in a detached `upstream/main` worktree, so verification used focused polling-session cases plus `monitor.test`.

## Verification
- `node --import tsx proof-telegram-stop-timeout.mjs`
- `node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/polling-session.test.ts -t "drains Telegram delivery queue after isolated ingress reports poll success|resets restart backoff after isolated ingress reports poll success|applies stop-timeout cooldown to isolated ingress forced restarts|uses backoff helpers|resets restart backoff|cools down repeated|forces a restart when polling stalls without getUpdates activity|forces a restart when the runner task is pending" --reporter=dot --testTimeout=30000 --hookTimeout=30000`
- `node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/polling-session.test.ts -t "applies stop-timeout cooldown to isolated ingress forced restarts|restarts isolated ingress when worker liveness stalls|resets restart backoff after isolated ingress reports poll success|cools down repeated" --reporter=dot --testTimeout=30000 --hookTimeout=30000`
- `node scripts/run-vitest.mjs extensions/telegram/src/monitor.test.ts`
- `pnpm tsgo:extensions:test`
- `pnpm lint --threads=8`
- `pnpm run lint:extensions:bundled`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/polling-session.ts extensions/telegram/src/polling-session.test.ts`
- `git diff --check`
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD`

Refs #88256
