### PR TITLE
perf(ui): record pending send paint timing

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1057,6 +1057,7 @@ describe("handleSendChat", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -1221,6 +1222,42 @@ describe("handleSendChat", () => {
     });
     expect(ack?.durationMs).toEqual(expect.any(Number));
     expect(ack?.requestDurationMs).toEqual(expect.any(Number));
+  });
+
+  it("records pending send paint timing before a delayed chat.send ACK", async () => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      queueMicrotask(() => callback(0));
+      return 1;
+    });
+    const chatSend = createDeferred<{ status: "started" }>();
+    const request = vi.fn((method: string) => {
+      if (method === "chat.send") {
+        return chatSend.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "measure painted pending send",
+      eventLogBuffer: [],
+      tab: "debug",
+    });
+
+    const send = handleSendChat(host);
+
+    await vi.waitFor(() =>
+      expect(eventPayloads(host, "control-ui.chat.send").map((payload) => payload.phase)).toEqual(
+        expect.arrayContaining(["pending-visible", "request-start", "pending-painted"]),
+      ),
+    );
+
+    chatSend.resolve({ status: "started" });
+    await send;
+
+    const phasesAfterAck = eventPayloads(host, "control-ui.chat.send").map(
+      (payload) => payload.phase,
+    );
+    expect(phasesAfterAck).toEqual(expect.arrayContaining(["ack"]));
   });
 
   it("waits for an in-flight model picker update before sending chat", async () => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -31,6 +31,7 @@ import {
   controlUiNowMs,
   recordControlUiPerformanceEvent,
   roundedControlUiDurationMs,
+  scheduleControlUiAfterPaint,
 } from "./control-ui-performance.ts";
 import { resolveControlUiAuthHeader } from "./control-ui-auth.ts";
 import {
@@ -417,6 +418,7 @@ function enqueuePendingSendMessage(
   };
   host.chatQueue = [...host.chatQueue, pending];
   recordChatSendTiming(host, pending, "pending-visible", submittedAtMs);
+  schedulePendingSendPaintTiming(host, pending, submittedAtMs);
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], true);
   return pending;
 }
@@ -563,6 +565,7 @@ type QueuedChatSendResult = "sent" | "pending" | "failed";
 
 type ChatSendTimingPhase =
   | "pending-visible"
+  | "pending-painted"
   | "request-start"
   | "ack"
   | "queued-busy"
@@ -597,6 +600,42 @@ function recordChatSendTiming(
       ...extra,
     },
     { console: false, maxBufferedEventsForType: 40 },
+  );
+}
+
+function shouldRecordPendingSendPaint(item: ChatQueueItem): boolean {
+  return (
+    typeof item.sendSubmittedAtMs === "number" &&
+    (item.sendState === "waiting-model" ||
+      item.sendState === "sending" ||
+      item.sendState === "waiting-reconnect")
+  );
+}
+
+function schedulePendingSendPaintTiming(
+  host: ChatHost,
+  item: ChatQueueItem,
+  startedAtMs = item.sendSubmittedAtMs,
+) {
+  const sessionKey = item.sessionKey ?? host.sessionKey;
+  const sendRunId = item.sendRunId;
+  if (!sendRunId || startedAtMs == null) {
+    return;
+  }
+  scheduleControlUiAfterPaint(
+    host as Parameters<typeof scheduleControlUiAfterPaint>[0],
+    () => {
+      if (!visibleSessionMatches(host, sessionKey, item.agentId)) {
+        return;
+      }
+      const queued = readChatQueueForSession(host, sessionKey).find(
+        (entry) => entry.id === item.id && entry.sendRunId === sendRunId,
+      );
+      if (!queued || !shouldRecordPendingSendPaint(queued)) {
+        return;
+      }
+      recordChatSendTiming(host, queued, "pending-painted", startedAtMs);
+    },
   );
 }
 

--- a/ui/src/ui/control-ui-performance.ts
+++ b/ui/src/ui/control-ui-performance.ts
@@ -159,6 +159,15 @@ export function scheduleControlUiTabVisibleTiming(
     .then(() => runAfterPaint(record));
 }
 
+export function scheduleControlUiAfterPaint(
+  host: Pick<ControlUiPerformanceHost, "updateComplete">,
+  callback: () => void,
+) {
+  void Promise.resolve(host.updateComplete)
+    .catch(() => undefined)
+    .then(() => runAfterPaint(callback));
+}
+
 export function beginControlUiRefresh(
   host: ControlUiPerformanceHost,
   tab: Tab,


### PR DESCRIPTION
Summary:
- Add a post-update/post-paint `pending-painted` chat-send timing phase.
- Record the phase only while the original queued send is still visible for the same session/run.
- Cover the delayed ACK path and clean up the RAF spy after the test.

Verification:
- node scripts/run-vitest.mjs run ui/src/ui/app-chat.test.ts ui/src/ui/control-ui-performance.test.ts --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner
- node scripts/run-vitest.mjs run ui/src/ui/e2e/chat-flow.e2e.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/control-ui-performance.test.ts --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner
- node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/ui/app-chat.ts ui/src/ui/app-chat.test.ts ui/src/ui/control-ui-performance.ts
- node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
- git diff --check origin/main...HEAD
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed (tbx_01kt0yfajejg9xkr4tj225xyt1)
