### PR TITLE
fix(qqbot): block file URI media tags [AI]

### DIFF
--- a/extensions/qqbot/src/engine/messaging/decode-media-path.test.ts
+++ b/extensions/qqbot/src/engine/messaging/decode-media-path.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { decodeMediaPath } from "./decode-media-path.js";
+import { decodeMediaPath, isFileUriMediaPath } from "./decode-media-path.js";
 
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
@@ -18,6 +18,12 @@ afterEach(() => {
 });
 
 describe("decodeMediaPath", () => {
+  it("identifies file URI media paths before path normalization", () => {
+    expect(isFileUriMediaPath(" file:///etc/passwd")).toBe(true);
+    expect(isFileUriMediaPath("FILE:///etc/passwd")).toBe(true);
+    expect(isFileUriMediaPath("/tmp/file.txt")).toBe(false);
+  });
+
   it("preserves Windows home-relative paths with digit segments", () => {
     delete process.env.HOME;
     process.env.USERPROFILE = String.raw`C:\Users\operator`;

--- a/extensions/qqbot/src/engine/messaging/decode-media-path.test.ts
+++ b/extensions/qqbot/src/engine/messaging/decode-media-path.test.ts
@@ -21,6 +21,7 @@ describe("decodeMediaPath", () => {
   it("identifies file URI media paths before path normalization", () => {
     expect(isFileUriMediaPath(" file:///etc/passwd")).toBe(true);
     expect(isFileUriMediaPath("FILE:///etc/passwd")).toBe(true);
+    expect(isFileUriMediaPath("file://%2Fetc%2Fpasswd")).toBe(true);
     expect(isFileUriMediaPath("/tmp/file.txt")).toBe(false);
   });
 

--- a/extensions/qqbot/src/engine/messaging/decode-media-path.ts
+++ b/extensions/qqbot/src/engine/messaging/decode-media-path.ts
@@ -44,6 +44,10 @@ function normalizePath(p: string): string {
   return result;
 }
 
+export function isFileUriMediaPath(raw: string): boolean {
+  return raw.trim().toLowerCase().startsWith("file://");
+}
+
 /**
  * Decode a media path by expanding `~` and unescaping octal/UTF-8 byte
  * sequences.

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -1,22 +1,29 @@
 import { describe, expect, it, vi } from "vitest";
 import { parseAndSendMediaTags, type DeliverDeps } from "./outbound-deliver.js";
 
-function makeDeps(): DeliverDeps {
+function makeDeps(): {
+  deps: DeliverDeps;
+  sendDocument: ReturnType<typeof vi.fn>;
+} {
+  const sendDocument = vi.fn(async () => ({ channel: "qqbot" }));
   return {
-    chunkText: (text) => [text],
-    mediaSender: {
-      sendPhoto: vi.fn(async () => ({ channel: "qqbot" })),
-      sendVoice: vi.fn(async () => ({ channel: "qqbot" })),
-      sendVideoMsg: vi.fn(async () => ({ channel: "qqbot" })),
-      sendDocument: vi.fn(async () => ({ channel: "qqbot" })),
-      sendMedia: vi.fn(async () => ({ channel: "qqbot" })),
+    deps: {
+      chunkText: (text) => [text],
+      mediaSender: {
+        sendPhoto: vi.fn(async () => ({ channel: "qqbot" })),
+        sendVoice: vi.fn(async () => ({ channel: "qqbot" })),
+        sendVideoMsg: vi.fn(async () => ({ channel: "qqbot" })),
+        sendDocument,
+        sendMedia: vi.fn(async () => ({ channel: "qqbot" })),
+      },
     },
+    sendDocument,
   };
 }
 
 describe("parseAndSendMediaTags", () => {
   it("blocks file URI media tags before they reach document sending", async () => {
-    const deps = makeDeps();
+    const { deps, sendDocument } = makeDeps();
     const log = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
 
     const result = await parseAndSendMediaTags(
@@ -43,7 +50,7 @@ describe("parseAndSendMediaTags", () => {
     );
 
     expect(result.handled).toBe(true);
-    expect(deps.mediaSender.sendDocument).not.toHaveBeenCalled();
+    expect(sendDocument).not.toHaveBeenCalled();
     expect(log.error).toHaveBeenCalledWith("Blocked file URI in <qqfile> media tag");
   });
 });

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseAndSendMediaTags, type DeliverDeps } from "./outbound-deliver.js";
+
+function makeDeps(): DeliverDeps {
+  return {
+    chunkText: (text) => [text],
+    mediaSender: {
+      sendPhoto: vi.fn(async () => ({ channel: "qqbot" })),
+      sendVoice: vi.fn(async () => ({ channel: "qqbot" })),
+      sendVideoMsg: vi.fn(async () => ({ channel: "qqbot" })),
+      sendDocument: vi.fn(async () => ({ channel: "qqbot" })),
+      sendMedia: vi.fn(async () => ({ channel: "qqbot" })),
+    },
+  };
+}
+
+describe("parseAndSendMediaTags", () => {
+  it("blocks file URI media tags before they reach document sending", async () => {
+    const deps = makeDeps();
+    const log = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    const result = await parseAndSendMediaTags(
+      "<qqfile>file:///etc/passwd</qqfile>",
+      {
+        type: "c2c",
+        senderId: "user-1",
+        messageId: "msg-1",
+      },
+      {
+        account: {
+          accountId: "acct",
+          appId: "app",
+          clientSecret: "secret",
+          markdownSupport: false,
+          config: {},
+        },
+        qualifiedTarget: "qqbot:c2c:user-1",
+        log,
+      },
+      async (send) => await send("token"),
+      () => undefined,
+      deps,
+    );
+
+    expect(result.handled).toBe(true);
+    expect(deps.mediaSender.sendDocument).not.toHaveBeenCalled();
+    expect(log.error).toHaveBeenCalledWith("Blocked file URI in <qqfile> media tag");
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
@@ -16,7 +16,7 @@ import {
   normalizeOptionalString,
 } from "../utils/string-normalize.js";
 import { filterInternalMarkers } from "../utils/text-parsing.js";
-import { decodeMediaPath } from "./decode-media-path.js";
+import { decodeMediaPath, isFileUriMediaPath } from "./decode-media-path.js";
 import {
   sendText as senderSendText,
   sendMedia as senderSendMedia,
@@ -416,7 +416,13 @@ export async function parseAndSendMediaTags(
     }
 
     const tagName = normalizeLowercaseStringOrEmpty(match[1]);
-    const mediaPath = decodeMediaPath(normalizeOptionalString(match[2]) ?? "", log);
+    const rawMediaPath = normalizeOptionalString(match[2]) ?? "";
+    if (isFileUriMediaPath(rawMediaPath)) {
+      log?.error?.(`Blocked file URI in <${tagName}> media tag`);
+      lastIndex = match.index + match[0].length;
+      continue;
+    }
+    const mediaPath = decodeMediaPath(rawMediaPath, log);
 
     if (mediaPath) {
       const typeMap: Record<string, QueueItem["type"]> = {

--- a/extensions/qqbot/src/engine/messaging/outbound.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound.ts
@@ -43,7 +43,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../utils/string-normalize.js";
-import { decodeMediaPath } from "./decode-media-path.js";
+import { decodeMediaPath, isFileUriMediaPath } from "./decode-media-path.js";
 import {
   isImageFile as coreIsImageFile,
   isVideoFile as coreIsVideoFile,
@@ -161,10 +161,14 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
 
       const tagName = normalizeLowercaseStringOrEmpty(match[1]);
 
-      const mediaPath = decodeMediaPath(
-        normalizeOptionalString(match[2]) ?? "",
-        mediaPathDecodeLog,
-      );
+      const rawMediaPath = normalizeOptionalString(match[2]) ?? "";
+      if (isFileUriMediaPath(rawMediaPath)) {
+        debugError(`[qqbot] sendText: Blocked file URI in <${tagName}> media tag`);
+        lastIndex = match.index + match[0].length;
+        continue;
+      }
+
+      const mediaPath = decodeMediaPath(rawMediaPath, mediaPathDecodeLog);
 
       if (mediaPath) {
         if (tagName === "qqmedia") {

--- a/extensions/qqbot/src/engine/messaging/streaming-media-send.test.ts
+++ b/extensions/qqbot/src/engine/messaging/streaming-media-send.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import { findFirstClosedMediaTag } from "./streaming-media-send.js";
 
 describe("findFirstClosedMediaTag", () => {
-  it("skips file URI media tags from streaming model output", () => {
+  it("returns a consumable empty media item for file URI tags", () => {
     const log = { error: vi.fn(), debug: vi.fn() };
 
-    expect(findFirstClosedMediaTag("<qqfile>file:///etc/passwd</qqfile>", log)).toBeNull();
+    const found = findFirstClosedMediaTag("<qqfile>file:///etc/passwd</qqfile>", log);
+
+    expect(found?.itemType).toBe("file");
+    expect(found?.mediaPath).toBe("");
+    expect(found?.tagEndIndex).toBe("<qqfile>file:///etc/passwd</qqfile>".length);
     expect(log.error).toHaveBeenCalledWith(
       "findFirstClosedMediaTag: blocked file URI in <qqfile> media tag",
     );

--- a/extensions/qqbot/src/engine/messaging/streaming-media-send.test.ts
+++ b/extensions/qqbot/src/engine/messaging/streaming-media-send.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { findFirstClosedMediaTag } from "./streaming-media-send.js";
+
+describe("findFirstClosedMediaTag", () => {
+  it("skips file URI media tags from streaming model output", () => {
+    const log = { error: vi.fn(), debug: vi.fn() };
+
+    expect(findFirstClosedMediaTag("<qqfile>file:///etc/passwd</qqfile>", log)).toBeNull();
+    expect(log.error).toHaveBeenCalledWith(
+      "findFirstClosedMediaTag: blocked file URI in <qqfile> media tag",
+    );
+  });
+
+  it("still accepts absolute local media paths", () => {
+    const found = findFirstClosedMediaTag("<qqfile>/tmp/openclaw-media/report.txt</qqfile>");
+
+    expect(found?.itemType).toBe("file");
+    expect(found?.mediaPath).toBe("/tmp/openclaw-media/report.txt");
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/streaming-media-send.ts
+++ b/extensions/qqbot/src/engine/messaging/streaming-media-send.ts
@@ -7,6 +7,7 @@
 
 import type { GatewayAccount } from "../types.js";
 import { normalizePath } from "../utils/platform.js";
+import { isFileUriMediaPath } from "./decode-media-path.js";
 import {
   sendPhoto,
   sendVoice,
@@ -206,6 +207,10 @@ export function findFirstClosedMediaTag(
     const textBefore = text.slice(0, match.index);
     const tagName = match[1].toLowerCase();
     let mediaPath = match[2]?.trim() ?? "";
+    if (isFileUriMediaPath(mediaPath)) {
+      log?.error?.(`findFirstClosedMediaTag: blocked file URI in <${tagName}> media tag`);
+      continue;
+    }
 
     mediaPath = normalizePath(mediaPath);
     mediaPath = fixPathEncoding(mediaPath, log);

--- a/extensions/qqbot/src/engine/messaging/streaming-media-send.ts
+++ b/extensions/qqbot/src/engine/messaging/streaming-media-send.ts
@@ -209,7 +209,13 @@ export function findFirstClosedMediaTag(
     let mediaPath = match[2]?.trim() ?? "";
     if (isFileUriMediaPath(mediaPath)) {
       log?.error?.(`findFirstClosedMediaTag: blocked file URI in <${tagName}> media tag`);
-      continue;
+      return {
+        textBefore,
+        tagName,
+        mediaPath: "",
+        tagEndIndex: match.index + match[0].length,
+        itemType: "file",
+      };
     }
 
     mediaPath = normalizePath(mediaPath);


### PR DESCRIPTION
## Summary

- Reject `file://` URIs in QQ Bot model-authored media tags before they enter the outbound send queue.
- Apply the same guard to standard outbound delivery, legacy `sendText` media parsing, and streaming media parsing.
- Consume blocked streaming tags so the raw tag is not emitted as ordinary QQ chat text.
- Add focused regression coverage for the decoder helper plus both non-streaming and streaming parser paths.
- AI-assisted change.

## Linked context

Which issue does this close?

N/A

Which issues, PRs, or discussions are related?

N/A

Was this requested by a maintainer or owner?

Security tracking intake requested this neutral remediation.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: QQ Bot rich-media tags no longer accept `file://` URI inputs from model-authored output.
- Real environment tested: Local OpenClaw source checkout and GitHub Actions PR CI on head `abe841bd7466ac2651fd1dd22f50583d5e9ad1e7`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/decode-media-path.test.ts extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts extensions/qqbot/src/engine/messaging/streaming-media-send.test.ts`; `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json <touched QQ Bot messaging files>`; review-pr; autoreview; security dry-run gate; GitHub CI.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Vitest reported 3 files passed, 6 tests passed; targeted oxlint passed; review-pr reported READY with 0 findings; autoreview reported clean; security dry-run reported PASS; GitHub CI completed with no related failures.
- Observed result after fix: File-URI media tags are skipped before document sending, blocked streaming tags are consumed instead of shown as chat text, and absolute local media paths remain accepted for the normal guarded media pipeline.
- What was not tested: Live QQ Bot delivery against QQ credentials was not run.
- Proof limitations or environment constraints: No live QQ Bot account or credentials were available in this environment, so validation is source-level plus GitHub Actions rather than live QQ delivery.
- Before evidence (optional but encouraged): Existing parser paths normalized media tag contents before queueing them for send handling.

## Tests and validation

Which commands did you run?

- `./node_modules/.bin/oxfmt --write --threads=1 extensions/qqbot/src/engine/messaging/decode-media-path.ts extensions/qqbot/src/engine/messaging/decode-media-path.test.ts extensions/qqbot/src/engine/messaging/outbound.ts extensions/qqbot/src/engine/messaging/outbound-deliver.ts extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts extensions/qqbot/src/engine/messaging/streaming-media-send.ts extensions/qqbot/src/engine/messaging/streaming-media-send.test.ts`
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/decode-media-path.test.ts extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts extensions/qqbot/src/engine/messaging/streaming-media-send.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/qqbot/src/engine/messaging/decode-media-path.test.ts extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts extensions/qqbot/src/engine/messaging/streaming-media-send.test.ts extensions/qqbot/src/engine/messaging/decode-media-path.ts extensions/qqbot/src/engine/messaging/outbound-deliver.ts extensions/qqbot/src/engine/messaging/outbound.ts extensions/qqbot/src/engine/messaging/streaming-media-send.ts`

What regression coverage was added or updated?

- Added coverage that file-URI media tags do not reach document sending in standard outbound delivery.
- Added coverage that streaming media tag parsing consumes blocked file-URI tags while preserving absolute local media paths.
- Added helper coverage for lowercase, uppercase, and percent-encoded file-URI media path detection.

What failed before this fix, if known?

The new regression expectations were not present before this patch.

If no test was added, why not?

N/A

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. QQ Bot media tags now reject `file://` URI syntax; normal absolute paths and remote URLs remain available.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This tightens QQ Bot outbound media-tag handling.

What is the highest-risk area?

Compatibility for any QQ Bot workflow that emitted `file://` media tags instead of normal local paths.

How is that risk mitigated?

QQ Bot media skill guidance already documents absolute local paths or URLs, and the tests verify absolute local paths still parse.

## Current review state

What is the next action?

Wait for ClawSweeper re-review and final gate completion.

What is still waiting on author, maintainer, CI, or external proof?

Live QQ Bot delivery proof was not available in this environment; maintainers may choose whether the local parser proof plus CI is sufficient.

Which bot or reviewer comments were addressed?

- Addressed autoreview’s streaming parser finding by consuming blocked closed tags instead of treating them as ordinary text.
- Updated this body with current local validation, review-pr, autoreview, security dry-run, and CI proof for the ClawSweeper proof-only blocker.
