### PR TITLE
Fix stuck-session recovery aborts for active reply runs

### DIFF
--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -12,7 +12,7 @@ export type EmbeddedAgentQueueHandle = {
   isStreaming: () => boolean;
   isCompacting: () => boolean;
   supportsTranscriptCommitWait?: boolean;
-  cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
+  cancel?: (reason?: "user_abort" | "restart" | "superseded" | "stuck_recovery") => void;
   abort: () => void;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3190,7 +3190,7 @@ export async function runEmbeddedAttempt(
       };
       const queueHandle: EmbeddedAgentQueueHandle & {
         kind: "embedded";
-        cancel: (reason?: "user_abort" | "restart" | "superseded") => void;
+        cancel: (reason?: "user_abort" | "restart" | "superseded" | "stuck_recovery") => void;
       } = {
         kind: "embedded",
         queueMessage: async (text: string, options) => {
@@ -3203,7 +3203,10 @@ export async function runEmbeddedAttempt(
         isCompacting: () => subscription.isCompacting(),
         supportsTranscriptCommitWait: true,
         sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-        cancel: abortActiveRunExternally,
+        cancel: (reason) => {
+          externalAbort = true;
+          abortRun(false, reason);
+        },
         abort: abortActiveRunExternally,
       };
       let lastAssistant: AssistantMessage | undefined;

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -8,6 +8,7 @@ import {
   queueReplyRunMessage,
   resolveActiveReplyRunSessionId,
   waitForReplyRunEndBySessionId,
+  type ReplyBackendCancelReason,
 } from "../../auto-reply/reply/reply-run-registry.js";
 import {
   markDiagnosticEmbeddedRunEnded,
@@ -434,18 +435,31 @@ function prepareEmbeddedAgentQueueMessage(
  * - With no sessionId, supports targeted abort modes (for example, compacting runs only).
  */
 export function abortEmbeddedAgentRun(sessionId: string): boolean;
+export function abortEmbeddedAgentRun(sessionId: string, opts?: { reason?: string }): boolean;
 export function abortEmbeddedAgentRun(
   sessionId: undefined,
   opts: { mode: "all" | "compacting" },
 ): boolean;
 export function abortEmbeddedAgentRun(
   sessionId?: string,
-  opts?: { mode?: "all" | "compacting" },
+  opts?: { mode?: "all" | "compacting"; reason?: string },
 ): boolean {
+  const mapAbortReasonToCancelReason = (
+    reason?: string,
+  ): ReplyBackendCancelReason | undefined => {
+    if (!reason) {
+      return undefined;
+    }
+    if (reason === "user_abort" || reason === "restart" || reason === "stuck_recovery") {
+      return reason;
+    }
+    return "superseded";
+  };
+
   if (typeof sessionId === "string" && sessionId.length > 0) {
     const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
     if (!handle) {
-      if (abortReplyRunBySessionId(sessionId)) {
+      if (abortReplyRunBySessionId(sessionId, opts?.reason ? { reason: opts.reason } : undefined)) {
         return true;
       }
       diag.debug(`abort failed: sessionId=${sessionId} reason=no_active_run`);
@@ -453,7 +467,12 @@ export function abortEmbeddedAgentRun(
     }
     diag.debug(`aborting run: sessionId=${sessionId}`);
     try {
-      handle.abort();
+      const cancelReason = mapAbortReasonToCancelReason(opts?.reason);
+      if (cancelReason && handle.cancel) {
+        handle.cancel(cancelReason);
+      } else {
+        handle.abort();
+      }
     } catch (err) {
       diag.warn(`abort failed: sessionId=${sessionId} err=${String(err)}`);
       return false;
@@ -698,7 +717,7 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
   reason?: string;
 }): Promise<AbortAndDrainEmbeddedAgentRunResult> {
   const settleMs = params.settleMs ?? 15_000;
-  const aborted = abortEmbeddedAgentRun(params.sessionId);
+  const aborted = abortEmbeddedAgentRun(params.sessionId, { reason: params.reason });
   const drained = aborted ? await waitForEmbeddedAgentRunEnd(params.sessionId, settleMs) : false;
   const forceCleared =
     params.forceClear === true && (!aborted || !drained)

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -7,6 +7,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
 import {
   testing,
   abortActiveReplyRuns,
+  abortReplyRunBySessionId,
   createReplyOperation,
   forceClearReplyRunBySessionId,
   isReplyRunActiveForSessionId,
@@ -102,6 +103,29 @@ describe("reply run registry", () => {
     operation.abortByUser();
 
     expect(operation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
+    expect(replyRunRegistry.isActive("agent:main:main")).toBe(false);
+  });
+
+  it("preserves stuck recovery when aborting through the session-id fallback", () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:main",
+      sessionId: "session-stuck-recovery",
+      resetTriggered: false,
+    });
+
+    expect(abortReplyRunBySessionId("session-stuck-recovery", { reason: "stuck_recovery" })).toBe(
+      true,
+    );
+
+    expect(operation.result).toEqual({
+      kind: "aborted",
+      code: "aborted_by_system",
+      reason: "stuck_recovery",
+    });
+    expect(operation.abortSignal.reason).toMatchObject({
+      name: "AbortError",
+      message: "Reply operation aborted by system reason=stuck_recovery",
+    });
     expect(replyRunRegistry.isActive("agent:main:main")).toBe(false);
   });
 

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -10,7 +10,11 @@ export type ReplyRunKey = string;
 
 export type ReplyBackendKind = "embedded" | "cli";
 
-export type ReplyBackendCancelReason = "user_abort" | "restart" | "superseded";
+export type ReplyBackendCancelReason =
+  | "user_abort"
+  | "restart"
+  | "superseded"
+  | "stuck_recovery";
 
 export type ReplyBackendHandle = {
   readonly kind: ReplyBackendKind;
@@ -40,12 +44,15 @@ export type ReplyOperationFailureCode =
   | "session_corruption_reset"
   | "run_failed";
 
-export type ReplyOperationAbortCode = "aborted_by_user" | "aborted_for_restart";
+export type ReplyOperationAbortCode =
+  | "aborted_by_user"
+  | "aborted_for_restart"
+  | "aborted_by_system";
 
 export type ReplyOperationResult =
   | { kind: "completed" }
   | { kind: "failed"; code: ReplyOperationFailureCode; cause?: unknown }
-  | { kind: "aborted"; code: ReplyOperationAbortCode };
+  | { kind: "aborted"; code: ReplyOperationAbortCode; reason?: string };
 
 export type ReplyOperation = {
   readonly key: ReplyRunKey;
@@ -68,6 +75,12 @@ export type ReplyOperation = {
   fail(code: Exclude<ReplyOperationFailureCode, "aborted_by_user">, cause?: unknown): void;
   abortByUser(): void;
   abortForRestart(): void;
+  abortWithReason?: (params: {
+    reason: string;
+    abortReason?: unknown;
+    cancelReason?: ReplyBackendCancelReason;
+    abortedCode?: Extract<ReplyOperationAbortCode, "aborted_by_system">;
+  }) => void;
 };
 
 export type ReplyRunRegistry = {
@@ -81,7 +94,7 @@ export type ReplyRunRegistry = {
   get(sessionKey: string): ReplyOperation | undefined;
   isActive(sessionKey: string): boolean;
   isStreaming(sessionKey: string): boolean;
-  abort(sessionKey: string): boolean;
+  abort(sessionKey: string, opts?: { reason?: string }): boolean;
   waitForIdle(
     sessionKey: string,
     timeoutMs?: number,
@@ -124,6 +137,12 @@ export class ReplyRunAlreadyActiveError extends Error {
 
 function createUserAbortError(): Error {
   const err = new Error("Reply operation aborted by user");
+  err.name = "AbortError";
+  return err;
+}
+
+function createSystemAbortError(reason: string): Error {
+  const err = new Error(`Reply operation aborted by system reason=${reason}`);
   err.name = "AbortError";
   return err;
 }
@@ -268,17 +287,39 @@ export function createReplyOperation(params: {
     }
   };
 
-  const abortWithReason = (
-    reason: ReplyBackendCancelReason,
-    abortReason: unknown,
-    opts?: { abortedCode?: ReplyOperationAbortCode },
-  ) => {
-    if (opts?.abortedCode && !result) {
-      result = { kind: "aborted", code: opts.abortedCode };
+  const applyAbort = (params: {
+    cancelReason: ReplyBackendCancelReason;
+    abortReason: unknown;
+    abortedCode?: ReplyOperationAbortCode;
+    resultReason?: string;
+  }) => {
+    if (params.abortedCode && !result) {
+      result = {
+        kind: "aborted",
+        code: params.abortedCode,
+        ...(params.resultReason ? { reason: params.resultReason } : {}),
+      };
     }
     phase = "aborted";
-    abortInternally(abortReason);
-    getAttachedBackend(operation)?.cancel(reason);
+    abortInternally(params.abortReason);
+    getAttachedBackend(operation)?.cancel(params.cancelReason);
+  };
+
+  const abortWithReason = (
+    reason: string,
+    opts?: {
+      abortReason?: unknown;
+      cancelReason?: ReplyBackendCancelReason;
+      abortedCode?: Extract<ReplyOperationAbortCode, "aborted_by_system">;
+    },
+  ) => {
+    applyAbort({
+      cancelReason:
+        opts?.cancelReason ?? (reason === "stuck_recovery" ? "stuck_recovery" : "superseded"),
+      abortReason: opts?.abortReason ?? createSystemAbortError(reason),
+      abortedCode: opts?.abortedCode ?? "aborted_by_system",
+      resultReason: reason,
+    });
   };
 
   if (params.upstreamAbortSignal) {
@@ -353,7 +394,11 @@ export function createReplyOperation(params: {
           result.kind === "aborted"
             ? result.code === "aborted_for_restart"
               ? "restart"
-              : "user_abort"
+              : result.code === "aborted_by_user"
+                ? "user_abort"
+                : result.reason === "stuck_recovery"
+                  ? "stuck_recovery"
+                  : "superseded"
             : "superseded",
         );
         return;
@@ -388,7 +433,9 @@ export function createReplyOperation(params: {
     },
     abortByUser() {
       const phaseBeforeAbort = phase;
-      abortWithReason("user_abort", createUserAbortError(), {
+      applyAbort({
+        cancelReason: "user_abort",
+        abortReason: createUserAbortError(),
         abortedCode: "aborted_by_user",
       });
       if (phaseBeforeAbort === "queued") {
@@ -397,8 +444,21 @@ export function createReplyOperation(params: {
     },
     abortForRestart() {
       const phaseBeforeAbort = phase;
-      abortWithReason("restart", new Error("Reply operation aborted for restart"), {
+      applyAbort({
+        cancelReason: "restart",
+        abortReason: new Error("Reply operation aborted for restart"),
         abortedCode: "aborted_for_restart",
+      });
+      if (phaseBeforeAbort === "queued") {
+        clearState();
+      }
+    },
+    abortWithReason(params) {
+      const phaseBeforeAbort = phase;
+      abortWithReason(params.reason, {
+        abortReason: params.abortReason,
+        cancelReason: params.cancelReason,
+        abortedCode: params.abortedCode,
       });
       if (phaseBeforeAbort === "queued") {
         clearState();
@@ -440,12 +500,16 @@ export const replyRunRegistry: ReplyRunRegistry = {
     }
     return getAttachedBackend(operation)?.isStreaming() ?? false;
   },
-  abort(sessionKey) {
+  abort(sessionKey, opts) {
     const operation = this.get(sessionKey);
     if (!operation) {
       return false;
     }
-    operation.abortByUser();
+    if (opts?.reason) {
+      operation.abortWithReason?.({ reason: opts.reason });
+    } else {
+      operation.abortByUser();
+    }
     return true;
   },
   waitForIdle(sessionKey, timeoutMs, opts) {
@@ -538,12 +602,19 @@ export function queueReplyRunMessage(sessionId: string, text: string): boolean {
   return true;
 }
 
-export function abortReplyRunBySessionId(sessionId: string): boolean {
+export function abortReplyRunBySessionId(
+  sessionId: string,
+  opts?: { reason?: string },
+): boolean {
   const operation = resolveReplyRunForCurrentSessionId(sessionId);
   if (!operation) {
     return false;
   }
-  operation.abortByUser();
+  if (opts?.reason) {
+    operation.abortWithReason?.({ reason: opts.reason });
+  } else {
+    operation.abortByUser();
+  }
   return true;
 }
 

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -10,11 +10,7 @@ export type ReplyRunKey = string;
 
 export type ReplyBackendKind = "embedded" | "cli";
 
-export type ReplyBackendCancelReason =
-  | "user_abort"
-  | "restart"
-  | "superseded"
-  | "stuck_recovery";
+export type ReplyBackendCancelReason = "user_abort" | "restart" | "superseded" | "stuck_recovery";
 
 export type ReplyBackendHandle = {
   readonly kind: ReplyBackendKind;
@@ -287,22 +283,22 @@ export function createReplyOperation(params: {
     }
   };
 
-  const applyAbort = (params: {
+  const applyAbort = (abortParams: {
     cancelReason: ReplyBackendCancelReason;
     abortReason: unknown;
     abortedCode?: ReplyOperationAbortCode;
     resultReason?: string;
   }) => {
-    if (params.abortedCode && !result) {
+    if (abortParams.abortedCode && !result) {
       result = {
         kind: "aborted",
-        code: params.abortedCode,
-        ...(params.resultReason ? { reason: params.resultReason } : {}),
+        code: abortParams.abortedCode,
+        ...(abortParams.resultReason ? { reason: abortParams.resultReason } : {}),
       };
     }
     phase = "aborted";
-    abortInternally(params.abortReason);
-    getAttachedBackend(operation)?.cancel(params.cancelReason);
+    abortInternally(abortParams.abortReason);
+    getAttachedBackend(operation)?.cancel(abortParams.cancelReason);
   };
 
   const abortWithReason = (
@@ -453,12 +449,12 @@ export function createReplyOperation(params: {
         clearState();
       }
     },
-    abortWithReason(params) {
+    abortWithReason(abortParams) {
       const phaseBeforeAbort = phase;
-      abortWithReason(params.reason, {
-        abortReason: params.abortReason,
-        cancelReason: params.cancelReason,
-        abortedCode: params.abortedCode,
+      abortWithReason(abortParams.reason, {
+        abortReason: abortParams.abortReason,
+        cancelReason: abortParams.cancelReason,
+        abortedCode: abortParams.abortedCode,
       });
       if (phaseBeforeAbort === "queued") {
         clearState();
@@ -602,10 +598,7 @@ export function queueReplyRunMessage(sessionId: string, text: string): boolean {
   return true;
 }
 
-export function abortReplyRunBySessionId(
-  sessionId: string,
-  opts?: { reason?: string },
-): boolean {
+export function abortReplyRunBySessionId(sessionId: string, opts?: { reason?: string }): boolean {
   const operation = resolveReplyRunForCurrentSessionId(sessionId);
   if (!operation) {
     return false;

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -145,6 +145,7 @@ describe("stuck session recovery integration", () => {
 
     expect(getQueueSize(lane)).toBe(2);
     await activeStarted;
+    await delay(5);
 
     const outcome = await recoverStuckDiagnosticSession({
       sessionId,
@@ -152,11 +153,21 @@ describe("stuck session recovery integration", () => {
       ageMs: 720_000,
       queueDepth: 1,
       allowActiveAbort: true,
+      staleActiveProgressAbortMs: 1,
     });
 
     await expect(active).resolves.toBe("aborted");
     await expect(queued).resolves.toBe("drained");
     expect(outcome.status).toBe("aborted");
+    expect(operation.result).toEqual({
+      kind: "aborted",
+      code: "aborted_by_system",
+      reason: "stuck_recovery",
+    });
+    expect(operation.abortSignal.reason).toMatchObject({
+      name: "AbortError",
+      message: "Reply operation aborted by system reason=stuck_recovery",
+    });
     expect(getQueueSize(lane)).toBe(0);
   });
 

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -180,6 +180,9 @@ describe("stuck session recovery", () => {
   });
   it("aborts an active embedded run when active abort recovery is enabled", async () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      lastProgressAgeMs: 10 * 60_000,
+    });
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
     mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
 
@@ -196,8 +199,38 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
+  it("does not abort an active embedded run with recent tracked progress even when active abort recovery is enabled", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      lastProgressAgeMs: 18_000,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "observe_only",
+      reason: "active_embedded_run",
+      activeSessionId: "session-1",
+    });
+    expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.waitForEmbeddedAgentRunEnd).not.toHaveBeenCalled();
+    expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+  });
+
   it("returns an abort outcome for a stale tool call on an active embedded run", async () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-tool");
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      activeToolAgeMs: 10 * 60_000,
+      lastProgressAgeMs: 10 * 60_000,
+    });
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
     mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
 
@@ -364,6 +397,9 @@ describe("stuck session recovery", () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
     mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
     mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      lastProgressAgeMs: 10 * 60_000,
+    });
     mocks.abortEmbeddedAgentRun.mockReturnValue(true);
     mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
 
@@ -383,6 +419,35 @@ describe("stuck session recovery", () => {
       "stuck session recovery: sessionId=queued-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=0",
       "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=0",
     ]);
+  });
+
+  it("does not abort active reply work with recent tracked progress even when active abort recovery is enabled", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      lastProgressAgeMs: 18_000,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "keep_lane",
+      reason: "active_reply_work",
+      activeSessionId: "queued-reply-session",
+    });
+    expect(mocks.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.waitForEmbeddedAgentRunEnd).not.toHaveBeenCalled();
+    expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
   it("reports queued lane work when aborting active work releases a lane", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -36,7 +36,27 @@ function resolveStaleActiveProgressAbortMs(params: StuckSessionRecoveryParams): 
     : STUCK_SESSION_PROGRESS_STALE_MS;
 }
 
-function isActiveRunProgressStale(params: {
+function getActiveRunProgressAgeMs(params: {
+  sessionId?: string;
+  sessionKey?: string;
+}): number | undefined {
+  const activity = getDiagnosticSessionActivitySnapshot({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+  });
+  return activity.lastProgressAgeMs;
+}
+
+function hasRecentTrackedActiveRunProgress(params: {
+  sessionId?: string;
+  sessionKey?: string;
+  staleAbortMs: number;
+}): boolean {
+  const lastProgressAgeMs = getActiveRunProgressAgeMs(params);
+  return typeof lastProgressAgeMs === "number" && lastProgressAgeMs < params.staleAbortMs;
+}
+
+function isQueuedActiveRunProgressStale(params: {
   sessionId?: string;
   sessionKey?: string;
   queueDepth?: number;
@@ -45,11 +65,7 @@ function isActiveRunProgressStale(params: {
   if ((params.queueDepth ?? 0) <= 0) {
     return false;
   }
-  const activity = getDiagnosticSessionActivitySnapshot({
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-  });
-  const lastProgressAgeMs = activity.lastProgressAgeMs;
+  const lastProgressAgeMs = getActiveRunProgressAgeMs(params);
   return typeof lastProgressAgeMs === "number" && lastProgressAgeMs >= params.staleAbortMs;
 }
 
@@ -137,15 +153,21 @@ export async function recoverStuckDiagnosticSession(
     const staleActiveProgressAbortMs = resolveStaleActiveProgressAbortMs(params);
 
     if (activeSessionId) {
+      const preserveTrackedActiveRun =
+        hasRecentTrackedActiveRunProgress({
+          sessionId: activeSessionId,
+          sessionKey: params.sessionKey,
+          staleAbortMs: staleActiveProgressAbortMs,
+        });
       const reclaimStaleActiveRun =
         params.allowActiveAbort !== true &&
-        isActiveRunProgressStale({
+        isQueuedActiveRunProgressStale({
           sessionId: activeSessionId,
           sessionKey: params.sessionKey,
           queueDepth: params.queueDepth,
           staleAbortMs: staleActiveProgressAbortMs,
         });
-      if (params.allowActiveAbort !== true && !reclaimStaleActiveRun) {
+      if (preserveTrackedActiveRun || (params.allowActiveAbort !== true && !reclaimStaleActiveRun)) {
         const outcome: StuckSessionRecoveryOutcome = {
           status: "skipped",
           action: "observe_only",
@@ -179,14 +201,33 @@ export async function recoverStuckDiagnosticSession(
     }
 
     if (!activeSessionId && activeWorkSessionId && isEmbeddedAgentRunActive(activeWorkSessionId)) {
+      const preserveTrackedReplyWork =
+        hasRecentTrackedActiveRunProgress({
+          sessionId: activeWorkSessionId,
+          sessionKey: params.sessionKey,
+          staleAbortMs: staleActiveProgressAbortMs,
+        });
       const reclaimStaleReplyWork =
         params.allowActiveAbort !== true &&
-        isActiveRunProgressStale({
+        isQueuedActiveRunProgressStale({
           sessionId: activeWorkSessionId,
           sessionKey: params.sessionKey,
           queueDepth: params.queueDepth,
           staleAbortMs: staleActiveProgressAbortMs,
         });
+      if (preserveTrackedReplyWork) {
+        const outcome: StuckSessionRecoveryOutcome = {
+          status: "skipped",
+          action: "keep_lane",
+          reason: "active_reply_work",
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          activeSessionId: activeWorkSessionId,
+          activeWorkKind: "embedded_run",
+        };
+        diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+        return outcome;
+      }
       if (params.allowActiveAbort === true || reclaimStaleReplyWork) {
         if (reclaimStaleReplyWork) {
           diag.warn(

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1689,7 +1689,7 @@ describe("stuck session diagnostics threshold", () => {
     expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
-  it("recovers queued sessions behind terminal embedded progress after the abort threshold", () => {
+  it("does not recover queued sessions behind recent terminal embedded progress just because the session is old", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionWarnMs = 30_000;
@@ -1739,6 +1739,59 @@ describe("stuck session diagnostics threshold", () => {
       terminalProgressStale: true,
       lastProgressReason: terminalReason,
     });
+    expect(events.findLast((event) => event.type === "session.recovery.requested")).toBeUndefined();
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
+  it("recovers queued sessions behind terminal embedded progress once that progress is stale", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 30_000;
+    const stuckSessionAbortMs = 60_000;
+    const terminalReason = "codex_app_server:notification:rawResponseItem/completed";
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs,
+            stuckSessionAbortMs,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+
+      vi.advanceTimersByTime(stuckSessionAbortMs - 1);
+      markDiagnosticRunProgressForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        reason: terminalReason,
+      });
+      vi.advanceTimersByTime(stuckSessionAbortMs + 1);
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecordFields(
+      requireRecord(
+        events.findLast((event) => event.type === "session.stalled"),
+        "stalled event",
+      ),
+      {
+        classification: "stalled_agent_run",
+        reason: "queued_behind_terminal_active_work",
+        activeWorkKind: "embedded_run",
+        queueDepth: 1,
+        terminalProgressStale: true,
+        lastProgressReason: terminalReason,
+      },
+    );
     expectRecoveryCall(
       recoverStuckSession,
       { sessionId: "s1", sessionKey: "main", queueDepth: 1, allowActiveAbort: true },

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -478,14 +478,16 @@ function resolveStalledEmbeddedRunAbortMs(stuckSessionWarnMs: number): number {
 
 function isStalledEmbeddedRunRecoveryEligible(params: {
   classification: SessionAttentionClassification | undefined;
-  ageMs: number;
+  activity?: DiagnosticSessionActivitySnapshot;
   stuckSessionAbortMs: number;
 }): boolean {
+  const lastProgressAgeMs = params.activity?.lastProgressAgeMs;
   return (
     params.classification?.eventType === "session.stalled" &&
     params.classification.classification === "stalled_agent_run" &&
     params.classification.activeWorkKind === "embedded_run" &&
-    params.ageMs >= params.stuckSessionAbortMs
+    typeof lastProgressAgeMs === "number" &&
+    lastProgressAgeMs >= params.stuckSessionAbortMs
   );
 }
 


### PR DESCRIPTION
﻿## Summary
- preserve `stuck_recovery` through reply-run session-id fallback and embedded-run cancel plumbing so recovery no longer degrades into a fake user abort
- require stale tracked progress before active embedded/reply work is abort-drained, even when active-abort recovery is enabled
- add regressions for fresh terminal progress, fresh active reply work, and streamed model progress so long-but-active runs stay alive

## Testing
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/reply-run-registry.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.logging.config.ts src/logging/diagnostic.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-embedded-agent.config.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts`

## Real behavior proof
- **Behavior or issue addressed**: Verify that this patch preserves `stuck_recovery` through the reply-run session-id fallback and does not abort a live embedded run that still has fresh tracked progress.
- **Real environment tested**: Local OpenClaw checkout on Windows 11 using the real modules from this PR branch via a Node/tsx runtime harness after commit `159943a6c0`.
- **Exact steps or command run after this patch**: Ran `pnpm exec tsx -` against the real repo modules in this branch with a runtime harness that (1) creates a reply operation and aborts it through `abortReplyRunBySessionId(..., { reason: "stuck_recovery" })`, then (2) registers an active embedded run, records fresh progress with `markDiagnosticRunProgressForTest(...)`, and calls `recoverStuckDiagnosticSession(...)` with `allowActiveAbort: true`.
- **Evidence after fix**: Terminal output from the local OpenClaw runtime harness after the fix:
  [reply-registry]
  {"aborted":true,"result":{"kind":"aborted","code":"aborted_by_system","reason":"stuck_recovery"},"abortSignalReason":"Reply operation aborted by system reason=stuck_recovery"}
  [stuck-recovery]
  {"snapshotBefore":{"activeWorkKind":"embedded_run","hasActiveEmbeddedRun":true,"lastProgressAgeMs":1,"lastProgressReason":"model chunk observed from runtime harness"},"outcome":{"status":"skipped","action":"observe_only","reason":"active_embedded_run","sessionId":"session-live-progress","sessionKey":"agent:main:main","activeSessionId":"session-live-progress","activeWorkKind":"embedded_run"},"abortCount":0,"cancelReasons":[],"snapshotAfter":{"activeWorkKind":"embedded_run","hasActiveEmbeddedRun":true,"lastProgressAgeMs":84,"lastProgressReason":"model chunk observed from runtime harness"}}
  [diagnostic] stuck session recovery skipped: sessionId=session-live-progress sessionKey=agent:main:main age=180s queueDepth=1 activeSessionId=session-live-progress
  [diagnostic] stuck session recovery outcome: status=skipped action=observe_only sessionId=session-live-progress sessionKey=agent:main:main activeSessionId=session-live-progress activeWorkKind=embedded_run reason=active_embedded_run
- **Observed result after fix**: The reply-run fallback keeps `reason: "stuck_recovery"` instead of degrading into a user-abort shape. The live-progress recovery path returns `status: "skipped"`, leaves the embedded run active, and does not call abort or cancel on the active handle.
- **What was not tested**: I did not rerun a multi-minute end-to-end Feishu + `claude-cli` channel repro in this environment, and I did not capture UI/video proof from a live chat surface.

## Notes
- `diagnostics.stuckSessionWarnMs` / `diagnostics.stuckSessionAbortMs` and the default `warnMs x 3` / minimum 5 minute behavior are already documented in the current docs/config help, so this PR focuses on the runtime regressions from `#88870`.

Closes #88870
