### PR TITLE
fix(mattermost): preserve Codex progress drafts

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -443,6 +443,77 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.Provider).toBe("mattermost");
   });
 
+  it("keeps Mattermost progress callbacks active for message-tool-only source replies", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const draftStream = {
+      update: vi.fn(),
+      stop: vi.fn(async () => {}),
+    };
+    mockState.createMattermostDraftStream.mockReturnValue(draftStream);
+    const runtimeCore = createRuntimeCore(testConfig);
+    runtimeCore.channel.reply.createReplyDispatcherWithTyping = vi.fn(() => ({
+      dispatcher: {},
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" as const },
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    }));
+    mockState.runtimeCore = runtimeCore;
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-progress",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "run a long task",
+          create_at: 1_714_000_000_000,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    const dispatchParams = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0] as {
+      replyOptions?: {
+        allowProgressCallbacksWhenSourceDeliverySuppressed?: boolean;
+        onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
+        sourceReplyDeliveryMode?: string;
+        suppressDefaultToolProgressMessages?: boolean;
+      };
+    };
+    expect(dispatchParams.replyOptions?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatchParams.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBe(
+      true,
+    );
+    expect(dispatchParams.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
+    await dispatchParams.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+    expect(draftStream.update).toHaveBeenCalledWith("Working");
+  });
+
   it("does not drop inline command-looking group text from non-command-authorized senders", async () => {
     const socket = new FakeWebSocket();
     const abortController = new AbortController();

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1884,6 +1884,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                           ...(suppressDefaultToolProgressMessages
                             ? { suppressDefaultToolProgressMessages: true }
                             : {}),
+                          ...(draftToolProgressEnabled
+                            ? { allowProgressCallbacksWhenSourceDeliverySuppressed: true }
+                            : {}),
                           onModelSelected,
                           onPartialReply: (payloadResult) => {
                             if (account.streamingMode !== "progress") {


### PR DESCRIPTION
Fixes #88766

## Summary
- Allow Mattermost draft tool-progress callbacks to keep running when source reply delivery is `message_tool_only`.
- Preserve the existing final-reply delivery behavior; this only restores the in-flight draft preview path.
- Add regression coverage for the Mattermost inbound dispatch path so the source-suppressed progress flag stays wired.

## Real behavior proof
- Behavior addressed: Mattermost turns using Codex/message-tool-only source delivery keep channel-owned draft progress callbacks enabled while final source replies remain suppressed.
- Real environment tested: local OpenClaw checkout on Linux, Node 22.22.0, running the production Mattermost monitor against a loopback Mattermost-compatible HTTP/WebSocket endpoint.
- Exact steps or command run after this patch: ran `node --import tsx --input-type=module` from the patched checkout with an inline script that started `monitorMattermostProvider`, emitted a Mattermost `posted` websocket event, and recorded the monitor's dispatch options plus Mattermost API writes.
- Evidence after fix: terminal output from that command:

```json
{
  "dispatchCalls": [
    {
      "sourceReplyDeliveryMode": "message_tool_only",
      "allowProgressCallbacksWhenSourceDeliverySuppressed": true,
      "suppressDefaultToolProgressMessages": true,
      "disableBlockStreaming": true
    }
  ],
  "draftUpdates": [
    "🛠️ Exec",
    "🧰 Tool Call: exec running"
  ],
  "deliveredFinalReplies": [],
  "dispatchIdle": true,
  "runComplete": true,
  "mattermostApiWrites": [
    {
      "method": "POST",
      "url": "/api/v4/posts",
      "message": "🛠️ Exec"
    },
    {
      "method": "PUT",
      "url": "/api/v4/posts/post-1",
      "message": "🧰 Tool Call: exec running"
    }
  ]
}
```

- Observed result after fix: the Mattermost monitor passed `sourceReplyDeliveryMode: "message_tool_only"` and `allowProgressCallbacksWhenSourceDeliverySuppressed: true`, wrote progress text through Mattermost draft POST/PUT calls, and left `deliveredFinalReplies` empty.
- What was not tested: a real external Mattermost workspace plus a real Codex model turn; the local endpoint exercised the production Mattermost monitor dispatch path without third-party credentials.

## Verification
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts`
- `pnpm tsgo:extensions:test`
- `pnpm exec oxfmt --check extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`
- `git diff --check`
