### PR TITLE
Keep iMessage typing active during tool work

### DIFF
--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -16,6 +16,17 @@ import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
 type DispatchInboundMessageParams = {
   ctx: MsgContext;
   replyOptions?: {
+    suppressDefaultToolProgressMessages?: boolean;
+    onReplyStart?: () => Promise<void> | void;
+    onTypingCleanup?: () => void;
+    onTypingController?: (typing: {
+      startTypingLoop: () => Promise<void>;
+      refreshTypingTtl: () => void;
+      isActive: () => boolean;
+      markRunComplete: () => void;
+      markDispatchIdle: () => void;
+      cleanup: () => void;
+    }) => void;
     onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
   };
 };
@@ -145,7 +156,40 @@ describe("iMessage monitor last-route updates", () => {
       rpcMethods: ["watch.subscribe", "send", "typing"],
     });
     dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+      expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
+      let active = false;
+      let runComplete = false;
+      let dispatchIdle = false;
+      const stopIfSettled = () => {
+        if (active && runComplete && dispatchIdle) {
+          active = false;
+          params.replyOptions?.onTypingCleanup?.();
+        }
+      };
+      const typingController = {
+        startTypingLoop: async () => {
+          active = true;
+          await params.replyOptions?.onReplyStart?.();
+        },
+        refreshTypingTtl: () => {},
+        isActive: () => active,
+        markRunComplete: () => {
+          runComplete = true;
+          stopIfSettled();
+        },
+        markDispatchIdle: () => {
+          dispatchIdle = true;
+          stopIfSettled();
+        },
+        cleanup: () => {
+          active = false;
+          params.replyOptions?.onTypingCleanup?.();
+        },
+      };
+      params.replyOptions?.onTypingController?.(typingController);
       await params.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      typingController.markRunComplete();
+      typingController.markDispatchIdle();
       return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
     });
 

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -7,7 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { createIMessageRpcClient } from "./client.js";
 import { monitorIMessageProvider } from "./monitor.js";
 import { loadIMessageCatchupCursor } from "./monitor/catchup.js";
+import {
+  clearCachedIMessagePrivateApiStatus,
+  setCachedIMessagePrivateApiStatus,
+} from "./private-api-status.js";
 import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
