### PR TITLE
test(browser): cover action input request shapes

### DIFF
--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
@@ -41,6 +41,44 @@ describe("browser element commands", () => {
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
   });
 
+  it("sends click requests with element action options", async () => {
+    const program = createElementProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "--browser-profile",
+        "qa",
+        "click",
+        "ref-42",
+        "--target-id",
+        "tab-main",
+        "--double",
+        "--button",
+        "right",
+        "--modifiers",
+        "Shift, Meta",
+      ],
+      { from: "user" },
+    );
+
+    const call = mocks.callBrowserRequest.mock.calls.at(-1);
+    expect(call?.[1]).toMatchObject({
+      method: "POST",
+      path: "/act",
+      query: { profile: "qa" },
+      body: {
+        kind: "click",
+        ref: "ref-42",
+        targetId: "tab-main",
+        doubleClick: true,
+        button: "right",
+        modifiers: ["Shift", "Meta"],
+      },
+    });
+    expect(call?.[2]).toMatchObject({ timeoutMs: 25000 });
+  });
+
   it("rejects non-decimal coordinate values before dispatch", async () => {
     const program = createElementProgram();
 

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
@@ -92,6 +92,54 @@ describe("browser action input wait command", () => {
   });
 });
 
+describe("browser action input fill command", () => {
+  beforeEach(() => {
+    mocks.callBrowserRequest.mockClear();
+    getBrowserCliRuntimeCapture().resetRuntimeCapture();
+  });
+
+  it("sends normalized fill fields with target and profile context", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "--browser-profile",
+        "qa",
+        "fill",
+        "--fields",
+        JSON.stringify([
+          { ref: "name", value: "Ada" },
+          { ref: "enabled", type: "checkbox", value: true },
+          { ref: "empty" },
+        ]),
+        "--target-id",
+        "tab-main",
+      ],
+      { from: "user" },
+    );
+
+    expect(mocks.callBrowserRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ browserProfile: "qa" }),
+      {
+        method: "POST",
+        path: "/act",
+        query: { profile: "qa" },
+        body: {
+          kind: "fill",
+          fields: [
+            { ref: "name", type: "text", value: "Ada" },
+            { ref: "enabled", type: "checkbox", value: true },
+            { ref: "empty", type: "text" },
+          ],
+          targetId: "tab-main",
+        },
+      },
+      { timeoutMs: 25000 },
+    );
+  });
+});
+
 describe("browser action input evaluate command", () => {
   beforeEach(() => {
     mocks.callBrowserRequest.mockClear();

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as browserCliResizeModule from "../browser-cli-resize.js";
+import * as browserCliSharedModule from "../browser-cli-shared.js";
 import {
   createBrowserProgram,
   getBrowserCliRuntime,
@@ -9,9 +10,11 @@ import {
 import * as cliCoreApiModule from "../core-api.js";
 
 const mocks = vi.hoisted(() => ({
+  callBrowserRequest: vi.fn(async () => ({ url: "https://example.test/app" })),
   runBrowserResizeWithOutput: vi.fn(async () => {}),
 }));
 
+vi.spyOn(browserCliSharedModule, "callBrowserRequest").mockImplementation(mocks.callBrowserRequest);
 vi.spyOn(browserCliResizeModule, "runBrowserResizeWithOutput").mockImplementation(
   mocks.runBrowserResizeWithOutput,
 );
@@ -33,8 +36,61 @@ function createNavigationProgram(): Command {
 
 describe("browser navigation commands", () => {
   beforeEach(() => {
+    mocks.callBrowserRequest.mockClear();
     mocks.runBrowserResizeWithOutput.mockClear();
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
+  });
+
+  it("sends navigate requests with target and profile context", async () => {
+    const program = createNavigationProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "--browser-profile",
+        "qa",
+        "navigate",
+        "https://example.test/app",
+        "--target-id",
+        "tab-main",
+      ],
+      { from: "user" },
+    );
+
+    expect(mocks.callBrowserRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ browserProfile: "qa" }),
+      {
+        method: "POST",
+        path: "/navigate",
+        query: { profile: "qa" },
+        body: {
+          url: "https://example.test/app",
+          targetId: "tab-main",
+        },
+      },
+      { timeoutMs: 20000 },
+    );
+  });
+
+  it("passes normalized resize dimensions into the resize runner", async () => {
+    const program = createNavigationProgram();
+
+    await program.parseAsync(
+      ["browser", "--browser-profile", "qa", "resize", "+01280", "0720", "--target-id", "tab-main"],
+      { from: "user" },
+    );
+
+    expect(mocks.runBrowserResizeWithOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent: expect.objectContaining({ browserProfile: "qa" }),
+        profile: "qa",
+        width: 1280,
+        height: 720,
+        targetId: "tab-main",
+        timeoutMs: 20000,
+        successMessage: "resized to 1280x720",
+      }),
+    );
   });
 
   it("rejects non-decimal resize dimensions before dispatch", async () => {


### PR DESCRIPTION
Refs #83877

## Summary
- Add small, focused CLI registrar tests for browser action-input request shapes that current main still does not assert.
- Cover representative happy paths for click, navigate, resize, and fill while leaving runtime browser behavior unchanged.
- Keep the scope intentionally smaller than the earlier closed broad coverage PR by extending only existing tests.

## Verification
- node scripts/run-vitest.mjs extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
- pnpm exec oxfmt --check extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
- pnpm exec oxlint extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
- git diff --check

## Real behavior proof
**Behavior addressed:** #83877 reports that browser action-input CLI command request-body wiring and validation could regress silently because most command registrars lacked CLI-layer coverage.

**Real environment tested:** Local OpenClaw source checkout on Linux with Node/pnpm dependencies installed in this worktree. In addition to targeted Vitest, I ran the real browser CLI source registrar directly with `node --import tsx` and `OPENCLAW_DISABLE_LAZY_SUBCOMMANDS=1`, without a test framework, to verify the action-input commands are present and the CLI validation path fires before any gateway request.

**Exact steps or command run after fix:**
```bash
node scripts/run-vitest.mjs \
  extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
pnpm exec oxfmt --check \
  extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
pnpm exec oxlint \
  extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
git diff --check
node --import tsx --input-type=module <<'EOF'
import { Command } from "commander";
import { registerBrowserCli } from "./extensions/browser/src/cli/browser-cli.ts";
import { defaultRuntime } from "./extensions/browser/src/cli/core-api.ts";
process.env.OPENCLAW_DISABLE_LAZY_SUBCOMMANDS = "1";
// Registers the real source CLI, checks action-input help, then runs blank-ref validation.
EOF
```

**Evidence after fix:** Targeted Vitest passed 4 files / 20 tests in the browser extension shard. The new tests assert real Commander parsing for `browser click`, `browser navigate`, `browser resize`, and `browser fill`, then verify the outgoing `/act` or `/navigate` request body, profile query, target id, timeout, and resize runner parameters.

Copied live output from the direct source-registrar proof:
```text
PASS: click help
  command: browser click --help
  tokens: Click an element by ref, --target-id, --double
PASS: navigate help
  command: browser navigate --help
  tokens: Navigate the current tab to a URL, --target-id
PASS: fill help
  command: browser fill --help
  tokens: Fill a form with JSON field descriptors, --fields, --fields-file
PASS: resize help
  command: browser resize --help
  tokens: Resize the viewport, --target-id
PASS: blank click ref validation
  command: browser click "   "
  runtimeExit: 1
  runtimeErrors: ref is required
```


**Observed result after fix:** Browser action-input tests now cover representative happy-path request shapes in addition to the validation-focused tests that were already on main. The direct source-registrar proof confirms the real browser CLI exposes the action-input commands and rejects a blank click ref locally before dispatch. The patch is test-only and touches no production browser CLI, gateway, or runtime behavior.

**What was not tested:** A live browser server or gateway was not started because the patch only adds CLI registrar tests and does not change browser runtime behavior.