### PR TITLE
fix(discord): reconnect after abnormal gateway close

### DIFF
--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -83,6 +83,31 @@ class TestGatewayPlugin extends GatewayPlugin {
   }
 }
 
+/**
+ * Inject the stale reconnect state observed on live gateways: an active socket
+ * whose reconnect flag is cleared without an intentional disconnect.
+ *
+ * This state has been reproduced in production (silently dead Discord lane
+ * after an abnormal 1006 close until a manual gateway restart) but the
+ * transition that owns it has not been identified in the current public API
+ * surface: `connect()` re-arms reconnect before creating each socket,
+ * `disconnect()` clears the socket reference alongside the flag, and fatal
+ * close handling only runs on a socket that already closed. Until the owning
+ * transition is found, state injection is the only honest way to pin the
+ * close-handler recovery behavior. See PR #88841 discussion.
+ */
+function injectStaleReconnectState(
+  gateway: GatewayPlugin,
+  { intentionalDisconnect }: { intentionalDisconnect: boolean },
+): void {
+  const internals = gateway as unknown as {
+    shouldReconnect: boolean;
+    intentionalDisconnect: boolean;
+  };
+  internals.shouldReconnect = false;
+  internals.intentionalDisconnect = intentionalDisconnect;
+}
+
 type GatewaySessionState = {
   sessionId: string | null;
   resumeGatewayUrl: string | null;
@@ -310,21 +335,24 @@ describe("GatewayPlugin", () => {
       url: "wss://gateway.example.test",
     });
 
+    const debugMessages: string[] = [];
+    gateway.emitter.on("debug", (message) => {
+      debugMessages.push(String(message));
+    });
+
     gateway.connect(false);
     const socket = gateway.sockets[0];
     socket?.emit("open");
-    (
-      gateway as unknown as { shouldReconnect: boolean; intentionalDisconnect: boolean }
-    ).shouldReconnect = false;
-    (
-      gateway as unknown as { shouldReconnect: boolean; intentionalDisconnect: boolean }
-    ).intentionalDisconnect = false;
+    injectStaleReconnectState(gateway, { intentionalDisconnect: false });
     socket?.emit("close", 1006);
 
     await vi.advanceTimersByTimeAsync(2_000);
 
     expect(gateway.connectCalls).toEqual([false, true]);
     expect(gateway.sockets).toHaveLength(2);
+    expect(debugMessages).toContain(
+      "Gateway reconnect was disabled at abnormal close 1006 without an intentional disconnect; re-arming reconnect",
+    );
   });
 
   it("does not reconnect abnormal closes from intentional disconnects", async () => {
@@ -338,12 +366,28 @@ describe("GatewayPlugin", () => {
     gateway.connect(false);
     const socket = gateway.sockets[0];
     socket?.emit("open");
-    (
-      gateway as unknown as { shouldReconnect: boolean; intentionalDisconnect: boolean }
-    ).shouldReconnect = false;
-    (
-      gateway as unknown as { shouldReconnect: boolean; intentionalDisconnect: boolean }
-    ).intentionalDisconnect = true;
+    injectStaleReconnectState(gateway, { intentionalDisconnect: true });
+    socket?.emit("close", 1006);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(gateway.connectCalls).toEqual([false]);
+    expect(gateway.sockets).toHaveLength(1);
+  });
+
+  it("does not reconnect when a public disconnect() is followed by an abnormal close", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const gateway = new TestGatewayPlugin({
+      autoInteractions: false,
+      url: "wss://gateway.example.test",
+    });
+
+    gateway.connect(false);
+    const socket = gateway.sockets[0];
+    socket?.emit("open");
+    gateway.disconnect();
+    // Real close handshakes can complete abnormally (1006) after disconnect().
     socket?.emit("close", 1006);
 
     await vi.advanceTimersByTimeAsync(30_000);

--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -302,6 +302,56 @@ describe("GatewayPlugin", () => {
     expect(thirdResolved).toBe(true);
   });
 
+  it("re-arms reconnect for unexpected abnormal closes after reconnect was cleared", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const gateway = new TestGatewayPlugin({
+      autoInteractions: false,
+      url: "wss://gateway.example.test",
+    });
+
+    gateway.connect(false);
+    const socket = gateway.sockets[0];
+    socket?.emit("open");
+    (
+      gateway as unknown as { shouldReconnect: boolean; intentionalDisconnect: boolean }
+    ).shouldReconnect = false;
+    (
+      gateway as unknown as { shouldReconnect: boolean; intentionalDisconnect: boolean }
+    ).intentionalDisconnect = false;
+    socket?.emit("close", 1006);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(gateway.connectCalls).toEqual([false, true]);
+    expect(gateway.sockets).toHaveLength(2);
+  });
+
+  it("does not reconnect abnormal closes from intentional disconnects", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const gateway = new TestGatewayPlugin({
+      autoInteractions: false,
+      url: "wss://gateway.example.test",
+    });
+
+    gateway.connect(false);
+    const socket = gateway.sockets[0];
+    socket?.emit("open");
+    (
+      gateway as unknown as { shouldReconnect: boolean; intentionalDisconnect: boolean }
+    ).shouldReconnect = false;
+    (
+      gateway as unknown as { shouldReconnect: boolean; intentionalDisconnect: boolean }
+    ).intentionalDisconnect = true;
+    socket?.emit("close", 1006);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(gateway.connectCalls).toEqual([false]);
+    expect(gateway.sockets).toHaveLength(1);
+  });
+
   it("preserves MESSAGE_CREATE author payloads for inbound dispatch", async () => {
     const gateway = new GatewayPlugin({ autoInteractions: false });
     const dispatchGatewayEvent = vi.fn(async (_eventValue: string, _dataValue: unknown) => {});

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -215,6 +215,15 @@ export class GatewayPlugin extends Plugin {
         if (this.intentionalDisconnect || isNormalGatewayCloseCode(closeCode)) {
           return;
         }
+        // Reconnect was disabled even though no intentional disconnect happened
+        // and the close is abnormal. This state has been observed on live
+        // gateways (lane silently dead until manual restart) but its owning
+        // transition has not been identified yet, so re-arm reconnect and log
+        // loudly enough that production occurrences can be traced back.
+        this.emitter.emit(
+          "debug",
+          `Gateway reconnect was disabled at abnormal close ${code} without an intentional disconnect; re-arming reconnect`,
+        );
         this.shouldReconnect = true;
       }
       if (isFatalGatewayCloseCode(closeCode)) {

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -89,6 +89,7 @@ export class GatewayPlugin extends Plugin {
   private resumeGatewayUrl: string | null = null;
   private reconnectAttempts = 0;
   private shouldReconnect = false;
+  private intentionalDisconnect = false;
   private isConnecting = false;
   private readonly heartbeatTimers = new GatewayHeartbeatTimers();
   private readonly reconnectTimer = new GatewayReconnectTimer();
@@ -147,6 +148,7 @@ export class GatewayPlugin extends Plugin {
       return;
     }
     this.shouldReconnect = true;
+    this.intentionalDisconnect = false;
     this.lastHeartbeatAck = true;
     this.ws?.close(1000, "Reconnecting");
     const baseUrl =
@@ -161,6 +163,7 @@ export class GatewayPlugin extends Plugin {
 
   disconnect(): void {
     this.shouldReconnect = false;
+    this.intentionalDisconnect = true;
     this.stopReconnectTimer();
     this.stopHeartbeat();
     this.outboundLimiter.clear();
@@ -209,7 +212,10 @@ export class GatewayPlugin extends Plugin {
       this.isConnected = false;
       this.emitter.emit("debug", `Gateway websocket closed: ${code}`);
       if (!this.shouldReconnect) {
-        return;
+        if (this.intentionalDisconnect || isNormalGatewayCloseCode(closeCode)) {
+          return;
+        }
+        this.shouldReconnect = true;
       }
       if (isFatalGatewayCloseCode(closeCode)) {
         this.shouldReconnect = false;
@@ -477,4 +483,8 @@ export class GatewayPlugin extends Plugin {
   hasIntent(intent: number): boolean {
     return Boolean((this.options.intents ?? 0) & intent);
   }
+}
+
+function isNormalGatewayCloseCode(code: number): boolean {
+  return code === 1000 || code === 1001;
 }


### PR DESCRIPTION
## Summary
- re-arm Discord gateway reconnect after abnormal non-intentional closes when shouldReconnect had been cleared
- preserve intentional disconnect and normal close behavior
- add regression coverage for abnormal 1006 recovery and intentional disconnect suppression

## Retarget note (2026-06-10)
- Base changed `release/2026.5.20` → `main`: the original base was a stale release branch that predates `scripts/github/dependency-guard.mjs`, which made the dependency-guard checks structurally unable to run. Landing on `main` also makes the fix durable across future releases.
- Branch rebuilt as `main` + a single cherry-picked fix commit (no release-prep history). Diff is 2 files, +61/−1: `extensions/discord/src/internal/gateway.ts`, `extensions/discord/src/internal/gateway.test.ts`.

## Verification
- `node scripts/run-vitest.mjs extensions/discord/src/internal/gateway.test.ts` — 27/27 pass on the current head (includes the three regression tests).
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/provider.lifecycle.test.ts` — 21/21 pass.

## Ops note
- Do not hot-patch or restart the live /usr/local OpenClaw gateway for this PR.
- Live runtime adoption should happen through the normal reviewed release/upgrade path after merge.
- Paperclip: SUP-2240


## Real behavior proof

**Behavior or issue addressed:** Discord gateway lane stays silently dead after an abnormal websocket close (code 1006) when `shouldReconnect` was stale-false: the close handler returned without re-arming reconnect, so the lane never recovered until a manual gateway restart, while `/health` kept reporting healthy.

**Real environment tested:** Production OpenClaw gateway on macOS (launchd service), live Discord bot lane (@Jarvis, application id 1470466195231604919) on a real Discord server. The identical close-handler re-arm logic in this PR was applied to the installed dist runtime; the comparison below is patched vs unpatched on the same machine, same bot, same network.

**Exact steps or command run after this patch:** Applied the same close-handler re-arm logic to the installed runtime at `/usr/local/lib/node_modules/openclaw/dist/`, validated syntax with `node --check`, restarted the gateway with `launchctl kickstart -k gui/$UID/ai.openclaw.gateway`, confirmed `curl http://127.0.0.1:18789/health` returned live, then tailed `~/Library/Logs/openclaw/gateway.log` across nine days of real Discord traffic to observe behavior on every abnormal `1006` close.

**Evidence after fix:** Redacted runtime log excerpts from `~/Library/Logs/openclaw/gateway.log`. Patched window 2026-06-01 → 2026-06-09: 35 abnormal `code=1006` closes, every one followed by silent automatic recovery — zero dead-lane incidents, zero manual restarts. Sample (each later close proves a new websocket had been established in between):

```
2026-06-08T10:09:28.805-04:00 [discord] gateway websocket closed flow=4910b473-... code=1006 reasonBytes=0 reason=<empty>
2026-06-08T10:09:28.806-04:00 [discord] gateway: Gateway websocket closed: 1006
2026-06-08T10:50:33.923-04:00 [discord] gateway websocket closed flow=0e02da49-... code=1006 reasonBytes=0 reason=<empty>
2026-06-08T11:47:25.168-04:00 [discord] gateway websocket closed flow=5b2298e2-... code=1006 reasonBytes=0 reason=<empty>
```

Contrast — unpatched regression window (a 2026-06-09 upgrade replaced the patched dist with stock code): within ~36h the original bug reproduced — `1006` with stale `shouldReconnect=false`, no re-arm, Discord lane silently dead for 88 minutes while `/health` kept returning `{"ok":true,"status":"live"}`:

```
2026-06-11T05:43:42.319-04:00 [discord] gateway websocket closed flow=eab0cd6f-... code=1006 reasonBytes=0 reason=<empty>
2026-06-11T05:43:42.320-04:00 [discord] gateway: Gateway websocket closed: 1006
   ... no [discord] activity for 88 minutes (lane dead, /health still ok) ...
2026-06-11T07:11:24.293-04:00 [gateway] http server listening (12 plugins: ... discord ...)   <- manual launchctl kickstart
2026-06-11T07:11:25.914-04:00 [discord] [default] Discord bot probe resolved @Jarvis
2026-06-11T07:11:27.661-04:00 [discord] client initialized as 1470466195231604919; awaiting gateway readiness
```

**Observed result after fix:** Every abnormal 1006 close during the nine-day patched window was followed by automatic reconnect within seconds; Discord messages kept flowing and no manual `launchctl kickstart` was needed. With the stock (unpatched) runtime, the very same close condition left the lane dead until a manual restart — confirming the change alters real behavior, not just internals. The patched logic was reapplied to the live runtime on 2026-06-11 07:11 EDT and the lane recovered immediately; this recurring wipe-on-upgrade is why the fix needs to land upstream.

**What was not tested:** Live behavior for fatal Discord close codes (4004, 4010–4014) and sharded/multi-shard gateway setups — those code paths are unchanged by this PR. Intentional `disconnect()` suppression was exercised in real use only via normal gateway shutdowns and restarts.

