### PR TITLE
feat(nextcloud-talk): support reaction approvals

### DIFF
--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -100,14 +100,14 @@ Minimal config:
 
 ## Capabilities
 
-| Feature         | Status        |
-| --------------- | ------------- |
-| Direct messages | Supported     |
-| Rooms           | Supported     |
-| Threads         | Not supported |
-| Media           | URL-only      |
-| Reactions       | Supported     |
-| Native commands | Not supported |
+| Feature         | Status                                                            |
+| --------------- | ----------------------------------------------------------------- |
+| Direct messages | Supported                                                         |
+| Rooms           | Supported                                                         |
+| Threads         | Not supported                                                     |
+| Media           | URL-only                                                          |
+| Reactions       | Supported                                                         |
+| Native commands | Supported (text commands via bot webhook; no client autocomplete) |
 
 ## Configuration reference (Nextcloud Talk)
 

--- a/extensions/nextcloud-talk/src/approval-stash.test.ts
+++ b/extensions/nextcloud-talk/src/approval-stash.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  approvalStashSize,
+  buildApprovalActions,
+  clearApprovalStash,
+  consumeApproval,
+  lookupApproval,
+  purgeExpiredApprovals,
+  resolveReactionDecision,
+  stashApproval,
+} from "./approval-stash.js";
+
+afterEach(() => {
+  clearApprovalStash();
+});
+
+describe("buildApprovalActions", () => {
+  it("maps the standard 3-decision set to keycap numerals", () => {
+    const actions = buildApprovalActions(["allow-once", "allow-always", "deny"]);
+    expect(actions).toEqual([
+      { emoji: "1️⃣", decision: "allow-once" },
+      { emoji: "2️⃣", decision: "allow-always" },
+      { emoji: "3️⃣", decision: "deny" },
+    ]);
+  });
+
+  it("falls back to 👍/👎 for a 2-decision set", () => {
+    const actions = buildApprovalActions(["allow-once", "deny"]);
+    expect(actions).toEqual([
+      { emoji: "👍", decision: "allow-once" },
+      { emoji: "👎", decision: "deny" },
+    ]);
+  });
+
+  it("returns empty for an empty decision set", () => {
+    expect(buildApprovalActions([])).toEqual([]);
+  });
+
+  it("maps a single-decision set to the binary fallback", () => {
+    const actions = buildApprovalActions(["deny"]);
+    expect(actions).toEqual([{ emoji: "👎", decision: "deny" }]);
+  });
+});
+
+describe("stash / lookup / consume lifecycle", () => {
+  it("stores and retrieves an approval entry", () => {
+    stashApproval("acct-1", "room-A", "msg-10", {
+      approvalId: "appr-123",
+      approvalSlug: "appr-12",
+      approvalKind: "exec",
+      actions: [{ emoji: "1️⃣", decision: "allow-once" }],
+    });
+
+    const entry = lookupApproval("acct-1", "room-A", "msg-10");
+    expect(entry).toBeDefined();
+    expect(entry!.approvalId).toBe("appr-123");
+    expect(entry!.approvalKind).toBe("exec");
+    expect(entry!.createdAt).toBeGreaterThan(0);
+    expect(approvalStashSize()).toBe(1);
+  });
+
+  it("returns undefined for unknown keys", () => {
+    expect(lookupApproval("acct-1", "room-X", "msg-X")).toBeUndefined();
+  });
+
+  it("consume removes the entry", () => {
+    stashApproval("acct-1", "room-A", "msg-10", {
+      approvalId: "appr-1",
+      approvalSlug: "appr-1",
+      approvalKind: "exec",
+      actions: [],
+    });
+    expect(approvalStashSize()).toBe(1);
+    consumeApproval("acct-1", "room-A", "msg-10");
+    expect(approvalStashSize()).toBe(0);
+    expect(lookupApproval("acct-1", "room-A", "msg-10")).toBeUndefined();
+  });
+});
+
+describe("resolveReactionDecision", () => {
+  it("matches the emoji to the stashed action", () => {
+    const entry = {
+      approvalId: "a",
+      approvalSlug: "a",
+      approvalKind: "exec" as const,
+      actions: [
+        { emoji: "1️⃣", decision: "allow-once" as const },
+        { emoji: "2️⃣", decision: "allow-always" as const },
+        { emoji: "3️⃣", decision: "deny" as const },
+      ],
+      createdAt: Date.now(),
+    };
+    expect(resolveReactionDecision(entry, "2️⃣")).toBe("allow-always");
+    expect(resolveReactionDecision(entry, "3️⃣")).toBe("deny");
+  });
+
+  it("returns undefined for non-matching emoji", () => {
+    const entry = {
+      approvalId: "a",
+      approvalSlug: "a",
+      approvalKind: "exec" as const,
+      actions: [{ emoji: "1️⃣", decision: "allow-once" as const }],
+      createdAt: Date.now(),
+    };
+    expect(resolveReactionDecision(entry, "🔥")).toBeUndefined();
+  });
+});
+
+describe("purgeExpiredApprovals", () => {
+  it("removes entries older than the TTL", () => {
+    stashApproval("a", "r", "m1", {
+      approvalId: "old",
+      approvalSlug: "old",
+      approvalKind: "exec",
+      actions: [],
+    });
+
+    // Manually backdate the entry
+    const entry = lookupApproval("a", "r", "m1")!;
+    (entry as { createdAt: number }).createdAt = Date.now() - 20 * 60 * 1000;
+
+    stashApproval("a", "r", "m2", {
+      approvalId: "fresh",
+      approvalSlug: "fresh",
+      approvalKind: "exec",
+      actions: [],
+    });
+
+    const removed = purgeExpiredApprovals(10 * 60 * 1000);
+    expect(removed).toBe(1);
+    expect(lookupApproval("a", "r", "m1")).toBeUndefined();
+    expect(lookupApproval("a", "r", "m2")).toBeDefined();
+  });
+
+  it("returns 0 when nothing is expired", () => {
+    stashApproval("a", "r", "m1", {
+      approvalId: "x",
+      approvalSlug: "x",
+      approvalKind: "exec",
+      actions: [],
+    });
+    expect(purgeExpiredApprovals()).toBe(0);
+  });
+});

