### PR TITLE
fix(agents): project nullable tool schemas for providers

### DIFF
--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -1,3 +1,4 @@
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import type { Tool } from "./types.js";
 import { validateToolArguments } from "./validation.js";
@@ -15,6 +16,20 @@ const decimalTool = {
     additionalProperties: false,
   },
 } as Tool;
+
+const nullableTypeBoxTool = {
+  name: "nullable-typebox-tool",
+  description: "test nullable TypeBox tool",
+  parameters: Type.Object({
+    agentId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    toolsAllow: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
+    nested: Type.Optional(
+      Type.Object({
+        sessionKey: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+      }),
+    ),
+  }),
+} satisfies Tool;
 
 describe("validateToolArguments", () => {
   it("coerces strict decimal numeric strings for plain JSON schemas", () => {
@@ -37,5 +52,24 @@ describe("validateToolArguments", () => {
         arguments: { amount: "0x10", count: "0b10" },
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
+  });
+
+  it("preserves explicit null values accepted by TypeBox unions", () => {
+    expect(
+      validateToolArguments(nullableTypeBoxTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "nullable-typebox-tool",
+        arguments: {
+          agentId: null,
+          toolsAllow: null,
+          nested: { sessionKey: null },
+        },
+      }),
+    ).toEqual({
+      agentId: null,
+      toolsAllow: null,
+      nested: { sessionKey: null },
+    });
   });
 });

--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -31,6 +31,20 @@ const nullableTypeBoxTool = {
   }),
 } satisfies Tool;
 
