### PR TITLE
feat(plugin-sdk): add resolve_exec_env hook

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -120,6 +120,7 @@ observation-only.
 
 - **`before_tool_call`** - rewrite tool params, block execution, or require approval
 - `after_tool_call` - observe tool results, errors, and duration
+- `resolve_exec_env` - contribute plugin-owned environment variables to `exec`
 - **`tool_result_persist`** - rewrite the assistant message produced from a tool result
 - **`before_message_write`** - inspect or block an in-progress message write (rare)
 
@@ -232,6 +233,28 @@ with `api.registerTrustedToolPolicy(...)`. These run before ordinary
 for host-trusted gates such as workspace policy, budget enforcement, or
 reserved workflow safety. External plugins should use normal `before_tool_call`
 hooks.
+
+### Exec environment hook
+
+`resolve_exec_env` lets plugins contribute environment variables to `exec`
+tool invocations after the base exec environment is built and before the
+command runs. It receives:
+
+- `event.sessionKey`
+- `event.toolName`, currently always `"exec"`
+- `event.host`, one of `"gateway"`, `"sandbox"`, or `"node"`
+- context fields such as `ctx.agentId`, `ctx.sessionKey`,
+  `ctx.messageProvider`, and `ctx.channelId`
+
+Return a `Record<string, string>` to merge into the exec environment. Handlers
+run in priority order, and later hook results override earlier hook results for
+the same key.
+
+Hook output is filtered through the host exec environment key policy before it
+is merged. Invalid keys, `PATH`, and dangerous host override keys such as
+`LD_*`, `DYLD_*`, `NODE_OPTIONS`, proxy variables, and TLS override variables
+are dropped. The filtered plugin env is included in gateway approval/audit
+metadata and forwarded to node-host execution requests.
 
 ### Tool result persistence
 

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -27,7 +27,7 @@ type BeforeToolCallPreparingTool = AnyAgentTool & {
   prepareBeforeToolCallParams?: (
     params: unknown,
     ctx: { toolCallId?: string; hookContext?: HookContext; signal?: AbortSignal },
-  ) => Promise<unknown> | unknown;
+  ) => unknown;
   finalizeBeforeToolCallParams?: (params: unknown, preparedParams: unknown) => unknown;
 };
 

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -23,6 +23,13 @@ import { normalizeToolName } from "./tool-policy.js";
 import { jsonResult, payloadTextResult } from "./tools/common.js";
 
 type AnyAgentTool = AgentTool;
+type BeforeToolCallPreparingTool = AnyAgentTool & {
+  prepareBeforeToolCallParams?: (
+    params: unknown,
+    ctx: { toolCallId?: string; hookContext?: HookContext; signal?: AbortSignal },
+  ) => Promise<unknown> | unknown;
+  finalizeBeforeToolCallParams?: (params: unknown, preparedParams: unknown) => unknown;
+};
 
 type ToolExecuteArgsCurrent = [
   string,
@@ -269,6 +276,32 @@ function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
   };
 }
 
+async function prepareToolParamsBeforeHook(params: {
+  tool: AnyAgentTool;
+  rawParams: unknown;
+  toolCallId?: string;
+  hookContext?: HookContext;
+  signal?: AbortSignal;
+}): Promise<unknown> {
+  const prepare = (params.tool as BeforeToolCallPreparingTool).prepareBeforeToolCallParams;
+  return prepare
+    ? await prepare(params.rawParams, {
+        ...(params.toolCallId ? { toolCallId: params.toolCallId } : {}),
+        ...(params.hookContext ? { hookContext: params.hookContext } : {}),
+        ...(params.signal ? { signal: params.signal } : {}),
+      })
+    : params.rawParams;
+}
+
+function finalizeToolParamsBeforeExecute(params: {
+  tool: AnyAgentTool;
+  executeParams: unknown;
+  preparedParams: unknown;
+}): unknown {
+  const finalize = (params.tool as BeforeToolCallPreparingTool).finalizeBeforeToolCallParams;
+  return finalize ? finalize(params.executeParams, params.preparedParams) : params.executeParams;
+}
+
 export const CLIENT_TOOL_NAME_CONFLICT_PREFIX = "client tool name conflict:";
 
 export function findClientToolNameConflicts(params: {
@@ -331,8 +364,21 @@ export function toToolDefinitions(
         let executeParams = params;
         try {
           if (!beforeHookWrapped) {
-            const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params });
-            const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params });
+            const preparedParams = await prepareToolParamsBeforeHook({
+              tool,
+              rawParams: params,
+              ...(toolCallId ? { toolCallId } : {}),
+              ...(hookContext ? { hookContext } : {}),
+              ...(signal ? { signal } : {}),
+            });
+            const hookParams = normalizeCodeModeExecBeforeHookParams({
+              tool,
+              params: preparedParams,
+            });
+            const hookMetadata = getCodeModeExecBeforeHookMetadata({
+              tool,
+              params: preparedParams,
+            });
             const hookOutcome = await runBeforeToolCallHook({
               toolName: name,
               params: hookParams,
@@ -351,9 +397,14 @@ export function toToolDefinitions(
             }
             executeParams = reconcileCodeModeExecBeforeHookParams({
               tool,
-              originalParams: params,
+              originalParams: preparedParams,
               hookParams,
               adjustedParams: hookOutcome.params,
+            });
+            executeParams = finalizeToolParamsBeforeExecute({
+              tool,
+              executeParams,
+              preparedParams,
             });
             recordAdjustedParamsForToolCall(toolCallId, executeParams, hookContext?.runId);
           }

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -155,6 +155,13 @@ type BeforeToolCallWrapperOptions = {
   approvalMode?: "request" | "report" | "defer";
   emitDiagnostics: boolean;
 };
+type BeforeToolCallPreparingTool = AnyAgentTool & {
+  prepareBeforeToolCallParams?: (
+    params: unknown,
+    ctx: { toolCallId?: string; hookContext?: HookContext; signal?: AbortSignal },
+  ) => Promise<unknown> | unknown;
+  finalizeBeforeToolCallParams?: (params: unknown, preparedParams: unknown) => unknown;
+};
 
 export type BeforeToolCallPolicyDiagnosticState = {
   hasBeforeToolCallHook: boolean;
@@ -1099,8 +1106,16 @@ export function wrapToolWithBeforeToolCallHook(
   const wrappedTool: AnyAgentTool = {
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
-      const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params });
-      const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params });
+      const prepare = (tool as BeforeToolCallPreparingTool).prepareBeforeToolCallParams;
+      const preparedParams = prepare
+        ? await prepare(params, {
+            ...(toolCallId ? { toolCallId } : {}),
+            ...(ctx ? { hookContext: ctx } : {}),
+            ...(signal ? { signal } : {}),
+          })
+        : params;
+      const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params: preparedParams });
+      const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params: preparedParams });
       const outcome = await runBeforeToolCallHook({
         toolName,
         params: hookParams,
@@ -1149,12 +1164,17 @@ export function wrapToolWithBeforeToolCallHook(
         });
         return blockedResult;
       }
-      const executeParams = reconcileCodeModeExecBeforeHookParams({
+      let executeParams = reconcileCodeModeExecBeforeHookParams({
         tool,
-        originalParams: params,
+        originalParams: preparedParams,
         hookParams,
         adjustedParams: outcome.params,
       });
+      executeParams =
+        (tool as BeforeToolCallPreparingTool).finalizeBeforeToolCallParams?.(
+          executeParams,
+          preparedParams,
+        ) ?? executeParams;
       recordAdjustedParamsForToolCall(toolCallId, executeParams, ctx?.runId);
       const normalizedToolName = normalizeToolName(toolName || "tool");
       const trace = ctx?.trace

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -159,7 +159,7 @@ type BeforeToolCallPreparingTool = AnyAgentTool & {
   prepareBeforeToolCallParams?: (
     params: unknown,
     ctx: { toolCallId?: string; hookContext?: HookContext; signal?: AbortSignal },
-  ) => Promise<unknown> | unknown;
+  ) => unknown;
   finalizeBeforeToolCallParams?: (params: unknown, preparedParams: unknown) => unknown;
 };
 

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -183,6 +183,10 @@ function createLazyExecTool(defaults?: ExecToolDefaults): AnyAgentTool {
       });
     },
     parameters: execSchema,
