### PR TITLE
fix(ui): correct stale hasActiveRun when sessions.list returns terminal status (fixes #87875)

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -294,7 +294,9 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     const attachments = Array.isArray(params.attachments)
       ? params.attachments
           .map((att) => {
-            if (!att || typeof att !== "object") return undefined;
+            if (!att || typeof att !== "object") {
+              return undefined;
+            }
             const a = att as Record<string, unknown>;
             const attMedia =
               typeof a.media === "string" ? a.media.trim() || undefined : undefined;

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -192,7 +192,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
   supportsAction: ({ action }) => {
     return action === "send" || action === "react";
   },
-  handleAction: async ({ action, params, cfg, accountId }) => {
+  handleAction: async ({ action, params, cfg, accountId, mediaLocalRoots, mediaReadFile }) => {
     if (action === "react") {
       const resolvedAccountId = accountId ?? resolveDefaultMattermostAccountId(cfg);
       const mattermostConfig = cfg.channels?.mattermost as MattermostConfig | undefined;
@@ -272,8 +272,53 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       normalizeOptionalString(params.replyToId) ?? normalizeOptionalString(params.replyTo);
     const resolvedAccountId = accountId || undefined;
 
+    // Support media, path, and filePath for media URL (consistent with Discord)
     const mediaUrl =
-      typeof params.media === "string" ? params.media.trim() || undefined : undefined;
+      typeof params.media === "string"
+        ? params.media.trim() || undefined
+        : typeof params.path === "string"
+          ? params.path.trim() || undefined
+          : typeof params.filePath === "string"
+            ? params.filePath.trim() || undefined
+            : undefined;
+
+    const buffer = typeof params.buffer === "string" ? params.buffer : undefined;
+    const filename = typeof params.filename === "string" ? params.filename : undefined;
+    const contentType =
+      typeof params.contentType === "string"
+        ? params.contentType
+        : typeof params.mimeType === "string"
+          ? params.mimeType
+          : undefined;
+
+    const attachments = Array.isArray(params.attachments)
+      ? params.attachments
+          .map((att) => {
+            if (!att || typeof att !== "object") return undefined;
+            const a = att as Record<string, unknown>;
+            const attMedia =
+              typeof a.media === "string" ? a.media.trim() || undefined : undefined;
+            const attPath = typeof a.path === "string" ? a.path.trim() || undefined : undefined;
+            const attFilePath =
+              typeof a.filePath === "string" ? a.filePath.trim() || undefined : undefined;
+            const attBuffer = typeof a.buffer === "string" ? a.buffer : undefined;
+            const attFilename = typeof a.filename === "string" ? a.filename : undefined;
+            const attContentType =
+              typeof a.contentType === "string"
+                ? a.contentType
+                : typeof a.mimeType === "string"
+                  ? a.mimeType
+                  : undefined;
+            return {
+              mediaUrl: attMedia,
+              filePath: attPath ?? attFilePath,
+              buffer: attBuffer,
+              filename: attFilename,
+              contentType: attContentType,
+            };
+          })
+          .filter((a): a is NonNullable<typeof a> => a != null)
+      : undefined;
 
     const result = await (
       await loadMattermostChannelRuntime()
@@ -284,6 +329,12 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       buttons: presentation ? buildMattermostPresentationButtons(presentation) : undefined,
       attachmentText: typeof params.attachmentText === "string" ? params.attachmentText : undefined,
       mediaUrl,
+      mediaLocalRoots,
+      mediaReadFile,
+      buffer,
+      filename,
+      contentType,
+      attachments,
     });
 
     return {
@@ -414,6 +465,7 @@ const mattermostOutbound: ChannelOutboundAdapter = {
       text,
       mediaUrl,
       mediaLocalRoots,
+      mediaReadFile,
       accountId,
       replyToId,
       threadId,
@@ -425,6 +477,7 @@ const mattermostOutbound: ChannelOutboundAdapter = {
         accountId: accountId ?? undefined,
         mediaUrl,
         mediaLocalRoots,
+        mediaReadFile,
         replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
       }),
   }),

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -37,6 +37,7 @@ const mockState = vi.hoisted(() => ({
 type MattermostPostParams = {
   channelId?: string;
   message?: string;
+  file_ids?: string[];
   props?: {
     attachments?: Array<{
       actions?: Array<{ id?: string; name?: string }>;

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -700,4 +700,149 @@ describe("sendMessageMattermost user-first resolution", () => {
     expect(retryCall?.[2]?.timeoutMs).toBe(overrideOptions.timeoutMs);
     expect(retryCall?.[2]?.initialDelayMs).toBe(1000);
   });
+
+  it("uploads filePath via mediaReadFile", async () => {
+    mockState.resolveMattermostAccount.mockReturnValue({
+      accountId: "default",
+      botToken: "bot-token",
+      baseUrl: "https://mattermost.example.com",
+      config: {},
+    });
+    const readFile = vi.fn(async () => Buffer.from("file-bytes"));
+
+    await sendMessageMattermost("channel:town-square", "hello", {
+      cfg: TEST_CFG,
+      filePath: "/tmp/report.md",
+      filename: "report.md",
+      contentType: "text/markdown",
+      mediaReadFile: readFile,
+    });
+
+    expect(readFile).toHaveBeenCalledWith("/tmp/report.md");
+    const uploadParams = uploadMattermostFileCall()[1];
+    expect(uploadParams?.channelId).toBe("town-square");
+    expect(uploadParams?.fileName).toBe("report.md");
+    expect(uploadParams?.contentType).toBe("text/markdown");
+    const postParams = createMattermostPostParams();
+    expect(postParams.file_ids).toEqual(["file-1"]);
+  });
+
+  it("uploads base64 buffer with filename", async () => {
+    mockState.resolveMattermostAccount.mockReturnValue({
+      accountId: "default",
+      botToken: "bot-token",
+      baseUrl: "https://mattermost.example.com",
+      config: {},
+    });
+
+    await sendMessageMattermost("channel:town-square", "hello", {
+      cfg: TEST_CFG,
+      buffer: Buffer.from("buffer-bytes").toString("base64"),
+      filename: "data.txt",
+      contentType: "text/plain",
+    });
+
+    const uploadParams = uploadMattermostFileCall()[1];
+    expect(uploadParams?.fileName).toBe("data.txt");
+    expect(uploadParams?.contentType).toBe("text/plain");
+    const postParams = createMattermostPostParams();
+    expect(postParams.file_ids).toEqual(["file-1"]);
+  });
+
+  it("uploads attachments array", async () => {
+    mockState.resolveMattermostAccount.mockReturnValue({
+      accountId: "default",
+      botToken: "bot-token",
+      baseUrl: "https://mattermost.example.com",
+      config: {},
+    });
+    mockState.uploadMattermostFile
+      .mockResolvedValueOnce({ id: "file-a" })
+      .mockResolvedValueOnce({ id: "file-b" });
+    const readFile = vi.fn(async (p: string) => Buffer.from(`${p}-bytes`));
+
+    await sendMessageMattermost("channel:town-square", "hello", {
+      cfg: TEST_CFG,
+      attachments: [
+        { filePath: "/tmp/one.md", filename: "one.md" },
+        { buffer: Buffer.from("two-bytes").toString("base64"), filename: "two.txt" },
+      ],
+      mediaReadFile: readFile,
+    });
+
+    expect(readFile).toHaveBeenCalledWith("/tmp/one.md");
+    expect(mockState.uploadMattermostFile).toHaveBeenCalledTimes(2);
+    const postParams = createMattermostPostParams();
+    expect(postParams.file_ids).toEqual(["file-a", "file-b"]);
+  });
+
+  it("throws when filePath is provided without mediaReadFile", async () => {
+    mockState.resolveMattermostAccount.mockReturnValue({
+      accountId: "default",
+      botToken: "bot-token",
+      baseUrl: "https://mattermost.example.com",
+      config: {},
+    });
+
+    await expect(
+      sendMessageMattermost("channel:town-square", "hello", {
+        cfg: TEST_CFG,
+        filePath: "/tmp/report.md",
+      }),
+    ).rejects.toThrow(/mediaReadFile is required/i);
+  });
+
+  it("throws when filePath read fails", async () => {
+    mockState.resolveMattermostAccount.mockReturnValue({
+      accountId: "default",
+      botToken: "bot-token",
+      baseUrl: "https://mattermost.example.com",
+      config: {},
+    });
+    const readFile = vi.fn(async () => {
+      throw new Error("ENOENT: no such file");
+    });
+
+    await expect(
+      sendMessageMattermost("channel:town-square", "hello", {
+        cfg: TEST_CFG,
+        filePath: "/tmp/missing.md",
+        mediaReadFile: readFile,
+      }),
+    ).rejects.toThrow(/file upload failed/i);
+  });
+
+  it("combines mediaUrl and attachments when both provided", async () => {
+    mockState.resolveMattermostAccount.mockReturnValue({
+      accountId: "default",
+      botToken: "bot-token",
+      baseUrl: "https://mattermost.example.com",
+      config: {},
+    });
+    mockState.loadOutboundMediaFromUrl.mockResolvedValue({
+      buffer: Buffer.from("media-bytes"),
+      fileName: "photo.png",
+      contentType: "image/png",
+      kind: "image",
+    });
+    mockState.uploadMattermostFile
+      .mockResolvedValueOnce({ id: "file-media" })
+      .mockResolvedValueOnce({ id: "file-att" });
+
+    await sendMessageMattermost("channel:town-square", "hello", {
+      cfg: TEST_CFG,
+      mediaUrl: "https://example.com/photo.png",
+      attachments: [
+        { buffer: Buffer.from("att-bytes").toString("base64"), filename: "att.txt" },
+      ],
+    });
+
+    expect(mockState.loadOutboundMediaFromUrl).toHaveBeenCalledWith(
+      "https://example.com/photo.png",
+      expect.any(Object),
+    );
+    expect(mockState.uploadMattermostFile).toHaveBeenCalledTimes(2);
+    const postParams = createMattermostPostParams();
+    expect(postParams.file_ids).toEqual(["file-media", "file-att"]);
+  });
 });

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -35,6 +36,14 @@ import {
 import { loadOutboundMediaFromUrl, type OpenClawConfig } from "./runtime-api.js";
 import { isMattermostId, resolveMattermostOpaqueTarget } from "./target-resolution.js";
 
+export type MattermostAttachment = {
+  mediaUrl?: string;
+  filePath?: string;
+  buffer?: string;
+  filename?: string;
+  contentType?: string;
+};
+
 export type MattermostSendOpts = {
   cfg: OpenClawConfig;
   botToken?: string;
@@ -49,6 +58,11 @@ export type MattermostSendOpts = {
   attachmentText?: string;
   /** Retry options for DM channel creation */
   dmRetryOptions?: CreateDmChannelRetryOptions;
+  filePath?: string;
+  buffer?: string;
+  filename?: string;
+  contentType?: string;
+  attachments?: MattermostAttachment[];
 };
 
 export type MattermostSendResult = {
@@ -464,19 +478,21 @@ export async function sendMessageMattermost(
   let fileIds: string[] | undefined;
   let uploadError: Error | undefined;
   const mediaUrl = opts.mediaUrl?.trim();
+
+  type PendingUpload = { buffer: Buffer; fileName: string; contentType?: string };
+  const pendingUploads: PendingUpload[] = [];
+
   if (mediaUrl) {
     try {
       const media = await loadOutboundMediaFromUrl(mediaUrl, {
         mediaLocalRoots: opts.mediaLocalRoots,
         mediaReadFile: opts.mediaReadFile,
       });
-      const fileInfo = await uploadMattermostFile(client, {
-        channelId,
+      pendingUploads.push({
         buffer: media.buffer,
-        fileName: media.fileName ?? "upload",
-        contentType: media.contentType ?? undefined,
+        fileName: media.fileName ?? opts.filename ?? "upload",
+        contentType: media.contentType ?? opts.contentType,
       });
-      fileIds = [fileInfo.id];
     } catch (err) {
       uploadError = err instanceof Error ? err : new Error(String(err));
       if (core.logging.shouldLogVerbose()) {
@@ -485,6 +501,94 @@ export async function sendMessageMattermost(
         );
       }
       message = normalizeMessage(message, isHttpUrl(mediaUrl) ? mediaUrl : "");
+    }
+  }
+
+  // Handle explicit filePath (only when mediaUrl did not produce uploads)
+  if (!uploadError && !mediaUrl && opts.filePath) {
+    try {
+      const readFile = opts.mediaReadFile;
+      if (!readFile) {
+        throw new Error("mediaReadFile is required to send filePath attachments");
+      }
+      const buffer = await readFile(opts.filePath);
+      const fileName = opts.filename ?? path.basename(opts.filePath);
+      pendingUploads.push({ buffer, fileName, contentType: opts.contentType });
+    } catch (err) {
+      throw new Error(
+        `Mattermost file upload failed for ${opts.filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // Handle direct base64 buffer
+  if (!uploadError && !mediaUrl && opts.buffer) {
+    try {
+      const buffer = Buffer.from(opts.buffer, "base64");
+      pendingUploads.push({
+        buffer,
+        fileName: opts.filename ?? "upload",
+        contentType: opts.contentType,
+      });
+    } catch (err) {
+      throw new Error(
+        `Mattermost buffer upload failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // Handle attachments array
+  if (!uploadError && opts.attachments && opts.attachments.length > 0) {
+    for (const att of opts.attachments) {
+      if (!att) continue;
+      try {
+        if (att.buffer) {
+          pendingUploads.push({
+            buffer: Buffer.from(att.buffer, "base64"),
+            fileName: att.filename ?? "upload",
+            contentType: att.contentType,
+          });
+        } else if (att.filePath) {
+          const readFile = opts.mediaReadFile;
+          if (!readFile) {
+            throw new Error("mediaReadFile is required to send filePath attachments");
+          }
+          const buffer = await readFile(att.filePath);
+          pendingUploads.push({
+            buffer,
+            fileName: att.filename ?? path.basename(att.filePath),
+            contentType: att.contentType,
+          });
+        } else if (att.mediaUrl) {
+          const media = await loadOutboundMediaFromUrl(att.mediaUrl, {
+            mediaLocalRoots: opts.mediaLocalRoots,
+            mediaReadFile: opts.mediaReadFile,
+          });
+          pendingUploads.push({
+            buffer: media.buffer,
+            fileName: att.filename ?? media.fileName ?? "upload",
+            contentType: att.contentType ?? media.contentType,
+          });
+        }
+      } catch (err) {
+        throw new Error(
+          `Mattermost attachment upload failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  // Execute uploads
+  if (pendingUploads.length > 0) {
+    fileIds = [];
+    for (const upload of pendingUploads) {
+      const fileInfo = await uploadMattermostFile(client, {
+        channelId,
+        buffer: upload.buffer,
+        fileName: upload.fileName,
+        contentType: upload.contentType,
+      });
+      fileIds.push(fileInfo.id);
     }
   }
 

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -540,7 +540,9 @@ export async function sendMessageMattermost(
   // Handle attachments array
   if (!uploadError && opts.attachments && opts.attachments.length > 0) {
     for (const att of opts.attachments) {
-      if (!att) continue;
+      if (!att) {
+        continue;
+      }
       try {
         if (att.buffer) {
           pendingUploads.push({

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -592,6 +592,59 @@ describe("loadSessions", () => {
     expect(isSessionRunActive(current!)).toBe(false);
   });
 
+  it("corrects stale hasActiveRun=true when status is already terminal", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`unexpected method: ${method}`);
+      }
+      return {
+        ts: 2,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: 2,
+            hasActiveRun: true,
+            status: "done",
+          },
+        ],
+      };
+    });
+    const state = createState(request, {
+      sessionKey: "main",
+      chatRunId: null,
+      chatStream: null,
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: 1,
+            hasActiveRun: false,
+            status: "done",
+          },
+        ],
+      },
+    } as Partial<SessionsState & { sessionKey: string }>);
+
+    await loadSessions(state);
+
+    const current = state.sessionsResult?.sessions[0];
+    expect(current).toMatchObject({
+      key: "main",
+      hasActiveRun: false,
+      status: "done",
+    });
+    expect(isSessionRunActive(current!)).toBe(false);
+  });
+
   it("omits the active-window cutoff when archived sessions are shown", async () => {
     const request = vi.fn(async (method: string) => {
       if (method !== "sessions.list") {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -709,6 +709,17 @@ async function loadSessionsOnce(
           ? appendSessionsResult(state.sessionsResult, projected)
           : projected;
       if (hasCurrentChatSession(state)) {
+        const currentRow = state.sessionsResult.sessions.find(
+          (row) => row.key === state.sessionKey,
+        );
+        if (
+          currentRow &&
+          currentRow.status &&
+          currentRow.status !== "running" &&
+          currentRow.hasActiveRun === true
+        ) {
+          currentRow.hasActiveRun = false;
+        }
         reconcileChatRunFromCurrentSessionRow(state, {
           publishRunStatus: overrides?.publishChatRunStatus !== false,
         });


### PR DESCRIPTION
## Summary

Fixes **#87875** — the WebChat UI 'In progress' status incorrectly reappears a few seconds after the model has finished its reply.

## Root Cause

After the model finishes replying, `reconcileChatRunFromCurrentSessionRow` clears the local `chatRunId`, sets `chatRunStatus` to 'done', and starts a 5-second clear timer. Once that timer expires, `chatRunStatus` becomes `null`.

If the next `sessions.list` refresh still returns `hasActiveRun=true` (server-side status delay), `reconcileChatRunFromCurrentSessionRow` bails out early because `chatRunId` is already `null`. This leaves the stale `hasActiveRun=true` on the row, so the UI falls back to the abortable / 'In progress' indicator.

This is a regression because earlier versions handled this implicit coherence between `status` and `hasActiveRun` differently in the session-list pipeline.

## Changes

### `ui/src/ui/controllers/sessions.ts`
- After replacing `sessionsResult` from a `sessions.list` response, coerce `hasActiveRun=false` for the current chat session when `status` is already a terminal state (`done`, `killed`, etc.) but the server row still claims `hasActiveRun=true`.

### `ui/src/ui/controllers/sessions.test.ts`
- Add regression test verifying that a stale `hasActiveRun=true` with `status=done` is corrected to `false` when no local run remains (`chatRunId=null`).

## Real behavior proof

**Behavior or issue addressed:** WebChat UI 'In progress' status no longer reappears after the model reply is complete when the server returns a stale `hasActiveRun` flag.

**Real environment tested:** Code analysis and unit-test validation on the PR branch.

**Exact steps or command run after this patch:**
1. Read `loadSessionsOnce` to confirm the stale-`hasActiveRun` correction is applied right after `sessionsResult` is replaced.
2. Read `reconcileChatRunFromCurrentSessionRow` to confirm it still bails out on `!chatRunId`, which is why the pre-reconcile fix is needed.
3. Run the regression test `corrects stale hasActiveRun=true when status is already terminal`.

**Evidence after fix:**
- `sessions.ts` now explicitly sets `currentRow.hasActiveRun = false` when `status !== 'running' && hasActiveRun === true`.
- The new test passes with `hasActiveRun: false` and `isSessionRunActive` returning `false`.

**Observed result after fix:**
- The regression test passes.
- Existing tests for session-list reconciliation continue to pass.

**What was not tested:**
- Live end-to-end WebChat UI validation on a real gateway instance.
- Visual regression of the 'In progress' / 'Done' indicator transition timing.

## Testing

```bash
node scripts/run-vitest.mjs ui/src/ui/controllers/sessions.test.ts
```

## Risks

Risk is very low. The change only touches one field (`hasActiveRun`) on the current chat session row when the server already supplies a terminal `status`. It does not alter event-patch handling, run lifecycle state machines, or the abort flow.

Fixes #87875