### PR TITLE
perf(ui): skip closed slash menu rerenders

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -45,62 +45,60 @@ const loadSessionsMock = vi.hoisted(() =>
   }),
 );
 const buildChatItemsMock = vi.hoisted(() =>
-  vi.fn(
-    (props: { messages: unknown[]; stream: string | null; streamStartedAt: number | null }) => {
-      if (
-        props.messages.some(
-          (message) =>
-            typeof message === "object" &&
-            message !== null &&
-            (message as { __testDivider?: unknown })["__testDivider"] === true,
-        )
-      ) {
-        return [
-          {
-            kind: "divider",
-            key: "divider:compaction:test",
-            label: "Compacted history",
-            description:
-              "The compacted transcript is preserved as a checkpoint. Open session checkpoints to branch or restore from that compacted view.",
-            action: {
-              kind: "session-checkpoints",
-              label: "Open checkpoints",
+  vi.fn((props: { messages: unknown[]; stream: string | null; streamStartedAt: number | null }) => {
+    if (
+      props.messages.some(
+        (message) =>
+          typeof message === "object" &&
+          message !== null &&
+          (message as { __testDivider?: unknown })["__testDivider"] === true,
+      )
+    ) {
+      return [
+        {
+          kind: "divider",
+          key: "divider:compaction:test",
+          label: "Compacted history",
+          description:
+            "The compacted transcript is preserved as a checkpoint. Open session checkpoints to branch or restore from that compacted view.",
+          action: {
+            kind: "session-checkpoints",
+            label: "Open checkpoints",
+          },
+          timestamp: 1,
+        },
+      ];
+    }
+    if (props.messages.length > 0) {
+      return [
+        {
+          kind: "group",
+          key: "group:assistant:test",
+          role: "assistant",
+          messages: props.messages.map((message, index) => ({
+            key: `message:${index}`,
+            message,
+          })),
+          timestamp: 1,
+          isStreaming: false,
+        },
+      ];
+    }
+    if (props.stream !== null) {
+      return props.stream
+        ? [
+            {
+              kind: "stream",
+              key: "stream:test",
+              text: props.stream,
+              startedAt: props.streamStartedAt ?? 1,
+              isStreaming: true,
             },
-            timestamp: 1,
-          },
-        ];
-      }
-      if (props.messages.length > 0) {
-        return [
-          {
-            kind: "group",
-            key: "group:assistant:test",
-            role: "assistant",
-            messages: props.messages.map((message, index) => ({
-              key: `message:${index}`,
-              message,
-            })),
-            timestamp: 1,
-            isStreaming: false,
-          },
-        ];
-      }
-      if (props.stream !== null) {
-        return props.stream
-          ? [
-              {
-                kind: "stream",
-                key: "stream:test",
-                text: props.stream,
-                startedAt: props.streamStartedAt ?? 1,
-                isStreaming: true,
-              },
-            ]
-          : [{ kind: "reading-indicator", key: "reading:test" }];
-      }
-      return [];
-    },
-  ),
+          ]
+        : [{ kind: "reading-indicator", key: "reading:test" }];
+    }
+    return [];
+  }),
 );
 
 function requireFirstAttachmentsChange(
@@ -1073,6 +1071,17 @@ describe("chat slash menu accessibility", () => {
     expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
     textarea!.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
   }
+
+  it("does not request a slash-menu rerender for plain draft input when suggestions are closed", () => {
+    const onDraftChange = vi.fn();
+    const onRequestUpdate = vi.fn();
+    const container = renderChatView({ onDraftChange, onRequestUpdate });
+
+    inputDraft(container, "plain first message");
+
+    expect(onDraftChange).toHaveBeenCalledWith("plain first message");
+    expect(onRequestUpdate).not.toHaveBeenCalled();
+  });
 
   it("wires command suggestions to the composer with stable active option ids", () => {
     let draft = "";

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -872,6 +872,26 @@ function resetSlashMenuState(): void {
   vs.slashMenuExpanded = false;
 }
 
+function hasVisibleSlashMenuState(): boolean {
+  return (
+    vs.slashMenuOpen ||
+    vs.slashMenuMode !== "command" ||
+    vs.slashMenuCommand !== null ||
+    vs.slashMenuArgItems.length > 0 ||
+    vs.slashMenuItems.length > 0 ||
+    vs.slashMenuExpanded
+  );
+}
+
+function closeSlashMenuIfNeeded(requestUpdate: () => void): void {
+  if (!hasVisibleSlashMenuState()) {
+    return;
+  }
+  vs.slashMenuOpen = false;
+  resetSlashMenuState();
+  requestUpdate();
+}
+
 function updateSlashMenu(value: string, requestUpdate: () => void): void {
   // Arg mode: /command <partial-arg>
   const argMatch = value.match(/^\/(\S+)\s(.*)$/);
@@ -894,9 +914,7 @@ function updateSlashMenu(value: string, requestUpdate: () => void): void {
         return;
       }
     }
-    vs.slashMenuOpen = false;
-    resetSlashMenuState();
-    requestUpdate();
+    closeSlashMenuIfNeeded(requestUpdate);
     return;
   }
 
@@ -911,8 +929,8 @@ function updateSlashMenu(value: string, requestUpdate: () => void): void {
     vs.slashMenuCommand = null;
     vs.slashMenuArgItems = [];
   } else {
-    vs.slashMenuOpen = false;
-    resetSlashMenuState();
+    closeSlashMenuIfNeeded(requestUpdate);
+    return;
   }
   requestUpdate();
 }


### PR DESCRIPTION
## Summary
- skip slash-menu `requestUpdate()` when plain composer input arrives while suggestions are already closed
- keep existing rerenders when an open/expanded command or argument menu needs to close
- add a regression covering the clean first-message input path

## Verification
- `node scripts/run-vitest.mjs run ui/src/ui/views/chat.test.ts ui/src/ui/chat/build-chat-items.test.ts --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner` (104 tests)
- `./node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts`
- `node scripts/run-oxlint.mjs ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` (`tbx_01kt1086xrbxfzm85vynsf25hq`, passed)
