### PR TITLE
feat(status): show session duration in footer

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -109,7 +109,7 @@ describe("buildStatusMessage", () => {
       sessionEntry: {
         sessionId: "abc",
         updatedAt: 0,
-        sessionStartedAt: 2 * 60_000,
+        sessionStartedAt: 1 * 60 * 60_000 + 46 * 60_000,
         inputTokens: 1200,
         outputTokens: 800,
         totalTokens: 16_000,
@@ -128,7 +128,7 @@ describe("buildStatusMessage", () => {
       pluginHealthLine: "🔌 Plugins: OK",
       modelAuth: "api-key",
       subagentsLine: "🤖 Subagents: 1\n- active run",
-      now: 10 * 60_000, // 10 minutes later
+      now: 4 * 60 * 60_000, // 4 hours after epoch
     });
     const normalized = normalizeTestText(text);
 
@@ -141,8 +141,8 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Context: 16k/32k (50%)");
     expect(normalized).toContain("Compactions: 2");
     expect(normalized).toContain("Session: agent:main:main");
-    expect(normalized).toContain("duration 8m");
-    expect(normalized).toContain("updated 10m ago");
+    expect(normalized).toContain("duration 2h 14m");
+    expect(normalized).toContain("updated 4h ago");
     expect(normalized).toContain("Execution: direct");
     expect(normalized).toContain("Runtime: OpenClaw Default");
     expect(normalized).not.toContain("Runner:");

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -109,6 +109,7 @@ describe("buildStatusMessage", () => {
       sessionEntry: {
         sessionId: "abc",
         updatedAt: 0,
+        sessionStartedAt: 2 * 60_000,
         inputTokens: 1200,
         outputTokens: 800,
         totalTokens: 16_000,
@@ -140,6 +141,7 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Context: 16k/32k (50%)");
     expect(normalized).toContain("Compactions: 2");
     expect(normalized).toContain("Session: agent:main:main");
+    expect(normalized).toContain("duration 8m");
     expect(normalized).toContain("updated 10m ago");
     expect(normalized).toContain("Execution: direct");
     expect(normalized).toContain("Runtime: OpenClaw Default");

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -41,8 +41,8 @@ import {
   type SessionEntry,
   type SessionScope,
 } from "../config/sessions.js";
-import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
 import { resolveSessionLifecycleTimestamps } from "../config/sessions/lifecycle.js";
+import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readRecentSessionUsageFromTranscript } from "../gateway/session-transcript-readers.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
@@ -907,7 +907,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   }).sessionStartedAt;
   const sessionDuration =
     typeof sessionStartedAt === "number"
-      ? formatDurationCompact(now - sessionStartedAt)
+      ? formatDurationCompact(now - sessionStartedAt, { spaced: true })
       : undefined;
   const sessionLine = [
     `Session: ${args.sessionKey ?? "unknown"}`,

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -33,17 +33,19 @@ import type {
 import { resolveChannelModelOverride } from "../channels/model-overrides.js";
 import {
   resolveMainSessionKey,
+  resolveFreshSessionTotalTokens,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   resolveSessionPluginStatusLines,
   resolveSessionPluginTraceLines,
-  resolveFreshSessionTotalTokens,
   type SessionEntry,
   type SessionScope,
 } from "../config/sessions.js";
 import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
+import { resolveSessionLifecycleTimestamps } from "../config/sessions/lifecycle.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readRecentSessionUsageFromTranscript } from "../gateway/session-transcript-readers.js";
+import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { resolveCommitHash } from "../infra/git-commit.js";
 import {
@@ -898,8 +900,18 @@ export function buildStatusMessage(args: StatusArgs): string {
   });
 
   const updatedAt = entry?.updatedAt;
+  const sessionStartedAt = resolveSessionLifecycleTimestamps({
+    entry,
+    agentId: args.agentId,
+    storePath: args.sessionStorePath,
+  }).sessionStartedAt;
+  const sessionDuration =
+    typeof sessionStartedAt === "number"
+      ? formatDurationCompact(now - sessionStartedAt)
+      : undefined;
   const sessionLine = [
     `Session: ${args.sessionKey ?? "unknown"}`,
+    sessionDuration ? `duration ${sessionDuration}` : null,
     typeof updatedAt === "number" ? `updated ${formatTimeAgo(now - updatedAt)}` : "no activity",
   ]
     .filter(Boolean)


### PR DESCRIPTION
Fixes #68226.

## Summary
- adds a session duration segment to the shared status footer when `sessionStartedAt` is available
- uses the existing session lifecycle timestamp resolver so stored session metadata and transcript header fallback stay centralized
- renders multi-unit durations with spaces, matching the requested `duration 2h 14m` footer format

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/status.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/status/status-message.ts src/auto-reply/status.test.ts`
- `pnpm exec oxlint src/status/status-message.ts src/auto-reply/status.test.ts`
- `git diff --check`

## Real behavior proof
- Behavior addressed: the shared status footer showed the session key and update age but omitted the current session lifetime even when `sessionStartedAt` was available.
- Real environment tested: Local OpenClaw checkout on Linux, PR head `26ad2cdd2dcd2638b72126712924f6afcd46f37b`.
- Exact steps or command run after this patch: `node --import tsx/esm --input-type=module` script importing the production `buildStatusMessage`, building a status message with `sessionStartedAt` 2h 14m before `now`, and printing the rendered session footer line.
- Evidence after fix:
```text
🧵 Session: agent:main:main • duration 2h 14m • updated 4h ago
```
- Observed result after fix: The runtime status renderer emits a session footer with the session id, readable multi-unit duration, and update age in the same footer line.
- What was not tested: A deployed channel `/status` command was not sent; this proof exercises the shared production renderer used by that command path.
