### PR TITLE
fix(ci): restore cron schema snapshots

### DIFF
--- a/extensions/phone-control/index.test.ts
+++ b/extensions/phone-control/index.test.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
@@ -72,6 +75,25 @@ function createApi(params: {
     registerCommand: params.registerCommand,
     ...(params.registerService ? { registerService: params.registerService } : {}),
   });
+}
+
+function createMockKeyedStore<T>(params: {
+  lookup?: (key: string) => Promise<T | null | undefined>;
+  delete?: (key: string) => Promise<boolean>;
+}): PluginStateKeyedStore<T> {
+  return {
+    register: vi.fn(async () => {}),
+    registerIfAbsent: vi.fn(async () => false),
+    update: vi.fn(async () => false),
+    lookup: async (key) => {
+      const value = await params.lookup?.(key);
+      return value === null ? undefined : value;
+    },
+    consume: vi.fn(async () => undefined),
+    delete: params.delete ?? vi.fn(async () => false),
+    entries: vi.fn(async () => []),
+    clear: vi.fn(async () => {}),
+  };
 }
 
 function createCommandContext(args: string): PluginCommandContext {
@@ -343,7 +365,7 @@ describe("phone-control plugin", () => {
   it("does not block service startup on the initial expiry check", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), PHONE_CONTROL_STATE_PREFIX));
     try {
-      const lookup = vi.fn(async () => null);
+      const lookup = vi.fn(async (_key: string) => null);
       let service: OpenClawPluginService | undefined;
 
       registerPhoneControl.register(
@@ -355,12 +377,10 @@ describe("phone-control plugin", () => {
           registerService: (registeredService) => {
             service = registeredService;
           },
-          openKeyedStore: () =>
-            ({
-              lookup,
-              delete: vi.fn(),
-              register: vi.fn(),
-            }) as ReturnType<OpenClawPluginApi["runtime"]["state"]["openKeyedStore"]>,
+          openKeyedStore: <T>() =>
+            createMockKeyedStore<T>({
+              lookup: async (key) => (await lookup(key)) as T | null | undefined,
+            }),
         }),
       );
 
@@ -376,7 +396,9 @@ describe("phone-control plugin", () => {
 
       expect(lookup).not.toHaveBeenCalled();
 
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
       expect(lookup).toHaveBeenCalledWith("current");
 
@@ -404,7 +426,7 @@ describe("phone-control plugin", () => {
       const writeConfigFile = vi.fn(async (next: Record<string, unknown>) => {
         config = next;
       });
-      const lookup = vi.fn(async () => ({
+      const lookup = vi.fn(async (_key: string) => ({
         version: 2,
         armedAtMs: Date.now() - 120_000,
         expiresAtMs: Date.now() - 60_000,
@@ -425,12 +447,11 @@ describe("phone-control plugin", () => {
           registerService: (registeredService) => {
             service = registeredService;
           },
-          openKeyedStore: () =>
-            ({
-              lookup,
+          openKeyedStore: <T>() =>
+            createMockKeyedStore<T>({
+              lookup: async (key) => (await lookup(key)) as T | null | undefined,
               delete: removeState,
-              register: vi.fn(),
-            }) as ReturnType<OpenClawPluginApi["runtime"]["state"]["openKeyedStore"]>,
+            }),
         }),
       );
 

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -334,7 +334,7 @@ async function runModelCode(code, timeoutMs) {
       }),
     ).then(
       (value) => ({ ok: true, value: toJsonSafe(value) }),
-      (error) => ({ ok: false, error: error instanceof Error ? error.message : String(error) }),
+      (error: unknown) => ({ ok: false, error: error instanceof Error ? error.message : String(error) }),
     );
     do {
       pumpController(controller);

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { normalizeToolParameterSchema } from "../agent-tools.schema.js";
 import { CronToolSchema } from "./cron-tool.js";
 
 /** Walk a TypeBox schema by dot-separated property path and return sorted keys. */
@@ -26,6 +27,9 @@ function propertyAt(
 
 describe("CronToolSchema", () => {
   const schemaRecord = CronToolSchema as unknown as Record<string, unknown>;
+  const providerSchemaRecord = normalizeToolParameterSchema(CronToolSchema, {
+    modelProvider: "gemini",
+  }) as Record<string, unknown>;
 
   // Regression: models like GPT-5.4 rely on these fields to populate job/patch.
   // If a field is removed from this list the test must be updated intentionally.
@@ -197,32 +201,32 @@ describe("CronToolSchema", () => {
     expect(schema?.description).toMatch(/false/i);
   });
 
-  it("job.agentId and job.sessionKey use plain string type for OpenAPI 3.0 compat", () => {
-    const root = schemaRecord.properties as
+  it("job.agentId and job.sessionKey use plain string type after provider normalization", () => {
+    const root = providerSchemaRecord.properties as
       | Record<string, { properties?: Record<string, unknown> }>
       | undefined;
     const jobProps = root?.job?.properties as Record<string, { type?: unknown }> | undefined;
 
-    // Must be plain "string" — not ["string", "null"] — for provider compat.
-    // Null semantics are conveyed via the field description and handled at runtime.
+    // Runtime schema accepts null clears; provider-facing schema stays OpenAPI 3.0-friendly.
     expect(jobProps?.agentId?.type).toBe("string");
     expect(jobProps?.sessionKey?.type).toBe("string");
   });
 
-  it("patch.payload.toolsAllow uses plain array type for OpenAPI 3.0 compat", () => {
-    const root = schemaRecord.properties as
+  it("patch.payload.toolsAllow uses plain array type after provider normalization", () => {
+    const root = providerSchemaRecord.properties as
       | Record<string, { properties?: Record<string, unknown> }>
       | undefined;
     const patchProps = root?.patch?.properties as
       | Record<string, { properties?: Record<string, { type?: unknown }> }>
       | undefined;
 
-    // Must be plain "array" — not ["array", "null"] — for provider compat.
+    // Runtime schema accepts null clears; provider-facing schema stays OpenAPI 3.0-friendly.
     expect(patchProps?.payload?.properties?.toolsAllow?.type).toBe("array");
   });
 
-  // Regression guard: ensure no OpenAPI 3.0 incompatible keywords leak into the
-  // serialized cron tool schema.  This catches future regressions at the source.
+  // Regression guard: ensure no type-array or not/const keywords leak into the
+  // serialized cron tool schema. Nullable clears use anyOf so runtime validation
+  // can preserve null values before provider-specific schema normalization.
   it("serialized schema contains no type-array or not/const keywords", () => {
     const json = JSON.stringify(CronToolSchema);
     // type arrays like ["string","null"] are not valid in OpenAPI 3.0

--- a/src/channels/message/types.ts
+++ b/src/channels/message/types.ts
@@ -404,7 +404,7 @@ export type ChannelMessageAdapter<
   TAdapter extends ChannelMessageAdapterShape = ChannelMessageAdapterShape,
 > = TAdapter;
 
-/** Back-compat alias for callers that derive extra durable final requirements. */
+/** Named requirement map used by callers that derive extra durable final requirements. */
 export type DurableFinalRequirementExtras = DurableFinalDeliveryRequirementMap;
 
 /** Inputs used to derive durable final-delivery requirements for a planned send. */

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -465,8 +465,8 @@ function loadBundledEntryModuleSync(
   return loaded;
 }
 
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic entry export loaders use caller-supplied export types.
 /** Loads one export from a bundled channel sidecar module through the guarded entry boundary. */
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic entry export loaders use caller-supplied export types.
 export function loadBundledEntryExportSync<T>(
   importMetaUrl: string,
   reference: BundledEntryModuleRef,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -183,8 +183,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to keep it unset",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to keep it unset"
             },
             "deleteAfterRun": {
               "description": "Delete after first run",
@@ -208,16 +215,27 @@
                   "additionalProperties": true,
                   "properties": {
                     "accountId": {
+                      "description": "Failure delivery account",
                       "type": "string"
                     },
                     "channel": {
+                      "description": "Failure delivery channel",
                       "type": "string"
                     },
                     "mode": {
-                      "enum": ["announce", "webhook"],
-                      "type": "string"
+                      "anyOf": [
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
                     },
                     "to": {
+                      "description": "Failure delivery target",
                       "type": "string"
                     }
                   },
@@ -383,8 +401,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "main | isolated | current | session:<id>",
@@ -409,8 +434,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to clear it"
             },
             "deleteAfterRun": {
               "type": "boolean"
@@ -419,34 +451,91 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Delivery account",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery account"
                 },
                 "bestEffort": {
                   "type": "boolean"
                 },
                 "channel": {
-                  "description": "Delivery channel",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery channel"
                 },
                 "failureDestination": {
-                  "additionalProperties": true,
-                  "properties": {
-                    "accountId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": true,
+                      "properties": {
+                        "accountId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery account"
+                        },
+                        "channel": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery channel"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery target"
+                        }
+                      },
+                      "type": "object"
                     },
-                    "channel": {
-                      "type": "string"
-                    },
-                    "mode": {
-                      "enum": ["announce", "webhook"],
-                      "type": "string"
-                    },
-                    "to": {
-                      "type": "string"
+                    {
+                      "type": "null"
                     }
-                  },
-                  "type": "object"
+                  ],
+                  "description": "Failure destination, or null to clear"
                 },
                 "mode": {
                   "description": "Delivery mode",
@@ -460,13 +549,23 @@
                     },
                     {
                       "type": "number"
+                    },
+                    {
+                      "type": "null"
                     }
                   ],
                   "description": "Thread/topic id"
                 },
                 "to": {
-                  "description": "Delivery target",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery target"
                 }
               },
               "type": "object"
@@ -559,11 +658,18 @@
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "description": "Allowed tool ids, or null to clear",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Allowed tool ids, or null to clear"
                 }
               },
               "type": "object"
@@ -607,8 +713,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "Session target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -183,8 +183,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to keep it unset",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to keep it unset"
             },
             "deleteAfterRun": {
               "description": "Delete after first run",
@@ -208,16 +215,27 @@
                   "additionalProperties": true,
                   "properties": {
                     "accountId": {
+                      "description": "Failure delivery account",
                       "type": "string"
                     },
                     "channel": {
+                      "description": "Failure delivery channel",
                       "type": "string"
                     },
                     "mode": {
-                      "enum": ["announce", "webhook"],
-                      "type": "string"
+                      "anyOf": [
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
                     },
                     "to": {
+                      "description": "Failure delivery target",
                       "type": "string"
                     }
                   },
@@ -383,8 +401,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "main | isolated | current | session:<id>",
@@ -409,8 +434,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to clear it"
             },
             "deleteAfterRun": {
               "type": "boolean"
@@ -419,34 +451,91 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Delivery account",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery account"
                 },
                 "bestEffort": {
                   "type": "boolean"
                 },
                 "channel": {
-                  "description": "Delivery channel",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery channel"
                 },
                 "failureDestination": {
-                  "additionalProperties": true,
-                  "properties": {
-                    "accountId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": true,
+                      "properties": {
+                        "accountId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery account"
+                        },
+                        "channel": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery channel"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery target"
+                        }
+                      },
+                      "type": "object"
                     },
-                    "channel": {
-                      "type": "string"
-                    },
-                    "mode": {
-                      "enum": ["announce", "webhook"],
-                      "type": "string"
-                    },
-                    "to": {
-                      "type": "string"
+                    {
+                      "type": "null"
                     }
-                  },
-                  "type": "object"
+                  ],
+                  "description": "Failure destination, or null to clear"
                 },
                 "mode": {
                   "description": "Delivery mode",
@@ -460,13 +549,23 @@
                     },
                     {
                       "type": "number"
+                    },
+                    {
+                      "type": "null"
                     }
                   ],
                   "description": "Thread/topic id"
                 },
                 "to": {
-                  "description": "Delivery target",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery target"
                 }
               },
               "type": "object"
@@ -559,11 +658,18 @@
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "description": "Allowed tool ids, or null to clear",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Allowed tool ids, or null to clear"
                 }
               },
               "type": "object"
@@ -607,8 +713,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "Session target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -183,8 +183,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to keep it unset",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to keep it unset"
             },
             "deleteAfterRun": {
               "description": "Delete after first run",
@@ -208,16 +215,27 @@
                   "additionalProperties": true,
                   "properties": {
                     "accountId": {
+                      "description": "Failure delivery account",
                       "type": "string"
                     },
                     "channel": {
+                      "description": "Failure delivery channel",
                       "type": "string"
                     },
                     "mode": {
-                      "enum": ["announce", "webhook"],
-                      "type": "string"
+                      "anyOf": [
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
                     },
                     "to": {
+                      "description": "Failure delivery target",
                       "type": "string"
                     }
                   },
@@ -383,8 +401,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "main | isolated | current | session:<id>",
@@ -409,8 +434,15 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "description": "Agent id, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Agent id, or null to clear it"
             },
             "deleteAfterRun": {
               "type": "boolean"
@@ -419,34 +451,91 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Delivery account",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery account"
                 },
                 "bestEffort": {
                   "type": "boolean"
                 },
                 "channel": {
-                  "description": "Delivery channel",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery channel"
                 },
                 "failureDestination": {
-                  "additionalProperties": true,
-                  "properties": {
-                    "accountId": {
-                      "type": "string"
+                  "anyOf": [
+                    {
+                      "additionalProperties": true,
+                      "properties": {
+                        "accountId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery account"
+                        },
+                        "channel": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery channel"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Failure delivery target"
+                        }
+                      },
+                      "type": "object"
                     },
-                    "channel": {
-                      "type": "string"
-                    },
-                    "mode": {
-                      "enum": ["announce", "webhook"],
-                      "type": "string"
-                    },
-                    "to": {
-                      "type": "string"
+                    {
+                      "type": "null"
                     }
-                  },
-                  "type": "object"
+                  ],
+                  "description": "Failure destination, or null to clear"
                 },
                 "mode": {
                   "description": "Delivery mode",
@@ -460,13 +549,23 @@
                     },
                     {
                       "type": "number"
+                    },
+                    {
+                      "type": "null"
                     }
                   ],
                   "description": "Thread/topic id"
                 },
                 "to": {
-                  "description": "Delivery target",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Delivery target"
                 }
               },
               "type": "object"
@@ -559,11 +658,18 @@
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "description": "Allowed tool ids, or null to clear",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Allowed tool ids, or null to clear"
                 }
               },
               "type": "object"
