### PR TITLE
fix(llm): preserve Windows path escapes in streamed args

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -545,7 +545,7 @@ describe("anthropic transport stream", () => {
           delta: {
             type: "input_json_delta",
             partial_json:
-              '{"to":1481220477346119781,"safe":42,"maxSafe":9007199254740991,"nested":{"ids":[9007199254740993,-9007199254740992]}}',
+              '{"to":1481220477346119781,"safe":42,"maxSafe":9007199254740991,"path":"C:/tmp\\new.txt","content":"C:\\nnext","nested":{"ids":[9007199254740993,-9007199254740992]}}',
           },
         },
         { type: "content_block_stop", index: 0 },
@@ -575,6 +575,8 @@ describe("anthropic transport stream", () => {
       to: "1481220477346119781",
       safe: 42,
       maxSafe: 9007199254740991,
+      path: "C:/tmp\\new.txt",
+      content: "C:\nnext",
       nested: { ids: ["9007199254740993", "-9007199254740992"] },
     });
   });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -3,7 +3,7 @@ import { getEnvApiKey } from "../llm/env-api-keys.js";
 import { calculateCost } from "../llm/model-utils.js";
 import type { AnthropicOptions } from "../llm/providers/anthropic.js";
 import type { Context, Model, SimpleStreamOptions, ThinkingLevel } from "../llm/types.js";
-import { parseStreamingJson } from "../llm/utils/json-parse.js";
+import { normalizeStreamingJsonPathEscapes, parseStreamingJson } from "../llm/utils/json-parse.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import {
   applyAnthropicPayloadPolicyToParams,
@@ -511,7 +511,8 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
 }
 
 function parseAnthropicToolCallArguments(inputJson: string): unknown {
-  return parseJsonObjectPreservingUnsafeIntegers(inputJson) ?? parseStreamingJson(inputJson);
+  const parsed = parseJsonObjectPreservingUnsafeIntegers(inputJson);
+  return parsed ? normalizeStreamingJsonPathEscapes(parsed) : parseStreamingJson(inputJson);
 }
 
 function mapStopReason(reason: string | undefined): string {

--- a/src/llm/utils/json-parse.test.ts
+++ b/src/llm/utils/json-parse.test.ts
@@ -35,9 +35,24 @@ describe("json-parse repairJson invalid \\u escapes", () => {
     });
   });
 
+  it("normalizes decoded Windows path escapes after mixed separators in path fields", () => {
+    expect(parseStreamingJson('{"path":"C:/tmp\\new.txt"}')).toEqual({
+      path: "C:/tmp\\new.txt",
+    });
+  });
+
   it("does not rewrite legitimate non-path control escapes", () => {
     expect(parseStreamingJson('{"message":"first\\nsecond"}')).toEqual({
       message: "first\nsecond",
+    });
+  });
+
+  it("does not rewrite non-path content that starts with a drive prefix", () => {
+    expect(parseStreamingJson('{"content":"C:/\\nnext"}')).toEqual({
+      content: "C:/\nnext",
+    });
+    expect(parseStreamingJson('{"content":"C:\\nnext"}')).toEqual({
+      content: "C:\nnext",
     });
   });
 });

--- a/src/llm/utils/json-parse.test.ts
+++ b/src/llm/utils/json-parse.test.ts
@@ -18,4 +18,26 @@ describe("json-parse repairJson invalid \\u escapes", () => {
     const args = '{"cmd":"\\underline{x}"}';
     expect(parseStreamingJson(args)).toEqual({ cmd: "\\underline{x}" });
   });
+
+  it.each([
+    ['{"path":"C:\\bin\\app.exe"}', "C:\\bin\\app.exe"],
+    ['{"path":"C:\\temp\\x"}', "C:\\temp\\x"],
+    ['{"path":"C:\\new\\file"}', "C:\\new\\file"],
+    ['{"path":"D:\\reports\\q"}', "D:\\reports\\q"],
+    ['{"path":"C:\\users\\bob"}', "C:\\users\\bob"],
+  ])("keeps unescaped Windows path control-letter segments literal for %s", (args, path) => {
+    expect(parseStreamingJson(args)).toEqual({ path });
+  });
+
+  it("normalizes decoded Windows path escapes in nested tool arguments", () => {
+    expect(parseStreamingJson('{"edits":[{"path":"C:\\new\\file"}]}')).toEqual({
+      edits: [{ path: "C:\\new\\file" }],
+    });
+  });
+
+  it("does not rewrite legitimate non-path control escapes", () => {
+    expect(parseStreamingJson('{"message":"first\\nsecond"}')).toEqual({
+      message: "first\nsecond",
+    });
+  });
 });

