### PR TITLE
fix: harden CLI and plugin edge cases

### DIFF
--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -22,6 +22,7 @@ Initialize the baseline config and agent workspace. With any onboarding flag pre
 | `--workspace <dir>`        | Agent workspace directory (default `~/.openclaw/workspace`; stored as `agents.defaults.workspace`). |
 | `--wizard`                 | Run interactive onboarding.                                                                         |
 | `--non-interactive`        | Run onboarding without prompts.                                                                     |
+| `--accept-risk`            | Acknowledge full-system agent access risk; required with `--non-interactive`.                       |
 | `--mode <mode>`            | Onboarding mode: `local` or `remote`.                                                               |
 | `--import-from <provider>` | Migration provider to run during onboarding.                                                        |
 | `--import-source <path>`   | Source agent home for `--import-from`.                                                              |
@@ -33,7 +34,7 @@ Initialize the baseline config and agent workspace. With any onboarding flag pre
 
 `openclaw setup` runs the wizard when any of these flags are explicitly present, even without `--wizard`:
 
-`--wizard`, `--non-interactive`, `--mode`, `--import-from`, `--import-source`, `--import-secrets`, `--remote-url`, `--remote-token`.
+`--wizard`, `--non-interactive`, `--accept-risk`, `--mode`, `--import-from`, `--import-source`, `--import-secrets`, `--remote-url`, `--remote-token`.
 
 ## Examples
 
@@ -42,7 +43,7 @@ openclaw setup
 openclaw setup --workspace ~/.openclaw/workspace
 openclaw setup --wizard
 openclaw setup --wizard --import-from hermes --import-source ~/.hermes
