### PR TITLE
fix(infra): wire session-delivery drain recovery guard onto the shared SQLite recovery_state column

### DIFF
--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -241,6 +241,13 @@ function resolveQueuedSessionDeliveryContext(entry: QueuedSessionDelivery):
 async function deliverQueuedSessionDelivery(params: {
   deps: CliDeps;
   entry: QueuedSessionDelivery;
+  // Recovery hooks: signal when the agent-turn re-run is actually about to run so the
+  // recovery layer can persist its send marker (and clear it if the attempt is merely
+  // deferred because the session is busy). Only the agentTurn dispatch path reports
+  // these; the no-op early-return paths (systemEvent / changed-session / no-route) do
+  // not run the turn and stay retryable.
+  onSendAttemptStart?: () => Promise<void>;
+  onSendDeferred?: () => Promise<void>;
 }) {
   const { cfg, entry, storePath, canonicalKey } = loadSessionEntry(params.entry.sessionKey);
   const queuedDeliveryContext = resolveQueuedSessionDeliveryContext(params.entry);
@@ -313,6 +320,10 @@ async function deliverQueuedSessionDelivery(params: {
       forceChatType: true,
     },
   );
+  // The agent turn is about to run (it may do non-idempotent work and send its reply
+  // via the message tool). Signal recovery to persist the send marker now; if the run
+  // turns out to be busy-deferred, the dispatchError branch below clears it again.
+  await params.onSendAttemptStart?.();
   await dispatchAssembledChannelTurn({
     cfg,
     channel: route.channel,
@@ -353,6 +364,15 @@ async function deliverQueuedSessionDelivery(params: {
     },
   });
   if (dispatchError) {
+    // A busy continuation merely defers — the turn produced a busy-retry response, not
+    // durable work — so clear the send marker and let recovery retry instead of
+    // fail-safing it to failed/. Any other thrown error means the turn may have run.
+    if (
+      dispatchError instanceof Error &&
+      dispatchError.message === RESTART_CONTINUATION_BUSY_RETRY_ERROR
+    ) {
+      await params.onSendDeferred?.();
+    }
     throw toLintErrorObject(dispatchError, "Non-Error thrown");
   }
 }
@@ -408,7 +428,13 @@ async function drainRestartContinuationQueue(params: {
       drainKey: `restart-continuation:${params.entryId}`,
       logLabel: "restart continuation",
       log: params.log,
-      deliver: (entry) => deliverQueuedSessionDelivery({ deps: params.deps, entry }),
+      deliver: (entry, hooks) =>
+      deliverQueuedSessionDelivery({
+        deps: params.deps,
+        entry,
+        onSendAttemptStart: hooks?.onSendAttemptStart,
+        onSendDeferred: hooks?.onSendDeferred,
+      }),
       selectEntry: (entry) => ({
         match: entry.id === params.entryId,
         bypassBackoff: true,
@@ -435,7 +461,13 @@ export async function recoverPendingRestartContinuationDeliveries(params: {
   maxEnqueuedAt?: number;
 }) {
   await recoverPendingSessionDeliveries({
-    deliver: (entry) => deliverQueuedSessionDelivery({ deps: params.deps, entry }),
+    deliver: (entry, hooks) =>
+      deliverQueuedSessionDelivery({
+        deps: params.deps,
+        entry,
+        onSendAttemptStart: hooks?.onSendAttemptStart,
+        onSendDeferred: hooks?.onSendDeferred,
+      }),
     log: params.log ?? log,
     maxEnqueuedAt: params.maxEnqueuedAt,
   });

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -7,9 +7,11 @@ import {
 import { formatErrorMessage } from "./errors.js";
 import {
   ackSessionDelivery,
+  clearSessionDeliveryRecoveryState,
   failSessionDelivery,
   loadPendingSessionDelivery,
   loadPendingSessionDeliveries,
+  markSessionDeliveryPlatformSendAttemptStarted,
   moveSessionDeliveryToFailed,
   type QueuedSessionDelivery,
 } from "./session-delivery-queue-storage.js";
@@ -23,7 +25,21 @@ type SessionDeliveryRecoverySummary = {
   deferredBackoff: number;
 };
 
-type DeliverSessionDeliveryFn = (entry: QueuedSessionDelivery) => Promise<void>;
+// Hooks let the deliver seam signal the send boundary to recovery: it calls
+// onSendAttemptStart once the turn is actually about to run (past any pre-send/busy
+// gate), and onSendDeferred if that attempt was deferred without running (e.g. the
+// session was busy). Recovery uses these to mark/clear the durable recovery_state
+// and to decide, on a thrown deliver, whether the turn may have run (refuse) or was
+// a pre-send no-op (safe to retry).
+export interface SessionDeliveryDeliverHooks {
+  onSendAttemptStart: () => Promise<void>;
+  onSendDeferred: () => Promise<void>;
+}
+
+type DeliverSessionDeliveryFn = (
+  entry: QueuedSessionDelivery,
+  hooks?: SessionDeliveryDeliverHooks,
+) => Promise<void>;
 
 export interface SessionDeliveryRecoveryLogger {
   info(msg: string): void;
@@ -111,6 +127,21 @@ export function isSessionDeliveryEligibleForRetry(
   return { eligible: false, remainingBackoffMs: nextEligibleAt - now };
 }
 
+async function moveSessionDeliveryToFailedSafe(
+  id: string,
+  stateDir: string | undefined,
+): Promise<"moved-to-failed" | "already-gone"> {
+  try {
+    await moveSessionDeliveryToFailed(id, stateDir);
+    return "moved-to-failed";
+  } catch (err) {
+    if (getErrnoCode(err) === "ENOENT") {
+      return "already-gone";
+    }
+    throw err;
+  }
+}
+
 async function drainQueuedEntry(opts: {
   entry: QueuedSessionDelivery;
   deliver: DeliverSessionDeliveryFn;
@@ -119,8 +150,40 @@ async function drainQueuedEntry(opts: {
   onFailed?: (entry: QueuedSessionDelivery, errMsg: string) => void;
 }): Promise<"recovered" | "failed" | "moved-to-failed" | "already-gone"> {
   const { entry } = opts;
+
+  // An entry recovered while still carrying the send marker was interrupted (crash)
+  // after the turn began running but before it acked. The deliver seam persists the
+  // marker only once the turn is actually about to run (past the busy/pre-send gate),
+  // so its presence on a recovered entry means a non-idempotent turn may have run and
+  // its reply may already have been sent. Without an adapter reconciliation capability
+  // we cannot confirm, so we refuse a blind replay and fail-safe to failed/, matching
+  // the outbound queue's no-reconcile contract. (Tradeoff: a crash in the narrow window
+  // after the turn starts but before ack moves the entry to failed/ rather than
+  // replaying it — fail-safe over at-least-once for that window.)
+  if (entry.recoveryState === "send_attempt_started") {
+    const errMsg =
+      "session delivery was interrupted after the turn began (send_attempt_started); refusing blind replay without adapter reconciliation";
+    opts.onFailed?.(entry, errMsg);
+    return moveSessionDeliveryToFailedSafe(entry.id, opts.stateDir);
+  }
+
+  // sendAttempted flips true only when the deliver seam reports the turn is actually
+  // running (onSendAttemptStart), and back to false if that attempt was deferred
+  // without running (onSendDeferred, e.g. the session was busy). It mirrors the durable
+  // marker in-process and decides a thrown deliver: turn-may-have-run (refuse) vs a
+  // pre-send / busy-deferred / no-op deliver (safe to retry).
+  let sendAttempted = false;
   try {
-    await opts.deliver(entry);
+    await opts.deliver(entry, {
+      onSendAttemptStart: async () => {
+        sendAttempted = true;
+        await markSessionDeliveryPlatformSendAttemptStarted(entry.id, opts.stateDir);
+      },
+      onSendDeferred: async () => {
+        sendAttempted = false;
+        await clearSessionDeliveryRecoveryState(entry.id, opts.stateDir);
+      },
+    });
     await ackSessionDelivery(entry.id, opts.stateDir);
     opts.onRecovered?.(entry);
     return "recovered";
@@ -128,6 +191,16 @@ async function drainQueuedEntry(opts: {
     const errMsg = formatErrorMessage(err);
     opts.onFailed?.(entry, errMsg);
     try {
+      if (sendAttempted) {
+        // The turn began running (and may have done non-idempotent work / sent its
+        // reply) before this throw — refuse a blind replay and fail-safe to failed/.
+        // The durable marker also persisted, so a crash here is refused on the next
+        // recovery by the guard above.
+        return await moveSessionDeliveryToFailedSafe(entry.id, opts.stateDir);
+      }
+      // The turn never started (pre-send / busy-deferred / no-op deliver path): no
+      // marker was persisted and nothing ran, so the entry stays retryable
+      // (at-least-once preserved for genuine pre-send failures).
       await failSessionDelivery(entry.id, errMsg, opts.stateDir);
       return "failed";
     } catch (failErr) {

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -62,6 +62,14 @@ export type QueuedSessionDelivery = QueuedSessionDeliveryPayload & {
   retryCount: number;
   lastAttemptAt?: number;
   lastError?: string;
+  // Durable recovery marker, persisted on the shared delivery-queue SQLite
+  // `recovery_state` column. Set to `send_attempt_started` while a delivery is
+  // mid-flight (the drain has begun deliver but not yet acked); a recovered entry
+  // carrying it is refused a blind replay (see session-delivery-queue-recovery.ts).
+  // Unlike the outbound queue we keep a single state: the drain refuses on this
+  // marker alone, so a post-deliver `unknown_after_send` upgrade would change no
+  // decision (the in-process `delivered` flag already covers a post-return failure).
+  recoveryState?: "send_attempt_started";
 };
 
 function buildEntryId(idempotencyKey?: string): string {
@@ -148,4 +156,29 @@ export async function loadPendingSessionDeliveries(
 /** Move an exhausted session delivery out of the pending queue. */
 export async function moveSessionDeliveryToFailed(id: string, stateDir?: string): Promise<void> {
   moveDeliveryQueueEntryToFailed(QUEUE_NAME, id, stateDir);
+}
+
+// Persist the send-attempt marker before the drain invokes the deliver seam, so a
+// crash anywhere between here and the ack leaves durable evidence that the delivery
+// may already have run. Mirrors the outbound queue's send_attempt_started.
+export async function markSessionDeliveryPlatformSendAttemptStarted(
+  id: string,
+  stateDir?: string,
+): Promise<void> {
+  updateDeliveryQueueEntry(QUEUE_NAME, id, stateDir, (entry) => ({
+    ...(entry as QueuedSessionDelivery),
+    recoveryState: "send_attempt_started",
+  }));
+}
+
+// Clear the recovery marker. Used only on a proven pre-send failure (deliver threw
+// before anything reached the platform), so the entry stays replayable.
+export async function clearSessionDeliveryRecoveryState(
+  id: string,
+  stateDir?: string,
+): Promise<void> {
+  updateDeliveryQueueEntry(QUEUE_NAME, id, stateDir, (entry) => ({
+    ...(entry as QueuedSessionDelivery),
+    recoveryState: undefined,
+  }));
 }

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -40,6 +40,193 @@ describe("session-delivery queue recovery", () => {
     });
   });
 
+  it("does not re-deliver a session entry whose delivery succeeded but ack was interrupted by a crash", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "continue",
+          messageId: "restart-sentinel:agent:main:main:agentTurn:123",
+          route: { channel: "telegram", to: "chat-1", chatType: "direct" },
+        },
+        tempDir,
+      );
+
+      let deliverCount = 0;
+      // Stand-in for deliverQueuedSessionDelivery: the agent turn runs (signalling
+      // onSendAttemptStart so recovery persists the send marker) and returns. With the
+      // fix, recovery refuses a blind replay of this already-run turn, so it runs once.
+      const deliver = vi.fn(async (_entry, hooks) => {
+        await hooks?.onSendAttemptStart?.();
+        deliverCount += 1;
+      });
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      // PASS 1: the turn runs but the ack is interrupted — models a crash after the
+      // turn ran but before ackSessionDelivery. recovery.ts imports ackSessionDelivery
+      // from the storage module, so spy that binding.
+      const storage = await import("./session-delivery-queue-storage.js");
+      const ackSpy = vi
+        .spyOn(storage, "ackSessionDelivery")
+        .mockImplementationOnce(async () => {
+          throw new Error("simulated crash before ack");
+        });
+      await recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log });
+      ackSpy.mockRestore();
+
+      // PASS 2: restart recovery re-enters and reloads the queue.
+      await recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log });
+
+      // Without the fix: deliverCount === 2 (blind replay — turn re-run + reply
+      // re-sent). With the fix: the turn reported onSendAttemptStart, so the ack
+      // failure fail-safes the entry to failed/ rather than requeuing it → 1.
+      expect(deliverCount).toBe(1);
+    });
+  });
+
+  it("refuses to replay an entry recovered while still carrying the send marker (crash then fresh-process recovery)", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const storage = await import("./session-delivery-queue-storage.js");
+      const id = await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "continue",
+          messageId: "restart-sentinel:agent:main:main:agentTurn:456",
+          route: { channel: "telegram", to: "chat-1", chatType: "direct" },
+        },
+        tempDir,
+      );
+
+      // Model the durable state left by a crash that struck after the drain began
+      // deliver but before ack: the send_attempt_started marker is persisted, the
+      // entry is still pending, and the process restarted (no in-process delivered
+      // flag survives). This is the real production scenario the fix guards.
+      await storage.markSessionDeliveryPlatformSendAttemptStarted(id, tempDir);
+
+      const deliver = vi.fn(async () => undefined);
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const summary = await recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log });
+
+      // Without the fix: recovery treats the pending entry as fresh and replays it
+      // (deliver called, turn re-run + reply re-sent). With the fix: the recovered
+      // send_attempt_started marker forces a fail-safe move to failed/ — no replay.
+      expect(deliver).not.toHaveBeenCalled();
+      expect(summary.recovered).toBe(0);
+      expect(await loadPendingSessionDeliveries(tempDir)).toStrictEqual([]);
+    });
+  });
+
+  it("refuses to replay a turn that sent before throwing (sent-before-error)", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "continue",
+          messageId: "restart-sentinel:agent:main:main:agentTurn:789",
+          route: { channel: "telegram", to: "chat-1", chatType: "direct" },
+        },
+        tempDir,
+      );
+
+      let deliverCount = 0;
+      // The turn starts running (onSendAttemptStart) and may already have sent via the
+      // message tool, then throws (a non-busy error after the send). This is the
+      // sent-before-error path: recovery must NOT treat it as a pre-send failure.
+      const deliver = vi.fn(async (_entry, hooks) => {
+        await hooks?.onSendAttemptStart?.();
+        deliverCount += 1;
+        throw new Error("turn threw after sending");
+      });
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      await recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log });
+      // PASS 2: restart recovery re-enters.
+      await recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log });
+
+      // Without the fix the catch clears the marker on the thrown deliver, so PASS 2
+      // replays the already-sent turn (deliverCount === 2). With the fix the
+      // sendAttempted signal fail-safes the entry to failed/ → delivered once.
+      expect(deliverCount).toBe(1);
+    });
+  });
+
+  it("retries a pre-send failure that never started the turn (at-least-once preserved)", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "continue",
+          messageId: "restart-sentinel:agent:main:main:agentTurn:abc",
+          route: { channel: "telegram", to: "chat-1", chatType: "direct" },
+        },
+        tempDir,
+      );
+
+      let deliverCount = 0;
+      // The turn never starts (the deliver throws before reporting onSendAttemptStart),
+      // e.g. a transient pre-send failure. Nothing ran or sent, so the entry must stay
+      // retryable — fail-safe must NOT swallow a genuine pre-send failure.
+      const deliver = vi.fn(async () => {
+        deliverCount += 1;
+        throw new Error("transient pre-send failure");
+      });
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      await recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log });
+
+      // The entry must stay pending with retry metadata and NO recovery marker — a
+      // genuine pre-send failure is not fail-safed to failed/. (The subsequent retry
+      // itself is gated by the normal backoff, covered by the backoff tests.)
+      expect(deliverCount).toBe(1);
+      const [pending] = await loadPendingSessionDeliveries(tempDir);
+      expect(pending).toBeDefined();
+      expect(pending?.retryCount).toBe(1);
+      expect(pending?.recoveryState).toBeUndefined();
+    });
+  });
+
+  it("clears the send marker and stays retryable when the attempt is busy-deferred", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "continue",
+          messageId: "restart-sentinel:agent:main:main:agentTurn:def",
+          route: { channel: "telegram", to: "chat-1", chatType: "direct" },
+        },
+        tempDir,
+      );
+
+      let deliverCount = 0;
+      // Model a busy continuation: the attempt starts (onSendAttemptStart persists the
+      // marker), but the session is busy so the seam defers it (onSendDeferred clears
+      // the marker) and throws the busy-retry error. No durable turn ran, so the entry
+      // must stay retryable with the marker cleared — exercises the
+      // clearSessionDeliveryRecoveryState() path.
+      const deliver = vi.fn(async (_entry, hooks) => {
+        deliverCount += 1;
+        await hooks?.onSendAttemptStart?.();
+        await hooks?.onSendDeferred?.();
+        throw new Error("restart continuation busy; retry later");
+      });
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      await recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log });
+
+      // Not moved to failed/ — the cleared marker leaves the entry retryable.
+      expect(deliverCount).toBe(1);
+      const [pending] = await loadPendingSessionDeliveries(tempDir);
+      expect(pending).toBeDefined();
+      expect(pending?.recoveryState).toBeUndefined();
+      expect(pending?.retryCount).toBe(1);
+    });
+  });
+
   it("defers recovery when the recovery budget would exceed the date range", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(MAX_DATE_TIMESTAMP_MS));