@@ -607,8 +713,15 @@
               "type": "object"
             },
             "sessionKey": {
-              "description": "Explicit session key, or null to clear it",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit session key, or null to clear it"
             },
             "sessionTarget": {
               "description": "Session target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40696,
-    "roughTokens": 10174
+    "chars": 44020,
+    "roughTokens": 11005
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68398,
-    "roughTokens": 17100
+    "chars": 71722,
+    "roughTokens": 17931
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40417,
-    "roughTokens": 10105
+    "chars": 43741,
+    "roughTokens": 10936
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66595,
-    "roughTokens": 16649
+    "chars": 69919,
+    "roughTokens": 17480
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41512,
-    "roughTokens": 10378
+    "chars": 44836,
+    "roughTokens": 11209
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68633,
-    "roughTokens": 17159
+    "chars": 71957,
+    "roughTokens": 17990
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary
- refreshes the affected Codex prompt snapshots against the provider-normalized cron tool schema
- keeps the cron runtime schema nullable so `null` clear values still reach cron patch normalization
- fixes the phone-control test lint/type regressions, plus adjacent main-branch guard/lint failures exposed by CI

## Real behavior proof
- Behavior addressed: PR CI was failing on `check-lint`, `check-test-types`, `check-additional-runtime-topology-architecture`, and prompt snapshot checks after the cron schema snapshot refresh.
- Real environment tested: main-based OpenClaw gwt with shared repo `node_modules` symlink; final proof was run in the L2 tmux lane.
- Exact steps or command run after this patch: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`; `node scripts/check-deprecated-jsdoc.mjs`; `node scripts/run-oxlint.mjs extensions/phone-control/index.test.ts src/channels/message/types.ts src/plugin-sdk/channel-entry-contract.ts src/agents/tool-search.ts`; `node scripts/run-vitest.mjs extensions/phone-control/index.test.ts src/agents/tools/cron-tool.schema.test.ts src/agents/tools/cron-tool.test.ts`; `node --import tsx scripts/generate-prompt-snapshots.ts --check`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`.
- Evidence after fix: extension test typecheck exited 0; deprecated JSDoc guard passed; targeted oxlint exited 0; targeted Vitest passed 3 shards / 113 tests; prompt snapshot check reported `Prompt snapshots are current (7 files).`; `git diff --check` exited 0; autoreview reported no accepted/actionable findings.
- Observed result after fix: cron runtime nullable schema tests still pass, provider-normalized schema assertions pass, phone-control startup/expiry tests pass, and the CI-only lint/type/guard issues are patched on head `ae9bb058acd`.
- What was not tested: full repo check; CI is running broad proof on this PR.

## Verification
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `node scripts/check-deprecated-jsdoc.mjs`
- `node scripts/run-oxlint.mjs extensions/phone-control/index.test.ts src/channels/message/types.ts src/plugin-sdk/channel-entry-contract.ts src/agents/tool-search.ts`
- `node scripts/run-vitest.mjs extensions/phone-control/index.test.ts src/agents/tools/cron-tool.schema.test.ts src/agents/tools/cron-tool.test.ts`
- `node --import tsx scripts/generate-prompt-snapshots.ts --check`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
