### PR TITLE
Persist OpenRouter model cache in SQLite

### DIFF
--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
@@ -1,11 +1,13 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 async function withOpenRouterStateDir(run: (stateDir: string) => Promise<void>) {
   const stateDir = mkdtempSync(join(tmpdir(), "openclaw-openrouter-capabilities-"));
+  resetPluginStateStoreForTests();
   process.env.OPENCLAW_STATE_DIR = stateDir;
   for (const key of [
     "ALL_PROXY",
@@ -20,6 +22,7 @@ async function withOpenRouterStateDir(run: (stateDir: string) => Promise<void>) 
   try {
     await run(stateDir);
   } finally {
+    resetPluginStateStoreForTests();
     rmSync(stateDir, { recursive: true, force: true });
   }
 }
@@ -33,6 +36,7 @@ async function importOpenRouterModelCapabilities(scope: string) {
 
 describe("openrouter-model-capabilities", () => {
   afterEach(() => {
+    resetPluginStateStoreForTests();
     vi.unstubAllGlobals();
     delete process.env.OPENCLAW_STATE_DIR;
   });
@@ -134,7 +138,7 @@ describe("openrouter-model-capabilities", () => {
     });
   });
 
-  it("does not reuse older disk caches with precomputed OpenRouter context windows", async () => {
+  it("does not reuse retired JSON caches with precomputed OpenRouter context windows", async () => {
     await withOpenRouterStateDir(async (stateDir) => {
       const modelId = "nvidia/nemotron-3-super-120b-a12b:free";
       const cacheDir = join(stateDir, "cache");
@@ -195,6 +199,49 @@ describe("openrouter-model-capabilities", () => {
         contextWindow: 262_144,
         maxTokens: 262_144,
       });
+    });
+  });
+
+  it("loads cached OpenRouter capabilities from SQLite on the next import", async () => {
+    await withOpenRouterStateDir(async () => {
+      const fetchSpy = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: "acme/sqlite-cached-model",
+                  name: "SQLite Cached Model",
+                  architecture: { modality: "text+image->text" },
+                  supported_parameters: ["tools"],
+                  context_length: 8765,
+                  max_completion_tokens: 4321,
+                  pricing: { prompt: "0.000005", completion: "0.000006" },
+                },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+      );
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const firstModule = await importOpenRouterModelCapabilities("sqlite-cache-writer");
+      await firstModule.loadOpenRouterModelCapabilities("acme/sqlite-cached-model");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      const secondModule = await importOpenRouterModelCapabilities("sqlite-cache-reader");
+      expect(secondModule.getOpenRouterModelCapabilities("acme/sqlite-cached-model")).toMatchObject(
+        {
+          input: ["text", "image"],
+          supportsTools: true,
+          contextWindow: 8765,
+          maxTokens: 4321,
+        },
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
@@ -6,7 +6,7 @@
  *
  * Cache layers (checked in order):
  * 1. In-memory Map (instant, cleared on process restart)
- * 2. On-disk JSON file (<stateDir>/cache/openrouter-models.json)
+ * 2. Shared SQLite state cache
  * 3. OpenRouter API fetch (populates both layers)
  *
  * Model capabilities are assumed stable — the cache has no TTL expiry.
@@ -18,21 +18,19 @@
  * capabilities instead of the text-only fallback.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
-import { resolveStateDir } from "../../config/paths.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveProxyFetchFromEnv } from "../../infra/net/proxy-fetch.js";
 import { parseStrictFiniteNumber } from "../../infra/parse-finite-number.js";
-import { privateFileStoreSync } from "../../infra/private-file-store.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { createCorePluginStateSyncKeyedStore } from "../../plugin-state/plugin-state-store.js";
 
 const log = createSubsystemLogger("openrouter-model-capabilities");
 
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const FETCH_TIMEOUT_MS = 10_000;
-const DISK_CACHE_FILENAME = "openrouter-models.json";
-const DISK_CACHE_VERSION = 3;
+const SQLITE_CACHE_OWNER_ID = "core:openrouter-model-capabilities";
+const SQLITE_CACHE_NAMESPACE = "models.v3";
+const SQLITE_CACHE_MAX_ENTRIES = 10_000;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -76,36 +74,9 @@ export interface OpenRouterModelCapabilities {
   };
 }
 
-interface DiskCachePayload {
-  version?: number;
-  models: Record<string, OpenRouterModelCapabilities>;
-}
-
 // ---------------------------------------------------------------------------
-// Disk cache
+// SQLite cache
 // ---------------------------------------------------------------------------
-
-function resolveDiskCacheDir(): string {
-  return join(resolveStateDir(), "cache");
-}
-
-function resolveDiskCachePath(): string {
-  return join(resolveDiskCacheDir(), DISK_CACHE_FILENAME);
-}
-
-function writeDiskCache(map: Map<string, OpenRouterModelCapabilities>): void {
-  try {
-    const cachePath = resolveDiskCachePath();
-    const payload: DiskCachePayload = {
-      version: DISK_CACHE_VERSION,
-      models: Object.fromEntries(map),
-    };
-    privateFileStoreSync(dirname(cachePath)).writeJson(basename(cachePath), payload);
-  } catch (err: unknown) {
-    const message = formatErrorMessage(err);
-    log.debug(`Failed to write OpenRouter disk cache: ${message}`);
-  }
-}
 
 function isValidCapabilities(value: unknown): value is OpenRouterModelCapabilities {
   if (!value || typeof value !== "object") {
@@ -121,33 +92,43 @@ function isValidCapabilities(value: unknown): value is OpenRouterModelCapabiliti
   );
 }
 
-function readDiskCache(): Map<string, OpenRouterModelCapabilities> | undefined {
+function openSqliteCacheStore() {
+  return createCorePluginStateSyncKeyedStore<OpenRouterModelCapabilities>({
+    ownerId: SQLITE_CACHE_OWNER_ID,
+    namespace: SQLITE_CACHE_NAMESPACE,
+    maxEntries: SQLITE_CACHE_MAX_ENTRIES,
+  });
+}
+
+function writeSqliteCache(map: Map<string, OpenRouterModelCapabilities>): void {
   try {
-    const cachePath = resolveDiskCachePath();
-    if (!existsSync(cachePath)) {
-      return undefined;
+    const store = openSqliteCacheStore();
+    store.clear();
+    for (const [id, capabilities] of map) {
+      store.register(id, capabilities);
     }
-    const raw = readFileSync(cachePath, "utf-8");
-    const payload = JSON.parse(raw) as unknown;
-    if (!payload || typeof payload !== "object") {
-      return undefined;
-    }
-    const cachePayload = payload as DiskCachePayload;
-    if (cachePayload.version !== DISK_CACHE_VERSION) {
-      return undefined;
-    }
-    const models = cachePayload.models;
-    if (!models || typeof models !== "object") {
+  } catch (err: unknown) {
+    const message = formatErrorMessage(err);
+    log.debug(`Failed to write OpenRouter SQLite cache: ${message}`);
+  }
+}
+
+function readSqliteCache(): Map<string, OpenRouterModelCapabilities> | undefined {
+  try {
+    const entries = openSqliteCacheStore().entries();
+    if (entries.length === 0) {
       return undefined;
     }
     const map = new Map<string, OpenRouterModelCapabilities>();
-    for (const [id, caps] of Object.entries(models)) {
-      if (isValidCapabilities(caps)) {
-        map.set(id, caps);
+    for (const { key, value } of entries) {
+      if (isValidCapabilities(value)) {
+        map.set(key, value);
       }
     }
     return map.size > 0 ? map : undefined;
-  } catch {
+  } catch (err: unknown) {
+    const message = formatErrorMessage(err);
+    log.debug(`Failed to read OpenRouter SQLite cache: ${message}`);
     return undefined;
   }
 }
@@ -222,7 +203,7 @@ async function doFetch(): Promise<void> {
     }
 
     cache = map;
-    writeDiskCache(map);
+    writeSqliteCache(map);
     log.debug(`Cached ${map.size} OpenRouter models from API`);
   } catch (err: unknown) {
     const message = formatErrorMessage(err);
@@ -246,7 +227,7 @@ function triggerFetch(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Ensure the cache is populated. Checks in-memory first, then disk, then
+ * Ensure the cache is populated. Checks in-memory first, then SQLite, then
  * triggers a background API fetch as a last resort.
  * Does not block — returns immediately.
  */
@@ -255,11 +236,10 @@ function ensureOpenRouterModelCache(): void {
     return;
   }
 
-  // Try loading from disk before hitting the network.
-  const disk = readDiskCache();
-  if (disk) {
-    cache = disk;
-    log.debug(`Loaded ${disk.size} OpenRouter models from disk cache`);
+  const stored = readSqliteCache();
+  if (stored) {
+    cache = stored;
+    log.debug(`Loaded ${stored.size} OpenRouter models from SQLite cache`);
     return;
   }
 


### PR DESCRIPTION
## Summary

- move OpenRouter model capability persistence from `state/cache/openrouter-models.json` to the shared SQLite state DB via a core plugin-state namespace
- keep the in-memory cache and one-shot OpenRouter fetch behavior, with no runtime JSON fallback
- cover SQLite reuse across fresh module imports and retired JSON cache rebuild behavior

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.agents.json --incremental --tsBuildInfoFile /tmp/openclaw-openrouter-cache-agents.tsbuildinfo`
- `pnpm lint --threads=8`
- `git diff --check origin/main...HEAD && git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
