### PR TITLE
refactor: add session accessor seam

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-9ce72d763de6c95566e0167f99f5454b07c7c67940675533cb24c07058619a63  plugin-sdk-api-baseline.json
-e4dfccb85b985fe865145e24978255b729cdcbca0e26650a363a11bfcfc2e27b  plugin-sdk-api-baseline.jsonl
+1fc413736b1320d11981317535e791cd40cb7b5ac14d6beef50cc032b4e28afb  plugin-sdk-api-baseline.json
+7a375996b95a8fd4fb4eade436497ea7153faf7061f65a4e4b16b54ed6690561  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1fc413736b1320d11981317535e791cd40cb7b5ac14d6beef50cc032b4e28afb  plugin-sdk-api-baseline.json
-7a375996b95a8fd4fb4eade436497ea7153faf7061f65a4e4b16b54ed6690561  plugin-sdk-api-baseline.jsonl
+3783a464b7d054abbe393a6fc826cabcdf5468de8db2a1407e3d76f7badf059d  plugin-sdk-api-baseline.json
+26dcaaf21d56ab9d5ad801cd5133e617d6e6c3f6bb34fa13918eef66efd07609  plugin-sdk-api-baseline.jsonl

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -208,6 +208,34 @@ describe("session accessor file-backed seam", () => {
     expect(loadSessionEntry(scope)?.model).toBeUndefined();
   });
 
+  it("can patch metadata without refreshing session activity", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const beforePatch = loadSessionEntry(scope);
+
+    await patchSessionEntry(
+      scope,
+      () => ({
+        model: "gpt-5.5",
+        updatedAt: 20,
+      }),
+      { preserveActivity: true },
+    );
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: beforePatch?.updatedAt,
+    });
+  });
+
   it("loads and appends transcript events through a session scope", async () => {
     const scope = {
       sessionFile: transcriptPath,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -13,6 +13,7 @@ import {
   upsertSessionEntry,
 } from "./session-accessor.js";
 import { loadSessionStore } from "./store.js";
+import type { SessionEntry } from "./types.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -159,13 +160,18 @@ describe("session accessor file-backed seam", () => {
       sessionKey: "agent:main:main",
       storePath,
     };
+    let missingContextEntry: SessionEntry | undefined;
+    let existingContextEntry: SessionEntry | undefined;
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: "gpt-5.5",
-      }),
+      (entry, context) => {
+        missingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: "gpt-5.5",
+        };
+      },
       {
         fallbackEntry: {
           sessionId: "session-1",
@@ -177,14 +183,19 @@ describe("session accessor file-backed seam", () => {
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: undefined,
-        providerOverride: "openai",
-      }),
+      (entry, context) => {
+        existingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: undefined,
+          providerOverride: "openai",
+        };
+      },
       { replaceEntry: true },
     );
 
+    expect(missingContextEntry).toBeUndefined();
+    expect(existingContextEntry).toMatchObject({ model: "gpt-5.5" });
     expect(loadSessionEntry(scope)).toMatchObject({
       providerOverride: "openai",
       sessionId: "session-1",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -124,6 +125,32 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+  });