-openclaw setup --non-interactive --mode remote --remote-url wss://gateway-host:18789 --remote-token <token>
+openclaw setup --non-interactive --accept-risk --mode remote --remote-url wss://gateway-host:18789 --remote-token <token>
 ```
 
 ## Notes

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   setRuntimeConfigSnapshot: vi.fn(),
   loadAuthProfileStoreForRuntime: vi.fn(() => ({ profiles: {}, order: {} })),
   listProfilesForProvider: vi.fn(() => []),
+  resolveApiKeyForProvider: vi.fn(),
   resolveAgentDir: vi.fn((_cfg: unknown, agentId: string) => `/tmp/agent-${agentId}`),
   updateAuthProfileStoreWithLock: vi.fn(
     async ({ updater }: { updater: (store: any) => boolean }) => {
@@ -96,6 +97,7 @@ const mocks = vi.hoisted(() => ({
   })),
   setTtsProvider: vi.fn(),
   setTtsPersona: vi.fn(),
+  resolveTtsConfig: vi.fn(() => ({})),
   resolveExplicitTtsOverrides: vi.fn(
     ({
       provider,
@@ -248,6 +250,11 @@ vi.mock("../agents/auth-profiles.js", () => ({
     mocks.listProfilesForProvider as typeof import("../agents/auth-profiles.js").listProfilesForProvider,
 }));
 
+vi.mock("../agents/model-auth.js", () => ({
+  resolveApiKeyForProvider:
+    mocks.resolveApiKeyForProvider as typeof import("../agents/model-auth.js").resolveApiKeyForProvider,
+}));
+
 vi.mock("../agents/auth-profiles/store.js", () => ({
   updateAuthProfileStoreWithLock:
     mocks.updateAuthProfileStoreWithLock as typeof import("../agents/auth-profiles/store.js").updateAuthProfileStoreWithLock,
@@ -338,7 +345,7 @@ vi.mock("../tts/tts.js", () => ({
   getTtsProvider: vi.fn(() => "openai"),
   listTtsPersonas: vi.fn(() => []),
   listSpeechVoices: vi.fn(async () => []),
-  resolveTtsConfig: vi.fn(() => ({})),
+  resolveTtsConfig: mocks.resolveTtsConfig as typeof import("../tts/tts.js").resolveTtsConfig,
   resolveTtsPrefsPath: vi.fn(() => "/tmp/tts.json"),
   setTtsEnabled: vi.fn(),
   setTtsPersona: mocks.setTtsPersona as typeof import("../tts/tts.js").setTtsPersona,
@@ -459,7 +466,9 @@ describe("capability cli", () => {
       .mockResolvedValue([{ id: "gpt-5.4", provider: "openai", name: "GPT-5.4" }] as never);
     mocks.loadAuthProfileStoreForRuntime.mockReset().mockReturnValue({ profiles: {}, order: {} });
     mocks.listProfilesForProvider.mockReset().mockReturnValue([]);
+    mocks.resolveApiKeyForProvider.mockReset().mockRejectedValue(new Error("no auth profile"));
     mocks.resolveAgentDir.mockClear();
+    mocks.resolveTtsConfig.mockReset().mockReturnValue({});
     mocks.getRuntimeConfigSourceSnapshot.mockReset().mockReturnValue(null);
     mocks.setRuntimeConfigSnapshot.mockClear();
     mocks.updateAuthProfileStoreWithLock
@@ -2118,6 +2127,120 @@ describe("capability cli", () => {
     expect(overrides?.providerOverrides?.openai?.modelId).toBe("gpt-4o-mini-tts");
     expect(overrides?.providerOverrides?.openai?.voiceId).toBe("alloy");
     expect(mocks.setTtsProvider).not.toHaveBeenCalled();
+  });
+
+  it("hydrates local TTS provider config from API-key auth profiles", async () => {
+    const rawConfig = { messages: { tts: { providers: { openai: { voice: "coral" } } } } };
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
+      apiKey: "profile-openai-key",
+      source: "profile:openai:qa",
+      mode: "api-key",
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "tts",
+        "convert",
+        "--text",
+        "hello",
+        "--model",
+        "openai/gpt-4o-mini-tts",
+        "--json",
+      ],
+    });
+
+    expect(mocks.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        cfg: rawConfig,
+        credentialPrecedence: "profile-first",
+      }),
+    );
+    const cfg = firstTextToSpeechCall()?.cfg as {
+      messages?: { tts?: { providers?: { openai?: { apiKey?: string; voice?: string } } } };
+    };
+    expect(cfg.messages?.tts?.providers?.openai).toMatchObject({
+      apiKey: "profile-openai-key",
+      voice: "coral",
+    });
+  });
+
+  it("hydrates local TTS default provider config from API-key auth profiles", async () => {
+    const rawConfig = { messages: { tts: { provider: "openai" } } };
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
+      apiKey: "profile-openai-key",
+      source: "profile:openai:qa",
+      mode: "api-key",
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "tts", "convert", "--text", "hello", "--json"],
+    });
+
+    expect(mocks.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        cfg: rawConfig,
+        credentialPrecedence: "profile-first",
+      }),
+    );
+    const cfg = firstTextToSpeechCall()?.cfg as {
+      messages?: { tts?: { providers?: { openai?: { apiKey?: string } } } };
+    };
+    expect(cfg.messages?.tts?.providers?.openai).toMatchObject({
+      apiKey: "profile-openai-key",
+    });
+  });
+
+  it("hydrates local TTS channel provider config from API-key auth profiles", async () => {
+    const rawConfig = { channels: { discord: { tts: { provider: "openai" } } } };
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
+      apiKey: "profile-openai-key",
+      source: "profile:openai:qa",
+      mode: "api-key",
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "tts", "convert", "--text", "hello", "--channel", "discord", "--json"],
+    });
+
+    expect(mocks.resolveTtsConfig).toHaveBeenCalledWith(rawConfig, { channelId: "discord" });
+    expect(mocks.resolveExplicitTtsOverrides).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: "discord" }),
+    );
+    const cfg = firstTextToSpeechCall()?.cfg as {
+      messages?: { tts?: { providers?: { openai?: { apiKey?: string } } } };
+    };
+    expect(cfg.messages?.tts?.providers?.openai).toMatchObject({
+      apiKey: "profile-openai-key",
+    });
+  });
+
+  it("does not hydrate local TTS provider config from token auth profiles", async () => {
+    const rawConfig = { messages: { tts: { provider: "openai" } } };
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
+      apiKey: "profile-openai-token",
+      source: "profile:openai:token",
+      mode: "token",
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "tts", "convert", "--text", "hello", "--json"],
+    });
+
+    const cfg = firstTextToSpeechCall()?.cfg as {
+      messages?: { tts?: { providers?: { openai?: { apiKey?: string } } } };
+    };
+    expect(cfg.messages?.tts?.providers?.openai?.apiKey).toBeUndefined();
   });
 
   it("disables TTS fallback when explicit provider or voice/model selection is requested", async () => {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2261,6 +2261,43 @@ describe("capability cli", () => {
     expect(mocks.setRuntimeConfigSnapshot).toHaveBeenLastCalledWith(cfg);
   });
 
+  it("does not override inherited local TTS channel provider API keys", async () => {
+    const rawConfig = {
+      messages: { tts: { providers: { openai: { apiKey: "config-key" } } } },
+      channels: {
+        discord: {
+          tts: {
+            providers: { openai: { speakerVoice: "nova" } },
+          },
+        },
+      },
+    };
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.resolveTtsConfig.mockReturnValue({
+      providers: { openai: { apiKey: "config-key", speakerVoice: "nova" } },
+    });
+    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
+      apiKey: "profile-openai-key",
+      source: "profile:openai:qa",
+      mode: "api-key",
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "tts", "convert", "--text", "hello", "--channel", "discord", "--json"],
+    });
+
+    const cfg = firstTextToSpeechCall()?.cfg as {
+      messages?: { tts?: { providers?: { openai?: { apiKey?: string } } } };
+      channels?: {
+        discord?: { tts?: { providers?: { openai?: { apiKey?: string; speakerVoice?: string } } } };
+      };
+    };
+    expect(cfg.messages?.tts?.providers?.openai?.apiKey).toBe("config-key");
+    expect(cfg.channels?.discord?.tts?.providers?.openai).toEqual({ speakerVoice: "nova" });
+    expect(mocks.resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
   it("does not hydrate local TTS provider config from token auth profiles", async () => {
     const rawConfig = { messages: { tts: { provider: "openai" } } };
     mocks.loadConfig.mockReturnValue(rawConfig);

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2167,6 +2167,7 @@ describe("capability cli", () => {
       apiKey: "profile-openai-key",
       voice: "coral",
     });
+    expect(mocks.setRuntimeConfigSnapshot).toHaveBeenLastCalledWith(cfg);
   });
 
   it("hydrates local TTS default provider config from API-key auth profiles", async () => {
@@ -2257,6 +2258,7 @@ describe("capability cli", () => {
       speakerVoice: "nova",
     });
     expect(cfg.messages?.tts?.providers?.openai).toBeUndefined();
+    expect(mocks.setRuntimeConfigSnapshot).toHaveBeenLastCalledWith(cfg);
   });
 
   it("does not hydrate local TTS provider config from token auth profiles", async () => {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2224,6 +2224,41 @@ describe("capability cli", () => {
     });
   });
 
+  it("hydrates local TTS channel direct provider config from API-key auth profiles", async () => {
+    const rawConfig = {
+      channels: {
+        discord: {
+          tts: {
+            openai: { speakerVoice: "nova" },
+          },
+        },
+      },
+    };
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
+      apiKey: "profile-openai-key",
+      source: "profile:openai:qa",
+      mode: "api-key",
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "tts", "convert", "--text", "hello", "--channel", "discord", "--json"],
+    });
+
+    const cfg = firstTextToSpeechCall()?.cfg as {
+      channels?: {
+        discord?: { tts?: { openai?: { apiKey?: string; speakerVoice?: string } } };
+      };
+      messages?: { tts?: { providers?: { openai?: { apiKey?: string } } } };
+    };
+    expect(cfg.channels?.discord?.tts?.openai).toMatchObject({
+      apiKey: "profile-openai-key",
+      speakerVoice: "nova",
+    });
+    expect(cfg.messages?.tts?.providers?.openai).toBeUndefined();
+  });
+
   it("does not hydrate local TTS provider config from token auth profiles", async () => {
     const rawConfig = { messages: { tts: { provider: "openai" } } };
     mocks.loadConfig.mockReturnValue(rawConfig);

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2275,6 +2275,41 @@ describe("capability cli", () => {
     expect(cfg.messages?.tts?.providers?.openai).toBeUndefined();
   });
 
+  it("does not override existing direct TTS provider API keys", async () => {
+    const rawConfig = { messages: { tts: { openai: { apiKey: "config-key" } } } };
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
+      apiKey: "profile-openai-key",
+      source: "profile:openai:qa",
+      mode: "api-key",
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "tts",
+        "convert",
+        "--text",
+        "hello",
+        "--model",
+        "openai/gpt-4o-mini-tts",
+        "--json",
+      ],
+    });
+
+    const cfg = firstTextToSpeechCall()?.cfg as {
+      messages?: {
+        tts?: {
+          openai?: { apiKey?: string };
+          providers?: { openai?: { apiKey?: string } };
+        };
+      };
+    };
+    expect(cfg.messages?.tts?.openai?.apiKey).toBe("config-key");
+    expect(cfg.messages?.tts?.providers?.openai).toBeUndefined();
+  });
+
   it("disables TTS fallback when explicit provider or voice/model selection is requested", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2243,6 +2243,38 @@ describe("capability cli", () => {
     expect(cfg.messages?.tts?.providers?.openai?.apiKey).toBeUndefined();
   });
 
+  it("does not override existing TTS provider API keys with different casing", async () => {
+    const rawConfig = { messages: { tts: { providers: { OpenAI: { apiKey: "config-key" } } } } };
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
+      apiKey: "profile-openai-key",
+      source: "profile:openai:qa",
+      mode: "api-key",
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "tts",
+        "convert",
+        "--text",
+        "hello",
+        "--model",
+        "openai/gpt-4o-mini-tts",
+        "--json",
+      ],
+    });
+
+    const cfg = firstTextToSpeechCall()?.cfg as {
+      messages?: {
+        tts?: { providers?: { openai?: { apiKey?: string }; OpenAI?: { apiKey?: string } } };
+      };
+    };
+    expect(cfg.messages?.tts?.providers?.OpenAI?.apiKey).toBe("config-key");
+    expect(cfg.messages?.tts?.providers?.openai).toBeUndefined();
+  });
+
   it("disables TTS fallback when explicit provider or voice/model selection is requested", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -345,7 +345,8 @@ vi.mock("../tts/tts.js", () => ({
   getTtsProvider: vi.fn(() => "openai"),
   listTtsPersonas: vi.fn(() => []),
   listSpeechVoices: vi.fn(async () => []),
-  resolveTtsConfig: mocks.resolveTtsConfig as typeof import("../tts/tts.js").resolveTtsConfig,
+  resolveTtsConfig:
+    mocks.resolveTtsConfig as unknown as typeof import("../tts/tts.js").resolveTtsConfig,
   resolveTtsPrefsPath: vi.fn(() => "/tmp/tts.json"),
   setTtsEnabled: vi.fn(),
   setTtsPersona: mocks.setTtsPersona as typeof import("../tts/tts.js").setTtsPersona,

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2274,7 +2274,7 @@ describe("capability cli", () => {
     };
     mocks.loadConfig.mockReturnValue(rawConfig);
     mocks.resolveTtsConfig.mockReturnValue({
-      providers: { openai: { apiKey: "config-key", speakerVoice: "nova" } },
+      providerConfigs: { openai: { apiKey: "config-key", speakerVoice: "nova" } },
     });
     mocks.resolveApiKeyForProvider.mockResolvedValueOnce({
       apiKey: "profile-openai-key",

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1497,17 +1497,21 @@ async function injectTtsAuthProfileApiKey(params: {
   if (!providerId) {
     return params.cfg;
   }
+  const effectiveTtsConfig = resolveTtsConfig(params.cfg, { channelId: params.channelId });
+  const effectiveProviderConfig = resolveExistingTtsProviderConfigInTts({
+    cfg: params.cfg,
+    tts: effectiveTtsConfig,
+    providerId,
+  });
+  if (ttsProviderConfigHasApiKey(effectiveProviderConfig?.value)) {
+    return params.cfg;
+  }
   const existingProviderConfig = resolveExistingTtsProviderConfig({
     cfg: params.cfg,
     providerId,
     channelId: params.channelId,
   });
-  if (
-    existingProviderConfig?.value &&
-    typeof existingProviderConfig.value === "object" &&
-    !Array.isArray(existingProviderConfig.value) &&
-    "apiKey" in existingProviderConfig.value
-  ) {
+  if (ttsProviderConfigHasApiKey(existingProviderConfig?.value)) {
     return params.cfg;
   }
   const auth = await resolveApiKeyForProvider({
@@ -1714,6 +1718,10 @@ function buildTtsConfigWithHydratedProvider(params: {
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function ttsProviderConfigHasApiKey(value: unknown): boolean {
+  return isObjectRecord(value) && "apiKey" in value;
 }
 
 async function runTtsProviders(transport: CapabilityTransport) {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1420,6 +1420,9 @@ async function runTtsConvert(params: {
     provider: ttsProvider,
     channelId: params.channel,
   });
+  if (effectiveCfg !== cfg) {
+    pinRuntimeConfigSnapshot(effectiveCfg);
+  }
   const overrides = resolveExplicitTtsOverrides({
     cfg: effectiveCfg,
     provider: params.provider,
@@ -1876,7 +1879,6 @@ async function resolveLocalCapabilityRuntimeConfig(params: {
   config?: OpenClawConfig;
 }): Promise<OpenClawConfig> {
   const cfg = params.config ?? getRuntimeConfig();
-  const sourceConfig = getRuntimeConfigSourceSnapshot();
   const { effectiveConfig } = await resolveCommandConfigWithSecrets({
     config: cfg,
     commandName: params.commandName,
@@ -1887,12 +1889,17 @@ async function resolveLocalCapabilityRuntimeConfig(params: {
     runtime: defaultRuntime,
     autoEnable: true,
   });
-  if (sourceConfig) {
-    setRuntimeConfigSnapshot(effectiveConfig, sourceConfig);
-  } else {
-    setRuntimeConfigSnapshot(effectiveConfig);
-  }
+  pinRuntimeConfigSnapshot(effectiveConfig);
   return effectiveConfig;
+}
+
+function pinRuntimeConfigSnapshot(config: OpenClawConfig): void {
+  const sourceConfig = getRuntimeConfigSourceSnapshot();
+  if (sourceConfig) {
+    setRuntimeConfigSnapshot(config, sourceConfig);
+  } else {
+    setRuntimeConfigSnapshot(config);
+  }
 }
 
 async function runWebSearchCommand(params: { query: string; provider?: string; limit?: number }) {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1519,7 +1519,7 @@ async function injectTtsAuthProfileApiKey(params: {
     return params.cfg;
   }
   if (existingProviderConfig?.scope === "channel") {
-    const channels = { ...(params.cfg.channels ?? {}) };
+    const channels = { ...params.cfg.channels };
     const channel = channels[existingProviderConfig.channelKey];
     if (!isObjectRecord(channel)) {
       return params.cfg;
@@ -1541,7 +1541,7 @@ async function injectTtsAuthProfileApiKey(params: {
       },
     };
   }
-  const messages = { ...(params.cfg.messages ?? {}) };
+  const messages = { ...params.cfg.messages };
   const nextTts = buildTtsConfigWithHydratedProvider({
     tts: messages.tts,
     existingProviderConfig,

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -26,6 +26,7 @@ import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js
 import { buildExplicitSessionIdSessionKey } from "../agents/command/session.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
+import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import { canonicalizeCaseOnlyCatalogModelRef } from "../agents/model-selection.js";
 import {
@@ -1408,11 +1409,22 @@ async function runTtsConvert(params: {
     commandName: "infer tts convert",
     targetIds: getTtsCommandSecretTargetIds(),
   });
-  const overrides = resolveExplicitTtsOverrides({
+  const ttsProvider = resolveTtsProviderForAuthHydration({
     cfg,
     provider: params.provider,
     modelId: params.modelId,
+    channelId: params.channel,
+  });
+  const effectiveCfg = await injectTtsAuthProfileApiKey({
+    cfg,
+    provider: ttsProvider,
+  });
+  const overrides = resolveExplicitTtsOverrides({
+    cfg: effectiveCfg,
+    provider: params.provider,
+    modelId: params.modelId,
     voiceId: params.voiceId,
+    channelId: params.channel,
   });
   const hasExplicitSelection = Boolean(
     overrides.provider ||
@@ -1421,7 +1433,7 @@ async function runTtsConvert(params: {
   );
   const result = await textToSpeech({
     text: params.text,
-    cfg,
+    cfg: effectiveCfg,
     channel: params.channel,
     overrides,
     disableFallback: hasExplicitSelection,
@@ -1450,6 +1462,74 @@ async function runTtsConvert(params: {
       },
     ],
   } satisfies CapabilityEnvelope;
+}
+
+function resolveTtsProviderForAuthHydration(params: {
+  cfg: OpenClawConfig;
+  provider?: string;
+  modelId?: string;
+  channelId?: string;
+}): string | undefined {
+  const explicitProvider =
+    params.provider ?? resolveSelectedProviderFromModelRef(normalizeOptionalString(params.modelId));
+  if (explicitProvider) {
+    return explicitProvider;
+  }
+  const ttsConfig = resolveTtsConfig(params.cfg, { channelId: params.channelId });
+  return getTtsProvider(ttsConfig, resolveTtsPrefsPath(ttsConfig));
+}
+
+async function injectTtsAuthProfileApiKey(params: {
+  cfg: OpenClawConfig;
+  provider?: string;
+}): Promise<OpenClawConfig> {
+  if (!params.provider) {
+    return params.cfg;
+  }
+  const providerId =
+    canonicalizeSpeechProviderId(params.provider, params.cfg) ??
+    normalizeLowercaseStringOrEmpty(params.provider);
+  if (!providerId) {
+    return params.cfg;
+  }
+  const existingProviderConfig = params.cfg.messages?.tts?.providers?.[providerId];
+  if (
+    existingProviderConfig &&
+    typeof existingProviderConfig === "object" &&
+    !Array.isArray(existingProviderConfig) &&
+    "apiKey" in existingProviderConfig
+  ) {
+    return params.cfg;
+  }
+  const auth = await resolveApiKeyForProvider({
+    provider: providerId,
+    cfg: params.cfg,
+    credentialPrecedence: "profile-first",
+  }).catch(() => undefined);
+  if (!auth?.apiKey || auth.mode !== "api-key") {
+    return params.cfg;
+  }
+  const messages = { ...(params.cfg.messages ?? {}) };
+  const tts = { ...(messages.tts ?? {}) };
+  const providers = { ...(tts.providers ?? {}) };
+  providers[providerId] = {
+    ...(existingProviderConfig &&
+    typeof existingProviderConfig === "object" &&
+    !Array.isArray(existingProviderConfig)
+      ? existingProviderConfig
+      : {}),
+    apiKey: auth.apiKey,
+  };
+  return {
+    ...params.cfg,
+    messages: {
+      ...messages,
+      tts: {
+        ...tts,
+        providers,
+      },
+    },
+  };
 }
 
 async function runTtsProviders(transport: CapabilityTransport) {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1418,6 +1418,7 @@ async function runTtsConvert(params: {
   const effectiveCfg = await injectTtsAuthProfileApiKey({
     cfg,
     provider: ttsProvider,
+    channelId: params.channel,
   });
   const overrides = resolveExplicitTtsOverrides({
     cfg: effectiveCfg,
@@ -1482,6 +1483,7 @@ function resolveTtsProviderForAuthHydration(params: {
 async function injectTtsAuthProfileApiKey(params: {
   cfg: OpenClawConfig;
   provider?: string;
+  channelId?: string;
 }): Promise<OpenClawConfig> {
   if (!params.provider) {
     return params.cfg;
@@ -1495,6 +1497,7 @@ async function injectTtsAuthProfileApiKey(params: {
   const existingProviderConfig = resolveExistingTtsProviderConfig({
     cfg: params.cfg,
     providerId,
+    channelId: params.channelId,
   });
   if (
     existingProviderConfig?.value &&
@@ -1512,25 +1515,36 @@ async function injectTtsAuthProfileApiKey(params: {
   if (!auth?.apiKey || auth.mode !== "api-key") {
     return params.cfg;
   }
-  const messages = { ...(params.cfg.messages ?? {}) };
-  const tts = { ...(messages.tts ?? {}) };
-  const providers = { ...(tts.providers ?? {}) };
-  const providerConfigKey = existingProviderConfig?.key ?? providerId;
-  const nextProviderConfig = {
-    ...(existingProviderConfig?.value &&
-    typeof existingProviderConfig.value === "object" &&
-    !Array.isArray(existingProviderConfig.value)
-      ? existingProviderConfig.value
-      : {}),
-    apiKey: auth.apiKey,
-  };
-  const nextTts = { ...tts };
-  if (existingProviderConfig?.container === "direct") {
-    (nextTts as Record<string, unknown>)[providerConfigKey] = nextProviderConfig;
-  } else {
-    providers[providerConfigKey] = nextProviderConfig;
-    nextTts.providers = providers;
+  if (existingProviderConfig?.scope === "channel") {
+    const channels = { ...(params.cfg.channels ?? {}) };
+    const channel = channels[existingProviderConfig.channelKey];
+    if (!isObjectRecord(channel)) {
+      return params.cfg;
+    }
+    const nextChannel = {
+      ...channel,
+      tts: buildTtsConfigWithHydratedProvider({
+        tts: channel.tts,
+        existingProviderConfig,
+        providerId,
+        apiKey: auth.apiKey,
+      }),
+    };
+    return {
+      ...params.cfg,
+      channels: {
+        ...channels,
+        [existingProviderConfig.channelKey]: nextChannel,
+      },
+    };
   }
+  const messages = { ...(params.cfg.messages ?? {}) };
+  const nextTts = buildTtsConfigWithHydratedProvider({
+    tts: messages.tts,
+    existingProviderConfig,
+    providerId,
+    apiKey: auth.apiKey,
+  });
   return {
     ...params.cfg,
     messages: {
@@ -1540,18 +1554,59 @@ async function injectTtsAuthProfileApiKey(params: {
   };
 }
 
-type ExistingTtsProviderConfig = {
+type TtsProviderConfigLocation = {
   container: "providers" | "direct";
   key: string;
   value: unknown;
 };
 
+type ExistingTtsProviderConfig =
+  | (TtsProviderConfigLocation & {
+      scope: "root";
+      channelKey?: never;
+    })
+  | (TtsProviderConfigLocation & {
+      scope: "channel";
+      channelKey: string;
+    });
+
 function resolveExistingTtsProviderConfig(params: {
   cfg: OpenClawConfig;
   providerId: string;
+  channelId?: string;
 }): ExistingTtsProviderConfig | undefined {
-  const tts = params.cfg.messages?.tts;
-  const providers = tts?.providers;
+  const channelTts = resolveChannelTtsConfigForAuthHydration(params);
+  if (channelTts) {
+    const channelProviderConfig = resolveExistingTtsProviderConfigInTts({
+      cfg: params.cfg,
+      tts: channelTts.tts,
+      providerId: params.providerId,
+    });
+    if (channelProviderConfig) {
+      return {
+        ...channelProviderConfig,
+        scope: "channel",
+        channelKey: channelTts.channelKey,
+      };
+    }
+  }
+  const rootProviderConfig = resolveExistingTtsProviderConfigInTts({
+    cfg: params.cfg,
+    tts: params.cfg.messages?.tts,
+    providerId: params.providerId,
+  });
+  return rootProviderConfig ? { ...rootProviderConfig, scope: "root" } : undefined;
+}
+
+function resolveExistingTtsProviderConfigInTts(params: {
+  cfg: OpenClawConfig;
+  tts: unknown;
+  providerId: string;
+}): TtsProviderConfigLocation | undefined {
+  if (!isObjectRecord(params.tts)) {
+    return undefined;
+  }
+  const providers = isObjectRecord(params.tts.providers) ? params.tts.providers : undefined;
   if (!providers) {
     return resolveDirectTtsProviderConfig(params);
   }
@@ -1587,13 +1642,13 @@ const TTS_CONFIG_RESERVED_KEYS = new Set([
 
 function resolveDirectTtsProviderConfig(params: {
   cfg: OpenClawConfig;
+  tts: unknown;
   providerId: string;
-}): ExistingTtsProviderConfig | undefined {
-  const tts = params.cfg.messages?.tts;
-  if (!tts) {
+}): TtsProviderConfigLocation | undefined {
+  if (!isObjectRecord(params.tts)) {
     return undefined;
   }
-  for (const [key, value] of Object.entries(tts)) {
+  for (const [key, value] of Object.entries(params.tts)) {
     if (TTS_CONFIG_RESERVED_KEYS.has(key)) {
       continue;
     }
@@ -1605,6 +1660,57 @@ function resolveDirectTtsProviderConfig(params: {
     }
   }
   return undefined;
+}
+
+function resolveChannelTtsConfigForAuthHydration(params: {
+  cfg: OpenClawConfig;
+  channelId?: string;
+}): { channelKey: string; tts: unknown } | undefined {
+  const channels = params.cfg.channels;
+  const normalizedChannelId = normalizeOptionalString(params.channelId);
+  if (!isObjectRecord(channels) || !normalizedChannelId) {
+    return undefined;
+  }
+  const channelKey = Object.hasOwn(channels, normalizedChannelId)
+    ? normalizedChannelId
+    : Object.keys(channels).find(
+        (candidate) =>
+          normalizeLowercaseStringOrEmpty(candidate) ===
+          normalizeLowercaseStringOrEmpty(normalizedChannelId),
+      );
+  const channel = channelKey ? channels[channelKey] : undefined;
+  if (!channelKey || !isObjectRecord(channel)) {
+    return undefined;
+  }
+  return { channelKey, tts: channel.tts };
+}
+
+function buildTtsConfigWithHydratedProvider(params: {
+  tts: unknown;
+  existingProviderConfig?: ExistingTtsProviderConfig;
+  providerId: string;
+  apiKey: string;
+}): Record<string, unknown> {
+  const tts = isObjectRecord(params.tts) ? { ...params.tts } : {};
+  const providers = isObjectRecord(tts.providers) ? { ...tts.providers } : {};
+  const providerConfigKey = params.existingProviderConfig?.key ?? params.providerId;
+  const nextProviderConfig = {
+    ...(isObjectRecord(params.existingProviderConfig?.value)
+      ? params.existingProviderConfig.value
+      : {}),
+    apiKey: params.apiKey,
+  };
+  if (params.existingProviderConfig?.container === "direct") {
+    tts[providerConfigKey] = nextProviderConfig;
+  } else {
+    providers[providerConfigKey] = nextProviderConfig;
+    tts.providers = providers;
+  }
+  return tts;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 async function runTtsProviders(transport: CapabilityTransport) {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1524,9 +1524,9 @@ async function injectTtsAuthProfileApiKey(params: {
       : {}),
     apiKey: auth.apiKey,
   };
-  const nextTts: Record<string, unknown> = { ...tts };
+  const nextTts = { ...tts };
   if (existingProviderConfig?.container === "direct") {
-    nextTts[providerConfigKey] = nextProviderConfig;
+    (nextTts as Record<string, unknown>)[providerConfigKey] = nextProviderConfig;
   } else {
     providers[providerConfigKey] = nextProviderConfig;
     nextTts.providers = providers;

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1498,12 +1498,7 @@ async function injectTtsAuthProfileApiKey(params: {
     return params.cfg;
   }
   const effectiveTtsConfig = resolveTtsConfig(params.cfg, { channelId: params.channelId });
-  const effectiveProviderConfig = resolveExistingTtsProviderConfigInTts({
-    cfg: params.cfg,
-    tts: effectiveTtsConfig,
-    providerId,
-  });
-  if (ttsProviderConfigHasApiKey(effectiveProviderConfig?.value)) {
+  if (resolvedTtsConfigHasProviderApiKey(effectiveTtsConfig, providerId)) {
     return params.cfg;
   }
   const existingProviderConfig = resolveExistingTtsProviderConfig({
@@ -1722,6 +1717,13 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
 
 function ttsProviderConfigHasApiKey(value: unknown): boolean {
   return isObjectRecord(value) && "apiKey" in value;
+}
+
+function resolvedTtsConfigHasProviderApiKey(config: unknown, providerId: string): boolean {
+  if (!isObjectRecord(config) || !isObjectRecord(config.providerConfigs)) {
+    return false;
+  }
+  return ttsProviderConfigHasApiKey(config.providerConfigs[providerId]);
 }
 
 async function runTtsProviders(transport: CapabilityTransport) {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1516,7 +1516,7 @@ async function injectTtsAuthProfileApiKey(params: {
   const tts = { ...(messages.tts ?? {}) };
   const providers = { ...(tts.providers ?? {}) };
   const providerConfigKey = existingProviderConfig?.key ?? providerId;
-  providers[providerConfigKey] = {
+  const nextProviderConfig = {
     ...(existingProviderConfig?.value &&
     typeof existingProviderConfig.value === "object" &&
     !Array.isArray(existingProviderConfig.value)
@@ -1524,36 +1524,84 @@ async function injectTtsAuthProfileApiKey(params: {
       : {}),
     apiKey: auth.apiKey,
   };
+  const nextTts: Record<string, unknown> = { ...tts };
+  if (existingProviderConfig?.container === "direct") {
+    nextTts[providerConfigKey] = nextProviderConfig;
+  } else {
+    providers[providerConfigKey] = nextProviderConfig;
+    nextTts.providers = providers;
+  }
   return {
     ...params.cfg,
     messages: {
       ...messages,
-      tts: {
-        ...tts,
-        providers,
-      },
+      tts: nextTts,
     },
   };
 }
 
+type ExistingTtsProviderConfig = {
+  container: "providers" | "direct";
+  key: string;
+  value: unknown;
+};
+
 function resolveExistingTtsProviderConfig(params: {
   cfg: OpenClawConfig;
   providerId: string;
-}): { key: string; value: unknown } | undefined {
-  const providers = params.cfg.messages?.tts?.providers;
+}): ExistingTtsProviderConfig | undefined {
+  const tts = params.cfg.messages?.tts;
+  const providers = tts?.providers;
   if (!providers) {
-    return undefined;
+    return resolveDirectTtsProviderConfig(params);
   }
   const exact = providers[params.providerId];
   if (exact !== undefined) {
-    return { key: params.providerId, value: exact };
+    return { container: "providers", key: params.providerId, value: exact };
   }
   for (const [key, value] of Object.entries(providers)) {
     const normalizedKey = normalizeLowercaseStringOrEmpty(
       canonicalizeSpeechProviderId(key, params.cfg) ?? key,
     );
     if (normalizedKey === params.providerId) {
-      return { key, value };
+      return { container: "providers", key, value };
+    }
+  }
+  return resolveDirectTtsProviderConfig(params);
+}
+
+const TTS_CONFIG_RESERVED_KEYS = new Set([
+  "auto",
+  "enabled",
+  "maxTextLength",
+  "mode",
+  "modelOverrides",
+  "persona",
+  "personas",
+  "prefsPath",
+  "provider",
+  "providers",
+  "summaryModel",
+  "timeoutMs",
+]);
+
+function resolveDirectTtsProviderConfig(params: {
+  cfg: OpenClawConfig;
+  providerId: string;
+}): ExistingTtsProviderConfig | undefined {
+  const tts = params.cfg.messages?.tts;
+  if (!tts) {
+    return undefined;
+  }
+  for (const [key, value] of Object.entries(tts)) {
+    if (TTS_CONFIG_RESERVED_KEYS.has(key)) {
+      continue;
+    }
+    const normalizedKey = normalizeLowercaseStringOrEmpty(
+      canonicalizeSpeechProviderId(key, params.cfg) ?? key,
+    );
+    if (normalizedKey === params.providerId) {
+      return { container: "direct", key, value };
     }
   }
   return undefined;

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1492,12 +1492,15 @@ async function injectTtsAuthProfileApiKey(params: {
   if (!providerId) {
     return params.cfg;
   }
-  const existingProviderConfig = params.cfg.messages?.tts?.providers?.[providerId];
+  const existingProviderConfig = resolveExistingTtsProviderConfig({
+    cfg: params.cfg,
+    providerId,
+  });
   if (
-    existingProviderConfig &&
-    typeof existingProviderConfig === "object" &&
-    !Array.isArray(existingProviderConfig) &&
-    "apiKey" in existingProviderConfig
+    existingProviderConfig?.value &&
+    typeof existingProviderConfig.value === "object" &&
+    !Array.isArray(existingProviderConfig.value) &&
+    "apiKey" in existingProviderConfig.value
   ) {
     return params.cfg;
   }
@@ -1512,11 +1515,12 @@ async function injectTtsAuthProfileApiKey(params: {
   const messages = { ...(params.cfg.messages ?? {}) };
   const tts = { ...(messages.tts ?? {}) };
   const providers = { ...(tts.providers ?? {}) };
-  providers[providerId] = {
-    ...(existingProviderConfig &&
-    typeof existingProviderConfig === "object" &&
-    !Array.isArray(existingProviderConfig)
-      ? existingProviderConfig
+  const providerConfigKey = existingProviderConfig?.key ?? providerId;
+  providers[providerConfigKey] = {
+    ...(existingProviderConfig?.value &&
+    typeof existingProviderConfig.value === "object" &&
+    !Array.isArray(existingProviderConfig.value)
+      ? existingProviderConfig.value
       : {}),
     apiKey: auth.apiKey,
   };
@@ -1530,6 +1534,29 @@ async function injectTtsAuthProfileApiKey(params: {
       },
     },
   };
+}
+
+function resolveExistingTtsProviderConfig(params: {
+  cfg: OpenClawConfig;
+  providerId: string;
+}): { key: string; value: unknown } | undefined {
+  const providers = params.cfg.messages?.tts?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  const exact = providers[params.providerId];
+  if (exact !== undefined) {
+    return { key: params.providerId, value: exact };
+  }
+  for (const [key, value] of Object.entries(providers)) {
+    const normalizedKey = normalizeLowercaseStringOrEmpty(
+      canonicalizeSpeechProviderId(key, params.cfg) ?? key,
+    );
+    if (normalizedKey === params.providerId) {
+      return { key, value };
+    }
+  }
+  return undefined;
 }
 
 async function runTtsProviders(transport: CapabilityTransport) {

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -69,11 +69,12 @@ describe("registerSetupCommand", () => {
   });
 
   it("runs setup wizard command when wizard-only flags are passed explicitly", async () => {
-    await runCli(["setup", "--mode", "remote", "--non-interactive"]);
+    await runCli(["setup", "--mode", "remote", "--non-interactive", "--accept-risk"]);
 
     expect(setupWizardCommandMock).toHaveBeenCalledWith(lastWizardOptions(), runtime);
     expect(lastWizardOptions()?.mode).toBe("remote");
     expect(lastWizardOptions()?.nonInteractive).toBe(true);
+    expect(lastWizardOptions()?.acceptRisk).toBe(true);
     expect(setupCommandMock).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -24,6 +24,11 @@ export function registerSetupCommand(program: Command): void {
     )
     .option("--wizard", "Run interactive onboarding", false)
     .option("--non-interactive", "Run onboarding without prompts", false)
+    .option(
+      "--accept-risk",
+      "Acknowledge that agents are powerful and full system access is risky (required for --non-interactive)",
+      false,
+    )
     .option("--mode <mode>", "Onboard mode: local|remote")
     .option("--import-from <provider>", "Migration provider to run during onboarding")
     .option("--import-source <path>", "Source agent home for --import-from")
@@ -36,6 +41,7 @@ export function registerSetupCommand(program: Command): void {
         const hasWizardFlags = hasExplicitOptions(command, [
           "wizard",
           "nonInteractive",
+          "acceptRisk",
           "mode",
           "importFrom",
           "importSource",
@@ -49,6 +55,7 @@ export function registerSetupCommand(program: Command): void {
             {
               workspace: opts.workspace as string | undefined,
               nonInteractive: Boolean(opts.nonInteractive),
+              acceptRisk: Boolean(opts.acceptRisk),
               mode: opts.mode as "local" | "remote" | undefined,
               importFrom: opts.importFrom as string | undefined,
               importSource: opts.importSource as string | undefined,

--- a/src/commands/agents.bind.commands.test.ts
+++ b/src/commands/agents.bind.commands.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelId, ChannelPlugin } from "../channels/plugins/types.public.js";
+import type { RuntimeEnv } from "../runtime.js";
 import {
   loadFreshAgentsBindCommandModuleForTest,
   readConfigFileSnapshotMock,
@@ -116,6 +117,21 @@ let agentsBindCommand: typeof import("./agents.commands.bind.js").agentsBindComm
 let agentsBindingsCommand: typeof import("./agents.commands.bind.js").agentsBindingsCommand;
 let agentsUnbindCommand: typeof import("./agents.commands.bind.js").agentsUnbindCommand;
 
+type JsonTestRuntime = RuntimeEnv & {
+  writeStdout: ReturnType<typeof vi.fn>;
+  writeJson: ReturnType<typeof vi.fn>;
+};
+
+function createJsonTestRuntime(): JsonTestRuntime {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+  };
+}
+
 describe("agents bind/unbind commands", () => {
   beforeAll(async () => {
     ({ agentsBindCommand, agentsBindingsCommand, agentsUnbindCommand } =
@@ -227,6 +243,26 @@ describe("agents bind/unbind commands", () => {
       { agentId: "main", match: { channel: "matrix" } },
     ]);
     expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("reports empty unbind-all as JSON without text logs", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {},
+    });
+    const jsonRuntime = createJsonTestRuntime();
+
+    await agentsUnbindCommand({ agent: "main", all: true, json: true }, jsonRuntime);
+
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+    expect(jsonRuntime.log).not.toHaveBeenCalled();
+    expect(jsonRuntime.writeJson.mock.calls[0]?.[0]).toStrictEqual({
+      agentId: "main",
+      removed: [],
+      missing: [],
+      conflicts: [],
+    });
+    expect(jsonRuntime.exit).not.toHaveBeenCalled();
   });
 
   it("reports ownership conflicts during unbind and exits 1", async () => {

--- a/src/commands/agents.commands.bind.ts
+++ b/src/commands/agents.commands.bind.ts
@@ -333,6 +333,20 @@ export async function agentsUnbindCommand(
     const keptRoutes = existing.filter((binding) => normalizeAgentId(binding.agentId) !== agentId);
     const nonRoutes = (cfg.bindings ?? []).filter((binding) => !isRouteBinding(binding));
     if (removed.length === 0) {
+      if (
+        emitJsonPayload({
+          runtime,
+          json: opts.json,
+          payload: {
+            agentId,
+            removed: [] as string[],
+            missing: [] as string[],
+            conflicts: [] as string[],
+          },
+        })
+      ) {
+        return;
+      }
       runtime.log(`No bindings to remove for agent "${agentId}".`);
       return;
     }

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -184,6 +184,13 @@ describe("channelsCapabilitiesCommand", () => {
     ]);
   });
 
+  it("prints an empty all-channel report when no channels are configured", async () => {
+    await channelsCapabilitiesCommand({ json: true }, runtime);
+
+    expect(errors).toStrictEqual([]);
+    expect(logs).toStrictEqual([JSON.stringify({ channels: [] }, null, 2)]);
+  });
+
   it("rejects malformed timeouts before capability probes", async () => {
     const probeAccount = vi.fn(async () => ({ ok: true }));
     const plugin = buildPlugin({

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -290,6 +290,20 @@ export async function channelsCapabilitiesCommand(
         })();
 
   if (!selected || selected.length === 0) {
+    if (!rawChannel || rawChannel === "all") {
+      if (opts.json) {
+        writeRuntimeJson(runtime, { channels: [] });
+        return;
+      }
+      runtime.log(
+        theme.muted(
+          `No configured channel capabilities found. Run ${formatCliCommand(
+            "openclaw channels list --all",
+          )} to see available channels.`,
+        ),
+      );
+      return;
+    }
     runtime.error(danger(formatUnknownChannelMessage({ channel: rawChannel })));
     runtime.exit(1);
     return;

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -234,6 +234,94 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
     }
   });
 
+  it("skips package entry validation for non-package registry records", async () => {
+    const root = await makeFixtureRoot("no-package-json-ref");
+    try {
+      const pluginDir = path.join(root, "dist", "extensions", "runtime-only");
+      await fs.mkdir(pluginDir, { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "index.js"), "export default {};", "utf-8");
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "runtime-only" }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "runtime-only",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              origin: "bundled",
+              enabled: true,
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      expect(report.findings).toHaveLength(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("validates legacy package records without packageJson metadata", async () => {
+    const root = await makeFixtureRoot("legacy-package-json-ref");
+    try {
+      const pluginDir = path.join(root, "user-plugins", "legacy-package");
+      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "legacy-package",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["./src/index.ts"] },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "legacy-package" }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "legacy-package",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              enabled: true,
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
+      expect(finding?.level).toBe("error");
+      expect(finding?.plugin).toBe("legacy-package");
+      expect(finding?.message).toMatch(/compiled runtime output/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("flags an entry that escapes the plugin package directory", async () => {
     const root = await makeFixtureRoot("entry-escape");
     try {
@@ -387,6 +475,110 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       expect(finding).toBeDefined();
       expect(finding?.level).toBe("error");
       expect(finding?.plugin).toBe("ts-only");
+      expect(finding?.message).toMatch(/compiled runtime output/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows TypeScript source-only entries for source checkout plugin records", async () => {
+    const root = await makeFixtureRoot("ts-source-checkout");
+    try {
+      await fs.mkdir(path.join(root, ".git"), { recursive: true });
+      await fs.writeFile(path.join(root, "pnpm-workspace.yaml"), "packages: []\n", "utf-8");
+      await fs.mkdir(path.join(root, "src"), { recursive: true });
+      const pluginDir = path.join(root, "extensions", "ts-source");
+      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "ts-source",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["./src/index.ts"] },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "ts-source" }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "ts-source",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              origin: "bundled",
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags TypeScript source-only entries for packaged bundled plugin records", async () => {
+    const root = await makeFixtureRoot("ts-packaged-bundled");
+    try {
+      const pluginDir = path.join(root, "dist", "extensions", "ts-packaged");
+      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
+      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
+      await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "ts-packaged",
+          version: "0.0.1",
+          type: "module",
+          openclaw: { extensions: ["./src/index.ts"] },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "ts-packaged" }),
+        "utf-8",
+      );
+
+      const installsPath = path.join(root, "plugins", "installs.json");
+      await fs.mkdir(path.dirname(installsPath), { recursive: true });
+      await fs.writeFile(
+        installsPath,
+        JSON.stringify({
+          version: 1,
+          plugins: [
+            {
+              pluginId: "ts-packaged",
+              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
+              rootDir: pluginDir,
+              origin: "bundled",
+              enabled: true,
+              packageJson: { path: "package.json" },
+            },
+          ],
+        }),
+        "utf-8",
+      );
+
+      const report = await runPostUpgradeProbes({ installsPath });
+      const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
+      expect(finding?.level).toBe("error");
+      expect(finding?.plugin).toBe("ts-packaged");
       expect(finding?.message).toMatch(/compiled runtime output/);
     } finally {
       await fs.rm(root, { recursive: true, force: true });

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
@@ -14,6 +15,7 @@ type InstalledPluginRecord = {
   pluginId: string;
   rootDir: string;
   enabled: boolean;
+  origin?: string;
   packageJson?: { path: string };
   manifestPath?: string;
   manifestHash?: string;
@@ -47,6 +49,33 @@ function isPackageJsonRef(value: unknown): value is InstalledPluginRecord["packa
   );
 }
 
+function isSourceCheckoutPluginRecord(record: InstalledPluginRecord): boolean {
+  if (record.origin === "workspace" || record.origin === "config") {
+    return true;
+  }
+  return record.origin === "bundled" && isBundledSourceCheckoutPluginRoot(record.rootDir);
+}
+
+function isBundledSourceCheckoutPluginRoot(pluginRootDir: string): boolean {
+  let current = path.resolve(pluginRootDir);
+  while (true) {
+    const extensionsDir = path.dirname(current);
+    if (path.basename(extensionsDir) === "extensions") {
+      const packageRoot = path.dirname(extensionsDir);
+      return (
+        fsSync.existsSync(path.join(packageRoot, ".git")) &&
+        fsSync.existsSync(path.join(packageRoot, "pnpm-workspace.yaml")) &&
+        fsSync.existsSync(path.join(packageRoot, "src"))
+      );
+    }
+    const next = path.dirname(current);
+    if (next === current) {
+      return false;
+    }
+    current = next;
+  }
+}
+
 function isInstalledPluginRecord(value: unknown): value is InstalledPluginRecord {
   if (typeof value !== "object" || value === null) {
     return false;
@@ -56,6 +85,7 @@ function isInstalledPluginRecord(value: unknown): value is InstalledPluginRecord
     typeof record.pluginId === "string" &&
     typeof record.rootDir === "string" &&
     typeof record.enabled === "boolean" &&
+    isOptionalString(record.origin) &&
     isPackageJsonRef(record.packageJson) &&
     isOptionalString(record.manifestPath) &&
     isOptionalString(record.manifestHash)
@@ -94,6 +124,20 @@ async function readInstalledPackageJson(
   return JSON.parse(raw) as PackageManifest;
 }
 
+async function resolvePackageJsonRelPath(
+  record: InstalledPluginRecord,
+): Promise<string | undefined> {
+  if (record.packageJson) {
+    return record.packageJson.path;
+  }
+  try {
+    await fs.access(path.join(record.rootDir, "package.json"));
+    return "package.json";
+  } catch {
+    return undefined;
+  }
+}
+
 async function sha256OfFile(absPath: string): Promise<string | null> {
   try {
     const raw = await fs.readFile(absPath);
@@ -123,35 +167,38 @@ export async function runPostUpgradeProbes(params: {
     if (!record.enabled) {
       continue;
     }
-    const pkgRelPath = record.packageJson?.path ?? "package.json";
-    let pkg: PackageManifest;
-    try {
-      pkg = await readInstalledPackageJson(record.rootDir, pkgRelPath);
-    } catch (err) {
-      process.stderr.write(
-        `[doctor-post-upgrade] could not read package.json for ${record.pluginId} at ${record.rootDir}: ${err instanceof Error ? err.message : String(err)}\n`,
-      );
-      continue;
-    }
-    const entries = pkg.openclaw?.extensions ?? [];
-    if (entries.length > 0) {
-      // Delegate to the install-time resolver so the probe enforces the same
-      // contract as plugin install/discovery: runtimeExtensions shape, plugin-root
-      // boundary, and inferred-built-output / TypeScript-source-only handling.
-      const validation = await validatePackageExtensionEntriesForInstall({
-        packageDir: record.rootDir,
-        extensions: [...entries],
-        manifest: pkg,
-      });
-      if (!validation.ok) {
-        const offendingEntry = entries.find((entry) => validation.error.includes(entry));
-        findings.push({
-          level: "error",
-          code: "plugin.entry_unresolved",
-          message: `Plugin ${record.pluginId}: ${validation.error}`,
-          plugin: record.pluginId,
-          ...(offendingEntry ? { entry: offendingEntry } : {}),
+    const pkgRelPath = await resolvePackageJsonRelPath(record);
+    if (pkgRelPath) {
+      let pkg: PackageManifest;
+      try {
+        pkg = await readInstalledPackageJson(record.rootDir, pkgRelPath);
+      } catch (err) {
+        process.stderr.write(
+          `[doctor-post-upgrade] could not read package.json for ${record.pluginId} at ${record.rootDir}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        continue;
+      }
+      const entries = pkg.openclaw?.extensions ?? [];
+      if (entries.length > 0) {
+        // Delegate to the install-time resolver so the probe enforces the same
+        // contract as plugin install/discovery: runtimeExtensions shape, plugin-root
+        // boundary, and inferred-built-output / TypeScript-source-only handling.
+        const validation = await validatePackageExtensionEntriesForInstall({
+          packageDir: record.rootDir,
+          extensions: [...entries],
+          manifest: pkg,
+          allowSourceTypeScriptEntries: isSourceCheckoutPluginRecord(record),
         });
+        if (!validation.ok) {
+          const offendingEntry = entries.find((entry) => validation.error.includes(entry));
+          findings.push({
+            level: "error",
+            code: "plugin.entry_unresolved",
+            message: `Plugin ${record.pluginId}: ${validation.error}`,
+            plugin: record.pluginId,
+            ...(offendingEntry ? { entry: offendingEntry } : {}),
+          });
+        }
       }
     }
 

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runPostUpgradeProbes: vi.fn(),
+  resolveInstalledPluginIndexStorePath: vi.fn(() => "/tmp/openclaw-installed-plugins.json"),
+}));
+
+vi.mock("./doctor-post-upgrade.js", () => ({
+  runPostUpgradeProbes: mocks.runPostUpgradeProbes,
+}));
+
+vi.mock("../plugins/installed-plugin-index-store-path.js", () => ({
+  resolveInstalledPluginIndexStorePath: mocks.resolveInstalledPluginIndexStorePath,
+}));
+
+const { doctorCommand } = await import("./doctor.js");
+
+describe("doctorCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("writes post-upgrade JSON through the runtime before exiting with findings", async () => {
+    const report = {
+      probesRun: ["plugin.index_unavailable"],
+      findings: [
+        {
+          level: "error",
+          code: "plugin.index_unavailable",
+          message: "missing index",
+        },
+      ],
+    };
+    mocks.runPostUpgradeProbes.mockResolvedValueOnce(report);
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      writeStdout: vi.fn(),
+      writeJson: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    await expect(doctorCommand(runtime, { postUpgrade: true, json: true })).rejects.toThrow(
+      "exit:1",
+    );
+
+    expect(runtime.writeJson).toHaveBeenCalledWith(report, 2);
+    expect(runtime.log).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,22 +1,23 @@
-import type { RuntimeEnv } from "../runtime.js";
+import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { runPostUpgradeProbes } from "./doctor-post-upgrade.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 
 export async function doctorCommand(runtime?: RuntimeEnv, options?: DoctorOptions): Promise<void> {
   if (options?.postUpgrade) {
+    const outputRuntime = runtime ?? defaultRuntime;
     const report = await runPostUpgradeProbes({});
     if (options.json) {
-      console.log(JSON.stringify(report, null, 2));
+      writeRuntimeJson(outputRuntime, report);
     } else {
       for (const f of report.findings) {
-        console.log(`[${f.level}] ${f.code}: ${f.message}`);
+        outputRuntime.log(`[${f.level}] ${f.code}: ${f.message}`);
       }
       if (report.findings.length === 0) {
-        console.log("post-upgrade: no findings");
+        outputRuntime.log("post-upgrade: no findings");
       }
     }
     const hasError = report.findings.some((f) => f.level === "error");
-    runtime?.exit(hasError ? 1 : 0);
+    outputRuntime.exit(hasError ? 1 : 0);
     return;
   }
   const doctorHealth = await import("../flows/doctor-health.js");

--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -46,12 +46,19 @@ function createRunningTaskRun(
   return task;
 }
 
-function createRuntime(): RuntimeEnv {
+type TestRuntime = RuntimeEnv & {
+  writeStdout: ReturnType<typeof vi.fn>;
+  writeJson: ReturnType<typeof vi.fn>;
+};
+
+function createRuntime(): TestRuntime {
   return {
     log: vi.fn(),
     error: vi.fn(),
     exit: vi.fn(),
-  } as unknown as RuntimeEnv;
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+  };
 }
 
 async function withTaskFlowCommandStateDir(run: (root: string) => Promise<void>): Promise<void> {
@@ -115,7 +122,8 @@ describe("flows commands", () => {
       const runtime = createRuntime();
       await flowsListCommand({ json: true, status: "blocked" }, runtime);
 
-      const payload = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0]));
+      expect(runtime.log).not.toHaveBeenCalled();
+      const payload = jsonRoundTrip(vi.mocked(runtime.writeJson).mock.calls[0]?.[0]);
 
       expect(payload).toStrictEqual({
         count: 1,
@@ -147,6 +155,34 @@ describe("flows commands", () => {
             },
           },
         ],
+      });
+    });
+  });
+
+  it("shows one TaskFlow as JSON through the runtime JSON writer", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/flows-command",
+        goal: "Inspect a single flow",
+        status: "running",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+
+      const runtime = createRuntime();
+      await flowsShowCommand({ lookup: flow.flowId, json: true }, runtime);
+
+      expect(runtime.log).not.toHaveBeenCalled();
+      expect(vi.mocked(runtime.writeJson).mock.calls[0]?.[0]).toMatchObject({
+        ...jsonRoundTrip(flow),
+        tasks: [],
+        taskSummary: {
+          total: 0,
+          active: 0,
+          terminal: 0,
+          failures: 0,
+        },
       });
     });
   });

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -6,6 +6,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { info } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { writeRuntimeJson } from "../runtime.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { cancelFlowById, getFlowTaskSummary } from "../tasks/task-executor.js";
 import type { TaskFlowRecord, TaskFlowStatus } from "../tasks/task-flow-registry.types.js";
