### PR TITLE
Fix BTW OAuth side-question routing

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -603,6 +603,67 @@ describe("runBtwSideQuestion", () => {
     expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
   });
 
+  it("reselects the Codex hook after resolving legacy openai-codex route state", async () => {
+    const codexSideQuestionMock = vi.fn().mockResolvedValue({ text: "Codex side answer." });
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex test harness",
+      supports: (ctx) =>
+        ctx.provider === "openai"
+          ? { supported: true, priority: 100 }
+          : { supported: false, reason: "openai only" },
+      runAttempt: vi.fn(),
+      runSideQuestion: codexSideQuestionMock,
+    });
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "openai",
+      id: "gpt-5.5",
+      api: "openai-responses",
+    });
+    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openai-codex:user@example.test");
+
+    const result = await runSideQuestion({
+      cfg: {
+        auth: {
+          order: {
+            openai: ["openai-codex:user@example.test"],
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+        },
+      } as never,
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
+
+    expect(result).toEqual({ text: "Codex side answer." });
+    expect(codexSideQuestionMock).toHaveBeenCalledTimes(1);
+    expect(
+      (mockArg(codexSideQuestionMock, 0, 0) as { provider?: string; authProfileId?: string })
+        .provider,
+    ).toBe("openai");
+    expect(
+      (mockArg(codexSideQuestionMock, 0, 0) as { provider?: string; authProfileId?: string })
+        .authProfileId,
+    ).toBe("openai-codex:user@example.test");
+    const authArgs = mockArg(resolveSessionAuthProfileOverrideMock, 0, 0) as {
+      provider?: string;
+      acceptedProviderIds?: string[];
+    };
+    expect(authArgs.provider).toBe("openai");
+    expect(authArgs.acceptedProviderIds).toEqual(["openai"]);
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+    expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
+  });
+
   it("does not fall back to the direct provider call when Codex lacks BTW support", async () => {
     registerAgentHarness({
       id: "codex",

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -24,6 +24,7 @@ import { resolveModelWithRegistry } from "./embedded-agent-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./embedded-agent-runner/runs.js";
 import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
 import { resolveAvailableAgentHarnessPolicy, selectAgentHarness } from "./harness/selection.js";
+import type { AgentHarness } from "./harness/types.js";
 import {
   resolveImageSanitizationLimits,
   type ImageSanitizationLimits,
@@ -262,15 +263,17 @@ async function resolveRuntimeModel(params: {
   if (!model) {
     throw new Error(`Unknown model: ${params.provider}/${params.model}`);
   }
+  const runtimeProvider = model.provider;
+  const runtimeModelId = model.id;
 
   const authProfileId = await resolveSessionAuthProfileOverride({
     cfg: params.cfg,
-    provider: params.provider,
+    provider: runtimeProvider,
     acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
-      provider: params.provider,
+      provider: runtimeProvider,
       harnessRuntime: resolveAvailableAgentHarnessPolicy({
-        provider: params.provider,
-        modelId: params.model,
+        provider: runtimeProvider,
+        modelId: runtimeModelId,
         config: params.cfg,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
@@ -342,33 +345,50 @@ export async function runBtwSideQuestion(
     agentId: sessionAgentId,
     sessionKey: params.sessionKey,
   });
-  if (harness.runSideQuestion) {
-    const { model, authProfileId, authProfileIdSource } = await resolveRuntimeModel({
-      cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
-      agentId: sessionAgentId,
-      agentDir: params.agentDir,
-      workspaceDir,
-      sessionEntry: params.sessionEntry,
-      sessionStore: params.sessionStore,
-      sessionKey: params.sessionKey,
-      storePath: params.storePath,
-      isNewSession: params.isNewSession,
-    });
-    const result = await harness.runSideQuestion({
+  let runtimeSelection: Awaited<ReturnType<typeof resolveRuntimeModel>> | undefined;
+  const resolveRuntimeSelection = async () => {
+    if (!runtimeSelection) {
+      runtimeSelection = await resolveRuntimeModel({
+        cfg: params.cfg,
+        provider: params.provider,
+        model: params.model,
+        agentId: sessionAgentId,
+        agentDir: params.agentDir,
+        workspaceDir,
+        sessionEntry: params.sessionEntry,
+        sessionStore: params.sessionStore,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+        isNewSession: params.isNewSession,
+      });
+    }
+    return runtimeSelection;
+  };
+  const runHarnessSideQuestion = async (
+    selectedHarness: AgentHarness,
+    runtime: Awaited<ReturnType<typeof resolveRuntimeModel>>,
+  ): Promise<ReplyPayload | undefined> => {
+    if (!selectedHarness.runSideQuestion) {
+      throw new Error(
+        `Selected agent harness "${selectedHarness.id}" does not support /btw side questions.`,
+      );
+    }
+    const result = await selectedHarness.runSideQuestion({
       ...params,
-      provider: model.provider,
-      model: model.id,
-      runtimeModel: model,
+      provider: runtime.model.provider,
+      model: runtime.model.id,
+      runtimeModel: runtime.model,
       sessionId,
       sessionFile,
       agentId: sessionAgentId,
       workspaceDir,
-      authProfileId,
-      authProfileIdSource,
+      authProfileId: runtime.authProfileId,
+      authProfileIdSource: runtime.authProfileIdSource,
     });
     return { text: result.text };
+  };
+  if (harness.runSideQuestion) {
+    return runHarnessSideQuestion(harness, await resolveRuntimeSelection());
   }
   if (harness.id === "codex") {
     throw new Error(`Selected agent harness "${harness.id}" does not support /btw side questions.`);
@@ -401,19 +421,26 @@ export async function runBtwSideQuestion(
     throw new Error("No active session context.");
   }
 
-  const { model, authProfileId, authProfileIdSource } = await resolveRuntimeModel({
-    cfg: params.cfg,
-    provider: params.provider,
-    model: params.model,
+  const { model, authProfileId, authProfileIdSource } = await resolveRuntimeSelection();
+  const runtimeHarness = selectAgentHarness({
+    provider: model.provider,
+    modelId: model.id,
+    config: params.cfg,
     agentId: sessionAgentId,
-    agentDir: params.agentDir,
-    workspaceDir,
-    sessionEntry: params.sessionEntry,
-    sessionStore: params.sessionStore,
     sessionKey: params.sessionKey,
-    storePath: params.storePath,
-    isNewSession: params.isNewSession,
   });
+  if (runtimeHarness.runSideQuestion) {
+    return runHarnessSideQuestion(runtimeHarness, {
+      model,
+      authProfileId,
+      authProfileIdSource,
+    });
+  }
+  if (runtimeHarness.id === "codex") {
+    throw new Error(
+      `Selected agent harness "${runtimeHarness.id}" does not support /btw side questions.`,
+    );
+  }
   let externalCliAuthScope = resolveExternalCliAuthOverlayScopeFromSelection({
     provider: model.provider,
     cfg: params.cfg,


### PR DESCRIPTION
Fixes #88902

## Real behavior proof

Behavior or issue addressed: `/btw` with stale `openai-codex` route state could miss the runtime side-question harness and fall through to direct public OpenAI Responses streaming instead of using the canonical OpenAI/Codex OAuth runtime.

Real environment tested: local OpenClaw checkout on macOS, branch `fix/codex-oauth-btw-88902`, Node 24.15.0, using the production harness registry and selection code from `src/agents/harness`.

Exact steps or command run after this patch: ran a direct `pnpm exec tsx --eval` command that registers a local side-question-capable runtime harness, selects once with legacy `openai-codex` route state, then selects again with the resolved canonical `openai/gpt-5.5` runtime shape that `/btw` now uses before direct streaming fallback.

Evidence after fix:
```console
$ pnpm exec tsx --eval "import { registerAgentHarness } from './src/agents/harness/registry.ts'; import { selectAgentHarness } from './src/agents/harness/selection.ts'; /* legacy openai-codex route state, then resolved openai runtime */"
{
  "legacyRouteState": {
    "provider": "openai-codex",
    "selectedHarness": "openclaw",
    "hasSideQuestionHook": false
  },
  "resolvedRuntime": {
    "provider": "openai",
    "model": "gpt-5.5",
    "selectedHarness": "codex",
    "hasSideQuestionHook": true
  },
  "directProviderFallbackWouldRun": false
}
```

Observed result after fix: legacy route state still lacks a side-question hook, but after runtime resolution the canonical `openai/gpt-5.5` selection finds the side-question-capable runtime harness and `directProviderFallbackWouldRun` is `false`.

What was not tested: no live Telegram/OAuth flow was run; the proof exercises the local OpenClaw runtime-selection behavior that decides whether `/btw` uses the side-question hook or falls back to direct provider streaming.

## Supplemental validation

- Added a regression where legacy `openai-codex` route state resolves to canonical `openai/gpt-5.5` with an OAuth profile and `/btw` reselects the runtime harness instead of direct provider streaming.
- The test asserts the side-question hook receives the canonical provider plus original OAuth profile id and that `streamSimple`/provider direct streaming are not called.
- Re-ran focused/wider side-question and auth tests after rebasing onto latest `upstream/main`: `node scripts/run-vitest.mjs src/agents/btw.test.ts src/auto-reply/reply/commands-btw.test.ts extensions/codex/src/app-server/side-question.test.ts src/commands/doctor-auth-flat-profiles.test.ts src/commands/doctor-session-state-providers.test.ts` passed.
- `git diff --check` passed.

@clawsweeper re-review
