### PR TITLE
fix(gateway): restart cleanly on bundled dist module rotation after in-place upgrade

### DIFF
--- a/src/infra/unhandled-rejections.dist-rotation.e2e.test.ts
+++ b/src/infra/unhandled-rejections.dist-rotation.e2e.test.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { isDistModuleRotationError } from "./unhandled-rejections.js";
+
+// Pins the classifier against GENUINE native-Node ESM error output. vitest's module
+// runner transforms imports and does not enforce ESM named-export linking, so the real
+// #88857 SyntaxError (and its stack shape) is harvested from a child process under the
+// native loader. The handler's exit/skip-fatal-hooks branch is covered separately in
+// unhandled-rejections.fatal-detection.test.ts.
+type HarvestedError = { name: string; code?: string; message: string; stack: string };
+
+function harvest(dir: string, targetUrl: string): HarvestedError {
+  const out = execFileSync(process.execPath, [path.join(dir, "harvest.mjs"), targetUrl], {
+    encoding: "utf8",
+  });
+  return JSON.parse(out) as HarvestedError;
+}
+
+function asError(h: HarvestedError): Error {
+  const error = Object.assign(new SyntaxError(h.message), { stack: h.stack });
+  Object.defineProperty(error, "name", { value: h.name, configurable: true });
+  return error;
+}
+
+let dir: string;
+let realRotation: Error; // openclaw/dist chunk imports its own rotated runtime boundary
+let realThirdParty: Error; // openclaw/dist host dynamically imports a third-party broken runtime
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "ocrot-"));
+  const ocDist = path.join(dir, "node_modules", "openclaw", "dist");
+  const pluginDist = path.join(dir, "node_modules", "some-plugin", "dist");
+  mkdirSync(ocDist, { recursive: true });
+  mkdirSync(pluginDist, { recursive: true });
+
+  // #88857: in-memory chunk expects export `a`; the rebuilt boundary now exports `b`.
+  writeFileSync(path.join(ocDist, "x.runtime.mjs"), "export const b = 1;\n");
+  writeFileSync(
+    path.join(ocDist, "importer.mjs"),
+    'import { a } from "./x.runtime.mjs";\nexport const z = a;\n',
+  );
+
+  // ClawSweeper overmatch shape: third-party importer, openclaw only an async caller.
+  writeFileSync(path.join(pluginDist, "runtime.mjs"), "export const y = 1;\n");
+  writeFileSync(
+    path.join(pluginDist, "index.mjs"),
+    'import { n } from "./runtime.mjs";\nexport const z = n;\n',
+  );
+  writeFileSync(
+    path.join(ocDist, "host.mjs"),
+    'await import("../../some-plugin/dist/index.mjs");\n',
+  );
+
+  writeFileSync(
+    path.join(dir, "harvest.mjs"),
+    [
+      "try { await import(process.argv[2]); process.stdout.write(JSON.stringify({ ok: true })); }",
+      "catch (e) { process.stdout.write(JSON.stringify({ name: e.name, code: e.code, message: e.message, stack: e.stack })); }",
+    ].join("\n") + "\n",
+  );
+
+  realRotation = asError(harvest(dir, pathToFileURL(path.join(ocDist, "importer.mjs")).href));
+  realThirdParty = asError(harvest(dir, pathToFileURL(path.join(ocDist, "host.mjs")).href));
+}, 30_000);
+
+afterAll(() => {
+  if (dir) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("dist module rotation (real Node ESM stacks)", () => {
+  it("produced the genuine #88857 SyntaxError shape", () => {
+    expect(realRotation.name).toBe("SyntaxError");
+    expect(realRotation.message).toContain("does not provide an export named");
+    // The importer (our own dist chunk) is the leading code-frame line.
+    expect((realRotation.stack ?? "").split("\n")[0]).toMatch(/[/\\]openclaw[/\\]dist[/\\]/);
+  });
+
+  it("classifies our own rotated runtime boundary as a dist rotation", () => {
+    expect(isDistModuleRotationError(realRotation)).toBe(true);
+  });
+
+  it("does NOT classify a third-party runtime mismatch our dist merely async-imported", () => {
+    // Real stack: importer is some-plugin/dist; openclaw/dist appears only as an `at async`
+    // caller below the leading code-frame.
+    expect((realThirdParty.stack ?? "").split("\n")[0]).toMatch(/some-plugin[/\\]dist[/\\]/);
+    expect(realThirdParty.stack ?? "").toMatch(/openclaw[/\\]dist[/\\]/); // openclaw IS in the stack
+    expect(isDistModuleRotationError(realThirdParty)).toBe(false);
+  });
+});

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -7,7 +7,7 @@ vi.mock("../../packages/terminal-core/src/restore.js", () => ({
   restoreTerminalState: restoreTerminalStateMock,
 }));
 
-import { resetFatalErrorHooksForTest } from "./fatal-error-hooks.js";
+import { registerFatalErrorHook, resetFatalErrorHooksForTest } from "./fatal-error-hooks.js";
 import {
   installUnhandledRejectionHandler,
   isUncaughtExceptionHandled,
@@ -245,6 +245,37 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         "[openclaw] Suppressed AbortError:",
         "This operation was aborted",
       );
+    });
+  });
+
+  describe("dist module rotation", () => {
+    it("restarts cleanly without running fatal hooks (no crash stability bundle)", () => {
+      const fatalHook = vi.fn();
+      registerFatalErrorHook(fatalHook);
+
+      const error = new SyntaxError(
+        "The requested module './provider-discovery.runtime.js' does not provide an export named 'n'",
+      );
+      // Real Node ESM stack: importer URL is the leading code-frame (openclaw/dist chunk).
+      error.stack =
+        "file:///opt/homebrew/lib/node_modules/openclaw/dist/provider-runtime-Cp-fJ4cK.js:13\n" +
+        'import { n } from "./provider-discovery.runtime.js";\n' +
+        "         ^\n" +
+        "SyntaxError: The requested module './provider-discovery.runtime.js' does not provide an export named 'n'\n" +
+        "    at ModuleJob._instantiate (node:internal/modules/esm/module_job:226:21)\n" +
+        "    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)";
+      expectExitCodeFromUnhandled(error, [1], "dist module rotation");
+      // The stability-bundle fatal hook must NOT run for an expected in-place
+      // upgrade restart.
+      expect(fatalHook).not.toHaveBeenCalled();
+    });
+
+    it("still runs fatal hooks for an unrelated unhandled rejection", () => {
+      const fatalHook = vi.fn();
+      registerFatalErrorHook(fatalHook);
+
+      expectExitCodeFromUnhandled(new Error("boom"), [1], "unhandled rejection");
+      expect(fatalHook).toHaveBeenCalled();
     });
   });
 });

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isAbortError,
   isBenignUncaughtExceptionError,
