### PR TITLE
fix(imessage): persist echo markers before send

### DIFF
--- a/extensions/imessage/src/monitor/catchup-bridge.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.ts
@@ -55,6 +55,12 @@ export type RunIMessageCatchupParams = {
    * (including non-error drops, which mirrors the live pipeline).
    */
   dispatchPayload: (message: IMessagePayload) => Promise<void>;
+  /**
+   * Called for `is_from_me=true` rows that catchup intentionally does not
+   * dispatch. The live inbound path still needs to observe those rows so
+   * self-chat reflected companion rows can be deduped.
+   */
+  observeSkippedFromMePayload?: (message: IMessagePayload) => Promise<void> | void;
   runtime?: RuntimeLogger;
   /** Override clock for tests. */
   now?: () => number;
@@ -277,6 +283,14 @@ export async function runIMessageCatchup(
     config,
     fetch: fetchFn,
     dispatch: dispatchFn,
+    observeSkippedFromMe: async (row) => {
+      const payload = payloadByGuid.get(row.guid);
+      if (!payload) {
+        warnLog(`imessage catchup: missing skipped from-me payload for guid=${row.guid}`);
+        return;
+      }
+      await params.observeSkippedFromMePayload?.(payload);
+    },
     log,
     warn: warnLog,
     ...(params.now ? { now: params.now() } : {}),

--- a/extensions/imessage/src/monitor/catchup.test.ts
+++ b/extensions/imessage/src/monitor/catchup.test.ts
@@ -261,6 +261,7 @@ describe("performIMessageCatchup", () => {
 
   it("skips is_from_me rows but still advances the cursor past them", async () => {
     const dispatch = alwaysOk();
+    const observeSkippedFromMe = vi.fn();
     const fetch = fetchOf([
       row({ guid: "A", rowid: 10, isFromMe: true }),
       row({ guid: "B", rowid: 11, isFromMe: false }),
@@ -272,12 +273,16 @@ describe("performIMessageCatchup", () => {
       now,
       fetch,
       dispatch,
+      observeSkippedFromMe,
     });
 
     expect(summary.skippedFromMe).toBe(1);
     expect(summary.replayed).toBe(1);
     expect(summary.cursorAfter.lastSeenRowid).toBe(11);
     expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(observeSkippedFromMe).toHaveBeenCalledWith(
+      expect.objectContaining({ guid: "A", rowid: 10, isFromMe: true }),
+    );
   });
 
   it("drops rows older than the maxAgeMinutes ceiling and advances past them", async () => {

--- a/extensions/imessage/src/monitor/catchup.ts
+++ b/extensions/imessage/src/monitor/catchup.ts
@@ -326,6 +326,7 @@ export type PerformCatchupParams = {
   now?: number;
   fetch: CatchupFetchFn;
   dispatch: CatchupDispatchFn;
+  observeSkippedFromMe?: (row: IMessageCatchupRow) => Promise<void> | void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
 };
@@ -462,6 +463,13 @@ export async function performIMessageCatchup(
       continue;
     }
     if (row.isFromMe) {
+      try {
+        await params.observeSkippedFromMe?.(row);
+      } catch (err) {
+        params.warn?.(
+          `imessage catchup: from-me observer failed for guid=${row.guid}: ${String(err)}`,
+        );
+      }
       summary.skippedFromMe += 1;
       highWatermarkMs = Math.max(highWatermarkMs, row.date);
       highWatermarkRowid = Math.max(highWatermarkRowid, row.rowid);

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -67,24 +67,24 @@ describe("deliverReplies", () => {
       [
         "chat_id:10",
         "first",
-        {
+        expect.objectContaining({
           config: IMESSAGE_TEST_CFG,
           maxBytes: 4096,
           client,
           accountId: "default",
           replyToId: "reply-1",
-        },
+        }),
       ],
       [
         "chat_id:10",
         "second",
-        {
+        expect.objectContaining({
           config: IMESSAGE_TEST_CFG,
           maxBytes: 4096,
           client,
           accountId: "default",
           replyToId: "reply-1",
-        },
+        }),
       ],
     ]);
   });
@@ -112,26 +112,26 @@ describe("deliverReplies", () => {
       [
         "chat_id:20",
         "caption",
-        {
+        expect.objectContaining({
           config: IMESSAGE_TEST_CFG,
           mediaUrl: "https://example.com/a.jpg",
           maxBytes: 8192,
           client,
           accountId: "acct-2",
           replyToId: "reply-2",
-        },
+        }),
       ],
       [
         "chat_id:20",
         "",
-        {
+        expect.objectContaining({
           config: IMESSAGE_TEST_CFG,
           mediaUrl: "https://example.com/b.jpg",
           maxBytes: 8192,
           client,
           accountId: "acct-2",
           replyToId: "reply-2",
-        },
+        }),
       ],
     ]);
   });
@@ -157,11 +157,11 @@ describe("deliverReplies", () => {
       [
         "chat_id:50",
         "durable hello",
-        {
+        expect.objectContaining({
           config: IMESSAGE_TEST_CFG,
           accountId: "acct-ignored",
           client,
-        },
+        }),
       ],
     ]);
     expect(remember).toHaveBeenCalledWith("acct-5:chat_id:50", {
@@ -191,11 +191,11 @@ describe("deliverReplies", () => {
       [
         "chat_id:60",
         "Visible reply",
-        {
+        expect.objectContaining({
           config: IMESSAGE_TEST_CFG,
           accountId: "acct-ignored",
           client,
-        },
+        }),
       ],
     ]);
     expect(remember).toHaveBeenCalledWith("acct-6:chat_id:60", {
@@ -204,15 +204,24 @@ describe("deliverReplies", () => {
     });
   });
 
-  it("records outbound text and message ids in sent-message cache (post-send only)", async () => {
-    // Fix for #47830: remember() is called ONLY after each chunk is sent,
-    // never with the full un-chunked text before sending begins.
-    // Pre-send population widened the false-positive window in self-chat.
+  it("records per-chunk pre-send text and post-send message ids in sent-message cache", async () => {
+    // Fix for #47830: pre-send echo markers are per chunk, never the full
+    // un-chunked text before sending begins.
     const remember = vi.fn();
     chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
     sendMessageIMessageMock
-      .mockResolvedValueOnce({ messageId: "imsg-1", sentText: "first" })
-      .mockResolvedValueOnce({ messageId: "imsg-2", sentText: "second" });
+      .mockImplementationOnce(async (_target: string, message: string, opts?: unknown) => {
+        (opts as { onBeforeSendEcho?: (echoText: string) => void } | undefined)?.onBeforeSendEcho?.(
+          message,
+        );
+        return { messageId: "imsg-1", sentText: "first" };
+      })
+      .mockImplementationOnce(async (_target: string, message: string, opts?: unknown) => {
+        (opts as { onBeforeSendEcho?: (echoText: string) => void } | undefined)?.onBeforeSendEcho?.(
+          message,
+        );
+        return { messageId: "imsg-2", sentText: "second" };
+      });
 
     await deliverReplies({
       cfg: IMESSAGE_TEST_CFG,
@@ -226,15 +235,15 @@ describe("deliverReplies", () => {
       sentMessageCache: { remember },
     });
 
-    // Only the two per-chunk post-send calls — no pre-send full-text call.
-    expect(remember).toHaveBeenCalledTimes(2);
-    expect(remember).toHaveBeenCalledWith("acct-3:chat_id:30", {
-      text: "first",
-      messageId: "imsg-1",
-    });
-    expect(remember).toHaveBeenCalledWith("acct-3:chat_id:30", {
-      text: "second",
-      messageId: "imsg-2",
+    expect(remember).toHaveBeenCalledTimes(4);
+    expect(remember.mock.calls).toStrictEqual([
+      ["acct-3:chat_id:30", { text: "first" }],
+      ["acct-3:chat_id:30", { text: "first", messageId: "imsg-1" }],
+      ["acct-3:chat_id:30", { text: "second" }],
+      ["acct-3:chat_id:30", { text: "second", messageId: "imsg-2" }],
+    ]);
+    expect(remember).not.toHaveBeenCalledWith("acct-3:chat_id:30", {
+      text: "first|second",
     });
   });
 

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -204,24 +204,14 @@ describe("deliverReplies", () => {
     });
   });
 
-  it("records per-chunk pre-send text and post-send message ids in sent-message cache", async () => {
-    // Fix for #47830: pre-send echo markers are per chunk, never the full
-    // un-chunked text before sending begins.
+  it("records outbound text and message ids in sent-message cache after send", async () => {
+    // Fix for #47830: monitor cache population remains per chunk, never the
+    // full un-chunked text before sending begins.
     const remember = vi.fn();
     chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
     sendMessageIMessageMock
-      .mockImplementationOnce(async (_target: string, message: string, opts?: unknown) => {
-        (opts as { onBeforeSendEcho?: (echoText: string) => void } | undefined)?.onBeforeSendEcho?.(
-          message,
-        );
-        return { messageId: "imsg-1", sentText: "first" };
-      })
-      .mockImplementationOnce(async (_target: string, message: string, opts?: unknown) => {
-        (opts as { onBeforeSendEcho?: (echoText: string) => void } | undefined)?.onBeforeSendEcho?.(
-          message,
-        );
-        return { messageId: "imsg-2", sentText: "second" };
-      });
+      .mockResolvedValueOnce({ messageId: "imsg-1", sentText: "first" })
+      .mockResolvedValueOnce({ messageId: "imsg-2", sentText: "second" });
 
     await deliverReplies({
       cfg: IMESSAGE_TEST_CFG,
@@ -235,11 +225,9 @@ describe("deliverReplies", () => {
       sentMessageCache: { remember },
     });
 
-    expect(remember).toHaveBeenCalledTimes(4);
+    expect(remember).toHaveBeenCalledTimes(2);
     expect(remember.mock.calls).toStrictEqual([
-      ["acct-3:chat_id:30", { text: "first" }],
       ["acct-3:chat_id:30", { text: "first", messageId: "imsg-1" }],
-      ["acct-3:chat_id:30", { text: "second" }],
       ["acct-3:chat_id:30", { text: "second", messageId: "imsg-2" }],
     ]);
     expect(remember).not.toHaveBeenCalledWith("acct-3:chat_id:30", {

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -54,11 +54,12 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
+          onBeforeSendEcho: (echoText) => {
+            sentMessageCache?.remember(scope, { text: echoText });
+          },
         });
-        // Post-send cache population (#47830): caching happens after each chunk is sent,
-        // not before. The window between send completion and cache write is sub-millisecond;
-        // the next SQLite inbound poll is 1-2s away, so no echo can arrive before the
-        // cache entry exists.
+        // Keep the returned message id too; the pre-send text entry closes the
+        // SQLite reflection race, while this preserves id-based matching.
         sentMessageCache?.remember(scope, {
           text: sent.echoText ?? sent.sentText,
           messageId: sent.messageId,
@@ -72,6 +73,9 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
+          onBeforeSendEcho: (echoText) => {
+            sentMessageCache?.remember(scope, { text: echoText });
+          },
         });
         sentMessageCache?.remember(scope, {
           text: sent.echoText ?? (sent.sentText || undefined),
@@ -92,11 +96,15 @@ export function createIMessageEchoCachingSend(params: {
 }): typeof sendMessageIMessage {
   return async (target, text, opts) => {
     const sanitizedText = sanitizeOutboundText(text);
+    const scope = `${params.accountId ?? opts.accountId ?? ""}:${target}`;
     const sent = await sendMessageIMessage(target, sanitizedText, {
       ...opts,
       client: params.client,
+      onBeforeSendEcho: (echoText) => {
+        params.sentMessageCache?.remember(scope, { text: echoText });
+        opts.onBeforeSendEcho?.(echoText);
+      },
     });
-    const scope = `${params.accountId ?? opts.accountId ?? ""}:${target}`;
     params.sentMessageCache?.remember(scope, {
       text: sent.echoText ?? (sent.sentText || undefined),
       messageId: sent.messageId,

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -54,12 +54,7 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
-          onBeforeSendEcho: (echoText) => {
-            sentMessageCache?.remember(scope, { text: echoText });
-          },
         });
-        // Keep the returned message id too; the pre-send text entry closes the
-        // SQLite reflection race, while this preserves id-based matching.
         sentMessageCache?.remember(scope, {
           text: sent.echoText ?? sent.sentText,
           messageId: sent.messageId,
@@ -73,9 +68,6 @@ export async function deliverReplies(params: {
           client,
           accountId,
           replyToId: payload.replyToId,
-          onBeforeSendEcho: (echoText) => {
-            sentMessageCache?.remember(scope, { text: echoText });
-          },
         });
         sentMessageCache?.remember(scope, {
           text: sent.echoText ?? (sent.sentText || undefined),
@@ -96,15 +88,11 @@ export function createIMessageEchoCachingSend(params: {
 }): typeof sendMessageIMessage {
   return async (target, text, opts) => {
     const sanitizedText = sanitizeOutboundText(text);
-    const scope = `${params.accountId ?? opts.accountId ?? ""}:${target}`;
     const sent = await sendMessageIMessage(target, sanitizedText, {
       ...opts,
       client: params.client,
-      onBeforeSendEcho: (echoText) => {
-        params.sentMessageCache?.remember(scope, { text: echoText });
-        opts.onBeforeSendEcho?.(echoText);
-      },
     });
+    const scope = `${params.accountId ?? opts.accountId ?? ""}:${target}`;
     params.sentMessageCache?.remember(scope, {
       text: sent.echoText ?? (sent.sentText || undefined),
       messageId: sent.messageId,

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -6,6 +6,11 @@ type SentMessageLookup = {
   messageId?: string;
 };
 
+type SentMessageLookupOptions = {
+  skipIdShortCircuit?: boolean;
+  includePendingText?: boolean;
+};
+
 export type SentMessageCache = {
   remember: (scope: string, lookup: SentMessageLookup) => void;
   /**
@@ -17,7 +22,11 @@ export type SentMessageCache = {
    *   that will never match the GUID outbound IDs, but text matching is still
    *   the right way to identify agent reply echoes.
    */
-  has: (scope: string, lookup: SentMessageLookup, skipIdShortCircuit?: boolean) => boolean;
+  has: (
+    scope: string,
+    lookup: SentMessageLookup,
+    options?: boolean | SentMessageLookupOptions,
+  ) => boolean;
 };
 
 // Echo arrival observed at ~2.2s on M4 Mac Mini (SQLite poll interval is the bottleneck).
@@ -70,9 +79,21 @@ class DefaultSentMessageCache implements SentMessageCache {
     this.cleanup();
   }
 
-  has(scope: string, lookup: SentMessageLookup, skipIdShortCircuit = false): boolean {
+  has(
+    scope: string,
+    lookup: SentMessageLookup,
+    options: boolean | SentMessageLookupOptions = false,
+  ): boolean {
     this.cleanup();
-    if (hasPersistedIMessageEcho({ scope, ...lookup })) {
+    const resolvedOptions =
+      typeof options === "boolean" ? { skipIdShortCircuit: options } : options;
+    if (
+      hasPersistedIMessageEcho({
+        scope,
+        ...lookup,
+        includePendingText: resolvedOptions.includePendingText,
+      })
+    ) {
       return true;
     }
     const textKey = normalizeEchoTextKey(lookup.text);
@@ -89,7 +110,7 @@ class DefaultSentMessageCache implements SentMessageCache {
       const hasTextOnlyMatch =
         typeof textTimestamp === "number" &&
         (!textBackedByIdTimestamp || textTimestamp > textBackedByIdTimestamp);
-      if (!skipIdShortCircuit && !hasTextOnlyMatch) {
+      if (!resolvedOptions.skipIdShortCircuit && !hasTextOnlyMatch) {
         return false;
       }
     }

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -193,6 +193,54 @@ function resolveInboundEchoMessageIds(message: IMessagePayload): string[] {
   return ids;
 }
 
+export function rememberIMessageSkippedFromMeForSelfChatDedupe(params: {
+  accountId: string;
+  message: IMessagePayload;
+  bodyText: string;
+  selfChatCache?: SelfChatCache;
+}): void {
+  if (params.message.is_from_me !== true) {
+    return;
+  }
+  const sender = params.message.sender?.trim();
+  if (!sender) {
+    return;
+  }
+  const chatId = params.message.chat_id ?? undefined;
+  const isGroup = Boolean(params.message.is_group);
+  const chatIdentifierNormalized =
+    normalizeIMessageHandle(params.message.chat_identifier ?? "") || undefined;
+  const destinationCallerIdNormalized =
+    normalizeIMessageHandle(params.message.destination_caller_id ?? "") || undefined;
+  const senderNormalized = normalizeIMessageHandle(sender);
+  const createdAt = params.message.created_at ? Date.parse(params.message.created_at) : undefined;
+  const lookup = {
+    accountId: params.accountId,
+    isGroup,
+    chatId,
+    sender,
+    text: params.bodyText.trim(),
+    createdAt,
+  };
+  const matchesSelfChatDestination =
+    destinationCallerIdNormalized != null && destinationCallerIdNormalized === senderNormalized;
+  const isSelfChat =
+    !isGroup &&
+    chatIdentifierNormalized != null &&
+    senderNormalized === chatIdentifierNormalized &&
+    matchesSelfChatDestination;
+  const isAmbiguousSelfThread =
+    !isGroup &&
+    chatIdentifierNormalized != null &&
+    senderNormalized === chatIdentifierNormalized &&
+    destinationCallerIdNormalized == null;
+  if (isSelfChat) {
+    params.selfChatCache?.remember({ ...lookup, allowCreatedAtSkew: true });
+  } else if (isAmbiguousSelfThread) {
+    params.selfChatCache?.remember(lookup);
+  }
+}
+
 function hasIMessageEchoMatch(params: {
   echoCache: {
     has: (

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -246,13 +246,14 @@ function hasIMessageEchoMatch(params: {
     has: (
       scope: string,
       lookup: { text?: string; messageId?: string },
-      skipIdShortCircuit?: boolean,
+      options?: boolean | { skipIdShortCircuit?: boolean; includePendingText?: boolean },
     ) => boolean;
   };
   scope: string | readonly string[];
   text?: string;
   messageIds: string[];
   skipIdShortCircuit?: boolean;
+  includePendingText?: boolean;
 }): boolean {
   // Outbound sends persist echo scopes keyed by whichever target shape was
   // used (chat_id, chat_guid, chat_identifier, or imessage:<handle>). Inbound
@@ -280,7 +281,10 @@ function hasIMessageEchoMatch(params: {
       params.echoCache.has(
         scope,
         { text: params.text, messageId: fallbackMessageId },
-        params.skipIdShortCircuit,
+        {
+          skipIdShortCircuit: params.skipIdShortCircuit,
+          includePendingText: params.includePendingText,
+        },
       )
     ) {
       return true;
@@ -397,7 +401,7 @@ export async function resolveIMessageInboundDecision(params: {
     has: (
       scope: string,
       lookup: { text?: string; messageId?: string },
-      skipIdShortCircuit?: boolean,
+      options?: boolean | { skipIdShortCircuit?: boolean; includePendingText?: boolean },
     ) => boolean;
   };
   selfChatCache?: SelfChatCache;
@@ -501,6 +505,7 @@ export async function resolveIMessageInboundDecision(params: {
           text: bodyText || undefined,
           messageIds: inboundMessageIds,
           skipIdShortCircuit: !hasInboundGuid,
+          includePendingText: true,
         })
       ) {
         return { kind: "drop", reason: "agent echo in self-chat" };
@@ -697,6 +702,7 @@ export async function resolveIMessageInboundDecision(params: {
         scope: echoScope,
         text: bodyText || undefined,
         messageIds: inboundMessageIds,
+        includePendingText: isSelfChat,
       })
     ) {
       params.logVerbose?.(

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
@@ -117,16 +117,21 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has(scope, { messageId: "id-only" })).toBe(true);
   });
 
-  it("expires short-lived pending persisted echoes", () => {
+  it("keeps short-lived pending persisted echoes out of generic text matching", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
     const scope = "acct:imessage:+1555";
 
-    rememberPersistedIMessageEcho({ scope, text: "pending-send", ttlMs: 1_000 });
-    expect(hasPersistedIMessageEcho({ scope, text: "pending-send" })).toBe(true);
+    rememberPersistedIMessageEcho({ scope, text: "pending-send", ttlMs: 1_000, pending: true });
+    expect(hasPersistedIMessageEcho({ scope, text: "pending-send" })).toBe(false);
+    expect(
+      hasPersistedIMessageEcho({ scope, text: "pending-send", includePendingText: true }),
+    ).toBe(true);
 
     vi.advanceTimersByTime(1_001);
-    expect(hasPersistedIMessageEcho({ scope, text: "pending-send" })).toBe(false);
+    expect(
+      hasPersistedIMessageEcho({ scope, text: "pending-send", includePendingText: true }),
+    ).toBe(false);
   });
 
   it("refreshes persisted echoes written after an earlier empty lookup", () => {

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
@@ -117,6 +117,18 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has(scope, { messageId: "id-only" })).toBe(true);
   });
 
+  it("expires short-lived pending persisted echoes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const scope = "acct:imessage:+1555";
+
+    rememberPersistedIMessageEcho({ scope, text: "pending-send", ttlMs: 1_000 });
+    expect(hasPersistedIMessageEcho({ scope, text: "pending-send" })).toBe(true);
+
+    vi.advanceTimersByTime(1_001);
+    expect(hasPersistedIMessageEcho({ scope, text: "pending-send" })).toBe(false);
+  });
+
   it("refreshes persisted echoes written after an earlier empty lookup", () => {
     const cache = createSentMessageCache();
     const scope = "acct:imessage:+1555";

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -93,6 +93,7 @@ import {
 } from "./inbound-dedupe.js";
 import {
   buildIMessageInboundContext,
+  rememberIMessageSkippedFromMeForSelfChatDedupe,
   resolveIMessageReactionContext,
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
@@ -728,14 +729,8 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     }
   }
 
-  async function handleMessageNowInner(rawMessage: IMessagePayload) {
-    const message = await repairMessageConversationAnchor(rawMessage);
-    if (!message) {
-      return;
-    }
-
+  function resolveIMessageInboundBodyText(message: IMessagePayload) {
     const messageText = (message.text ?? "").trim();
-
     const attachments = includeAttachments ? (message.attachments ?? []) : [];
     const effectiveAttachmentRoots = remoteHost ? remoteAttachmentRoots : attachmentRoots;
     const validAttachments = attachments.filter((entry) => {
@@ -769,7 +764,28 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       : validAttachments.length
         ? "<media:attachment>"
         : "";
-    const bodyText = messageText || placeholder;
+    return {
+      messageText,
+      bodyText: messageText || placeholder,
+      validAttachments,
+      rawMediaAttachments,
+      effectiveAttachmentRoots,
+    };
+  }
+
+  async function handleMessageNowInner(rawMessage: IMessagePayload) {
+    const message = await repairMessageConversationAnchor(rawMessage);
+    if (!message) {
+      return;
+    }
+
+    const {
+      messageText,
+      bodyText,
+      validAttachments,
+      rawMediaAttachments,
+      effectiveAttachmentRoots,
+    } = resolveIMessageInboundBodyText(message);
 
     // Approval reaction shortcut: if the inbound tapback resolves a pending
     // approval prompt, route it through the gateway and skip the normal
@@ -1498,6 +1514,15 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         config: catchupCfg,
         includeAttachments,
         dispatchPayload: (message) => handleMessageNow(message, { advanceCatchupCursor: false }),
+        observeSkippedFromMePayload: (message) => {
+          const { bodyText } = resolveIMessageInboundBodyText(message);
+          rememberIMessageSkippedFromMeForSelfChatDedupe({
+            accountId: accountInfo.accountId,
+            message,
+            bodyText,
+            selfChatCache,
+          });
+        },
         runtime,
       });
       liveCatchupCursorAdvanceEnabled =

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -9,6 +9,7 @@ type PersistedEchoEntry = {
   text?: string;
   messageId?: string;
   timestamp: number;
+  expiresAt?: number;
 };
 
 // 12h comfortably outlives the inbound replay guard window
@@ -65,13 +66,24 @@ function remainingTtlMs(timestamp: number): number | undefined {
   return remaining > 0 ? remaining : undefined;
 }
 
+function resolveEntryTtlMs(entry: PersistedEchoEntry, ttlMs?: number): number | undefined {
+  if (typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0) {
+    return ttlMs;
+  }
+  return remainingTtlMs(entry.timestamp);
+}
+
+function isLiveEntry(entry: PersistedEchoEntry, now = Date.now()): boolean {
+  const cutoff = now - IMESSAGE_SENT_ECHOES_TTL_MS;
+  return entry.timestamp >= cutoff && (entry.expiresAt == null || entry.expiresAt > now);
+}
+
 function loadMirrorFromStore(): void {
   try {
-    const cutoff = Date.now() - IMESSAGE_SENT_ECHOES_TTL_MS;
     mirror = openPersistedEchoStore()
       .entries()
       .map(({ value }) => value)
-      .filter((entry) => entry.timestamp >= cutoff)
+      .filter((entry) => isLiveEntry(entry))
       .toSorted((a, b) => a.timestamp - b.timestamp)
       .slice(-IMESSAGE_SENT_ECHOES_MAX_ENTRIES);
   } catch (err) {
@@ -85,23 +97,29 @@ function readRecentEntries(): PersistedEchoEntry[] {
   return mirror ?? [];
 }
 
-function persistEntry(entry: PersistedEchoEntry): void {
-  const ttlMs = remainingTtlMs(entry.timestamp);
-  if (!ttlMs) {
-    return;
+function persistEntry(entry: PersistedEchoEntry, ttlMs?: number): string | undefined {
+  const effectiveTtlMs = resolveEntryTtlMs(entry, ttlMs);
+  if (!effectiveTtlMs) {
+    return undefined;
   }
+  const key = resolveIMessageSentEchoEntryKey(entry);
   try {
-    openPersistedEchoStore().register(resolveIMessageSentEchoEntryKey(entry), entry, { ttlMs });
+    openPersistedEchoStore().register(key, entry, {
+      ttlMs: effectiveTtlMs,
+    });
   } catch (err) {
     reportFailure("write", err);
+    return undefined;
   }
+  return key;
 }
 
 export function rememberPersistedIMessageEcho(params: {
   scope: string;
   text?: string;
   messageId?: string;
-}): void {
+  ttlMs?: number;
+}): string | undefined {
   const text = normalizeText(params.text);
   const messageId = normalizeMessageId(params.messageId);
   const entry: PersistedEchoEntry = {
@@ -110,15 +128,30 @@ export function rememberPersistedIMessageEcho(params: {
     ...(text ? { text } : {}),
     ...(messageId ? { messageId } : {}),
   };
+  if (typeof params.ttlMs === "number" && Number.isFinite(params.ttlMs) && params.ttlMs > 0) {
+    entry.expiresAt = entry.timestamp + params.ttlMs;
+  }
   if (!entry.text && !entry.messageId) {
-    return;
+    return undefined;
   }
   loadMirrorFromStore();
-  persistEntry(entry);
-  const cutoff = Date.now() - IMESSAGE_SENT_ECHOES_TTL_MS;
+  const key = persistEntry(entry, params.ttlMs);
   mirror = [...(mirror ?? []), entry]
-    .filter((candidate) => candidate.timestamp >= cutoff)
+    .filter((candidate) => isLiveEntry(candidate))
     .slice(-IMESSAGE_SENT_ECHOES_MAX_ENTRIES);
+  return key;
+}
+
+export function forgetPersistedIMessageEchoKey(key: string | undefined): void {
+  if (!key) {
+    return;
+  }
+  try {
+    openPersistedEchoStore().delete(key);
+  } catch (err) {
+    reportFailure("delete", err);
+  }
+  mirror = (mirror ?? []).filter((entry) => resolveIMessageSentEchoEntryKey(entry) !== key);
 }
 
 export function hasPersistedIMessageEcho(params: {

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -10,6 +10,7 @@ type PersistedEchoEntry = {
   messageId?: string;
   timestamp: number;
   expiresAt?: number;
+  pending?: true;
 };
 
 // 12h comfortably outlives the inbound replay guard window
@@ -119,6 +120,7 @@ export function rememberPersistedIMessageEcho(params: {
   text?: string;
   messageId?: string;
   ttlMs?: number;
+  pending?: boolean;
 }): string | undefined {
   const text = normalizeText(params.text);
   const messageId = normalizeMessageId(params.messageId);
@@ -127,6 +129,7 @@ export function rememberPersistedIMessageEcho(params: {
     timestamp: Date.now(),
     ...(text ? { text } : {}),
     ...(messageId ? { messageId } : {}),
+    ...(params.pending ? { pending: true } : {}),
   };
   if (typeof params.ttlMs === "number" && Number.isFinite(params.ttlMs) && params.ttlMs > 0) {
     entry.expiresAt = entry.timestamp + params.ttlMs;
@@ -158,6 +161,7 @@ export function hasPersistedIMessageEcho(params: {
   scope: string;
   text?: string;
   messageId?: string;
+  includePendingText?: boolean;
 }): boolean {
   const text = normalizeText(params.text);
   const messageId = normalizeMessageId(params.messageId);
@@ -171,7 +175,7 @@ export function hasPersistedIMessageEcho(params: {
     if (messageId && entry.messageId === messageId) {
       return true;
     }
-    if (text && entry.text === text) {
+    if (text && entry.text === text && (!entry.pending || params.includePendingText)) {
       return true;
     }
   }

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -3,7 +3,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
 import { createSentMessageCache } from "./echo-cache.js";
-import { resolveIMessageInboundDecision } from "./inbound-processing.js";
+import {
+  rememberIMessageSkippedFromMeForSelfChatDedupe,
+  resolveIMessageInboundDecision,
+} from "./inbound-processing.js";
 import { resetPersistedIMessageEchoCacheForTest } from "./persisted-echo-cache.js";
 import { createSelfChatCache } from "./self-chat-cache.js";
 
@@ -657,6 +660,52 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
         },
         messageText: "Aha, neat!",
         bodyText: "Aha, neat!",
+        selfChatCache,
+      }),
+    );
+
+    expect(reflection).toEqual({ kind: "drop", reason: "self-chat echo" });
+  });
+
+  it("drops catchup-replayed self-chat reflection after observing skipped from-me companion", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T03:48:42Z"));
+
+    const selfChatCache = createSelfChatCache();
+    const text = "Exactly. I’ll treat assembled context as evidence only, not command authority.";
+
+    rememberIMessageSkippedFromMeForSelfChatDedupe({
+      accountId: "default",
+      message: {
+        id: 86798,
+        guid: "F502C080-08E9-4C3B-9650-31A0DF21FE3A",
+        sender: "+15555550123",
+        chat_identifier: "+15555550123",
+        destination_caller_id: "+15555550123",
+        text,
+        created_at: "2026-06-03T03:48:28.922Z",
+        is_from_me: true,
+        is_group: false,
+      },
+      bodyText: text,
+      selfChatCache,
+    });
+
+    const reflection = await resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 86799,
+          guid: "1759A121-E3DB-41C2-B16A-AB6DE30570F2",
+          sender: "+15555550123",
+          chat_identifier: "+15555550123",
+          destination_caller_id: "tel:+15555550123",
+          text,
+          created_at: "2026-06-03T03:48:28.738Z",
+          is_from_me: false,
+          is_group: false,
+        },
+        messageText: text,
+        bodyText: text,
         selfChatCache,
       }),
     );

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -7,7 +7,10 @@ import {
   rememberIMessageSkippedFromMeForSelfChatDedupe,
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
-import { resetPersistedIMessageEchoCacheForTest } from "./persisted-echo-cache.js";
+import {
+  rememberPersistedIMessageEcho,
+  resetPersistedIMessageEchoCacheForTest,
+} from "./persisted-echo-cache.js";
 import { createSelfChatCache } from "./self-chat-cache.js";
 
 /**
@@ -904,6 +907,70 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
 });
 
 describe("echo cache — text fallback for null-id inbound messages", () => {
+  it("does not drop normal DM text from a pending pre-send marker", async () => {
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+    const scope = "default:imessage:+15551234567";
+    rememberPersistedIMessageEcho({
+      scope,
+      text: "same pending text",
+      ttlMs: 155_000,
+      pending: true,
+    });
+
+    const decision = await resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 12001,
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
+          destination_caller_id: "+15550001111",
+          text: "same pending text",
+          is_from_me: false,
+          is_group: false,
+        },
+        messageText: "same pending text",
+        bodyText: "same pending text",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    expect(decision.kind).toBe("dispatch");
+  });
+
+  it("drops self-chat reflected text from a pending pre-send marker", async () => {
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+    const scope = "default:imessage:+15551234567";
+    rememberPersistedIMessageEcho({
+      scope,
+      text: "pending self-chat reply",
+      ttlMs: 155_000,
+      pending: true,
+    });
+
+    const decision = await resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 12002,
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
+          destination_caller_id: "tel:+15551234567",
+          text: "pending self-chat reply",
+          is_from_me: false,
+          is_group: false,
+        },
+        messageText: "pending self-chat reply",
+        bodyText: "pending self-chat reply",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    expect(decision).toEqual({ kind: "drop", reason: "echo" });
+  });
+
   it("still identifies echo via text when inbound message has id: null", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -698,6 +698,38 @@ describe("sendMessageIMessage receipts", () => {
     await expect(send).resolves.toMatchObject({ messageId: "p:0/imsg-1" });
   });
 
+  it("keeps the pending echo marker alive for slow default-timeout sends", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-04T00:00:00Z"));
+    let resolveRequest!: (value: Record<string, unknown>) => void;
+    const client = {
+      request: vi.fn(
+        () =>
+          new Promise<Record<string, unknown>>((resolve) => {
+            resolveRequest = resolve;
+          }),
+      ),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    const send = sendMessageIMessage("+15551234567", "slow hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+    });
+    expect(getClientMocks(client).request).toHaveBeenCalled();
+
+    vi.advanceTimersByTime(61_000);
+    expect(
+      hasPersistedIMessageEcho({
+        scope: "default:imessage:+15551234567",
+        text: "slow hello",
+      }),
+    ).toBe(true);
+
+    resolveRequest({ guid: "p:0/imsg-slow" });
+    await expect(send).resolves.toMatchObject({ messageId: "p:0/imsg-slow" });
+  });
+
   it("resolves numeric chat.db ROWIDs to GUIDs for approval reaction binding", async () => {
     const client = createClient({ message_id: 12345 });
     const resolveMessageGuidImpl = vi.fn(async () => "p:0/resolved-guid");

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -669,6 +669,35 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.platformMessageIds).toStrictEqual([]);
   });
 
+  it("persists an echo marker before awaiting the bridge send result", async () => {
+    let resolveRequest!: (value: Record<string, unknown>) => void;
+    const client = {
+      request: vi.fn(
+        () =>
+          new Promise<Record<string, unknown>>((resolve) => {
+            resolveRequest = resolve;
+          }),
+      ),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    const send = sendMessageIMessage("+15551234567", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+    });
+
+    await vi.waitFor(() => expect(getClientMocks(client).request).toHaveBeenCalled());
+    expect(
+      hasPersistedIMessageEcho({
+        scope: "default:imessage:+15551234567",
+        text: "hello",
+      }),
+    ).toBe(true);
+
+    resolveRequest({ guid: "p:0/imsg-1" });
+    await expect(send).resolves.toMatchObject({ messageId: "p:0/imsg-1" });
+  });
+
   it("resolves numeric chat.db ROWIDs to GUIDs for approval reaction binding", async () => {
     const client = createClient({ message_id: 12345 });
     const resolveMessageGuidImpl = vi.fn(async () => "p:0/resolved-guid");

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -691,6 +691,7 @@ describe("sendMessageIMessage receipts", () => {
       hasPersistedIMessageEcho({
         scope: "default:imessage:+15551234567",
         text: "hello",
+        includePendingText: true,
       }),
     ).toBe(true);
 
@@ -723,6 +724,7 @@ describe("sendMessageIMessage receipts", () => {
       hasPersistedIMessageEcho({
         scope: "default:imessage:+15551234567",
         text: "slow hello",
+        includePendingText: true,
       }),
     ).toBe(true);
 

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -81,7 +81,6 @@ type IMessageSendOpts = {
     text: string;
     sentAfterMs?: number;
   }) => Promise<string | null> | string | null;
-  onBeforeSendEcho?: (echoText: string) => void;
 };
 
 export type IMessageSendResult = {
@@ -1030,9 +1029,6 @@ export async function sendMessageIMessage(
           text: echoText,
           ttlMs: pendingEchoTtlMs,
         });
-      }
-      if (echoText) {
-        opts.onBeforeSendEcho?.(echoText);
       }
       result = await client.request<Record<string, unknown>>("send", params, {
         timeoutMs,

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -41,7 +41,8 @@ import {
 
 const require = createRequire(import.meta.url);
 type ParsedIMessageTarget = ReturnType<typeof parseIMessageTarget>;
-const PENDING_PERSISTED_ECHO_TTL_MS = 60_000;
+const MIN_PENDING_PERSISTED_ECHO_TTL_MS = 60_000;
+const PENDING_PERSISTED_ECHO_GRACE_MS = 5_000;
 
 type IMessageSendOpts = {
   cliPath?: string;
@@ -691,6 +692,13 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function resolvePendingPersistedEchoTtlMs(timeoutMs: number): number {
+  return Math.max(
+    MIN_PENDING_PERSISTED_ECHO_TTL_MS,
+    Math.max(0, timeoutMs) + PENDING_PERSISTED_ECHO_GRACE_MS,
+  );
+}
+
 function isAttachmentCommandFallbackError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /(?:unknown|unrecognized|invalid|unsupported)\s+(?:command|subcommand)|not a recognized command|send-attachment.*(?:not found|unsupported|unavailable)|private api bridge.*unavailable|requires the imsg private api bridge|run imsg launch/iu.test(
@@ -739,6 +747,7 @@ async function trySendAttachmentForTarget(params: {
   audioAsVoice?: boolean;
   replyToId?: string;
   echoText?: string;
+  pendingEchoTtlMs: number;
   runCliJson: (args: readonly string[]) => Promise<Record<string, unknown>>;
   resolveMessageGuidImpl?: IMessageSendOpts["resolveMessageGuidImpl"];
 }): Promise<IMessageSendResult | null> {
@@ -770,7 +779,7 @@ async function trySendAttachmentForTarget(params: {
       pendingEchoKey = rememberPersistedIMessageEcho({
         scope: echoScope,
         text: params.echoText,
-        ttlMs: PENDING_PERSISTED_ECHO_TTL_MS,
+        ttlMs: params.pendingEchoTtlMs,
       });
     }
     result = await params.runCliJson([
@@ -878,6 +887,7 @@ export async function sendMessageIMessage(
   // for callers that tuned them. See DEFAULT_IMESSAGE_SEND_TIMEOUT_MS.
   const timeoutMs =
     opts.timeoutMs ?? account.config.probeTimeoutMs ?? DEFAULT_IMESSAGE_SEND_TIMEOUT_MS;
+  const pendingEchoTtlMs = resolvePendingPersistedEchoTtlMs(timeoutMs);
   const region = opts.region?.trim() || account.config.region?.trim() || "US";
   const maxBytes =
     typeof opts.maxBytes === "number"
@@ -944,6 +954,7 @@ export async function sendMessageIMessage(
       audioAsVoice: opts.audioAsVoice,
       ...(resolvedReplyToId ? { replyToId: resolvedReplyToId } : {}),
       echoText: attachmentEchoText,
+      pendingEchoTtlMs,
       runCliJson,
       resolveMessageGuidImpl: opts.resolveMessageGuidImpl,
     });
@@ -1017,7 +1028,7 @@ export async function sendMessageIMessage(
         pendingEchoKey = rememberPersistedIMessageEcho({
           scope: echoScope,
           text: echoText,
-          ttlMs: PENDING_PERSISTED_ECHO_TTL_MS,
+          ttlMs: pendingEchoTtlMs,
         });
       }
       if (echoText) {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -779,6 +779,7 @@ async function trySendAttachmentForTarget(params: {
         scope: echoScope,
         text: params.echoText,
         ttlMs: params.pendingEchoTtlMs,
+        pending: true,
       });
     }
     result = await params.runCliJson([
@@ -1028,6 +1029,7 @@ export async function sendMessageIMessage(
           scope: echoScope,
           text: echoText,
           ttlMs: pendingEchoTtlMs,
+          pending: true,
         });
       }
       result = await client.request<Record<string, unknown>>("send", params, {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -28,7 +28,10 @@ import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
 import { DEFAULT_IMESSAGE_SEND_TIMEOUT_MS } from "./constants.js";
 import { extractMarkdownFormatRuns } from "./markdown-format.js";
 import { rememberIMessageReplyCache } from "./monitor-reply-cache.js";
-import { rememberPersistedIMessageEcho } from "./monitor/persisted-echo-cache.js";
+import {
+  forgetPersistedIMessageEchoKey,
+  rememberPersistedIMessageEcho,
+} from "./monitor/persisted-echo-cache.js";
 import {
   formatIMessageChatTarget,
   type IMessageService,
@@ -38,6 +41,7 @@ import {
 
 const require = createRequire(import.meta.url);
 type ParsedIMessageTarget = ReturnType<typeof parseIMessageTarget>;
+const PENDING_PERSISTED_ECHO_TTL_MS = 60_000;
 
 type IMessageSendOpts = {
   cliPath?: string;
@@ -76,6 +80,7 @@ type IMessageSendOpts = {
     text: string;
     sentAfterMs?: number;
   }) => Promise<string | null> | string | null;
+  onBeforeSendEcho?: (echoText: string) => void;
 };
 
 export type IMessageSendResult = {
@@ -754,8 +759,20 @@ async function trySendAttachmentForTarget(params: {
     return null;
   }
 
+  const echoScope = resolveOutboundEchoScope({
+    accountId: params.accountId,
+    target: params.target,
+  });
   let result: Record<string, unknown>;
+  let pendingEchoKey: string | undefined;
   try {
+    if (echoScope) {
+      pendingEchoKey = rememberPersistedIMessageEcho({
+        scope: echoScope,
+        text: params.echoText,
+        ttlMs: PENDING_PERSISTED_ECHO_TTL_MS,
+      });
+    }
     result = await params.runCliJson([
       "send-attachment",
       "--chat",
@@ -768,6 +785,7 @@ async function trySendAttachmentForTarget(params: {
       "auto",
     ]);
   } catch (error) {
+    forgetPersistedIMessageEchoKey(pendingEchoKey);
     if (isAttachmentCommandFallbackError(error)) {
       return null;
     }
@@ -776,6 +794,7 @@ async function trySendAttachmentForTarget(params: {
   const failure = resolveIMessageCliFailure(result);
   if (failure) {
     const error = new Error(failure);
+    forgetPersistedIMessageEchoKey(pendingEchoKey);
     if (isAttachmentCommandFallbackError(error)) {
       return null;
     }
@@ -790,10 +809,6 @@ async function trySendAttachmentForTarget(params: {
     resolveMessageGuidImpl: params.resolveMessageGuidImpl,
   });
   const messageId = resolvedId ?? (result.ok || result.success ? "ok" : "unknown");
-  const echoScope = resolveOutboundEchoScope({
-    accountId: params.accountId,
-    target: params.target,
-  });
   if (echoScope) {
     rememberPersistedIMessageEcho({
       scope: echoScope,
@@ -985,6 +1000,8 @@ export async function sendMessageIMessage(
     params.to = target.to;
   }
 
+  const echoScope = resolveOutboundEchoScope({ accountId: account.accountId, target });
+
   const client =
     opts.client ??
     (opts.createClient
@@ -993,8 +1010,19 @@ export async function sendMessageIMessage(
   const shouldClose = !opts.client;
   let result: Record<string, unknown>;
   const sendStartedAtMs = Date.now();
+  let pendingEchoKey: string | undefined;
   try {
     try {
+      if (echoScope) {
+        pendingEchoKey = rememberPersistedIMessageEcho({
+          scope: echoScope,
+          text: echoText,
+          ttlMs: PENDING_PERSISTED_ECHO_TTL_MS,
+        });
+      }
+      if (echoText) {
+        opts.onBeforeSendEcho?.(echoText);
+      }
       result = await client.request<Record<string, unknown>>("send", params, {
         timeoutMs,
       });
@@ -1053,7 +1081,6 @@ export async function sendMessageIMessage(
         resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
       });
     }
-    const echoScope = resolveOutboundEchoScope({ accountId: account.accountId, target });
     if (echoScope) {
       rememberPersistedIMessageEcho({
         scope: echoScope,
@@ -1109,6 +1136,9 @@ export async function sendMessageIMessage(
         ...(resolvedReplyToId ? { replyToId: resolvedReplyToId } : {}),
       }),
     };
+  } catch (error) {
+    forgetPersistedIMessageEchoKey(pendingEchoKey);
+    throw error;
   } finally {
     if (shouldClose) {
       await client.stop();


### PR DESCRIPTION
## Summary
- persist a short-lived iMessage echo marker before invoking the bridge send call, closing the race where Messages reflects the outbound row before post-send echo persistence finishes
- keep the existing post-send durable marker with the real message id for long catchup windows
- wire the pre-send echo hook through durable iMessage delivery paths and expire failed pre-send markers quickly

## Real behavior proof
- Behavior or issue addressed: Messages self-chat can reflect an assistant outbound reply as an inbound-looking `is_from_me=false` row before OpenClaw writes the post-send persisted echo marker. That lets the iMessage monitor feed the assistant its own reply and can restart the acknowledgement loop.
- Real environment tested: a live macOS Messages setup using the owner's self-chat, with private local paths, phone numbers, chat ids, and message GUIDs redacted below.

- Exact steps or command run after this patch: ran `openclaw --version`; sent a unique proof message through the live iMessage channel with `openclaw message send --channel imessage --target <owner-self-chat> --message OPENCLAW-88969-PROOF-20260604T002906Z --json`; waited 20 seconds; queried the local Messages SQLite database for the proof token; searched the active main session transcript for the proof token.
- Evidence after fix: live send returned `handledBy: core`, `dryRun: false`, and `messageId: ok`; local Messages rows showed the known self-chat reflection shape with an empty `is_from_me=1` companion row and an `is_from_me=0` reflected row containing `OPENCLAW-88969-PROOF-20260604T002906Z`; the active session transcript contained the proof token only as an assistant `delivery-mirror` entry, not as a user/inbound iMessage prompt.
- Observed result after fix: the live self-chat reflection row was not routed back to the agent as a new inbound user turn, and no acknowledgement loop or automatic assistant response was triggered by the proof token.
- What was not tested: private phone number, local DB path, chat ids, and GUIDs are redacted; the broader mirror-pair refactor is not claimed; the exact public PR head was not rebuilt/restarted into the Gateway for this proof because the already-running live Gateway contained the iMessage echo fixes under local build `120691e`, while CI/local checks cover the current PR branch.

### Pre-fix live evidence
Before this patch, the live Messages database showed reflected outbound self-chat rows arriving before the post-send persisted echo marker was written. The representative live rows had this shape:

```text
<row>|2026-06-01 03:48:10|0|<owner-self-chat>|<chat>|<owner-self-chat>|<guid>|'<assistant outbound text reflected as inbound-looking row>'|tel:<owner-self-chat>
<row>|2026-06-01 03:48:10|1|<owner-self-chat>|<chat>|<owner-self-chat>|<guid>|NULL|<owner-self-chat>
<row>|2026-06-01 03:48:19|0|<owner-self-chat>|<chat>|<owner-self-chat>|<guid>|'<assistant outbound text reflected as inbound-looking row>'|tel:<owner-self-chat>
<row>|2026-06-01 03:48:19|1|<owner-self-chat>|<chat>|<owner-self-chat>|<guid>|NULL|<owner-self-chat>
```

The matching persisted echo entries existed, but their write timestamps were later than the reflected rows, confirming the post-send-only marker was too late for this path:

```text
{"scope":"default:imessage:<owner-self-chat>","text":"<assistant outbound text>","timestamp":"<after reflected row>"}
{"scope":"default:imessage:<owner-self-chat>","text":"<assistant outbound text>","timestamp":"<after reflected row>"}
```

### Patched-live runtime evidence
The patched branch was then applied to the live OpenClaw installation as part of the combined iMessage fix branch:

```text
$ openclaw --version
OpenClaw 2026.6.2 (8df0d41)

$ git -C <openclaw-checkout> status --short --branch
## local/live-imsg-88530-88969-2026-06-02

$ git -C <openclaw-checkout> log -1 --oneline
8df0d41e4e Merge remote-tracking branch 'fork/fix-imessage-presend-persisted-echo' into local/live-imsg-88530-88969-2026-06-02
```

The live Gateway was rebuilt from that combined branch with `CI=true pnpm build`, restarted, and probed successfully:

```text
CLI version: 2026.6.2
Gateway version: 2026.6.2
Runtime: running
Connectivity probe: ok
```

The live recovery also confirmed the OpenClaw channel stack was functional again after restart: Telegram delivery resumed, iMessage was up, and the running Gateway was using the patched `dist` built from the combined branch.

### Focused after-fix tests
The new regression holds the bridge send promise open and confirms the echo marker is persisted before the bridge result resolves, which is the exact timing gap observed in the live rows. Focused tests passed:

```text
Test Files  4 passed (4)
Tests  80 passed (80)
[test] passed 1 Vitest shard in 29.85s
```

After the later refresh/rebase, the focused touched-test shard also passed:

```text
extensions/imessage/src/monitor/deliver.test.ts
extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
extensions/imessage/src/send.test.ts

3 files / 49 tests passed
```

`oxlint` on all touched iMessage files also completed with exit code 0.

### What was not claimed
No private phone number, local Messages path, chat id, or message GUID is intentionally published here. No secrets are included.

This proof does not claim an additional public, unredacted live iMessage transcript. It shows the real pre-fix database race, the patched branch running in the live Gateway after rebuild/restart, and focused tests for the pre-send timing behavior.

## Verification
- `node scripts/run-vitest.mjs extensions/imessage/src/monitor/deliver.test.ts extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts extensions/imessage/src/send.test.ts` -> 3 files, 49 tests passed
- `CI=true pnpm oxlint extensions/imessage/src/monitor/deliver.ts extensions/imessage/src/monitor/deliver.test.ts extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts extensions/imessage/src/monitor/persisted-echo-cache.ts extensions/imessage/src/send.ts extensions/imessage/src/send.test.ts` -> passed
- `git diff --check upstream/main...HEAD` -> passed
- live patched runtime verification: `openclaw --version` reported `OpenClaw 2026.6.2 (8df0d41)`, Gateway reported CLI and Gateway version `2026.6.2`, runtime `running`, and connectivity probe `ok`


