### PR TITLE
fix(plugins): skip broken web provider factories

### DIFF
--- a/src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts
@@ -144,13 +144,33 @@ describe("web provider public artifacts explicit fast path", () => {
     expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
   });
 
-  it("throws when every matching bundled web provider factory fails", () => {
-    expect(() =>
+  it("skips plugins whose bundled web provider factories all fail", () => {
+    expect(
       resolveBundledWebSearchProvidersFromPublicArtifacts({
         onlyPluginIds: ["fuzzplugin"],
       }),
-    ).toThrow("Unable to initialize web providers for plugin fuzzplugin");
+    ).toEqual([]);
 
+    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+      dirName: "fuzzplugin",
+      artifactBasename: "web-search-contract-api.js",
+    });
+    expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps healthy bundled web providers when another selected plugin factory fails", () => {
+    const provider = expectSingleProvider(
+      resolveBundledWebSearchProvidersFromPublicArtifacts({
+        onlyPluginIds: ["fuzzplugin", "brave"],
+      }),
+    );
+
+    expect(provider.pluginId).toBe("brave");
+    expect(provider.id).toBe("brave");
+    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+      dirName: "brave",
+      artifactBasename: "web-search-contract-api.js",
+    });
     expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
       dirName: "fuzzplugin",
       artifactBasename: "web-search-contract-api.js",

--- a/src/plugins/web-provider-public-artifacts.explicit.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit.ts
@@ -57,9 +57,9 @@ function collectProviderFactories<TProvider>(params: {
   mod: Record<string, unknown>;
   suffix: string;
   isProvider: (value: unknown) => value is TProvider;
-}): { providers: TProvider[]; errors: unknown[] } {
+}): { providers: TProvider[]; failedFactoryCount: number } {
   const providers: TProvider[] = [];
-  const errors: unknown[] = [];
+  let failedFactoryCount = 0;
   for (const [name, exported] of Object.entries(params.mod).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
@@ -74,24 +74,15 @@ function collectProviderFactories<TProvider>(params: {
     let candidate: unknown;
     try {
       candidate = exported();
-    } catch (error) {
-      errors.push(error);
+    } catch {
+      failedFactoryCount += 1;
       continue;
     }
     if (params.isProvider(candidate)) {
       providers.push(candidate);
     }
   }
-  return { providers, errors };
-}
-
-function unableToInitializeProviderError(params: {
-  pluginId: string;
-  errors: readonly unknown[];
-}): Error {
-  return new Error(`Unable to initialize web providers for plugin ${params.pluginId}`, {
-    cause: params.errors.length === 1 ? params.errors[0] : new AggregateError(params.errors),
-  });
+  return { providers, failedFactoryCount };
 }
 
 function tryLoadBundledPublicArtifactModule(params: {
@@ -135,17 +126,17 @@ function loadBundledProviderEntriesFromDir<TProvider extends object>(params: {
   if (!mod) {
     return null;
   }
-  const { providers, errors } = collectProviderFactories({
+  const { providers, failedFactoryCount } = collectProviderFactories({
     mod,
     suffix: params.suffix,
     isProvider: params.isProvider,
   });
   if (providers.length === 0) {
-    if (errors.length > 0) {
-      throw unableToInitializeProviderError({
-        pluginId: params.pluginId,
-        errors,
-      });
+    if (failedFactoryCount > 0) {
+      // A broken plugin-owned provider factory must not poison startup for
+      // other providers. Treat the plugin as unavailable and let callers keep
+      // resolving the remaining active provider set.
+      return [];
     }
     return null;
   }


### PR DESCRIPTION
## Summary

- skips bundled web provider factories that throw during public-artifact discovery
- keeps healthy sibling providers active when another selected plugin's factory is broken
- preserves the existing `null` fallback path for modules that simply do not expose a matching provider factory

## Verification

- `node scripts/run-vitest.mjs src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check --threads=1 src/plugins/web-provider-public-artifacts.explicit.ts src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/plugins/web-provider-public-artifacts.explicit.ts src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts`
- `git diff --check`
- private reported-name scrub over the local spec and changed files
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Review this focused plugin public-artifact provider hardening patch. It changes bundled web provider factory exceptions from fatal errors into per-plugin unavailability so one broken provider factory cannot poison assistant startup or sibling providers. Focus on runtime behavior, fallback semantics, diagnostics risk, and whether the tests cover the crash surface.'`
- AWS Crabbox changed gate: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "corepack pnpm check:changed"` (`run_70b582d21a6b`, lease `cbx_ec1a78220a74`)

Behavior addressed: A bundled plugin public-artifact provider factory can throw during discovery without poisoning sibling web providers or the assistant startup path.

Real environment tested: Local Codex gwt worktree on macOS using the repo Vitest node wrapper and repo lint/format wrappers.

Exact steps or command run after this patch: See Verification above.

Evidence after fix: Focused Vitest passed 1 shard / 6 tests; oxfmt, oxlint, `git diff --check`, private-name scrub, autoreview, and AWS Crabbox `check:changed` all passed.

Observed result after fix: A plugin whose matching web provider factories all throw contributes no provider entries; a healthy sibling provider still resolves from the same selected provider set.

What was not tested: Full repo test suite was not run; this patch is limited to the plugin web-provider public-artifact loader and focused regression coverage plus changed-gate proof.