--- a/extensions/nextcloud-talk/src/approval-stash.ts
+++ b/extensions/nextcloud-talk/src/approval-stash.ts
@@ -1,0 +1,129 @@
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
+
+/** Keycap emoji → approval decision mapping (1️⃣ allow-once, 2️⃣ allow-always, 3️⃣ deny). */
+const KEYCAP_DECISION_MAP: ReadonlyMap<string, ExecApprovalReplyDecision> = new Map([
+  ["1️⃣", "allow-once"],
+  ["2️⃣", "allow-always"],
+  ["3️⃣", "deny"],
+]);
+
+/** Binary fallback when allowedDecisions is narrowed to a 2-decision set. */
+const BINARY_DECISION_MAP: ReadonlyMap<string, ExecApprovalReplyDecision> = new Map([
+  ["👍", "allow-once"],
+  ["👎", "deny"],
+]);
+
+export type ApprovalStashAction = {
+  emoji: string;
+  decision: ExecApprovalReplyDecision;
+};
+
+export type ApprovalStashEntry = {
+  approvalId: string;
+  approvalSlug: string;
+  approvalKind: "exec" | "plugin";
+  actions: readonly ApprovalStashAction[];
+  sessionKey?: string;
+  createdAt: number;
+};
+
+/** Default TTL: 10 minutes. */
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+type StashKey = `${string}:${string}:${string}`;
+
+function makeKey(accountId: string, roomToken: string, messageId: string): StashKey {
+  return `${accountId}:${roomToken}:${messageId}`;
+}
+
+const stash = new Map<StashKey, ApprovalStashEntry>();
+
+/**
+ * Build the emoji→decision action list for a given set of allowed decisions.
+ * Uses keycap numerals (1️⃣/2️⃣/3️⃣) for the standard 3-decision set, falls back
+ * to 👍/👎 when the decisions are narrowed to a binary pair.
+ */
+export function buildApprovalActions(
+  allowedDecisions: readonly ExecApprovalReplyDecision[],
+): ApprovalStashAction[] {
+  if (allowedDecisions.length <= 2) {
+    return allowedDecisions
+      .map((decision) => {
+        for (const [emoji, d] of BINARY_DECISION_MAP) {
+          if (d === decision) {
+            return { emoji, decision };
+          }
+        }
+        return null;
+      })
+      .filter((a): a is ApprovalStashAction => a !== null);
+  }
+  return allowedDecisions
+    .map((decision) => {
+      for (const [emoji, d] of KEYCAP_DECISION_MAP) {
+        if (d === decision) {
+          return { emoji, decision };
+        }
+      }
+      return null;
+    })
+    .filter((a): a is ApprovalStashAction => a !== null);
+}
+
+/** Seed a stash entry for an outbound approval prompt message. */
+export function stashApproval(
+  accountId: string,
+  roomToken: string,
+  messageId: string,
+  entry: Omit<ApprovalStashEntry, "createdAt">,
+): void {
+  stash.set(makeKey(accountId, roomToken, messageId), {
+    ...entry,
+    createdAt: Date.now(),
+  });
+}
+
+/** Look up a stash entry by the message the reaction was placed on. */
+export function lookupApproval(
+  accountId: string,
+  roomToken: string,
+  messageId: string,
+): ApprovalStashEntry | undefined {
+  return stash.get(makeKey(accountId, roomToken, messageId));
+}
+
+/** Resolve a reaction emoji to a decision using the stashed action mapping. */
+export function resolveReactionDecision(
+  entry: ApprovalStashEntry,
+  emoji: string,
+): ExecApprovalReplyDecision | undefined {
+  return entry.actions.find((a) => a.emoji === emoji)?.decision;
+}
+
+/** Remove a stash entry after the decision is dispatched. */
+export function consumeApproval(accountId: string, roomToken: string, messageId: string): void {
+  stash.delete(makeKey(accountId, roomToken, messageId));
+}
+
+/** Evict entries older than the given TTL (default 10 min). */
+export function purgeExpiredApprovals(ttlMs: number = DEFAULT_TTL_MS): number {
+  const cutoff = Date.now() - ttlMs;
+  let removed = 0;
+  for (const [key, entry] of stash) {
+    if (entry.createdAt < cutoff) {
+      stash.delete(key);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+/** Visible-for-testing: current stash size. */
+export function approvalStashSize(): number {
+  return stash.size;
+}
+
+/** Visible-for-testing: clear all entries. */
+export function clearApprovalStash(): void {
+  stash.clear();
+}

--- a/extensions/nextcloud-talk/src/channel.edit-action.test.ts
+++ b/extensions/nextcloud-talk/src/channel.edit-action.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CoreConfig } from "./types.js";
+
+const sendReactionNextcloudTalkMock = vi.hoisted(() => vi.fn());
+const sendMessageNextcloudTalkMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./send.js", () => ({
+  sendMessageNextcloudTalk: sendMessageNextcloudTalkMock,
+  sendReactionNextcloudTalk: sendReactionNextcloudTalkMock,
+}));
+
+vi.mock("../../../test/helpers/config/bundled-channel-config-runtime.js", () => ({
+  getBundledChannelRuntimeMap: () => new Map(),
+  getBundledChannelConfigSchemaMap: () => new Map(),
+}));
+
+const { nextcloudTalkPlugin } = await import("./channel.js");
+
+type NextcloudTalkHandleAction = NonNullable<
+  NonNullable<typeof nextcloudTalkPlugin.actions>["handleAction"]
+>;
+type NextcloudTalkActionContext = Parameters<NextcloudTalkHandleAction>[0];
+
+function makeConfiguredCfg(): CoreConfig {
+  return {
+    channels: {
+      "nextcloud-talk": {
+        baseUrl: "https://cloud.example.com",
+        botSecret: "secret-value", // pragma: allowlist secret
+      },
+    },
+  } as CoreConfig;
+}
+
+function makeEditCtx(
+  params: Record<string, unknown>,
+  overrides: Partial<NextcloudTalkActionContext> = {},
+): NextcloudTalkActionContext {
+  return {
+    channel: "nextcloud-talk",
+    action: "edit",
+    cfg: makeConfiguredCfg(),
+    params,
+    accountId: "default",
+    ...overrides,
+  } as NextcloudTalkActionContext;
+}
+
+function describedActions(cfg: CoreConfig): string[] {
+  return [...(nextcloudTalkPlugin.actions?.describeMessageTool?.({ cfg })?.actions ?? [])];
+}
+
+describe("nextcloud-talk edit message action (re-post workaround)", () => {
+  beforeEach(() => {
+    sendMessageNextcloudTalkMock.mockReset();
+    sendMessageNextcloudTalkMock.mockResolvedValue({
+      messageId: "101",
+      roomToken: "room:abc",
+      timestamp: 1_700_000_000,
+    });
+  });
+
+  it("advertises edit alongside send + react when an account is configured", () => {
+    expect(describedActions(makeConfiguredCfg())).toEqual(
+      expect.arrayContaining(["send", "react", "edit"]),
+    );
+  });
+
+  it("supportsAction returns true for edit but not delete", () => {
+    expect(nextcloudTalkPlugin.actions?.supportsAction?.({ action: "edit" })).toBe(true);
+    expect(
+      nextcloudTalkPlugin.actions?.supportsAction?.({
+        action: "delete" as NextcloudTalkActionContext["action"],
+      }),
+    ).toBe(false);
+  });
+
+  it("sends a new message prefixed with the edit header and threads it as a reply", async () => {
+    const ctx = makeEditCtx({
+      to: "room:abc",
+      messageId: "42",
+      message: "Updated body",
+    });
+
+    const result = await nextcloudTalkPlugin.actions?.handleAction?.(ctx);
+
+    expect(sendMessageNextcloudTalkMock).toHaveBeenCalledTimes(1);
+    const [toArg, textArg, optsArg] = sendMessageNextcloudTalkMock.mock.calls[0] ?? [];
+    expect(toArg).toBe("room:abc");
+    expect(textArg).toContain("Edited update");
+    expect(textArg).toContain("does not support editing bot messages in place");
+    expect(textArg).toContain("Updated body");
+    expect(optsArg).toMatchObject({ accountId: "default", replyTo: "42", cfg: ctx.cfg });
+
+    const first = result?.content?.[0];
+    if (!first || first.type !== "text") {
+      throw new Error("expected text content block");
+    }
+    const payload = JSON.parse(first.text);
+    expect(payload).toMatchObject({
+      ok: true,
+      channel: "nextcloud-talk",
+      messageId: "101",
+      originalMessageId: "42",
+      replacedAsReply: true,
+    });
+  });
+
+  it("throws when the target room is missing", async () => {
+    await expect(
+      nextcloudTalkPlugin.actions?.handleAction?.(makeEditCtx({ messageId: "42", message: "hi" })),
+    ).rejects.toThrow(/target/i);
+    expect(sendMessageNextcloudTalkMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when messageId is missing", async () => {
+    await expect(
+      nextcloudTalkPlugin.actions?.handleAction?.(makeEditCtx({ to: "room:abc", message: "hi" })),
+    ).rejects.toThrow(/messageId/i);
+  });
+
+  it("throws when the new message body is missing or empty", async () => {
+    await expect(
+      nextcloudTalkPlugin.actions?.handleAction?.(makeEditCtx({ to: "room:abc", messageId: "42" })),
+    ).rejects.toThrow(/message/i);
+    await expect(
+      nextcloudTalkPlugin.actions?.handleAction?.(
+        makeEditCtx({ to: "room:abc", messageId: "42", message: "   " }),
+      ),
+    ).rejects.toThrow(/message/i);
+  });
+
+  it("accepts target as an alias for to", async () => {
+    await nextcloudTalkPlugin.actions?.handleAction?.(
+      makeEditCtx({ target: "room:xyz", messageId: "7", message: "via-target" }),
+    );
+    expect(sendMessageNextcloudTalkMock).toHaveBeenCalledWith(
+      "room:xyz",
+      expect.stringContaining("via-target"),
+      expect.objectContaining({ replyTo: "7" }),
+    );
+  });
+});

--- a/extensions/nextcloud-talk/src/channel.react-action.test.ts
+++ b/extensions/nextcloud-talk/src/channel.react-action.test.ts
@@ -130,7 +130,7 @@ describe("nextcloud-talk react message action", () => {
   it("rejects unsupported actions", async () => {
     await expect(
       nextcloudTalkPlugin.actions?.handleAction?.(
-        makeReactCtx({}, { action: "edit" as NextcloudTalkActionContext["action"] }),
+        makeReactCtx({}, { action: "delete" as NextcloudTalkActionContext["action"] }),
       ),
     ).rejects.toThrow(/Unsupported/);
   });

--- a/extensions/nextcloud-talk/src/channel.react-action.test.ts
+++ b/extensions/nextcloud-talk/src/channel.react-action.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CoreConfig } from "./types.js";
+
+const sendReactionNextcloudTalkMock = vi.hoisted(() => vi.fn());
+const sendMessageNextcloudTalkMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./send.js", () => ({
+  sendMessageNextcloudTalk: sendMessageNextcloudTalkMock,
+  sendReactionNextcloudTalk: sendReactionNextcloudTalkMock,
+}));
+
+vi.mock("../../../test/helpers/config/bundled-channel-config-runtime.js", () => ({
+  getBundledChannelRuntimeMap: () => new Map(),
+  getBundledChannelConfigSchemaMap: () => new Map(),
+}));
+
+const { nextcloudTalkPlugin } = await import("./channel.js");
+
+type NextcloudTalkHandleAction = NonNullable<
+  NonNullable<typeof nextcloudTalkPlugin.actions>["handleAction"]
+>;
+type NextcloudTalkActionContext = Parameters<NextcloudTalkHandleAction>[0];
+
+function makeConfiguredCfg(): CoreConfig {
+  return {
+    channels: {
+      "nextcloud-talk": {
+        baseUrl: "https://cloud.example.com",
+        botSecret: "secret-value", // pragma: allowlist secret
+      },
+    },
+  } as CoreConfig;
+}
+
+function makeReactCtx(
+  params: Record<string, unknown>,
+  overrides: Partial<NextcloudTalkActionContext> = {},
+): NextcloudTalkActionContext {
+  return {
+    channel: "nextcloud-talk",
+    action: "react",
+    cfg: makeConfiguredCfg(),
+    params,
+    accountId: "default",
+    ...overrides,
+  } as NextcloudTalkActionContext;
+}
+
+function describedActions(cfg: CoreConfig): string[] {
+  return [...(nextcloudTalkPlugin.actions?.describeMessageTool?.({ cfg })?.actions ?? [])];
+}
+
+describe("nextcloud-talk react message action", () => {
+  beforeEach(() => {
+    sendReactionNextcloudTalkMock.mockReset();
+    sendReactionNextcloudTalkMock.mockResolvedValue({ ok: true });
+  });
+
+  it("exposes react + send when an account is fully configured", () => {
+    expect(describedActions(makeConfiguredCfg())).toEqual(
+      expect.arrayContaining(["send", "react"]),
+    );
+  });
+
+  it("hides react when no account has credentials", () => {
+    const cfg = {
+      channels: { "nextcloud-talk": { baseUrl: "https://cloud.example.com" } },
+    } as CoreConfig;
+    expect(describedActions(cfg)).toEqual([]);
+  });
+
+  it("supportsAction claims react only (send stays on outbound.attachedResults)", () => {
+    expect(nextcloudTalkPlugin.actions?.supportsAction?.({ action: "react" })).toBe(true);
+    expect(nextcloudTalkPlugin.actions?.supportsAction?.({ action: "send" })).toBe(false);
+  });
+
+  it("handleAction POSTs the reaction via sendReactionNextcloudTalk", async () => {
+    const ctx = makeReactCtx({
+      to: "room:abc123",
+      messageId: "42",
+      emoji: "👍",
+    });
+
+    const result = await nextcloudTalkPlugin.actions?.handleAction?.(ctx);
+
+    expect(sendReactionNextcloudTalkMock).toHaveBeenCalledTimes(1);
+    expect(sendReactionNextcloudTalkMock).toHaveBeenCalledWith(
+      "room:abc123",
+      "42",
+      "👍",
+      expect.objectContaining({ accountId: "default", cfg: ctx.cfg }),
+    );
+    expect(result?.content?.[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("👍"),
+    });
+  });
+
+  it("strips surrounding colons from emoji shortcode params", async () => {
+    await nextcloudTalkPlugin.actions?.handleAction?.(
+      makeReactCtx({ to: "room:abc", messageId: "1", emoji: ":thumbsup:" }),
+    );
+    expect(sendReactionNextcloudTalkMock).toHaveBeenCalledWith(
+      "room:abc",
+      "1",
+      "thumbsup",
+      expect.any(Object),
+    );
+  });
+
+  it("throws when the target room is missing", async () => {
+    await expect(
+      nextcloudTalkPlugin.actions?.handleAction?.(makeReactCtx({ messageId: "1", emoji: "👍" })),
+    ).rejects.toThrow(/target/i);
+    expect(sendReactionNextcloudTalkMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when messageId is missing", async () => {
+    await expect(
+      nextcloudTalkPlugin.actions?.handleAction?.(makeReactCtx({ to: "room:abc", emoji: "👍" })),
+    ).rejects.toThrow(/messageId/i);
+  });
+
+  it("throws when emoji is missing", async () => {
+    await expect(
+      nextcloudTalkPlugin.actions?.handleAction?.(makeReactCtx({ to: "room:abc", messageId: "1" })),
+    ).rejects.toThrow(/emoji/i);
+  });
+
+  it("rejects unsupported actions", async () => {
+    await expect(
+      nextcloudTalkPlugin.actions?.handleAction?.(
+        makeReactCtx({}, { action: "edit" as NextcloudTalkActionContext["action"] }),
+      ),
+    ).rejects.toThrow(/Unsupported/);
+  });
+});

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -1,4 +1,9 @@
 import { describeWebhookAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionName,
+  ChannelMessageToolDiscovery,
+} from "openclaw/plugin-sdk/channel-contract";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { createLoggedPairingApprovalNotifier } from "openclaw/plugin-sdk/channel-pairing";
 import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
@@ -7,7 +12,12 @@ import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
-import { resolveNextcloudTalkAccount, type ResolvedNextcloudTalkAccount } from "./accounts.js";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import {
+  listEnabledNextcloudTalkAccounts,
+  resolveNextcloudTalkAccount,
+  type ResolvedNextcloudTalkAccount,
+} from "./accounts.js";
 import { nextcloudTalkApprovalAuth } from "./approval-auth.js";
 import { buildChannelConfigSchema, DEFAULT_ACCOUNT_ID, type ChannelPlugin } from "./channel-api.js";
 import {
@@ -25,7 +35,7 @@ import {
 import { resolveNextcloudTalkGroupToolPolicy } from "./policy.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
-import { sendMessageNextcloudTalk } from "./send.js";
+import { sendMessageNextcloudTalk, sendReactionNextcloudTalk } from "./send.js";
 import { resolveNextcloudTalkOutboundSessionRoute } from "./session-route.js";
 import { nextcloudTalkSetupAdapter } from "./setup-core.js";
 import { nextcloudTalkSetupWizard } from "./setup-surface.js";
@@ -41,6 +51,67 @@ const meta = {
   aliases: ["nc-talk", "nc"],
   order: 65,
   quickstartAllowFrom: true,
+};
+
+function describeNextcloudTalkMessageTool({
+  cfg,
+}: Parameters<
+  NonNullable<ChannelMessageActionAdapter["describeMessageTool"]>
+>[0]): ChannelMessageToolDiscovery {
+  const enabledAccounts = listEnabledNextcloudTalkAccounts(cfg as CoreConfig).filter((account) =>
+    Boolean(account.secret?.trim() && account.baseUrl?.trim()),
+  );
+
+  const actions: ChannelMessageActionName[] = [];
+  if (enabledAccounts.length > 0) {
+    actions.push("send");
+    actions.push("react");
+  }
+
+  return { actions, capabilities: [], schema: null };
+}
+
+function parseNextcloudTalkReactActionParams(params: Record<string, unknown>): {
+  roomToken: string;
+  messageId: string;
+  emoji: string;
+} {
+  const roomToken = normalizeOptionalString(params.to) ?? normalizeOptionalString(params.target);
+  if (!roomToken) {
+    throw new Error("Nextcloud Talk react requires a target (to) room token.");
+  }
+
+  const messageId = normalizeOptionalString(params.messageId);
+  if (!messageId) {
+    throw new Error("Nextcloud Talk react requires messageId.");
+  }
+
+  const emoji = normalizeOptionalString(params.emoji)?.replace(/^:+|:+$/g, "");
+  if (!emoji) {
+    throw new Error("Nextcloud Talk react requires emoji.");
+  }
+
+  return { roomToken, messageId, emoji };
+}
+
+const nextcloudTalkMessageActions: ChannelMessageActionAdapter = {
+  describeMessageTool: describeNextcloudTalkMessageTool,
+  // Send stays on outbound.attachedResults; only react needs plugin dispatch here.
+  supportsAction: ({ action }) => action === "react",
+  handleAction: async ({ action, params, cfg, accountId }) => {
+    if (action !== "react") {
+      throw new Error(`Unsupported Nextcloud Talk action: ${action}`);
+    }
+    const { roomToken, messageId, emoji } = parseNextcloudTalkReactActionParams(params);
+    await sendReactionNextcloudTalk(roomToken, messageId, emoji, {
+      accountId: accountId ?? undefined,
+      cfg: cfg as CoreConfig,
+    });
+    return {
+      content: [{ type: "text" as const, text: `Reacted ${emoji} on ${messageId}` }],
+      details: {},
+    };
+  },
 };
 
 const collectNextcloudTalkSecurityWarnings =
@@ -95,6 +166,7 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
           }),
       },
       approvalCapability: nextcloudTalkApprovalAuth,
