### PR TITLE
feat(dreaming): expose shadow-trial scoring in reports

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -114,6 +114,13 @@ as rejected for that scoring pass. This signal is still report-only: it can
 change candidate ordering or review metadata, but it does not write to
 `MEMORY.md` or promote the candidate by itself.
 
+Shadow-trial reports can include that scoring metadata when a caller supplies
+the candidate's base score. The report records the base score, shadow-trial
+delta, final review score, rejected-by-shadow-trial flag, and `scoring action:
+report-only` beside the existing `promotion action: report-only` marker. Those
+fields are review evidence only; they do not make a dry-run policy decision and
+do not enable automatic promotion.
+
 ## QA shadow trial report coverage
 
 QA Lab includes a report-only scenario for exploring how a future dreaming

--- a/extensions/memory-core/src/dreaming-shadow-trial.test.ts
+++ b/extensions/memory-core/src/dreaming-shadow-trial.test.ts
@@ -38,6 +38,7 @@ describe("dreaming shadow trial runner", () => {
     });
 
     expect(report.recommendation).toBe("promote");
+    expect(report.scoringAction).toBe("report-only");
     expect(report.promotionAction).toBe("report-only");
     expect(report.markdown).toContain("candidate: The user prefers release notes");
     expect(report.markdown).toContain("baseline outcome: Mentions tests passed");
@@ -47,8 +48,54 @@ describe("dreaming shadow trial runner", () => {
     expect(report.markdown).toContain("risk flags:");
     expect(report.markdown).toContain("- no secret exposure");
     expect(report.markdown).toContain("evidence refs:");
+    expect(report.markdown).toContain("scoring:");
+    expect(report.markdown).toContain("scoring action: report-only");
+    expect(report.markdown).toContain("score fields: not supplied");
     expect(report.markdown).toContain("promotion action: report-only");
     expect(report.markdown).not.toContain("promoted to MEMORY.md");
+  });
+
+  it("exposes shadow-trial scoring in the report without changing promotion action", () => {
+    const report = buildDreamingShadowTrialReport({
+      ...baseInput,
+      verdict: "helpful",
+      candidateScore: 0.74,
+    });
+
+    expect(report.scoreBeforeShadowTrial).toBe(0.74);
+    expect(report.shadowTrialScoreDelta).toBe(0.04);
+    expect(report.scoreAfterShadowTrial).toBe(0.78);
+    expect(report.rejectedByShadowTrial).toBe(false);
+    expect(report.scoringAction).toBe("report-only");
+    expect(report.promotionAction).toBe("report-only");
+    expect(report.markdown).toContain("base score: 0.74");
+    expect(report.markdown).toContain("shadow-trial delta: 0.04");
+    expect(report.markdown).toContain("final review score: 0.78");
+    expect(report.markdown).toContain("rejected by shadow trial: no");
+    expect(report.markdown).toContain("scoring action: report-only");
+    expect(report.markdown).toContain("promotion action: report-only");
+    expect(report.markdown).not.toContain("would-promote");
+    expect(report.markdown).not.toContain("promoted to MEMORY.md");
+  });
+
+  it("exposes harmful scoring as report-only rejection metadata", () => {
+    const report = buildDreamingShadowTrialReport({
+      ...baseInput,
+      verdict: "harmful",
+      candidateScore: 0.92,
+      reason: "The candidate would normalize credential exposure.",
+      riskFlags: ["credential exposure"],
+    });
+
+    expect(report.scoreBeforeShadowTrial).toBe(0.92);
+    expect(report.shadowTrialScoreDelta).toBe(-1);
+    expect(report.scoreAfterShadowTrial).toBe(0);
+    expect(report.rejectedByShadowTrial).toBe(true);
+    expect(report.scoringAction).toBe("report-only");
+    expect(report.promotionAction).toBe("report-only");
+    expect(report.markdown).toContain("rejected by shadow trial: yes");
+    expect(report.markdown).toContain("scoring action: report-only");
+    expect(report.markdown).toContain("promotion action: report-only");
   });
 
   it("writes only the shadow-trial report and leaves MEMORY.md unchanged", async () => {
@@ -64,6 +111,7 @@ describe("dreaming shadow trial runner", () => {
     });
 
     expect(report.recommendation).toBe("defer");
+    expect(report.scoringAction).toBe("report-only");
     expect(path.dirname(report.reportPath!)).toBe(
       path.join(workspaceDir, "memory", "dreaming", "shadow-trials", "2026-05-18"),
     );
@@ -122,6 +170,33 @@ describe("dreaming shadow trial runner", () => {
     );
     await expect(fs.readFile(second.reportPath!, "utf-8")).resolves.toContain(
       "candidate: The user prefers terse release notes",
+    );
+  });
+
+  it("keeps scored and unscored reports in separate default report files", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-shadow-trial-score-collisions-");
+    const nowMs = Date.parse("2026-05-18T18:00:00.000Z");
+
+    const unscored = await writeDreamingShadowTrialReport({
+      ...baseInput,
+      verdict: "helpful",
+      workspaceDir,
+      nowMs,
+    });
+    const scored = await writeDreamingShadowTrialReport({
+      ...baseInput,
+      verdict: "helpful",
+      candidateScore: 0.74,
+      workspaceDir,
+      nowMs,
+    });
+
+    expect(unscored.reportPath).not.toBe(scored.reportPath);
+    await expect(fs.readFile(unscored.reportPath!, "utf-8")).resolves.toContain(
+      "score fields: not supplied",
+    );
+    await expect(fs.readFile(scored.reportPath!, "utf-8")).resolves.toContain(
+      "final review score: 0.78",
     );
   });
 

