### PR TITLE
perf(telegram): avoid broad reset-boundary scan

### DIFF
--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -760,6 +760,45 @@ describe("telegram message cache", () => {
     expect(context.map((entry) => entry.node.body)).not.toContain(staleInstruction);
   });
 
+  it("uses the current reset command as the session boundary", async () => {
+    const cache = createTelegramMessageCache();
+    const chat = { id: 7, type: "group", title: "Ops" } as const;
+    await cache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat,
+        message_id: 100,
+        date: 1736380800,
+        text: "stale context",
+        from: { id: 100, is_bot: false, first_name: "Requester" },
+      } as Message,
+    });
+    await cache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat,
+        message_id: 101,
+        date: 1736380860,
+        text: "/new",
+        from: { id: 101, is_bot: false, first_name: "Requester" },
+      } as Message,
+    });
+
+    const context = await buildTelegramConversationContext({
+      cache,
+      accountId: "default",
+      chatId: 7,
+      messageId: "101",
+      replyChainNodes: [],
+      recentLimit: 10,
+      replyTargetWindowSize: 1,
+    });
+
+    expect(context).toEqual([]);
+  });
+
   it("does not select messages before the persisted session start when the reset command is absent", async () => {
     const cache = createTelegramMessageCache();
     const beforeSession = Date.parse("2026-05-10T12:40:00.000Z");

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -54,6 +54,13 @@ export type TelegramMessageCache = {
     before: number;
     after: number;
   }) => Promise<TelegramCachedMessageNode[]>;
+  latestBeforeMatching: (params: {
+    accountId: string;
+    chatId: string | number;
+    messageId?: string;
+    threadId?: number;
+    matches: (node: TelegramCachedMessageNode) => boolean;
+  }) => Promise<TelegramCachedMessageNode | null>;
 };
 
 type MessageWithExternalReply = Message & { external_reply?: Message };
@@ -712,6 +719,40 @@ export function createTelegramMessageCache(params?: {
         targetIndex + Math.max(0, after) + 1,
       );
     },
+    latestBeforeMatching: async ({ accountId, chatId, messageId, threadId, matches }) => {
+      if (!messageId) {
+        return null;
+      }
+      const targetId = parseSafeMessageId(messageId);
+      if (targetId === undefined) {
+        return null;
+      }
+      await hydrateMessageCacheBucket(bucket, maxMessages, scopeKey);
+      const prefix = telegramMessageCacheKeyPrefix({ scopeKey, accountId, chatId });
+      const normalizedThreadId = normalizeTelegramCacheThreadId(threadId);
+      if (threadId != null && normalizedThreadId === undefined) {
+        return null;
+      }
+      const normalizedThread =
+        normalizedThreadId !== undefined ? String(normalizedThreadId) : undefined;
+      let latest: TelegramCachedMessageNode | null = null;
+      for (const [key, entry] of messages) {
+        if (!key.startsWith(prefix)) {
+          continue;
+        }
+        if (normalizedThread !== undefined && entry.threadId !== normalizedThread) {
+          continue;
+        }
+        const entryId = parseSafeMessageId(entry.messageId);
+        if (entryId === undefined || entryId >= targetId || !matches(entry)) {
+          continue;
+        }
+        if (!latest || compareCachedMessageNodes(entry, latest) > 0) {
+          latest = entry;
+        }
+      }
+      return latest;
+    },
   };
 }
 
