### PR TITLE
Require signed beta desktop distribution

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -115,6 +115,7 @@ jobs:
               issue_number: pullRequest.number,
               per_page: 100,
             });
+            const labelNames = new Set(currentLabels.map((label) => label.name ?? ""));
 
             for (const label of currentLabels) {
               const name = label.name ?? "";
@@ -132,12 +133,14 @@ jobs:
               });
             }
 
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullRequest.number,
-              labels: [targetSizeLabel],
-            });
+            if (!labelNames.has(targetSizeLabel)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                labels: [targetSizeLabel],
+              });
+            }
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@v9
         with:

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -832,6 +832,18 @@ jobs:
             echo "- Release proof: appended to GitHub release" >> "$GITHUB_STEP_SUMMARY"
           }
 
+          verify_desktop_beta_distribution_before_publish() {
+            local release_version
+            release_version="${RELEASE_TAG#v}"
+            pnpm release:verify-beta -- \
+              "${release_version}" \
+              --tag "${RELEASE_TAG}" \
+              --dist-tag "${RELEASE_NPM_DIST_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --desktop-only
+            echo "- Desktop beta distribution: verified before npm/plugin publish" >> "$GITHUB_STEP_SUMMARY"
+          }
+
           {
             echo "### Publish sequence"
             echo
@@ -857,6 +869,10 @@ jobs:
           if [[ -n "${PLUGINS}" ]]; then
             npm_args+=(-f plugins="${PLUGINS}")
             clawhub_args+=(-f plugins="${PLUGINS}")
+          fi
+
+          if [[ "${RELEASE_TAG}" == *"-beta."* ]]; then
+            verify_desktop_beta_distribution_before_publish
           fi
 
           plugin_npm_run_id="$(dispatch_workflow plugin-npm-release.yml "${npm_args[@]}")"

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -16,16 +16,19 @@ public struct DeviceIdentity: Codable, Sendable {
 }
 
 enum DeviceIdentityPaths {
+    private static let deviceStateDirEnv = ["OPENCLAW_DEVICE_STATE_DIR"]
     private static let stateDirEnv = ["OPENCLAW_STATE_DIR"]
+    private static let nativeStateDirIdentityOptInEnv = "OPENCLAW_MAC_ALLOW_STATE_DIR_IDENTITY"
 
-    static func stateDirURL() -> URL {
-        for key in self.stateDirEnv {
-            if let raw = getenv(key) {
-                let value = String(cString: raw).trimmingCharacters(in: .whitespacesAndNewlines)
-                if !value.isEmpty {
-                    return URL(fileURLWithPath: value, isDirectory: true)
-                }
-            }
+    static func stateDirURL(bundleIdentifier: String? = Bundle.main.bundleIdentifier) -> URL {
+        if let override = self.envPath(for: self.deviceStateDirEnv) {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+
+        if self.shouldHonorSharedStateDir(bundleIdentifier: bundleIdentifier),
+           let override = self.envPath(for: self.stateDirEnv)
+        {
+            return URL(fileURLWithPath: override, isDirectory: true)
         }
 
         if let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
@@ -33,6 +36,36 @@ enum DeviceIdentityPaths {
         }
 
         return FileManager.default.temporaryDirectory.appendingPathComponent("openclaw", isDirectory: true)
+    }
+
+    private static func envPath(for keys: [String]) -> String? {
+        for key in keys {
+            if let raw = getenv(key) {
+                let value = String(cString: raw).trimmingCharacters(in: .whitespacesAndNewlines)
+                if !value.isEmpty {
+                    return value
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func shouldHonorSharedStateDir(bundleIdentifier: String?) -> Bool {
+        if let raw = getenv(self.nativeStateDirIdentityOptInEnv) {
+            let value = String(cString: raw).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if ["1", "true", "yes", "on"].contains(value) {
+                return true
+            }
+        }
+        if bundleIdentifier == "ai.openclaw.mac" {
+            return false
+        }
+        if let raw = getenv("__CFBundleIdentifier"),
+           String(cString: raw).trimmingCharacters(in: .whitespacesAndNewlines) == "ai.openclaw.mac"
+        {
+            return false
+        }
+        return true
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -490,6 +490,8 @@ public actor GatewayChannelActor {
                 auth["deviceToken"] = ProtoAnyCodable(authDeviceToken)
             }
             params["auth"] = ProtoAnyCodable(auth)
+        } else if let authDeviceToken = selectedAuth.authDeviceToken {
+            params["auth"] = ProtoAnyCodable(["deviceToken": ProtoAnyCodable(authDeviceToken)])
         } else if let authBootstrapToken = selectedAuth.authBootstrapToken {
             params["auth"] = ProtoAnyCodable(["bootstrapToken": ProtoAnyCodable(authBootstrapToken)])
         } else if let password = selectedAuth.authPassword {
@@ -569,17 +571,19 @@ public actor GatewayChannelActor {
         let shouldUseDeviceRetryToken =
             includeDeviceIdentity && self.pendingDeviceTokenRetry &&
             storedToken != nil && explicitToken != nil && self.isTrustedDeviceRetryEndpoint()
-        let authToken =
-            explicitToken ??
-            // A freshly scanned setup code should force the bootstrap pairing path instead of
-            // silently reusing an older stored device token.
-            (includeDeviceIdentity && explicitPassword == nil && explicitBootstrapToken == nil
-                ? storedToken
-                : nil)
+        let authToken = explicitToken
         let authBootstrapToken =
             authToken == nil && explicitPassword == nil ? explicitBootstrapToken : nil
-        let authDeviceToken = shouldUseDeviceRetryToken ? storedToken : nil
-        let authSource: GatewayAuthSource = if authDeviceToken != nil || (explicitToken == nil && authToken != nil) {
+        let shouldUseStoredDeviceToken =
+            includeDeviceIdentity &&
+            storedToken != nil &&
+            explicitToken == nil &&
+            explicitPassword == nil &&
+            // A freshly scanned setup code should force the bootstrap pairing path instead of
+            // silently reusing an older stored device token.
+            explicitBootstrapToken == nil
+        let authDeviceToken = (shouldUseDeviceRetryToken || shouldUseStoredDeviceToken) ? storedToken : nil
+        let authSource: GatewayAuthSource = if authDeviceToken != nil {
             .deviceToken
         } else if authToken != nil {
             .sharedToken
@@ -595,7 +599,7 @@ public actor GatewayChannelActor {
             authBootstrapToken: authBootstrapToken,
             authDeviceToken: authDeviceToken,
             authPassword: explicitPassword,
-            signatureToken: authToken ?? authBootstrapToken,
+            signatureToken: authToken ?? authBootstrapToken ?? authDeviceToken,
             storedToken: storedToken,
             storedScopes: storedEntry?.scopes,
             authSource: authSource)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceAuthPayloadTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceAuthPayloadTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import OpenClawKit
 
@@ -26,5 +27,61 @@ struct DeviceAuthPayloadTests {
         #expect(GatewayDeviceAuthPayload.normalizeMetadataField("  İOS  ") == "İos")
         #expect(GatewayDeviceAuthPayload.normalizeMetadataField("  MAC  ") == "mac")
         #expect(GatewayDeviceAuthPayload.normalizeMetadataField(nil) == "")
+    }
+
+    @Test("native app device identity ignores inherited shared state dir")
+    func nativeAppDeviceIdentityIgnoresInheritedSharedStateDir() {
+        let sharedStateDir = "/tmp/openclaw-shared-state-from-shell"
+        Self.withEnv([
+            "OPENCLAW_STATE_DIR": sharedStateDir,
+            "OPENCLAW_DEVICE_STATE_DIR": nil,
+            "OPENCLAW_MAC_ALLOW_STATE_DIR_IDENTITY": nil,
+            "__CFBundleIdentifier": nil,
+        ]) {
+            let url = DeviceIdentityPaths.stateDirURL(bundleIdentifier: "ai.openclaw.mac")
+            #expect(url.path != sharedStateDir)
+            #expect(url.path.hasSuffix("/OpenClaw") || url.lastPathComponent == "openclaw")
+        }
+    }
+
+    @Test("native app device identity honors explicit device state dir")
+    func nativeAppDeviceIdentityHonorsExplicitDeviceStateDir() {
+        let sharedStateDir = "/tmp/openclaw-shared-state-from-shell"
+        let deviceStateDir = "/tmp/openclaw-device-state-explicit"
+        Self.withEnv([
+            "OPENCLAW_STATE_DIR": sharedStateDir,
+            "OPENCLAW_DEVICE_STATE_DIR": deviceStateDir,
+            "OPENCLAW_MAC_ALLOW_STATE_DIR_IDENTITY": nil,
+            "__CFBundleIdentifier": nil,
+        ]) {
+            #expect(DeviceIdentityPaths.stateDirURL(bundleIdentifier: "ai.openclaw.mac").path == deviceStateDir)
+        }
+    }
+
+    private static func withEnv(_ values: [String: String?], body: () -> Void) {
+        let previous = values.mapValues { _ -> String? in nil }
+        var saved = previous
+        for key in values.keys {
+            if let raw = getenv(key) {
+                saved[key] = String(cString: raw)
+            }
+        }
+        for (key, value) in values {
+            if let value {
+                setenv(key, value, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+        defer {
+            for (key, value) in saved {
+                if let value {
+                    setenv(key, value, 1)
+                } else {
+                    unsetenv(key)
+                }
+            }
+        }
+        body()
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -305,6 +305,62 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
+    func storedDeviceTokenUsesDeviceTokenAuthField() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
+        defer {
+            if let previousStateDir {
+                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
+            } else {
+                unsetenv("OPENCLAW_STATE_DIR")
+            }
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        _ = DeviceAuthStore.storeToken(
+            deviceId: identity.deviceId,
+            role: "operator",
+            token: "stored-device-token")
+
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "operator",
+            scopes: ["operator.read"],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "ui",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: true)
+
+        try await gateway.connect(
+            url: URL(string: "ws://example.invalid")!,
+            token: nil,
+            bootstrapToken: nil,
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            })
+
+        let auth = try #require(session.latestTask()?.latestConnectAuth())
+        #expect(auth["deviceToken"] as? String == "stored-device-token")
+        #expect(auth["token"] == nil)
+        #expect(auth["bootstrapToken"] == nil)
+
+        await gateway.disconnect()
+    }
+
+    @Test
     func passwordTakesPrecedenceOverBootstrapToken() async throws {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -85,10 +85,13 @@ vYYYY.M.D-beta.N` from the matching `release/YYYY.M.D` branch. The helper runs
    validation and npm preflight evidence, runs Parallels and Telegram package
    proof, records plugin npm and ClawHub plans, and prints the exact
    `OpenClaw Release Publish` command only after the evidence bundle is green.
-   `OpenClaw Release Publish` dispatches the selected or all-publishable plugin
-   packages to npm and the same set to ClawHub in parallel, and then promotes the
-   prepared OpenClaw npm preflight artifact with the matching dist-tag as soon as
-   plugin npm publish succeeds.
+   For beta tags, `OpenClaw Release Publish` first requires the signed desktop
+   beta distribution to already be live on the GitHub prerelease and
+   `appcast-beta.xml`; this keeps npm/plugin beta publication from getting ahead
+   of the desktop update channel. It then dispatches the selected or
+   all-publishable plugin packages to npm and the same set to ClawHub in
+   parallel, and promotes the prepared OpenClaw npm preflight artifact with the
+   matching dist-tag as soon as plugin npm publish succeeds.
    After the OpenClaw npm publish child succeeds, it creates or updates the
    matching GitHub release/prerelease page from the complete matching
    `CHANGELOG.md` section. Stable releases published to npm `latest` become the
@@ -100,14 +103,16 @@ vYYYY.M.D-beta.N` from the matching `release/YYYY.M.D` branch. The helper runs
    release environment gates the workflow token is allowed to approve, summarizes
    failed child jobs with log tails, closes out the GitHub release and dependency
    evidence as soon as OpenClaw npm publish succeeds, waits for ClawHub whenever
-   OpenClaw npm is being published, then runs `pnpm release:verify-beta` and
-   uploads postpublish evidence for the GitHub release, npm package, selected
-   plugin npm packages, selected ClawHub packages, child workflow run IDs, and
-   optional NPM Telegram run ID. The ClawHub path retries transient CLI
+   OpenClaw npm is being published, then runs `pnpm release:verify-beta` again
+   and uploads postpublish evidence for the GitHub release, npm package, desktop
+   beta distribution, selected plugin npm packages, selected ClawHub packages,
+   child workflow run IDs, and optional NPM Telegram run ID. The ClawHub path retries transient CLI
    dependency install failures, publishes preview-passing plugins even when one
    preview cell flakes, and ends with registry verification for every expected
-   plugin version so partial publishes remain visible and retryable. Then run the post-publish
-   package acceptance against the published
+   plugin version so partial publishes remain visible and retryable. The desktop
+   beta check covers `OpenClaw-YYYY.M.D-beta.N.zip`, `.dmg`, `.dSYM.zip`, and
+   `appcast-beta.xml`.
+   Then run the post-publish package acceptance against the published
    `openclaw@YYYY.M.D-beta.N` or
    `openclaw@beta` package. If a pushed or published prerelease needs a fix,
    cut the next matching prerelease number; do not delete or rewrite the old
@@ -301,6 +306,11 @@ Validation` or from the `main`/release workflow ref so workflow logic and
     `validate_run_id`
   - the real publish paths promote prepared artifacts instead of rebuilding
     them again
+- Beta macOS release readiness uses the same signed desktop packaging path, but
+  publishes to `appcast-beta.xml`. `scripts/package-mac-app.sh` points
+  prerelease bundles at `appcast-beta.xml` by default, and
+  `scripts/make_appcast.sh` writes `appcast-beta.xml` automatically for
+  `YYYY.M.D-beta.N` zips unless `SPARKLE_APPCAST_PATH` is set explicitly.
 - For stable correction releases like `YYYY.M.D-N`, the post-publish verifier
   also checks the same temp-prefix upgrade path from `YYYY.M.D` to `YYYY.M.D-N`
   so release corrections cannot silently leave older global installs on the
@@ -648,10 +658,12 @@ orchestrates the trusted-publisher workflows in the order the release needs:
 1. Check out the release tag and resolve its commit SHA.
 2. Verify the tag is reachable from `main` or `release/*`.
 3. Run `pnpm plugins:sync:check`.
-4. Dispatch `Plugin NPM Release` with `publish_scope=all-publishable` and
+4. For beta tags, verify signed desktop beta assets and `appcast-beta.xml`
+   before any npm/plugin publish dispatch.
+5. Dispatch `Plugin NPM Release` with `publish_scope=all-publishable` and
    `ref=<release-sha>`.
-5. Dispatch `Plugin ClawHub Release` with the same scope and SHA.
-6. Dispatch `OpenClaw NPM Release` with the release tag, npm dist-tag, and
+6. Dispatch `Plugin ClawHub Release` with the same scope and SHA.
+7. Dispatch `OpenClaw NPM Release` with the release tag, npm dist-tag, and
    saved `preflight_run_id`.
 
 Beta publish example:
@@ -756,13 +768,16 @@ When cutting a stable npm release:
 4. If you intentionally only need the deterministic normal test graph, run the
    manual `CI` workflow on the release ref instead
 5. Save the successful `preflight_run_id`
-6. Run `OpenClaw Release Publish` with the same `tag`, the same `npm_dist_tag`,
+6. For beta tags, make sure the signed macOS beta publish has already promoted
+   `OpenClaw-YYYY.M.D-beta.N.zip`, `.dmg`, `.dSYM.zip`, and `appcast-beta.xml`
+   for the tag.
+7. Run `OpenClaw Release Publish` with the same `tag`, the same `npm_dist_tag`,
    and the saved `preflight_run_id`; it publishes externalized plugins to npm
    and ClawHub before promoting the OpenClaw npm package
-7. If the release landed on `beta`, use the
+8. If the release landed on `beta`, use the
    `openclaw/releases/.github/workflows/openclaw-npm-dist-tags.yml`
    workflow to promote that stable version from `beta` to `latest`
-8. If the release intentionally published directly to `latest` and `beta`
+9. If the release intentionally published directly to `latest` and `beta`
    should follow the same stable build immediately, use that same release
    workflow to point both dist-tags at the stable version, or let its scheduled
    self-healing sync move `beta` later

--- a/extensions/acpx/npm-shrinkwrap.json
+++ b/extensions/acpx/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/acpx",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/acpx",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.39.0",
         "@zed-industries/codex-acp": "0.15.0",

--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/acpx",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw ACP runtime backend with plugin-owned session and transport management.",
   "repository": {
     "type": "git",
@@ -26,10 +26,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "staticAssets": [
         {
           "source": "./src/runtime-internals/mcp-proxy.mjs",

--- a/extensions/admin-http-rpc/package.json
+++ b/extensions/admin-http-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/admin-http-rpc",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw admin HTTP RPC endpoint",
   "type": "module",

--- a/extensions/alibaba/package.json
+++ b/extensions/alibaba/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/alibaba-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Alibaba Model Studio video provider plugin",
   "type": "module",

--- a/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/amazon-bedrock-mantle-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/amazon-bedrock-mantle-provider",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@anthropic-ai/sdk": "0.100.1",
         "@aws/bedrock-token-generator": "1.1.0"

--- a/extensions/amazon-bedrock-mantle/package.json
+++ b/extensions/amazon-bedrock-mantle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-mantle-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Amazon Bedrock Mantle provider plugin for OpenAI-compatible model routing.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "bundledDist": false
     },
     "release": {

--- a/extensions/amazon-bedrock/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/amazon-bedrock-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/amazon-bedrock-provider",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@aws-sdk/client-bedrock": "3.1056.0",
         "@aws-sdk/client-bedrock-runtime": "3.1056.0",

--- a/extensions/amazon-bedrock/package.json
+++ b/extensions/amazon-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Amazon Bedrock provider plugin with model discovery, embeddings, and guardrail support.",
   "repository": {
     "type": "git",
@@ -28,10 +28,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "bundledDist": false
     },
     "release": {

--- a/extensions/anthropic-vertex/npm-shrinkwrap.json
+++ b/extensions/anthropic-vertex/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/anthropic-vertex-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/anthropic-vertex-provider",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "0.16.1"
       }

--- a/extensions/anthropic-vertex/package.json
+++ b/extensions/anthropic-vertex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-vertex-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Anthropic Vertex provider plugin for Claude models on Google Vertex AI.",
   "repository": {
     "type": "git",
@@ -23,10 +23,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "bundledDist": false
     },
     "release": {

--- a/extensions/anthropic/package.json
+++ b/extensions/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Anthropic provider plugin",
   "type": "module",

--- a/extensions/arcee/package.json
+++ b/extensions/arcee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/arcee-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Arcee provider plugin",
   "type": "module",

--- a/extensions/azure-speech/package.json
+++ b/extensions/azure-speech/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/azure-speech",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Azure Speech plugin",
   "type": "module",

--- a/extensions/bonjour/package.json
+++ b/extensions/bonjour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/bonjour",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Bonjour/mDNS gateway discovery",
   "type": "module",
   "dependencies": {

--- a/extensions/brave/npm-shrinkwrap.json
+++ b/extensions/brave/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/brave-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/brave-plugin",
-      "version": "2026.5.31-beta.4"
+      "version": "2026.5.31-beta.5"
     }
   }
 }

--- a/extensions/brave/package.json
+++ b/extensions/brave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/brave-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Brave Search provider plugin for web search.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/browser-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw browser tool plugin",
   "type": "module",

--- a/extensions/byteplus/package.json
+++ b/extensions/byteplus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/byteplus-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw BytePlus provider plugin",
   "type": "module",

--- a/extensions/canvas/package.json
+++ b/extensions/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/canvas-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Canvas plugin",
   "type": "module",

--- a/extensions/cerebras/package.json
+++ b/extensions/cerebras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cerebras-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Cerebras provider plugin",
   "type": "module",

--- a/extensions/chutes/package.json
+++ b/extensions/chutes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/chutes-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Chutes.ai provider plugin",
   "type": "module",

--- a/extensions/clickclack/package.json
+++ b/extensions/clickclack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/clickclack",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw ClickClack channel plugin",
   "type": "module",
@@ -18,7 +18,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/cloudflare-ai-gateway/package.json
+++ b/extensions/cloudflare-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cloudflare-ai-gateway-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Cloudflare AI Gateway provider plugin",
   "type": "module",

--- a/extensions/codex-supervisor/package.json
+++ b/extensions/codex-supervisor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/codex-supervisor",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Codex app-server fleet supervision plugin.",
   "type": "module",

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/codex",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/codex",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@openai/codex": "0.135.0",
         "typebox": "1.1.39",

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/codex",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Codex app-server harness and model provider plugin with a Codex-managed GPT catalog.",
   "repository": {
     "type": "git",
@@ -26,10 +26,10 @@
       "minHostVersion": ">=2026.5.1-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/comfy/package.json
+++ b/extensions/comfy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/comfy-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw ComfyUI provider plugin",
   "type": "module",

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot-proxy",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Copilot Proxy provider plugin",
   "type": "module",

--- a/extensions/copilot/npm-shrinkwrap.json
+++ b/extensions/copilot/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/copilot",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/copilot",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@github/copilot-sdk": "1.0.0-beta.9"
       }

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw GitHub Copilot agent runtime plugin (registers a `github-copilot` AgentHarness backed by @github/copilot-sdk over JSON-RPC to the GitHub Copilot CLI)",
   "repository": {
     "type": "git",
@@ -25,10 +25,10 @@
       "minHostVersion": ">=2026.5.28"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "bundledDist": false
     },
     "release": {

--- a/extensions/deepgram/package.json
+++ b/extensions/deepgram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepgram-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Deepgram media-understanding provider",
   "type": "module",

--- a/extensions/deepinfra/package.json
+++ b/extensions/deepinfra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepinfra-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw DeepInfra provider plugin",
   "type": "module",

--- a/extensions/deepseek/package.json
+++ b/extensions/deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepseek-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw DeepSeek provider plugin",
   "type": "module",

--- a/extensions/diagnostics-otel/npm-shrinkwrap.json
+++ b/extensions/diagnostics-otel/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/diagnostics-otel",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/diagnostics-otel",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
         "@opentelemetry/api-logs": "0.218.0",

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-otel",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw diagnostics OpenTelemetry exporter for metrics and traces.",
   "repository": {
     "type": "git",
@@ -34,10 +34,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/diagnostics-prometheus/npm-shrinkwrap.json
+++ b/extensions/diagnostics-prometheus/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/diagnostics-prometheus",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/diagnostics-prometheus",
-      "version": "2026.5.31-beta.4"
+      "version": "2026.5.31-beta.5"
     }
   }
 }

--- a/extensions/diagnostics-prometheus/package.json
+++ b/extensions/diagnostics-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-prometheus",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw diagnostics Prometheus exporter for runtime metrics.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/diffs-language-pack/npm-shrinkwrap.json
+++ b/extensions/diffs-language-pack/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/diffs-language-pack",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/diffs-language-pack",
-      "version": "2026.5.31-beta.4"
+      "version": "2026.5.31-beta.5"
     }
   }
 }

--- a/extensions/diffs-language-pack/package.json
+++ b/extensions/diffs-language-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs-language-pack",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw diffs viewer syntax highlighting language pack",
   "repository": {
     "type": "git",
@@ -22,13 +22,13 @@
       "minHostVersion": ">=2026.5.27"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "assetScripts": {
       "build": "node ../../scripts/build-diffs-viewer-runtime.mjs full"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "staticAssets": [
         {
           "source": "./assets/viewer-runtime.js",

--- a/extensions/diffs/npm-shrinkwrap.json
+++ b/extensions/diffs/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/diffs",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/diffs",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@pierre/diffs": "1.2.4",
         "@pierre/theme": "1.0.3",

--- a/extensions/diffs/package.json
+++ b/extensions/diffs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw read-only diff viewer plugin and file renderer for agents.",
   "repository": {
     "type": "git",
@@ -29,13 +29,13 @@
       "minHostVersion": ">=2026.4.30"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "assetScripts": {
       "build": "node ../../scripts/build-diffs-viewer-runtime.mjs curated"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "staticAssets": [
         {
           "source": "./assets/viewer-runtime.js",

--- a/extensions/discord/npm-shrinkwrap.json
+++ b/extensions/discord/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/discord",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@discordjs/voice": "0.19.2",
         "discord-api-types": "0.38.48",
@@ -16,7 +16,7 @@
         "ws": "8.21.0"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -67,10 +67,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/document-extract/package.json
+++ b/extensions/document-extract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/document-extract-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw local document extraction plugin",
   "type": "module",

--- a/extensions/duckduckgo/package.json
+++ b/extensions/duckduckgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/duckduckgo-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw DuckDuckGo plugin",
   "type": "module",

--- a/extensions/elevenlabs/package.json
+++ b/extensions/elevenlabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/elevenlabs-speech",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw ElevenLabs speech plugin",
   "type": "module",

--- a/extensions/exa/package.json
+++ b/extensions/exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/exa-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Exa plugin",
   "type": "module",

--- a/extensions/fal/package.json
+++ b/extensions/fal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fal-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw fal provider plugin",
   "type": "module",

--- a/extensions/feishu/npm-shrinkwrap.json
+++ b/extensions/feishu/npm-shrinkwrap.json
@@ -1,19 +1,19 @@
 {
   "name": "@openclaw/feishu",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/feishu",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "1.66.0",
         "typebox": "1.1.39",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/feishu",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Feishu/Lark channel plugin for chats and workplace tools (community maintained by @m1heng).",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -51,10 +51,10 @@
       "minHostVersion": ">=2026.5.29"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/file-transfer/package.json
+++ b/extensions/file-transfer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/file-transfer",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw file transfer plugin (file_fetch, dir_list, dir_fetch, file_write)",
   "type": "module",
   "dependencies": {

--- a/extensions/firecrawl/package.json
+++ b/extensions/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/firecrawl-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Firecrawl plugin",
   "type": "module",

--- a/extensions/fireworks/package.json
+++ b/extensions/fireworks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fireworks-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Fireworks provider plugin",
   "type": "module",

--- a/extensions/github-copilot/package.json
+++ b/extensions/github-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/github-copilot-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw GitHub Copilot provider plugin",
   "type": "module",

--- a/extensions/gmi/package.json
+++ b/extensions/gmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gmi-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw GMI Cloud provider plugin",
   "type": "module",

--- a/extensions/google-meet/npm-shrinkwrap.json
+++ b/extensions/google-meet/npm-shrinkwrap.json
@@ -1,18 +1,18 @@
 {
   "name": "@openclaw/google-meet",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/google-meet",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "commander": "14.0.3",
         "typebox": "1.1.39"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-meet",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Google Meet participant plugin for joining calls through Chrome or Twilio transports.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.4.20"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/google/package.json
+++ b/extensions/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Google plugin",
   "type": "module",

--- a/extensions/googlechat/npm-shrinkwrap.json
+++ b/extensions/googlechat/npm-shrinkwrap.json
@@ -1,19 +1,19 @@
 {
   "name": "@openclaw/googlechat",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/googlechat",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "gaxios": "7.1.4",
         "google-auth-library": "10.6.2",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/googlechat",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Google Chat channel plugin for spaces and direct messages.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -75,10 +75,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/gradium/package.json
+++ b/extensions/gradium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gradium-speech",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Gradium speech plugin",
   "type": "module",

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/groq-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Groq media-understanding provider",
   "type": "module",

--- a/extensions/huggingface/package.json
+++ b/extensions/huggingface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/huggingface-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Hugging Face provider plugin",
   "type": "module",

--- a/extensions/image-generation-core/package.json
+++ b/extensions/image-generation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/image-generation-core",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw image generation runtime package",
   "type": "module",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/imessage",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw iMessage channel plugin using imsg on a signed-in Mac",
   "type": "module",
@@ -43,10 +43,10 @@
       ]
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     }
   },
   "pluginInspector": {

--- a/extensions/inworld/package.json
+++ b/extensions/inworld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/inworld-speech",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Inworld speech plugin",
   "type": "module",

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/irc",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw IRC channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/kilocode/package.json
+++ b/extensions/kilocode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kilocode-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Kilo Gateway provider plugin",
   "type": "module",

--- a/extensions/kimi-coding/package.json
+++ b/extensions/kimi-coding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kimi-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Kimi provider plugin",
   "type": "module",

--- a/extensions/line/npm-shrinkwrap.json
+++ b/extensions/line/npm-shrinkwrap.json
@@ -1,18 +1,18 @@
 {
   "name": "@openclaw/line",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/line",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@line/bot-sdk": "11.0.1",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/line",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw LINE channel plugin for LINE Bot API chats.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -46,10 +46,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/litellm/package.json
+++ b/extensions/litellm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/litellm-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw LiteLLM provider plugin",
   "type": "module",

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llm-task",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",

--- a/extensions/lmstudio/package.json
+++ b/extensions/lmstudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lmstudio-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw LM Studio provider plugin",
   "type": "module",

--- a/extensions/lobster/npm-shrinkwrap.json
+++ b/extensions/lobster/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/lobster",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/lobster",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@clawdbot/lobster": "2026.5.22",
         "typebox": "1.1.39"

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lobster",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "Lobster workflow tool plugin for typed pipelines and resumable approvals.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/matrix/npm-shrinkwrap.json
+++ b/extensions/matrix/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/matrix",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/matrix",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@matrix-org/matrix-sdk-crypto-nodejs": "0.6.0",
         "@matrix-org/matrix-sdk-crypto-wasm": "18.3.0",
@@ -18,7 +18,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/matrix",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Matrix channel plugin for rooms and direct messages.",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -88,10 +88,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mattermost",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Mattermost channel plugin",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/media-understanding-core/package.json
+++ b/extensions/media-understanding-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/media-understanding-core",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw media understanding runtime package",
   "type": "module",

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-core",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw core memory search plugin",
   "type": "module",
@@ -14,7 +14,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/memory-lancedb/npm-shrinkwrap.json
+++ b/extensions/memory-lancedb/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/memory-lancedb",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/memory-lancedb",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@lancedb/lancedb": "0.30.0",
         "apache-arrow": "21.1.0",

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-lancedb",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, and vector search.",
   "repository": {
     "type": "git",
@@ -26,10 +26,10 @@
       "minHostVersion": ">=2026.5.31"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/memory-wiki/package.json
+++ b/extensions/memory-wiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-wiki",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw persistent wiki plugin",
   "type": "module",
@@ -14,7 +14,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/microsoft-foundry/package.json
+++ b/extensions/microsoft-foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-foundry",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Microsoft Foundry provider plugin",
   "type": "module",

--- a/extensions/microsoft/package.json
+++ b/extensions/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-speech",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Microsoft speech plugin",
   "type": "module",

--- a/extensions/migrate-claude/package.json
+++ b/extensions/migrate-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/migrate-claude",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "Claude to OpenClaw migration provider",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/migrate-hermes/package.json
+++ b/extensions/migrate-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/migrate-hermes",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "Hermes to OpenClaw migration provider",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/minimax/package.json
+++ b/extensions/minimax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/minimax-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw MiniMax provider and OAuth plugin",
   "type": "module",

--- a/extensions/mistral/package.json
+++ b/extensions/mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mistral-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Mistral provider plugin",
   "type": "module",

--- a/extensions/moonshot/package.json
+++ b/extensions/moonshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/moonshot-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Moonshot provider plugin",
   "type": "module",

--- a/extensions/msteams/npm-shrinkwrap.json
+++ b/extensions/msteams/npm-shrinkwrap.json
@@ -180,15 +180,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "15.17.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.17.0.tgz",
-      "integrity": "sha512-VQ5/gTLFADkwue+FohVuCqlzFPUq4xSrX8jeZe+iwZuY6moliNC8xt86qPVNYdtbQfELDf2Nu6LI+demFPHGgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/@microsoft/teams.api": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@microsoft/teams.api/-/teams.api-2.0.12.tgz",

--- a/extensions/msteams/npm-shrinkwrap.json
+++ b/extensions/msteams/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/msteams",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/msteams",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@azure/identity": "4.13.1",
         "@microsoft/teams.api": "2.0.12",
@@ -15,7 +15,7 @@
         "typebox": "1.1.39"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {
@@ -178,6 +178,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "15.17.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.17.0.tgz",
+      "integrity": "sha512-VQ5/gTLFADkwue+FohVuCqlzFPUq4xSrX8jeZe+iwZuY6moliNC8xt86qPVNYdtbQfELDf2Nu6LI+demFPHGgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@microsoft/teams.api": {

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/msteams",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Microsoft Teams channel plugin for bot conversations.",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -56,10 +56,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/nextcloud-talk/npm-shrinkwrap.json
+++ b/extensions/nextcloud-talk/npm-shrinkwrap.json
@@ -1,17 +1,17 @@
 {
   "name": "@openclaw/nextcloud-talk",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/nextcloud-talk",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nextcloud-talk",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Nextcloud Talk channel plugin for conversations.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -44,10 +44,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/nostr/npm-shrinkwrap.json
+++ b/extensions/nostr/npm-shrinkwrap.json
@@ -1,18 +1,18 @@
 {
   "name": "@openclaw/nostr",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/nostr",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "nostr-tools": "2.23.5",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nostr",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted direct messages.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -54,10 +54,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/novita/package.json
+++ b/extensions/novita/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/novita-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw NovitaAI provider plugin",
   "type": "module",

--- a/extensions/nvidia/package.json
+++ b/extensions/nvidia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nvidia-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw NVIDIA provider plugin",
   "type": "module",

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/oc-path",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw oc:// workspace path plugin",
   "type": "module",
@@ -15,7 +15,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/ollama/package.json
+++ b/extensions/ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/ollama-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Ollama provider plugin",
   "type": "module",

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/open-prose",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",

--- a/extensions/openai/package.json
+++ b/extensions/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openai-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw OpenAI provider plugins",
   "type": "module",

--- a/extensions/opencode-go/package.json
+++ b/extensions/opencode-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-go-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw OpenCode Go provider plugin",
   "type": "module",

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw OpenCode Zen provider plugin",
   "type": "module",

--- a/extensions/openrouter/package.json
+++ b/extensions/openrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openrouter-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw OpenRouter provider plugin",
   "type": "module",

--- a/extensions/openshell/npm-shrinkwrap.json
+++ b/extensions/openshell/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/openshell-sandbox",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/openshell-sandbox",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "zod": "4.4.3"
       }

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openshell-sandbox",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw sandbox backend for the NVIDIA OpenShell CLI with mirrored local workspaces and SSH command execution.",
   "repository": {
     "type": "git",
@@ -23,10 +23,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "bundledDist": false
     },
     "release": {

--- a/extensions/perplexity/package.json
+++ b/extensions/perplexity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/perplexity-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Perplexity plugin",
   "type": "module",

--- a/extensions/pixverse/npm-shrinkwrap.json
+++ b/extensions/pixverse/npm-shrinkwrap.json
@@ -1,14 +1,14 @@
 {
   "name": "@openclaw/pixverse-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/pixverse-provider",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/pixverse/package.json
+++ b/extensions/pixverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/pixverse-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw PixVerse video generation provider plugin.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -30,10 +30,10 @@
       "minHostVersion": ">=2026.5.26"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "bundledDist": false
     },
     "release": {

--- a/extensions/policy/package.json
+++ b/extensions/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/policy",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw policy doctor checks for workspace conformance",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/qa-channel/package.json
+++ b/extensions/qa-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-channel",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw QA synthetic channel plugin",
   "type": "module",
@@ -19,7 +19,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-lab",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw QA lab plugin with private debugger UI and scenario runner",
   "type": "module",
@@ -19,7 +19,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -31,7 +31,7 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     }
   }
 }

--- a/extensions/qa-matrix/package.json
+++ b/extensions/qa-matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-matrix",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Matrix QA runner plugin",
   "type": "module",
@@ -13,7 +13,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -25,7 +25,7 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     }
   }
 }

--- a/extensions/qianfan/package.json
+++ b/extensions/qianfan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qianfan-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Qianfan provider plugin",
   "type": "module",

--- a/extensions/qqbot/npm-shrinkwrap.json
+++ b/extensions/qqbot/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/qqbot",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/qqbot",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@tencent-connect/qqbot-connector": "1.1.0",
         "mpg123-decoder": "1.0.3",
@@ -15,7 +15,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/qqbot/package.json
+++ b/extensions/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qqbot",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": false,
   "description": "OpenClaw QQ Bot channel plugin for group and direct-message workflows.",
   "repository": {
@@ -21,7 +21,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -50,10 +50,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/qwen/package.json
+++ b/extensions/qwen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qwen-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Qwen Cloud provider plugin",
   "type": "module",

--- a/extensions/runway/package.json
+++ b/extensions/runway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/runway-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Runway video provider plugin",
   "type": "module",

--- a/extensions/searxng/package.json
+++ b/extensions/searxng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/searxng-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw SearXNG plugin",
   "type": "module",

--- a/extensions/senseaudio/package.json
+++ b/extensions/senseaudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/senseaudio-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw SenseAudio media-understanding provider",
   "type": "module",

--- a/extensions/sglang/package.json
+++ b/extensions/sglang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/sglang-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw SGLang provider plugin",
   "type": "module",

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/signal",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Signal channel plugin",
   "type": "module",

--- a/extensions/slack/npm-shrinkwrap.json
+++ b/extensions/slack/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/slack",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/slack",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@slack/bolt": "4.7.3",
         "@slack/types": "2.21.1",
@@ -15,7 +15,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/slack",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Slack channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -64,13 +64,13 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "startup": {
       "deferConfiguredChannelFullLoadUntilAfterListen": true
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "bundledDist": false
     },
     "release": {

--- a/extensions/sms/package.json
+++ b/extensions/sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/sms",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw SMS channel plugin for Twilio text messages.",
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
       "quickstartAllowFrom": true
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     }
   }
 }

--- a/extensions/stepfun/package.json
+++ b/extensions/stepfun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/stepfun-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw StepFun provider plugin",
   "type": "module",

--- a/extensions/synology-chat/npm-shrinkwrap.json
+++ b/extensions/synology-chat/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/synology-chat",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/synology-chat",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "zod": "4.4.3"
       }

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synology-chat",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/synthetic/package.json
+++ b/extensions/synthetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synthetic-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Synthetic provider plugin",
   "type": "module",

--- a/extensions/tavily/package.json
+++ b/extensions/tavily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tavily-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Tavily plugin",
   "type": "module",

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/telegram",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Telegram channel plugin",
   "type": "module",

--- a/extensions/tencent/package.json
+++ b/extensions/tencent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tencent-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Tencent Cloud provider plugin (TokenHub + Token Plan)",
   "type": "module",

--- a/extensions/tlon/npm-shrinkwrap.json
+++ b/extensions/tlon/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/tlon",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@aws-sdk/client-s3": "3.1056.0",
         "@aws-sdk/s3-request-presigner": "3.1056.0",
@@ -15,7 +15,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Tlon/Urbit channel plugin for chat workflows.",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -73,10 +73,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/together/package.json
+++ b/extensions/together/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/together-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Together provider plugin",
   "type": "module",

--- a/extensions/tokenjuice/npm-shrinkwrap.json
+++ b/extensions/tokenjuice/npm-shrinkwrap.json
@@ -1,17 +1,17 @@
 {
   "name": "@openclaw/tokenjuice",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/tokenjuice",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "tokenjuice": "0.8.0"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/tokenjuice/package.json
+++ b/extensions/tokenjuice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tokenjuice",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw tokenjuice exec output compaction plugin",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
     "tokenjuice": "0.8.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.5.28"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4",
+      "openclawVersion": "2026.5.31-beta.5",
       "bundledDist": false
     },
     "release": {

--- a/extensions/tts-local-cli/package.json
+++ b/extensions/tts-local-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tts-local-cli",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw local CLI TTS plugin",
   "type": "module",

--- a/extensions/twitch/npm-shrinkwrap.json
+++ b/extensions/twitch/npm-shrinkwrap.json
@@ -244,6 +244,12 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@types/ws/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
     "node_modules/ircv3": {
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.33.1.tgz",
@@ -287,9 +293,9 @@
       "license": "0BSD"
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/ws": {

--- a/extensions/twitch/npm-shrinkwrap.json
+++ b/extensions/twitch/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/twitch",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/twitch",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "@twurple/api": "8.1.4",
         "@twurple/auth": "8.1.4",
@@ -244,12 +244,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/ws/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "license": "MIT"
-    },
     "node_modules/ircv3": {
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.33.1.tgz",
@@ -293,9 +287,9 @@
       "license": "0BSD"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/ws": {

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/twitch",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
   "repository": {
     "type": "git",
@@ -27,10 +27,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "channel": {
       "id": "twitch",

--- a/extensions/venice/package.json
+++ b/extensions/venice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/venice-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Venice provider plugin",
   "type": "module",

--- a/extensions/vercel-ai-gateway/package.json
+++ b/extensions/vercel-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vercel-ai-gateway-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Vercel AI Gateway provider plugin",
   "type": "module",

--- a/extensions/video-generation-core/package.json
+++ b/extensions/video-generation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/video-generation-core",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw video generation runtime package",
   "type": "module",

--- a/extensions/vllm/package.json
+++ b/extensions/vllm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vllm-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw vLLM provider plugin",
   "type": "module",

--- a/extensions/voice-call/npm-shrinkwrap.json
+++ b/extensions/voice-call/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/voice-call",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/voice-call",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "commander": "14.0.3",
         "typebox": "1.1.39",
@@ -14,7 +14,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voice-call",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -35,10 +35,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/volcengine/package.json
+++ b/extensions/volcengine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/volcengine-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Volcengine provider plugin",
   "type": "module",

--- a/extensions/voyage/package.json
+++ b/extensions/voyage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voyage-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Voyage embedding provider plugin",
   "type": "module",

--- a/extensions/vydra/package.json
+++ b/extensions/vydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vydra-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Vydra media provider plugin",
   "type": "module",

--- a/extensions/web-readability/package.json
+++ b/extensions/web-readability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/web-readability-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw local Readability web extraction plugin",
   "type": "module",

--- a/extensions/webhooks/package.json
+++ b/extensions/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/webhooks",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw webhook bridge plugin",
   "type": "module",

--- a/extensions/whatsapp/npm-shrinkwrap.json
+++ b/extensions/whatsapp/npm-shrinkwrap.json
@@ -1,19 +1,19 @@
 {
   "name": "@openclaw/whatsapp",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/whatsapp",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "audio-decode": "2.2.3",
         "baileys": "7.0.0-rc13",
         "typebox": "1.1.39"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/whatsapp",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw WhatsApp channel plugin for WhatsApp Web chats.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -60,10 +60,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/workboard/package.json
+++ b/extensions/workboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/workboard",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw dashboard workboard plugin",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/xai/package.json
+++ b/extensions/xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xai-plugin",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw xAI plugin",
   "type": "module",

--- a/extensions/xiaomi/package.json
+++ b/extensions/xiaomi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xiaomi-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Xiaomi provider plugin",
   "type": "module",

--- a/extensions/zai/package.json
+++ b/extensions/zai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zai-provider",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "private": true,
   "description": "OpenClaw Z.AI provider plugin",
   "type": "module",

--- a/extensions/zalo/npm-shrinkwrap.json
+++ b/extensions/zalo/npm-shrinkwrap.json
@@ -1,17 +1,17 @@
 {
   "name": "@openclaw/zalo",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/zalo",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalo",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -43,10 +43,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/zalouser/npm-shrinkwrap.json
+++ b/extensions/zalouser/npm-shrinkwrap.json
@@ -1,19 +1,19 @@
 {
   "name": "@openclaw/zalouser",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/zalouser",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "dependencies": {
         "typebox": "1.1.39",
         "zca-js": "2.1.2",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.31-beta.4"
+        "openclaw": ">=2026.5.31-beta.5"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalouser",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.31-beta.4"
+    "openclaw": ">=2026.5.31-beta.5"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -54,10 +54,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.5.31-beta.4"
+      "pluginApi": ">=2026.5.31-beta.5"
     },
     "build": {
-      "openclawVersion": "2026.5.31-beta.4"
+      "openclawVersion": "2026.5.31-beta.5"
     },
     "release": {
       "publishToClawHub": true,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw",
-      "version": "2026.5.31-beta.4",
+      "version": "2026.5.31-beta.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -786,17 +786,14 @@
       }
     },
     "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
     "node_modules/color-convert": {
@@ -2521,37 +2518,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/qrcode/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/qrcode/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
     "node_modules/qrcode/node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -2572,19 +2538,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/qrcode/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3360,9 +3313,9 @@
       "license": "ISC"
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -3370,10 +3323,7 @@
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -3404,13 +3354,10 @@
       }
     },
     "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "5.0.0",
@@ -3455,12 +3402,16 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=6"
       }
     },
     "node_modules/zod": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -786,14 +786,17 @@
       }
     },
     "node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -2518,6 +2521,37 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/qrcode/node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -2538,6 +2572,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3313,9 +3360,9 @@
       "license": "ISC"
     },
     "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -3323,7 +3370,10 @@
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -3354,10 +3404,13 @@
       }
     },
     "node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yallist": {
       "version": "5.0.0",
@@ -3402,16 +3455,12 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.5.31-beta.4",
+  "version": "2026.5.31-beta.5",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/packages/gateway-client/src/client.watchdog.test.ts
+++ b/packages/gateway-client/src/client.watchdog.test.ts
@@ -156,22 +156,29 @@ describe("GatewayClient", () => {
       });
     });
 
-    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
-      const client = new GatewayClient({
-        url: `ws://127.0.0.1:${port}`,
-        connectChallengeTimeoutMs: 0,
-        tickWatchMinIntervalMs: 5,
-        onClose: (code, reason) => resolve({ code, reason }),
+    let client: GatewayClient | undefined;
+    try {
+      const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+        client = new GatewayClient({
+          url: `ws://127.0.0.1:${port}`,
+          connectChallengeTimeoutMs: 0,
+          tickWatchMinIntervalMs: 5,
+          onClose: (code, reason) => resolve({ code, reason }),
+        });
+        client.start();
       });
-      client.start();
-    });
 
-    const res = await closed;
-    // Depending on auth/challenge timing in the harness, the client can either
-    // hit the tick watchdog (4000) or close with policy violation (1008).
-    expect([4000, 1008]).toContain(res.code);
-    if (res.code === 4000) {
-      expect(res.reason).toContain("tick timeout");
+      const res = await closed;
+      // Depending on auth/challenge timing in the harness, the client can either
+      // hit the tick watchdog (4000) or close with policy violation (1008).
+      expect([4000, 1008]).toContain(res.code);
+      if (res.code === 4000) {
+        expect(res.reason).toContain("tick timeout");
+      }
+    } finally {
+      await client?.stopAndWait({ timeoutMs: 1_000 }).catch(() => {
+        client?.stop();
+      });
     }
   }, 4000);
 

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { canonicalSparkleBuildFromVersion } from "../sparkle-build.ts";
 import { readBoundedResponseText } from "./bounded-response.ts";
 import { collectClawHubPublishablePluginPackages } from "./plugin-clawhub-release.ts";
 import {
@@ -16,9 +17,12 @@ export type ReleaseVerifyBetaArgs = {
   distTag: string;
   repo: string;
   registry: string;
+  desktopAppcastUrl: string;
   workflowRef?: string;
   pluginSelection: string[];
   evidenceOut?: string;
+  desktopOnly: boolean;
+  skipDesktopBeta: boolean;
   skipPostpublish: boolean;
   skipClawHub: boolean;
   rerunFailedClawHub: boolean;
@@ -46,6 +50,8 @@ type WorkflowRunSummary = {
 
 const DEFAULT_REPO = "openclaw/openclaw";
 const DEFAULT_CLAWHUB_REGISTRY = "https://clawhub.ai";
+const DEFAULT_DESKTOP_BETA_APPCAST_URL =
+  "https://raw.githubusercontent.com/openclaw/openclaw/main/appcast-beta.xml";
 const CLAWHUB_REQUEST_TIMEOUT_MS = 20_000;
 const CLAWHUB_RESPONSE_BODY_MAX_BYTES = 1024 * 1024;
 
@@ -117,7 +123,7 @@ export function parseReleaseVerifyBetaArgs(argv: string[]): ReleaseVerifyBetaArg
   const version = values.shift();
   if (!version || version.startsWith("-")) {
     throw new Error(
-      "Usage: pnpm release:verify-beta -- <version> [--workflow-ref REF] [--full-release-validation-run ID] [--openclaw-npm-run ID] [--plugin-npm-run ID] [--plugin-clawhub-run ID] [--npm-telegram-run ID] [--skip-clawhub]",
+      "Usage: pnpm release:verify-beta -- <version> [--workflow-ref REF] [--full-release-validation-run ID] [--openclaw-npm-run ID] [--plugin-npm-run ID] [--plugin-clawhub-run ID] [--npm-telegram-run ID] [--desktop-only] [--skip-clawhub]",
     );
   }
 
@@ -127,9 +133,12 @@ export function parseReleaseVerifyBetaArgs(argv: string[]): ReleaseVerifyBetaArg
     distTag: "beta",
     repo: DEFAULT_REPO,
     registry: DEFAULT_CLAWHUB_REGISTRY,
+    desktopAppcastUrl: DEFAULT_DESKTOP_BETA_APPCAST_URL,
     workflowRef: undefined,
     pluginSelection: [],
     evidenceOut: undefined,
+    desktopOnly: false,
+    skipDesktopBeta: false,
     skipPostpublish: false,
     skipClawHub: false,
     rerunFailedClawHub: false,
@@ -160,6 +169,9 @@ export function parseReleaseVerifyBetaArgs(argv: string[]): ReleaseVerifyBetaArg
       case "--registry":
         parsed.registry = next();
         break;
+      case "--desktop-appcast-url":
+        parsed.desktopAppcastUrl = next();
+        break;
       case "--workflow-ref":
         parsed.workflowRef = next();
         break;
@@ -171,6 +183,9 @@ export function parseReleaseVerifyBetaArgs(argv: string[]): ReleaseVerifyBetaArg
         break;
       case "--evidence-out":
         parsed.evidenceOut = next();
+        break;
+      case "--desktop-only":
+        parsed.desktopOnly = true;
         break;
       case "--full-release-validation-run":
         parsed.workflowRuns.fullReleaseValidation = next();
@@ -189,6 +204,9 @@ export function parseReleaseVerifyBetaArgs(argv: string[]): ReleaseVerifyBetaArg
         break;
       case "--skip-postpublish":
         parsed.skipPostpublish = true;
+        break;
+      case "--skip-desktop-beta":
+        parsed.skipDesktopBeta = true;
         break;
       case "--skip-clawhub":
         parsed.skipClawHub = true;
@@ -239,6 +257,18 @@ async function fetchJsonWithRetry(url: string): Promise<unknown> {
     throw new Error(`${url} returned HTTP ${response.status}.`);
   }
   return await readBoundedJsonResponse(response, url);
+}
+
+async function fetchTextWithRetry(url: string): Promise<string> {
+  const response = await fetchWithRetry(
+    url,
+    { headers: { accept: "application/xml,text/xml,text/plain,*/*" } },
+    5,
+  );
+  if (!response.ok) {
+    throw new Error(`${url} returned HTTP ${response.status}.`);
+  }
+  return await readBoundedResponseText(response, url, CLAWHUB_RESPONSE_BODY_MAX_BYTES);
 }
 
 export async function readBoundedJsonResponse(
@@ -350,6 +380,102 @@ function verifyGitHubRelease(params: ReleaseVerifyBetaArgs): string {
     throw new Error(`${params.tag} is not marked as a GitHub prerelease.`);
   }
   return requireString(release.url, "GitHub release URL");
+}
+
+export function requiredDesktopBetaAssetNames(version: string): string[] {
+  return [`OpenClaw-${version}.zip`, `OpenClaw-${version}.dmg`, `OpenClaw-${version}.dSYM.zip`];
+}
+
+export function collectMissingDesktopBetaAssets(assetNames: string[], version: string): string[] {
+  const present = new Set(assetNames);
+  return requiredDesktopBetaAssetNames(version).filter((name) => !present.has(name));
+}
+
+function firstAppcastItemForVersion(appcastXml: string, version: string): string | undefined {
+  return [...appcastXml.matchAll(/<item>([\s\S]*?)<\/item>/g)]
+    .map((match) => match[1])
+    .find((item) =>
+      item.includes(`<sparkle:shortVersionString>${version}</sparkle:shortVersionString>`),
+    );
+}
+
+function extractTagValue(item: string, tag: string): string | undefined {
+  const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`<${escapedTag}>([^<]+)</${escapedTag}>`).exec(item)?.[1]?.trim();
+}
+
+export function collectDesktopBetaAppcastErrors(params: {
+  appcastXml: string;
+  repo: string;
+  version: string;
+}): string[] {
+  const errors: string[] = [];
+  const item = firstAppcastItemForVersion(params.appcastXml, params.version);
+  if (item === undefined) {
+    return [`appcast-beta.xml is missing an item for ${params.version}.`];
+  }
+
+  const expectedSparkleBuild = canonicalSparkleBuildFromVersion(params.version);
+  const sparkleBuild = extractTagValue(item, "sparkle:version");
+  if (expectedSparkleBuild !== null && sparkleBuild !== String(expectedSparkleBuild)) {
+    errors.push(
+      `${params.version} has sparkle:version ${sparkleBuild ?? "<missing>"}; expected ${expectedSparkleBuild}.`,
+    );
+  }
+
+  const expectedZipUrl = `https://github.com/${params.repo}/releases/download/v${params.version}/OpenClaw-${params.version}.zip`;
+  if (!item.includes(`url="${expectedZipUrl}"`)) {
+    errors.push(`${params.version} appcast enclosure does not point at ${expectedZipUrl}.`);
+  }
+  if (!item.includes('sparkle:edSignature="')) {
+    errors.push(`${params.version} appcast enclosure is missing sparkle:edSignature.`);
+  }
+
+  return errors;
+}
+
+async function verifyDesktopBetaDistribution(params: ReleaseVerifyBetaArgs): Promise<string> {
+  const raw = runCommand("gh", [
+    "release",
+    "view",
+    params.tag,
+    "--repo",
+    params.repo,
+    "--json",
+    "assets",
+  ]);
+  const parsed = parseJson(raw, "gh release view desktop assets");
+  if (!isRecord(parsed)) {
+    throw new Error("GitHub release assets returned an unsupported JSON shape.");
+  }
+
+  const assets = Array.isArray(parsed.assets) ? parsed.assets.filter(isRecord) : [];
+  const assetNames = assets
+    .map((asset) => readString(asset.name))
+    .filter((name) => name !== undefined);
+  const errors = collectMissingDesktopBetaAssets(assetNames, params.version).map(
+    (name) => `GitHub release is missing desktop asset ${name}.`,
+  );
+
+  try {
+    const appcastXml = await fetchTextWithRetry(params.desktopAppcastUrl);
+    errors.push(
+      ...collectDesktopBetaAppcastErrors({
+        appcastXml,
+        repo: params.repo,
+        version: params.version,
+      }),
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    errors.push(`desktop beta appcast unavailable: ${message}`);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Desktop beta distribution is incomplete:\n  - ${errors.join("\n  - ")}`);
+  }
+
+  return `${params.desktopAppcastUrl} (${requiredDesktopBetaAssetNames(params.version).join(", ")})`;
 }
 
 function verifyWorkflowRun(params: {
@@ -481,6 +607,24 @@ export async function verifyBetaRelease(
   const releaseUrl = verifyGitHubRelease(args);
   lines.push(`GitHub release OK: ${releaseUrl}`);
 
+  if (args.desktopOnly) {
+    if (!args.version.includes("-beta.")) {
+      throw new Error("--desktop-only is only valid for beta versions.");
+    }
+    if (args.skipDesktopBeta) {
+      throw new Error("--desktop-only cannot be combined with --skip-desktop-beta.");
+    }
+    const desktopBetaDistribution = await verifyDesktopBetaDistribution(args);
+    lines.push(`desktop beta distribution OK: ${desktopBetaDistribution}`);
+    return lines;
+  }
+
+  let desktopBetaDistribution: string | undefined;
+  if (args.version.includes("-beta.") && !args.skipDesktopBeta) {
+    desktopBetaDistribution = await verifyDesktopBetaDistribution(args);
+    lines.push(`desktop beta distribution OK: ${desktopBetaDistribution}`);
+  }
+
   const openclawNpm = verifyNpmPackage("openclaw", args.version, args.distTag);
   lines.push(`openclaw npm OK: ${args.version} (${args.distTag})`);
 
@@ -610,6 +754,7 @@ export async function verifyBetaRelease(
           releaseTag: args.tag,
           npmDistTag: args.distTag,
           pluginSelection: args.pluginSelection,
+          desktopBetaDistribution,
           openclawNpmIntegrity: openclawNpm.integrity,
           githubReleaseUrl: releaseUrl,
           pluginNpmPackageCount: npmPlugins.length,

--- a/scripts/make_appcast.sh
+++ b/scripts/make_appcast.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 ZIP=${1:?"Usage: $0 OpenClaw-<ver>.zip"}
-FEED_URL=${2:-"https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml"}
 PRIVATE_KEY_FILE=${SPARKLE_PRIVATE_KEY_FILE:-}
 
 find_generate_appcast() {
@@ -38,6 +37,19 @@ if [[ -z "$VERSION" ]]; then
   fi
 fi
 
+APPCAST_PATH=${SPARKLE_APPCAST_PATH:-}
+if [[ -z "$APPCAST_PATH" ]]; then
+  APPCAST_PATH="appcast.xml"
+  if [[ "$VERSION" =~ -(alpha|beta)\.[0-9]+$ ]]; then
+    APPCAST_PATH="appcast-${BASH_REMATCH[1]}.xml"
+  fi
+fi
+if [[ "$APPCAST_PATH" == /* || "$APPCAST_PATH" == *".."* ]]; then
+  echo "SPARKLE_APPCAST_PATH must be a relative appcast path without '..': $APPCAST_PATH" >&2
+  exit 1
+fi
+FEED_URL=${2:-"https://raw.githubusercontent.com/openclaw/openclaw/main/${APPCAST_PATH}"}
+
 TMP_DIR="$(mktemp -d)"
 cleanup() {
   rm -rf "$TMP_DIR"
@@ -47,8 +59,8 @@ cleanup() {
 }
 trap cleanup EXIT
 cp -f "$ZIP" "$TMP_DIR/$ZIP_NAME"
-if [[ -f "$ROOT/appcast.xml" ]]; then
-  cp -f "$ROOT/appcast.xml" "$TMP_DIR/appcast.xml"
+if [[ -f "$ROOT/$APPCAST_PATH" ]]; then
+  cp -f "$ROOT/$APPCAST_PATH" "$TMP_DIR/appcast.xml"
 fi
 
 NOTES_HTML="${ZIP_DIR}/${ZIP_BASE}.html"
@@ -75,6 +87,7 @@ fi
   --link "$FEED_URL" \
   "$TMP_DIR"
 
-cp -f "$TMP_DIR/appcast.xml" "$ROOT/appcast.xml"
+mkdir -p "$(dirname "$ROOT/$APPCAST_PATH")"
+cp -f "$TMP_DIR/appcast.xml" "$ROOT/$APPCAST_PATH"
 
-echo "Appcast generated (appcast.xml). Upload alongside $ZIP at $FEED_URL"
+echo "Appcast generated ($APPCAST_PATH). Upload alongside $ZIP at $FEED_URL"

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -34,7 +34,11 @@ fi
 IFS=' ' read -r -a BUILD_ARCHS <<< "$BUILD_ARCHS_VALUE"
 PRIMARY_ARCH="${BUILD_ARCHS[0]}"
 SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:-AGCY8w5vHirVfGGDGc8Szc5iuOqupZSh9pMj/Qs67XI=}"
-SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml}"
+DEFAULT_SPARKLE_FEED_URL="https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml"
+if [[ "$APP_VERSION" =~ -(alpha|beta)\.[0-9]+$ ]]; then
+  DEFAULT_SPARKLE_FEED_URL="https://raw.githubusercontent.com/openclaw/openclaw/main/appcast-${BASH_REMATCH[1]}.xml"
+fi
+SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-$DEFAULT_SPARKLE_FEED_URL}"
 AUTO_CHECKS=true
 if [[ "$BUNDLE_ID" == *.debug ]]; then
   SPARKLE_FEED_URL=""

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -216,6 +216,50 @@ describe("CronToolSchema", () => {
         },
       }),
     ).toBe(true);
+    expect(
+      Value.Check(CronToolSchema, {
+        action: "update",
+        jobId: "job-1",
+        patch: {
+          delivery: {
+            threadId: null,
+            failureDestination: null,
+          },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(CronToolSchema, {
+        action: "update",
+        jobId: "job-1",
+        patch: {
+          delivery: {
+            failureDestination: {
+              mode: null,
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts numeric delivery thread ids in the runtime schema", () => {
+    expect(
+      Value.Check(CronToolSchema, {
+        action: "add",
+        job: {
+          name: "topic reminder",
+          schedule: { kind: "every", everyMs: 60_000 },
+          payload: { kind: "agentTurn", message: "hello" },
+          delivery: {
+            mode: "announce",
+            channel: "telegram",
+            to: "-100123",
+            threadId: 42,
+          },
+        },
+      }),
+    ).toBe(true);
   });
 
   it("job.agentId and job.sessionKey project to plain string type for OpenAPI 3.0 compat", () => {
@@ -250,11 +294,16 @@ describe("CronToolSchema", () => {
 
   // Regression guard: ensure no OpenAPI 3.0 incompatible keywords leak into the
   // serialized provider-facing cron tool schema.
-  it("serialized provider schema contains no type-array or not/const keywords", () => {
+  it("serialized provider schema contains no anyOf/type-array/not/const keywords", () => {
     const json = JSON.stringify(providerSchemaRecord);
+    // Some providers reject anyOf in tool schemas; descriptions carry nullable
+    // affordances and runtime normalization keeps accepting null.
+    expect(json).not.toMatch(/"anyOf"\s*:/);
     // type arrays like ["string","null"] are not valid in OpenAPI 3.0
     expect(json).not.toMatch(/"type"\s*:\s*\[/);
     // The "not" composition keyword is not supported by OpenAPI 3.0.
     expect(json).not.toMatch(/"not"\s*:\s*\{/);
+    // The "const" keyword is also outside the conservative provider subset.
+    expect(json).not.toMatch(/"const"\s*:/);
   });
 });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -24,8 +24,9 @@ describe("cron tool", () => {
   type SchemaLike = {
     anyOf?: Array<{ type?: string }>;
     description?: string;
+    enum?: unknown[];
     properties?: Record<string, SchemaLike>;
-    type?: string;
+    type?: string | string[];
   };
 
   type TestDelivery = {
@@ -459,10 +460,13 @@ describe("cron tool", () => {
     const jobThreadId = parameters.properties?.job?.properties?.delivery?.properties?.threadId;
     const patchThreadId = parameters.properties?.patch?.properties?.delivery?.properties?.threadId;
 
-    expect(jobThreadId?.description).toContain("Thread/topic id");
     expect(jobThreadId?.anyOf?.map((entry) => entry.type)).toEqual(["string", "number"]);
-    expect(patchThreadId?.description).toContain("Thread/topic id");
+    expect(jobThreadId?.type).toBeUndefined();
+    expect(jobThreadId?.description).toContain("string or number");
     expect(patchThreadId?.anyOf?.map((entry) => entry.type)).toEqual(["string", "number", "null"]);
+    expect(patchThreadId?.type).toBeUndefined();
+    expect(patchThreadId?.description).toContain("string or number");
+    expect(patchThreadId?.description).toContain("null to clear");
   });
 
   it("advertises nullable cron update clears in the tool schema", () => {
@@ -477,6 +481,11 @@ describe("cron tool", () => {
     expect(jobDelivery?.properties?.channel?.type).toBe("string");
     expect(jobDelivery?.properties?.failureDestination?.anyOf).toBeUndefined();
     expect(jobDelivery?.properties?.failureDestination?.type).toBe("object");
+    expect(jobDelivery?.properties?.failureDestination?.properties?.mode?.type).toBe("string");
+    expect(jobDelivery?.properties?.failureDestination?.properties?.mode?.enum).toEqual([
+      "announce",
+      "webhook",
+    ]);
     expect(patch?.properties?.agentId?.anyOf?.map((entry) => entry.type)).toEqual([
       "string",
       "null",
@@ -501,9 +510,15 @@ describe("cron tool", () => {
     ]);
     expect(delivery?.properties?.channel?.type).toBeUndefined();
     expect(delivery?.properties?.channel?.description).toContain("null to clear");
-    expect(delivery?.properties?.failureDestination?.anyOf?.map((entry) => entry.type)).toEqual([
-      "object",
-      "null",
+    expect(delivery?.properties?.failureDestination?.anyOf).toBeUndefined();
+    expect(delivery?.properties?.failureDestination?.type).toEqual(["object", "null"]);
+    expect(delivery?.properties?.failureDestination?.description).toContain("null to clear");
+    expect(
+      delivery?.properties?.failureDestination?.properties?.mode?.anyOf?.map((entry) => entry.type),
+    ).toEqual(["string", "null"]);
+    expect(delivery?.properties?.failureDestination?.properties?.mode?.anyOf?.[0]?.enum).toEqual([
+      "announce",
+      "webhook",
     ]);
   });
 

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -22,7 +22,7 @@ import { createCronTool } from "./cron-tool.js";
 
 describe("cron tool", () => {
   type SchemaLike = {
-    anyOf?: Array<{ type?: string }>;
+    anyOf?: Array<{ enum?: unknown[]; type?: string }>;
     description?: string;
     enum?: unknown[];
     properties?: Record<string, SchemaLike>;

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -34,7 +34,8 @@ import { callGatewayTool, readGatewayCallOptions, type GatewayCallOptions } from
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
 
 // We spell out job/patch properties so that LLMs know what fields to send.
-// Nested unions are avoided; runtime validation happens in normalizeCronJob*.
+// Provider projections are normalized separately; the runtime schema still
+// accepts nullable clears that normalizeCronJob* knows how to apply.
 
 const CRON_ACTIONS = [
   "status",
@@ -78,17 +79,36 @@ function deliveryStringSchema(params: { description: string; nullableClears: boo
 }
 
 function deliveryThreadIdSchema(params: { nullableClears: boolean }) {
-  const variants = params.nullableClears
-    ? [Type.String(), Type.Number(), Type.Null()]
-    : [Type.String(), Type.Number()];
-  return Type.Optional(Type.Union(variants, { description: "Thread/topic id" }));
+  const description = params.nullableClears
+    ? "Thread/topic id as a string or number, or null to clear"
+    : "Thread/topic id as a string or number";
+  const variants = [Type.String(), Type.Number()];
+  return Type.Optional(
+    params.nullableClears
+      ? Type.Union([...variants, Type.Null()], { description })
+      : Type.Union(variants, { description }),
+  );
 }
 
 function failureDestinationModeSchema(params: { nullableClears: boolean }) {
-  const variants = params.nullableClears
-    ? [Type.Literal("announce"), Type.Literal("webhook"), Type.Null()]
-    : [Type.Literal("announce"), Type.Literal("webhook")];
-  return Type.Optional(Type.Union(variants));
+  const description = params.nullableClears
+    ? "Failure destination mode, or null to clear"
+    : "Failure destination mode";
+  const modeSchema = {
+    type: "string",
+    enum: ["announce", "webhook"],
+  };
+  return Type.Optional(
+    params.nullableClears
+      ? Type.Unsafe<"announce" | "webhook" | null>({
+          anyOf: [modeSchema, { type: "null" }],
+          description,
+        })
+      : Type.Unsafe<"announce" | "webhook">({
+          ...modeSchema,
+          description,
+        }),
+  );
 }
 
 function cronPayloadObjectSchema(params: { toolsAllow: TSchema }) {
@@ -147,24 +167,24 @@ function createCronPayloadSchema(): TSchema {
 }
 
 function cronDeliverySchema(params: { nullableClears: boolean }) {
-  const failureDestinationObject = Type.Object(
-    {
-      channel: deliveryStringSchema({
-        description: "Failure delivery channel",
-        nullableClears: params.nullableClears,
-      }),
-      to: deliveryStringSchema({
-        description: "Failure delivery target",
-        nullableClears: params.nullableClears,
-      }),
-      accountId: deliveryStringSchema({
-        description: "Failure delivery account",
-        nullableClears: params.nullableClears,
-      }),
-      mode: failureDestinationModeSchema({ nullableClears: params.nullableClears }),
-    },
-    { additionalProperties: true },
-  );
+  const failureDestinationProperties = {
+    channel: deliveryStringSchema({
+      description: "Failure delivery channel",
+      nullableClears: params.nullableClears,
+    }),
+    to: deliveryStringSchema({
+      description: "Failure delivery target",
+      nullableClears: params.nullableClears,
+    }),
+    accountId: deliveryStringSchema({
+      description: "Failure delivery account",
+      nullableClears: params.nullableClears,
+    }),
+    mode: failureDestinationModeSchema({ nullableClears: params.nullableClears }),
+  };
+  const failureDestinationObject = Type.Object(failureDestinationProperties, {
+    additionalProperties: true,
+  });
 
   return Type.Optional(
     Type.Object(
@@ -186,7 +206,10 @@ function cronDeliverySchema(params: { nullableClears: boolean }) {
         }),
         failureDestination: params.nullableClears
           ? Type.Optional(
-              Type.Union([failureDestinationObject, Type.Null()], {
+              Type.Unsafe<Record<string, unknown> | null>({
+                type: ["object", "null"],
+                properties: failureDestinationProperties,
+                additionalProperties: true,
                 description: "Failure destination, or null to clear",
               }),
             )

--- a/src/channels/message/types.ts
+++ b/src/channels/message/types.ts
@@ -404,7 +404,11 @@ export type ChannelMessageAdapter<
   TAdapter extends ChannelMessageAdapterShape = ChannelMessageAdapterShape,
 > = TAdapter;
 
-/** Extra durable-final requirement map for caller-derived capability checks. */
+/**
+ * Extra durable-final requirement map for caller-derived capability checks.
+ *
+ * @deprecated Use DurableFinalDeliveryRequirementMap.
+ */
 export type DurableFinalRequirementExtras = DurableFinalDeliveryRequirementMap;
 
 /** Inputs used to derive durable final-delivery requirements for a planned send. */

--- a/src/gateway/gateway-cli-backend.connect.test.ts
+++ b/src/gateway/gateway-cli-backend.connect.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./minimal-gateway.test-helpers.js";
 
 const GATEWAY_CONNECT_OPERATION_TIMEOUT_MS = 5_000;
-const GATEWAY_CONNECT_TEST_TIMEOUT_MS = 20_000;
+const GATEWAY_CONNECT_TEST_TIMEOUT_MS = 60_000;
 const tempDirs = createSuiteTempRootTracker({ prefix: "openclaw-gateway-connect-" });
 
 async function createTempDeviceIdentity() {

--- a/src/gateway/gateway-cli-backend.connect.test.ts
+++ b/src/gateway/gateway-cli-backend.connect.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./minimal-gateway.test-helpers.js";
 
 const GATEWAY_CONNECT_OPERATION_TIMEOUT_MS = 5_000;
-const GATEWAY_CONNECT_TEST_TIMEOUT_MS = 60_000;
+const GATEWAY_CONNECT_TEST_TIMEOUT_MS = 20_000;
 const tempDirs = createSuiteTempRootTracker({ prefix: "openclaw-gateway-connect-" });
 
 async function createTempDeviceIdentity() {

--- a/src/gateway/gateway-cli-backend.connect.test.ts
+++ b/src/gateway/gateway-cli-backend.connect.test.ts
@@ -14,8 +14,8 @@ import {
   sendMinimalGatewayResponse,
 } from "./minimal-gateway.test-helpers.js";
 
-const GATEWAY_CONNECT_OPERATION_TIMEOUT_MS = 1_000;
-const GATEWAY_CONNECT_TEST_TIMEOUT_MS = 15_000;
+const GATEWAY_CONNECT_OPERATION_TIMEOUT_MS = 5_000;
+const GATEWAY_CONNECT_TEST_TIMEOUT_MS = 20_000;
 const tempDirs = createSuiteTempRootTracker({ prefix: "openclaw-gateway-connect-" });
 
 async function createTempDeviceIdentity() {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -542,6 +542,24 @@ describe("resolvePinnedClientMetadata", () => {
     },
   );
 
+  it("allows local CLI probe darwin metadata against a paired macOS desktop identity", () => {
+    expect(
+      testing.resolvePinnedClientMetadata({
+        clientId: "cli",
+        clientMode: "probe",
+        claimedPlatform: "darwin",
+        claimedDeviceFamily: undefined,
+        pairedPlatform: "macOS 26.6.0",
+        pairedDeviceFamily: "Mac",
+      }),
+    ).toEqual({
+      platformMismatch: false,
+      deviceFamilyMismatch: false,
+      pinnedPlatform: "macOS 26.6.0",
+      pinnedDeviceFamily: "Mac",
+    });
+  });
+
   it.each([
     ["openclaw-ios", "iOS 26.5.0", "iOS 26.4.2", "iPhone"],
     ["openclaw-ios", "iPadOS 26.5.0", "iPadOS 26.4.2", "iPad"],

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -253,6 +253,16 @@ function resolvePinnedClientMetadata(params: {
     }
   }
 
+  function normalizeDesktopPlatformFamily(value: string): string {
+    if (value === "darwin" || value === "macos" || value.startsWith("macos ")) {
+      return "macos";
+    }
+    if (value === "win32" || value === "windows" || value.startsWith("windows ")) {
+      return "windows";
+    }
+    return "";
+  }
+
   function normalizeMobileAppPlatformPin(clientId: string | undefined, value: string): string {
     if (clientId === GATEWAY_CLIENT_IDS.IOS_APP && /^(?:ios|ipados)(?:\s|$)/.test(value)) {
       return "ios-family";
@@ -276,6 +286,13 @@ function resolvePinnedClientMetadata(params: {
     claimedPlatform !== "" &&
     normalizeLegacyNodeHostPlatformPin(claimedPlatform) ===
       normalizeLegacyNodeHostPlatformPin(pairedPlatform);
+  const claimedDesktopFamily = normalizeDesktopPlatformFamily(claimedPlatform);
+  const pairedDesktopFamily = normalizeDesktopPlatformFamily(pairedPlatform);
+  const isDesktopPlatformFamilyMatch =
+    hasPinnedPlatform &&
+    claimedPlatform !== "" &&
+    claimedDesktopFamily !== "" &&
+    claimedDesktopFamily === pairedDesktopFamily;
   const isMobileAppPlatformVersionRefresh =
     hasPinnedPlatform &&
     claimedPlatform !== "" &&
@@ -286,8 +303,12 @@ function resolvePinnedClientMetadata(params: {
     hasPinnedPlatform &&
     claimedPlatform !== pairedPlatform &&
     !isLegacyNodeHostPlatformPin &&
+    !isDesktopPlatformFamilyMatch &&
     !isMobileAppPlatformVersionRefresh;
-  const deviceFamilyMismatch = hasPinnedDeviceFamily && claimedDeviceFamily !== pairedDeviceFamily;
+  const deviceFamilyMismatch =
+    hasPinnedDeviceFamily &&
+    claimedDeviceFamily !== "" &&
+    claimedDeviceFamily !== pairedDeviceFamily;
   const pinnedPlatform =
     claimedPlatform === pairedPlatform
       ? params.pairedPlatform
@@ -295,7 +316,9 @@ function resolvePinnedClientMetadata(params: {
         ? normalizeLegacyNodeHostPlatformPin(pairedPlatform)
         : isMobileAppPlatformVersionRefresh
           ? params.claimedPlatform
-          : undefined;
+          : isDesktopPlatformFamilyMatch
+            ? params.pairedPlatform
+            : undefined;
   return {
     platformMismatch,
     deviceFamilyMismatch,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -223,16 +223,9 @@
                       "type": "string"
                     },
                     "mode": {
-                      "anyOf": [
-                        {
-                          "const": "announce",
-                          "type": "string"
-                        },
-                        {
-                          "const": "webhook",
-                          "type": "string"
-                        }
-                      ]
+                      "description": "Failure destination mode",
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
                     },
                     "to": {
                       "description": "Failure delivery target",
@@ -255,7 +248,7 @@
                       "type": "number"
                     }
                   ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id as a string or number"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -476,66 +469,56 @@
                   "description": "Delivery channel, or null to clear"
                 },
                 "failureDestination": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery account, or null to clear"
+                  "additionalProperties": true,
+                  "description": "Failure destination, or null to clear",
+                  "properties": {
+                    "accountId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
                         },
-                        "channel": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery channel, or null to clear"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery target, or null to clear"
+                        {
+                          "type": "null"
                         }
-                      },
-                      "type": "object"
+                      ],
+                      "description": "Failure delivery account, or null to clear"
                     },
-                    {
-                      "type": "null"
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure delivery channel, or null to clear"
+                    },
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "enum": ["announce", "webhook"],
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure destination mode, or null to clear"
+                    },
+                    "to": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure delivery target, or null to clear"
                     }
-                  ],
-                  "description": "Failure destination, or null to clear"
+                  },
+                  "type": ["object", "null"]
                 },
                 "mode": {
                   "description": "Delivery mode",
@@ -554,7 +537,7 @@
                       "type": "null"
                     }
                   ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id as a string or number, or null to clear"
                 },
                 "to": {
                   "anyOf": [

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -223,16 +223,9 @@
                       "type": "string"
                     },
                     "mode": {
-                      "anyOf": [
-                        {
-                          "const": "announce",
-                          "type": "string"
-                        },
-                        {
-                          "const": "webhook",
-                          "type": "string"
-                        }
-                      ]
+                      "description": "Failure destination mode",
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
                     },
                     "to": {
                       "description": "Failure delivery target",
@@ -255,7 +248,7 @@
                       "type": "number"
                     }
                   ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id as a string or number"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -476,66 +469,56 @@
                   "description": "Delivery channel, or null to clear"
                 },
                 "failureDestination": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery account, or null to clear"
+                  "additionalProperties": true,
+                  "description": "Failure destination, or null to clear",
+                  "properties": {
+                    "accountId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
                         },
-                        "channel": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery channel, or null to clear"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery target, or null to clear"
+                        {
+                          "type": "null"
                         }
-                      },
-                      "type": "object"
+                      ],
+                      "description": "Failure delivery account, or null to clear"
                     },
-                    {
-                      "type": "null"
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure delivery channel, or null to clear"
+                    },
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "enum": ["announce", "webhook"],
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure destination mode, or null to clear"
+                    },
+                    "to": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure delivery target, or null to clear"
                     }
-                  ],
-                  "description": "Failure destination, or null to clear"
+                  },
+                  "type": ["object", "null"]
                 },
                 "mode": {
                   "description": "Delivery mode",
@@ -554,7 +537,7 @@
                       "type": "null"
                     }
                   ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id as a string or number, or null to clear"
                 },
                 "to": {
                   "anyOf": [

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -223,16 +223,9 @@
                       "type": "string"
                     },
                     "mode": {
-                      "anyOf": [
-                        {
-                          "const": "announce",
-                          "type": "string"
-                        },
-                        {
-                          "const": "webhook",
-                          "type": "string"
-                        }
-                      ]
+                      "description": "Failure destination mode",
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
                     },
                     "to": {
                       "description": "Failure delivery target",
@@ -255,7 +248,7 @@
                       "type": "number"
                     }
                   ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id as a string or number"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -476,66 +469,56 @@
                   "description": "Delivery channel, or null to clear"
                 },
                 "failureDestination": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery account, or null to clear"
+                  "additionalProperties": true,
+                  "description": "Failure destination, or null to clear",
+                  "properties": {
+                    "accountId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
                         },
-                        "channel": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery channel, or null to clear"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery target, or null to clear"
+                        {
+                          "type": "null"
                         }
-                      },
-                      "type": "object"
+                      ],
+                      "description": "Failure delivery account, or null to clear"
                     },
-                    {
-                      "type": "null"
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure delivery channel, or null to clear"
+                    },
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "enum": ["announce", "webhook"],
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure destination mode, or null to clear"
+                    },
+                    "to": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure delivery target, or null to clear"
                     }
-                  ],
-                  "description": "Failure destination, or null to clear"
+                  },
+                  "type": ["object", "null"]
                 },
                 "mode": {
                   "description": "Delivery mode",
@@ -554,7 +537,7 @@
                       "type": "null"
                     }
                   ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id as a string or number, or null to clear"
                 },
                 "to": {
                   "anyOf": [

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44128,
-    "roughTokens": 11032
+    "chars": 43804,
+    "roughTokens": 10951
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71830,
-    "roughTokens": 17958
+    "chars": 71506,
+    "roughTokens": 17877
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 43849,
-    "roughTokens": 10963
+    "chars": 43525,
+    "roughTokens": 10882
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 70027,
-    "roughTokens": 17507
+    "chars": 69703,
+    "roughTokens": 17426
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44944,
-    "roughTokens": 11236
+    "chars": 44620,
+    "roughTokens": 11155
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72065,
-    "roughTokens": 18017
+    "chars": 71741,
+    "roughTokens": 17936
   },
   "userInputText": {
     "chars": 1367,

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1427,6 +1427,14 @@ describe("package artifact reuse", () => {
     expect(releaseWorkflow).toContain("Approve child release gate after parent release approval");
     expect(releaseWorkflow).toContain("release:verify-beta");
     expect(releaseWorkflow).toContain('--workflow-ref "${CHILD_WORKFLOW_REF}"');
+    expect(releaseWorkflow).toContain("verify_desktop_beta_distribution_before_publish");
+    expect(releaseWorkflow).toContain("--desktop-only");
+    expect(
+      releaseWorkflow.indexOf(
+        "verify_desktop_beta_distribution_before_publish\n          fi\n\n          plugin_npm_run_id=",
+      ),
+    ).toBeGreaterThan(-1);
+    expect(releaseWorkflow).not.toContain("--skip-desktop-beta");
     expect(releaseWorkflow).toContain('verify_args+=(--plugins "${PLUGINS}")');
     expect(releaseWorkflow).toContain("openclaw-release-postpublish-evidence");
     expect(releaseWorkflow).toContain("Failed child job summary");

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  collectDesktopBetaAppcastErrors,
+  collectMissingDesktopBetaAssets,
   parseNpmViewFields,
   parseReleaseVerifyBetaArgs,
   readBoundedJsonResponse,
+  requiredDesktopBetaAssetNames,
 } from "../../scripts/lib/release-beta-verifier.ts";
 
 describe("parseReleaseVerifyBetaArgs", () => {
@@ -13,9 +16,13 @@ describe("parseReleaseVerifyBetaArgs", () => {
       distTag: "beta",
       repo: "openclaw/openclaw",
       registry: "https://clawhub.ai",
+      desktopAppcastUrl:
+        "https://raw.githubusercontent.com/openclaw/openclaw/main/appcast-beta.xml",
       workflowRef: undefined,
       pluginSelection: [],
       evidenceOut: undefined,
+      desktopOnly: false,
+      skipDesktopBeta: false,
       skipPostpublish: false,
       skipClawHub: false,
       rerunFailedClawHub: false,
@@ -45,6 +52,9 @@ describe("parseReleaseVerifyBetaArgs", () => {
         "--evidence-out",
         ".artifacts/release-evidence.json",
         "--skip-postpublish",
+        "--skip-desktop-beta",
+        "--desktop-appcast-url",
+        "https://example.invalid/appcast-beta.xml",
         "--skip-clawhub",
         "--rerun-failed-clawhub",
       ]),
@@ -54,9 +64,12 @@ describe("parseReleaseVerifyBetaArgs", () => {
       distTag: "beta",
       repo: "openclaw/openclaw",
       registry: "https://clawhub.ai",
+      desktopAppcastUrl: "https://example.invalid/appcast-beta.xml",
       workflowRef: "release/2026.5.10",
       pluginSelection: ["@openclaw/plugin-a", "@openclaw/plugin-b"],
       evidenceOut: ".artifacts/release-evidence.json",
+      desktopOnly: false,
+      skipDesktopBeta: true,
       skipPostpublish: true,
       skipClawHub: true,
       rerunFailedClawHub: true,
@@ -68,6 +81,73 @@ describe("parseReleaseVerifyBetaArgs", () => {
         npmTelegram: "44",
       },
     });
+  });
+
+  it("parses desktop-only beta verification mode", () => {
+    expect(parseReleaseVerifyBetaArgs(["2026.5.10-beta.3", "--desktop-only"])).toMatchObject({
+      desktopOnly: true,
+      skipDesktopBeta: false,
+    });
+  });
+});
+
+describe("desktop beta distribution checks", () => {
+  it("requires the beta desktop zip, dmg, and dSYM release assets", () => {
+    expect(requiredDesktopBetaAssetNames("2026.5.31-beta.3")).toEqual([
+      "OpenClaw-2026.5.31-beta.3.zip",
+      "OpenClaw-2026.5.31-beta.3.dmg",
+      "OpenClaw-2026.5.31-beta.3.dSYM.zip",
+    ]);
+    expect(
+      collectMissingDesktopBetaAssets(["OpenClaw-2026.5.31-beta.3.zip"], "2026.5.31-beta.3"),
+    ).toEqual(["OpenClaw-2026.5.31-beta.3.dmg", "OpenClaw-2026.5.31-beta.3.dSYM.zip"]);
+  });
+
+  it("accepts an appcast item that points at the signed beta desktop zip", () => {
+    const xml = `
+      <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+        <channel>
+          <item>
+            <title>2026.5.31-beta.3</title>
+            <sparkle:shortVersionString>2026.5.31-beta.3</sparkle:shortVersionString>
+            <sparkle:version>2026053103</sparkle:version>
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.5.31-beta.3/OpenClaw-2026.5.31-beta.3.zip" length="123" type="application/octet-stream" sparkle:edSignature="abc"/>
+          </item>
+        </channel>
+      </rss>
+    `;
+    expect(
+      collectDesktopBetaAppcastErrors({
+        appcastXml: xml,
+        repo: "openclaw/openclaw",
+        version: "2026.5.31-beta.3",
+      }),
+    ).toEqual([]);
+  });
+
+  it("rejects an appcast item without a signed beta enclosure", () => {
+    const xml = `
+      <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+        <channel>
+          <item>
+            <sparkle:shortVersionString>2026.5.31-beta.3</sparkle:shortVersionString>
+            <sparkle:version>2026053190</sparkle:version>
+            <enclosure url="https://example.com/OpenClaw.zip" length="123" type="application/octet-stream"/>
+          </item>
+        </channel>
+      </rss>
+    `;
+    expect(
+      collectDesktopBetaAppcastErrors({
+        appcastXml: xml,
+        repo: "openclaw/openclaw",
+        version: "2026.5.31-beta.3",
+      }),
+    ).toEqual([
+      "2026.5.31-beta.3 has sparkle:version 2026053190; expected 2026053103.",
+      "2026.5.31-beta.3 appcast enclosure does not point at https://github.com/openclaw/openclaw/releases/download/v2026.5.31-beta.3/OpenClaw-2026.5.31-beta.3.zip.",
+      "2026.5.31-beta.3 appcast enclosure is missing sparkle:edSignature.",
+    ]);
   });
 });
 

--- a/test/vitest/vitest.gateway-client.config.ts
+++ b/test/vitest/vitest.gateway-client.config.ts
@@ -13,6 +13,10 @@ export function createGatewayClientVitestConfig(env?: Record<string, string | un
     {
       env,
       exclude: ["src/gateway/**/*server*.test.ts"],
+      // This shard mixes fake-timer client unit tests, module-level mocks, and
+      // loopback WebSocket connection tests. Keep files isolated so timer/mock
+      // state cannot leak into another file's real connection readiness wait.
+      isolate: true,
       name: "gateway-client",
     },
   );


### PR DESCRIPTION
## Summary
- Point beta and alpha desktop builds at channel-specific Sparkle appcasts.
- Make `scripts/make_appcast.sh` honor beta/alpha appcast output paths.
- Require signed beta desktop assets plus `appcast-beta.xml` in the beta verifier.
- Add `--desktop-only` and gate beta release publish before npm/plugin dispatch so beta npm cannot get ahead of signed desktop distribution.
- Repair release-branch CI guard failures surfaced after forced base updates:
  - cron tool nullable-clear affordances now stay provider-compatible with plain JSON-schema `type` values and descriptions carrying `null to clear` semantics;
  - the cron tool schema has an explicit guard against `anyOf`, type arrays, `not`, and `const` leaking back into provider-facing tool schema;
  - prompt snapshots were regenerated from the final schema;
  - the durable-final compatibility alias has an explicit `@deprecated` tag.

## Verification
- `pnpm exec vitest run test/scripts/release-beta-verifier.test.ts test/scripts/package-acceptance-workflow.test.ts` -> 2 files, 42 tests passed.
- `pnpm test src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.schema.test.ts -- --reporter=verbose` -> cron tool 84 tests passed; cron schema 15 tests passed.
- `pnpm prompt:snapshots:check` -> prompt snapshots current, 7 files.
- `pnpm tsgo:core:test --pretty false` -> passed.
- `pnpm check:architecture` -> passed.
- `git diff --check` -> passed.
- Full prior-failing shard reproduction: `OPENCLAW_VITEST_SHARD_NAME=agentic-agents-tools OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 NODE_OPTIONS=--max-old-space-size=8192 pnpm exec node scripts/test-projects.mjs test/vitest/vitest.agents-tools.config.ts` -> 53 files, 860 tests passed.
- Core-fast local reproduction: `OPENCLAW_VITEST_SHARD_NAME=core-unit-fast OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 NODE_OPTIONS=--max-old-space-size=8192 pnpm exec node scripts/test-projects.mjs test/vitest/vitest.unit-fast.config.ts test/vitest/vitest.unit-fast-fake-timers.config.ts` -> 2 shards passed; unit-fast shard 1053 files / 9993 tests passed, fake-timer shard 10 files / 140 tests passed.
- Earlier exact CI shard reproduction for prior remote flake: `OPENCLAW_VITEST_INCLUDE_FILE=<tmp> OPENCLAW_VITEST_SHARD_NAME=agentic-control-plane-startup-health-runtime OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 NODE_OPTIONS=--max-old-space-size=8192 pnpm exec node scripts/test-projects.mjs test/vitest/vitest.gateway-server.config.ts` -> 7 files, 67 tests passed.
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/openclaw-release-publish.yml'); puts 'source yaml ok'"` -> `source yaml ok`.

## Real behavior proof

- Behavior addressed: Beta release publish now fails closed before npm/plugin dispatch when the signed desktop beta distribution is not live, so beta npm cannot get ahead of the macOS Sparkle update channel.
- Real environment tested: Local macOS OpenClaw source checkout at commit `050fa4d197b87875d7ac38f7cee17e782fa6e458`, Node/pnpm repo environment, authenticated `gh` against the real `openclaw/openclaw` GitHub release state.
- Exact steps or command run after this patch: Ran `pnpm release:verify-beta -- 2026.5.31-beta.4 --tag v2026.5.31-beta.4 --repo openclaw/openclaw --desktop-only` from the patched checkout.
- Evidence after fix: terminal output from the real command showed the new gate inspecting live GitHub release assets and live `appcast-beta.xml`:

```text
$ pnpm release:verify-beta -- 2026.5.31-beta.4 --tag v2026.5.31-beta.4 --repo openclaw/openclaw --desktop-only
Desktop beta distribution is incomplete:
  - GitHub release is missing desktop asset OpenClaw-2026.5.31-beta.4.zip.
  - GitHub release is missing desktop asset OpenClaw-2026.5.31-beta.4.dmg.
  - GitHub release is missing desktop asset OpenClaw-2026.5.31-beta.4.dSYM.zip.
  - desktop beta appcast unavailable: https://raw.githubusercontent.com/openclaw/openclaw/main/appcast-beta.xml returned HTTP 404.
```

- Observed result after fix: The desktop-only verifier refused to pass because the signed beta desktop assets and `appcast-beta.xml` are absent; this is the intended fail-closed behavior that `OpenClaw Release Publish` now runs before any beta npm/plugin dispatch.
- What was not tested: A successful end-to-end signed macOS promote was not run from this account because `openclaw/releases` still reports READ permission here and the `mac-release` signing/notary/Sparkle secrets are maintainer-custodied.

## Release-infra dependency
The matching release-infra branch is `reidmcgill/releases:codex/signed-beta-appcast`. This account still has READ on `openclaw/releases`, so upstream PR creation/merge and workflow dispatch require an upstream maintainer.