@@ -159,21 +160,15 @@ export async function flowsListCommand(
   });
 
   if (opts.json) {
-    runtime.log(
-      JSON.stringify(
-        {
-          count: flows.length,
-          status: statusFilter ?? null,
-          flows: flows.map((flow) => ({
-            ...flow,
-            tasks: listTasksForFlowId(flow.flowId),
-            taskSummary: getFlowTaskSummary(flow.flowId),
-          })),
-        },
-        null,
-        2,
-      ),
-    );
+    writeRuntimeJson(runtime, {
+      count: flows.length,
+      status: statusFilter ?? null,
+      flows: flows.map((flow) => ({
+        ...flow,
+        tasks: listTasksForFlowId(flow.flowId),
+        taskSummary: getFlowTaskSummary(flow.flowId),
+      })),
+    });
     return;
   }
 
@@ -209,17 +204,11 @@ export async function flowsShowCommand(
   const stateSummary = summarizeFlowState(flow);
 
   if (opts.json) {
-    runtime.log(
-      JSON.stringify(
-        {
-          ...flow,
-          tasks,
-          taskSummary,
-        },
-        null,
-        2,
-      ),
-    );
+    writeRuntimeJson(runtime, {
+      ...flow,
+      tasks,
+      taskSummary,
+    });
     return;
   }
 

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -181,6 +181,7 @@ export async function loadPluginCliCommandRegistryWithContext(params: {
         ...(onlyPluginIds && onlyPluginIds.length > 0 ? { onlyPluginIds } : {}),
         activate: false,
         cache: false,
+        forceFullRuntimeForChannelPlugins: true,
         runtimeOptions: {
           nodes: createPluginCliGatewayNodesRuntime(),
         },

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -370,6 +370,7 @@ describe("registerPluginCliCommands", () => {
     });
     expect(loadOptions.activate).toBe(false);
     expect(loadOptions.cache).toBe(false);
+    expect(loadOptions.forceFullRuntimeForChannelPlugins).toBe(true);
     expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
   });
 

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -4034,6 +4034,32 @@ describe("linkOpenClawPeerDependencies (via installPluginFromDir)", () => {
     expect(vi.mocked(runCommandWithTimeout)).not.toHaveBeenCalled();
   });
 
+  it("replaces a copied local openclaw package with the host peer symlink", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+    const fakeHostRoot = suiteTempRootTracker.makeTempDir();
+    resolveRootMock.mockReturnValue(fakeHostRoot);
+
+    writePluginWithPeerDeps(pluginDir, { openclaw: "*" });
+    fs.mkdirSync(path.join(pluginDir, "node_modules", "openclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "node_modules", "openclaw", "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.5.31" }),
+      "utf-8",
+    );
+
+    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(true);
+    expect(warnings).toHaveLength(0);
+    if (!result.ok) {
+      return;
+    }
+
+    const symlinkPath = path.join(result.targetDir, "node_modules", "openclaw");
+    expect(fs.lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(symlinkPath)).toBe(fs.realpathSync(fakeHostRoot));
+  });
+
   it("does not create a symlink when peerDependencies is empty", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
     resolveRootMock.mockReturnValue(suiteTempRootTracker.makeTempDir());

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -713,6 +713,111 @@ module.exports = {
     );
   });
 
