### PR TITLE
fix(agents): cap tool search fanout in lean mode

### DIFF
--- a/docs/concepts/experimental-features.md
+++ b/docs/concepts/experimental-features.md
@@ -30,7 +30,7 @@ Treat them differently from normal config:
 
 ## Local model lean mode
 
-`agents.defaults.experimental.localModelLean: true` is a pressure-release valve for weaker local-model setups. When it is on, OpenClaw drops three default tools — `browser`, `cron`, and `message` — from the agent's tool surface for every turn. Nothing else changes. Use `agents.list[].experimental.localModelLean` to enable or disable the same behavior for one configured agent.
+`agents.defaults.experimental.localModelLean: true` is a pressure-release valve for weaker local-model setups. When it is on, OpenClaw drops three default tools — `browser`, `cron`, and `message` — from the agent's tool surface for every turn. When Tool Search is enabled, lean agents also use smaller implicit Tool Search result limits so lookup results stay easier for small models to inspect. Use `agents.list[].experimental.localModelLean` to enable or disable the same behavior for one configured agent.
 
 ### Why these three tools
 
@@ -40,7 +40,7 @@ These three tools have the largest descriptions and the most parameter shapes in
 - The model picking the right tool vs. emitting malformed tool calls because there are too many similar-looking schemas.
 - The Chat Completions adapter staying inside the server's structured-output limits vs. tripping a 400 on tool-call payload size.
 
-Removing them does not silently rewire OpenClaw — it just makes the tool list shorter. The model still has `read`, `write`, `edit`, `exec`, `apply_patch`, web search/fetch (when configured), memory, and session/agent tools available.
+Removing them does not silently rewire OpenClaw — it just makes the model-facing tool list shorter. The model still has `read`, `write`, `edit`, `exec`, `apply_patch`, web search/fetch (when configured), memory, and session/agent tools available. If Tool Search is enabled, explicit `tools.toolSearch.searchDefaultLimit` and `tools.toolSearch.maxSearchLimit` still win over the lean defaults.
 
 ### When to turn it on
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -692,7 +692,7 @@ Use these as starting points and replace model IDs with the exact names from `ol
     ```
 
     Use `compat.supportsTools: false` only when the model or server reliably fails on tool schemas. It trades agent capability for stability.