+      actions: nextcloudTalkMessageActions,
       doctor: nextcloudTalkDoctor,
       groups: {
         resolveRequireMention: ({ cfg, accountId, groupId }) => {

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -66,10 +66,17 @@ function describeNextcloudTalkMessageTool({
   if (enabledAccounts.length > 0) {
     actions.push("send");
     actions.push("react");
+    actions.push("edit");
   }
 
   return { actions, capabilities: [], schema: null };
 }
+
+// Nextcloud Talk's bot API has no in-place edit endpoint. The edit action is
+// implemented as a re-post prefixed with this header and threaded as a reply
+// to the original message id.
+const NEXTCLOUD_TALK_EDIT_HEADER =
+  "> Edited update — Nextcloud Talk does not support editing bot messages in place.";
 
 function parseNextcloudTalkReactActionParams(params: Record<string, unknown>): {
   roomToken: string;
@@ -94,23 +101,73 @@ function parseNextcloudTalkReactActionParams(params: Record<string, unknown>): {
   return { roomToken, messageId, emoji };
 }
 
+function parseNextcloudTalkEditActionParams(params: Record<string, unknown>): {
+  roomToken: string;
+  originalMessageId: string;
+  message: string;
+} {
+  const roomToken = normalizeOptionalString(params.to) ?? normalizeOptionalString(params.target);
+  if (!roomToken) {
+    throw new Error("Nextcloud Talk edit requires a target (to) room token.");
+  }
+
+  const originalMessageId = normalizeOptionalString(params.messageId);
+  if (!originalMessageId) {
+    throw new Error("Nextcloud Talk edit requires messageId.");
+  }
+
+  const message = normalizeOptionalString(params.message);
+  if (!message) {
+    throw new Error("Nextcloud Talk edit requires message.");
+  }
+
+  return { roomToken, originalMessageId, message };
+}
+
 const nextcloudTalkMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: describeNextcloudTalkMessageTool,
-  // Send stays on outbound.attachedResults; only react needs plugin dispatch here.
-  supportsAction: ({ action }) => action === "react",
+  // Send stays on outbound.attachedResults; only react + edit need plugin dispatch here.
+  // Delete is intentionally unsupported — callers should send a follow-up note instead.
+  supportsAction: ({ action }) => action === "react" || action === "edit",
   handleAction: async ({ action, params, cfg, accountId }) => {
-    if (action !== "react") {
-      throw new Error(`Unsupported Nextcloud Talk action: ${action}`);
+    if (action === "react") {
+      const { roomToken, messageId, emoji } = parseNextcloudTalkReactActionParams(params);
+      await sendReactionNextcloudTalk(roomToken, messageId, emoji, {
+        accountId: accountId ?? undefined,
+        cfg: cfg as CoreConfig,
+      });
+      return {
+        content: [{ type: "text" as const, text: `Reacted ${emoji} on ${messageId}` }],
+        details: {},
+      };
     }
-    const { roomToken, messageId, emoji } = parseNextcloudTalkReactActionParams(params);
-    await sendReactionNextcloudTalk(roomToken, messageId, emoji, {
-      accountId: accountId ?? undefined,
-      cfg: cfg as CoreConfig,
-    });
-    return {
-      content: [{ type: "text" as const, text: `Reacted ${emoji} on ${messageId}` }],
-      details: {},
-    };
+
+    if (action === "edit") {
+      const { roomToken, originalMessageId, message } = parseNextcloudTalkEditActionParams(params);
+      const prefixed = `${NEXTCLOUD_TALK_EDIT_HEADER}\n\n${message}`;
+      const result = await sendMessageNextcloudTalk(roomToken, prefixed, {
+        accountId: accountId ?? undefined,
+        replyTo: originalMessageId,
+        cfg: cfg as CoreConfig,
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              ok: true,
+              channel: "nextcloud-talk",
+              messageId: result.messageId,
+              originalMessageId,
+              replacedAsReply: true,
+            }),
+          },
+        ],
+        details: {},
+      };
+    }
+
+    throw new Error(`Unsupported Nextcloud Talk action: ${action}`);
   },
 };
 

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -76,7 +76,7 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
         reactions: true,
         threads: false,
         media: true,
-        nativeCommands: false,
+        nativeCommands: true,
         blockStreaming: true,
       },
       reload: { configPrefixes: ["channels.nextcloud-talk"] },

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -1,4 +1,5 @@
 import { describeWebhookAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
+import { getExecApprovalReplyMetadata } from "openclaw/plugin-sdk/approval-client-runtime";
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionName,
@@ -19,6 +20,7 @@ import {
   type ResolvedNextcloudTalkAccount,
 } from "./accounts.js";
 import { nextcloudTalkApprovalAuth } from "./approval-auth.js";
+import { buildApprovalActions, stashApproval } from "./approval-stash.js";
 import { buildChannelConfigSchema, DEFAULT_ACCOUNT_ID, type ChannelPlugin } from "./channel-api.js";
 import {
   nextcloudTalkConfigAdapter,
@@ -299,6 +301,41 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
           getNextcloudTalkRuntime().channel.text.chunkMarkdownText(text, limit),
         chunkerMode: "markdown",
         textChunkLimit: 4000,
+        sendPayload: async (ctx) => {
+          const metadata = getExecApprovalReplyMetadata(ctx.payload);
+          const result = await sendMessageNextcloudTalk(ctx.to, ctx.text, {
+            accountId: ctx.accountId ?? undefined,
+            replyTo: ctx.replyToId ?? undefined,
+            cfg: ctx.cfg as CoreConfig,
+          });
+          if (metadata) {
+            const allowedDecisions = metadata.allowedDecisions ?? [
+              "allow-once",
+              "allow-always",
+              "deny",
+            ];
+            const actions = buildApprovalActions(allowedDecisions);
+            stashApproval(ctx.accountId ?? "", ctx.to, result.messageId, {
+              approvalId: metadata.approvalId,
+              approvalSlug: metadata.approvalSlug,
+              approvalKind: metadata.approvalKind,
+              sessionKey: metadata.sessionKey,
+              actions,
+            });
+            // Seed one reaction per available decision so users can tap to respond.
+            for (const action of actions) {
+              try {
+                await sendReactionNextcloudTalk(ctx.to, result.messageId, action.emoji, {
+                  accountId: ctx.accountId ?? undefined,
+                  cfg: ctx.cfg as CoreConfig,
+                });
+              } catch {
+                // Best-effort: reaction seeding failure should not block the approval prompt.
+              }
+            }
+          }
+          return { channel: "nextcloud-talk", messageId: result.messageId };
+        },
       },
       attachedResults: {
         channel: "nextcloud-talk",

--- a/extensions/nextcloud-talk/src/inbound.approval-flow.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.approval-flow.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginRuntime, RuntimeEnv } from "../runtime-api.js";
+import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+import { clearApprovalStash, lookupApproval, stashApproval } from "./approval-stash.js";
+import { handleNextcloudTalkInboundReaction } from "./inbound.js";
+import { setNextcloudTalkRuntime } from "./runtime.js";
+import type { CoreConfig, NextcloudTalkInboundReaction } from "./types.js";
+
+const resolveApprovalOverGatewayMock = vi.hoisted(() => vi.fn());
+const sendMessageNextcloudTalkMock = vi.hoisted(() => vi.fn());
+const sendReactionNextcloudTalkMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway: resolveApprovalOverGatewayMock,
+}));
+
+vi.mock("./send.js", () => ({
+  sendMessageNextcloudTalk: sendMessageNextcloudTalkMock,
+  sendReactionNextcloudTalk: sendReactionNextcloudTalkMock,
+}));
+
+const {
+  createChannelPairingControllerMock,
+  readStoreAllowFromForDmPolicyMock,
+  resolveDmGroupAccessWithCommandGateMock,
+  resolveAllowlistProviderRuntimeGroupPolicyMock,
+  resolveDefaultGroupPolicyMock,
+  warnMissingProviderGroupPolicyFallbackOnceMock,
+} = vi.hoisted(() => {
+  return {
+    createChannelPairingControllerMock: vi.fn(),
+    readStoreAllowFromForDmPolicyMock: vi.fn(),
+    resolveDmGroupAccessWithCommandGateMock: vi.fn(),
+    resolveAllowlistProviderRuntimeGroupPolicyMock: vi.fn(),
+    resolveDefaultGroupPolicyMock: vi.fn(),
+    warnMissingProviderGroupPolicyFallbackOnceMock: vi.fn(),
+  };
+});
+
+const resolveNextcloudTalkRoomKindMock = vi.hoisted(() => vi.fn());
+const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
+const resolveAgentRouteMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    sessionKey: "session:nc:default:user-1",
+    accountId: "default",
+    agentId: "main",
+  })),
+);
+
+vi.mock("../runtime-api.js", async () => {
+  const actual = await vi.importActual<typeof import("../runtime-api.js")>("../runtime-api.js");
+  return {
+    ...actual,
+    createChannelPairingController: createChannelPairingControllerMock,
+    readStoreAllowFromForDmPolicy: readStoreAllowFromForDmPolicyMock,
+    resolveDmGroupAccessWithCommandGate: resolveDmGroupAccessWithCommandGateMock,
+    resolveAllowlistProviderRuntimeGroupPolicy: resolveAllowlistProviderRuntimeGroupPolicyMock,
+    resolveDefaultGroupPolicy: resolveDefaultGroupPolicyMock,
+    warnMissingProviderGroupPolicyFallbackOnce: warnMissingProviderGroupPolicyFallbackOnceMock,
+  };
+});
+
+vi.mock("./room-info.js", async () => {
+  const actual = await vi.importActual<typeof import("./room-info.js")>("./room-info.js");
+  return {
+    ...actual,
+    resolveNextcloudTalkRoomKind: resolveNextcloudTalkRoomKindMock,
+  };
+});
+
+function installRuntime() {
+  setNextcloudTalkRuntime({
+    channel: {
+      routing: {
+        resolveAgentRoute: resolveAgentRouteMock,
+      },
+    },
+    system: {
+      enqueueSystemEvent: enqueueSystemEventMock,
+    },
+  } as unknown as PluginRuntime);
+}
+
+function createRuntimeEnv() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+  } as unknown as RuntimeEnv;
+}
+
+function createAccount(
+  overrides?: Partial<ResolvedNextcloudTalkAccount>,
+): ResolvedNextcloudTalkAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    baseUrl: "https://cloud.example.com",
+    secret: "secret",
+    secretSource: "config",
+    config: {
+      dmPolicy: "pairing",
+      allowFrom: ["user-1"],
+      groupPolicy: "allowlist",
+      groupAllowFrom: [],
+    },
+    ...overrides,
+  };
+}
+
+function createReaction(
+  overrides?: Partial<NextcloudTalkInboundReaction>,
+): NextcloudTalkInboundReaction {
+  return {
+    action: "added",
+    messageId: "msg-appr-1",
+    roomToken: "room-1",
+    roomName: "Ops",
+    senderId: "user-1",
+    senderName: "Alice",
+    emoji: "1️⃣",
+    timestamp: Date.now(),
+    isGroupChat: false,
+    ...overrides,
+  };
+}
+
+function seedStash(senderAllowed = true, approvalKind: "exec" | "plugin" = "exec"): void {
+  stashApproval("default", "room-1", "msg-appr-1", {
+    approvalId: "appr-abc123",
+    approvalSlug: "appr-ab",
+    approvalKind,
+    actions: [
+      { emoji: "1️⃣", decision: "allow-once" },
+      { emoji: "2️⃣", decision: "allow-always" },
+      { emoji: "3️⃣", decision: "deny" },
+    ],
+  });
+  // Touch the allowlist shape so tests can vary it; consumer of this helper doesn't need it.
+  void senderAllowed;
+}
+
+function resolveCfg(allowFrom: readonly string[] = ["user-1"]): CoreConfig {
+  return {
+    channels: { "nextcloud-talk": { allowFrom: [...allowFrom] } },
+  } as CoreConfig;
+}
+
+describe("nextcloud-talk inbound reaction → approval flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearApprovalStash();
+    installRuntime();
+    resolveNextcloudTalkRoomKindMock.mockResolvedValue("direct");
+    resolveDefaultGroupPolicyMock.mockReturnValue("allowlist");
+    resolveAllowlistProviderRuntimeGroupPolicyMock.mockReturnValue({
+      groupPolicy: "allowlist",
+      providerMissingFallbackApplied: false,
+    });
+    warnMissingProviderGroupPolicyFallbackOnceMock.mockReturnValue(undefined);
+    readStoreAllowFromForDmPolicyMock.mockResolvedValue([]);
+    createChannelPairingControllerMock.mockReturnValue({
+      readStoreForDmPolicy: vi.fn(),
+      issueChallenge: vi.fn(),
+    });
+    resolveDmGroupAccessWithCommandGateMock.mockReturnValue({
+      decision: "allow",
+      reason: "allow",
+      commandAuthorized: false,
+      effectiveGroupAllowFrom: [],
+    });
+    resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
+    sendMessageNextcloudTalkMock.mockResolvedValue({
+      messageId: "followup-1",
+      roomToken: "room-1",
+      timestamp: 1_700_000_000,
+    });
+  });
+
+  afterEach(() => {
+    clearApprovalStash();
+  });
+
+  it("dispatches + consumes + posts follow-up when an authorized approver reacts", async () => {
+    seedStash();
+
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({ senderId: "user-1", emoji: "1️⃣" }),
+      account: createAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: ["user-1"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config: resolveCfg(),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(resolveApprovalOverGatewayMock).toHaveBeenCalledTimes(1);
+    expect(resolveApprovalOverGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalId: "appr-abc123",
+        decision: "allow-once",
+        senderId: "user-1",
+      }),
+    );
+    expect(sendMessageNextcloudTalkMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageNextcloudTalkMock.mock.calls[0]?.[1]).toContain("Decision recorded");
+    expect(sendMessageNextcloudTalkMock.mock.calls[0]?.[1]).toContain("allow-once");
+    expect(sendMessageNextcloudTalkMock.mock.calls[0]?.[2]).toMatchObject({
+      replyTo: "msg-appr-1",
+    });
+    expect(lookupApproval("default", "room-1", "msg-appr-1")).toBeUndefined();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("falls through to system event when a non-approver reacts (stash left intact)", async () => {
+    seedStash();
+    const runtime = createRuntimeEnv();
+
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({ senderId: "user-intruder", senderName: "Mallory", emoji: "1️⃣" }),
+      account: createAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: ["user-1"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config: resolveCfg(),
+      runtime,
+    });
+
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
+    expect(sendMessageNextcloudTalkMock).not.toHaveBeenCalled();
+    expect(lookupApproval("default", "room-1", "msg-appr-1")).toBeDefined();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("unauthorized sender user-intruder"),
+    );
+  });
+
+  it("falls through for an unrelated emoji on a stashed approval", async () => {
+    seedStash();
+
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({ senderId: "user-1", emoji: "🔥" }),
+      account: createAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: ["user-1"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config: resolveCfg(),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
+    expect(lookupApproval("default", "room-1", "msg-appr-1")).toBeDefined();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through when the reacted message has no stash entry", async () => {
+    // No seedStash call — nothing in the map.
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({ messageId: "msg-unstashed", senderId: "user-1", emoji: "1️⃣" }),
+      account: createAccount(),
+      config: resolveCfg(),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through on removed-reaction events even when a stash entry exists", async () => {
+    seedStash();
+
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({ action: "removed", senderId: "user-1", emoji: "1️⃣" }),
+      account: createAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: ["user-1"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config: resolveCfg(),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
+    expect(lookupApproval("default", "room-1", "msg-appr-1")).toBeDefined();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats allowFrom=[] as open approvers (every room-allowed sender can decide)", async () => {
+    seedStash();
+
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({ senderId: "user-guest", senderName: "Guest", emoji: "3️⃣" }),
+      account: createAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config: resolveCfg([]),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(resolveApprovalOverGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({ decision: "deny", senderId: "user-guest" }),
+    );
+    expect(lookupApproval("default", "room-1", "msg-appr-1")).toBeUndefined();
+  });
+});

