### PR TITLE
docs: clarify diffs language pack additions

### DIFF
--- a/docs/plugins/reference/diffs-language-pack.md
+++ b/docs/plugins/reference/diffs-language-pack.md
@@ -17,3 +17,15 @@ Adds syntax highlighting for languages outside the default diffs viewer set.
 ## Surface
 
 plugin
+
+<!-- openclaw-plugin-reference:manual-start -->
+
+## Added languages
+
+The base `diffs` plugin already highlights the common languages documented in [Diffs](/tools/diffs). Install this language pack when you want syntax highlighting for a broader set of Shiki-supported languages. If the pack is not installed, those files still render as readable plain text.
+
+Examples include Astro, Vue, Svelte, MDX, GraphQL, Terraform/HCL, Nix, Clojure, Elixir, Haskell, OCaml, Scala, Zig, Solidity, Verilog/VHDL, Fortran, MATLAB, LaTeX, Mermaid, Sass/Less/SCSS, Nginx, Apache, CSV, dotenv, INI, and diff files.
+
+See [Shiki languages](https://shiki.style/languages) for Shiki's upstream language and alias catalog.
+
+<!-- openclaw-plugin-reference:manual-end -->

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -216,7 +216,9 @@ Install the Diff Viewer Language Pack plugin to highlight other languages:
 openclaw plugins install clawhub:@openclaw/diffs-language-pack
 ```
 
-With the language pack available, OpenClaw automatically uses it for languages outside the default list. Without it, those files stay readable as plain text.
+With the language pack available, OpenClaw can highlight many more languages. If the pack is not installed, files outside the default list still render as readable plain text. Examples include Astro, Vue, Svelte, MDX, GraphQL, Terraform/HCL, Nix, Clojure, Elixir, Haskell, OCaml, Scala, Zig, Solidity, Verilog/VHDL, Fortran, MATLAB, LaTeX, Mermaid, Sass/Less/SCSS, Nginx, Apache, CSV, dotenv, INI, and diff files.
+
+See [Diffs Language Pack plugin](/plugins/reference/diffs-language-pack) for details and [Shiki languages](https://shiki.style/languages) for Shiki's upstream language and alias catalog.
 
 ## Output details contract
 

--- a/extensions/diffs-language-pack/README.md
+++ b/extensions/diffs-language-pack/README.md
@@ -4,6 +4,8 @@ Official extended syntax highlighting pack for the OpenClaw Diffs plugin.
 
 The base `@openclaw/diffs` plugin ships a curated language set. Install this package when you want the full Shiki language catalog available in rendered diff viewers and diff image/PDF output.
 
+The pack adds highlighting for languages outside the default diffs viewer set, including Astro, Vue, Svelte, MDX, GraphQL, Terraform/HCL, Nix, Clojure, Elixir, Haskell, OCaml, Scala, Zig, Solidity, Verilog/VHDL, Fortran, MATLAB, LaTeX, Mermaid, Sass/Less/SCSS, Nginx, Apache, CSV, dotenv, INI, and diff files. See the plugin reference and Shiki language catalog for details.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary

- Clarify that the default diffs viewer ships a curated 29-language Shiki bucket while `diffs-language-pack` adds languages outside that default set.
- Add concise examples of languages the pack enables, including Astro, Vue, Svelte, MDX, GraphQL, Terraform/HCL, Nix, Clojure, Elixir, Haskell, OCaml, Scala, Zig, Solidity, Verilog/VHDL, Fortran, MATLAB, LaTeX, Mermaid, Sass/Less/SCSS, Nginx, Apache, CSV, dotenv, INI, and diff files.
- Link to Shiki's upstream language catalog instead of maintaining a copied full language list in OpenClaw docs, with a note that OpenClaw uses its pinned Shiki version.

Follow-up context: #87162 split the language pack out of the default runtime; #87372 expanded the default bucket to 29 languages.

## Verification

- `pnpm format:docs:check docs/tools/diffs.md docs/plugins/reference/diffs-language-pack.md extensions/diffs-language-pack/README.md`
- `git diff --check origin/main...HEAD`

## Notes

`node scripts/generate-plugin-inventory-doc.mjs --check` currently reports an unrelated stale OpenAI description in generated plugin inventory docs on `main`; this PR leaves that unrelated generated-doc drift untouched.
