### PR TITLE
fix(agents): quarantine normalized runtime tools

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -267,9 +267,9 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     },
   });
   toolBuildStages.mark("create-openclaw-coding-tools");
-  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
+  const toolSchemaDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
   const readableAllToolProjection = filterProviderNormalizableTools(allTools);
-  preNormalizationDiagnostics.push(...readableAllToolProjection.diagnostics);
+  toolSchemaDiagnostics.push(...readableAllToolProjection.diagnostics);
   const readableAllTools = [...readableAllToolProjection.tools];
   const codexFilteredTools = addNodeShellDynamicToolsIfNeeded(
     addSandboxShellDynamicToolsIfAvailable(
@@ -301,17 +301,16 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelId: params.modelId,
     modelApi: params.model.api,
     model: params.model,
-    onPreNormalizationSchemaDiagnostics: (diagnostics) =>
-      preNormalizationDiagnostics.push(...diagnostics),
+    onToolSchemaDiagnostics: (diagnostics) => toolSchemaDiagnostics.push(...diagnostics),
   });
   toolBuildStages.mark("runtime-normalization");
-  if (preNormalizationDiagnostics.length > 0) {
+  if (toolSchemaDiagnostics.length > 0) {
     embeddedAgentLog.warn(
-      `codex app-server quarantined ${preNormalizationDiagnostics.length} unsupported runtime tool schema${preNormalizationDiagnostics.length === 1 ? "" : "s"} before dynamic tool registration`,
+      `codex app-server quarantined ${toolSchemaDiagnostics.length} unsupported runtime tool schema${toolSchemaDiagnostics.length === 1 ? "" : "s"} before dynamic tool registration`,
       {
         runId: params.runId,
         sessionId: params.sessionId,
-        diagnostics: preNormalizationDiagnostics.map((diagnostic) => ({
+        diagnostics: toolSchemaDiagnostics.map((diagnostic) => ({
           index: diagnostic.toolIndex,
           tool: diagnostic.toolName,
           violations: diagnostic.violations.slice(0, 12),

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1413,7 +1413,7 @@ export async function runEmbeddedAttempt(
       modelApi: params.model.api,
       model: params.model,
       runtimeHandle: getProviderRuntimeHandle(),
-      onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
+      onToolSchemaDiagnostics: (diagnostics, sourceTools) =>
         logRuntimeToolSchemaQuarantine({
           diagnostics,
           tools: sourceTools,
@@ -1509,7 +1509,7 @@ export async function runEmbeddedAttempt(
             modelApi: params.model.api,
             model: params.model,
             runtimeHandle: getProviderRuntimeHandle(),
-            onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
+            onToolSchemaDiagnostics: (diagnostics, sourceTools) =>
               logRuntimeToolSchemaQuarantine({
                 diagnostics,
                 tools: sourceTools,

--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -80,7 +80,7 @@ describe("AgentRuntimePlan tool policy helpers", () => {
         runtimePlan,
         tools,
         provider: "openai",
-        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+        onToolSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
       }),
     ).toEqual([healthy]);
     expect(normalize).toHaveBeenCalledWith([healthy], {
@@ -112,7 +112,7 @@ describe("AgentRuntimePlan tool policy helpers", () => {
       normalizeAgentRuntimeTools({
         tools: [arraySchema, healthy],
         provider: "openai",
-        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+        onToolSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
       }),
     ).toEqual([healthy]);
     expect(mocks.normalizeProviderToolSchemas).toHaveBeenCalledWith(
@@ -130,6 +130,53 @@ describe("AgentRuntimePlan tool policy helpers", () => {
         },
       ],
     ]);
+  });
+
+  it("quarantines provider-normalized tools that remain runtime-incompatible", () => {
+    const source = {
+      ...createParameterFreeTool("fuzzplugin_dynamic_ref"),
+    } as unknown as AgentTool;
+    setPluginToolMeta(source, {
+      pluginId: "fuzzplugin",
+      optional: false,
+    });
+    const dynamicSchema = {
+      ...source,
+      parameters: { type: "object", $dynamicRef: "#fuzz" },
+    } as unknown as AgentTool;
+    const healthy = { ...createParameterFreeTool(), name: "healthy" } as AgentTool;
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    const diagnosticSources: (readonly AgentTool[])[] = [];
+    mocks.normalizeProviderToolSchemas.mockReturnValueOnce([dynamicSchema, healthy]);
+
+    expect(
+      normalizeAgentRuntimeTools({
+        tools: [source, healthy],
+        provider: "openai",
+        onToolSchemaDiagnostics: (entries, sourceTools) => {
+          diagnostics.push([...entries]);
+          diagnosticSources.push(sourceTools);
+        },
+      }),
+    ).toEqual([healthy]);
+    expect(mocks.normalizeProviderToolSchemas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: [source, healthy],
+        provider: "openai",
+      }),
+    );
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "fuzzplugin_dynamic_ref",
+          toolIndex: 0,
+          violations: ["fuzzplugin_dynamic_ref.parameters.$dynamicRef"],
+        },
+      ],
+    ]);
+    expect(getPluginToolMeta(diagnosticSources[0]?.[0])).toMatchObject({
+      pluginId: "fuzzplugin",
+    });
   });
 
   it("accepts legacy optional model fields while normalizing RuntimePlan context", () => {
@@ -253,7 +300,7 @@ describe("AgentRuntimePlan tool policy helpers", () => {
     const result = normalizeAgentRuntimeTools({
       tools: [unreadableName, healthy],
       provider: "openai",
-      onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+      onToolSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
     });
 
     expect(result).toEqual([normalized]);
@@ -270,6 +317,111 @@ describe("AgentRuntimePlan tool policy helpers", () => {
           toolName: "tool[0]",
           toolIndex: 0,
           violations: ["tool[0].name is unreadable"],
+        },
+      ],
+    ]);
+  });
+
+  it("quarantines unreadable provider-normalized tools before preserving metadata", () => {
+    const source = createParameterFreeTool("fixture__lookup_note") as AgentTool;
+    setPluginToolMeta(source, {
+      pluginId: "bundle-mcp",
+      optional: false,
+      mcp: {
+        serverName: "fixture",
+        safeServerName: "fixture",
+        toolName: "lookup_note",
+        operation: "tool",
+      },
+    });
+    const unreadableNormalized = {
+      ...createParameterFreeTool("fuzzplugin_normalized_unreadable"),
+    } as AgentTool;
+    Object.defineProperty(unreadableNormalized, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin normalized name getter exploded");
+      },
+    });
+    const normalized = {
+      ...source,
+      parameters: normalizedParameterFreeSchema(),
+    };
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    mocks.normalizeProviderToolSchemas.mockReturnValueOnce([unreadableNormalized, normalized]);
+
+    const result = normalizeAgentRuntimeTools({
+      tools: [source],
+      provider: "openai",
+      onToolSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+    });
+
+    expect(result).toEqual([normalized]);
+    expect(getPluginToolMeta(result[0])).toMatchObject({
+      pluginId: "bundle-mcp",
+      mcp: {
+        serverName: "fixture",
+        toolName: "lookup_note",
+      },
+    });
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["tool[0].name is unreadable"],
+        },
+      ],
+    ]);
+  });
+
+  it("quarantines unreadable provider-normalized array entries before preserving metadata", () => {
+    const source = createParameterFreeTool("fixture__lookup_note") as AgentTool;
+    setPluginToolMeta(source, {
+      pluginId: "bundle-mcp",
+      optional: false,
+      mcp: {
+        serverName: "fixture",
+        safeServerName: "fixture",
+        toolName: "lookup_note",
+        operation: "tool",
+      },
+    });
+    const normalized = {
+      ...source,
+      parameters: normalizedParameterFreeSchema(),
+    };
+    const normalizedTools = new Proxy([undefined, normalized] as unknown as AgentTool[], {
+      get(target, property, receiver) {
+        if (property === "0") {
+          throw new Error("fuzzplugin normalized array slot exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    mocks.normalizeProviderToolSchemas.mockReturnValueOnce(normalizedTools);
+
+    const result = normalizeAgentRuntimeTools({
+      tools: [source],
+      provider: "openai",
+      onToolSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+    });
+
+    expect(result).toEqual([normalized]);
+    expect(getPluginToolMeta(result[0])).toMatchObject({
+      pluginId: "bundle-mcp",
+      mcp: {
+        serverName: "fixture",
+        toolName: "lookup_note",
+      },
+    });
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["tool[0] is unreadable"],
         },
       ],
     ]);
@@ -292,7 +444,7 @@ describe("AgentRuntimePlan tool policy helpers", () => {
       normalizeAgentRuntimeTools({
         tools,
         provider: "openai",
-        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+        onToolSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
       }),
     ).toEqual([healthy]);
     expect(mocks.normalizeProviderToolSchemas).toHaveBeenCalledWith(

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -11,6 +11,7 @@ import {
 import type { AgentTool } from "../runtime/index.js";
 import {
   filterProviderNormalizableTools,
+  filterRuntimeCompatibleTools,
   type RuntimeToolSchemaDiagnostic,
 } from "../tool-schema-projection.js";
 import type { AgentRuntimePlan } from "./types.js";
@@ -27,7 +28,7 @@ type AgentRuntimeToolPolicyParams<TSchemaType extends TSchema = TSchema, TResult
   model?: ProviderRuntimeModel;
   runtimeHandle?: ProviderRuntimePluginHandle;
   allowProviderRuntimePluginLoad?: boolean;
-  onPreNormalizationSchemaDiagnostics?: (
+  onToolSchemaDiagnostics?: (
     diagnostics: readonly RuntimeToolSchemaDiagnostic[],
     tools: readonly AgentTool<TSchemaType, TResult>[],
   ) => void;
@@ -53,14 +54,49 @@ function copyRuntimeToolMetadata(source: AgentTool, target: AgentTool): void {
   copyChannelAgentToolMeta(source as never, target as never);
 }
 
+function readRuntimeToolName(tool: AgentTool): string | undefined {
+  try {
+    return typeof tool.name === "string" && tool.name ? tool.name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readRuntimeToolArrayLength(tools: readonly AgentTool[]): number {
+  try {
+    return tools.length;
+  } catch {
+    return 0;
+  }
+}
+
+function readRuntimeToolAt<TSchemaType extends TSchema = TSchema, TResult = unknown>(
+  tools: readonly AgentTool<TSchemaType, TResult>[],
+  index: number,
+): AgentTool<TSchemaType, TResult> | undefined {
+  try {
+    return tools[index];
+  } catch {
+    return undefined;
+  }
+}
+
 function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TResult = unknown>(
   sourceTools: AgentTool<TSchemaType, TResult>[],
   normalizedTools: AgentTool<TSchemaType, TResult>[],
 ): AgentTool<TSchemaType, TResult>[] {
   const sourcesByUniqueName = new Map<string, AgentTool<TSchemaType, TResult>>();
   const duplicateNames = new Set<string>();
-  for (const source of sourceTools) {
-    const name = source.name;
+  const sourceLength = readRuntimeToolArrayLength(sourceTools);
+  for (let index = 0; index < sourceLength; index += 1) {
+    const source = readRuntimeToolAt(sourceTools, index);
+    if (!source) {
+      continue;
+    }
+    const name = readRuntimeToolName(source);
+    if (!name) {
+      continue;
+    }
     if (sourcesByUniqueName.has(name)) {
       duplicateNames.add(name);
       sourcesByUniqueName.delete(name);
@@ -70,10 +106,20 @@ function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TRes
       sourcesByUniqueName.set(name, source);
     }
   }
-  for (const [index, target] of normalizedTools.entries()) {
+  const targetLength = readRuntimeToolArrayLength(normalizedTools);
+  for (let index = 0; index < targetLength; index += 1) {
+    const target = readRuntimeToolAt(normalizedTools, index);
+    if (!target) {
+      continue;
+    }
+    const targetName = readRuntimeToolName(target);
+    if (!targetName) {
+      continue;
+    }
     const indexedSource = sourceTools[index];
+    const indexedSourceName = indexedSource ? readRuntimeToolName(indexedSource) : undefined;
     const source =
-      indexedSource?.name === target.name ? indexedSource : sourcesByUniqueName.get(target.name);
+      indexedSourceName === targetName ? indexedSource : sourcesByUniqueName.get(targetName);
     if (source) {
       copyRuntimeToolMetadata(source, target);
     }
@@ -88,10 +134,7 @@ export function normalizeAgentRuntimeTools<
   const planContext = runtimePlanToolContext(params);
   const normalizableToolProjection = filterProviderNormalizableTools(params.tools);
   if (normalizableToolProjection.diagnostics.length > 0) {
-    params.onPreNormalizationSchemaDiagnostics?.(
-      normalizableToolProjection.diagnostics,
-      params.tools,
-    );
+    params.onToolSchemaDiagnostics?.(normalizableToolProjection.diagnostics, params.tools);
   }
   const normalizableTools = [...normalizableToolProjection.tools] as AgentTool<
     TSchemaType,
@@ -112,7 +155,16 @@ export function normalizeAgentRuntimeTools<
       allowRuntimePluginLoad: params.allowProviderRuntimePluginLoad,
     });
   const normalizedTools = Array.isArray(normalized) ? normalized : normalizableTools;
-  return preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
+  const metadataPreservedTools = preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
+  const runtimeToolProjection = filterRuntimeCompatibleTools(metadataPreservedTools);
+  if (runtimeToolProjection.diagnostics.length > 0) {
+    params.onToolSchemaDiagnostics?.(runtimeToolProjection.diagnostics, metadataPreservedTools);
+  }
+  const runtimeCompatibleTools =
+    runtimeToolProjection.diagnostics.length > 0
+      ? [...runtimeToolProjection.tools]
+      : metadataPreservedTools;
+  return runtimeCompatibleTools;
 }
 
 export function logAgentRuntimeToolDiagnostics(params: AgentRuntimeToolPolicyParams): void {

--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -208,7 +208,7 @@ export function buildRuntimeCompatibleToolInventory(params: {
 } {
   const rawToolsByName = buildReadableRawToolsByName(params.tools);
   const preNormalizationProjection = filterProviderNormalizableTools(params.tools);
-  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [
+  const toolSchemaDiagnostics: RuntimeToolSchemaDiagnostic[] = [
     ...preNormalizationProjection.diagnostics,
   ];
   const normalizedTools = normalizeAgentRuntimeTools({
@@ -221,11 +221,10 @@ export function buildRuntimeCompatibleToolInventory(params: {
     modelId: params.modelId,
     modelApi: params.modelApi ?? undefined,
     model: params.runtimeModel,
-    onPreNormalizationSchemaDiagnostics: (diagnostics) =>
-      preNormalizationDiagnostics.push(...diagnostics),
+    onToolSchemaDiagnostics: (diagnostics) => toolSchemaDiagnostics.push(...diagnostics),
   });
   const projection = filterRuntimeCompatibleTools(normalizedTools);
-  const diagnostics = [...preNormalizationDiagnostics, ...projection.diagnostics];
+  const diagnostics = [...toolSchemaDiagnostics, ...projection.diagnostics];
   return {
     entries: buildEffectiveToolInventoryEntries(projection.tools, rawToolsByName),
     notices: buildUnsupportedToolSchemaNotices({

--- a/src/agents/tools-effective-mcp-inventory.ts
+++ b/src/agents/tools-effective-mcp-inventory.ts
@@ -98,7 +98,7 @@ export function buildRuntimeCompatibleMcpToolInventory(params: {
   notices: EffectiveToolInventoryNotice[];
 } {
   const preNormalizationProjection = filterProviderNormalizableTools(params.tools);
-  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [
+  const toolSchemaDiagnostics: RuntimeToolSchemaDiagnostic[] = [
     ...preNormalizationProjection.diagnostics,
   ];
   const normalizedTools = normalizeAgentRuntimeTools({
@@ -110,11 +110,10 @@ export function buildRuntimeCompatibleMcpToolInventory(params: {
     modelApi: params.modelApi ?? undefined,
     model: params.runtimeModel,
     allowProviderRuntimePluginLoad: false,
-    onPreNormalizationSchemaDiagnostics: (diagnostics) =>
-      preNormalizationDiagnostics.push(...diagnostics),
+    onToolSchemaDiagnostics: (diagnostics) => toolSchemaDiagnostics.push(...diagnostics),
   });
   const projection = filterRuntimeCompatibleTools(normalizedTools);
-  const diagnostics = [...preNormalizationDiagnostics, ...projection.diagnostics];
+  const diagnostics = [...toolSchemaDiagnostics, ...projection.diagnostics];
   return {
     entries: buildMcpToolInventoryEntries(projection.tools),
     notices: diagnostics.map(buildMcpUnsupportedToolSchemaNotice),

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -170,7 +170,7 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
     }
 
     const rawToolsByName = buildReadableToolsByName(tools);
-    const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
+    const toolSchemaDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
     let normalizedTools: typeof tools;
     try {
       normalizedTools = normalizeAgentRuntimeTools({
@@ -182,8 +182,7 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
         modelId: modelRef.model,
         modelApi: runtimeModelContext.modelApi,
         model: runtimeModelContext.model,
-        onPreNormalizationSchemaDiagnostics: (diagnostics) =>
-          preNormalizationDiagnostics.push(...diagnostics),
+        onToolSchemaDiagnostics: (diagnostics) => toolSchemaDiagnostics.push(...diagnostics),
       });
     } catch (error) {
       warnings.push(
@@ -193,7 +192,7 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
       );
       continue;
     }
-    for (const diagnostic of preNormalizationDiagnostics) {
+    for (const diagnostic of toolSchemaDiagnostics) {
       const rawTool = rawToolsByName.get(diagnostic.toolName);
       const pluginId = readPluginId(rawTool);
       warnings.push(

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -607,7 +607,7 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
     warn: () => {},
     toolPolicyAuditLogLevel: "debug",
   });
-  const preNormalizationFindings: HealthFinding[] = [];
+  const toolSchemaFindings: HealthFinding[] = [];
 
   let normalizedTools: AnyAgentTool[];
   try {
@@ -620,8 +620,8 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
       modelId: params.modelRef.model,
       modelApi: params.model.api,
       model: params.model,
-      onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) => {
-        preNormalizationFindings.push(
+      onToolSchemaDiagnostics: (diagnostics, sourceTools) => {
+        toolSchemaFindings.push(
           ...diagnostics.map((diagnostic) =>
             toolSchemaDiagnosticToFinding({
               agentId: params.agentId,
@@ -633,11 +633,11 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
       },
     });
   } catch (error) {
-    return [...preNormalizationFindings, bundleMcpRuntimeNormalizationFailureFinding(error)];
+    return [...toolSchemaFindings, bundleMcpRuntimeNormalizationFailureFinding(error)];
   }
 
   return [
-    ...preNormalizationFindings,
+    ...toolSchemaFindings,
     ...collectToolSchemaFindings({
       agentId: params.agentId,
       tools: normalizedTools,
@@ -701,7 +701,7 @@ function collectAgentRuntimeToolSchemaFindings(params: {
     return [agentRuntimeToolLoadFailureFinding({ agentId: params.agentId, error })];
   }
 
-  const preNormalizationFindings: HealthFinding[] = [];
+  const toolSchemaFindings: HealthFinding[] = [];
 
   let normalizedTools: AnyAgentTool[];
   try {
@@ -714,8 +714,8 @@ function collectAgentRuntimeToolSchemaFindings(params: {
       modelId: params.modelRef.model,
       modelApi: params.model.api,
       model: params.model,
-      onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) => {
-        preNormalizationFindings.push(
+      onToolSchemaDiagnostics: (diagnostics, sourceTools) => {
+        toolSchemaFindings.push(
           ...diagnostics.map((diagnostic) =>
             toolSchemaDiagnosticToFinding({
               agentId: params.agentId,
@@ -728,13 +728,13 @@ function collectAgentRuntimeToolSchemaFindings(params: {
     });
   } catch (error) {
     return [
-      ...preNormalizationFindings,
+      ...toolSchemaFindings,
       agentRuntimeToolNormalizationFailureFinding({ agentId: params.agentId, error }),
     ];
   }
 
   return [
-    ...preNormalizationFindings,
+    ...toolSchemaFindings,
     ...collectToolSchemaFindings({
       agentId: params.agentId,
       tools: normalizedTools,


### PR DESCRIPTION
## Summary

- Quarantines provider-normalized runtime tools that still contain schemas unsupported by the assistant/runtime projection.
- Preserves plugin/channel/MCP ownership metadata on readable normalized clones before reporting diagnostics, so warnings still identify the owning plugin surface.
- Hardens metadata preservation against hostile provider-normalized results with unreadable names or throwing array slots.
- Renames the diagnostic callback from pre-normalization-only to general tool-schema diagnostics because callers now receive both pre-provider and post-provider quarantine events.

## Linked context

Closes #

Related #88936
Related #88950
Related #88959
Related #88977

Was this requested by a maintainer or owner?

Maintainer fuzzing/hardening sweep for provider/tool-schema runtime crash surfaces.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: provider tool-schema normalization could return runtime-incompatible or hostile normalized tools that reached assistant/Codex dynamic-tool paths before final quarantine.
- Real environment tested: local macOS worktree with Node wrapper tests, plus AWS Crabbox Linux changed gate.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/runtime-plan/tools.test.ts src/agents/runtime-plan/tools.diagnostics.test.ts --reporter=dot`; `node scripts/run-vitest.mjs src/agents/tools-effective-inventory.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts src/flows/doctor-core-checks.runtime.test.ts src/flows/doctor-core-checks.runtime-errors.test.ts --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 ...`; `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json ...`; `git diff --check origin/main...HEAD`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): local focused tests passed 14 runtime-plan tests and 143 caller/doctor/Codex-path tests; AWS Crabbox changed gate passed with provider `aws`, run `run_ba62f5cbca01`, lease `cbx_54d56c47e7e8`, exit 0, lease stopped.
- Observed result after fix: normalized tools with `$dynamicRef` are quarantined after provider normalization; unreadable normalized tool names and throwing normalized array slots are quarantined without crashing metadata preservation; healthy normalized tools still keep plugin/MCP metadata.
- What was not tested: live provider/plugin runtime with private plugin data; Blacksmith Testbox proof was blocked by missing local Blacksmith auth.
- Proof limitations or environment constraints: direct Blacksmith check failed with `not authenticated - run 'blacksmith auth login' first`, so broad proof used AWS Crabbox instead.
- Before evidence (optional but encouraged): current main only filtered before provider normalization, allowing provider-normalized incompatible/hostile tools to continue into the returned runtime tool list.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/runtime-plan/tools.test.ts src/agents/runtime-plan/tools.diagnostics.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs src/agents/tools-effective-inventory.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts src/flows/doctor-core-checks.runtime.test.ts src/flows/doctor-core-checks.runtime-errors.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/dynamic-tool-build.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/runtime-plan/tools.test.ts src/agents/runtime-plan/tools.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-mcp-inventory.ts src/commands/doctor/shared/active-tool-schema-warnings.ts src/flows/doctor-core-checks.runtime.ts`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/codex/src/app-server/dynamic-tool-build.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/runtime-plan/tools.test.ts src/agents/runtime-plan/tools.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-mcp-inventory.ts src/commands/doctor/shared/active-tool-schema-warnings.ts src/flows/doctor-core-checks.runtime.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

What regression coverage was added or updated?

- Added runtime-plan coverage for provider-normalized `$dynamicRef` quarantine after provider normalization.
- Added hostile normalized-tool regressions for unreadable normalized names and throwing normalized array slots.
- Updated caller diagnostics to consume general tool-schema diagnostics rather than only pre-normalization diagnostics.

What failed before this fix, if known?

- A provider-normalized tool that stayed runtime-incompatible could still be returned by `normalizeAgentRuntimeTools`.
- Hostile normalized tool results could be touched by metadata preservation before safe runtime projection.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Unsupported provider-normalized runtime tools are now quarantined instead of passed to assistant runtime paths.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This hardens tool execution registration boundaries by preventing unsupported/hostile normalized tool definitions from reaching runtime paths.

What is the highest-risk area?

Tool availability for providers/plugins that depend on schema normalization.

How is that risk mitigated?

The pre-provider filter still lets provider-normalizable schemas reach normalization hooks, and the new filter runs only after hooks have had their chance to produce runtime-compatible schemas. Healthy normalized tools are preserved and retain ownership metadata.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Blacksmith Testbox proof is blocked by missing local auth; AWS Crabbox changed gate passed instead.

Which bot or reviewer comments were addressed?

Local autoreview first caught a test typecheck issue in the diagnostic source accumulator; fixed and rerun. Final autoreview is clean: no accepted/actionable findings, `overall: patch is correct (0.83)`.