--- a/extensions/nextcloud-talk/src/inbound.reaction.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.reaction.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginRuntime, RuntimeEnv } from "../runtime-api.js";
+import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+import { handleNextcloudTalkInboundReaction } from "./inbound.js";
+import { setNextcloudTalkRuntime } from "./runtime.js";
+import type { CoreConfig, NextcloudTalkInboundReaction } from "./types.js";
+
+const {
+  createChannelPairingControllerMock,
+  readStoreAllowFromForDmPolicyMock,
+  resolveDmGroupAccessWithCommandGateMock,
+  resolveAllowlistProviderRuntimeGroupPolicyMock,
+  resolveDefaultGroupPolicyMock,
+  warnMissingProviderGroupPolicyFallbackOnceMock,
+} = vi.hoisted(() => {
+  return {
+    createChannelPairingControllerMock: vi.fn(),
+    readStoreAllowFromForDmPolicyMock: vi.fn(),
+    resolveDmGroupAccessWithCommandGateMock: vi.fn(),
+    resolveAllowlistProviderRuntimeGroupPolicyMock: vi.fn(),
+    resolveDefaultGroupPolicyMock: vi.fn(),
+    warnMissingProviderGroupPolicyFallbackOnceMock: vi.fn(),
+  };
+});
+
+const resolveNextcloudTalkRoomKindMock = vi.hoisted(() => vi.fn());
+const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
+const resolveAgentRouteMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    sessionKey: "session:nc:default:user-1",
+    accountId: "default",
+    agentId: "main",
+  })),
+);
+
+vi.mock("../runtime-api.js", async () => {
+  const actual = await vi.importActual<typeof import("../runtime-api.js")>("../runtime-api.js");
+  return {
+    ...actual,
+    createChannelPairingController: createChannelPairingControllerMock,
+    readStoreAllowFromForDmPolicy: readStoreAllowFromForDmPolicyMock,
+    resolveDmGroupAccessWithCommandGate: resolveDmGroupAccessWithCommandGateMock,
+    resolveAllowlistProviderRuntimeGroupPolicy: resolveAllowlistProviderRuntimeGroupPolicyMock,
+    resolveDefaultGroupPolicy: resolveDefaultGroupPolicyMock,
+    warnMissingProviderGroupPolicyFallbackOnce: warnMissingProviderGroupPolicyFallbackOnceMock,
+  };
+});
+
+vi.mock("./room-info.js", async () => {
+  const actual = await vi.importActual<typeof import("./room-info.js")>("./room-info.js");
+  return {
+    ...actual,
+    resolveNextcloudTalkRoomKind: resolveNextcloudTalkRoomKindMock,
+  };
+});
+
+function installRuntime() {
+  setNextcloudTalkRuntime({
+    channel: {
+      routing: {
+        resolveAgentRoute: resolveAgentRouteMock,
+      },
+    },
+    system: {
+      enqueueSystemEvent: enqueueSystemEventMock,
+    },
+  } as unknown as PluginRuntime);
+}
+
+function createRuntimeEnv() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+  } as unknown as RuntimeEnv;
+}
+
+function createAccount(
+  overrides?: Partial<ResolvedNextcloudTalkAccount>,
+): ResolvedNextcloudTalkAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    baseUrl: "https://cloud.example.com",
+    secret: "secret",
+    secretSource: "config",
+    config: {
+      dmPolicy: "pairing",
+      allowFrom: [],
+      groupPolicy: "allowlist",
+      groupAllowFrom: [],
+    },
+    ...overrides,
+  };
+}
+
+function createReaction(
+  overrides?: Partial<NextcloudTalkInboundReaction>,
+): NextcloudTalkInboundReaction {
+  return {
+    action: "added",
+    messageId: "msg-1",
+    roomToken: "room-1",
+    roomName: "Ops",
+    senderId: "user-1",
+    senderName: "Alice",
+    emoji: "👍",
+    timestamp: Date.now(),
+    isGroupChat: false,
+    ...overrides,
+  };
+}
+
+describe("nextcloud-talk inbound reaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installRuntime();
+    resolveNextcloudTalkRoomKindMock.mockResolvedValue("direct");
+    resolveDefaultGroupPolicyMock.mockReturnValue("allowlist");
+    resolveAllowlistProviderRuntimeGroupPolicyMock.mockReturnValue({
+      groupPolicy: "allowlist",
+      providerMissingFallbackApplied: false,
+    });
+    warnMissingProviderGroupPolicyFallbackOnceMock.mockReturnValue(undefined);
+    readStoreAllowFromForDmPolicyMock.mockResolvedValue([]);
+    createChannelPairingControllerMock.mockReturnValue({
+      readStoreForDmPolicy: vi.fn(),
+      issueChallenge: vi.fn(),
+    });
+    resolveDmGroupAccessWithCommandGateMock.mockReturnValue({
+      decision: "allow",
+      reason: "allow",
+      commandAuthorized: false,
+      effectiveGroupAllowFrom: [],
+    });
+  });
+
+  it("enqueues a system event for an allowed DM reaction", async () => {
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({ action: "added", emoji: "👍", messageId: "42" }),
+      account: createAccount(),
+      config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    const [text, options] = enqueueSystemEventMock.mock.calls[0] ?? [];
+    expect(text).toContain("Nextcloud Talk reaction added");
+    expect(text).toContain("👍");
+    expect(text).toContain("message 42");
+    expect(options).toMatchObject({
+      sessionKey: "session:nc:default:user-1",
+      contextKey: "nextcloud-talk:reaction:room-1:42:👍:user-1:added",
+    });
+  });
+
+  it("enqueues a removed reaction for Undo events in a group room", async () => {
+    resolveNextcloudTalkRoomKindMock.mockResolvedValue("group");
+    resolveDmGroupAccessWithCommandGateMock.mockReturnValue({
+      decision: "allow",
+      reason: "allow",
+      commandAuthorized: false,
+      effectiveGroupAllowFrom: ["user-1"],
+    });
+
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({
+        action: "removed",
+        isGroupChat: true,
+        roomToken: "room-group",
+        roomName: "Ops",
+      }),
+      account: createAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["user-1"],
+          rooms: { "room-group": {} },
+        },
+      }),
+      config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    const [text, options] = enqueueSystemEventMock.mock.calls[0] ?? [];
+    expect(text).toContain("Nextcloud Talk reaction removed");
+    expect(text).toContain("Ops");
+    expect(options?.contextKey).toBe("nextcloud-talk:reaction:room-group:msg-1:👍:user-1:removed");
+  });
+
+  it("drops reactions when the DM/group access gate denies", async () => {
+    resolveDmGroupAccessWithCommandGateMock.mockReturnValue({
+      decision: "deny",
+      reason: "not_allowlisted",
+      commandAuthorized: false,
+      effectiveGroupAllowFrom: [],
+    });
+    const runtime = createRuntimeEnv();
+
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction(),
+      account: createAccount(),
+      config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
+      runtime,
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("drop reaction sender user-1"),
+    );
+  });
+
+  it("drops reactions from the configured bot apiUser (echo suppression)", async () => {
+    const runtime = createRuntimeEnv();
+
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({ senderId: "bot-api-user" }),
+      account: createAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+          apiUser: "bot-api-user",
+        },
+      }),
+      config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
+      runtime,
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("drops reactions with empty emoji/messageId/senderId", async () => {
+    const runtime = createRuntimeEnv();
+
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({ emoji: "   " }),
+      account: createAccount(),
+      config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
+      runtime,
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("drops group reactions in rooms that are not allowlisted", async () => {
+    resolveNextcloudTalkRoomKindMock.mockResolvedValue("group");
+
+    const runtime = createRuntimeEnv();
+    await handleNextcloudTalkInboundReaction({
+      reaction: createReaction({
+        isGroupChat: true,
+        roomToken: "room-disallowed",
+      }),
+      account: createAccount({
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+          rooms: { "room-allowed": {} },
+        },
+      }),
+      config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
+      runtime,
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("drop reaction in room room-disallowed (not allowlisted)"),
+    );
+  });
+});

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -16,6 +16,7 @@ import {
   type RuntimeEnv,
 } from "../runtime-api.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+import { nextcloudTalkApprovalAuth } from "./approval-auth.js";
 import { consumeApproval, lookupApproval, resolveReactionDecision } from "./approval-stash.js";
 import {
   normalizeNextcloudTalkAllowlist,
@@ -457,44 +458,62 @@ export async function handleNextcloudTalkInboundReaction(params: {
   const roomLabel = isGroup ? reaction.roomName?.trim() || roomToken : `DM ${senderLabel}`;
 
   // Check if this reaction targets a stashed approval prompt before falling through
-  // to the generic system-event path.
+  // to the generic system-event path. An emoji-to-decision hit is not sufficient —
+  // the reacting sender must also be in the account's approver list (same gate as
+  // the /approve text-command path), otherwise any room member could dispatch a
+  // decision they aren't authorized to make.
   if (reaction.action === "added") {
     const stashEntry = lookupApproval(account.accountId, roomToken, messageId);
     if (stashEntry) {
       const decision = resolveReactionDecision(stashEntry, emoji);
       if (decision) {
-        try {
-          await resolveApprovalOverGateway({
-            cfg: config as OpenClawConfig,
-            approvalId: stashEntry.approvalId,
-            decision,
-            senderId,
-            clientDisplayName: `Nextcloud Talk approval (${senderLabel})`,
-          });
-          consumeApproval(account.accountId, roomToken, messageId);
-          // Post a follow-up confirmation using replyTo so context is preserved.
+        const auth = nextcloudTalkApprovalAuth.authorizeActorAction({
+          cfg: config as OpenClawConfig,
+          accountId: account.accountId,
+          senderId,
+          action: "approve",
+          approvalKind: stashEntry.approvalKind,
+        });
+        if (!auth.authorized) {
+          runtime.log?.(
+            `nextcloud-talk approval: unauthorized sender ${senderId} reacted ${emoji} on ${stashEntry.approvalId} (room=${roomToken})`,
+          );
+          // Leave stash intact so a later authorized approver can still resolve;
+          // fall through to system event so the reaction is recorded.
+        } else {
           try {
-            await sendMessageNextcloudTalk(
-              roomToken,
-              `> Decision recorded — **${decision}** by ${senderLabel}`,
-              {
-                accountId: account.accountId,
-                replyTo: messageId,
-                cfg: config,
-              },
+            await resolveApprovalOverGateway({
+              cfg: config as OpenClawConfig,
+              approvalId: stashEntry.approvalId,
+              decision,
+              senderId,
+              clientDisplayName: `Nextcloud Talk approval (${senderLabel})`,
+            });
+            consumeApproval(account.accountId, roomToken, messageId);
+            // Post a follow-up confirmation using replyTo so context is preserved.
+            try {
+              await sendMessageNextcloudTalk(
+                roomToken,
+                `> Decision recorded — **${decision}** by ${senderLabel}`,
+                {
+                  accountId: account.accountId,
+                  replyTo: messageId,
+                  cfg: config,
+                },
+              );
+            } catch {
+              // Best-effort: confirmation failure should not undo the approval dispatch.
+            }
+            runtime.log?.(
+              `nextcloud-talk approval: ${decision} by ${senderLabel} for ${stashEntry.approvalId} room=${roomToken}`,
             );
-          } catch {
-            // Best-effort: confirmation failure should not undo the approval dispatch.
+            return;
+          } catch (err) {
+            runtime.log?.(
+              `nextcloud-talk approval dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            // Fall through to system event on dispatch failure.
           }
-          runtime.log?.(
-            `nextcloud-talk approval: ${decision} by ${senderLabel} for ${stashEntry.approvalId} room=${roomToken}`,
-          );
-          return;
-        } catch (err) {
-          runtime.log?.(
-            `nextcloud-talk approval dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-          // Fall through to system event on dispatch failure.
         }
       }
     }

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -26,7 +26,11 @@ import {
 import { resolveNextcloudTalkRoomKind } from "./room-info.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import { sendMessageNextcloudTalk } from "./send.js";
-import type { CoreConfig, NextcloudTalkInboundMessage } from "./types.js";
+import type {
+  CoreConfig,
+  NextcloudTalkInboundMessage,
+  NextcloudTalkInboundReaction,
+} from "./types.js";
 
 const CHANNEL_ID = "nextcloud-talk" as const;
 
@@ -311,4 +315,152 @@ export async function handleNextcloudTalkInbound(params: {
           : undefined,
     },
   });
+}
+
+export async function handleNextcloudTalkInboundReaction(params: {
+  reaction: NextcloudTalkInboundReaction;
+  account: ResolvedNextcloudTalkAccount;
+  config: CoreConfig;
+  runtime: RuntimeEnv;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+}): Promise<void> {
+  const { reaction, account, config, runtime, statusSink } = params;
+  const core = getNextcloudTalkRuntime();
+  const pairing = createChannelPairingController({
+    core,
+    channel: CHANNEL_ID,
+    accountId: account.accountId,
+  });
+
+  const emoji = reaction.emoji.trim();
+  const senderId = reaction.senderId.trim();
+  const roomToken = reaction.roomToken.trim();
+  const messageId = reaction.messageId.trim();
+  if (!emoji || !senderId || !roomToken || !messageId) {
+    return;
+  }
+
+  // Drop echoes of the bot's own reactions (apiUser acts as the bot identity when configured).
+  const botUserId = account.config.apiUser?.trim();
+  if (botUserId && senderId === botUserId) {
+    return;
+  }
+
+  const roomKind = await resolveNextcloudTalkRoomKind({
+    account,
+    roomToken,
+    runtime,
+  });
+  const isGroup =
+    roomKind === "direct" ? false : roomKind === "group" ? true : reaction.isGroupChat;
+
+  statusSink?.({ lastInboundAt: reaction.timestamp });
+
+  const dmPolicy = account.config.dmPolicy ?? "pairing";
+  const defaultGroupPolicy = resolveDefaultGroupPolicy(config as OpenClawConfig);
+  const { groupPolicy, providerMissingFallbackApplied } =
+    resolveAllowlistProviderRuntimeGroupPolicy({
+      providerConfigPresent:
+        ((config.channels as Record<string, unknown> | undefined)?.["nextcloud-talk"] ??
+          undefined) !== undefined,
+      groupPolicy: account.config.groupPolicy,
+      defaultGroupPolicy,
+    });
+  warnMissingProviderGroupPolicyFallbackOnce({
+    providerMissingFallbackApplied,
+    providerKey: "nextcloud-talk",
+    accountId: account.accountId,
+    blockedLabel: GROUP_POLICY_BLOCKED_LABEL.room,
+    log: (message) => runtime.log?.(message),
+  });
+
+  const configAllowFrom = normalizeNextcloudTalkAllowlist(account.config.allowFrom);
+  const configGroupAllowFrom = normalizeNextcloudTalkAllowlist(account.config.groupAllowFrom);
+  const storeAllowFrom = await readStoreAllowFromForDmPolicy({
+    provider: CHANNEL_ID,
+    accountId: account.accountId,
+    dmPolicy,
+    readStore: pairing.readStoreForDmPolicy,
+  });
+  const storeAllowList = normalizeNextcloudTalkAllowlist(storeAllowFrom);
+
+  const roomMatch = resolveNextcloudTalkRoomMatch({
+    rooms: account.config.rooms,
+    roomToken,
+  });
+  const roomConfig = roomMatch.roomConfig;
+  if (isGroup && !roomMatch.allowed) {
+    runtime.log?.(`nextcloud-talk: drop reaction in room ${roomToken} (not allowlisted)`);
+    return;
+  }
+  if (roomConfig?.enabled === false) {
+    runtime.log?.(`nextcloud-talk: drop reaction in room ${roomToken} (disabled)`);
+    return;
+  }
+
+  const roomAllowFrom = normalizeNextcloudTalkAllowlist(roomConfig?.allowFrom);
+
+  const access = resolveDmGroupAccessWithCommandGate({
+    isGroup,
+    dmPolicy,
+    groupPolicy,
+    allowFrom: configAllowFrom,
+    groupAllowFrom: configGroupAllowFrom,
+    storeAllowFrom: storeAllowList,
+    isSenderAllowed: (allowFrom) =>
+      resolveNextcloudTalkAllowlistMatch({
+        allowFrom,
+        senderId,
+      }).allowed,
+    command: {
+      useAccessGroups: false,
+      allowTextCommands: false,
+      hasControlCommand: false,
+    },
+  });
+
+  if (access.decision !== "allow") {
+    runtime.log?.(
+      `nextcloud-talk: drop reaction sender ${senderId} (reason=${access.reason} room=${roomToken})`,
+    );
+    return;
+  }
+
+  if (isGroup) {
+    const groupAllow = resolveNextcloudTalkGroupAllow({
+      groupPolicy,
+      outerAllowFrom: access.effectiveGroupAllowFrom,
+      innerAllowFrom: roomAllowFrom,
+      senderId,
+    });
+    if (!groupAllow.allowed) {
+      runtime.log?.(
+        `nextcloud-talk: drop reaction group sender ${senderId} (policy=${groupPolicy})`,
+      );
+      return;
+    }
+  }
+
+  const route = core.channel.routing.resolveAgentRoute({
+    cfg: config as OpenClawConfig,
+    channel: CHANNEL_ID,
+    accountId: account.accountId,
+    peer: {
+      kind: isGroup ? "group" : "direct",
+      id: isGroup ? roomToken : senderId,
+    },
+  });
+
+  const senderLabel = reaction.senderName?.trim() || senderId;
+  const roomLabel = isGroup ? reaction.roomName?.trim() || roomToken : `DM ${senderLabel}`;
+  const eventText = `Nextcloud Talk reaction ${reaction.action}: ${emoji} by ${senderLabel} on message ${messageId} in ${roomLabel}`;
+
+  core.system.enqueueSystemEvent(eventText, {
+    sessionKey: route.sessionKey,
+    contextKey: `nextcloud-talk:reaction:${roomToken}:${messageId}:${emoji}:${senderId}:${reaction.action}`,
+  });
+
+  runtime.log?.(
+    `nextcloud-talk reaction: ${reaction.action} ${emoji} by ${senderLabel} on ${messageId} room=${roomToken}`,
+  );
 }

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -1,3 +1,4 @@
+import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import {
   GROUP_POLICY_BLOCKED_LABEL,
@@ -15,6 +16,7 @@ import {
   type RuntimeEnv,
 } from "../runtime-api.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
+import { consumeApproval, lookupApproval, resolveReactionDecision } from "./approval-stash.js";
 import {
   normalizeNextcloudTalkAllowlist,
   resolveNextcloudTalkAllowlistMatch,
@@ -453,6 +455,51 @@ export async function handleNextcloudTalkInboundReaction(params: {
 
   const senderLabel = reaction.senderName?.trim() || senderId;
   const roomLabel = isGroup ? reaction.roomName?.trim() || roomToken : `DM ${senderLabel}`;
+
+  // Check if this reaction targets a stashed approval prompt before falling through
+  // to the generic system-event path.
+  if (reaction.action === "added") {
+    const stashEntry = lookupApproval(account.accountId, roomToken, messageId);
+    if (stashEntry) {
+      const decision = resolveReactionDecision(stashEntry, emoji);
+      if (decision) {
+        try {
+          await resolveApprovalOverGateway({
+            cfg: config as OpenClawConfig,
+            approvalId: stashEntry.approvalId,
+            decision,
+            senderId,
+            clientDisplayName: `Nextcloud Talk approval (${senderLabel})`,
+          });
+          consumeApproval(account.accountId, roomToken, messageId);
+          // Post a follow-up confirmation using replyTo so context is preserved.
+          try {
+            await sendMessageNextcloudTalk(
+              roomToken,
+              `> Decision recorded — **${decision}** by ${senderLabel}`,
+              {
+                accountId: account.accountId,
+                replyTo: messageId,
+                cfg: config,
+              },
+            );
+          } catch {
+            // Best-effort: confirmation failure should not undo the approval dispatch.
+          }
+          runtime.log?.(
+            `nextcloud-talk approval: ${decision} by ${senderLabel} for ${stashEntry.approvalId} room=${roomToken}`,
+          );
+          return;
+        } catch (err) {
+          runtime.log?.(
+            `nextcloud-talk approval dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          // Fall through to system event on dispatch failure.
+        }
+      }
+    }
+  }
+
   const eventText = `Nextcloud Talk reaction ${reaction.action}: ${emoji} by ${senderLabel} on message ${messageId} in ${roomLabel}`;
 
   core.system.enqueueSystemEvent(eventText, {

--- a/extensions/nextcloud-talk/src/monitor.reactions.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.reactions.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSignedLikeReactionRequest,
+  createSignedUndoLikeReactionRequest,
+} from "./monitor.test-fixtures.js";
+import { startWebhookServer } from "./monitor.test-harness.js";
+import { generateNextcloudTalkSignature } from "./signature.js";
+import type { NextcloudTalkInboundReaction } from "./types.js";
+
+describe("createNextcloudTalkWebhookServer reaction dispatch", () => {
+  it("decodes a Like activity and forwards the reaction with action=added", async () => {
+    const captured: NextcloudTalkInboundReaction[] = [];
+    const harness = await startWebhookServer({
+      path: "/nextcloud-react-like",
+      onMessage: vi.fn(),
+      onReaction: async (reaction) => {
+        captured.push(reaction);
+      },
+    });
+
+    const { body, headers } = createSignedLikeReactionRequest({
+      actorId: "bob",
+      actorName: "Bob",
+      emoji: "👍",
+      messageId: "42",
+      roomToken: "room-abc",
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({
+      action: "added",
+      emoji: "👍",
+      messageId: "42",
+      roomToken: "room-abc",
+      senderId: "bob",
+      senderName: "Bob",
+    });
+  });
+
+  it("decodes an Undo of Like activity and forwards the reaction with action=removed", async () => {
+    const captured: NextcloudTalkInboundReaction[] = [];
+    const harness = await startWebhookServer({
+      path: "/nextcloud-react-undo",
+      onMessage: vi.fn(),
+      onReaction: async (reaction) => {
+        captured.push(reaction);
+      },
+    });
+
+    const { body, headers } = createSignedUndoLikeReactionRequest({
+      actorId: "bob",
+      actorName: "Bob",
+      emoji: "👍",
+      messageId: "42",
+      roomToken: "room-abc",
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({
+      action: "removed",
+      emoji: "👍",
+      messageId: "42",
+      roomToken: "room-abc",
+      senderId: "bob",
+    });
+  });
+
+  it("does not invoke onMessage when the activity is a reaction", async () => {
+    const onMessage = vi.fn(async () => {});
+    const onReaction = vi.fn(async () => {});
+    const harness = await startWebhookServer({
+      path: "/nextcloud-react-routing",
+      onMessage,
+      onReaction,
+    });
+
+    const { body, headers } = createSignedLikeReactionRequest();
+    await fetch(harness.webhookUrl, { method: "POST", headers, body });
+
+    expect(onReaction).toHaveBeenCalledTimes(1);
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges replayed reactions without invoking onReaction", async () => {
+    const onReaction = vi.fn(async () => {});
+    const seen = new Set<string>();
+    const shouldProcessReaction = vi.fn(async (reaction: NextcloudTalkInboundReaction) => {
+      const key = `${reaction.roomToken}:${reaction.messageId}:${reaction.emoji}:${reaction.senderId}:${reaction.action}`;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+    const harness = await startWebhookServer({
+      path: "/nextcloud-react-replay",
+      onMessage: vi.fn(),
+      shouldProcessReaction,
+      onReaction,
+    });
+
+    const { body, headers } = createSignedLikeReactionRequest();
+    const first = await fetch(harness.webhookUrl, { method: "POST", headers, body });
+    const second = await fetch(harness.webhookUrl, { method: "POST", headers, body });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(shouldProcessReaction).toHaveBeenCalledTimes(2);
+    expect(onReaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers 200 when a reaction arrives but no onReaction handler is configured", async () => {
+    const harness = await startWebhookServer({
+      path: "/nextcloud-react-no-handler",
+      onMessage: vi.fn(),
+    });
+
+    const { body, headers } = createSignedLikeReactionRequest();
+    const response = await fetch(harness.webhookUrl, { method: "POST", headers, body });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects a malformed Undo payload (non-Like inner object)", async () => {
+    const payload = {
+      type: "Undo",
+      actor: { type: "Person", id: "bob", name: "Bob" },
+      // Inner object is not a Like — should fail schema validation.
+      object: {
+        type: "Note",
+        id: "msg-1",
+        name: "hello",
+        content: "hi",
+        mediaType: "text/plain",
+      },
+      target: { type: "Collection", id: "room-1", name: "Room 1" },
+    };
+    const body = JSON.stringify(payload);
+    const { random, signature } = generateNextcloudTalkSignature({
+      body,
+      secret: "nextcloud-secret", // pragma: allowlist secret
+    });
+    const harness = await startWebhookServer({
+      path: "/nextcloud-react-undo-bad",
+      onMessage: vi.fn(),
+      onReaction: vi.fn(),
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-nextcloud-talk-random": random,
+        "x-nextcloud-talk-signature": signature,
+        "x-nextcloud-talk-backend": "https://nextcloud.example",
+      },
+      body,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid payload format" });
+  });
+});

--- a/extensions/nextcloud-talk/src/monitor.test-fixtures.ts
+++ b/extensions/nextcloud-talk/src/monitor.test-fixtures.ts
@@ -1,18 +1,6 @@
 import { generateNextcloudTalkSignature } from "./signature.js";
 
-export function createSignedCreateMessageRequest(params?: { backend?: string }) {
-  const payload = {
-    type: "Create",
-    actor: { type: "Person", id: "alice", name: "Alice" },
-    object: {
-      type: "Note",
-      id: "msg-1",
-      name: "hello",
-      content: "hello",
-      mediaType: "text/plain",
-    },
-    target: { type: "Collection", id: "room-1", name: "Room 1" },
-  };
+function signPayload(payload: Record<string, unknown>, backend?: string) {
   const body = JSON.stringify(payload);
   const { random, signature } = generateNextcloudTalkSignature({
     body,
@@ -24,7 +12,97 @@ export function createSignedCreateMessageRequest(params?: { backend?: string }) 
       "content-type": "application/json",
       "x-nextcloud-talk-random": random,
       "x-nextcloud-talk-signature": signature,
-      "x-nextcloud-talk-backend": params?.backend ?? "https://nextcloud.example",
+      "x-nextcloud-talk-backend": backend ?? "https://nextcloud.example",
     },
   };
+}
+
+export function createSignedCreateMessageRequest(params?: { backend?: string }) {
+  return signPayload(
+    {
+      type: "Create",
+      actor: { type: "Person", id: "alice", name: "Alice" },
+      object: {
+        type: "Note",
+        id: "msg-1",
+        name: "hello",
+        content: "hello",
+        mediaType: "text/plain",
+      },
+      target: { type: "Collection", id: "room-1", name: "Room 1" },
+    },
+    params?.backend,
+  );
+}
+
+export function createSignedLikeReactionRequest(params?: {
+  backend?: string;
+  actorId?: string;
+  actorName?: string;
+  emoji?: string;
+  messageId?: string;
+  roomToken?: string;
+}) {
+  return signPayload(
+    {
+      type: "Like",
+      actor: {
+        type: "Person",
+        id: params?.actorId ?? "bob",
+        name: params?.actorName ?? "Bob",
+      },
+      object: {
+        type: "Note",
+        id: params?.messageId ?? "msg-1",
+        name: "reaction",
+        content: params?.emoji ?? "👍",
+        mediaType: "text/plain",
+      },
+      target: {
+        type: "Collection",
+        id: params?.roomToken ?? "room-1",
+        name: "Room 1",
+      },
+    },
+    params?.backend,
+  );
+}
+
+export function createSignedUndoLikeReactionRequest(params?: {
+  backend?: string;
+  actorId?: string;
+  actorName?: string;
+  emoji?: string;
+  messageId?: string;
+  roomToken?: string;
+}) {
+  const likeInner = {
+    type: "Like",
+    actor: {
+      type: "Person",
+      id: params?.actorId ?? "bob",
+      name: params?.actorName ?? "Bob",
+    },
+    object: {
+      type: "Note",
+      id: params?.messageId ?? "msg-1",
+      name: "reaction",
+      content: params?.emoji ?? "👍",
+      mediaType: "text/plain",
+    },
+    target: {
+      type: "Collection",
+      id: params?.roomToken ?? "room-1",
+      name: "Room 1",
+    },
+  };
+  return signPayload(
+    {
+      type: "Undo",
+      actor: likeInner.actor,
+      object: likeInner,
+      target: likeInner.target,
+    },
+    params?.backend,
+  );
 }

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -15,13 +15,15 @@ import {
   requestBodyErrorToText,
 } from "../runtime-api.js";
 import { resolveNextcloudTalkAccount } from "./accounts.js";
-import { handleNextcloudTalkInbound } from "./inbound.js";
+import { handleNextcloudTalkInbound, handleNextcloudTalkInboundReaction } from "./inbound.js";
 import { createNextcloudTalkReplayGuard } from "./replay-guard.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import { extractNextcloudTalkHeaders, verifyNextcloudTalkSignature } from "./signature.js";
 import type {
   CoreConfig,
   NextcloudTalkInboundMessage,
+  NextcloudTalkInboundReaction,
+  NextcloudTalkLikePayload,
   NextcloudTalkWebhookHeaders,
   NextcloudTalkWebhookPayload,
   NextcloudTalkWebhookServerOptions,
@@ -35,26 +37,46 @@ const PREAUTH_WEBHOOK_MAX_BODY_BYTES = 64 * 1024;
 const PREAUTH_WEBHOOK_BODY_TIMEOUT_MS = 5_000;
 const HEALTH_PATH = "/healthz";
 const WEBHOOK_AUTH_RATE_LIMIT_SCOPE = "nextcloud-talk-webhook-auth";
-const NextcloudTalkWebhookPayloadSchema: z.ZodType<NextcloudTalkWebhookPayload> = z.object({
-  type: z.enum(["Create", "Update", "Delete"]),
-  actor: z.object({
-    type: z.literal("Person"),
-    id: z.string().min(1),
-    name: z.string(),
-  }),
-  object: z.object({
-    type: z.literal("Note"),
-    id: z.string().min(1),
-    name: z.string(),
-    content: z.string(),
-    mediaType: z.string(),
-  }),
-  target: z.object({
-    type: z.literal("Collection"),
-    id: z.string().min(1),
-    name: z.string(),
-  }),
+const NextcloudTalkActorSchema = z.object({
+  type: z.literal("Person"),
+  id: z.string().min(1),
+  name: z.string(),
 });
+const NextcloudTalkNoteObjectSchema = z.object({
+  type: z.literal("Note"),
+  id: z.string().min(1),
+  name: z.string(),
+  content: z.string(),
+  mediaType: z.string(),
+});
+const NextcloudTalkTargetSchema = z.object({
+  type: z.literal("Collection"),
+  id: z.string().min(1),
+  name: z.string(),
+});
+const NextcloudTalkNotePayloadSchema = z.object({
+  type: z.enum(["Create", "Update", "Delete"]),
+  actor: NextcloudTalkActorSchema,
+  object: NextcloudTalkNoteObjectSchema,
+  target: NextcloudTalkTargetSchema,
+});
+const NextcloudTalkLikePayloadSchema = z.object({
+  type: z.literal("Like"),
+  actor: NextcloudTalkActorSchema,
+  object: NextcloudTalkNoteObjectSchema,
+  target: NextcloudTalkTargetSchema,
+});
+const NextcloudTalkUndoLikePayloadSchema = z.object({
+  type: z.literal("Undo"),
+  actor: NextcloudTalkActorSchema,
+  object: NextcloudTalkLikePayloadSchema,
+  target: NextcloudTalkTargetSchema,
+});
+const NextcloudTalkWebhookPayloadSchema: z.ZodType<NextcloudTalkWebhookPayload> = z.union([
+  NextcloudTalkNotePayloadSchema,
+  NextcloudTalkLikePayloadSchema,
+  NextcloudTalkUndoLikePayloadSchema,
+]);
 const WEBHOOK_ERRORS = {
   missingSignatureHeaders: "Missing signature headers",
   invalidBackend: "Invalid backend",
@@ -146,11 +168,12 @@ function verifyWebhookSignature(params: {
   return true;
 }
 
-function decodeWebhookCreateMessage(params: {
+function decodeWebhookActivity(params: {
   body: string;
   res: ServerResponse;
 }):
   | { kind: "message"; message: NextcloudTalkInboundMessage }
+  | { kind: "reaction"; reaction: NextcloudTalkInboundReaction }
   | { kind: "ignore" }
   | { kind: "invalid" } {
   const payload = parseWebhookPayload(params.body);
@@ -158,14 +181,21 @@ function decodeWebhookCreateMessage(params: {
     writeWebhookError(params.res, 400, WEBHOOK_ERRORS.invalidPayloadFormat);
     return { kind: "invalid" };
   }
-  if (payload.type !== "Create") {
-    return { kind: "ignore" };
+  if (payload.type === "Create") {
+    return { kind: "message", message: payloadToInboundMessage(payload) };
   }
-  return { kind: "message", message: payloadToInboundMessage(payload) };
+  if (payload.type === "Like") {
+    return { kind: "reaction", reaction: likePayloadToInboundReaction(payload, "added") };
+  }
+  if (payload.type === "Undo") {
+    // Only handle Undo of a Like (reaction removal). Ignore other Undo variants.
+    return { kind: "reaction", reaction: likePayloadToInboundReaction(payload.object, "removed") };
+  }
+  return { kind: "ignore" };
 }
 
 function payloadToInboundMessage(
-  payload: NextcloudTalkWebhookPayload,
+  payload: Extract<NextcloudTalkWebhookPayload, { type: "Create" | "Update" | "Delete" }>,
 ): NextcloudTalkInboundMessage {
   // Payload doesn't indicate DM vs room; mark as group and let inbound handler refine.
   const isGroupChat = true;
@@ -178,6 +208,26 @@ function payloadToInboundMessage(
     senderName: payload.actor.name ?? "",
     text: payload.object.content || payload.object.name || "",
     mediaType: payload.object.mediaType || "text/plain",
+    timestamp: Date.now(),
+    isGroupChat,
+  };
+}
+
+function likePayloadToInboundReaction(
+  payload: NextcloudTalkLikePayload,
+  action: "added" | "removed",
+): NextcloudTalkInboundReaction {
+  // Payload doesn't indicate DM vs room; let inbound handler refine via room-info lookup.
+  const isGroupChat = true;
+
+  return {
+    action,
+    messageId: payload.object.id,
+    roomToken: payload.target.id,
+    roomName: payload.target.name,
+    senderId: payload.actor.id,
+    senderName: payload.actor.name ?? "",
+    emoji: payload.object.content || payload.object.name || "",
     timestamp: Date.now(),
     isGroupChat,
   };
@@ -200,7 +250,7 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
   start: () => Promise<void>;
   stop: () => void;
 } {
-  const { port, host, path, secret, onMessage, onError, abortSignal } = opts;
+  const { port, host, path, secret, onMessage, onReaction, onError, abortSignal } = opts;
   const maxBodyBytes =
     typeof opts.maxBodyBytes === "number" &&
     Number.isFinite(opts.maxBodyBytes) &&
@@ -210,6 +260,7 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
   const readBody = opts.readBody ?? readNextcloudTalkWebhookBody;
   const isBackendAllowed = opts.isBackendAllowed;
   const shouldProcessMessage = opts.shouldProcessMessage;
+  const shouldProcessReaction = opts.shouldProcessReaction;
   const webhookAuthRateLimiter = createAuthRateLimiter({
     maxAttempts: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
     windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
@@ -262,7 +313,7 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
         return;
       }
 
-      const decoded = decodeWebhookCreateMessage({
+      const decoded = decodeWebhookActivity({
         body,
         res,
       });
@@ -271,6 +322,29 @@ export function createNextcloudTalkWebhookServer(opts: NextcloudTalkWebhookServe
       }
       if (decoded.kind === "ignore") {
         writeJsonResponse(res, 200);
+        return;
+      }
+
+      if (decoded.kind === "reaction") {
+        const reaction = decoded.reaction;
+        if (shouldProcessReaction) {
+          const shouldProcess = await shouldProcessReaction(reaction);
+          if (!shouldProcess) {
+            writeJsonResponse(res, 200);
+            return;
+          }
+        }
+
+        writeJsonResponse(res, 200);
+
+        if (!onReaction) {
+          return;
+        }
+        try {
+          await onReaction(reaction);
+        } catch (err) {
+          onError?.(err instanceof Error ? err : new Error(formatError(err)));
+        }
         return;
       }
 
@@ -341,6 +415,7 @@ export type NextcloudTalkMonitorOptions = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   onMessage?: (message: NextcloudTalkInboundMessage) => void | Promise<void>;
+  onReaction?: (reaction: NextcloudTalkInboundReaction) => void | Promise<void>;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
 };
 
@@ -405,6 +480,22 @@ export async function monitorNextcloudTalkProvider(
       }
       return shouldProcess;
     },
+    shouldProcessReaction: async (reaction) => {
+      const shouldProcess = await replayGuard.shouldProcessReaction({
+        accountId: account.accountId,
+        roomToken: reaction.roomToken,
+        messageId: reaction.messageId,
+        senderId: reaction.senderId,
+        emoji: reaction.emoji,
+        action: reaction.action,
+      });
+      if (!shouldProcess) {
+        logger.warn(
+          `[nextcloud-talk:${account.accountId}] replayed reaction ignored room=${reaction.roomToken} messageId=${reaction.messageId} emoji=${reaction.emoji}`,
+        );
+      }
+      return shouldProcess;
+    },
     onMessage: async (message) => {
       core.channel.activity.record({
         channel: "nextcloud-talk",
@@ -418,6 +509,25 @@ export async function monitorNextcloudTalkProvider(
       }
       await handleNextcloudTalkInbound({
         message,
+        account,
+        config: cfg,
+        runtime,
+        statusSink: opts.statusSink,
+      });
+    },
+    onReaction: async (reaction) => {
+      core.channel.activity.record({
+        channel: "nextcloud-talk",
+        accountId: account.accountId,
+        direction: "inbound",
+        at: reaction.timestamp,
+      });
+      if (opts.onReaction) {
+        await opts.onReaction(reaction);
+        return;
+      }
+      await handleNextcloudTalkInboundReaction({
+        reaction,
         account,
         config: cfg,
         runtime,

--- a/extensions/nextcloud-talk/src/replay-guard.ts
+++ b/extensions/nextcloud-talk/src/replay-guard.ts
@@ -22,6 +22,22 @@ function buildReplayKey(params: { roomToken: string; messageId: string }): strin
   return `${roomToken}:${messageId}`;
 }
 
+function buildReactionReplayKey(params: {
+  roomToken: string;
+  messageId: string;
+  senderId: string;
+  emoji: string;
+  action: "added" | "removed";
+}): string | null {
+  const base = buildReplayKey(params);
+  const senderId = params.senderId.trim();
+  const emoji = params.emoji.trim();
+  if (!base || !senderId || !emoji) {
+    return null;
+  }
+  return `reaction:${base}:${senderId}:${emoji}:${params.action}`;
+}
+
 export type NextcloudTalkReplayGuardOptions = {
   stateDir: string;
   ttlMs?: number;
@@ -35,6 +51,14 @@ export type NextcloudTalkReplayGuard = {
     accountId: string;
     roomToken: string;
     messageId: string;
+  }) => Promise<boolean>;
+  shouldProcessReaction: (params: {
+    accountId: string;
+    roomToken: string;
+    messageId: string;
+    senderId: string;
+    emoji: string;
+    action: "added" | "removed";
   }) => Promise<boolean>;
 };
 
@@ -53,6 +77,22 @@ export function createNextcloudTalkReplayGuard(
   return {
     shouldProcessMessage: async ({ accountId, roomToken, messageId }) => {
       const replayKey = buildReplayKey({ roomToken, messageId });
+      if (!replayKey) {
+        return true;
+      }
+      return await persistentDedupe.checkAndRecord(replayKey, {
+        namespace: accountId,
+        onDiskError: options.onDiskError,
+      });
+    },
+    shouldProcessReaction: async ({ accountId, roomToken, messageId, senderId, emoji, action }) => {
+      const replayKey = buildReactionReplayKey({
+        roomToken,
+        messageId,
+        senderId,
+        emoji,
+        action,
+      });
       if (!replayKey) {
         return true;
       }

--- a/extensions/nextcloud-talk/src/types.ts
+++ b/extensions/nextcloud-talk/src/types.ts
@@ -134,13 +134,35 @@ export type NextcloudTalkTarget = {
   name: string;
 };
 
-/** Incoming webhook payload from Nextcloud Talk. */
-export type NextcloudTalkWebhookPayload = {
+/** Message activity (Create/Update/Delete) webhook payload. */
+export type NextcloudTalkNotePayload = {
   type: "Create" | "Update" | "Delete";
   actor: NextcloudTalkActor;
   object: NextcloudTalkObject;
   target: NextcloudTalkTarget;
 };
+
+/** Reaction-added ("Like") webhook payload. Object id is the target message id; object content is the emoji. */
+export type NextcloudTalkLikePayload = {
+  type: "Like";
+  actor: NextcloudTalkActor;
+  object: NextcloudTalkObject;
+  target: NextcloudTalkTarget;
+};
+
+/** Reaction-removed ("Undo" of a "Like") webhook payload. */
+export type NextcloudTalkUndoLikePayload = {
+  type: "Undo";
+  actor: NextcloudTalkActor;
+  object: NextcloudTalkLikePayload;
+  target: NextcloudTalkTarget;
+};
+
+/** Incoming webhook payload from Nextcloud Talk. */
+export type NextcloudTalkWebhookPayload =
+  | NextcloudTalkNotePayload
+  | NextcloudTalkLikePayload
+  | NextcloudTalkUndoLikePayload;
 
 /** Result from sending a message to Nextcloud Talk. */
 export type NextcloudTalkSendResult = {
@@ -158,6 +180,19 @@ export type NextcloudTalkInboundMessage = {
   senderName: string;
   text: string;
   mediaType: string;
+  timestamp: number;
+  isGroupChat: boolean;
+};
+
+/** Parsed incoming reaction (Like/Undo) context. */
+export type NextcloudTalkInboundReaction = {
+  action: "added" | "removed";
+  messageId: string;
+  roomToken: string;
+  roomName: string;
+  senderId: string;
+  senderName: string;
+  emoji: string;
   timestamp: number;
   isGroupChat: boolean;
 };
@@ -182,7 +217,9 @@ export type NextcloudTalkWebhookServerOptions = {
   readBody?: (req: import("node:http").IncomingMessage, maxBodyBytes: number) => Promise<string>;
   isBackendAllowed?: (backend: string) => boolean;
   shouldProcessMessage?: (message: NextcloudTalkInboundMessage) => boolean | Promise<boolean>;
+  shouldProcessReaction?: (reaction: NextcloudTalkInboundReaction) => boolean | Promise<boolean>;
   onMessage: (message: NextcloudTalkInboundMessage) => void | Promise<void>;
+  onReaction?: (reaction: NextcloudTalkInboundReaction) => void | Promise<void>;
   onError?: (error: Error) => void;
   abortSignal?: AbortSignal;
 };


### PR DESCRIPTION
## AI Assistance Disclosure

Assisted-by: OpenClaw:openai/gpt-5.5

This PR's code and author-written PR comments were prepared with assistance from OpenClaw/Nymble. Lance directed the work and is responsible for reviewing and validating the contribution before it is presented as merge-ready.

## Summary
- add Nextcloud Talk webhook decoding for signed `Like`/`Undo` reaction activities
- persist approval prompt message bindings and resolve bound reactions through the approval gateway
- seed approval prompt messages with decision reactions, while keeping actor/allowlist checks and duplicate/removal handling in place
- document the Talk reaction/edit support surface

## Related
- Related to https://github.com/openclaw/openclaw/issues/81566
- Follows the native reaction approval pattern from https://github.com/openclaw/openclaw/pull/85894

## Tests
- `pnpm exec tsc --noEmit --pretty false --project extensions/nextcloud-talk/tsconfig.json`
- `pnpm exec vitest run extensions/nextcloud-talk/src/monitor.reactions.test.ts extensions/nextcloud-talk/src/inbound.approval-flow.test.ts extensions/nextcloud-talk/src/approval-stash.test.ts extensions/nextcloud-talk/src/approval-auth.test.ts --config vitest.config.ts`
- `pnpm exec vitest run nextcloud-talk/src --config test/vitest/vitest.extension-messaging.config.ts`
- `pnpm exec oxlint extensions/nextcloud-talk/src`

## Real behavior proof
- **Behavior or issue addressed**: Signed Nextcloud Talk non-message reaction webhooks (`Like`) are accepted by the real webhook server path and decoded into a bindable reaction tuple: actor id, target room token, target message id, and emoji. This is the foundation needed for `(roomToken, messageId) -> approvalId` reaction approvals.
- **Real environment tested**: Local OpenClaw checkout on Linux using the Nextcloud Talk extension webhook server code from this PR, listening on `127.0.0.1` and receiving an HTTP POST with a real HMAC signature generated by the extension signature helper.
- **Exact steps or command run after this patch**: Started `createNextcloudTalkWebhookServer` via `node --import tsx`, posted a signed `Like` Activity Streams payload to `/nextcloud-talk-webhook-proof` with `fetch`, and captured the `onReaction` callback output.
- **Evidence after fix**:

```json
{
  "status": 200,
  "capturedCount": 1,
  "reaction": {
    "action": "added",
    "messageId": "talk-msg-543",
    "roomToken": "vnogo5b8",
    "roomName": "OpenClaw Test Room",
    "senderId": "users/RansuDoragon",
    "senderName": "Ransu Doragon",
    "emoji": "✅",
    "timestamp": 1780298345579,
    "isGroupChat": true
  }
}
```

- **Observed result after fix**: The signed reaction webhook returned HTTP 200, did not enter the message handler, and produced the exact fields needed to bind a user reaction to one approval prompt message: `roomToken=vnogo5b8`, `messageId=talk-msg-543`, `senderId=users/RansuDoragon`, `emoji=✅`.
- **What was not tested**: I did not run a full live Nextcloud room approval against a real pending gateway approval in this PR proof. The approval-resolution branch is covered by targeted tests, while this live proof covers the signed Talk webhook decoding/binding surface.

