### PR TITLE
fix(infra): recognize npm shrinkwrap in update status

### DIFF
--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -29,6 +29,32 @@ describe("detectPackageManager", () => {
     );
   });
 
+  it("uses npm-shrinkwrap.json as npm package install evidence", async () => {
+    await withPackageManagerRoot(
+      [
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@10.8.1" }) },
+        { path: "npm-shrinkwrap.json", content: "" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("npm");
+      },
+    );
+  });
+
+  it("does not treat a pnpm workspace source checkout shrinkwrap as npm install evidence", async () => {
+    await withPackageManagerRoot(
+      [
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@10.8.1" }) },
+        { path: "pnpm-workspace.yaml", content: "packages: []\n" },
+        { path: "pnpm-lock.yaml", content: "" },
+        { path: "npm-shrinkwrap.json", content: "" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("pnpm");
+      },
+    );
+  });
+
   it.each([
     {
       name: "uses bun.lock",
@@ -45,6 +71,14 @@ describe("detectPackageManager", () => {
       files: [
         { path: "package.json", content: JSON.stringify({ packageManager: "yarn@4.0.0" }) },
         { path: "package-lock.json", content: "" },
+      ],
+      expected: "npm",
+    },
+    {
+      name: "falls back to npm shrinkwrap for unsupported packageManager values",
+      files: [
+        { path: "package.json", content: JSON.stringify({ packageManager: "yarn@4.0.0" }) },
+        { path: "npm-shrinkwrap.json", content: "" },
       ],
       expected: "npm",
     },

--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -29,10 +29,11 @@ describe("detectPackageManager", () => {
     );
   });
 
-  it("uses npm-shrinkwrap.json as npm package install evidence", async () => {
+  it("uses published npm package markers as npm install evidence", async () => {
     await withPackageManagerRoot(
       [
         { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@10.8.1" }) },
+        { path: "pnpm-workspace.yaml", content: "packages: []\n" },
         { path: "npm-shrinkwrap.json", content: "" },
       ],
       async (root) => {

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -4,19 +4,26 @@ import { readPackageManagerSpec } from "./package-json.js";
 type DetectedPackageManager = "pnpm" | "bun" | "npm";
 
 export async function detectPackageManager(root: string): Promise<DetectedPackageManager | null> {
+  const files = await fs.readdir(root).catch((): string[] => []);
+  const hasNpmShrinkwrap = files.includes("npm-shrinkwrap.json");
+  const hasPnpmLock = files.includes("pnpm-lock.yaml");
+  const hasPnpmWorkspace = files.includes("pnpm-workspace.yaml");
+  if (hasNpmShrinkwrap && !hasPnpmLock && !hasPnpmWorkspace) {
+    return "npm";
+  }
+
   const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (pm === "pnpm" || pm === "bun" || pm === "npm") {
     return pm;
   }
 
-  const files = await fs.readdir(root).catch((): string[] => []);
-  if (files.includes("pnpm-lock.yaml")) {
+  if (hasPnpmLock) {
     return "pnpm";
   }
   if (files.includes("bun.lock") || files.includes("bun.lockb")) {
     return "bun";
   }
-  if (files.includes("package-lock.json")) {
+  if (files.includes("package-lock.json") || hasNpmShrinkwrap) {
     return "npm";
   }
   return null;

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -7,8 +7,7 @@ export async function detectPackageManager(root: string): Promise<DetectedPackag
   const files = await fs.readdir(root).catch((): string[] => []);
   const hasNpmShrinkwrap = files.includes("npm-shrinkwrap.json");
   const hasPnpmLock = files.includes("pnpm-lock.yaml");
-  const hasPnpmWorkspace = files.includes("pnpm-workspace.yaml");
-  if (hasNpmShrinkwrap && !hasPnpmLock && !hasPnpmWorkspace) {
+  if (hasNpmShrinkwrap && !hasPnpmLock) {
     return "npm";
   }
 

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -291,6 +291,7 @@ describe("checkUpdateStatus", () => {
         JSON.stringify({ packageManager: "pnpm@11.2.2" }),
         "utf8",
       );
+      await fs.writeFile(path.join(root, "pnpm-workspace.yaml"), "packages: []\n", "utf8");
       await fs.writeFile(shrinkwrapPath, "lock", "utf8");
       await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
 

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -230,6 +230,20 @@ describe("checkDepsStatus", () => {
       expect(okDeps.status).toBe("ok");
     });
   });
+
+  it("uses npm-shrinkwrap.json as the npm dependency lock marker", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-" }, async (base) => {
+      const shrinkwrapPath = path.join(base, "npm-shrinkwrap.json");
+      await fs.writeFile(shrinkwrapPath, "lock", "utf8");
+      await fs.mkdir(path.join(base, "node_modules"), { recursive: true });
+
+      const deps = await checkDepsStatus({ root: base, manager: "npm" });
+
+      expect(deps.manager).toBe("npm");
+      expect(deps.status).toBe("ok");
+      expect(deps.lockfilePath).toBe(shrinkwrapPath);
+    });
+  });
 });
 
 describe("checkUpdateStatus", () => {
@@ -266,6 +280,32 @@ describe("checkUpdateStatus", () => {
       expect(status.git).toBeUndefined();
       expect(status.registry).toBeUndefined();
       expect(status.deps?.manager).toBe("npm");
+    });
+  });
+
+  it("detects npm package installs that ship pnpm package metadata with shrinkwrap", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-shrinkwrap-" }, async (root) => {
+      const shrinkwrapPath = path.join(root, "npm-shrinkwrap.json");
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "pnpm@11.2.2" }),
+        "utf8",
+      );
+      await fs.writeFile(shrinkwrapPath, "lock", "utf8");
+      await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+
+      const status = await checkUpdateStatus({
+        root,
+        includeRegistry: false,
+        fetchGit: false,
+        timeoutMs: 1000,
+      });
+
+      expect(status.installKind).toBe("package");
+      expect(status.packageManager).toBe("npm");
+      expect(status.deps?.manager).toBe("npm");
+      expect(status.deps?.status).toBe("ok");
+      expect(status.deps?.lockfilePath).toBe(shrinkwrapPath);
     });
   });
 

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -200,10 +200,10 @@ async function statMtimeMs(p: string): Promise<number | null> {
   }
 }
 
-function resolveDepsMarker(params: { root: string; manager: PackageManager }): {
+async function resolveDepsMarker(params: { root: string; manager: PackageManager }): Promise<{
   lockfilePath: string | null;
   markerPath: string | null;
-} {
+}> {
   const root = params.root;
   if (params.manager === "pnpm") {
     return {
@@ -218,8 +218,11 @@ function resolveDepsMarker(params: { root: string; manager: PackageManager }): {
     };
   }
   if (params.manager === "npm") {
+    const shrinkwrapPath = path.join(root, "npm-shrinkwrap.json");
     return {
-      lockfilePath: path.join(root, "package-lock.json"),
+      lockfilePath: (await exists(shrinkwrapPath))
+        ? shrinkwrapPath
+        : path.join(root, "package-lock.json"),
       markerPath: path.join(root, "node_modules"),
     };
   }
@@ -231,7 +234,7 @@ export async function checkDepsStatus(params: {
   manager: PackageManager;
 }): Promise<DepsStatus> {
   const root = path.resolve(params.root);
-  const { lockfilePath, markerPath } = resolveDepsMarker({
+  const { lockfilePath, markerPath } = await resolveDepsMarker({
     root,
     manager: params.manager,
   });


### PR DESCRIPTION
## Summary

Fixes #87732.

- Treat published npm package roots with `npm-shrinkwrap.json` as npm installs even when their bundled `package.json` declares the repo's pnpm dev package manager.
- Carry `npm-shrinkwrap.json` through `checkDepsStatus` / `checkUpdateStatus` so npm status uses the shrinkwrap lock marker instead of falling through to missing `package-lock.json`.
- Preserve pnpm source checkout detection when `pnpm-lock.yaml` is present, while matching the published package shape called out on #88666.

## Relationship to #88666

This is an alternate/completing fix for #88666. That PR fixes the detector layer, but ClawSweeper noted the status/update path still expected `package-lock.json` after detecting npm. This PR covers the full status surface and adds the requested `checkUpdateStatus` regression.

## Real behavior proof

- Behavior or issue addressed: Published npm package roots with `npm-shrinkwrap.json`, `pnpm-workspace.yaml`, no `pnpm-lock.yaml`, no `package-lock.json`, and `package.json` declaring pnpm should report npm in update/status detection and should use `npm-shrinkwrap.json` as the npm dependency lock marker.
- Real environment tested: Unpacked real npm artifact from `npm pack openclaw@2026.5.27`; package root only, temp path redacted. A `node_modules` marker directory was added to represent an installed package root. The changed PR source was used to run the same `checkUpdateStatus` path used by `openclaw update status` / status update reporting.
- Exact steps or command run after this patch: Downloaded the real published package with `npm pack --silent openclaw@2026.5.27`, extracted the tarball, inspected the package root markers, added a `node_modules` marker directory for dependency-status evaluation, then ran the changed `checkUpdateStatus({ includeRegistry: false, fetchGit: false })` path against the unpacked package root.
- Evidence after fix: Terminal transcript from the unpacked published package root:

```json
{
  "fixture": "npm pack openclaw@2026.5.27, unpacked package root",
  "markers": {
    "npmShrinkwrap": true,
    "pnpmWorkspace": true,
    "pnpmLock": false,
    "packageLock": false,
    "packageManager": "pnpm@11.2.2+sha512.<redacted>"
  },
  "observed": {
    "installKind": "package",
    "packageManager": "npm",
    "deps": {
      "manager": "npm",
      "status": "ok",
      "lockfile": "npm-shrinkwrap.json"
    }
  }
}
```

- Observed result after fix: The real published package marker shape now resolves to `packageManager: npm`; dependency status uses `manager: npm`, returns `status: ok`, and reports `lockfile: npm-shrinkwrap.json`.
- What was not tested: Live reporter hardware and a live global npm install were not used. The proof uses the real published npm tarball unpacked locally with private paths redacted.
- Proof limitations or environment constraints: The package-root temp path is intentionally omitted; the proof focuses on the real published package markers and the changed update/status detection path.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts src/commands/status.update.test.ts src/commands/status-json-payload.test.ts`

Result: `4 files`, `36 tests`, all passing.
