### PR TITLE
fix(update): strip service markers for auto updates

### DIFF
--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -509,14 +509,16 @@ describe("update-startup", () => {
       "beta",
       "--json",
     ]);
-    expect(options).toEqual({
-      timeoutMs: 45 * 60 * 1000,
-      env: {
-        OPENCLAW_AUTO_UPDATE: "1",
-        OPENCLAW_SERVICE_KIND: undefined,
-        OPENCLAW_SERVICE_MARKER: undefined,
-      },
+    if (typeof options === "number") {
+      throw new Error("expected auto-update command options object");
+    }
+    expect(options.timeoutMs).toBe(45 * 60 * 1000);
+    expect(options.env).toEqual({
+      OPENCLAW_AUTO_UPDATE: "1",
     });
+    expect(options.baseEnv?.OPENCLAW_STATE_DIR).toBe(tempDir);
+    expect(options.baseEnv?.OPENCLAW_SERVICE_KIND).toBeUndefined();
+    expect(options.baseEnv?.OPENCLAW_SERVICE_MARKER).toBeUndefined();
   });
 
   it("scheduleGatewayUpdateCheck returns a cleanup function", () => {

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -77,6 +77,8 @@ describe("update-startup", () => {
     tempDir = await suiteRootTracker.make("case");
     envSnapshot = captureEnv([
       "OPENCLAW_NO_AUTO_UPDATE",
+      "OPENCLAW_SERVICE_KIND",
+      "OPENCLAW_SERVICE_MARKER",
       "OPENCLAW_STATE_DIR",
       "NODE_ENV",
       "VITEST",
@@ -485,6 +487,8 @@ describe("update-startup", () => {
     });
 
     const originalArgv = process.argv.slice();
+    process.env.OPENCLAW_SERVICE_KIND = "gateway";
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     process.argv = [process.execPath, "/opt/openclaw/dist/entry.js"];
     try {
       await runAutoUpdateCheckWithDefaults({
@@ -509,6 +513,8 @@ describe("update-startup", () => {
       timeoutMs: 45 * 60 * 1000,
       env: {
         OPENCLAW_AUTO_UPDATE: "1",
+        OPENCLAW_SERVICE_KIND: undefined,
+        OPENCLAW_SERVICE_MARKER: undefined,
       },
     });
   });

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -290,10 +290,9 @@ async function runAutoUpdateCommand(params: {
   try {
     const res = await runCommandWithTimeout(argv, {
       timeoutMs: params.timeoutMs,
+      baseEnv: resolveAutoUpdateCommandBaseEnv(),
       env: {
         OPENCLAW_AUTO_UPDATE: "1",
-        OPENCLAW_SERVICE_MARKER: undefined,
-        OPENCLAW_SERVICE_KIND: undefined,
       },
     });
     return {
@@ -310,6 +309,15 @@ async function runAutoUpdateCommand(params: {
       reason: String(err),
     };
   }
+}
+
+function resolveAutoUpdateCommandBaseEnv(): NodeJS.ProcessEnv {
+  const {
+    OPENCLAW_SERVICE_KIND: _serviceKind,
+    OPENCLAW_SERVICE_MARKER: _serviceMarker,
+    ...baseEnv
+  } = process.env;
+  return baseEnv;
 }
 
 function clearAutoState(nextState: UpdateCheckState): void {

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -292,6 +292,8 @@ async function runAutoUpdateCommand(params: {
       timeoutMs: params.timeoutMs,
       env: {
         OPENCLAW_AUTO_UPDATE: "1",
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
       },
     });
     return {


### PR DESCRIPTION
Fixes #78492.

## Summary
- clears inherited `OPENCLAW_SERVICE_MARKER` / `OPENCLAW_SERVICE_KIND` from the auto-update child command base environment
- preserves `OPENCLAW_AUTO_UPDATE=1` so the update command still knows it is an auto-update run
- extends the startup update test to cover the actual resolved command environment shape instead of relying on `undefined` overrides

## Verification
- `node scripts/run-vitest.mjs src/infra/update-startup.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/update-startup.ts src/infra/update-startup.test.ts`
- `pnpm exec oxlint src/infra/update-startup.ts src/infra/update-startup.test.ts`
- `git diff --check`

## Real behavior proof
- Behavior addressed: auto-update child commands inherited service-process environment markers, so package update guards could treat the updater as an active OpenClaw service process.
- Real environment tested: Local OpenClaw checkout on Linux, PR head `1bed2b5a92760a3d809aa5f89769b76f870db7df`.
- Exact steps or command run after this patch: `node --import tsx/esm --input-type=module` script importing production `resolveCommandEnv`, starting from a service-like environment with `OPENCLAW_SERVICE_KIND=gateway` and `OPENCLAW_SERVICE_MARKER=openclaw`, applying the same sanitized base-env shape used by the auto-update command, and printing the resolved child environment fields.
- Evidence after fix:
```text
{
  "OPENCLAW_AUTO_UPDATE": "1",
  "OPENCLAW_SERVICE_KIND": null,
  "OPENCLAW_SERVICE_MARKER": null,
  "OPENCLAW_STATE_DIR": "/tmp/openclaw-state"
}
```
- Observed result after fix: The real env merge path keeps `OPENCLAW_AUTO_UPDATE=1` and `OPENCLAW_STATE_DIR`, while both service markers are absent from the child command environment.
- What was not tested: A live npm package self-update was not run because it would mutate the local installation outside the test fixture; the proof exercises the production env merge used by the updater child command.
