### PR TITLE
test(gateway): add small model live profile

### DIFF
--- a/docs/help/testing-live.md
+++ b/docs/help/testing-live.md
@@ -110,9 +110,10 @@ Live tests are split into two layers so we can isolate failures:
   - `pnpm test:live` (or `OPENCLAW_LIVE_TEST=1` if invoking Vitest directly)
 - How to select models:
   - Default: modern allowlist (Opus/Sonnet 4.6+, GPT-5.2 + Codex, Gemini 3, DeepSeek V4, GLM 4.7, MiniMax M3, Grok 4.3)
+  - `OPENCLAW_LIVE_GATEWAY_MODELS=small` to run the same constrained small-model allowlist through the full gateway+agent pipeline
   - `OPENCLAW_LIVE_GATEWAY_MODELS=all` is an alias for the modern allowlist
   - Or set `OPENCLAW_LIVE_GATEWAY_MODELS="provider/model"` (or comma list) to narrow
-  - Modern/all gateway sweeps default to a curated high-signal cap; set `OPENCLAW_LIVE_GATEWAY_MAX_MODELS=0` for an exhaustive modern sweep or a positive number for a smaller cap.
+  - Modern/all and small gateway sweeps default to their curated caps; set `OPENCLAW_LIVE_GATEWAY_MAX_MODELS=0` for an exhaustive selected sweep or a positive number for a smaller cap.
 - How to select providers (avoid "OpenRouter everything"):
   - `OPENCLAW_LIVE_GATEWAY_PROVIDERS="google,google-antigravity,google-gemini-cli,openai,anthropic,zai,minimax"` (comma allowlist)
 - Tool + image probes are always on in this live test:
@@ -343,6 +344,9 @@ Narrow, explicit allowlists are fastest and least flaky:
 
 - Small-model direct profile:
   - `OPENCLAW_LIVE_MODELS=small pnpm test:live src/agents/models.profiles.live.test.ts`
+
+- Small-model gateway profile:
+  - `OPENCLAW_LIVE_GATEWAY_MODELS=small pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 - Ollama Cloud API smoke:
   - `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_OLLAMA=1 OPENCLAW_LIVE_OLLAMA_BASE_URL=https://ollama.com OPENCLAW_LIVE_OLLAMA_MODEL=glm-5.1:cloud OPENCLAW_LIVE_OLLAMA_WEB_SEARCH=0 pnpm test:live -- extensions/ollama/ollama.live.test.ts`

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -52,6 +52,7 @@ import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { clearRuntimeConfigSnapshot, getRuntimeConfig } from "../config/io.js";
 import type { ModelsConfig, ModelProviderConfig, OpenClawConfig } from "../config/types.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import type { ModelRegistry } from "../llm/model-registry.js";
 import { normalizeGoogleModelId } from "../plugin-sdk/google-model-id.js";
 import { resolveProviderThinkingProfile } from "../plugins/provider-runtime.js";
 import type { ProviderThinkingModelCompat } from "../plugins/provider-thinking.types.js";
@@ -195,6 +196,29 @@ function providerScopedModelRegistryProviders(params: {
     modelFilter: params.modelFilter,
     providerFilter: params.providerFilter,
   });
+}
+
+function filterGatewayLiveModelRefsByProvider(
+  refs: readonly { provider: string; id: string }[],
+  providerFilter: ReadonlySet<string> | null,
+): Array<{ provider: string; id: string }> {
+  if (!providerFilter) {
+    return [...refs];
+  }
+  const providers = new Set(
+    [...providerFilter].map((provider) => normalizeProviderId(provider)).filter(Boolean),
+  );
+  return refs.filter((ref) => providers.has(normalizeProviderId(ref.provider)));
+}
+
+function isWantedSmallGatewayLiveModel(params: {
+  model: Pick<Model, "provider" | "id">;
+  targetMatcher: ReturnType<typeof createLiveTargetMatcher>;
+}): boolean {
+  return (
+    params.targetMatcher.matchesProvider(params.model.provider) &&
+    isSmallLiveModelRef({ provider: params.model.provider, id: params.model.id })
+  );
 }
 
 function shouldSuppressGatewayLiveOllamaWarnings(): boolean {
@@ -998,6 +1022,24 @@ function createExplicitLiveFallbackModel(provider: string, id: string): Model {
   };
 }
 
