### PR TITLE
fix(memory-core): keep startup cron retries quiet

### DIFF
--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -1682,7 +1682,8 @@ describe("gateway startup reconciliation", () => {
 
       await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
       expect(harness.addCalls).toHaveLength(0);
-      expectLogContains(logger.warn, "cron service unavailable");
+      expectLogNotContains(logger.warn, "cron service unavailable");
+      expectLogContains(logger.debug, "cron service not yet available at gateway_start");
 
       cronAvailable = true;
       await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
@@ -1697,6 +1698,56 @@ describe("gateway startup reconciliation", () => {
       expect(payload.lightContext).toBe(true);
     } finally {
       vi.useRealTimers();
+      clearInternalHooks();
+    }
+  });
+
+  it("keeps startup cron retry warnings quiet until the retry window is exhausted", async () => {
+    vi.useFakeTimers();
+    clearInternalHooks();
+    const logger = createLogger();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerGatewayStart(onMock, {
+        config: api.config,
+        getCron: () => undefined,
+      });
+
+      await vi.advanceTimersByTimeAsync(
+        constants.STARTUP_CRON_RETRY_DELAY_MS * (constants.STARTUP_CRON_RETRY_MAX_ATTEMPTS - 1),
+      );
+      expectLogNotContains(logger.warn, "cron service unavailable");
+
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+
+      expectLogContains(logger.warn, "cron service unavailable");
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      await triggerGatewayStop(onMock);
       clearInternalHooks();
     }
   });
