### PR TITLE
fix(sessions): preserve labels on upsert

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -723,6 +723,106 @@ describe("sessions", () => {
     expect(store[sessionKey]?.acp).toBeUndefined();
   });
 
+  it("upsertSessionEntry preserves the main session title when replacement metadata is empty", async () => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "upsertSessionEntry-main-title-preserve",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Primary Lane",
+          displayName: "Primary Lane",
+        },
+      },
+    });
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 200,
+        label: null as unknown as string,
+        displayName: "",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.sessionId).toBe("sess-2");
+    expect(store[sessionKey]?.label).toBe("Primary Lane");
+    expect(store[sessionKey]?.displayName).toBe("Primary Lane");
+  });
+
+  it("upsertSessionEntry preserves a telegram-backed session title when runtime metadata omits it", async () => {
+    const sessionKey = "agent:main:telegram:direct:opaque-user";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "upsertSessionEntry-channel-title-preserve",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Channel Lane",
+          displayName: "Channel Lane",
+          origin: {
+            provider: "telegram",
+            chatType: "direct",
+            from: "opaque-user",
+          },
+        },
+      },
+    });
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 200,
+        origin: {
+          provider: "telegram",
+          chatType: "direct",
+          from: "opaque-user",
+        },
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.sessionId).toBe("sess-2");
+    expect(store[sessionKey]?.label).toBe("Channel Lane");
+    expect(store[sessionKey]?.displayName).toBe("Channel Lane");
+  });
+
+  it("upsertSessionEntry accepts replacement human titles when provided", async () => {
+    const sessionKey = "agent:main:ops-lane";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "upsertSessionEntry-title-replace",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Old Lane",
+          displayName: "Old Lane",
+        },
+      },
+    });
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 200,
+        label: "Ops Lane",
+        displayName: "Ops Lane",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.label).toBe("Ops Lane");
+    expect(store[sessionKey]?.displayName).toBe("Ops Lane");
+  });
+
   it("updateSessionStore preserves concurrent additions", async () => {
     const dir = await createCaseDir("updateSessionStore");
     const storePath = path.join(dir, "sessions.json");

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -193,6 +193,28 @@ function cloneSessionEntry(entry: SessionEntry): SessionEntry {
   return cloneSessionStoreRecord({ entry }).entry;
 }
 
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function preserveHumanSessionTitleFields(params: {
+  existing?: SessionEntry;
+  next: SessionEntry;
+}): void {
+  if (!params.existing) {
+    return;
+  }
+  if (!hasNonEmptyString(params.next.label) && hasNonEmptyString(params.existing.label)) {
+    params.next.label = params.existing.label;
+  }
+  if (
+    !hasNonEmptyString(params.next.displayName) &&
+    hasNonEmptyString(params.existing.displayName)
+  ) {
+    params.next.displayName = params.existing.displayName;
+  }
+}
+
 function resolveSessionWorkflowStorePath(
   options: SessionEntryWorkflowOptions & { sessionKey?: string },
 ): string {
@@ -1048,6 +1070,10 @@ export async function upsertSessionEntry(
     const store = loadMutableSessionStoreForWriter(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
     const next = cloneSessionEntry(params.entry);
+    preserveHumanSessionTitleFields({
+      existing: resolved.existing,
+      next,
+    });
     await persistResolvedSessionEntry({
       storePath,
       store,


### PR DESCRIPTION
## Summary

- Problem: `upsertSessionEntry` could replace a persistent session record with empty/null human title metadata and erase the existing `label`/`displayName`.
- Solution: preserve existing non-empty human title fields when replacement metadata does not provide a non-empty value.
- What changed: session-store upsert merge logic plus focused regression coverage for empty/null replacement metadata and explicit non-empty replacement titles.
- What did NOT change (scope boundary): validated session patch/update rename flows, ACP metadata replacement semantics, and intentional non-empty runtime-owned title updates.

## Motivation

A persistent session can be displayed under fallback origin metadata after its stored human title fields are wiped. The fix belongs at the session-store boundary because callers using replacement upserts should not need to preserve stable title fields manually.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #89003
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: Persistent sessions with existing human titles no longer lose `label` or `displayName` when a runtime replacement upsert carries empty/null human metadata. This covers the observed class of session-title regressions where the UI falls back to origin metadata.
- Real environment tested: Local installed OpenClaw runtime on macOS, with a running local gateway service restarted after applying the installed-runtime hotfix. Private session names, local paths, and port details are intentionally redacted.
- Exact steps or command run after this patch: Applied the same guard to the installed runtime, restarted the gateway, ran a temp-store smoke through the installed `upsertSessionEntry`, then queried the live gateway session list and redacted private identifiers before posting evidence.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Redacted copied live output from the real gateway session list and installed-runtime temp-store smoke:

```json
{
  "key": "agent:demo:primary",
  "label": "user-session-alpha",
  "displayName": "user-session-alpha",
  "derivedTitle": null
}
{
  "key": "agent:demo:secondary",
  "label": "user-session-beta",
  "displayName": "user-session-beta",
  "derivedTitle": null
}
{
  "key": "agent:demo:tertiary",
  "label": "user-session-gamma",
  "displayName": "user-session-gamma",
  "derivedTitle": null
}
{
  "sessionId": "sess-demo",
  "label": "user-session-alpha",
  "displayName": "user-session-alpha"
}
```

- Observed result after fix: Replacement upsert with `label: null` and `displayName: ""` preserved the existing synthetic `user-session-alpha` title in the installed runtime smoke. The live gateway continued to report stable labels/display names for the affected persistent sessions after restart; private identifiers were redacted from the copied output above.
- What was not tested: No known gaps for this narrow session-store regression. Broad cross-platform install/update validation was not run.
- Before evidence (optional but encouraged): Before the fix, a replacement upsert could persist the replacement entry without merging existing human title fields, allowing session lists to fall back to origin metadata.

## Root Cause (if applicable)

- Root cause: `upsertSessionEntry` replaced the whole persisted session entry while only preserving ACP metadata. Human title fields were not preserved when replacement metadata was missing, empty, or null.
- Missing detection / guardrail: Existing tests covered replacement semantics and ACP metadata preservation, but not human `label`/`displayName` preservation across replacement upserts.
- Contributing context (if known): Runtime refresh paths can send replacement session metadata that is authoritative for runtime fields but not for stable human titles.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/sessions.test.ts`
- Scenario the test should lock in: replacement upsert with empty/null `label`/`displayName` preserves existing non-empty title fields, while non-empty replacement titles still replace the previous values.
- Why this is the smallest reliable guardrail: the bug is in the session-store merge policy and can be reproduced without gateway/UI setup.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Persistent sessions should keep their stable visible names when runtime replacement metadata does not provide a new non-empty human title.

## Diagram (if applicable)

```text
Before:
existing named session -> replacement upsert with empty title metadata -> stored title erased -> UI fallback title

After:
existing named session -> replacement upsert with empty title metadata -> stored title preserved -> stable session title
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS for local/live verification
- Runtime/container: installed OpenClaw runtime plus local source checkout
- Model/provider: N/A
- Integration/channel (if any): persistent session list display was the observed fallback case
- Relevant config (redacted): persistent session entries under the local session registry

### Steps

1. Start with a stored session entry that has non-empty `label` and `displayName`.
2. Run `upsertSessionEntry` for the same session key using replacement metadata with empty/null human title fields.
3. Read the stored entry or session list after the upsert.

### Expected

The existing non-empty `label` and `displayName` remain unless replacement metadata provides non-empty new values.

### Actual

Before this fix, the replacement entry could erase those title fields. After this fix, the title fields are preserved for empty/null replacements and still intentionally replaceable with non-empty values.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- `npm test -- src/config/sessions.test.ts` - 47 passed
- `npx oxfmt --check --threads=1 src/config/sessions/store.ts src/config/sessions.test.ts`
- `git diff --check`
- `npm run lint:core -- src/config/sessions/store.ts src/config/sessions.test.ts`
- Installed-runtime hotfix smoke using the same guard, followed by gateway restart and live session-list verification on the affected machine with private identifiers redacted from public evidence