+const plainJsonUnionTool = {
+  name: "plain-json-union-tool",
+  description: "test plain JSON schema unions",
+  parameters: {
+    type: "object",
+    properties: {
+      amount: { anyOf: [{ type: "number" }, { type: "string" }] },
+      clearedAt: { anyOf: [{ type: "number" }, { type: "null" }] },
+    },
+    required: ["amount", "clearedAt"],
+    additionalProperties: false,
+  },
+} as Tool;
+
 describe("validateToolArguments", () => {
   it("coerces strict decimal numeric strings for plain JSON schemas", () => {
     expect(
@@ -71,5 +85,16 @@ describe("validateToolArguments", () => {
       toolsAllow: null,
       nested: { sessionKey: null },
     });
+  });
+
+  it("keeps ordered coercion for non-null plain JSON union values", () => {
+    expect(
+      validateToolArguments(plainJsonUnionTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "plain-json-union-tool",
+        arguments: { amount: "3.5", clearedAt: null },
+      }),
+    ).toEqual({ amount: 3.5, clearedAt: null });
   });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -205,6 +205,13 @@ function applySchemaArrayCoercion(value: unknown[], schema: JsonSchemaObject): v
 
 function coerceWithUnionSchema(value: unknown, schemas: JsonSchemaObject[]): unknown {
   for (const schema of schemas) {
+    const validator = getSubSchemaValidator(schema);
+    if (validator?.Check(value)) {
+      return value;
+    }
+  }
+
+  for (const schema of schemas) {
     const candidate = structuredClone(value);
     const coerced = coerceWithJsonSchema(candidate, schema);
     const validator = getSubSchemaValidator(schema);

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -204,10 +204,12 @@ function applySchemaArrayCoercion(value: unknown[], schema: JsonSchemaObject): v
 }
 
 function coerceWithUnionSchema(value: unknown, schemas: JsonSchemaObject[]): unknown {
-  for (const schema of schemas) {
-    const validator = getSubSchemaValidator(schema);
-    if (validator?.Check(value)) {
-      return value;
+  if (value === null) {
+    for (const schema of schemas) {
+      const validator = getSubSchemaValidator(schema);
+      if (validator?.Check(value)) {
+        return value;
+      }
     }
   }
 

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -82,6 +82,69 @@ describe("runtime tool input schema projection", () => {
     ).toEqual([]);
   });
 
+  it("projects nullable and literal unions to OpenAPI-friendly provider schemas", () => {
+    expect(
+      projectRuntimeToolInputSchema({
+        type: "object",
+        properties: {
+          agentId: {
+            anyOf: [{ type: "string" }, { type: "null" }],
+            description: "Agent id, or null to clear",
+          },
+          toolsAllow: {
+            anyOf: [{ type: "array", items: { type: "string" } }, { type: "null" }],
+            description: "Allowed tools, or null to clear",
+          },
+          mode: {
+            anyOf: [
+              { type: "string", const: "announce" },
+              { type: "string", const: "webhook" },
+              { type: "null" },
+            ],
+          },
+          singleLiteral: {
+            anyOf: [{ type: "string", const: "last" }, { type: "null" }],
+          },
+          flexibleId: {
+            anyOf: [{ type: "string", const: "last" }, { type: "string" }, { type: "null" }],
+          },
+          threadId: {
+            anyOf: [{ type: "string" }, { type: "number" }, { type: "null" }],
+            description: "Thread/topic id",
+          },
+        },
+      }).schema,
+    ).toEqual({
+      type: "object",
+      properties: {
+        agentId: {
+          type: "string",
+          description: "Agent id, or null to clear",
+        },
+        toolsAllow: {
+          type: "array",
+          items: { type: "string" },
+          description: "Allowed tools, or null to clear",
+        },
+        mode: {
+          type: "string",
+          enum: ["announce", "webhook"],
+        },
+        singleLiteral: {
+          type: "string",
+          enum: ["last"],
+        },
+        flexibleId: {
+          type: "string",
+        },
+        threadId: {
+          type: "string",
+          description: "Thread/topic id",
+        },
+      },
+    });
+  });
+
   it("filters unsupported schemas without dropping healthy tools", () => {
     const healthy = {
       name: "healthy",

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -135,10 +135,10 @@ describe("runtime tool input schema projection", () => {
           enum: ["last"],
         },
         flexibleId: {
-          type: "string",
+          anyOf: [{ type: "string", const: "last" }, { type: "string" }],
         },
         threadId: {
-          type: "string",
+          anyOf: [{ type: "string" }, { type: "number" }],
           description: "Thread/topic id",
         },
       },
@@ -158,6 +158,7 @@ describe("runtime tool input schema projection", () => {
     expect(projectRuntimeToolInputSchema(hiddenByProjection.parameters)).toEqual({
       schema: {
         type: "object",
+        anyOf: [{ $dynamicRef: "#target" }, { type: "string" }],
         properties: {},
       },
       violations: ["parameters.anyOf[0].$dynamicRef"],

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -145,6 +145,35 @@ describe("runtime tool input schema projection", () => {
     });
   });
 
+  it("reports dynamic JSON Schema keywords before provider projection", () => {
+    const hiddenByProjection = {
+      name: "fuzzplugin_dynamic_ref_union",
+      parameters: {
+        type: "object",
+        anyOf: [{ $dynamicRef: "#target" }, { type: "string" }],
+        properties: {},
+      },
+    };
+
+    expect(projectRuntimeToolInputSchema(hiddenByProjection.parameters)).toEqual({
+      schema: {
+        type: "object",
+        properties: {},
+      },
+      violations: ["parameters.anyOf[0].$dynamicRef"],
+    });
+    expect(filterRuntimeCompatibleTools([hiddenByProjection])).toEqual({
+      tools: [],
+      diagnostics: [
+        {
+          toolName: "fuzzplugin_dynamic_ref_union",
+          toolIndex: 0,
+          violations: ["fuzzplugin_dynamic_ref_union.parameters.anyOf[0].$dynamicRef"],
+        },
+      ],
+    });
+  });
+
   it("filters unsupported schemas without dropping healthy tools", () => {
     const healthy = {
       name: "healthy",

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -132,9 +132,85 @@ function serializeToolInputSchema(value: unknown, path: string): RuntimeToolInpu
     };
   }
   return {
-    schema: parsed,
+    schema: normalizeProviderToolInputSchema(parsed),
     violations: [],
   };
+}
+
+function isNullSchema(schema: RuntimeToolInputSchemaJson): boolean {
+  return isJsonObject(schema) && schema.type === "null";
+}
+
+function isStringConstSchema(
+  schema: RuntimeToolInputSchemaJson,
+): schema is { type: "string"; const: string } {
+  return isJsonObject(schema) && schema.type === "string" && typeof schema.const === "string";
+}
+
+function mergeCompositionWrapper(
+  wrapper: { [key: string]: RuntimeToolInputSchemaJson },
+  replacement: { [key: string]: RuntimeToolInputSchemaJson },
+  keyword: "anyOf" | "oneOf",
+): { [key: string]: RuntimeToolInputSchemaJson } {
+  const { [keyword]: _composition, ...metadata } = wrapper;
+  return {
+    ...replacement,
+    ...metadata,
+  };
+}
+
+function normalizeSchemaComposition(
+  schema: { [key: string]: RuntimeToolInputSchemaJson },
+  keyword: "anyOf" | "oneOf",
+): { [key: string]: RuntimeToolInputSchemaJson } | undefined {
+  const variants = schema[keyword];
+  if (!Array.isArray(variants)) {
+    return undefined;
+  }
+  const hasNullVariant = variants.some(isNullSchema);
+  const nonNullVariants = variants.filter((variant) => !isNullSchema(variant));
+  if (nonNullVariants.length === 0) {
+    return undefined;
+  }
+  if (nonNullVariants.every(isStringConstSchema)) {
+    return mergeCompositionWrapper(
+      schema,
+      {
+        type: "string",
+        enum: nonNullVariants.map((variant) => variant.const),
+      },
+      keyword,
+    );
+  }
+  if (hasNullVariant && nonNullVariants.length === 1 && isJsonObject(nonNullVariants[0])) {
+    return mergeCompositionWrapper(schema, nonNullVariants[0], keyword);
+  }
+  const stringVariant = nonNullVariants.find(
+    (variant) => isJsonObject(variant) && variant.type === "string" && !("const" in variant),
+  );
+  if (stringVariant !== undefined && isJsonObject(stringVariant)) {
+    return mergeCompositionWrapper(schema, stringVariant, keyword);
+  }
+  return undefined;
+}
+
+function normalizeProviderToolInputSchema(
+  schema: RuntimeToolInputSchemaJson,
+): RuntimeToolInputSchemaJson {
+  if (Array.isArray(schema)) {
+    return schema.map(normalizeProviderToolInputSchema);
+  }
+  if (!isJsonObject(schema)) {
+    return schema;
+  }
+  const normalized = Object.fromEntries(
+    Object.entries(schema).map(([key, value]) => [key, normalizeProviderToolInputSchema(value)]),
+  );
+  return (
+    normalizeSchemaComposition(normalized, "anyOf") ??
+    normalizeSchemaComposition(normalized, "oneOf") ??
+    normalized
+  );
 }
 
 function findDynamicSchemaKeywordViolations(

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -190,11 +190,14 @@ function normalizeSchemaComposition(
   if (hasNullVariant && nonNullVariants.length === 1 && isJsonObject(nonNullVariants[0])) {
     return mergeCompositionWrapper(schema, nonNullVariants[0], keyword);
   }
-  const stringVariant = nonNullVariants.find(
-    (variant) => isJsonObject(variant) && variant.type === "string" && !("const" in variant),
-  );
-  if (stringVariant !== undefined && isJsonObject(stringVariant)) {
-    return mergeCompositionWrapper(schema, stringVariant, keyword);
+  if (hasNullVariant) {
+    return mergeCompositionWrapper(
+      schema,
+      {
+        [keyword]: nonNullVariants,
+      },
+      keyword,
+    );
   }
   return undefined;
 }

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -24,6 +24,11 @@ export type RuntimeToolSchemaInspection<TTool extends Pick<AnyAgentTool, "name" 
   readonly diagnostics: readonly RuntimeToolSchemaDiagnostic[];
 };
 
+type SerializedToolInputSchema = {
+  readonly schema: RuntimeToolInputSchemaJson;
+  readonly violations: readonly string[];
+};
+
 type RuntimeToolEntryRead<TTool extends Pick<AnyAgentTool, "name" | "parameters">> =
   | {
       readonly ok: true;
@@ -108,7 +113,7 @@ function isJsonObject(value: RuntimeToolInputSchemaJson): value is {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function serializeToolInputSchema(value: unknown, path: string): RuntimeToolInputSchemaProjection {
+function serializeToolInputSchema(value: unknown, path: string): SerializedToolInputSchema {
   let text: string | undefined;
   try {
     text = JSON.stringify(value);
@@ -132,7 +137,7 @@ function serializeToolInputSchema(value: unknown, path: string): RuntimeToolInpu
     };
   }
   return {
-    schema: normalizeProviderToolInputSchema(parsed),
+    schema: parsed,
     violations: [],
   };
 }
@@ -261,16 +266,16 @@ export function projectRuntimeToolInputSchema(
   schema: unknown,
   path = "parameters",
 ): RuntimeToolInputSchemaProjection {
-  const projection = serializeToolInputSchema(schema, path);
-  const violations = [...projection.violations];
-  if (!isJsonObject(projection.schema)) {
+  const serialized = serializeToolInputSchema(schema, path);
+  const violations = [...serialized.violations];
+  if (!isJsonObject(serialized.schema)) {
     violations.push(`${path} must be a JSON object schema`);
-  } else if (projection.schema.type !== undefined && projection.schema.type !== "object") {
+  } else if (serialized.schema.type !== undefined && serialized.schema.type !== "object") {
     violations.push(`${path}.type must be "object"`);
   }
-  violations.push(...findDynamicSchemaKeywordViolations(projection.schema, path));
+  violations.push(...findDynamicSchemaKeywordViolations(serialized.schema, path));
   return {
-    schema: projection.schema,
+    schema: normalizeProviderToolInputSchema(serialized.schema),
     violations,
   };
 }

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -1,3 +1,4 @@
+import { validateToolArguments, type Tool } from "openclaw/plugin-sdk/llm";
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import { normalizeToolParameterSchema } from "../agent-tools.schema.js";
@@ -31,6 +32,11 @@ describe("CronToolSchema", () => {
   const providerSchemaRecord = normalizeToolParameterSchema(createCronToolSchema(), {
     modelProvider: "gemini",
   }) as unknown as Record<string, unknown>;
+  const cronTool = {
+    name: "cron",
+    description: "Manage scheduled jobs",
+    parameters: CronToolSchema,
+  } satisfies Tool;
 
   // Regression: models like GPT-5.4 rely on these fields to populate job/patch.
   // If a field is removed from this list the test must be updated intentionally.
@@ -248,13 +254,48 @@ describe("CronToolSchema", () => {
     expect(patchProps?.payload?.properties?.toolsAllow?.description).toMatch(/null to clear/i);
   });
 
+  it("raw validation preserves null clear sentinels before provider projection", () => {
+    const validated = validateToolArguments(cronTool, {
+      type: "toolCall",
+      id: "call-1",
+      name: "cron",
+      arguments: {
+        action: "update",
+        id: "job-1",
+        patch: {
+          agentId: null,
+          sessionKey: null,
+          payload: {
+            kind: "agentTurn",
+            message: "refresh status",
+            toolsAllow: null,
+          },
+        },
+      },
+    }) as {
+      patch: {
+        agentId: unknown;
+        sessionKey: unknown;
+        payload: { toolsAllow: unknown };
+      };
+    };
+
+    expect(validated.patch.agentId).toBeNull();
+    expect(validated.patch.sessionKey).toBeNull();
+    expect(validated.patch.payload.toolsAllow).toBeNull();
+  });
+
   // Regression guard: ensure no OpenAPI 3.0 incompatible keywords leak into the
   // serialized provider-facing cron tool schema.
-  it("serialized provider schema contains no type-array or not/const keywords", () => {
+  it("serialized provider schema contains no OpenAPI 3.0 incompatible null keywords", () => {
     const json = JSON.stringify(providerSchemaRecord);
     // type arrays like ["string","null"] are not valid in OpenAPI 3.0
     expect(json).not.toMatch(/"type"\s*:\s*\[/);
+    // null-type composition is also rejected by strict OpenAPI 3.0 tool adapters.
+    expect(json).not.toMatch(/"type"\s*:\s*"null"/);
     // The "not" composition keyword is not supported by OpenAPI 3.0.
     expect(json).not.toMatch(/"not"\s*:\s*\{/);
+    // "const" is not part of the OpenAPI 3.0 schema subset.
+    expect(json).not.toMatch(/"const"\s*:/);
   });
 });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../config/sessions/delivery-info.js", () => ({
 }));
 
 import { buildAgentPeerSessionKey } from "../../routing/session-key.js";
+import { projectRuntimeToolInputSchema } from "../tool-schema-projection.js";
 import { createCronTool } from "./cron-tool.js";
 
 describe("cron tool", () => {
@@ -465,9 +466,21 @@ describe("cron tool", () => {
     expect(patchThreadId?.anyOf?.map((entry) => entry.type)).toEqual(["string", "number", "null"]);
   });
 
-  it("advertises nullable cron update clears in the tool schema", () => {
+  it("does not share mutable schema objects across cron tool instances", () => {
+    const first = createTestCronTool().parameters as SchemaLike;
+    const second = createTestCronTool().parameters as SchemaLike;
+
+    expect(first).not.toBe(second);
+    expect(first.properties?.patch).not.toBe(second.properties?.patch);
+    expect(first.properties?.patch?.properties?.agentId).not.toBe(
+      second.properties?.patch?.properties?.agentId,
+    );
+  });
+
+  it("advertises provider-compatible nullable cron update clears in the tool schema", () => {
     const tool = createTestCronTool();
-    const parameters = tool.parameters as SchemaLike;
+    const parameters = projectRuntimeToolInputSchema(tool.parameters, "cron.parameters")
+      .schema as SchemaLike;
     const jobDelivery = parameters.properties?.job?.properties?.delivery;
     const patch = parameters.properties?.patch;
     const payload = patch?.properties?.payload;
@@ -477,34 +490,20 @@ describe("cron tool", () => {
     expect(jobDelivery?.properties?.channel?.type).toBe("string");
     expect(jobDelivery?.properties?.failureDestination?.anyOf).toBeUndefined();
     expect(jobDelivery?.properties?.failureDestination?.type).toBe("object");
-    expect(patch?.properties?.agentId?.anyOf?.map((entry) => entry.type)).toEqual([
-      "string",
-      "null",
-    ]);
-    expect(patch?.properties?.agentId?.type).toBeUndefined();
+    expect(patch?.properties?.agentId?.anyOf).toBeUndefined();
+    expect(patch?.properties?.agentId?.type).toBe("string");
     expect(patch?.properties?.agentId?.description).toContain("null to clear");
-    expect(patch?.properties?.sessionKey?.anyOf?.map((entry) => entry.type)).toEqual([
-      "string",
-      "null",
-    ]);
-    expect(patch?.properties?.sessionKey?.type).toBeUndefined();
+    expect(patch?.properties?.sessionKey?.anyOf).toBeUndefined();
+    expect(patch?.properties?.sessionKey?.type).toBe("string");
     expect(patch?.properties?.sessionKey?.description).toContain("null to clear");
-    expect(payload?.properties?.toolsAllow?.anyOf?.map((entry) => entry.type)).toEqual([
-      "array",
-      "null",
-    ]);
-    expect(payload?.properties?.toolsAllow?.type).toBeUndefined();
+    expect(payload?.properties?.toolsAllow?.anyOf).toBeUndefined();
+    expect(payload?.properties?.toolsAllow?.type).toBe("array");
     expect(payload?.properties?.toolsAllow?.description).toContain("null to clear");
-    expect(delivery?.properties?.channel?.anyOf?.map((entry) => entry.type)).toEqual([
-      "string",
-      "null",
-    ]);
-    expect(delivery?.properties?.channel?.type).toBeUndefined();
+    expect(delivery?.properties?.channel?.anyOf).toBeUndefined();
+    expect(delivery?.properties?.channel?.type).toBe("string");
     expect(delivery?.properties?.channel?.description).toContain("null to clear");
-    expect(delivery?.properties?.failureDestination?.anyOf?.map((entry) => entry.type)).toEqual([
-      "object",
-      "null",
-    ]);
+    expect(delivery?.properties?.failureDestination?.anyOf).toBeUndefined();
+    expect(delivery?.properties?.failureDestination?.type).toBe("object");
   });
 
   it.each([

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -183,15 +183,8 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to keep it unset"
+              "description": "Agent id, or null to keep it unset",
+              "type": "string"
             },
             "deleteAfterRun": {
               "description": "Delete after first run",
@@ -223,16 +216,8 @@
                       "type": "string"
                     },
                     "mode": {
-                      "anyOf": [
-                        {
-                          "const": "announce",
-                          "type": "string"
-                        },
-                        {
-                          "const": "webhook",
-                          "type": "string"
-                        }
-                      ]
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
                     },
                     "to": {
                       "description": "Failure delivery target",
@@ -247,15 +232,8 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -401,15 +379,8 @@
               "type": "object"
             },
             "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
+              "description": "Explicit session key, or null to clear it",
+              "type": "string"
             },
             "sessionTarget": {
               "description": "main | isolated | current | session:<id>",
@@ -434,15 +405,8 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to clear it"
+              "description": "Agent id, or null to clear it",
+              "type": "string"
             },
             "deleteAfterRun": {
               "type": "boolean"
@@ -451,91 +415,38 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery account, or null to clear"
+                  "description": "Delivery account, or null to clear",
+                  "type": "string"
                 },
                 "bestEffort": {
                   "type": "boolean"
                 },
                 "channel": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery channel, or null to clear"
+                  "description": "Delivery channel, or null to clear",
+                  "type": "string"
                 },
                 "failureDestination": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery account, or null to clear"
-                        },
-                        "channel": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery channel, or null to clear"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery target, or null to clear"
-                        }
-                      },
-                      "type": "object"
+                  "additionalProperties": true,
+                  "description": "Failure destination, or null to clear",
+                  "properties": {
+                    "accountId": {
+                      "description": "Failure delivery account, or null to clear",
+                      "type": "string"
                     },
-                    {
-                      "type": "null"
+                    "channel": {
+                      "description": "Failure delivery channel, or null to clear",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Failure delivery target, or null to clear",
+                      "type": "string"
                     }
-                  ],
-                  "description": "Failure destination, or null to clear"
+                  },
+                  "type": "object"
                 },
                 "mode": {
                   "description": "Delivery mode",
@@ -543,29 +454,12 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery target, or null to clear"
+                  "description": "Delivery target, or null to clear",
+                  "type": "string"
                 }
               },
               "type": "object"
@@ -658,18 +552,11 @@
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "anyOf": [
-                    {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Allowed tool ids, or null to clear"
+                  "description": "Allowed tool ids, or null to clear",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "type": "object"
@@ -713,15 +600,8 @@
               "type": "object"
             },
             "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
+              "description": "Explicit session key, or null to clear it",
+              "type": "string"
             },
             "sessionTarget": {
               "description": "Session target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -232,8 +232,15 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "description": "Thread/topic id",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ],
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -454,8 +461,15 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "description": "Thread/topic id",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ],
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target, or null to clear",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -183,15 +183,8 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to keep it unset"
+              "description": "Agent id, or null to keep it unset",
+              "type": "string"
             },
             "deleteAfterRun": {
               "description": "Delete after first run",
@@ -223,16 +216,8 @@
                       "type": "string"
                     },
                     "mode": {
-                      "anyOf": [
-                        {
-                          "const": "announce",
-                          "type": "string"
-                        },
-                        {
-                          "const": "webhook",
-                          "type": "string"
-                        }
-                      ]
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
                     },
                     "to": {
                       "description": "Failure delivery target",
@@ -247,15 +232,8 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -401,15 +379,8 @@
               "type": "object"
             },
             "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
+              "description": "Explicit session key, or null to clear it",
+              "type": "string"
             },
             "sessionTarget": {
               "description": "main | isolated | current | session:<id>",
@@ -434,15 +405,8 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to clear it"
+              "description": "Agent id, or null to clear it",
+              "type": "string"
             },
             "deleteAfterRun": {
               "type": "boolean"
@@ -451,91 +415,38 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery account, or null to clear"
+                  "description": "Delivery account, or null to clear",
+                  "type": "string"
                 },
                 "bestEffort": {
                   "type": "boolean"
                 },
                 "channel": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery channel, or null to clear"
+                  "description": "Delivery channel, or null to clear",
+                  "type": "string"
                 },
                 "failureDestination": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery account, or null to clear"
-                        },
-                        "channel": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery channel, or null to clear"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery target, or null to clear"
-                        }
-                      },
-                      "type": "object"
+                  "additionalProperties": true,
+                  "description": "Failure destination, or null to clear",
+                  "properties": {
+                    "accountId": {
+                      "description": "Failure delivery account, or null to clear",
+                      "type": "string"
                     },
-                    {
-                      "type": "null"
+                    "channel": {
+                      "description": "Failure delivery channel, or null to clear",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Failure delivery target, or null to clear",
+                      "type": "string"
                     }
-                  ],
-                  "description": "Failure destination, or null to clear"
+                  },
+                  "type": "object"
                 },
                 "mode": {
                   "description": "Delivery mode",
@@ -543,29 +454,12 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery target, or null to clear"
+                  "description": "Delivery target, or null to clear",
+                  "type": "string"
                 }
               },
               "type": "object"
@@ -658,18 +552,11 @@
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "anyOf": [
-                    {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Allowed tool ids, or null to clear"
+                  "description": "Allowed tool ids, or null to clear",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "type": "object"
@@ -713,15 +600,8 @@
               "type": "object"
             },
             "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
+              "description": "Explicit session key, or null to clear it",
+              "type": "string"
             },
             "sessionTarget": {
               "description": "Session target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -232,8 +232,15 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "description": "Thread/topic id",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ],
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -454,8 +461,15 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "description": "Thread/topic id",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ],
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target, or null to clear",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -183,15 +183,8 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to keep it unset"
+              "description": "Agent id, or null to keep it unset",
+              "type": "string"
             },
             "deleteAfterRun": {
               "description": "Delete after first run",
@@ -223,16 +216,8 @@
                       "type": "string"
                     },
                     "mode": {
-                      "anyOf": [
-                        {
-                          "const": "announce",
-                          "type": "string"
-                        },
-                        {
-                          "const": "webhook",
-                          "type": "string"
-                        }
-                      ]
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
                     },
                     "to": {
                       "description": "Failure delivery target",
@@ -247,15 +232,8 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -401,15 +379,8 @@
               "type": "object"
             },
             "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
+              "description": "Explicit session key, or null to clear it",
+              "type": "string"
             },
             "sessionTarget": {
               "description": "main | isolated | current | session:<id>",
@@ -434,15 +405,8 @@
           "additionalProperties": true,
           "properties": {
             "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to clear it"
+              "description": "Agent id, or null to clear it",
+              "type": "string"
             },
             "deleteAfterRun": {
               "type": "boolean"
@@ -451,91 +415,38 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery account, or null to clear"
+                  "description": "Delivery account, or null to clear",
+                  "type": "string"
                 },
                 "bestEffort": {
                   "type": "boolean"
                 },
                 "channel": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery channel, or null to clear"
+                  "description": "Delivery channel, or null to clear",
+                  "type": "string"
                 },
                 "failureDestination": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery account, or null to clear"
-                        },
-                        "channel": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery channel, or null to clear"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery target, or null to clear"
-                        }
-                      },
-                      "type": "object"
+                  "additionalProperties": true,
+                  "description": "Failure destination, or null to clear",
+                  "properties": {
+                    "accountId": {
+                      "description": "Failure delivery account, or null to clear",
+                      "type": "string"
                     },
-                    {
-                      "type": "null"
+                    "channel": {
+                      "description": "Failure delivery channel, or null to clear",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Failure delivery target, or null to clear",
+                      "type": "string"
                     }
-                  ],
-                  "description": "Failure destination, or null to clear"
+                  },
+                  "type": "object"
                 },
                 "mode": {
                   "description": "Delivery mode",
@@ -543,29 +454,12 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Thread/topic id"
+                  "description": "Thread/topic id",
+                  "type": "string"
                 },
                 "to": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery target, or null to clear"
+                  "description": "Delivery target, or null to clear",
+                  "type": "string"
                 }
               },
               "type": "object"
