### PR TITLE
fix(ui): render pending sends in chat thread

### DIFF
--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -413,6 +413,122 @@ describe("buildChatItems", () => {
     expect(messageRecord(requireGroup(items[1])).content).toBe("Missing timestamp.");
   });
 
+  it("renders submitted queued sends as user turns before chat.send ACK", () => {
+    const groups = messageGroups({
+      messages: [{ role: "assistant", content: "Ready.", timestamp: 1 }],
+      queue: [
+        {
+          id: "pending-send-1",
+          text: "first visible send",
+          createdAt: 2,
+          sendSubmittedAtMs: 10,
+          sendState: "sending",
+        },
+      ],
+    });
+
+    expect(groups.map((group) => group.role)).toEqual(["assistant", "user"]);
+    expect(messageRecord(groups[1]).content).toStrictEqual([
+      { type: "text", text: "first visible send" },
+    ]);
+  });
+
+  it("renders submitted queued attachment sends with attachment blocks before chat.send ACK", () => {
+    const groups = messageGroups({
+      queue: [
+        {
+          id: "pending-attachment-send-1",
+          text: "see attached",
+          createdAt: 2,
+          sendSubmittedAtMs: 10,
+          sendState: "sending",
+          attachments: [
+            {
+              id: "attachment-1",
+              mimeType: "image/png",
+              fileName: "screenshot.png",
+              previewUrl: "/media/screenshot.png",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(messageRecord(groups[0]).content).toStrictEqual([
+      { type: "text", text: "see attached" },
+      {
+        type: "image",
+        url: "/media/screenshot.png",
+        source: { type: "url", url: "/media/screenshot.png" },
+      },
+    ]);
+  });
+
+  it("does not collapse pending sends with matching history text", () => {
+    const groups = messageGroups({
+      messages: [{ role: "user", content: "same prompt", timestamp: 1 }],
+      queue: [
+        {
+          id: "pending-send-1",
+          text: "same prompt",
+          createdAt: 2,
+          sendSubmittedAtMs: 10,
+          sendState: "sending",
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].messages).toHaveLength(2);
+    expect(groups[0].messages[0].duplicateCount).toBeUndefined();
+    expect(groups[0].messages[1].duplicateCount).toBeUndefined();
+  });
+
+  it("keeps failed queued sends out of the thread", () => {
+    const groups = messageGroups({
+      queue: [
+        {
+          id: "failed-send-1",
+          text: "restore me to the composer",
+          createdAt: 1,
+          sendSubmittedAtMs: 10,
+          sendState: "failed",
+        },
+      ],
+    });
+
+    expect(groups).toStrictEqual([]);
+  });
+
+  it("filters submitted queued sends while chat search is active", () => {
+    const groups = messageGroups({
+      searchOpen: true,
+      searchQuery: "matching",
+      queue: [
+        {
+          id: "pending-send-1",
+          text: "matching prompt",
+          createdAt: 1,
+          sendSubmittedAtMs: 10,
+          sendState: "sending",
+        },
+        {
+          id: "pending-send-2",
+          text: "unrelated prompt",
+          createdAt: 2,
+          sendSubmittedAtMs: 11,
+          sendState: "sending",
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(messageRecord(groups[0]).content).toStrictEqual([
+      { type: "text", text: "matching prompt" },
+    ]);
+  });
+
   it("attaches lifted canvas previews to the nearest assistant turn", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -1,4 +1,5 @@
 import type { ChatItem, MessageGroup, NormalizedMessage, ToolCard } from "../types/chat-types.ts";
+import type { ChatQueueItem } from "../ui-types.ts";
 import {
   isAssistantHeartbeatAckForDisplay,
   stripHeartbeatTokenForDisplay,
@@ -9,6 +10,7 @@ import { normalizeMessage, stripMessageDisplayMetadataText } from "./message-nor
 import { normalizeRoleForGrouping } from "./role-normalizer.ts";
 import { messageMatchesSearchQuery } from "./search-match.ts";
 import { extractToolCardsCached, extractToolPreview } from "./tool-cards.ts";
+import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
 
 export type BuildChatItemsProps = {
   sessionKey: string;
@@ -17,6 +19,7 @@ export type BuildChatItemsProps = {
   streamSegments: Array<{ text: string; ts: number }>;
   stream: string | null;
   streamStartedAt: number | null;
+  queue?: ChatQueueItem[];
   showToolCalls: boolean;
   searchOpen?: boolean;
   searchQuery?: string;
@@ -223,6 +226,10 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
 }
 
 function collapseDuplicateDisplaySignature(message: unknown): string | null {
+  const marker = asRecord(message)?.["__openclaw"];
+  if (asRecord(marker)?.kind === "pending-send") {
+    return null;
+  }
   const normalized = safeNormalizeMessage(message);
   if (!normalized) {
     return null;
@@ -290,6 +297,34 @@ function trimAccumulatedStreamPrefix(text: string, previousText: string | null):
     return text;
   }
   return text.slice(previousText.length).trimStart();
+}
+
+function shouldRenderQueuedSendInThread(item: ChatQueueItem): boolean {
+  if (typeof item.sendSubmittedAtMs !== "number" || item.sendState === "failed") {
+    return false;
+  }
+  return (
+    item.sendState === "waiting-model" ||
+    item.sendState === "sending" ||
+    item.sendState === "waiting-reconnect"
+  );
+}
+
+function queuedSendThreadMessage(item: ChatQueueItem): Record<string, unknown> | null {
+  const content = buildUserChatMessageContentBlocks(item.text, item.attachments);
+  if (content.length === 0) {
+    return null;
+  }
+  return {
+    role: "user",
+    content,
+    timestamp: item.createdAt,
+    __openclaw: {
+      kind: "pending-send",
+      id: item.id,
+      state: item.sendState,
+    },
+  };
 }
 
 function rawMessageTimestamp(message: unknown): number | null {
@@ -533,6 +568,29 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       kind: "message",
       key: messageKey(msg, i),
       message: msg,
+    });
+  }
+  const queuedSends = Array.isArray(props.queue) ? props.queue : [];
+  for (const queued of queuedSends) {
+    if (!shouldRenderQueuedSendInThread(queued)) {
+      continue;
+    }
+    const message = queuedSendThreadMessage(queued);
+    if (!message) {
+      continue;
+    }
+    const searchQuery = props.searchQuery ?? "";
+    if (
+      props.searchOpen &&
+      searchQuery.trim() &&
+      !messageMatchesSearchQuery(message, searchQuery)
+    ) {
+      continue;
+    }
+    items.push({
+      kind: "message",
+      key: `pending-send:${queued.id}`,
+      message,
     });
   }
   for (const liftedCanvasSource of liftedCanvasSources) {

--- a/ui/src/ui/chat/user-message-content.ts
+++ b/ui/src/ui/chat/user-message-content.ts
@@ -1,0 +1,63 @@
+import type { ChatAttachment } from "../ui-types.ts";
+import { getChatAttachmentPreviewUrl } from "./attachment-payload-store.ts";
+
+export type UserChatMessageContentBlock = {
+  type: string;
+  text?: string;
+  url?: string;
+  source?: unknown;
+  attachment?: {
+    url: string;
+    kind: "audio" | "document";
+    label: string;
+    mimeType?: string;
+  };
+};
+
+function isInlineDataUrl(value: string): boolean {
+  return /^\s*data:/iu.test(value);
+}
+
+function formatInlineImageAttachmentPlaceholder(attachment: ChatAttachment): string {
+  const label = attachment.fileName?.trim();
+  return label ? `Attached image: ${label}` : "Attached image";
+}
+
+export function buildUserChatMessageContentBlocks(
+  message: string,
+  attachments?: readonly ChatAttachment[],
+): UserChatMessageContentBlock[] {
+  const blocks: UserChatMessageContentBlock[] = [];
+  const text = message.trim();
+  if (text) {
+    blocks.push({ type: "text", text });
+  }
+  for (const attachment of attachments ?? []) {
+    const previewUrl = getChatAttachmentPreviewUrl(attachment);
+    if (!previewUrl) {
+      continue;
+    }
+    if (attachment.mimeType.startsWith("image/")) {
+      if (isInlineDataUrl(previewUrl)) {
+        blocks.push({ type: "text", text: formatInlineImageAttachmentPlaceholder(attachment) });
+        continue;
+      }
+      blocks.push({
+        type: "image",
+        url: previewUrl,
+        source: { type: "url", url: previewUrl },
+      });
+      continue;
+    }
+    blocks.push({
+      type: "attachment",
+      attachment: {
+        url: previewUrl,
+        kind: attachment.mimeType.startsWith("audio/") ? "audio" : "document",
+        label: attachment.fileName?.trim() || "Attached file",
+        mimeType: attachment.mimeType,
+      },
+    });
+  }
+  return blocks;
+}

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,14 +1,12 @@
 import { resetToolStream } from "../app-tool-stream.ts";
-import {
-  getChatAttachmentDataUrl,
-  getChatAttachmentPreviewUrl,
-} from "../chat/attachment-payload-store.ts";
+import { getChatAttachmentDataUrl } from "../chat/attachment-payload-store.ts";
 import {
   isAssistantHeartbeatAckForDisplay,
   stripHeartbeatTokenForDisplay,
 } from "../chat/heartbeat-display.ts";
 import { extractText } from "../chat/message-extract.ts";
 import { reconcileChatRunLifecycle } from "../chat/run-lifecycle.ts";
+import { buildUserChatMessageContentBlocks } from "../chat/user-message-content.ts";
 import { formatConnectError } from "../connect-error.ts";
 import { GatewayRequestError, type GatewayBrowserClient, type GatewayHelloOk } from "../gateway.ts";
 import {
@@ -634,15 +632,6 @@ function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string }
   return { mimeType: match[1], content: match[2] };
 }
 
-function isInlineDataUrl(value: string): boolean {
-  return /^\s*data:/iu.test(value);
-}
-
-function formatInlineImageAttachmentPlaceholder(attachment: ChatAttachment): string {
-  const label = attachment.fileName?.trim();
-  return label ? `Attached image: ${label}` : "Attached image";
-}
-
 function buildApiAttachments(attachments?: ChatAttachment[]) {
   const hasAttachments = attachments && attachments.length > 0;
   return hasAttachments
@@ -861,57 +850,11 @@ export function appendUserChatMessage(
   attachments?: ChatAttachment[],
   timestamp = Date.now(),
 ) {
-  const msg = message.trim();
-  const hasAttachments = attachments && attachments.length > 0;
-  const contentBlocks: Array<{
-    type: string;
-    text?: string;
-    url?: string;
-    source?: unknown;
-    attachment?: {
-      url: string;
-      kind: "audio" | "document";
-      label: string;
-      mimeType?: string;
-    };
-  }> = [];
-  if (msg) {
-    contentBlocks.push({ type: "text", text: msg });
-  }
-  if (hasAttachments) {
-    for (const att of attachments) {
-      const previewUrl = getChatAttachmentPreviewUrl(att);
-      if (!previewUrl) {
-        continue;
-      }
-      if (att.mimeType.startsWith("image/")) {
-        if (isInlineDataUrl(previewUrl)) {
-          contentBlocks.push({ type: "text", text: formatInlineImageAttachmentPlaceholder(att) });
-          continue;
-        }
-        contentBlocks.push({
-          type: "image",
-          url: previewUrl,
-          source: { type: "url", url: previewUrl },
-        });
-        continue;
-      }
-      contentBlocks.push({
-        type: "attachment",
-        attachment: {
-          url: previewUrl,
-          kind: att.mimeType.startsWith("audio/") ? "audio" : "document",
-          label: att.fileName?.trim() || "Attached file",
-          mimeType: att.mimeType,
-        },
-      });
-    }
-  }
   state.chatMessages = [
     ...state.chatMessages,
     {
       role: "user",
-      content: contentBlocks,
+      content: buildUserChatMessageContentBlocks(message, attachments),
       timestamp,
     },
   ];

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -272,6 +272,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       expect(params.sessionKey).toBe("main");
 
       const runId = requireString(params.idempotencyKey, "chat send idempotency key");
+      await page.locator(".chat-thread").getByText(prompt).waitFor({ timeout: 10_000 });
       await gateway.resolveDeferred("chat.history", {
         messages: [],
         sessionId: "control-ui-e2e-session",
@@ -310,7 +311,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
 
       await page.locator(".chat-queue").getByText("Sending").waitFor({ timeout: 10_000 });
       await page.locator(".chat-queue").getByText(prompt).waitFor({ timeout: 10_000 });
-      expect(await page.locator(".chat-thread").getByText(prompt).count()).toBe(0);
+      await page.locator(".chat-thread").getByText(prompt).waitFor({ timeout: 10_000 });
 
       await gateway.resolveDeferred("chat.send", { runId, status: "started" });
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1308,6 +1308,7 @@ export function renderChat(props: ChatProps) {
     streamSegments: props.streamSegments,
     stream: displayStream,
     streamStartedAt: props.streamStartedAt,
+    queue: props.queue,
     showToolCalls: props.showToolCalls,
     searchOpen: vs.searchOpen,
     searchQuery: vs.searchQuery,


### PR DESCRIPTION
Summary:
- render submitted Control UI sends directly in the chat thread before the Gateway acknowledges `chat.send`
- share user-message content block construction between acknowledged history messages and pending queued sends so text, images, audio, and documents render consistently
- keep failed queued sends out of the transcript and make pending sends obey active chat search filtering

Verification:
- `node scripts/run-vitest.mjs run ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/e2e/chat-flow.e2e.test.ts --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/ui/chat/build-chat-items.ts ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/views/chat.ts ui/src/ui/e2e/chat-flow.e2e.test.ts ui/src/ui/controllers/chat.ts ui/src/ui/chat/user-message-content.ts ui/src/ui/app-chat.test.ts ui/src/ui/controllers/chat.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check origin/main...HEAD`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` (`tbx_01kt0vnr2bv55aa6x588r77x0z`)
- `.agents/skills/autoreview/scripts/autoreview --mode local`
