### PR TITLE
fix(android): render chat content through Markdown

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -4515,7 +4515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 697,
+      "line": 699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
       "source": "Image unavailable",
       "surface": "android",
@@ -4675,7 +4675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 712,
+      "line": 704,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -4683,7 +4683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 717,
+      "line": 709,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -4691,7 +4691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 727,
+      "line": 719,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -4699,7 +4699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 728,
+      "line": 720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -4707,7 +4707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 821,
+      "line": 813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -4715,7 +4715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 838,
+      "line": 830,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -4723,7 +4723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 928,
+      "line": 920,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -4731,7 +4731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 943,
+      "line": 935,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -4739,7 +4739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 958,
+      "line": 950,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -4747,7 +4747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 996,
+      "line": 988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -4755,7 +4755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1008,
+      "line": 1000,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -4763,7 +4763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1017,
+      "line": 1009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -4771,7 +4771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1073,
+      "line": 1065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -4779,7 +4779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1112,
+      "line": 1104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
@@ -104,7 +104,7 @@ fun ChatMarkdown(
   text: String,
   textColor: Color,
 ) {
-  val document = remember(text) { markdownParser.parse(text) as Document }
+  val document = remember(text) { parseChatMarkdown(text) }
   val inlineStyles =
     InlineStyles(inlineCodeBg = mobileCodeBg, inlineCodeColor = mobileCodeText, linkColor = mobileAccent, baseCallout = mobileCallout)
 
@@ -588,7 +588,7 @@ internal fun buildChatInlineMarkdown(
   text: String,
   linkColor: Color = Color.Blue,
 ): AnnotatedString {
-  val document = markdownParser.parse(text) as Document
+  val document = parseChatMarkdown(text)
   val paragraph = document.firstChild as? Paragraph ?: return AnnotatedString("")
   return buildInlineMarkdown(
     paragraph.firstChild,
@@ -600,6 +600,8 @@ internal fun buildChatInlineMarkdown(
     ),
   )
 }
+
+internal fun parseChatMarkdown(text: String): Document = markdownParser.parse(text) as Document
 
 private fun buildPlainText(start: Node?): String {
   val sb = StringBuilder()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -694,15 +694,7 @@ private fun ChatText(
   text: String,
   textColor: Color,
 ) {
-  if (text.hasMarkdownSyntax()) {
-    ChatMarkdown(text = text, textColor = textColor)
-  } else {
-    Text(
-      text = text,
-      style = ClawTheme.type.body,
-      color = textColor,
-    )
-  }
+  ChatMarkdown(text = text, textColor = textColor)
 }
 
 @Composable
@@ -1121,9 +1113,3 @@ internal fun contextMeterThinkingLabel(value: String): String =
   }
 
 private fun formatChatTimestamp(timestampMs: Long): String = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault()).format(Date(timestampMs))
-
-/** Quick markdown detector used to avoid routing plain chat text through the markdown renderer. */
-private fun String.hasMarkdownSyntax(): Boolean =
-  any { it == '#' || it == '*' || it == '`' || it == '[' || it == '|' } ||
-    contains("\n- ") ||
-    contains("\n1. ")

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMarkdownTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMarkdownTest.kt
@@ -1,6 +1,11 @@
 package ai.openclaw.app.ui.chat
 
 import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.font.FontStyle
+import org.commonmark.node.BlockQuote
+import org.commonmark.node.BulletList
+import org.commonmark.node.Emphasis
+import org.commonmark.node.Paragraph
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -55,6 +60,30 @@ class ChatMarkdownTest {
 
     assertEquals("No link here", annotated.text)
     assertTrue(annotated.getLinkAnnotations(0, annotated.length).isEmpty())
+  }
+
+  @Test
+  fun leadingListsAndQuotesParseAsBlockMarkdown() {
+    assertTrue(parseChatMarkdown("- first\n- second").firstChild is BulletList)
+    assertTrue(parseChatMarkdown("> quoted").firstChild is BlockQuote)
+  }
+
+  @Test
+  fun underscoreEmphasisRendersAsItalicText() {
+    val document = parseChatMarkdown("_important_")
+    val paragraph = document.firstChild as Paragraph
+
+    assertTrue(paragraph.firstChild is Emphasis)
+    val annotated = buildChatInlineMarkdown("_important_")
+    assertEquals("important", annotated.text)
+    val emphasis =
+      annotated.spanStyles
+        .single()
+        .item
+    assertEquals(
+      FontStyle.Italic,
+      emphasis.fontStyle,
+    )
   }
 
   @Test


### PR DESCRIPTION
## What Problem This Solves

Closes #88014.

Android's active chat screen bypassed `ChatMarkdown` unless a small text heuristic recognized Markdown syntax. Bare URLs, leading lists or quotes, and underscore emphasis could therefore appear as raw text even though the shared renderer supports them.

## Why This Change Was Made

- Route every active chat message through the existing `ChatMarkdown` owner, matching the sibling chat surface.
- Remove the incomplete syntax detector instead of extending a second Markdown parser.
- Expose the existing CommonMark parse step for focused block-routing tests.
- Drop the original width edits because current `main` and v2026.6.11 already contain the wider bubble layout.

## User Impact

Links, lists, quotes, emphasis, code, and plain text now take one consistent rendering path. Existing safe-link and bounded data-image restrictions remain unchanged.

## Evidence

- Focused Android Markdown unit tests, ktlint, Play debug assembly, and native-i18n inventory check passed.
- Full exact-head CI passed, including Android Play/third-party tests and build.
- Android 16 emulator against a real isolated OpenClaw Gateway reproduced raw bare links and leading list markers on current `main`; this head rendered a clickable link and bullet list in the same persisted state.
- Before/after screenshots and live setup details: https://github.com/openclaw/openclaw/pull/88899#issuecomment-4872299406
- Fresh Codex autoreview: clean, no actionable findings.

Proof gap: no physical Android device; emulator used.
