### PR TITLE
fix #85871: [Bug]: Heartbeat scheduler silently fails to fire on 5.20 and all 5.x versions (regression from 4.23)

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -15,6 +15,11 @@ import {
   type FollowupRun,
   type QueueSettings,
 } from "./queue.js";
+import {
+  REPLY_OPERATION_RUN_STATE,
+  type ReplyOperationRunState,
+  type ReplyOptionsWithOperationRunState,
+} from "./reply-operation-run-state.js";
 import { createReplyOperation, testing as replyRunTesting } from "./reply-run-registry.js";
 import { consumeReplyUsageState } from "./reply-usage-state.js";
 import { createMockTypingController } from "./test-helpers.js";
@@ -152,7 +157,7 @@ beforeEach(() => {
 });
 
 function createMinimalRun(params?: {
-  opts?: GetReplyOptions;
+  opts?: GetReplyOptions & ReplyOptionsWithOperationRunState;
   resolvedVerboseLevel?: "off" | "on";
   sessionStore?: Record<string, SessionEntry>;
   sessionEntry?: SessionEntry;
@@ -245,13 +250,14 @@ function createMinimalRun(params?: {
 
 describe("runReplyAgent heartbeat followup guard", () => {
   it("drops heartbeat runs when reply-lane admission finds an active owner", async () => {
+    const runState: ReplyOperationRunState = {};
     const active = createReplyOperation({
       sessionKey: "main",
       sessionId: "active-session",
       resetTriggered: false,
     });
     const { run, typing } = createMinimalRun({
-      opts: { isHeartbeat: true },
+      opts: { isHeartbeat: true, [REPLY_OPERATION_RUN_STATE]: runState },
       isActive: false,
       shouldFollowup: false,
     });
@@ -261,7 +267,19 @@ describe("runReplyAgent heartbeat followup guard", () => {
     expect(result).toBeUndefined();
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
     expect(typing.cleanup).toHaveBeenCalledTimes(1);
+    expect(runState.admission).toEqual({ status: "skipped", reason: "active-run" });
     active.complete();
+  });
+
+  it("records the operation owned by an admitted heartbeat run", async () => {
+    const runState: ReplyOperationRunState = {};
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: true, [REPLY_OPERATION_RUN_STATE]: runState },
+    });
+
+    await run();
+
+    expect(runState.admission).toEqual({ status: "owned" });
   });
 
   it("runs visible turns with the session id returned by admission", async () => {
@@ -315,8 +333,12 @@ describe("runReplyAgent heartbeat followup guard", () => {
   it("drops runs when reply-lane admission sees an already-aborted caller", async () => {
     const abortController = new AbortController();
     abortController.abort();
+    const runState: ReplyOperationRunState = {};
     const { run, typing } = createMinimalRun({
-      opts: { abortSignal: abortController.signal },
+      opts: {
+        abortSignal: abortController.signal,
+        [REPLY_OPERATION_RUN_STATE]: runState,
+      },
       isActive: false,
       shouldFollowup: false,
     });
@@ -326,11 +348,13 @@ describe("runReplyAgent heartbeat followup guard", () => {
     expect(result).toBeUndefined();
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
     expect(typing.cleanup).toHaveBeenCalledTimes(1);
+    expect(runState.admission).toEqual({ status: "skipped", reason: "aborted" });
   });
 
   it("drops heartbeat runs when another run is active", async () => {
+    const runState: ReplyOperationRunState = {};
     const { run, typing } = createMinimalRun({
-      opts: { isHeartbeat: true },
+      opts: { isHeartbeat: true, [REPLY_OPERATION_RUN_STATE]: runState },
       isActive: true,
       shouldFollowup: true,
       resolvedQueueMode: "collect",
@@ -342,6 +366,7 @@ describe("runReplyAgent heartbeat followup guard", () => {
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
     expect(typing.cleanup).toHaveBeenCalledTimes(1);
+    expect(runState.admission).toEqual({ status: "skipped", reason: "active-run" });
   });
 
   it("drops heartbeat runs before steering active streams", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -118,6 +118,7 @@ import {
   type QueueSettings,
 } from "./queue.js";
 import { createReplyMediaContext } from "./reply-media-paths.js";
+import { resolveReplyOperationRunState } from "./reply-operation-run-state.js";
 import {
   replyRunRegistry,
   runAfterReplyOperationClear,
@@ -1202,6 +1203,7 @@ export async function runReplyAgent(params: {
   const activeRunQueueMode = effectiveResetTriggered ? "interrupt" : resolvedQueue.mode;
 
   const isHeartbeat = opts?.isHeartbeat === true;
+  const replyOperationRunState = resolveReplyOperationRunState(opts);
   const traceAttributes = {
     provider: followupRun.run.provider,
     hasSessionKey: Boolean(sessionKey ?? followupRun.run.sessionKey),
@@ -1295,6 +1297,9 @@ export async function runReplyAgent(params: {
   });
 
   if (activeRunQueueAction === "drop") {
+    if (replyOperationRunState) {
+      replyOperationRunState.admission = { status: "skipped", reason: "active-run" };
+    }
     typing.cleanup();
     return undefined;
   }
@@ -1405,6 +1410,9 @@ export async function runReplyAgent(params: {
   let replyOperation: ReplyOperation;
   if (providedReplyOperation) {
     replyOperation = providedReplyOperation;
+    if (replyOperationRunState) {
+      replyOperationRunState.admission = { status: "owned" };
+    }
   } else {
     const replyTurnKind = resolveReplyTurnKind(opts);
     const admission = await admitReplyTurn({
@@ -1415,6 +1423,12 @@ export async function runReplyAgent(params: {
       routeThreadId: replyRouteThreadId,
       upstreamAbortSignal: opts?.abortSignal,
     });
+    if (replyOperationRunState) {
+      replyOperationRunState.admission =
+        admission.status === "owned"
+          ? { status: "owned" }
+          : { status: "skipped", reason: admission.reason };
+    }
     if (admission.status === "skipped") {
       typing.cleanup();
       if (admission.reason !== "active-run" || replyTurnKind !== "visible") {

--- a/src/auto-reply/reply/reply-operation-run-state.ts
+++ b/src/auto-reply/reply/reply-operation-run-state.ts
@@ -1,0 +1,21 @@
+export type ReplyOperationAdmissionSnapshot =
+  | { status: "owned" }
+  | { status: "skipped"; reason: "active-run" | "aborted" };
+
+export type ReplyOperationRunState = {
+  admission?: ReplyOperationAdmissionSnapshot;
+};
+
+// Carries this invocation's admission decision through reply option spreads so
+// heartbeat cleanup never infers it from whichever operation is active later.
+export const REPLY_OPERATION_RUN_STATE = Symbol("openclaw.replyOperationRunState");
+
+export type ReplyOptionsWithOperationRunState = {
+  [REPLY_OPERATION_RUN_STATE]?: ReplyOperationRunState;
+};
+
+export function resolveReplyOperationRunState(
+  options: object | undefined,
+): ReplyOperationRunState | undefined {
+  return (options as ReplyOptionsWithOperationRunState | undefined)?.[REPLY_OPERATION_RUN_STATE];
+}

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -706,6 +706,7 @@ describe("runHeartbeatOnce", () => {
     options?: {
       nowMs?: number;
       getReplyFromConfig?: HeartbeatDeps["getReplyFromConfig"];
+      listActiveEmbeddedRunSessionKeys?: HeartbeatDeps["listActiveEmbeddedRunSessionKeys"];
     },
   ): HeartbeatDeps => ({
     whatsapp: sendWhatsApp,
@@ -714,6 +715,9 @@ describe("runHeartbeatOnce", () => {
     webAuthExists: async () => true,
     hasActiveWebListener: () => true,
     ...(options?.getReplyFromConfig ? { getReplyFromConfig: options.getReplyFromConfig } : null),
+    ...(options?.listActiveEmbeddedRunSessionKeys
+      ? { listActiveEmbeddedRunSessionKeys: options.listActiveEmbeddedRunSessionKeys }
+      : null),
   });
 
   it("skips when agent heartbeat is not enabled", async () => {
@@ -729,6 +733,33 @@ describe("runHeartbeatOnce", () => {
     if (res.status === "skipped") {
       expect(res.reason).toBe("disabled");
     }
+  });
+
+  it.each([
+    ["the heartbeat main session", (cfg: OpenClawConfig) => resolveMainSessionKey(cfg)],
+    ["another session for the same agent", () => "agent:main:telegram:alerts"],
+  ])("retries instead of dispatching while %s has an embedded run", async (_name, activeKey) => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: { every: "5m", target: "none" },
+        },
+      },
+    };
+    const replySpy = vi.fn().mockResolvedValue({ text: "heartbeat reply" });
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    const res = await runHeartbeatOnce({
+      cfg,
+      deps: createHeartbeatDeps(sendWhatsApp, {
+        getReplyFromConfig: replySpy,
+        listActiveEmbeddedRunSessionKeys: () => [activeKey(cfg)],
+      }),
+    });
+
+    expect(res).toEqual({ status: "skipped", reason: "requests-in-flight" });
+    expect(replySpy).not.toHaveBeenCalled();
+    expect(sendWhatsApp).not.toHaveBeenCalled();
   });
 
   it("skips outside active hours", async () => {

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -360,6 +360,39 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     });
   });
 
+  it("returns requests-in-flight when reply admission races after the preflight checks", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      const sessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+      let operation: ReturnType<typeof createReplyOperation> | undefined;
+      const replySpy = vi.fn(async () => {
+        operation = createReplyOperation({
+          sessionKey,
+          sessionId: "racing-visible-session",
+          resetTriggered: false,
+        });
+        operation.setPhase("running");
+        return undefined;
+      });
+
+      try {
+        const result = await runHeartbeatOnce({
+          cfg,
+          deps: {
+            getQueueSize: vi.fn((_lane?: string) => 0),
+            nowMs: () => Date.now(),
+            getReplyFromConfig: replySpy,
+          } as HeartbeatDeps,
+        });
+
+        expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+        expect(replySpy).toHaveBeenCalledOnce();
+      } finally {
+        operation?.complete();
+      }
+    });
+  });
+
   it("returns requests-in-flight when an isolated heartbeat reply run is still active", async () => {
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
       const cfg = createHeartbeatTelegramConfig();

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -1,6 +1,7 @@
 // Covers heartbeat skipping while session lanes or cron jobs are busy.
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveNestedAgentLaneForSession } from "../agents/lanes.js";
+import { resolveReplyOperationRunState } from "../auto-reply/reply/reply-operation-run-state.js";
 import {
   __testing as replyRunRegistryTesting,
   createReplyOperation,
@@ -360,12 +361,17 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     });
   });
 
-  it("returns requests-in-flight when reply admission races after the preflight checks", async () => {
+  it("does not infer admission rejection from a replacement run after an empty heartbeat", async () => {
     await withTempHeartbeatSandbox(async ({ storePath }) => {
       const cfg = createHeartbeatTelegramConfig();
       const sessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
       let operation: ReturnType<typeof createReplyOperation> | undefined;
-      const replySpy = vi.fn(async () => {
+      const replySpy = vi.fn(async (_ctx, replyOptions) => {
+        const runState = resolveReplyOperationRunState(replyOptions);
+        if (!runState) {
+          throw new Error("expected heartbeat reply operation state");
+        }
+        runState.admission = { status: "owned" };
         operation = createReplyOperation({
           sessionKey,
           sessionId: "racing-visible-session",
@@ -385,7 +391,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
           } as HeartbeatDeps,
         });
 
-        expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+        expect(result.status).toBe("ran");
         expect(replySpy).toHaveBeenCalledOnce();
       } finally {
         operation?.complete();

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1816,6 +1816,19 @@ export async function runHeartbeatOnce(opts: {
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const heartbeatToolResponse = resolveHeartbeatToolResponseFromReplyResult(replyResult);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
+    if (
+      !heartbeatToolResponse &&
+      (!replyPayload || !hasOutboundReplyContent(replyPayload)) &&
+      (isReplyRunActive(runSessionKey) ||
+        hasActiveRunForSession(runSessionKey, listActiveEmbeddedRuns))
+    ) {
+      emitHeartbeatEvent({
+        status: "skipped",
+        reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+        durationMs: Date.now() - startedAt,
+      });
+      return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
+    }
     const includeReasoning = heartbeat?.includeReasoning === true;
     const reasoningPayloads = includeReasoning
       ? resolveHeartbeatReasoningPayloads(replyResult).filter((payload) => payload !== replyPayload)

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -20,6 +20,7 @@ import {
 } from "../agents/agent-scope.js";
 import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
 import { resolveEmbeddedSessionLane } from "../agents/embedded-agent-runner/lanes.js";
+import { listActiveEmbeddedRunSessionKeys } from "../agents/embedded-agent-runner/run-state.js";
 import { formatReasoningMessage } from "../agents/embedded-agent-utils.js";
 import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelRefFromString, type ModelRef } from "../agents/model-selection.js";
@@ -155,6 +156,7 @@ export type HeartbeatDeps = OutboundSendDeps &
     getCommandLaneSnapshots?: () => readonly CommandLaneSnapshot[];
     isReplyRunActive?: (sessionKey: string) => boolean;
     listActiveReplyRunSessionKeys?: () => readonly string[];
+    listActiveEmbeddedRunSessionKeys?: () => readonly string[];
     nowMs?: () => number;
   };
 
@@ -229,15 +231,20 @@ function hasAgentOptInBusyLaneWork(
   return hasQueuedWorkInLaneSnapshots(getSnapshots(), (lane) => laneBelongsToAgent(lane, agentId));
 }
 
-function hasActiveReplyRunForAgent(
-  agentId: string,
-  listSessionKeys: () => readonly string[],
-): boolean {
+function hasActiveRunForAgent(agentId: string, listSessionKeys: () => readonly string[]): boolean {
   const normalizedAgentId = normalizeAgentId(agentId);
   return listSessionKeys().some((sessionKey) => {
     const parsed = parseAgentSessionKey(sessionKey);
     return parsed ? normalizeAgentId(parsed.agentId) === normalizedAgentId : false;
   });
+}
+
+function hasActiveRunForSession(
+  sessionKey: string,
+  listSessionKeys: () => readonly string[],
+): boolean {
+  const normalizedSessionKey = sessionKey.trim();
+  return Boolean(normalizedSessionKey) && listSessionKeys().includes(normalizedSessionKey);
 }
 
 function resolveHeartbeatChannelPlugin(channel: string): ChannelPlugin | undefined {
@@ -1358,10 +1365,16 @@ export async function runHeartbeatOnce(opts: {
   const shouldHonorActiveReplyRuns = opts.intent !== "immediate" && opts.intent !== "manual";
   const listActiveReplyRuns =
     opts.deps?.listActiveReplyRunSessionKeys ?? listActiveReplyRunSessionKeys;
+  const listActiveEmbeddedRuns =
+    opts.deps?.listActiveEmbeddedRunSessionKeys ?? listActiveEmbeddedRunSessionKeys;
   // Scheduled heartbeats are background work, so defer them when any session on
   // the same agent is already replying; immediate/manual wakes keep their
   // existing semantics for explicit user/system actions.
-  if (shouldHonorActiveReplyRuns && hasActiveReplyRunForAgent(agentId, listActiveReplyRuns)) {
+  if (
+    shouldHonorActiveReplyRuns &&
+    (hasActiveRunForAgent(agentId, listActiveReplyRuns) ||
+      hasActiveRunForAgent(agentId, listActiveEmbeddedRuns))
+  ) {
     emitHeartbeatEvent({
       status: "skipped",
       reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
@@ -1417,7 +1430,7 @@ export async function runHeartbeatOnce(opts: {
   const { entry, sessionKey, storePath, suppressOriginatingContext } = preflight.session;
   const isReplyRunActive =
     opts.deps?.isReplyRunActive ?? ((key: string) => replyRunRegistry.isActive(key));
-  if (isReplyRunActive(sessionKey)) {
+  if (isReplyRunActive(sessionKey) || hasActiveRunForSession(sessionKey, listActiveEmbeddedRuns)) {
     emitHeartbeatEvent({
       status: "skipped",
       reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
@@ -1576,7 +1589,10 @@ export async function runHeartbeatOnce(opts: {
       isolatedSessionKey,
       isolatedBaseSessionKey,
     });
-    if (isReplyRunActive(isolatedSessionKey)) {
+    if (
+      isReplyRunActive(isolatedSessionKey) ||
+      hasActiveRunForSession(isolatedSessionKey, listActiveEmbeddedRuns)
+    ) {
       emitHeartbeatEvent({
         status: "skipped",
         reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -45,6 +45,10 @@ import {
 import { replaceGenericExternalRunFailureText } from "../auto-reply/reply/agent-runner-failure-copy.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
 import {
+  REPLY_OPERATION_RUN_STATE,
+  type ReplyOperationRunState,
+} from "../auto-reply/reply/reply-operation-run-state.js";
+import {
   listActiveReplyRunSessionKeys,
   replyRunRegistry,
 } from "../auto-reply/reply/reply-run-registry.js";
@@ -1797,8 +1801,10 @@ export async function runHeartbeatOnce(opts: {
     const timeoutOverrideSeconds = resolveHeartbeatTimeoutOverrideSeconds(cfg, heartbeat);
     const bootstrapContextMode: "lightweight" | undefined =
       heartbeat?.lightContext === true ? "lightweight" : undefined;
+    const replyOperationRunState: ReplyOperationRunState = {};
     const replyOpts = {
       isHeartbeat: true,
+      [REPLY_OPERATION_RUN_STATE]: replyOperationRunState,
       ...(heartbeatModelOverride ? { heartbeatModelOverride } : {}),
       suppressToolErrorWarnings,
       ...(usesHeartbeatResponseTool ? { enableHeartbeatTool: true, forceHeartbeatTool: true } : {}),
@@ -1819,8 +1825,8 @@ export async function runHeartbeatOnce(opts: {
     if (
       !heartbeatToolResponse &&
       (!replyPayload || !hasOutboundReplyContent(replyPayload)) &&
-      (isReplyRunActive(runSessionKey) ||
-        hasActiveRunForSession(runSessionKey, listActiveEmbeddedRuns))
+      replyOperationRunState.admission?.status === "skipped" &&
+      replyOperationRunState.admission.reason === "active-run"
     ) {
       emitHeartbeatEvent({
         status: "skipped",


### PR DESCRIPTION
## Summary

- Problem: scheduled heartbeat turns could be accepted by the scheduler but never reach a real model turn when reply work was already active around the same session/agent.
- Why it matters / User impact: affected 5.x installs can look like heartbeat is configured and wake requests are accepted, but the heartbeat tick can be consumed as handled without the main agent session receiving the heartbeat prompt. That matches the reporter-visible failure mode where a manual wake can return OK while no model inference reaches the main agent session.
- Root cause: the source-of-truth busy-state lifecycle was split across the heartbeat scheduler boundary and reply-turn admission. `runHeartbeatOnce` checked queued lanes / active reply work before calling `getReplyFromConfig`, but downstream reply admission intentionally rejects heartbeat turns when another reply run wins the same session slot. Because that admission rejection surfaced back to the heartbeat runner as an empty reply, the scheduler emitted `ok-empty` / returned `ran` instead of the retryable `requests-in-flight` result. The existing active embedded-run path had the same root contract failure: background heartbeat work could enter a reply path that intentionally drops heartbeat turns rather than queueing them.
- Why this is root-cause fix: heartbeat scheduling is the source-of-truth owner for deciding whether background heartbeat work dispatches or retries. This patch restores that invariant at the scheduler boundary: scheduled heartbeat dispatch now defers before model dispatch when same-agent embedded work is active, and it rechecks the resolved run session after `getReplyFromConfig` returns an empty result so a reply-admission race is converted into `requests-in-flight` instead of a phantom `ran`. That fixes the state-owner contract rather than masking the symptom with a provider-specific retry, timeout, or fallback.
- Fix classification: Root cause fix.
- Solution: return the existing retryable `requests-in-flight` status when heartbeat dispatch collides with active embedded/reply work, including the race where activity appears after preflight but before reply admission.
- What changed: heartbeat runner now checks active embedded-run session keys alongside active reply runs before dispatch, and treats an empty reply result as busy when the run session is still active after the reply runtime returns.
- What did NOT change: heartbeat cadence calculation, public config shape, provider/model routing, outbound delivery contracts, persisted session formats, and visible user-turn queue policy are unchanged. Manual/immediate wakes still keep their existing semantics for other active sessions; the fix only prevents busy heartbeat work from being marked completed without a model turn.
- Related open PR scan: this is an update to the existing linked PR #88970, not a new competing PR. The current discussion/review evidence points this PR at issue #85871 and RF-001; no separate canonical PR is used as the source of truth for this heartbeat busy-state boundary.
- Patch quality notes: the retry/default-looking changes are limited to the heartbeat scheduler guardrail. The `requests-in-flight` result is the existing wake-layer retry contract, and the test-only `return undefined` simulates the actual reply-admission skip that previously became phantom `ran`; it is not a production fallback, catch-all, or symptom-masking default.
- Maintainer-ready confidence: High for the gateway scheduler starting and reaching dispatch on current head, and high for the busy/retry boundary. Medium for the reporter's exact Ubuntu/Ollama deployment because local proof used an available local provider/model and shortened the interval instead of waiting a full production 5-minute cadence.
- Architecture / source-of-truth check: the heartbeat runner remains the source-of-truth dispatch boundary for scheduled heartbeat work. The patch reads the existing active reply/embedded-run registries; it does not add downstream string matching, mirrored busy state, provider-specific behavior, or persistence migrations.

## Linked context

- Fixes #85871.
- Existing PR: #88970.
- Current review finding addressed: RF-001 asked for proof beyond a narrow unit path. The updated proof starts a real gateway, observes scheduler startup, observes heartbeat dispatch after startup, and separately proves the busy defer/retry behavior.

## Real behavior proof

- Behavior addressed: the live gateway heartbeat scheduler starts and reaches agent/model dispatch, and scheduled heartbeats defer instead of being silently consumed while same-agent work is active.
- Real environment tested: local OpenClaw gateway started through `pnpm gateway:dev` with isolated runtime state, a short `every: 2s` heartbeat, `target: none`, and a real configured provider/model. The busy/retry boundary was exercised through the actual scheduler wake path with active embedded work registered for `agent:main:main`.
- Exact steps or command run after this patch:
  - `daily-fix run-validation --name live-heartbeat-gateway-current -- bash heartbeat-live-gateway-proof.sh`
  - `daily-fix run-validation --name heartbeat-busy-retry-current -- pnpm exec tsx heartbeat-scheduled-embedded-proof.ts`
- Evidence after fix: live gateway log excerpt shows the gateway became ready, the scheduler emitted `[heartbeat] started`, and a heartbeat turn reached agent dispatch:

  ```text
  READY=ok
  HEARTBEAT_STARTED=1
  HEARTBEAT_DISPATCH_AFTER_STARTED=1
  HEARTBEAT_RESULT_SIGNAL=0
  2026-06-10T02:46:14.313+08:00 [gateway] http server listening (8 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 18.8s)
  2026-06-10T02:46:14.329+08:00 [gateway] ready
  2026-06-10T02:46:15.063+08:00 [heartbeat] started
  2026-06-10T02:46:40.733+08:00 [agent/embedded] [trace:embedded-run] core-plugin-tool stages: runId=9f3da39f-5bc1-4dc3-ba19-2a88326fdea2 sessionId=e287404c-562f-4139-baee-21beb02b705c phase=core-plugin-tools ... attempt:tools-allow:0ms
  ```

  The busy/retry proof then showed the first scheduled wake deferred before dispatch while active embedded work existed, and the retry dispatched after the busy run cleared:

  ```text
  [proof] active embedded run registered: sessionId=proof-active-embedded-run sessionKey=agent:main:main
  [heartbeat] started
  [proof] scheduled wake attempt #1: source=interval intent=scheduled reason=interval activeBefore=["agent:main:main"] result={"status":"skipped","reason":"requests-in-flight"} dispatchCount=0
  [proof] active embedded run cleared after first busy skip: sessionId=proof-active-embedded-run
  [proof] model dispatch reached after busy cleared: dispatchCount=1
  [proof] scheduled wake attempt #2: source=interval intent=scheduled reason=interval activeBefore=[] result={"status":"ran","durationMs":160} dispatchCount=1
  [proof] PASS: scheduled heartbeat deferred while active embedded work existed, then wake retry dispatched after it cleared
  ```
- Observed result after fix: a real gateway heartbeat cycle no longer stayed silent after startup; it logged scheduler startup and reached agent/model dispatch on the configured interval. When same-agent embedded work was active, the scheduled wake returned the retryable `requests-in-flight` result before model dispatch, then retried and dispatched after the active run cleared.
- What was not tested: the reporter's exact Ubuntu/Ollama install and a full 5-minute interval / 10+ minute wall-clock wait. The local proof shortened the interval to exercise the same scheduler path without waiting multiple production cycles.

## Tests and validation

- Target test file: `src/infra/heartbeat-runner.skips-busy-session-lane.test.ts` covers the reply-admission race where activity appears after heartbeat preflight and `getReplyFromConfig` returns an empty result; `src/infra/heartbeat-runner.returns-default-unset.test.ts` covers active embedded-run pre-dispatch deferral for the resolved heartbeat session and another same-agent session.
- Scenario locked in: scheduled heartbeat work that collides with same-session/same-agent active reply or embedded work returns the retryable `requests-in-flight` skip instead of phantom `ran`, then the wake retry can dispatch after the active run clears.
- Why this is the smallest reliable guardrail: the tests pin the scheduler/reply-admission boundary that lost heartbeat turns without mocking provider-specific Ollama behavior, changing public config/schema contracts, or rewriting visible user-turn queue policy.
- `daily-fix run-validation --name heartbeat-busy-regression-current-head -- node scripts/run-vitest.mjs run src/infra/heartbeat-runner.skips-busy-session-lane.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts src/infra/heartbeat-wake.test.ts` — passed: 3 files, 75 tests.
- `daily-fix run-validation --name heartbeat-lint-current-head -- pnpm exec oxlint src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.skips-busy-session-lane.test.ts` — passed.
- `daily-fix run-validation --name live-heartbeat-gateway-current -- bash heartbeat-live-gateway-proof.sh` — passed; real `pnpm gateway:dev` startup logged `READY=ok`, `[heartbeat] started`, and `HEARTBEAT_DISPATCH_AFTER_STARTED=1`.
- `daily-fix run-validation --name heartbeat-busy-retry-current -- pnpm exec tsx heartbeat-scheduled-embedded-proof.ts` — passed; scheduled `source=interval` / `intent=scheduled` heartbeat returned `requests-in-flight` while `agent:main:main` had active embedded work, then the wake retry reached model dispatch and returned `ran` after the embedded run cleared.

## Risk checklist

- Risk labels considered: compatibility, session-state.
- Risk explanation: merge risk is limited to scheduled heartbeat retry behavior when active reply/embedded work is already occupying the relevant heartbeat session or same-agent background-work boundary.
- Why acceptable: this aligns heartbeat behavior with the existing wake retry contract. A busy heartbeat is now retried by the scheduler instead of being counted as completed before a model turn happens.
- Public contract / config boundary: no public config schema, defaults, migration behavior, provider selection, channel delivery contract, or session-store format changes.
- Out of scope / not changed: no provider-specific Ollama workaround, no full 5-minute production wait in local proof, no channel delivery rewrite, no reply queue policy rewrite, and no legacy config migration change.

## Current review state

- Which bot or reviewer comments were addressed?
  - RF-001 `[P1]`: addressed with current-head live gateway proof plus scheduler busy/retry proof.
- Remaining maintainer decision points:
  - The proof uses a shortened 2-second heartbeat interval rather than waiting 10+ minutes on the reporter's exact cadence.
  - The local provider/model differs from the reporter's Ollama deployment, but it exercises the same gateway scheduler and heartbeat dispatch path.
