### PR TITLE
fix(plugins): ignore throwing provider runtime hooks

### DIFF
--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1329,6 +1329,38 @@ describe("provider-runtime", () => {
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores throwing model-id normalization hooks", () => {
+    resolvePluginProvidersMock.mockReturnValue([
+      {
+        id: "fuzz-provider",
+        pluginId: "fuzzplugin\nWARN forged",
+        label: "Fuzz Provider",
+        aliases: ["fuzz"],
+        auth: [],
+        normalizeModelId: () => {
+          throw new Error("bad\nmodel hook");
+        },
+      },
+    ]);
+
+    expect(
+      normalizeProviderModelIdWithPlugin({
+        provider: "fuzz",
+        context: {
+          provider: "fuzz",
+          modelId: "demo-model",
+        },
+      }),
+    ).toBeUndefined();
+
+    expect(providerRuntimeWarnMock).toHaveBeenCalledTimes(1);
+    const warning = firstMockStringArg(providerRuntimeWarnMock, "provider warning");
+    expect(warning).toContain('Provider plugin "fuzzpluginWARN forged"');
+    expect(warning).toContain("normalizeModelId hook failed");
+    expect(warning).toContain("badmodel hook");
+    expect(warning).not.toContain("\n");
+  });
+
   it("resolves config hooks through hook-only aliases without changing provider surfaces", () => {
     resolvePluginProvidersMock.mockReturnValue([
       {
@@ -1660,6 +1692,50 @@ describe("provider-runtime", () => {
       api: "google-generative-ai",
       baseUrl: "https://generativelanguage.googleapis.com/v1beta",
     });
+  });
+
+  it("keeps scanning transport hooks after one provider hook throws", () => {
+    resolvePluginProvidersMock.mockImplementation((params) => {
+      const plugins: ProviderPlugin[] = [
+        {
+          id: "custom-fuzz",
+          pluginId: "fuzzplugin",
+          label: "Fuzz Provider",
+          auth: [],
+          normalizeTransport: () => {
+            throw new Error("bad transport hook");
+          },
+        },
+        {
+          id: "fuzz-transport-family",
+          pluginId: "fuzzplugin",
+          label: "Fuzz Transport Family",
+          auth: [],
+          normalizeTransport: ({ api, baseUrl }) =>
+            api === "openai-completions" ? { api: "openai-responses", baseUrl } : undefined,
+        },
+      ];
+      return params.providerRefs?.includes("custom-fuzz") ? [plugins[0]] : plugins;
+    });
+
+    expect(
+      normalizeProviderTransportWithPlugin({
+        provider: "custom-fuzz",
+        context: {
+          provider: "custom-fuzz",
+          api: "openai-completions",
+          baseUrl: "https://api.example.com/v1",
+        },
+      }),
+    ).toEqual({
+      api: "openai-responses",
+      baseUrl: "https://api.example.com/v1",
+    });
+
+    expect(providerRuntimeWarnMock).toHaveBeenCalledTimes(1);
+    expect(firstMockStringArg(providerRuntimeWarnMock, "provider warning")).toContain(
+      'Provider plugin "fuzzplugin" normalizeTransport hook failed',
+    );
   });
 
   it("invalidates cached runtime providers when config mutates in place", () => {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -14,6 +14,7 @@ import {
 import type { ProviderSystemPromptContribution } from "../agents/system-prompt-contribution.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
 import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
@@ -121,6 +122,29 @@ function resolveProviderHookRefs(
 
 function matchesAnyProviderPluginRef(provider: ProviderPlugin, providerRefs: readonly string[]) {
   return providerRefs.some((providerRef) => matchesProviderPluginRef(provider, providerRef));
+}
+
+function getProviderRuntimePluginKey(plugin: ProviderPlugin): string {
+  return `${plugin.pluginId ?? ""}:${plugin.id}`;
+}
+
+function runProviderRuntimeHook<TResult>(params: {
+  plugin: ProviderPlugin | undefined;
+  hookName: string;
+  run: (plugin: ProviderPlugin) => TResult;
+}): TResult | undefined {
+  if (!params.plugin) {
+    return undefined;
+  }
+  try {
+    return params.run(params.plugin);
+  } catch (error) {
+    const pluginId = params.plugin.pluginId ?? params.plugin.id;
+    log.warn(
+      `Provider plugin "${sanitizeForLog(pluginId)}" ${sanitizeForLog(params.hookName)} hook failed; ignoring hook: ${sanitizeForLog(formatErrorMessage(error))}`,
+    );
+    return undefined;
+  }
 }
 
 function hasExplicitProviderRuntimePluginActivation(params: {
@@ -369,8 +393,13 @@ export function normalizeProviderModelIdWithPlugin(params: {
 }): string | undefined {
   const plugin = resolveProviderHookPlugin(params);
   return (
-    normalizeOptionalString(plugin?.normalizeModelId?.(params.context)) ??
-    normalizeProviderModelIdWithManifest(params)
+    normalizeOptionalString(
+      runProviderRuntimeHook({
+        plugin,
+        hookName: "normalizeModelId",
+        run: (providerPlugin) => providerPlugin.normalizeModelId?.(params.context),
+      }),
+    ) ?? normalizeProviderModelIdWithManifest(params)
   );
 }
 
@@ -385,16 +414,28 @@ export function normalizeProviderTransportWithPlugin(params: {
     (normalized.api ?? params.context.api) !== params.context.api ||
     (normalized.baseUrl ?? params.context.baseUrl) !== params.context.baseUrl;
   const matchedPlugin = resolveProviderHookPlugin(params);
-  const normalizedMatched = matchedPlugin?.normalizeTransport?.(params.context);
+  const normalizedMatched = runProviderRuntimeHook({
+    plugin: matchedPlugin,
+    hookName: "normalizeTransport",
+    run: (providerPlugin) => providerPlugin.normalizeTransport?.(params.context),
+  });
+  const matchedPluginKey = matchedPlugin ? getProviderRuntimePluginKey(matchedPlugin) : undefined;
   if (normalizedMatched && hasTransportChange(normalizedMatched)) {
     return normalizedMatched;
   }
 
   for (const candidate of resolveProviderPluginsForHooks(params)) {
-    if (!candidate.normalizeTransport || candidate === matchedPlugin) {
+    if (
+      !candidate.normalizeTransport ||
+      (matchedPluginKey && getProviderRuntimePluginKey(candidate) === matchedPluginKey)
+    ) {
       continue;
     }
-    const normalized = candidate.normalizeTransport(params.context);
+    const normalized = runProviderRuntimeHook({
+      plugin: candidate,
+      hookName: "normalizeTransport",
+      run: (providerPlugin) => providerPlugin.normalizeTransport?.(params.context),
+    });
     if (normalized && hasTransportChange(normalized)) {
       return normalized;
     }


### PR DESCRIPTION
## Summary

- catch throwing provider runtime `normalizeModelId` and `normalizeTransport` hooks so model/transport normalization keeps its existing fallback paths
- log sanitized provider hook failures instead of letting a bad plugin poison provider lookup
- keep transport fallback scanning sibling providers, including same-package provider surfaces, while avoiding rerunning the same failed provider hook

## Verification

- `node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-runtime.ts src/plugins/provider-runtime.test.ts`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/provider-runtime.ts src/plugins/provider-runtime.test.ts`
- `git diff --check HEAD~1..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the updated OpenClaw provider-runtime patch after changing the transport skip key to plugin package plus provider id. Focus on whether throwing normalizeModelId/normalizeTransport hooks preserve manifest and sibling transport fallback, including same-package multi-provider plugins."`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "corepack pnpm check:changed"` (`run_8c7e8041e188`, lease `cbx_739f083002ff`, exit 0; lanes `core`, `coreTests`)

## Real behavior proof

Behavior addressed: provider runtime normalization hooks that throw no longer abort model-id or transport fallback resolution.

Real environment tested: local focused Vitest/format/lint/autoreview plus AWS Crabbox Linux changed gate.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "corepack pnpm check:changed"`.

Evidence after fix: focused provider-runtime tests passed 58/58; autoreview reported no accepted/actionable findings; AWS Crabbox run `run_8c7e8041e188` exited 0.

Observed result after fix: throwing `normalizeModelId` returns to manifest fallback, and throwing matched `normalizeTransport` keeps scanning sibling transport hooks without duplicate same-provider invocation.

What was not tested: direct Blacksmith Testbox was not available because `blacksmith testbox list` reported missing auth.
