### PR TITLE
fix(plugins): preserve mutable hook context

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2729,6 +2729,73 @@ module.exports = { id: "throws-after-import", register() {} };`,
     clearInternalHooks();
   });
 
+  it("preserves plugin hook context mutations without leaking plugin config", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "hook-context-mutation",
+      filename: "hook-context-mutation.cjs",
+      body: `module.exports = {
+        id: "hook-context-mutation",
+        register(api) {
+          api.registerHook(
+            "agent:bootstrap",
+            (event) => {
+              event.messages.push(event.context.pluginConfig?.marker);
+              event.context.bootstrapFiles = [
+                { name: "SENTINEL.md", content: "SENTINEL_BOOTSTRAP_CONTEXT" },
+              ];
+            },
+            { name: "hook-context-mutation" },
+          );
+        },
+      };`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "hook-context-mutation",
+          configSchema: { type: "object" },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    clearInternalHooks();
+
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["hook-context-mutation"],
+          entries: {
+            "hook-context-mutation": {
+              config: {
+                marker: "plugin-config-visible",
+              },
+            },
+          },
+        },
+      },
+      onlyPluginIds: ["hook-context-mutation"],
+    });
+
+    const event = createInternalHookEvent("agent", "bootstrap", "agent:bootstrap", {
+      bootstrapFiles: [{ name: "AGENTS.md", content: "ORIGINAL_CONTEXT" }],
+    });
+    await triggerInternalHook(event);
+    expect(event.messages).toEqual(["plugin-config-visible"]);
+    expect(event.context).toStrictEqual({
+      bootstrapFiles: [{ name: "SENTINEL.md", content: "SENTINEL_BOOTSTRAP_CONTEXT" }],
+    });
+
+    clearInternalHooks();
+  });
+
   it("injects plugin config into internal hook event context", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2796,6 +2796,101 @@ module.exports = { id: "throws-after-import", register() {} };`,
     clearInternalHooks();
   });
 
