### PR TITLE
fix(ui): pass agentId to sessions.list in Control UI session picker

### DIFF
--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -27,6 +27,8 @@ export type SessionsState = {
   sessionsCheckpointLoadingKey: string | null;
   sessionsCheckpointBusyKey: string | null;
   sessionsCheckpointErrorByKey: Record<string, string>;
+  /** Currently selected agent id — passed to sessions.list for server-side filtering. */
+  agentsSelectedId?: string | null;
 };
 
 function checkpointSummarySignature(
@@ -166,6 +168,9 @@ export async function loadSessions(
     }
     if (limit > 0) {
       params.limit = limit;
+    }
+    if (state.agentsSelectedId) {
+      params.agentId = state.agentsSelectedId;
     }
     const res = await client.request<SessionsListResult | undefined>("sessions.list", params);
     if (res) {


### PR DESCRIPTION
## Summary

- Control UI session picker called `sessions.list` without the selected agent's `agentId` parameter
- Backend `sessions.list` supports `agentId` filtering, but the Control UI never passed it
- Added `agentsSelectedId` to `SessionsState` type and pass it in the `loadSessions` request params

## Change Type

- [x] Bug fix

## Scope

- [x] UI/UX (Control UI session picker)

## Real behavior proof

**Behavior addressed:** Control UI session picker now passes the currently selected `agentId` to `sessions.list`, so the picker only shows sessions belonging to the selected agent.

**Environment tested:** Node 22.x on Linux, pnpm test.

**Steps run after the patch:** Ran Control UI tests in `ui/src/ui/app-chat.test.ts` and `ui/src/ui/app-settings.test.ts`.

**Evidence after fix:**

```text
pnpm test --run ui/src/ui/app-chat.test.ts ui/src/ui/app-settings.test.ts

 Test Files  2 passed (2)
      Tests  20 passed (20)
```

**Observed result:** All UI tests pass. The `sessions.list` RPC now receives `agentId` when an agent is selected.

**Not tested:** Live multi-agent Control UI with real gateway session filtering.

## Root Cause

`loadSessions` in `ui/src/ui/controllers/sessions.ts` constructed the `sessions.list` request params with only `includeGlobal`, `includeUnknown`, `activeMinutes`, and `limit` — never including `agentId`. The `SessionsState` type also lacked an `agentsSelectedId` field.

## User-visible / Behavior Changes

When a specific agent is selected in Control UI, the session picker will only display sessions belonging to that agent, matching the backend's `agentId` filter behavior.

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No

Closes #86183