--- a/extensions/memory-core/src/dreaming-shadow-trial.ts
+++ b/extensions/memory-core/src/dreaming-shadow-trial.ts
@@ -15,6 +15,7 @@ export type DreamingShadowTrialInput = {
   reason: string;
   riskFlags?: string[];
   evidenceRefs?: string[];
+  candidateScore?: number;
   workspaceDir?: string;
   reportPath?: string;
   nowMs?: number;
@@ -31,6 +32,11 @@ export type DreamingShadowTrialReport = {
   reason: string;
   riskFlags: string[];
   evidenceRefs: string[];
+  scoreBeforeShadowTrial?: number;
+  shadowTrialScoreDelta?: number;
+  scoreAfterShadowTrial?: number;
+  rejectedByShadowTrial?: boolean;
+  scoringAction: "report-only";
   promotionAction: "report-only";
   reportPath?: string;
   markdown: string;
@@ -107,6 +113,12 @@ function formatList(values: string[]): string {
   return values.map((value) => `- ${value}`).join("\n");
 }
 
+function formatScore(value: number): string {
+  return Number.isInteger(value)
+    ? String(value)
+    : value.toFixed(4).replace(/0+$/, "").replace(/\.$/, "");
+}
+
 function resolveReportContentHash(params: {
   candidate: string;
   trialPrompt: string;
@@ -116,6 +128,7 @@ function resolveReportContentHash(params: {
   reason: string;
   riskFlags: string[];
   evidenceRefs: string[];
+  candidateScore?: number;
 }): string {
   const seed = JSON.stringify([
     params.candidate,
@@ -126,6 +139,7 @@ function resolveReportContentHash(params: {
     params.reason,
     params.riskFlags,
     params.evidenceRefs,
+    params.candidateScore,
   ]);
   return crypto.createHash("sha256").update(seed).digest("hex").slice(0, 12);
 }
@@ -153,6 +167,7 @@ export function defaultDreamingShadowTrialReportPath(params: {
   reason: string;
   riskFlags?: string[];
   evidenceRefs?: string[];
+  candidateScore?: number;
   nowMs?: number;
   timezone?: string;
 }): string {
@@ -167,6 +182,9 @@ export function defaultDreamingShadowTrialReportPath(params: {
     reason: normalizeRequiredText(params.reason, "reason"),
     riskFlags: normalizeDataList(params.riskFlags),
     evidenceRefs: normalizeDataList(params.evidenceRefs),
+    ...(params.candidateScore !== undefined
+      ? { candidateScore: clampScore(params.candidateScore) }
+      : {}),
   });
   return path.join(
     params.workspaceDir,
@@ -188,6 +206,7 @@ function resolveReportPath(params: {
   reason: string;
   riskFlags: string[];
   evidenceRefs: string[];
+  candidateScore?: number;
   reportPath?: string;
   nowMs?: number;
   timezone?: string;
@@ -214,6 +233,7 @@ function resolveReportPath(params: {
     reason: params.reason,
     riskFlags: params.riskFlags,
     evidenceRefs: params.evidenceRefs,
+    candidateScore: params.candidateScore,
     nowMs: params.nowMs,
     timezone: params.timezone,
   });
@@ -230,6 +250,22 @@ export function buildDreamingShadowTrialReport(
   const riskFlags = normalizeDataList(input.riskFlags);
   const evidenceRefs = normalizeDataList(input.evidenceRefs);
   const recommendation = resolveDreamingShadowTrialRecommendation(input.verdict);
+  const hasCandidateScore = input.candidateScore !== undefined;
+  const scoreBeforeShadowTrial = hasCandidateScore
+    ? clampScore(input.candidateScore ?? 0)
+    : undefined;
+  const shadowTrialScoreDelta = hasCandidateScore
+    ? resolveDreamingShadowTrialScoreDelta(input.verdict)
+    : undefined;
+  const rejectedByShadowTrial = hasCandidateScore
+    ? input.verdict === "harmful" || recommendation === "reject"
+    : undefined;
+  const scoreAfterShadowTrial =
+    scoreBeforeShadowTrial === undefined || shadowTrialScoreDelta === undefined
+      ? undefined
+      : rejectedByShadowTrial
+        ? 0
+        : clampScore(scoreBeforeShadowTrial + shadowTrialScoreDelta);
   const reportPath = resolveReportPath({
     workspaceDir: input.workspaceDir,
     candidate,
@@ -240,6 +276,7 @@ export function buildDreamingShadowTrialReport(
     reason,
     riskFlags,
     evidenceRefs,
+    candidateScore: input.candidateScore,
     reportPath: input.reportPath,
     nowMs: input.nowMs,
     timezone: input.timezone,
@@ -259,6 +296,16 @@ export function buildDreamingShadowTrialReport(
     formatList(normalizeList(riskFlags, "none recorded")),
     "evidence refs:",
     formatList(normalizeList(evidenceRefs, "none supplied")),
+    "scoring:",
+    ...(hasCandidateScore
+      ? [
+          `- base score: ${formatScore(scoreBeforeShadowTrial ?? 0)}`,
+          `- shadow-trial delta: ${formatScore(shadowTrialScoreDelta ?? 0)}`,
+          `- final review score: ${formatScore(scoreAfterShadowTrial ?? 0)}`,
+          `- rejected by shadow trial: ${rejectedByShadowTrial ? "yes" : "no"}`,
+          "- scoring action: report-only",
+        ]
+      : ["- scoring action: report-only", "- score fields: not supplied"]),
     "promotion action: report-only",
     "",
   ].join("\n");
@@ -273,6 +320,11 @@ export function buildDreamingShadowTrialReport(
     reason,
     riskFlags,
     evidenceRefs,
+    ...(scoreBeforeShadowTrial !== undefined ? { scoreBeforeShadowTrial } : {}),
+    ...(shadowTrialScoreDelta !== undefined ? { shadowTrialScoreDelta } : {}),
+    ...(scoreAfterShadowTrial !== undefined ? { scoreAfterShadowTrial } : {}),
+    ...(rejectedByShadowTrial !== undefined ? { rejectedByShadowTrial } : {}),
+    scoringAction: "report-only",
     promotionAction: "report-only",
     ...(reportPath ? { reportPath } : {}),
     markdown,


### PR DESCRIPTION
Expose the PR3 shadow-trial scoring signal in the report artifact while keeping the Dreaming path report-only.

This keeps the scoring helper private and only adds report metadata when a caller supplies `candidateScore`:
- base score
- shadow-trial delta
- final review score
- rejected-by-shadow-trial flag
- `scoring action: report-only` beside the existing `promotion action: report-only`

The PR also keeps scored and unscored default report files distinct by including the normalized candidate score in the report hash.

## Real behavior proof

Behavior or issue addressed:
Shadow-trial reports now expose the scoring signal from PR3 as report metadata only, without introducing policy decisions or durable memory writes.

Real environment tested:
Local OpenClaw checkout on branch `feature/dreaming-report-scoring`, using a temporary workspace with a real `MEMORY.md`.

Exact steps or command run after this patch:
```bash
git diff --check
./node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/dreaming-shadow-trial.ts extensions/memory-core/src/dreaming-shadow-trial.test.ts docs/concepts/dreaming.md
node scripts/check-docs-mdx.mjs docs/concepts/dreaming.md
./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core/src/dreaming-shadow-trial.ts extensions/memory-core/src/dreaming-shadow-trial.test.ts
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-shadow-trial.test.ts
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-shadow-trial.test.ts extensions/memory-core/src/short-term-promotion.test.ts
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/dreaming-shadow-trial.test.ts
pnpm check:test-types
node --import tsx - <<'EOF'
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { writeDreamingShadowTrialReport } from './extensions/memory-core/src/dreaming-shadow-trial.ts';

const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-pr4-shadow-report-'));
const memoryPath = path.join(workspaceDir, 'MEMORY.md');
const before = '# Memory\n\nExisting durable memory.\n';
await fs.writeFile(memoryPath, before, 'utf-8');
const common = {
  candidate: 'The user wants release updates with exact verification and risk notes.',
  trialPrompt: 'Prepare a release readiness note.',
  baselineOutcome: 'Mentions tests passed without the exact command.',
  candidateOutcome: 'Includes exact verification, risk notes, and no private data.',
  verdict: 'helpful',
  reason: 'The candidate improves review quality without changing durable memory.',
  riskFlags: ['no secret exposure'],
  evidenceRefs: ['memory/2026-06-01.md#L28'],
  workspaceDir,
  nowMs: Date.parse('2026-06-01T04:10:00.000Z'),
  timezone: 'Asia/Riyadh',
};
const unscored = await writeDreamingShadowTrialReport(common);
const scored = await writeDreamingShadowTrialReport({ ...common, candidateScore: 0.74 });
const after = await fs.readFile(memoryPath, 'utf-8');
const reportText = await fs.readFile(scored.reportPath, 'utf-8');
console.log(JSON.stringify({
  unscoredReportPath: path.relative(workspaceDir, unscored.reportPath),
  scoredReportPath: path.relative(workspaceDir, scored.reportPath),
  pathsAreDistinct: unscored.reportPath !== scored.reportPath,
  scoreBeforeShadowTrial: scored.scoreBeforeShadowTrial,
  shadowTrialScoreDelta: scored.shadowTrialScoreDelta,
  scoreAfterShadowTrial: scored.scoreAfterShadowTrial,
  scoringAction: scored.scoringAction,
  promotionAction: scored.promotionAction,
  memoryUnchanged: after === before,
  reportContainsFinalReviewScore: reportText.includes('final review score: 0.78'),
  reportContainsNoPromotionMarker: reportText.includes('promotion action: report-only'),
}, null, 2));
EOF
```

Evidence after fix:
```json
{
  "unscoredReportPath": "memory/dreaming/shadow-trials/2026-06-01/0950174b886a.md",
  "scoredReportPath": "memory/dreaming/shadow-trials/2026-06-01/27901c9c106a.md",
  "pathsAreDistinct": true,
  "scoreBeforeShadowTrial": 0.74,
  "shadowTrialScoreDelta": 0.04,
  "scoreAfterShadowTrial": 0.78,
  "scoringAction": "report-only",
  "promotionAction": "report-only",
  "memoryUnchanged": true,
  "reportContainsFinalReviewScore": true,
  "reportContainsNoPromotionMarker": true
}
```

Observed result after fix:
The scored shadow-trial report includes the final review score and both report-only action markers, while the original `MEMORY.md` contents stay unchanged. Scored and unscored reports are written to separate default report files.

What was not tested:
No live dreaming integration, dry-run promotion policy, audit ledger, config flag, automatic promotion, or durable `MEMORY.md` mutation was tested because those are intentionally outside PR4 scope.

## Tests

```bash
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-shadow-trial.test.ts # 14 passed
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-shadow-trial.test.ts extensions/memory-core/src/short-term-promotion.test.ts # 91 passed
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/dreaming-shadow-trial.test.ts # 62 passed
pnpm check:test-types # passed
```

`pnpm lint --threads=8` still reports two unrelated existing Matrix extension lint findings in `extensions/matrix/src/matrix/monitor/auto-join.ts` and `extensions/matrix/src/matrix/monitor/events.ts`. Direct oxlint on the touched files passed.

If this lands, please preserve Firas Alswihry / @iFiras-Max1 as the contributor attribution.
