### PR TITLE
fix(memory-core): don't run the LLM reranker in vsearch/search modes

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4070,6 +4070,46 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("disables the LLM reranker (rerank:false) for vsearch mode via mcporter", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "vsearch",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    let captured: Record<string, unknown> | null = null;
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        captured = JSON.parse(args[args.indexOf("--args") + 1]);
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
+    await manager.close();
+
+    expect(captured).not.toBeNull();
+    const sentArgs = captured as unknown as Record<string, unknown>;
+    // vsearch is a vector-only mode (see buildV2Searches) — it must NOT trigger
+    // QMD's LLM reranker, which the "query" tool enables by default.
+    expect(sentArgs.rerank).toBe(false);
+    const searchTypes = (sentArgs.searches as Array<{ type?: unknown }>).map((s) => s.type);
+    expect(searchTypes).toEqual(["vec"]);
+  });
+
   it("keeps hyphenated tokens in lexical QMD searches while normalizing semantic searches", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2638,6 +2638,13 @@ export class QmdMemoryManager implements MemorySearchManager {
           // its own reranking pipeline and does not accept a minScore parameter.
           searches: this.buildV2Searches(params.query, params.searchCommand),
           limit: params.limit,
+          // "search"/"vsearch" are lexical/vector-only modes (see buildV2Searches):
+          // they must not trigger the LLM reranker. QMD's "query" tool defaults
+          // rerank:true, so disable it explicitly for those modes; full "query"
+          // mode keeps reranking.
+          ...(params.searchCommand === "search" || params.searchCommand === "vsearch"
+            ? { rerank: false }
+            : {}),
         }
       : {
           // QMD 1.x tools accept a flat query string.


### PR DESCRIPTION
## What

`searchMode: "vsearch"` / `"search"` are documented as vector/lexical-only modes that must not do LLM work — `buildV2Searches`' own doc comment says they exist "so lexical-only or vector-only modes don't trigger unnecessary LLM/embedding work." But `runQmdSearchViaMcporter` builds `callArgs` without `rerank`, and QMD's unified `query` tool **defaults `rerank: true`**. So every `vsearch`/`search` memory search silently runs the LLM reranker anyway. QMD's own tool docs flag it: *"rerank … (default: true). Set to false for faster results on CPU-only machines."*

## Fix

Pass `rerank: false` for `search`/`vsearch` in `runQmdSearchViaMcporter` (full `query` mode keeps reranking). The cold/CLI path (`buildSearchArgs`) is unaffected — it already maps each mode to qmd's dedicated `vsearch`/`search` subcommands, which don't rerank.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: In `searchMode: "vsearch"`/`"search"`, every memory search silently invoked QMD's LLM reranker. `runQmdSearchViaMcporter` omitted `rerank` from the query `callArgs` and QMD's `query` tool defaults `rerank: true`, contradicting those modes' vector/lexical-only contract.
- Real environment tested: Live OpenClaw gateway (memory-core extension, mcporter warm path) → QMD `qmd mcp` running on an Intel UHD 630 iGPU (Gen9.5), host Linux 7.0.6-2-pve. Each case below is a fresh `qmd mcp` process fed exactly the `callArgs` openclaw builds; host kernel watched via `dmesg`.
- Exact steps or command run after this patch: ran a `qmd mcp` client that calls the `query` tool with the patched vsearch args `{"searches":[{"type":"vec","query":"how do I handle errors gracefully"}],"limit":3,"rerank":false}`, and compared it against the unpatched args (no `rerank`). Command: `node demo.mjs false` → spawns `qmd mcp`, sends `tools/call query`.
- Evidence after fix (terminal capture / copied live output):
  ```
  AFTER this patch — openclaw sends rerank:false:
    → {"searches":[{"type":"vec","query":"how do I handle errors gracefully"}],"limit":3,"rerank":false}
    ← 3650ms  OK — 3 hits          new host-kernel GPU HANGs during this call: 0

  BEFORE (current behavior — openclaw omits rerank):
    → {"searches":[{"type":"vec","query":"how do I handle errors gracefully"}],"limit":3}
    Reranking error: [Error: vk::Queue::submit: ErrorDeviceLost]
    ← 12303ms  ERROR: vk::Queue::submit: ErrorDeviceLost   new host-kernel GPU HANGs during this call: 3

  host dmesg during the BEFORE call:
    i915 0000:00:02.0: [drm] GPU HANG: ecode 9:1:8ed1fff2, in libuv-worker [275718]
    i915 0000:00:02.0: [drm] Resetting rcs0 for preemption time out
    i915 0000:00:02.0: [drm] libuv-worker[277683] context reset due to GPU hang
  ```
- Observed result after fix: vsearch now sends `rerank:false`, returns 3 hits with zero host-kernel GPU hangs and no reranker invoked; the unpatched path errors with `ErrorDeviceLost` and produces 3 kernel GPU hangs. In my deployment, warm memory recall went from a CPU-fallback spin to ~126 ms on the GPU.
- What was not tested: the QMD v1 tool-name fallback path (`vector_search`/`search`) on real hardware — only the v2 unified `query` tool was exercised live (the new unit test covers the v2 mcporter `callArgs`); and non-iGPU reranker hardware.
- Proof limitations or environment constraints: the GPU-hang symptom is specific to a constrained iGPU; on capable hardware the same bug manifests as wasted reranker compute rather than a hang. The 3650 ms above is a fresh-process cold model load — warm recall in my deployment is ~126 ms.
- Before evidence (optional but encouraged): shown inline in the Evidence block above (BEFORE case → `ErrorDeviceLost` + 3 kernel GPU hangs; `dmesg` excerpt included).

## Tests and validation

- Added a unit test: `vsearch` mode sends `rerank: false` via mcporter (and the existing `query`-mode test still asserts it does **not**). `pnpm test:extension memory-core` passes; type-check (`pnpm tsgo:test`) clean.
- The only failing memory-core test, `dreaming-phases.test.ts > suppresses cleanup warnings during request-scoped narrative fallback`, is already red on clean `main` (verified by stashing this change) and is unrelated to this PR.

---

🤖 **AI-assisted** — implemented with an AI coding agent; the real-behavior proof above is from my own live OpenClaw setup, not AI-generated. *Allow edits by maintainers* enabled. No `CHANGELOG.md` change (per CONTRIBUTING).