### PR DESCRIPTION
## Summary

- **Problem**: The session-delivery recovery queue blind-replays an unacked agent turn after a crash. `drainQueuedEntry` (`src/infra/session-delivery-queue-recovery.ts`) runs `await deliver(entry)` then `ackSessionDelivery`. If the agent turn re-runs (`dispatchAssembledChannelTurn`, which can send via the message tool) but the process dies before the ack, the entry stays pending and the next recovery re-delivers it.
- **Why it matters**: The same restart-continuation `agentTurn` runs twice (non-idempotent LLM/tool side effects) and its reply is sent twice. Restart continuations are, by definition, on the crash/restart path.
- **What changed**: Wire the shared SQLite `recovery_state` column (`#88665` already added it) into the session drain, at the turn-execution boundary. The deliver seam (`server-restart-sentinel.ts`) reports `onSendAttemptStart` right before the agent turn runs, and `onSendDeferred` if that attempt is merely deferred because the session is busy. `drainQueuedEntry` persists the marker on `onSendAttemptStart` and refuses a recovered marked entry (fail-safe move to `failed/`). On a thrown deliver, a turn that began running is refused even if it threw after sending; a pre-send / busy-deferred / no-op failure stays retryable.
- **What did NOT change**: No adapter contract, no channel adapter, no new config / permission / secret / network surface. The `recovery_state` column itself already exists (`#88665`). Genuine pre-send failures still retry (at-least-once preserved); the no-op deliver paths (`systemEvent` / changed-session / no-route) never mark and stay retryable.