--- a/src/llm/utils/json-parse.ts
+++ b/src/llm/utils/json-parse.ts
@@ -1,6 +1,14 @@
 import { parse as partialParse } from "partial-json";
 
 const VALID_JSON_ESCAPES = new Set(['"', "\\", "/", "b", "f", "n", "r", "t", "u"]);
+const JSON_CONTROL_ESCAPES = new Set(["b", "f", "n", "r", "t"]);
+const DECODED_WINDOWS_PATH_ESCAPES = new Map([
+  ["\b", "\\b"],
+  ["\f", "\\f"],
+  ["\n", "\\n"],
+  ["\r", "\\r"],
+  ["\t", "\\t"],
+]);
 
 function isControlCharacter(char: string): boolean {
   const codePoint = char.codePointAt(0);
@@ -24,6 +32,31 @@ function escapeControlCharacter(char: string): string {
   }
 }
 
+function isLikelyWindowsPathPrefix(value: string): boolean {
+  return /^[A-Za-z]:(?:[\\/].*)?$/u.test(value);
+}
+
+function normalizeDecodedWindowsPathEscapes(value: unknown): unknown {
+  if (typeof value === "string") {
+    if (!/^[A-Za-z]:[\\/\b\f\n\r\t]/u.test(value)) {
+      return value;
+    }
+    return value.replace(
+      /[\b\f\n\r\t]/gu,
+      (char) => DECODED_WINDOWS_PATH_ESCAPES.get(char) ?? char,
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeDecodedWindowsPathEscapes(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, normalizeDecodedWindowsPathEscapes(item)]),
+    );
+  }
+  return value;
+}
+
 /**
  * Repairs malformed JSON string literals by:
  * - escaping raw control characters inside strings
@@ -32,6 +65,7 @@ function escapeControlCharacter(char: string): string {
 export function repairJson(json: string): string {
   let repaired = "";
   let inString = false;
+  let stringPrefix = "";
 
   for (let index = 0; index < json.length; index++) {
     const char = json[index];
@@ -40,6 +74,7 @@ export function repairJson(json: string): string {
       repaired += char;
       if (char === '"') {
         inString = true;
+        stringPrefix = "";
       }
       continue;
     }
@@ -47,6 +82,7 @@ export function repairJson(json: string): string {
     if (char === '"') {
       repaired += char;
       inString = false;
+      stringPrefix = "";
       continue;
     }
 
@@ -54,6 +90,7 @@ export function repairJson(json: string): string {
       const nextChar = json[index + 1];
       if (nextChar === undefined) {
         repaired += "\\\\";
+        stringPrefix += "\\";
         continue;
       }
 
@@ -61,6 +98,7 @@ export function repairJson(json: string): string {
         const unicodeDigits = json.slice(index + 2, index + 6);
         if (/^[0-9a-fA-F]{4}$/.test(unicodeDigits)) {
           repaired += `\\u${unicodeDigits}`;
+          stringPrefix += String.fromCodePoint(Number.parseInt(unicodeDigits, 16));
           index += 5;
           continue;
         }
@@ -69,32 +107,48 @@ export function repairJson(json: string): string {
         // hit the valid-escape branch (VALID_JSON_ESCAPES contains "u") and
         // re-emit the broken \u, leaving the JSON unparseable.
         repaired += "\\\\";
+        stringPrefix += "\\";
+        continue;
+      }
+
+      if (JSON_CONTROL_ESCAPES.has(nextChar) && isLikelyWindowsPathPrefix(stringPrefix)) {
+        repaired += "\\\\";
+        stringPrefix += "\\";
         continue;
       }
 
       if (VALID_JSON_ESCAPES.has(nextChar)) {
         repaired += `\\${nextChar}`;
+        stringPrefix += nextChar;
         index += 1;
         continue;
       }
 
       repaired += "\\\\";
+      stringPrefix += "\\";
       continue;
     }
 
     repaired += isControlCharacter(char) ? escapeControlCharacter(char) : char;
+    stringPrefix += char;
   }
 
   return repaired;
 }
 
-export function parseJsonWithRepair(json: string): unknown {
+export function parseJsonWithRepair(
+  json: string,
+  options?: { normalizeWindowsPathEscapes?: boolean },
+): unknown {
+  const normalize = (value: unknown): unknown =>
+    options?.normalizeWindowsPathEscapes ? normalizeDecodedWindowsPathEscapes(value) : value;
+
   try {
-    return JSON.parse(json) as unknown;
+    return normalize(JSON.parse(json) as unknown);
   } catch (error) {
     const repairedJson = repairJson(json);
     if (repairedJson !== json) {
-      return JSON.parse(repairedJson) as unknown;
+      return normalize(JSON.parse(repairedJson) as unknown);
     }
     throw error;
   }
@@ -113,15 +167,17 @@ export function parseStreamingJson(partialJson: string | undefined): Record<stri
   }
 
   try {
-    return parseJsonWithRepair(partialJson) as Record<string, unknown>;
+    return parseJsonWithRepair(partialJson, {
+      normalizeWindowsPathEscapes: true,
+    }) as Record<string, unknown>;
   } catch {
     try {
       const result = partialParse(partialJson);
-      return (result ?? {}) as Record<string, unknown>;
+      return normalizeDecodedWindowsPathEscapes(result ?? {}) as Record<string, unknown>;
     } catch {
       try {
         const result = partialParse(repairJson(partialJson));
-        return (result ?? {}) as Record<string, unknown>;
+        return normalizeDecodedWindowsPathEscapes(result ?? {}) as Record<string, unknown>;
       } catch {
         return {};
       }

--- a/src/llm/utils/json-parse.ts
+++ b/src/llm/utils/json-parse.ts
@@ -9,6 +9,20 @@ const DECODED_WINDOWS_PATH_ESCAPES = new Map([
   ["\r", "\\r"],
   ["\t", "\\t"],
 ]);
+const PATH_LIKE_JSON_KEY_WORDS = new Set([
+  "cwd",
+  "dir",
+  "dirs",
+  "directories",
+  "directory",
+  "file",
+  "files",
+  "folder",
+  "folders",
+  "path",
+  "paths",
+  "root",
+]);
 
 function isControlCharacter(char: string): boolean {
   const codePoint = char.codePointAt(0);
@@ -36,9 +50,19 @@ function isLikelyWindowsPathPrefix(value: string): boolean {
   return /^[A-Za-z]:(?:[\\/].*)?$/u.test(value);
 }
 
-function normalizeDecodedWindowsPathEscapes(value: unknown): unknown {
+function isPathLikeJsonKey(key: string | undefined): boolean {
+  if (!key) {
+    return false;
+  }
+  return key
+    .replace(/([a-z0-9])([A-Z])/gu, "$1 $2")
+    .split(/[^A-Za-z0-9]+/u)
+    .some((word) => PATH_LIKE_JSON_KEY_WORDS.has(word.toLowerCase()));
+}
+
+export function normalizeStreamingJsonPathEscapes(value: unknown, key?: string): unknown {
   if (typeof value === "string") {
-    if (!/^[A-Za-z]:[\\/\b\f\n\r\t]/u.test(value)) {
+    if (!isPathLikeJsonKey(key) || !/^[A-Za-z]:[\\/\b\f\n\r\t]/u.test(value)) {
       return value;
     }
     return value.replace(
@@ -47,11 +71,14 @@ function normalizeDecodedWindowsPathEscapes(value: unknown): unknown {
     );
   }
   if (Array.isArray(value)) {
-    return value.map((item) => normalizeDecodedWindowsPathEscapes(item));
+    return value.map((item) => normalizeStreamingJsonPathEscapes(item, key));
   }
   if (value && typeof value === "object") {
     return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, normalizeDecodedWindowsPathEscapes(item)]),
+      Object.entries(value).map(([entryKey, item]) => [
+        entryKey,
+        normalizeStreamingJsonPathEscapes(item, entryKey),
+      ]),
     );
   }
   return value;
@@ -66,6 +93,16 @@ export function repairJson(json: string): string {
   let repaired = "";
   let inString = false;
   let stringPrefix = "";
+  let stringRole: "key" | "value" = "value";
+  let stringKey: string | undefined;
+  const stack: Array<
+    | {
+        kind: "object";
+        expectingKey: boolean;
+        pendingKey?: string;
+      }
+    | { kind: "array" }
+  > = [];
 
   for (let index = 0; index < json.length; index++) {
     const char = json[index];
@@ -75,14 +112,40 @@ export function repairJson(json: string): string {
       if (char === '"') {
         inString = true;
         stringPrefix = "";
+        const container = stack.at(-1);
+        stringRole = container?.kind === "object" && container.expectingKey ? "key" : "value";
+        stringKey =
+          stringRole === "value" && container?.kind === "object" ? container.pendingKey : undefined;
+      } else if (char === "{") {
+        stack.push({ kind: "object", expectingKey: true });
+      } else if (char === "[") {
+        stack.push({ kind: "array" });
+      } else if (char === "}" || char === "]") {
+        stack.pop();
+      } else if (char === ":") {
+        const container = stack.at(-1);
+        if (container?.kind === "object") {
+          container.expectingKey = false;
+        }
+      } else if (char === ",") {
+        const container = stack.at(-1);
+        if (container?.kind === "object") {
+          container.expectingKey = true;
+          container.pendingKey = undefined;
+        }
       }
       continue;
     }
 
     if (char === '"') {
       repaired += char;
+      const container = stack.at(-1);
+      if (stringRole === "key" && container?.kind === "object") {
+        container.pendingKey = stringPrefix;
+      }
       inString = false;
       stringPrefix = "";
+      stringKey = undefined;
       continue;
     }
 
@@ -111,7 +174,11 @@ export function repairJson(json: string): string {
         continue;
       }
 
-      if (JSON_CONTROL_ESCAPES.has(nextChar) && isLikelyWindowsPathPrefix(stringPrefix)) {
+      if (
+        JSON_CONTROL_ESCAPES.has(nextChar) &&
+        isPathLikeJsonKey(stringKey) &&
+        isLikelyWindowsPathPrefix(stringPrefix)
+      ) {
         repaired += "\\\\";
         stringPrefix += "\\";
         continue;
@@ -141,7 +208,7 @@ export function parseJsonWithRepair(
   options?: { normalizeWindowsPathEscapes?: boolean },
 ): unknown {
   const normalize = (value: unknown): unknown =>
-    options?.normalizeWindowsPathEscapes ? normalizeDecodedWindowsPathEscapes(value) : value;
+    options?.normalizeWindowsPathEscapes ? normalizeStreamingJsonPathEscapes(value) : value;
 
   try {
     return normalize(JSON.parse(json) as unknown);
@@ -173,11 +240,11 @@ export function parseStreamingJson(partialJson: string | undefined): Record<stri
   } catch {
     try {
       const result = partialParse(partialJson);
-      return normalizeDecodedWindowsPathEscapes(result ?? {}) as Record<string, unknown>;
+      return normalizeStreamingJsonPathEscapes(result ?? {}) as Record<string, unknown>;
     } catch {
       try {
         const result = partialParse(repairJson(partialJson));
-        return normalizeDecodedWindowsPathEscapes(result ?? {}) as Record<string, unknown>;
+        return normalizeStreamingJsonPathEscapes(result ?? {}) as Record<string, unknown>;
       } catch {
         return {};
       }


### PR DESCRIPTION
Fixes #88918

## Summary
- Preserve path-like Windows drive strings when streamed tool-call arguments contain unescaped control-letter segments such as `\bin`, `\temp`, `\new`, or `\reports`.
- Normalize decoded control escapes only in streaming tool-argument parsing for strings that look like Windows drive paths, so normal JSON text such as `first\nsecond` keeps newline semantics.
- Add focused parser regressions for the reported path cases, nested arguments, and the non-path escape guard.

## Verification
- node scripts/run-vitest.mjs src/llm/utils/json-parse.test.ts
- pnpm exec oxfmt --check src/llm/utils/json-parse.ts src/llm/utils/json-parse.test.ts
- pnpm exec oxlint src/llm/utils/json-parse.ts src/llm/utils/json-parse.test.ts
- git diff --check

## Real behavior proof
**Behavior addressed:** #88918 reports that streamed tool-call JSON arguments containing unescaped Windows path segments can decode `\b`, `\t`, `\n`, `\f`, or `\r` into control characters before the tool executor receives the argument.

**Real environment tested:** Local OpenClaw source checkout on Linux with the patched parser loaded through Node + tsx. This exercises the real `parseStreamingJson` module used by streaming provider tool-call argument paths; no external provider account is required for the parser-level repro.

**Exact steps or command run after fix:**
```bash
node --import tsx --input-type=module <<'EOF'
import { parseStreamingJson } from './src/llm/utils/json-parse.ts';
const cases = [
  ['C-bin', '{"path":"C:\\bin\\app.exe"}', 'C:\\bin\\app.exe'],
  ['C-temp', '{"path":"C:\\temp\\x"}', 'C:\\temp\\x'],
  ['C-new-file', '{"path":"C:\\new\\file"}', 'C:\\new\\file'],
  ['D-reports', '{"path":"D:\\reports\\q"}', 'D:\\reports\\q'],
  ['non-path-newline', '{"message":"first\\nsecond"}', 'first\nsecond'],
];
for (const [name, input, expected] of cases) {
  const parsed = parseStreamingJson(input);
  const actual = parsed.path ?? parsed.message;
  const ok = actual === expected;
  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}: ${JSON.stringify(actual)}`);
  if (!ok) {
    console.log(`  expected: ${JSON.stringify(expected)}`);
    process.exitCode = 1;
  }
}
EOF
```

**Evidence after fix:**
```text
PASS C-bin: "C:\\bin\\app.exe"
PASS C-temp: "C:\\temp\\x"
PASS C-new-file: "C:\\new\\file"
PASS D-reports: "D:\\reports\\q"
PASS non-path-newline: "first\nsecond"
```

**Observed result after fix:** The reported Windows path shapes remain literal backslash paths when parsed as streaming tool-call arguments, while ordinary non-path JSON newline text remains a newline.

**What was not tested:** I did not run a live model/provider stream because the bug and fix are in the shared parser and are covered by direct real-module execution plus unit tests.

## Maintainer update (2026-06-01)
- Rebased the contributor fix onto current `main` and pushed maintainer follow-up `9050d3b7968` to the existing PR branch.
- Narrowed Windows path repair to path-like JSON keys so non-path content such as `C:/\nnext` keeps normal newline semantics.
- Routed Anthropic transport's unsafe-integer parser result through the same path-key normalizer, preserving unsafe integer handling while covering the valid-JSON bypass case.

Verification:
- `node scripts/run-vitest.mjs src/llm/utils/json-parse.test.ts src/agents/anthropic-transport-stream.test.ts` - 61 tests passed.
- `node scripts/run-oxlint.mjs src/llm/utils/json-parse.ts src/llm/utils/json-parse.test.ts src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts` - passed.
- `./node_modules/.bin/oxfmt --check --threads=1 src/llm/utils/json-parse.ts src/llm/utils/json-parse.test.ts src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts` - passed.
- `git diff --check origin/main...HEAD` - passed.
- Real-module parser repro with `node --import tsx --input-type=module` - passed reported Windows path cases, mixed separators, and non-path newline guards.
- L2 tmux proof on head `9050d3b7968`: `L2_JSON_EXIT=0 vitest=0 lint=0 diff=0`.
- Testbox-through-Crabbox changed gate: `tbx_01kt0y02tdx34kq1znc0n6xpq7`, lanes `core, coreTests`, exit 0, stopped completed.
- Autoreview: branch mode against `origin/main`, clean with no accepted/actionable findings.
