### PR TITLE
fix(agents): repair context-engine tool-result pairing

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1740,6 +1740,44 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(hoisted.preemptiveCompactionCalls.at(-1)).not.toHaveProperty("unwindowedMessages");
   });
 
+  it("repairs tool-result pairing after context engine assembly", async () => {
+    let promptMessages: AgentMessage[] = [];
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createTestContextEngine({
+        assemble: async () => ({
+          messages: [
+            { role: "user", content: "assembled context", timestamp: 1 },
+            {
+              role: "toolResult",
+              toolCallId: "call_orphan",
+              toolUseId: "call_orphan",
+              toolName: "read",
+              content: [{ type: "text", text: "orphaned result" }],
+              timestamp: 2,
+            },
+          ] as AgentMessage[],
+          estimatedTokens: 8,
+        }),
+      }),
+      sessionKey,
+      tempPaths,
+      sessionPrompt: async (session) => {
+        promptMessages = [...session.messages];
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 3 },
+        ];
+      },
+    });
+
+    expect(promptMessages).toContainEqual(
+      expect.objectContaining({ role: "user", content: "assembled context" }),
+    );
+    expect(promptMessages.some((message) => message.role === "toolResult")).toBe(false);
+    expect(JSON.stringify(promptMessages)).not.toContain("orphaned result");
+  });
+
   it("honors context engines that opt into preassembly overflow authority", async () => {
     const lockEvents = trackSessionWriteLocks();
     let sawPrompt = false;

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1763,7 +1763,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       sessionKey,
       tempPaths,
       sessionPrompt: async (session) => {
-        promptMessages = [...session.messages];
+        promptMessages = session.messages.map((message) => message as AgentMessage);
         session.messages = [
           ...session.messages,
           { role: "assistant", content: "done", timestamp: 3 },

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -681,6 +681,7 @@ vi.mock("../../tool-policy.js", async (importOriginal) => {
 vi.mock("../../transcript-policy.js", () => ({
   resolveTranscriptPolicy: () => ({
     allowSyntheticToolResults: false,
+    repairToolUseResultPairing: true,
   }),
   shouldAllowProviderOwnedThinkingReplay: () => false,
 }));

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -597,6 +597,16 @@ function flushSessionManagerFile(sessionManager: ReturnType<typeof guardSessionM
   (sessionManager as unknown as { rewriteFile?: () => void }).rewriteFile?.();
 }
 
+function repairAttemptToolUseResultPairing(
+  messages: AgentMessage[],
+  isOpenAIResponsesApi: boolean,
+): AgentMessage[] {
+  return sanitizeToolUseResultPairing(messages, {
+    erroredAssistantResultPolicy: "drop",
+    ...(isOpenAIResponsesApi ? { missingToolResultText: "aborted" } : {}),
+  });
+}
+
 function shouldPreservePromptErrorAfterCleanupError(params: {
   promptError: unknown;
   cleanupError: unknown;
@@ -1955,6 +1965,10 @@ export async function runEmbeddedAttempt(
         config: params.config,
         env: process.env,
       });
+      const isOpenAIResponsesApi =
+        params.model.api === "openai-responses" ||
+        params.model.api === "azure-openai-responses" ||
+        params.model.api === "openai-chatgpt-responses";
 
       await prewarmSessionFile(params.sessionFile);
       const preparedUserTurnMessage = await params.userTurnTranscriptRecorder?.resolveMessage();
@@ -2348,6 +2362,12 @@ export async function runEmbeddedAttempt(
           sessionFile: params.sessionFile,
           tokenBudget: params.contextTokenBudget,
           modelId: params.modelId,
+          ...(transcriptPolicy.repairToolUseResultPairing
+            ? {
+                repairAssembledMessages: (messages) =>
+                  repairAttemptToolUseResultPairing(messages, isOpenAIResponsesApi),
+              }
+            : {}),
           getPrePromptMessageCount: () => prePromptMessageCount,
           onAfterTurnCheckpoint: (messageCount) => {
             contextEngineAfterTurnCheckpoint = messageCount;
@@ -2645,11 +2665,6 @@ export async function runEmbeddedAttempt(
       // historical messages at attempt start, but the agent loop's internal tool call →
       // tool result cycles bypass that path. Wrap streamFn so every outbound request
       // sees sanitized tool call IDs.
-      const isOpenAIResponsesApi =
-        params.model.api === "openai-responses" ||
-        params.model.api === "azure-openai-responses" ||
-        params.model.api === "openai-chatgpt-responses";
-
       const replayToolCallIdSanitizerDecision = {
         sanitizeToolCallIds: transcriptPolicy.sanitizeToolCallIds,
         toolCallIdMode: transcriptPolicy.toolCallIdMode,
@@ -2912,10 +2927,7 @@ export async function runEmbeddedAttempt(
           // limitHistoryTurns can orphan tool_result blocks by removing the
           // assistant message that contained the matching tool_use.
           const limited = transcriptPolicy.repairToolUseResultPairing
-            ? sanitizeToolUseResultPairing(truncated, {
-                erroredAssistantResultPolicy: "drop",
-                ...(isOpenAIResponsesApi ? { missingToolResultText: "aborted" } : {}),
-              })
+            ? repairAttemptToolUseResultPairing(truncated, isOpenAIResponsesApi)
             : truncated;
           cacheTrace?.recordStage("session:limited", { messages: limited });
           if (limited.length > 0 || prior.length > 0) {
@@ -2944,8 +2956,11 @@ export async function runEmbeddedAttempt(
             if (!assembled) {
               throw new Error("context engine assemble returned no result");
             }
-            if (assembled.messages !== activeSession.messages) {
-              activeSession.agent.state.messages = assembled.messages;
+            const assembledMessages = transcriptPolicy.repairToolUseResultPairing
+              ? repairAttemptToolUseResultPairing(assembled.messages, isOpenAIResponsesApi)
+              : assembled.messages;
+            if (assembledMessages !== activeSession.messages) {
+              activeSession.agent.state.messages = assembledMessages;
             }
             contextEnginePromptAuthority = assembled.promptAuthority ?? "assembled";
             if (contextEnginePromptAuthority === "preassembly_may_overflow") {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -816,6 +816,33 @@ describe("installContextEngineLoopHook", () => {
     );
   });
 
+  it("repairs same-reference ownsCompaction assembled loop views", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+      repairAssembledMessages: sanitizeToolUseResultPairing,
+    });
+
+    const { transformed, withNew } = await callAfterInitialToolResult(agent, {
+      includeSecondUser: false,
+      firstResultText: "r",
+    });
+
+    expect(recordMockArg(engine.assemble).messages).toBe(withNew);
+    expect(transformed).not.toBe(withNew);
+    expect(transformed).toEqual([expect.objectContaining({ role: "user", content: "first" })]);
+    expect((transformed as AgentMessage[]).some((message) => message.role === "toolResult")).toBe(
+      false,
+    );
+  });
+
   it("clears an assembled view when the engine fails on a later source", async () => {
     const agent = makeGuardableAgent();
     const compactedView = [makeUser("compacted")];

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it, vi } from "vitest";
 import type { ContextEngine } from "../../context-engine/types.js";
+import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
 import { MidTurnPrecheckSignal } from "./run/midturn-precheck.js";
 import {
@@ -785,6 +786,34 @@ describe("installContextEngineLoopHook", () => {
     });
 
     expect(transformed).toBe(compactedView);
+  });
+
+  it("repairs tool-result pairing in ownsCompaction assembled loop views", async () => {
+    const agent = makeGuardableAgent();
+    const assembledView = [makeUser("compacted"), makeToolResult("call_orphan", "stale")];
+    const engine = makeMockEngine({
+      assemble: async () => ({ messages: assembledView, estimatedTokens: 0 }),
+    });
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+      repairAssembledMessages: sanitizeToolUseResultPairing,
+    });
+
+    const { transformed } = await callAfterInitialToolResult(agent, {
+      includeSecondUser: false,
+      firstResultText: "r",
+    });
+
+    expect(transformed).toEqual([expect.objectContaining({ role: "user", content: "compacted" })]);
+    expect((transformed as AgentMessage[]).some((message) => message.role === "toolResult")).toBe(
+      false,
+    );
   });
 
   it("clears an assembled view when the engine fails on a later source", async () => {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -324,6 +324,7 @@ export function installContextEngineLoopHook(params: {
   sessionFile: string;
   tokenBudget?: number;
   modelId: string;
+  repairAssembledMessages?: (messages: AgentMessage[]) => AgentMessage[];
   getPrePromptMessageCount?: () => number;
   onAfterTurnCheckpoint?: (messageCount: number) => void;
   getRuntimeContext?: (params: {
@@ -430,8 +431,10 @@ export function installContextEngineLoopHook(params: {
         Array.isArray(assembled.messages) &&
         assembled.messages !== providerMessages
       ) {
-        lastAssembledView = assembled.messages;
-        return assembled.messages;
+        const repairedMessages =
+          params.repairAssembledMessages?.(assembled.messages) ?? assembled.messages;
+        lastAssembledView = repairedMessages;
+        return repairedMessages;
       }
       lastAssembledView = null;
     } catch {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -428,13 +428,14 @@ export function installContextEngineLoopHook(params: {
       });
       if (
         assembled &&
-        Array.isArray(assembled.messages) &&
-        assembled.messages !== providerMessages
+        Array.isArray(assembled.messages)
       ) {
         const repairedMessages =
           params.repairAssembledMessages?.(assembled.messages) ?? assembled.messages;
-        lastAssembledView = repairedMessages;
-        return repairedMessages;
+        if (repairedMessages !== providerMessages || assembled.messages !== providerMessages) {
+          lastAssembledView = repairedMessages;
+          return repairedMessages;
+        }
       }
       lastAssembledView = null;
     } catch {


### PR DESCRIPTION
## Summary

Fixes #88561.

Context-engine assembly could replace the attempt transcript after the existing truncation-time tool-use/result repair had already run. If the assembled messages contained a free-floating `toolResult`, the OpenAI chat-completions adapter later serialized it as a `role: "tool"` message without a preceding assistant `tool_calls` entry, which strict OpenAI-compatible providers reject.

This PR reuses the existing attempt-level pairing repair after context-engine `assemble()` returns, before assembled transcripts are used by the active session or the ownsCompaction loop-hook prompt path. It handles both rewritten assembled arrays and same-reference/in-place loop assemblies, and keeps the pre-existing post-truncation repair on the same helper so each repair site uses identical policy.

## Real behavior proof

Behavior addressed: Context-engine assembled transcripts from initial attempt assembly, rewritten ownsCompaction loop assembly, and same-reference ownsCompaction loop assembly no longer leave orphaned `toolResult` messages in the prompt path.
Real environment tested: Local OpenClaw PR worktree at `75f12f87bc88` on Node `v26.0.0`, using production modules through `node --import tsx` rather than a Vitest/mock runner.
Exact steps or command run after this patch: `node --import tsx ../openclaw-88561-real-proof.mts`
Evidence after fix: Terminal output from the production-module probe:

```json
{
  "currentHead": "75f12f87bc88",
  "initialAssembleRoles": [
    "user"
  ],
  "initialAssembleHasOrphanToolResult": false,
  "differentReferenceLoopAssembleRoles": [
    "user"
  ],
  "differentReferenceLoopAssembleHasOrphanToolResult": false,
  "sameReferenceLoopAssembleRoles": [
    "user",
    "user"
  ],
  "sameReferenceLoopAssembleHasOrphanToolResult": false
}
```

Observed result after fix: The same repair removes the orphan tool result from the initial assembled context and both ownsCompaction loop assembled views, including the same-reference path ClawSweeper flagged.
What was not tested: Live WeChat/lossless-claw model-switch repro was not run; the live proof is a local production-module terminal probe plus focused regression coverage for the issue shape.

## Verification

- `node --import tsx ../openclaw-88561-real-proof.mts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts --testNamePattern "repairs tool-result pairing after context engine assembly"`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-context-guard.test.ts --testNamePattern "repairs tool-result pairing in ownsCompaction assembled loop views"`
- `node scripts/run-vitest.mjs src/agents/session-transcript-repair.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings after the initial patch and again after the loop-hook follow-up
