### PR TITLE
fix(microsoft-foundry): satisfy extension lint

### DIFF
--- a/extensions/microsoft-foundry/provider.ts
+++ b/extensions/microsoft-foundry/provider.ts
@@ -58,7 +58,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         const nextModel = Object.assign({}, model, {
           name: selectedModelCapabilities.modelName,
           api: selectedModelCapabilities.api,
-          reasoning: selectedModelCapabilities.reasoning || model.reasoning === true,
+          reasoning: selectedModelCapabilities.reasoning || model.reasoning,
           thinkingLevelMap: selectedModelCapabilities.thinkingLevelMap ?? model.thinkingLevelMap,
           input: selectedModelCapabilities.input,
         });
@@ -69,7 +69,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
               : undefined;
           const preserveExplicitReasoningEffort =
             !selectedModelCapabilities.reasoning &&
-            model.reasoning === true &&
+            model.reasoning &&
             explicitSupportsReasoningEffort !== false;
           const explicitMaxTokensField =
             typeof model.compat?.maxTokensField === "string"
@@ -78,7 +78,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
                 ? "max_completion_tokens"
                 : undefined;
           nextModel.compat = {
-            ...(model.compat ?? {}),
+            ...model.compat,
             ...selectedModelCapabilities.compat,
             ...(explicitSupportsReasoningEffort !== undefined
               ? { supportsReasoningEffort: explicitSupportsReasoningEffort }
@@ -138,7 +138,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         typeof model.compat?.supportsReasoningEffort === "boolean"
           ? model.compat.supportsReasoningEffort
           : undefined;
-      const preserveExplicitReasoningEffort = !capabilities.reasoning && model.reasoning === true;
+      const preserveExplicitReasoningEffort = !capabilities.reasoning && model.reasoning;
       const explicitMaxTokensField =
         typeof model.compat?.maxTokensField === "string"
           ? model.compat.maxTokensField
@@ -147,7 +147,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
             : undefined;
       const compat = capabilities.compat
         ? {
-            ...(model.compat ?? {}),
+            ...model.compat,
             ...capabilities.compat,
             ...(explicitSupportsReasoningEffort !== undefined
               ? { supportsReasoningEffort: explicitSupportsReasoningEffort }
@@ -161,7 +161,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         ...model,
         name: capabilities.modelName,
         api: capabilities.api,
-        reasoning: capabilities.reasoning || model.reasoning === true,
+        reasoning: capabilities.reasoning || model.reasoning,
         thinkingLevelMap: capabilities.thinkingLevelMap ?? model.thinkingLevelMap,
         input: capabilities.input,
         baseUrl: buildFoundryProviderBaseUrl(


### PR DESCRIPTION
## Summary

- Fix unrelated `check-lint` failure from PR #88847 by satisfying new extension oxlint rules in `extensions/microsoft-foundry/provider.ts`.
- Replace redundant boolean literal comparisons with direct boolean expressions.
- Remove unnecessary `{}` fallbacks from object spreads.

## Verification

- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/microsoft-foundry/provider.ts`
- `../test-cleanup-bucket-1/node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/microsoft-foundry/provider.ts`
- `../test-cleanup-bucket-1/node_modules/.bin/oxfmt --check extensions/microsoft-foundry/provider.ts`
- `git diff --check`
