### PR TITLE
fix #87768: [Bug]: push to talk mac os companion app hard codes thinking low

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -224,6 +224,53 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
         #expect(params?["thinking"] == nil)
     }
 
+    @Test func `chat send includes explicit thinking override`() async throws {
+        let recorder = WebSocketMessageRecorder()
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
+                recorder.append(message)
+                guard sendIndex > 0,
+                      let data = Self.messageData(message),
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let id = json["id"] as? String
+                else { return }
+                task.emitReceiveSuccess(.data(Self.chatSendOkResponseData(id: id)))
+            })
+        })
+        let connection = GatewayConnection(
+            configProvider: {
+                (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil)
+            },
+            sessionBox: WebSocketSessionBox(session: session))
+
+        _ = try await connection.chatSend(
+            sessionKey: "main",
+            message: "hello",
+            thinking: "low",
+            idempotencyKey: "chat-2",
+            attachments: [])
+        await connection.shutdown()
+
+        guard let chatMessage = recorder.snapshot().reversed().first(where: { message in
+            guard let data = Self.messageData(message),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return false }
+            return json["method"] as? String == "chat.send"
+        }) else {
+            Issue.record("expected chat.send websocket payload")
+            return
+        }
+
+        guard let payloadData = Self.messageData(chatMessage) else {
+            Issue.record("unexpected chat.send websocket message type")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: payloadData) as? [String: Any]
+        let params = json?["params"] as? [String: Any]
+        #expect(params?["thinking"] as? String == "low")
+    }
+
     private static func messageData(_ message: URLSessionWebSocketTask.Message) -> Data? {
         switch message {
         case let .string(text):


### PR DESCRIPTION
## Summary

- Problem: macOS voice sends now omit inherited thinking, but the gateway contract also needs to keep explicit thinking overrides when a caller intentionally sets one.
- Solution: Add a macOS gateway regression test proving `chat.send` still serializes an explicit `thinking` override.
- What changed: `apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift` adds the explicit non-nil `thinking` case next to the inherited-default omission test.
- What did NOT change: no production code, no voice routing, no provider/model policy, no gateway protocol schema.

Fixes #87768

## Real behavior proof

- **Behavior or issue addressed:** macOS gateway `chat.send` payloads omit `thinking` when inheriting defaults, while preserving an explicit caller-provided override.
- **Real environment tested:** GitHub Actions macOS 26.3, Apple Swift 6.2.3, OpenClaw worktree SHA 152361e.
- **Exact steps or command run after this patch:**
  ```bash
  swift --version
  swift test --package-path apps/macos --parallel --enable-code-coverage --show-codecov-path
  ```
- **Evidence after fix:** macos-swift check passed for this PR head. Relevant terminal output from the macOS runner:
  ```text
  ProductName:        macOS
  ProductVersion:     26.3
  Apple Swift version 6.2.3 (swiftlang-6.2.3.3.21 clang-1700.6.3.2)
  if swift test --package-path apps/macos --parallel --enable-code-coverage --show-codecov-path; then
  /Users/runner/_work/openclaw/openclaw/apps/macos/.build/arm64-apple-macosx/debug/codecov/OpenClaw.json
  macos-swift: SUCCESS
  Real behavior proof: SUCCESS
  ```
- **Observed result after fix:** The macOS Swift test suite completed successfully, including the gateway payload tests that assert inherited thinking is omitted and explicit `thinking: "low"` is included when intentionally provided.
- **What was not tested:** live macOS companion app plus Ollama push-to-talk was not rerun; the macOS CI test exercised the changed gateway payload contract directly.

## Regression Test Plan

- Coverage level: Swift package test
- Target test file: `apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift`
- Scenario locked in: `chat.send` includes an explicit non-nil `thinking` override while the adjacent inherited-default test keeps omitted `thinking` pinned.
- Why this is the smallest reliable guardrail: it covers the gateway request serialization contract directly without changing runtime voice behavior already fixed on main.

## Root Cause

- Root cause: the original macOS voice path forced `thinking: "low"`; after the main fix removed that forced override, the missing guardrail was the opposite side of the contract: explicit overrides must still survive serialization.
- Missing detection / guardrail: there was no macOS gateway test proving explicit `thinking` remains present when a caller intentionally sets it.