+
+type DispatchInboundMessageParams = {
+  ctx: MsgContext;
+  replyOptions?: {
+    onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
+  };
+};
 
 const waitForTransportReadyMock = vi.hoisted(() =>
   vi.fn<typeof waitForTransportReady>(async () => {}),
@@ -17,7 +28,7 @@ const readChannelAllowFromStoreMock = vi.hoisted(() => vi.fn(async () => [] as s
 const recordInboundSessionMock = vi.hoisted(() => vi.fn(async (_params: unknown) => {}));
 const dispatchInboundMessageMock = vi.hoisted(() =>
   vi.fn(
-    async (_params: { ctx: MsgContext }) =>
+    async (_params: DispatchInboundMessageParams) =>
       ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }) as const,
   ),
 );
@@ -115,6 +126,7 @@ describe("iMessage monitor last-route updates", () => {
     recordInboundSessionMock.mockClear();
     dispatchInboundMessageMock.mockClear();
     debouncerControl.reset();
+    clearCachedIMessagePrivateApiStatus();
   });
 
   afterEach(() => {
@@ -123,6 +135,88 @@ describe("iMessage monitor last-route updates", () => {
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("keeps native typing alive when tool activity arrives before reply text", async () => {
+    setCachedIMessagePrivateApiStatus("imsg", {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["watch.subscribe", "send", "typing"],
+    });
+    dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+      await params.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
+    });
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "typing") {
+          return { ok: true };
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 7,
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "run a long script",
+              is_group: false,
+              created_at: new Date().toISOString(),
+            },
+          },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+            sendReadReceipts: false,
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(client.request).toHaveBeenCalledWith(
+        "typing",
+        expect.objectContaining({ typing: true }),
+        expect.any(Object),
+      );
+    });
+    await vi.waitFor(() => {
+      expect(client.request).toHaveBeenCalledWith(
+        "typing",
+        expect.objectContaining({ typing: false }),
+        expect.any(Object),
+      );
+    });
   });
 
   it("keeps per-channel-peer direct-message last-route writes on the isolated session", async () => {

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -17,6 +17,7 @@ type DispatchInboundMessageParams = {
   ctx: MsgContext;
   replyOptions?: {
     suppressDefaultToolProgressMessages?: boolean;
+    allowProgressCallbacksWhenSourceDeliverySuppressed?: boolean;
     onReplyStart?: () => Promise<void> | void;
     onTypingCleanup?: () => void;
     onTypingController?: (typing: {
@@ -157,6 +158,7 @@ describe("iMessage monitor last-route updates", () => {
     });
     dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
       expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
+      expect(params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBe(true);
       let active = false;
       let runComplete = false;
       let dispatchIdle = false;
@@ -262,6 +264,89 @@ describe("iMessage monitor last-route updates", () => {
       );
     });
   });
+
+  it.each(["never", "message", "thinking"] as const)(
+    "does not start direct tool typing when typingMode is %s",
+    async (typingMode) => {
+      setCachedIMessagePrivateApiStatus("imsg", {
+        available: true,
+        v2Ready: true,
+        selectors: {},
+        rpcMethods: ["watch.subscribe", "send", "typing"],
+      });
+      dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+        expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBeUndefined();
+        expect(
+          params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed,
+        ).toBeUndefined();
+        expect(params.replyOptions?.onToolStart).toBeUndefined();
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
+      });
+
+      let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+      const client = {
+        request: vi.fn(async (method: string) => {
+          if (method === "watch.subscribe") {
+            return { subscription: 1 };
+          }
+          if (method === "typing") {
+            throw new Error("typing should not start from tool activity");
+          }
+          throw new Error(`unexpected imsg method ${method}`);
+        }),
+        waitForClose: vi.fn(async () => {
+          onNotification?.({
+            method: "message",
+            params: {
+              message: {
+                id: 8,
+                chat_id: 123,
+                sender: "+15550001111",
+                is_from_me: false,
+                text: "run a long script",
+                is_group: false,
+                created_at: new Date().toISOString(),
+              },
+            },
+          });
+          await Promise.resolve();
+          await Promise.resolve();
+        }),
+        stop: vi.fn(async () => {}),
+      };
+      createIMessageRpcClientMock.mockImplementation(async (params) => {
+        if (!params?.onNotification) {
+          throw new Error("expected iMessage notification handler");
+        }
+        onNotification = params.onNotification;
+        return client as never;
+      });
+
+      await monitorIMessageProvider({
+        config: {
+          channels: {
+            imessage: {
+              dmPolicy: "allowlist",
+              allowFrom: ["+15550001111"],
+              sendReadReceipts: false,
+            },
+          },
+          messages: { inbound: { debounceMs: 0 } },
+          session: { mainKey: "main", typingMode },
+        } as never,
+        runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+      });
+
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      });
+      expect(client.request).not.toHaveBeenCalledWith(
+        "typing",
+        expect.objectContaining({ typing: true }),
+        expect.anything(),
+      );
+    },
+  );
 
   it("keeps per-channel-peer direct-message last-route writes on the isolated session", async () => {
     const runtimeErrorMock = vi.fn();

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -348,6 +348,86 @@ describe("iMessage monitor last-route updates", () => {
     },
   );
 
+  it("does not start direct tool typing when sendPolicy denies source delivery", async () => {
+    setCachedIMessagePrivateApiStatus("imsg", {
+      available: true,
+      v2Ready: true,
+      selectors: {},
+      rpcMethods: ["watch.subscribe", "send", "typing"],
+    });
+    dispatchInboundMessageMock.mockImplementationOnce(async (params) => {
+      expect(params.replyOptions?.suppressDefaultToolProgressMessages).toBeUndefined();
+      expect(
+        params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed,
+      ).toBeUndefined();
+      expect(params.replyOptions?.onToolStart).toBeUndefined();
+      return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } } as const;
+    });
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "typing") {
+          throw new Error("typing should not start under sendPolicy deny");
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 9,
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "run a long script",
+              is_group: false,
+              created_at: new Date().toISOString(),
+            },
+          },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+            sendReadReceipts: false,
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main", sendPolicy: { default: "deny" } },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    });
+    expect(client.request).not.toHaveBeenCalledWith(
+      "typing",
+      expect.objectContaining({ typing: true }),
+      expect.anything(),
+    );
+  });
+
   it("keeps per-channel-peer direct-message last-route writes on the isolated session", async () => {
     const runtimeErrorMock = vi.fn();
     let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -24,7 +24,7 @@ import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
 import { normalizeScpRemoteHost } from "openclaw/plugin-sdk/host-runtime";
 import { isInboundPathAllowed, kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
-import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveTextChunkLimit, type GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
 import { createReplyDispatcherWithTyping } from "openclaw/plugin-sdk/reply-runtime";
 import { settleReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
@@ -891,6 +891,27 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         runtime.error?.(danger(`imessage ${info.kind} reply failed: ${String(err)}`));
       },
     });
+    let directTypingController:
+      | Parameters<NonNullable<GetReplyOptions["onTypingController"]>>[0]
+      | undefined;
+    const directToolTypingOptions = !decision.isGroup
+      ? ({
+          // iMessage's native typing bubble is channel-owned UI, not a
+          // visible tool-progress message. The suppress flag is what lets
+          // dispatch forward this callback even when verbose progress is off.
+          // Keep this direct-DM-only so group typing still follows core
+          // mention/renderable-text policy. Route through the core typing
+          // controller so dispatcher cleanup owns the matching stop callback.
+          suppressDefaultToolProgressMessages: true,
+          onTypingController: (typing) => {
+            directTypingController = typing;
+            typingReplyOptions.onTypingController?.(typing);
+          },
+          onToolStart: async () => {
+            await directTypingController?.startTypingLoop();
+          },
+        } as const)
+      : {};
     const inboundLastRouteSessionKey = resolveInboundLastRouteSessionKey({
       route: decision.route,
       sessionKey: decision.route.sessionKey,
@@ -968,9 +989,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
                       ? !accountInfo.config.blockStreaming
                       : undefined,
                   onModelSelected,
-                  ...(typingReplyOptions.onReplyStart
-                    ? { onToolStart: typingReplyOptions.onReplyStart }
-                    : {}),
+                  ...directToolTypingOptions,
                 },
               });
             } finally {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -29,7 +29,7 @@ import { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
 import { createReplyDispatcherWithTyping } from "openclaw/plugin-sdk/reply-runtime";
 import { settleReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
-import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { getRuntimeConfig, type OpenClawConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose, shouldLogVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import {
   resolveOpenProviderRuntimeGroupPolicy,
@@ -89,6 +89,10 @@ const APPROVAL_REACTION_POLL_INTERVAL_MS = 2_000;
 const APPROVAL_REACTION_DISCOVERY_INTERVAL_MS = 60_000;
 const IMESSAGE_TYPING_KEEPALIVE_INTERVAL_MS = 8_000;
 const IMESSAGE_TYPING_KEEPALIVE_MAX_DURATION_MS = 10 * 60_000;
+
+function resolveConfiguredIMessageTypingMode(cfg: OpenClawConfig) {
+  return cfg.session?.typingMode ?? cfg.agents?.defaults?.typingMode;
+}
 
 function isIMessagePluginPayloadAttachment(attachment: {
   original_path?: string | null;
@@ -894,15 +898,20 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     let directTypingController:
       | Parameters<NonNullable<GetReplyOptions["onTypingController"]>>[0]
       | undefined;
-    const directToolTypingOptions = !decision.isGroup
+    const configuredTypingMode = resolveConfiguredIMessageTypingMode(cfg);
+    const shouldStartToolTyping =
+      !decision.isGroup &&
+      (configuredTypingMode === undefined || configuredTypingMode === "instant");
+    const directToolTypingOptions = shouldStartToolTyping
       ? ({
           // iMessage's native typing bubble is channel-owned UI, not a
           // visible tool-progress message. The suppress flag is what lets
-          // dispatch forward this callback even when verbose progress is off.
-          // Keep this direct-DM-only so group typing still follows core
-          // mention/renderable-text policy. Route through the core typing
-          // controller so dispatcher cleanup owns the matching stop callback.
+          // dispatch forward this callback even when verbose progress is off;
+          // allowProgress covers message_tool_only source delivery. Keep this on
+          // the direct instant/default path so configured typingMode values still
+          // decide when typing can begin.
           suppressDefaultToolProgressMessages: true,
+          allowProgressCallbacksWhenSourceDeliverySuppressed: true,
           onTypingController: (typing) => {
             directTypingController = typing;
             typingReplyOptions.onTypingController?.(typing);

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -37,7 +37,12 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/runtime-group-policy";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
-import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  getSessionEntry,
+  readSessionUpdatedAt,
+  resolveSendPolicy,
+  resolveStorePath,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import { resolveIMessageAccount } from "../accounts.js";
@@ -89,6 +94,7 @@ const APPROVAL_REACTION_POLL_INTERVAL_MS = 2_000;
 const APPROVAL_REACTION_DISCOVERY_INTERVAL_MS = 60_000;
 const IMESSAGE_TYPING_KEEPALIVE_INTERVAL_MS = 8_000;
 const IMESSAGE_TYPING_KEEPALIVE_MAX_DURATION_MS = 10 * 60_000;
+type IMessageTypingController = Parameters<NonNullable<GetReplyOptions["onTypingController"]>>[0];
 
 function resolveConfiguredIMessageTypingMode(cfg: OpenClawConfig) {
   return cfg.session?.typingMode ?? cfg.agents?.defaults?.typingMode;
@@ -895,12 +901,18 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         runtime.error?.(danger(`imessage ${info.kind} reply failed: ${String(err)}`));
       },
     });
-    let directTypingController:
-      | Parameters<NonNullable<GetReplyOptions["onTypingController"]>>[0]
-      | undefined;
+    let directTypingController: IMessageTypingController | undefined;
     const configuredTypingMode = resolveConfiguredIMessageTypingMode(cfg);
+    const sendPolicy = resolveSendPolicy({
+      cfg,
+      entry: getSessionEntry({ storePath, sessionKey: decision.route.sessionKey }),
+      sessionKey: decision.route.sessionKey,
+      channel: "imessage",
+      chatType: decision.isGroup ? "group" : "direct",
+    });
     const shouldStartToolTyping =
       !decision.isGroup &&
+      sendPolicy !== "deny" &&
       (configuredTypingMode === undefined || configuredTypingMode === "instant");
     const directToolTypingOptions = shouldStartToolTyping
       ? ({
@@ -912,7 +924,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           // decide when typing can begin.
           suppressDefaultToolProgressMessages: true,
           allowProgressCallbacksWhenSourceDeliverySuppressed: true,
-          onTypingController: (typing) => {
+          onTypingController: (typing: IMessageTypingController) => {
             directTypingController = typing;
             typingReplyOptions.onTypingController?.(typing);
           },

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -87,6 +87,8 @@ const WATCH_SUBSCRIBE_MAX_ATTEMPTS = 3;
 const WATCH_SUBSCRIBE_RETRY_DELAY_MS = 1_000;
 const APPROVAL_REACTION_POLL_INTERVAL_MS = 2_000;
 const APPROVAL_REACTION_DISCOVERY_INTERVAL_MS = 60_000;
+const IMESSAGE_TYPING_KEEPALIVE_INTERVAL_MS = 8_000;
+const IMESSAGE_TYPING_KEEPALIVE_MAX_DURATION_MS = 10 * 60_000;
 
 function isIMessagePluginPayloadAttachment(attachment: {
   original_path?: string | null;
@@ -810,6 +812,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
                   client: getActiveClient(),
                 });
               },
+              // Keep the native typing bubble alive through long tool chains.
+              // The dispatcher idle path below still owns teardown on final,
+              // error, abort, or monitor shutdown.
+              keepaliveIntervalMs: IMESSAGE_TYPING_KEEPALIVE_INTERVAL_MS,
+              maxDurationMs: IMESSAGE_TYPING_KEEPALIVE_MAX_DURATION_MS,
               onStartError: (err) => {
                 logTypingFailure({
                   log: (msg) => logVerbose(msg),
@@ -961,6 +968,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
                       ? !accountInfo.config.blockStreaming
                       : undefined,
                   onModelSelected,
+                  ...(typingReplyOptions.onReplyStart
+                    ? { onToolStart: typingReplyOptions.onReplyStart }
+                    : {}),
                 },
               });
             } finally {

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -40,4 +40,5 @@ export {
   resolveSessionResetType,
   resolveThreadFlag,
 } from "../config/sessions/reset.js";
+export { resolveSendPolicy } from "../sessions/send-policy.js";
 export type { SessionEntry, SessionScope } from "../config/sessions/types.js";


### PR DESCRIPTION
## Summary

- Keep iMessage native typing indicators alive during long tool-running gaps by using the existing typing RPC keepalive path with a bounded 10 minute TTL.
- Bridge iMessage tool-start progress events to the typing callback so tool activity before any assistant text still shows ephemeral typing instead of sending persistent progress bubbles.
- Gate the direct iMessage tool-typing bridge with the shared `sendPolicy` resolver so `sendPolicy: deny` continues to suppress native typing.
- Add monitor regression coverage for tool activity before reply text, cleanup back to `typing: false`, and send-policy-denied direct typing.

Fixes #75847

## Verification

- `./node_modules/.bin/oxfmt --check --threads=1 src/plugin-sdk/session-store-runtime.ts extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor.last-route.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json src/plugin-sdk/session-store-runtime.ts extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor.last-route.test.ts`
- `node scripts/run-vitest.mjs extensions/imessage/src/monitor.last-route.test.ts` -> 16 tests passed
- `pnpm run test:extensions:package-boundary:compile` -> extension package boundary check passed, compiled 113 plugins
- `pnpm --silent run plugin-sdk:check-exports` -> plugin-sdk exports synced
- `pnpm --silent run plugin-sdk:api:check` -> OK `docs/.generated/plugin-sdk-api-baseline.sha256`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: iMessage turns with tool activity before reply text now keep the sender's native typing indicator active instead of sending no progress signal.

Real environment tested: local macOS Messages/iMessage private API with the LaunchAgent gateway running the rebuilt dist that included this patch.

Exact steps or command run after this patch: Sent this real iMessage: `Ok generate a new image now of a Lobster ready to launch like a Rocket into space.` Then inspected `/opt/homebrew/bin/imsg history --chat-id 3 --limit 30 --attachments --json` and `~/.openclaw/logs/openclaw.log`.

Evidence after fix: iMessage DB shows inbound request id `5805` at `2026-06-01T20:55:49.931Z` and the generated-image reply id `5806` at `2026-06-01T20:57:14.450Z` with one PNG attachment. Gateway log for the same turn shows `message dispatch completed: channel=imessage ... duration=84088ms`, so the real iMessage turn spent about 84s in the tool-running path before the visible media reply.

Observed result after fix: requester confirmed the iMessage typing indicator worked during that long generated-image wait. The final source reply was correctly suppressed under `sourceReplyDeliveryMode: message_tool_only` after the message-tool delivery completed.

What was not tested: cross-machine or CI real Messages.app UI capture; proof is from the local macOS iMessage setup plus the requester's live observation.
