### PR TITLE
fix: enforce iMessage outbound allowlist

### DIFF
--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -690,6 +690,54 @@ describe("imessage message actions", () => {
     expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
   });
 
+  it("does not trust inferred-target markers when the delivered alias differs", async () => {
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "reply",
+        cfg: cfg(undefined, {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15551230000"],
+        }),
+        params: {
+          target: "chat_identifier:team-thread",
+          to: "chat_identifier:blocked-thread",
+          __openclawInferredTargetFromCurrentChannel: true,
+          messageId: "message-guid",
+          text: "reply",
+        },
+        toolContext: { currentChannelId: "chat_identifier:team-thread" },
+        requesterSenderId: "+15551230000",
+      } as never),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not trust gateway-supplied requester sender for group reply authorization", async () => {
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "reply",
+        cfg: cfg(undefined, {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15551230000"],
+        }),
+        params: {
+          messageId: "message-guid",
+          text: "reply",
+        },
+        toolContext: { currentChannelId: "chat_identifier:team-thread" },
+        requesterSenderId: "+15551230000",
+        gatewayClientScopes: ["operator.write"],
+      } as never),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+  });
+
   it("does not use trusted requester sender for explicit group reply targets", async () => {
     await expect(
       imessageMessageActions.handleAction?.({

--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -12,6 +12,11 @@ const runtimeMock = vi.hoisted(() => ({
   sendReaction: vi.fn(),
   sendRichMessage: vi.fn(),
   sendAttachment: vi.fn(),
+  renameGroup: vi.fn(),
+  setGroupIcon: vi.fn(),
+  addParticipant: vi.fn(),
+  removeParticipant: vi.fn(),
+  leaveGroup: vi.fn(),
 }));
 
 const rememberIMessageReplyCacheMock = vi.hoisted(() => vi.fn());
@@ -93,6 +98,11 @@ describe("imessage message actions", () => {
     runtimeMock.sendReaction.mockReset();
     runtimeMock.sendRichMessage.mockReset();
     runtimeMock.sendAttachment.mockReset();
+    runtimeMock.renameGroup.mockReset();
+    runtimeMock.setGroupIcon.mockReset();
+    runtimeMock.addParticipant.mockReset();
+    runtimeMock.removeParticipant.mockReset();
+    runtimeMock.leaveGroup.mockReset();
     rememberIMessageReplyCacheMock.mockReset();
     probeMock.getCachedIMessagePrivateApiStatus.mockReset();
     probeMock.probeIMessagePrivateApi.mockReset();
@@ -464,6 +474,87 @@ describe("imessage message actions", () => {
     );
     expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
     expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+    expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["renameGroup", { chatIdentifier: "blocked-thread", displayName: "Blocked" }, "renameGroup"],
+    ["setGroupIcon", { chatIdentifier: "blocked-thread", buffer: "aWNvbg==" }, "setGroupIcon"],
+    [
+      "addParticipant",
+      { chatIdentifier: "blocked-thread", address: "+15551230000" },
+      "addParticipant",
+    ],
+    [
+      "removeParticipant",
+      { chatIdentifier: "blocked-thread", address: "+15551230000" },
+      "removeParticipant",
+    ],
+    ["leaveGroup", { chatIdentifier: "blocked-thread" }, "leaveGroup"],
+  ] as const)(
+    "blocks %s when the group target is not allowlisted",
+    async (action, params, runtimeMethod) => {
+      await expect(
+        imessageMessageActions.handleAction?.({
+          action,
+          cfg: cfg(undefined, {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["chat_identifier:allowed-thread"],
+          }),
+          params,
+        } as never),
+      ).rejects.toThrow(
+        "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+      );
+      expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+      expect(runtimeMock[runtimeMethod]).not.toHaveBeenCalled();
+      expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows group mutation actions when the group target is allowlisted", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+    runtimeMock.resolveChatGuidForTarget.mockResolvedValue("iMessage;+;allowed-thread");
+    runtimeMock.renameGroup.mockResolvedValue(undefined);
+
+    await imessageMessageActions.handleAction?.({
+      action: "renameGroup",
+      cfg: cfg(undefined, {
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["chat_identifier:allowed-thread"],
+      }),
+      params: {
+        chatIdentifier: "allowed-thread",
+        displayName: "Allowed",
+      },
+    } as never);
+
+    expect(runtimeMock.renameGroup).toHaveBeenCalledWith({
+      chatGuid: "iMessage;+;allowed-thread",
+      displayName: "Allowed",
+      options: imsgOptions("iMessage;+;allowed-thread"),
+    });
+  });
+
+  it("validates group mutation inputs before outbound policy", async () => {
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "renameGroup",
+        cfg: cfg(undefined, {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["chat_identifier:allowed-thread"],
+        }),
+        params: {
+          chatIdentifier: "blocked-thread",
+        },
+      } as never),
+    ).rejects.toThrow("iMessage renameGroup requires displayName or name.");
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.renameGroup).not.toHaveBeenCalled();
     expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
   });
 

--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -467,6 +467,84 @@ describe("imessage message actions", () => {
     expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
   });
 
+  it("allows reply when sender-based group allowlist matches the trusted requester", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+    runtimeMock.resolveChatGuidForTarget.mockResolvedValue("iMessage;+;team-thread");
+    runtimeMock.sendRichMessage.mockResolvedValue({ messageId: "reply-guid" });
+
+    await imessageMessageActions.handleAction?.({
+      action: "reply",
+      cfg: cfg(undefined, {
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["+15551230000"],
+      }),
+      params: {
+        messageId: "message-guid",
+        text: "reply",
+      },
+      toolContext: { currentChannelId: "chat_identifier:team-thread" },
+      requesterSenderId: "+15551230000",
+    } as never);
+
+    expect(runtimeMock.sendRichMessage).toHaveBeenCalledWith({
+      chatGuid: "iMessage;+;team-thread",
+      text: "reply",
+      replyToMessageId: "message-guid",
+      partIndex: undefined,
+      attachment: undefined,
+      options: imsgOptions("iMessage;+;team-thread"),
+    });
+  });
+
+  it("does not use trusted requester sender for explicit group reply targets", async () => {
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "reply",
+        cfg: cfg(undefined, {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15551230000"],
+        }),
+        params: {
+          chatIdentifier: "team-thread",
+          messageId: "message-guid",
+          text: "reply",
+        },
+        requesterSenderId: "+15551230000",
+      } as never),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+    expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+  });
+
+  it("blocks sender-based group replies without a trusted requester", async () => {
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "reply",
+        cfg: cfg(undefined, {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15551230000"],
+        }),
+        params: {
+          chatIdentifier: "team-thread",
+          messageId: "message-guid",
+          text: "reply",
+        },
+      } as never),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+    expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+  });
+
   describe("reply with attachment (openclaw/imsg#114 plumbing)", () => {
     // The core message-action runner hydrates path/media/filePath/etc.
     // through the outbound media resolver (mediaLocalRoots/sandbox/size)

--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -10,6 +10,8 @@ const runtimeMock = vi.hoisted(() => ({
   resolveIMessageMessageId: vi.fn((id: string) => id),
   resolveChatGuidForTarget: vi.fn(),
   sendReaction: vi.fn(),
+  editMessage: vi.fn(),
+  unsendMessage: vi.fn(),
   sendRichMessage: vi.fn(),
   sendAttachment: vi.fn(),
   renameGroup: vi.fn(),
@@ -96,6 +98,8 @@ describe("imessage message actions", () => {
     runtimeMock.resolveIMessageMessageId.mockImplementation((id: string) => id);
     runtimeMock.resolveChatGuidForTarget.mockReset();
     runtimeMock.sendReaction.mockReset();
+    runtimeMock.editMessage.mockReset();
+    runtimeMock.unsendMessage.mockReset();
     runtimeMock.sendRichMessage.mockReset();
     runtimeMock.sendAttachment.mockReset();
     runtimeMock.renameGroup.mockReset();
@@ -476,6 +480,40 @@ describe("imessage message actions", () => {
     expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
     expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
   });
+
+  it.each([
+    [
+      "react",
+      { chatIdentifier: "blocked-thread", messageId: "message-guid", emoji: "👍" },
+      "sendReaction",
+    ],
+    [
+      "edit",
+      { chatIdentifier: "blocked-thread", messageId: "message-guid", text: "updated" },
+      "editMessage",
+    ],
+    ["unsend", { chatIdentifier: "blocked-thread", messageId: "message-guid" }, "unsendMessage"],
+  ] as const)(
+    "blocks %s when the group target is not allowlisted",
+    async (action, params, runtimeMethod) => {
+      await expect(
+        imessageMessageActions.handleAction?.({
+          action,
+          cfg: cfg(undefined, {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["chat_identifier:allowed-thread"],
+          }),
+          params,
+        } as never),
+      ).rejects.toThrow(
+        "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+      );
+      expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+      expect(runtimeMock.resolveIMessageMessageId).not.toHaveBeenCalled();
+      expect(runtimeMock[runtimeMethod]).not.toHaveBeenCalled();
+      expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     ["renameGroup", { chatIdentifier: "blocked-thread", displayName: "Blocked" }, "renameGroup"],

--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -629,6 +629,67 @@ describe("imessage message actions", () => {
     });
   });
 
+  it("keeps runner-inferred reply targets sender-authorized", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+    runtimeMock.resolveChatGuidForTarget.mockResolvedValue("iMessage;+;team-thread");
+    runtimeMock.sendRichMessage.mockResolvedValue({ messageId: "reply-guid" });
+
+    await imessageMessageActions.handleAction?.({
+      action: "reply",
+      cfg: cfg(undefined, {
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["+15551230000"],
+      }),
+      params: {
+        target: "chat_identifier:team-thread",
+        to: "chat_identifier:team-thread",
+        __openclawInferredTargetFromCurrentChannel: true,
+        messageId: "message-guid",
+        text: "reply",
+      },
+      toolContext: { currentChannelId: "chat_identifier:team-thread" },
+      requesterSenderId: "+15551230000",
+    } as never);
+
+    expect(runtimeMock.sendRichMessage).toHaveBeenCalledWith({
+      chatGuid: "iMessage;+;team-thread",
+      text: "reply",
+      replyToMessageId: "message-guid",
+      partIndex: undefined,
+      attachment: undefined,
+      options: imsgOptions("iMessage;+;team-thread"),
+    });
+  });
+
+  it("does not trust spoofed inferred-target markers for other groups", async () => {
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "reply",
+        cfg: cfg(undefined, {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15551230000"],
+        }),
+        params: {
+          target: "chat_identifier:blocked-thread",
+          to: "chat_identifier:blocked-thread",
+          __openclawInferredTargetFromCurrentChannel: true,
+          messageId: "message-guid",
+          text: "reply",
+        },
+        toolContext: { currentChannelId: "chat_identifier:team-thread" },
+        requesterSenderId: "+15551230000",
+      } as never),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+  });
+
   it("does not use trusted requester sender for explicit group reply targets", async () => {
     await expect(
       imessageMessageActions.handleAction?.({

--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -60,13 +60,17 @@ vi.mock("./monitor-reply-cache.js", async () => {
 
 const { imessageMessageActions } = await import("./actions.js");
 
-function cfg(actions?: Record<string, boolean | undefined>): OpenClawConfig {
+function cfg(
+  actions?: Record<string, boolean | undefined>,
+  imessage?: Record<string, unknown>,
+): OpenClawConfig {
   return {
     channels: {
       imessage: {
         cliPath: "imsg",
         dbPath: "/tmp/messages.db",
         actions,
+        ...imessage,
       },
     },
   } as OpenClawConfig;
@@ -439,6 +443,30 @@ describe("imessage message actions", () => {
     });
   });
 
+  it("blocks reply when the group target is not allowlisted", async () => {
+    runtimeMock.sendRichMessage.mockResolvedValue({ messageId: "reply-guid" });
+
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "reply",
+        cfg: cfg(undefined, {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["chat_identifier:allowed-thread"],
+        }),
+        params: {
+          chatIdentifier: "blocked-thread",
+          messageId: "message-guid",
+          text: "reply",
+        },
+      } as never),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+    expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+  });
+
   describe("reply with attachment (openclaw/imsg#114 plumbing)", () => {
     // The core message-action runner hydrates path/media/filePath/etc.
     // through the outbound media resolver (mediaLocalRoots/sandbox/size)
@@ -807,6 +835,58 @@ describe("imessage message actions", () => {
       ]);
     });
 
+    it("blocks sendWithEffect targets outside iMessage allowlist policy", async () => {
+      runtimeMock.sendRichMessage.mockResolvedValue({ messageId: "ok" });
+
+      await expect(
+        imessageMessageActions.handleAction?.({
+          action: "sendWithEffect",
+          cfg: {
+            channels: {
+              imessage: {
+                cliPath: "imsg",
+                dbPath: "/tmp/messages.db",
+                dmPolicy: "allowlist",
+                allowFrom: ["+15551230000"],
+              },
+            },
+          } as OpenClawConfig,
+          params: {
+            to: "+15559999999",
+            text: "boom",
+            effect: "slam",
+          },
+        } as never),
+      ).rejects.toThrow(
+        "iMessage outbound blocked: target is not in channels.imessage.allowFrom/defaultTo",
+      );
+      expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+      expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+    });
+
+    it("blocks sendWithEffect when the group target is not allowlisted", async () => {
+      runtimeMock.sendRichMessage.mockResolvedValue({ messageId: "ok" });
+
+      await expect(
+        imessageMessageActions.handleAction?.({
+          action: "sendWithEffect",
+          cfg: cfg(undefined, {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["chat_guid:iMessage;+;allowed"],
+          }),
+          params: {
+            chatGuid: "iMessage;+;blocked",
+            text: "boom",
+            effect: "slam",
+          },
+        } as never),
+      ).rejects.toThrow(
+        "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+      );
+      expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+      expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+    });
+
     it.each([
       ["echo", "com.apple.messages.effect.CKEchoEffect"],
       ["happybirthday", "com.apple.messages.effect.CKHappyBirthdayEffect"],
@@ -909,4 +989,25 @@ describe("imessage message actions", () => {
       expect(result?.details).toEqual({ ok: true, messageId: "sent-guid" });
     },
   );
+
+  it("blocks upload-file when the group target is not allowlisted", async () => {
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "upload-file",
+        cfg: cfg(undefined, {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["chat_guid:iMessage;+;allowed"],
+        }),
+        params: {
+          chatGuid: "iMessage;+;blocked",
+          filename: "photo.jpg",
+          buffer: Buffer.from("image").toString("base64"),
+        },
+      } as never),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(probeMock.probeIMessagePrivateApi).not.toHaveBeenCalled();
+    expect(runtimeMock.sendAttachment).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -257,6 +257,25 @@ function readOutboundActionTarget(params: {
   return rawTarget ? parseIMessageTarget(rawTarget) : null;
 }
 
+function readRawOutboundActionTarget(params: {
+  actionParams: Record<string, unknown>;
+  currentChannelId?: string;
+}): string | undefined {
+  return (
+    readStringParam(params.actionParams, "chatGuid")?.trim() ||
+    (typeof readPositiveIntegerParam(params.actionParams, "chatId") === "number"
+      ? `chat_id:${readPositiveIntegerParam(params.actionParams, "chatId")}`
+      : undefined) ||
+    (readStringParam(params.actionParams, "chatIdentifier")?.trim()
+      ? `chat_identifier:${readStringParam(params.actionParams, "chatIdentifier")?.trim()}`
+      : undefined) ||
+    readStringParam(params.actionParams, "to")?.trim() ||
+    readStringParam(params.actionParams, "target")?.trim() ||
+    params.currentChannelId?.trim() ||
+    undefined
+  );
+}
+
 function hasExplicitOutboundActionTarget(
   params: Record<string, unknown>,
   currentChannelId?: string,
@@ -267,7 +286,7 @@ function hasExplicitOutboundActionTarget(
   const targetWasInferred =
     params[MESSAGE_ACTION_INFERRED_TARGET_PARAM] === true &&
     Boolean(currentTarget) &&
-    (targetParam === currentTarget || toParam === currentTarget);
+    readRawOutboundActionTarget({ actionParams: params, currentChannelId }) === currentTarget;
   return (
     Boolean(readStringParam(params, "chatGuid")?.trim()) ||
     typeof readPositiveIntegerParam(params, "chatId") === "number" ||
@@ -447,7 +466,15 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     leaveGroup: { aliases: ["chatGuid", "chatIdentifier", "chatId"] },
   },
   extractToolSend: ({ args }) => extractToolSend(args, "sendMessage"),
-  handleAction: async ({ action, params, cfg, accountId, requesterSenderId, toolContext }) => {
+  handleAction: async ({
+    action,
+    params,
+    cfg,
+    accountId,
+    requesterSenderId,
+    toolContext,
+    gatewayClientScopes,
+  }) => {
     const runtime = await loadIMessageActionsRuntime();
     const account = resolveIMessageAccount({
       cfg,
@@ -524,7 +551,9 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
           toolContext?.currentChannelId,
         )
           ? undefined
-          : assertOpts?.replyRequesterSender;
+          : gatewayClientScopes
+            ? undefined
+            : assertOpts?.replyRequesterSender;
         await assertIMessageOutboundAllowed({
           cfg,
           account,

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -25,6 +25,7 @@ import {
   type IMessageChatContext,
 } from "./monitor-reply-cache.js";
 import { getCachedIMessagePrivateApiStatus, probeIMessagePrivateApi } from "./probe.js";
+import { assertIMessageOutboundAllowed } from "./send.js";
 import { parseIMessageTarget, type IMessageTarget } from "./targets.js";
 
 const loadIMessageActionsRuntime = createLazyRuntimeNamedExport(
@@ -230,6 +231,29 @@ function buildChatContextFromActionParams(params: {
           ? target.chatId
           : undefined,
   };
+}
+
+function readOutboundActionTarget(params: {
+  actionParams: Record<string, unknown>;
+  currentChannelId?: string;
+}): IMessageTarget | null {
+  const explicitChatGuid = readStringParam(params.actionParams, "chatGuid")?.trim();
+  if (explicitChatGuid) {
+    return { kind: "chat_guid", chatGuid: explicitChatGuid };
+  }
+  const explicitChatId = readPositiveIntegerParam(params.actionParams, "chatId");
+  if (typeof explicitChatId === "number") {
+    return { kind: "chat_id", chatId: explicitChatId };
+  }
+  const explicitChatIdentifier = readStringParam(params.actionParams, "chatIdentifier")?.trim();
+  if (explicitChatIdentifier) {
+    return { kind: "chat_identifier", chatIdentifier: explicitChatIdentifier };
+  }
+  const rawTarget =
+    readStringParam(params.actionParams, "to") ??
+    readStringParam(params.actionParams, "target") ??
+    (params.currentChannelId?.trim() || undefined);
+  return rawTarget ? parseIMessageTarget(rawTarget) : null;
 }
 
 function mapTapbackReaction(emoji?: string): string | undefined {
@@ -466,6 +490,15 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
         },
       );
     };
+    const assertOutboundActionAllowed = async () => {
+      const target = readOutboundActionTarget({
+        actionParams: params,
+        currentChannelId: toolContext?.currentChannelId,
+      });
+      if (target) {
+        await assertIMessageOutboundAllowed({ cfg, account, target });
+      }
+    };
 
     if (action === "react") {
       await assertPrivateApiEnabled();
@@ -541,12 +574,13 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "reply") {
-      await assertPrivateApiEnabled();
       const resolvedMessageId = messageId();
       const text = readMessageText(params);
       if (!text) {
         throw new Error("iMessage reply requires text or message.");
       }
+      await assertOutboundActionAllowed();
+      await assertPrivateApiEnabled();
       const attachment = extractReplyAttachment(params);
       if (attachment) {
         if (attachment.spec === null) {
@@ -588,7 +622,6 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "sendWithEffect") {
-      await assertPrivateApiEnabled();
       const text = readMessageText(params);
       const effectId = effectIdFromParam(
         readStringParam(params, "effectId") ?? readStringParam(params, "effect"),
@@ -596,6 +629,8 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
       if (!text || !effectId) {
         throw new Error("iMessage sendWithEffect requires text/message and effect/effectId.");
       }
+      await assertOutboundActionAllowed();
+      await assertPrivateApiEnabled();
       const resolvedChatGuid = await chatGuid();
       const result = await runtime.sendRichMessage({
         chatGuid: resolvedChatGuid,
@@ -674,6 +709,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "sendAttachment" || action === "upload-file") {
+      await assertOutboundActionAllowed();
       await assertPrivateApiEnabled();
       const filename = readStringParam(params, "filename", { required: true });
       const asVoice = readBooleanParam(params, "asVoice") ?? readBooleanParam(params, "as_voice");

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -256,6 +256,16 @@ function readOutboundActionTarget(params: {
   return rawTarget ? parseIMessageTarget(rawTarget) : null;
 }
 
+function hasExplicitOutboundActionTarget(params: Record<string, unknown>): boolean {
+  return (
+    Boolean(readStringParam(params, "chatGuid")?.trim()) ||
+    typeof readPositiveIntegerParam(params, "chatId") === "number" ||
+    Boolean(readStringParam(params, "chatIdentifier")?.trim()) ||
+    Boolean(readStringParam(params, "to")?.trim()) ||
+    Boolean(readStringParam(params, "target")?.trim())
+  );
+}
+
 function mapTapbackReaction(emoji?: string): string | undefined {
   const value = normalizeOptionalLowercaseString(emoji)?.replace(/\ufe0f/g, "");
   if (!value) {
@@ -426,7 +436,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     leaveGroup: { aliases: ["chatGuid", "chatIdentifier", "chatId"] },
   },
   extractToolSend: ({ args }) => extractToolSend(args, "sendMessage"),
-  handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
+  handleAction: async ({ action, params, cfg, accountId, requesterSenderId, toolContext }) => {
     const runtime = await loadIMessageActionsRuntime();
     const account = resolveIMessageAccount({
       cfg,
@@ -490,13 +500,23 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
         },
       );
     };
-    const assertOutboundActionAllowed = async () => {
+    const assertOutboundActionAllowed = async (assertOpts?: {
+      replyRequesterSender?: string | null;
+    }) => {
       const target = readOutboundActionTarget({
         actionParams: params,
         currentChannelId: toolContext?.currentChannelId,
       });
       if (target) {
-        await assertIMessageOutboundAllowed({ cfg, account, target });
+        const replyRequesterSender = hasExplicitOutboundActionTarget(params)
+          ? undefined
+          : assertOpts?.replyRequesterSender;
+        await assertIMessageOutboundAllowed({
+          cfg,
+          account,
+          target,
+          replyRequesterSender,
+        });
       }
     };
 
@@ -579,7 +599,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
       if (!text) {
         throw new Error("iMessage reply requires text or message.");
       }
-      await assertOutboundActionAllowed();
+      await assertOutboundActionAllowed({ replyRequesterSender: requesterSenderId });
       await assertPrivateApiEnabled();
       const attachment = extractReplyAttachment(params);
       if (attachment) {

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -521,7 +521,6 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     };
 
     if (action === "react") {
-      await assertPrivateApiEnabled();
       const { emoji, remove, isEmpty } = readReactionParams(params, {
         removeErrorMessage: "Emoji is required to remove an iMessage reaction.",
       });
@@ -538,6 +537,8 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
           "iMessage react supports love, like, dislike, laugh, emphasize, and question tapbacks.",
         );
       }
+      await assertOutboundActionAllowed();
+      await assertPrivateApiEnabled();
       const resolvedMessageId = messageId();
       const partIndex = readNonNegativeIntegerParam(params, "partIndex");
       const resolvedChatGuid = await chatGuid();
@@ -556,8 +557,6 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "edit") {
-      await assertPrivateApiEnabled();
-      const resolvedMessageId = messageId({ requireFromMe: true });
       const text =
         readStringParam(params, "text") ??
         readStringParam(params, "newText") ??
@@ -565,6 +564,9 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
       if (!text) {
         throw new Error("iMessage edit requires text, newText, or message.");
       }
+      await assertOutboundActionAllowed();
+      await assertPrivateApiEnabled();
+      const resolvedMessageId = messageId({ requireFromMe: true });
       const partIndex = readNonNegativeIntegerParam(params, "partIndex");
       const backwardsCompatMessage = readStringParam(params, "backwardsCompatMessage");
       const resolvedChatGuid = await chatGuid();
@@ -580,6 +582,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "unsend") {
+      await assertOutboundActionAllowed();
       await assertPrivateApiEnabled();
       const resolvedMessageId = messageId({ requireFromMe: true });
       const partIndex = readNonNegativeIntegerParam(params, "partIndex");

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -24,8 +24,8 @@ import {
   rememberIMessageReplyCache,
   type IMessageChatContext,
 } from "./monitor-reply-cache.js";
+import { assertIMessageOutboundAllowed } from "./outbound-allowlist.js";
 import { getCachedIMessagePrivateApiStatus, probeIMessagePrivateApi } from "./probe.js";
-import { assertIMessageOutboundAllowed } from "./send.js";
 import { parseIMessageTarget, type IMessageTarget } from "./targets.js";
 
 const loadIMessageActionsRuntime = createLazyRuntimeNamedExport(

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -36,6 +36,7 @@ const loadIMessageActionsRuntime = createLazyRuntimeNamedExport(
 const log = createSubsystemLogger("channels/imessage");
 
 const providerId = "imessage";
+const MESSAGE_ACTION_INFERRED_TARGET_PARAM = "__openclawInferredTargetFromCurrentChannel";
 
 const SUPPORTED_ACTIONS = new Set<ChannelMessageActionName>([
   ...IMESSAGE_ACTION_NAMES,
@@ -256,13 +257,23 @@ function readOutboundActionTarget(params: {
   return rawTarget ? parseIMessageTarget(rawTarget) : null;
 }
 
-function hasExplicitOutboundActionTarget(params: Record<string, unknown>): boolean {
+function hasExplicitOutboundActionTarget(
+  params: Record<string, unknown>,
+  currentChannelId?: string,
+): boolean {
+  const currentTarget = currentChannelId?.trim();
+  const targetParam = readStringParam(params, "target")?.trim();
+  const toParam = readStringParam(params, "to")?.trim();
+  const targetWasInferred =
+    params[MESSAGE_ACTION_INFERRED_TARGET_PARAM] === true &&
+    Boolean(currentTarget) &&
+    (targetParam === currentTarget || toParam === currentTarget);
   return (
     Boolean(readStringParam(params, "chatGuid")?.trim()) ||
     typeof readPositiveIntegerParam(params, "chatId") === "number" ||
     Boolean(readStringParam(params, "chatIdentifier")?.trim()) ||
-    Boolean(readStringParam(params, "to")?.trim()) ||
-    Boolean(readStringParam(params, "target")?.trim())
+    (!targetWasInferred && Boolean(toParam)) ||
+    (!targetWasInferred && Boolean(targetParam))
   );
 }
 
@@ -508,7 +519,10 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
         currentChannelId: toolContext?.currentChannelId,
       });
       if (target) {
-        const replyRequesterSender = hasExplicitOutboundActionTarget(params)
+        const replyRequesterSender = hasExplicitOutboundActionTarget(
+          params,
+          toolContext?.currentChannelId,
+        )
           ? undefined
           : assertOpts?.replyRequesterSender;
         await assertIMessageOutboundAllowed({

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -667,11 +667,12 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "renameGroup") {
-      await assertPrivateApiEnabled();
       const displayName = readStringParam(params, "displayName") ?? readStringParam(params, "name");
       if (!displayName) {
         throw new Error("iMessage renameGroup requires displayName or name.");
       }
+      await assertOutboundActionAllowed();
+      await assertPrivateApiEnabled();
       const resolvedChatGuid = await chatGuid();
       await runtime.renameGroup({
         chatGuid: resolvedChatGuid,
@@ -682,6 +683,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "setGroupIcon") {
+      await assertOutboundActionAllowed();
       await assertPrivateApiEnabled();
       const filename =
         readStringParam(params, "filename") ?? readStringParam(params, "name") ?? "icon.png";
@@ -696,11 +698,12 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "addParticipant" || action === "removeParticipant") {
-      await assertPrivateApiEnabled();
       const address = readStringParam(params, "address") ?? readStringParam(params, "participant");
       if (!address) {
         throw new Error(`iMessage ${action} requires address or participant.`);
       }
+      await assertOutboundActionAllowed();
+      await assertPrivateApiEnabled();
       const resolvedChatGuid = await chatGuid();
       if (action === "addParticipant") {
         await runtime.addParticipant({
@@ -719,6 +722,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "leaveGroup") {
+      await assertOutboundActionAllowed();
       await assertPrivateApiEnabled();
       const resolvedChatGuid = await chatGuid();
       await runtime.leaveGroup({

--- a/extensions/imessage/src/channel.runtime.test.ts
+++ b/extensions/imessage/src/channel.runtime.test.ts
@@ -122,6 +122,7 @@ describe("sendIMessageOutbound", () => {
       to: "chat_id:42",
       text: "hello",
       replyToId: "reply-1",
+      replyToIdSource: "implicit",
       replyRequesterSender: "+15551230000",
     });
 
@@ -130,6 +131,7 @@ describe("sendIMessageOutbound", () => {
       "hello",
       expect.objectContaining({
         replyToId: "reply-1",
+        replyToIdSource: "implicit",
         replyRequesterSender: "+15551230000",
       }),
     );

--- a/extensions/imessage/src/channel.runtime.test.ts
+++ b/extensions/imessage/src/channel.runtime.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 
 const monitorMock = vi.hoisted(() => vi.fn(async () => undefined));
+const sendMock = vi.hoisted(() => ({
+  sendMessageIMessage: vi.fn(async () => ({ messageId: "m1" })),
+}));
 
 vi.mock("./monitor.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./monitor.js")>()),
   monitorIMessageProvider: monitorMock,
 }));
+vi.mock("./send.js", () => ({
+  sendMessageIMessage: sendMock.sendMessageIMessage,
+}));
 
-const { startIMessageGatewayAccount } = await import("./channel.runtime.js");
+const { sendIMessageOutbound, startIMessageGatewayAccount } = await import("./channel.runtime.js");
 const { resolveIMessageAccount } = await import("./accounts.js");
 
 function makeCtx(params: {
@@ -104,5 +110,28 @@ describe("startIMessageGatewayAccount duplicate-source handling", () => {
 
     await startIMessageGatewayAccount(ctx);
     expect(monitorMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sendIMessageOutbound", () => {
+  it("forwards trusted requester sender context with reply sends", async () => {
+    sendMock.sendMessageIMessage.mockClear();
+
+    await sendIMessageOutbound({
+      cfg: { channels: { imessage: {} } },
+      to: "chat_id:42",
+      text: "hello",
+      replyToId: "reply-1",
+      replyRequesterSender: "+15551230000",
+    });
+
+    expect(sendMock.sendMessageIMessage).toHaveBeenCalledWith(
+      "chat_id:42",
+      "hello",
+      expect.objectContaining({
+        replyToId: "reply-1",
+        replyRequesterSender: "+15551230000",
+      }),
+    );
   });
 });

--- a/extensions/imessage/src/channel.runtime.ts
+++ b/extensions/imessage/src/channel.runtime.ts
@@ -19,6 +19,7 @@ export async function sendIMessageOutbound(params: {
   accountId?: string;
   deps?: { [channelId: string]: unknown };
   replyToId?: string;
+  replyToIdSource?: "explicit" | "implicit";
   replyRequesterSender?: string | null;
 }) {
   const send =
@@ -39,6 +40,7 @@ export async function sendIMessageOutbound(params: {
     maxBytes,
     accountId: params.accountId ?? undefined,
     replyToId: params.replyToId ?? undefined,
+    replyToIdSource: params.replyToIdSource ?? undefined,
     replyRequesterSender: params.replyRequesterSender ?? undefined,
   });
 }

--- a/extensions/imessage/src/channel.runtime.ts
+++ b/extensions/imessage/src/channel.runtime.ts
@@ -19,6 +19,7 @@ export async function sendIMessageOutbound(params: {
   accountId?: string;
   deps?: { [channelId: string]: unknown };
   replyToId?: string;
+  replyRequesterSender?: string | null;
 }) {
   const send =
     resolveOutboundSendDep<IMessageSendFn>(params.deps, "imessage", {
@@ -38,6 +39,7 @@ export async function sendIMessageOutbound(params: {
     maxBytes,
     accountId: params.accountId ?? undefined,
     replyToId: params.replyToId ?? undefined,
+    replyRequesterSender: params.replyRequesterSender ?? undefined,
   });
 }
 

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -53,6 +53,7 @@ import {
   looksLikeIMessageExplicitTargetId,
   normalizeIMessageHandle,
   parseIMessageTarget,
+  resolveIMessageDirectChatHandle,
 } from "./targets.js";
 
 const loadIMessageChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
@@ -153,6 +154,42 @@ function resolveIMessageOutboundSessionRoute(params: {
         : account.config.service === "sms"
           ? "sms"
           : "imessage";
+    const directTarget = `${service}:${handle}`;
+    const peer: RoutePeer = { kind: "direct", id: handle };
+    const baseSessionKey = buildIMessageBaseSessionKey({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      accountId: params.accountId,
+      peer,
+    });
+    return {
+      sessionKey: baseSessionKey,
+      baseSessionKey,
+      peer,
+      chatType: "direct" as const,
+      from: directTarget,
+      to: directTarget,
+    };
+  }
+
+  const directHandle =
+    parsed.kind === "chat_identifier"
+      ? resolveIMessageDirectChatHandle(parsed.chatIdentifier)
+      : parsed.kind === "chat_guid"
+        ? resolveIMessageDirectChatHandle(parsed.chatGuid)
+        : null;
+  if (directHandle) {
+    const handle = normalizeIMessageHandle(directHandle);
+    if (!handle) {
+      return null;
+    }
+    const rawDirectTarget =
+      parsed.kind === "chat_identifier"
+        ? parsed.chatIdentifier.trim()
+        : parsed.kind === "chat_guid"
+          ? parsed.chatGuid.trim()
+          : "";
+    const service = /^SMS;-;/iu.test(rawDirectTarget) ? "sms" : "imessage";
     const directTarget = `${service}:${handle}`;
     const peer: RoutePeer = { kind: "direct", id: handle };
     const baseSessionKey = buildIMessageBaseSessionKey({

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -100,6 +100,7 @@ const imessageMessageAdapter = defineChannelMessageAdapter({
         accountId: ctx.accountId ?? undefined,
         deps: (ctx as typeof ctx & IMessageMessageContextExtras).deps,
         replyToId: ctx.replyToId ?? undefined,
+        replyRequesterSender: ctx.requesterSenderId ?? undefined,
       });
       return toIMessageMessageSendResult(result, "text", ctx.replyToId);
     },
@@ -115,6 +116,7 @@ const imessageMessageAdapter = defineChannelMessageAdapter({
         accountId: ctx.accountId ?? undefined,
         deps: (ctx as typeof ctx & IMessageMessageContextExtras).deps,
         replyToId: ctx.replyToId ?? undefined,
+        replyRequesterSender: ctx.requesterSenderId ?? undefined,
       });
       return toIMessageMessageSendResult(result, "media", ctx.replyToId);
     },
@@ -344,7 +346,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
       },
       attachedResults: {
         channel: "imessage",
-        sendText: async ({ cfg, to, text, accountId, deps, replyToId }) =>
+        sendText: async ({ cfg, to, text, accountId, deps, replyToId, requesterSenderId }) =>
           await (
             await loadIMessageChannelRuntime()
           ).sendIMessageOutbound({
@@ -354,6 +356,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
             accountId: accountId ?? undefined,
             deps,
             replyToId: replyToId ?? undefined,
+            replyRequesterSender: requesterSenderId ?? undefined,
           }),
         sendMedia: async ({
           cfg,
@@ -364,6 +367,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
           accountId,
           deps,
           replyToId,
+          requesterSenderId,
         }) =>
           await (
             await loadIMessageChannelRuntime()
@@ -376,6 +380,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
             accountId: accountId ?? undefined,
             deps,
             replyToId: replyToId ?? undefined,
+            replyRequesterSender: requesterSenderId ?? undefined,
           }),
       },
     },

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -100,6 +100,7 @@ const imessageMessageAdapter = defineChannelMessageAdapter({
         accountId: ctx.accountId ?? undefined,
         deps: (ctx as typeof ctx & IMessageMessageContextExtras).deps,
         replyToId: ctx.replyToId ?? undefined,
+        replyToIdSource: ctx.replyToIdSource ?? undefined,
         replyRequesterSender: ctx.requesterSenderId ?? undefined,
       });
       return toIMessageMessageSendResult(result, "text", ctx.replyToId);
@@ -116,6 +117,7 @@ const imessageMessageAdapter = defineChannelMessageAdapter({
         accountId: ctx.accountId ?? undefined,
         deps: (ctx as typeof ctx & IMessageMessageContextExtras).deps,
         replyToId: ctx.replyToId ?? undefined,
+        replyToIdSource: ctx.replyToIdSource ?? undefined,
         replyRequesterSender: ctx.requesterSenderId ?? undefined,
       });
       return toIMessageMessageSendResult(result, "media", ctx.replyToId);
@@ -346,7 +348,16 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
       },
       attachedResults: {
         channel: "imessage",
-        sendText: async ({ cfg, to, text, accountId, deps, replyToId, requesterSenderId }) =>
+        sendText: async ({
+          cfg,
+          to,
+          text,
+          accountId,
+          deps,
+          replyToId,
+          replyToIdSource,
+          requesterSenderId,
+        }) =>
           await (
             await loadIMessageChannelRuntime()
           ).sendIMessageOutbound({
@@ -356,6 +367,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
             accountId: accountId ?? undefined,
             deps,
             replyToId: replyToId ?? undefined,
+            replyToIdSource: replyToIdSource ?? undefined,
             replyRequesterSender: requesterSenderId ?? undefined,
           }),
         sendMedia: async ({
@@ -367,6 +379,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
           accountId,
           deps,
           replyToId,
+          replyToIdSource,
           requesterSenderId,
         }) =>
           await (
@@ -380,6 +393,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
             accountId: accountId ?? undefined,
             deps,
             replyToId: replyToId ?? undefined,
+            replyToIdSource: replyToIdSource ?? undefined,
             replyRequesterSender: requesterSenderId ?? undefined,
           }),
       },

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -111,6 +111,7 @@ describe("deliverReplies", () => {
           client,
           accountId: "acct-3",
           replyToId: "reply-3",
+          replyToIdSource: "implicit",
           replyRequesterSender: "+15551230000",
         },
       ],
@@ -194,6 +195,7 @@ describe("deliverReplies", () => {
           client,
           accountId: "acct-4",
           replyToId: "reply-4",
+          replyToIdSource: "implicit",
           replyRequesterSender: "+15551230000",
         },
       ],
@@ -234,7 +236,7 @@ describe("deliverReplies", () => {
     });
   });
 
-  it("injects trusted requester sender into durable send overrides", async () => {
+  it("does not infer an implicit reply source from durable send defaults", async () => {
     const send = createIMessageEchoCachingSend({
       client,
       accountId: "acct-7",
@@ -272,6 +274,7 @@ describe("deliverReplies", () => {
     await send("chat_id:80", "durable reply", {
       config: IMESSAGE_TEST_CFG,
       replyToId: "reply-8",
+      replyToIdSource: "implicit",
       replyRequesterSender: "+15550009999",
     });
 
@@ -282,6 +285,7 @@ describe("deliverReplies", () => {
         {
           config: IMESSAGE_TEST_CFG,
           replyToId: "reply-8",
+          replyToIdSource: "implicit",
           replyRequesterSender: "+15550009999",
           client,
         },

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -88,7 +88,7 @@ describe("deliverReplies", () => {
     ]);
   });
 
-  it("propagates trusted reply requester sender through text sends", async () => {
+  it("does not stamp payload reply ids as implicit through text sends", async () => {
     await deliverReplies({
       cfg: IMESSAGE_TEST_CFG,
       replies: [{ text: "reply", replyToId: "reply-3" }],
@@ -111,7 +111,6 @@ describe("deliverReplies", () => {
           client,
           accountId: "acct-3",
           replyToId: "reply-3",
-          replyToIdSource: "implicit",
           replyRequesterSender: "+15551230000",
         },
       ],
@@ -165,7 +164,7 @@ describe("deliverReplies", () => {
     ]);
   });
 
-  it("propagates trusted reply requester sender through media sends", async () => {
+  it("does not stamp payload reply ids as implicit through media sends", async () => {
     await deliverReplies({
       cfg: IMESSAGE_TEST_CFG,
       replies: [
@@ -195,7 +194,6 @@ describe("deliverReplies", () => {
           client,
           accountId: "acct-4",
           replyToId: "reply-4",
-          replyToIdSource: "implicit",
           replyRequesterSender: "+15551230000",
         },
       ],

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -88,7 +88,7 @@ describe("deliverReplies", () => {
     ]);
   });
 
-  it("does not stamp payload reply ids as implicit through text sends", async () => {
+  it("defaults trusted monitor reply ids to implicit through text sends", async () => {
     await deliverReplies({
       cfg: IMESSAGE_TEST_CFG,
       replies: [{ text: "reply", replyToId: "reply-3" }],
@@ -111,6 +111,7 @@ describe("deliverReplies", () => {
           client,
           accountId: "acct-3",
           replyToId: "reply-3",
+          replyToIdSource: "implicit",
           replyRequesterSender: "+15551230000",
         },
       ],
@@ -200,7 +201,7 @@ describe("deliverReplies", () => {
     ]);
   });
 
-  it("does not stamp payload reply ids as implicit through media sends", async () => {
+  it("defaults trusted monitor reply ids to implicit through media sends", async () => {
     await deliverReplies({
       cfg: IMESSAGE_TEST_CFG,
       replies: [
@@ -230,6 +231,7 @@ describe("deliverReplies", () => {
           client,
           accountId: "acct-4",
           replyToId: "reply-4",
+          replyToIdSource: "implicit",
           replyRequesterSender: "+15551230000",
         },
       ],

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -117,6 +117,42 @@ describe("deliverReplies", () => {
     ]);
   });
 
+  it("preserves implicit reply source through legacy text sends", async () => {
+    const payload = {
+      text: "reply",
+      replyToId: "reply-implicit",
+      replyToIdSource: "implicit",
+    } as const;
+
+    await deliverReplies({
+      cfg: IMESSAGE_TEST_CFG,
+      replies: [payload],
+      target: "chat_id:31",
+      client,
+      accountId: "acct-31",
+      runtime,
+      maxBytes: 4096,
+      textLimit: 4000,
+      replyRequesterSender: "+15551230000",
+    });
+
+    expect(sendMessageIMessageMock.mock.calls).toStrictEqual([
+      [
+        "chat_id:31",
+        "reply",
+        {
+          config: IMESSAGE_TEST_CFG,
+          maxBytes: 4096,
+          client,
+          accountId: "acct-31",
+          replyToId: "reply-implicit",
+          replyToIdSource: "implicit",
+          replyRequesterSender: "+15551230000",
+        },
+      ],
+    ]);
+  });
+
   it("propagates payload replyToId through media sends", async () => {
     await deliverReplies({
       cfg: IMESSAGE_TEST_CFG,

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -88,6 +88,35 @@ describe("deliverReplies", () => {
     ]);
   });
 
+  it("propagates trusted reply requester sender through text sends", async () => {
+    await deliverReplies({
+      cfg: IMESSAGE_TEST_CFG,
+      replies: [{ text: "reply", replyToId: "reply-3" }],
+      target: "chat_id:30",
+      client,
+      accountId: "acct-3",
+      runtime,
+      maxBytes: 4096,
+      textLimit: 4000,
+      replyRequesterSender: "+15551230000",
+    });
+
+    expect(sendMessageIMessageMock.mock.calls).toStrictEqual([
+      [
+        "chat_id:30",
+        "reply",
+        {
+          config: IMESSAGE_TEST_CFG,
+          maxBytes: 4096,
+          client,
+          accountId: "acct-3",
+          replyToId: "reply-3",
+          replyRequesterSender: "+15551230000",
+        },
+      ],
+    ]);
+  });
+
   it("propagates payload replyToId through media sends", async () => {
     await deliverReplies({
       cfg: IMESSAGE_TEST_CFG,
@@ -135,6 +164,42 @@ describe("deliverReplies", () => {
     ]);
   });
 
+  it("propagates trusted reply requester sender through media sends", async () => {
+    await deliverReplies({
+      cfg: IMESSAGE_TEST_CFG,
+      replies: [
+        {
+          text: "caption",
+          mediaUrls: ["https://example.com/a.jpg"],
+          replyToId: "reply-4",
+        },
+      ],
+      target: "chat_id:40",
+      client,
+      accountId: "acct-4",
+      runtime,
+      maxBytes: 8192,
+      textLimit: 4000,
+      replyRequesterSender: "+15551230000",
+    });
+
+    expect(sendMessageIMessageMock.mock.calls).toStrictEqual([
+      [
+        "chat_id:40",
+        "caption",
+        {
+          config: IMESSAGE_TEST_CFG,
+          mediaUrl: "https://example.com/a.jpg",
+          maxBytes: 8192,
+          client,
+          accountId: "acct-4",
+          replyToId: "reply-4",
+          replyRequesterSender: "+15551230000",
+        },
+      ],
+    ]);
+  });
+
   it("records durable outbound sends in the sent-message cache", async () => {
     const remember = vi.fn();
     const send = createIMessageEchoCachingSend({
@@ -167,6 +232,61 @@ describe("deliverReplies", () => {
       text: "durable hello",
       messageId: "imsg-durable-1",
     });
+  });
+
+  it("injects trusted requester sender into durable send overrides", async () => {
+    const send = createIMessageEchoCachingSend({
+      client,
+      accountId: "acct-7",
+      replyRequesterSender: "+15551230000",
+    });
+
+    await send("chat_id:70", "durable reply", {
+      config: IMESSAGE_TEST_CFG,
+      accountId: "acct-ignored",
+      replyToId: "reply-7",
+    });
+
+    expect(sendMessageIMessageMock.mock.calls).toStrictEqual([
+      [
+        "chat_id:70",
+        "durable reply",
+        {
+          config: IMESSAGE_TEST_CFG,
+          accountId: "acct-ignored",
+          replyToId: "reply-7",
+          client,
+          replyRequesterSender: "+15551230000",
+        },
+      ],
+    ]);
+  });
+
+  it("prefers per-send requester sender over durable send defaults", async () => {
+    const send = createIMessageEchoCachingSend({
+      client,
+      accountId: "acct-8",
+      replyRequesterSender: "+15551230000",
+    });
+
+    await send("chat_id:80", "durable reply", {
+      config: IMESSAGE_TEST_CFG,
+      replyToId: "reply-8",
+      replyRequesterSender: "+15550009999",
+    });
+
+    expect(sendMessageIMessageMock.mock.calls).toStrictEqual([
+      [
+        "chat_id:80",
+        "durable reply",
+        {
+          config: IMESSAGE_TEST_CFG,
+          replyToId: "reply-8",
+          replyRequesterSender: "+15550009999",
+          client,
+        },
+      ],
+    ]);
   });
 
   it("sanitizes durable outbound text before sending", async () => {

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -54,9 +54,6 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
-          ...(payload.replyToId && params.replyRequesterSender
-            ? { replyToIdSource: "implicit" as const }
-            : {}),
           ...(params.replyRequesterSender
             ? { replyRequesterSender: params.replyRequesterSender }
             : {}),
@@ -78,9 +75,6 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
-          ...(payload.replyToId && params.replyRequesterSender
-            ? { replyToIdSource: "implicit" as const }
-            : {}),
           ...(params.replyRequesterSender
             ? { replyRequesterSender: params.replyRequesterSender }
             : {}),

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -44,6 +44,9 @@ export async function deliverReplies(params: {
   const chunkMode = resolveChunkMode(cfg, "imessage", accountId);
   for (const payload of replies) {
     const replyPayload = payload as ReplyPayloadWithReplySource;
+    const replyToIdSource =
+      replyPayload.replyToIdSource ??
+      (payload.replyToId && params.replyRequesterSender ? "implicit" : undefined);
     const rawText = sanitizeOutboundText(payload.text ?? "");
     const reply = resolveSendableOutboundReplyParts(payload, {
       text: convertMarkdownTables(rawText, tableMode),
@@ -59,9 +62,7 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
-          ...(replyPayload.replyToIdSource
-            ? { replyToIdSource: replyPayload.replyToIdSource }
-            : {}),
+          ...(replyToIdSource ? { replyToIdSource } : {}),
           ...(params.replyRequesterSender
             ? { replyRequesterSender: params.replyRequesterSender }
             : {}),
@@ -83,9 +84,7 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
-          ...(replyPayload.replyToIdSource
-            ? { replyToIdSource: replyPayload.replyToIdSource }
-            : {}),
+          ...(replyToIdSource ? { replyToIdSource } : {}),
           ...(params.replyRequesterSender
             ? { replyRequesterSender: params.replyRequesterSender }
             : {}),

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -16,6 +16,10 @@ import {
 import type { SentMessageCache } from "./echo-cache.js";
 import { sanitizeOutboundText } from "./sanitize-outbound.js";
 
+type ReplyPayloadWithReplySource = ReplyPayload & {
+  replyToIdSource?: "explicit" | "implicit";
+};
+
 export async function deliverReplies(params: {
   cfg: OpenClawConfig;
   replies: ReplyPayload[];
@@ -39,6 +43,7 @@ export async function deliverReplies(params: {
   });
   const chunkMode = resolveChunkMode(cfg, "imessage", accountId);
   for (const payload of replies) {
+    const replyPayload = payload as ReplyPayloadWithReplySource;
     const rawText = sanitizeOutboundText(payload.text ?? "");
     const reply = resolveSendableOutboundReplyParts(payload, {
       text: convertMarkdownTables(rawText, tableMode),
@@ -54,6 +59,9 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
+          ...(replyPayload.replyToIdSource
+            ? { replyToIdSource: replyPayload.replyToIdSource }
+            : {}),
           ...(params.replyRequesterSender
             ? { replyRequesterSender: params.replyRequesterSender }
             : {}),
@@ -75,6 +83,9 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
+          ...(replyPayload.replyToIdSource
+            ? { replyToIdSource: replyPayload.replyToIdSource }
+            : {}),
           ...(params.replyRequesterSender
             ? { replyRequesterSender: params.replyRequesterSender }
             : {}),

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -54,6 +54,9 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
+          ...(payload.replyToId && params.replyRequesterSender
+            ? { replyToIdSource: "implicit" as const }
+            : {}),
           ...(params.replyRequesterSender
             ? { replyRequesterSender: params.replyRequesterSender }
             : {}),
@@ -75,6 +78,9 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
+          ...(payload.replyToId && params.replyRequesterSender
+            ? { replyToIdSource: "implicit" as const }
+            : {}),
           ...(params.replyRequesterSender
             ? { replyRequesterSender: params.replyRequesterSender }
             : {}),

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -25,6 +25,7 @@ export async function deliverReplies(params: {
   runtime: RuntimeEnv;
   maxBytes: number;
   textLimit: number;
+  replyRequesterSender?: string | null;
   sentMessageCache?: Pick<SentMessageCache, "remember">;
 }) {
   const { replies, target, client, runtime, maxBytes, textLimit, accountId, sentMessageCache } =
@@ -53,6 +54,9 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
+          ...(params.replyRequesterSender
+            ? { replyRequesterSender: params.replyRequesterSender }
+            : {}),
         });
         // Post-send cache population (#47830): caching happens after each chunk is sent,
         // not before. The window between send completion and cache write is sub-millisecond;
@@ -71,6 +75,9 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
+          ...(params.replyRequesterSender
+            ? { replyRequesterSender: params.replyRequesterSender }
+            : {}),
         });
         sentMessageCache?.remember(scope, {
           text: sent.echoText ?? (sent.sentText || undefined),
@@ -87,13 +94,16 @@ export async function deliverReplies(params: {
 export function createIMessageEchoCachingSend(params: {
   client: IMessageRpcClient;
   accountId?: string;
+  replyRequesterSender?: string | null;
   sentMessageCache?: Pick<SentMessageCache, "remember">;
 }): typeof sendMessageIMessage {
   return async (target, text, opts) => {
     const sanitizedText = sanitizeOutboundText(text);
+    const replyRequesterSender = opts.replyRequesterSender ?? params.replyRequesterSender;
     const sent = await sendMessageIMessage(target, sanitizedText, {
       ...opts,
       client: params.client,
+      ...(replyRequesterSender ? { replyRequesterSender } : {}),
     });
     const scope = `${params.accountId ?? opts.accountId ?? ""}:${target}`;
     params.sentMessageCache?.remember(scope, {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -673,7 +673,6 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
             client: getActiveClient(),
             maxBytes: mediaMaxBytes,
             accountId: accountInfo.accountId,
-            ...(chatId ? { chatId } : {}),
           });
         },
         onReplyError: (err) => {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -858,6 +858,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
             imessage: createIMessageEchoCachingSend({
               client: getActiveClient(),
               accountId: accountInfo.accountId,
+              replyRequesterSender: decision.sender,
               sentMessageCache,
             }),
           },
@@ -877,6 +878,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           runtime,
           maxBytes: mediaMaxBytes,
           textLimit,
+          replyRequesterSender: decision.sender,
           sentMessageCache,
         });
       },

--- a/extensions/imessage/src/outbound-allowlist.ts
+++ b/extensions/imessage/src/outbound-allowlist.ts
@@ -1,0 +1,232 @@
+import { expandAllowFromWithAccessGroups } from "openclaw/plugin-sdk/access-groups";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  resolveDefaultGroupPolicy,
+  resolveOpenProviderRuntimeGroupPolicy,
+} from "openclaw/plugin-sdk/runtime-group-policy";
+import type { ResolvedIMessageAccount } from "./accounts.js";
+import {
+  isAllowedIMessageReplyContextSender,
+  type IMessageTarget,
+  normalizeIMessageHandle,
+} from "./targets.js";
+
+function normalizeIMessageOutboundAllowValue(raw: string | number | null | undefined): string {
+  if (raw === null || raw === undefined) {
+    return "";
+  }
+  const value = String(raw).trim();
+  if (value === "*") {
+    return "*";
+  }
+  return normalizeIMessageHandle(value);
+}
+
+function resolveIMessageDirectChatIdentifier(target: IMessageTarget): string | null {
+  if (target.kind !== "chat_identifier") {
+    return null;
+  }
+  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(target.chatIdentifier.trim());
+  const handle = match?.[1]?.trim();
+  return handle || null;
+}
+
+function resolveIMessageDirectChatGuid(target: IMessageTarget): string | null {
+  if (target.kind !== "chat_guid") {
+    return null;
+  }
+  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(target.chatGuid.trim());
+  const handle = match?.[1]?.trim();
+  return handle || null;
+}
+
+function normalizeIMessageOutboundTarget(target: IMessageTarget): string {
+  if (target.kind === "chat_id") {
+    return `chat_id:${target.chatId}`;
+  }
+  const directChatGuid = resolveIMessageDirectChatGuid(target);
+  if (directChatGuid) {
+    return normalizeIMessageHandle(directChatGuid);
+  }
+  if (target.kind === "chat_guid") {
+    return `chat_guid:${target.chatGuid}`;
+  }
+  const directChatIdentifier = resolveIMessageDirectChatIdentifier(target);
+  if (directChatIdentifier) {
+    return normalizeIMessageHandle(directChatIdentifier);
+  }
+  if (target.kind === "chat_identifier") {
+    return `chat_identifier:${target.chatIdentifier}`;
+  }
+  return normalizeIMessageHandle(target.to);
+}
+
+function isIMessageOutboundDmTarget(target: IMessageTarget): boolean {
+  return (
+    target.kind === "handle" ||
+    resolveIMessageDirectChatIdentifier(target) !== null ||
+    resolveIMessageDirectChatGuid(target) !== null
+  );
+}
+
+function isIMessageOutboundAllowlisted(params: {
+  allowFrom: readonly (string | number)[];
+  normalizedTarget: string;
+}): boolean {
+  const allowed = new Set(
+    params.allowFrom.map(normalizeIMessageOutboundAllowValue).filter(Boolean),
+  );
+  return allowed.has("*") || allowed.has(params.normalizedTarget);
+}
+
+function getIMessageConversationFacts(
+  target: IMessageTarget,
+): Pick<
+  Parameters<typeof isAllowedIMessageReplyContextSender>[0],
+  "chatId" | "chatGuid" | "chatIdentifier"
+> {
+  if (target.kind === "chat_id") {
+    return { chatId: target.chatId };
+  }
+  if (target.kind === "chat_guid") {
+    return { chatGuid: target.chatGuid };
+  }
+  if (target.kind === "chat_identifier") {
+    return { chatIdentifier: target.chatIdentifier };
+  }
+  return {};
+}
+
+function isIMessageOutboundTargetAllowed(
+  senderId: string,
+  allowFrom: readonly (string | number)[],
+): boolean {
+  return isIMessageOutboundAllowlisted({ allowFrom, normalizedTarget: senderId });
+}
+
+async function expandIMessageOutboundAllowFrom(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedIMessageAccount;
+  target: IMessageTarget;
+  allowFrom: Array<string | number>;
+}): Promise<string[]> {
+  const normalizedTarget = normalizeIMessageOutboundTarget(params.target);
+  return await expandAllowFromWithAccessGroups({
+    cfg: params.cfg,
+    allowFrom: params.allowFrom,
+    channel: "imessage",
+    accountId: params.account.accountId,
+    senderId: normalizedTarget,
+    isSenderAllowed: isIMessageOutboundTargetAllowed,
+  });
+}
+
+async function isIMessageSenderBasedGroupReplyAllowed(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedIMessageAccount;
+  target: IMessageTarget;
+  allowFrom: Array<string | number>;
+  replyRequesterSender?: string | null;
+}): Promise<boolean> {
+  const sender = params.replyRequesterSender?.trim();
+  if (!sender) {
+    return false;
+  }
+  const normalizedSender = normalizeIMessageHandle(sender);
+  if (!normalizedSender) {
+    return false;
+  }
+  const senderAllowFrom = await expandAllowFromWithAccessGroups({
+    cfg: params.cfg,
+    allowFrom: params.allowFrom,
+    channel: "imessage",
+    accountId: params.account.accountId,
+    senderId: normalizedSender,
+    isSenderAllowed: isIMessageOutboundTargetAllowed,
+  });
+  return isAllowedIMessageReplyContextSender({
+    allowFrom: senderAllowFrom,
+    sender: normalizedSender,
+    ...getIMessageConversationFacts(params.target),
+  });
+}
+
+function resolveIMessageOutboundGroupPolicy(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedIMessageAccount;
+}) {
+  return resolveOpenProviderRuntimeGroupPolicy({
+    providerConfigPresent: params.cfg.channels?.imessage !== undefined,
+    groupPolicy: params.account.config.groupPolicy,
+    defaultGroupPolicy: resolveDefaultGroupPolicy(params.cfg),
+  }).groupPolicy;
+}
+
+export async function assertIMessageOutboundAllowed(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedIMessageAccount;
+  target: IMessageTarget;
+  replyRequesterSender?: string | null;
+}): Promise<void> {
+  const { cfg, account, target } = params;
+  if (!isIMessageOutboundDmTarget(target)) {
+    const groupPolicy = resolveIMessageOutboundGroupPolicy({ cfg, account });
+    if (groupPolicy === "disabled") {
+      throw new Error("iMessage outbound blocked: group targets are disabled");
+    }
+    if (groupPolicy !== "allowlist") {
+      return;
+    }
+    const normalizedTarget = normalizeIMessageOutboundTarget(target);
+    const configuredGroupAllowFrom = [
+      ...(account.config.groupAllowFrom ?? account.config.allowFrom ?? []),
+    ];
+    const allowFrom = await expandIMessageOutboundAllowFrom({
+      cfg,
+      account,
+      target,
+      allowFrom: configuredGroupAllowFrom,
+    });
+    const targetAllowed = isIMessageOutboundAllowlisted({
+      allowFrom,
+      normalizedTarget,
+    });
+    const replyRequesterAllowed = await isIMessageSenderBasedGroupReplyAllowed({
+      cfg,
+      account,
+      target,
+      allowFrom: configuredGroupAllowFrom,
+      replyRequesterSender: params.replyRequesterSender,
+    });
+    if (allowFrom.length === 0 && !replyRequesterAllowed) {
+      throw new Error("iMessage outbound blocked: channels.imessage.groupAllowFrom is empty");
+    }
+    if (!targetAllowed && !replyRequesterAllowed) {
+      throw new Error(
+        "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+      );
+    }
+    return;
+  }
+  if (account.config.dmPolicy !== "allowlist") {
+    return;
+  }
+  const normalizedTarget = normalizeIMessageOutboundTarget(target);
+  const allowFrom = await expandIMessageOutboundAllowFrom({
+    cfg,
+    account,
+    target,
+    allowFrom: [
+      ...(account.config.allowFrom ?? []),
+      ...(account.config.defaultTo ? [account.config.defaultTo] : []),
+    ],
+  });
+  if (allowFrom.length === 0) {
+    throw new Error("iMessage outbound blocked: channels.imessage.allowFrom/defaultTo is empty");
+  }
+  if (!isIMessageOutboundAllowlisted({ allowFrom, normalizedTarget })) {
+    throw new Error(
+      "iMessage outbound blocked: target is not in channels.imessage.allowFrom/defaultTo",
+    );
+  }
+}

--- a/extensions/imessage/src/outbound-allowlist.ts
+++ b/extensions/imessage/src/outbound-allowlist.ts
@@ -8,6 +8,7 @@ import type { ResolvedIMessageAccount } from "./accounts.js";
 import {
   isAllowedIMessageReplyContextSender,
   type IMessageTarget,
+  resolveIMessageDirectChatHandle,
   normalizeIMessageHandle,
 } from "./targets.js";
 
@@ -22,41 +23,18 @@ function normalizeIMessageOutboundAllowValue(raw: string | number | null | undef
   return normalizeIMessageHandle(value);
 }
 
-function isIMessageDirectEmailHandle(raw: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(raw);
-}
-
-function isIMessageDirectPhoneHandle(raw: string): boolean {
-  if (!/^\+[0-9][0-9\s().-]*$/u.test(raw)) {
-    return false;
-  }
-  const digitCount = raw.replace(/\D/g, "").length;
-  return digitCount >= 7 && digitCount <= 15;
-}
-
 function resolveIMessageDirectChatIdentifier(target: IMessageTarget): string | null {
   if (target.kind !== "chat_identifier") {
     return null;
   }
-  const raw = target.chatIdentifier.trim();
-  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(raw);
-  const handle = match?.[1]?.trim();
-  if (handle) {
-    return handle;
-  }
-  if (isIMessageDirectEmailHandle(raw) || isIMessageDirectPhoneHandle(raw)) {
-    return raw;
-  }
-  return null;
+  return resolveIMessageDirectChatHandle(target.chatIdentifier);
 }
 
 function resolveIMessageDirectChatGuid(target: IMessageTarget): string | null {
   if (target.kind !== "chat_guid") {
     return null;
   }
-  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(target.chatGuid.trim());
-  const handle = match?.[1]?.trim();
-  return handle || null;
+  return resolveIMessageDirectChatHandle(target.chatGuid);
 }
 
 function normalizeIMessageOutboundTarget(target: IMessageTarget): string {

--- a/extensions/imessage/src/outbound-allowlist.ts
+++ b/extensions/imessage/src/outbound-allowlist.ts
@@ -90,7 +90,7 @@ function resolveIMessageOutboundGroupAllowFrom(
   if (account.config.groupAllowFrom !== undefined) {
     return [...account.config.groupAllowFrom];
   }
-  return [...(account.config.allowFrom ?? []).filter(isIMessageConversationAllowTarget)];
+  return (account.config.allowFrom ?? []).filter(isIMessageConversationAllowTarget);
 }
 
 function getIMessageConversationFacts(

--- a/extensions/imessage/src/outbound-allowlist.ts
+++ b/extensions/imessage/src/outbound-allowlist.ts
@@ -84,13 +84,22 @@ function isIMessageConversationAllowTarget(entry: string | number): boolean {
   );
 }
 
-function resolveIMessageOutboundGroupAllowFrom(
+function resolveIMessageOutboundGroupTargetAllowFrom(
   account: ResolvedIMessageAccount,
 ): Array<string | number> {
   if (account.config.groupAllowFrom !== undefined) {
     return [...account.config.groupAllowFrom];
   }
   return (account.config.allowFrom ?? []).filter(isIMessageConversationAllowTarget);
+}
+
+function resolveIMessageOutboundGroupReplyAllowFrom(
+  account: ResolvedIMessageAccount,
+): Array<string | number> {
+  if (account.config.groupAllowFrom !== undefined) {
+    return [...account.config.groupAllowFrom];
+  }
+  return [...(account.config.allowFrom ?? [])];
 }
 
 function getIMessageConversationFacts(
@@ -192,12 +201,12 @@ export async function assertIMessageOutboundAllowed(params: {
       return;
     }
     const normalizedTarget = normalizeIMessageOutboundTarget(target);
-    const configuredGroupAllowFrom = resolveIMessageOutboundGroupAllowFrom(account);
+    const configuredGroupTargetAllowFrom = resolveIMessageOutboundGroupTargetAllowFrom(account);
     const allowFrom = await expandIMessageOutboundAllowFrom({
       cfg,
       account,
       target,
-      allowFrom: configuredGroupAllowFrom,
+      allowFrom: configuredGroupTargetAllowFrom,
     });
     const targetAllowed = isIMessageOutboundAllowlisted({
       allowFrom,
@@ -207,7 +216,7 @@ export async function assertIMessageOutboundAllowed(params: {
       cfg,
       account,
       target,
-      allowFrom: configuredGroupAllowFrom,
+      allowFrom: resolveIMessageOutboundGroupReplyAllowFrom(account),
       replyRequesterSender: params.replyRequesterSender,
     });
     if (allowFrom.length === 0 && !replyRequesterAllowed) {

--- a/extensions/imessage/src/outbound-allowlist.ts
+++ b/extensions/imessage/src/outbound-allowlist.ts
@@ -10,6 +10,7 @@ import {
   type IMessageTarget,
   resolveIMessageDirectChatHandle,
   normalizeIMessageHandle,
+  parseIMessageAllowTarget,
 } from "./targets.js";
 
 function normalizeIMessageOutboundAllowValue(raw: string | number | null | undefined): string {
@@ -74,6 +75,22 @@ function isIMessageOutboundAllowlisted(params: {
     params.allowFrom.map(normalizeIMessageOutboundAllowValue).filter(Boolean),
   );
   return allowed.has("*") || allowed.has(params.normalizedTarget);
+}
+
+function isIMessageConversationAllowTarget(entry: string | number): boolean {
+  const parsed = parseIMessageAllowTarget(String(entry));
+  return (
+    parsed.kind === "chat_id" || parsed.kind === "chat_guid" || parsed.kind === "chat_identifier"
+  );
+}
+
+function resolveIMessageOutboundGroupAllowFrom(
+  account: ResolvedIMessageAccount,
+): Array<string | number> {
+  if (account.config.groupAllowFrom !== undefined) {
+    return [...account.config.groupAllowFrom];
+  }
+  return [...(account.config.allowFrom ?? []).filter(isIMessageConversationAllowTarget)];
 }
 
 function getIMessageConversationFacts(
@@ -175,9 +192,7 @@ export async function assertIMessageOutboundAllowed(params: {
       return;
     }
     const normalizedTarget = normalizeIMessageOutboundTarget(target);
-    const configuredGroupAllowFrom = [
-      ...(account.config.groupAllowFrom ?? account.config.allowFrom ?? []),
-    ];
+    const configuredGroupAllowFrom = resolveIMessageOutboundGroupAllowFrom(account);
     const allowFrom = await expandIMessageOutboundAllowFrom({
       cfg,
       account,

--- a/extensions/imessage/src/outbound-allowlist.ts
+++ b/extensions/imessage/src/outbound-allowlist.ts
@@ -22,13 +22,32 @@ function normalizeIMessageOutboundAllowValue(raw: string | number | null | undef
   return normalizeIMessageHandle(value);
 }
 
+function isIMessageDirectEmailHandle(raw: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(raw);
+}
+
+function isIMessageDirectPhoneHandle(raw: string): boolean {
+  if (!/^\+[0-9][0-9\s().-]*$/u.test(raw)) {
+    return false;
+  }
+  const digitCount = raw.replace(/\D/g, "").length;
+  return digitCount >= 7 && digitCount <= 15;
+}
+
 function resolveIMessageDirectChatIdentifier(target: IMessageTarget): string | null {
   if (target.kind !== "chat_identifier") {
     return null;
   }
-  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(target.chatIdentifier.trim());
+  const raw = target.chatIdentifier.trim();
+  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(raw);
   const handle = match?.[1]?.trim();
-  return handle || null;
+  if (handle) {
+    return handle;
+  }
+  if (isIMessageDirectEmailHandle(raw) || isIMessageDirectPhoneHandle(raw)) {
+    return raw;
+  }
+  return null;
 }
 
 function resolveIMessageDirectChatGuid(target: IMessageTarget): string | null {
@@ -207,6 +226,9 @@ export async function assertIMessageOutboundAllowed(params: {
       );
     }
     return;
+  }
+  if (account.config.dmPolicy === "disabled") {
+    throw new Error("iMessage outbound blocked: dm targets are disabled");
   }
   if (account.config.dmPolicy !== "allowlist") {
     return;

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -461,6 +461,30 @@ describe("sendMessageIMessage receipts", () => {
     expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 
+  it("preserves sender-based group allowance after an implicit reply id is consumed", async () => {
+    const client = createClient({ guid: "p:0/group-consumed-reply-id" });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["+15551230000"],
+          },
+        },
+      },
+      client,
+      replyToIdSource: "implicit",
+      replyRequesterSender: "+15551230000",
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_id: 42 }),
+      expect.any(Object),
+    );
+  });
+
   it("blocks sender-based group allowance when the reply id sanitizes empty", async () => {
     const client = createClient({ guid: "p:0/group-empty-reply-id" });
 

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -231,6 +231,7 @@ describe("sendMessageIMessage receipts", () => {
       },
       client,
       replyToId: "inbound-1",
+      replyToIdSource: "implicit",
       replyRequesterSender: "+15551230000",
     });
 
@@ -256,6 +257,7 @@ describe("sendMessageIMessage receipts", () => {
         },
         client,
         replyToId: "inbound-1",
+        replyToIdSource: "implicit",
       }),
     ).rejects.toThrow(
       "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
@@ -278,6 +280,7 @@ describe("sendMessageIMessage receipts", () => {
         },
         client,
         replyToId: "inbound-1",
+        replyToIdSource: "implicit",
         replyRequesterSender: "+15550009999",
       }),
     ).rejects.toThrow(
@@ -301,6 +304,7 @@ describe("sendMessageIMessage receipts", () => {
         },
         client,
         replyToId: "inbound-1",
+        replyToIdSource: "implicit",
         replyRequesterSender: "   \t ",
       }),
     ).rejects.toThrow(
@@ -367,6 +371,54 @@ describe("sendMessageIMessage receipts", () => {
         },
         client,
         replyToId: "[]",
+        replyToIdSource: "implicit",
+        replyRequesterSender: "+15551230000",
+      }),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("blocks group reply targets when replyToId is explicit", async () => {
+    const client = createClient({ guid: "p:0/group-explicit-reply" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15551230000"],
+            },
+          },
+        },
+        client,
+        replyToId: "inbound-1",
+        replyToIdSource: "explicit",
+        replyRequesterSender: "+15551230000",
+      }),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("blocks group reply targets when replyToId source is missing", async () => {
+    const client = createClient({ guid: "p:0/group-missing-reply-source" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15551230000"],
+            },
+          },
+        },
+        client,
+        replyToId: "inbound-1",
         replyRequesterSender: "+15551230000",
       }),
     ).rejects.toThrow(
@@ -394,6 +446,65 @@ describe("sendMessageIMessage receipts", () => {
     expect(getClientMocks(client).request).toHaveBeenCalledWith(
       "send",
       expect.objectContaining({ chat_identifier: "iMessage;-;+15551230000" }),
+      expect.any(Object),
+    );
+  });
+
+  it("keeps malformed email-like chat identifiers on the group policy", async () => {
+    const client = createClient({ guid: "p:0/malformed-email-like-chat" });
+
+    await expect(
+      sendMessageIMessage("chat_identifier:team@", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "disabled",
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: group targets are disabled");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("keeps separator-only phone-like chat identifiers on the group policy", async () => {
+    const client = createClient({ guid: "p:0/malformed-phone-like-chat" });
+
+    await expect(
+      sendMessageIMessage("chat_identifier:+1 () . -", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "disabled",
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: group targets are disabled");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("treats raw direct chat identifiers as DM allowlist targets", async () => {
+    const client = createClient({ guid: "p:0/raw-direct-chat" });
+
+    await sendMessageIMessage("chat_identifier:+15551230000", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+1 (555) 123-0000"],
+            groupPolicy: "disabled",
+          },
+        },
+      },
+      client,
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_identifier: "+15551230000" }),
       expect.any(Object),
     );
   });
@@ -555,6 +666,65 @@ describe("sendMessageIMessage receipts", () => {
       expect.objectContaining({ chat_id: 42 }),
       expect.any(Object),
     );
+  });
+
+  it("blocks direct DM handles when dmPolicy is disabled", async () => {
+    const client = createClient({ guid: "p:0/disabled-dm" });
+
+    await expect(
+      sendMessageIMessage("+15551230000", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              dmPolicy: "disabled",
+              allowFrom: ["+1 (555) 123-0000"],
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: dm targets are disabled");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("blocks raw chat identifier DM targets when dmPolicy is disabled", async () => {
+    const client = createClient({ guid: "p:0/disabled-raw-chat-identifier" });
+
+    await expect(
+      sendMessageIMessage("chat_identifier:+15551230000", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              dmPolicy: "disabled",
+              allowFrom: ["+1 (555) 123-0000"],
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: dm targets are disabled");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("blocks explicit DM replies when dmPolicy is disabled", async () => {
+    const client = createClient({ guid: "p:0/disabled-explicit-dm-reply" });
+
+    await expect(
+      sendMessageIMessage("+15551230000", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              dmPolicy: "disabled",
+            },
+          },
+        },
+        client,
+        replyToId: "reply-1",
+        replyToIdSource: "explicit",
+        replyRequesterSender: "+15551230000",
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: dm targets are disabled");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 
   it("allows outbound handles listed by allowlist policy", async () => {

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -98,7 +98,7 @@ describe("sendMessageIMessage receipts", () => {
         client,
       }),
     ).rejects.toThrow("iMessage outbound blocked: group targets are disabled");
-    expect(client.request).not.toHaveBeenCalled();
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 
   it("allows explicit chat targets listed by group allowlist policy", async () => {
@@ -117,7 +117,7 @@ describe("sendMessageIMessage receipts", () => {
       client,
     });
 
-    expect(client.request).toHaveBeenCalledWith(
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
       "send",
       expect.objectContaining({ chat_id: 42 }),
       expect.any(Object),
@@ -147,7 +147,7 @@ describe("sendMessageIMessage receipts", () => {
       client,
     });
 
-    expect(client.request).toHaveBeenCalledWith(
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
       "send",
       expect.objectContaining({ chat_id: 42 }),
       expect.any(Object),
@@ -169,7 +169,7 @@ describe("sendMessageIMessage receipts", () => {
       client,
     });
 
-    expect(client.request).toHaveBeenCalledWith(
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
       "send",
       expect.objectContaining({ to: "+15551230000" }),
       expect.any(Object),
@@ -191,7 +191,7 @@ describe("sendMessageIMessage receipts", () => {
       client,
     });
 
-    expect(client.request).toHaveBeenCalledWith(
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
       "send",
       expect.objectContaining({ to: "+15551230000" }),
       expect.any(Object),
@@ -221,7 +221,7 @@ describe("sendMessageIMessage receipts", () => {
       client,
     });
 
-    expect(client.request).toHaveBeenCalledWith(
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
       "send",
       expect.objectContaining({ to: "+15551230000" }),
       expect.any(Object),

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -101,6 +101,25 @@ describe("sendMessageIMessage receipts", () => {
     expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 
+  it("applies channel default group policy to explicit chat targets", async () => {
+    const client = createClient({ guid: "p:0/default-disabled" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            defaults: {
+              groupPolicy: "disabled",
+            },
+            imessage: {},
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: group targets are disabled");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
   it("allows explicit chat targets listed by group allowlist policy", async () => {
     const client = createClient({ guid: "p:0/group" });
 
@@ -122,6 +141,50 @@ describe("sendMessageIMessage receipts", () => {
       expect.objectContaining({ chat_id: 42 }),
       expect.any(Object),
     );
+  });
+
+  it("falls back to legacy allowFrom conversation entries when groupAllowFrom is absent", async () => {
+    const client = createClient({ guid: "p:0/group-legacy-allow-from" });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: {
+        channels: {
+          defaults: {
+            groupPolicy: "allowlist",
+          },
+          imessage: {
+            allowFrom: ["chat_id:42"],
+          },
+        },
+      },
+      client,
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_id: 42 }),
+      expect.any(Object),
+    );
+  });
+
+  it("does not fall back to legacy allowFrom when groupAllowFrom is explicitly empty", async () => {
+    const client = createClient({ guid: "p:0/group-empty-explicit" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              allowFrom: ["chat_id:42"],
+              groupPolicy: "allowlist",
+              groupAllowFrom: [],
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: channels.imessage.groupAllowFrom is empty");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 
   it("allows explicit chat targets through configured group access groups", async () => {

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -221,6 +221,52 @@ describe("sendMessageIMessage receipts", () => {
     );
   });
 
+  it("treats SMS direct chat identifiers as DM allowlist targets", async () => {
+    const client = createClient({ guid: "p:0/direct-chat-sms" });
+
+    await sendMessageIMessage("chat_identifier:SMS;-;+15551230000", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+1 (555) 123-0000"],
+            groupPolicy: "disabled",
+          },
+        },
+      },
+      client,
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_identifier: "SMS;-;+15551230000" }),
+      expect.any(Object),
+    );
+  });
+
+  it("treats auto direct chat identifiers as DM allowlist targets", async () => {
+    const client = createClient({ guid: "p:0/direct-chat-auto" });
+
+    await sendMessageIMessage("chat_identifier:any;-;+15551230000", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+1 (555) 123-0000"],
+            groupPolicy: "disabled",
+          },
+        },
+      },
+      client,
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_identifier: "any;-;+15551230000" }),
+      expect.any(Object),
+    );
+  });
+
   it("honors wildcard iMessage DM allowlist entries for outbound sends", async () => {
     const client = createClient({ guid: "p:0/wildcard-dm" });
 

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -444,6 +444,75 @@ describe("sendMessageIMessage receipts", () => {
     );
   });
 
+  for (const service of ["iMessage", "SMS", "any"] as const) {
+    it(`treats ${service} direct chat GUIDs as DM allowlist targets`, async () => {
+      const client = createClient({ guid: `p:0/direct-guid-${service}` });
+      const chatGuid = `${service};-;+15551230000`;
+
+      await sendMessageIMessage(`chat_guid:${chatGuid}`, "hello", {
+        config: {
+          channels: {
+            imessage: {
+              dmPolicy: "allowlist",
+              allowFrom: ["+1 (555) 123-0000"],
+              groupPolicy: "disabled",
+            },
+          },
+        },
+        client,
+      });
+
+      expect(getClientMocks(client).request).toHaveBeenCalledWith(
+        "send",
+        expect.objectContaining({ chat_guid: chatGuid }),
+        expect.any(Object),
+      );
+    });
+  }
+
+  it("treats direct chat GUID pairing replies as DM targets", async () => {
+    const client = createClient({ guid: "p:0/direct-guid-pairing" });
+
+    await sendMessageIMessage("chat_guid:SMS;-;+15551230000", "pairing code", {
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "pairing",
+            groupPolicy: "disabled",
+          },
+        },
+      },
+      client,
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_guid: "SMS;-;+15551230000" }),
+      expect.any(Object),
+    );
+  });
+
+  it("keeps group chat GUIDs on the group allowlist policy", async () => {
+    const client = createClient({ guid: "p:0/group-guid" });
+
+    await expect(
+      sendMessageIMessage("chat_guid:iMessage;+;thread-42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              dmPolicy: "allowlist",
+              allowFrom: ["+1 (555) 123-0000"],
+              groupPolicy: "disabled",
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: group targets are disabled");
+
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
   it("honors wildcard iMessage DM allowlist entries for outbound sends", async () => {
     const client = createClient({ guid: "p:0/wildcard-dm" });
 

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -352,6 +352,29 @@ describe("sendMessageIMessage receipts", () => {
     expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 
+  it("blocks sender-based group allowance when the reply id sanitizes empty", async () => {
+    const client = createClient({ guid: "p:0/group-empty-reply-id" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15551230000"],
+            },
+          },
+        },
+        client,
+        replyToId: "[]",
+        replyRequesterSender: "+15551230000",
+      }),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
   it("treats direct chat identifiers as DM allowlist targets", async () => {
     const client = createClient({ guid: "p:0/direct-chat" });
 

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -167,6 +167,28 @@ describe("sendMessageIMessage receipts", () => {
     );
   });
 
+  it("does not use DM allowFrom wildcard entries as group allowlist fallback", async () => {
+    const client = createClient({ guid: "p:0/group-dm-wildcard" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            defaults: {
+              groupPolicy: "allowlist",
+            },
+            imessage: {
+              dmPolicy: "open",
+              allowFrom: ["*"],
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: channels.imessage.groupAllowFrom is empty");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
   it("does not fall back to legacy allowFrom when groupAllowFrom is explicitly empty", async () => {
     const client = createClient({ guid: "p:0/group-empty-explicit" });
 

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -154,6 +154,117 @@ describe("sendMessageIMessage receipts", () => {
     );
   });
 
+  it("allows group reply targets when group allowlist names sender handles", async () => {
+    const client = createClient({ guid: "p:0/group-reply" });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["+15551230000"],
+          },
+        },
+      },
+      client,
+      replyToId: "inbound-1",
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_id: 42 }),
+      expect.any(Object),
+    );
+  });
+
+  it("keeps fresh group sends blocked when group allowlist only names sender handles", async () => {
+    const client = createClient({ guid: "p:0/group-fresh" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15551230000"],
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("treats direct chat identifiers as DM allowlist targets", async () => {
+    const client = createClient({ guid: "p:0/direct-chat" });
+
+    await sendMessageIMessage("chat_identifier:iMessage;-;+15551230000", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+1 (555) 123-0000"],
+            groupPolicy: "disabled",
+          },
+        },
+      },
+      client,
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_identifier: "iMessage;-;+15551230000" }),
+      expect.any(Object),
+    );
+  });
+
+  it("honors wildcard iMessage DM allowlist entries for outbound sends", async () => {
+    const client = createClient({ guid: "p:0/wildcard-dm" });
+
+    await sendMessageIMessage("+15559999999", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["*"],
+          },
+        },
+      },
+      client,
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ to: "+15559999999" }),
+      expect.any(Object),
+    );
+  });
+
+  it("honors wildcard iMessage group allowlist entries for outbound sends", async () => {
+    const client = createClient({ guid: "p:0/wildcard-group" });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["*"],
+          },
+        },
+      },
+      client,
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_id: 42 }),
+      expect.any(Object),
+    );
+  });
+
   it("allows outbound handles listed by allowlist policy", async () => {
     const client = createClient({ guid: "p:0/allowed" });
 

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -189,6 +189,89 @@ describe("sendMessageIMessage receipts", () => {
     expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 
+  it("allows implicit group replies through legacy allowFrom sender fallback", async () => {
+    const client = createClient({ guid: "p:0/group-legacy-sender-reply" });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: {
+        channels: {
+          defaults: {
+            groupPolicy: "allowlist",
+          },
+          imessage: {
+            allowFrom: ["+15551230000"],
+          },
+        },
+      },
+      client,
+      replyToId: "inbound-1",
+      replyToIdSource: "implicit",
+      replyRequesterSender: "+15551230000",
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_id: 42 }),
+      expect.any(Object),
+    );
+  });
+
+  it("allows implicit group replies through legacy allowFrom access groups", async () => {
+    const client = createClient({ guid: "p:0/group-legacy-access-reply" });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: {
+        accessGroups: {
+          owners: {
+            type: "message.senders",
+            members: {
+              imessage: ["+15551230000"],
+            },
+          },
+        },
+        channels: {
+          defaults: {
+            groupPolicy: "allowlist",
+          },
+          imessage: {
+            allowFrom: ["accessGroup:owners"],
+          },
+        },
+      },
+      client,
+      replyToId: "inbound-1",
+      replyToIdSource: "implicit",
+      replyRequesterSender: "+15551230000",
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_id: 42 }),
+      expect.any(Object),
+    );
+  });
+
+  it("keeps fresh group sends blocked when legacy allowFrom fallback only names senders", async () => {
+    const client = createClient({ guid: "p:0/group-legacy-sender-fresh" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            defaults: {
+              groupPolicy: "allowlist",
+            },
+            imessage: {
+              allowFrom: ["+15551230000"],
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: channels.imessage.groupAllowFrom is empty");
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
   it("does not fall back to legacy allowFrom when groupAllowFrom is explicitly empty", async () => {
     const client = createClient({ guid: "p:0/group-empty-explicit" });
 

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -168,6 +168,7 @@ describe("sendMessageIMessage receipts", () => {
       },
       client,
       replyToId: "inbound-1",
+      replyRequesterSender: "+15551230000",
     });
 
     expect(getClientMocks(client).request).toHaveBeenCalledWith(
@@ -175,6 +176,74 @@ describe("sendMessageIMessage receipts", () => {
       expect.objectContaining({ chat_id: 42 }),
       expect.any(Object),
     );
+  });
+
+  it("blocks group reply targets when sender-based allowlist lacks a trusted requester", async () => {
+    const client = createClient({ guid: "p:0/group-reply-missing-sender" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15551230000"],
+            },
+          },
+        },
+        client,
+        replyToId: "inbound-1",
+      }),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("blocks group reply targets when the trusted requester is not allowlisted", async () => {
+    const client = createClient({ guid: "p:0/group-reply-wrong-sender" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15551230000"],
+            },
+          },
+        },
+        client,
+        replyToId: "inbound-1",
+        replyRequesterSender: "+15550009999",
+      }),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("blocks group reply targets when the trusted requester is blank", async () => {
+    const client = createClient({ guid: "p:0/group-reply-blank-sender" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15551230000"],
+            },
+          },
+        },
+        client,
+        replyToId: "inbound-1",
+        replyRequesterSender: "   \t ",
+      }),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
   });
 
   it("keeps fresh group sends blocked when group allowlist only names sender handles", async () => {
@@ -191,6 +260,28 @@ describe("sendMessageIMessage receipts", () => {
           },
         },
         client,
+      }),
+    ).rejects.toThrow(
+      "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+    );
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("keeps fresh group sends blocked when a trusted requester is present without reply context", async () => {
+    const client = createClient({ guid: "p:0/group-fresh-sender-only" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15551230000"],
+            },
+          },
+        },
+        client,
+        replyRequesterSender: "+15551230000",
       }),
     ).rejects.toThrow(
       "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -80,6 +80,154 @@ describe("sendMessageIMessage receipts", () => {
     vi.useRealTimers();
   });
 
+  it("blocks explicit chat targets when group targets are disabled", async () => {
+    const client = createClient({ guid: "p:0/blocked" });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              dmPolicy: "allowlist",
+              allowFrom: ["+15551230000"],
+              defaultTo: "+15551230000",
+              groupPolicy: "disabled",
+            },
+          },
+        },
+        client,
+      }),
+    ).rejects.toThrow("iMessage outbound blocked: group targets are disabled");
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("allows explicit chat targets listed by group allowlist policy", async () => {
+    const client = createClient({ guid: "p:0/group" });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["chat_id:42"],
+          },
+        },
+      },
+      client,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_id: 42 }),
+      expect.any(Object),
+    );
+  });
+
+  it("allows explicit chat targets through configured group access groups", async () => {
+    const client = createClient({ guid: "p:0/group-access" });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: {
+        accessGroups: {
+          owners: {
+            type: "message.senders",
+            members: {
+              imessage: ["chat_id:42"],
+            },
+          },
+        },
+        channels: {
+          imessage: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["accessGroup:owners"],
+          },
+        },
+      },
+      client,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_id: 42 }),
+      expect.any(Object),
+    );
+  });
+
+  it("allows outbound handles listed by allowlist policy", async () => {
+    const client = createClient({ guid: "p:0/allowed" });
+
+    await sendMessageIMessage("+15551230000", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+1 (555) 123-0000"],
+          },
+        },
+      },
+      client,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ to: "+15551230000" }),
+      expect.any(Object),
+    );
+  });
+
+  it("allows outbound handles matching defaultTo under allowlist policy", async () => {
+    const client = createClient({ guid: "p:0/default" });
+
+    await sendMessageIMessage("+15551230000", "hello", {
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            defaultTo: "+1 (555) 123-0000",
+          },
+        },
+      },
+      client,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ to: "+15551230000" }),
+      expect.any(Object),
+    );
+  });
+
+  it("allows outbound handles through configured access groups", async () => {
+    const client = createClient({ guid: "p:0/access-group" });
+
+    await sendMessageIMessage("+15551230000", "hello", {
+      config: {
+        accessGroups: {
+          owners: {
+            type: "message.senders",
+            members: {
+              imessage: ["+1 (555) 123-0000"],
+            },
+          },
+        },
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["accessGroup:owners"],
+          },
+        },
+      },
+      client,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ to: "+15551230000" }),
+      expect.any(Object),
+    );
+  });
+
   it("attaches a text receipt for native send ids", async () => {
     const client = createClient({ guid: "p:0/imsg-1" });
 

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -47,6 +47,7 @@ type IMessageSendOpts = {
   region?: string;
   accountId?: string;
   replyToId?: string;
+  replyToIdSource?: "explicit" | "implicit";
   /** Trusted inbound sender for server-injected reply delivery; never source this from model params. */
   replyRequesterSender?: string | null;
   mediaUrl?: string;
@@ -856,7 +857,10 @@ export async function sendMessageIMessage(
     cfg,
     account,
     target,
-    replyRequesterSender: resolvedReplyToId ? opts.replyRequesterSender : undefined,
+    replyRequesterSender:
+      resolvedReplyToId && opts.replyToIdSource === "implicit"
+        ? opts.replyRequesterSender
+        : undefined,
   });
   const service =
     opts.service ??

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -14,6 +14,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { kindFromMime, resolveOutboundAttachmentFromUrl } from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
+import {
+  resolveDefaultGroupPolicy,
+  resolveOpenProviderRuntimeGroupPolicy,
+} from "openclaw/plugin-sdk/runtime-group-policy";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
@@ -953,6 +957,24 @@ async function isIMessageSenderBasedGroupReplyAllowed(params: {
   });
 }
 
+function resolveIMessageOutboundGroupPolicy(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedIMessageAccount;
+}) {
+  return resolveOpenProviderRuntimeGroupPolicy({
+    providerConfigPresent: params.cfg.channels?.imessage !== undefined,
+    groupPolicy: params.account.config.groupPolicy,
+    defaultGroupPolicy: resolveDefaultGroupPolicy(params.cfg),
+  }).groupPolicy;
+}
+
+function resolveIMessageOutboundGroupAllowFrom(
+  account: ResolvedIMessageAccount,
+): Array<string | number> {
+  const configuredGroupAllowFrom = account.config.groupAllowFrom;
+  return [...(configuredGroupAllowFrom ?? account.config.allowFrom ?? [])];
+}
+
 export async function assertIMessageOutboundAllowed(params: {
   cfg: OpenClawConfig;
   account: ResolvedIMessageAccount;
@@ -961,14 +983,15 @@ export async function assertIMessageOutboundAllowed(params: {
 }): Promise<void> {
   const { cfg, account, target } = params;
   if (!isIMessageOutboundDmTarget(target)) {
-    if (account.config.groupPolicy === "disabled") {
+    const groupPolicy = resolveIMessageOutboundGroupPolicy({ cfg, account });
+    if (groupPolicy === "disabled") {
       throw new Error("iMessage outbound blocked: group targets are disabled");
     }
-    if (account.config.groupPolicy !== "allowlist") {
+    if (groupPolicy !== "allowlist") {
       return;
     }
     const normalizedTarget = normalizeIMessageOutboundTarget(target);
-    const configuredGroupAllowFrom = account.config.groupAllowFrom ?? [];
+    const configuredGroupAllowFrom = resolveIMessageOutboundGroupAllowFrom(account);
     const allowFrom = await expandIMessageOutboundAllowFrom({
       cfg,
       account,

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -831,7 +831,20 @@ function normalizeIMessageOutboundAllowValue(raw: string | number | null | undef
   if (raw === null || raw === undefined) {
     return "";
   }
-  return normalizeIMessageHandle(String(raw));
+  const value = String(raw).trim();
+  if (value === "*") {
+    return "*";
+  }
+  return normalizeIMessageHandle(value);
+}
+
+function resolveIMessageDirectChatIdentifier(target: ParsedIMessageTarget): string | null {
+  if (target.kind !== "chat_identifier") {
+    return null;
+  }
+  const match = /^(?:iMessage|SMS);-;(.+)$/iu.exec(target.chatIdentifier.trim());
+  const handle = match?.[1]?.trim();
+  return handle || null;
 }
 
 function normalizeIMessageOutboundTarget(target: ParsedIMessageTarget): string {
@@ -841,17 +854,62 @@ function normalizeIMessageOutboundTarget(target: ParsedIMessageTarget): string {
   if (target.kind === "chat_guid") {
     return `chat_guid:${target.chatGuid}`;
   }
+  const directChatIdentifier = resolveIMessageDirectChatIdentifier(target);
+  if (directChatIdentifier) {
+    return normalizeIMessageHandle(directChatIdentifier);
+  }
   if (target.kind === "chat_identifier") {
     return `chat_identifier:${target.chatIdentifier}`;
   }
   return normalizeIMessageHandle(target.to);
 }
 
+function isIMessageOutboundDmTarget(target: ParsedIMessageTarget): boolean {
+  return target.kind === "handle" || resolveIMessageDirectChatIdentifier(target) !== null;
+}
+
+function isIMessageConversationAllowEntry(normalized: string): boolean {
+  return (
+    normalized.startsWith("chat_id:") ||
+    normalized.startsWith("chat_guid:") ||
+    normalized.startsWith("chat_identifier:")
+  );
+}
+
+function hasIMessageSenderBasedAllowEntry(allowFrom: readonly (string | number)[]): boolean {
+  return allowFrom.some((entry) => {
+    const normalized = normalizeIMessageOutboundAllowValue(entry);
+    if (!normalized || normalized === "*") {
+      return false;
+    }
+    if (normalized.toLowerCase().startsWith("accessgroup:")) {
+      return false;
+    }
+    return !isIMessageConversationAllowEntry(normalized);
+  });
+}
+
+function isIMessageOutboundAllowlisted(params: {
+  allowFrom: readonly (string | number)[];
+  normalizedTarget: string;
+  allowSenderBasedGroupReply?: boolean;
+}): boolean {
+  const allowed = new Set(
+    params.allowFrom.map(normalizeIMessageOutboundAllowValue).filter(Boolean),
+  );
+  if (allowed.has("*") || allowed.has(params.normalizedTarget)) {
+    return true;
+  }
+  return (
+    params.allowSenderBasedGroupReply === true && hasIMessageSenderBasedAllowEntry(params.allowFrom)
+  );
+}
+
 function isIMessageOutboundTargetAllowed(
   senderId: string,
   allowFrom: readonly (string | number)[],
 ): boolean {
-  return allowFrom.some((entry) => normalizeIMessageOutboundAllowValue(entry) === senderId);
+  return isIMessageOutboundAllowlisted({ allowFrom, normalizedTarget: senderId });
 }
 
 async function expandIMessageOutboundAllowFrom(params: {
@@ -875,9 +933,10 @@ export async function assertIMessageOutboundAllowed(params: {
   cfg: OpenClawConfig;
   account: ResolvedIMessageAccount;
   target: ParsedIMessageTarget;
+  replyContext?: boolean;
 }): Promise<void> {
   const { cfg, account, target } = params;
-  if (target.kind !== "handle") {
+  if (!isIMessageOutboundDmTarget(target)) {
     if (account.config.groupPolicy === "disabled") {
       throw new Error("iMessage outbound blocked: group targets are disabled");
     }
@@ -891,11 +950,16 @@ export async function assertIMessageOutboundAllowed(params: {
       target,
       allowFrom: account.config.groupAllowFrom ?? [],
     });
-    const allowed = new Set(allowFrom.map(normalizeIMessageOutboundAllowValue).filter(Boolean));
-    if (allowed.size === 0) {
+    if (allowFrom.length === 0) {
       throw new Error("iMessage outbound blocked: channels.imessage.groupAllowFrom is empty");
     }
-    if (!allowed.has(normalizedTarget)) {
+    if (
+      !isIMessageOutboundAllowlisted({
+        allowFrom,
+        normalizedTarget,
+        allowSenderBasedGroupReply: params.replyContext === true,
+      })
+    ) {
       throw new Error(
         "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
       );
@@ -915,11 +979,10 @@ export async function assertIMessageOutboundAllowed(params: {
       ...(account.config.defaultTo ? [account.config.defaultTo] : []),
     ],
   });
-  const allowed = new Set(allowFrom.map(normalizeIMessageOutboundAllowValue).filter(Boolean));
-  if (allowed.size === 0) {
+  if (allowFrom.length === 0) {
     throw new Error("iMessage outbound blocked: channels.imessage.allowFrom/defaultTo is empty");
   }
-  if (!allowed.has(normalizedTarget)) {
+  if (!isIMessageOutboundAllowlisted({ allowFrom, normalizedTarget })) {
     throw new Error(
       "iMessage outbound blocked: target is not in channels.imessage.allowFrom/defaultTo",
     );
@@ -946,7 +1009,12 @@ export async function sendMessageIMessage(
     remoteHost: account.config.remoteHost,
   });
   const target = parseIMessageTarget(opts.chatId ? formatIMessageChatTarget(opts.chatId) : to);
-  await assertIMessageOutboundAllowed({ cfg, account, target });
+  await assertIMessageOutboundAllowed({
+    cfg,
+    account,
+    target,
+    replyContext: Boolean(opts.replyToId),
+  });
   const service =
     opts.service ??
     resolveTargetService(target) ??

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -854,9 +854,22 @@ function resolveIMessageDirectChatIdentifier(target: ParsedIMessageTarget): stri
   return handle || null;
 }
 
+function resolveIMessageDirectChatGuid(target: ParsedIMessageTarget): string | null {
+  if (target.kind !== "chat_guid") {
+    return null;
+  }
+  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(target.chatGuid.trim());
+  const handle = match?.[1]?.trim();
+  return handle || null;
+}
+
 function normalizeIMessageOutboundTarget(target: ParsedIMessageTarget): string {
   if (target.kind === "chat_id") {
     return `chat_id:${target.chatId}`;
+  }
+  const directChatGuid = resolveIMessageDirectChatGuid(target);
+  if (directChatGuid) {
+    return normalizeIMessageHandle(directChatGuid);
   }
   if (target.kind === "chat_guid") {
     return `chat_guid:${target.chatGuid}`;
@@ -872,7 +885,11 @@ function normalizeIMessageOutboundTarget(target: ParsedIMessageTarget): string {
 }
 
 function isIMessageOutboundDmTarget(target: ParsedIMessageTarget): boolean {
-  return target.kind === "handle" || resolveIMessageDirectChatIdentifier(target) !== null;
+  return (
+    target.kind === "handle" ||
+    resolveIMessageDirectChatIdentifier(target) !== null ||
+    resolveIMessageDirectChatGuid(target) !== null
+  );
 }
 
 function isIMessageOutboundAllowlisted(params: {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -3,6 +3,7 @@ import { constants, accessSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import { expandAllowFromWithAccessGroups } from "openclaw/plugin-sdk/access-groups";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -826,6 +827,105 @@ async function trySendAttachmentForTarget(params: {
   };
 }
 
+function normalizeIMessageOutboundAllowValue(raw: string | number | null | undefined): string {
+  if (raw === null || raw === undefined) {
+    return "";
+  }
+  return normalizeIMessageHandle(String(raw));
+}
+
+function normalizeIMessageOutboundTarget(target: ParsedIMessageTarget): string {
+  if (target.kind === "chat_id") {
+    return `chat_id:${target.chatId}`;
+  }
+  if (target.kind === "chat_guid") {
+    return `chat_guid:${target.chatGuid}`;
+  }
+  if (target.kind === "chat_identifier") {
+    return `chat_identifier:${target.chatIdentifier}`;
+  }
+  return normalizeIMessageHandle(target.to);
+}
+
+function isIMessageOutboundTargetAllowed(
+  senderId: string,
+  allowFrom: readonly (string | number)[],
+): boolean {
+  return allowFrom.some((entry) => normalizeIMessageOutboundAllowValue(entry) === senderId);
+}
+
+async function expandIMessageOutboundAllowFrom(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedIMessageAccount;
+  target: ParsedIMessageTarget;
+  allowFrom: Array<string | number>;
+}): Promise<string[]> {
+  const normalizedTarget = normalizeIMessageOutboundTarget(params.target);
+  return await expandAllowFromWithAccessGroups({
+    cfg: params.cfg,
+    allowFrom: params.allowFrom,
+    channel: "imessage",
+    accountId: params.account.accountId,
+    senderId: normalizedTarget,
+    isSenderAllowed: isIMessageOutboundTargetAllowed,
+  });
+}
+
+export async function assertIMessageOutboundAllowed(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedIMessageAccount;
+  target: ParsedIMessageTarget;
+}): Promise<void> {
+  const { cfg, account, target } = params;
+  if (target.kind !== "handle") {
+    if (account.config.groupPolicy === "disabled") {
+      throw new Error("iMessage outbound blocked: group targets are disabled");
+    }
+    if (account.config.groupPolicy !== "allowlist") {
+      return;
+    }
+    const normalizedTarget = normalizeIMessageOutboundTarget(target);
+    const allowFrom = await expandIMessageOutboundAllowFrom({
+      cfg,
+      account,
+      target,
+      allowFrom: account.config.groupAllowFrom ?? [],
+    });
+    const allowed = new Set(allowFrom.map(normalizeIMessageOutboundAllowValue).filter(Boolean));
+    if (allowed.size === 0) {
+      throw new Error("iMessage outbound blocked: channels.imessage.groupAllowFrom is empty");
+    }
+    if (!allowed.has(normalizedTarget)) {
+      throw new Error(
+        "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
+      );
+    }
+    return;
+  }
+  if (account.config.dmPolicy !== "allowlist") {
+    return;
+  }
+  const normalizedTarget = normalizeIMessageOutboundTarget(target);
+  const allowFrom = await expandIMessageOutboundAllowFrom({
+    cfg,
+    account,
+    target,
+    allowFrom: [
+      ...(account.config.allowFrom ?? []),
+      ...(account.config.defaultTo ? [account.config.defaultTo] : []),
+    ],
+  });
+  const allowed = new Set(allowFrom.map(normalizeIMessageOutboundAllowValue).filter(Boolean));
+  if (allowed.size === 0) {
+    throw new Error("iMessage outbound blocked: channels.imessage.allowFrom/defaultTo is empty");
+  }
+  if (!allowed.has(normalizedTarget)) {
+    throw new Error(
+      "iMessage outbound blocked: target is not in channels.imessage.allowFrom/defaultTo",
+    );
+  }
+}
+
 export async function sendMessageIMessage(
   to: string,
   text: string,
@@ -846,6 +946,7 @@ export async function sendMessageIMessage(
     remoteHost: account.config.remoteHost,
   });
   const target = parseIMessageTarget(opts.chatId ? formatIMessageChatTarget(opts.chatId) : to);
+  await assertIMessageOutboundAllowed({ cfg, account, target });
   const service =
     opts.service ??
     resolveTargetService(target) ??

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -1061,12 +1061,13 @@ export async function sendMessageIMessage(
     dbPath,
     remoteHost: account.config.remoteHost,
   });
+  const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
   const target = parseIMessageTarget(opts.chatId ? formatIMessageChatTarget(opts.chatId) : to);
   await assertIMessageOutboundAllowed({
     cfg,
     account,
     target,
-    replyRequesterSender: opts.replyToId ? opts.replyRequesterSender : undefined,
+    replyRequesterSender: resolvedReplyToId ? opts.replyRequesterSender : undefined,
   });
   const service =
     opts.service ??
@@ -1121,7 +1122,6 @@ export async function sendMessageIMessage(
     throw new Error("iMessage send requires text or media");
   }
   const echoText = resolveOutboundEchoText(message, filePath ? mediaContentType : undefined);
-  const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
   const runCliJson =
     opts.runCliJson ??
     ((args: readonly string[]) => runIMessageCliJson(cliPath, dbPath, args, timeoutMs));

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -30,6 +30,7 @@ import { rememberIMessageReplyCache } from "./monitor-reply-cache.js";
 import { rememberPersistedIMessageEcho } from "./monitor/persisted-echo-cache.js";
 import {
   formatIMessageChatTarget,
+  isAllowedIMessageReplyContextSender,
   type IMessageService,
   normalizeIMessageHandle,
   parseIMessageTarget,
@@ -45,6 +46,8 @@ type IMessageSendOpts = {
   region?: string;
   accountId?: string;
   replyToId?: string;
+  /** Trusted inbound sender for server-injected reply delivery; never source this from model params. */
+  replyRequesterSender?: string | null;
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
@@ -868,41 +871,32 @@ function isIMessageOutboundDmTarget(target: ParsedIMessageTarget): boolean {
   return target.kind === "handle" || resolveIMessageDirectChatIdentifier(target) !== null;
 }
 
-function isIMessageConversationAllowEntry(normalized: string): boolean {
-  return (
-    normalized.startsWith("chat_id:") ||
-    normalized.startsWith("chat_guid:") ||
-    normalized.startsWith("chat_identifier:")
-  );
-}
-
-function hasIMessageSenderBasedAllowEntry(allowFrom: readonly (string | number)[]): boolean {
-  return allowFrom.some((entry) => {
-    const normalized = normalizeIMessageOutboundAllowValue(entry);
-    if (!normalized || normalized === "*") {
-      return false;
-    }
-    if (normalized.toLowerCase().startsWith("accessgroup:")) {
-      return false;
-    }
-    return !isIMessageConversationAllowEntry(normalized);
-  });
-}
-
 function isIMessageOutboundAllowlisted(params: {
   allowFrom: readonly (string | number)[];
   normalizedTarget: string;
-  allowSenderBasedGroupReply?: boolean;
 }): boolean {
   const allowed = new Set(
     params.allowFrom.map(normalizeIMessageOutboundAllowValue).filter(Boolean),
   );
-  if (allowed.has("*") || allowed.has(params.normalizedTarget)) {
-    return true;
+  return allowed.has("*") || allowed.has(params.normalizedTarget);
+}
+
+function getIMessageConversationFacts(
+  target: ParsedIMessageTarget,
+): Pick<
+  Parameters<typeof isAllowedIMessageReplyContextSender>[0],
+  "chatId" | "chatGuid" | "chatIdentifier"
+> {
+  if (target.kind === "chat_id") {
+    return { chatId: target.chatId };
   }
-  return (
-    params.allowSenderBasedGroupReply === true && hasIMessageSenderBasedAllowEntry(params.allowFrom)
-  );
+  if (target.kind === "chat_guid") {
+    return { chatGuid: target.chatGuid };
+  }
+  if (target.kind === "chat_identifier") {
+    return { chatIdentifier: target.chatIdentifier };
+  }
+  return {};
 }
 
 function isIMessageOutboundTargetAllowed(
@@ -929,11 +923,41 @@ async function expandIMessageOutboundAllowFrom(params: {
   });
 }
 
+async function isIMessageSenderBasedGroupReplyAllowed(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedIMessageAccount;
+  target: ParsedIMessageTarget;
+  allowFrom: Array<string | number>;
+  replyRequesterSender?: string | null;
+}): Promise<boolean> {
+  const sender = params.replyRequesterSender?.trim();
+  if (!sender) {
+    return false;
+  }
+  const normalizedSender = normalizeIMessageHandle(sender);
+  if (!normalizedSender) {
+    return false;
+  }
+  const senderAllowFrom = await expandAllowFromWithAccessGroups({
+    cfg: params.cfg,
+    allowFrom: params.allowFrom,
+    channel: "imessage",
+    accountId: params.account.accountId,
+    senderId: normalizedSender,
+    isSenderAllowed: isIMessageOutboundTargetAllowed,
+  });
+  return isAllowedIMessageReplyContextSender({
+    allowFrom: senderAllowFrom,
+    sender: normalizedSender,
+    ...getIMessageConversationFacts(params.target),
+  });
+}
+
 export async function assertIMessageOutboundAllowed(params: {
   cfg: OpenClawConfig;
   account: ResolvedIMessageAccount;
   target: ParsedIMessageTarget;
-  replyContext?: boolean;
+  replyRequesterSender?: string | null;
 }): Promise<void> {
   const { cfg, account, target } = params;
   if (!isIMessageOutboundDmTarget(target)) {
@@ -944,22 +968,28 @@ export async function assertIMessageOutboundAllowed(params: {
       return;
     }
     const normalizedTarget = normalizeIMessageOutboundTarget(target);
+    const configuredGroupAllowFrom = account.config.groupAllowFrom ?? [];
     const allowFrom = await expandIMessageOutboundAllowFrom({
       cfg,
       account,
       target,
-      allowFrom: account.config.groupAllowFrom ?? [],
+      allowFrom: configuredGroupAllowFrom,
     });
-    if (allowFrom.length === 0) {
+    const targetAllowed = isIMessageOutboundAllowlisted({
+      allowFrom,
+      normalizedTarget,
+    });
+    const replyRequesterAllowed = await isIMessageSenderBasedGroupReplyAllowed({
+      cfg,
+      account,
+      target,
+      allowFrom: configuredGroupAllowFrom,
+      replyRequesterSender: params.replyRequesterSender,
+    });
+    if (allowFrom.length === 0 && !replyRequesterAllowed) {
       throw new Error("iMessage outbound blocked: channels.imessage.groupAllowFrom is empty");
     }
-    if (
-      !isIMessageOutboundAllowlisted({
-        allowFrom,
-        normalizedTarget,
-        allowSenderBasedGroupReply: params.replyContext === true,
-      })
-    ) {
+    if (!targetAllowed && !replyRequesterAllowed) {
       throw new Error(
         "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
       );
@@ -1013,7 +1043,7 @@ export async function sendMessageIMessage(
     cfg,
     account,
     target,
-    replyContext: Boolean(opts.replyToId),
+    replyRequesterSender: opts.replyToId ? opts.replyRequesterSender : undefined,
   });
   const service =
     opts.service ??

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -858,7 +858,7 @@ export async function sendMessageIMessage(
     account,
     target,
     replyRequesterSender:
-      resolvedReplyToId && opts.replyToIdSource === "implicit"
+      opts.replyToIdSource === "implicit" && (opts.replyToId == null || resolvedReplyToId)
         ? opts.replyRequesterSender
         : undefined,
   });

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -3,7 +3,6 @@ import { constants, accessSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { expandAllowFromWithAccessGroups } from "openclaw/plugin-sdk/access-groups";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -14,10 +13,6 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { kindFromMime, resolveOutboundAttachmentFromUrl } from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
-import {
-  resolveDefaultGroupPolicy,
-  resolveOpenProviderRuntimeGroupPolicy,
-} from "openclaw/plugin-sdk/runtime-group-policy";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
@@ -32,13 +27,15 @@ import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
 import { extractMarkdownFormatRuns } from "./markdown-format.js";
 import { rememberIMessageReplyCache } from "./monitor-reply-cache.js";
 import { rememberPersistedIMessageEcho } from "./monitor/persisted-echo-cache.js";
+import { assertIMessageOutboundAllowed } from "./outbound-allowlist.js";
 import {
   formatIMessageChatTarget,
-  isAllowedIMessageReplyContextSender,
   type IMessageService,
   normalizeIMessageHandle,
   parseIMessageTarget,
 } from "./targets.js";
+
+export { assertIMessageOutboundAllowed };
 
 const require = createRequire(import.meta.url);
 type ParsedIMessageTarget = ReturnType<typeof parseIMessageTarget>;
@@ -832,231 +829,6 @@ async function trySendAttachmentForTarget(params: {
       kind: "media",
     }),
   };
-}
-
-function normalizeIMessageOutboundAllowValue(raw: string | number | null | undefined): string {
-  if (raw === null || raw === undefined) {
-    return "";
-  }
-  const value = String(raw).trim();
-  if (value === "*") {
-    return "*";
-  }
-  return normalizeIMessageHandle(value);
-}
-
-function resolveIMessageDirectChatIdentifier(target: ParsedIMessageTarget): string | null {
-  if (target.kind !== "chat_identifier") {
-    return null;
-  }
-  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(target.chatIdentifier.trim());
-  const handle = match?.[1]?.trim();
-  return handle || null;
-}
-
-function resolveIMessageDirectChatGuid(target: ParsedIMessageTarget): string | null {
-  if (target.kind !== "chat_guid") {
-    return null;
-  }
-  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(target.chatGuid.trim());
-  const handle = match?.[1]?.trim();
-  return handle || null;
-}
-
-function normalizeIMessageOutboundTarget(target: ParsedIMessageTarget): string {
-  if (target.kind === "chat_id") {
-    return `chat_id:${target.chatId}`;
-  }
-  const directChatGuid = resolveIMessageDirectChatGuid(target);
-  if (directChatGuid) {
-    return normalizeIMessageHandle(directChatGuid);
-  }
-  if (target.kind === "chat_guid") {
-    return `chat_guid:${target.chatGuid}`;
-  }
-  const directChatIdentifier = resolveIMessageDirectChatIdentifier(target);
-  if (directChatIdentifier) {
-    return normalizeIMessageHandle(directChatIdentifier);
-  }
-  if (target.kind === "chat_identifier") {
-    return `chat_identifier:${target.chatIdentifier}`;
-  }
-  return normalizeIMessageHandle(target.to);
-}
-
-function isIMessageOutboundDmTarget(target: ParsedIMessageTarget): boolean {
-  return (
-    target.kind === "handle" ||
-    resolveIMessageDirectChatIdentifier(target) !== null ||
-    resolveIMessageDirectChatGuid(target) !== null
-  );
-}
-
-function isIMessageOutboundAllowlisted(params: {
-  allowFrom: readonly (string | number)[];
-  normalizedTarget: string;
-}): boolean {
-  const allowed = new Set(
-    params.allowFrom.map(normalizeIMessageOutboundAllowValue).filter(Boolean),
-  );
-  return allowed.has("*") || allowed.has(params.normalizedTarget);
-}
-
-function getIMessageConversationFacts(
-  target: ParsedIMessageTarget,
-): Pick<
-  Parameters<typeof isAllowedIMessageReplyContextSender>[0],
-  "chatId" | "chatGuid" | "chatIdentifier"
-> {
-  if (target.kind === "chat_id") {
-    return { chatId: target.chatId };
-  }
-  if (target.kind === "chat_guid") {
-    return { chatGuid: target.chatGuid };
-  }
-  if (target.kind === "chat_identifier") {
-    return { chatIdentifier: target.chatIdentifier };
-  }
-  return {};
-}
-
-function isIMessageOutboundTargetAllowed(
-  senderId: string,
-  allowFrom: readonly (string | number)[],
-): boolean {
-  return isIMessageOutboundAllowlisted({ allowFrom, normalizedTarget: senderId });
-}
-
-async function expandIMessageOutboundAllowFrom(params: {
-  cfg: OpenClawConfig;
-  account: ResolvedIMessageAccount;
-  target: ParsedIMessageTarget;
-  allowFrom: Array<string | number>;
-}): Promise<string[]> {
-  const normalizedTarget = normalizeIMessageOutboundTarget(params.target);
-  return await expandAllowFromWithAccessGroups({
-    cfg: params.cfg,
-    allowFrom: params.allowFrom,
-    channel: "imessage",
-    accountId: params.account.accountId,
-    senderId: normalizedTarget,
-    isSenderAllowed: isIMessageOutboundTargetAllowed,
-  });
-}
-
-async function isIMessageSenderBasedGroupReplyAllowed(params: {
-  cfg: OpenClawConfig;
-  account: ResolvedIMessageAccount;
-  target: ParsedIMessageTarget;
-  allowFrom: Array<string | number>;
-  replyRequesterSender?: string | null;
-}): Promise<boolean> {
-  const sender = params.replyRequesterSender?.trim();
-  if (!sender) {
-    return false;
-  }
-  const normalizedSender = normalizeIMessageHandle(sender);
-  if (!normalizedSender) {
-    return false;
-  }
-  const senderAllowFrom = await expandAllowFromWithAccessGroups({
-    cfg: params.cfg,
-    allowFrom: params.allowFrom,
-    channel: "imessage",
-    accountId: params.account.accountId,
-    senderId: normalizedSender,
-    isSenderAllowed: isIMessageOutboundTargetAllowed,
-  });
-  return isAllowedIMessageReplyContextSender({
-    allowFrom: senderAllowFrom,
-    sender: normalizedSender,
-    ...getIMessageConversationFacts(params.target),
-  });
-}
-
-function resolveIMessageOutboundGroupPolicy(params: {
-  cfg: OpenClawConfig;
-  account: ResolvedIMessageAccount;
-}) {
-  return resolveOpenProviderRuntimeGroupPolicy({
-    providerConfigPresent: params.cfg.channels?.imessage !== undefined,
-    groupPolicy: params.account.config.groupPolicy,
-    defaultGroupPolicy: resolveDefaultGroupPolicy(params.cfg),
-  }).groupPolicy;
-}
-
-function resolveIMessageOutboundGroupAllowFrom(
-  account: ResolvedIMessageAccount,
-): Array<string | number> {
-  const configuredGroupAllowFrom = account.config.groupAllowFrom;
-  return [...(configuredGroupAllowFrom ?? account.config.allowFrom ?? [])];
-}
-
-export async function assertIMessageOutboundAllowed(params: {
-  cfg: OpenClawConfig;
-  account: ResolvedIMessageAccount;
-  target: ParsedIMessageTarget;
-  replyRequesterSender?: string | null;
-}): Promise<void> {
-  const { cfg, account, target } = params;
-  if (!isIMessageOutboundDmTarget(target)) {
-    const groupPolicy = resolveIMessageOutboundGroupPolicy({ cfg, account });
-    if (groupPolicy === "disabled") {
-      throw new Error("iMessage outbound blocked: group targets are disabled");
-    }
-    if (groupPolicy !== "allowlist") {
-      return;
-    }
-    const normalizedTarget = normalizeIMessageOutboundTarget(target);
-    const configuredGroupAllowFrom = resolveIMessageOutboundGroupAllowFrom(account);
-    const allowFrom = await expandIMessageOutboundAllowFrom({
-      cfg,
-      account,
-      target,
-      allowFrom: configuredGroupAllowFrom,
-    });
-    const targetAllowed = isIMessageOutboundAllowlisted({
-      allowFrom,
-      normalizedTarget,
-    });
-    const replyRequesterAllowed = await isIMessageSenderBasedGroupReplyAllowed({
-      cfg,
-      account,
-      target,
-      allowFrom: configuredGroupAllowFrom,
-      replyRequesterSender: params.replyRequesterSender,
-    });
-    if (allowFrom.length === 0 && !replyRequesterAllowed) {
-      throw new Error("iMessage outbound blocked: channels.imessage.groupAllowFrom is empty");
-    }
-    if (!targetAllowed && !replyRequesterAllowed) {
-      throw new Error(
-        "iMessage outbound blocked: target is not in channels.imessage.groupAllowFrom",
-      );
-    }
-    return;
-  }
-  if (account.config.dmPolicy !== "allowlist") {
-    return;
-  }
-  const normalizedTarget = normalizeIMessageOutboundTarget(target);
-  const allowFrom = await expandIMessageOutboundAllowFrom({
-    cfg,
-    account,
-    target,
-    allowFrom: [
-      ...(account.config.allowFrom ?? []),
-      ...(account.config.defaultTo ? [account.config.defaultTo] : []),
-    ],
-  });
-  if (allowFrom.length === 0) {
-    throw new Error("iMessage outbound blocked: channels.imessage.allowFrom/defaultTo is empty");
-  }
-  if (!isIMessageOutboundAllowlisted({ allowFrom, normalizedTarget })) {
-    throw new Error(
-      "iMessage outbound blocked: target is not in channels.imessage.allowFrom/defaultTo",
-    );
-  }
 }
 
 export async function sendMessageIMessage(

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -842,7 +842,7 @@ function resolveIMessageDirectChatIdentifier(target: ParsedIMessageTarget): stri
   if (target.kind !== "chat_identifier") {
     return null;
   }
-  const match = /^(?:iMessage|SMS);-;(.+)$/iu.exec(target.chatIdentifier.trim());
+  const match = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(target.chatIdentifier.trim());
   const handle = match?.[1]?.trim();
   return handle || null;
 }

--- a/extensions/imessage/src/targets.test.ts
+++ b/extensions/imessage/src/targets.test.ts
@@ -160,6 +160,10 @@ describe("imessage targets", () => {
 
   it("infers direct and group chat types from normalized targets", () => {
     expect(inferIMessageTargetChatType("+15552223333")).toBe("direct");
+    expect(inferIMessageTargetChatType("chat_identifier:+15552223333")).toBe("direct");
+    expect(inferIMessageTargetChatType("chat_identifier:iMessage;-;+15552223333")).toBe("direct");
+    expect(inferIMessageTargetChatType("chat_guid:SMS;-;+15552223333")).toBe("direct");
+    expect(inferIMessageTargetChatType("chat_identifier:team-thread")).toBe("group");
     expect(inferIMessageTargetChatType("chat_id:42")).toBe("group");
   });
 });

--- a/extensions/imessage/src/targets.ts
+++ b/extensions/imessage/src/targets.ts
@@ -74,6 +74,28 @@ export function normalizeIMessageHandle(raw: string): string {
   return trimmed.replace(/\s+/g, "");
 }
 
+export function resolveIMessageDirectChatHandle(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const serviceMatch = /^(?:iMessage|SMS|any);-;(.+)$/iu.exec(trimmed);
+  const serviceHandle = serviceMatch?.[1]?.trim();
+  if (serviceHandle) {
+    return serviceHandle;
+  }
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(trimmed)) {
+    return trimmed;
+  }
+  if (/^\+[0-9][0-9\s().-]*$/u.test(trimmed)) {
+    const digitCount = trimmed.replace(/\D/g, "").length;
+    if (digitCount >= 7 && digitCount <= 15) {
+      return trimmed;
+    }
+  }
+  return null;
+}
+
 export function parseIMessageTarget(raw: string): IMessageTarget {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -131,6 +153,13 @@ export function inferIMessageTargetChatType(raw: string): "direct" | "group" | u
   try {
     const parsed = parseIMessageTarget(raw);
     if (parsed.kind === "handle") {
+      return "direct";
+    }
+    if (
+      (parsed.kind === "chat_identifier" &&
+        resolveIMessageDirectChatHandle(parsed.chatIdentifier) !== null) ||
+      (parsed.kind === "chat_guid" && resolveIMessageDirectChatHandle(parsed.chatGuid) !== null)
+    ) {
       return "direct";
     }
     return "group";

--- a/extensions/imessage/src/test-plugin.test.ts
+++ b/extensions/imessage/src/test-plugin.test.ts
@@ -153,6 +153,74 @@ describe("createIMessageTestPlugin", () => {
     ).toBe(true);
   });
 
+  it("routes handle-shaped chat identifiers as direct outbound sessions", () => {
+    const route = imessagePlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {} as never,
+      agentId: "agent-1",
+      accountId: "default",
+      target: "chat_identifier:+15552223333",
+    });
+
+    expect(route).toStrictEqual({
+      sessionKey: "agent:agent-1:main",
+      baseSessionKey: "agent:agent-1:main",
+      peer: { kind: "direct", id: "+15552223333" },
+      chatType: "direct",
+      from: "imessage:+15552223333",
+      to: "imessage:+15552223333",
+    });
+  });
+
+  it("routes SMS chat identifiers as direct outbound sessions", () => {
+    const route = imessagePlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {} as never,
+      agentId: "agent-1",
+      accountId: "default",
+      target: "chat_identifier:SMS;-;+15552223333",
+    });
+
+    expect(route).toMatchObject({
+      peer: { kind: "direct", id: "+15552223333" },
+      chatType: "direct",
+      from: "sms:+15552223333",
+      to: "sms:+15552223333",
+    });
+  });
+
+  it("routes direct chat GUIDs as direct outbound sessions", () => {
+    const route = imessagePlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {} as never,
+      agentId: "agent-1",
+      accountId: "default",
+      target: "chat_guid:iMessage;-;+15552223333",
+    });
+
+    expect(route).toMatchObject({
+      peer: { kind: "direct", id: "+15552223333" },
+      chatType: "direct",
+      from: "imessage:+15552223333",
+      to: "imessage:+15552223333",
+    });
+  });
+
+  it("routes opaque chat identifiers as group outbound sessions", () => {
+    const route = imessagePlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {} as never,
+      agentId: "agent-1",
+      accountId: "default",
+      target: "chat_identifier:team-thread",
+    });
+
+    expect(route).toStrictEqual({
+      sessionKey: "agent:agent-1:imessage:group:team-thread",
+      baseSessionKey: "agent:agent-1:imessage:group:team-thread",
+      peer: { kind: "group", id: "team-thread" },
+      chatType: "group",
+      from: "imessage:group:team-thread",
+      to: "chat_identifier:team-thread",
+    });
+  });
+
   it("backs declared durable final capabilities with delivery proofs", async () => {
     const outbound = requireOutbound();
     const sendText = requireOutboundSendText(outbound);

--- a/src/channels/message/types.ts
+++ b/src/channels/message/types.ts
@@ -168,6 +168,7 @@ export type ChannelMessageSendTextContext<TConfig = OpenClawConfig> = {
   accountId?: string | null;
   deps?: OutboundSendDeps;
   replyToId?: string | null;
+  requesterSenderId?: string | null;
   replyToIdSource?: "explicit" | "implicit";
   replyToMode?: ReplyToMode;
   threadId?: string | number | null;

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -34,6 +34,7 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
+  requesterSenderId?: string | null;
   gatewayClientScopes?: readonly string[];
 };
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1281,6 +1281,45 @@ describe("deliverOutboundPayloads", () => {
     resolveMediaAccessSpy.mockRestore();
   });
 
+  it("forwards requester sender id to channel send contexts", async () => {
+    const sendText = vi.fn().mockResolvedValue({
+      channel: "matrix" as const,
+      messageId: "m-requester",
+      roomId: "!room:example",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText,
+            },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      session: {
+        requesterSenderId: "sender-1",
+      },
+    });
+
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requesterSenderId: "sender-1",
+      }),
+    );
+  });
+
   it("scopes media access after reply payload hooks add local media", async () => {
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "reply_payload_sending",

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -205,6 +205,7 @@ type ChannelHandlerParams = {
   forceDocument?: boolean;
   silent?: boolean;
   mediaAccess?: OutboundMediaAccess;
+  requesterSenderId?: string | null;
   gatewayClientScopes?: readonly string[];
   onPlatformSendStart?: () => Promise<void>;
 };
@@ -580,6 +581,7 @@ function createChannelOutboundContextBase(
     forceDocument: params.forceDocument,
     deps: params.deps,
     silent: params.silent,
+    requesterSenderId: params.requesterSenderId,
     mediaAccess: params.mediaAccess,
     mediaLocalRoots: params.mediaAccess?.localRoots,
     mediaReadFile: params.mediaAccess?.readFile,
@@ -1445,6 +1447,7 @@ async function deliverOutboundPayloadsCore(
       forceDocument: params.forceDocument,
       silent: params.silent,
       mediaAccess: resolveMediaAccess(mediaSources),
+      requesterSenderId: params.session?.requesterSenderId,
       gatewayClientScopes: params.gatewayClientScopes,
       ...(params.onPlatformSendStart ? { onPlatformSendStart: params.onPlatformSendStart } : {}),
     });

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { normalizeMessageActionInput } from "./message-action-normalization.js";
+import {
+  MESSAGE_ACTION_INFERRED_TARGET_PARAM,
+  normalizeMessageActionInput,
+} from "./message-action-normalization.js";
 
 vi.mock("../../channels/plugins/bootstrap-registry.js", async () => ({
   getBootstrapChannelPlugin: (
@@ -62,13 +65,18 @@ describe("normalizeMessageActionInput", () => {
           currentChannelId: "channel:C1",
         },
       },
-      expectedFields: { target: "channel:C1", to: "channel:C1" },
+      expectedFields: {
+        target: "channel:C1",
+        to: "channel:C1",
+        [MESSAGE_ACTION_INFERRED_TARGET_PARAM]: true,
+      },
     },
     {
       input: {
         action: "send",
         args: {
           target: "channel:C1",
+          [MESSAGE_ACTION_INFERRED_TARGET_PARAM]: true,
         },
         toolContext: {
           currentChannelId: "C1",
@@ -76,6 +84,7 @@ describe("normalizeMessageActionInput", () => {
         },
       },
       expectedFields: { channel: "workspace" },
+      absentFields: [MESSAGE_ACTION_INFERRED_TARGET_PARAM],
     },
     {
       input: {

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -10,6 +10,8 @@ import {
 import { applyTargetToParams } from "./channel-target.js";
 import { actionHasTarget, actionRequiresTarget } from "./message-action-spec.js";
 
+export const MESSAGE_ACTION_INFERRED_TARGET_PARAM = "__openclawInferredTargetFromCurrentChannel";
+
 /** Normalizes message-action args before target validation and dispatch. */
 export function normalizeMessageActionInput(params: {
   action: ChannelMessageActionName;
@@ -17,6 +19,7 @@ export function normalizeMessageActionInput(params: {
   toolContext?: ChannelThreadingToolContext;
 }): Record<string, unknown> {
   const normalizedArgs = { ...params.args };
+  delete normalizedArgs[MESSAGE_ACTION_INFERRED_TARGET_PARAM];
   const { action, toolContext } = params;
   const explicitChannel = normalizeOptionalString(normalizedArgs.channel) ?? "";
   const inferredChannel =
@@ -44,6 +47,7 @@ export function normalizeMessageActionInput(params: {
     const inferredTarget = normalizeOptionalString(toolContext?.currentChannelId);
     if (inferredTarget) {
       normalizedArgs.target = inferredTarget;
+      normalizedArgs[MESSAGE_ACTION_INFERRED_TARGET_PARAM] = true;
     }
   }
 


### PR DESCRIPTION
## Summary

- Enforce iMessage outbound allowlist checks before private API probing or send calls for reply, sendWithEffect, upload-file, and normal send paths.
- Keep direct-message and group-target policies separate while preserving configured accessGroup expansion.
- Add blocked-target and allowlisted-target coverage for the affected send paths.

## Verification

- `node scripts/run-vitest.mjs extensions/imessage/src/actions.test.ts extensions/imessage/src/send.test.ts`
- `pnpm run lint:extensions:bundled`
- `git diff --check`

## Real behavior proof

Behavior addressed: iMessage outbound sends now fail closed before transport/runtime calls when the configured allowlist does not include the handle or group target.

Real environment tested: Local OpenClaw source checkout on macOS at PR head `cb227048c2`; commands ran against the actual OpenClaw iMessage extension code, with no live iMessage account or private API secrets used.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/imessage/src/actions.test.ts extensions/imessage/src/send.test.ts`; `pnpm run lint:extensions:bundled`; `git diff --check`.

Evidence after fix: Terminal capture from the local OpenClaw checkout:

```text
$ node scripts/run-vitest.mjs extensions/imessage/src/actions.test.ts extensions/imessage/src/send.test.ts
Test Files  2 passed (2)
Tests  71 passed (71)
[test] passed 1 Vitest shard in 5.21s

$ pnpm run lint:extensions:bundled
$ node scripts/run-bundled-extension-oxlint.mjs
exit status: 0

$ git diff --check
exit status: 0
```

Observed result after fix: Blocked-target paths reject before `runtimeMock.sendRichMessage`, `runtimeMock.sendAttachment`, or `client.request` are called; allowlisted paths still call `client.request` with the expected iMessage payload. The bundled-extension lint command exits 0.

What was not tested: A live iMessage private API send was not run from this machine; this PR intentionally avoids live account credentials and validates the fail-closed behavior in the extension runtime.

## Fork Context

This is a temporary upstream-review branch. The same accepted fix remains on `LDMB123/openclaw` fork `main`, per the fork cleanup plan.