@@ -658,18 +552,11 @@
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "anyOf": [
-                    {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Allowed tool ids, or null to clear"
+                  "description": "Allowed tool ids, or null to clear",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "type": "object"
@@ -713,15 +600,8 @@
               "type": "object"
             },
             "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
+              "description": "Explicit session key, or null to clear it",
+              "type": "string"
             },
             "sessionTarget": {
               "description": "Session target",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -232,8 +232,15 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "description": "Thread/topic id",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ],
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -454,8 +461,15 @@
                   "type": "string"
                 },
                 "threadId": {
-                  "description": "Thread/topic id",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ],
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target, or null to clear",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44128,
-    "roughTokens": 11032
+    "chars": 40904,
+    "roughTokens": 10226
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71830,
-    "roughTokens": 17958
+    "chars": 68606,
+    "roughTokens": 17152
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40904,
-    "roughTokens": 10226
+    "chars": 41266,
+    "roughTokens": 10317
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68606,
-    "roughTokens": 17152
+    "chars": 68968,
+    "roughTokens": 17242
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 43849,
-    "roughTokens": 10963
+    "chars": 40625,
+    "roughTokens": 10157
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 70027,
-    "roughTokens": 17507
+    "chars": 66803,
+    "roughTokens": 16701
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40625,
-    "roughTokens": 10157
+    "chars": 40987,
+    "roughTokens": 10247
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66803,
-    "roughTokens": 16701
+    "chars": 67165,
+    "roughTokens": 16792
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44944,
-    "roughTokens": 11236
+    "chars": 41720,
+    "roughTokens": 10430
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72065,
-    "roughTokens": 18017
+    "chars": 68841,
+    "roughTokens": 17211
   },
   "userInputText": {
     "chars": 1367,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41720,
-    "roughTokens": 10430
+    "chars": 42082,
+    "roughTokens": 10521
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68841,
-    "roughTokens": 17211
+    "chars": 69203,
+    "roughTokens": 17301
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary

- project nullable and string-literal tool schemas into provider-compatible shapes before sending runtime tool schemas to providers
- keep unsupported dynamic-schema diagnostics on the raw serialized schema so projection cannot hide a blocker
- preserve explicit `null` clear sentinels during raw argument validation before provider projection
- preserve non-null union branches when dropping nullable variants, instead of narrowing mixed unions to `string`
- refresh only the prompt snapshots affected by the provider-facing dynamic tool schema

## Verification

Reviewed/proved local head: `8aeaadf963a`  
Reviewed/proved base: `db4990d2605`  
Current note: `origin/main` advanced again after the final review; GitHub CI/mergeability should arbitrate the pushed branch against the newest base.

- `node scripts/run-vitest.mjs packages/llm-core/src/validation.test.ts src/agents/tool-schema-projection.test.ts src/agents/tools/cron-tool.schema.test.ts src/agents/tools/cron-tool.test.ts --reporter=dot` - passed 3 shards / 118 tests
- `node --import tsx scripts/generate-prompt-snapshots.ts --check` - passed, `Prompt snapshots are current (7 files).`
- `node_modules/.bin/oxfmt --check --threads=1 packages/llm-core/src/validation.test.ts packages/llm-core/src/validation.ts src/agents/tool-schema-projection.test.ts src/agents/tool-schema-projection.ts src/agents/tools/cron-tool.schema.test.ts src/agents/tools/cron-tool.test.ts` - passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json packages/llm-core/src/validation.test.ts packages/llm-core/src/validation.ts src/agents/tool-schema-projection.test.ts src/agents/tool-schema-projection.ts src/agents/tools/cron-tool.schema.test.ts src/agents/tools/cron-tool.test.ts` - passed
- `git diff --check origin/main...HEAD` - passed on the reviewed base
- private reported-name scrub across the spec, changed TS files, and prompt snapshots - clean
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt 'Review the pruned provider/runtime tool schema projection hardening branch after rebasing onto latest main. Focus only on actionable regressions in provider-facing schema projection, raw validation preservation, non-null union preservation, and prompt snapshot correctness. Do not inspect external repositories unless essential.'` - clean, no accepted/actionable findings, `overall: patch is correct (0.76)`

## Real behavior proof

Behavior addressed: Provider-facing runtime tool schema projection no longer leaks nullable OpenAPI-incompatible shapes for covered runtime schemas, while raw validation still accepts explicit null clear sentinels and mixed non-null unions remain represented as unions.

Real environment tested: Local OpenClaw Codex/gwt worktree on macOS with shared repo `node_modules`, using the repo Vitest wrapper plus snapshot, format, lint, diff, scrub, and autoreview gates.

Exact steps or command run after this patch: The focused Vitest, prompt snapshot, oxfmt, oxlint, diff-check, private-name scrub, and autoreview commands listed above were run after the final rebase.

Evidence after fix: Focused tests passed 3 shards / 118 tests; prompt snapshots were current; oxfmt, oxlint, and diff-check passed; autoreview reported no accepted/actionable findings.

Observed result after fix: Nullable provider schema branches are projected to provider-compatible schemas, unsupported dynamic keywords are still reported from raw schemas, explicit null clear values validate correctly, and mixed non-null unions are preserved instead of narrowed.

What was not tested: A live provider turn or full `pnpm check:changed` was not run for this narrow PR; GitHub CI is expected to cover the pushed branch against the latest moving `main`.