+function createGatewayLiveTestRegistry(overrides: Partial<ModelRegistry>): ModelRegistry {
+  return {
+    find() {
+      return undefined;
+    },
+    getAll() {
+      return [];
+    },
+    getAvailable() {
+      return [];
+    },
+    hasConfiguredAuth() {
+      return true;
+    },
+    ...overrides,
+  };
+}
+
 describe("resolveExplicitLiveModelCandidates", () => {
   it("uses targeted registry lookup for explicit provider/model filters", () => {
     const model = createGatewayLiveTestModel("xai", "grok-4.3");
@@ -1007,7 +1049,7 @@ describe("resolveExplicitLiveModelCandidates", () => {
       env: {},
     });
     const candidates = resolveExplicitLiveModelCandidates({
-      modelRegistry: {
+      modelRegistry: createGatewayLiveTestRegistry({
         find(provider, modelId) {
           expect(provider).toBe("xai");
           expect(modelId).toBe("grok-4.3");
@@ -1016,7 +1058,7 @@ describe("resolveExplicitLiveModelCandidates", () => {
         getAll() {
           throw new Error("explicit model lookup should not enumerate registry");
         },
-      },
+      }),
       modelFilter: new Set(["xai/grok-4.3"]),
       providerFilter: new Set(["xai"]),
       targetMatcher: matcher,
@@ -1033,7 +1075,7 @@ describe("resolveExplicitLiveModelCandidates", () => {
       env: {},
     });
     const candidates = resolveExplicitLiveModelCandidates({
-      modelRegistry: {
+      modelRegistry: createGatewayLiveTestRegistry({
         find(provider, modelId) {
           expect(provider).toBe("google");
           expect(modelId).toBe("gemini-3.1-pro-preview");
@@ -1042,7 +1084,7 @@ describe("resolveExplicitLiveModelCandidates", () => {
         getAll() {
           throw new Error("explicit model lookup should not enumerate registry");
         },
-      },
+      }),
       modelFilter: new Set(["google/gemini-3-pro-preview"]),
       providerFilter: new Set(["google"]),
       targetMatcher: matcher,
@@ -1058,7 +1100,7 @@ describe("resolveExplicitLiveModelCandidates", () => {
       env: {},
     });
     const candidates = resolveExplicitLiveModelCandidates({
-      modelRegistry: {
+      modelRegistry: createGatewayLiveTestRegistry({
         find(provider, modelId) {
           expect(provider).toBe("openai");
           expect(modelId).toBe("gpt-5.5");
@@ -1067,7 +1109,7 @@ describe("resolveExplicitLiveModelCandidates", () => {
         getAll() {
           throw new Error("explicit model lookup should not enumerate registry");
         },
-      },
+      }),
       modelFilter: new Set(["openai/gpt-5.5"]),
       providerFilter: new Set(["openai"]),
       targetMatcher: matcher,
@@ -1089,14 +1131,14 @@ describe("resolveExplicitLiveModelCandidates", () => {
 
     expect(
       resolveExplicitLiveModelCandidates({
-        modelRegistry: {
+        modelRegistry: createGatewayLiveTestRegistry({
           find() {
             throw new Error("ambiguous model-only lookup should not use direct find");
           },
           getAll() {
             return [];
           },
-        },
+        }),
         modelFilter: new Set(["grok-4.3"]),
         providerFilter: null,
         targetMatcher: matcher,
@@ -1152,6 +1194,36 @@ describe("providerScopedModelRegistryProviders", () => {
         providerFilter: new Set(["ollama", "openai"]),
       }),
     ).toEqual(["ollama"]);
+  });
+
+  it("filters prioritized small refs before dynamic lookup", () => {
+    expect(
+      filterGatewayLiveModelRefsByProvider(
+        listPrioritizedSmallLiveModelRefs(),
+        new Set(["ollama"]),
+      ),
+    ).toEqual([{ provider: "ollama", id: "gemma3:4b" }]);
+  });
+
+  it("does not count small models outside a provider-scoped gateway sweep", () => {
+    const matcher = createLiveTargetMatcher({
+      providerFilter: new Set(["ollama"]),
+      modelFilter: null,
+      env: {},
+    });
+
+    expect(
+      isWantedSmallGatewayLiveModel({
+        model: createGatewayLiveTestModel("openrouter", "qwen/qwen3.5-9b"),
+        targetMatcher: matcher,
+      }),
+    ).toBe(false);
+    expect(
+      isWantedSmallGatewayLiveModel({
+        model: createGatewayLiveTestModel("ollama", "gemma3:4b"),
+        targetMatcher: matcher,
+      }),
+    ).toBe(true);
   });
 
   it("uses explicit provider-qualified model refs without enumerating the full registry", () => {
@@ -2157,10 +2229,7 @@ type GatewayModelSuiteParams = {
   providerOverrides?: Record<string, ModelProviderConfig>;
 };
 
-type LiveModelRegistry = {
-  find(provider: string, modelId: string): Model | null | undefined;
-  getAll(): Array<Model>;
-};
+type LiveModelRegistry = ModelRegistry;
 
 function toGatewayLiveModel(params: {
   provider: string;
@@ -2258,6 +2327,12 @@ function createStaticLiveModelRegistry(models: Array<Model>): LiveModelRegistry 
     },
     getAll() {
       return models;
+    },
+    getAvailable() {
+      return models;
+    },
+    hasConfiguredAuth() {
+      return true;
     },
   };
 }
@@ -3512,7 +3587,10 @@ describeLive("gateway live (dev agent, profile keys)", () => {
               workspaceDir,
               env: process.env,
               modelRegistry,
-              refs: listPrioritizedSmallLiveModelRefs(),
+              refs: filterGatewayLiveModelRefsByProvider(
+                listPrioritizedSmallLiveModelRefs(),
+                PROVIDERS,
+              ),
             }),
             "[all-models] load dynamic small model refs",
           );
@@ -3543,7 +3621,7 @@ describeLive("gateway live (dev agent, profile keys)", () => {
           wanted = filter
             ? all.filter((m) => targetMatcher.matchesModel(m.provider, m.id))
             : useSmall
-              ? all.filter((m) => isSmallLiveModelRef({ provider: m.provider, id: m.id }))
+              ? all.filter((m) => isWantedSmallGatewayLiveModel({ model: m, targetMatcher }))
               : all.filter(
                   (m) =>
                     !shouldExcludeProviderFromDefaultHighSignalLiveSweep({

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -22,14 +22,19 @@ import {
 } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { collectAnthropicApiKeys } from "../agents/live-auth-keys.js";
+import { appendPrioritizedDynamicLiveModels } from "../agents/live-model-dynamic-candidates.js";
 import { isModelNotFoundErrorMessage } from "../agents/live-model-errors.js";
 import {
   DEFAULT_HIGH_SIGNAL_LIVE_MODEL_LIMIT,
+  DEFAULT_SMALL_LIVE_MODEL_LIMIT,
   getHighSignalLiveModelPriorityIndex,
   getHighSignalLiveModelProviders,
   isHighSignalLiveModelRef,
+  isSmallLiveModelRef,
+  listPrioritizedSmallLiveModelRefs,
   resolveHighSignalLiveModelLimit,
   selectHighSignalLiveItems,
+  selectSmallLiveItems,
   shouldExcludeProviderFromDefaultHighSignalLiveSweep,
 } from "../agents/live-model-filter.js";
 import { createLiveTargetMatcher } from "../agents/live-target-matcher.js";
@@ -166,6 +171,7 @@ function providerListFromExplicitModelFilter(params: {
 
 function providerScopedModelRegistryProviders(params: {
   providerList: string[] | undefined;
+  useSmall: boolean;
   useExplicit: boolean;
   modelFilter: Set<string> | null;
   providerFilter: Set<string> | null;
@@ -174,7 +180,14 @@ function providerScopedModelRegistryProviders(params: {
     return params.providerList;
   }
   if (!params.useExplicit) {
-    return getHighSignalLiveModelProviders().filter((provider) =>
+    const providers = params.useSmall
+      ? [
+          ...new Set(
+            listPrioritizedSmallLiveModelRefs().map((ref) => normalizeProviderId(ref.provider)),
+          ),
+        ].toSorted((left, right) => left.localeCompare(right))
+      : getHighSignalLiveModelProviders();
+    return providers.filter((provider) =>
       params.providerFilter ? params.providerFilter.has(provider) : true,
     );
   }
@@ -227,11 +240,15 @@ function resolveGatewayLiveMaxModels(): number {
     return Math.max(0, toInt(gatewayRaw, 0));
   }
   const rawModels = process.env.OPENCLAW_LIVE_GATEWAY_MODELS?.trim();
-  const useExplicitModels = Boolean(rawModels) && rawModels !== "modern" && rawModels !== "all";
+  const useSmallModels = rawModels === "small";
+  const useExplicitModels =
+    Boolean(rawModels) && rawModels !== "modern" && rawModels !== "all" && !useSmallModels;
   return resolveHighSignalLiveModelLimit({
     rawMaxModels: process.env.OPENCLAW_LIVE_MAX_MODELS,
     useExplicitModels,
-    defaultLimit: DEFAULT_HIGH_SIGNAL_LIVE_MODEL_LIMIT,
+    defaultLimit: useSmallModels
+      ? DEFAULT_SMALL_LIVE_MODEL_LIMIT
+      : DEFAULT_HIGH_SIGNAL_LIVE_MODEL_LIMIT,
   });
 }
 
@@ -336,6 +353,7 @@ function assertGatewayLiveSelectedSomeModels(params: {
   modelFilter: ReadonlySet<string> | null;
   providerFilter: ReadonlySet<string> | null;
   total: number;
+  useSmall: boolean;
   useExplicit: boolean;
   wantedCount: number;
 }): void {
@@ -351,7 +369,7 @@ function assertGatewayLiveSelectedSomeModels(params: {
   ) {
     return;
   }
-  const mode = params.useExplicit ? "explicit" : "high-signal";
+  const mode = params.useExplicit ? "explicit" : params.useSmall ? "small" : "high-signal";
   throw new Error(
     `[${params.label}] selected no ${mode} live models for providers=${formatGatewayLiveFilterSet(params.providerFilter)} models=${formatGatewayLiveFilterSet(params.modelFilter)} from ${params.total} registry model(s); update the live model selection or pass explicit live model refs.`,
   );
@@ -860,6 +878,7 @@ describe("assertGatewayLiveSelectedSomeModels", () => {
         modelFilter: null,
         providerFilter: null,
         total: 0,
+        useSmall: false,
         useExplicit: false,
         wantedCount: 0,
       }),
@@ -874,6 +893,7 @@ describe("assertGatewayLiveSelectedSomeModels", () => {
         modelFilter: null,
         providerFilter: new Set(["openai"]),
         total: 42,
+        useSmall: false,
         useExplicit: false,
         wantedCount: 0,
       }),
@@ -888,6 +908,7 @@ describe("assertGatewayLiveSelectedSomeModels", () => {
         modelFilter: null,
         providerFilter: new Set(["minimax", "minimax-portal"]),
         total: 0,
+        useSmall: false,
         useExplicit: false,
         wantedCount: 0,
       }),
@@ -933,6 +954,14 @@ describe("resolveGatewayLiveMaxModels", () => {
     delete process.env.OPENCLAW_LIVE_MAX_MODELS;
 
     expect(resolveGatewayLiveMaxModels()).toBe(DEFAULT_HIGH_SIGNAL_LIVE_MODEL_LIMIT);
+  });
+
+  it("defaults small gateway sweeps to the curated small-model cap", () => {
+    process.env.OPENCLAW_LIVE_GATEWAY_MODELS = "small";
+    delete process.env.OPENCLAW_LIVE_GATEWAY_MAX_MODELS;
+    delete process.env.OPENCLAW_LIVE_MAX_MODELS;
+
+    expect(resolveGatewayLiveMaxModels()).toBe(DEFAULT_SMALL_LIVE_MODEL_LIMIT);
   });
 
   it("keeps explicit gateway model lists uncapped unless a cap is provided", () => {
@@ -1081,6 +1110,7 @@ describe("providerScopedModelRegistryProviders", () => {
     expect(
       providerScopedModelRegistryProviders({
         providerList: undefined,
+        useSmall: false,
         useExplicit: false,
         modelFilter: null,
         providerFilter: null,
@@ -1092,6 +1122,7 @@ describe("providerScopedModelRegistryProviders", () => {
     expect(
       providerScopedModelRegistryProviders({
         providerList: undefined,
+        useSmall: false,
         useExplicit: false,
         modelFilter: null,
         providerFilter: new Set(["openai", "not-high-signal"]),
@@ -1099,10 +1130,35 @@ describe("providerScopedModelRegistryProviders", () => {
     ).toEqual(["openai"]);
   });
 
+  it("uses curated small-model providers for small sweeps", () => {
+    expect(
+      providerScopedModelRegistryProviders({
+        providerList: undefined,
+        useSmall: true,
+        useExplicit: false,
+        modelFilter: null,
+        providerFilter: null,
+      }),
+    ).toEqual(["lmstudio", "ollama", "openrouter", "sglang", "vllm", "zai"]);
+  });
+
+  it("intersects small gateway sweeps with provider filters", () => {
+    expect(
+      providerScopedModelRegistryProviders({
+        providerList: undefined,
+        useSmall: true,
+        useExplicit: false,
+        modelFilter: null,
+        providerFilter: new Set(["ollama", "openai"]),
+      }),
+    ).toEqual(["ollama"]);
+  });
+
   it("uses explicit provider-qualified model refs without enumerating the full registry", () => {
     expect(
       providerScopedModelRegistryProviders({
         providerList: undefined,
+        useSmall: false,
         useExplicit: true,
         modelFilter: new Set(["openai/gpt-5.2", "anthropic/claude-sonnet-4-6"]),
         providerFilter: null,
@@ -1114,6 +1170,7 @@ describe("providerScopedModelRegistryProviders", () => {
     expect(
       providerScopedModelRegistryProviders({
         providerList: undefined,
+        useSmall: false,
         useExplicit: true,
         modelFilter: new Set(["gpt-5.2"]),
         providerFilter: new Set(["openai"]),
@@ -1125,6 +1182,7 @@ describe("providerScopedModelRegistryProviders", () => {
     expect(
       providerScopedModelRegistryProviders({
         providerList: undefined,
+        useSmall: false,
         useExplicit: true,
         modelFilter: new Set(["gpt-5.2"]),
         providerFilter: null,
@@ -3406,10 +3464,12 @@ describeLive("gateway live (dev agent, profile keys)", () => {
 
         const rawModels = process.env.OPENCLAW_LIVE_GATEWAY_MODELS?.trim();
         const useModern = !rawModels || rawModels === "modern" || rawModels === "all";
-        const useExplicit = Boolean(rawModels) && !useModern;
+        const useSmall = rawModels === "small";
+        const useExplicit = Boolean(rawModels) && !useModern && !useSmall;
         const filter = useExplicit ? parseFilter(rawModels) : null;
         const providerScopedModelProviders = providerScopedModelRegistryProviders({
           providerList,
+          useSmall,
           useExplicit,
           modelFilter: filter,
           providerFilter: PROVIDERS,
@@ -3443,6 +3503,27 @@ describeLive("gateway live (dev agent, profile keys)", () => {
           modelRegistry = authBacked.modelRegistry;
           all = authBacked.all;
         }
+        if (useSmall) {
+          const augmented = await withGatewayLiveSetupTimeout(
+            appendPrioritizedDynamicLiveModels({
+              models: all,
+              config: cfg,
+              agentDir,
+              workspaceDir,
+              env: process.env,
+              modelRegistry,
+              refs: listPrioritizedSmallLiveModelRefs(),
+            }),
+            "[all-models] load dynamic small model refs",
+          );
+          if (augmented.added.length > 0) {
+            logProgress(
+              `[all-models] loaded ${augmented.added.length} prioritized dynamic small model refs`,
+            );
+            all = augmented.models;
+            modelRegistry = createStaticLiveModelRegistry(all);
+          }
+        }
         const maxModels = GATEWAY_LIVE_MAX_MODELS;
         const targetMatcher = createLiveTargetMatcher({
           providerFilter: PROVIDERS,
@@ -3461,24 +3542,27 @@ describeLive("gateway live (dev agent, profile keys)", () => {
         if (!wanted) {
           wanted = filter
             ? all.filter((m) => targetMatcher.matchesModel(m.provider, m.id))
-            : all.filter(
-                (m) =>
-                  !shouldExcludeProviderFromDefaultHighSignalLiveSweep({
-                    provider: m.provider,
-                    useExplicitModels: useExplicit,
-                    providerFilter: PROVIDERS,
-                    config: cfg,
-                    env: process.env,
-                  }) && isHighSignalLiveModelRef({ provider: m.provider, id: m.id }),
-              );
+            : useSmall
+              ? all.filter((m) => isSmallLiveModelRef({ provider: m.provider, id: m.id }))
+              : all.filter(
+                  (m) =>
+                    !shouldExcludeProviderFromDefaultHighSignalLiveSweep({
+                      provider: m.provider,
+                      useExplicitModels: useExplicit,
+                      providerFilter: PROVIDERS,
+                      config: cfg,
+                      env: process.env,
+                    }) && isHighSignalLiveModelRef({ provider: m.provider, id: m.id }),
+                );
         }
         logProgress(`[all-models] wanted=${wanted.length} total=${all.length}`);
         assertGatewayLiveSelectedSomeModels({
-          allowProviderDriftSkip: useModern,
+          allowProviderDriftSkip: useModern || useSmall,
           label: "all-models",
           modelFilter: filter,
           providerFilter: PROVIDERS,
           total: all.length,
+          useSmall,
           useExplicit,
           wantedCount: wanted.length,
         });
@@ -3529,13 +3613,16 @@ describeLive("gateway live (dev agent, profile keys)", () => {
           logProgress("[all-models] no API keys found; skipping");
           return;
         }
-        const selectedCandidates = selectHighSignalLiveItems(
+        const selectCandidates = useSmall ? selectSmallLiveItems : selectHighSignalLiveItems;
+        const selectedCandidates = selectCandidates(
           candidates,
           maxModels > 0 ? maxModels : candidates.length,
           (model) => ({ provider: model.provider, id: model.id }),
           (model) => model.provider,
         );
-        logProgress(`[all-models] selection=${useExplicit ? "explicit" : "high-signal"}`);
+        logProgress(
+          `[all-models] selection=${useExplicit ? "explicit" : useSmall ? "small" : "high-signal"}`,
+        );
         if (selectedCandidates.length < candidates.length) {
           logProgress(
             `[all-models] capped to ${selectedCandidates.length}/${candidates.length} via OPENCLAW_LIVE_GATEWAY_MAX_MODELS=${maxModels}`,
@@ -3550,7 +3637,7 @@ describeLive("gateway live (dev agent, profile keys)", () => {
           label: "all-models",
           cfg,
           candidates: selectedCandidates,
-          allowNotFoundSkip: useModern,
+          allowNotFoundSkip: useModern || useSmall,
           extraToolProbes: ENABLE_EXTRA_TOOL_PROBES,
           extraImageProbes: ENABLE_EXTRA_IMAGE_PROBES,
           thinkingLevel: THINKING_LEVEL,


### PR DESCRIPTION
## Summary

- add `OPENCLAW_LIVE_GATEWAY_MODELS=small` to the gateway live model profile harness
- reuse the direct-model small allowlist, provider scoping, dynamic prioritized refs, and small-model cap for full gateway+agent validation
- keep provider-scoped small sweeps honest by filtering dynamic refs and counted candidates through the requested provider filter
- document the small-model gateway recipe next to the existing direct-model recipe

Related: https://github.com/openclaw/openclaw/issues/86599

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts --configLoader runner src/gateway/gateway-models.profiles.live.test.ts --reporter=dot` — 82 passed, 2 skipped after rebase onto `28550c3847cc2525f42b4ef6354f76877f53274b`
- `node scripts/check-docs-mdx.mjs docs/help/testing-live.md`
- `node scripts/docs-list.js`
- `node_modules/.bin/oxfmt --check src/gateway/gateway-models.profiles.live.test.ts docs/help/testing-live.md`
- `node scripts/run-oxlint.mjs src/gateway/gateway-models.profiles.live.test.ts`
- `git diff --check origin/main...HEAD`
- AWS Crabbox `run_37f274101856`, lease `cbx_bc7ffedf1c7c`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` passed with lanes `coreTests, docs`

## Real behavior proof

Behavior addressed: small-model live validation can now run through the full gateway+agent path instead of only the direct completion path.
Real environment tested: local macOS worktree for focused live-config tests; AWS Crabbox Linux remote changed gate for typecheck/lint/docs changed lanes.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts --configLoader runner src/gateway/gateway-models.profiles.live.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --label live-gateway-small-models-88882-final --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`.
Evidence after fix: targeted live-config test passed with 82 tests passed and 2 live-provider tests skipped; remote changed gate passed `coreTests, docs` with exit 0.
Observed result after fix: `OPENCLAW_LIVE_GATEWAY_MODELS=small` is parsed as a curated small-model gateway sweep, gets the small provider/model cap, filters provider-scoped dynamic refs correctly, loads prioritized dynamic small refs, and uses small-model selection ordering.
What was not tested: real live provider execution with small-model credentials; the local live-config run skips provider calls when live env is not enabled.
