### PR TITLE
Fix speech-core runtime packaging and poll send guard

### DIFF
--- a/extensions/speech-core/api.ts
+++ b/extensions/speech-core/api.ts
@@ -1,0 +1,1 @@
+export * from "../../packages/speech-core/api.js";

--- a/extensions/speech-core/runtime-api.ts
+++ b/extensions/speech-core/runtime-api.ts
@@ -1,0 +1,1 @@
+export * from "../../packages/speech-core/runtime-api.js";

--- a/scripts/copy-bundled-plugin-metadata.mjs
+++ b/scripts/copy-bundled-plugin-metadata.mjs
@@ -19,6 +19,7 @@ import {
 const GENERATED_BUNDLED_SKILLS_DIR = "bundled-skills";
 const TRANSIENT_COPY_ERROR_CODES = new Set(["EEXIST", "ENOENT", "ENOTEMPTY", "EBUSY"]);
 const COPY_RETRY_DELAYS_MS = [10, 25, 50];
+const MANIFESTLESS_CORE_RUNTIME_SUPPORT_DIRS = new Set(["speech-core"]);
 
 function shouldCopyBundledPluginMetadata(id, env, buildablePluginDirs) {
   if (!buildablePluginDirs.has(id)) {
@@ -77,6 +78,9 @@ function collectTopLevelPublicSurfaceEntries(pluginDir) {
 }
 
 function isManifestlessBundledRuntimeSupportPackage(params) {
+  if (MANIFESTLESS_CORE_RUNTIME_SUPPORT_DIRS.has(params.dirName)) {
+    return params.topLevelPublicSurfaceEntries.length > 0;
+  }
   const packageName = typeof params.packageJson?.name === "string" ? params.packageJson.name : "";
   if (packageName !== `@openclaw/${params.dirName}`) {
     return false;

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -14,6 +14,7 @@ const EXCLUDED_CORE_BUNDLED_PLUGIN_DIRS = new Set(["qqbot", "whatsapp"]);
 const BUNDLED_PLUGIN_BUILD_IDS_ENV = "OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS";
 const TOP_LEVEL_PRIVATE_TEST_SURFACE_RE =
   /(?:^|[._-])(?:test|spec|test-support|test-helpers|test-fixtures|test-harness|mock-setup)(?:[._-]|$)/u;
+const MANIFESTLESS_CORE_RUNTIME_SUPPORT_DIRS = new Set(["speech-core"]);
 const toPosixPath = (value) => value.replaceAll("\\", "/");
 
 function parseBundledPluginBuildIdFilter(env = process.env) {
@@ -41,6 +42,9 @@ function readBundledPluginPackageJson(packageJsonPath, options = {}) {
 }
 
 function isManifestlessBundledRuntimeSupportPackage(params) {
+  if (MANIFESTLESS_CORE_RUNTIME_SUPPORT_DIRS.has(params.dirName)) {
+    return params.topLevelPublicSurfaceEntries.length > 0;
+  }
   if (params.packageJson?.openclaw?.release?.publishToNpm === true) {
     return false;
   }

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -324,16 +324,6 @@ describe("runMessageAction send validation", () => {
       },
     },
     {
-      name: "string-encoded poll params",
-      actionParams: {
-        channel: "workspace",
-        target: "#C12345678",
-        message: "hi",
-        pollDurationSeconds: "60",
-        pollPublic: "true",
-      },
-    },
-    {
       name: "snake_case poll params",
       actionParams: {
         channel: "workspace",
@@ -344,15 +334,6 @@ describe("runMessageAction send validation", () => {
         poll_public: "true",
       },
     },
-    {
-      name: "negative poll duration params",
-      actionParams: {
-        channel: "workspace",
-        target: "#C12345678",
-        message: "hi",
-        pollDurationSeconds: -5,
-      },
-    },
   ])("rejects send actions that include $name", async ({ actionParams }) => {
     await expect(
       runDrySend({
@@ -361,6 +342,25 @@ describe("runMessageAction send validation", () => {
         toolContext: { currentChannelId: "C12345678" },
       }),
     ).rejects.toThrow(/use action "poll" instead of "send"/i);
+  });
+
+  it("allows send actions with poll metadata defaults but no poll creation anchor", async () => {
+    const result = await runDrySend({
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "workspace",
+        target: "#C12345678",
+        message: "hi",
+        pollDurationSeconds: "60",
+        pollDurationHours: 2,
+        pollPublic: "true",
+        pollAnonymous: true,
+        pollMulti: true,
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
   });
 });
 

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -505,4 +505,25 @@ describe("copyBundledPluginMetadata", () => {
       type: "module",
     });
   });
+
+  it("keeps manifestless speech-core runtime support outputs", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-speech-core-support-");
+    const sourcePluginDir = path.join(repoRoot, "extensions", "speech-core");
+    fs.mkdirSync(sourcePluginDir, { recursive: true });
+    fs.writeFileSync(path.join(sourcePluginDir, "api.ts"), "export {};\n", "utf8");
+    fs.writeFileSync(path.join(sourcePluginDir, "runtime-api.ts"), "export {};\n", "utf8");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "speech-core");
+    fs.mkdirSync(distPluginDir, { recursive: true });
+    fs.writeFileSync(path.join(distPluginDir, "api.js"), "export {};\n", "utf8");
+    fs.writeFileSync(path.join(distPluginDir, "runtime-api.js"), "export {};\n", "utf8");
+    fs.writeFileSync(path.join(distPluginDir, "openclaw.plugin.json"), "{}\n", "utf8");
+    fs.writeFileSync(path.join(distPluginDir, "package.json"), "{}\n", "utf8");
+
+    copyBundledPluginMetadata({ repoRoot });
+
+    expect(fs.existsSync(path.join(distPluginDir, "api.js"))).toBe(true);
+    expect(fs.existsSync(path.join(distPluginDir, "runtime-api.js"))).toBe(true);
+    expect(fs.existsSync(path.join(distPluginDir, "openclaw.plugin.json"))).toBe(false);
+    expect(fs.existsSync(path.join(distPluginDir, "package.json"))).toBe(false);
+  });
 });

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -13,23 +13,23 @@ describe("poll params", () => {
   });
 
   it.each([{ key: "pollMulti" }, { key: "pollAnonymous" }, { key: "pollPublic" }])(
-    "treats $key=true as poll creation intent",
+    "does not treat $key=true as poll creation intent without a question or option",
     ({ key }) => {
       expect(
         hasPollCreationParams({
           [key]: true,
         }),
-      ).toBe(true);
+      ).toBe(false);
     },
   );
 
-  it("treats non-zero finite numeric poll params as poll creation intent", () => {
-    expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationSeconds: "+60" })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationHours: -1 })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationSeconds: "-5" })).toBe(true);
+  it("does not treat numeric poll metadata as poll creation intent without a question or option", () => {
+    expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: "+60" })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: -1 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: "-5" })).toBe(false);
     expect(hasPollCreationParams({ pollDurationHours: Number.NaN })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: Infinity })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: "60abc" })).toBe(false);