+  it("can force channel runtime entries for CLI registration when setup entries exist", () => {
+    useNoBundledPlugins();
+    const pluginDir = makeTempDir();
+    const modeMarker = path.join(pluginDir, "registration-mode.txt");
+    const setupMarker = path.join(pluginDir, "setup-loaded.txt");
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/force-runtime-cli-channel",
+          openclaw: { extensions: ["./index.cjs"], setupEntry: "./setup-entry.cjs" },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "force-runtime-cli-channel",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+          channels: ["force-runtime-cli-channel"],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "index.cjs"),
+      `${inlineChannelPluginEntryFactorySource()}
+module.exports = {
+  ...defineChannelPluginEntry({
+    id: "force-runtime-cli-channel",
+    name: "Force Runtime CLI Channel",
+    description: "force runtime cli channel",
+    plugin: {
+      id: "force-runtime-cli-channel",
+      meta: {
+        id: "force-runtime-cli-channel",
+        label: "Force Runtime CLI Channel",
+        selectionLabel: "Force Runtime CLI Channel",
+        docsPath: "/channels/force-runtime-cli-channel",
+        blurb: "force runtime cli channel",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({ accountId: "default" }),
+      },
+      outbound: { deliveryMode: "direct" },
+    },
+    registerCliMetadata(api) {
+      require("node:fs").writeFileSync(
+        ${JSON.stringify(modeMarker)},
+        String(api.registrationMode),
+        "utf-8",
+      );
+      api.registerCli(() => {}, {
+        descriptors: [
+          {
+            name: "force-runtime-cli-channel",
+            description: "Forced runtime channel CLI metadata",
+            hasSubcommands: true,
+          },
+        ],
+      });
+    },
+  }),
+};`,
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "setup-entry.cjs"),
+      `require("node:fs").writeFileSync(${JSON.stringify(setupMarker)}, "loaded", "utf-8");`,
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      activate: false,
+      cache: false,
+      forceFullRuntimeForChannelPlugins: true,
+      config: {
+        plugins: {
+          load: { paths: [pluginDir] },
+          allow: ["force-runtime-cli-channel"],
+          entries: {
+            "force-runtime-cli-channel": {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(fs.existsSync(setupMarker)).toBe(false);
+    expect(fs.readFileSync(modeMarker, "utf-8")).toBe("discovery");
+    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain(
+      "force-runtime-cli-channel",
+    );
+  });
+
   it("sets bundled channel runtime before discovery CLI metadata registration", () => {
     const pluginDir = makeTempDir();
     const runtimeMarker = path.join(pluginDir, "runtime-set.txt");

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -209,6 +209,11 @@ export type PluginLoadOptions = {
    */
   preferSetupRuntimeForChannelPlugins?: boolean;
   /**
+   * Load channel runtime entries even when setup entries are available. Plugin CLI
+   * registration needs the runtime entry because setup entries only own setup state.
+   */
+  forceFullRuntimeForChannelPlugins?: boolean;
+  /**
    * For hot startup paths, prefer bundled plugin JS artifacts over source TS
    * entrypoints when both are present in a source checkout.
    */
@@ -919,6 +924,7 @@ function buildCacheKey(params: {
   forceSetupOnlyChannelPlugins?: boolean;
   requireSetupEntryForSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
+  forceFullRuntimeForChannelPlugins?: boolean;
   preferBuiltPluginArtifacts?: boolean;
   resolveRawConfigEnvVars?: boolean;
   toolDiscovery?: boolean;
@@ -961,7 +967,11 @@ function buildCacheKey(params: {
       ? "require-setup-entry"
       : "allow-full-fallback";
   const startupChannelMode =
-    params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
+    params.forceFullRuntimeForChannelPlugins === true
+      ? "force-full"
+      : params.preferSetupRuntimeForChannelPlugins === true
+        ? "prefer-setup"
+        : "full";
   const bundledArtifactMode =
     params.preferBuiltPluginArtifacts === true ? "prefer-built-artifacts" : "source-default";
   const rawConfigEnvMode =
@@ -1174,6 +1184,7 @@ function resolvePluginRegistrationPlan(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   preferSetupRuntimeForChannelPlugins: boolean;
+  forceFullRuntimeForChannelPlugins: boolean;
   toolDiscovery: boolean;
 }): PluginRegistrationPlan | null {
   if (params.canLoadScopedSetupOnlyChannelPlugin) {
@@ -1204,6 +1215,7 @@ function resolvePluginRegistrationPlan(params: {
     };
   }
   const loadSetupRuntimeEntry =
+    !params.forceFullRuntimeForChannelPlugins &&
     params.shouldLoadModules &&
     !params.validateOnly &&
     shouldLoadChannelPluginInSetupRuntime({
@@ -1283,6 +1295,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const requireSetupEntryForSetupOnlyChannelPlugins =
     options.requireSetupEntryForSetupOnlyChannelPlugins === true;
   const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
+  const forceFullRuntimeForChannelPlugins = options.forceFullRuntimeForChannelPlugins === true;
   const preferBuiltPluginArtifacts = options.preferBuiltPluginArtifacts === true;
   const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
   const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
@@ -1308,6 +1321,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     forceSetupOnlyChannelPlugins,
     requireSetupEntryForSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
+    forceFullRuntimeForChannelPlugins,
     preferBuiltPluginArtifacts,
     resolveRawConfigEnvVars: options.resolveRawConfigEnvVars,
     toolDiscovery: options.toolDiscovery,
@@ -1329,6 +1343,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     forceSetupOnlyChannelPlugins,
     requireSetupEntryForSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
+    forceFullRuntimeForChannelPlugins,
     preferBuiltPluginArtifacts,
     shouldActivate: options.activate !== false,
     shouldLoadModules: options.loadModules !== false,
@@ -1724,6 +1739,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     forceSetupOnlyChannelPlugins,
     requireSetupEntryForSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
+    forceFullRuntimeForChannelPlugins,
     preferBuiltPluginArtifacts,
     shouldActivate,
     shouldLoadModules,
@@ -2100,7 +2116,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         manifestRecord,
         cfg,
         env,
-        preferSetupRuntimeForChannelPlugins,
+        preferSetupRuntimeForChannelPlugins: forceFullRuntimeForChannelPlugins
+          ? false
+          : preferSetupRuntimeForChannelPlugins,
+        forceFullRuntimeForChannelPlugins,
         toolDiscovery: options.toolDiscovery === true,
       });
 

--- a/src/plugins/plugin-peer-link.ts
+++ b/src/plugins/plugin-peer-link.ts
@@ -251,6 +251,17 @@ async function linkOpenClawPeerDependency(params: {
     });
     if (existing) {
       if (!existing.isSymbolicLink()) {
+        if (params.peerName === "openclaw" && existing.isDirectory()) {
+          const existingPackageName = await readPackageName(linkPath);
+          if (existingPackageName === "openclaw") {
+            await fs.rm(linkPath, { recursive: true, force: true });
+            await fs.symlink(params.hostRoot, linkPath, "junction");
+            params.logger.info?.(
+              `Linked peerDependency "${params.peerName}" -> ${params.hostRoot}`,
+            );
+            return "linked";
+          }
+        }
         params.logger.warn?.(
           `Skipping openclaw peerDependency link because ${linkPath} already exists and is not a symlink.`,
         );
@@ -264,6 +275,19 @@ async function linkOpenClawPeerDependency(params: {
   } catch (err) {
     params.logger.warn?.(`Failed to symlink peerDependency "${params.peerName}": ${String(err)}`);
     return "skipped";
+  }
+}
+
+async function readPackageName(packageDir: string): Promise<string | undefined> {
+  try {
+    const raw = await fs.readFile(path.join(packageDir, "package.json"), "utf8");
+    const parsed = JSON.parse(raw) as { name?: unknown };
+    return typeof parsed.name === "string" ? parsed.name : undefined;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary

- harden CLI JSON output and setup flag handling, including setup docs for `--accept-risk`
- make local TTS conversion hydrate API-key auth profiles without overriding explicit provider, direct, or channel-scoped TTS config
- tighten plugin install/doctor/CLI metadata edge cases for local peers, post-upgrade probes, and channel plugin command registration

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests 'pnpm test src/cli/capability-cli.test.ts src/cli/program/register.setup.test.ts src/commands/agents.bind.commands.test.ts src/commands/channels/capabilities.test.ts src/commands/doctor-post-upgrade.test.ts src/commands/doctor.test.ts src/commands/flows.test.ts src/plugins/install.test.ts src/plugins/cli.test.ts src/plugins/loader.cli-metadata.test.ts -- --reporter=verbose'` clean
- `pnpm test src/cli/capability-cli.test.ts -- --reporter=verbose`
- `pnpm docs:list`
- `git diff --check`

Known gap: `pnpm check:test-types` reaches unrelated existing failures in `extensions/phone-control/index.test.ts` keyed store mock generic types after the TTS patch-specific type issue was fixed.