## Change Type

Bug fix (reliability / crash recovery).

## Scope

`src/infra/` (session-delivery queue recovery + storage) and `src/gateway/server-restart-sentinel.ts` (the deliver seam reports the send boundary). No owner-gated paths touched.

## Linked Issue

Closes #88015

## Root Cause

The session-delivery queue is at-least-once: `drainQueuedEntry` delivers then acks. There was no durable marker recording that a delivery's turn had begun, so recovery could not distinguish "never ran" from "ran but not yet acked." The parallel outbound queue already guards exactly this with a `recovery_state` marker and refuses a blind replay on recovery without adapter reconciliation. `#88665` moved both queues onto a shared SQLite backing carrying a `recovery_state` column, but the session-delivery drain neither set nor read it.

## Regression Test Plan

Four tests in `src/infra/session-delivery-queue.recovery.test.ts` (profile: infra), RED before / GREEN after:

1. `does not re-deliver a session entry whose delivery succeeded but ack was interrupted by a crash` — the turn runs (signals `onSendAttemptStart`); the ack throws once; a second recovery pass must not replay it.
2. `refuses to replay an entry recovered while still carrying the send marker` — durable `send_attempt_started` on a pending entry (the cross-restart scenario); recovery refuses (no `deliver`, moved to `failed/`).
3. `refuses to replay a turn that sent before throwing (sent-before-error)` — the turn signals `onSendAttemptStart` then throws; recovery must not treat it as pre-send and replay it.
4. `retries a pre-send failure that never started the turn` — `deliver` throws before `onSendAttemptStart`; the entry stays pending and retryable with no marker (at-least-once preserved).