@@ -46,8 +46,8 @@ describe("poll params", () => {
     expect(hasPollCreationParams({ poll_duration_hours: "0" })).toBe(false);
   });
 
-  it("treats string-encoded boolean poll params as poll creation intent when true", () => {
-    expect(hasPollCreationParams({ pollPublic: "true" })).toBe(true);
+  it("does not treat string-encoded boolean poll metadata as poll creation intent", () => {
+    expect(hasPollCreationParams({ pollPublic: "true" })).toBe(false);
     expect(hasPollCreationParams({ pollAnonymous: "false" })).toBe(false);
   });
 
@@ -58,8 +58,8 @@ describe("poll params", () => {
   it("detects snake_case poll fields as poll creation intent", () => {
     expect(hasPollCreationParams({ poll_question: "Lunch?" })).toBe(true);
     expect(hasPollCreationParams({ poll_option: ["Pizza", "Sushi"] })).toBe(true);
-    expect(hasPollCreationParams({ poll_duration_seconds: "60" })).toBe(true);
-    expect(hasPollCreationParams({ poll_public: "true" })).toBe(true);
+    expect(hasPollCreationParams({ poll_duration_seconds: "60" })).toBe(false);
+    expect(hasPollCreationParams({ poll_public: "true" })).toBe(false);
   });
 
   it("ignores poll vote params when deciding whether send should become poll", () => {

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -1,4 +1,3 @@
-import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { readSnakeCaseParamRaw } from "./param-key.js";
 
@@ -23,13 +22,8 @@ type SharedPollCreationParamName = keyof typeof SHARED_POLL_CREATION_PARAM_DEFS;
 export const SHARED_POLL_CREATION_PARAM_NAMES = Object.keys(
   SHARED_POLL_CREATION_PARAM_DEFS,
 ) as SharedPollCreationParamName[];
-const SHARED_POLL_CREATION_PARAM_KEY_SET = new Set(
-  SHARED_POLL_CREATION_PARAM_NAMES.map(normalizePollParamKey),
-);
-const POLL_VOTE_PARAM_KEY_SET = new Set(
-  ["pollId", "pollOptionId", "pollOptionIds", "pollOptionIndex", "pollOptionIndexes"].map(
-    normalizePollParamKey,
-  ),
+const POLL_CREATION_ANCHOR_PARAM_KEY_SET = new Set(
+  ["pollQuestion", "pollOption"].map(normalizePollParamKey),
 );
 
 function readPollParamRaw(params: Record<string, unknown>, key: string): unknown {
@@ -40,85 +34,23 @@ function normalizePollParamKey(key: string): string {
   return normalizeLowercaseStringOrEmpty(key.replaceAll("_", ""));
 }
 
-function isChannelPollCreationParamName(key: string): boolean {
-  const normalized = normalizePollParamKey(key);
-  return (
-    normalized.startsWith("poll") &&
-    !SHARED_POLL_CREATION_PARAM_KEY_SET.has(normalized) &&
-    !POLL_VOTE_PARAM_KEY_SET.has(normalized)
-  );
-}
-
-function hasExplicitUnknownPollValue(key: string, value: unknown): boolean {
-  if (value === true) {
-    return true;
-  }
-  if (typeof value === "number") {
-    return Number.isFinite(value) && value !== 0;
-  }
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (trimmed.length === 0) {
-      return false;
-    }
-    if (normalizePollParamKey(key).includes("duration")) {
-      const parsed = parseStrictFiniteNumber(trimmed);
-      return Number.isFinite(parsed) && parsed !== 0;
-    }
-    const normalized = normalizeLowercaseStringOrEmpty(trimmed);
-    return normalized !== "false" && normalized !== "0";
-  }
-  if (Array.isArray(value)) {
-    return value.some((entry) => hasExplicitUnknownPollValue(key, entry));
-  }
-  return false;
-}
-
 export function hasPollCreationParams(params: Record<string, unknown>): boolean {
   for (const key of SHARED_POLL_CREATION_PARAM_NAMES) {
     const def = POLL_CREATION_PARAM_DEFS[key];
     const value = readPollParamRaw(params, key);
     if (def.kind === "string" && typeof value === "string" && value.trim().length > 0) {
-      return true;
+      return POLL_CREATION_ANCHOR_PARAM_KEY_SET.has(normalizePollParamKey(key));
     }
     if (def.kind === "stringArray") {
       if (
         Array.isArray(value) &&
         value.some((entry) => typeof entry === "string" && entry.trim())
       ) {
-        return true;
+        return POLL_CREATION_ANCHOR_PARAM_KEY_SET.has(normalizePollParamKey(key));
       }
       if (typeof value === "string" && value.trim().length > 0) {
-        return true;
+        return POLL_CREATION_ANCHOR_PARAM_KEY_SET.has(normalizePollParamKey(key));
       }
-    }
-    if (def.kind === "positiveInteger") {
-      // Treat zero-valued numeric defaults as unset, but preserve any non-zero
-      // numeric value as explicit poll intent so invalid durations still hit
-      // the poll-only validation path.
-      if (typeof value === "number" && Number.isFinite(value) && value !== 0) {
-        return true;
-      }
-      if (typeof value === "string") {
-        const trimmed = value.trim();
-        const parsed = parseStrictFiniteNumber(trimmed);
-        if (parsed !== undefined && parsed !== 0) {
-          return true;
-        }
-      }
-    }
-    if (def.kind === "boolean") {
-      if (value === true) {
-        return true;
-      }
-      if (typeof value === "string" && normalizeLowercaseStringOrEmpty(value) === "true") {
-        return true;
-      }
-    }
-  }
-  for (const [key, value] of Object.entries(params)) {
-    if (isChannelPollCreationParamName(key) && hasExplicitUnknownPollValue(key, value)) {
-      return true;
     }
   }
   return false;

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -52,6 +52,8 @@ describe("bundled plugin build entries", () => {
         "extensions/image-generation-core/runtime-api.ts",
       "extensions/media-understanding-core/runtime-api":
         "extensions/media-understanding-core/runtime-api.ts",
+      "extensions/speech-core/api": "extensions/speech-core/api.ts",
+      "extensions/speech-core/runtime-api": "extensions/speech-core/runtime-api.ts",
     };
 
     expect(pickEntries(entries, Object.keys(expectedEntries))).toStrictEqual(expectedEntries);
@@ -140,6 +142,9 @@ describe("bundled plugin build entries", () => {
     expect(artifacts).not.toContain(
       "dist/extensions/media-understanding-core/openclaw.plugin.json",
     );
+    expect(artifacts).toContain("dist/extensions/speech-core/api.js");
+    expect(artifacts).toContain("dist/extensions/speech-core/runtime-api.js");
+    expect(artifacts).not.toContain("dist/extensions/speech-core/openclaw.plugin.json");
   });
 
   it("packs the Matrix packaged runtime shim", () => {


### PR DESCRIPTION
## Summary
- add bundled `speech-core` runtime surface wrappers so `dist/extensions/speech-core/runtime-api.js` is built and packed
- keep manifestless `speech-core` runtime support outputs during bundled metadata copy
- narrow send-time poll detection so metadata-only poll fields do not force `action: poll`; only `pollQuestion` / `pollOption` anchors do

## Why
Discord send payloads can include default poll metadata fields from shared tool schemas. Treating those metadata/default fields as poll creation blocks normal `action: send` replies with `Poll fields require action "poll"`. Separately, the npm/runtime packaging path can drop the manifestless `speech-core/runtime-api.js` surface needed by runtime consumers.

## Validation
- `node scripts/run-vitest.mjs run src/poll-params.test.ts src/infra/outbound/message-action-runner.send-validation.test.ts src/plugins/copy-bundled-plugin-metadata.test.ts test/scripts/bundled-plugin-build-entries.test.ts --maxWorkers=1`
