### PR TITLE
fix: keep Convex tsconfig valid JSON

### DIFF
--- a/qa/convex-credential-broker/convex/tsconfig.json
+++ b/qa/convex-credential-broker/convex/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  /* This TypeScript project config describes the environment that
-   * Convex functions run in and is used to typecheck them.
-   * You can modify it, but some settings are required to use Convex.
-   */
   "compilerOptions": {
-    /* These settings are not required by Convex and can be modified. */
     "allowJs": true,
     "strict": true,
     "moduleResolution": "Bundler",
@@ -12,7 +7,6 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
 
-    /* These compiler options are required by Convex */
     "target": "ESNext",
     "lib": ["ES2023", "dom"],
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

- Remove invalid JSON comments from the Convex credential broker `tsconfig.json`.
- Keep the file parseable by standard JSON tooling.
- Preserve the fork-owned fix on fork `main` while offering this temporary branch for upstream review.

## Verification

- `python3 -m json.tool qa/convex-credential-broker/convex/tsconfig.json >/dev/null`
- `git diff --check`

## Real behavior proof

Behavior addressed: The Convex credential broker TypeScript config is now valid JSON and can be read by JSON tooling without syntax errors.

Real environment tested: Local OpenClaw source checkout on macOS at PR head `b6c283a04d`; commands ran against the actual `qa/convex-credential-broker/convex/tsconfig.json` file.

Exact steps or command run after this patch: `python3 -m json.tool qa/convex-credential-broker/convex/tsconfig.json >/dev/null`; `git diff --check`.

Evidence after fix: Terminal capture from the local OpenClaw checkout:

```text
$ python3 -m json.tool qa/convex-credential-broker/convex/tsconfig.json >/dev/null
exit status: 0

$ git diff --check
exit status: 0
```

Observed result after fix: The standard JSON parser accepts the Convex credential broker `tsconfig.json`; whitespace validation also exits 0.

What was not tested: A live Convex deployment was not run; this PR only fixes and validates JSON syntax for the existing config file.

## Fork Context

This is a temporary upstream-review branch. The same accepted fix remains on `LDMB123/openclaw` fork `main`, per the fork cleanup plan.
