### PR TITLE
fix(status): detect npm shrinkwrap package installs

### DIFF
--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -29,6 +29,20 @@ describe("detectPackageManager", () => {
     );
   });
 
+  it("can prefer npm publish lockfiles over build-time packageManager metadata", async () => {
+    await withPackageManagerRoot(
+      [
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@11.2.2" }) },
+        { path: "npm-shrinkwrap.json", content: "{}" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root, { preferPackageLockfiles: true })).resolves.toBe(
+          "npm",
+        );
+      },
+    );
+  });
+
   it.each([
     {
       name: "uses bun.lock",
@@ -46,6 +60,11 @@ describe("detectPackageManager", () => {
         { path: "package.json", content: JSON.stringify({ packageManager: "yarn@4.0.0" }) },
         { path: "package-lock.json", content: "" },
       ],
+      expected: "npm",
+    },
+    {
+      name: "uses npm-shrinkwrap.json",
+      files: [{ path: "npm-shrinkwrap.json", content: "{}" }],
       expected: "npm",
     },
   ])("falls back to lockfiles when $name", async ({ files, expected }) => {

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -3,21 +3,39 @@ import { readPackageManagerSpec } from "./package-json.js";
 
 type DetectedPackageManager = "pnpm" | "bun" | "npm";
 
-export async function detectPackageManager(root: string): Promise<DetectedPackageManager | null> {
-  const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
-  if (pm === "pnpm" || pm === "bun" || pm === "npm") {
-    return pm;
-  }
+type DetectPackageManagerOptions = {
+  preferPackageLockfiles?: boolean;
+};
 
-  const files = await fs.readdir(root).catch((): string[] => []);
+function detectPackageManagerFromLockfiles(files: string[]): DetectedPackageManager | null {
   if (files.includes("pnpm-lock.yaml")) {
     return "pnpm";
   }
   if (files.includes("bun.lock") || files.includes("bun.lockb")) {
     return "bun";
   }
-  if (files.includes("package-lock.json")) {
+  if (files.includes("npm-shrinkwrap.json") || files.includes("package-lock.json")) {
     return "npm";
   }
   return null;
+}
+
+export async function detectPackageManager(
+  root: string,
+  options?: DetectPackageManagerOptions,
+): Promise<DetectedPackageManager | null> {
+  const files = await fs.readdir(root).catch((): string[] => []);
+  if (options?.preferPackageLockfiles) {
+    const detected = detectPackageManagerFromLockfiles(files);
+    if (detected) {
+      return detected;
+    }
+  }
+
+  const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
+  if (pm === "pnpm" || pm === "bun" || pm === "npm") {
+    return pm;
+  }
+
+  return detectPackageManagerFromLockfiles(files);
 }

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -194,6 +194,22 @@ describe("formatGitInstallLabel", () => {
 });
 
 describe("checkDepsStatus", () => {
+  it("uses npm-shrinkwrap.json as the npm dependency lock marker", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-" }, async (base) => {
+      await fs.writeFile(path.join(base, "npm-shrinkwrap.json"), "{}", "utf8");
+      await fs.mkdir(path.join(base, "node_modules"), { recursive: true });
+
+      const status = await checkDepsStatus({ root: base, manager: "npm" });
+
+      expect(status).toMatchObject({
+        manager: "npm",
+        status: "ok",
+        lockfilePath: path.join(base, "npm-shrinkwrap.json"),
+        markerPath: path.join(base, "node_modules"),
+      });
+    });
+  });
+
   it("reports unknown, missing, stale, and ok states from lockfile markers", async () => {
     await withTempDir({ prefix: "openclaw-update-check-" }, async (base) => {
       await expect(checkDepsStatus({ root: base, manager: "unknown" })).resolves.toEqual({
@@ -266,6 +282,31 @@ describe("checkUpdateStatus", () => {
       expect(status.git).toBeUndefined();
       expect(status.registry).toBeUndefined();
       expect(status.deps?.manager).toBe("npm");
+    });
+  });
+
+  it("detects published npm package roots from shrinkwrap before build packageManager metadata", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-" }, async (root) => {
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ name: "openclaw", packageManager: "pnpm@11.2.2" }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "{}", "utf8");
+      await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+
+      const status = await checkUpdateStatus({
+        root,
+        includeRegistry: false,
+        fetchGit: false,
+        timeoutMs: 1000,
+      });
+
+      expect(status.root).toBe(root);
+      expect(status.installKind).toBe("package");
+      expect(status.packageManager).toBe("npm");
+      expect(status.deps?.manager).toBe("npm");
+      expect(status.deps?.lockfilePath).toBe(path.join(root, "npm-shrinkwrap.json"));
     });
   });
 

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -86,6 +86,10 @@ async function detectPackageManager(root: string): Promise<PackageManager> {
   return (await detectPackageManagerImpl(root)) ?? "unknown";
 }
 
+async function detectPackageInstallManager(root: string): Promise<PackageManager> {
+  return (await detectPackageManagerImpl(root, { preferPackageLockfiles: true })) ?? "unknown";
+}
+
 async function detectGitRoot(root: string): Promise<string | null> {
   const res = await runCommandWithTimeout(["git", "-C", root, "rev-parse", "--show-toplevel"], {
     timeoutMs: 4000,
@@ -200,10 +204,10 @@ async function statMtimeMs(p: string): Promise<number | null> {
   }
 }
 
-function resolveDepsMarker(params: { root: string; manager: PackageManager }): {
+async function resolveDepsMarker(params: { root: string; manager: PackageManager }): Promise<{
   lockfilePath: string | null;
   markerPath: string | null;
-} {
+}> {
   const root = params.root;
   if (params.manager === "pnpm") {
     return {
@@ -218,8 +222,11 @@ function resolveDepsMarker(params: { root: string; manager: PackageManager }): {
     };
   }
   if (params.manager === "npm") {
+    const shrinkwrapPath = path.join(root, "npm-shrinkwrap.json");
     return {
-      lockfilePath: path.join(root, "package-lock.json"),
+      lockfilePath: (await exists(shrinkwrapPath))
+        ? shrinkwrapPath
+        : path.join(root, "package-lock.json"),
       markerPath: path.join(root, "node_modules"),
     };
   }
@@ -231,7 +238,7 @@ export async function checkDepsStatus(params: {
   manager: PackageManager;
 }): Promise<DepsStatus> {
   const root = path.resolve(params.root);
-  const { lockfilePath, markerPath } = resolveDepsMarker({
+  const { lockfilePath, markerPath } = await resolveDepsMarker({
     root,
     manager: params.manager,
   });
@@ -423,12 +430,12 @@ export async function checkUpdateStatus(params: {
   }
 
   const rootRealpath = await fs.realpath(root).catch(() => root);
-  const [pm, gitRoot, registry] = await Promise.all([
-    detectPackageManager(root),
+  const [gitRoot, registry] = await Promise.all([
     detectGitRoot(root),
     params.includeRegistry ? fetchRegistry() : Promise.resolve(undefined),
   ]);
   const isGit = gitRoot && path.resolve(gitRoot) === path.resolve(rootRealpath);
+  const pm = isGit ? await detectPackageManager(root) : await detectPackageInstallManager(root);
 
   const installKind: UpdateCheckResult["installKind"] = isGit ? "git" : "package";
   const [git, deps] = await Promise.all([


### PR DESCRIPTION
Summary
- Detect published npm package roots with npm-shrinkwrap.json as npm installs even when package.json keeps pnpm build metadata.
- Use npm-shrinkwrap.json as the npm dependency lock marker before falling back to package-lock.json.
- Keep git/source checkouts on the build-time packageManager path so local pnpm development status is unchanged.

Tests
- bun scripts/run-vitest.mjs src/infra/detect-package-manager.test.ts --reporter=verbose (RED before fix: new shrinkwrap tests failed)
- bun scripts/run-vitest.mjs src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts
- vitest run src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts --config test/vitest/vitest.infra.config.ts
- vitest run src/commands/status.update.test.ts src/commands/status-json-payload.test.ts --config test/vitest/vitest.unit-fast.config.ts
- oxlint --tsconfig config/tsconfig/oxlint.json src/infra/detect-package-manager.ts src/infra/detect-package-manager.test.ts src/infra/update-check.ts src/infra/update-check.test.ts
- tsgo -p tsconfig.core.json --incremental false --declaration false --singleThreaded --checkers 1
- git diff --check
- node scripts/check-changed.mjs --dry-run

Real behavior proof
Behavior addressed: openclaw status/update status now classifies package roots containing npm-shrinkwrap.json as npm installs instead of using the pnpm packageManager build metadata from package.json.
Real environment tested: local macOS source worktree with focused fixture tests for the reported published npm package shape; npm shrinkwrap contract checked via npm help shrinkwrap.
Exact steps or command run after this patch: bun scripts/run-vitest.mjs src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts
Evidence after fix: 2 files passed, 22 tests passed.
Observed result after fix: package install fixtures with packageManager=pnpm and npm-shrinkwrap.json report packageManager/deps.manager npm and use npm-shrinkwrap.json as deps.lockfilePath.
What was not tested: a real global npm install on Raspberry Pi/Linux systemd; the regression is covered by local filesystem fixtures matching the issue evidence.

Closes #87732