+  it("runs consecutive plugin hook handlers on the shared context without config leakage", async () => {
+    useNoBundledPlugins();
+    const firstPlugin = writePlugin({
+      id: "hook-context-first",
+      filename: "hook-context-first.cjs",
+      body: `module.exports = {
+        id: "hook-context-first",
+        register(api) {
+          api.registerHook(
+            "agent:bootstrap",
+            (event) => {
+              event.messages.push("first:" + (event.context.pluginConfig?.marker ?? "missing"));
+              event.context.bootstrapFiles = [
+                { name: "FIRST.md", content: "FIRST_HANDLER_MUTATION" },
+              ];
+              event.context.note = "mutated-by-first-handler";
+              event.context.pluginConfig = { marker: "leaked-first-config" };
+            },
+            { name: "hook-context-first" },
+          );
+        },
+      };`,
+    });
+    const secondPlugin = writePlugin({
+      id: "hook-context-second",
+      filename: "hook-context-second.cjs",
+      body: `module.exports = {
+        id: "hook-context-second",
+        register(api) {
+          api.registerHook(
+            "agent:bootstrap",
+            (event) => {
+              event.messages.push("second:" + (event.context.pluginConfig?.marker ?? "none"));
+              event.messages.push(event.context.bootstrapFiles?.[0]?.name ?? "missing-mutation");
+              event.messages.push(event.context.note ?? "missing-note");
+            },
+            { name: "hook-context-second" },
+          );
+        },
+      };`,
+    });
+    for (const plugin of [firstPlugin, secondPlugin]) {
+      fs.writeFileSync(
+        path.join(plugin.dir, "openclaw.plugin.json"),
+        JSON.stringify(
+          {
+            id: plugin.id,
+            configSchema: { type: "object" },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+    }
+
+    clearInternalHooks();
+
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: firstPlugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [firstPlugin.file, secondPlugin.file] },
+          allow: ["hook-context-first", "hook-context-second"],
+          entries: {
+            "hook-context-first": {
+              config: {
+                marker: "first-config-visible",
+              },
+            },
+          },
+        },
+      },
+      onlyPluginIds: ["hook-context-first", "hook-context-second"],
+    });
+
+    const event = createInternalHookEvent("agent", "bootstrap", "agent:bootstrap", {
+      bootstrapFiles: [{ name: "AGENTS.md", content: "ORIGINAL_CONTEXT" }],
+    });
+    await triggerInternalHook(event);
+    expect(event.messages).toEqual([
+      "first:first-config-visible",
+      "second:none",
+      "FIRST.md",
+      "mutated-by-first-handler",
+    ]);
+    expect(event.context).toStrictEqual({
+      bootstrapFiles: [{ name: "FIRST.md", content: "FIRST_HANDLER_MUTATION" }],
+      note: "mutated-by-first-handler",
+    });
+
+    clearInternalHooks();
+  });
+
   it("injects plugin config into internal hook event context", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -735,9 +735,20 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }> = [];
     for (const event of normalizedEvents) {
       const wrappedHandler: typeof handler = async (evt) => {
-        // Shallow-copy to avoid mutating the shared event object
-        // passed to all handlers sequentially by triggerInternalHook
-        return handler({ ...evt, context: { ...evt.context, pluginConfig } });
+        const context = evt.context;
+        const hadPluginConfig = Object.hasOwn(context, "pluginConfig");
+        const previousPluginConfig = context.pluginConfig;
+
+        context.pluginConfig = pluginConfig;
+        try {
+          return await handler({ ...evt, context });
+        } finally {
+          if (hadPluginConfig) {
+            context.pluginConfig = previousPluginConfig;
+          } else {
+            delete context.pluginConfig;
+          }
+        }
       };
       registerInternalHook(event, wrappedHandler);
       nextRegistrations.push({ event, handler: wrappedHandler });


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Preserve the original mutable hook context object when plugin `registerHook` handlers run.
- Temporarily expose `pluginConfig` to each handler and restore/remove it afterward so config does not leak onto the shared event context.
- Add regression coverage for both bootstrap context replacement and back-to-back hook handlers: the first handler mutates the shared context with config present, and the second handler sees that mutation without seeing the first handler's `pluginConfig`.

## Test Plan
- RED: temporarily restored `src/plugins/registry.ts` to `upstream/main`, then ran `node scripts/run-vitest.mjs src/plugins/loader.test.ts --testNamePattern "runs consecutive plugin hook handlers" --reporter dot` → failed as expected because the second handler saw `AGENTS.md` / `missing-note` instead of the first handler's context mutation.
- GREEN: `node scripts/run-vitest.mjs src/plugins/loader.test.ts --testNamePattern "runs consecutive plugin hook handlers|preserves plugin hook context mutations|injects plugin config" --reporter dot` → 1 test file passed; 3 tests passed, 148 skipped.
- GREEN: `node_modules/.bin/tsx /tmp/proof-pr89002-hook-context.ts` → real plugin-loader proof passed.
- GREEN: `node_modules/.bin/oxfmt --write src/plugins/loader.test.ts` and `git diff --staged --check` → passed before commit.
- BLOCKED: `pnpm check:changed --staged` could not complete locally because pnpm attempted dependency hydration/removal in this worktree and aborted in non-TTY mode with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. Earlier direct `pnpm install --frozen-lockfile` also failed on the known lockfile/dependency hydration issue for `@lydell/node-pty-darwin-arm64`.

## Real behavior proof
Behavior addressed: plugin hook handlers could mutate the context object they received, but current main's registry wrapper shallow-copied `evt.context`, so later core code and later handlers did not observe context replacements such as `bootstrapFiles`; `pluginConfig` still needs to be visible only to the owning handler and cleaned before the next handler.

Real environment tested: local PR worktree on macOS 15.5; Node v22.22.1 via `tsx`; two temporary real plugin directories each containing `openclaw.plugin.json` and a CJS entrypoint were loaded through `loadOpenClawPlugins` with the normal plugin loader path, then `agent:bootstrap` was triggered through `triggerInternalHook`.

Exact steps or command run after this patch: `node_modules/.bin/tsx /tmp/proof-pr89002-hook-context.ts`

Evidence after fix:
```text
PR #89002 real plugin-loader proof
tempRoot=/var/folders/xk/3knfjhwn1yb6hf9jw4853pmc0000gn/T/openclaw-pr89002-real-plugin-KCTpCx
messages=["firstConfig=visible-to-first-real-plugin","secondConfig=none","bootstrapFile=REAL-FIRST.md","note=mutation-from-first-real-plugin"]
context={"bootstrapFiles":[{"name":"REAL-FIRST.md","content":"from-first-real-plugin"}],"note":"mutation-from-first-real-plugin"}
pluginConfigPresent=false
PASS: real plugin hooks loaded through loadOpenClawPlugins share context mutations while pluginConfig is cleaned before the next handler.
```

Observed result after fix: the first real plugin saw its own config and replaced `event.context.bootstrapFiles`; the second real plugin saw no `pluginConfig` leakage but did see `REAL-FIRST.md` and `mutation-from-first-real-plugin`; the final shared event context retained the mutation and had `pluginConfigPresent=false`.

What was not tested: the full `pnpm check:changed --staged` gate was not completed locally because pnpm attempted dependency hydration/removal and aborted in non-TTY mode; focused Vitest coverage, formatter/check-diff sanity, and the real plugin-loader proof above were run instead.

## Risk/Notes
- The wrapper restores/removes `pluginConfig` in a `finally` block, so existing context config state is preserved even if a handler throws.
- Scope is limited to plugin internal hook handler invocation; hook registration/unregistration logic is unchanged.
- This intentionally preserves the shared mutable context contract used by `agent:bootstrap` while keeping per-handler config isolated.

Closes #75245