+    prepareBeforeToolCallParams: async (...args) =>
+      (await loadTool()).prepareBeforeToolCallParams?.(...args) ?? args[0],
+    finalizeBeforeToolCallParams: (params, preparedParams) =>
+      loadedTool?.finalizeBeforeToolCallParams?.(params, preparedParams) ?? params,
     execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>
       (await loadTool()).execute(...args),
   } as AnyAgentTool;

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -6,8 +6,10 @@ const mocks = vi.hoisted(() => ({
     | {
         hasHooks: ReturnType<typeof vi.fn>;
         runResolveExecEnv: ReturnType<typeof vi.fn>;
+        runBeforeToolCall?: ReturnType<typeof vi.fn>;
       }
     | undefined,
+  beforeToolCallParams: [] as Array<Record<string, unknown>>,
   gatewayParams: [] as Array<{
     env: Record<string, string>;
     requestedEnv?: Record<string, string>;
@@ -92,6 +94,7 @@ vi.mock("../process/supervisor/index.js", () => ({
 }));
 
 let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
+let toToolDefinitions: typeof import("./agent-tool-definition-adapter.js").toToolDefinitions;
 
 function installResolveExecEnvHook(result: Record<string, string>) {
   mocks.hookRunner = {
@@ -103,10 +106,12 @@ function installResolveExecEnvHook(result: Record<string, string>) {
 describe("exec resolve_exec_env hook wiring", () => {
   beforeAll(async () => {
     ({ createExecTool } = await import("./bash-tools.exec.js"));
+    ({ toToolDefinitions } = await import("./agent-tool-definition-adapter.js"));
   });
 
   beforeEach(() => {
     mocks.hookRunner = undefined;
+    mocks.beforeToolCallParams.length = 0;
     mocks.gatewayParams.length = 0;
     mocks.nodeHostParams.length = 0;
     mocks.spawnInputs.length = 0;
@@ -192,5 +197,48 @@ describe("exec resolve_exec_env hook wiring", () => {
       REQUEST_SAFE: "request",
     });
     expect(mocks.nodeHostParams[0]?.env).not.toHaveProperty("LD_PRELOAD");
+  });
+
+  it("includes plugin env in before_tool_call params before approval", async () => {
+    mocks.hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
+      ),
+      runResolveExecEnv: vi.fn(async () => ({ PLUGIN_SAFE: "yes" })),
+      runBeforeToolCall: vi.fn(async (event: { params: Record<string, unknown> }) => {
+        mocks.beforeToolCallParams.push({ ...event.params });
+        return undefined;
+      }),
+    };
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:main:telegram:chat-1",
+      messageProvider: "telegram",
+      currentChannelId: "chat-1",
+    });
+    const [definition] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+      channelId: "chat-1",
+    });
+
+    await definition.execute("call-before", {
+      command: "echo ok",
+      env: { EXISTING: "request" },
+      yieldMs: 120_000,
+    });
+
+    expect(mocks.beforeToolCallParams[0]?.env).toEqual({
+      EXISTING: "request",
+      PLUGIN_SAFE: "yes",
+    });
+    expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenCalledTimes(1);
+    expect(mocks.gatewayParams[0]?.requestedEnv).toEqual({
+      EXISTING: "request",
+      PLUGIN_SAFE: "yes",
+    });
   });
 });

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -210,6 +210,7 @@ describe("exec resolve_exec_env hook wiring", () => {
       ),
       runResolveExecEnv: vi.fn(async () => ({ PLUGIN_SAFE: "yes" })),
       runBeforeToolCall: vi.fn(async (event: { params: Record<string, unknown> }) => {
+        expect(Object.getOwnPropertySymbols(event.params)).toHaveLength(0);
         mocks.beforeToolCallParams.push({ ...event.params });
         return undefined;
       }),
@@ -258,6 +259,7 @@ describe("exec resolve_exec_env hook wiring", () => {
       ),
       runResolveExecEnv: vi.fn(async () => ({ LAZY_PLUGIN_SAFE: "yes" })),
       runBeforeToolCall: vi.fn(async (event: { params: Record<string, unknown> }) => {
+        expect(Object.getOwnPropertySymbols(event.params)).toHaveLength(0);
         mocks.beforeToolCallParams.push({ ...event.params });
         return undefined;
       }),

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -332,4 +332,37 @@ describe("exec resolve_exec_env hook wiring", () => {
     });
     expect(mocks.nodeHostParams[0]?.requestedEnv).not.toHaveProperty("GATEWAY_PLUGIN_SAFE");
   });
+
+  it("lets before_tool_call rewrite host when no resolve_exec_env hook is registered", async () => {
+    mocks.hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "before_tool_call"),
+      runResolveExecEnv: vi.fn(),
+      runBeforeToolCall: vi.fn(async (event: { params: Record<string, unknown> }) => ({
+        params: { ...event.params, host: "gateway" },
+      })),
+    };
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+    const [definition] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+
+    await definition.execute("call-host-sanitize", {
+      command: "echo ok",
+      host: "node",
+      env: { REQUEST_SAFE: "request" },
+      yieldMs: 120_000,
+    });
+
+    expect(mocks.hookRunner.runResolveExecEnv).not.toHaveBeenCalled();
+    expect(mocks.gatewayParams[0]?.requestedEnv).toEqual({
+      REQUEST_SAFE: "request",
+    });
+  });
 });

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
+import type { ExtensionContext } from "./sessions/index.js";
 
 const mocks = vi.hoisted(() => ({
   hookRunner: undefined as
@@ -96,6 +97,7 @@ vi.mock("../process/supervisor/index.js", () => ({
 let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
 let toToolDefinitions: typeof import("./agent-tool-definition-adapter.js").toToolDefinitions;
 let createOpenClawCodingTools: typeof import("./agent-tools.js").createOpenClawCodingTools;
+const testExtensionContext = {} as ExtensionContext;
 
 function installResolveExecEnvHook(result: Record<string, string>) {
   mocks.hookRunner = {
@@ -227,11 +229,17 @@ describe("exec resolve_exec_env hook wiring", () => {
       channelId: "chat-1",
     });
 
-    await definition.execute("call-before", {
-      command: "echo ok",
-      env: { EXISTING: "request" },
-      yieldMs: 120_000,
-    });
+    await definition.execute(
+      "call-before",
+      {
+        command: "echo ok",
+        env: { EXISTING: "request" },
+        yieldMs: 120_000,
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
 
     expect(mocks.beforeToolCallParams[0]?.env).toEqual({
       EXISTING: "request",
@@ -269,11 +277,17 @@ describe("exec resolve_exec_env hook wiring", () => {
       channelId: "chat-1",
     });
 
-    await definition.execute("call-lazy", {
-      command: "echo ok",
-      env: { REQUEST_SAFE: "request" },
-      yieldMs: 120_000,
-    });
+    await definition.execute(
+      "call-lazy",
+      {
+        command: "echo ok",
+        env: { REQUEST_SAFE: "request" },
+        yieldMs: 120_000,
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
 
     expect(mocks.beforeToolCallParams[0]?.env).toEqual({
       LAZY_PLUGIN_SAFE: "yes",
@@ -310,10 +324,16 @@ describe("exec resolve_exec_env hook wiring", () => {
       sessionKey: "agent:main:telegram:chat-1",
     });
 
-    await definition.execute("call-host-rewrite", {
-      command: "echo ok",
-      env: { REQUEST_SAFE: "request" },
-    });
+    await definition.execute(
+      "call-host-rewrite",
+      {
+        command: "echo ok",
+        env: { REQUEST_SAFE: "request" },
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
 
     expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenCalledTimes(2);
     expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenNthCalledWith(
@@ -353,12 +373,18 @@ describe("exec resolve_exec_env hook wiring", () => {
       sessionKey: "agent:main:telegram:chat-1",
     });
 
-    await definition.execute("call-host-sanitize", {
-      command: "echo ok",
-      host: "node",
-      env: { REQUEST_SAFE: "request" },
-      yieldMs: 120_000,
-    });
+    await definition.execute(
+      "call-host-sanitize",
+      {
+        command: "echo ok",
+        host: "node",
+        env: { REQUEST_SAFE: "request" },
+        yieldMs: 120_000,
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
 
     expect(mocks.hookRunner.runResolveExecEnv).not.toHaveBeenCalled();
     expect(mocks.gatewayParams[0]?.requestedEnv).toEqual({

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -203,7 +203,7 @@ describe("exec resolve_exec_env hook wiring", () => {
     expect(mocks.nodeHostParams[0]?.env).not.toHaveProperty("LD_PRELOAD");
   });
 
-  it("includes plugin env in before_tool_call params before approval", async () => {
+  it("keeps plugin env out of before_tool_call params before execution", async () => {
     mocks.hookRunner = {
       hasHooks: vi.fn(
         (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
@@ -243,7 +243,6 @@ describe("exec resolve_exec_env hook wiring", () => {
 
     expect(mocks.beforeToolCallParams[0]?.env).toEqual({
       EXISTING: "request",
-      PLUGIN_SAFE: "yes",
     });
     expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenCalledTimes(1);
     expect(mocks.gatewayParams[0]?.requestedEnv).toEqual({
@@ -252,7 +251,7 @@ describe("exec resolve_exec_env hook wiring", () => {
     });
   });
 
-  it("forwards env preparation through the lazy exec tool", async () => {
+  it("forwards private env preparation through the lazy exec tool", async () => {
     mocks.hookRunner = {
       hasHooks: vi.fn(
         (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
@@ -290,7 +289,6 @@ describe("exec resolve_exec_env hook wiring", () => {
     );
 
     expect(mocks.beforeToolCallParams[0]?.env).toEqual({
-      LAZY_PLUGIN_SAFE: "yes",
       REQUEST_SAFE: "request",
     });
     expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenCalledTimes(1);

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -95,6 +95,7 @@ vi.mock("../process/supervisor/index.js", () => ({
 
 let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
 let toToolDefinitions: typeof import("./agent-tool-definition-adapter.js").toToolDefinitions;
+let createOpenClawCodingTools: typeof import("./agent-tools.js").createOpenClawCodingTools;
 
 function installResolveExecEnvHook(result: Record<string, string>) {
   mocks.hookRunner = {
@@ -107,6 +108,7 @@ describe("exec resolve_exec_env hook wiring", () => {
   beforeAll(async () => {
     ({ createExecTool } = await import("./bash-tools.exec.js"));
     ({ toToolDefinitions } = await import("./agent-tool-definition-adapter.js"));
+    ({ createOpenClawCodingTools } = await import("./agent-tools.js"));
   });
 
   beforeEach(() => {
@@ -128,7 +130,7 @@ describe("exec resolve_exec_env hook wiring", () => {
     });
 
     const tool = createExecTool({
-      host: "gateway",
+      host: "auto",
       security: "full",
       ask: "off",
       sessionKey: "agent:main:telegram:chat-1",
@@ -212,7 +214,7 @@ describe("exec resolve_exec_env hook wiring", () => {
     };
 
     const tool = createExecTool({
-      host: "gateway",
+      host: "auto",
       security: "full",
       ask: "off",
       sessionKey: "agent:main:telegram:chat-1",
@@ -240,5 +242,94 @@ describe("exec resolve_exec_env hook wiring", () => {
       EXISTING: "request",
       PLUGIN_SAFE: "yes",
     });
+  });
+
+  it("forwards env preparation through the lazy exec tool", async () => {
+    mocks.hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
+      ),
+      runResolveExecEnv: vi.fn(async () => ({ LAZY_PLUGIN_SAFE: "yes" })),
+      runBeforeToolCall: vi.fn(async (event: { params: Record<string, unknown> }) => {
+        mocks.beforeToolCallParams.push({ ...event.params });
+        return undefined;
+      }),
+    };
+
+    const exec = createOpenClawCodingTools({
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+      cwd: process.cwd(),
+      exec: { host: "gateway", security: "full", ask: "off" },
+    }).find((tool) => tool.name === "exec");
+    expect(exec).toBeDefined();
+    const [definition] = toToolDefinitions([exec!], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+      channelId: "chat-1",
+    });
+
+    await definition.execute("call-lazy", {
+      command: "echo ok",
+      env: { REQUEST_SAFE: "request" },
+      yieldMs: 120_000,
+    });
+
+    expect(mocks.beforeToolCallParams[0]?.env).toEqual({
+      LAZY_PLUGIN_SAFE: "yes",
+      REQUEST_SAFE: "request",
+    });
+    expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenCalledTimes(1);
+    expect(mocks.gatewayParams[0]?.requestedEnv).toEqual({
+      LAZY_PLUGIN_SAFE: "yes",
+      REQUEST_SAFE: "request",
+    });
+  });
+
+  it("recomputes plugin env when before_tool_call changes exec host", async () => {
+    mocks.hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
+      ),
+      runResolveExecEnv: vi.fn(async (event: { host: "gateway" | "sandbox" | "node" }) =>
+        event.host === "node" ? { NODE_PLUGIN_SAFE: "node" } : { GATEWAY_PLUGIN_SAFE: "gateway" },
+      ),
+      runBeforeToolCall: vi.fn(async (event: { params: Record<string, unknown> }) => ({
+        params: { ...event.params, host: "node" },
+      })),
+    };
+
+    const tool = createExecTool({
+      host: "auto",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+    const [definition] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+
+    await definition.execute("call-host-rewrite", {
+      command: "echo ok",
+      env: { REQUEST_SAFE: "request" },
+    });
+
+    expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenCalledTimes(2);
+    expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ host: "gateway" }),
+      expect.anything(),
+    );
+    expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ host: "node" }),
+      expect.anything(),
+    );
+    expect(mocks.nodeHostParams[0]?.requestedEnv).toEqual({
+      NODE_PLUGIN_SAFE: "node",
+      REQUEST_SAFE: "request",
+    });
+    expect(mocks.nodeHostParams[0]?.requestedEnv).not.toHaveProperty("GATEWAY_PLUGIN_SAFE");
   });
 });

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -389,4 +389,50 @@ describe("exec resolve_exec_env hook wiring", () => {
       REQUEST_SAFE: "request",
     });
   });
+
+  it("resolves plugin env after before_tool_call adds a command", async () => {
+    mocks.hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
+      ),
+      runResolveExecEnv: vi.fn(async () => ({ PLUGIN_SAFE: "yes" })),
+      runBeforeToolCall: vi.fn(async (event: { params: Record<string, unknown> }) => {
+        mocks.beforeToolCallParams.push({ ...event.params });
+        return {
+          params: { ...event.params, command: "echo ok" },
+        };
+      }),
+    };
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+    const [definition] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+
+    await definition.execute(
+      "call-command-rewrite",
+      {
+        env: { REQUEST_SAFE: "request" },
+        yieldMs: 120_000,
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
+
+    expect(mocks.beforeToolCallParams[0]?.env).toEqual({
+      REQUEST_SAFE: "request",
+    });
+    expect(mocks.hookRunner.runResolveExecEnv).toHaveBeenCalledTimes(1);
+    expect(mocks.gatewayParams[0]?.requestedEnv).toEqual({
+      PLUGIN_SAFE: "yes",
+      REQUEST_SAFE: "request",
+    });
+  });
 });

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
 
 const mocks = vi.hoisted(() => ({
   hookRunner: undefined as
@@ -117,6 +118,7 @@ describe("exec resolve_exec_env hook wiring", () => {
       PLUGIN_SAFE: "yes",
       PATH: "/tmp/plugin-bin",
       NODE_OPTIONS: "--require /tmp/hook.js",
+      OPENCLAW_CLI: "0",
       "bad-key": "bad",
     });
 
@@ -156,6 +158,7 @@ describe("exec resolve_exec_env hook wiring", () => {
       PLUGIN_SAFE: "yes",
     });
     expect(mocks.gatewayParams[0]?.env).not.toHaveProperty("NODE_OPTIONS");
+    expect(mocks.gatewayParams[0]?.env.OPENCLAW_CLI).toBe(OPENCLAW_CLI_ENV_VALUE);
     expect(mocks.gatewayParams[0]?.env.PATH).not.toBe("/tmp/plugin-bin");
     expect(mocks.spawnInputs[0]?.env).toMatchObject({
       EXISTING: "plugin",

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -1,0 +1,193 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  hookRunner: undefined as
+    | {
+        hasHooks: ReturnType<typeof vi.fn>;
+        runResolveExecEnv: ReturnType<typeof vi.fn>;
+      }
+    | undefined,
+  gatewayParams: [] as Array<{
+    env: Record<string, string>;
+    requestedEnv?: Record<string, string>;
+  }>,
+  nodeHostParams: [] as Array<{
+    env: Record<string, string>;
+    requestedEnv?: Record<string, string>;
+  }>,
+  spawnInputs: [] as Array<{
+    env?: Record<string, string>;
+  }>,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => mocks.hookRunner,
+}));
+
+vi.mock("../infra/shell-env.js", () => ({
+  getShellPathFromLoginShell: vi.fn(() => null),
+  resolveShellEnvFallbackTimeoutMs: vi.fn(() => 0),
+}));
+
+vi.mock("./bash-tools.exec-host-gateway.js", () => ({
+  processGatewayAllowlist: vi.fn(
+    async (params: { env: Record<string, string>; requestedEnv?: Record<string, string> }) => {
+      mocks.gatewayParams.push({
+        env: { ...params.env },
+        requestedEnv: params.requestedEnv ? { ...params.requestedEnv } : undefined,
+      });
+      return {};
+    },
+  ),
+}));
+
+vi.mock("./bash-tools.exec-host-node.js", () => ({
+  executeNodeHostCommand: vi.fn(
+    async (params: { env: Record<string, string>; requestedEnv?: Record<string, string> }) => {
+      mocks.nodeHostParams.push({
+        env: { ...params.env },
+        requestedEnv: params.requestedEnv ? { ...params.requestedEnv } : undefined,
+      });
+      return {
+        content: [{ type: "text", text: "node ok" }],
+        details: {
+          status: "completed",
+          exitCode: 0,
+          durationMs: 0,
+          aggregated: "node ok",
+        },
+      };
+    },
+  ),
+}));
+
+vi.mock("../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => ({
+    spawn: async (input: { env?: Record<string, string>; onStdout?: (chunk: string) => void }) => {
+      mocks.spawnInputs.push({ env: input.env ? { ...input.env } : undefined });
+      input.onStdout?.("ok\n");
+      return {
+        runId: "mock-run",
+        startedAtMs: Date.now(),
+        stdin: undefined,
+        wait: async () => ({
+          reason: "exit" as const,
+          exitCode: 0,
+          exitSignal: null,
+          durationMs: 0,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          noOutputTimedOut: false,
+        }),
+        cancel: vi.fn(),
+      };
+    },
+    cancel: vi.fn(),
+    cancelScope: vi.fn(),
+    reconcileOrphans: vi.fn(),
+    getRecord: vi.fn(),
+  }),
+}));
+
+let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
+
+function installResolveExecEnvHook(result: Record<string, string>) {
+  mocks.hookRunner = {
+    hasHooks: vi.fn((hookName: string) => hookName === "resolve_exec_env"),
+    runResolveExecEnv: vi.fn(async () => result),
+  };
+}
+
+describe("exec resolve_exec_env hook wiring", () => {
+  beforeAll(async () => {
+    ({ createExecTool } = await import("./bash-tools.exec.js"));
+  });
+
+  beforeEach(() => {
+    mocks.hookRunner = undefined;
+    mocks.gatewayParams.length = 0;
+    mocks.nodeHostParams.length = 0;
+    mocks.spawnInputs.length = 0;
+  });
+
+  it("merges filtered plugin env into gateway execution and approval-visible requested env", async () => {
+    installResolveExecEnvHook({
+      EXISTING: "plugin",
+      PLUGIN_SAFE: "yes",
+      PATH: "/tmp/plugin-bin",
+      NODE_OPTIONS: "--require /tmp/hook.js",
+      "bad-key": "bad",
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:main:telegram:chat-1",
+      messageProvider: "telegram",
+      currentChannelId: "chat-1",
+    });
+    await tool.execute("call-1", {
+      command: "echo ok",
+      env: { EXISTING: "request" },
+      yieldMs: 120_000,
+    });
+
+    expect(mocks.hookRunner?.runResolveExecEnv).toHaveBeenCalledWith(
+      {
+        sessionKey: "agent:main:telegram:chat-1",
+        toolName: "exec",
+        host: "gateway",
+      },
+      {
+        agentId: "main",
+        sessionKey: "agent:main:telegram:chat-1",
+        messageProvider: "telegram",
+        channelId: "chat-1",
+      },
+    );
+    expect(mocks.gatewayParams[0]?.requestedEnv).toEqual({
+      EXISTING: "plugin",
+      PLUGIN_SAFE: "yes",
+    });
+    expect(mocks.gatewayParams[0]?.env).toMatchObject({
+      EXISTING: "plugin",
+      PLUGIN_SAFE: "yes",
+    });
+    expect(mocks.gatewayParams[0]?.env).not.toHaveProperty("NODE_OPTIONS");
+    expect(mocks.gatewayParams[0]?.env.PATH).not.toBe("/tmp/plugin-bin");
+    expect(mocks.spawnInputs[0]?.env).toMatchObject({
+      EXISTING: "plugin",
+      PLUGIN_SAFE: "yes",
+    });
+  });
+
+  it("forwards filtered plugin env to node host requests", async () => {
+    installResolveExecEnvHook({
+      NODE_HOST_SAFE: "yes",
+      LD_PRELOAD: "/tmp/preload.dylib",
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:main:main",
+    });
+    await tool.execute("call-node", {
+      command: "echo ok",
+      env: { REQUEST_SAFE: "request" },
+    });
+
+    expect(mocks.nodeHostParams[0]?.requestedEnv).toEqual({
+      NODE_HOST_SAFE: "yes",
+      REQUEST_SAFE: "request",
+    });
+    expect(mocks.nodeHostParams[0]?.env).toMatchObject({
+      NODE_HOST_SAFE: "yes",
+      REQUEST_SAFE: "request",
+    });
+    expect(mocks.nodeHostParams[0]?.env).not.toHaveProperty("LD_PRELOAD");
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -100,7 +100,14 @@ type ExecToolArgs = Record<string, unknown> & {
   node?: string;
 };
 const RESOLVE_EXEC_ENV_PREPARED = Symbol("openclaw.resolveExecEnvPrepared");
-type PreparedExecToolArgs = ExecToolArgs & { [RESOLVE_EXEC_ENV_PREPARED]?: true };
+type ResolvedExecEnvPreparedState = {
+  host?: ExecHost;
+  pluginEnv?: Record<string, string>;
+  previousEnv?: Record<string, string | undefined>;
+};
+type PreparedExecToolArgs = ExecToolArgs & {
+  [RESOLVE_EXEC_ENV_PREPARED]?: ResolvedExecEnvPreparedState;
+};
 
 const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
   "command",
@@ -132,17 +139,55 @@ function filterPluginExecEnv(rawEnv: Record<string, string>): Record<string, str
   return Object.keys(env).length > 0 ? env : undefined;
 }
 
-function markResolveExecEnvPrepared<T extends ExecToolArgs>(params: T): T {
+function markResolveExecEnvPrepared<T extends ExecToolArgs>(
+  params: T,
+  state: ResolvedExecEnvPreparedState = {},
+): T {
   Object.defineProperty(params, RESOLVE_EXEC_ENV_PREPARED, {
-    value: true,
+    value: state,
     enumerable: true,
     configurable: true,
   });
   return params;
 }
 
+function getResolvedExecEnvPreparedState(
+  params: ExecToolArgs,
+): ResolvedExecEnvPreparedState | undefined {
+  return (params as PreparedExecToolArgs)[RESOLVE_EXEC_ENV_PREPARED];
+}
+
 function isResolveExecEnvPrepared(params: ExecToolArgs): boolean {
-  return (params as PreparedExecToolArgs)[RESOLVE_EXEC_ENV_PREPARED] === true;
+  return Boolean(getResolvedExecEnvPreparedState(params));
+}
+
+function removeResolvedPluginEnv(
+  params: ExecToolArgs,
+  state: ResolvedExecEnvPreparedState,
+): ExecToolArgs {
+  if (!params.env || !state.pluginEnv) {
+    const next = { ...params };
+    delete (next as PreparedExecToolArgs)[RESOLVE_EXEC_ENV_PREPARED];
+    return next;
+  }
+  const env = { ...params.env };
+  for (const [key, value] of Object.entries(state.pluginEnv)) {
+    if (env[key] !== value) {
+      continue;
+    }
+    const previous = state.previousEnv?.[key];
+    if (typeof previous === "string") {
+      env[key] = previous;
+    } else {
+      delete env[key];
+    }
+  }
+  const next = {
+    ...params,
+    ...(Object.keys(env).length > 0 ? { env } : { env: undefined }),
+  };
+  delete (next as PreparedExecToolArgs)[RESOLVE_EXEC_ENV_PREPARED];
+  return next;
 }
 
 function buildExecForegroundResult(params: {
@@ -1418,8 +1463,12 @@ export function createExecTool(
       },
     );
     const pluginEnv = filterPluginExecEnv(rawPluginEnv);
+    const previousEnv = pluginEnv
+      ? Object.fromEntries(Object.keys(pluginEnv).map((key) => [key, params.env?.[key]]))
+      : undefined;
     return markResolveExecEnvPrepared(
       pluginEnv ? { ...params, env: { ...params.env, ...pluginEnv } } : params,
+      { host, ...(pluginEnv ? { pluginEnv, previousEnv } : {}) },
     );
   };
   const autoReviewer =
@@ -1443,9 +1492,17 @@ export function createExecTool(
         hookContext: context.hookContext as HookContext | undefined,
       }),
     finalizeBeforeToolCallParams: (params, preparedParams) =>
-      isResolveExecEnvPrepared(preparedParams as ExecToolArgs)
-        ? markResolveExecEnvPrepared(params as ExecToolArgs)
-        : params,
+      (() => {
+        const state = getResolvedExecEnvPreparedState(preparedParams as ExecToolArgs);
+        if (!state) {
+          return params;
+        }
+        const execParams = params as ExecToolArgs;
+        if (state.host && execParams.command && resolveHostForParams(execParams) !== state.host) {
+          return removeResolvedPluginEnv(execParams, state);
+        }
+        return markResolveExecEnvPrepared(execParams, state);
+      })(),
     execute: async (_toolCallId, args, signal, onUpdate) => {
       const params = isResolveExecEnvPrepared(args as ExecToolArgs)
         ? stripMalformedXmlArgValueSuffixFromKeys(

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1444,10 +1444,15 @@ export function createExecTool(
     if (!params.command || isResolveExecEnvPrepared(params)) {
       return markResolveExecEnvPrepared(params);
     }
-    const host = resolveHostForParams(params);
     const hookRunner = getGlobalHookRunner();
     if (!hookRunner?.hasHooks("resolve_exec_env")) {
       return markResolveExecEnvPrepared(params);
+    }
+    let host: ExecHost;
+    try {
+      host = resolveHostForParams(params);
+    } catch {
+      return params;
     }
     const rawPluginEnv = await hookRunner.runResolveExecEnv(
       {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -99,14 +99,11 @@ type ExecToolArgs = Record<string, unknown> & {
   ask?: string;
   node?: string;
 };
-const RESOLVE_EXEC_ENV_PREPARED = Symbol("openclaw.resolveExecEnvPrepared");
 type ResolvedExecEnvPreparedState = {
   host?: ExecHost;
   pluginEnv?: Record<string, string>;
 };
-type PreparedExecToolArgs = ExecToolArgs & {
-  [RESOLVE_EXEC_ENV_PREPARED]?: ResolvedExecEnvPreparedState;
-};
+const resolvedExecEnvPreparedStates = new WeakMap<ExecToolArgs, ResolvedExecEnvPreparedState>();
 
 const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
   "command",
@@ -142,18 +139,14 @@ function markResolveExecEnvPrepared<T extends ExecToolArgs>(
   params: T,
   state: ResolvedExecEnvPreparedState = {},
 ): T {
-  Object.defineProperty(params, RESOLVE_EXEC_ENV_PREPARED, {
-    value: state,
-    enumerable: false,
-    configurable: true,
-  });
+  resolvedExecEnvPreparedStates.set(params, state);
   return params;
 }
 
 function getResolvedExecEnvPreparedState(
   params: ExecToolArgs,
 ): ResolvedExecEnvPreparedState | undefined {
-  return (params as PreparedExecToolArgs)[RESOLVE_EXEC_ENV_PREPARED];
+  return resolvedExecEnvPreparedStates.get(params);
 }
 
 function isResolveExecEnvPrepared(params: ExecToolArgs): boolean {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -103,7 +103,6 @@ const RESOLVE_EXEC_ENV_PREPARED = Symbol("openclaw.resolveExecEnvPrepared");
 type ResolvedExecEnvPreparedState = {
   host?: ExecHost;
   pluginEnv?: Record<string, string>;
-  previousEnv?: Record<string, string | undefined>;
 };
 type PreparedExecToolArgs = ExecToolArgs & {
   [RESOLVE_EXEC_ENV_PREPARED]?: ResolvedExecEnvPreparedState;
@@ -145,7 +144,7 @@ function markResolveExecEnvPrepared<T extends ExecToolArgs>(
 ): T {
   Object.defineProperty(params, RESOLVE_EXEC_ENV_PREPARED, {
     value: state,
-    enumerable: true,
+    enumerable: false,
     configurable: true,
   });
   return params;
@@ -159,35 +158,6 @@ function getResolvedExecEnvPreparedState(
 
 function isResolveExecEnvPrepared(params: ExecToolArgs): boolean {
   return Boolean(getResolvedExecEnvPreparedState(params));
-}
-
-function removeResolvedPluginEnv(
-  params: ExecToolArgs,
-  state: ResolvedExecEnvPreparedState,
-): ExecToolArgs {
-  if (!params.env || !state.pluginEnv) {
-    const next = { ...params };
-    delete (next as PreparedExecToolArgs)[RESOLVE_EXEC_ENV_PREPARED];
-    return next;
-  }
-  const env = { ...params.env };
-  for (const [key, value] of Object.entries(state.pluginEnv)) {
-    if (env[key] !== value) {
-      continue;
-    }
-    const previous = state.previousEnv?.[key];
-    if (typeof previous === "string") {
-      env[key] = previous;
-    } else {
-      delete env[key];
-    }
-  }
-  const next = {
-    ...params,
-    ...(Object.keys(env).length > 0 ? { env } : { env: undefined }),
-  };
-  delete (next as PreparedExecToolArgs)[RESOLVE_EXEC_ENV_PREPARED];
-  return next;
 }
 
 function buildExecForegroundResult(params: {
@@ -1468,13 +1438,7 @@ export function createExecTool(
       },
     );
     const pluginEnv = filterPluginExecEnv(rawPluginEnv);
-    const previousEnv = pluginEnv
-      ? Object.fromEntries(Object.keys(pluginEnv).map((key) => [key, params.env?.[key]]))
-      : undefined;
-    return markResolveExecEnvPrepared(
-      pluginEnv ? { ...params, env: { ...params.env, ...pluginEnv } } : params,
-      { host, ...(pluginEnv ? { pluginEnv, previousEnv } : {}) },
-    );
+    return markResolveExecEnvPrepared(params, { host, ...(pluginEnv ? { pluginEnv } : {}) });
   };
   const autoReviewer =
     defaults?.autoReviewer ??
@@ -1504,7 +1468,7 @@ export function createExecTool(
         }
         const execParams = params as ExecToolArgs;
         if (state.host && execParams.command && resolveHostForParams(execParams) !== state.host) {
-          return removeResolvedPluginEnv(execParams, state);
+          return { ...execParams };
         }
         return markResolveExecEnvPrepared(execParams, state);
       })(),
@@ -1704,17 +1668,21 @@ export function createExecTool(
       rejectUnsafeControlShellCommand(params.command);
 
       const inheritedBaseEnv = coerceEnv(process.env);
+      const resolvedExecEnvState = getResolvedExecEnvPreparedState(params);
+      const requestedEnv = resolvedExecEnvState?.pluginEnv
+        ? { ...params.env, ...resolvedExecEnvState.pluginEnv }
+        : params.env;
       const hostEnvResult =
         host === "sandbox"
           ? null
           : sanitizeHostExecEnvWithDiagnostics({
               baseEnv: inheritedBaseEnv,
-              overrides: params.env,
+              overrides: requestedEnv,
               blockPathOverrides: true,
             });
       if (
         hostEnvResult &&
-        params.env &&
+        requestedEnv &&
         (hostEnvResult.rejectedOverrideBlockedKeys.length > 0 ||
           hostEnvResult.rejectedOverrideInvalidKeys.length > 0)
       ) {
@@ -1751,13 +1719,13 @@ export function createExecTool(
         sandbox && host === "sandbox"
           ? buildSandboxEnv({
               defaultPath: DEFAULT_PATH,
-              paramsEnv: params.env,
+              paramsEnv: requestedEnv,
               sandboxEnv: sandbox.env,
               containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
             })
           : (hostEnvResult?.env ?? inheritedBaseEnv);
 
-      if (!sandbox && host === "gateway" && !params.env?.PATH) {
+      if (!sandbox && host === "gateway" && !requestedEnv?.PATH) {
         const shellPath = getShellPathFromLoginShell({
           env: process.env,
           timeoutMs: resolveShellEnvFallbackTimeoutMs(process.env),
@@ -1780,7 +1748,7 @@ export function createExecTool(
           command: params.command,
           workdir,
           env,
-          requestedEnv: params.env,
+          requestedEnv,
           requestedNode: params.node?.trim(),
           boundNode: defaults?.node?.trim(),
           sessionKey: defaults?.sessionKey,
@@ -1817,7 +1785,7 @@ export function createExecTool(
           workdir,
           env,
           pathPrepend: defaultPathPrepend,
-          requestedEnv: params.env,
+          requestedEnv,
           pty: params.pty === true && !sandbox,
           timeoutSec: params.timeout,
           defaultTimeoutSec,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -42,6 +42,7 @@ import {
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
+import type { HookContext } from "./agent-tools.before-tool-call.js";
 import { stripMalformedXmlArgValueSuffixFromKeys } from "./agent-tools.params.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { describeExecTool } from "./bash-tools.descriptions.js";
@@ -98,6 +99,8 @@ type ExecToolArgs = Record<string, unknown> & {
   ask?: string;
   node?: string;
 };
+const RESOLVE_EXEC_ENV_PREPARED = Symbol("openclaw.resolveExecEnvPrepared");
+type PreparedExecToolArgs = ExecToolArgs & { [RESOLVE_EXEC_ENV_PREPARED]?: true };
 
 const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
   "command",
@@ -127,6 +130,19 @@ function filterPluginExecEnv(rawEnv: Record<string, string>): Record<string, str
     env[key] = value;
   }
   return Object.keys(env).length > 0 ? env : undefined;
+}
+
+function markResolveExecEnvPrepared<T extends ExecToolArgs>(params: T): T {
+  Object.defineProperty(params, RESOLVE_EXEC_ENV_PREPARED, {
+    value: true,
+    enumerable: true,
+    configurable: true,
+  });
+  return params;
+}
+
+function isResolveExecEnvPrepared(params: ExecToolArgs): boolean {
+  return (params as PreparedExecToolArgs)[RESOLVE_EXEC_ENV_PREPARED] === true;
 }
 
 function buildExecForegroundResult(params: {
@@ -1344,6 +1360,68 @@ export function createExecTool(
   const agentId =
     defaults?.agentId ??
     (parsedAgentSession ? resolveAgentIdFromSessionKey(defaults?.sessionKey) : undefined);
+  const resolveHostForParams = (params: ExecToolArgs): ExecHost => {
+    const elevatedDefaults = defaults?.elevated;
+    const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);
+    const elevatedDefaultMode =
+      elevatedDefaults?.defaultLevel === "full"
+        ? "full"
+        : elevatedDefaults?.defaultLevel === "ask"
+          ? "ask"
+          : elevatedDefaults?.defaultLevel === "on"
+            ? "ask"
+            : "off";
+    const effectiveDefaultMode = elevatedAllowed ? elevatedDefaultMode : "off";
+    const elevatedMode =
+      typeof params.elevated === "boolean"
+        ? params.elevated
+          ? elevatedDefaultMode === "full"
+            ? "full"
+            : "ask"
+          : "off"
+        : effectiveDefaultMode;
+    const requestedTarget = requireValidExecTarget(params.host);
+    return resolveExecTarget({
+      configuredTarget: defaults?.host,
+      requestedTarget,
+      elevatedRequested: elevatedMode !== "off",
+      sandboxAvailable: Boolean(defaults?.sandbox),
+    }).effectiveHost;
+  };
+  const prepareParamsWithResolvedExecEnv = async (
+    rawArgs: unknown,
+    context?: { hookContext?: HookContext },
+  ): Promise<ExecToolArgs> => {
+    const params = stripMalformedXmlArgValueSuffixFromKeys(
+      rawArgs as ExecToolArgs,
+      XML_ARG_VALUE_EXEC_PARAM_KEYS,
+    );
+    if (!params.command || isResolveExecEnvPrepared(params)) {
+      return markResolveExecEnvPrepared(params);
+    }
+    const host = resolveHostForParams(params);
+    const hookRunner = getGlobalHookRunner();
+    if (!hookRunner?.hasHooks("resolve_exec_env")) {
+      return markResolveExecEnvPrepared(params);
+    }
+    const rawPluginEnv = await hookRunner.runResolveExecEnv(
+      {
+        sessionKey: defaults?.sessionKey ?? context?.hookContext?.sessionKey,
+        toolName: "exec",
+        host,
+      },
+      {
+        agentId: agentId ?? context?.hookContext?.agentId,
+        sessionKey: defaults?.sessionKey ?? context?.hookContext?.sessionKey,
+        messageProvider: defaults?.messageProvider,
+        channelId: defaults?.currentChannelId ?? context?.hookContext?.channelId,
+      },
+    );
+    const pluginEnv = filterPluginExecEnv(rawPluginEnv);
+    return markResolveExecEnvPrepared(
+      pluginEnv ? { ...params, env: { ...params.env, ...pluginEnv } } : params,
+    );
+  };
   const autoReviewer =
     defaults?.autoReviewer ??
     createModelExecAutoReviewer({
@@ -1360,11 +1438,21 @@ export function createExecTool(
       return describeExecTool({ agentId, hasCronTool: defaults?.hasCronTool === true });
     },
     parameters: execSchema,
+    prepareBeforeToolCallParams: async (args, context) =>
+      prepareParamsWithResolvedExecEnv(args, {
+        hookContext: context.hookContext as HookContext | undefined,
+      }),
+    finalizeBeforeToolCallParams: (params, preparedParams) =>
+      isResolveExecEnvPrepared(preparedParams as ExecToolArgs)
+        ? markResolveExecEnvPrepared(params as ExecToolArgs)
+        : params,
     execute: async (_toolCallId, args, signal, onUpdate) => {
-      const params = stripMalformedXmlArgValueSuffixFromKeys(
-        args as ExecToolArgs,
-        XML_ARG_VALUE_EXEC_PARAM_KEYS,
-      );
+      const params = isResolveExecEnvPrepared(args as ExecToolArgs)
+        ? stripMalformedXmlArgValueSuffixFromKeys(
+            args as ExecToolArgs,
+            XML_ARG_VALUE_EXEC_PARAM_KEYS,
+          )
+        : await prepareParamsWithResolvedExecEnv(args);
 
       if (!params.command) {
         throw new Error("Provide a command to start.");
@@ -1625,35 +1713,12 @@ export function createExecTool(
         applyPathPrepend(env, defaultPathPrepend);
       }
 
-      let pluginEnv: Record<string, string> | undefined;
-      const hookRunner = getGlobalHookRunner();
-      if (hookRunner?.hasHooks("resolve_exec_env")) {
-        const rawPluginEnv = await hookRunner.runResolveExecEnv(
-          {
-            sessionKey: defaults?.sessionKey,
-            toolName: "exec",
-            host,
-          },
-          {
-            agentId,
-            sessionKey: defaults?.sessionKey,
-            messageProvider: defaults?.messageProvider,
-            channelId: defaults?.currentChannelId,
-          },
-        );
-        pluginEnv = filterPluginExecEnv(rawPluginEnv);
-        if (pluginEnv) {
-          Object.assign(env, pluginEnv);
-        }
-      }
-      const requestedEnv = pluginEnv ? { ...params.env, ...pluginEnv } : params.env;
-
       if (host === "node") {
         return executeNodeHostCommand({
           command: params.command,
           workdir,
           env,
-          requestedEnv,
+          requestedEnv: params.env,
           requestedNode: params.node?.trim(),
           boundNode: defaults?.node?.trim(),
           sessionKey: defaults?.sessionKey,
@@ -1690,7 +1755,7 @@ export function createExecTool(
           workdir,
           env,
           pathPrepend: defaultPathPrepend,
-          requestedEnv,
+          requestedEnv: params.env,
           pty: params.pty === true && !sandbox,
           timeoutSec: params.timeout,
           defaultTimeoutSec,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1411,7 +1411,10 @@ export function createExecTool(
       rawArgs as ExecToolArgs,
       XML_ARG_VALUE_EXEC_PARAM_KEYS,
     );
-    if (!params.command || isResolveExecEnvPrepared(params)) {
+    if (!params.command) {
+      return params;
+    }
+    if (isResolveExecEnvPrepared(params)) {
       return markResolveExecEnvPrepared(params);
     }
     const hookRunner = getGlobalHookRunner();

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -21,12 +21,18 @@ import {
   resolveExecModePolicy,
 } from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
-import { sanitizeHostExecEnvWithDiagnostics } from "../infra/host-env-security.js";
+import {
+  isDangerousHostEnvOverrideVarName,
+  isDangerousHostEnvVarName,
+  normalizeHostOverrideEnvVarKey,
+  sanitizeHostExecEnvWithDiagnostics,
+} from "../infra/host-env-security.js";
 import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
 } from "../infra/shell-env.js";
 import { logInfo } from "../logger.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
   normalizeAgentId,
   parseAgentSessionKey,
@@ -100,6 +106,26 @@ const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
   "ask",
   "node",
 ] as const;
+
+function filterPluginExecEnv(rawEnv: Record<string, string>): Record<string, string> | undefined {
+  const env: Record<string, string> = {};
+  for (const [rawKey, value] of Object.entries(rawEnv)) {
+    const key = normalizeHostOverrideEnvVarKey(rawKey);
+    if (!key) {
+      continue;
+    }
+    const upperKey = key.toUpperCase();
+    if (
+      upperKey === "PATH" ||
+      isDangerousHostEnvVarName(upperKey) ||
+      isDangerousHostEnvOverrideVarName(upperKey)
+    ) {
+      continue;
+    }
+    env[key] = value;
+  }
+  return Object.keys(env).length > 0 ? env : undefined;
+}
 
 function buildExecForegroundResult(params: {
   outcome: ExecProcessOutcome;
@@ -1597,12 +1623,35 @@ export function createExecTool(
         applyPathPrepend(env, defaultPathPrepend);
       }
 
+      let pluginEnv: Record<string, string> | undefined;
+      const hookRunner = getGlobalHookRunner();
+      if (hookRunner?.hasHooks("resolve_exec_env")) {
+        const rawPluginEnv = await hookRunner.runResolveExecEnv(
+          {
+            sessionKey: defaults?.sessionKey,
+            toolName: "exec",
+            host,
+          },
+          {
+            agentId,
+            sessionKey: defaults?.sessionKey,
+            messageProvider: defaults?.messageProvider,
+            channelId: defaults?.currentChannelId,
+          },
+        );
+        pluginEnv = filterPluginExecEnv(rawPluginEnv);
+        if (pluginEnv) {
+          Object.assign(env, pluginEnv);
+        }
+      }
+      const requestedEnv = pluginEnv ? { ...params.env, ...pluginEnv } : params.env;
+
       if (host === "node") {
         return executeNodeHostCommand({
           command: params.command,
           workdir,
           env,
-          requestedEnv: params.env,
+          requestedEnv,
           requestedNode: params.node?.trim(),
           boundNode: defaults?.node?.trim(),
           sessionKey: defaults?.sessionKey,
@@ -1639,7 +1688,7 @@ export function createExecTool(
           workdir,
           env,
           pathPrepend: defaultPathPrepend,
-          requestedEnv: params.env,
+          requestedEnv,
           pty: params.pty === true && !sandbox,
           timeoutSec: params.timeout,
           defaultTimeoutSec,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -27,6 +27,7 @@ import {
   normalizeHostOverrideEnvVarKey,
   sanitizeHostExecEnvWithDiagnostics,
 } from "../infra/host-env-security.js";
+import { OPENCLAW_CLI_ENV_VAR } from "../infra/openclaw-exec-env.js";
 import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
@@ -117,6 +118,7 @@ function filterPluginExecEnv(rawEnv: Record<string, string>): Record<string, str
     const upperKey = key.toUpperCase();
     if (
       upperKey === "PATH" ||
+      upperKey === OPENCLAW_CLI_ENV_VAR ||
       isDangerousHostEnvVarName(upperKey) ||
       isDangerousHostEnvOverrideVarName(upperKey)
     ) {

--- a/src/agents/shell-snapshot.test.ts
+++ b/src/agents/shell-snapshot.test.ts
@@ -304,6 +304,44 @@ describe("exec shell snapshots", () => {
     await expect(runWithPnpmHome("/second")).resolves.toBe("/second");
   });
 
+  it("preserves per-call env outside the snapshot allowlist", async () => {
+    const bash = resolveBashForTest();
+    if (!bash) {
+      return;
+    }
+
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-plugin-env-home-"));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-plugin-env-state-"));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-plugin-env-cwd-"));
+    tempDirs.push(home, stateDir, cwd);
+    setSnapshotStateForTest(stateDir, { home });
+    fs.writeFileSync(path.join(home, ".bashrc"), "alias oc_snapshot_alias='printf alias-ok'\n");
+
+    const env = {
+      ...process.env,
+      HOME: home,
+      OPENCLAW_STATE_DIR: stateDir,
+      PLUGIN_SAFE: "plugin-ok",
+    };
+    const shellArgs = getPosixShellArgs(bash);
+    const wrapped = await maybeWrapCommandWithShellSnapshot({
+      command: 'oc_snapshot_alias; printf ":%s" "$PLUGIN_SAFE"',
+      shell: bash,
+      shellArgs,
+      cwd,
+      env,
+    });
+    const result = spawnSync(bash, [...shellArgs, wrapped], {
+      cwd,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("alias-ok:plugin-ok");
+  });
+
   it("does not let non-fingerprinted env change captured shell state", async () => {
     const bash = resolveBashForTest();
     if (!bash) {

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -25,7 +25,7 @@ export type AgentToolWithMeta<TParameters extends TSchema, TResult> = AgentTool<
   prepareBeforeToolCallParams?: (
     params: unknown,
     ctx: { toolCallId?: string; hookContext?: unknown; signal?: AbortSignal },
-  ) => Promise<unknown> | unknown;
+  ) => unknown;
   finalizeBeforeToolCallParams?: (params: unknown, preparedParams: unknown) => unknown;
 };
 

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -42,6 +42,14 @@ type ErasedAgentToolExecute = {
 export type AnyAgentTool = Omit<AgentTool, "execute"> &
   ErasedAgentToolExecute & {
     displaySummary?: string;
+    prepareBeforeToolCallParams?: AgentToolWithMeta<
+      TSchema,
+      unknown
+    >["prepareBeforeToolCallParams"];
+    finalizeBeforeToolCallParams?: AgentToolWithMeta<
+      TSchema,
+      unknown
+    >["finalizeBeforeToolCallParams"];
   };
 
 export function asToolParamsRecord(params: unknown): Record<string, unknown> {

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -22,6 +22,11 @@ export type AgentToolWithMeta<TParameters extends TSchema, TResult> = AgentTool<
   TResult
 > & {
   displaySummary?: string;
+  prepareBeforeToolCallParams?: (
+    params: unknown,
+    ctx: { toolCallId?: string; hookContext?: unknown; signal?: AbortSignal },
+  ) => Promise<unknown> | unknown;
+  finalizeBeforeToolCallParams?: (params: unknown, preparedParams: unknown) => unknown;
 };
 
 type ErasedAgentToolExecute = {

--- a/src/plugins/hook-resolve-exec-env.test.ts
+++ b/src/plugins/hook-resolve-exec-env.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
 import { addStaticTestHooks, addTestHook } from "./hooks.test-helpers.js";
 import { createEmptyPluginRegistry } from "./registry.js";
@@ -12,6 +12,10 @@ const ctx: PluginHookResolveExecEnvContext = {
 };
 
 describe("resolve_exec_env hook", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns an empty env when no handlers are registered", async () => {
     const runner = createHookRunner(createEmptyPluginRegistry());
 
@@ -84,6 +88,38 @@ describe("resolve_exec_env hook", () => {
     ).resolves.toEqual({ HEALTHY_ENV: "ok" });
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining("resolve_exec_env handler from crasher failed"),
+    );
+  });
+
+  it("skips handlers that exceed the default timeout", async () => {
+    vi.useFakeTimers();
+    const logger = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    const registry = createEmptyPluginRegistry();
+    addTestHook({
+      registry,
+      pluginId: "hanging",
+      hookName: "resolve_exec_env",
+      handler: () => new Promise<never>(() => {}),
+      priority: 100,
+    });
+    addTestHook({
+      registry,
+      pluginId: "healthy",
+      hookName: "resolve_exec_env",
+      handler: async () => ({ HEALTHY_ENV: "ok" }),
+      priority: 50,
+    });
+
+    const runner = createHookRunner(registry, { logger });
+    const resultPromise = runner.runResolveExecEnv(
+      { sessionKey: ctx.sessionKey, toolName: "exec", host: "gateway" },
+      ctx,
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(resultPromise).resolves.toEqual({ HEALTHY_ENV: "ok" });
+    expect(logger.error).toHaveBeenCalledWith(
+      "[hooks] resolve_exec_env handler from hanging failed: timed out after 15000ms",
     );
   });
 });

--- a/src/plugins/hook-resolve-exec-env.test.ts
+++ b/src/plugins/hook-resolve-exec-env.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { addStaticTestHooks, addTestHook } from "./hooks.test-helpers.js";
+import { createEmptyPluginRegistry } from "./registry.js";
+import type { PluginHookResolveExecEnvContext } from "./types.js";
+
+const ctx: PluginHookResolveExecEnvContext = {
+  agentId: "agent-1",
+  sessionKey: "agent:agent-1:main",
+  messageProvider: "telegram",
+  channelId: "chat-1",
+};
+
+describe("resolve_exec_env hook", () => {
+  it("returns an empty env when no handlers are registered", async () => {
+    const runner = createHookRunner(createEmptyPluginRegistry());
+
+    await expect(
+      runner.runResolveExecEnv(
+        { sessionKey: ctx.sessionKey, toolName: "exec", host: "gateway" },
+        ctx,
+      ),
+    ).resolves.toEqual({});
+  });
+
+  it("merges env vars from multiple plugins in priority order", async () => {
+    const registry = createEmptyPluginRegistry();
+    addStaticTestHooks<Record<string, string>>(registry, {
+      hookName: "resolve_exec_env",
+      hooks: [
+        {
+          pluginId: "first",
+          priority: 100,
+          result: { SHARED: "first", FIRST_ONLY: "1" },
+        },
+        {
+          pluginId: "second",
+          priority: 50,
+          result: { SHARED: "second", SECOND_ONLY: "2" },
+        },
+      ],
+    });
+    const runner = createHookRunner(registry);
+
+    await expect(
+      runner.runResolveExecEnv(
+        { sessionKey: ctx.sessionKey, toolName: "exec", host: "gateway" },
+        ctx,
+      ),
+    ).resolves.toEqual({
+      FIRST_ONLY: "1",
+      SECOND_ONLY: "2",
+      SHARED: "second",
+    });
+  });
+
+  it("isolates handler errors so other plugins can still contribute env", async () => {
+    const registry = createEmptyPluginRegistry();
+    const logger = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    addTestHook({
+      registry,
+      pluginId: "crasher",
+      hookName: "resolve_exec_env",
+      handler: async () => {
+        throw new Error("plugin failed");
+      },
+      priority: 100,
+    });
+    addTestHook({
+      registry,
+      pluginId: "healthy",
+      hookName: "resolve_exec_env",
+      handler: async () => ({ HEALTHY_ENV: "ok" }),
+      priority: 50,
+    });
+
+    const runner = createHookRunner(registry, { logger });
+
+    await expect(
+      runner.runResolveExecEnv(
+        { sessionKey: ctx.sessionKey, toolName: "exec", host: "gateway" },
+        ctx,
+      ),
+    ).resolves.toEqual({ HEALTHY_ENV: "ok" });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("resolve_exec_env handler from crasher failed"),
+    );
+  });
+});

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -109,7 +109,8 @@ export type PluginHookName =
   | "before_dispatch"
   | "reply_dispatch"
   | "before_install"
-  | "before_agent_run";
+  | "before_agent_run"
+  | "resolve_exec_env";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -150,6 +151,7 @@ export const PLUGIN_HOOK_NAMES = [
   "reply_dispatch",
   "before_install",
   "before_agent_run",
+  "resolve_exec_env",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -982,6 +984,14 @@ export type PluginHookBeforeAgentRunEvent = {
 /** Result type for before_agent_run. Returns pass/block or void (= pass). */
 export type PluginHookBeforeAgentRunResult = InputGateDecision | void;
 
+export type PluginHookResolveExecEnvEvent = {
+  sessionKey?: string;
+  toolName: "exec";
+  host: "gateway" | "sandbox" | "node";
+};
+
+export type PluginHookResolveExecEnvContext = PluginHookAgentContext;
+
 export type PluginHookHandlerMap = {
   agent_turn_prepare: (
     event: PluginAgentTurnPrepareEvent,
@@ -1159,6 +1169,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeAgentRunEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentRunResult> | PluginHookBeforeAgentRunResult;
+  resolve_exec_env: (
+    event: PluginHookResolveExecEnvEvent,
+    ctx: PluginHookResolveExecEnvContext,
+  ) => Promise<Record<string, string> | void> | Record<string, string> | void;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -229,6 +229,7 @@ const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, 
   // logged and the run proceeds without its modifications.
   before_agent_start: 15_000,
   before_prompt_build: 15_000,
+  resolve_exec_env: 15_000,
 };
 
 type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
@@ -1599,7 +1600,7 @@ export function createHookRunner(
       event,
       ctx,
       {
-        mergeResults: (acc, next) => ({ ...(acc ?? {}), ...next }),
+        mergeResults: (acc, next) => (acc ? { ...acc, ...next } : next),
       },
     );
     return result ?? {};

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -90,6 +90,8 @@ import type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookResolveExecEnvContext,
+  PluginHookResolveExecEnvEvent,
 } from "./hook-types.js";
 
 // Re-export types for consumers
@@ -161,6 +163,8 @@ export type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookResolveExecEnvContext,
+  PluginHookResolveExecEnvEvent,
 };
 
 export type HookRunnerLogger = {
@@ -1586,6 +1590,21 @@ export function createHookRunner(
     );
   }
 
+  async function runResolveExecEnv(
+    event: PluginHookResolveExecEnvEvent,
+    ctx: PluginHookResolveExecEnvContext,
+  ): Promise<Record<string, string>> {
+    const result = await runModifyingHook<"resolve_exec_env", Record<string, string>>(
+      "resolve_exec_env",
+      event,
+      ctx,
+      {
+        mergeResults: (acc, next) => ({ ...(acc ?? {}), ...next }),
+      },
+    );
+    return result ?? {};
+  }
+
   // =========================================================================
   // Utility
   // =========================================================================
@@ -1649,6 +1668,7 @@ export function createHookRunner(
     runCronChanged,
     // Install hooks
     runBeforeInstall,
+    runResolveExecEnv,
     // Utility
     hasHooks,
     getHookCount,


### PR DESCRIPTION
## Summary

- Add a typed `resolve_exec_env` plugin hook for plugin-contributed `exec` environment variables.
- Wire the hook into `exec` for gateway, sandbox, and node-host execution with host-env key filtering.
- Include filtered plugin env in gateway approval-visible `requestedEnv` and node-host request metadata.
- Document the hook and add focused hook-runner plus exec wiring tests.

This revives the upstreamable core of #72797 only. Sender/chat context and MCP stdio env propagation are intentionally left for follow-up PRs.

## Verification

- `pnpm docs:list`
- `pnpm exec oxfmt --write --threads=1 docs/plugins/hooks.md src/agents/bash-tools.exec.ts src/agents/bash-tools.exec.resolve-env-hook.test.ts src/plugins/hook-types.ts src/plugins/hooks.ts src/plugins/hook-resolve-exec-env.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs src/plugins/hook-resolve-exec-env.test.ts src/agents/bash-tools.exec.resolve-env-hook.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: plugins can contribute filtered environment variables to `exec` through a typed `resolve_exec_env` hook, and those variables are visible to execution plus approval/node metadata.
Real environment tested: local macOS checkout worktree with Node/Vitest wrapper.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/hook-resolve-exec-env.test.ts src/agents/bash-tools.exec.resolve-env-hook.test.ts`.
Evidence after fix: focused tests passed, including gateway execution env, gateway approval-visible `requestedEnv`, node-host request forwarding, hook merge order, and handler error isolation.
Observed result after fix: 3 test files passed, 7 tests passed.
What was not tested: no live external channel plugin was run; sender/chat context and MCP stdio env propagation are not part of this PR.