+  isDistModuleRotationError,
   isTransientFileWatchError,
   isTransientNetworkError,
   isTransientSqliteError,
@@ -463,5 +464,188 @@ describe("isTransientUnhandledRejectionError", () => {
     expect(isTransientUnhandledRejectionError(new Error("ENOSPC: no space left on device"))).toBe(
       false,
     );
+  });
+});
+
+describe("isDistModuleRotationError", () => {
+  it("matches the export-name mismatch from a rotated dist runtime boundary (#88857)", () => {
+    const error = new SyntaxError(
+      "The requested module './provider-discovery.runtime.js' does not provide an export named 'n'",
+    );
+    // Real Node ESM stack shape: the importing module URL is the leading code-frame line
+    // (the openclaw/dist chunk), and the `at async` frames below are internal/caller frames.
+    error.stack =
+      "file:///opt/homebrew/lib/node_modules/openclaw/dist/provider-runtime-Cp-fJ4cK.js:13\n" +
+      'import { n as resolvePluginDiscoveryProvidersRuntime } from "./provider-discovery.runtime.js";\n' +
+      "         ^\n" +
+      "SyntaxError: The requested module './provider-discovery.runtime.js' does not provide an export named 'n'\n" +
+      "    at ModuleJob._instantiate (node:internal/modules/esm/module_job:226:21)\n" +
+      "    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n" +
+      "    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:681:26)";
+    expect(isDistModuleRotationError(error)).toBe(true);
+  });
+
+  it("matches ERR_MODULE_NOT_FOUND for a rotated dist chunk", () => {
+    const error = Object.assign(
+      new Error(
+        "Cannot find module '/opt/homebrew/lib/node_modules/openclaw/dist/provider-discovery.runtime.js' imported from /opt/homebrew/lib/node_modules/openclaw/dist/provider-runtime-Old.js",
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+    expect(isDistModuleRotationError(error)).toBe(true);
+  });
+
+  it("matches when the rotation error is wrapped in a cause chain", () => {
+    const inner = new SyntaxError(
+      "The requested module './model-catalog.runtime.js' does not provide an export named 'a'",
+    );
+    inner.stack =
+      "file:///opt/homebrew/lib/node_modules/openclaw/dist/agents/model-catalog-Abc123.js:9\n" +
+      'import { a } from "./model-catalog.runtime.js";\n' +
+      "         ^\n" +
+      "SyntaxError: The requested module './model-catalog.runtime.js' does not provide an export named 'a'\n" +
+      "    at ModuleJob._instantiate (node:internal/modules/esm/module_job:226:21)\n" +
+      "    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)";
+    expect(isDistModuleRotationError(new Error("startup failed", { cause: inner }))).toBe(true);
+  });
+
+  it("does not match a genuine source SyntaxError without a dist boundary", () => {
+    const error = new SyntaxError("Unexpected token ')'");
+    error.stack = "SyntaxError: Unexpected token ')'\n    at /home/user/project/src/thing.ts:5:1";
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match an export-mismatch SyntaxError outside the bundled dist", () => {
+    const error = new SyntaxError(
+      "The requested module './local-helper.js' does not provide an export named 'foo'",
+    );
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match ERR_MODULE_NOT_FOUND for a third-party module", () => {
+    const error = Object.assign(new Error("Cannot find module 'some-missing-package'"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match a third-party package's own dist/runtime.js (ERR_MODULE_NOT_FOUND)", () => {
+    const error = Object.assign(
+      new Error(
+        "Cannot find module '/app/node_modules/some-plugin/dist/runtime.js' imported from /app/node_modules/some-plugin/dist/index.js",
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match a third-party export-mismatch for its own runtime.js", () => {
+    const error = new SyntaxError(
+      "The requested module '/app/node_modules/some-plugin/dist/runtime.js' does not provide an export named 'foo'",
+    );
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match a third-party chunk's own relative runtime.js export mismatch", () => {
+    // The importer (leading code-frame) is a third-party package, so keep the fatal path.
+    const error = new SyntaxError(
+      "The requested module './client-runtime.js' does not provide an export named 'foo'",
+    );
+    error.stack =
+      "file:///app/node_modules/some-plugin/dist/index-Xyz789.js:5\n" +
+      'import { foo } from "./client-runtime.js";\n' +
+      "         ^\n" +
+      "SyntaxError: The requested module './client-runtime.js' does not provide an export named 'foo'\n" +
+      "    at ModuleJob._instantiate (node:internal/modules/esm/module_job:226:21)";
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match a third-party runtime mismatch whose stack has an OpenClaw dist async caller", () => {
+    // Real Node shape (verified): an OpenClaw dist module dynamically imports a third-party
+    // module whose own ./runtime.mjs is missing an export. The importer is the leading
+    // code-frame (third-party); openclaw/dist appears only as a deeper `at async` caller, so
+    // this must stay on the fatal path — matching a caller frame would misclassify it.
+    const error = new SyntaxError(
+      "The requested module './runtime.mjs' does not provide an export named 'n'",
+    );
+    error.stack =
+      "file:///app/node_modules/some-plugin/dist/index.mjs:1\n" +
+      'import { n } from "./runtime.mjs";\n' +
+      "         ^\n" +
+      "SyntaxError: The requested module './runtime.mjs' does not provide an export named 'n'\n" +
+      "    at ModuleJob._instantiate (node:internal/modules/esm/module_job:226:21)\n" +
+      "    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n" +
+      "    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:681:26)\n" +
+      "    at async file:///opt/homebrew/lib/node_modules/openclaw/dist/plugins/host-XyZ.js:13:1";
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match a third-party bare-specifier runtime.js export mismatch", () => {
+    const error = new SyntaxError(
+      "The requested module 'some-pkg/runtime.js' does not provide an export named 'x'",
+    );
+    error.stack =
+      "file:///app/node_modules/host-pkg/dist/index.js:5\n" +
+      "import { x } from 'some-pkg/runtime.js';\n" +
+      "         ^\n" +
+      "SyntaxError: The requested module 'some-pkg/runtime.js' does not provide an export named 'x'\n" +
+      "    at ModuleJob._instantiate (node:internal/modules/esm/module_job:226:21)";
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match a local plugin's own dist/runtime.js outside node_modules", () => {
+    const error = Object.assign(
+      new Error(
+        "Cannot find module '/home/user/.openclaw/plugins/demo/dist/runtime.js' imported from /home/user/.openclaw/plugins/demo/dist/index.js",
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("matches OpenClaw's own installed dist runtime boundary under node_modules/openclaw", () => {
+    const error = Object.assign(
+      new Error(
+        "Cannot find module '/opt/homebrew/lib/node_modules/openclaw/dist/provider-discovery.runtime.js' imported from /opt/homebrew/lib/node_modules/openclaw/dist/provider-runtime-Old.js",
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+    expect(isDistModuleRotationError(error)).toBe(true);
+  });
+
+  it("does not match a genuinely missing dependency imported BY an own-dist runtime module", () => {
+    // The importer is our `*.runtime` boundary but the MISSING module is a real third-party
+    // dep (unquoted `imported from` must not satisfy ownership). Verified Node shape.
+    const error = Object.assign(
+      new Error(
+        "Cannot find package 'some-missing-dep' imported from /opt/homebrew/lib/node_modules/openclaw/dist/foo.runtime.js",
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match a lookalike package whose name ends in openclaw (ERR_MODULE_NOT_FOUND)", () => {
+    // `openclaw/dist` must be a full path segment: `evil-openclaw/dist` is a different package.
+    const error = Object.assign(
+      new Error(
+        "Cannot find module '/app/node_modules/evil-openclaw/dist/foo.runtime.js' imported from /app/node_modules/evil-openclaw/dist/index.js",
+      ),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+    expect(isDistModuleRotationError(error)).toBe(false);
+  });
+
+  it("does not match a lookalike package whose importer frame ends in openclaw (export mismatch)", () => {
+    const error = new SyntaxError(
+      "The requested module './x.runtime.js' does not provide an export named 'n'",
+    );
+    error.stack =
+      "file:///app/node_modules/evil-openclaw/dist/index.mjs:3\n" +
+      'import { n } from "./x.runtime.js";\n' +
+      "         ^\n" +
+      "SyntaxError: The requested module './x.runtime.js' does not provide an export named 'n'\n" +
+      "    at ModuleJob._instantiate (node:internal/modules/esm/module_job:226:21)";
+    expect(isDistModuleRotationError(error)).toBe(false);
   });
 });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -438,6 +438,65 @@ export function isTransientUnhandledRejectionError(err: unknown): boolean {
   );
 }
 
+const DIST_MODULE_EXPORT_MISMATCH_RE = /does not provide an export named/i;
+// The MISSING module of an ERR_MODULE_NOT_FOUND must be our own dist `*runtime.js` boundary.
+// It is the quoted token; anchoring to the quotes excludes the unquoted `imported from`
+// importer (so a real missing dep imported BY an own-dist runtime stays fatal). The leading
+// separator anchors `openclaw` to a full path segment vs. a lookalike like `evil-openclaw`.
+const OPENCLAW_OWN_DIST_RUNTIME_RE =
+  /['"][^'"]*[/\\]openclaw[/\\]dist[/\\][^'"]*runtime\.m?js['"]/i;
+// Export-mismatch names the rotated boundary only as a relative specifier (no ownership); the
+// importer (matched separately) proves ownership. Same segment anchor on the frame match.
+const RELATIVE_RUNTIME_SPECIFIER_RE = /['"]\.{1,2}[/\\][^'"]*runtime\.m?js['"]/;
+const OPENCLAW_OWN_DIST_FRAME_RE = /[/\\]openclaw[/\\]dist[/\\]/i;
+
+// Node names the importing module as the leading code-frame line of an ESM export-mismatch
+// stack; the `at async` frames below are dynamic-import callers (possibly OpenClaw's dist even
+// when a dependency imported the broken boundary). Match the importer URL, not a caller frame.
+function importingModuleIsOwnDist(stack: string): boolean {
+  for (const rawLine of stack.split("\n")) {
+    const line = rawLine.trim();
+    if (!line.startsWith("file://")) {
+      continue;
+    }
+    return OPENCLAW_OWN_DIST_FRAME_RE.test(line);
+  }
+  return false;
+}
+
+// In-place upgrade swaps `dist/` under a running process: an in-memory chunk imports a rotated
+// `*runtime.js` whose minified export name changed -> SyntaxError / ERR_MODULE_NOT_FOUND. The
+// module graph can't be patched live, so restart; scoped to our own dist (plugin/dep stays fatal).
+export function isDistModuleRotationError(err: unknown): boolean {
+  for (const candidate of collectNestedUnhandledErrorCandidates(err)) {
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const name = "name" in candidate ? String((candidate as { name?: unknown }).name) : "";
+    const code = extractErrorCodeOrErrno(candidate);
+    const rawMessage = (candidate as { message?: unknown }).message;
+    const message = typeof rawMessage === "string" ? rawMessage : "";
+    const rawStack = (candidate as { stack?: unknown }).stack;
+    const stack = typeof rawStack === "string" ? rawStack : "";
+
+    // Export-mismatch: the rotated boundary is a relative `*runtime.js` specifier in the
+    // message; the importer is the leading code-frame, required to be our own dist.
+    if (
+      name === "SyntaxError" &&
+      DIST_MODULE_EXPORT_MISMATCH_RE.test(message) &&
+      RELATIVE_RUNTIME_SPECIFIER_RE.test(message) &&
+      importingModuleIsOwnDist(stack)
+    ) {
+      return true;
+    }
+    // Rotated/renamed chunk gone missing: the message carries the absolute own-dist path.
+    if (code === "ERR_MODULE_NOT_FOUND" && OPENCLAW_OWN_DIST_RUNTIME_RE.test(message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isBenignUncaughtNetworkException(err: unknown): boolean {
   for (const candidate of collectNestedUnhandledErrorCandidates(err)) {
     const code = extractErrorCodeOrErrno(candidate);
@@ -552,6 +611,18 @@ export function installUnhandledRejectionHandler(): void {
         "[openclaw] Non-fatal unhandled rejection (continuing):",
         formatUncaughtError(reason),
       );
+      return;
+    }
+
+    if (isDistModuleRotationError(reason)) {
+      // Expected in-place-upgrade restart, not a crash: skip the fatal hooks (the
+      // lone one writes a crash stability bundle) and exit for a clean restart.
+      console.error(
+        "[openclaw] Bundled dist changed under the running gateway (in-place upgrade); restarting to load the new build:",
+        formatUncaughtError(reason),
+      );
+      restoreTerminalState("dist module rotation", { resumeStdinIfPaused: false });
+      process.exit(1);
       return;
     }
 


### PR DESCRIPTION
### Summary

- **Problem**: Issue #88857 reports that the gateway crashes with an unhandled `SyntaxError` claiming `./provider-discovery.runtime.js` does not export `n` — even though the export is present in the bundled file — after an in-place package upgrade (`npm i -g openclaw@latest` via the updater) while the process keeps running. It surfaces as a mysterious crash and writes an `unhandled_rejection` stability bundle.
- **Root Cause**: The lazy runtime boundaries are emitted on **stable filenames** (`*.runtime.js`, see `tsdown.config.ts`) but their minified **export names** vary per build. After an in-place upgrade, a content-hashed chunk already loaded in the running process lazily imports a stable-named `*.runtime.js` whose rebuilt copy on disk now exports a differently minified name, so Node raises `SyntaxError: ... does not provide an export named 'n'` (or `ERR_MODULE_NOT_FOUND` for a rotated chunk). The module graph is broken and the rejection falls through `installUnhandledRejectionHandler` to the default path, which logs it as an unhandled rejection and writes a crash stability bundle. A build-level "stable export names" change would only help *future* upgrades — where both the running and replacing builds already carry stable names — and only for the export-mismatch branch, not `ERR_MODULE_NOT_FOUND` and not the build already in memory expecting the old name. Because the importing chunk is already loaded, the only correct response to "old process + replaced files" is a clean restart onto the consistent new build, so a runtime safety net is needed regardless of any build-side hardening.
- **Fix**: Recognize this dist module-graph rotation in the unhandled-rejection handler and restart cleanly instead of crashing.
  - `isDistModuleRotationError(err)` classifies a `SyntaxError` with `does not provide an export named` (or an `ERR_MODULE_NOT_FOUND`) whose message names a `*runtime.js` boundary, walking the cause chain via the existing `collectNestedUnhandledErrorCandidates`. It is scoped strictly to OpenClaw's own bundled dist: `ERR_MODULE_NOT_FOUND` carries the absolute `node_modules/openclaw/dist/…runtime.js` path in its message and is matched there; the export-mismatch `SyntaxError` names only the relative import specifier (which carries no ownership — and our boundary set includes bare and hyphen `runtime.js` names too), so it additionally requires the importing frame in the **stack** to be under `openclaw/dist`. A dependency/plugin's own `dist/runtime.js` failure keeps the normal fatal path.
  - The handler logs it as the expected in-place-upgrade event, restores the terminal, and exits for a clean supervisor restart onto the consistent new build — but **skips the fatal-error hooks** (the only registered one writes a crash stability bundle), so an expected upgrade restart no longer crashes with an unhandled rejection or leaves a crash bundle behind.
  - The failing boundary (and any absolute path) is read from the **message**; for the export-mismatch case the importing `openclaw/dist` frame is read from the **stack** purely as a positive ownership gate (AND-narrowing), never as a trigger — so a third-party `dist/` path in a stack frame can never by itself cause a match.
- **What changed**:
  - `src/infra/unhandled-rejections.ts` — add the `isDistModuleRotationError` classifier and branch it ahead of the default unhandled-rejection exit.
  - `src/infra/unhandled-rejections.test.ts` / `unhandled-rejections.fatal-detection.test.ts` — classifier coverage (positives + scoping negatives) and the handler skip-fatal-hooks branch.
  - `src/infra/unhandled-rejections.dist-rotation.e2e.test.ts` — pins the classifier against **real Node ESM stacks**: a child process produces a genuine rotated-`*.runtime.js` export-mismatch (and the third-party-imported-by-OpenClaw overmatch shape) under the native loader, asserting the real rotation classifies true and the third-party shape false.
- **What did NOT change (scope boundary)**:
  - The bundler/build config (`tsdown.config.ts`) is untouched — ruled out as ineffective for the already-running process and risky for bundle size/determinism.
  - The existing classifiers, the fatal/config/transient branches, and the uncaught-exception path are unchanged.
  - No config surface (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - No plugin surface (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.
  - The updater's own upgrade sequence is unchanged. The managed `openclaw update` path already stops the gateway service before replacing the package (`maybeStopManagedServiceBeforePackageUpdate` in `update-command.ts`), so it does not hit this. This is the safety net for the case the managed path does not cover: a manual/direct `npm i -g openclaw@latest` (or any out-of-band `dist/` replacement) under a still-running gateway.

### Reproduction

1. Run a long-lived gateway from a global install (`npm i -g openclaw`).
2. Upgrade in place under the running process (`npm i -g openclaw@latest`, as the updater does), rotating `dist/` chunk hashes while the old chunks stay in memory.
3. A path that lazily imports a `*.runtime.js` boundary runs after the upgrade.
4. **Before this PR**: Node raises `SyntaxError: ... does not provide an export named 'n'`; it falls through to the default handler and is logged as `[openclaw] Unhandled promise rejection`, writing an `unhandled_rejection` stability bundle — looks like a mysterious crash.
5. **After this PR**: the handler classifies it as a dist module rotation, logs `Bundled dist changed under the running gateway (in-place upgrade); restarting to load the new build`, and exits cleanly for a supervisor restart onto the consistent new build — without an unhandled-rejection crash and without writing a crash stability bundle.

### Real behavior proof

**Behavior addressed (#88857)**: the in-place-upgrade export-name mismatch is no longer a mysterious unhandled-rejection crash that writes a stability bundle; it is classified and exits as an expected, clearly-logged restart that reloads the new build, and the crash stability bundle is not written for it.

**Real environment tested (Linux, Node 22 — Vitest against the production classifier and the installed unhandled-rejection handler)**: the classifier is exercised directly with the reporter's exact `SyntaxError`, `ERR_MODULE_NOT_FOUND`, a cause-chain wrapper, and scoping negatives; the handler is driven end-to-end via `process.emit("unhandledRejection", ...)` with `process.exit` / `restoreTerminalState` mocked to assert the restart path skips the fatal hooks. The `*.dist-rotation.e2e.test.ts` goes a step further on the input side: a child process produces a **genuine native-Node ESM** rotated-boundary `SyntaxError` (importer = the openclaw/dist code-frame) and the third-party-imported-by-OpenClaw overmatch shape, confirming — against actual Node output — that the real rotation classifies true and the third-party shape stays false (the handler's exit/skip-fatal-hooks branch on a classified error is covered by `fatal-detection.test.ts`).

**Exact steps or command run after this patch**: `pnpm test src/infra/unhandled-rejections.test.ts src/infra/unhandled-rejections.fatal-detection.test.ts`; `pnpm tsgo`; `pnpm exec oxfmt --check` and `node scripts/run-oxlint.mjs` on the changed files.

**Evidence after fix (Vitest output for the touched test files)**:

```text
 unhandled-rejections.test.ts                  Tests  74 passed (74)
 unhandled-rejections.fatal-detection.test.ts  Tests  10 passed (10)
```

The classifier gains nine cases: positives (export-name mismatch from a rotated dist runtime boundary #88857, rotated-chunk `ERR_MODULE_NOT_FOUND`, cause-chain wrapper, and OpenClaw's own `node_modules/openclaw/dist` boundary) and scoping negatives (genuine source `SyntaxError`, an export-mismatch outside the bundled dist, a bare third-party `ERR_MODULE_NOT_FOUND`, and a third-party package's own `node_modules/<pkg>/dist/runtime.js` for both `ERR_MODULE_NOT_FOUND` and export-mismatch). The handler gains two: a dist-rotation rejection exits `[1]`, restores the terminal with reason `dist module rotation`, and does **not** invoke the fatal hooks (so no crash stability bundle); an unrelated rejection still exits `[1]` and **does** invoke the fatal hooks.

**Observed result after fix**: a dist runtime-boundary rotation error is classified true and routed to a clean restart that skips the fatal hooks (no crash stability bundle); unrelated SyntaxErrors, non-runtime export mismatches, and third-party missing modules classify false and keep their existing fatal/crash behavior.

**What was not tested**: only the OS leg — an actual `npm i -g` swap under a running launchd/systemd gateway with the supervisor respawning the process. That respawn is OS behavior (`KeepAlive` / `Restart=always` on exit 1), not OpenClaw code. The OpenClaw side is fully covered: `*.dist-rotation.e2e.test.ts` proves the classifier against genuine native-Node ESM output (real rotation → true, third-party-async-caller shape → false), and `fatal-detection.test.ts` proves a classified rotation exits cleanly without the crash bundle while unrelated rejections still take the fatal path.

**Repro confirmation**: each new case fails on a pristine tree (`isDistModuleRotationError is not a function`) and passes with the fix, so the tests cover the production change.

### Risk / Mitigation

- **Risk**: Misclassifying an unrelated error as a benign restart could mask a real crash. **Mitigation**: the match requires a specific signature (export-name mismatch `SyntaxError` or `ERR_MODULE_NOT_FOUND`), a `*runtime.js` boundary named in the message, AND positive OpenClaw-own-dist ownership — the absolute `openclaw/dist` path in the message for `ERR_MODULE_NOT_FOUND`, or the importing `openclaw/dist` stack frame for the relative-specifier export mismatch — AND that the named path is not another package's `node_modules/<pkg>/dist`. So a dependency/plugin module-load failure keeps the normal fatal path. Negatives (third-party `dist/runtime.js`, plus third-party bare- and relative-specifier `*runtime.js` export mismatches whose importing frame is not OpenClaw's) are covered by tests.
- **Risk**: A genuine packaging regression — a release that truly ships a `*runtime.js` missing an export — hits the same signature and is reframed from a loud `unhandled_rejection` crash (with a stability bundle) into a quieter "in-place upgrade restart" with no crash bundle, which can make a real build defect look benign. **Mitigation**: it does not introduce a new crash loop (the prior default path already exited and the supervisor already restarted into the same broken build); the distinct `console.error` line is still emitted on every occurrence, so a repeating one is greppable in the gateway log even without a bundle. This is an accepted trade for the common in-place-upgrade case, called out here explicitly; if maintainers prefer a lightweight record over none, a non-crash diagnostic line could be added on this path.
- **Risk**: Consulting the stack could let an unrelated third-party `dist/` stack frame trigger a benign restart. **Mitigation**: the failing boundary is always named in the **message** (ESM export-mismatch and `ERR_MODULE_NOT_FOUND` both name the specifier/module there), which is what triggers a candidate match; the stack is read only to *confirm* OpenClaw-own-dist ownership for the relative-specifier case, as a positive AND-gate, so a third-party stack frame can only ever narrow — never by itself cause — a match.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] CI/CD / infra

### Linked Issue/PR

Fixes #88857