These exercise the SQLite-backed queue and require Node 24+ (`node:sqlite` `StatementSync.columns`), matching the repo CI test lane.

## Security Impact

None. No new permission, secret, or network call; no change to data scope or the adapter surface. The only behavioral change is fail-safe refusal of a blind replay on recovery.

## Repro + Verification

- **Environment**: macOS (darwin arm64), Node 24.x, OpenClaw built from this branch; isolated `OPENCLAW_HOME` / `OPENCLAW_STATE_DIR`.
- **Steps**: enqueue an `agentTurn` session delivery, let the turn run (mark) without acking (crash-before-ack), then run `recoverPendingSessionDeliveries` again.
- **Expected (fixed)**: delivered once; the recovered marker forces a fail-safe move to `failed/`.
- **Actual (before fix)**: delivered twice (turn re-run + reply re-sent).

## Evidence

Regression tests RED before / GREEN after (see Regression Test Plan). Local gates on this branch: `pnpm build` exit 0, typecheck clean, `pnpm check` exit 0; target tests `session-delivery-queue.recovery` + `.storage` + `server-restart-sentinel` pass on Node 24. The Real behavior proof below measures `deliver()` invocation count across a crash-before-ack + restart sequence on the SQLite-backed queue.

## Human Verification

Compared the rewritten recovery flow against the outbound-queue sibling (`src/infra/outbound/delivery-queue-recovery.ts`) to confirm the marker/refuse contract matches; confirmed the busy continuation path (which produces a busy-retry response, no durable work) clears the marker so it stays retryable; traced the production caller (`recoverPendingSessionDeliveries` ← `server-restart-sentinel.ts`, `deliverQueuedSessionDelivery` → `dispatchAssembledChannelTurn`) to place the `onSendAttemptStart` boundary at the actual turn execution.

