### PR TITLE
fix: bound remote media reference reads [AI]

### DIFF
--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -1758,6 +1758,9 @@ describe("createImageGenerateTool", () => {
     const defaultLoadOptions = mockCallArg(webMedia.loadWebMedia, 0, "loadWebMedia", 1);
     expect(defaultLoadUrl).toBe("http://198.18.0.153/reference.png");
     expect(requireRecord(defaultLoadOptions, "loadWebMedia options").ssrfPolicy).toBeUndefined();
+    expect(requireRecord(defaultLoadOptions, "loadWebMedia options").readIdleTimeoutMs).toBe(
+      120_000,
+    );
 
     const tool = requireImageGenerateTool(
       createImageGenerateTool({
@@ -1782,6 +1785,9 @@ describe("createImageGenerateTool", () => {
     expect(requireRecord(configuredLoadOptions, "loadWebMedia options").ssrfPolicy).toEqual({
       allowRfc2544BenchmarkRange: true,
     });
+    expect(requireRecord(configuredLoadOptions, "loadWebMedia options").readIdleTimeoutMs).toBe(
+      120_000,
+    );
     expect(mockCallArg(generateImage, 1, "generateImage").ssrfPolicy).toEqual({
       allowRfc2544BenchmarkRange: true,
     });

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -81,6 +81,7 @@ import {
   hasGenerationToolAvailability,
   normalizeMediaReferenceInputs,
   readGenerationTimeoutMs,
+  REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
   resolveRemoteMediaSsrfPolicy,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
@@ -618,6 +619,7 @@ async function loadReferenceImages(params: {
             maxBytes: params.maxBytes,
             localRoots,
             ssrfPolicy: params.ssrfPolicy,
+            ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
           });
     if (media.kind !== "image") {
       throw new ToolInputError(`Unsupported media type: ${media.kind}`);

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1981,6 +1981,46 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("passes the shared remote read idle timeout when loading remote image references", async () => {
+    const fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ content: "ok", base_resp: { status_code: 0, status_msg: "" } }),
+        ),
+    );
+    global.fetch = withFetchPreconnect(fetch);
+    vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
+    const loadWebMedia = vi.fn(async () => ({
+      buffer: Buffer.from(ONE_PIXEL_PNG_B64, "base64"),
+      contentType: "image/png",
+      kind: "image" as const,
+    }));
+    installImageUnderstandingProviderDeps([minimaxProvider, moonshotProvider], {
+      loadImageWebMediaRuntime: async () => ({
+        loadWebMedia,
+        optimizeImageBufferForWebMedia: async ({ buffer, contentType, fileName }) => ({
+          buffer,
+          contentType: contentType ?? "image/png",
+          kind: "image",
+          fileName,
+        }),
+      }),
+    });
+
+    await withTempAgentDir(async (agentDir) => {
+      const tool = createRequiredImageTool({
+        config: createMinimaxImageConfig(),
+        agentDir,
+      });
+
+      await expectImageToolExecOk(tool, "https://example.test/reference.png");
+
+      expect(loadWebMedia).toHaveBeenCalledTimes(1);
+      const [, options] = fetchCallAt(loadWebMedia, 0);
+      expect((options as { readIdleTimeoutMs?: number }).readIdleTimeoutMs).toBe(120_000);
+    });
+  });
+
   it("sandboxes image paths like the read tool", async () => {
     await withTempSandboxState(async ({ agentDir, sandboxRoot }) => {
       await fs.writeFile(path.join(sandboxRoot, "img.png"), "fake", "utf8");

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -59,6 +59,7 @@ import {
 import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
+  REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
   resolveMediaToolInboundRoots,
   resolveMediaToolLocalRoots,
   resolveRemoteMediaSsrfPolicy,
@@ -90,6 +91,7 @@ type ImageToolLoadWebMediaOptions = {
   localRoots?: readonly string[] | "any";
   inboundRoots?: readonly string[];
   ssrfPolicy?: ReturnType<typeof resolveRemoteMediaSsrfPolicy>;
+  readIdleTimeoutMs?: number;
 };
 
 type ImageWebMediaRuntime = {
@@ -974,6 +976,7 @@ export function createImageTool(options?: {
                 localRoots: mediaLocalRoots,
                 inboundRoots: mediaInboundRoots,
                 ssrfPolicy: remoteMediaSsrfPolicy,
+                ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
                 imageCompression,
               });
         if (media.kind !== "image") {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -70,6 +70,8 @@ type TaskRunDetailHandle = {
   runId: string;
 };
 
+export const REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS = 120_000;
+
 export function applyImageModelConfigDefaults(
   cfg: OpenClawConfig | undefined,
   imageModelConfig: ImageModelConfig,

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -20,6 +20,7 @@ import { coerceImageModelConfig, type ImageModelConfig } from "./image-tool.help
 import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
+  REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
   resolveModelFromRegistry,
   resolveMediaToolLocalRoots,
   resolveModelRuntimeApiKey,
@@ -54,7 +55,6 @@ const DEFAULT_PROMPT = "Analyze this PDF document.";
 const DEFAULT_MAX_PDFS = 10;
 const DEFAULT_MAX_BYTES_MB = 10;
 const DEFAULT_MAX_PAGES = 20;
-const PDF_REMOTE_READ_IDLE_TIMEOUT_MS = 120_000;
 
 const PDF_MIN_TEXT_CHARS = 200;
 const PDF_MAX_PIXELS = 4_000_000;
@@ -457,7 +457,7 @@ export function createPdfTool(options?: {
           : await loadWebMediaRaw(resolvedPathInfo.resolved, {
               maxBytes,
               localRoots,
-              ...(isHttpUrl ? { readIdleTimeoutMs: PDF_REMOTE_READ_IDLE_TIMEOUT_MS } : {}),
+              ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
               ssrfPolicy: remoteMediaSsrfPolicy,
             });
 

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -1515,6 +1515,30 @@ describe("createVideoGenerateTool", () => {
     expect(call.inputImages?.[1]?.role).toBe("last_frame");
   });
 
+  it("passes direct remote reference URLs to the provider without local media loading", async () => {
+    mockVideoPluginProvider({
+      imageToVideo: { enabled: true, maxInputImages: 1 },
+    });
+    const loadWebMedia = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      kind: "image",
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    const generateSpy = mockSavedVideoResult();
+    const tool = createVideoPluginTool();
+
+    await tool.execute("call-1", {
+      prompt: "lobster",
+      image: "https://example.test/reference.png",
+    });
+
+    expect(loadWebMedia).not.toHaveBeenCalled();
+    const call = firstMockCallArg(generateSpy) as {
+      inputImages?: Array<{ url?: string }>;
+    };
+    expect(call.inputImages).toEqual([{ url: "https://example.test/reference.png" }]);
+  });
+
   it("passes web_fetch SSRF policy when loading reference assets", async () => {
     mockVideoPluginProvider({
       imageToVideo: { enabled: true, maxInputImages: 1 },

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -64,6 +64,7 @@ import {
   normalizeMediaReferenceInputs,
   readBooleanToolParam,
   readGenerationTimeoutMs,
+  REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
   resolveMediaToolLocalRoots,
@@ -630,6 +631,7 @@ async function loadReferenceAssets(params: {
             maxBytes: params.maxBytes,
             localRoots,
             ssrfPolicy: params.ssrfPolicy,
+            ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
           });
     if (media.kind !== params.expectedKind) {
       throw new ToolInputError(`Unsupported media type: ${media.kind ?? "unknown"}`);

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -64,7 +64,6 @@ import {
   normalizeMediaReferenceInputs,
   readBooleanToolParam,
   readGenerationTimeoutMs,
-  REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
   resolveMediaToolLocalRoots,
@@ -631,7 +630,6 @@ async function loadReferenceAssets(params: {
             maxBytes: params.maxBytes,
             localRoots,
             ssrfPolicy: params.ssrfPolicy,
-            ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
           });
     if (media.kind !== params.expectedKind) {
       throw new ToolInputError(`Unsupported media type: ${media.kind ?? "unknown"}`);


### PR DESCRIPTION
## Summary

- Adds a shared remote media read idle timeout for media-tool reference downloads.
- Applies the timeout to remote image references used by image read and image generation, and reuses the same shared value for PDF remote reads.
- Keeps local, sandboxed, data URL, video provider URL handoff, and public tool schema behavior unchanged.
- Adds focused regression coverage for image reference loading option forwarding and video remote URL handoff.

## Linked context

Which issue does this close?

None linked publicly.

Which issues, PRs, or discussions are related?

None linked publicly.

Was this requested by a maintainer or owner?

Automated tracking workflow.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: remote media reference downloads now receive a per-chunk idle timeout where the OpenClaw tool fetches the referenced media.
- Real environment tested: local OpenClaw source checkout on Node/Vitest via the repo test wrapper, plus a local stalled HTTP server proof against `loadWebMedia`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tools/image-tool.test.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts src/agents/tools/pdf-tool.test.ts`
- Exact stalled-server proof command run after this patch: temporary `pnpm exec tsx` script started a local HTTP server on `127.0.0.1`, sent headers for `image/png`, stopped sending body bytes, and called `loadWebMedia(url, { readIdleTimeoutMs: 75, ssrfPolicy: { allowPrivateNetwork: true } })`.
- Evidence after fix: 4 test files passed, 187 tests passed.
- Stalled-server evidence after fix:
  - `proof: stalled local HTTP media read timed out after 223ms`
  - `proof error: Failed to fetch media from http://127.0.0.1:<port>/stalled.png: Media download stalled: no data received for 75ms`
- Observed result after fix: image reference loaders forward `readIdleTimeoutMs: 120_000`, the existing PDF behavior still uses the same timeout, direct remote `video_generate` references are handed to the provider without local media loading, and the real stalled local HTTP media read exits through the loader idle-timeout error instead of waiting indefinitely.
- What was not tested: live public internet stalled media service behavior.
- Proof limitations or environment constraints: local loopback was used for safe reproducibility; the command allowed private-network fetches only for the local proof server.
- Before evidence (optional but encouraged): existing image reference load tests asserted SSRF/local-root forwarding but did not assert read idle timeout forwarding.

## Tests and validation

Which commands did you run?

- `git diff --check`
- `pnpm exec oxfmt --write --threads=1 src/agents/tools/media-tool-shared.ts src/agents/tools/pdf-tool.ts src/agents/tools/image-tool.ts src/agents/tools/image-generate-tool.ts src/agents/tools/video-generate-tool.ts src/agents/tools/image-tool.test.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/image-tool.test.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts src/agents/tools/pdf-tool.test.ts`
- `pnpm exec tsx <temporary stalled-server proof script>`

What regression coverage was added or updated?

Image read and image generation tests now assert the remote reference load options include the shared idle timeout. Video generation tests now assert direct remote reference URLs are passed to the provider without local `loadWebMedia`.

What failed before this fix, if known?

Remote image reference load option forwarding did not include a per-chunk read idle timeout.

If no test was added, why not?

Not applicable.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No, except remote media reads can now fail instead of waiting indefinitely if no data arrives for the idle window.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, network media fetch behavior is bounded by the existing loader timeout support.

What is the highest-risk area?

Remote media references on very slow servers may now fail once the idle timeout is exceeded.

How is that risk mitigated?

The timeout matches the existing PDF remote media behavior and only applies to HTTP media reads performed by these tool paths; video remote URL handoff remains provider-owned and is covered by a focused test.

## Current review state

What is the next action?

Rerun GHSA dry-run and reviewer checks after the video evidence test commit.

What is still waiting on author, maintainer, CI, or external proof?

Fresh GHSA dry-run, review-pr, autoreview, CI, and final gate verification on the latest head.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper feedback by adding real stalled-server proof, removing unreachable video timeout wiring, and adding a video remote URL handoff regression test.

AI-assisted: yes.
