### PR TITLE
fix(agents): tolerate provider tool schema hook failures

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -205,6 +205,32 @@ describe("Codex app-server dynamic tool build", () => {
     await expect(buildDynamicToolsForTest(params, workspaceDir)).resolves.toEqual([messageTool]);
   });
 
+  it("uses assistant-tolerant provider schema hooks for dynamic tool projection", async () => {
+    const messageTool = createRuntimeDynamicTool("message");
+    setOpenClawCodingToolsFactoryForTests(() => [messageTool]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    const normalize = vi.fn((tools: unknown[]) => tools);
+    params.disableTools = false;
+    params.runtimePlan = {
+      ...createCodexRuntimePlanFixture(),
+      tools: {
+        normalize,
+        logDiagnostics: () => undefined,
+      },
+    } as never;
+
+    await expect(buildDynamicToolsForTest(params, workspaceDir)).resolves.toEqual([messageTool]);
+
+    expect(normalize).toHaveBeenCalledWith([messageTool], {
+      workspaceDir,
+      modelApi: params.model.api,
+      model: params.model,
+      schemaHookFailureMode: "warn",
+    });
+  });
+
   it("limits Codex memory flush runs to managed read and write tools", async () => {
     const factoryOptions: unknown[] = [];
     setOpenClawCodingToolsFactoryForTests((options) => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -301,6 +301,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelId: params.modelId,
     modelApi: params.model.api,
     model: params.model,
+    schemaHookFailureMode: "warn",
     onPreNormalizationSchemaDiagnostics: (diagnostics) =>
       preNormalizationDiagnostics.push(...diagnostics),
   });

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -174,6 +174,8 @@ export const rotateTranscriptAfterCompactionMock: Mock<
   rotated: false,
 }));
 export const enqueueCommandInLaneMock = vi.fn((_lane: unknown, task: () => unknown) => task());
+export const runtimePlanNormalizeToolsMock = vi.fn((tools: unknown[]) => tools);
+export const runtimePlanLogDiagnosticsMock = vi.fn();
 
 function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
@@ -215,8 +217,8 @@ function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): Age
       preparedPlanning: {
         loadMetadataSnapshot: () => ({}),
       },
