### PR TITLE
perf(ui): guard chat composer controls

### DIFF
--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -2,6 +2,7 @@
 
 import { html, render } from "lit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "../i18n/index.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import type { ChatProps } from "./views/chat.ts";
 import type { QuickSettingsProps } from "./views/config-quick.ts";
@@ -13,6 +14,7 @@ const chatProps = vi.hoisted(() => ({
   current: null as ChatProps | null,
 }));
 const localStorageValues = vi.hoisted(() => new Map<string, string>());
+const renderChatControlsMock = vi.hoisted(() => vi.fn(() => "chat-controls"));
 
 vi.mock("../local-storage.ts", () => ({
   getSafeLocalStorage: () => ({
@@ -33,9 +35,17 @@ vi.mock("./views/config-quick.ts", () => ({
 vi.mock("./views/chat.ts", () => ({
   renderChat: (props: ChatProps) => {
     chatProps.current = props;
-    return html`<div data-testid="chat"></div>`;
+    return html`<div data-testid="chat">${props.composerControls}</div>`;
   },
 }));
+
+vi.mock("./app-render.helpers.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./app-render.helpers.ts")>();
+  return {
+    ...actual,
+    renderChatControls: renderChatControlsMock,
+  };
+});
 
 vi.mock("./icons.ts", () => ({
   icons: {},
@@ -218,10 +228,12 @@ function createState(overrides: Partial<AppViewState> = {}): AppViewState {
   } as unknown as AppViewState;
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  await i18n.setLocale("en");
   localStorageValues.clear();
   quickSettingsProps.current = null;
   chatProps.current = null;
+  renderChatControlsMock.mockClear();
 });
 
 describe("renderApp assistant avatar routing", () => {
@@ -330,6 +342,35 @@ describe("renderApp assistant avatar routing", () => {
     );
 
     expect(chatProps.current?.error).toBe("gateway disconnected");
+  });
+
+  it("does not rebuild chat composer controls for draft-only rerenders", () => {
+    const container = document.createElement("div");
+    const state = createState({ tab: "chat", chatMessage: "" });
+
+    render(renderApp(state), container);
+    state.chatMessage = "h";
+    render(renderApp(state), container);
+    state.chatMessage = "hello";
+    render(renderApp(state), container);
+
+    expect(renderChatControlsMock).toHaveBeenCalledTimes(1);
+
+    state.chatSending = true;
+    render(renderApp(state), container);
+
+    expect(renderChatControlsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rebuilds chat composer controls after locale changes", async () => {
+    const container = document.createElement("div");
+    const state = createState({ tab: "chat", chatMessage: "" });
+
+    render(renderApp(state), container);
+    await i18n.setLocale("zh-CN");
+    render(renderApp(state), container);
+
+    expect(renderChatControlsMock).toHaveBeenCalledTimes(2);
   });
 
   it("passes security quick setting fields to Quick Settings", () => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
+import { guard } from "lit/directives/guard.js";
 import { styleMap } from "lit/directives/style-map.js";
-import { t } from "../i18n/index.ts";
+import { i18n, t } from "../i18n/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import {
   createChatSessionsLoadOverrides,
@@ -752,6 +753,46 @@ function renderMeasured<T>(
     durationMs: roundedControlUiDurationMs(controlUiNowMs() - startedAtMs),
   });
   return result;
+}
+
+function renderGuardedChatControls(state: AppViewState) {
+  return guard(
+    [
+      state.sessionKey,
+      state.connected,
+      state.client,
+      state.onboarding,
+      state.chatManualRefreshInFlight,
+      state.chatLoading,
+      state.chatSending,
+      state.chatStream,
+      state.chatRunId,
+      state.chatMobileControlsOpen,
+      state.sessionsHideCron ?? true,
+      state.sessionsResult,
+      state.sessionsShowArchived,
+      state.agentsList,
+      state.chatModelOverrides,
+      state.chatModelSwitchPromises,
+      state.chatModelsLoading,
+      state.chatModelCatalog,
+      state.settings.chatShowThinking,
+      state.settings.chatShowToolCalls,
+      state.settings.chatAutoScroll,
+      state.chatSessionPickerOpen,
+      state.chatSessionPickerSurface,
+      state.chatSessionPickerQuery,
+      state.chatSessionPickerAppliedQuery,
+      state.chatSessionPickerLoading,
+      state.chatSessionPickerError,
+      state.chatSessionPickerResult,
+      state.sessionSwitchNotice?.id ?? null,
+      state.sessionSwitchNotice?.text ?? null,
+      state.sessionSwitchFlashKey,
+      i18n.getLocale(),
+    ],
+    () => renderChatControls(state),
+  );
 }
 
 function resolveAssistantAvatarUrl(state: AppViewState): string | undefined {
@@ -3149,7 +3190,7 @@ export function renderApp(state: AppViewState) {
                   runStatus: state.chatRunStatus,
                   onDismissError: () => dismissChatError(state),
                   sessions: state.sessionsResult,
-                  composerControls: renderChatControls(state),
+                  composerControls: renderGuardedChatControls(state),
                   workspaceFiles: {
                     agentId: chatAgentId,
                     list:

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -179,7 +179,7 @@ export type ChatProps = {
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
   basePath?: string;
-  composerControls?: TemplateResult | typeof nothing;
+  composerControls?: TemplateResult | typeof nothing | ReturnType<typeof guard>;
   workspaceFiles?: {
     agentId: string;
     list: AgentsFilesListResult | null;


### PR DESCRIPTION
## Summary

- guard Control UI chat composer controls so draft-only rerenders do not rebuild the model/session/settings picker
- keep locale changes, busy state, session picker state, model state, settings, and session data in the guard key
- add regression coverage for draft-only reuse and locale-triggered invalidation

## Verification

- `./node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/app-render.ts ui/src/ui/views/chat.ts ui/src/ui/app-render.assistant-avatar.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs run ui/src/ui/app-render.assistant-avatar.test.ts ui/src/ui/views/chat.test.ts --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner`
- `node scripts/run-oxlint.mjs ui/src/ui/app-render.ts ui/src/ui/views/chat.ts ui/src/ui/app-render.assistant-avatar.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean after fixing the accepted locale-invalidation finding
