### PR TITLE
fix: deliver compaction.notifyUser notices via routeReply when no active turn

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -109,10 +109,12 @@ import {
 } from "./provider-request-error-classifier.js";
 import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
+import type { ReplyDispatchKind } from "./reply-dispatcher.types.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
 import { createReplyMediaContext } from "./reply-media-paths.runtime.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import { isReplyProfilerEnabled } from "./reply-timing-tracker.js";
+import { isRoutableChannel, routeReply } from "./route-reply.runtime.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
 // Maximum number of LiveSessionModelSwitchError retries before surfacing a
@@ -1564,9 +1566,6 @@ export async function runAgentTurnWithFallback(params: {
   const shouldNotifyUserAboutCompaction =
     runtimeConfig?.agents?.defaults?.compaction?.notifyUser === true;
   const sendCompactionNotice = async (phase: "start" | "end" | "incomplete") => {
-    if (!params.opts?.onBlockReply) {
-      return;
-    }
     const text =
       phase === "start"
         ? "🧹 Compacting context..."
@@ -1579,12 +1578,51 @@ export async function runAgentTurnWithFallback(params: {
       replyToCurrent: true,
       isCompactionNotice: true,
     });
+
+    // Primary path: deliver through the active turn's streaming callback.
+    if (params.opts?.onBlockReply) {
+      try {
+        await params.opts.onBlockReply(noticePayload);
+      } catch (err) {
+        logVerbose(`compaction ${phase} notice delivery failed (non-fatal): ${String(err)}`);
+      }
+      return;
+    }
+
+    // Fallback path: deliver through the canonical session outbound path when
+    // no active streaming turn is available (e.g. async / preflight compactions).
+    // Only send when notifyUser is enabled and the channel is routable.
+    if (!shouldNotifyUserAboutCompaction) {
+      return;
+    }
+    const channel = params.sessionCtx.Surface ?? params.sessionCtx.Provider;
+    if (!channel || !isRoutableChannel(channel)) {
+      return;
+    }
+    const to = params.sessionCtx.OriginatingTo ?? params.sessionCtx.To;
+    if (!to) {
+      return;
+    }
+
     try {
-      await params.opts.onBlockReply(noticePayload);
+      const replyKind: ReplyDispatchKind = "block";
+      await routeReply({
+        payload: noticePayload,
+        channel,
+        to,
+        sessionKey: params.sessionKey,
+        accountId: params.sessionCtx.AccountId,
+        requesterSenderId: params.sessionCtx.SenderId,
+        requesterSenderName: params.sessionCtx.SenderName,
+        requesterSenderUsername: params.sessionCtx.SenderUsername,
+        requesterSenderE164: params.sessionCtx.SenderE164,
+        threadId: params.followupRun.originatingThreadId ?? params.sessionCtx.MessageThreadId,
+        cfg: runtimeConfig,
+        replyKind,
+        runId: params.followupRun.run.runId,
+      });
     } catch (err) {
-      // Non-critical notice delivery failure should not bubble out of the
-      // fire-and-forget event handler.
-      logVerbose(`compaction ${phase} notice delivery failed (non-fatal): ${String(err)}`);
+      logVerbose(`compaction ${phase} notice route-reply failed (non-fatal): ${String(err)}`);
     }
   };
   const readCompactionHookMessages = (value: unknown): string[] => {


### PR DESCRIPTION
Fixes #88933

## Summary

When `agents.defaults.compaction.notifyUser: true` is configured but no active streaming turn callback (`onBlockReply`) is available, `sendCompactionNotice` now falls back to routing the notice through the canonical session outbound path (`routeReply`) instead of silently returning early.

This fixes the issue where async/preflight compactions (triggered outside of active inbound-driven streaming reply turns — e.g. proactive `maxHistoryShare` compactions, subagent-completion auto-announce compactions) produce no user-visible notice even when `notifyUser: true` is configured.

## Root cause

`sendCompactionNotice` was guarded by an early `return` when `params.opts?.onBlockReply` was absent. All three call sites (start/end/incomplete phases) go through this guard, so any compaction without an active streaming turn silently skips notification.

## Fix

The fix adds a fallback delivery path:

1. **Primary path** (unchanged): deliver via `onBlockReply` when available
2. **Fallback path** (new): when `onBlockReply` is absent but `notifyUser` is enabled, route the notice through `routeReply` using the session's channel/surface info

The fallback only activates when:
- `notifyUser` is `true` in runtime config
- The session has a routable `channel` (`Surface ?? Provider`)
- The session has a valid `to` address (`OriginatingTo ?? To`)

Errors in both paths are caught and logged as non-fatal (fire-and-forget semantics preserved).

## Tests

All 152 tests in `src/auto-reply/reply/agent-runner-execution.test.ts` pass, including the 9 compaction-related tests:

```
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts
✓ auto-reply  src/auto-reply/reply/agent-runner-execution.test.ts (152 tests) 1715ms
Test Files  1 passed (1)
     Tests  152 passed (152)
```

## Review notes

- Clawsweeper previously marked this issue `clawsweeper:fix-shape-clear` and `clawsweeper:queueable-fix` — the fix follows the identified canonical delivery seam (`routeReply` → `sendDurableMessageBatch`).
- The fix reuses existing `ReplyDispatchKind.block` for compaction notices, consistent with their transient/status semantics.
- A subsequent PR could add a unit test specifically covering the no-`onBlockReply` fallback path for completeness.