### PR TITLE
fix(agents): project cron tool schemas for providers

### DIFF
--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -1,3 +1,4 @@
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import type { Tool } from "./types.js";
 import { validateToolArguments } from "./validation.js";
@@ -15,6 +16,20 @@ const decimalTool = {
     additionalProperties: false,
   },
 } as Tool;
+
+const nullableTypeBoxTool = {
+  name: "nullable-typebox-tool",
+  description: "test nullable TypeBox tool",
+  parameters: Type.Object({
+    agentId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    toolsAllow: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
+    nested: Type.Optional(
+      Type.Object({
+        sessionKey: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      }),
+    ),
+  }),
+} satisfies Tool;
 
 describe("validateToolArguments", () => {
   it("coerces strict decimal numeric strings for plain JSON schemas", () => {
@@ -37,5 +52,24 @@ describe("validateToolArguments", () => {
         arguments: { amount: "0x10", count: "0b10" },
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
+  });
+
+  it("preserves explicit null values accepted by TypeBox unions", () => {
+    expect(
+      validateToolArguments(nullableTypeBoxTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "nullable-typebox-tool",
+        arguments: {
+          agentId: null,
+          toolsAllow: null,
+          nested: { sessionKey: null },
+        },
+      }),
+    ).toEqual({
+      agentId: null,
+      toolsAllow: null,
+      nested: { sessionKey: null },
+    });
   });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -205,6 +205,13 @@ function applySchemaArrayCoercion(value: unknown[], schema: JsonSchemaObject): v
 
 function coerceWithUnionSchema(value: unknown, schemas: JsonSchemaObject[]): unknown {
   for (const schema of schemas) {
+    const validator = getSubSchemaValidator(schema);
+    if (validator?.Check(value)) {
+      return value;
+    }
+  }
+
+  for (const schema of schemas) {
     const candidate = structuredClone(value);
     const coerced = coerceWithJsonSchema(candidate, schema);
     const validator = getSubSchemaValidator(schema);

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -82,6 +82,56 @@ describe("runtime tool input schema projection", () => {
     ).toEqual([]);
   });
 
+  it("projects nullable and literal unions to OpenAPI-friendly provider schemas", () => {
+    expect(
+      projectRuntimeToolInputSchema({
+        type: "object",
+        properties: {
+          agentId: {
+            anyOf: [{ type: "string" }, { type: "null" }],
+            description: "Agent id, or null to clear",
+          },
+          toolsAllow: {
+            anyOf: [{ type: "array", items: { type: "string" } }, { type: "null" }],
+            description: "Allowed tools, or null to clear",
+          },
+          mode: {
+            anyOf: [
+              { type: "string", const: "announce" },
+              { type: "string", const: "webhook" },
+              { type: "null" },
+            ],
+          },
+          threadId: {
+            anyOf: [{ type: "string" }, { type: "number" }, { type: "null" }],
+            description: "Thread/topic id",
+          },
+        },
+      }).schema,
+    ).toEqual({
+      type: "object",
+      properties: {
+        agentId: {
+          type: "string",
+          description: "Agent id, or null to clear",
+        },
+        toolsAllow: {
+          type: "array",
+          items: { type: "string" },
+          description: "Allowed tools, or null to clear",
+        },
+        mode: {
+          type: "string",
+          enum: ["announce", "webhook"],
+        },
+        threadId: {
+          type: "string",
+          description: "Thread/topic id",
+        },
+      },
+    });
+  });
+
   it("filters unsupported schemas without dropping healthy tools", () => {
     const healthy = {
       name: "healthy",

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -132,9 +132,85 @@ function serializeToolInputSchema(value: unknown, path: string): RuntimeToolInpu
     };
   }
   return {
-    schema: parsed,
+    schema: normalizeProviderToolInputSchema(parsed),
     violations: [],
   };
+}
+
+function isNullSchema(schema: RuntimeToolInputSchemaJson): boolean {
+  return isJsonObject(schema) && schema.type === "null";
+}
+
+function isStringConstSchema(
+  schema: RuntimeToolInputSchemaJson,
+): schema is { type: "string"; const: string } {
+  return isJsonObject(schema) && schema.type === "string" && typeof schema.const === "string";
+}
+
+function mergeCompositionWrapper(
+  wrapper: { [key: string]: RuntimeToolInputSchemaJson },
+  replacement: { [key: string]: RuntimeToolInputSchemaJson },
+  keyword: "anyOf" | "oneOf",
+): { [key: string]: RuntimeToolInputSchemaJson } {
+  const { [keyword]: _composition, ...metadata } = wrapper;
+  return {
+    ...replacement,
+    ...metadata,
+  };
+}
+
+function normalizeSchemaComposition(
+  schema: { [key: string]: RuntimeToolInputSchemaJson },
+  keyword: "anyOf" | "oneOf",
+): { [key: string]: RuntimeToolInputSchemaJson } | undefined {
+  const variants = schema[keyword];
+  if (!Array.isArray(variants)) {
+    return undefined;
+  }
+  const hasNullVariant = variants.some(isNullSchema);
+  const nonNullVariants = variants.filter((variant) => !isNullSchema(variant));
+  if (nonNullVariants.length === 0) {
+    return undefined;
+  }
+  if (hasNullVariant && nonNullVariants.length === 1 && isJsonObject(nonNullVariants[0])) {
+    return mergeCompositionWrapper(schema, nonNullVariants[0], keyword);
+  }
+  if (nonNullVariants.every(isStringConstSchema)) {
+    return mergeCompositionWrapper(
+      schema,
+      {
+        type: "string",
+        enum: nonNullVariants.map((variant) => variant.const),
+      },
+      keyword,
+    );
+  }
+  const stringVariant = nonNullVariants.find(
+    (variant) => isJsonObject(variant) && variant.type === "string",
+  );
+  if (stringVariant !== undefined && isJsonObject(stringVariant)) {
+    return mergeCompositionWrapper(schema, stringVariant, keyword);
+  }
+  return undefined;
+}
+
+function normalizeProviderToolInputSchema(
+  schema: RuntimeToolInputSchemaJson,
+): RuntimeToolInputSchemaJson {
+  if (Array.isArray(schema)) {
+    return schema.map(normalizeProviderToolInputSchema);
+  }
+  if (!isJsonObject(schema)) {
+    return schema;
+  }
+  const normalized = Object.fromEntries(
+    Object.entries(schema).map(([key, value]) => [key, normalizeProviderToolInputSchema(value)]),
+  );
+  return (
+    normalizeSchemaComposition(normalized, "anyOf") ??
+    normalizeSchemaComposition(normalized, "oneOf") ??
+    normalized
+  );
 }
 
 function findDynamicSchemaKeywordViolations(

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -1,4 +1,6 @@
+import { validateToolArguments, type Tool } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
+import { projectRuntimeToolInputSchema } from "../tool-schema-projection.js";
 import { CronToolSchema } from "./cron-tool.js";
 
 /** Walk a TypeBox schema by dot-separated property path and return sorted keys. */
@@ -25,7 +27,13 @@ function propertyAt(
 }
 
 describe("CronToolSchema", () => {
-  const schemaRecord = CronToolSchema as unknown as Record<string, unknown>;
+  const schemaRecord = projectRuntimeToolInputSchema(CronToolSchema, "cron.parameters")
+    .schema as Record<string, unknown>;
+  const cronTool = {
+    name: "cron",
+    description: "Manage scheduled jobs",
+    parameters: CronToolSchema,
+  } satisfies Tool;
 
   // Regression: models like GPT-5.4 rely on these fields to populate job/patch.
   // If a field is removed from this list the test must be updated intentionally.
@@ -221,13 +229,51 @@ describe("CronToolSchema", () => {
     expect(patchProps?.payload?.properties?.toolsAllow?.type).toBe("array");
   });
 
+  it("raw validation preserves null clear sentinels before provider projection", () => {
+    const validated = validateToolArguments(cronTool, {
+      type: "toolCall",
+      id: "call-1",
+      name: "cron",
+      arguments: {
+        action: "update",
+        id: "job-1",
+        patch: {
+          agentId: null,
+          sessionKey: null,
+          payload: {
+            kind: "agentTurn",
+            message: "refresh status",
+            toolsAllow: null,
+          },
+        },
+      },
+    }) as {
+      patch: {
+        agentId: unknown;
+        sessionKey: unknown;
+        payload: { toolsAllow: unknown };
+      };
+    };
+
+    expect(validated.patch.agentId).toBeNull();
+    expect(validated.patch.sessionKey).toBeNull();
+    expect(validated.patch.payload.toolsAllow).toBeNull();
+  });
+
   // Regression guard: ensure no OpenAPI 3.0 incompatible keywords leak into the
   // serialized cron tool schema.  This catches future regressions at the source.
-  it("serialized schema contains no type-array or not/const keywords", () => {
-    const json = JSON.stringify(CronToolSchema);
+  it("projected schema contains no OpenAPI 3.0 incompatible composition/null keywords", () => {
+    const json = JSON.stringify(schemaRecord);
     // type arrays like ["string","null"] are not valid in OpenAPI 3.0
     expect(json).not.toMatch(/"type"\s*:\s*\[/);
+    // null-type composition is also rejected by strict OpenAPI 3.0 tool adapters.
+    expect(json).not.toMatch(/"type"\s*:\s*"null"/);
+    expect(json).not.toMatch(/"anyOf"\s*:/);
+    expect(json).not.toMatch(/"oneOf"\s*:/);
+    expect(json).not.toMatch(/"allOf"\s*:/);
     // "not" composition keyword is not supported by OpenAPI 3.0
     expect(json).not.toMatch(/"not"\s*:\s*\{/);
+    // "const" is not part of the OpenAPI 3.0 schema subset.
+    expect(json).not.toMatch(/"const"\s*:/);
   });
 });

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -208,9 +208,11 @@
                   "additionalProperties": true,
                   "properties": {
                     "accountId": {
+                      "description": "Failure delivery account",
                       "type": "string"
                     },
                     "channel": {
+                      "description": "Failure delivery channel",
                       "type": "string"
                     },
                     "mode": {
@@ -218,6 +220,7 @@
                       "type": "string"
                     },
                     "to": {
+                      "description": "Failure delivery target",
                       "type": "string"
                     }
                   },
@@ -229,15 +232,8 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -431,11 +427,14 @@
                 },
                 "failureDestination": {
                   "additionalProperties": true,
+                  "description": "Failure destination, or null to clear",
                   "properties": {
                     "accountId": {
+                      "description": "Failure delivery account",
                       "type": "string"
                     },
                     "channel": {
+                      "description": "Failure delivery channel",
                       "type": "string"
                     },
                     "mode": {
@@ -443,6 +442,7 @@
                       "type": "string"
                     },
                     "to": {
+                      "description": "Failure delivery target",
                       "type": "string"
                     }
                   },
@@ -454,15 +454,8 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
                   "description": "Delivery target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -208,9 +208,11 @@
                   "additionalProperties": true,
                   "properties": {
                     "accountId": {
+                      "description": "Failure delivery account",
                       "type": "string"
                     },
                     "channel": {
+                      "description": "Failure delivery channel",
                       "type": "string"
                     },
                     "mode": {
@@ -218,6 +220,7 @@
                       "type": "string"
                     },
                     "to": {
+                      "description": "Failure delivery target",
                       "type": "string"
                     }
                   },
@@ -229,15 +232,8 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -431,11 +427,14 @@
                 },
                 "failureDestination": {
                   "additionalProperties": true,
+                  "description": "Failure destination, or null to clear",
                   "properties": {
                     "accountId": {
+                      "description": "Failure delivery account",
                       "type": "string"
                     },
                     "channel": {
+                      "description": "Failure delivery channel",
                       "type": "string"
                     },
                     "mode": {
@@ -443,6 +442,7 @@
                       "type": "string"
                     },
                     "to": {
+                      "description": "Failure delivery target",
                       "type": "string"
                     }
                   },
@@ -454,15 +454,8 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
                   "description": "Delivery target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -208,9 +208,11 @@
                   "additionalProperties": true,
                   "properties": {
                     "accountId": {
+                      "description": "Failure delivery account",
                       "type": "string"
                     },
                     "channel": {
+                      "description": "Failure delivery channel",
                       "type": "string"
                     },
                     "mode": {
@@ -218,6 +220,7 @@
                       "type": "string"
                     },
                     "to": {
+                      "description": "Failure delivery target",
                       "type": "string"
                     }
                   },
@@ -229,15 +232,8 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -431,11 +427,14 @@
                 },
                 "failureDestination": {
                   "additionalProperties": true,
+                  "description": "Failure destination, or null to clear",
                   "properties": {
                     "accountId": {
+                      "description": "Failure delivery account",
                       "type": "string"
                     },
                     "channel": {
+                      "description": "Failure delivery channel",
                       "type": "string"
                     },
                     "mode": {
@@ -443,6 +442,7 @@
                       "type": "string"
                     },
                     "to": {
+                      "description": "Failure delivery target",
                       "type": "string"
                     }
                   },
@@ -454,15 +454,8 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
                   "description": "Delivery target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40696,
-    "roughTokens": 10174
+    "chars": 40796,
+    "roughTokens": 10199
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68398,
-    "roughTokens": 17100
+    "chars": 68498,
+    "roughTokens": 17125
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40417,
-    "roughTokens": 10105
+    "chars": 40517,
+    "roughTokens": 10130
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66595,
-    "roughTokens": 16649
+    "chars": 66695,
+    "roughTokens": 16674
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41512,
-    "roughTokens": 10378
+    "chars": 41612,
+    "roughTokens": 10403
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68633,
-    "roughTokens": 17159
+    "chars": 68733,
+    "roughTokens": 17184
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary
- project runtime tool schemas into provider-facing OpenAPI-friendly shapes by dropping nullable composition wrappers and converting string literal unions to enums
- keep raw TypeBox validation intact so `null` clear sentinels still reach cron runtime normalization
- refresh Codex happy-path prompt snapshots that drifted on current main

Unblocks current CI failures seen on https://github.com/openclaw/openclaw/pull/87856 after `d86b6da0120` made cron clear fields nullable in the raw tool schema.

## Verification
- `node scripts/run-vitest.mjs packages/llm-core/src/validation.test.ts src/agents/tool-schema-projection.test.ts src/agents/tools/cron-tool.schema.test.ts src/agents/tools/cron-tool.test.ts --reporter=dot`: passed, 3 shards / 114 tests
- `node --import tsx scripts/generate-prompt-snapshots.ts --check`: passed, 7 files current
- `node_modules/.bin/oxfmt --check --threads=1 packages/llm-core/src/validation.test.ts packages/llm-core/src/validation.ts src/agents/tool-schema-projection.test.ts src/agents/tool-schema-projection.ts src/agents/tools/cron-tool.schema.test.ts test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md`: passed
- `node scripts/run-oxlint.mjs packages/llm-core/src/validation.test.ts packages/llm-core/src/validation.ts src/agents/tool-schema-projection.test.ts src/agents/tool-schema-projection.ts src/agents/tools/cron-tool.schema.test.ts`: passed
- `git diff --check origin/main...HEAD`: passed
- AWS Crabbox `pnpm check:changed`: attempted with `node scripts/crabbox-wrapper.mjs run --provider aws --label cron-tool-provider-schema-check-changed --shell -- "pnpm check:changed"`, but coordinator returned `active lease limit exceeded: 9/8` before allocation; no lease was created.

## Real behavior proof
Behavior addressed: provider-facing tool schemas should avoid OpenAPI 3.0-incompatible nullable/composition shapes, while runtime validation still accepts explicit `null` clear sentinels.

Real environment tested: linked OpenClaw gwt worktree on current `origin/main`.

Exact steps or command run after this patch: targeted Vitest files for llm validation, tool-schema projection, cron schema, and cron runtime behavior; prompt snapshot check; oxfmt; oxlint; diff-check; attempted AWS Crabbox changed gate.

Evidence after fix: cron schema projection tests now see plain `string`/`array` provider fields, raw validation preserves `null` clear sentinels, and prompt snapshots are current.

Observed result after fix: provider schemas no longer expose `anyOf`/`oneOf`/`type: null`/`const` for these tool fields, but cron updates can still carry `null` through raw validation into runtime normalization.

What was not tested: remote `pnpm check:changed`, blocked by AWS Crabbox lease capacity.
