### PR TITLE
fix(agents): trim media tools in lean mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - **Exec output sanitization:** remove complete ANSI sequences and render residual C0/C1 controls as visible escapes instead of silently discarding output bytes. (#100327) Thanks @LavyaTandel.
 - **Assistant visible text:** unwrap leaked standalone `<parameter>` tags while preserving their content and literal code/XML examples. (#100302) Thanks @nankingjing.
 - **Android microphone capture:** treat negative `AudioRecord.read` results as fatal shared-session errors so both transcription and Talk capture stop cleanly after device loss. (#100028) Thanks @NianJiuZst.
+- **Lean local-model tools:** trim media generation, TTS, and PDF tools from lean agent surfaces while preserving explicit config and runtime opt-ins. (#88881) Thanks @vincentkoc.
 - **iOS QR gateway handoff:** stop VisionKit before delivering scanned setup codes, and keep deferred auth, approval, Watch, and foreground-node work bound to its originating gateway across reconnects. (#99572) Thanks @PollyBot13.
 - **Agent terminal failures:** surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed.
 - **MCP loopback tool results:** preserve schema-valid text, image, and embedded-resource content through HTTP tool calls while rendering malformed or protocol-incompatible blocks as safe text. (#100336) Thanks @tzy-17.

--- a/docs/concepts/experimental-features.md
+++ b/docs/concepts/experimental-features.md
@@ -85,13 +85,7 @@ For one agent only:
 }
 ```
 
-Restart the Gateway after changing the flag, then confirm the trimmed tool list with:
-
-```bash
-openclaw status --deep
-```
-
-The deep status output lists the active agent tools; `browser`, `cron`, `message`, `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf` should be absent when lean mode is on unless you explicitly preserved them with `tools.allow`.
+Restart the Gateway after changing the flag. `browser`, `cron`, `message`, `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf` are omitted when lean mode is on unless you explicitly preserve them with `tools.allow` or `tools.alsoAllow`.
 
 ## Experimental does not mean hidden
 

--- a/docs/concepts/experimental-features.md
+++ b/docs/concepts/experimental-features.md
@@ -25,19 +25,19 @@ Experimental features are opt-in preview surfaces behind explicit flags. They ne
 
 ## Local model lean mode
 
-`agents.defaults.experimental.localModelLean: true` drops three default tools - `browser`, `cron`, and `message` - from the agent's tool surface every turn. It also defaults to structured Tool Search (`tool_search`, `tool_describe`, `tool_call`) for plugin/MCP/client tool catalogs when `tools.toolSearch` is not already set, so those catalogs stay off the prompt instead of being dumped in. Runs that require direct `message` delivery keep it direct rather than picking up the lean-mode Tool Search default. Use `agents.list[].experimental.localModelLean` to scope this to one agent.
+`agents.defaults.experimental.localModelLean: true` drops heavyweight optional tools from the agent's direct surface every turn: `browser`, `cron`, `message`, `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf`. Explicitly allowed or delivery-required tools remain direct. Lean mode also defaults plugin/MCP/client catalogs to structured Tool Search (`tool_search`, `tool_describe`, `tool_call`) when `tools.toolSearch` is not already set. Use `agents.list[].experimental.localModelLean` to scope this to one agent.
 
 If you already tune Tool Search globally, OpenClaw leaves that config alone. Set `tools.toolSearch: false` to opt out of the lean-mode Tool Search default.
 
-### Why these three tools
+### Why these tools
 
-`browser`, `cron`, and `message` have the largest descriptions and most parameter shapes in the default runtime. On a small-context or stricter OpenAI-compatible backend, that is the difference between:
+These tools have the largest descriptions, broadest parameter shapes, or highest chance of distracting a small model from the normal coding and conversation path. On a small-context or stricter OpenAI-compatible backend that is the difference between:
 
 - Tool schemas fitting the prompt vs. crowding out conversation history.
 - The model picking the right tool vs. emitting malformed tool calls from too many similar schemas.
 - The Chat Completions adapter staying inside structured-output limits vs. a 400 on tool-call payload size.
 
-Removing them only shortens the direct tool list. The model still has `read`, `write`, `edit`, `exec`, `apply_patch`, web search/fetch (when configured), memory, and session/agent tools. Extra catalogs stay reachable through Tool Search unless you set `tools.toolSearch: false`.
+Removing them only shortens the direct tool list. The model still has `read`, `write`, `edit`, `exec`, `apply_patch`, image understanding, web search/fetch (when configured), memory, and session/agent tools. Extra catalogs stay reachable through Tool Search unless you set `tools.toolSearch: false`; explicit tool allows can opt a lean agent back into a trimmed workflow.
 
 ### When to turn it on
 
@@ -85,7 +85,13 @@ For one agent only:
 }
 ```
 
-Restart the Gateway after changing the flag.
+Restart the Gateway after changing the flag, then confirm the trimmed tool list with:
+
+```bash
+openclaw status --deep
+```
+
+The deep status output lists the active agent tools; `browser`, `cron`, `message`, `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf` should be absent when lean mode is on unless you explicitly preserved them with `tools.allow`.
 
 ## Experimental does not mean hidden
 

--- a/docs/concepts/experimental-features.md
+++ b/docs/concepts/experimental-features.md
@@ -25,7 +25,7 @@ Experimental features are opt-in preview surfaces behind explicit flags. They ne
 
 ## Local model lean mode
 
-`agents.defaults.experimental.localModelLean: true` drops heavyweight optional tools from the agent's direct surface every turn: `browser`, `cron`, `message`, `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf`. Explicitly allowed or delivery-required tools remain direct. Lean mode also defaults plugin/MCP/client catalogs to structured Tool Search (`tool_search`, `tool_describe`, `tool_call`) when `tools.toolSearch` is not already set. Use `agents.list[].experimental.localModelLean` to scope this to one agent.
+`agents.defaults.experimental.localModelLean: true` drops heavyweight optional tools from the agent's direct surface every turn: `browser`, `cron`, `message`, `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf`. Explicitly allowed or delivery-required tools remain available, though Tool Search may catalog them instead of exposing them directly. Lean mode also defaults plugin/MCP/client catalogs to structured Tool Search (`tool_search`, `tool_describe`, `tool_call`) when `tools.toolSearch` is not already set. Use `agents.list[].experimental.localModelLean` to scope this to one agent.
 
 If you already tune Tool Search globally, OpenClaw leaves that config alone. Set `tools.toolSearch: false` to opt out of the lean-mode Tool Search default.
 
@@ -85,7 +85,7 @@ For one agent only:
 }
 ```
 
-Restart the Gateway after changing the flag. `browser`, `cron`, `message`, `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf` are omitted when lean mode is on unless you explicitly preserve them with `tools.allow` or `tools.alsoAllow`.
+Restart the Gateway after changing the flag. Lean filtering removes `browser`, `cron`, `message`, `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf` unless you explicitly preserve them with `tools.allow` or `tools.alsoAllow`; Tool Search may still catalog preserved tools instead of exposing them directly.
 
 ## Experimental does not mean hidden
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2339,7 +2339,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Currently documented flags
   - H2: Local model lean mode
-  - H3: Why these three tools
+  - H3: Why these tools
   - H3: When to turn it on
   - H3: When to leave it off
   - H3: Enable

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -263,7 +263,7 @@ If the model loads cleanly but full agent turns misbehave, work top-down: confir
    openclaw infer model run --gateway --model <provider/model> --prompt "Reply with exactly: pong" --json
    ```
 
-3. **Try lean mode** if both probes pass but real agent turns fail with malformed tool calls or oversized prompts: set `agents.defaults.experimental.localModelLean: true`. It drops the three heaviest default tools (`browser`, `cron`, `message` - unless a run must keep direct `message` delivery semantics) and defaults larger tool catalogs behind structured Tool Search controls. See [Experimental Features -> Local model lean mode](/concepts/experimental-features#local-model-lean-mode) for details and how to confirm it's on.
+3. **Try lean mode** if both probes pass but real agent turns fail with malformed tool calls or oversized prompts: set `agents.defaults.experimental.localModelLean: true`. It drops heavyweight browser, cron, message, media-generation, voice, and PDF tools unless explicitly required, and defaults larger tool catalogs behind structured Tool Search controls. See [Experimental Features -> Local model lean mode](/concepts/experimental-features#local-model-lean-mode) for details and how to confirm it's on.
 
 4. **Disable tools entirely as a last resort** by setting `models.providers.<provider>.models[].compat.supportsTools: false` for that model - the agent then runs without tool calls.
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -752,12 +752,12 @@ Replace model IDs with exact names from `ollama list` or
 
     Use `compat.supportsTools: false` only when the model or server reliably
     fails on tool schemas — it trades agent capability for stability.
-    `localModelLean` removes the browser, cron, and message tools from the
-    direct agent surface (message stays if the run needs direct message
-    delivery semantics) and puts larger catalogs behind Tool Search, but does
-    not change Ollama's runtime context or thinking mode. Pair it with
-    `params.num_ctx` and `params.thinking: false` for small Qwen-style
-    thinking models that loop or spend their budget on hidden reasoning.
+    `localModelLean` removes heavyweight browser, cron, message, media-generation,
+    voice, and PDF tools from the direct agent surface unless explicitly required,
+    and puts larger catalogs behind Tool Search. It does not change Ollama's
+    runtime context or thinking mode. Pair it with `params.num_ctx` and
+    `params.thinking: false` for small Qwen-style thinking models that loop or
+    spend their budget on hidden reasoning.
 
   </Accordion>
 </AccordionGroup>

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -1186,6 +1186,24 @@ describe("createCopilotToolBridge", () => {
       expect(result.sourceTools.map((tool) => tool.name).toSorted()).toEqual(["edit", "read"]);
     });
 
+    it("does not discard lean-mode overrides after tool construction", async () => {
+      const result = await createCopilotToolBridge({
+        agentId: "agent-1",
+        attemptParams: {
+          config: {
+            agents: { defaults: { experimental: { localModelLean: true } } },
+            tools: { alsoAllow: ["image_generate"] },
+          },
+        } as never,
+        createOpenClawCodingTools: async () => [makeTool({ name: "image_generate" })],
+        modelId: "gpt-4o",
+        modelProvider: "github-copilot",
+        sessionId: "session-1",
+      });
+
+      expect(result.sourceTools.map((tool) => tool.name)).toEqual(["image_generate"]);
+    });
+
     it("keeps plugin tools for plugin group allowlists", async () => {
       const createOpenClawCodingTools = vi.fn(async () => [
         makeTool({ name: "memory_search", pluginId: "active-memory" } as never),

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -193,6 +193,8 @@ export async function createCopilotToolBridge(
     executeTool: (toolParams) => executeCatalogTool(input, toolParams),
     forceMessageTool: shouldForceCopilotMessageTool(attemptParams),
     isRawModelRun: isCopilotRawModelRun(attemptParams),
+    modelId: input.modelId,
+    modelProvider: input.modelProvider,
     modelToolsEnabled: true,
     prompt: attemptParams.prompt,
     runId: attemptParams.runId,
@@ -231,7 +233,9 @@ export async function createCopilotToolBridge(
     sourceTools as AnyAgentTool[],
     toolSurfaceRuntime.runtimeToolAllowlist,
   );
-  const compactedTools = toolSurfaceRuntime.compactTools(allowedSourceTools);
+  const compactedTools = toolSurfaceRuntime.compactTools(allowedSourceTools, {
+    localModelLeanApplied: true,
+  });
   const plannedTools = filterCopilotToolsForConstructionPlan(
     compactedTools.tools,
     effectiveToolPlan.codingToolConstructionPlan,

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -440,6 +440,55 @@ describe("createOpenClawCodingTools", () => {
     expect(toolNameList(tools)).toContain("message");
   });
 
+  it("preserves configured media tools through local model lean filtering", () => {
+    const tools = createOpenClawCodingTools({
+      config: {
+        agents: {
+          defaults: {
+            experimental: {
+              localModelLean: true,
+            },
+          },
+          list: [
+            {
+              id: "artist",
+              tools: {
+                alsoAllow: ["video_generate"],
+                byProvider: {
+                  ollama: {
+                    alsoAllow: ["tts"],
+                  },
+                },
+              },
+            },
+          ],
+        },
+        tools: {
+          alsoAllow: ["pdf"],
+          byProvider: {
+            "ollama/qwen3.5:9b": {
+              alsoAllow: ["image_generate"],
+            },
+          },
+        },
+      },
+      agentId: "artist",
+      modelProvider: "ollama",
+      modelId: "qwen3.5:9b",
+      toolConstructionPlan: {
+        includeBaseCodingTools: false,
+        includeShellTools: false,
+        includeChannelTools: false,
+        includeOpenClawTools: true,
+        includePluginTools: false,
+      },
+    });
+
+    expect(toolNameList(tools)).toEqual(
+      expect.arrayContaining(["image_generate", "pdf", "tts", "video_generate"]),
+    );
+  });
+
   it("preserves forced message through local model lean filtering without runtime allowlist", () => {
     const tools = createOpenClawCodingTools({
       config: {

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -489,6 +489,34 @@ describe("createOpenClawCodingTools", () => {
     );
   });
 
+  it("does not treat built-in profile tools as lean-mode overrides", () => {
+    const tools = createOpenClawCodingTools({
+      config: {
+        agents: {
+          defaults: {
+            experimental: {
+              localModelLean: true,
+            },
+          },
+        },
+        tools: {
+          profile: "coding",
+        },
+      },
+      toolConstructionPlan: {
+        includeBaseCodingTools: false,
+        includeShellTools: false,
+        includeChannelTools: false,
+        includeOpenClawTools: true,
+        includePluginTools: false,
+      },
+    });
+
+    expect(toolNameList(tools)).not.toEqual(
+      expect.arrayContaining(["image_generate", "video_generate"]),
+    );
+  });
+
   it("preserves forced message through local model lean filtering without runtime allowlist", () => {
     const tools = createOpenClawCodingTools({
       config: {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -639,7 +639,7 @@ export function createOpenClawCodingTools(options?: {
     return normalized === "*" || normalized === "message";
   });
   const localModelLeanPreserveToolNames = resolveLocalModelLeanPreserveToolNames({
-    toolNames: options?.runtimeToolAllowlist,
+    toolNames: capabilityProfile.policy.explicitToolAllowlist,
     forceMessageTool: options?.forceMessageTool,
     sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
   });

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -639,7 +639,7 @@ export function createOpenClawCodingTools(options?: {
     return normalized === "*" || normalized === "message";
   });
   const localModelLeanPreserveToolNames = resolveLocalModelLeanPreserveToolNames({
-    toolNames: capabilityProfile.policy.explicitToolAllowlist,
+    toolNames: capabilityProfile.policy.explicitToolOverrideAllowlist,
     forceMessageTool: options?.forceMessageTool,
     sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
   });

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
@@ -96,6 +99,41 @@ describe("resolveConversationCapabilityProfile", () => {
 
     expect(profile.policy.explicitToolAllowlist).toContain("image_generate");
     expect(profile.policy.explicitToolOverrideAllowlist).toEqual(["pdf"]);
+  });
+
+  it("keeps inherited subagent grants out of explicit overrides", () => {
+    const storePath = path.join(
+      os.tmpdir(),
+      `openclaw-capability-profile-inherited-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+    );
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:subagent:limited": {
+          sessionId: "limited-session",
+          updatedAt: Date.now(),
+          spawnDepth: 1,
+          subagentRole: "orchestrator",
+          subagentControlScope: "children",
+          inheritedToolAllow: ["image_generate"],
+        },
+      }),
+    );
+
+    try {
+      const profile = resolveConversationCapabilityProfile({
+        config: { session: { store: storePath } },
+        sessionKey: "agent:main:subagent:limited",
+        agentId: "main",
+        modelProvider: "ollama",
+        modelId: "qwen3.5:9b",
+      });
+
+      expect(profile.policy.explicitToolAllowlist).toContain("image_generate");
+      expect(profile.policy.explicitToolOverrideAllowlist).not.toContain("image_generate");
+    } finally {
+      fs.rmSync(storePath, { force: true });
+    }
   });
 
   it("does not classify the conversation as shared from a dropped caller group id", () => {

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -82,6 +82,22 @@ describe("resolveConversationCapabilityProfile", () => {
     expect(profile.policy.explicitToolAllowlist).toEqual(["read", "exec"]);
   });
 
+  it("keeps built-in profile grants out of explicit overrides", () => {
+    const profile = resolveConversationCapabilityProfile({
+      config: {
+        tools: {
+          profile: "coding",
+          allow: ["pdf"],
+        },
+      },
+      modelProvider: "ollama",
+      modelId: "qwen3.5:9b",
+    });
+
+    expect(profile.policy.explicitToolAllowlist).toContain("image_generate");
+    expect(profile.policy.explicitToolOverrideAllowlist).toEqual(["pdf"]);
+  });
+
   it("does not classify the conversation as shared from a dropped caller group id", () => {
     // Non-group session key cannot vouch for the caller-supplied group facts:
     // the trust check drops them, so scope must stay unknown instead of

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -166,6 +166,8 @@ export type ResolvedConversationCapabilityProfile = {
     inheritedToolPolicy?: SandboxToolPolicy;
     inheritancePolicies: Array<ToolPolicyLike | undefined>;
     explicitToolAllowlist: string[];
+    /** Explicit config/runtime grants only; excludes built-in profile expansion. */
+    explicitToolOverrideAllowlist: string[];
     explicitToolDenylist: string[];
   };
 };
@@ -236,9 +238,7 @@ export function resolveConversationCapabilityProfile(
       store: subagentStore,
     },
   );
-  const inheritancePolicies = [
-    profilePolicy,
-    providerProfilePolicy,
+  const explicitOverridePolicies = [
     effective.globalPolicy,
     effective.globalProviderPolicy,
     effective.agentPolicy,
@@ -250,6 +250,7 @@ export function resolveConversationCapabilityProfile(
     inheritedToolPolicy,
     params.runtimeToolAllowlist ? { allow: params.runtimeToolAllowlist } : undefined,
   ];
+  const inheritancePolicies = [profilePolicy, providerProfilePolicy, ...explicitOverridePolicies];
 
   return {
     agentId: effective.agentId,
@@ -345,6 +346,7 @@ export function resolveConversationCapabilityProfile(
       inheritedToolPolicy,
       inheritancePolicies,
       explicitToolAllowlist: collectExplicitAllowlist(inheritancePolicies),
+      explicitToolOverrideAllowlist: collectExplicitAllowlist(explicitOverridePolicies),
       explicitToolDenylist: collectExplicitDenylist(inheritancePolicies),
     },
   };

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -238,7 +238,7 @@ export function resolveConversationCapabilityProfile(
       store: subagentStore,
     },
   );
-  const explicitOverridePolicies = [
+  const configuredOverridePolicies = [
     effective.globalPolicy,
     effective.globalProviderPolicy,
     effective.agentPolicy,
@@ -247,10 +247,18 @@ export function resolveConversationCapabilityProfile(
     senderPolicy,
     params.sandboxToolPolicy,
     subagentPolicy,
-    inheritedToolPolicy,
-    params.runtimeToolAllowlist ? { allow: params.runtimeToolAllowlist } : undefined,
   ];
-  const inheritancePolicies = [profilePolicy, providerProfilePolicy, ...explicitOverridePolicies];
+  const runtimeToolPolicy = params.runtimeToolAllowlist
+    ? { allow: params.runtimeToolAllowlist }
+    : undefined;
+  const explicitOverridePolicies = [...configuredOverridePolicies, runtimeToolPolicy];
+  const inheritancePolicies = [
+    profilePolicy,
+    providerProfilePolicy,
+    ...configuredOverridePolicies,
+    inheritedToolPolicy,
+    runtimeToolPolicy,
+  ];
 
   return {
     agentId: effective.agentId,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1189,11 +1189,6 @@ export async function runEmbeddedAttempt(
             ]),
           ]
         : toolsAllowWithForcedRuntimeTools;
-    const localModelLeanPreserveToolNames = resolveLocalModelLeanPreserveToolNames({
-      toolNames: effectiveToolsAllow,
-      forceMessageTool: params.forceMessageTool,
-      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-    });
     const shouldConstructTools =
       toolConstructionPlan.constructTools ||
       toolSearchControlsEnabledForRun ||
@@ -1256,6 +1251,11 @@ export async function runEmbeddedAttempt(
       skillsSnapshot: skillsSnapshotForRun,
       sandboxToolPolicy: sandbox?.tools,
       runtimeToolAllowlist: effectiveToolsAllow,
+    });
+    const localModelLeanPreserveToolNames = resolveLocalModelLeanPreserveToolNames({
+      toolNames: runtimeCapabilityProfile.policy.explicitToolAllowlist,
+      forceMessageTool: params.forceMessageTool,
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     });
     const toolsRaw = !shouldConstructTools
       ? []

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1253,7 +1253,7 @@ export async function runEmbeddedAttempt(
       runtimeToolAllowlist: effectiveToolsAllow,
     });
     const localModelLeanPreserveToolNames = resolveLocalModelLeanPreserveToolNames({
-      toolNames: runtimeCapabilityProfile.policy.explicitToolAllowlist,
+      toolNames: runtimeCapabilityProfile.policy.explicitToolOverrideAllowlist,
       forceMessageTool: params.forceMessageTool,
       sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     });

--- a/src/agents/harness/tool-surface-bridge.test.ts
+++ b/src/agents/harness/tool-surface-bridge.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { AnyAgentTool } from "../tools/common.js";
+import { createStubTool } from "../test-helpers/agent-tool-stubs.js";
 import { createAgentHarnessToolSurfaceRuntime } from "./tool-surface-bridge.js";
 
-function tools(names: string[]): AnyAgentTool[] {
-  return names.map((name) => ({
-    name,
-    parameters: { type: "object", properties: {}, additionalProperties: false },
-  })) as AnyAgentTool[];
+function tools(names: string[]) {
+  return names.map(createStubTool);
 }
 
 describe("createAgentHarnessToolSurfaceRuntime", () => {
@@ -18,7 +15,7 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
     };
     const runtime = createAgentHarnessToolSurfaceRuntime({
       config,
-      executeTool: async () => ({ content: [] }),
+      executeTool: async () => ({ content: [], details: {} }),
       modelToolsEnabled: true,
     });
 

--- a/src/agents/harness/tool-surface-bridge.test.ts
+++ b/src/agents/harness/tool-surface-bridge.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { AnyAgentTool } from "../tools/common.js";
+import { createAgentHarnessToolSurfaceRuntime } from "./tool-surface-bridge.js";
+
+function tools(names: string[]): AnyAgentTool[] {
+  return names.map((name) => ({
+    name,
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  })) as AnyAgentTool[];
+}
+
+describe("createAgentHarnessToolSurfaceRuntime", () => {
+  it("filters raw SDK tools but does not refilter prepared constructor output", () => {
+    const config: OpenClawConfig = {
+      agents: { defaults: { experimental: { localModelLean: true } } },
+      tools: { alsoAllow: ["image_generate"], toolSearch: { enabled: false } },
+    };
+    const runtime = createAgentHarnessToolSurfaceRuntime({
+      config,
+      executeTool: async () => ({ content: [] }),
+      modelToolsEnabled: true,
+    });
+
+    expect(
+      runtime
+        .compactTools(tools(["read", "browser", "image_generate"]))
+        .tools.map((tool) => tool.name),
+    ).toEqual(["read", "image_generate"]);
+    expect(
+      runtime
+        .compactTools(tools(["read", "browser"]), { localModelLeanApplied: true })
+        .tools.map((tool) => tool.name),
+    ).toEqual(["read", "browser"]);
+    runtime.cleanup();
+  });
+});

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -7,7 +7,12 @@ import {
   createCodeModeTools,
   resolveCodeModeConfig,
 } from "../code-mode.js";
-import { applyLocalModelLeanToolSearchDefaults } from "../local-model-lean.js";
+import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
+import {
+  applyLocalModelLeanToolSearchDefaults,
+  filterLocalModelLeanTools,
+  resolveLocalModelLeanPreserveToolNames,
+} from "../local-model-lean.js";
 import { filterRuntimeCompatibleTools } from "../tool-schema-projection.js";
 import {
   applyToolSchemaDirectoryCatalog,
@@ -37,7 +42,7 @@ export type AgentHarnessToolSurfaceRuntime = {
   codeModeControlsEnabled: boolean;
   compactTools: (
     tools: AnyAgentTool[],
-    options?: { hookContext?: HookContext },
+    options?: { hookContext?: HookContext; localModelLeanApplied?: boolean },
   ) => {
     tools: AnyAgentTool[];
   };
@@ -58,6 +63,8 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
   executeTool: ToolSearchCatalogToolExecutor;
   forceMessageTool?: boolean;
   isRawModelRun?: boolean;
+  modelId?: string;
+  modelProvider?: string;
   modelToolsEnabled: boolean;
   prompt?: string;
   runId?: string;
@@ -102,13 +109,35 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
         : undefined;
   const toolSearchCatalogExecutor =
     toolSearchControlsEnabled || codeModeControlsEnabled ? params.executeTool : undefined;
+  const capabilityProfile = resolveConversationCapabilityProfile({
+    config: params.config,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
+    runtimeToolAllowlist,
+  });
+  const preserveToolNames = resolveLocalModelLeanPreserveToolNames({
+    toolNames: capabilityProfile.policy.explicitToolOverrideAllowlist,
+    forceMessageTool: params.forceMessageTool,
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+  });
   const compactTools = (
     tools: AnyAgentTool[],
-    options: { hookContext?: HookContext } = {},
+    options: { hookContext?: HookContext; localModelLeanApplied?: boolean } = {},
   ): { tools: AnyAgentTool[] } => {
-    // Tool construction already applies the prepared lean policy. Re-deriving it here can
-    // discard explicit overrides because this compaction boundary has less policy context.
-    const uncompactedProjection = filterRuntimeCompatibleTools(tools);
+    // Native harness callers may supply raw tools, while the bundled tool constructor
+    // already applied the full prepared policy and must not be filtered a second time.
+    const projectedUncompactedTools = options.localModelLeanApplied
+      ? tools
+      : filterLocalModelLeanTools({
+          tools,
+          config: params.config,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          preserveToolNames,
+        });
+    const uncompactedProjection = filterRuntimeCompatibleTools(projectedUncompactedTools);
     let effectiveTools = [...uncompactedProjection.tools];
     const codeModeTools = codeModeControlsEnabled
       ? createCodeModeTools({
@@ -172,7 +201,16 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
             catalogRef: toolSearchCatalogRef,
             toolHookContext: options.hookContext,
           });
-    effectiveTools = [...filterRuntimeCompatibleTools(compacted.tools).tools];
+    const projectedCompactedTools = options.localModelLeanApplied
+      ? compacted.tools
+      : filterLocalModelLeanTools({
+          tools: compacted.tools,
+          config: params.config,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          preserveToolNames,
+        });
+    effectiveTools = [...filterRuntimeCompatibleTools(projectedCompactedTools).tools];
     return { tools: effectiveTools };
   };
   return {

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -7,11 +7,7 @@ import {
   createCodeModeTools,
   resolveCodeModeConfig,
 } from "../code-mode.js";
-import {
-  applyLocalModelLeanToolSearchDefaults,
-  filterLocalModelLeanTools,
-  resolveLocalModelLeanPreserveToolNames,
-} from "../local-model-lean.js";
+import { applyLocalModelLeanToolSearchDefaults } from "../local-model-lean.js";
 import { filterRuntimeCompatibleTools } from "../tool-schema-projection.js";
 import {
   applyToolSchemaDirectoryCatalog,
@@ -110,18 +106,9 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
     tools: AnyAgentTool[],
     options: { hookContext?: HookContext } = {},
   ): { tools: AnyAgentTool[] } => {
-    const preserveToolNames = resolveLocalModelLeanPreserveToolNames({
-      toolNames: runtimeToolAllowlist,
-      forceMessageTool: params.forceMessageTool,
-      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-    });
-    const projectedUncompactedTools = filterLocalModelLeanTools({
-      tools,
-      config: params.config,
-      agentId: params.agentId,
-      preserveToolNames,
-    });
-    const uncompactedProjection = filterRuntimeCompatibleTools(projectedUncompactedTools);
+    // Tool construction already applies the prepared lean policy. Re-deriving it here can
+    // discard explicit overrides because this compaction boundary has less policy context.
+    const uncompactedProjection = filterRuntimeCompatibleTools(tools);
     let effectiveTools = [...uncompactedProjection.tools];
     const codeModeTools = codeModeControlsEnabled
       ? createCodeModeTools({
@@ -185,13 +172,7 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
             catalogRef: toolSearchCatalogRef,
             toolHookContext: options.hookContext,
           });
-    const projectedCompactedTools = filterLocalModelLeanTools({
-      tools: compacted.tools,
-      config: params.config,
-      agentId: params.agentId,
-      preserveToolNames,
-    });
-    effectiveTools = [...filterRuntimeCompatibleTools(projectedCompactedTools).tools];
+    effectiveTools = [...filterRuntimeCompatibleTools(compacted.tools).tools];
     return { tools: effectiveTools };
   };
   return {

--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -34,7 +34,18 @@ describe("local model lean tool filtering", () => {
     expect(isLocalModelLeanEnabled({ config: cfg, agentId: "gemma" })).toBe(true);
     expect(
       filterLocalModelLeanTools({
-        tools: tools(["read", "browser", "cron", "message", "exec"]),
+        tools: tools([
+          "read",
+          "browser",
+          "cron",
+          "message",
+          "image_generate",
+          "music_generate",
+          "pdf",
+          "tts",
+          "video_generate",
+          "exec",
+        ]),
         config: cfg,
         agentId: "gemma",
       }).map((tool) => tool.name),
@@ -54,11 +65,52 @@ describe("local model lean tool filtering", () => {
 
     expect(
       filterLocalModelLeanTools({
-        tools: tools(["read", "browser", "cron", "message", "exec"]),
+        tools: tools([
+          "read",
+          "browser",
+          "cron",
+          "message",
+          "image_generate",
+          "music_generate",
+          "pdf",
+          "tts",
+          "video_generate",
+          "exec",
+        ]),
         config: cfg,
-        preserveToolNames: ["browser", "cron", "group:messaging"],
+        preserveToolNames: ["browser", "cron", "group:messaging", "group:media", "pdf"],
       }).map((tool) => tool.name),
-    ).toEqual(["read", "browser", "cron", "message", "exec"]);
+    ).toEqual([
+      "read",
+      "browser",
+      "cron",
+      "message",
+      "image_generate",
+      "music_generate",
+      "pdf",
+      "tts",
+      "video_generate",
+      "exec",
+    ]);
+  });
+
+  it("keeps image understanding while trimming optional media production tools", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      },
+    };
+
+    expect(
+      filterLocalModelLeanTools({
+        tools: tools(["read", "image", "image_generate", "music_generate", "video_generate"]),
+        config: cfg,
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "image"]);
   });
 
   it("adds reply-required message tools to lean preservation", () => {

--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -152,6 +152,19 @@ describe("local model lean tool filtering", () => {
     ).toEqual(["read", "exec"]);
   });
 
+  it("matches wildcard preservation without treating a bare wildcard as an override", () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { experimental: { localModelLean: true } } },
+    };
+    expect(
+      filterLocalModelLeanTools({
+        tools: tools(["read", "image_generate", "video_generate", "browser"]),
+        config: cfg,
+        preserveToolNames: ["image_*", "*"],
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "image_generate"]);
+  });
+
   it("lets an agent opt out of an inherited global lean setting", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -9,7 +9,16 @@ import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope-config.
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { expandToolGroups, normalizeToolName } from "./tool-policy.js";
 
-const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = new Set(["browser", "cron", "message"]);
+const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = new Set([
+  "browser",
+  "cron",
+  "image_generate",
+  "message",
+  "music_generate",
+  "pdf",
+  "tts",
+  "video_generate",
+]);
 const LOCAL_MODEL_LEAN_TOOL_SEARCH_DEFAULTS = {
   enabled: true,
   mode: "tools",

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope-config.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import { expandToolGroups, normalizeToolName } from "./tool-policy.js";
 
 const LOCAL_MODEL_LEAN_DENY_TOOL_NAMES = new Set([
@@ -26,15 +27,14 @@ const LOCAL_MODEL_LEAN_TOOL_SEARCH_DEFAULTS = {
   maxSearchLimit: 10,
 } as const;
 
-function resolvePreservedLocalModelLeanToolNames(names?: Iterable<string>): Set<string> {
+function resolvePreservedLocalModelLeanToolNames(names?: Iterable<string>) {
   if (!names) {
-    return new Set();
+    return [];
   }
-  return new Set(
-    expandToolGroups([...names])
-      .map(normalizeToolName)
-      .filter((name) => name && name !== "*"),
-  );
+  return compileGlobPatterns({
+    raw: expandToolGroups([...names]).filter((name) => normalizeToolName(name) !== "*"),
+    normalize: normalizeToolName,
+  });
 }
 
 /** Resolves tool names that must survive local-model lean filtering. */
@@ -101,7 +101,7 @@ export function filterLocalModelLeanTools(params: {
   return params.tools.filter((tool) => {
     const normalizedName = normalizeToolName(tool.name);
     return (
-      preservedToolNames.has(normalizedName) ||
+      matchesAnyGlobPattern(normalizedName, preservedToolNames) ||
       !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(normalizedName)
     );
   });


### PR DESCRIPTION
## Summary
- trim additional heavyweight optional tools from `localModelLean`: media generation, voice, and PDF alongside browser, cron, and message
- keep image-understanding available so lean local agents can still inspect inbound images when configured
- document the broader lean-mode surface and preserve explicit `tools.allow` / `tools.alsoAllow` opt-ins, including provider-scoped policies

## Verification
- `node scripts/run-vitest.mjs src/agents/local-model-lean.test.ts src/agents/agent-tools.model-provider-collision.test.ts src/agents/codex-native-web-search.test.ts src/llm/providers/stream-wrappers/openai.test.ts src/plugin-sdk/provider-stream.test.ts src/agents/embedded-agent-runner-extraparams.test.ts extensions/openai/openai-provider.test.ts --reporter=dot`: passed, 4 shards / 227 tests
- `node scripts/check-docs-mdx.mjs docs/concepts/experimental-features.md docs/gateway/local-models.md docs/providers/ollama.md`: passed
- `node scripts/docs-list.js`: passed
- `node_modules/.bin/oxfmt --check --threads=1 docs/concepts/experimental-features.md docs/gateway/local-models.md docs/providers/ollama.md src/agents/local-model-lean.ts src/agents/local-model-lean.test.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts`: passed
- `node scripts/run-oxlint.mjs src/agents/local-model-lean.ts src/agents/local-model-lean.test.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts`: passed
- `git diff --check origin/main...HEAD`: passed
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings
- AWS Crabbox `node scripts/crabbox-wrapper.mjs run --provider aws --label local-model-lean-media-trim-check --shell -- "pnpm check:changed"`: passed, provider `aws`, lease `cbx_d52017c2bdb6`, run `run_fed513bf5711`, exit 0

## Real behavior proof
Behavior addressed: lean local-model agents should expose a smaller direct tool surface now that OpenClaw includes broader optional media, voice, and PDF tools, without overriding explicit operator allowlists.

Real environment tested: OpenClaw gwt worktree rebased onto current `origin/main`, plus AWS Crabbox Linux remote changed gate.

Exact steps or command run after this patch: targeted local-model lean/provider regression tests, docs MDX/list checks, oxfmt, oxlint, diff-check, autoreview, and AWS Crabbox `pnpm check:changed`.

Evidence after fix: `filterLocalModelLeanTools` removes `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf` in lean mode while preserving `image` understanding and honoring explicit global, agent, runtime, and provider-scoped tool allowlists.

Observed result after fix: lean mode keeps the normal coding/conversation path available with fewer heavyweight optional schemas in the prompt; explicit allowlists can still opt an agent back into removed tools.

What was not tested: live Ollama model run; this is policy/filtering behavior covered by focused unit and changed-gate proof.