-      normalize: vi.fn((tools) => tools),
-      logDiagnostics: vi.fn(),
+      normalize: runtimePlanNormalizeToolsMock,
+      logDiagnostics: runtimePlanLogDiagnosticsMock,
     },
     transcript: {
       policy: transcriptPolicy,
@@ -336,6 +338,9 @@ export function resetCompactSessionStateMocks(): void {
   rotateTranscriptAfterCompactionMock.mockResolvedValue({ rotated: false });
   enqueueCommandInLaneMock.mockReset();
   enqueueCommandInLaneMock.mockImplementation((_lane: unknown, task: () => unknown) => task());
+  runtimePlanNormalizeToolsMock.mockReset();
+  runtimePlanNormalizeToolsMock.mockImplementation((tools: unknown[]) => tools);
+  runtimePlanLogDiagnosticsMock.mockReset();
   listRegisteredPluginAgentPromptGuidanceMock.mockReset();
   listRegisteredPluginAgentPromptGuidanceMock.mockImplementation((params?: { surface?: string }) =>
     params?.surface === "subagent"

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -24,6 +24,8 @@ import {
   resolveEmbeddedAgentStreamFnMock,
   resolveMemorySearchConfigMock,
   resolveModelMock,
+  runtimePlanLogDiagnosticsMock,
+  runtimePlanNormalizeToolsMock,
   resolveSandboxContextMock,
   resolveSessionAgentIdMock,
   resolveSessionAgentIdsMock,
@@ -494,6 +496,49 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       (sessionOptions.customTools as Array<{ name: string }>).map((tool) => tool.name),
     ).toEqual(["healthy_lookup"]);
     expect(sessionOptions.tools).toEqual(["healthy_lookup"]);
+  });
+
+  it("uses assistant-tolerant provider schema hooks during compaction tool projection", async () => {
+    resolveContextEngineMock.mockResolvedValueOnce({
+      info: { ownsCompaction: false },
+      compact: contextEngineCompactMock,
+    });
+    resolveModelMock.mockReturnValueOnce({
+      model: { provider: "openai", api: "openai-responses", id: "fake", input: [] },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    });
+    createOpenClawCodingToolsMock.mockReturnValueOnce([
+      {
+        name: "healthy_lookup",
+        label: "Healthy Lookup",
+        description: "Look up safe data.",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({ text: "ok" }),
+      },
+    ] as never);
+
+    await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      runId: "run-tool-schema-hook-tolerance",
+    });
+
+    expect(runtimePlanNormalizeToolsMock).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ name: "healthy_lookup" })]),
+      expect.objectContaining({
+        schemaHookFailureMode: "warn",
+      }),
+    );
+    expect(runtimePlanLogDiagnosticsMock).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ name: "healthy_lookup" })]),
+      expect.objectContaining({
+        schemaHookFailureMode: "warn",
+      }),
+    );
   });
 
   it("clamps the caller context token budget to the compaction model", async () => {

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -829,6 +829,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       workspaceDir: effectiveWorkspace,
       modelApi: model.api,
       model,
+      schemaHookFailureMode: "warn" as const,
     };
     const normalizableToolProjection = filterProviderNormalizableTools(
       toolsEnabled ? toolsRaw : [],

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1413,6 +1413,7 @@ export async function runEmbeddedAttempt(
       modelApi: params.model.api,
       model: params.model,
       runtimeHandle: getProviderRuntimeHandle(),
+      schemaHookFailureMode: "warn",
       onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
         logRuntimeToolSchemaQuarantine({
           diagnostics,
@@ -1509,6 +1510,7 @@ export async function runEmbeddedAttempt(
             modelApi: params.model.api,
             model: params.model,
             runtimeHandle: getProviderRuntimeHandle(),
+            schemaHookFailureMode: "warn",
             onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
               logRuntimeToolSchemaQuarantine({
                 diagnostics,
@@ -1666,6 +1668,7 @@ export async function runEmbeddedAttempt(
       modelApi: params.model.api,
       model: params.model,
       runtimeHandle: getProviderRuntimeHandle(),
+      schemaHookFailureMode: "warn",
     });
 
     const machineName = await getMachineDisplayName();

--- a/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   inspectProviderToolSchemasWithPlugin: vi.fn(),
@@ -21,7 +21,25 @@ vi.mock("./logger.js", () => ({
 const { logProviderToolSchemaDiagnostics, normalizeProviderToolSchemas } =
   await import("./tool-schema-runtime.js");
 
+function createHostileThrownValue() {
+  return new Proxy(() => undefined, {
+    get(target, property, receiver) {
+      if (property === Symbol.toStringTag) {
+        throw new Error("tag exploded");
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  }) as unknown as Error;
+}
+
 describe("tool schema runtime diagnostics", () => {
+  beforeEach(() => {
+    mocks.log.info.mockReset();
+    mocks.log.warn.mockReset();
+    mocks.inspectProviderToolSchemasWithPlugin.mockReset();
+    mocks.normalizeProviderToolSchemasWithPlugin.mockReset();
+  });
+
   it("stays quiet when a provider reports no diagnostics", () => {
     mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([]);
 
@@ -57,6 +75,68 @@ describe("tool schema runtime diagnostics", () => {
     );
   });
 
+  it("keeps the current runtime tools when provider schema normalization throws", () => {
+    const tools = [{ name: "alpha" }] as never;
+    mocks.normalizeProviderToolSchemasWithPlugin.mockImplementationOnce(() => {
+      throw new Error("bad\nnormalizer");
+    });
+
+    expect(
+      normalizeProviderToolSchemas({
+        provider: "fuzz-provider\nWARN forged",
+        tools,
+        hookFailureMode: "warn",
+      }),
+    ).toBe(tools);
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema normalizeToolSchemas hook failed for fuzz-providerWARN forged; keeping current runtime tools: badnormalizer",
+      {
+        provider: "fuzz-providerWARN forged",
+        hookName: "normalizeToolSchemas",
+        toolCount: 1,
+      },
+    );
+  });
+
+  it("does not crash warn-mode normalization for hostile thrown values", () => {
+    const tools = [{ name: "alpha" }] as never;
+    mocks.normalizeProviderToolSchemasWithPlugin.mockImplementationOnce(() => {
+      throw createHostileThrownValue();
+    });
+
+    expect(
+      normalizeProviderToolSchemas({
+        provider: "example",
+        tools,
+        hookFailureMode: "warn",
+      }),
+    ).toBe(tools);
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema normalizeToolSchemas hook failed for example; keeping current runtime tools: [object Function]",
+      {
+        provider: "example",
+        hookName: "normalizeToolSchemas",
+        toolCount: 1,
+      },
+    );
+  });
+
+  it("keeps doctor-style schema normalization strict by default", () => {
+    mocks.normalizeProviderToolSchemasWithPlugin.mockImplementationOnce(() => {
+      throw new Error("bad normalizer");
+    });
+
+    expect(() =>
+      normalizeProviderToolSchemas({
+        provider: "example",
+        tools: [{ name: "alpha" }] as never,
+      }),
+    ).toThrow("bad normalizer");
+    expect(mocks.log.warn).not.toHaveBeenCalled();
+  });
+
   it("logs one summarized warning for provider tool schema diagnostics", () => {
     mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([
       { toolName: "alpha", toolIndex: 0, violations: ["one", "two"] },
@@ -83,5 +163,40 @@ describe("tool schema runtime diagnostics", () => {
         ],
       },
     );
+  });
+
+  it("does not crash runtime diagnostics when provider schema inspection throws", () => {
+    mocks.inspectProviderToolSchemasWithPlugin.mockImplementationOnce(() => {
+      throw new Error("bad inspector");
+    });
+
+    logProviderToolSchemaDiagnostics({
+      provider: "example",
+      tools: [{ name: "alpha" }] as never,
+      hookFailureMode: "warn",
+    });
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema inspectToolSchemas hook failed for example; keeping current runtime tools: bad inspector",
+      {
+        provider: "example",
+        hookName: "inspectToolSchemas",
+        toolCount: 1,
+      },
+    );
+  });
+
+  it("keeps doctor-style schema inspection strict by default", () => {
+    mocks.inspectProviderToolSchemasWithPlugin.mockImplementationOnce(() => {
+      throw new Error("bad inspector");
+    });
+
+    expect(() =>
+      logProviderToolSchemaDiagnostics({
+        provider: "example",
+        tools: [{ name: "alpha" }] as never,
+      }),
+    ).toThrow("bad inspector");
+    expect(mocks.log.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/embedded-agent-runner/tool-schema-runtime.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.ts
@@ -1,5 +1,7 @@
 import type { TSchema } from "typebox";
+import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import type { ProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import {
@@ -22,6 +24,7 @@ type ProviderToolSchemaParams<TSchemaType extends TSchema = TSchema, TResult = u
   model?: ProviderRuntimeModel;
   runtimeHandle?: ProviderRuntimePluginHandle;
   allowRuntimePluginLoad?: boolean;
+  hookFailureMode?: "throw" | "warn";
 };
 
 function buildProviderToolSchemaContext<TSchemaType extends TSchema = TSchema, TResult = unknown>(
@@ -40,6 +43,23 @@ function buildProviderToolSchemaContext<TSchemaType extends TSchema = TSchema, T
   };
 }
 
+function warnProviderToolSchemaHookFailure(params: {
+  provider: string;
+  hookName: "normalizeToolSchemas" | "inspectToolSchemas";
+  toolCount: number;
+  error: unknown;
+}): void {
+  const provider = sanitizeForLog(params.provider);
+  log.warn(
+    `provider tool schema ${params.hookName} hook failed for ${provider}; keeping current runtime tools: ${sanitizeForLog(formatErrorMessage(params.error))}`,
+    {
+      provider,
+      hookName: params.hookName,
+      toolCount: params.toolCount,
+    },
+  );
+}
+
 /**
  * Runs provider-owned tool-schema normalization without encoding provider
  * families in the embedded runner.
@@ -49,15 +69,29 @@ export function normalizeProviderToolSchemas<
   TResult = unknown,
 >(params: ProviderToolSchemaParams<TSchemaType, TResult>): AgentTool<TSchemaType, TResult>[] {
   const provider = params.provider.trim();
-  const pluginNormalized = normalizeProviderToolSchemasWithPlugin({
-    provider,
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    runtimeHandle: params.runtimeHandle,
-    allowRuntimePluginLoad: params.allowRuntimePluginLoad,
-    context: buildProviderToolSchemaContext(params, provider),
-  });
+  let pluginNormalized: unknown;
+  try {
+    pluginNormalized = normalizeProviderToolSchemasWithPlugin({
+      provider,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      runtimeHandle: params.runtimeHandle,
+      allowRuntimePluginLoad: params.allowRuntimePluginLoad,
+      context: buildProviderToolSchemaContext(params, provider),
+    });
+  } catch (error) {
+    if (params.hookFailureMode !== "warn") {
+      throw error;
+    }
+    warnProviderToolSchemaHookFailure({
+      provider,
+      hookName: "normalizeToolSchemas",
+      toolCount: params.tools.length,
+      error,
+    });
+    return params.tools;
+  }
   return Array.isArray(pluginNormalized)
     ? (pluginNormalized as AgentTool<TSchemaType, TResult>[])
     : params.tools;
@@ -68,15 +102,29 @@ export function normalizeProviderToolSchemas<
  */
 export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParams): void {
   const provider = params.provider.trim();
-  const diagnostics = inspectProviderToolSchemasWithPlugin({
-    provider,
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    runtimeHandle: params.runtimeHandle,
-    allowRuntimePluginLoad: params.allowRuntimePluginLoad,
-    context: buildProviderToolSchemaContext(params, provider),
-  });
+  let diagnostics: unknown;
+  try {
+    diagnostics = inspectProviderToolSchemasWithPlugin({
+      provider,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      runtimeHandle: params.runtimeHandle,
+      allowRuntimePluginLoad: params.allowRuntimePluginLoad,
+      context: buildProviderToolSchemaContext(params, provider),
+    });
+  } catch (error) {
+    if (params.hookFailureMode !== "warn") {
+      throw error;
+    }
+    warnProviderToolSchemaHookFailure({
+      provider,
+      hookName: "inspectToolSchemas",
+      toolCount: params.tools.length,
+      error,
+    });
+    return;
+  }
   if (!Array.isArray(diagnostics)) {
     return;
   }

--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -291,11 +291,15 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
           workspaceDir?: string;
           modelApi?: string;
           model?: BuildAgentRuntimePlanParams["model"];
+          schemaHookFailureMode?: "throw" | "warn";
         },
       ): AgentTool<TSchemaType, TResult>[] {
         return normalizeProviderToolSchemas({
           ...resolveToolContext(overrides),
           tools,
+          ...(overrides?.schemaHookFailureMode
+            ? { hookFailureMode: overrides.schemaHookFailureMode }
+            : {}),
         });
       },
       logDiagnostics(
@@ -304,11 +308,15 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
           workspaceDir?: string;
           modelApi?: string;
           model?: BuildAgentRuntimePlanParams["model"];
+          schemaHookFailureMode?: "throw" | "warn";
         },
       ): void {
         logProviderToolSchemaDiagnostics({
           ...resolveToolContext(overrides),
           tools,
+          ...(overrides?.schemaHookFailureMode
+            ? { hookFailureMode: overrides.schemaHookFailureMode }
+            : {}),
         });
       },
     },

--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -330,6 +330,31 @@ describe("AgentRuntimePlan tool policy helpers", () => {
     );
   });
 
+  it("passes assistant-runtime schema hook tolerance to RuntimePlan normalization", () => {
+    const tools = [createParameterFreeTool()] as AgentTool[];
+    const normalize = vi.fn(() => tools);
+    const runtimePlan = {
+      tools: {
+        normalize,
+        logDiagnostics: vi.fn(),
+      },
+    } as unknown as AgentRuntimePlan;
+
+    normalizeAgentRuntimeTools({
+      runtimePlan,
+      tools,
+      provider: "openai",
+      schemaHookFailureMode: "warn",
+    });
+
+    expect(normalize).toHaveBeenCalledWith(tools, {
+      workspaceDir: undefined,
+      modelApi: undefined,
+      model: undefined,
+      schemaHookFailureMode: "warn",
+    });
+  });
+
   it("routes diagnostics through RuntimePlan when a plan is available", () => {
     const tools = [createParameterFreeTool()] as AgentTool[];
     const model = createNativeOpenAIResponsesModel() as never;
@@ -355,6 +380,31 @@ describe("AgentRuntimePlan tool policy helpers", () => {
       workspaceDir: "/tmp/openclaw-runtime-plan-tools",
       modelApi: "openai-responses",
       model,
+    });
+  });
+
+  it("passes assistant-runtime schema hook tolerance to RuntimePlan diagnostics", () => {
+    const tools = [createParameterFreeTool()] as AgentTool[];
+    const logDiagnostics = vi.fn();
+    const runtimePlan = {
+      tools: {
+        normalize: vi.fn(),
+        logDiagnostics,
+      },
+    } as unknown as AgentRuntimePlan;
+
+    logAgentRuntimeToolDiagnostics({
+      runtimePlan,
+      tools,
+      provider: "openai",
+      schemaHookFailureMode: "warn",
+    });
+
+    expect(logDiagnostics).toHaveBeenCalledWith(tools, {
+      workspaceDir: undefined,
+      modelApi: undefined,
+      model: undefined,
+      schemaHookFailureMode: "warn",
     });
   });
 });

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -27,6 +27,7 @@ type AgentRuntimeToolPolicyParams<TSchemaType extends TSchema = TSchema, TResult
   model?: ProviderRuntimeModel;
   runtimeHandle?: ProviderRuntimePluginHandle;
   allowProviderRuntimePluginLoad?: boolean;
+  schemaHookFailureMode?: "throw" | "warn";
   onPreNormalizationSchemaDiagnostics?: (
     diagnostics: readonly RuntimeToolSchemaDiagnostic[],
     tools: readonly AgentTool<TSchemaType, TResult>[],
@@ -37,11 +38,15 @@ function runtimePlanToolContext(params: {
   workspaceDir?: string;
   modelApi?: string | null;
   model?: ProviderRuntimeModel;
+  schemaHookFailureMode?: "throw" | "warn";
 }) {
   return {
     workspaceDir: params.workspaceDir,
     modelApi: params.modelApi ?? undefined,
     model: params.model,
+    ...(params.schemaHookFailureMode
+      ? { schemaHookFailureMode: params.schemaHookFailureMode }
+      : {}),
   };
 }
 
@@ -110,6 +115,7 @@ export function normalizeAgentRuntimeTools<
       model: params.model,
       runtimeHandle: params.runtimeHandle,
       allowRuntimePluginLoad: params.allowProviderRuntimePluginLoad,
+      ...(params.schemaHookFailureMode ? { hookFailureMode: params.schemaHookFailureMode } : {}),
     });
   const normalizedTools = Array.isArray(normalized) ? normalized : normalizableTools;
   return preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
@@ -131,5 +137,6 @@ export function logAgentRuntimeToolDiagnostics(params: AgentRuntimeToolPolicyPar
     modelApi: params.modelApi,
     model: params.model,
     runtimeHandle: params.runtimeHandle,
+    ...(params.schemaHookFailureMode ? { hookFailureMode: params.schemaHookFailureMode } : {}),
   });
 }

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -356,6 +356,7 @@ export type AgentRuntimeToolPlan = {
       workspaceDir?: string;
       modelApi?: string;
       model?: AgentRuntimeModel;
+      schemaHookFailureMode?: "throw" | "warn";
     },
   ): AgentTool<TSchemaType, TResult>[];
   logDiagnostics(
@@ -364,6 +365,7 @@ export type AgentRuntimeToolPlan = {
       workspaceDir?: string;
       modelApi?: string;
       model?: AgentRuntimeModel;
+      schemaHookFailureMode?: "throw" | "warn";
     },
   ): void;
 };

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -16,6 +16,34 @@ function createCircularObject() {
   return circular;
 }
 
+function createHostileToStringTagFunction() {
+  return new Proxy(() => undefined, {
+    get(target, property, receiver) {
+      if (property === Symbol.toStringTag) {
+        throw new Error("tag exploded");
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+}
+
+function createHostilePrototypeObject() {
+  return new Proxy(
+    {},
+    {
+      getPrototypeOf() {
+        throw new Error("prototype exploded");
+      },
+    },
+  );
+}
+
+function createRevokedProxy() {
+  const proxy = Proxy.revocable({}, {});
+  proxy.revoke();
+  return proxy.proxy;
+}
+
 describe("error helpers", () => {
   it.each([
     { value: { code: "EADDRINUSE" }, expected: "EADDRINUSE" },
@@ -65,6 +93,12 @@ describe("error helpers", () => {
     { value: 123n, expected: "123" },
     { value: false, expected: "false" },
     { value: createCircularObject(), expected: "[object Object]" },
+    { value: undefined, expected: "[object Undefined]" },
+    { value: Symbol("fuzz"), expected: "[object Symbol]" },
+    { value: () => undefined, expected: "[object Function]" },
+    { value: createHostileToStringTagFunction(), expected: "[object Function]" },
+    { value: createHostilePrototypeObject(), expected: "[object Object]" },
+    { value: createRevokedProxy(), expected: "[object Unknown]" },
   ])("formats error messages for case %#", ({ value, expected }) => {
     expect(formatErrorMessage(value)).toBe(expected);
   });

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -65,7 +65,15 @@ export function hasErrnoCode(err: unknown, code: string): boolean {
   return isErrno(err) && err.code === code;
 }
 
-export function formatErrorMessage(err: unknown): string {
+function safeObjectTag(value: unknown): string {
+  try {
+    return Object.prototype.toString.call(value);
+  } catch {
+    return typeof value === "function" ? "[object Function]" : "[object Unknown]";
+  }
+}
+
+function formatErrorMessageValue(err: unknown): string {
   let formatted: string;
   if (err instanceof Error) {
     formatted = err.message || err.name || "Error";
@@ -99,10 +107,20 @@ export function formatErrorMessage(err: unknown): string {
     formatted = String(err);
   } else {
     try {
-      formatted = JSON.stringify(err);
+      formatted = JSON.stringify(err) ?? safeObjectTag(err);
     } catch {
-      formatted = Object.prototype.toString.call(err);
+      formatted = safeObjectTag(err);
     }
+  }
+  return formatted;
+}
+
+export function formatErrorMessage(err: unknown): string {
+  let formatted: string;
+  try {
+    formatted = formatErrorMessageValue(err);
+  } catch {
+    formatted = safeObjectTag(err);
   }
   // Security: best-effort token redaction before returning/logging.
   return redactSensitiveText(formatted);
@@ -123,9 +141,9 @@ export function stringifyNonErrorCause(value: unknown): string {
     return String(value);
   }
   try {
-    return JSON.stringify(value) ?? Object.prototype.toString.call(value);
+    return JSON.stringify(value) ?? safeObjectTag(value);
   } catch {
-    return Object.prototype.toString.call(value);
+    return safeObjectTag(value);
   }
 }
 


### PR DESCRIPTION
## Summary

- keep provider `normalizeToolSchemas` and `inspectToolSchemas` strict by default for doctor/check validation
- pass assistant-only warn mode through embedded attempts, Codex dynamic tools, and compaction so hook failures log and keep current runtime tools
- make error formatting total for arbitrary thrown values, including hostile proxies/functions, before warning logs are emitted

## Verification

- `node scripts/run-vitest.mjs src/infra/errors.test.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts src/agents/runtime-plan/tools.test.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.runtime-errors.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check --threads=1 src/infra/errors.ts src/infra/errors.test.ts src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts src/agents/runtime-plan/build.ts src/agents/runtime-plan/types.ts src/agents/embedded-agent-runner/run/attempt.ts extensions/codex/src/app-server/dynamic-tool-build.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts src/agents/embedded-agent-runner/compact.ts src/agents/embedded-agent-runner/compact.hooks.test.ts src/agents/embedded-agent-runner/compact.hooks.harness.ts`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/infra/errors.ts src/infra/errors.test.ts src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts src/agents/runtime-plan/build.ts src/agents/runtime-plan/types.ts src/agents/embedded-agent-runner/run/attempt.ts extensions/codex/src/app-server/dynamic-tool-build.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts src/agents/embedded-agent-runner/compact.ts src/agents/embedded-agent-runner/compact.hooks.test.ts src/agents/embedded-agent-runner/compact.hooks.harness.ts`
- `git diff --check origin/main...HEAD`
- private reported-name scrub across spec and changed files
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "..."`

## Real behavior proof

Behavior addressed: assistant-visible tool projection no longer aborts when a provider tool-schema hook throws; doctor/check paths still surface the failure because strict behavior remains the default.

Real environment tested: local Codex worktree with Node/Vitest routed through `scripts/run-vitest.mjs`; broad remote proof attempted through AWS Crabbox and Blacksmith Testbox.

Exact steps or command run after this patch: focused Vitest commands, oxfmt, oxlint, `git diff --check origin/main...HEAD`, private-name scrub, local autoreview, and remote `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "corepack pnpm check:changed"`.

Evidence after fix: focused tests passed 146 tests across 3 routed shards and 67 tests across 3 routed shards; formatter/lint/diff/scrub passed; final autoreview reported no accepted/actionable findings with `overall: patch is correct (0.87)`.

Observed result after fix: warn-mode paths keep the current runtime tools and log sanitized hook failures, including non-Error and hostile thrown values; strict callers still throw for doctor/check visibility.

What was not tested: remote `check:changed` did not run because AWS Crabbox allocation failed twice with `active lease limit exceeded: 9/8`, and Blacksmith Testbox failed with `not authenticated -- run 'blacksmith auth login' first`.
