### PR TITLE
fix(ui): keep first control chat sends responsive

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1501,6 +1501,33 @@ describe("handleSendChat", () => {
     expect(host.chatMessage).toBe("do not send on rollback");
   });
 
+  it("does not restore a canceled model-wait send into a different session", async () => {
+    const switchUpdate = createDeferred<boolean>();
+    const request = vi.fn(async (method: string) => {
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "send from session a",
+      chatModelSwitchPromises: { "agent:main": switchUpdate.promise },
+      sessionKey: "agent:main",
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+    expect(host.chatMessage).toBe("");
+    expect(host.chatQueue[0]?.text).toBe("send from session a");
+
+    host.sessionKey = "agent:other";
+    host.chatMessage = "session b draft";
+    switchUpdate.resolve(true);
+    await send;
+
+    expect(request).not.toHaveBeenCalled();
+    expect(host.chatMessage).toBe("session b draft");
+    expect(host.chatQueue).toStrictEqual([]);
+  });
+
   it("keeps slash-command model changes in sync with the chat header cache", async () => {
     vi.stubGlobal(
       "fetch",

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1241,7 +1241,11 @@ describe("handleSendChat", () => {
     await Promise.resolve();
 
     expect(request).not.toHaveBeenCalled();
-    expect(host.chatMessage).toBe("use the newly selected model");
+    expect(host.chatMessage).toBe("");
+    expect(host.chatQueue[0]).toMatchObject({
+      sendState: "sending",
+      text: "use the newly selected model",
+    });
 
     switchUpdate.resolve(true);
     await send;
@@ -1333,11 +1337,11 @@ describe("handleSendChat", () => {
     expect(attachments[0]?.mimeType).toBe("application/pdf");
     expect(attachments[0]?.type).toBe("file");
     expect(host.chatMessage).toBe("keep typing with the attachment");
-    expect(host.chatAttachments).toEqual([attachment]);
-    expect(getChatAttachmentDataUrl(attachment)).toBe("data:application/pdf;base64,JVBERi0xLjQK");
+    expect(host.chatAttachments).toStrictEqual([]);
+    expect(getChatAttachmentDataUrl(attachment)).toBeNull();
   });
 
-  it("preserves draft text when only attachments change during a delayed send", async () => {
+  it("preserves edited attachments when attachments change during a delayed send", async () => {
     const switchUpdate = createDeferred<boolean>();
     const request = vi.fn(async (method: string) => {
       if (method === "chat.send") {
@@ -1393,7 +1397,7 @@ describe("handleSendChat", () => {
     expect(attachments[0]?.fileName).toBe("original.pdf");
     expect(attachments[0]?.mimeType).toBe("application/pdf");
     expect(attachments[0]?.type).toBe("file");
-    expect(host.chatMessage).toBe("send this");
+    expect(host.chatMessage).toBe("");
     expect(host.chatAttachments).toEqual([editedAttachment]);
     expect(getChatAttachmentDataUrl(originalAttachment)).toBeNull();
     expect(getChatAttachmentDataUrl(editedAttachment)).toBe("data:application/pdf;base64,ZWRpdGVk");
@@ -1445,7 +1449,7 @@ describe("handleSendChat", () => {
     expect(attachments[0]?.fileName).toBe("original.pdf");
     expect(attachments[0]?.mimeType).toBe("application/pdf");
     expect(attachments[0]?.type).toBe("file");
-    expect(host.chatMessage).toBe("send this");
+    expect(host.chatMessage).toBe("");
     expect(host.chatAttachments).toStrictEqual([]);
     expect(getChatAttachmentDataUrl(attachment)).toBeNull();
   });

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1589,6 +1589,34 @@ describe("handleSendChat", () => {
     expect(host.chatQueue).toStrictEqual([]);
   });
 
+  it("does not restore a failed model-wait send into a different session", async () => {
+    const switchUpdate = createDeferred<boolean>();
+    const request = vi.fn(async (method: string) => {
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "send from session a",
+      chatModelSwitchPromises: { "agent:main": switchUpdate.promise },
+      sessionKey: "agent:main",
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+    host.chatQueueBySession = { "agent:main": [...host.chatQueue] };
+    host.chatQueue = [];
+    host.sessionKey = "agent:other";
+    host.chatMessage = "";
+
+    switchUpdate.resolve(false);
+    await send;
+
+    expect(request).not.toHaveBeenCalled();
+    expect(host.chatMessage).toBe("");
+    expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatQueueBySession?.["agent:main"]).toBeUndefined();
+  });
+
   it("does not flush model-wait sends before the model picker update finishes", async () => {
     const switchUpdate = createDeferred<boolean>();
     const request = vi.fn(async (method: string) => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -107,6 +107,21 @@ function findRequestPayload(source: MockCallSource, method: string, label: strin
   return requireRecord(call[1], label);
 }
 
+function eventPayloads(host: ChatHost, event: string): Array<Record<string, unknown>> {
+  return (host.eventLogBuffer ?? [])
+    .filter((entry): entry is { event: string; payload: Record<string, unknown> } => {
+      if (!entry || typeof entry !== "object") {
+        return false;
+      }
+      const candidate = entry as { event?: unknown; payload?: unknown };
+      return (
+        candidate.event === event &&
+        Boolean(candidate.payload && typeof candidate.payload === "object")
+      );
+    })
+    .map((entry) => entry.payload);
+}
+
 function fetchInit(source: MockCallSource, callIndex: number) {
   return requireRecord(mockArg(source, callIndex, 1, `fetch init ${callIndex}`), "fetch init");
 }
@@ -1176,6 +1191,36 @@ describe("handleSendChat", () => {
     expect(payload.sessionKey).toBe("agent:main");
     expect(payload.message).toBe("/reset");
     expect(host.chatMessage).toBe("");
+  });
+
+  it("records visible send timing phases for a normal chat send", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return { status: "started" };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "measure first send",
+      eventLogBuffer: [],
+      tab: "debug",
+    });
+
+    await handleSendChat(host);
+
+    const sendEvents = eventPayloads(host, "control-ui.chat.send");
+    expect(sendEvents.map((payload) => payload.phase)).toEqual(
+      expect.arrayContaining(["pending-visible", "request-start", "ack"]),
+    );
+    const ack = sendEvents.find((payload) => payload.phase === "ack");
+    expect(ack).toMatchObject({
+      ackStatus: "started",
+      sessionKey: "agent:main",
+      sendState: "sending",
+    });
+    expect(ack?.durationMs).toEqual(expect.any(Number));
+    expect(ack?.requestDurationMs).toEqual(expect.any(Number));
   });
 
   it("waits for an in-flight model picker update before sending chat", async () => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1243,7 +1243,7 @@ describe("handleSendChat", () => {
     expect(request).not.toHaveBeenCalled();
     expect(host.chatMessage).toBe("");
     expect(host.chatQueue[0]).toMatchObject({
-      sendState: "sending",
+      sendState: "waiting-model",
       text: "use the newly selected model",
     });
 

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1562,7 +1562,7 @@ describe("handleSendChat", () => {
     expect(host.chatQueue).toStrictEqual([]);
   });
 
-  it("does not restore a canceled model-wait send into a different session", async () => {
+  it("keeps resolved model-wait sends queued under the submitted session after switching", async () => {
     const switchUpdate = createDeferred<boolean>();
     const request = vi.fn(async (method: string) => {
       throw new Error(`Unexpected request: ${method}`);
@@ -1579,6 +1579,8 @@ describe("handleSendChat", () => {
     expect(host.chatMessage).toBe("");
     expect(host.chatQueue[0]?.text).toBe("send from session a");
 
+    host.chatQueueBySession = { "agent:main": [...host.chatQueue] };
+    host.chatQueue = [];
     host.sessionKey = "agent:other";
     host.chatMessage = "session b draft";
     switchUpdate.resolve(true);
@@ -1587,9 +1589,13 @@ describe("handleSendChat", () => {
     expect(request).not.toHaveBeenCalled();
     expect(host.chatMessage).toBe("session b draft");
     expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatQueueBySession?.["agent:main"]?.[0]).toMatchObject({
+      sendState: undefined,
+      text: "send from session a",
+    });
   });
 
-  it("does not restore a failed model-wait send into a different session", async () => {
+  it("keeps failed model-wait sends retryable under the submitted session after switching", async () => {
     const switchUpdate = createDeferred<boolean>();
     const request = vi.fn(async (method: string) => {
       throw new Error(`Unexpected request: ${method}`);
@@ -1614,7 +1620,11 @@ describe("handleSendChat", () => {
     expect(request).not.toHaveBeenCalled();
     expect(host.chatMessage).toBe("");
     expect(host.chatQueue).toStrictEqual([]);
-    expect(host.chatQueueBySession?.["agent:main"]).toBeUndefined();
+    expect(host.chatQueueBySession?.["agent:main"]?.[0]).toMatchObject({
+      sendError: "Model selection was interrupted. Review and retry when ready.",
+      sendState: "failed",
+      text: "send from session a",
+    });
   });
 
   it("does not flush model-wait sends before the model picker update finishes", async () => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1537,6 +1537,31 @@ describe("handleSendChat", () => {
     expect(getChatAttachmentDataUrl(attachment)).toBeNull();
   });
 
+  it("does not restore a manually removed model-wait send after model update failure", async () => {
+    const switchUpdate = createDeferred<boolean>();
+    const request = vi.fn(async (method: string) => {
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "remove this pending send",
+      chatModelSwitchPromises: { "agent:main": switchUpdate.promise },
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+    const queuedId = host.chatQueue[0]?.id;
+    expect(queuedId).toEqual(expect.any(String));
+    removeQueuedMessage(host, queuedId);
+
+    switchUpdate.resolve(false);
+    await send;
+
+    expect(request).not.toHaveBeenCalled();
+    expect(host.chatMessage).toBe("");
+    expect(host.chatQueue).toStrictEqual([]);
+  });
+
   it("does not restore a canceled model-wait send into a different session", async () => {
     const switchUpdate = createDeferred<boolean>();
     const request = vi.fn(async (method: string) => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1528,6 +1528,42 @@ describe("handleSendChat", () => {
     expect(host.chatQueue).toStrictEqual([]);
   });
 
+  it("does not flush model-wait sends before the model picker update finishes", async () => {
+    const switchUpdate = createDeferred<boolean>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return { status: "started" };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "wait for selected model",
+      chatModelSwitchPromises: { "agent:main": switchUpdate.promise },
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+    expect(host.chatQueue[0]).toMatchObject({
+      sendState: "waiting-model",
+      text: "wait for selected model",
+    });
+
+    await retryReconnectableQueuedChatSends(host);
+    expect(request).not.toHaveBeenCalled();
+    expect(host.chatQueue[0]?.sendState).toBe("waiting-model");
+
+    switchUpdate.resolve(true);
+    await send;
+
+    const payload = findRequestPayload(
+      request as unknown as MockCallSource,
+      "chat.send",
+      "chat send payload",
+    );
+    expect(payload.message).toBe("wait for selected model");
+  });
+
   it("keeps slash-command model changes in sync with the chat header cache", async () => {
     vi.stubGlobal(
       "fetch",

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1501,6 +1501,42 @@ describe("handleSendChat", () => {
     expect(host.chatMessage).toBe("do not send on rollback");
   });
 
+  it("does not restore canceled attachments onto new draft text after model update failure", async () => {
+    const switchUpdate = createDeferred<boolean>();
+    const request = vi.fn(async (method: string) => {
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const file = new File(["private"], "private.txt", { type: "text/plain" });
+    const attachment = registerChatAttachmentPayload({
+      attachment: {
+        id: "private-att",
+        mimeType: "text/plain",
+        fileName: "private.txt",
+        sizeBytes: file.size,
+      },
+      dataUrl: "data:text/plain;base64,cHJpdmF0ZQ==",
+      file,
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatAttachments: [attachment],
+      chatMessage: "send this attachment",
+      chatModelSwitchPromises: { "agent:main": switchUpdate.promise },
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+    host.chatMessage = "new unrelated draft";
+
+    switchUpdate.resolve(false);
+    await send;
+
+    expect(request).not.toHaveBeenCalled();
+    expect(host.chatMessage).toBe("new unrelated draft");
+    expect(host.chatAttachments).toStrictEqual([]);
+    expect(getChatAttachmentDataUrl(attachment)).toBeNull();
+  });
+
   it("does not restore a canceled model-wait send into a different session", async () => {
     const switchUpdate = createDeferred<boolean>();
     const request = vi.fn(async (method: string) => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -703,10 +703,17 @@ async function sendQueuedChatMessage(
         );
         void loadChatHistory(host as unknown as ChatState);
       } else {
+        const hasAlreadyAdoptedRunStream =
+          host.chatRunId === ack.runId && typeof host.chatStream === "string";
         host.chatRunId = ack.runId;
-        host.chatStream = "";
-        (host as ChatHost & { chatStreamStartedAt?: number | null }).chatStreamStartedAt =
-          startedAt;
+        // Gateway can deliver the first delta before the chat.send ACK resolves.
+        // Preserve that adopted stream; resetting here makes first replies vanish
+        // until a later delta or final event arrives.
+        if (!hasAlreadyAdoptedRunStream) {
+          host.chatStream = "";
+          (host as ChatHost & { chatStreamStartedAt?: number | null }).chatStreamStartedAt =
+            startedAt;
+        }
       }
     }
     if (prepared.refreshSessions) {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -525,9 +525,8 @@ function cancelPendingSendBeforeRequest(
     queued.sessionKey,
   );
   const restoreComposer = opts.restoreComposer !== false;
-  const willRestoreDraft = Boolean(
-    restoreComposer && opts.previousDraft != null && !host.chatMessage.trim(),
-  );
+  const willRestoreDraft =
+    restoreComposer && opts.previousDraft != null && !host.chatMessage.trim();
   const willRestoreAttachments = Boolean(
     restoreComposer &&
       opts.previousAttachments?.length &&

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -475,6 +475,17 @@ function removeQueuedMessageWithoutReleasing(
   return item;
 }
 
+function removeVisibleOrScopedQueuedMessageWithoutReleasing(
+  host: ChatHost,
+  id: string,
+  sessionKey: string | undefined,
+): ChatQueueItem | null {
+  return (
+    removeQueuedMessageWithoutReleasing(host, id) ??
+    (sessionKey ? removeQueuedMessageWithoutReleasing(host, id, sessionKey) : null)
+  );
+}
+
 function isRecoverableChatSendError(err: unknown, formattedError: string): boolean {
   if (err instanceof GatewayRequestError) {
     return err.retryable;
@@ -494,6 +505,28 @@ function restoreComposerAfterFailedSend(
   }
   if (opts.previousAttachments?.length && host.chatAttachments.length === 0) {
     host.chatAttachments = opts.previousAttachments;
+  }
+}
+
+function cancelPendingSendBeforeRequest(
+  host: ChatHost,
+  queued: ChatQueueItem,
+  opts: {
+    previousAttachments?: ChatAttachment[];
+    previousDraft?: string;
+  },
+) {
+  const removed = removeVisibleOrScopedQueuedMessageWithoutReleasing(
+    host,
+    queued.id,
+    queued.sessionKey,
+  );
+  const willRestoreAttachments = Boolean(
+    opts.previousAttachments?.length && host.chatAttachments.length === 0,
+  );
+  restoreComposerAfterFailedSend(host, opts);
+  if (removed && !willRestoreAttachments) {
+    releaseChatAttachmentPayloads(excludeComposerAttachments(host, removed.attachments));
   }
 }
 
@@ -1312,10 +1345,6 @@ export async function handleSendChat(
   const refreshSessions = isChatResetCommand(message);
   const submitKey = chatSubmitKey(host, "message", message, attachmentsToSend);
   await withChatSubmitGuard(host, submitKey, async () => {
-    const modelSwitchReady = waitForPendingChatModelSwitch(host, submittedSessionKey);
-    if (modelSwitchReady !== true && !(await modelSwitchReady)) {
-      return;
-    }
     if (host.sessionKey !== submittedSessionKey) {
       return;
     }
@@ -1323,26 +1352,49 @@ export async function handleSendChat(
       messageOverride == null
         ? clearSubmittedComposerState(host, previousDraft, attachmentsToSend)
         : {};
+    if (messageOverride == null) {
+      recordNonTranscriptInputHistory(host, message);
+    }
+
+    const queued = enqueuePendingSendMessage(
+      host,
+      message,
+      hasAttachments ? attachmentsToSend : undefined,
+      refreshSessions,
+      submittedAtMs,
+    );
+    if (!queued) {
+      return;
+    }
+
+    const modelSwitchReady = waitForPendingChatModelSwitch(host, submittedSessionKey);
+    if (modelSwitchReady !== true && !(await modelSwitchReady)) {
+      cancelPendingSendBeforeRequest(host, queued, {
+        previousDraft: cleared.previousDraft,
+        previousAttachments: cleared.previousAttachments,
+      });
+      return;
+    }
+    if (host.sessionKey !== submittedSessionKey) {
+      cancelPendingSendBeforeRequest(host, queued, {
+        previousDraft: cleared.previousDraft,
+        previousAttachments: cleared.previousAttachments,
+      });
+      return;
+    }
 
     if (isChatBusy(host)) {
-      if (messageOverride == null) {
-        recordNonTranscriptInputHistory(host, message);
-      }
-      enqueueChatMessage(host, message, attachmentsToSend, refreshSessions);
-      recordControlUiPerformanceEvent(
-        host as Parameters<typeof recordControlUiPerformanceEvent>[0],
-        "control-ui.chat.send",
-        {
-          phase: "queued-busy",
-          durationMs: roundedControlUiDurationMs(controlUiNowMs() - submittedAtMs),
-          sessionKey: host.sessionKey,
-        },
-        { console: false, maxBufferedEventsForType: 40 },
-      );
+      updateQueuedMessage(host, queued.id, (item) => ({
+        ...item,
+        sendError: undefined,
+        sendState: undefined,
+      }));
+      recordChatSendTiming(host, queued, "queued-busy", submittedAtMs);
       return;
     }
 
     await sendChatMessageNow(host, message, {
+      queueItemId: queued.id,
       previousDraft: cleared.previousDraft,
       restoreDraft: Boolean(messageOverride && opts?.restoreDraft),
       attachments: hasAttachments ? attachmentsToSend : undefined,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -389,6 +389,8 @@ function enqueuePendingSendMessage(
   attachments?: ChatAttachment[],
   refreshSessions?: boolean,
   submittedAtMs = controlUiNowMs(),
+  sendState: ChatQueueItem["sendState"] =
+    host.connected && host.client ? "sending" : "waiting-reconnect",
 ): ChatQueueItem | null {
   const trimmed = text.trim();
   const hasAttachments = Boolean(attachments && attachments.length > 0);
@@ -403,7 +405,7 @@ function enqueuePendingSendMessage(
     refreshSessions,
     sendAttempts: 0,
     sendRunId: generateUUID(),
-    sendState: host.connected && host.client ? "sending" : "waiting-reconnect",
+    sendState,
     sendSubmittedAtMs: submittedAtMs,
     sessionKey: host.sessionKey,
     agentId: scopedAgentIdForSession(host, host.sessionKey),
@@ -541,6 +543,7 @@ type ChatSendTimingPhase =
   | "request-start"
   | "ack"
   | "queued-busy"
+  | "waiting-model"
   | "waiting-reconnect"
   | "failed";
 
@@ -1360,18 +1363,20 @@ export async function handleSendChat(
       recordNonTranscriptInputHistory(host, message);
     }
 
+    const modelSwitchReady = waitForPendingChatModelSwitch(host, submittedSessionKey);
+    const waitingForModel = modelSwitchReady !== true;
     const queued = enqueuePendingSendMessage(
       host,
       message,
       hasAttachments ? attachmentsToSend : undefined,
       refreshSessions,
       submittedAtMs,
+      waitingForModel ? "waiting-model" : undefined,
     );
     if (!queued) {
       return;
     }
 
-    const modelSwitchReady = waitForPendingChatModelSwitch(host, submittedSessionKey);
     if (modelSwitchReady !== true && !(await modelSwitchReady)) {
       cancelPendingSendBeforeRequest(host, queued, {
         previousDraft: cleared.previousDraft,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -7,7 +7,11 @@ import {
   getChatAttachmentDataUrl,
   releaseChatAttachmentPayloads,
 } from "./chat/attachment-payload-store.ts";
-import { removeStoredChatComposerQueueItem } from "./chat/composer-persistence.ts";
+import {
+  INTERRUPTED_MODEL_WAIT_ERROR,
+  persistStoredChatComposerQueue,
+  removeStoredChatComposerQueueItem,
+} from "./chat/composer-persistence.ts";
 import {
   handleChatDraftChange,
   handleChatInputHistoryKey,
@@ -461,6 +465,10 @@ function updateQueuedMessageForSession(
   });
   writeChatQueueForSession(host, sessionKey, nextQueue);
   return nextItem;
+}
+
+function persistQueuedMessagesForSession(host: ChatHost, sessionKey: string) {
+  persistStoredChatComposerQueue(host, sessionKey, readChatQueueForSession(host, sessionKey));
 }
 
 function removeQueuedMessageWithoutReleasing(
@@ -1406,19 +1414,28 @@ export async function handleSendChat(
     }
 
     if (modelSwitchReady !== true && !(await modelSwitchReady)) {
-      cancelPendingSendBeforeRequest(host, queued, {
-        previousDraft: cleared.previousDraft,
-        previousAttachments: cleared.previousAttachments,
-        restoreComposer: host.sessionKey === submittedSessionKey,
-      });
+      if (host.sessionKey === submittedSessionKey) {
+        cancelPendingSendBeforeRequest(host, queued, {
+          previousDraft: cleared.previousDraft,
+          previousAttachments: cleared.previousAttachments,
+        });
+      } else {
+        updateQueuedMessageForSession(host, submittedSessionKey, queued.id, (item) => ({
+          ...item,
+          sendError: INTERRUPTED_MODEL_WAIT_ERROR,
+          sendState: "failed",
+        }));
+        persistQueuedMessagesForSession(host, submittedSessionKey);
+      }
       return;
     }
     if (host.sessionKey !== submittedSessionKey) {
-      cancelPendingSendBeforeRequest(host, queued, {
-        previousDraft: cleared.previousDraft,
-        previousAttachments: cleared.previousAttachments,
-        restoreComposer: false,
-      });
+      updateQueuedMessageForSession(host, submittedSessionKey, queued.id, (item) => ({
+        ...item,
+        sendError: undefined,
+        sendState: undefined,
+      }));
+      persistQueuedMessagesForSession(host, submittedSessionKey);
       return;
     }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -22,6 +22,11 @@ import type { ChatSideResult } from "./chat/side-result.ts";
 import { executeSlashCommand } from "./chat/slash-command-executor.ts";
 import { parseSlashCommand, refreshSlashCommands } from "./chat/slash-commands.ts";
 import { formatConnectError } from "./connect-error.ts";
+import {
+  controlUiNowMs,
+  recordControlUiPerformanceEvent,
+  roundedControlUiDurationMs,
+} from "./control-ui-performance.ts";
 import { resolveControlUiAuthHeader } from "./control-ui-auth.ts";
 import {
   abortChatRun,
@@ -96,6 +101,9 @@ export type ChatHost = ChatInputHistoryState & {
   chatSubmitGuards?: Map<string, Promise<void>>;
   assistantAgentId?: string | null;
   agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
+  eventLogBuffer?: unknown[];
+  eventLog?: unknown[];
+  tab?: string;
   /** Callback for slash-command side effects that need app-level access. */
   onSlashAction?: (action: string) => void | Promise<void>;
 };
@@ -380,6 +388,7 @@ function enqueuePendingSendMessage(
   text: string,
   attachments?: ChatAttachment[],
   refreshSessions?: boolean,
+  submittedAtMs = controlUiNowMs(),
 ): ChatQueueItem | null {
   const trimmed = text.trim();
   const hasAttachments = Boolean(attachments && attachments.length > 0);
@@ -395,10 +404,12 @@ function enqueuePendingSendMessage(
     sendAttempts: 0,
     sendRunId: generateUUID(),
     sendState: host.connected && host.client ? "sending" : "waiting-reconnect",
+    sendSubmittedAtMs: submittedAtMs,
     sessionKey: host.sessionKey,
     agentId: scopedAgentIdForSession(host, host.sessionKey),
   };
   host.chatQueue = [...host.chatQueue, pending];
+  recordChatSendTiming(host, pending, "pending-visible", submittedAtMs);
   return pending;
 }
 
@@ -488,6 +499,44 @@ function restoreComposerAfterFailedSend(
 
 type QueuedChatSendResult = "sent" | "pending" | "failed";
 
+type ChatSendTimingPhase =
+  | "pending-visible"
+  | "request-start"
+  | "ack"
+  | "queued-busy"
+  | "waiting-reconnect"
+  | "failed";
+
+function recordChatSendTiming(
+  host: ChatHost,
+  item: Pick<
+    ChatQueueItem,
+    "sendRunId" | "sessionKey" | "agentId" | "sendAttempts" | "sendState" | "sendSubmittedAtMs"
+  >,
+  phase: ChatSendTimingPhase,
+  startedAtMs = item.sendSubmittedAtMs,
+  extra: Record<string, unknown> = {},
+) {
+  if (startedAtMs == null) {
+    return;
+  }
+  recordControlUiPerformanceEvent(
+    host as Parameters<typeof recordControlUiPerformanceEvent>[0],
+    "control-ui.chat.send",
+    {
+      phase,
+      durationMs: roundedControlUiDurationMs(controlUiNowMs() - startedAtMs),
+      runId: item.sendRunId,
+      sessionKey: item.sessionKey,
+      agentId: item.agentId,
+      sendAttempts: item.sendAttempts ?? 0,
+      sendState: item.sendState,
+      ...extra,
+    },
+    { console: false, maxBufferedEventsForType: 40 },
+  );
+}
+
 function ensureQueuedSendState(
   host: ChatHost,
   item: ChatQueueItem,
@@ -543,15 +592,18 @@ async function sendQueuedChatMessage(
 
   const runId = prepared.sendRunId ?? generateUUID();
   const startedAt = Date.now();
+  const requestStartedAtMs = controlUiNowMs();
   updateQueuedMessageForSession(host, sessionKey, id, (item) => ({
     ...item,
     sendAttempts: (item.sendAttempts ?? 0) + 1,
     sendError: undefined,
     sendRunId: runId,
     sendState: "sending",
+    sendRequestStartedAtMs: requestStartedAtMs,
     sessionKey,
     agentId: prepared.agentId,
   }));
+  recordChatSendTiming(host, prepared, "request-start", prepared.sendSubmittedAtMs);
   host.chatSending = true;
   const isVisibleSession = () => visibleSessionMatches(host, sessionKey, prepared.agentId);
   if (isVisibleSession()) {
@@ -568,6 +620,10 @@ async function sendQueuedChatMessage(
       runId,
       sessionKey,
       agentId: prepared.agentId,
+    });
+    recordChatSendTiming(host, prepared, "ack", prepared.sendSubmittedAtMs, {
+      ackStatus: ack.status,
+      requestDurationMs: roundedControlUiDurationMs(controlUiNowMs() - requestStartedAtMs),
     });
     removeQueuedMessageWithoutReleasing(host, id, sessionKey);
     if (isVisibleSession()) {
@@ -626,6 +682,9 @@ async function sendQueuedChatMessage(
       if (isVisibleSession()) {
         setChatError(host, "Message will send when the Gateway reconnects.");
       }
+      recordChatSendTiming(host, prepared, "waiting-reconnect", prepared.sendSubmittedAtMs, {
+        error,
+      });
       return "pending";
     }
     updateQueuedMessageForSession(host, sessionKey, id, (item) => ({
@@ -637,6 +696,7 @@ async function sendQueuedChatMessage(
       setChatError(host, error);
       restoreComposerAfterFailedSend(host, opts ?? {});
     }
+    recordChatSendTiming(host, prepared, "failed", prepared.sendSubmittedAtMs, { error });
     return "failed";
   } finally {
     host.chatSending = false;
@@ -654,6 +714,7 @@ async function sendChatMessageNow(
     previousAttachments?: ChatAttachment[];
     restoreAttachments?: boolean;
     refreshSessions?: boolean;
+    submittedAtMs?: number;
   },
 ) {
   resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
@@ -662,7 +723,13 @@ async function sendChatMessageNow(
   const queued =
     opts?.queueItemId != null
       ? (host.chatQueue.find((item) => item.id === opts.queueItemId) ?? null)
-      : enqueuePendingSendMessage(host, message, opts?.attachments, opts?.refreshSessions);
+      : enqueuePendingSendMessage(
+          host,
+          message,
+          opts?.attachments,
+          opts?.refreshSessions,
+          opts?.submittedAtMs,
+        );
   if (!queued) {
     return false;
   }
@@ -1164,6 +1231,7 @@ export async function handleSendChat(
 ) {
   const previousDraft = host.chatMessage;
   const message = (messageOverride ?? host.chatMessage).trim();
+  const submittedAtMs = controlUiNowMs();
   const submittedSessionKey = host.sessionKey;
   const attachments = host.chatAttachments ?? [];
   const attachmentsToSend = messageOverride == null ? snapshotChatAttachments(attachments) : [];
@@ -1261,6 +1329,16 @@ export async function handleSendChat(
         recordNonTranscriptInputHistory(host, message);
       }
       enqueueChatMessage(host, message, attachmentsToSend, refreshSessions);
+      recordControlUiPerformanceEvent(
+        host as Parameters<typeof recordControlUiPerformanceEvent>[0],
+        "control-ui.chat.send",
+        {
+          phase: "queued-busy",
+          durationMs: roundedControlUiDurationMs(controlUiNowMs() - submittedAtMs),
+          sessionKey: host.sessionKey,
+        },
+        { console: false, maxBufferedEventsForType: 40 },
+      );
       return;
     }
 
@@ -1271,6 +1349,7 @@ export async function handleSendChat(
       previousAttachments: cleared.previousAttachments,
       restoreAttachments: Boolean(messageOverride && opts?.restoreDraft),
       refreshSessions,
+      submittedAtMs,
     });
   });
 }

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1003,6 +1003,7 @@ async function flushChatQueue(host: ChatHost) {
     (item) =>
       !item.pendingRunId &&
       item.sendState !== "sending" &&
+      item.sendState !== "waiting-model" &&
       item.sendState !== "failed" &&
       (item.sessionKey == null || item.sessionKey === host.sessionKey),
   );
@@ -1250,7 +1251,13 @@ export async function retryReconnectableQueuedChatSends(host: ChatHost) {
 
 export async function retryQueuedChatMessage(host: ChatHost, id: string) {
   const item = host.chatQueue.find((entry) => entry.id === id);
-  if (!item || item.localCommandName || item.pendingRunId || item.sendState === "sending") {
+  if (
+    !item ||
+    item.localCommandName ||
+    item.pendingRunId ||
+    item.sendState === "sending" ||
+    item.sendState === "waiting-model"
+  ) {
     return;
   }
   updateQueuedMessage(host, id, (entry) => ({

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -7,6 +7,7 @@ import {
   getChatAttachmentDataUrl,
   releaseChatAttachmentPayloads,
 } from "./chat/attachment-payload-store.ts";
+import { removeStoredChatComposerQueueItem } from "./chat/composer-persistence.ts";
 import {
   handleChatDraftChange,
   handleChatInputHistoryKey,
@@ -78,7 +79,7 @@ export type ChatHost = ChatInputHistoryState & {
   lastError?: string | null;
   chatError?: string | null;
   basePath: string;
-  settings?: { token?: string | null };
+  settings?: { gatewayUrl?: string | null; token?: string | null };
   password?: string | null;
   hello: GatewayHelloOk | null;
   chatAvatarUrl: string | null;
@@ -540,6 +541,9 @@ function cancelPendingSendBeforeRequest(
     if (willRestoreAttachments) {
       host.chatAttachments = opts.previousAttachments ?? [];
     }
+  }
+  if (removed?.sessionKey) {
+    removeStoredChatComposerQueueItem(host, removed.sessionKey, removed.id);
   }
   if (removed && !willRestoreAttachments) {
     releaseChatAttachmentPayloads(excludeComposerAttachments(host, removed.attachments));

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -525,11 +525,22 @@ function cancelPendingSendBeforeRequest(
     queued.sessionKey,
   );
   const restoreComposer = opts.restoreComposer !== false;
+  const willRestoreDraft = Boolean(
+    restoreComposer && opts.previousDraft != null && !host.chatMessage.trim(),
+  );
   const willRestoreAttachments = Boolean(
-    restoreComposer && opts.previousAttachments?.length && host.chatAttachments.length === 0,
+    restoreComposer &&
+      opts.previousAttachments?.length &&
+      host.chatAttachments.length === 0 &&
+      (willRestoreDraft || !host.chatMessage.trim()),
   );
   if (restoreComposer) {
-    restoreComposerAfterFailedSend(host, opts);
+    if (willRestoreDraft) {
+      host.chatMessage = opts.previousDraft ?? "";
+    }
+    if (willRestoreAttachments) {
+      host.chatAttachments = opts.previousAttachments ?? [];
+    }
   }
   if (removed && !willRestoreAttachments) {
     releaseChatAttachmentPayloads(excludeComposerAttachments(host, removed.attachments));

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -524,7 +524,7 @@ function cancelPendingSendBeforeRequest(
     queued.id,
     queued.sessionKey,
   );
-  const restoreComposer = opts.restoreComposer !== false;
+  const restoreComposer = opts.restoreComposer !== false && removed != null;
   const willRestoreDraft =
     restoreComposer && opts.previousDraft != null && !host.chatMessage.trim();
   const willRestoreAttachments = Boolean(

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -514,6 +514,7 @@ function cancelPendingSendBeforeRequest(
   opts: {
     previousAttachments?: ChatAttachment[];
     previousDraft?: string;
+    restoreComposer?: boolean;
   },
 ) {
   const removed = removeVisibleOrScopedQueuedMessageWithoutReleasing(
@@ -521,10 +522,13 @@ function cancelPendingSendBeforeRequest(
     queued.id,
     queued.sessionKey,
   );
+  const restoreComposer = opts.restoreComposer !== false;
   const willRestoreAttachments = Boolean(
-    opts.previousAttachments?.length && host.chatAttachments.length === 0,
+    restoreComposer && opts.previousAttachments?.length && host.chatAttachments.length === 0,
   );
-  restoreComposerAfterFailedSend(host, opts);
+  if (restoreComposer) {
+    restoreComposerAfterFailedSend(host, opts);
+  }
   if (removed && !willRestoreAttachments) {
     releaseChatAttachmentPayloads(excludeComposerAttachments(host, removed.attachments));
   }
@@ -1379,6 +1383,7 @@ export async function handleSendChat(
       cancelPendingSendBeforeRequest(host, queued, {
         previousDraft: cleared.previousDraft,
         previousAttachments: cleared.previousAttachments,
+        restoreComposer: false,
       });
       return;
     }

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1398,6 +1398,7 @@ export async function handleSendChat(
       cancelPendingSendBeforeRequest(host, queued, {
         previousDraft: cleared.previousDraft,
         previousAttachments: cleared.previousAttachments,
+        restoreComposer: host.sessionKey === submittedSessionKey,
       });
       return;
     }

--- a/ui/src/ui/chat/chat-queue.ts
+++ b/ui/src/ui/chat/chat-queue.ts
@@ -13,6 +13,8 @@ export type ChatQueueProps = {
 
 function sendStateLabel(item: ChatQueueItem): string | null {
   switch (item.sendState) {
+    case "waiting-model":
+      return "Waiting for model";
     case "sending":
       return "Sending";
     case "waiting-reconnect":

--- a/ui/src/ui/chat/composer-persistence.test.ts
+++ b/ui/src/ui/chat/composer-persistence.test.ts
@@ -190,6 +190,34 @@ describe("chat composer persistence", () => {
     ).toBeNull();
   });
 
+  it("restores pre-request model-wait sends as queued messages", () => {
+    persistChatComposerState(
+      createState({
+        chatQueue: [
+          {
+            id: "waiting-model-1",
+            text: "not sent yet",
+            createdAt: 1,
+            sendRunId: "run-waiting-model",
+            sendState: "waiting-model",
+          },
+        ],
+      }),
+    );
+
+    const restored = createState();
+    expect(restoreChatComposerState(restored)).toBe(true);
+
+    expect(restored.chatQueue).toEqual([
+      {
+        id: "waiting-model-1",
+        text: "not sent yet",
+        createdAt: 1,
+        sendRunId: "run-waiting-model",
+      },
+    ]);
+  });
+
   it("does not restore steered messages tied to a previous active run", () => {
     persistChatComposerState(
       createState({

--- a/ui/src/ui/chat/composer-persistence.test.ts
+++ b/ui/src/ui/chat/composer-persistence.test.ts
@@ -5,6 +5,7 @@ import type { ChatQueueItem } from "../ui-types.ts";
 import {
   loadChatComposerSnapshot,
   persistChatComposerState,
+  removeStoredChatComposerQueueItem,
   restoreChatComposerState,
 } from "./composer-persistence.ts";
 
@@ -216,6 +217,30 @@ describe("chat composer persistence", () => {
         sendRunId: "run-waiting-model",
       },
     ]);
+  });
+
+  it("removes one stored queued item without dropping the stored draft", () => {
+    persistChatComposerState(
+      createState({
+        chatMessage: "keep this draft",
+        chatQueue: [
+          { id: "remove-me", text: "stale queued send", createdAt: 1 },
+          { id: "keep-me", text: "still queued", createdAt: 2 },
+        ],
+      }),
+    );
+
+    removeStoredChatComposerQueueItem(createState(), "agent:lily:main", "remove-me");
+
+    expect(
+      loadChatComposerSnapshot(
+        { settings: { gatewayUrl: "ws://gateway.test/control" } },
+        "agent:lily:main",
+      ),
+    ).toEqual({
+      draft: "keep this draft",
+      queue: [{ id: "keep-me", text: "still queued", createdAt: 2 }],
+    });
   });
 
   it("does not restore steered messages tied to a previous active run", () => {

--- a/ui/src/ui/chat/composer-persistence.test.ts
+++ b/ui/src/ui/chat/composer-persistence.test.ts
@@ -191,7 +191,7 @@ describe("chat composer persistence", () => {
     ).toBeNull();
   });
 
-  it("restores pre-request model-wait sends as queued messages", () => {
+  it("restores pre-request model-wait sends for manual retry only", () => {
     persistChatComposerState(
       createState({
         chatQueue: [
@@ -215,6 +215,8 @@ describe("chat composer persistence", () => {
         text: "not sent yet",
         createdAt: 1,
         sendRunId: "run-waiting-model",
+        sendState: "failed",
+        sendError: "Model selection was interrupted. Review and retry when ready.",
       },
     ]);
   });

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -182,7 +182,9 @@ function serializeQueueItem(item: ChatQueueItem): ChatQueueItem | null {
     return null;
   }
   const sendState =
-    item.sendState === "failed" || item.sendState === "waiting-reconnect"
+    item.sendState === "failed" ||
+    item.sendState === "waiting-reconnect" ||
+    item.sendState === "waiting-model"
       ? item.sendState
       : undefined;
   return {
@@ -240,6 +242,8 @@ function normalizeQueueItem(value: unknown): ChatQueueItem | null {
   }
   if (entry.sendState === "failed" || entry.sendState === "waiting-reconnect") {
     item.sendState = entry.sendState;
+  } else if (entry.sendState === "waiting-model") {
+    item.sendState = undefined;
   }
   const sendError = normalizeOptionalString(entry.sendError);
   if (sendError) {

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -6,6 +6,8 @@ import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
 const STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v1:";
 const MAX_STORED_SESSIONS = 20;
 const MAX_STORED_QUEUE_ITEMS = 50;
+const INTERRUPTED_MODEL_WAIT_ERROR =
+  "Model selection was interrupted. Review and retry when ready.";
 
 type ChatComposerPersistenceState = {
   settings?: { gatewayUrl?: string | null };
@@ -243,7 +245,8 @@ function normalizeQueueItem(value: unknown): ChatQueueItem | null {
   if (entry.sendState === "failed" || entry.sendState === "waiting-reconnect") {
     item.sendState = entry.sendState;
   } else if (entry.sendState === "waiting-model") {
-    item.sendState = undefined;
+    item.sendState = "failed";
+    item.sendError = INTERRUPTED_MODEL_WAIT_ERROR;
   }
   const sendError = normalizeOptionalString(entry.sendError);
   if (sendError) {

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -359,6 +359,42 @@ export function persistChatComposerState(
   }
 }
 
+export function removeStoredChatComposerQueueItem(
+  state: Pick<
+    ChatComposerPersistenceState,
+    "settings" | "assistantAgentId" | "agentsList" | "hello"
+  >,
+  sessionKey: string,
+  id: string,
+): void {
+  const storage = getSafeSessionStorage();
+  if (!storage || !sessionKey.trim() || !id.trim()) {
+    return;
+  }
+  try {
+    const key = storageKeyForGateway(state.settings?.gatewayUrl);
+    const store = readStore(storage, key);
+    const storeSessionKey = storageSessionKeyForState(state, sessionKey);
+    const session = normalizeStoredSession(store.sessions[storeSessionKey]);
+    if (!session?.queue?.length) {
+      return;
+    }
+    const queue = session.queue.filter((item) => item.id !== id);
+    if (!session.draft && queue.length === 0) {
+      delete store.sessions[storeSessionKey];
+    } else {
+      store.sessions[storeSessionKey] = {
+        ...(session.draft ? { draft: session.draft } : {}),
+        ...(queue.length ? { queue } : {}),
+        updatedAt: Date.now(),
+      };
+    }
+    writeStore(storage, key, store);
+  } catch {
+    // Best-effort only: queue persistence must not make cancellation fail.
+  }
+}
+
 export function restoreChatComposerState(
   state: ChatComposerPersistenceState,
   options: RestoreOptions = {},

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -6,7 +6,7 @@ import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
 const STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v1:";
 const MAX_STORED_SESSIONS = 20;
 const MAX_STORED_QUEUE_ITEMS = 50;
-const INTERRUPTED_MODEL_WAIT_ERROR =
+export const INTERRUPTED_MODEL_WAIT_ERROR =
   "Model selection was interrupted. Review and retry when ready.";
 
 type ChatComposerPersistenceState = {
@@ -395,6 +395,42 @@ export function removeStoredChatComposerQueueItem(
     writeStore(storage, key, store);
   } catch {
     // Best-effort only: queue persistence must not make cancellation fail.
+  }
+}
+
+export function persistStoredChatComposerQueue(
+  state: Pick<
+    ChatComposerPersistenceState,
+    "settings" | "assistantAgentId" | "agentsList" | "hello"
+  >,
+  sessionKey: string,
+  queue: ChatQueueItem[],
+): void {
+  const storage = getSafeSessionStorage();
+  if (!storage || !sessionKey.trim()) {
+    return;
+  }
+  try {
+    const key = storageKeyForGateway(state.settings?.gatewayUrl);
+    const store = readStore(storage, key);
+    const storeSessionKey = storageSessionKeyForState(state, sessionKey);
+    const session = normalizeStoredSession(store.sessions[storeSessionKey]);
+    const serializedQueue = queue
+      .slice(0, MAX_STORED_QUEUE_ITEMS)
+      .map(serializeQueueItem)
+      .filter((item): item is ChatQueueItem => item !== null);
+    if (!session?.draft && serializedQueue.length === 0) {
+      delete store.sessions[storeSessionKey];
+    } else {
+      store.sessions[storeSessionKey] = {
+        ...(session?.draft ? { draft: session.draft } : {}),
+        ...(serializedQueue.length ? { queue: serializedQueue } : {}),
+        updatedAt: Date.now(),
+      };
+    }
+    writeStore(storage, key, store);
+  } catch {
+    // Best-effort only: queue persistence must not make send recovery fail.
   }
 }
 

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -446,6 +446,51 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("shows a pending send while a model override save is still pending", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["sessions.patch"],
+      methodResponses: {
+        "sessions.list": chatSessionListResponse(),
+      },
+      models: [
+        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+        { id: "claude-opus-4.5", name: "Claude Opus 4.5", provider: "bedrock" },
+      ],
+      sessionKey: "agent:main:session-a",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const main = page.getByRole("main");
+      await main.locator('[data-chat-model-select="true"]').click();
+      await main.locator('[data-chat-model-option="bedrock/claude-opus-4.5"]').click();
+      await gateway.waitForRequest("sessions.patch");
+
+      const prompt = "send while the model save is pending";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      await page.locator(".chat-queue").getByText("Sending").waitFor({ timeout: 10_000 });
+      await page.locator(".chat-queue").getByText(prompt).waitFor({ timeout: 10_000 });
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+
+      await gateway.resolveDeferred("sessions.patch", {});
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      const params = requireRecord(sendRequest.params);
+      expect(params.message).toBe(prompt);
+      expect(params.sessionKey).toBe("agent:main:session-a");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("refreshes history after a tool-call window disconnects and reconnects", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -477,7 +477,9 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
       await page.getByRole("button", { name: "Send message" }).click();
 
-      await page.locator(".chat-queue").getByText("Sending").waitFor({ timeout: 10_000 });
+      await page.locator(".chat-queue").getByText("Waiting for model").waitFor({
+        timeout: 10_000,
+      });
       await page.locator(".chat-queue").getByText(prompt).waitFor({ timeout: 10_000 });
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
 

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -145,6 +145,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}chat`);
 
       const prompt = "stream markdown through the GUI";
+      await gateway.deferNext("chat.send");
       await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
       await page.getByRole("button", { name: "Send message" }).click();
 
@@ -171,6 +172,17 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         timeout: 10_000,
       });
       expect(await page.locator(".markdown-plain-text-fallback strong").count()).toBe(0);
+
+      await gateway.resolveDeferred("chat.send", { runId, status: "started" });
+      await page.waitForFunction(() => {
+        const app = document.querySelector("openclaw-app") as
+          | (Element & { chatSending?: unknown })
+          | null;
+        return app?.chatSending === false;
+      });
+      await page.locator(".chat-thread h2").getByText("Streaming heading").waitFor({
+        timeout: 10_000,
+      });
 
       await gateway.emitChatFinal({
         runId,

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -20,7 +20,7 @@ export type ChatQueueItem = {
   sendAttempts?: number;
   sendError?: string;
   sendRunId?: string;
-  sendState?: "sending" | "waiting-reconnect" | "failed";
+  sendState?: "waiting-model" | "sending" | "waiting-reconnect" | "failed";
   sendSubmittedAtMs?: number;
   sendRequestStartedAtMs?: number;
   sessionKey?: string;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -21,6 +21,8 @@ export type ChatQueueItem = {
   sendError?: string;
   sendRunId?: string;
   sendState?: "sending" | "waiting-reconnect" | "failed";
+  sendSubmittedAtMs?: number;
+  sendRequestStartedAtMs?: number;
   sessionKey?: string;
   agentId?: string;
 };


### PR DESCRIPTION
Summary
- Make Control UI chat sends visibly queue immediately while a pending model override save is in flight.
- Preserve queued model-wait sends across session switches, including failed model-save retry state and sessionStorage queue updates.
- Preserve early streaming deltas that arrive before the chat.send ACK, preventing first replies from disappearing until a later event.

Verification
- node scripts/run-vitest.mjs run ui/src/ui/app-chat.test.ts ui/src/ui/chat/composer-persistence.test.ts ui/src/ui/e2e/chat-flow.e2e.test.ts --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner
- node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/ui/app-chat.test.ts ui/src/ui/app-chat.ts ui/src/ui/chat/chat-queue.ts ui/src/ui/chat/composer-persistence.test.ts ui/src/ui/chat/composer-persistence.ts ui/src/ui/e2e/chat-flow.e2e.test.ts ui/src/ui/ui-types.ts
- node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Notes
- Exact pnpm check:changed/Testbox proof was not obtained here: linked-worktree pnpm reconciliation blocks local pnpm, earlier Testbox delegated sync attempts failed before checks, and direct Crabbox hit active lease capacity.