@@ -1825,6 +1876,67 @@ describe("gateway startup reconciliation", () => {
       expect(harness.addCalls).toHaveLength(0);
     } finally {
       vi.useRealTimers();
+      clearInternalHooks();
+    }
+  });
+
+  it("does not recreate startup cron from stale enabled config after live memory-core config is removed", async () => {
+    vi.useFakeTimers();
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const onMock = vi.fn();
+    const runtimeCurrentConfig = vi.fn(
+      () =>
+        ({
+          plugins: {
+            entries: {},
+          },
+        }) as OpenClawConfig,
+    );
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      pluginConfig: {},
+      logger,
+      runtime: {
+        config: {
+          current: runtimeCurrentConfig,
+        },
+      },
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      let cronAvailable = false;
+      await triggerGatewayStart(onMock, {
+        config: api.config,
+        getCron: () => (cronAvailable ? harness.cron : undefined),
+      });
+
+      cronAvailable = true;
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+
+      expect(runtimeCurrentConfig).toHaveBeenCalled();
+      expect(harness.addCalls).toHaveLength(0);
+      expectLogNotContains(logger.warn, "cron service unavailable");
+    } finally {
+      vi.useRealTimers();
+      await triggerGatewayStop(onMock).catch(() => undefined);
       clearInternalHooks();
     }
   });

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -760,18 +760,18 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     ].join("|");
 
   const reconcileManagedDreamingCron = async (params: {
-    reason: "startup" | "runtime";
+    reason: "startup" | "startup_retry" | "runtime";
     startupConfig?: OpenClawConfig;
     startupCron?: (() => CronServiceLike | null) | null;
   }): Promise<ShortTermPromotionDreamingConfig> => {
     const startupCfg =
       params.reason === "startup" ? (params.startupConfig ?? api.config) : resolveCurrentConfig();
     const pluginConfig =
-      params.reason === "runtime"
-        ? resolveMemoryCorePluginConfig(startupCfg)
-        : (resolveMemoryCorePluginConfig(startupCfg) ??
+      params.reason === "startup"
+        ? (resolveMemoryCorePluginConfig(startupCfg) ??
           resolveMemoryCorePluginConfig(api.config) ??
-          api.pluginConfig);
+          api.pluginConfig)
+        : resolveMemoryCorePluginConfig(startupCfg);
     const config = resolveShortTermPromotionDreamingConfig({
       pluginConfig,
       cfg: startupCfg,
@@ -784,7 +784,7 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     // This handles the case where the cron service was not yet available during
     // gateway_start (250ms deferred init race in startGatewaySidecars) but is
     // available now.  Fixes #67362.
-    if (!cron && params.reason === "runtime" && gatewayContext) {
+    if (!cron && params.reason !== "startup" && gatewayContext) {
       try {
         cron = resolveCronServiceFromGatewayContext(gatewayContext);
         if (cron) {
@@ -800,7 +800,7 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
       // Avoid a noisy startup-path warning when the gateway has not exposed cron yet.
       // The runtime reconciliation path (heartbeat-driven) will still warn if the
       // cron service remains unavailable after boot.
-      if (params.reason === "startup") {
+      if (params.reason === "startup" || params.reason === "startup_retry") {
         api.logger.debug?.(
           "memory-core: cron service not yet available at gateway_start; deferring to runtime reconciliation.",
         );
@@ -852,10 +852,14 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
         return;
       }
       startupCronRetryAttempts += 1;
-      void reconcileManagedDreamingCron({ reason: "runtime" })
-        .then(() => {
+      void reconcileManagedDreamingCron({ reason: "startup_retry" })
+        .then(async () => {
           if (disposed || hasStartupCron()) {
             clearStartupCronRetry();
+            return;
+          }
+          if (startupCronRetryAttempts >= STARTUP_CRON_RETRY_MAX_ATTEMPTS) {
+            await reconcileManagedDreamingCron({ reason: "runtime" });
             return;
           }
           scheduleStartupCronRetry();


### PR DESCRIPTION
## Summary

- Keep managed dreaming startup cron retries at debug level while cron may still be unavailable during startup.
- Preserve live/runtime config semantics during startup retries so removed or disabled memory-core config is not recreated from stale startup config.
- Add regression coverage for the quiet retry window, exhausted-window warning, and stale startup config removal case.

Closes #75889.

## Real behavior proof

Behavior addressed: managed dreaming startup retries no longer emit warn-level cron-unavailable logs during the bounded startup retry window, while genuine runtime cron-unavailable warnings still fire after the retry window exhausts.

Real environment tested: local OpenClaw checkout on branch `ben/issue-75889-memory-core-cron-startup`, rebased onto `upstream/main` at `371617f9ed3`.

Exact steps or command run after this patch:

- `fnm exec --using 22 pnpm test extensions/memory-core/src/dreaming.test.ts`
- `fnm exec --using 22 pnpm test:extension memory-core`
- `OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled CI=1 fnm exec --using 22 pnpm check:changed --base upstream/main --head HEAD -- extensions/memory-core/src/dreaming.ts extensions/memory-core/src/dreaming.test.ts`
- `git diff --check upstream/main...HEAD`
- `fnm exec --using 22 pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/dreaming.ts extensions/memory-core/src/dreaming.test.ts`
- `PATH="$HOME/.local/bin:$PATH" scripts/run-opengrep.sh --error -- extensions/memory-core/src/dreaming.ts`
- Isolated runtime smoke with a temp config/state/workspace: enable `plugins.entries.memory-core.config.dreaming.enabled=true`, run `fnm exec --using 22 pnpm openclaw gateway run --port 19265 --bind loopback --auth none --verbose --allow-unconfigured`, query `curl -fsS http://127.0.0.1:19265/healthz`, then grep the captured gateway log for the reported warning.

Evidence after fix: focused dreaming tests passed with 50 tests, the memory-core extension shard passed with 61 files and 805 tests, changed-file gates passed for extension production/test lanes, formatting/whitespace checks passed, and the focused static security scan reported 0 findings.

Runtime terminal output from the isolated OpenClaw setup:

```text
config enabled: true
healthz: {"ok":true,"status":"live"}
cron-unavailable warnings: 0
2026-06-01T03:00:04.144-04:00 [plugins] loading memory-core from <repo>/dist/extensions/memory-core/index.js
2026-06-01T03:00:04.201-04:00 Registered plugin command: /dreaming (plugin: memory-core)
2026-06-01T03:00:04.295-04:00 [gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 1.6s)
2026-06-01T03:00:05.178-04:00 [plugins] [hooks] running gateway_start (1 handlers)
2026-06-01T03:00:05.203-04:00 [plugins] memory-core: created managed dreaming cron job.
```

Observed result after fix: startup retry reconciliation stays quiet at warn level until cron becomes available or the bounded retry window exhausts; the isolated gateway startup reached live health, ran `gateway_start`, and created the managed dreaming cron job with zero occurrences of the reported warn-level `managed dreaming cron could not be reconciled (cron service unavailable)` log. One runtime warning is still emitted when cron remains unavailable after the retry window; retries use live config semantics and do not recreate a managed cron job from stale startup config after live memory-core config is removed.

What was not tested: no systemd/launchd managed-service restart or manual app smoke was run; the live runtime proof used a foreground isolated OpenClaw gateway with temp config/state/workspace plus the focused gateway hook tests and the memory-core extension test shard.

## Security note

This changes scheduler reconciliation and log-level behavior only. It does not touch auth, secrets, uploads, payments, external integrations, or messaging permission boundaries.
