### PR TITLE
fix(agents): strip streamed reasoning tags

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -6984,6 +6984,448 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("keeps buffered visible text before following tool calls", async () => {
+    const model = {
+      id: "plain-openai-compatible",
+      name: "Plain OpenAI Compatible",
+      api: "openai-completions",
+      provider: "plain-openai-compatible",
+      baseUrl: "https://api.compat.test/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-buffered-text-tool",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { content: "Use <" },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-buffered-text-tool",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_0",
+                    type: "function",
+                    function: { name: "exec", arguments: '{"command":"ls"}' },
+                  },
+                ],
+              },
+              logprobs: null,
+              finish_reason: "tool_calls" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content[0]).toEqual({ type: "text", text: "Use <" });
+    expectRecordFields(output.content[1], {
+      type: "toolCall",
+      id: "call_0",
+      name: "exec",
+      arguments: { command: "ls" },
+    });
+  });
+
+  it("partitions inline reasoning tags out of OpenAI-compatible visible text", async () => {
+    const model = {
+      id: "MiniMax-M2.7",
+      name: "MiniMax M2.7",
+      api: "openai-completions",
+      provider: "minimax",
+      baseUrl: "https://api.minimax.test/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-reasoning-tags",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "Before <thi",
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-reasoning-tags",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "nk>private reasoning</think> after",
+                reasoning_content: "private reasoning",
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-reasoning-tags",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    const visibleText = output.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+    const thinkingText = output.content
+      .filter((block): block is { type: "thinking"; thinking: string } => block.type === "thinking")
+      .map((block) => block.thinking)
+      .join("");
+
+    expect(visibleText).toBe("Before  after");
+    expect(visibleText).not.toContain("private reasoning");
+    expect(thinkingText).toBe("private reasoning");
+    expect(events.filter((event) => event.type === "thinking_delta")).toHaveLength(1);
+  });
+
+  it("keeps literal reasoning tag examples visible without mirrored reasoning", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-literal-tags",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "Use `<think>private</think>` only as an example.",
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toContainEqual({
+      type: "text",
+      text: "Use `<think>private</think>` only as an example.",
+    });
+    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("keeps prose mentions of unclosed reasoning tags visible without mirrored reasoning", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-literal-unclosed-tag",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "The <reasoning> tag is deprecated in this example.",
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toContainEqual({
+      type: "text",
+      text: "The <reasoning> tag is deprecated in this example.",
+    });
+    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("keeps prose mentions of unmatched close tags visible without mirrored reasoning", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-literal-close-tag",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "Use </think> to close the tag.",
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toContainEqual({
+      type: "text",
+      text: "Use </think> to close the tag.",
+    });
+    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("strips content-only reasoning tags from OpenAI-compatible visible text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-content-only-tags",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "Before <think>private reasoning</think> after",
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toContainEqual({
+      type: "text",
+      text: "Before  after",
+    });
+    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("recovers fully wrapped unclosed OpenAI-compatible reasoning text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-unclosed-tags",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "<think>Visible answer from a malformed local model",
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toContainEqual({
+      type: "text",
+      text: "Visible answer from a malformed local model",
+    });
+  });
+
+  it("does not recover buffered reasoning tags after structured thinking content", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-structured-thinking",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "<think>private reasoning",
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-structured-thinking",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: { type: "reasoning", text: "private reasoning" },
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    const visibleText = output.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+    const thinkingText = output.content
+      .filter((block): block is { type: "thinking"; thinking: string } => block.type === "thinking")
+      .map((block) => block.thinking)
+      .join("");
+
+    expect(visibleText).toBe("");
+    expect(thinkingText).toBe("private reasoning");
+  });
+
+  it("keeps literal reasoning tag examples visible with mirrored reasoning", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-literal-tags",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "Use `<thi",
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-literal-tags",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "nk>private</think>` only as an example.",
+                reasoning_content: "Actual hidden reasoning.",
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toContainEqual({
+      type: "text",
+      text: "Use `<think>private</think>` only as an example.",
+    });
+    expect(output.content).toContainEqual({
+      type: "thinking",
+      thinking: "Actual hidden reasoning.",
+      thinkingSignature: "reasoning_content",
+    });
+  });
+
   it("promotes silent tool calls when provider signals finish_reason stop", async () => {
     const model = {
       id: "qwen3.6-27b",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -29,6 +29,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { resolveProviderTransportTurnStateWithPlugin } from "../plugins/provider-runtime.js";
 import { isGemma4ModelId } from "../shared/google-models.js";
+import { createReasoningTagTextPartitioner } from "../shared/text/reasoning-tag-text-partitioner.js";
 import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../utils/cjk-chars.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { createDeepSeekTextFilter } from "./deepseek-text-filter.js";
@@ -2526,6 +2527,7 @@ async function processOpenAICompletionsStream(
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat)
     ? createDeepSeekTextFilter()
     : null;
+  const reasoningTagTextPartitioner = createReasoningTagTextPartitioner();
   type ToolCallBlock = {
     type: "toolCall";
     id: string;
@@ -2661,6 +2663,22 @@ async function processOpenAICompletionsStream(
       appendVisibleTextDelta(part);
     }
   };
+  const appendRoutedContentDelta = (delta: CompletionsReasoningDelta) => {
+    if (delta.kind === "text") {
+      appendFilteredVisibleTextDelta(delta.text);
+      return;
+    }
+    if (currentBlock?.type === "toolCall") {
+      queuePostToolCallDelta(delta);
+    } else {
+      appendThinkingDelta(delta);
+    }
+  };
+  const appendPartitionedVisibleDelta = (delta: { kind: "text" | "thinking"; text: string }) => {
+    if (delta.kind === "text") {
+      appendFilteredVisibleTextDelta(delta.text);
+    }
+  };
   const flushDeepSeekTextFilterAtEnd = () => {
     const parts = deepSeekTextFilter?.flush();
     if (!parts) {
@@ -2668,6 +2686,11 @@ async function processOpenAICompletionsStream(
     }
     for (const part of parts) {
       appendVisibleTextDelta(part);
+    }
+  };
+  const flushReasoningTagTextPartitionerAtEnd = () => {
+    for (const delta of reasoningTagTextPartitioner.flush()) {
+      appendPartitionedVisibleDelta(delta);
     }
   };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
@@ -2708,24 +2731,32 @@ async function processOpenAICompletionsStream(
       await cooperativeScheduler.afterEvent();
       continue;
     }
+    const reasoningDeltas = getCompletionsReasoningDeltas(
+      choiceDelta as Record<string, unknown>,
+      compat.visibleReasoningDetailTypes,
+    );
+    const hasMirroredReasoning = reasoningDeltas.some((delta) => delta.kind === "thinking");
+    if (hasMirroredReasoning) {
+      reasoningTagTextPartitioner.markStrict();
+    }
     if (choiceDelta.content) {
       // Structured content can contain visible text and thinking blocks in the
       // same delta, so route each extracted block through the normal stream path.
       const contentDeltas = getCompletionsContentDeltas(choiceDelta.content);
       for (const contentDelta of contentDeltas) {
         if (contentDelta.kind === "text") {
-          appendFilteredVisibleTextDelta(contentDelta.text);
-        } else if (currentBlock?.type === "toolCall") {
-          queuePostToolCallDelta(contentDelta);
+          const routedDeltas = hasMirroredReasoning
+            ? reasoningTagTextPartitioner.push(contentDelta.text)
+            : reasoningTagTextPartitioner.pushVisible(contentDelta.text);
+          for (const routedDelta of routedDeltas) {
+            appendPartitionedVisibleDelta(routedDelta);
+          }
         } else {
-          appendThinkingDelta(contentDelta);
+          reasoningTagTextPartitioner.markStrict();
+          appendRoutedContentDelta(contentDelta);
         }
       }
     }
-    const reasoningDeltas = getCompletionsReasoningDeltas(
-      choiceDelta as Record<string, unknown>,
-      compat.visibleReasoningDetailTypes,
-    );
     for (const reasoningDelta of reasoningDeltas) {
       if (currentBlock?.type === "toolCall") {
         queuePostToolCallDelta({ ...reasoningDelta });
@@ -2738,6 +2769,7 @@ async function processOpenAICompletionsStream(
       }
     }
     if (choiceDelta.tool_calls && choiceDelta.tool_calls.length > 0) {
+      flushReasoningTagTextPartitionerAtEnd();
       for (const toolCall of choiceDelta.tool_calls) {
         const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
         let block = streamIndex !== undefined ? toolCallBlocksByIndex.get(streamIndex) : undefined;
@@ -2803,6 +2835,7 @@ async function processOpenAICompletionsStream(
     flushPendingPostToolCallDeltas();
     await cooperativeScheduler.afterEvent();
   }
+  flushReasoningTagTextPartitionerAtEnd();
   flushDeepSeekTextFilterAtEnd();
   finishAllToolCallBlocks();
   currentBlock = null;

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -3,8 +3,17 @@ import { describe, expect, it, vi } from "vitest";
 import type { Context, Model } from "../types.js";
 
 type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
+type OpenAICompatibleDelta = DeepPartial<ChatCompletionChunk["choices"][number]["delta"]> & {
+  reasoning_content?: string;
+};
+type OpenAICompatibleChoice = Omit<DeepPartial<ChatCompletionChunk["choices"][number]>, "delta"> & {
+  delta?: OpenAICompatibleDelta;
+};
+type OpenAICompatibleChatCompletionChunk = Omit<DeepPartial<ChatCompletionChunk>, "choices"> & {
+  choices?: OpenAICompatibleChoice[];
+};
 
-const mockChunksRef: { chunks: DeepPartial<ChatCompletionChunk>[] } = { chunks: [] };
+const mockChunksRef: { chunks: OpenAICompatibleChatCompletionChunk[] } = { chunks: [] };
 
 vi.mock("openai", () => {
   class MockOpenAI {
@@ -63,7 +72,7 @@ function createModel(maxTokens: number): Model<"openai-completions"> {
   };
 }
 
-function makeTextChunk(text: string): DeepPartial<ChatCompletionChunk> {
+function makeTextChunk(text: string): OpenAICompatibleChatCompletionChunk {
   return {
     id: "chatcmpl-test",
     choices: [{ index: 0, delta: { content: text, role: "assistant" } }],
@@ -75,7 +84,7 @@ function makeToolCallChunk(
   name: string,
   args: string,
   finishReason?: string,
-): DeepPartial<ChatCompletionChunk> {
+): OpenAICompatibleChatCompletionChunk {
   return {
     id: "chatcmpl-test",
     choices: [
@@ -93,7 +102,7 @@ function makeToolCallChunk(
 function makeFinishChunk(
   finishReason: string,
   usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number },
-): DeepPartial<ChatCompletionChunk> {
+): OpenAICompatibleChatCompletionChunk {
   return {
     id: "chatcmpl-test",
     choices: [{ index: 0, delta: {}, finish_reason: finishReason as never }],
@@ -138,6 +147,229 @@ describe("OpenAI-compatible completions params", () => {
 });
 
 describe("openai-completions stop-reason tool-call guard", () => {
+  it("keeps literal reasoning tag examples visible when no reasoning field is mirrored", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("Use `<think>private</think>` only as an example."),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Use `<think>private</think>` only as an example.",
+    });
+    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("keeps prose mentions of unclosed reasoning tags visible without mirrored reasoning", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("The <reasoning> tag is deprecated in this example."),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "The <reasoning> tag is deprecated in this example.",
+    });
+    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("keeps prose mentions of unmatched close tags visible without mirrored reasoning", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("Use </think> to close the tag."),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Use </think> to close the tag.",
+    });
+    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("strips content-only reasoning tags from visible text", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("Before <think>private reasoning</think> after"),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Before  after",
+    });
+    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
+  });
+
+  it("recovers fully wrapped unclosed content-only reasoning tags", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("<think>Visible answer from a malformed local model"),
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Visible answer from a malformed local model",
+    });
+  });
+
+  it("keeps literal reasoning tag examples visible when reasoning is mirrored", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "Use `<thi",
+            },
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "nk>private</think>` only as an example.",
+              reasoning_content: "Actual hidden reasoning.",
+            },
+          },
+        ],
+      },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Use `<think>private</think>` only as an example.",
+    });
+    expect(result.content).toContainEqual({
+      type: "thinking",
+      thinking: "Actual hidden reasoning.",
+      thinkingSignature: "reasoning_content",
+    });
+  });
+
+  it("partitions inline reasoning tags out of visible text", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "Before <thi",
+            },
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "nk>private reasoning</think> after",
+              reasoning_content: "private reasoning",
+            },
+          },
+        ],
+      },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+    const visibleText = result.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+    const thinkingText = result.content
+      .filter((block): block is { type: "thinking"; thinking: string } => block.type === "thinking")
+      .map((block) => block.thinking)
+      .join("");
+
+    expect(visibleText).toBe("Before  after");
+    expect(visibleText).not.toContain("private reasoning");
+    expect(thinkingText).toBe("private reasoning");
+  });
+
+  it("does not recover unclosed reasoning tags when mirrored reasoning arrives later", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "<think>private reasoning",
+            },
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              reasoning_content: "private reasoning",
+            },
+          },
+        ],
+      },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+    const visibleText = result.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+
+    expect(visibleText).toBe("");
+    expect(result.content).toContainEqual({
+      type: "thinking",
+      thinking: "private reasoning",
+      thinkingSignature: "reasoning_content",
+    });
+  });
+
   it("promotes silent tool_calls with finish_reason stop to toolUse", async () => {
     mockChunksRef.chunks = [
       makeToolCallChunk("call_1", "bash", '{"cmd":"ls"}'),
@@ -185,6 +417,22 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(result.stopReason).toBe("toolUse");
     const toolCalls = result.content.filter((b) => b.type === "toolCall");
     expect(toolCalls).toHaveLength(1);
+  });
+
+  it("keeps buffered visible text before following tool calls", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("Use <"),
+      makeToolCallChunk("call_1", "bash", '{"cmd":"ls"}'),
+      makeFinishChunk("tool_calls"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+
+    expect(result.content[0]).toEqual({ type: "text", text: "Use <" });
+    expect(result.content[1]).toMatchObject({ type: "toolCall", id: "call_1", name: "bash" });
   });
 
   it("strips toolCall blocks when finish_reason is length but tool_calls were accumulated", async () => {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -10,6 +10,7 @@ import type {
   ChatCompletionSystemMessageParam,
   ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
+import { createReasoningTagTextPartitioner } from "../../shared/text/reasoning-tag-text-partitioner.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
@@ -244,6 +245,26 @@ export const streamOpenAICompletions: StreamFunction<
         }
         return thinkingBlock;
       };
+      const appendTextDelta = (delta: string) => {
+        const block = ensureTextBlock();
+        block.text += delta;
+        stream.push({
+          type: "text_delta",
+          contentIndex: getContentIndex(block),
+          delta,
+          partial: output,
+        });
+      };
+      const appendThinkingDelta = (thinkingSignature: string, delta: string) => {
+        const block = ensureThinkingBlock(thinkingSignature);
+        block.thinking += delta;
+        stream.push({
+          type: "thinking_delta",
+          contentIndex: getContentIndex(block),
+          delta,
+          partial: output,
+        });
+      };
       const ensureToolCallBlock = (toolCall: StreamingToolCallDelta) => {
         const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
         let block = streamIndex !== undefined ? toolCallBlocksByIndex.get(streamIndex) : undefined;
@@ -280,6 +301,24 @@ export const streamOpenAICompletions: StreamFunction<
           toolCallBlocksById.set(toolCall.id, block);
         }
         return block;
+      };
+      const reasoningTagTextPartitioner = createReasoningTagTextPartitioner();
+      const appendPartitionedContent = (text: string, hasMirroredReasoning: boolean) => {
+        const routedDeltas = hasMirroredReasoning
+          ? reasoningTagTextPartitioner.push(text)
+          : reasoningTagTextPartitioner.pushVisible(text);
+        for (const delta of routedDeltas) {
+          if (delta.kind === "text") {
+            appendTextDelta(delta.text);
+          }
+        }
+      };
+      const flushPartitionedContent = () => {
+        for (const delta of reasoningTagTextPartitioner.flush()) {
+          if (delta.kind === "text") {
+            appendTextDelta(delta.text);
+          }
+        }
       };
 
       for await (const chunk of openaiStream) {
@@ -321,21 +360,6 @@ export const streamOpenAICompletions: StreamFunction<
         }
 
         if (choice.delta) {
-          if (
-            choice.delta.content !== null &&
-            choice.delta.content !== undefined &&
-            choice.delta.content.length > 0
-          ) {
-            const block = ensureTextBlock();
-            block.text += choice.delta.content;
-            stream.push({
-              type: "text_delta",
-              contentIndex: getContentIndex(block),
-              delta: choice.delta.content,
-              partial: output,
-            });
-          }
-
           // Some endpoints return reasoning in reasoning_content (llama.cpp),
           // or reasoning (other openai compatible endpoints)
           // Use the first non-empty reasoning field to avoid duplication
@@ -350,6 +374,16 @@ export const streamOpenAICompletions: StreamFunction<
               break;
             }
           }
