### PR TITLE
Persist Discord thread bindings in SQLite

### DIFF
--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts
@@ -147,4 +147,143 @@ describe("Discord model picker preference migration", () => {
       }),
     ).toEqual(["+275760-09-13T00:00:00.000Z", "+275760-09-12T23:59:59.999Z"]);
   });
+
+  it("plans legacy thread bindings JSON import into plugin state", async () => {
+    const stateDir = await makeStateDir();
+    const sourcePath = path.join(stateDir, "discord", "thread-bindings.json");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    const boundAt = Date.now() - 10_000;
+    const expiresAt = boundAt + 60_000;
+    await fs.writeFile(
+      sourcePath,
+      JSON.stringify({
+        version: 1,
+        bindings: {
+          "legacy-thread": {
+            accountId: "default",
+            channelId: "parent-1",
+            threadId: "legacy-thread",
+            targetKind: "subagent",
+            targetSessionKey: "agent:main:subagent:legacy",
+            agentId: "main",
+            boundBy: "system",
+            boundAt,
+            expiresAt,
+          },
+        },
+      }),
+    );
+
+    const plans = await Promise.resolve(
+      detectDiscordLegacyStateMigrations({
+        cfg: {},
+        env: {},
+        oauthDir: path.join(stateDir, "credentials"),
+        stateDir,
+      }),
+    );
+
+    expect(plans).toHaveLength(1);
+    const plan = plans?.[0];
+    expect(plan?.kind).toBe("plugin-state-import");
+    if (plan?.kind !== "plugin-state-import") {
+      throw new Error("expected plugin-state import plan");
+    }
+    expect(plan.pluginId).toBe("discord");
+    expect(plan.namespace).toBe("thread-bindings");
+    const entries = await plan.readEntries();
+    expect(entries).toEqual([
+      {
+        key: "default:legacy-thread",
+        value: {
+          accountId: "default",
+          channelId: "parent-1",
+          threadId: "legacy-thread",
+          targetKind: "subagent",
+          targetSessionKey: "agent:main:subagent:legacy",
+          agentId: "main",
+          boundBy: "system",
+          boundAt,
+          lastActivityAt: boundAt,
+          idleTimeoutMs: 0,
+          maxAgeMs: expiresAt - boundAt,
+        },
+      },
+    ]);
+  });
+
+  it("detects model picker and thread binding legacy JSON together", async () => {
+    const stateDir = await makeStateDir();
+    const discordDir = path.join(stateDir, "discord");
+    await fs.mkdir(discordDir, { recursive: true });
+    await fs.writeFile(
+      path.join(discordDir, "model-picker-preferences.json"),
+      JSON.stringify({ version: 1, entries: {} }),
+    );
+    await fs.writeFile(
+      path.join(discordDir, "thread-bindings.json"),
+      JSON.stringify({ version: 1, bindings: {} }),
+    );
+
+    const plans = await Promise.resolve(
+      detectDiscordLegacyStateMigrations({
+        cfg: {},
+        env: {},
+        oauthDir: path.join(stateDir, "credentials"),
+        stateDir,
+      }),
+    );
+
+    expect(plans?.map((plan) => plan.label)).toEqual([
+      "Discord model picker preferences",
+      "Discord thread bindings",
+    ]);
+  });
+
+  it("archives valid empty legacy thread bindings after an empty import", async () => {
+    const stateDir = await makeStateDir();
+    const sourcePath = path.join(stateDir, "discord", "thread-bindings.json");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, JSON.stringify({ version: 1, bindings: {} }));
+
+    const plans = await Promise.resolve(
+      detectDiscordLegacyStateMigrations({
+        cfg: {},
+        env: {},
+        oauthDir: path.join(stateDir, "credentials"),
+        stateDir,
+      }),
+    );
+
+    const plan = plans?.[0];
+    if (plan?.kind !== "plugin-state-import") {
+      throw new Error("expected plugin-state import plan");
+    }
+    expect(plan.cleanupWhenEmpty).toBe(true);
+    expect(plan.readEntries()).toEqual([]);
+  });
+
+  it("keeps malformed legacy thread bindings for doctor warning", async () => {
+    const stateDir = await makeStateDir();
+    const sourcePath = path.join(stateDir, "discord", "thread-bindings.json");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, JSON.stringify({ version: 2, bindings: {} }));
+
+    const plans = await Promise.resolve(
+      detectDiscordLegacyStateMigrations({
+        cfg: {},
+        env: {},
+        oauthDir: path.join(stateDir, "credentials"),
+        stateDir,
+      }),
+    );
+
+    const plan = plans?.[0];
+    if (plan?.kind !== "plugin-state-import") {
+      throw new Error("expected plugin-state import plan");
+    }
+    expect(() => plan.readEntries()).toThrow(
+      "legacy Discord thread bindings store must have version 1 bindings",
+    );
+  });
 });

--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
@@ -1,9 +1,16 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import type { ChannelLegacyStateMigrationPlan } from "openclaw/plugin-sdk/channel-contract";
 import type { BundledChannelLegacyStateMigrationDetector } from "openclaw/plugin-sdk/channel-entry-contract";
 import { MAX_DATE_TIMESTAMP_MS, timestampMsToIsoString } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  normalizePersistedBinding,
+  THREAD_BINDINGS_MAX_ENTRIES,
+  THREAD_BINDINGS_NAMESPACE,
+  toBindingRecordKey,
+} from "./thread-bindings.state.js";
 
 const PREFERENCE_MAX_ENTRIES = 2_000;
 const MAX_PLUGIN_STATE_KEY_BYTES = 512;
