### PR TITLE
docs(agents): add recovery card handoff guidance

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -56,6 +56,34 @@ Type `/compact` in any chat to force a compaction. Add instructions to guide the
 
 When `agents.defaults.compaction.keepRecentTokens` is set, manual compaction honors that OpenClaw cut-point and keeps the recent tail in rebuilt context. Without an explicit keep budget, manual compaction behaves as a hard checkpoint and continues from the new summary alone.
 
+## Recovery notes before long compactions
+
+For long-running work, ask the agent for a short recovery note before manual
+compaction or before switching devices. A recovery note is different from the
+model-generated compaction summary: it is written for the next human or agent
+that has to continue the task.
+
+Use a recovery note when the task has any of these:
+
+- open files or pending patches
+- a blocked login, approval, or external service
+- sub-agent results that still need to be merged
+- commands or tests that must be rerun
+- public, security, or credential-sensitive context that should not be guessed
+
+Recommended prompt:
+
+```text
+Before compacting, write a recovery note with: current objective, latest user
+correction, files touched, commands run, blockers, decisions, safety notes, and
+the exact next action. Do not include secrets, tokens, cookies, private contact
+details, or raw credentials.
+```
+
+Keep the note short enough to paste back into the same thread after `/compact`
+or into a new agent session. Store durable facts in [Memory](/concepts/memory)
+when they should survive beyond this task.
+
 ## Configuration
 
 Configure compaction under `agents.defaults.compaction` in your `openclaw.json`. The most common knobs are listed below; for the full reference, see [Session management deep dive](/reference/session-management-compaction).

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -506,6 +506,31 @@ Announce context is normalized to a stable internal event block:
 Terminal failed runs report failure status without replaying captured
 reply text. Tool/toolResult output is not promoted into child result text.
 
+### Recovery-card output
+
+For larger delegated tasks, ask sub-agents or orchestrator agents to return a
+small recovery card instead of a loose progress note. This makes the parent run
+easier to resume after compaction, timeout, or handoff.
+
+Use this shape when the child touched files, hit a blocker, or produced work
+that another agent must merge:
+
+```text
+Objective:
+Files touched:
+Commands run:
+Decisions:
+Blockers:
+Safety notes:
+Next action:
+```
+
+The recovery card should name paths relative to the workspace, describe proof
+that was actually run, and state what was not tested. It should not include
+secrets, raw tokens, cookies, OTPs, private contact details, or credential
+values. If a child saw credential-like text, it should say that credentials were
+visible and recommend rotation without repeating the value.
+
 ### Stats line
 
 Announce payloads include a stats line at the end (even when wrapped):


### PR DESCRIPTION
## Summary

- Add recovery-note guidance to the compaction docs for long-running sessions.
- Add a recovery-card output shape to the sub-agents docs so delegated work is easier to merge, resume, or hand off.
- Call out proof, blockers, safety notes, and credential redaction expectations.

## Verification

- `git diff --check HEAD~1..HEAD`
- Reviewed the touched docs against `docs/AGENTS.md` link and wording rules.

## Real behavior proof

Behavior addressed: Long-running agent and sub-agent work can be hard to resume after compaction, timeout, or handoff unless the agent leaves a compact recovery note.

Real environment tested: Windows local checkout of `m4stanuj/openclaw`, branch `docs/recovery-card-handoff`.

Exact steps or command run after this patch:

```powershell
git diff --check HEAD~1..HEAD
git show --stat --oneline --no-renames HEAD
```

Evidence after fix: Copied terminal output from the local OpenClaw checkout after this patch:

```text
PASS: git diff --check HEAD~1..HEAD
0d048756 docs(agents): add recovery card handoff guidance
 docs/concepts/compaction.md | 28 ++++++++++++++++++++++++++++
 docs/tools/subagents.md     | 25 +++++++++++++++++++++++++
 2 files changed, 53 insertions(+)
```

Observed result after fix: The docs provide an explicit resume/handoff checklist without changing runtime behavior or adding new config surfaces.

What was not tested: No site build was run. `corepack pnpm --version` works in this Windows shell, but `corepack pnpm docs:list` was interrupted before producing useful docs inventory output, so this PR relies on diff-level proof and the repository CI docs check.

AI assistance: Drafted with Codex under contributor direction.