-    `localModelLean` removes the browser, cron, and message tools from the agent surface, but it does not change Ollama's runtime context or thinking mode. Pair it with explicit `params.num_ctx` and `params.thinking: false` for small Qwen-style thinking models that loop or spend their response budget on hidden reasoning.
+    `localModelLean` removes the browser, cron, and message tools from the agent surface and uses smaller implicit Tool Search result limits when Tool Search is enabled. It does not change Ollama's runtime context or thinking mode. Pair it with explicit `params.num_ctx` and `params.thinking: false` for small Qwen-style thinking models that loop or spend their response budget on hidden reasoning.
 
   </Accordion>
 </AccordionGroup>

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -581,7 +581,11 @@ export function createOpenClawCodingTools(options?: {
     (options?.trigger === "heartbeat" &&
       options?.config?.messages?.visibleReplies === "message_tool");
   const forceHeartbeatTool = options?.forceHeartbeatTool === true || enableHeartbeatTool;
-  const toolSearchConfig = resolveToolSearchConfig(options?.config);
+  const toolSearchConfig = resolveToolSearchConfig({
+    config: options?.config,
+    agentId,
+    sessionKey: options?.sessionKey,
+  });
   const toolSearchControlsEnabled =
     options?.includeToolSearchControls === true && toolSearchConfig.enabled;
   const toolSearchControlAllowlist = toolSearchControlsEnabled

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1123,7 +1123,11 @@ export async function runEmbeddedAttempt(
       !isRawModelRun &&
       params.toolsAllow?.length !== 0 &&
       !codeModeControlsEnabledForRun &&
-      resolveToolSearchConfig(params.config).enabled;
+      resolveToolSearchConfig({
+        config: params.config,
+        agentId: sessionAgentId,
+        sessionKey: sandboxSessionKey,
+      }).enabled;
     const effectiveToolsAllow =
       toolSearchControlsEnabledForRun && toolsAllowWithForcedRuntimeTools
         ? [

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -77,6 +77,101 @@ describe("Tool Search", () => {
     expect(resolved.mode).toBe("tools");
   });
 
+  it("uses smaller implicit search limits for lean local agents", () => {
+    const baseConfig = {
+      tools: {
+        toolSearch: true,
+      },
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+        list: [
+          {
+            id: "full",
+            experimental: {
+              localModelLean: false,
+            },
+          },
+        ],
+      },
+    };
+    const config = baseConfig as never;
+
+    expect(testing.resolveToolSearchConfig({ config, agentId: "local" })).toMatchObject({
+      searchDefaultLimit: 4,
+      maxSearchLimit: 8,
+    });
+    expect(testing.resolveToolSearchConfig({ config, agentId: "full" })).toMatchObject({
+      searchDefaultLimit: 8,
+      maxSearchLimit: 20,
+    });
+    expect(
+      testing.resolveToolSearchConfig({
+        config: {
+          ...baseConfig,
+          tools: {
+            toolSearch: {
+              enabled: true,
+              searchDefaultLimit: 10,
+              maxSearchLimit: 12,
+            },
+          },
+        } as never,
+        agentId: "local",
+      }),
+    ).toMatchObject({
+      searchDefaultLimit: 10,
+      maxSearchLimit: 12,
+    });
+  });
+
+  it("applies lean search defaults when runtime search omits a limit", async () => {
+    const config = {
+      tools: {
+        toolSearch: true,
+      },
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      },
+    } as never;
+    const sessionId = "session-lean-search-limit";
+    applyToolSearchCatalog({
+      tools: [
+        fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode"),
+        fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search"),
+        fakeTool(TOOL_DESCRIBE_RAW_TOOL_NAME, "describe"),
+        fakeTool(TOOL_CALL_RAW_TOOL_NAME, "call"),
+        pluginTool("fake_ticket_alpha", "Ticket workflow alpha"),
+        pluginTool("fake_ticket_beta", "Ticket workflow beta"),
+        pluginTool("fake_ticket_delta", "Ticket workflow delta"),
+        pluginTool("fake_ticket_gamma", "Ticket workflow gamma"),
+        pluginTool("fake_ticket_zeta", "Ticket workflow zeta"),
+      ],
+      config,
+      agentId: "local",
+      sessionId,
+    });
+
+    const searchTool = createToolSearchTools({
+      config,
+      agentId: "local",
+      sessionId,
+    }).find((tool) => tool.name === TOOL_SEARCH_RAW_TOOL_NAME);
+    if (!searchTool) {
+      throw new Error("Expected Tool Search control");
+    }
+    const result = await searchTool.execute("search-lean", { query: "ticket" });
+
+    expect(result.details as unknown[]).toHaveLength(4);
+  });
+
   it("falls back to structured controls when code mode is unsupported", () => {
     testing.setToolSearchCodeModeSupportedForTest(false);
     try {

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -14,6 +14,7 @@ import {
   type HookContext,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
+import { isLocalModelLeanEnabled } from "./local-model-lean.js";
 import type { AgentMessage, AgentToolResult, AgentToolUpdateCallback } from "./runtime/index.js";
 import type { ToolDefinition } from "./sessions/index.js";
 import { asToolParamsRecord, jsonResult, ToolInputError } from "./tools/common.js";
@@ -34,6 +35,8 @@ const TOOL_SEARCH_CONTROL_TOOL_NAMES = new Set([
 const DEFAULT_CODE_TIMEOUT_MS = 10_000;
 const DEFAULT_SEARCH_LIMIT = 8;
 const DEFAULT_MAX_SEARCH_LIMIT = 20;
+const LOCAL_MODEL_LEAN_DEFAULT_SEARCH_LIMIT = 4;
+const LOCAL_MODEL_LEAN_DEFAULT_MAX_SEARCH_LIMIT = 8;
 const MAX_REUSABLE_CATALOG_SNAPSHOTS = 256;
 
 type ToolSearchMode = "code" | "tools";
@@ -87,6 +90,18 @@ export type ToolSearchToolContext = {
   abortSignal?: AbortSignal;
   executeTool?: ToolSearchCatalogToolExecutor;
 };
+
+type ToolSearchConfigContext = {
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+};
+
+function isToolSearchConfigContext(
+  input: OpenClawConfig | ToolSearchConfigContext,
+): input is ToolSearchConfigContext {
+  return "config" in input || "agentId" in input || "sessionKey" in input;
+}
 
 export type ToolSearchCatalogEntry = {
   id: string;
@@ -420,17 +435,39 @@ function resolveMinCodeTimeoutMs(): number {
   return toolSearchMinCodeTimeoutMsForTest ?? 1000;
 }
 
-export function resolveToolSearchConfig(config?: OpenClawConfig): ToolSearchConfig {
-  const raw = readToolSearchConfig(config);
+function resolveToolSearchConfigContext(
+  input?: OpenClawConfig | ToolSearchConfigContext,
+): ToolSearchConfigContext {
+  if (!input) {
+    return {};
+  }
+  if (isToolSearchConfigContext(input)) {
+    return input;
+  }
+  return { config: input };
+}
+
+export function resolveToolSearchConfig(
+  input?: OpenClawConfig | ToolSearchConfigContext,
+): ToolSearchConfig {
+  const context = resolveToolSearchConfigContext(input);
+  const raw = readToolSearchConfig(context.config);
   const rawMode = typeof raw.mode === "string" ? raw.mode : "code";
   const requestedMode: ToolSearchMode =
     rawMode === "tools" || rawMode === "code" ? rawMode : "code";
   const mode: ToolSearchMode =
     requestedMode === "code" && !isToolSearchCodeModeSupported() ? "tools" : requestedMode;
   const configured = Object.keys(raw).some((key) => key !== "enabled");
+  const leanEnabled = isLocalModelLeanEnabled(context);
+  const defaultSearchLimit = leanEnabled
+    ? LOCAL_MODEL_LEAN_DEFAULT_SEARCH_LIMIT
+    : DEFAULT_SEARCH_LIMIT;
+  const defaultMaxSearchLimit = leanEnabled
+    ? LOCAL_MODEL_LEAN_DEFAULT_MAX_SEARCH_LIMIT
+    : DEFAULT_MAX_SEARCH_LIMIT;
   const maxSearchLimit = Math.max(
     1,
-    Math.min(50, readInteger(raw.maxSearchLimit, DEFAULT_MAX_SEARCH_LIMIT)),
+    Math.min(50, readInteger(raw.maxSearchLimit, defaultMaxSearchLimit)),
   );
   return {
     enabled: readBoolean(raw.enabled, configured),
@@ -441,7 +478,7 @@ export function resolveToolSearchConfig(config?: OpenClawConfig): ToolSearchConf
     ),
     searchDefaultLimit: Math.max(
       1,
-      Math.min(maxSearchLimit, readInteger(raw.searchDefaultLimit, DEFAULT_SEARCH_LIMIT)),
+      Math.min(maxSearchLimit, readInteger(raw.searchDefaultLimit, defaultSearchLimit)),
     ),
     maxSearchLimit,
   };
@@ -847,7 +884,7 @@ export function applyToolSearchCatalog(params: {
   catalogRegistered: boolean;
   catalogReused: boolean;
 } {
-  const config = resolveToolSearchConfig(params.config);
+  const config = resolveToolSearchConfig(params);
   return applyToolCatalogCompaction({
     ...params,
     enabled: config.enabled,
@@ -868,7 +905,7 @@ export function addClientToolsToToolSearchCatalog(params: {
 }): { tools: ToolDefinition[]; compacted: boolean; catalogToolCount: number } {
   return addClientToolsToToolCatalog({
     ...params,
-    enabled: resolveToolSearchConfig(params.config).enabled,
+    enabled: resolveToolSearchConfig(params).enabled,
   });
 }
 
@@ -1646,7 +1683,11 @@ function readCode(args: unknown): string {
 }
 
 export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[] {
-  const config = resolveToolSearchConfig(ctx.runtimeConfig ?? ctx.config);
+  const config = resolveToolSearchConfig({
+    config: ctx.runtimeConfig ?? ctx.config,
+    agentId: ctx.agentId,
+    sessionKey: ctx.sessionKey,
+  });
   const runtime = new ToolSearchRuntime(ctx, config);
   return [
     {


### PR DESCRIPTION
Summary:
- make Tool Search config resolution agent/session-aware so localModelLean agents get smaller implicit search fanout
- default lean Tool Search results to 4 and max to 8 while preserving explicit searchDefaultLimit/maxSearchLimit
- cover resolver and runtime search behavior, and update local-model docs

Verification:
- node scripts/run-vitest.mjs src/agents/tool-search.test.ts src/agents/local-model-lean.test.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts --reporter=dot
- node_modules/.bin/oxfmt --check src/agents/tool-search.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/tool-search.test.ts docs/providers/ollama.md docs/concepts/experimental-features.md
- git diff --check
- node scripts/run-oxlint.mjs src/agents/tool-search.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/tool-search.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- AWS Crabbox: provider=aws, lease=cbx_90082d181b0a, run=run_16c7af06aee0, command `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`, exit 0

What was not tested:
- live Ollama/API model turns; this PR is scoped to deterministic Tool Search fanout behavior under localModelLean.
