### PR TITLE
fix(status): detect npm shrinkwrap installs

### DIFF
--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -29,6 +29,18 @@ describe("detectPackageManager", () => {
     );
   });
 
+  it("treats npm shrinkwrap as the install manager when packageManager is build-time pnpm", async () => {
+    await withPackageManagerRoot(
+      [
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@11.2.2" }) },
+        { path: "npm-shrinkwrap.json", content: "{}" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("npm");
+      },
+    );
+  });
+
   it.each([
     {
       name: "uses bun.lock",

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -4,12 +4,16 @@ import { readPackageManagerSpec } from "./package-json.js";
 type DetectedPackageManager = "pnpm" | "bun" | "npm";
 
 export async function detectPackageManager(root: string): Promise<DetectedPackageManager | null> {
+  const files = await fs.readdir(root).catch((): string[] => []);
+  if (files.includes("npm-shrinkwrap.json")) {
+    return "npm";
+  }
+
   const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (pm === "pnpm" || pm === "bun" || pm === "npm") {
     return pm;
   }
 
-  const files = await fs.readdir(root).catch((): string[] => []);
   if (files.includes("pnpm-lock.yaml")) {
     return "pnpm";
   }

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -194,6 +194,21 @@ describe("formatGitInstallLabel", () => {
 });
 
 describe("checkDepsStatus", () => {
+  it("uses npm shrinkwrap as the npm package lockfile marker", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-" }, async (base) => {
+      const shrinkwrapPath = path.join(base, "npm-shrinkwrap.json");
+      await fs.writeFile(shrinkwrapPath, "{}", "utf8");
+      await fs.mkdir(path.join(base, "node_modules"), { recursive: true });
+
+      await expect(checkDepsStatus({ root: base, manager: "npm" })).resolves.toMatchObject({
+        manager: "npm",
+        status: "ok",
+        lockfilePath: shrinkwrapPath,
+        markerPath: path.join(base, "node_modules"),
+      });
+    });
+  });
+
   it("reports unknown, missing, stale, and ok states from lockfile markers", async () => {
     await withTempDir({ prefix: "openclaw-update-check-" }, async (base) => {
       await expect(checkDepsStatus({ root: base, manager: "unknown" })).resolves.toEqual({

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -200,10 +200,10 @@ async function statMtimeMs(p: string): Promise<number | null> {
   }
 }
 
-function resolveDepsMarker(params: { root: string; manager: PackageManager }): {
+async function resolveDepsMarker(params: { root: string; manager: PackageManager }): Promise<{
   lockfilePath: string | null;
   markerPath: string | null;
-} {
+}> {
   const root = params.root;
   if (params.manager === "pnpm") {
     return {
@@ -218,8 +218,11 @@ function resolveDepsMarker(params: { root: string; manager: PackageManager }): {
     };
   }
   if (params.manager === "npm") {
+    const shrinkwrapPath = path.join(root, "npm-shrinkwrap.json");
     return {
-      lockfilePath: path.join(root, "package-lock.json"),
+      lockfilePath: (await exists(shrinkwrapPath))
+        ? shrinkwrapPath
+        : path.join(root, "package-lock.json"),
       markerPath: path.join(root, "node_modules"),
     };
   }
@@ -231,7 +234,7 @@ export async function checkDepsStatus(params: {
   manager: PackageManager;
 }): Promise<DepsStatus> {
   const root = path.resolve(params.root);
-  const { lockfilePath, markerPath } = resolveDepsMarker({
+  const { lockfilePath, markerPath } = await resolveDepsMarker({
     root,
     manager: params.manager,
   });


### PR DESCRIPTION
Summary
- Treat npm-shrinkwrap.json as an npm install marker before package.json packageManager metadata, so published npm installs that retain build-time pnpm metadata report npm.
- Use npm-shrinkwrap.json as the npm dependency lockfile marker when status checks dependency freshness.
- Add regression coverage for package manager detection and dependency status against shrinkwrapped npm package roots.

Tests
- RED: node --no-maglev node_modules/vitest/vitest.mjs run src/infra/detect-package-manager.test.ts --reporter=verbose (failed on new npm-shrinkwrap regression: expected npm, received pnpm)
- RED: node --no-maglev node_modules/vitest/vitest.mjs run src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts --reporter=verbose (failed on npm-shrinkwrap detection and deps marker)
- GREEN: node --no-maglev node_modules/vitest/vitest.mjs run src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts --reporter=dot (20 passed)
- git diff --check

Real behavior proof
Behavior addressed: openclaw status/update detection no longer classifies npm-published package roots with npm-shrinkwrap.json as pnpm just because package.json has build-time packageManager=pnpm.
Real environment tested: Local macOS source checkout using temp package roots in Vitest; npm contract checked with npm help shrinkwrap, which states npm-shrinkwrap.json is publishable and takes precedence over package-lock.json.
Exact steps or command run after this patch: node --no-maglev node_modules/vitest/vitest.mjs run src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts --reporter=dot
Evidence after fix: detectPackageManager returns npm for package.json packageManager=pnpm plus npm-shrinkwrap.json, and checkDepsStatus uses npm-shrinkwrap.json as the npm lockfile marker.
Observed result after fix: 20 tests passed across src/infra/detect-package-manager.test.ts and src/infra/update-check.test.ts.
What was not tested: A live Raspberry Pi global npm install; local pnpm-based format/check wrappers were blocked because pnpm install retries timed out fetching optional packages.

Closes #87732
