### PR TITLE
fix(google): forward stop sequences to Gemini generationConfig

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1628,6 +1628,35 @@ describe("google transport stream", () => {
     expect(generationConfig).not.toHaveProperty("thinkingConfig");
   });
 
+  it("forwards configured stop sequences to the Gemini generationConfig", () => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      } as never,
+      {
+        stop: ["</tool>", "\n\nObservation:"],
+      } as never,
+    );
+
+    const generationConfig = requireGenerationConfig(params);
+    expect(generationConfig.stopSequences).toEqual(["</tool>", "\n\nObservation:"]);
+  });
+
+  it("omits stopSequences when the stop list is empty", () => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      } as never,
+      {
+        stop: [],
+      } as never,
+    );
+
+    expect(params.generationConfig ?? {}).not.toHaveProperty("stopSequences");
+  });
+
   it("strips explicit thinkingBudget=0 but preserves includeThoughts for Gemini 2.5 Pro", () => {
     const params = buildGoogleGenerativeAiParams(
       buildGeminiModel(),

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1657,6 +1657,47 @@ describe("google transport stream", () => {
     expect(params.generationConfig ?? {}).not.toHaveProperty("stopSequences");
   });
 
+  it("sends stopSequences in the serialized Gemini request body via the guarded fetch transport", async () => {
+    guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
+
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+        api: "google-generative-ai",
+        provider: "google",
+        baseUrl: "https://generativelanguage.googleapis.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+      } satisfies Model<"google-generative-ai">,
+      {},
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gemini-api-key",
+          stop: ["</tool>", "\n\nObservation:"],
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    const init = requireRequestInit(guardedCall, "guarded fetch");
+    const payload = parseRequestJsonBody(init);
+    const generationConfig = requireGenerationConfig(payload);
+    expect(generationConfig.stopSequences).toEqual(["</tool>", "\n\nObservation:"]);
+  });
+
   it("strips explicit thinkingBudget=0 but preserves includeThoughts for Gemini 2.5 Pro", () => {
     const params = buildGoogleGenerativeAiParams(
       buildGeminiModel(),

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -703,6 +703,9 @@ export function buildGoogleGenerativeAiParams(
   if (typeof options?.maxTokens === "number") {
     generationConfig.maxOutputTokens = options.maxTokens;
   }
+  if (options?.stop !== undefined && options.stop.length > 0) {
+    generationConfig.stopSequences = options.stop;
+  }
   const thinkingConfig = resolveGoogleThinkingConfig(model, options);
   if (thinkingConfig) {
     generationConfig.thinkingConfig = thinkingConfig;


### PR DESCRIPTION
## Summary

The live Google/Gemini transport never forwards configured stop sequences to the model. `buildGoogleGenerativeAiParams` in `extensions/google/transport-stream.ts` builds `generationConfig` from `temperature`, `maxTokens`, and `thinkingConfig`, but drops `options.stop` — so Gemini and Vertex generate past where the user asked them to stop.

- The `stop` field is part of the shared `StreamOptions` contract (`packages/llm-core/src/types.ts:60`), documented as forwarded "to their native request field, such as OpenAI `stop` or Anthropic `stop_sequences`." Gemini's native field is `generationConfig.stopSequences`.
- It is a real user path: `src/agents/embedded-agent-runner/extra-params.ts:511` plumbs `normalizeStopSequences(extraParams.stop)` into `streamParams.stop`.
- Every other provider maps it — OpenAI (`openai-transport-stream.ts:3662`), Anthropic (`anthropic-transport-stream.ts:849`), Mistral (`mistral.ts:287`), and the now-unused core Google sibling (`google-shared.ts:484`). The live extension transport was the lone omission; the mapping was lost when the Google transport was internalized into the plugin in `bb46b79d3c`.
- Dependency contract: `@google/genai` (the package the plugin uses) declares `GenerateContentConfig.stopSequences?: string[]`, matching the field this PR sets.

Fix mirrors the existing sibling guard:

```ts
if (options?.stop !== undefined && options.stop.length > 0) {
  generationConfig.stopSequences = options.stop;
}
```

### Sibling-surface completeness

This is the only live text-generation request builder that drops `stop`. Checked the adjacent surfaces:

- `buildGoogleGemini3FirstResponseRetryParams` clones the original request and only mutates `thinkingConfig`, so `stopSequences` is preserved through the zero-output retry path (no change needed).
- The image-generation, realtime-voice, and speech providers build their own `generationConfig` for non-text modalities where stop sequences do not apply.

## Verification

- `oxfmt --check` on touched files — clean
- `node scripts/run-oxlint.mjs` on touched files — clean (exit 0)
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` — exit 0
- `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts` — 61 passed
- `git diff --check` — clean

## Real behavior proof

- Behavior addressed: Before this patch, a stop sequence configured for a Gemini/Vertex model (for example `stop: ["</tool>", "\n\nObservation:"]`) is dropped from the actual request body OpenClaw sends, so the model never receives it and generates past the stop. After this patch the real serialized request body carries `generationConfig.stopSequences`.
- Real environment tested: Real OpenClaw source checkout on macOS at current `upstream/main`, driving the live Google transport stream function `createGoogleGenerativeAiTransportStreamFn` end to end and capturing the exact serialized JSON request body it POSTs to the real Gemini endpoint (the transport boundary is the only mock; the request is built and serialized by production code). No live paid round-trip was made because no Google API key is configured in this environment.
- Exact steps or command run after this patch: drive the real transport, capture the outbound HTTP request body, then repeat with only the production file reverted to `upstream/main` to show the regression:

```
node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts
git checkout upstream/main -- extensions/google/transport-stream.ts
node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts
git checkout HEAD -- extensions/google/transport-stream.ts
node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts
```

- Evidence after fix: real outbound request captured by the transport (POST to `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse`).

  Before (production file at `upstream/main`) — `stopSequences` absent from the body:

```json
{
  "contents": [{ "role": "user", "parts": [{ "text": "hello" }] }],
  "generationConfig": {
    "thinkingConfig": { "thinkingLevel": "LOW" }
  }
}
```

  After (with the fix) — `stopSequences` present in the body:

```json
{
  "contents": [{ "role": "user", "parts": [{ "text": "hello" }] }],
  "generationConfig": {
    "stopSequences": ["</tool>", "\n\nObservation:"],
    "thinkingConfig": { "thinkingLevel": "LOW" }
  }
}
```

  Test-level before/after on the same run (production file reverted, bug present):

```
× sends stopSequences in the serialized Gemini request body via the guarded fetch transport
× forwards configured stop sequences to the Gemini generationConfig
Tests  2 failed | 59 passed (61)
```

  With the fix restored:

```
Tests  61 passed (61)
```

- Observed result after fix: The serialized Gemini/Vertex request body POSTed by the live transport includes `generationConfig.stopSequences` equal to the configured stop list when non-empty, and omits it when the list is empty.
- What was not tested: No live paid Gemini/Vertex API round-trip (no API key in this environment); proof is the exact request payload OpenClaw transmits, captured from the production transport. Gemini honoring `stopSequences` is a documented API guarantee and the field matches the typed `@google/genai` contract.

(The `gemini-api-key` value in the test is a literal placeholder, not a real credential; the captured payloads contain no secrets.)