@@ -790,24 +831,22 @@ async function resolveSessionBoundaryNode(params: {
     return undefined;
   }
   const { messageId } = params;
-  const candidates = (
-    await params.cache.recentBefore({
-      accountId: params.accountId,
-      chatId: params.chatId,
-      messageId,
-      ...(params.threadId !== undefined ? { threadId: params.threadId } : {}),
-      limit: Number.MAX_SAFE_INTEGER,
-    })
-  ).filter(isSessionBoundaryCommandNode);
+  const latestBefore = await params.cache.latestBeforeMatching({
+    accountId: params.accountId,
+    chatId: params.chatId,
+    messageId,
+    ...(params.threadId !== undefined ? { threadId: params.threadId } : {}),
+    matches: isSessionBoundaryCommandNode,
+  });
   const current = await params.cache.get({
     accountId: params.accountId,
     chatId: params.chatId,
     messageId,
   });
   if (current && isSessionBoundaryCommandNode(current)) {
-    candidates.push(current);
+    return current;
   }
-  return candidates.toSorted(compareCachedMessageNodes).at(-1);
+  return latestBefore ?? undefined;
 }
 
 export async function buildTelegramReplyChain(params: {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -54,7 +54,7 @@ export type TelegramMessageCache = {
     before: number;
     after: number;
   }) => Promise<TelegramCachedMessageNode[]>;
-  latestBeforeMatching: (params: {
+  latestMatchingAtOrBefore: (params: {
     accountId: string;
     chatId: string | number;
     messageId?: string;
@@ -719,7 +719,7 @@ export function createTelegramMessageCache(params?: {
         targetIndex + Math.max(0, after) + 1,
       );
     },
-    latestBeforeMatching: async ({ accountId, chatId, messageId, threadId, matches }) => {
+    latestMatchingAtOrBefore: async ({ accountId, chatId, messageId, threadId, matches }) => {
       if (!messageId) {
         return null;
       }
@@ -744,7 +744,7 @@ export function createTelegramMessageCache(params?: {
           continue;
         }
         const entryId = parseSafeMessageId(entry.messageId);
-        if (entryId === undefined || entryId >= targetId || !matches(entry)) {
+        if (entryId === undefined || entryId > targetId || !matches(entry)) {
           continue;
         }
         if (!latest || compareCachedMessageNodes(entry, latest) > 0) {
@@ -830,23 +830,15 @@ async function resolveSessionBoundaryNode(params: {
   if (!params.messageId) {
     return undefined;
   }
-  const { messageId } = params;
-  const latestBefore = await params.cache.latestBeforeMatching({
-    accountId: params.accountId,
-    chatId: params.chatId,
-    messageId,
-    ...(params.threadId !== undefined ? { threadId: params.threadId } : {}),
-    matches: isSessionBoundaryCommandNode,
-  });
-  const current = await params.cache.get({
-    accountId: params.accountId,
-    chatId: params.chatId,
-    messageId,
-  });
-  if (current && isSessionBoundaryCommandNode(current)) {
-    return current;
-  }
-  return latestBefore ?? undefined;
+  return (
+    (await params.cache.latestMatchingAtOrBefore({
+      accountId: params.accountId,
+      chatId: params.chatId,
+      messageId: params.messageId,
+      ...(params.threadId !== undefined ? { threadId: params.threadId } : {}),
+      matches: isSessionBoundaryCommandNode,
+    })) ?? undefined
+  );
 }
 
 export async function buildTelegramReplyChain(params: {


### PR DESCRIPTION
## Summary

- Add a targeted Telegram message-cache helper for finding the latest matching message at or before the current message.
- Use it for `/new` and hard `/reset` session-boundary detection instead of materializing every previous cached message with `recentBefore(..., Number.MAX_SAFE_INTEGER)`.
- Fold current-message and previous-message boundary selection into one cache scan while leaving `recentBefore` and `around` behavior unchanged.

## Real behavior proof

Behavior addressed: Telegram `/new` and hard `/reset` session-boundary lookup no longer needs to materialize every previous cached message while still fencing conversation context after the reset boundary.

Real environment tested: Local OpenClaw worktree on PR branch `codex/telegram-cache-context-fastpath`, using Node 26 and the actual `extensions/telegram/src/message-cache.ts` runtime loaded through `tsx` with grammY-shaped Telegram message objects.

Exact steps or command run after this patch: Ran `pnpm exec tsx --eval ...` against this PR head. The command seeded one Telegram thread cache with 3,011 messages: 2,500 stale messages before `/new`, the `/new` boundary at message `12500`, 10 post-reset context messages, and current message `13010`; then called `cache.latestMatchingAtOrBefore(...)` and `buildTelegramConversationContext(...)`.

Evidence after fix: Console output after fix:

```json
{"cachedMessages":3011,"boundaryId":"12500","contextIds":[13000,13001,13002,13003,13004,13005,13006,13007,13008,13009],"staleLeaked":false}
```

Observed result after fix: `latestMatchingAtOrBefore` found the `/new` boundary at `12500`, and `buildTelegramConversationContext` returned only post-reset message IDs `13000` through `13009`; no stale pre-reset body or message ID at or before `12500` leaked into the prompt context.

What was not tested: A live Telegram bot/Desktop roundtrip was not run; this proof exercises the real Telegram cache/context runtime with Telegram-shaped messages rather than a mocked helper.

## Verification

- Runtime proof command described above
- `node scripts/run-vitest.mjs extensions/telegram/src/message-cache.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings
- `git diff --check`
