### PR TITLE
Fix Workboard card status persistence

### DIFF
--- a/ui/src/ui/controllers/workboard.test.ts
+++ b/ui/src/ui/controllers/workboard.test.ts
@@ -351,7 +351,7 @@ describe("workboard controller", () => {
     await syncWorkboardLifecycle({
       host,
       client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 }],
+      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 }],
     });
 
     expect(client.request).toHaveBeenCalledTimes(1);
@@ -1406,7 +1406,7 @@ describe("workboard controller", () => {
     await syncWorkboardLifecycle({
       host,
       client: client as never,
-      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 }],
+      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 }],
     });
 
     expect(client.request).toHaveBeenCalledTimes(1);
@@ -1415,6 +1415,73 @@ describe("workboard controller", () => {
       status: "running",
       position: 2000,
     });
+    expect(state.cards[0]).toMatchObject({ status: "running", position: 2000 });
+  });
+
+  it("applies fresh completed lifecycle sync after a dragged active-column status change", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    const linked = { ...sampleCard, sessionKey: sampleSession.key };
+    const moved = { ...linked, status: "running", position: 2000, updatedAt: 2 };
+    const completed = { ...moved, status: "review", updatedAt: 4 };
+    state.loaded = true;
+    state.cards = [linked];
+    const client = createClient((method) => {
+      if (method === "workboard.cards.move") {
+        return { card: moved };
+      }
+      if (method === "workboard.cards.update") {
+        return { card: completed };
+      }
+      return {};
+    });
+
+    await moveWorkboardCard({
+      host,
+      client: client as never,
+      cardId: "card-1",
+      status: "running",
+      position: 2000,
+    });
+    await syncWorkboardLifecycle({
+      host,
+      client: client as never,
+      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 }],
+    });
+
+    expect(client.request).toHaveBeenCalledTimes(2);
+    expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", {
+      id: "card-1",
+      patch: expect.objectContaining({ status: "review" }),
+    });
+    expect(state.cards[0]).toMatchObject({ status: "review", position: 2000 });
+  });
+
+  it("keeps stale lifecycle sync skipped after a Workboard host reload", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    const moved = {
+      ...sampleCard,
+      status: "running",
+      sessionKey: sampleSession.key,
+      position: 2000,
+      updatedAt: 2,
+    } satisfies WorkboardCard;
+    state.loaded = true;
+    state.cards = [moved];
+    const client = createClient({
+      "workboard.cards.update": {
+        card: { ...moved, status: "review", updatedAt: 3 },
+      },
+    });
+
+    await syncWorkboardLifecycle({
+      host,
+      client: client as never,
+      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 }],
+    });
+
+    expect(client.request).not.toHaveBeenCalled();
     expect(state.cards[0]).toMatchObject({ status: "running", position: 2000 });
   });
 
@@ -1700,6 +1767,72 @@ describe("workboard controller", () => {
     expect(state.tasksByCardId.get("card-1")).toMatchObject({ status: "completed" });
   });
 