+          if (foundReasoningField) {
+            reasoningTagTextPartitioner.markStrict();
+          }
+          if (
+            choice.delta.content !== null &&
+            choice.delta.content !== undefined &&
+            choice.delta.content.length > 0
+          ) {
+            appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
+          }
 
           if (foundReasoningField) {
             const delta = deltaFields[foundReasoningField];
@@ -358,18 +392,12 @@ export const streamOpenAICompletions: StreamFunction<
                 model.provider === "opencode-go" && foundReasoningField === "reasoning"
                   ? "reasoning_content"
                   : foundReasoningField;
-              const block = ensureThinkingBlock(thinkingSignature);
-              block.thinking += delta;
-              stream.push({
-                type: "thinking_delta",
-                contentIndex: getContentIndex(block),
-                delta,
-                partial: output,
-              });
+              appendThinkingDelta(thinkingSignature, delta);
             }
           }
 
           if (choice?.delta?.tool_calls) {
+            flushPartitionedContent();
             for (const toolCall of choice.delta.tool_calls) {
               const block = ensureToolCallBlock(toolCall);
               if (!block.id && toolCall.id) {
@@ -411,6 +439,8 @@ export const streamOpenAICompletions: StreamFunction<
           }
         }
       }
+
+      flushPartitionedContent();
 
       for (const block of blocks) {
         finishBlock(block);

--- a/src/shared/text/reasoning-tag-text-partitioner.test.ts
+++ b/src/shared/text/reasoning-tag-text-partitioner.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest";
+import { createReasoningTagTextPartitioner } from "./reasoning-tag-text-partitioner.js";
+
+describe("createReasoningTagTextPartitioner", () => {
+  it("routes split inline reasoning tags away from visible text", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+    const deltas = [
+      ...partitioner.push("before <thi"),
+      ...partitioner.push("nk>hidden"),
+      ...partitioner.push("</think> after"),
+      ...partitioner.flush(),
+    ];
+
+    expect(deltas).toEqual([
+      { kind: "text", text: "before " },
+      { kind: "thinking", text: "hidden" },
+      { kind: "text", text: " after" },
+    ]);
+  });
+
+  it("keeps unterminated reasoning as thinking on flush", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect([...partitioner.push("visible <reasoning>hidden tail"), ...partitioner.flush()]).toEqual(
+      [
+        { kind: "text", text: "visible " },
+        { kind: "thinking", text: "hidden tail" },
+      ],
+    );
+  });
+
+  it("emits ordinary angle-bracket text immediately", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.push("<div>visible")).toEqual([{ kind: "text", text: "<div>visible" }]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("reports pending partial tags and active reasoning", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.hasPending()).toBe(false);
+    expect(partitioner.push("before <thi")).toEqual([{ kind: "text", text: "before " }]);
+    expect(partitioner.hasPending()).toBe(true);
+    expect(partitioner.push("nk>hidden")).toEqual([{ kind: "thinking", text: "hidden" }]);
+    expect(partitioner.hasPending()).toBe(true);
+    expect(partitioner.isInsideReasoning()).toBe(true);
+    expect(partitioner.push("</think> after")).toEqual([{ kind: "text", text: " after" }]);
+    expect(partitioner.hasPending()).toBe(false);
+    expect(partitioner.isInsideReasoning()).toBe(false);
+  });
+
+  it("holds possible reasoning opens in visible mode until they are resolved", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("before <thi")).toEqual([{ kind: "text", text: "before " }]);
+    expect(partitioner.push("nk>hidden")).toEqual([{ kind: "thinking", text: "hidden" }]);
+  });
+
+  it("strips complete reasoning tags in visible mode", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("Use <think>literal</think> here")).toEqual([
+      { kind: "text", text: "Use " },
+      { kind: "thinking", text: "literal" },
+      { kind: "text", text: " here" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("keeps split reasoning tags with attributes out of visible text", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+    const deltas = [
+      ...partitioner.pushVisible("Before <think "),
+      ...partitioner.pushVisible("id='x'>secret</think> after"),
+      ...partitioner.flush(),
+    ];
+
+    expect(deltas).toEqual([
+      { kind: "text", text: "Before " },
+      { kind: "thinking", text: "secret" },
+      { kind: "text", text: " after" },
+    ]);
+  });
+
+  it("keeps split antml reasoning tags out of visible text", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+    const deltas = [
+      ...partitioner.pushVisible("Before <antml:reas"),
+      ...partitioner.pushVisible("oning>secret</antml:reasoning> after"),
+      ...partitioner.flush(),
+    ];
+
+    expect(deltas).toEqual([
+      { kind: "text", text: "Before " },
+      { kind: "thinking", text: "secret" },
+      { kind: "text", text: " after" },
+    ]);
+  });
+
+  it("keeps nested reasoning hidden until the outer tag closes", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(
+      partitioner.pushVisible("<think>outer <think>inner</think> still outer</think>visible"),
+    ).toEqual([
+      { kind: "thinking", text: "outer inner still outer" },
+      { kind: "text", text: "visible" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("drops malformed reasoning before orphan close tags in strict mode", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.push("private chain of thought </think> Visible answer")).toEqual([
+      { kind: "text", text: " Visible answer" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("keeps unmatched close-tag prose visible in visible mode", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("Use </think> to close the tag")).toEqual([
+      { kind: "text", text: "Use </think> to close the tag" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("buffers split orphan close tags until the visible suffix arrives", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.push("private chain of thought </think>")).toEqual([]);
+    expect(partitioner.push(" Visible answer")).toEqual([
+      { kind: "text", text: " Visible answer" },
+    ]);
+  });
+
+  it("buffers split orphan close tag prefixes with their hidden prefix", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.push("private chain of thought </thi")).toEqual([]);
+    expect(partitioner.push("nk> Visible answer")).toEqual([
+      { kind: "text", text: " Visible answer" },
+    ]);
+  });
+
+  it("keeps close tags inside hidden code fences private", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("<think>\n```ts\nliteral ")).toEqual([]);
+    expect(partitioner.pushVisible("</think> still private")).toEqual([]);
+    expect(partitioner.flush()).toEqual([
+      { kind: "thinking", text: "\n```ts\nliteral </think> still private" },
+    ]);
+  });
+
+  it("recovers fully wrapped unclosed visible-mode text on flush", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("<think>Visible answer from a malformed local model")).toEqual(
+      [],
+    );
+    expect(partitioner.flush()).toEqual([
+      { kind: "text", text: "Visible answer from a malformed local model" },
+    ]);
+  });
+
+  it("recovers unclosed trailing tags as visible prose in visible mode", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("Use <think> only in this mode")).toEqual([
+      { kind: "text", text: "Use " },
+    ]);
+    expect(partitioner.flush()).toEqual([{ kind: "text", text: "<think> only in this mode" }]);
+  });
+
+  it("does not treat code-span reasoning tag examples as hidden reasoning", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.push("Use `<think>literal</think>` here")).toEqual([
+      { kind: "text", text: "Use `<think>literal</think>` here" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("preserves split code-span reasoning tag examples when active routing begins", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("Use `<thi")).toEqual([{ kind: "text", text: "Use `<thi" }]);
+    expect(partitioner.push("nk>literal</think>` here")).toEqual([
+      { kind: "text", text: "nk>literal</think>` here" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("preserves code-span reasoning tag examples when the closing backtick arrives later", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("Use `<think>literal</think>")).toEqual([
+      { kind: "text", text: "Use " },
+    ]);
+    expect(partitioner.pushVisible("` here")).toEqual([
+      { kind: "text", text: "`<think>literal</think>` here" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("preserves code-span reasoning tag examples when the stream splits after the opener", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("Use `")).toEqual([{ kind: "text", text: "Use `" }]);
+    expect(partitioner.pushVisible("<think>literal</think>` here")).toEqual([
+      { kind: "text", text: "<think>literal</think>` here" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("preserves multi-backtick code-span reasoning tag examples across chunks", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("Use ``<think>")).toEqual([{ kind: "text", text: "Use " }]);
+    expect(partitioner.pushVisible("literal</think>`` here")).toEqual([
+      { kind: "text", text: "``<think>literal</think>`` here" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("reclassifies reasoning tags inside unclosed inline code on final flush", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("Start `unclosed <think>secret</think> end")).toEqual([
+      { kind: "text", text: "Start " },
+    ]);
+    expect(partitioner.flush()).toEqual([
+      { kind: "text", text: "`unclosed " },
+      { kind: "thinking", text: "secret" },
+      { kind: "text", text: " end" },
+    ]);
+  });
+
+  it("keeps buffered unclosed reasoning hidden after strict mode is marked", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("<think>secret")).toEqual([]);
+    partitioner.markStrict();
+    expect(partitioner.flush()).toEqual([{ kind: "thinking", text: "secret" }]);
+  });
+
+  it("preserves fenced reasoning tag examples when the stream splits after the fence", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("Example:\n```")).toEqual([
+      { kind: "text", text: "Example:\n```" },
+    ]);
+    expect(partitioner.pushVisible("\n<think>literal</think>\n```\nDone.")).toEqual([
+      { kind: "text", text: "\n<think>literal</think>\n```\nDone." },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+
+  it("preserves fenced reasoning tag examples when the fence marker is split", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+
+    expect(partitioner.pushVisible("``")).toEqual([]);
+    expect(
+      partitioner.pushVisible(
+        "`xml\n<thinking>literal</thinking>\n```\n<think>secret</think>answer",
+      ),
+    ).toEqual([
+      {
+        kind: "text",
+        text: "```xml\n<thinking>literal</thinking>\n```\n",
+      },
+      { kind: "thinking", text: "secret" },
+      { kind: "text", text: "answer" },
+    ]);
+    expect(partitioner.flush()).toEqual([]);
+  });
+});

--- a/src/shared/text/reasoning-tag-text-partitioner.ts
+++ b/src/shared/text/reasoning-tag-text-partitioner.ts
@@ -1,0 +1,359 @@
+import {
+  buildCodeSpanIndex,
+  createInlineCodeState,
+  type InlineCodeState,
+} from "../../../packages/markdown-core/src/code-spans.js";
+import type { FenceScanState } from "../../../packages/markdown-core/src/fences.js";
+
+export type ReasoningTagTextDelta =
+  | { kind: "text"; text: string }
+  | { kind: "thinking"; text: string };
+
+const REASONING_TAG_RE =
+  /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought|reasoning)|antthinking)\b[^<>]*>/gi;
+const REASONING_TAG_NAMES = [
+  "think",
+  "thinking",
+  "thought",
+  "reasoning",
+  "antthinking",
+  "antml:think",
+  "antml:thinking",
+  "antml:thought",
+  "antml:reasoning",
+] as const;
+
+export interface ReasoningTagTextPartitioner {
+  markStrict(): void;
+  push(chunk: string): ReasoningTagTextDelta[];
+  pushVisible(chunk: string): ReasoningTagTextDelta[];
+  flush(): ReasoningTagTextDelta[];
+  hasPending(): boolean;
+  isInsideReasoning(): boolean;
+}
+
+export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner {
+  let buffer = "";
+  let reasoningDepth = 0;
+  let strictMode = false;
+  let emittedVisibleText = false;
+  let inlineCodeState: InlineCodeState = createInlineCodeState();
+  let fenceState: FenceScanState | undefined;
+  let hiddenInlineCodeState: InlineCodeState = createInlineCodeState();
+  let hiddenFenceState: FenceScanState | undefined;
+  let recoverableOpenTagText: string | undefined;
+
+  const consume = (final: boolean, recoverFullUnclosed: boolean): ReasoningTagTextDelta[] => {
+    const output: ReasoningTagTextDelta[] = [];
+    const emit = (kind: ReasoningTagTextDelta["kind"], text: string) => {
+      if (!text) {
+        return;
+      }
+      if (kind === "text" && text.trim().length > 0) {
+        emittedVisibleText = true;
+      }
+      if (kind === "text") {
+        const nextCode = buildCodeSpanIndex(text, inlineCodeState, fenceState);
+        inlineCodeState = nextCode.inlineState;
+        fenceState = nextCode.fenceState;
+      } else {
+        const nextCode = buildCodeSpanIndex(text, hiddenInlineCodeState, hiddenFenceState);
+        hiddenInlineCodeState = nextCode.inlineState;
+        hiddenFenceState = nextCode.fenceState;
+      }
+      const previous = output[output.length - 1];
+      if (previous?.kind === kind) {
+        previous.text += text;
+        return;
+      }
+      output.push({ kind, text });
+    };
+
+    while (buffer) {
+      const activeInlineCodeState = reasoningDepth === 0 ? inlineCodeState : hiddenInlineCodeState;
+      const activeFenceState = reasoningDepth === 0 ? fenceState : hiddenFenceState;
+      const codeSpans = buildCodeSpanIndex(buffer, activeInlineCodeState, activeFenceState);
+      const hasUnclosedCode =
+        reasoningDepth === 0 && Boolean(codeSpans.inlineState.open || codeSpans.fenceState.open);
+      const hasRawReasoning = hasRawReasoningTag(buffer);
+      const tag = findNextReasoningTag(buffer, (index) =>
+        final && hasUnclosedCode && hasRawReasoning ? false : codeSpans.isInside(index),
+      );
+      if (!tag) {
+        if (final) {
+          const recoverAsText =
+            reasoningDepth > 0 && recoverFullUnclosed && !hasRawReasoningCloseTag(buffer);
+          const recoveredText =
+            recoverAsText && recoverableOpenTagText ? recoverableOpenTagText + buffer : buffer;
+          emit(reasoningDepth > 0 && !recoverAsText ? "thinking" : "text", recoveredText);
+          buffer = "";
+          reasoningDepth = 0;
+          recoverableOpenTagText = undefined;
+          return output;
+        }
+        if (
+          reasoningDepth > 0 &&
+          recoverFullUnclosed &&
+          (!emittedVisibleText || recoverableOpenTagText)
+        ) {
+          return output;
+        }
+        if (hasUnclosedCode && hasRawReasoning) {
+          const openCodeIndex =
+            inlineCodeState.open || fenceState?.open ? 0 : findOpenCodeContextStart(buffer);
+          if (openCodeIndex !== -1) {
+            emit("text", buffer.slice(0, openCodeIndex));
+            buffer = buffer.slice(openCodeIndex);
+            return output;
+          }
+        }
+        const trailingFenceStart = findTrailingFenceFragmentStart(
+          buffer,
+          activeInlineCodeState,
+          activeFenceState,
+        );
+        if (trailingFenceStart !== -1) {
+          emit(reasoningDepth > 0 ? "thinking" : "text", buffer.slice(0, trailingFenceStart));
+          buffer = buffer.slice(trailingFenceStart);
+          return output;
+        }
+        const keepFrom = reasoningTagPrefixSuffixIndex(buffer, (index) =>
+          codeSpans.isInside(index),
+        );
+        if (keepFrom === -1) {
+          emit(reasoningDepth > 0 ? "thinking" : "text", buffer);
+          buffer = "";
+          return output;
+        }
+        if (
+          reasoningDepth === 0 &&
+          keepFrom > 0 &&
+          buffer.slice(0, keepFrom).trim().length > 0 &&
+          isReasoningCloseTagPrefix(buffer.slice(keepFrom))
+        ) {
+          return output;
+        }
+        if (keepFrom > 0) {
+          emit(reasoningDepth > 0 ? "thinking" : "text", buffer.slice(0, keepFrom));
+          buffer = buffer.slice(keepFrom);
+        }
+        return output;
+      }
+
+      const beforeTag = buffer.slice(0, tag.index);
+      const afterTag = buffer.slice(tag.index + tag.text.length);
+      if (tag.isClose && reasoningDepth === 0) {
+        if (recoverFullUnclosed && beforeTag.trim().length > 0 && afterTag.trim().length > 0) {
+          emit("text", beforeTag + tag.text);
+          buffer = afterTag;
+          continue;
+        }
+        if (beforeTag.trim().length > 0 && afterTag.trim().length === 0 && !final) {
+          return output;
+        }
+        if (beforeTag.trim().length === 0 || afterTag.trim().length === 0) {
+          emit("text", beforeTag);
+        }
+        buffer = afterTag;
+        continue;
+      }
+
+      emit(reasoningDepth > 0 ? "thinking" : "text", buffer.slice(0, tag.index));
+      buffer = afterTag;
+      if (tag.isClose) {
+        reasoningDepth = Math.max(0, reasoningDepth - 1);
+        if (reasoningDepth === 0) {
+          recoverableOpenTagText = undefined;
+          hiddenInlineCodeState = createInlineCodeState();
+          hiddenFenceState = undefined;
+        }
+      } else {
+        if (reasoningDepth === 0) {
+          recoverableOpenTagText = recoverFullUnclosed && emittedVisibleText ? tag.text : undefined;
+          hiddenInlineCodeState = createInlineCodeState();
+          hiddenFenceState = undefined;
+        }
+        reasoningDepth += 1;
+      }
+    }
+    return output;
+  };
+
+  return {
+    markStrict() {
+      strictMode = true;
+    },
+    push(chunk: string) {
+      strictMode = true;
+      buffer += chunk;
+      return consume(false, false);
+    },
+    pushVisible(chunk: string) {
+      buffer += chunk;
+      return consume(false, true);
+    },
+    flush() {
+      return consume(true, !strictMode);
+    },
+    hasPending() {
+      return buffer.length > 0 || reasoningDepth > 0;
+    },
+    isInsideReasoning() {
+      return reasoningDepth > 0;
+    },
+  };
+}
+
+function hasRawReasoningTag(text: string): boolean {
+  REASONING_TAG_RE.lastIndex = 0;
+  return REASONING_TAG_RE.test(text);
+}
+
+function hasRawReasoningCloseTag(text: string): boolean {
+  REASONING_TAG_RE.lastIndex = 0;
+  for (;;) {
+    const match = REASONING_TAG_RE.exec(text);
+    if (!match) {
+      return false;
+    }
+    if (match[1] === "/") {
+      return true;
+    }
+  }
+}
+
+function findNextReasoningTag(
+  text: string,
+  isIndexInsideCode: (index: number) => boolean,
+): { index: number; text: string; isClose: boolean } | null {
+  REASONING_TAG_RE.lastIndex = 0;
+  for (;;) {
+    const match = REASONING_TAG_RE.exec(text);
+    if (!match) {
+      return null;
+    }
+    if (!isIndexInsideCode(match.index)) {
+      return {
+        index: match.index,
+        text: match[0],
+        isClose: match[1] === "/",
+      };
+    }
+  }
+}
+
+function reasoningTagPrefixSuffixIndex(
+  text: string,
+  isIndexInsideCode: (index: number) => boolean,
+): number {
+  for (let index = text.lastIndexOf("<"); index >= 0; ) {
+    if (!isIndexInsideCode(index) && isReasoningTagPrefix(text.slice(index))) {
+      return index;
+    }
+    if (index === 0) {
+      break;
+    }
+    index = text.lastIndexOf("<", index - 1);
+  }
+  return -1;
+}
+
+function isReasoningTagPrefix(text: string): boolean {
+  const name = normalizeReasoningTagPrefixName(text);
+  return REASONING_TAG_NAMES.some((tagName) => {
+    if (tagName.startsWith(name)) {
+      return true;
+    }
+    if (!name.startsWith(tagName)) {
+      return false;
+    }
+    const rest = name.slice(tagName.length);
+    return rest.length === 0 || /^[\s/>]/.test(rest);
+  });
+}
+
+function isReasoningCloseTagPrefix(text: string): boolean {
+  const normalized = text
+    .replace(/^<\s*/, "<")
+    .replace(/^<\s*\//, "</")
+    .replace(/^<\/\s*/, "</")
+    .toLowerCase();
+  return normalized.startsWith("</") && isReasoningTagPrefix(text);
+}
+
+function normalizeReasoningTagPrefixName(text: string): string {
+  const normalized = text
+    .replace(/^<\s*/, "<")
+    .replace(/^<\s*\//, "</")
+    .replace(/^<\/\s*/, "</")
+    .toLowerCase();
+  const rawName = normalized.startsWith("</") ? normalized.slice(2) : normalized.slice(1);
+  return rawName.trimStart();
+}
+
+function findOpenCodeContextStart(text: string): number {
+  const fence = findOpenFenceStart(text);
+  const inline = findOpenInlineCodeStart(text);
+  if (fence === -1) {
+    return inline;
+  }
+  if (inline === -1) {
+    return fence;
+  }
+  return Math.min(fence, inline);
+}
+
+function findOpenInlineCodeStart(text: string): number {
+  let openStart = -1;
+  let openTicks = 0;
+  let index = 0;
+  while (index < text.length) {
+    if (text[index] !== "`") {
+      index += 1;
+      continue;
+    }
+    const runStart = index;
+    let runLength = 0;
+    while (index < text.length && text[index] === "`") {
+      runLength += 1;
+      index += 1;
+    }
+    if (openStart === -1) {
+      openStart = runStart;
+      openTicks = runLength;
+    } else if (runLength === openTicks) {
+      openStart = -1;
+      openTicks = 0;
+    }
+  }
+  return openStart;
+}
+
+function findOpenFenceStart(text: string): number {
+  const fenceRe = /(^|\n)(```|~~~)[^\n]*(?:\n|$)/g;
+  let open: { marker: string; index: number } | null = null;
+  for (const match of text.matchAll(fenceRe)) {
+    const index = (match.index ?? 0) + match[1].length;
+    const marker = match[2] ?? "";
+    if (open !== null && open.marker === marker) {
+      open = null;
+    } else if (!open) {
+      open = { marker, index };
+    }
+  }
+  return open?.index ?? -1;
+}
+
+function findTrailingFenceFragmentStart(
+  text: string,
+  inlineState: InlineCodeState,
+  fenceState: FenceScanState | undefined,
+): number {
+  if (inlineState.open || fenceState?.open) {
+    return -1;
+  }
+  const lineStart = Math.max(text.lastIndexOf("\n") + 1, 0);
+  const line = text.slice(lineStart);
+  const match = line.match(/^( {0,3})(`{1,2}|~{1,2})$/);
+  return match ? lineStart : -1;
+}


### PR DESCRIPTION
Summary:
- split streamed inline reasoning tags out of visible OpenAI-compatible text deltas before channels render them
- share the reasoning-tag partitioner between OpenAI Completions and the OpenAI transport stream path
- preserve literal tag examples in Markdown code spans/fences and flush buffered visible text before tool calls

Fixes #88741

Verification:
- `node_modules/.bin/oxfmt --check --threads=1 src/shared/text/reasoning-tag-text-partitioner.ts src/shared/text/reasoning-tag-text-partitioner.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-reasoning-tags-main-$RANDOM node scripts/run-vitest.mjs src/shared/text/reasoning-tag-text-partitioner.test.ts src/llm/providers/openai-completions.test.ts src/agents/openai-transport-stream.test.ts` -> 3 shards passed; parser 25 tests, openai-completions 16 tests, openai-transport-stream 227 tests
- `git diff --check main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local --thinking low` -> clean, no accepted/actionable findings