## Review Conversations

New PR — earlier internal review flagged that clearing the marker on every thrown deliver would let a sent-before-error turn replay; this revision moves the marker to the turn-execution boundary so a turn that began running is refused while genuine pre-send failures stay retryable.

## Compatibility / Migration

Backward compatible, no migration. The `recovery_state` column already exists in the shared delivery-queue schema (`#88665`); pre-change entries read back with no marker and follow the normal path. A single marker state (`send_attempt_started`) is used.

## Risks and Mitigations

- **Fail-safe over the crash window (intentional tradeoff)**: a crash in the narrow window after the turn starts running but before the ack moves the entry to `failed/` rather than replaying it. This favors no-duplicate over at-least-once for that window — the same product choice the outbound queue makes when it has no reconcile capability. Pre-send failures, busy-deferred attempts, and no-op deliver paths are unaffected (they stay retryable). **Mitigation / follow-up**: a precise adapter-side `reconcileUnknownSend` (as the outbound queue has) would let recovery confirm actual send status and replay safely; that is a larger, multi-adapter change kept out of this one-thing-per-PR fix.

## Real behavior proof

- **Behavior or issue addressed**: Without this patch, the session-delivery recovery queue blind-replays an unacked agent turn after a crash. drainQueuedEntry (session-delivery-queue-recovery.ts) runs `await deliver(entry)` then `ackSessionDelivery`. If the process is killed after deliver succeeds (the agent turn re-runs via dispatchAssembledChannelTurn and the platform reply is sent) but before ack, the entry stays pending. The next recovery re-delivers it unconditionally, re-running the turn and re-sending the reply. #88665 moved the delivery queues onto a shared SQLite backing (delivery-queue-sqlite.ts) that already carries a recovery_state column, but the session-delivery drain does not set or read it; the parallel outbound queue (outbound/delivery-queue-recovery.ts) does, reconciling actual send status before replay and refusing blind replay when it cannot confirm. With this patch the session drain wires the existing recovery_state column so it refuses blind replay of an already-sent turn, matching the outbound queue.
- **Real environment tested**: macOS (darwin arm64), Node 24.x (node:sqlite StatementSync.columns), OpenClaw built from this branch. Isolated OPENCLAW_HOME + explicit OPENCLAW_STATE_DIR via the real-behavior-proof harness env isolation; the session-delivery queue now lives in the shared state SQLite DB. No external dependencies (no OAuth/LLM/channel calls) - the deliver callback only counts invocations. Production touched: none. The crash is modelled deterministically as deliver-success-then-ack-skip followed by a real recoverPendingSessionDeliveries restart pass (same production recovery code path); a real process SIGKILL/restart strengthens this in the post-sol run.
- **Exact steps or command run after this patch**:

```text
$ node_modules/.bin/tsx <probe>.mts          (worktree-relative, isolated state dir, Node 24)
  probe: enqueueSessionDelivery(agentTurn) ->
         PASS 1 deliver(entry) success, SKIP ack   (crash-before-ack model) ->
         PASS 2 recoverPendingSessionDeliveries()   (restart, real recovery path) ->
         count deliver() invocations on the same entry
```

- **Evidence after fix**:

Live Node.js measurement of deliver() invocation count for one unacked agentTurn entry across a crash-before-ack then restart-recovery sequence (SQLite-backed session queue):

```text
[Build A] without this patch (base sha):
  pendingAfterEnqueue=1 pendingAfterCrash=1 recoveryStateAfterCrash=field-absent
  deliverCount=2  recovered=1 pendingAfterRecover=0
  -> same entry delivered twice (blind replay): turn re-run + reply re-sent.

[Build B] with this patch (head sha):
  pendingAfterEnqueue=1 pendingAfterCrash=1 recoveryStateAfterCrash=send_attempt_started
  deliverCount=1  recovered=0 pendingAfterRecover=0
  -> recovery sees the persisted recovery_state and refuses blind replay: delivered once.
```

- **Observed result after fix**: With the patch, deliver() is invoked 1x for the unacked agentTurn (vs 2x without the patch). Wiring the existing shared recovery_state column into the session drain lets it refuse blind replay of an already-sent turn, matching the outbound queue's reconciliation guarantee.
- **What was not tested**: Real adapter-side reconcile round-trip (post-sol fix scope; this proof measures replay suppression via the persisted recovery_state). Real OS-level SIGKILL between deliver and ack (modelled here as ack-skip + restart pass; post-sol uses a real forked process restart). Platform-side message dedup inside dispatchAssembledChannelTurn (turn/kernel path out of scope).

---

AI-assisted: drafted with Claude Code (claude-opus-4-8); fully tested (build + typecheck + Node 24 target tests + real-behavior-proof). Author reviewed and understands the change.