+  it("skips stale task lifecycle sync for cards updated after the task", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    const linked = {
+      ...sampleCard,
+      status: "running",
+      sessionKey: sampleTaskSessionKey,
+      runId: "run-1",
+      taskId: "task-1",
+      updatedAt: 5,
+    } satisfies WorkboardCard;
+    state.loaded = true;
+    state.cards = [linked];
+    state.tasksByCardId.set("card-1", sampleTask);
+    const client = createClient({
+      "tasks.list": { tasks: [{ ...sampleTask, status: "completed", updatedAt: 2 }] },
+      "workboard.cards.update": {
+        card: { ...linked, status: "review" },
+      },
+    });
+
+    await syncWorkboardLifecycle({
+      host,
+      client: client as never,
+      sessions: [],
+    });
+
+    expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
+    expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.any(Object));
+    expect(state.cards[0]).toMatchObject({ status: "running" });
+  });
+
+  it("applies fresh failed task lifecycle sync after a newer task update", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    const linked = {
+      ...sampleCard,
+      status: "running",
+      sessionKey: sampleTaskSessionKey,
+      runId: "run-1",
+      taskId: "task-1",
+      updatedAt: 5,
+    } satisfies WorkboardCard;
+    state.loaded = true;
+    state.cards = [linked];
+    state.tasksByCardId.set("card-1", sampleTask);
+    const client = createClient({
+      "tasks.list": { tasks: [{ ...sampleTask, status: "failed", updatedAt: 6 }] },
+      "workboard.cards.update": {
+        card: { ...linked, status: "blocked", updatedAt: 7 },
+      },
+    });
+
+    await syncWorkboardLifecycle({
+      host,
+      client: client as never,
+      sessions: [],
+    });
+
+    expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", {
+      id: "card-1",
+      patch: { status: "blocked" },
+    });
+    expect(state.cards[0]).toMatchObject({ status: "blocked" });
+  });
+
   it("moves stale running sessions into running while recording stale metadata", async () => {
     const host = {};
     const state = getWorkboardState(host);
@@ -1902,7 +2035,7 @@ describe("workboard controller", () => {
     await syncWorkboardLifecycle({
       host,
       client: client as never,
-      sessions: [completedSession],
+      sessions: [{ ...completedSession, updatedAt: 5000 }],
     });
 
     expect(client.request).toHaveBeenCalledTimes(2);

--- a/ui/src/ui/controllers/workboard.test.ts
+++ b/ui/src/ui/controllers/workboard.test.ts
@@ -324,6 +324,44 @@ describe("workboard controller", () => {
     expect(state.editingCardId).toBeNull();
   });
 
+  it("keeps edit-modal status saves from being rewritten by stale lifecycle sync", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    const linked = { ...sampleCard, sessionKey: sampleSession.key };
+    state.loaded = true;
+    state.cards = [linked];
+    state.draftOpen = true;
+    state.editingCardId = linked.id;
+    state.draftTitle = linked.title;
+    state.draftNotes = linked.notes ?? "";
+    state.draftStatus = "running";
+    state.draftPriority = linked.priority;
+    state.draftLabels = linked.labels.join(", ");
+    state.draftAgentId = linked.agentId ?? "";
+    state.draftSessionKey = linked.sessionKey ?? "";
+    const saved = { ...linked, status: "running", updatedAt: 2 } satisfies WorkboardCard;
+    const client = createClient((method) => {
+      if (method === "workboard.cards.update") {
+        return { card: saved };
+      }
+      return {};
+    });
+
+    await saveWorkboardCardDraft({ host, client: client as never });
+    await syncWorkboardLifecycle({
+      host,
+      client: client as never,
+      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 }],
+    });
+
+    expect(client.request).toHaveBeenCalledTimes(1);
+    expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
+      id: "card-1",
+      patch: expect.objectContaining({ status: "running" }),
+    });
+    expect(state.cards[0]).toMatchObject({ status: "running" });
+  });
+
   it("adds operator notes to a selected detail card without opening the edit draft", async () => {
     const host = {};
     const state = getWorkboardState(host);
@@ -1339,6 +1377,94 @@ describe("workboard controller", () => {
       status: "blocked",
       position: 2000,
     });
+  });
+
+  it("keeps dragged status changes from being rewritten by stale lifecycle sync", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    const linked = { ...sampleCard, sessionKey: sampleSession.key };
+    const moved = { ...linked, status: "running", position: 2000, updatedAt: 2 };
+    state.loaded = true;
+    state.cards = [linked];
+    const client = createClient((method) => {
+      if (method === "workboard.cards.move") {
+        return { card: moved };
+      }
+      if (method === "workboard.cards.update") {
+        return { card: { ...moved, status: "review", updatedAt: 3 } };
+      }
+      return {};
+    });
+
+    await moveWorkboardCard({
+      host,
+      client: client as never,
+      cardId: "card-1",
+      status: "running",
+      position: 2000,
+    });
+    await syncWorkboardLifecycle({
+      host,
+      client: client as never,
+      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 }],
+    });
+
+    expect(client.request).toHaveBeenCalledTimes(1);
+    expect(client.request).toHaveBeenCalledWith("workboard.cards.move", {
+      id: "card-1",
+      status: "running",
+      position: 2000,
+    });
+    expect(state.cards[0]).toMatchObject({ status: "running", position: 2000 });
+  });
+
+  it("keeps same-status moves following linked session lifecycle sync", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    const linked = {
+      ...sampleCard,
+      status: "running",
+      sessionKey: sampleSession.key,
+      position: 1000,
+    } satisfies WorkboardCard;
+    const moved = { ...linked, position: 2000, updatedAt: 2 } satisfies WorkboardCard;
+    const completed = { ...moved, status: "review", updatedAt: 3 } satisfies WorkboardCard;
+    state.loaded = true;
+    state.cards = [linked];
+    const client = createClient((method) => {
+      if (method === "workboard.cards.move") {
+        return { card: moved };
+      }
+      if (method === "workboard.cards.update") {
+        return { card: completed };
+      }
+      return {};
+    });
+
+    await moveWorkboardCard({
+      host,
+      client: client as never,
+      cardId: "card-1",
+      status: "running",
+      position: 2000,
+    });
+    await syncWorkboardLifecycle({
+      host,
+      client: client as never,
+      sessions: [{ ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 }],
+    });
+
+    expect(client.request).toHaveBeenCalledTimes(2);
+    expect(client.request).toHaveBeenNthCalledWith(1, "workboard.cards.move", {
+      id: "card-1",
+      status: "running",
+      position: 2000,
+    });
+    expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", {
+      id: "card-1",
+      patch: expect.objectContaining({ status: "review" }),
+    });
+    expect(state.cards[0]).toMatchObject({ status: "review", position: 2000 });
   });
 
   it("removes stale dependency links from local cards after delete", async () => {

--- a/ui/src/ui/controllers/workboard.test.ts
+++ b/ui/src/ui/controllers/workboard.test.ts
@@ -1799,6 +1799,41 @@ describe("workboard controller", () => {
     expect(state.cards[0]).toMatchObject({ status: "running" });
   });
 
+  it("keeps task lifecycle sync active when task timestamps are missing", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    const linked = {
+      ...sampleCard,
+      status: "running",
+      sessionKey: sampleTaskSessionKey,
+      runId: "run-1",
+      taskId: "task-1",
+      updatedAt: 5,
+    } satisfies WorkboardCard;
+    const { updatedAt: _ignored, ...taskWithoutUpdatedAt } = sampleTask;
+    state.loaded = true;
+    state.cards = [linked];
+    state.tasksByCardId.set("card-1", sampleTask);
+    const client = createClient({
+      "tasks.list": { tasks: [{ ...taskWithoutUpdatedAt, status: "completed" }] },
+      "workboard.cards.update": {
+        card: { ...linked, status: "review", updatedAt: 6 },
+      },
+    });
+
+    await syncWorkboardLifecycle({
+      host,
+      client: client as never,
+      sessions: [],
+    });
+
+    expect(client.request).toHaveBeenNthCalledWith(2, "workboard.cards.update", {
+      id: "card-1",
+      patch: { status: "review" },
+    });
+    expect(state.cards[0]).toMatchObject({ status: "review" });
+  });
+
   it("applies fresh failed task lifecycle sync after a newer task update", async () => {
     const host = {};
     const state = getWorkboardState(host);

--- a/ui/src/ui/controllers/workboard.ts
+++ b/ui/src/ui/controllers/workboard.ts
@@ -352,6 +352,7 @@ export type WorkboardUiState = {
   busyCardId: string | null;
   draggedCardId: string | null;
   syncingCardIds: Set<string>;
+  manualStatusCardIds: Set<string>;
   capturingSessionKeys: Set<string>;
 };
 
@@ -396,6 +397,7 @@ function createDefaultState(): WorkboardUiState {
     busyCardId: null,
     draggedCardId: null,
     syncingCardIds: new Set(),
+    manualStatusCardIds: new Set(),
     capturingSessionKeys: new Set(),
   };
 }
@@ -1297,6 +1299,21 @@ function shouldSyncCardStatus(card: WorkboardCard, targetStatus: WorkboardStatus
   return false;
 }
 
+function shouldPreserveManualCardStatus(
+  state: WorkboardUiState,
+  card: WorkboardCard,
+  targetStatus: WorkboardStatus | undefined,
+) {
+  if (!state.manualStatusCardIds.has(card.id)) {
+    return false;
+  }
+  if (!targetStatus || targetStatus === card.status) {
+    state.manualStatusCardIds.delete(card.id);
+    return false;
+  }
+  return true;
+}
+
 function executionStatusForLifecycle(
   lifecycle: WorkboardLifecycle,
 ): WorkboardExecutionStatus | undefined {
@@ -1570,7 +1587,10 @@ export async function syncWorkboardLifecycle(params: {
     );
     const executionStatus = executionStatusForLifecycle(lifecycle);
     const patch: Record<string, unknown> = {};
-    if (shouldSyncCardStatus(card, lifecycle.targetStatus)) {
+    if (
+      !shouldPreserveManualCardStatus(state, card, lifecycle.targetStatus) &&
+      shouldSyncCardStatus(card, lifecycle.targetStatus)
+    ) {
       patch.status = lifecycle.targetStatus;
     }
     if (shouldSyncExecutionStatus(card, executionStatus)) {
@@ -1665,13 +1685,18 @@ export async function saveWorkboardCardDraft(params: {
   }
   state.loading = true;
   state.error = null;
+  const previousStatus = state.cards.find((card) => card.id === state.editingCardId)?.status;
   params.requestUpdate?.();
   try {
     const payload = await params.client.request("workboard.cards.update", {
       id: state.editingCardId,
       patch: draftPayload(state),
     });
-    replaceCard(state, normalizeCardPayload(payload));
+    const card = normalizeCardPayload(payload);
+    replaceCard(state, card);
+    if (previousStatus && card.status !== previousStatus) {
+      state.manualStatusCardIds.add(card.id);
+    }
     resetDraftState(state);
   } catch (error) {
     state.error = formatError(error);
@@ -1730,6 +1755,7 @@ export async function moveWorkboardCard(params: {
   }
   state.busyCardId = params.cardId;
   state.error = null;
+  const previousStatus = state.cards.find((card) => card.id === params.cardId)?.status;
   params.requestUpdate?.();
   try {
     const payload = await params.client.request("workboard.cards.move", {
@@ -1737,7 +1763,11 @@ export async function moveWorkboardCard(params: {
       status: params.status,
       position: params.position,
     });
-    replaceCard(state, normalizeCardPayload(payload));
+    const card = normalizeCardPayload(payload);
+    replaceCard(state, card);
+    if (previousStatus && card.status !== previousStatus) {
+      state.manualStatusCardIds.add(params.cardId);
+    }
   } catch (error) {
     state.error = formatError(error);
   } finally {

--- a/ui/src/ui/controllers/workboard.ts
+++ b/ui/src/ui/controllers/workboard.ts
@@ -289,6 +289,7 @@ export type WorkboardLifecycle = {
   session: GatewaySessionRow | null;
   state: WorkboardLifecycleState;
   targetStatus?: WorkboardStatus;
+  sourceUpdatedAt?: number;
 };
 
 export type WorkboardTaskStatus =
@@ -352,7 +353,6 @@ export type WorkboardUiState = {
   busyCardId: string | null;
   draggedCardId: string | null;
   syncingCardIds: Set<string>;
-  manualStatusCardIds: Set<string>;
   capturingSessionKeys: Set<string>;
 };
 
@@ -397,7 +397,6 @@ function createDefaultState(): WorkboardUiState {
     busyCardId: null,
     draggedCardId: null,
     syncingCardIds: new Set(),
-    manualStatusCardIds: new Set(),
     capturingSessionKeys: new Set(),
   };
 }
@@ -1004,6 +1003,10 @@ function taskUpdatedAtValue(task: WorkboardTaskSummary): number {
   return 0;
 }
 
+function sessionUpdatedAtValue(session: GatewaySessionRow): number | undefined {
+  return typeof session.updatedAt === "number" ? session.updatedAt : undefined;
+}
+
 function taskSessionKeyMatchesCardSession(
   cardSessionKey: string,
   taskSessionKey: string | undefined,
@@ -1248,12 +1251,14 @@ export function getWorkboardLifecycle(
           session,
           state: "running",
           targetStatus: "running",
+          sourceUpdatedAt: taskUpdatedAtValue(task),
         };
       case "completed":
         return {
           session,
           state: "succeeded",
           targetStatus: "review",
+          sourceUpdatedAt: taskUpdatedAtValue(task),
         };
       case "failed":
       case "cancelled":
@@ -1262,6 +1267,7 @@ export function getWorkboardLifecycle(
           session,
           state: "failed",
           targetStatus: "blocked",
+          sourceUpdatedAt: taskUpdatedAtValue(task),
         };
     }
   }
@@ -1272,16 +1278,36 @@ export function getWorkboardLifecycle(
     return { session: null, state: "missing" };
   }
   if (staleSessionState(session)) {
-    return { session, state: "stale", targetStatus: "running" };
+    return {
+      session,
+      state: "stale",
+      targetStatus: "running",
+      sourceUpdatedAt: sessionUpdatedAtValue(session),
+    };
   }
   if (session.hasActiveRun === true || session.status === "running") {
-    return { session, state: "running", targetStatus: "running" };
+    return {
+      session,
+      state: "running",
+      targetStatus: "running",
+      sourceUpdatedAt: sessionUpdatedAtValue(session),
+    };
   }
   if (session.abortedLastRun || isFailedSessionStatus(session.status)) {
-    return { session, state: "failed", targetStatus: "blocked" };
+    return {
+      session,
+      state: "failed",
+      targetStatus: "blocked",
+      sourceUpdatedAt: sessionUpdatedAtValue(session),
+    };
   }
   if (session.status === "done") {
-    return { session, state: "succeeded", targetStatus: "review" };
+    return {
+      session,
+      state: "succeeded",
+      targetStatus: "review",
+      sourceUpdatedAt: sessionUpdatedAtValue(session),
+    };
   }
   return { session, state: "idle" };
 }
@@ -1299,19 +1325,12 @@ function shouldSyncCardStatus(card: WorkboardCard, targetStatus: WorkboardStatus
   return false;
 }
 
-function shouldPreserveManualCardStatus(
-  state: WorkboardUiState,
-  card: WorkboardCard,
-  targetStatus: WorkboardStatus | undefined,
-) {
-  if (!state.manualStatusCardIds.has(card.id)) {
-    return false;
-  }
-  if (!targetStatus || targetStatus === card.status) {
-    state.manualStatusCardIds.delete(card.id);
-    return false;
-  }
-  return true;
+function shouldSkipStaleLifecycleStatusSync(card: WorkboardCard, lifecycle: WorkboardLifecycle) {
+  return (
+    Boolean(lifecycle.targetStatus) &&
+    typeof lifecycle.sourceUpdatedAt === "number" &&
+    lifecycle.sourceUpdatedAt < card.updatedAt
+  );
 }
 
 function executionStatusForLifecycle(
@@ -1353,6 +1372,7 @@ function lifecycleSyncKey(card: WorkboardCard, lifecycle: WorkboardLifecycle): s
     session?.status ?? "",
     session?.hasActiveRun === true ? "active" : "idle",
     session?.updatedAt ?? "",
+    lifecycle.sourceUpdatedAt ?? "",
     card.execution?.status ?? "",
     card.execution?.updatedAt ?? "",
   ].join(":");
@@ -1588,7 +1608,7 @@ export async function syncWorkboardLifecycle(params: {
     const executionStatus = executionStatusForLifecycle(lifecycle);
     const patch: Record<string, unknown> = {};
     if (
-      !shouldPreserveManualCardStatus(state, card, lifecycle.targetStatus) &&
+      !shouldSkipStaleLifecycleStatusSync(card, lifecycle) &&
       shouldSyncCardStatus(card, lifecycle.targetStatus)
     ) {
       patch.status = lifecycle.targetStatus;
@@ -1685,18 +1705,13 @@ export async function saveWorkboardCardDraft(params: {
   }
   state.loading = true;
   state.error = null;
-  const previousStatus = state.cards.find((card) => card.id === state.editingCardId)?.status;
   params.requestUpdate?.();
   try {
     const payload = await params.client.request("workboard.cards.update", {
       id: state.editingCardId,
       patch: draftPayload(state),
     });
-    const card = normalizeCardPayload(payload);
-    replaceCard(state, card);
-    if (previousStatus && card.status !== previousStatus) {
-      state.manualStatusCardIds.add(card.id);
-    }
+    replaceCard(state, normalizeCardPayload(payload));
     resetDraftState(state);
   } catch (error) {
     state.error = formatError(error);
@@ -1755,7 +1770,6 @@ export async function moveWorkboardCard(params: {
   }
   state.busyCardId = params.cardId;
   state.error = null;
-  const previousStatus = state.cards.find((card) => card.id === params.cardId)?.status;
   params.requestUpdate?.();
   try {
     const payload = await params.client.request("workboard.cards.move", {
@@ -1763,11 +1777,7 @@ export async function moveWorkboardCard(params: {
       status: params.status,
       position: params.position,
     });
-    const card = normalizeCardPayload(payload);
-    replaceCard(state, card);
-    if (previousStatus && card.status !== previousStatus) {
-      state.manualStatusCardIds.add(params.cardId);
-    }
+    replaceCard(state, normalizeCardPayload(payload));
   } catch (error) {
     state.error = formatError(error);
   } finally {

--- a/ui/src/ui/controllers/workboard.ts
+++ b/ui/src/ui/controllers/workboard.ts
@@ -1007,6 +1007,11 @@ function sessionUpdatedAtValue(session: GatewaySessionRow): number | undefined {
   return typeof session.updatedAt === "number" ? session.updatedAt : undefined;
 }
 
+function taskLifecycleSourceUpdatedAt(task: WorkboardTaskSummary): number | undefined {
+  const updatedAt = taskUpdatedAtValue(task);
+  return updatedAt > 0 ? updatedAt : undefined;
+}
+
 function taskSessionKeyMatchesCardSession(
   cardSessionKey: string,
   taskSessionKey: string | undefined,
@@ -1251,14 +1256,14 @@ export function getWorkboardLifecycle(
           session,
           state: "running",
           targetStatus: "running",
-          sourceUpdatedAt: taskUpdatedAtValue(task),
+          sourceUpdatedAt: taskLifecycleSourceUpdatedAt(task),
         };
       case "completed":
         return {
           session,
           state: "succeeded",
           targetStatus: "review",
-          sourceUpdatedAt: taskUpdatedAtValue(task),
+          sourceUpdatedAt: taskLifecycleSourceUpdatedAt(task),
         };
       case "failed":
       case "cancelled":
@@ -1267,7 +1272,7 @@ export function getWorkboardLifecycle(
           session,
           state: "failed",
           targetStatus: "blocked",
-          sourceUpdatedAt: taskUpdatedAtValue(task),
+          sourceUpdatedAt: taskLifecycleSourceUpdatedAt(task),
         };
     }
   }
@@ -1329,6 +1334,7 @@ function shouldSkipStaleLifecycleStatusSync(card: WorkboardCard, lifecycle: Work
   return (
     Boolean(lifecycle.targetStatus) &&
     typeof lifecycle.sourceUpdatedAt === "number" &&
+    lifecycle.sourceUpdatedAt > 0 &&
     lifecycle.sourceUpdatedAt < card.updatedAt
   );
 }

--- a/ui/src/ui/views/workboard.test.ts
+++ b/ui/src/ui/views/workboard.test.ts
@@ -1016,7 +1016,7 @@ describe("renderWorkboard", () => {
     title!.dispatchEvent(new InputEvent("input", { bubbles: true }));
     const priority = [
       ...container.querySelectorAll<HTMLSelectElement>(".workboard-draft__meta select"),
-    ].at(1);
+    ].find((select) => [...select.options].some((option) => option.value === "urgent"));
     priority!.value = "high";
     priority!.dispatchEvent(new Event("change", { bubbles: true }));
     container
@@ -1032,6 +1032,23 @@ describe("renderWorkboard", () => {
         priority: "high",
       }),
     });
+    expect(state.cards[0]).toMatchObject({ title: "Renamed", priority: "high", updatedAt: 2 });
+
+    render(renderWorkboard(props), container);
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    container
+      .querySelector<HTMLButtonElement>('button[title="Edit card"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    render(renderWorkboard(props), container);
+
+    expect(container.querySelector<HTMLInputElement>(".workboard-draft__title")?.value).toBe(
+      "Renamed",
+    );
+    expect(
+      [...container.querySelectorAll<HTMLSelectElement>(".workboard-draft__meta select")].find(
+        (select) => [...select.options].some((option) => option.value === "urgent"),
+      )?.value,
+    ).toBe("high");
   });
 
   it("locks edit-modal actions while a comment request is in flight", () => {

--- a/ui/src/ui/views/workboard.ts
+++ b/ui/src/ui/views/workboard.ts
@@ -470,7 +470,10 @@ function renderCardModal(props: WorkboardProps) {
               }}
             >
               ${state.statuses.map(
-                (status) => html`<option value=${status}>${formatStatusLabel(status)}</option>`,
+                (status) =>
+                  html`<option value=${status} ?selected=${state.draftStatus === status}>
+                    ${formatStatusLabel(status)}
+                  </option>`,
               )}
             </select>
           </label>
@@ -486,7 +489,10 @@ function renderCardModal(props: WorkboardProps) {
               }}
             >
               ${WORKBOARD_PRIORITIES.map(
-                (priority) => html`<option value=${priority}>${priority}</option>`,
+                (priority) =>
+                  html`<option value=${priority} ?selected=${state.draftPriority === priority}>
+                    ${priority}
+                  </option>`,
               )}
             </select>
           </label>
@@ -500,10 +506,12 @@ function renderCardModal(props: WorkboardProps) {
                 props.onRequestUpdate?.();
               }}
             >
-              <option value="">${t("workboard.defaultAgent")}</option>
+              <option value="" ?selected=${!state.draftAgentId}>
+                ${t("workboard.defaultAgent")}
+              </option>
               ${agents.map(
                 (agent) =>
-                  html`<option value=${agent.id}>
+                  html`<option value=${agent.id} ?selected=${state.draftAgentId === agent.id}>
                     ${agent.name ?? agent.identity?.name ?? agent.id}
                   </option>`,
               )}
@@ -519,10 +527,15 @@ function renderCardModal(props: WorkboardProps) {
                 props.onRequestUpdate?.();
               }}
             >
-              <option value="">${t("workboard.noLinkedSession")}</option>
+              <option value="" ?selected=${!state.draftSessionKey}>
+                ${t("workboard.noLinkedSession")}
+              </option>
               ${sessions.map(
                 (session) =>
-                  html`<option value=${session.key}>
+                  html`<option
+                    value=${session.key}
+                    ?selected=${state.draftSessionKey === session.key}
+                  >
                     ${session.displayName ?? session.label ?? session.key}
                   </option>`,
               )}


### PR DESCRIPTION
Fixes #88592

## Real behavior proof

Behavior or issue addressed: Workboard linked cards could bounce away from an explicit operator status change because stale linked-session lifecycle sync rewrote the card after drag/edit saves. The follow-up fix also preserves the documented contract that fresh linked session/task lifecycle updates still move active `todo`/`running` cards to `review` or `blocked`, including task payloads that do not provide a valid `updatedAt` timestamp.

Real environment tested: local OpenClaw checkout on macOS, branch `codex/workboard-persist-running`, Node 24.15.0, using the production Workboard UI controller functions from `ui/src/ui/controllers/workboard.ts`.

Exact steps or command run after this patch: ran direct `pnpm exec tsx --eval` commands that import `getWorkboardState`, `moveWorkboardCard`, and `syncWorkboardLifecycle`; they exercise production-controller scenarios for stale/fresh session lifecycle sync, stale/fresh task lifecycle sync, and the Copilot-reviewed missing-task-timestamp case.

Evidence after fix:

```console
$ pnpm exec tsx --eval '<script importing getWorkboardState, moveWorkboardCard, syncWorkboardLifecycle from ./ui/src/ui/controllers/workboard.ts and exercising stale/fresh session + task lifecycle sync>'
{
  "staleCompletedSessionAfterReload": {
    "finalStatus": "running",
    "finalPosition": 2000,
    "requestMethods": [],
    "updateWasCalled": false
  },
  "freshCompletedSessionAfterMove": {
    "finalStatus": "review",
    "finalPosition": 2000,
    "requestMethods": [
      "workboard.cards.move",
      "workboard.cards.update"
    ],
    "updatePatch": {
      "status": "review"
    }
  },
  "staleCompletedTaskAfterNewerCardUpdate": {
    "finalStatus": "running",
    "requestMethods": [
      "tasks.list"
    ],
    "updateWasCalled": false
  },
  "freshFailedTaskAfterNewerTaskUpdate": {
    "finalStatus": "blocked",
    "requestMethods": [
      "tasks.list",
      "workboard.cards.update"
    ],
    "updatePatch": {
      "status": "blocked"
    }
  }
}
```

```console
$ pnpm exec tsx --eval '<script importing getWorkboardState and syncWorkboardLifecycle from ./ui/src/ui/controllers/workboard.ts and exercising a completed task without updatedAt>'
{
  "missingTaskTimestampLifecycleSync": {
    "finalStatus": "review",
    "requestMethods": [
      "tasks.list",
      "workboard.cards.update"
    ],
    "updatePatch": {
      "status": "review"
    }
  }
}
```

Observed result after fix: stale lifecycle events older than the persisted card update no longer issue `workboard.cards.update`, so the explicit operator change survives reload/new-host state. Fresh completed/failed session and task lifecycle events still issue the expected `workboard.cards.update` patches. Task payloads without valid timestamps fall back to the previous sync behavior instead of being treated as stale.

What was not tested: no live browser recording was captured; the proof exercises the real local Workboard controller path and request methods directly.

## Supplemental validation

- Replaced the transient host-local `manualStatusCardIds` override with a timestamp-aware lifecycle guard based on persisted card update time and linked session/task update time.
- Updated the task timestamp path so the staleness guard only applies to valid positive task timestamps; missing/unparseable task timestamps do not suppress task-driven lifecycle sync.
- Added controller regressions for stale completed session after edit save, stale completed session after drag, fresh completed session after drag, reload/new-host stale sync, stale completed task, missing task timestamp sync, and fresh failed task lifecycle updates.
- Preserved the view regression proving returned card state is reflected after save and still appears when the edit modal is reopened.
- `node scripts/run-vitest.mjs ui/src/ui/controllers/workboard.test.ts ui/src/ui/views/workboard.test.ts` passed, 83 tests.
- `node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts extensions/workboard/src/gateway.test.ts` passed, 75 tests.
- `pnpm check:test-types` passed.
- `pnpm lint` passed.
- `pnpm run format:check -- ui/src/ui/controllers/workboard.ts ui/src/ui/controllers/workboard.test.ts` passed.
- `git diff --check` passed.
