### PR TITLE
Repair compacted tool-result chains

### DIFF
--- a/src/agents/harness/context-engine-lifecycle.test.ts
+++ b/src/agents/harness/context-engine-lifecycle.test.ts
@@ -16,6 +16,24 @@ function textMessage(role: "user" | "assistant", text: string, timestamp: number
   } as AgentMessage;
 }
 
+function assistantToolCallMessage(id: string, timestamp: number): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id, name: "read", arguments: {} }],
+    timestamp,
+  } as AgentMessage;
+}
+
+function toolResultMessage(id: string, text: string, timestamp: number): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: id,
+    toolName: "read",
+    content: [{ type: "text", text }],
+    timestamp,
+  } as AgentMessage;
+}
+
 function runtimeContextMessage(content: string, timestamp: number): AgentMessage {
   // Runtime context is hidden harness metadata. Context engines should see
   // user/assistant transcript messages, not this internal custom channel.
@@ -141,6 +159,28 @@ describe("harness context engine lifecycle", () => {
     it("passes through a well-formed AssembleResult unchanged", async () => {
       const wellFormed = { messages: [visibleUser], estimatedTokens: 0 };
       await expect(runAssembleWithEngineResult(wellFormed)).resolves.toBe(wellFormed);
+    });
+
+    it("drops orphan tool results returned by assemble()", async () => {
+      const orphanToolResult = toolResultMessage("call_dropped", "orphaned output", 2);
+      const assembled = await runAssembleWithEngineResult({
+        messages: [visibleUser, orphanToolResult],
+        estimatedTokens: 1,
+      });
+
+      expect(assembled?.messages).toEqual([visibleUser]);
+      expect(JSON.stringify(assembled?.messages)).not.toContain("call_dropped");
+    });
+
+    it("keeps assembled assistant tool calls paired with their tool results", async () => {
+      const assistant = assistantToolCallMessage("call_keep", 2);
+      const result = toolResultMessage("call_keep", "kept output", 3);
+      const assembled = await runAssembleWithEngineResult({
+        messages: [visibleUser, assistant, result],
+        estimatedTokens: 1,
+      });
+
+      expect(assembled?.messages).toEqual([visibleUser, assistant, result]);
     });
 
     it("rejects an undefined assemble result with the engine id", async () => {

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -14,6 +14,7 @@ import {
 } from "../embedded-agent-runner/run/attempt.prompt-helpers.js";
 import { stripRuntimeContextCustomMessages } from "../internal-runtime-context.js";
 import type { AgentMessage } from "../runtime/index.js";
+import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import type { SessionWriteLockAcquireTimeoutConfig } from "../session-write-lock.js";
 
 export type HarnessContextEngine = ContextEngine;
@@ -90,7 +91,9 @@ export async function assembleHarnessContextEngine(params: {
     model: params.modelId,
     ...(params.prompt !== undefined ? { prompt: params.prompt } : {}),
   });
-  return ensureAssembleResultShape(result, params.contextEngine.info.id);
+  return repairAssembleResultMessages(
+    ensureAssembleResultShape(result, params.contextEngine.info.id),
+  );
 }
 
 /**
@@ -116,6 +119,14 @@ function ensureAssembleResultShape(result: unknown, engineId: string): AssembleR
     );
   }
   return result as AssembleResult;
+}
+
+function repairAssembleResultMessages(result: AssembleResult): AssembleResult {
+  const repair = repairToolUseResultPairing(result.messages);
+  if (repair.messages === result.messages) {
+    return result;
+  }
+  return { ...result, messages: repair.messages };
 }
 
 function describeAssembleResultType(value: unknown): string {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2431,6 +2431,114 @@ describe("openai transport stream", () => {
     expect(params.top_p).toBe(0.9);
   });
 
+  it("drops orphaned tool results before building chat completions request params", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "old request", timestamp: 1 },
+          {
+            role: "toolResult",
+            toolCallId: "call_orphan",
+            toolName: "read",
+            content: [{ type: "text", text: "orphaned output" }],
+            isError: false,
+            timestamp: 2,
+          },
+          { role: "user", content: "continue after model switch", timestamp: 3 },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params.messages).toEqual([
+      { role: "system", content: "system" },
+      { role: "user", content: "old request" },
+      { role: "user", content: "continue after model switch" },
+    ]);
+    expect(JSON.stringify(params.messages)).not.toContain("call_orphan");
+  });
+
+  it("drops failed assistant tool-call turns before chat completions serialization", () => {
+    const model = {
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      api: "openai-completions",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+    const abortedToolCall = {
+      role: "assistant",
+      provider: "openai",
+      api: "openai-completions",
+      model: "gpt-5.4",
+      stopReason: "aborted",
+      content: [{ type: "toolCall", id: "call_aborted", name: "read", arguments: {} }],
+      timestamp: 1,
+    };
+
+    const missingResultParams = buildOpenAICompletionsParams(
+      model,
+      {
+        systemPrompt: "system",
+        messages: [
+          abortedToolCall,
+          { role: "user", content: "continue after abort", timestamp: 2 },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    );
+    const pairedResultParams = buildOpenAICompletionsParams(
+      model,
+      {
+        systemPrompt: "system",
+        messages: [
+          abortedToolCall,
+          {
+            role: "toolResult",
+            toolCallId: "call_aborted",
+            toolName: "read",
+            content: [{ type: "text", text: "No result provided" }],
+            isError: true,
+            timestamp: 2,
+          },
+          { role: "user", content: "continue after abort", timestamp: 3 },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    for (const params of [missingResultParams, pairedResultParams]) {
+      const messages = params.messages as Array<{ role?: string }>;
+      expect(params.messages).toEqual([
+        { role: "system", content: "system" },
+        { role: "user", content: "continue after abort" },
+      ]);
+      expect(messages.some((message) => message.role === "tool")).toBe(false);
+      expect(JSON.stringify(messages)).not.toContain("call_aborted");
+    }
+  });
+
   it("forwards penalty params and seed to chat completions request params", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -79,6 +79,7 @@ import {
 } from "./provider-transport-fetch.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
 import type { StreamFn } from "./runtime/index.js";
+import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
 import { stripSystemPromptCacheBoundary } from "./system-prompt-cache-boundary.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
@@ -4054,8 +4055,16 @@ export function buildOpenAICompletionsParams(
         systemPrompt: stripSystemPromptCacheBoundary(context.systemPrompt),
       }
     : context;
-  let messages = convertMessages(model as never, completionsContext, compat as never);
-  injectToolCallThoughtSignatures(messages as unknown[], context, model);
+  const repairedContextMessages = sanitizeToolUseResultPairing(completionsContext.messages, {
+    erroredAssistantResultPolicy: "drop",
+    missingToolResultText: "No result provided",
+  }) as Context["messages"];
+  const repairedCompletionsContext =
+    repairedContextMessages === completionsContext.messages
+      ? completionsContext
+      : ({ ...completionsContext, messages: repairedContextMessages } satisfies Context);
+  let messages = convertMessages(model as never, repairedCompletionsContext, compat as never);
+  injectToolCallThoughtSignatures(messages as unknown[], repairedCompletionsContext, model);
   sanitizeCompletionsReasoningReplayFields(messages, {
     preserveOpenRouterReasoning:
       compat.thinkingFormat === "openrouter" && shouldPreserveOpenRouterReasoningReplay(model),

--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -99,6 +99,48 @@ describe("transformTransportMessages synthetic tool-result policy", () => {
     expect(toolResult.content).toEqual([{ type: "text", text: "aborted" }]);
   });
 
+  it("drops orphaned tool results before OpenAI Chat Completions conversion", () => {
+    const messages: Context["messages"] = [
+      { role: "user", content: "old request", timestamp: Date.now() },
+      {
+        role: "toolResult",
+        toolCallId: "call_orphan",
+        toolName: "read",
+        content: [{ type: "text", text: "orphaned result" }],
+        isError: false,
+        timestamp: Date.now(),
+      },
+      { role: "user", content: "continue after model switch", timestamp: Date.now() },
+    ];
+
+    const result = transformTransportMessages(
+      messages,
+      makeModel("openai-completions", "openai", "gpt-5.4"),
+    );
+
+    expect(result.map((msg) => msg.role)).toEqual(["user", "user"]);
+    expect(JSON.stringify(result)).not.toContain("call_orphan");
+    expect(JSON.stringify(result)).not.toContain("orphaned result");
+  });
+
+  it("synthesizes missing results for surviving OpenAI Chat Completions tool calls", () => {
+    const messages: Context["messages"] = [
+      assistantToolCall("call_chat_1"),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+
+    const result = transformTransportMessages(
+      messages,
+      makeModel("openai-completions", "openai", "gpt-5.4"),
+    );
+
+    expect(result.map((msg) => msg.role)).toEqual(["assistant", "toolResult", "user"]);
+    const toolResult = requireToolResultMessage(result[1]);
+    expect(toolResult.toolCallId).toBe("call_chat_1");
+    expect(toolResult.isError).toBe(true);
+    expect(toolResult.content).toEqual([{ type: "text", text: "No result provided" }]);
+  });
+
   it("preserves real OpenAI transport results and aborts missing parallel siblings", () => {
     const messages: Context["messages"] = [
       {

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -12,6 +12,7 @@ const SYNTHETIC_TOOL_RESULT_APIS = new Set<string>([
   "bedrock-converse-stream",
   "google-generative-ai",
   "openclaw-google-generative-ai-transport",
+  "openai-completions",
   "openai-responses",
   "openai-chatgpt-responses",
   "azure-openai-responses",


### PR DESCRIPTION
Fixes #88561

## Real behavior proof

Behavior or issue addressed: lossless-claw/context-engine compaction can leave an orphan tool result after the assistant tool-call turn is dropped, causing OpenAI Chat Completions replay to contain an invalid tool-message chain after model switch.

Real environment tested: local OpenClaw checkout on macOS, branch `fix/lossless-tool-chain-88561`, Node 24.15.0, using the production `buildOpenAICompletionsParams` path from `src/agents/openai-transport-stream.ts`.

Exact steps or command run after this patch: ran a direct `pnpm exec tsx --eval` command that imports `buildOpenAICompletionsParams`, builds an OpenAI Chat Completions request from a compacted transcript shaped as `user -> orphan toolResult -> user`, and prints the resulting request messages.

Evidence after fix:
```console
$ pnpm exec tsx --eval "import { buildOpenAICompletionsParams } from './src/agents/openai-transport-stream.ts'; /* compacted transcript contains user, orphan toolResult, user */"
{
  "messageRoles": [
    "system",
    "user",
    "user"
  ],
  "containsOrphan": false,
  "messages": [
    {
      "role": "system",
      "content": "system"
    },
    {
      "role": "user",
      "content": "old request"
    },
    {
      "role": "user",
      "content": "continue after model switch"
    }
  ]
}
```

Observed result after fix: the built OpenAI Chat Completions request contains only `system`, `user`, and `user` messages, and `containsOrphan` is `false`; the orphan `toolResult`/`call_orphan` entry is removed before the request leaves OpenClaw.

What was not tested: no live WeChat or live OpenAI API call was run; the proof exercises the local OpenClaw request-building path that creates the invalid provider payload described in the issue.

## Supplemental validation

- Added source-level regressions where context-engine assembled output contains an orphan `toolResult` after the assistant tool-call turn was dropped; the repaired assembled view drops the orphan before reuse.
- Added OpenAI Chat Completions conversion coverage proving an orphan `toolResult` is removed before request params are built.
- Re-ran focused shards after rebasing onto latest `upstream/main`: `node scripts/run-vitest.mjs src/agents/harness/context-engine-lifecycle.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts src/agents/transport-message-transform.test.ts src/agents/openai-transport-stream.test.ts` passed.
- `git diff --check` passed.

@clawsweeper re-review
