### PR TITLE
fix(plugins): ignore throwing provider policy hooks

### DIFF
--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -24,6 +24,7 @@ describe("provider public artifacts", () => {
     vi.doUnmock("./bundled-dir.js");
     vi.doUnmock("./manifest-registry.js");
     vi.doUnmock("./public-surface-loader.js");
+    vi.doUnmock("../logging/subsystem.js");
     vi.resetModules();
   });
 
@@ -313,5 +314,62 @@ describe("provider public artifacts", () => {
       dirName: "openai",
       artifactBasename: "provider-policy-api.js",
     });
+  });
+
+  it("ignores throwing bundled provider policy hooks without poisoning callers", async () => {
+    const warn = vi.fn();
+    let shouldThrow = true;
+    const loadBundledPluginPublicArtifactModuleSync = vi.fn(() => ({
+      normalizeConfig: (ctx: { providerConfig: ModelProviderConfig }) => {
+        if (shouldThrow) {
+          throw new Error("fuzzplugin provider policy exploded");
+        }
+        return {
+          ...ctx.providerConfig,
+          baseUrl: "https://recovered.example/v1",
+        };
+      },
+    }));
+    vi.doMock("../logging/subsystem.js", () => ({
+      createSubsystemLogger: () => ({ warn }),
+    }));
+    vi.doMock("./public-surface-loader.js", () => ({
+      loadBundledPluginPublicArtifactModuleSync,
+    }));
+
+    const {
+      consumeBundledProviderPolicyHookFailure,
+      resolveBundledProviderPolicySurface: resolvePolicySurface,
+    } = await importFreshModule<typeof import("./provider-public-artifacts.js")>(
+      import.meta.url,
+      "./provider-public-artifacts.js?scope=throwing-policy-hook",
+    );
+
+    const providerConfig: ModelProviderConfig = {
+      baseUrl: "https://api.fuzzplugin.example/v1",
+      api: "openai-completions",
+      models: [],
+    };
+    const surface = resolvePolicySurface("fuzzplugin");
+
+    expect(
+      surface?.normalizeConfig?.({
+        provider: "fuzzplugin",
+        providerConfig,
+      }),
+    ).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("fuzzplugin.normalizeConfig failed"));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("fuzzplugin provider policy exploded"),
+    );
+
+    shouldThrow = false;
+    expect(
+      surface?.normalizeConfig?.({
+        provider: "fuzzplugin",
+        providerConfig,
+      })?.baseUrl,
+    ).toBe("https://recovered.example/v1");
+    expect(consumeBundledProviderPolicyHookFailure(surface?.normalizeConfig)).toBe(false);
   });
 });

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -1,6 +1,8 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
 import type {
@@ -16,6 +18,8 @@ import { loadBundledPluginPublicArtifactModuleSync } from "./public-surface-load
 
 const PROVIDER_POLICY_ARTIFACT_CANDIDATES = ["provider-policy-api.js"] as const;
 const providerPolicySurfaceByPluginId = new Map<string, BundledProviderPolicySurface | null>();
+const providerPolicyHookFailures = new WeakSet<object>();
+const log = createSubsystemLogger("plugins/provider-policy");
 
 export type BundledProviderPolicySurface = {
   normalizeConfig?: (ctx: ProviderNormalizeConfigContext) => ModelProviderConfig | null | undefined;
@@ -39,6 +43,81 @@ function hasProviderPolicyHook(
   );
 }
 
+function wrapProviderPolicyHook<TContext, TResult>(params: {
+  pluginId: string;
+  hookName: keyof BundledProviderPolicySurface;
+  hook: ((ctx: TContext) => TResult) | undefined;
+}): ((ctx: TContext) => TResult | undefined) | undefined {
+  if (!params.hook) {
+    return undefined;
+  }
+  const hook = params.hook;
+  const wrappedHook = (ctx: TContext): TResult | undefined => {
+    providerPolicyHookFailures.delete(wrappedHook);
+    try {
+      return hook(ctx);
+    } catch (error) {
+      providerPolicyHookFailures.add(wrappedHook);
+      log.warn(
+        `bundled provider policy hook ${params.pluginId}.${params.hookName} failed; ignoring hook: ${formatErrorMessage(error)}`,
+      );
+      return undefined;
+    }
+  };
+  return wrappedHook;
+}
+
+export function consumeBundledProviderPolicyHookFailure(hook: object | undefined): boolean {
+  if (!hook) {
+    return false;
+  }
+  if (!providerPolicyHookFailures.has(hook)) {
+    return false;
+  }
+  providerPolicyHookFailures.delete(hook);
+  return true;
+}
+
+function wrapBundledProviderPolicySurface(params: {
+  pluginId: string;
+  surface: BundledProviderPolicySurface;
+}): BundledProviderPolicySurface {
+  const wrapped: BundledProviderPolicySurface = {};
+  const normalizeConfig = wrapProviderPolicyHook({
+    pluginId: params.pluginId,
+    hookName: "normalizeConfig",
+    hook: params.surface.normalizeConfig,
+  });
+  if (normalizeConfig) {
+    wrapped.normalizeConfig = normalizeConfig;
+  }
+  const applyConfigDefaults = wrapProviderPolicyHook({
+    pluginId: params.pluginId,
+    hookName: "applyConfigDefaults",
+    hook: params.surface.applyConfigDefaults,
+  });
+  if (applyConfigDefaults) {
+    wrapped.applyConfigDefaults = applyConfigDefaults;
+  }
+  const resolveConfigApiKey = wrapProviderPolicyHook({
+    pluginId: params.pluginId,
+    hookName: "resolveConfigApiKey",
+    hook: params.surface.resolveConfigApiKey,
+  });
+  if (resolveConfigApiKey) {
+    wrapped.resolveConfigApiKey = resolveConfigApiKey;
+  }
+  const resolveThinkingProfile = wrapProviderPolicyHook({
+    pluginId: params.pluginId,
+    hookName: "resolveThinkingProfile",
+    hook: params.surface.resolveThinkingProfile,
+  });
+  if (resolveThinkingProfile) {
+    wrapped.resolveThinkingProfile = resolveThinkingProfile;
+  }
+  return wrapped;
+}
+
 function tryLoadBundledProviderPolicySurface(
   pluginId: string,
 ): BundledProviderPolicySurface | null {
@@ -54,8 +133,12 @@ function tryLoadBundledProviderPolicySurface(
         artifactBasename,
       });
       if (hasProviderPolicyHook(mod)) {
-        providerPolicySurfaceByPluginId.set(cacheKey, mod);
-        return mod;
+        const surface = wrapBundledProviderPolicySurface({
+          pluginId,
+          surface: mod,
+        });
+        providerPolicySurfaceByPluginId.set(cacheKey, surface);
+        return surface;
       }
     } catch (error) {
       if (

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -29,6 +29,8 @@ type ResolveOwningPluginIdsForProvider =
   typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 type ResolveBundledProviderPolicySurface =
   typeof import("./provider-public-artifacts.js").resolveBundledProviderPolicySurface;
+type ConsumeBundledProviderPolicyHookFailure =
+  typeof import("./provider-public-artifacts.js").consumeBundledProviderPolicyHookFailure;
 
 const resolvePluginProvidersMock = vi.fn<ResolvePluginProviders>((_) => [] as ProviderPlugin[]);
 const isPluginProvidersLoadInFlightMock = vi.fn<IsPluginProvidersLoadInFlight>((_) => false);
@@ -44,6 +46,9 @@ const resolveOwningPluginIdsForProviderMock = vi.fn<ResolveOwningPluginIdsForPro
 );
 const resolveBundledProviderPolicySurfaceMock = vi.fn<ResolveBundledProviderPolicySurface>(
   (_) => null,
+);
+const consumeBundledProviderPolicyHookFailureMock = vi.fn<ConsumeBundledProviderPolicyHookFailure>(
+  () => false,
 );
 const providerRuntimeWarnMock = vi.fn();
 
@@ -281,6 +286,8 @@ describe("provider-runtime", () => {
   beforeAll(async () => {
     vi.resetModules();
     vi.doMock("./provider-public-artifacts.js", () => ({
+      consumeBundledProviderPolicyHookFailure: (hook: object | undefined) =>
+        consumeBundledProviderPolicyHookFailureMock(hook),
       resolveBundledProviderPolicySurface: (provider: string) =>
         resolveBundledProviderPolicySurfaceMock(provider),
     }));
@@ -379,6 +386,8 @@ describe("provider-runtime", () => {
     resolveOwningPluginIdsForProviderMock.mockReturnValue(undefined);
     resolveBundledProviderPolicySurfaceMock.mockReset();
     resolveBundledProviderPolicySurfaceMock.mockReturnValue(null);
+    consumeBundledProviderPolicyHookFailureMock.mockReset();
+    consumeBundledProviderPolicyHookFailureMock.mockReturnValue(false);
     providerRuntimeWarnMock.mockReset();
   });
 
@@ -1381,6 +1390,91 @@ describe("provider-runtime", () => {
 
     expect(normalizeConfig).toHaveBeenCalledTimes(1);
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to runtime provider hooks after bundled policy hook failures", () => {
+    const providerConfig: ModelProviderConfig = {
+      baseUrl: "https://api.fuzzplugin.example/v1",
+      api: "openai-completions",
+      models: [],
+    };
+    const normalizeConfig = vi.fn(() => undefined);
+    const resolveConfigApiKey = vi.fn(() => undefined);
+    const resolveThinkingProfile = vi.fn(() => undefined);
+    const applyConfigDefaults = vi.fn(() => undefined);
+    resolveBundledProviderPolicySurfaceMock.mockReturnValue({
+      normalizeConfig,
+      resolveConfigApiKey,
+      resolveThinkingProfile,
+      applyConfigDefaults,
+    });
+    consumeBundledProviderPolicyHookFailureMock.mockImplementation(
+      (hook) =>
+        hook === normalizeConfig ||
+        hook === resolveConfigApiKey ||
+        hook === resolveThinkingProfile ||
+        hook === applyConfigDefaults,
+    );
+    resolvePluginProvidersMock.mockReturnValue([
+      {
+        id: "fuzzplugin",
+        label: "Fuzz Plugin",
+        auth: [],
+        normalizeConfig: ({ providerConfig: config }) => ({
+          ...config,
+          baseUrl: "https://runtime.example.com/v1",
+        }),
+        resolveConfigApiKey: () => "runtime-api-key",
+        resolveThinkingProfile: () => ({
+          levels: [{ id: "low" }],
+          defaultLevel: "low",
+        }),
+        applyConfigDefaults: ({ config }) => ({
+          ...config,
+          pluginDefaultsApplied: true,
+        }),
+      },
+    ]);
+
+    expect(
+      normalizeProviderConfigWithPlugin({
+        provider: "fuzzplugin",
+        context: {
+          provider: "fuzzplugin",
+          providerConfig,
+        },
+      })?.baseUrl,
+    ).toBe("https://runtime.example.com/v1");
+    expect(
+      resolveProviderConfigApiKeyWithPlugin({
+        provider: "fuzzplugin",
+        context: {
+          provider: "fuzzplugin",
+          providerConfig,
+          env: {},
+        },
+      }),
+    ).toBe("runtime-api-key");
+    expect(
+      resolveProviderThinkingProfile({
+        provider: "fuzzplugin",
+        context: {
+          provider: "fuzzplugin",
+          modelId: "fuzz-model",
+          reasoning: true,
+        },
+      }),
+    ).toEqual({ levels: [{ id: "low" }], defaultLevel: "low" });
+    expect(
+      applyProviderConfigDefaultsWithPlugin({
+        provider: "fuzzplugin",
+        context: {
+          provider: "fuzzplugin",
+          config: {},
+          env: {},
+        },
+      }),
+    ).toEqual({ pluginDefaultsApplied: true });
   });
 
   it("resolves thinking profiles from bundled policy surface before runtime plugins", () => {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -32,7 +32,10 @@ import {
   type ProviderRuntimePluginHandle,
   wrapProviderStreamFn,
 } from "./provider-hook-runtime.js";
-import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
+import {
+  consumeBundledProviderPolicyHookFailure,
+  resolveBundledProviderPolicySurface,
+} from "./provider-public-artifacts.js";
 import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
 import type { ProviderThinkingProfile } from "./provider-thinking.types.js";
 import {
@@ -414,9 +417,12 @@ export function normalizeProviderConfigWithPlugin(params: {
   const hasConfigChange = (normalized: ModelProviderConfig) =>
     normalized !== params.context.providerConfig;
   const bundledSurface = resolveBundledProviderPolicySurface(params.provider);
-  if (bundledSurface?.normalizeConfig) {
-    const normalized = bundledSurface.normalizeConfig(params.context);
-    return normalized && hasConfigChange(normalized) ? normalized : undefined;
+  const bundledNormalizeConfig = bundledSurface?.normalizeConfig;
+  if (bundledNormalizeConfig) {
+    const normalized = bundledNormalizeConfig(params.context);
+    if (!consumeBundledProviderPolicyHookFailure(bundledNormalizeConfig)) {
+      return normalized && hasConfigChange(normalized) ? normalized : undefined;
+    }
   }
   if (!hasExplicitProviderRuntimePluginActivation(params)) {
     return undefined;
@@ -455,8 +461,12 @@ export function resolveProviderConfigApiKeyWithPlugin(params: {
   allowRuntimePluginLoad?: boolean;
 }): string | undefined {
   const bundledSurface = resolveBundledProviderPolicySurface(params.provider);
-  if (bundledSurface?.resolveConfigApiKey) {
-    return normalizeOptionalString(bundledSurface.resolveConfigApiKey(params.context));
+  const bundledResolveConfigApiKey = bundledSurface?.resolveConfigApiKey;
+  if (bundledResolveConfigApiKey) {
+    const apiKey = normalizeOptionalString(bundledResolveConfigApiKey(params.context));
+    if (!consumeBundledProviderPolicyHookFailure(bundledResolveConfigApiKey)) {
+      return apiKey;
+    }
   }
   if (params.allowRuntimePluginLoad === false) {
     return undefined;
@@ -766,8 +776,12 @@ export function resolveProviderThinkingProfile(params: {
   context: ProviderDefaultThinkingPolicyContext;
 }): ProviderThinkingProfile | null | undefined {
   const bundledSurface = resolveBundledProviderPolicySurface(params.provider);
-  if (bundledSurface?.resolveThinkingProfile) {
-    return bundledSurface.resolveThinkingProfile(params.context) ?? undefined;
+  const bundledResolveThinkingProfile = bundledSurface?.resolveThinkingProfile;
+  if (bundledResolveThinkingProfile) {
+    const profile = bundledResolveThinkingProfile(params.context) ?? undefined;
+    if (!consumeBundledProviderPolicyHookFailure(bundledResolveThinkingProfile)) {
+      return profile;
+    }
   }
   return resolveProviderRuntimePlugin(params)?.resolveThinkingProfile?.(params.context);
 }
@@ -790,8 +804,12 @@ export function applyProviderConfigDefaultsWithPlugin(params: {
   context: ProviderApplyConfigDefaultsContext;
 }) {
   const bundledSurface = resolveBundledProviderPolicySurface(params.provider);
-  if (bundledSurface?.applyConfigDefaults) {
-    return bundledSurface.applyConfigDefaults(params.context) ?? undefined;
+  const bundledApplyConfigDefaults = bundledSurface?.applyConfigDefaults;
+  if (bundledApplyConfigDefaults) {
+    const config = bundledApplyConfigDefaults(params.context) ?? undefined;
+    if (!consumeBundledProviderPolicyHookFailure(bundledApplyConfigDefaults)) {
+      return config;
+    }
   }
   return resolveProviderRuntimePlugin(params)?.applyConfigDefaults?.(params.context) ?? undefined;
 }


### PR DESCRIPTION
## Summary

- wraps bundled provider-policy public-artifact hooks so a throwing hook is ignored instead of poisoning provider/config resolution
- logs the plugin id and hook name when a bundled policy hook fails
- preserves existing no-op short-circuit semantics, while allowing runtime provider hooks to run after an actual bundled-hook failure

## Verification

- `node scripts/run-vitest.mjs src/plugins/provider-public-artifacts.test.ts src/plugins/provider-runtime.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-public-artifacts.ts src/plugins/provider-public-artifacts.test.ts src/plugins/provider-runtime.ts src/plugins/provider-runtime.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/plugins/provider-public-artifacts.ts src/plugins/provider-public-artifacts.test.ts src/plugins/provider-runtime.ts src/plugins/provider-runtime.test.ts`
- `git diff --check`
- private reported-name scrub over the local spec and changed files
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Review the corrected provider-policy public-artifact hardening patch after addressing prior findings. Bundled provider policy hooks are wrapped to log and fail open; failure state is per current invocation and cleared before each hook call; provider-runtime callers continue to runtime provider hooks only when the current bundled hook failed, preserving no-op short-circuit semantics otherwise. Focus on fallback correctness, stale failure state, logging, cache behavior, and regression coverage.'`
- PR proof workflow rerun: current `Real behavior proof` completed successfully

Behavior addressed: A broken bundled provider-policy hook no longer crashes config/provider/thinking resolution, and runtime provider hooks are still available when the public-artifact hook is the broken part.

Real environment tested: Local Codex gwt worktree on macOS using the repo Vitest node wrapper and repo lint/format wrappers.

Exact steps or command run after this patch: See Verification above.

Evidence after fix: Focused Vitest passed 1 shard / 64 tests; oxfmt, oxlint, `git diff --check`, private-name scrub, autoreview, and PR proof workflow all passed.

Observed result after fix: Throwing synthetic `fuzzplugin` provider-policy hooks are logged and ignored; stale hook-failure state is cleared before later successful calls; runtime provider hooks still run after current bundled-hook failures.

What was not tested: Remote `check:changed` and `pnpm build` are blocked right now: Blacksmith Testbox auth is missing, AWS Crabbox is at the active lease limit, and direct local `pnpm build` in this Codex worktree attempted dependency reconciliation and aborted before build execution.