+
+  it("replaces entries so deleted fields stay removed", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      providerOverride: "openai",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    await replaceSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 20,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
+    expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
 
@@ -75,6 +76,34 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("updates existing entries without creating missing sessions", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await expect(updateSessionEntry(scope, () => ({ model: "gpt-5.5" }))).resolves.toBeNull();
+    expect(listSessionEntries({ storePath })).toEqual([]);
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const beforeNullUpdate = loadSessionEntry(scope);
+    await expect(updateSessionEntry(scope, () => null)).resolves.toEqual(beforeNullUpdate);
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: beforeNullUpdate?.updatedAt,
+    });
+    await expect(
+      updateSessionEntry(scope, () => ({ model: "gpt-5.5", updatedAt: 20 })),
+    ).resolves.toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendTranscriptEvent,
+  listSessionEntries,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntry,
+} from "./session-accessor.js";
+
+describe("session accessor file-backed seam", () => {
+  let tempDir: string;
+  let storePath: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-accessor-"));
+    storePath = path.join(tempDir, "sessions.json");
+    transcriptPath = path.join(tempDir, "session.jsonl");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("loads, lists, and patches session entries without exposing the file store shape", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(listSessionEntries({ storePath })).toEqual([
+      {
+        sessionKey: "agent:main:main",
+        entry: expect.objectContaining({
+          model: "gpt-5.5",
+          sessionId: "session-1",
+          updatedAt: expect.any(Number),
+        }),
+      },
+    ]);
+
+    await upsertSessionEntry(scope, { model: "sonnet-4.6", updatedAt: 20 });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "sonnet-4.6",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+  });
+
+  it("creates durable session ids for metadata-only inserts", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    const inserted = await upsertSessionEntry(scope, { model: "gpt-5.5" });
+
+    expect(inserted?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(inserted?.sessionId).not.toBe(scope.sessionKey);
+    expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("loads and appends transcript events through a session scope", async () => {
+    const scope = {
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
+    await appendTranscriptEvent(scope, event);
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      { type: "session", sessionId: "session-1" },
+      event,
+    ]);
+    expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("honors thread fallback paths when resolving transcript scope from the store", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:demo-channel:1234:thread:456",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(scope, event);
+
+    const expectedTranscriptPath = path.join(tempDir, "session-1-topic-456.jsonl");
+    expect(fs.existsSync(expectedTranscriptPath)).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "session-1.jsonl"))).toBe(false);
+    expect(fs.realpathSync(loadSessionEntry(scope)?.sessionFile ?? "")).toBe(
+      fs.realpathSync(expectedTranscriptPath),
+    );
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("persists transcript metadata under the normalized session key", async () => {
+    const canonicalScope = {
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(canonicalScope, {
+      sessionId: canonicalScope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(
+      {
+        agentId: "main",
+        sessionId: canonicalScope.sessionId,
+        sessionKey: "AGENT:MAIN:MAIN",
+        storePath,
+      },
+      { id: "msg-1", type: "message" },
+    );
+
+    expect(listSessionEntries({ storePath }).map((entry) => entry.sessionKey)).toEqual([
+      canonicalScope.sessionKey,
+    ]);
+    expect(loadSessionEntry(canonicalScope)?.sessionFile).toBeTruthy();
+  });
+});

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -10,6 +10,7 @@ import {
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
+import { loadSessionStore } from "./store.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -76,6 +77,25 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("can borrow cached entry objects for read-only hot paths", async () => {
+    const scope = {
+      clone: false,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const cachedStore = loadSessionStore(storePath, { clone: false });
+
+    expect(loadSessionEntry(scope)).toBe(cachedStore["agent:main:main"]);
+    expect(listSessionEntries({ clone: false, storePath })[0]?.entry).toBe(
+      cachedStore["agent:main:main"],
+    );
   });
 
   it("updates existing entries without creating missing sessions", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -6,6 +6,7 @@ import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
   appendTranscriptMessage,
   appendTranscriptEvent,
+  cleanupSessionLifecycleArtifacts,
   listSessionEntries,
   loadExactSessionEntry,
   loadSessionEntry,
@@ -264,6 +265,83 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: beforePatch?.updatedAt,
     });
+  });
+
+  it("cleans scoped lifecycle entries and unreferenced transcript artifacts", async () => {
+    const nowMs = Date.now();
+    const oldDate = new Date(nowMs - 600_000);
+    const removedTranscriptPath = path.join(tempDir, "removed-lifecycle.jsonl");
+    const customTranscriptPath = path.join(tempDir, "custom-lifecycle-old.jsonl");
+    const freshDefaultTranscriptPath = path.join(tempDir, "custom-lifecycle.jsonl");
+    const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
+    const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
+    const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
+
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:lifecycle-cleanup-removed": {
+          sessionId: "removed-lifecycle",
+        },
+        "agent:main:lifecycle-cleanup-fresh": {
+          sessionId: "fresh-lifecycle",
+        },
+        "agent:main:lifecycle-cleanup-custom": {
+          sessionFile: "custom-lifecycle-old.jsonl",
+          sessionId: "custom-lifecycle",
+        },
+        "agent:main:telegram:group:lifecycle-cleanup-room": {
+          sessionId: "kept-by-segment",
+        },
+        "agent:main:regular": {
+          sessionId: "referenced",
+        },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(removedTranscriptPath, '{"runId":"lifecycle-marker-removed"}\n', "utf-8");
+    fs.writeFileSync(customTranscriptPath, '{"runId":"lifecycle-marker-custom"}\n', "utf-8");
+    fs.writeFileSync(freshDefaultTranscriptPath, '{"runId":"lifecycle-marker-default"}\n', "utf-8");
+    fs.writeFileSync(freshTranscriptPath, '{"runId":"lifecycle-marker-fresh"}\n', "utf-8");
+    fs.writeFileSync(
+      referencedTranscriptPath,
+      '{"runId":"lifecycle-marker-referenced"}\n',
+      "utf-8",
+    );
+    fs.writeFileSync(orphanTranscriptPath, '{"runId":"lifecycle-marker-orphan"}\n', "utf-8");
+    fs.utimesSync(removedTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(customTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(referencedTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
+
+    const result = await cleanupSessionLifecycleArtifacts({
+      storePath,
+      sessionKeySegmentPrefix: "lifecycle-cleanup-",
+      transcriptContentMarker: "lifecycle-marker-",
+      orphanTranscriptMinAgeMs: 300_000,
+      nowMs,
+    });
+
+    expect(result).toEqual({ removedEntries: 2, archivedTranscriptArtifacts: 3 });
+    const loaded = loadSessionStore(storePath, { skipCache: true });
+    expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
+    expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-custom");
+    expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
+    expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
+    expect(loaded).toHaveProperty("agent:main:regular");
+    const files = fs.readdirSync(tempDir);
+    expect(
+      files.filter((file) => file.startsWith("removed-lifecycle.jsonl.deleted.")),
+    ).toHaveLength(1);
+    expect(files.filter((file) => file.startsWith("orphan-lifecycle.jsonl.deleted."))).toHaveLength(
+      1,
+    );
+    expect(
+      files.filter((file) => file.startsWith("custom-lifecycle-old.jsonl.deleted.")),
+    ).toHaveLength(1);
+    expect(files).toContain("custom-lifecycle.jsonl");
+    expect(files).toContain("fresh-lifecycle.jsonl");
+    expect(files).toContain("referenced.jsonl");
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -2,12 +2,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
+  appendTranscriptMessage,
   appendTranscriptEvent,
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
+  publishTranscriptUpdate,
+  readSessionUpdatedAt,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -47,6 +51,7 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+    expect(readSessionUpdatedAt(scope)).toEqual(expect.any(Number));
     expect(listSessionEntries({ storePath })).toEqual([
       {
         sessionKey: "agent:main:main",
@@ -225,6 +230,75 @@ describe("session accessor file-backed seam", () => {
       event,
     ]);
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("appends messages and publishes updates through a session scope", async () => {
+    const scope = {
+      agentId: "main",
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const updates: unknown[] = [];
+    const unsubscribe = onSessionTranscriptUpdate((update) => {
+      updates.push(update);
+    });
+
+    const appended = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    const replayed = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello again",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    await publishTranscriptUpdate(scope, {
+      agentId: "main",
+      message: appended.message,
+      messageId: appended.messageId,
+      sessionKey: scope.sessionKey,
+    });
+    unsubscribe();
+
+    expect(replayed).toMatchObject({
+      appended: false,
+      messageId: appended.messageId,
+      message: expect.objectContaining({
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      }),
+    });
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      expect.objectContaining({ type: "session" }),
+      expect.objectContaining({
+        id: appended.messageId,
+        message: expect.objectContaining({
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        }),
+        type: "message",
+      }),
+    ]);
+    expect(updates).toEqual([
+      {
+        agentId: "main",
+        message: appended.message,
+        messageId: appended.messageId,
+        sessionFile: transcriptPath,
+        sessionKey: scope.sessionKey,
+      },
+    ]);
   });
 
   it("honors thread fallback paths when resolving transcript scope from the store", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -270,18 +270,21 @@ describe("session accessor file-backed seam", () => {
   it("cleans scoped lifecycle entries and unreferenced transcript artifacts", async () => {
     const nowMs = Date.now();
     const oldDate = new Date(nowMs - 600_000);
-    const removedTranscriptPath = path.join(tempDir, "removed-lifecycle.jsonl");
-    const customTranscriptPath = path.join(tempDir, "custom-lifecycle-old.jsonl");
-    const freshDefaultTranscriptPath = path.join(tempDir, "custom-lifecycle.jsonl");
-    const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
-    const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
-    const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
-    const siblingDir = `${tempDir}-sibling-sessions`;
+    const lifecycleSessionsDir = path.join(tempDir, "state", "agents", "main", "sessions");
+    const lifecycleStorePath = path.join(lifecycleSessionsDir, "sessions.json");
+    const removedTranscriptPath = path.join(lifecycleSessionsDir, "removed-lifecycle.jsonl");
+    const customTranscriptPath = path.join(lifecycleSessionsDir, "custom-lifecycle-old.jsonl");
+    const freshDefaultTranscriptPath = path.join(lifecycleSessionsDir, "custom-lifecycle.jsonl");
+    const freshTranscriptPath = path.join(lifecycleSessionsDir, "fresh-lifecycle.jsonl");
+    const referencedTranscriptPath = path.join(lifecycleSessionsDir, "referenced.jsonl");
+    const orphanTranscriptPath = path.join(lifecycleSessionsDir, "orphan-lifecycle.jsonl");
+    const siblingDir = path.join(tempDir, "state", "agents", "sibling", "sessions");
     const siblingTranscriptPath = path.join(siblingDir, "sibling-lifecycle.jsonl");
+    fs.mkdirSync(lifecycleSessionsDir, { recursive: true });
     fs.mkdirSync(siblingDir, { recursive: true });
 
     fs.writeFileSync(
-      storePath,
+      lifecycleStorePath,
       JSON.stringify({
         "agent:main:lifecycle-cleanup-removed": {
           sessionId: "removed-lifecycle",
@@ -324,7 +327,7 @@ describe("session accessor file-backed seam", () => {
     fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
 
     const result = await cleanupSessionLifecycleArtifacts({
-      storePath,
+      storePath: lifecycleStorePath,
       sessionKeySegmentPrefix: "lifecycle-cleanup-",
       transcriptContentMarker: "lifecycle-marker-",
       orphanTranscriptMinAgeMs: 300_000,
@@ -332,14 +335,14 @@ describe("session accessor file-backed seam", () => {
     });
 
     expect(result).toEqual({ removedEntries: 3, archivedTranscriptArtifacts: 3 });
-    const loaded = loadSessionStore(storePath, { skipCache: true });
+    const loaded = loadSessionStore(lifecycleStorePath, { skipCache: true });
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-custom");
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-sibling");
     expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
     expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
     expect(loaded).toHaveProperty("agent:main:regular");
-    const files = fs.readdirSync(tempDir);
+    const files = fs.readdirSync(lifecycleSessionsDir);
     expect(
       files.filter((file) => file.startsWith("removed-lifecycle.jsonl.deleted.")),
     ).toHaveLength(1);

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   appendTranscriptMessage,
   appendTranscriptEvent,
   listSessionEntries,
+  loadExactSessionEntry,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
@@ -104,6 +105,35 @@ describe("session accessor file-backed seam", () => {
     expect(listSessionEntries({ clone: false, storePath })[0]?.entry).toBe(
       cachedStore["agent:main:main"],
     );
+  });
+
+  it("keeps exact persisted-key lookup separate from canonical entry reads", async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "session-1",
+          updatedAt: 10,
+          model: "gpt-5.5",
+        },
+      }),
+      "utf8",
+    );
+
+    const mixedCaseScope = {
+      sessionKey: "AGENT:MAIN:MAIN",
+      storePath,
+    };
+
+    expect(loadSessionEntry(mixedCaseScope)?.sessionId).toBe("session-1");
+    expect(loadExactSessionEntry(mixedCaseScope)).toBeUndefined();
+    expect(loadExactSessionEntry({ sessionKey: "agent:main:main", storePath })).toEqual({
+      sessionKey: "agent:main:main",
+      entry: expect.objectContaining({
+        sessionId: "session-1",
+        model: "gpt-5.5",
+      }),
+    });
   });
 
   it("updates existing entries without creating missing sessions", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -232,6 +232,48 @@ describe("session accessor file-backed seam", () => {
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
   });
 
+  it("loads transcript events without a session key when the read target is explicit", async () => {
+    const scope = {
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await appendTranscriptEvent(
+      {
+        ...scope,
+        sessionKey: "agent:main:main",
+        storePath,
+      },
+      event,
+    );
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("loads transcript events from a generated read target without a session key", async () => {
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    fs.writeFileSync(path.join(tempDir, "session-1.jsonl"), `${JSON.stringify(event)}\n`, "utf-8");
+
+    await expect(
+      loadTranscriptEvents({
+        sessionId: "session-1",
+        storePath,
+      }),
+    ).resolves.toEqual([event]);
+  });
+
   it("appends messages and publishes updates through a session scope", async () => {
     const scope = {
       agentId: "main",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  patchSessionEntry,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -151,6 +152,44 @@ describe("session accessor file-backed seam", () => {
     });
     expect(loadSessionEntry(scope)?.model).toBeUndefined();
     expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
+  });
+
+  it("patches entries atomically with a fallback entry", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: "gpt-5.5",
+      }),
+      {
+        fallbackEntry: {
+          sessionId: "session-1",
+          updatedAt: 10,
+        },
+        replaceEntry: true,
+      },
+    );
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: undefined,
+        providerOverride: "openai",
+      }),
+      { replaceEntry: true },
+    );
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      providerOverride: "openai",
+      sessionId: "session-1",
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -276,6 +276,9 @@ describe("session accessor file-backed seam", () => {
     const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
     const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
     const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
+    const siblingDir = `${tempDir}-sibling-sessions`;
+    const siblingTranscriptPath = path.join(siblingDir, "sibling-lifecycle.jsonl");
+    fs.mkdirSync(siblingDir, { recursive: true });
 
     fs.writeFileSync(
       storePath,
@@ -290,6 +293,10 @@ describe("session accessor file-backed seam", () => {
           sessionFile: "custom-lifecycle-old.jsonl",
           sessionId: "custom-lifecycle",
         },
+        "agent:main:lifecycle-cleanup-sibling": {
+          sessionFile: siblingTranscriptPath,
+          sessionId: "sibling-lifecycle",
+        },
         "agent:main:telegram:group:lifecycle-cleanup-room": {
           sessionId: "kept-by-segment",
         },
@@ -303,6 +310,7 @@ describe("session accessor file-backed seam", () => {
     fs.writeFileSync(customTranscriptPath, '{"runId":"lifecycle-marker-custom"}\n', "utf-8");
     fs.writeFileSync(freshDefaultTranscriptPath, '{"runId":"lifecycle-marker-default"}\n', "utf-8");
     fs.writeFileSync(freshTranscriptPath, '{"runId":"lifecycle-marker-fresh"}\n', "utf-8");
+    fs.writeFileSync(siblingTranscriptPath, '{"runId":"lifecycle-marker-sibling"}\n', "utf-8");
     fs.writeFileSync(
       referencedTranscriptPath,
       '{"runId":"lifecycle-marker-referenced"}\n',
@@ -311,6 +319,7 @@ describe("session accessor file-backed seam", () => {
     fs.writeFileSync(orphanTranscriptPath, '{"runId":"lifecycle-marker-orphan"}\n', "utf-8");
     fs.utimesSync(removedTranscriptPath, oldDate, oldDate);
     fs.utimesSync(customTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(siblingTranscriptPath, oldDate, oldDate);
     fs.utimesSync(referencedTranscriptPath, oldDate, oldDate);
     fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
 
@@ -322,10 +331,11 @@ describe("session accessor file-backed seam", () => {
       nowMs,
     });
 
-    expect(result).toEqual({ removedEntries: 2, archivedTranscriptArtifacts: 3 });
+    expect(result).toEqual({ removedEntries: 3, archivedTranscriptArtifacts: 3 });
     const loaded = loadSessionStore(storePath, { skipCache: true });
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-custom");
+    expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-sibling");
     expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
     expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
     expect(loaded).toHaveProperty("agent:main:regular");
@@ -342,6 +352,8 @@ describe("session accessor file-backed seam", () => {
     expect(files).toContain("custom-lifecycle.jsonl");
     expect(files).toContain("fresh-lifecycle.jsonl");
     expect(files).toContain("referenced.jsonl");
+    expect(fs.existsSync(siblingTranscriptPath)).toBe(true);
+    expect(fs.readdirSync(siblingDir)).toEqual(["sibling-lifecycle.jsonl"]);
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { resolveAndPersistSessionFile } from "./session-file.js";
+import {
+  getSessionEntry,
+  listSessionEntries as listFileSessionEntries,
+  loadSessionStore,
+  patchSessionEntry as patchFileSessionEntry,
+  resolveSessionStoreEntry,
+} from "./store.js";
+import { parseSessionThreadInfo } from "./thread-info.js";
+import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import { streamSessionTranscriptLines } from "./transcript-stream.js";
+import { resolveSessionTranscriptFile } from "./transcript.js";
+import type { SessionEntry } from "./types.js";
+
+export type SessionAccessScope = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  hydrateSkillPromptRefs?: boolean;
+  sessionKey: string;
+  storePath?: string;
+};
+
+export type SessionTranscriptAccessScope = SessionAccessScope & {
+  sessionFile?: string;
+  sessionId: string;
+  threadId?: string | number;
+};
+
+export type SessionEntrySummary = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+export type TranscriptEvent = unknown;
+
+/** Loads one session entry through the storage-neutral accessor seam. */
+export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  return getSessionEntry(scope);
+}
+
+/** Lists session entries through the storage-neutral accessor seam. */
+export function listSessionEntries(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+): SessionEntrySummary[] {
+  return listFileSessionEntries(scope);
+}
+
+/** Applies a partial entry update through the storage-neutral accessor seam. */
+export async function upsertSessionEntry(
+  scope: SessionAccessScope,
+  patch: Partial<SessionEntry>,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: createFallbackSessionEntry(patch),
+    update: () => patch,
+  });
+}
+
+/** Loads raw transcript events through the storage-neutral accessor seam. */
+export async function loadTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+): Promise<TranscriptEvent[]> {
+  const transcript = await resolveTranscriptAccess(scope);
+  const events: TranscriptEvent[] = [];
+  for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
+    events.push(JSON.parse(line) as TranscriptEvent);
+  }
+  return events;
+}
+
+/** Appends one raw transcript event through the storage-neutral accessor seam. */
+export async function appendTranscriptEvent(
+  scope: SessionTranscriptAccessScope,
+  event: TranscriptEvent,
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  await appendSessionTranscriptEvent({
+    event,
+    transcriptPath: transcript.sessionFile,
+  });
+}
+
+function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
+  const now = Date.now();
+  return {
+    sessionId: patch.sessionId ?? randomUUID(),
+    updatedAt: patch.updatedAt ?? now,
+    ...patch,
+  };
+}
+
+async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+  sessionFile: string;
+}> {
+  if (scope.sessionFile?.trim()) {
+    return { sessionFile: scope.sessionFile };
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const sessionStore = scope.storePath
+    ? loadSessionStore(scope.storePath, { skipCache: true })
+    : undefined;
+  const resolvedStoreEntry = sessionStore
+    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
+    : undefined;
+  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
+  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
+  if (sessionStore && scope.storePath) {
+    const sessionsDir = path.dirname(path.resolve(scope.storePath));
+    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
+    const fallbackSessionFile =
+      !sessionEntry?.sessionFile && threadId !== undefined
+        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
+        : undefined;
+    return await resolveAndPersistSessionFile({
+      agentId,
+      fallbackSessionFile,
+      sessionEntry,
+      sessionId: scope.sessionId,
+      sessionKey,
+      sessionStore,
+      sessionsDir,
+      storePath: scope.storePath,
+    });
+  }
+  return await resolveSessionTranscriptFile({
+    agentId,
+    sessionEntry,
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    ...(sessionStore ? { sessionStore } : {}),
+    ...(scope.storePath ? { storePath: scope.storePath } : {}),
+    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
+  });
+}

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -13,12 +13,15 @@ import {
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
+  cleanupSessionLifecycleArtifacts as cleanupFileSessionLifecycleArtifacts,
   listSessionEntries as listFileSessionEntries,
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
   readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   updateSessionStoreEntry as updateFileSessionStoreEntry,
+  type SessionLifecycleArtifactCleanupParams,
+  type SessionLifecycleArtifactCleanupResult,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import {
@@ -98,6 +101,8 @@ export type SessionEntryPatchOptions = {
 export type SessionEntryPatchContext = {
   existingEntry?: SessionEntry;
 };
+
+export type { SessionLifecycleArtifactCleanupParams, SessionLifecycleArtifactCleanupResult };
 
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
@@ -212,6 +217,13 @@ export async function updateSessionEntry(
     takeCacheOwnership: options.takeCacheOwnership,
     update,
   });
+}
+
+/** Cleans scoped session lifecycle entries and transcript artifacts through the accessor seam. */
+export async function cleanupSessionLifecycleArtifacts(
+  params: SessionLifecycleArtifactCleanupParams,
+): Promise<SessionLifecycleArtifactCleanupResult> {
+  return await cleanupFileSessionLifecycleArtifacts(params);
 }
 
 /** Loads raw transcript events through the storage-neutral accessor seam. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { getRuntimeConfig } from "../io.js";
+import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
@@ -9,6 +10,7 @@ import {
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
   resolveSessionStoreEntry,
+  updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptEvent } from "./transcript-append.js";
@@ -37,6 +39,11 @@ export type SessionEntrySummary = {
 
 export type TranscriptEvent = unknown;
 
+export type SessionEntryUpdateOptions = {
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   return getSessionEntry(scope);
@@ -58,6 +65,23 @@ export async function upsertSessionEntry(
     ...scope,
     fallbackEntry: createFallbackSessionEntry(patch),
     update: () => patch,
+  });
+}
+
+/** Updates an existing session entry through the storage-neutral accessor seam. */
+export async function updateSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryUpdateOptions = {},
+): Promise<SessionEntry | null> {
+  return await updateFileSessionStoreEntry({
+    storePath: resolveAccessStorePath(scope),
+    sessionKey: scope.sessionKey,
+    skipMaintenance: options.skipMaintenance,
+    takeCacheOwnership: options.takeCacheOwnership,
+    update,
   });
 }
 
@@ -92,6 +116,17 @@ function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry 
     updatedAt: patch.updatedAt ?? now,
     ...patch,
   };
+}
+
+function resolveAccessStorePath(scope: SessionAccessScope): string {
+  if (scope.storePath) {
+    return scope.storePath;
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  return resolveStorePath(getRuntimeConfig().session?.store, {
+    agentId,
+    env: scope.env,
+  });
 }
 
 async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -84,6 +84,19 @@ export async function upsertSessionEntry(
   });
 }
 
+/** Replaces one entry through the storage-neutral accessor seam. */
+export async function replaceSessionEntry(
+  scope: SessionAccessScope,
+  entry: SessionEntry,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: entry,
+    replaceEntry: true,
+    update: () => entry,
+  });
+}
+
 /** Updates an existing session entry through the storage-neutral accessor seam. */
 export async function updateSessionEntry(
   scope: SessionAccessScope,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
@@ -9,11 +12,15 @@ import {
   listSessionEntries as listFileSessionEntries,
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
+  readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
-import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import {
+  appendSessionTranscriptEvent,
+  appendSessionTranscriptMessage,
+} from "./transcript-append.js";
 import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import { resolveSessionTranscriptFile } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
@@ -33,12 +40,34 @@ export type SessionTranscriptAccessScope = SessionAccessScope & {
   threadId?: string | number;
 };
 
+export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
+  sessionId?: string;
+};
+
 export type SessionEntrySummary = {
   sessionKey: string;
   entry: SessionEntry;
 };
 
 export type TranscriptEvent = unknown;
+
+export type TranscriptMessageAppendOptions<TMessage> = {
+  config?: OpenClawConfig;
+  cwd?: string;
+  idempotencyLookup?: "scan" | "caller-checked";
+  message: TMessage;
+  now?: number;
+  prepareMessageAfterIdempotencyCheck?: (message: TMessage) => TMessage | undefined;
+  useRawWhenLinear?: boolean;
+};
+
+export type TranscriptMessageAppendResult<TMessage> = {
+  appended: boolean;
+  message: TMessage;
+  messageId: string;
+};
+
+export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
 
 export type SessionEntryUpdateOptions = {
   skipMaintenance?: boolean;
@@ -79,6 +108,17 @@ export function listSessionEntries(
     ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
   }
   return listFileSessionEntries(scope);
+}
+
+/** Reads a session activity timestamp through the storage-neutral accessor seam. */
+export function readSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
+  if (scope.storePath) {
+    return readFileSessionUpdatedAt({
+      storePath: scope.storePath,
+      sessionKey: scope.sessionKey,
+    });
+  }
+  return loadSessionEntry(scope)?.updatedAt;
 }
 
 /** Applies a partial entry update through the storage-neutral accessor seam. */
@@ -164,6 +204,51 @@ export async function appendTranscriptEvent(
   });
 }
 
+/** Appends one transcript message through the storage-neutral writer seam. */
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage> & {
+    prepareMessageAfterIdempotencyCheck: (message: TMessage) => TMessage | undefined;
+  },
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage>>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
+  const transcript = await resolveTranscriptAccess(scope);
+  return await appendSessionTranscriptMessage({
+    transcriptPath: transcript.sessionFile,
+    message: options.message,
+    ...(scope.sessionId ? { sessionId: scope.sessionId } : {}),
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    ...(options.config ? { config: options.config } : {}),
+    ...(options.idempotencyLookup ? { idempotencyLookup: options.idempotencyLookup } : {}),
+    ...(options.now !== undefined ? { now: options.now } : {}),
+    ...(options.prepareMessageAfterIdempotencyCheck
+      ? { prepareMessageAfterIdempotencyCheck: options.prepareMessageAfterIdempotencyCheck }
+      : {}),
+    ...(options.useRawWhenLinear !== undefined
+      ? { useRawWhenLinear: options.useRawWhenLinear }
+      : {}),
+  });
+}
+
+/** Publishes a transcript update after resolving the current storage target. */
+export async function publishTranscriptUpdate(
+  scope: SessionTranscriptWriteScope,
+  update: TranscriptUpdatePayload = {},
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  emitSessionTranscriptUpdate({
+    ...update,
+    sessionFile: transcript.sessionFile,
+  });
+}
+
 function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
   const now = Date.now();
   return {
@@ -184,11 +269,14 @@ function resolveAccessStorePath(scope: SessionAccessScope): string {
   });
 }
 
-async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Promise<{
   sessionFile: string;
 }> {
   if (scope.sessionFile?.trim()) {
     return { sessionFile: scope.sessionFile };
+  }
+  if (!scope.sessionId) {
+    throw new Error(`Cannot resolve transcript scope without a session id: ${scope.sessionKey}`);
   }
   const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
   if (!agentId) {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -20,6 +20,7 @@ import type { SessionEntry } from "./types.js";
 
 export type SessionAccessScope = {
   agentId?: string;
+  clone?: boolean;
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   sessionKey: string;
@@ -46,6 +47,13 @@ export type SessionEntryUpdateOptions = {
 
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  if (scope.clone === false) {
+    const store = loadSessionStore(resolveAccessStorePath(scope), {
+      clone: false,
+      ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+    });
+    return resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey }).existing;
+  }
   return getSessionEntry(scope);
 }
 
@@ -53,6 +61,14 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
 export function listSessionEntries(
   scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
 ): SessionEntrySummary[] {
+  if (scope.clone === false) {
+    return Object.entries(
+      loadSessionStore(resolveAccessStorePath({ ...scope, sessionKey: "" }), {
+        clone: false,
+        ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+      }),
+    ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
+  }
   return listFileSessionEntries(scope);
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -50,6 +50,10 @@ export type SessionEntryPatchOptions = {
   replaceEntry?: boolean;
 };
 
+export type SessionEntryPatchContext = {
+  existingEntry?: SessionEntry;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -107,6 +111,7 @@ export async function patchSessionEntry(
   scope: SessionAccessScope,
   update: (
     entry: SessionEntry,
+    context: SessionEntryPatchContext,
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
   options: SessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -85,6 +85,7 @@ export type SessionEntryUpdateOptions = {
 
 export type SessionEntryPatchOptions = {
   fallbackEntry?: SessionEntry;
+  preserveActivity?: boolean;
   replaceEntry?: boolean;
 };
 
@@ -167,6 +168,7 @@ export async function patchSessionEntry(
   return await patchFileSessionEntry({
     ...scope,
     fallbackEntry: options.fallbackEntry,
+    preserveActivity: options.preserveActivity,
     replaceEntry: options.replaceEntry,
     update,
   });

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -58,6 +58,12 @@ export type SessionEntrySummary = {
   entry: SessionEntry;
 };
 
+/** Session entry read by the exact persisted session key, without alias resolution. */
+export type ExactSessionEntry = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
 export type TranscriptEvent = unknown;
 
 export type TranscriptMessageAppendOptions<TMessage> = {
@@ -103,6 +109,23 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
     return resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey }).existing;
   }
   return getSessionEntry(scope);
+}
+
+/**
+ * Loads one entry only when the persisted key exactly matches the requested key.
+ * Approval routing uses this to avoid canonical alias lookup crossing accounts.
+ */
+export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined {
+  const sessionKey = scope.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const store = loadSessionStore(resolveAccessStorePath(scope), {
+    ...(scope.clone === false ? { clone: false } : {}),
+    ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+  });
+  const entry = Object.hasOwn(store, sessionKey) ? store[sessionKey] : undefined;
+  return entry ? { sessionKey, entry } : undefined;
 }
 
 /** Lists session entries through the storage-neutral accessor seam. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -45,6 +45,11 @@ export type SessionEntryUpdateOptions = {
   takeCacheOwnership?: boolean;
 };
 
+export type SessionEntryPatchOptions = {
+  fallbackEntry?: SessionEntry;
+  replaceEntry?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -94,6 +99,22 @@ export async function replaceSessionEntry(
     fallbackEntry: entry,
     replaceEntry: true,
     update: () => entry,
+  });
+}
+
+/** Patches one entry atomically through the storage-neutral accessor seam. */
+export async function patchSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: options.fallbackEntry,
+    replaceEntry: options.replaceEntry,
+    update,
   });
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -5,7 +5,11 @@ import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js
 import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
-import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
+import {
+  resolveSessionTranscriptPath,
+  resolveSessionTranscriptPathInDir,
+  resolveStorePath,
+} from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
@@ -34,10 +38,15 @@ export type SessionAccessScope = {
   storePath?: string;
 };
 
-export type SessionTranscriptAccessScope = SessionAccessScope & {
+export type SessionTranscriptReadScope = Omit<SessionAccessScope, "sessionKey"> & {
   sessionFile?: string;
   sessionId: string;
+  sessionKey?: string;
   threadId?: string | number;
+};
+
+export type SessionTranscriptAccessScope = SessionTranscriptReadScope & {
+  sessionKey: string;
 };
 
 export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
@@ -182,9 +191,9 @@ export async function updateSessionEntry(
 
 /** Loads raw transcript events through the storage-neutral accessor seam. */
 export async function loadTranscriptEvents(
-  scope: SessionTranscriptAccessScope,
+  scope: SessionTranscriptReadScope,
 ): Promise<TranscriptEvent[]> {
-  const transcript = await resolveTranscriptAccess(scope);
+  const transcript = await resolveTranscriptReadAccess(scope);
   const events: TranscriptEvent[] = [];
   for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
     events.push(JSON.parse(line) as TranscriptEvent);
@@ -267,6 +276,32 @@ function resolveAccessStorePath(scope: SessionAccessScope): string {
     agentId,
     env: scope.env,
   });
+}
+
+async function resolveTranscriptReadAccess(scope: SessionTranscriptReadScope): Promise<{
+  sessionFile: string;
+}> {
+  if (scope.sessionFile?.trim()) {
+    return { sessionFile: scope.sessionFile };
+  }
+  if (scope.sessionKey) {
+    return await resolveTranscriptAccess({ ...scope, sessionKey: scope.sessionKey });
+  }
+  if (scope.storePath) {
+    return {
+      sessionFile: resolveSessionTranscriptPathInDir(
+        scope.sessionId,
+        path.dirname(path.resolve(scope.storePath)),
+        scope.threadId,
+      ),
+    };
+  }
+  if (scope.agentId) {
+    return {
+      sessionFile: resolveSessionTranscriptPath(scope.sessionId, scope.agentId, scope.threadId),
+    };
+  }
+  throw new Error(`Cannot resolve transcript read scope without a session target`);
 }
 
 async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Promise<{

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -32,79 +32,153 @@ import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import { resolveSessionTranscriptFile } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
 
+/**
+ * Identifies a session entry within one agent's session store.
+ *
+ * `sessionKey` is the caller-facing routing key. Accessors may normalize aliases
+ * when reading or writing unless the exact-key variant is used. `agentId` and
+ * `storePath` are explicit owner hints for callers that already know the target
+ * store; otherwise the owner is derived from the session key and runtime config.
+ */
 export type SessionAccessScope = {
+  /** Agent that owns the session store, when the caller already knows it. */
   agentId?: string;
+  /** Return the stored object by reference when false; default reads are cloned. */
   clone?: boolean;
+  /** Environment used only while resolving the configured session store path. */
   env?: NodeJS.ProcessEnv;
+  /** Disable skill prompt hydration for callers that need raw stored fields. */
   hydrateSkillPromptRefs?: boolean;
+  /** Session routing key requested by the caller. */
   sessionKey: string;
+  /** Explicit store path for scoped tools, tests, or already-resolved callers. */
   storePath?: string;
 };
 
+/**
+ * Identifies transcript content for read-only access.
+ *
+ * A read can target a named transcript artifact directly with `sessionFile`, or
+ * resolve the artifact from `sessionId` plus store/agent/thread identity. Reads
+ * do not require `sessionKey` because historical projections often already have
+ * the persisted session id but not the original routing key.
+ */
 export type SessionTranscriptReadScope = Omit<SessionAccessScope, "sessionKey"> & {
+  /** Explicit transcript artifact path for compatibility and import/export callers. */
   sessionFile?: string;
+  /** Stable session identifier stored in the session entry and transcript header. */
   sessionId: string;
+  /** Routing key when available; used to preserve scoped agent/thread semantics. */
   sessionKey?: string;
+  /** Optional thread discriminator for thread-scoped transcript artifacts. */
   threadId?: string | number;
 };
 
+/**
+ * Identifies transcript content for operations that must also know the session key.
+ */
 export type SessionTranscriptAccessScope = SessionTranscriptReadScope & {
   sessionKey: string;
 };
 
+/**
+ * Identifies transcript content for append/update operations.
+ *
+ * Writers may create or persist the transcript target, so they require
+ * `sessionKey` and either an existing `sessionId` or enough entry context for the
+ * caller to supply one later. Direct `sessionFile` remains an explicit artifact
+ * target, not the normal identity for runtime callers.
+ */
 export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
   sessionId?: string;
 };
 
+/** One listed session entry paired with the routing key used to find it. */
 export type SessionEntrySummary = {
   sessionKey: string;
   entry: SessionEntry;
 };
 
-/** Session entry read by the exact persisted session key, without alias resolution. */
+/**
+ * Session entry read by exact persisted key.
+ *
+ * Use this when the caller must not cross aliases or normalized account/session
+ * keys, such as approval routing and account binding decisions.
+ */
 export type ExactSessionEntry = {
   sessionKey: string;
   entry: SessionEntry;
 };
 
+/** Raw transcript record as stored by the transcript append pipeline. */
 export type TranscriptEvent = unknown;
 
+/** Options for appending one projected message to a transcript. */
 export type TranscriptMessageAppendOptions<TMessage> = {
+  /** Runtime config used by message normalization and transcript append helpers. */
   config?: OpenClawConfig;
+  /** Working directory for resolving relative media paths in appended messages. */
   cwd?: string;
+  /** Idempotency strategy for callers that already performed duplicate checks. */
   idempotencyLookup?: "scan" | "caller-checked";
+  /** Message payload to append after optional idempotency preparation. */
   message: TMessage;
+  /** Timestamp override for deterministic tests or replayed events. */
   now?: number;
+  /** Last chance to transform or drop a message after idempotency checks pass. */
   prepareMessageAfterIdempotencyCheck?: (message: TMessage) => TMessage | undefined;
+  /** Preserve raw message bytes when the existing transcript is linear. */
   useRawWhenLinear?: boolean;
 };
 
+/** Result returned when a message append either writes or reuses an idempotent hit. */
 export type TranscriptMessageAppendResult<TMessage> = {
   appended: boolean;
   message: TMessage;
   messageId: string;
 };
 
+/**
+ * Transcript update payload supplied by callers.
+ *
+ * The accessor resolves the concrete transcript artifact before publishing, so
+ * callers provide session identity fields and optional update metadata only.
+ */
 export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
 
+/** Options for updating an existing entry without creating a fallback entry. */
 export type SessionEntryUpdateOptions = {
+  /** Skip pruning or other maintenance work owned by the backing store. */
   skipMaintenance?: boolean;
+  /** Let the update take ownership of any store cache invalidation. */
   takeCacheOwnership?: boolean;
 };
 
+/** Options for patching or creating one session entry. */
 export type SessionEntryPatchOptions = {
+  /** Entry to create when the target key does not currently exist. */
   fallbackEntry?: SessionEntry;
+  /** Keep the existing activity timestamp unless the patch changes it explicitly. */
   preserveActivity?: boolean;
+  /** Replace the entry with the update result instead of merging fields. */
   replaceEntry?: boolean;
 };
 
+/** Existing entry snapshot supplied to patch callbacks. */
 export type SessionEntryPatchContext = {
   existingEntry?: SessionEntry;
 };
 
 export type { SessionLifecycleArtifactCleanupParams, SessionLifecycleArtifactCleanupResult };
 
-/** Loads one session entry through the storage-neutral accessor seam. */
+/**
+ * Loads one session entry.
+ *
+ * The returned entry follows normal session-key aliasing rules. Pass
+ * `clone: false` only for tightly scoped callers that intentionally mutate or
+ * compare the live store object; most callers should use the default cloned
+ * value.
+ */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
     const store = loadSessionStore(resolveAccessStorePath(scope), {
@@ -133,7 +207,12 @@ export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEn
   return entry ? { sessionKey, entry } : undefined;
 }
 
-/** Lists session entries through the storage-neutral accessor seam. */
+/**
+ * Lists all session entries visible in the resolved store.
+ *
+ * Each result includes the persisted routing key so callers can preserve the
+ * exact key in UI projections, maintenance tasks, and export surfaces.
+ */
 export function listSessionEntries(
   scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
 ): SessionEntrySummary[] {
@@ -148,7 +227,9 @@ export function listSessionEntries(
   return listFileSessionEntries(scope);
 }
 
-/** Reads a session activity timestamp through the storage-neutral accessor seam. */
+/**
+ * Reads the stored session activity timestamp without requiring a full entry projection.
+ */
 export function readSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
   if (scope.storePath) {
     return readFileSessionUpdatedAt({
@@ -159,7 +240,12 @@ export function readSessionUpdatedAt(scope: SessionAccessScope): number | undefi
   return loadSessionEntry(scope)?.updatedAt;
 }
 
-/** Applies a partial entry update through the storage-neutral accessor seam. */
+/**
+ * Creates or patches one session entry by merging a partial update.
+ *
+ * Missing entries are created from the supplied patch, including a generated
+ * `sessionId` and current `updatedAt` when the patch does not provide them.
+ */
 export async function upsertSessionEntry(
   scope: SessionAccessScope,
   patch: Partial<SessionEntry>,
@@ -171,7 +257,9 @@ export async function upsertSessionEntry(
   });
 }
 
-/** Replaces one entry through the storage-neutral accessor seam. */
+/**
+ * Creates or replaces one session entry with the supplied entry shape.
+ */
 export async function replaceSessionEntry(
   scope: SessionAccessScope,
   entry: SessionEntry,
@@ -184,7 +272,14 @@ export async function replaceSessionEntry(
   });
 }
 
-/** Patches one entry atomically through the storage-neutral accessor seam. */
+/**
+ * Applies a callback-driven patch to one session entry.
+ *
+ * The callback receives the current entry and may return a partial update, a
+ * replacement entry when `replaceEntry` is true, or `null` to leave the entry
+ * unchanged. Store-level locking and timestamp handling are owned by the
+ * backing implementation.
+ */
 export async function patchSessionEntry(
   scope: SessionAccessScope,
   update: (
@@ -202,7 +297,13 @@ export async function patchSessionEntry(
   });
 }
 
-/** Updates an existing session entry through the storage-neutral accessor seam. */
+/**
+ * Updates an existing session entry without creating a fallback entry.
+ *
+ * Use this when absence is meaningful and the caller should not materialize a
+ * new session row. The update callback returns `null` to leave the entry
+ * unchanged.
+ */
 export async function updateSessionEntry(
   scope: SessionAccessScope,
   update: (
@@ -219,14 +320,27 @@ export async function updateSessionEntry(
   });
 }
 
-/** Cleans scoped session lifecycle entries and transcript artifacts through the accessor seam. */
+/**
+ * Removes lifecycle-owned session records and transcript artifacts for one scoped target.
+ *
+ * This operation is for owner-managed cleanup such as reset, archive, delete,
+ * or temporary run/session reclamation. It must stay scoped to the requested
+ * session identity and report what was removed so callers can make cleanup
+ * idempotent.
+ */
 export async function cleanupSessionLifecycleArtifacts(
   params: SessionLifecycleArtifactCleanupParams,
 ): Promise<SessionLifecycleArtifactCleanupResult> {
   return await cleanupFileSessionLifecycleArtifacts(params);
 }
 
-/** Loads raw transcript events through the storage-neutral accessor seam. */
+/**
+ * Loads raw transcript events for a resolved transcript target.
+ *
+ * This is intentionally an event-level API: callers that need projected chat
+ * messages should use the transcript reader helpers that preserve projection,
+ * bounding, and visibility rules.
+ */
 export async function loadTranscriptEvents(
   scope: SessionTranscriptReadScope,
 ): Promise<TranscriptEvent[]> {
@@ -238,7 +352,12 @@ export async function loadTranscriptEvents(
   return events;
 }
 
-/** Appends one raw transcript event through the storage-neutral accessor seam. */
+/**
+ * Appends one raw transcript event to the resolved transcript target.
+ *
+ * Prefer `appendTranscriptMessage` for normal assistant/user message writes so
+ * idempotency and message normalization remain centralized.
+ */
 export async function appendTranscriptEvent(
   scope: SessionTranscriptAccessScope,
   event: TranscriptEvent,
@@ -250,7 +369,14 @@ export async function appendTranscriptEvent(
   });
 }
 
-/** Appends one transcript message through the storage-neutral writer seam. */
+/**
+ * Appends one projected transcript message to the resolved transcript target.
+ *
+ * The overload with `prepareMessageAfterIdempotencyCheck` may return
+ * `undefined` when the preparation callback drops the message. Without that
+ * callback, successful calls always return the appended or idempotently reused
+ * message result.
+ */
 export async function appendTranscriptMessage<TMessage>(
   scope: SessionTranscriptWriteScope,
   options: TranscriptMessageAppendOptions<TMessage> & {
@@ -283,7 +409,13 @@ export async function appendTranscriptMessage<TMessage>(
   });
 }
 
-/** Publishes a transcript update after resolving the current storage target. */
+/**
+ * Publishes a transcript update for subscribers of the resolved transcript target.
+ *
+ * Callers provide storage-neutral identity and update metadata. The accessor
+ * resolves the concrete transcript artifact needed by current subscribers and
+ * includes it in the emitted event.
+ */
 export async function publishTranscriptUpdate(
   scope: SessionTranscriptWriteScope,
   update: TranscriptUpdatePayload = {},

--- a/src/config/sessions/store.runtime.ts
+++ b/src/config/sessions/store.runtime.ts
@@ -1,6 +1,11 @@
 // Runtime facade for session store mutation helpers.
 export {
   applySessionStoreEntryPatch,
+  cleanupSessionLifecycleArtifacts,
   updateSessionStore,
   updateSessionStoreEntry,
+} from "./store.js";
+export type {
+  SessionLifecycleArtifactCleanupParams,
+  SessionLifecycleArtifactCleanupResult,
 } from "./store.js";

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -5,6 +5,7 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import { writeTextAtomic } from "../../infra/json-files.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
   deliveryContextFromChannelRoute,
   deliveryContextFromSession,
@@ -15,9 +16,10 @@ import {
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import { getRuntimeConfig } from "../io.js";
+import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
-import { resolveStorePath } from "./paths.js";
+import { resolveSessionFilePath, resolveStorePath } from "./paths.js";
 import {
   ensureSessionStorePromptBlobsForPersistence,
   isSessionSkillPromptBlobReadable,
@@ -189,6 +191,24 @@ type SessionEntryWorkflowOptions = {
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   storePath?: string;
+};
+
+export type SessionLifecycleArtifactCleanupParams = {
+  /** Session store to clean. */
+  storePath: string;
+  /** Matches the persisted session-key segment after `agent:<id>:`. */
+  sessionKeySegmentPrefix: string;
+  /** Marker that identifies transcript artifacts owned by this lifecycle. */
+  transcriptContentMarker: string;
+  /** Minimum age before a present transcript can be reclaimed or archived. */
+  orphanTranscriptMinAgeMs: number;
+  /** Testable clock override. */
+  nowMs?: number;
+};
+
+export type SessionLifecycleArtifactCleanupResult = {
+  removedEntries: number;
+  archivedTranscriptArtifacts: number;
 };
 
 function cloneSessionEntry(entry: SessionEntry): SessionEntry {
@@ -501,6 +521,66 @@ function sessionEntriesHaveSameSerializedForm(
   next: SessionEntry,
 ): boolean {
   return previous !== undefined && JSON.stringify(previous) === JSON.stringify(next);
+}
+
+function normalizePathForLifecycleComparison(filePath: string): string {
+  try {
+    return path.normalize(fs.realpathSync(filePath));
+  } catch {
+    return path.normalize(path.resolve(filePath));
+  }
+}
+
+function sessionKeySegmentStartsWith(sessionKey: string, prefix: string): boolean {
+  const firstSeparator = sessionKey.indexOf(":");
+  if (firstSeparator < 0) {
+    return sessionKey.startsWith(prefix);
+  }
+  const secondSeparator = sessionKey.indexOf(":", firstSeparator + 1);
+  const sessionSegment = secondSeparator < 0 ? sessionKey : sessionKey.slice(secondSeparator + 1);
+  return sessionSegment.startsWith(prefix);
+}
+
+function resolveLifecycleTranscriptPath(params: {
+  entry: SessionEntry | undefined;
+  sessionsDir: string;
+}): string | null {
+  const sessionId = params.entry?.sessionId?.trim();
+  if (!sessionId) {
+    return null;
+  }
+  try {
+    return resolveSessionFilePath(sessionId, params.entry, { sessionsDir: params.sessionsDir });
+  } catch {
+    return null;
+  }
+}
+
+function lifecycleTranscriptIsReclaimable(params: {
+  transcriptPath: string | null;
+  nowMs: number;
+  orphanTranscriptMinAgeMs: number;
+}): boolean {
+  if (!params.transcriptPath || !fs.existsSync(params.transcriptPath)) {
+    return true;
+  }
+  try {
+    const stat = fs.statSync(params.transcriptPath);
+    return params.nowMs - stat.mtimeMs >= params.orphanTranscriptMinAgeMs;
+  } catch {
+    return true;
+  }
+}
+
+function archiveExactLifecycleTranscriptPath(transcriptPath: string): number {
+  const archivedPath = `${transcriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
+  try {
+    fs.renameSync(transcriptPath, archivedPath);
+    emitSessionTranscriptUpdate({ sessionFile: archivedPath });
+    return 1;
+  } catch {
+    return 0;
+  }
 }
 
 async function saveSessionStoreUnlocked(
@@ -816,6 +896,158 @@ export async function updateSessionStore<T>(
     });
     return result;
   });
+}
+
+async function archiveUnreferencedLifecycleTranscriptArtifacts(params: {
+  storePath: string;
+  transcriptContentMarker: string;
+  orphanTranscriptMinAgeMs: number;
+  nowMs: number;
+}): Promise<number> {
+  const sessionsDir = path.dirname(path.resolve(params.storePath));
+  return await runExclusiveSessionStoreWrite(params.storePath, async () => {
+    const store = loadMutableSessionStoreForWriter(params.storePath);
+    const referencedTranscriptPaths = new Set<string>();
+    for (const entry of Object.values(store)) {
+      const transcriptPath = resolveLifecycleTranscriptPath({ entry, sessionsDir });
+      if (transcriptPath) {
+        referencedTranscriptPaths.add(normalizePathForLifecycleComparison(transcriptPath));
+      }
+    }
+    restoreUnchangedSessionStoreCache(params.storePath, store);
+
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+
+    const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
+    let archived = 0;
+    // Only archive primary transcripts that are no longer referenced by the
+    // current store and still carry the lifecycle marker supplied by the caller.
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+        continue;
+      }
+      const transcriptPath = path.join(sessionsDir, entry.name);
+      if (referencedTranscriptPaths.has(normalizePathForLifecycleComparison(transcriptPath))) {
+        continue;
+      }
+      let stat: fs.Stats;
+      try {
+        stat = await fs.promises.stat(transcriptPath);
+      } catch {
+        continue;
+      }
+      if (params.nowMs - stat.mtimeMs < params.orphanTranscriptMinAgeMs) {
+        continue;
+      }
+      let content: string;
+      try {
+        content = await fs.promises.readFile(transcriptPath, "utf-8");
+      } catch {
+        continue;
+      }
+      if (!content.includes(params.transcriptContentMarker)) {
+        continue;
+      }
+      const sessionId = entry.name.slice(0, -".jsonl".length);
+      archived += archiveSessionTranscripts({
+        sessionId,
+        storePath: params.storePath,
+        sessionFile: transcriptPath,
+        reason: "deleted",
+        restrictToStoreDir: true,
+      }).length;
+    }
+    return archived;
+  });
+}
+
+/** Cleans scoped session lifecycle entries and their unreferenced transcript artifacts. */
+export async function cleanupSessionLifecycleArtifacts(
+  params: SessionLifecycleArtifactCleanupParams,
+): Promise<SessionLifecycleArtifactCleanupResult> {
+  const sessionKeySegmentPrefix = params.sessionKeySegmentPrefix.trim();
+  const transcriptContentMarker = params.transcriptContentMarker;
+  if (!sessionKeySegmentPrefix || !transcriptContentMarker) {
+    return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
+  }
+
+  const nowMs = params.nowMs ?? Date.now();
+  const storePath = path.resolve(params.storePath);
+  const sessionsDir = path.dirname(storePath);
+  const removedSessionFiles = new Map<string, string | undefined>();
+  const removedTranscriptPaths: Array<{ sessionId: string; transcriptPath: string }> = [];
+  let removedEntries = 0;
+  let archivedTranscriptArtifacts = 0;
+
+  await runExclusiveSessionStoreWrite(storePath, async () => {
+    const store = loadMutableSessionStoreForWriter(storePath);
+    // Delete only rows owned by the named lifecycle. Orphan transcript cleanup
+    // reacquires this writer lock later so its reference set cannot go stale.
+    for (const [sessionKey, entry] of Object.entries(store)) {
+      const transcriptPath = resolveLifecycleTranscriptPath({ entry, sessionsDir });
+      const matchesLifecycle = sessionKeySegmentStartsWith(sessionKey, sessionKeySegmentPrefix);
+      if (
+        matchesLifecycle &&
+        lifecycleTranscriptIsReclaimable({
+          transcriptPath,
+          nowMs,
+          orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        })
+      ) {
+        rememberRemovedSessionFile(removedSessionFiles, entry);
+        if (entry.sessionId && transcriptPath && fs.existsSync(transcriptPath)) {
+          removedTranscriptPaths.push({ sessionId: entry.sessionId, transcriptPath });
+        }
+        delete store[sessionKey];
+        removedEntries += 1;
+        continue;
+      }
+    }
+
+    if (removedEntries === 0) {
+      restoreUnchangedSessionStoreCache(storePath, store);
+      return;
+    }
+
+    const referencedSessionIds = new Set(
+      Object.values(store)
+        .map((entry) => entry?.sessionId)
+        .filter((sessionId): sessionId is string => Boolean(sessionId)),
+    );
+    // Archive only the exact transcript path that passed the age/missing guard.
+    // Broader session-id candidate scans can include fresh sibling transcripts.
+    for (const { sessionId: removedSessionId, transcriptPath } of removedTranscriptPaths) {
+      if (referencedSessionIds.has(removedSessionId)) {
+        continue;
+      }
+      archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath(transcriptPath);
+    }
+    const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
+    await removeRemovedSessionTrajectoryArtifacts({
+      removedSessionFiles,
+      referencedSessionIds,
+      storePath,
+      restrictToStoreDir: true,
+    });
+    await saveSessionStoreUnlocked(storePath, store, { skipMaintenance: true });
+  });
+
+  return {
+    removedEntries,
+    archivedTranscriptArtifacts:
+      archivedTranscriptArtifacts +
+      (await archiveUnreferencedLifecycleTranscriptArtifacts({
+        storePath,
+        transcriptContentMarker,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        nowMs,
+      })),
+  };
 }
 
 export async function runQuotaSuspensionMaintenance(params: {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1016,6 +1016,7 @@ export async function patchSessionEntry(
     replaceEntry?: boolean;
     update: (
       entry: SessionEntry,
+      context: { existingEntry?: SessionEntry },
     ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
   },
 ): Promise<SessionEntry | null> {
@@ -1027,7 +1028,9 @@ export async function patchSessionEntry(
     if (!existing) {
       return null;
     }
-    const patch = await params.update(cloneSessionEntry(existing));
+    const patch = await params.update(cloneSessionEntry(existing), {
+      existingEntry: resolved.existing ? cloneSessionEntry(resolved.existing) : undefined,
+    });
     if (!patch) {
       return existing;
     }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -572,10 +572,19 @@ function lifecycleTranscriptIsReclaimable(params: {
   }
 }
 
-function archiveExactLifecycleTranscriptPath(transcriptPath: string): number {
-  const archivedPath = `${transcriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
+function archiveExactLifecycleTranscriptPath(params: {
+  sessionsDir: string;
+  transcriptPath: string;
+}): number {
+  const resolvedSessionsDir = normalizePathForLifecycleComparison(params.sessionsDir);
+  const resolvedTranscriptPath = normalizePathForLifecycleComparison(params.transcriptPath);
+  const relative = path.relative(resolvedSessionsDir, resolvedTranscriptPath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return 0;
+  }
+  const archivedPath = `${resolvedTranscriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
   try {
-    fs.renameSync(transcriptPath, archivedPath);
+    fs.renameSync(resolvedTranscriptPath, archivedPath);
     emitSessionTranscriptUpdate({ sessionFile: archivedPath });
     return 1;
   } catch {
@@ -1025,7 +1034,10 @@ export async function cleanupSessionLifecycleArtifacts(
       if (referencedSessionIds.has(removedSessionId)) {
         continue;
       }
-      archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath(transcriptPath);
+      archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath({
+        sessionsDir,
+        transcriptPath,
+      });
     }
     const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
     await removeRemovedSessionTrajectoryArtifacts({

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -15,6 +15,7 @@ import { redactSecrets } from "../../logging/redact.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   appendJsonlEntry,
+  serializeJsonlEntry,
   serializeJsonlLine,
   writeJsonlEntry,
   writeJsonlLines,
@@ -289,6 +290,31 @@ export async function appendSessionTranscriptMessage<TMessage>(
   );
 }
 
+export type AppendSessionTranscriptEventParams = {
+  config?: OpenClawConfig;
+  event: unknown;
+  transcriptPath: string;
+};
+
+/** Appends a raw transcript event using the same write lock and FIFO as message appends. */
+export async function appendSessionTranscriptEvent(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  const activeLockRunner = resolveOwnedSessionTranscriptWriteLockRunner({
+    sessionFile: params.transcriptPath,
+  });
+  if (activeLockRunner) {
+    return await activeLockRunner(() =>
+      withTranscriptAppendQueue(params.transcriptPath, () =>
+        appendSessionTranscriptEventLocked(params),
+      ),
+    );
+  }
+  return await withTranscriptAppendQueue(params.transcriptPath, () =>
+    withSessionTranscriptWriteLock(params, () => appendSessionTranscriptEventLocked(params)),
+  );
+}
+
 async function withSessionTranscriptWriteLock<T>(
   params: Pick<AppendSessionTranscriptMessageParams, "transcriptPath" | "config">,
   run: () => Promise<T> | T,
@@ -302,6 +328,18 @@ async function withSessionTranscriptWriteLock<T>(
     return await run();
   } finally {
     await lock.release();
+  }
+}
+
+async function appendSessionTranscriptEventLocked(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  await fs.mkdir(path.dirname(params.transcriptPath), { recursive: true });
+  const handle = await fs.open(params.transcriptPath, "a", 0o600);
+  try {
+    await handle.appendFile(serializeJsonlEntry(params.event), "utf-8");
+  } finally {
+    await handle.close();
   }
 }
 

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -22,6 +22,7 @@ export { resolveGroupSessionKey } from "../config/sessions/group.js";
 export { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
 export {
   clearSessionStoreCacheForTest,
+  cleanupSessionLifecycleArtifacts,
   getSessionEntry,
   listSessionEntries,
   patchSessionEntry,
@@ -32,6 +33,10 @@ export {
   updateSessionStore,
   updateSessionStoreEntry,
   upsertSessionEntry,
+} from "../config/sessions/store.js";
+export type {
+  SessionLifecycleArtifactCleanupParams,
+  SessionLifecycleArtifactCleanupResult,
 } from "../config/sessions/store.js";
 export {
   evaluateSessionFreshness,


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Adds the first additive slice for #88838: a file-backed session/transcript accessor seam that can later be implemented by SQLite without changing caller-facing domain shapes.
- Keeps runtime storage behavior unchanged: the new seam delegates to the current file-backed session store and transcript JSONL helpers.
- Adds a raw transcript event append helper that uses the existing transcript write lock and FIFO, so the seam does not introduce an unsafe write path.
- Intentionally out of scope: SQLite schema/store modules, runtime storage flip, doctor import, broad caller migration, and plugin SDK behavior changes.
- Success means reviewers can validate the seam shape and safety rules before later PRs use it as the SQLite migration boundary.
- Review focus: seam shape, transcript locking/path resolution, normalized session-key handling, and whether the additive boundary is small enough for the first migration slice.

Why does this matter now?

The core session/transcript SQLite migration is broad because many callers currently depend on file-era shapes. This creates a stable internal boundary first so storage changes and caller modernization can land separately.

What is the intended outcome?

A behavior-neutral internal seam over current file storage that later SQLite store modules can satisfy.

What is intentionally out of scope?

SQLite schema/store modules, runtime storage flip, doctor migration, and subsystem caller modernization.

What does success look like?

The seam is additive, tested against file storage behavior, and safe to build subsequent migration PRs on.

What should reviewers focus on?

Transcript write locking, topic/session path resolution, normalized session keys, metadata-only insert behavior, and whether the seam avoids runtime dual-read/fallback behavior.

## Linked context

Which issue does this close?

Does not close an issue.

Which issues, PRs, or discussions are related?

Refs #88838.
Related #79902.

Was this requested by a maintainer or owner?

Yes. This follows Josh's Path 3 SQLite decomposition plan for the core session/transcript migration.

## Path 3 implementation map

This PR is the PR 3.1a base seam for the broader #88838 SQLite migration. The current open PRs in the stack are:

| Section | PR | Status | Notes |
|---|---|---|---|
| PR 3.1a: canonical accessor seam | #88840 | Open | This PR; base for the 3.1b caller slices. |
| PR 3.1b: gateway entry/list/describe/get | #89120 | Open | Routes gateway session entry reads through the seam. |
| PR 3.1b: transcript readers | #89121 | Open | Routes storage-neutral transcript readers through the facade. |
| PR 3.1b: cron/infra/commands | #89122 | Open | Routes command/status/health read paths through the seam; 3.2 writer race remains tracked outside this PR. |
| PR 3.1b: transcript writers | #89123 | Open | Routes core transcript writer helpers through the seam. |
| PR 3.1b: auto-reply/agent runtime | #89124 | Open | Routes agent/runtime session writes through the seam. |
| PR 3.1b: plugin SDK compatibility | Not open yet | In validation/backport | Patch/preserveActivity and SQLite resolver findings are still being backported before PR creation. |
| PR 3.1b: bundled plugin consumers | Not open yet | In validation/backport | Narrow bundled plugin callers are being moved off whole-store mutation; remaining whole-store compatibility is a design item. |
| PR 3.2: SQLite store foundation | Not open yet | In blocker resolution | Additive SQLite foundation exists on a branch, with path parity and writer race fixes still being finalized. |
| Storage flip / doctor migration | Not open yet | Future phase | Explicitly out of scope for this PR and the current 3.1b caller slices. |

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Adds an internal file-backed accessor seam for the core session/transcript SQLite migration plan.
- Real environment tested: Local OpenClaw source checkout in a Codex worktree on macOS.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/config/sessions/transcript.test.ts`
  - `pnpm exec oxfmt --check src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/config/sessions/transcript-append.ts`
  - `node scripts/run-oxlint.mjs src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/config/sessions/transcript-append.ts`
  - `pnpm tsgo:core`
  - `pnpm tsgo:core:test`
  - `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode local`
- Evidence after fix: Focused Vitest passed 2 files / 32 tests; oxfmt, oxlint, core/test typechecks passed; autoreview reported no accepted/actionable findings.
- Observed result after fix: Session accessor reads/writes file-backed entries, creates durable session ids for metadata-only inserts, preserves topic transcript paths, persists normalized session keys, creates transcript files with 0600 mode, and appends raw transcript events through the existing lock/FIFO.
- What was not tested: Full runtime session migration, SQLite-backed implementation, doctor import, broad gateway/agent/SDK caller migration, and live end-to-end OpenClaw runs.
- Proof limitations or environment constraints: This PR is intentionally additive and does not flip storage behavior.
- Before evidence (optional but encouraged): Existing runtime used direct file-store/transcript helper paths without a dedicated storage-agnostic seam for the migration.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/config/sessions/transcript.test.ts`
- `pnpm exec oxfmt --check src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/config/sessions/transcript-append.ts`
- `node scripts/run-oxlint.mjs src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/config/sessions/transcript-append.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode local`

What regression coverage was added or updated?

Added `src/config/sessions/session-accessor.test.ts` covering file-backed load/list/upsert, metadata-only insert ids, transcript event load/append, secure transcript file creation, topic fallback paths, and normalized session-key persistence.

What failed before this fix, if known?

Autoreview caught several seam risks before this PR was opened: unsafe fallback session ids, insecure raw transcript file creation, missing topic fallback handling, cache mutation outside the writer, non-canonical session-key persistence, and raw appends bypassing the transcript lock/FIFO. Those were fixed before opening this PR.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The new raw transcript event append helper could become a reusable write path, so it must preserve existing transcript locking and file-permission behavior.

How is that risk mitigated?

The helper routes through the existing transcript append FIFO and session write lock, creates new files with `0600`, and has focused regression coverage.

## Current review state

What is the next action?

Maintainer review of the additive seam shape and safety constraints.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review. The broader migration remains tracked in #88838.

Which bot or reviewer comments were addressed?

No PR comments yet. Local autoreview findings were addressed before PR creation.