@@ -16,6 +23,11 @@ type LegacyModelPickerPreferencesEntry = {
 
 type LegacyModelPickerPreferencesStore = {
   entries?: unknown;
+};
+
+type LegacyThreadBindingsStore = {
+  version?: unknown;
+  bindings?: unknown;
 };
 
 function fileExists(filePath: string): boolean {
@@ -35,6 +47,14 @@ function readLegacyStore(filePath: string): LegacyModelPickerPreferencesStore | 
   } catch {
     return null;
   }
+}
+
+function readLegacyThreadBindingsStore(filePath: string): LegacyThreadBindingsStore {
+  const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("legacy Discord thread bindings store must be an object");
+  }
+  return parsed as LegacyThreadBindingsStore;
 }
 
 function normalizeLegacyPreferenceKey(key: string): string | undefined {
@@ -107,15 +127,13 @@ function legacyUpdatedAtForIndex(updatedAt: unknown, index: number, total: numbe
 export const detectDiscordLegacyStateMigrations: BundledChannelLegacyStateMigrationDetector = ({
   stateDir,
 }) => {
-  const sourcePath = path.join(stateDir, "discord", "model-picker-preferences.json");
-  if (!fileExists(sourcePath)) {
-    return [];
-  }
-  return [
-    {
+  const plans: ChannelLegacyStateMigrationPlan[] = [];
+  const modelPickerSourcePath = path.join(stateDir, "discord", "model-picker-preferences.json");
+  if (fileExists(modelPickerSourcePath)) {
+    plans.push({
       kind: "plugin-state-import",
       label: "Discord model picker preferences",
-      sourcePath,
+      sourcePath: modelPickerSourcePath,
       targetPath: "plugin state:model-picker-preferences",
       pluginId: "discord",
       namespace: "model-picker-preferences",
@@ -123,7 +141,7 @@ export const detectDiscordLegacyStateMigrations: BundledChannelLegacyStateMigrat
       scopeKey: "",
       cleanupSource: "rename",
       readEntries: () => {
-        const store = readLegacyStore(sourcePath);
+        const store = readLegacyStore(modelPickerSourcePath);
         if (!store || !store.entries || typeof store.entries !== "object") {
           return [];
         }
@@ -149,6 +167,40 @@ export const detectDiscordLegacyStateMigrations: BundledChannelLegacyStateMigrat
         }
         return out;
       },
-    },
-  ];
+    });
+  }
+
+  const threadBindingsSourcePath = path.join(stateDir, "discord", "thread-bindings.json");
+  if (fileExists(threadBindingsSourcePath)) {
+    plans.push({
+      kind: "plugin-state-import",
+      label: "Discord thread bindings",
+      sourcePath: threadBindingsSourcePath,
+      targetPath: `plugin state:${THREAD_BINDINGS_NAMESPACE}`,
+      pluginId: "discord",
+      namespace: THREAD_BINDINGS_NAMESPACE,
+      maxEntries: THREAD_BINDINGS_MAX_ENTRIES,
+      scopeKey: "",
+      cleanupSource: "rename",
+      cleanupWhenEmpty: true,
+      readEntries: () => {
+        const store = readLegacyThreadBindingsStore(threadBindingsSourcePath);
+        if (store?.version !== 1 || !store.bindings || typeof store.bindings !== "object") {
+          throw new Error("legacy Discord thread bindings store must have version 1 bindings");
+        }
+        const out: Array<{ key: string; value: unknown }> = [];
+        for (const [rawKey, rawEntry] of Object.entries(
+          store.bindings as Record<string, unknown>,
+        )) {
+          const normalized = normalizePersistedBinding(rawKey, rawEntry);
+          if (normalized) {
+            out.push({ key: toBindingRecordKey(normalized), value: normalized });
+          }
+        }
+        return out;
+      },
+    });
+  }
+
+  return plans;
 };

--- a/extensions/discord/src/monitor/model-picker-preferences.test.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences.test.ts
@@ -128,9 +128,9 @@ describe("discord model picker preferences", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("imports legacy JSON preferences into plugin state", async () => {
+  it("ignores retired legacy JSON preferences at runtime", async () => {
     const env = await createStateEnv();
-    const scope = { accountId: "main", guildId: "guild-1", userId: "user-1" };
+    const scope = { userId: "legacy-runtime-user" };
     const key = buildDiscordModelPickerPreferenceKey(scope);
     expect(key).toBeTruthy();
     const legacyPath = path.join(
@@ -145,7 +145,7 @@ describe("discord model picker preferences", () => {
         version: 1,
         entries: {
           [key as string]: {
-            recent: ["openai/gpt-4.1", "bad-model", "openai/gpt-4o"],
+            recent: ["openai/gpt-4.1"],
             updatedAt: "2026-01-01T00:00:00.000Z",
           },
         },
@@ -153,108 +153,7 @@ describe("discord model picker preferences", () => {
       "utf8",
     );
 
-    const recent = await readDiscordModelPickerRecentModels({ env, scope });
-    expect(recent).toEqual(["openai/gpt-4.1", "openai/gpt-4o"]);
-
-    await fs.rm(legacyPath, { force: true });
-    expect(await readDiscordModelPickerRecentModels({ env, scope })).toEqual([
-      "openai/gpt-4.1",
-      "openai/gpt-4o",
-    ]);
-  });
-
-  it("imports legacy JSON preferences with max Date timestamps", async () => {
-    const env = await createStateEnv();
-    const scope = { accountId: "main", guildId: "guild-max-date", userId: "user-max-date" };
-    const key = buildDiscordModelPickerPreferenceKey(scope);
-    expect(key).toBeTruthy();
-    const legacyPath = path.join(
-      env.OPENCLAW_STATE_DIR as string,
-      "discord",
-      "model-picker-preferences.json",
-    );
-    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
-    await fs.writeFile(
-      legacyPath,
-      JSON.stringify({
-        version: 1,
-        entries: {
-          [key as string]: {
-            recent: ["openai/gpt-4.1", "openai/gpt-4o"],
-            updatedAt: "+275760-09-13T00:00:00.000Z",
-          },
-        },
-      }),
-      "utf8",
-    );
-
-    await expect(readDiscordModelPickerRecentModels({ env, scope })).resolves.toEqual([
-      "openai/gpt-4.1",
-      "openai/gpt-4o",
-    ]);
-  });
-
-  it("preserves legacy JSON preference order near max Date", async () => {
-    const env = await createStateEnv();
-    const scope = { accountId: "main", guildId: "guild-near-max-date", userId: "user-near-max" };
-    const key = buildDiscordModelPickerPreferenceKey(scope);
-    expect(key).toBeTruthy();
-    const legacyPath = path.join(
-      env.OPENCLAW_STATE_DIR as string,
-      "discord",
-      "model-picker-preferences.json",
-    );
-    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
-    await fs.writeFile(
-      legacyPath,
-      JSON.stringify({
-        version: 1,
-        entries: {
-          [key as string]: {
-            recent: ["openai/gpt-4.1", "openai/gpt-4o"],
-            updatedAt: "+275760-09-12T23:59:59.999Z",
-          },
-        },
-      }),
-      "utf8",
-    );
-
-    await expect(readDiscordModelPickerRecentModels({ env, scope })).resolves.toEqual([
-      "openai/gpt-4.1",
-      "openai/gpt-4o",
-    ]);
-  });
-
-  it("skips malformed legacy JSON entries during import", async () => {
-    const env = await createStateEnv();
-    const scope = { userId: "valid-legacy-user" };
-    const key = buildDiscordModelPickerPreferenceKey(scope);
-    expect(key).toBeTruthy();
-    const legacyPath = path.join(
-      env.OPENCLAW_STATE_DIR as string,
-      "discord",
-      "model-picker-preferences.json",
-    );
-    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
-    await fs.writeFile(
-      legacyPath,
-      JSON.stringify({
-        version: 1,
-        entries: {
-          "": { recent: ["openai/bad-empty"], updatedAt: "bad" },
-          ["x".repeat(600)]: { recent: ["openai/bad-long"], updatedAt: "bad" },
-          [key as string]: {
-            recent: ["not-a-model", "openai/gpt-4.1"],
-            updatedAt: "2026-01-01T00:00:00.000Z",
-          },
-        },
-      }),
-      "utf8",
-    );
-
-    await expect(readDiscordModelPickerRecentModels({ env, scope })).resolves.toEqual([
-      "openai/gpt-4.1",
-    ]);
+    await expect(readDiscordModelPickerRecentModels({ env, scope })).resolves.toEqual([]);
   });
 
   it("preserves concurrent model picker selections for the same scope", async () => {

--- a/extensions/discord/src/monitor/model-picker-preferences.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences.ts
@@ -1,23 +1,16 @@
 import { createHash } from "node:crypto";
-import os from "node:os";
-import path from "node:path";
 import { normalizeAccountId as normalizeSharedAccountId } from "openclaw/plugin-sdk/account-id";
-import { readJsonFileWithFallback } from "openclaw/plugin-sdk/json-store";
 import {
   MAX_DATE_TIMESTAMP_MS,
   resolveDateTimestampMs,
   resolveTimestampMsToIsoString,
-  timestampMsToIsoString,
 } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
-import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getDiscordRuntime } from "../runtime.js";
 
 const DEFAULT_RECENT_LIMIT = 5;
 const PREFERENCE_MAX_ENTRIES = 2_000;
-const MAX_PLUGIN_STATE_KEY_BYTES = 512;
-const textEncoder = new TextEncoder();
 let lastPreferenceTimestampMs = 0;
 let lastPreferenceOrder = 0;
 
@@ -27,18 +20,6 @@ type ModelPickerPreferencesEntry = {
   updatedAt: string;
   updatedOrder?: number;
 };
-
-type LegacyModelPickerPreferencesEntry = {
-  recent: string[];
-  updatedAt: string;
-};
-
-type LegacyModelPickerPreferencesStore = {
-  version?: unknown;
-  entries?: unknown;
-};
-
-const legacyPreferenceImports = new Map<string, Promise<void>>();
 
 function openPreferenceStore(env?: NodeJS.ProcessEnv) {
   return getDiscordRuntime().state.openKeyedStore<ModelPickerPreferencesEntry>({
@@ -107,23 +88,6 @@ function sanitizeRecentModels(models: string[] | undefined, limit: number): stri
   return deduped;
 }
 
-function sanitizeLegacyPreferenceEntry(
-  value: unknown,
-): LegacyModelPickerPreferencesEntry | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const typedValue = value as {
-    recent?: unknown;
-    updatedAt?: unknown;
-  };
-  const recent = Array.isArray(typedValue.recent)
-    ? typedValue.recent.filter((item: unknown): item is string => typeof item === "string")
-    : [];
-  const updatedAt = typeof typedValue.updatedAt === "string" ? typedValue.updatedAt : "";
-  return { recent, updatedAt };
-}
-
 function sanitizeStoredPreferenceEntry(value: unknown): ModelPickerPreferencesEntry | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
@@ -180,18 +144,6 @@ function comparePreferenceEntries(
   );
 }
 
-function legacyUpdatedAtForIndex(updatedAt: string, index: number, total: number): string {
-  const baseMs = timestampMs(updatedAt);
-  const anchorMs = Math.min(baseMs + Math.max(0, total), MAX_DATE_TIMESTAMP_MS);
-  const shiftedMs = anchorMs - Math.max(0, index);
-  return (
-    timestampMsToIsoString(shiftedMs) ??
-    timestampMsToIsoString(baseMs) ??
-    timestampMsToIsoString(Math.max(0, total - index)) ??
-    "1970-01-01T00:00:00.000Z"
-  );
-}
-
 function nextPreferenceTimestamp(existingEntries: ModelPickerPreferencesEntry[]): {
   updatedAt: string;
   updatedOrder: number;
@@ -219,67 +171,6 @@ function nextPreferenceTimestamp(existingEntries: ModelPickerPreferencesEntry[])
   };
 }
 
-function normalizeLegacyPreferenceKey(key: string): string | undefined {
-  const trimmed = key.trim();
-  if (!trimmed || textEncoder.encode(trimmed).length > MAX_PLUGIN_STATE_KEY_BYTES) {
-    return undefined;
-  }
-  return trimmed;
-}
-
-function resolveLegacyPreferencesPath(env?: NodeJS.ProcessEnv): string {
-  return path.join(
-    resolveStateDir(env ?? process.env, os.homedir),
-    "discord",
-    "model-picker-preferences.json",
-  );
-}
-
-async function importLegacyPreferences(env?: NodeJS.ProcessEnv): Promise<void> {
-  const legacyPath = resolveLegacyPreferencesPath(env);
-  const stateDir = path.dirname(path.dirname(legacyPath));
-  const existingImport = legacyPreferenceImports.get(stateDir);
-  if (existingImport) {
-    await existingImport;
-    return;
-  }
-
-  const importPromise = (async () => {
-    const { value, exists } =
-      await readJsonFileWithFallback<LegacyModelPickerPreferencesStore | null>(legacyPath, null);
-    if (!exists || !value || typeof value.entries !== "object" || value.entries == null) {
-      return;
-    }
-
-    const store = openPreferenceStore(env);
-    for (const [rawKey, rawEntry] of Object.entries(value.entries as Record<string, unknown>)) {
-      const key = normalizeLegacyPreferenceKey(rawKey);
-      if (!key) {
-        continue;
-      }
-      const entry = sanitizeLegacyPreferenceEntry(rawEntry);
-      if (!entry || (entry.recent.length === 0 && !entry.updatedAt)) {
-        continue;
-      }
-      const recent = sanitizeRecentModels(entry.recent, 10);
-      for (const [index, modelRef] of recent.entries()) {
-        await store.registerIfAbsent(buildPreferenceModelKey(key, modelRef), {
-          scopeKey: key,
-          modelRef,
-          updatedAt: legacyUpdatedAtForIndex(entry.updatedAt, index, recent.length),
-        });
-      }
-    }
-  })();
-  legacyPreferenceImports.set(stateDir, importPromise);
-  try {
-    await importPromise;
-  } catch (error) {
-    legacyPreferenceImports.delete(stateDir);
-    throw error;
-  }
-}
-
 export async function readDiscordModelPickerRecentModels(params: {
   scope: DiscordModelPickerPreferenceScope;
   limit?: number;
@@ -292,7 +183,6 @@ export async function readDiscordModelPickerRecentModels(params: {
   }
   const limit = Math.max(1, Math.min(params.limit ?? DEFAULT_RECENT_LIMIT, 10));
   try {
-    await importLegacyPreferences(params.env);
     const store = openPreferenceStore(params.env);
     const recent = (await store.entries())
       .map((entry) => ({ key: entry.key, value: sanitizeStoredPreferenceEntry(entry.value) }))
@@ -327,7 +217,6 @@ export async function recordDiscordModelPickerRecentModel(params: {
   }
 
   try {
-    await importLegacyPreferences(params.env);
     const store = openPreferenceStore(params.env);
     const existingEntries = (await store.entries())
       .map((entry) => sanitizeStoredPreferenceEntry(entry.value))

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -3,12 +3,18 @@ import os from "node:os";
 import path from "node:path";
 import { ChannelType } from "discord-api-types/v10";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setDiscordRuntime, type DiscordRuntime } from "../runtime.js";
 import { EMPTY_DISCORD_TEST_CONFIG } from "../test-support/config.js";
 
 const hoisted = vi.hoisted(() => {
@@ -115,7 +121,14 @@ function mockCallArg(mock: unknown, callIndex: number, argIndex: number, label: 
 
 describe("thread binding lifecycle", () => {
   beforeEach(() => {
+    resetPluginStateStoreForTests();
     testing.resetThreadBindingsForTests();
+    setDiscordRuntime({
+      state: {
+        openSyncKeyedStore: (options: OpenKeyedStoreOptions) =>
+          createPluginStateSyncKeyedStoreForTests("discord", options),
+      },
+    } as unknown as DiscordRuntime);
     clearRuntimeConfigSnapshot();
     vi.restoreAllMocks();
     hoisted.sendMessageDiscord.mockReset().mockResolvedValue({});
@@ -772,6 +785,34 @@ describe("thread binding lifecycle", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
       vi.useRealTimers();
     }
+  });
+
+  it("keeps thread binding startup in memory when SQLite persistence is unavailable", async () => {
+    setDiscordRuntime({
+      state: {
+        openSyncKeyedStore: () => {
+          throw new Error("sqlite unavailable");
+        },
+      },
+    } as unknown as DiscordRuntime);
+
+    const manager = createTestThreadBindingManager({
+      accountId: "default",
+      persist: true,
+      enableSweeper: false,
+    });
+
+    await manager.bindTarget({
+      threadId: "thread-sqlite-down",
+      channelId: "parent-1",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:subagent:sqlite-down",
+      agentId: "main",
+    });
+
+    expect(manager.getByThreadId("thread-sqlite-down")).toMatchObject({
+      targetSessionKey: "agent:main:subagent:sqlite-down",
+    });
   });
 
   it("reuses webhook credentials after unbind when rebinding in the same channel", async () => {
@@ -1840,45 +1881,34 @@ describe("thread binding lifecycle", () => {
     process.env.OPENCLAW_STATE_DIR = stateDir;
     try {
       testing.resetThreadBindingsForTests();
-      const bindingsPath = testing.resolveThreadBindingsPath();
-      fs.mkdirSync(path.dirname(bindingsPath), { recursive: true });
       const boundAt = Date.now() - 10_000;
       const expiresAt = boundAt + 60_000;
-      fs.writeFileSync(
-        bindingsPath,
-        JSON.stringify(
-          {
-            version: 1,
-            bindings: {
-              "thread-legacy-active": {
-                accountId: "default",
-                channelId: "parent-1",
-                threadId: "thread-legacy-active",
-                targetKind: "subagent",
-                targetSessionKey: "agent:main:subagent:legacy-active",
-                agentId: "main",
-                boundBy: "system",
-                boundAt,
-                expiresAt,
-              },
-              "thread-legacy-disabled": {
-                accountId: "default",
-                channelId: "parent-1",
-                threadId: "thread-legacy-disabled",
-                targetKind: "subagent",
-                targetSessionKey: "agent:main:subagent:legacy-disabled",
-                agentId: "main",
-                boundBy: "system",
-                boundAt,
-                expiresAt: 0,
-              },
-            },
-          },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
+      const store = createPluginStateSyncKeyedStoreForTests("discord", {
+        namespace: "thread-bindings",
+        maxEntries: 10_000,
+      });
+      store.register("default:thread-legacy-active", {
+        accountId: "default",
+        channelId: "parent-1",
+        threadId: "thread-legacy-active",
+        targetKind: "subagent",
+        targetSessionKey: "agent:main:subagent:legacy-active",
+        agentId: "main",
+        boundBy: "system",
+        boundAt,
+        expiresAt,
+      });
+      store.register("default:thread-legacy-disabled", {
+        accountId: "default",
+        channelId: "parent-1",
+        threadId: "thread-legacy-disabled",
+        targetKind: "subagent",
+        targetSessionKey: "agent:main:subagent:legacy-disabled",
+        agentId: "main",
+        boundBy: "system",
+        boundAt,
+        expiresAt: 0,
+      });
 
       const manager = createTestThreadBindingManager({
         accountId: "default",
@@ -1942,45 +1972,30 @@ describe("thread binding lifecycle", () => {
     process.env.OPENCLAW_STATE_DIR = stateDir;
     try {
       testing.resetThreadBindingsForTests();
-      const bindingsPath = testing.resolveThreadBindingsPath();
-      fs.mkdirSync(path.dirname(bindingsPath), { recursive: true });
       const now = Date.now();
-      fs.writeFileSync(
-        bindingsPath,
-        JSON.stringify(
-          {
-            version: 1,
-            bindings: {
-              "thread-1": {
-                accountId: "default",
-                channelId: "parent-1",
-                threadId: "thread-1",
-                targetKind: "subagent",
-                targetSessionKey: "agent:main:subagent:child",
-                agentId: "main",
-                boundBy: "system",
-                boundAt: now,
-                lastActivityAt: now,
-                idleTimeoutMs: 60_000,
-                maxAgeMs: 0,
-              },
-            },
-          },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
+      const store = createPluginStateSyncKeyedStoreForTests("discord", {
+        namespace: "thread-bindings",
+        maxEntries: 10_000,
+      });
+      store.register("default:thread-1", {
+        accountId: "default",
+        channelId: "parent-1",
+        threadId: "thread-1",
+        targetKind: "subagent",
+        targetSessionKey: "agent:main:subagent:child",
+        agentId: "main",
+        boundBy: "system",
+        boundAt: now,
+        lastActivityAt: now,
+        idleTimeoutMs: 60_000,
+        maxAgeMs: 0,
+      });
 
       const removed = unbindThreadBindingsBySessionKey({
         targetSessionKey: "agent:main:subagent:child",
       });
       expect(removed).toHaveLength(1);
-
-      const payload = JSON.parse(fs.readFileSync(bindingsPath, "utf-8")) as {
-        bindings?: Record<string, unknown>;
-      };
-      expect(Object.keys(payload.bindings ?? {})).toStrictEqual([]);
+      expect(store.entries()).toStrictEqual([]);
     } finally {
       testing.resetThreadBindingsForTests();
       if (previousStateDir === undefined) {

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -45,7 +45,6 @@ import {
   resolveThreadBindingInactivityExpiresAt,
   resolveThreadBindingMaxAgeExpiresAt,
   resolveThreadBindingMaxAgeMs,
-  resolveThreadBindingsPath,
   saveBindingsToDisk,
   setBindingRecord,
   THREAD_BINDING_TOUCH_PERSIST_MIN_INTERVAL_MS,
@@ -544,7 +543,6 @@ export function getThreadBindingManager(accountId?: string): ThreadBindingManage
 }
 
 export const testing = {
-  resolveThreadBindingsPath,
   resolveThreadBindingThreadName,
   resetThreadBindingsForTests,
   runThreadBindingSweepForAccount: async (accountId?: string) => {

--- a/extensions/discord/src/monitor/thread-bindings.state.ts
+++ b/extensions/discord/src/monitor/thread-bindings.state.ts
@@ -1,24 +1,19 @@
-import fs from "node:fs";
-import path from "node:path";
-import { loadJsonFile, saveJsonFile } from "openclaw/plugin-sdk/json-store";
 import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeAccountId, resolveAgentIdFromSessionKey } from "openclaw/plugin-sdk/routing";
-import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { getDiscordRuntime } from "../runtime.js";
 import {
   DEFAULT_THREAD_BINDING_IDLE_TIMEOUT_MS,
   DEFAULT_THREAD_BINDING_MAX_AGE_MS,
   RECENT_UNBOUND_WEBHOOK_ECHO_WINDOW_MS,
-  THREAD_BINDINGS_VERSION,
   type PersistedThreadBindingRecord,
-  type PersistedThreadBindingsPayload,
   type ThreadBindingManager,
   type ThreadBindingRecord,
   type ThreadBindingTargetKind,
@@ -33,6 +28,8 @@ type ThreadBindingsGlobalState = {
   reusableWebhooksByAccountChannel: Map<string, { webhookId: string; webhookToken: string }>;
   persistByAccountId: Map<string, boolean>;
   loadedBindings: boolean;
+  loadedPersistentBindings: boolean;
+  persistenceAvailable: boolean;
   lastPersistedAtMs: number;
 };
 
@@ -58,6 +55,8 @@ function createThreadBindingsGlobalState(): ThreadBindingsGlobalState {
     >(),
     persistByAccountId: new Map<string, boolean>(),
     loadedBindings: false,
+    loadedPersistentBindings: false,
+    persistenceAvailable: true,
     lastPersistedAtMs: 0,
   };
 }
@@ -85,6 +84,8 @@ export const REUSABLE_WEBHOOKS_BY_ACCOUNT_CHANNEL =
   THREAD_BINDINGS_STATE.reusableWebhooksByAccountChannel;
 export const PERSIST_BY_ACCOUNT_ID = THREAD_BINDINGS_STATE.persistByAccountId;
 export const THREAD_BINDING_TOUCH_PERSIST_MIN_INTERVAL_MS = 15_000;
+export const THREAD_BINDINGS_NAMESPACE = "thread-bindings";
+export const THREAD_BINDINGS_MAX_ENTRIES = 10_000;
 
 export function rememberThreadBindingToken(params: { accountId?: string; token?: string }) {
   const normalizedAccountId = normalizeAccountId(params.accountId);
@@ -107,8 +108,11 @@ export function shouldDefaultPersist(): boolean {
   return !(process.env.VITEST || process.env.NODE_ENV === "test");
 }
 
-export function resolveThreadBindingsPath(): string {
-  return path.join(resolveStateDir(process.env), "discord", "thread-bindings.json");
+function openThreadBindingsStore() {
+  return getDiscordRuntime().state.openSyncKeyedStore<PersistedThreadBindingRecord>({
+    namespace: THREAD_BINDINGS_NAMESPACE,
+    maxEntries: THREAD_BINDINGS_MAX_ENTRIES,
+  });
 }
 
 export function normalizeTargetKind(
@@ -143,7 +147,10 @@ export function resolveBindingRecordKey(params: {
   });
 }
 
-function normalizePersistedBinding(threadIdKey: string, raw: unknown): ThreadBindingRecord | null {
+export function normalizePersistedBinding(
+  threadIdKey: string,
+  raw: unknown,
+): ThreadBindingRecord | null {
   if (!raw || typeof raw !== "object") {
     return null;
   }
@@ -434,14 +441,28 @@ function shouldPersistAnyBindingState(): boolean {
 }
 
 export function shouldPersistBindingMutations(): boolean {
+  if (!THREAD_BINDINGS_STATE.persistenceAvailable) {
+    return false;
+  }
   if (shouldPersistAnyBindingState()) {
     return true;
   }
-  return fs.existsSync(resolveThreadBindingsPath());
+  return THREAD_BINDINGS_STATE.loadedPersistentBindings;
+}
+
+function toPersistedBindingRecord(record: ThreadBindingRecord): PersistedThreadBindingRecord {
+  const serialized = JSON.stringify(record);
+  if (!serialized) {
+    return { ...record };
+  }
+  return JSON.parse(serialized) as unknown as PersistedThreadBindingRecord;
 }
 
 export function saveBindingsToDisk(params: { force?: boolean; minIntervalMs?: number } = {}) {
   if (!params.force && !shouldPersistAnyBindingState()) {
+    return;
+  }
+  if (!THREAD_BINDINGS_STATE.persistenceAvailable) {
     return;
   }
   const minIntervalMs =
@@ -457,16 +478,23 @@ export function saveBindingsToDisk(params: { force?: boolean; minIntervalMs?: nu
   ) {
     return;
   }
-  const bindings: Record<string, PersistedThreadBindingRecord> = {};
-  for (const [bindingKey, record] of BINDINGS_BY_THREAD_ID.entries()) {
-    bindings[bindingKey] = { ...record };
+  try {
+    const store = openThreadBindingsStore();
+    const persistedKeys = new Set<string>();
+    for (const [bindingKey, record] of BINDINGS_BY_THREAD_ID.entries()) {
+      store.register(bindingKey, toPersistedBindingRecord(record));
+      persistedKeys.add(bindingKey);
+    }
+    for (const entry of store.entries()) {
+      if (!persistedKeys.has(entry.key)) {
+        store.delete(entry.key);
+      }
+    }
+    THREAD_BINDINGS_STATE.loadedPersistentBindings = persistedKeys.size > 0;
+    THREAD_BINDINGS_STATE.lastPersistedAtMs = now;
+  } catch {
+    THREAD_BINDINGS_STATE.persistenceAvailable = false;
   }
-  const payload: PersistedThreadBindingsPayload = {
-    version: THREAD_BINDINGS_VERSION,
-    bindings,
-  };
-  saveJsonFile(resolveThreadBindingsPath(), payload);
-  THREAD_BINDINGS_STATE.lastPersistedAtMs = now;
 }
 
 export function ensureBindingsLoaded() {
@@ -477,18 +505,23 @@ export function ensureBindingsLoaded() {
   BINDINGS_BY_THREAD_ID.clear();
   BINDINGS_BY_SESSION_KEY.clear();
   REUSABLE_WEBHOOKS_BY_ACCOUNT_CHANNEL.clear();
+  THREAD_BINDINGS_STATE.loadedPersistentBindings = false;
 
-  const raw = loadJsonFile(resolveThreadBindingsPath());
-  if (!raw || typeof raw !== "object") {
+  const entries = (() => {
+    try {
+      return openThreadBindingsStore().entries();
+    } catch {
+      THREAD_BINDINGS_STATE.persistenceAvailable = false;
+      return null;
+    }
+  })();
+  if (!entries) {
     return;
   }
-  const payload = raw as Partial<PersistedThreadBindingsPayload>;
-  if (payload.version !== 1 || !payload.bindings || typeof payload.bindings !== "object") {
-    return;
-  }
-
-  for (const [threadId, entry] of Object.entries(payload.bindings)) {
-    const normalized = normalizePersistedBinding(threadId, entry);
+  THREAD_BINDINGS_STATE.persistenceAvailable = true;
+  THREAD_BINDINGS_STATE.loadedPersistentBindings = entries.length > 0;
+  for (const entry of entries) {
+    const normalized = normalizePersistedBinding(entry.key, entry.value);
     if (!normalized) {
       continue;
     }
@@ -545,5 +578,7 @@ export function resetThreadBindingsForTests() {
   TOKENS_BY_ACCOUNT_ID.clear();
   PERSIST_BY_ACCOUNT_ID.clear();
   THREAD_BINDINGS_STATE.loadedBindings = false;
+  THREAD_BINDINGS_STATE.loadedPersistentBindings = false;
+  THREAD_BINDINGS_STATE.persistenceAvailable = true;
   THREAD_BINDINGS_STATE.lastPersistedAtMs = 0;
 }

--- a/scripts/dev/discord-acp-plain-language-smoke.ts
+++ b/scripts/dev/discord-acp-plain-language-smoke.ts
@@ -3,11 +3,11 @@ import { execFile } from "node:child_process";
 // Manual ACP thread smoke for plain-language routing.
 // Keep this script available for regression/debug validation. Do not delete.
 import { randomUUID } from "node:crypto";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { formatErrorMessage } from "../../src/infra/errors.ts";
+import { createPluginStateKeyedStore } from "../../src/plugin-state/plugin-state-store.ts";
 import { readBoundedResponseText } from "../lib/bounded-response.ts";
 import {
   maskIdentifier,
@@ -40,11 +40,6 @@ type ThreadBindingRecord = {
   boundAt?: number;
 };
 
-type ThreadBindingsPayload = {
-  version?: number;
-  bindings?: Record<string, ThreadBindingRecord>;
-};
-
 type DiscordMessage = {
   id: string;
   content?: string;
@@ -68,6 +63,8 @@ type WebhookForCleanup = {
 };
 
 const execFileAsync = promisify(execFile);
+const THREAD_BINDINGS_NAMESPACE = "thread-bindings";
+const THREAD_BINDINGS_MAX_ENTRIES = 10_000;
 
 type DriverMode = "token" | "webhook" | "openclaw";
 
@@ -83,7 +80,7 @@ type Args = {
   pollMs: number;
   mentionUserId?: string;
   instruction?: string;
-  threadBindingsPath: string;
+  stateDir: string;
   openclawBin: string;
   json: boolean;
 };
@@ -296,7 +293,7 @@ function usage(): string {
     "  --instruction <text>         Custom instruction template (optional)\n" +
     "  --timeout-ms <n>             Total timeout in ms (default: 240000)\n" +
     "  --poll-ms <n>                Poll interval in ms (default: 1500)\n" +
-    "  --thread-bindings-path <p>   Override thread-bindings json path\n" +
+    "  --state-dir <p>              Override OpenClaw state dir for plugin-state polling\n" +
     "  --openclaw-bin <path>        OpenClaw CLI binary for driver=openclaw (default: openclaw)\n" +
     "  --json                       Emit JSON output\n" +
     "\n" +
@@ -311,7 +308,7 @@ function usage(): string {
     "  OPENCLAW_DISCORD_SMOKE_MENTION_USER_ID\n" +
     "  OPENCLAW_DISCORD_SMOKE_TIMEOUT_MS\n" +
     "  OPENCLAW_DISCORD_SMOKE_POLL_MS\n" +
-    "  OPENCLAW_DISCORD_SMOKE_THREAD_BINDINGS_PATH\n" +
+    "  OPENCLAW_STATE_DIR\n" +
     "  OPENCLAW_DISCORD_SMOKE_OPENCLAW_BIN"
   );
 }
@@ -349,11 +346,7 @@ function parseArgs(): Args {
     1_500,
     "--poll-ms",
   );
-  const defaultBindingsPath = path.join(resolveStateDir(), "discord", "thread-bindings.json");
-  const threadBindingsPath =
-    resolveArg("--thread-bindings-path") ||
-    process.env.OPENCLAW_DISCORD_SMOKE_THREAD_BINDINGS_PATH ||
-    defaultBindingsPath;
+  const stateDir = path.resolve(resolveArg("--state-dir") || resolveStateDir());
   const openclawBin =
     resolveArg("--openclaw-bin") || process.env.OPENCLAW_DISCORD_SMOKE_OPENCLAW_BIN || "openclaw";
   const json = hasFlag("--json");
@@ -380,7 +373,7 @@ function parseArgs(): Args {
     pollMs,
     mentionUserId,
     instruction,
-    threadBindingsPath,
+    stateDir,
     openclawBin,
     json,
   };
@@ -599,11 +592,16 @@ async function requestDiscordJson<T>(params: {
   );
 }
 
-async function readThreadBindings(filePath: string): Promise<ThreadBindingRecord[]> {
-  const raw = await fs.readFile(filePath, "utf8");
-  const payload = JSON.parse(raw) as ThreadBindingsPayload;
-  const entries = Object.values(payload.bindings ?? {});
-  return entries.filter((entry) => Boolean(entry?.threadId && entry?.targetSessionKey));
+async function readThreadBindings(stateDir: string): Promise<ThreadBindingRecord[]> {
+  const store = createPluginStateKeyedStore<ThreadBindingRecord>("discord", {
+    namespace: THREAD_BINDINGS_NAMESPACE,
+    maxEntries: THREAD_BINDINGS_MAX_ENTRIES,
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+  });
+  const entries = await store.entries();
+  return entries
+    .map((entry) => entry.value)
+    .filter((entry) => Boolean(entry?.threadId && entry?.targetSessionKey));
 }
 
 function normalizeBoundAt(record: ThreadBindingRecord): number {
@@ -896,7 +894,7 @@ async function run(): Promise<SuccessResult | FailureResult> {
   try {
     while (Date.now() < deadline && !winningBinding) {
       try {
-        const entries = await readThreadBindings(args.threadBindingsPath);
+        const entries = await readThreadBindings(args.stateDir);
         latestCandidates = resolveCandidateBindings({
           entries,
           minBoundAt: minBindingBoundAt,
@@ -926,7 +924,7 @@ async function run(): Promise<SuccessResult | FailureResult> {
         ok: false,
         stage: "wait-binding",
         smokeId,
-        error: `Timed out waiting for new ACP thread binding (path: ${redactHomePath(args.threadBindingsPath)}).`,
+        error: `Timed out waiting for new ACP thread binding (state: ${redactHomePath(args.stateDir)}).`,
         diagnostics: {
           bindingCandidates: latestCandidates.slice(0, 6).map((entry) => ({
             threadId: entry.threadId || "",

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -228,6 +228,7 @@ describe("ensureConfigReady", () => {
 
   it.each([
     ["Discord model picker preferences", "discord/model-picker-preferences.json"],
+    ["Discord thread bindings", "discord/thread-bindings.json"],
     ["Feishu dedupe sidecar", "feishu/dedup/default.json"],
     ["Telegram bot info cache", "telegram/bot-info-default.json"],
     ["Telegram update offset", "telegram/update-offset-default.json"],

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -75,7 +75,10 @@ function hasLegacyIMessageStateFiles(stateDir: string): boolean {
 }
 
 function hasBundledChannelLegacyStateMigrationInputs(stateDir: string, oauthDir: string): boolean {
-  if (fileOrDirExists(path.join(stateDir, "discord", "model-picker-preferences.json"))) {
+  if (
+    fileOrDirExists(path.join(stateDir, "discord", "model-picker-preferences.json")) ||
+    fileOrDirExists(path.join(stateDir, "discord", "thread-bindings.json"))
+  ) {
     return true;
   }
   if (dirHasFile(path.join(stateDir, "feishu", "dedup"), (name) => name.endsWith(".json"))) {


### PR DESCRIPTION
## Summary
- Persist Discord ACP thread bindings in the Discord plugin-state SQLite namespace instead of `state/discord/thread-bindings.json`.
- Move legacy JSON handling into doctor migration detection, including startup guard detection and valid-empty cleanup.
- Remove Discord model-picker runtime legacy JSON import so runtime reads canonical plugin-state only.
- Update the live Discord ACP smoke script to poll the SQLite plugin-state store.

## Verification
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts extensions/discord/src/monitor/model-picker-preferences.test.ts extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts src/cli/program/config-guard.test.ts`
- `node scripts/run-tsgo.mjs -p extensions/discord/tsconfig.json --incremental --tsBuildInfoFile /tmp/openclaw-discord-thread-bindings.tsbuildinfo`
- `node scripts/run-oxlint.mjs extensions/discord/src/monitor/thread-bindings.state.ts extensions/discord/src/monitor/thread-bindings.manager.ts extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts extensions/discord/src/monitor/model-picker-preferences.ts extensions/discord/src/monitor/model-picker-preferences.test.ts extensions/discord/src/monitor/model-picker-preferences-migrations.ts extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts src/cli/program/config-guard.ts src/cli/program/config-guard.test.ts scripts/dev/discord-acp-plain-language-smoke.ts`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Notes
- Full `pnpm lint --threads=8` is blocked on existing `extensions/microsoft-foundry/provider.ts` lint findings on latest `main`, unrelated to this branch.
