### PR TITLE
fix(agents): quarantine invalid session custom tools

### DIFF
--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -32,6 +32,7 @@ import type {
   TextContent,
 } from "../../llm/types.js";
 import { isContextOverflow } from "../../llm/utils/overflow.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type {
   Agent,
   AgentEvent,
@@ -51,6 +52,10 @@ import {
   prepareCompaction,
   shouldCompact,
 } from "../runtime/index.js";
+import {
+  filterRuntimeCompatibleTools,
+  type RuntimeToolSchemaDiagnostic,
+} from "../tool-schema-projection.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
 import { sleep } from "../utils/sleep.js";
 import { formatNoApiKeyFoundMessage, formatNoModelSelectedMessage } from "./auth-guidance.js";
@@ -95,6 +100,8 @@ import { createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.js";
 
+const log = createSubsystemLogger("agents/sessions");
+
 function unwrapCoreResult<T>(result: { ok: true; value: T } | { ok: false; error: Error }): T {
   if (result.ok) {
     return result.value;
@@ -120,6 +127,201 @@ function normalizeBranchSummaryResult(
     return { aborted: true, error: result.error.message };
   }
   return { error: result.error.message };
+}
+
+function readToolDefinitionName(definition: ToolDefinition, fallback: string): string {
+  try {
+    return typeof definition.name === "string" && definition.name ? definition.name : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function readToolDefinitionField(
+  definition: ToolDefinition,
+  field: keyof ToolDefinition,
+): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: definition[field] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function toolDefinitionDiagnostic(
+  toolIndex: number,
+  toolName: string,
+  violation: string,
+): RuntimeToolSchemaDiagnostic {
+  return {
+    toolName,
+    toolIndex,
+    violations: [violation],
+  };
+}
+
+function formatToolSchemaDiagnostic(diagnostic: RuntimeToolSchemaDiagnostic): string {
+  return `${diagnostic.toolName}: ${diagnostic.violations.join(", ")}`;
+}
+
+function formatToolSource(sourceInfo: SourceInfo | undefined): string {
+  return sourceInfo?.path ?? "unknown source";
+}
+
+function materializeToolDefinitionEntry(
+  entry: ToolDefinitionEntry,
+  toolIndex: number,
+): ToolDefinitionRead {
+  const fallbackName = `tool[${toolIndex}]`;
+  const nameRead = readToolDefinitionField(entry.definition, "name");
+  const toolName =
+    nameRead.ok && typeof nameRead.value === "string" && nameRead.value
+      ? nameRead.value
+      : fallbackName;
+  if (!nameRead.ok) {
+    return {
+      ok: false,
+      sourceInfo: entry.sourceInfo,
+      diagnostic: toolDefinitionDiagnostic(toolIndex, toolName, `${toolName}.name is unreadable`),
+    };
+  }
+  if (typeof nameRead.value !== "string" || !nameRead.value) {
+    return {
+      ok: false,
+      sourceInfo: entry.sourceInfo,
+      diagnostic: toolDefinitionDiagnostic(
+        toolIndex,
+        toolName,
+        `${toolName}.name must be a non-empty string`,
+      ),
+    };
+  }
+
+  const labelRead = readToolDefinitionField(entry.definition, "label");
+  if (!labelRead.ok || typeof labelRead.value !== "string") {
+    return {
+      ok: false,
+      sourceInfo: entry.sourceInfo,
+      diagnostic: toolDefinitionDiagnostic(
+        toolIndex,
+        toolName,
+        `${toolName}.label must be a string`,
+      ),
+    };
+  }
+
+  const descriptionRead = readToolDefinitionField(entry.definition, "description");
+  if (!descriptionRead.ok || typeof descriptionRead.value !== "string") {
+    return {
+      ok: false,
+      sourceInfo: entry.sourceInfo,
+      diagnostic: toolDefinitionDiagnostic(
+        toolIndex,
+        toolName,
+        `${toolName}.description must be a string`,
+      ),
+    };
+  }
+
+  const parametersRead = readToolDefinitionField(entry.definition, "parameters");
+  if (!parametersRead.ok) {
+    return {
+      ok: false,
+      sourceInfo: entry.sourceInfo,
+      diagnostic: toolDefinitionDiagnostic(
+        toolIndex,
+        toolName,
+        `${toolName}.parameters is unreadable`,
+      ),
+    };
+  }
+
+  const parameters = parametersRead.value === undefined ? {} : parametersRead.value;
+  const executeRead = readToolDefinitionField(entry.definition, "execute");
+  if (!executeRead.ok || typeof executeRead.value !== "function") {
+    return {
+      ok: false,
+      sourceInfo: entry.sourceInfo,
+      diagnostic: toolDefinitionDiagnostic(
+        toolIndex,
+        toolName,
+        `${toolName}.execute must be a function`,
+      ),
+    };
+  }
+
+  const definition: ToolDefinition = {
+    name: nameRead.value,
+    label: labelRead.value,
+    description: descriptionRead.value,
+    parameters: parameters as ToolDefinition["parameters"],
+    execute: executeRead.value.bind(entry.definition) as ToolDefinition["execute"],
+  };
+
+  const promptSnippetRead = readToolDefinitionField(entry.definition, "promptSnippet");
+  if (promptSnippetRead.ok && typeof promptSnippetRead.value === "string") {
+    definition.promptSnippet = promptSnippetRead.value;
+  }
+  const promptGuidelinesRead = readToolDefinitionField(entry.definition, "promptGuidelines");
+  if (
+    promptGuidelinesRead.ok &&
+    Array.isArray(promptGuidelinesRead.value) &&
+    promptGuidelinesRead.value.every(
+      (guideline): guideline is string => typeof guideline === "string",
+    )
+  ) {
+    definition.promptGuidelines = promptGuidelinesRead.value;
+  }
+  const renderShellRead = readToolDefinitionField(entry.definition, "renderShell");
+  if (
+    renderShellRead.ok &&
+    (renderShellRead.value === "default" || renderShellRead.value === "self")
+  ) {
+    definition.renderShell = renderShellRead.value;
+  }
+  const prepareArgumentsRead = readToolDefinitionField(entry.definition, "prepareArguments");
+  if (prepareArgumentsRead.ok && typeof prepareArgumentsRead.value === "function") {
+    definition.prepareArguments = prepareArgumentsRead.value.bind(
+      entry.definition,
+    ) as ToolDefinition["prepareArguments"];
+  }
+  const executionModeRead = readToolDefinitionField(entry.definition, "executionMode");
+  if (
+    executionModeRead.ok &&
+    (executionModeRead.value === "sequential" || executionModeRead.value === "parallel")
+  ) {
+    definition.executionMode = executionModeRead.value;
+  }
+  const renderCallRead = readToolDefinitionField(entry.definition, "renderCall");
+  if (renderCallRead.ok && typeof renderCallRead.value === "function") {
+    definition.renderCall = renderCallRead.value.bind(
+      entry.definition,
+    ) as ToolDefinition["renderCall"];
+  }
+  const renderResultRead = readToolDefinitionField(entry.definition, "renderResult");
+  if (renderResultRead.ok && typeof renderResultRead.value === "function") {
+    definition.renderResult = renderResultRead.value.bind(
+      entry.definition,
+    ) as ToolDefinition["renderResult"];
+  }
+
+  return {
+    ok: true,
+    entry: {
+      definition,
+      sourceInfo: entry.sourceInfo,
+    },
+  };
+}
+
+function createToolDefinitionSchemaCandidate(
+  entry: ToolDefinitionEntry,
+): ToolDefinitionSchemaCandidate {
+  return {
+    entry,
+    name: entry.definition.name,
+    parameters: entry.definition.parameters,
+  };
 }
 
 // ============================================================================
@@ -282,6 +484,23 @@ interface ToolDefinitionEntry {
   definition: ToolDefinition;
   sourceInfo: SourceInfo;
 }
+
+type ToolDefinitionSchemaCandidate = {
+  readonly entry: ToolDefinitionEntry;
+  readonly name: string;
+  readonly parameters: ToolDefinition["parameters"];
+};
+
+type ToolDefinitionRead =
+  | {
+      readonly ok: true;
+      readonly entry: ToolDefinitionEntry;
+    }
+  | {
+      readonly ok: false;
+      readonly diagnostic: RuntimeToolSchemaDiagnostic;
+      readonly sourceInfo: SourceInfo;
+    };
 
 type ActiveToolPromptMetadata = {
   validToolNames: string[];
@@ -2377,6 +2596,48 @@ export class AgentSession {
     );
   }
 
+  private reportToolSchemaDiagnostics(
+    candidates: readonly ToolDefinitionSchemaCandidate[],
+    diagnostics: readonly RuntimeToolSchemaDiagnostic[],
+  ): void {
+    for (const diagnostic of diagnostics) {
+      const sourceInfo = candidates[diagnostic.toolIndex]?.entry.sourceInfo;
+      const source = formatToolSource(sourceInfo);
+      const message = `quarantined unsupported session tool schema from ${source}: ${formatToolSchemaDiagnostic(diagnostic)}`;
+      log.warn(message);
+      this.currentExtensionRunner.emitError({
+        extensionPath: source,
+        event: "tool_schema",
+        error: message,
+      });
+    }
+  }
+
+  private filterRuntimeCompatibleToolDefinitions(
+    entries: readonly ToolDefinitionEntry[],
+  ): ToolDefinitionEntry[] {
+    const reads = entries.map(materializeToolDefinitionEntry);
+    const materializedEntries: ToolDefinitionEntry[] = [];
+    for (const read of reads) {
+      if (read.ok) {
+        materializedEntries.push(read.entry);
+        continue;
+      }
+      const message = `quarantined unsupported session tool schema from ${formatToolSource(read.sourceInfo)}: ${formatToolSchemaDiagnostic(read.diagnostic)}`;
+      log.warn(message);
+      this.currentExtensionRunner.emitError({
+        extensionPath: formatToolSource(read.sourceInfo),
+        event: "tool_schema",
+        error: message,
+      });
+    }
+
+    const candidates = materializedEntries.map(createToolDefinitionSchemaCandidate);
+    const projection = filterRuntimeCompatibleTools(candidates);
+    this.reportToolSchemaDiagnostics(candidates, projection.diagnostics);
+    return projection.tools.map((candidate) => candidate.entry);
+  }
+
   private refreshToolRegistry(options?: {
     activeToolNames?: string[];
     includeAllExtensionTools?: boolean;
@@ -2388,15 +2649,28 @@ export class AgentSession {
       this.disableBuiltInTools && this.baseToolDefinitions.has(name);
     const isAllowedTool = (name: string): boolean =>
       !isDisabledBuiltInToolName(name) && (!allowedToolNames || allowedToolNames.has(name));
+    const shouldInspectCustomTool = (tool: ToolDefinitionEntry): boolean => {
+      const name = readToolDefinitionName(tool.definition, "");
+      if (name) {
+        return isAllowedTool(name);
+      }
+      return !allowedToolNames;
+    };
 
     const registeredTools = this.currentExtensionRunner.getAllRegisteredTools();
-    const allCustomTools = [
+    const candidateCustomTools = [
       ...registeredTools,
-      ...this.customTools.map((definition) => ({
-        definition,
-        sourceInfo: createSyntheticSourceInfo(`<sdk:${definition.name}>`, { source: "sdk" }),
-      })),
-    ].filter((tool) => isAllowedTool(tool.definition.name));
+      ...this.customTools.map((definition, index) => {
+        const name = readToolDefinitionName(definition, `tool[${index}]`);
+        return {
+          definition,
+          sourceInfo: createSyntheticSourceInfo(`<sdk:${name}>`, { source: "sdk" }),
+        };
+      }),
+    ];
+    const allCustomTools = this.filterRuntimeCompatibleToolDefinitions(
+      candidateCustomTools.filter(shouldInspectCustomTool),
+    );
     const definitionRegistry = new Map<string, ToolDefinitionEntry>(
       Array.from(this.baseToolDefinitions.entries())
         .filter(([name]) => isAllowedTool(name))

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -1,9 +1,10 @@
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import type { Model } from "../../llm/types.js";
+import { toClientToolDefinitions } from "../agent-tool-definition-adapter.js";
 import { AuthStorage } from "./auth-storage.js";
 import { createExtensionRuntime } from "./extensions/loader.js";
-import type { LoadExtensionsResult, ToolDefinition } from "./extensions/types.js";
+import type { LoadExtensionsResult, RegisteredTool, ToolDefinition } from "./extensions/types.js";
 import { ModelRegistry } from "./model-registry.js";
 import type { ResourceLoader } from "./resource-loader.js";
 import { createAgentSession } from "./sdk.js";
@@ -64,6 +65,67 @@ function createResourceLoaderWithHandlers(
   };
 }
 
+function createResourceLoaderWithTools(tools: ToolDefinition[]): ResourceLoader {
+  const sourceInfo = createSyntheticSourceInfo("<test-extension>", { source: "temporary" });
+  const registeredTools = new Map<string, RegisteredTool>();
+  for (const tool of tools) {
+    registeredTools.set(tool.name, { definition: tool, sourceInfo });
+  }
+  const extensionsResult: LoadExtensionsResult = {
+    extensions: [
+      {
+        path: "<test-extension>",
+        resolvedPath: "<test-extension>",
+        sourceInfo,
+        handlers: new Map(),
+        tools: registeredTools,
+        messageRenderers: new Map(),
+        commands: new Map(),
+        flags: new Map(),
+        shortcuts: new Map(),
+      },
+    ],
+    errors: [],
+    runtime: createExtensionRuntime(),
+  };
+  return {
+    getExtensions: () => extensionsResult,
+    getSkills: () => ({ skills: [], diagnostics: [] }),
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: [] }),
+    getSystemPrompt: () => undefined,
+    getAppendSystemPrompt: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  };
+}
+
+function createCustomLookupTool(name = "custom_lookup"): ToolDefinition {
+  return {
+    name,
+    label: "Custom Lookup",
+    description: "Looks up a test value.",
+    promptSnippet: "Lookup test values",
+    promptGuidelines: [`Use ${name} for test values.`],
+    parameters: Type.Object({}),
+    execute: async () => ({
+      content: [{ type: "text", text: "ok" }],
+      details: {},
+    }),
+  };
+}
+
+function createUnsupportedSchemaTool(name = "broken_lookup"): ToolDefinition {
+  return {
+    ...createCustomLookupTool(name),
+    parameters: {
+      type: "object",
+      $dynamicRef: "#broken",
+    } as unknown as ToolDefinition["parameters"],
+  };
+}
+
 describe("createAgentSession tool defaults", () => {
   it("forwards max thinking budgets from settings to the agent", async () => {
     const { session } = await createAgentSession({
@@ -86,18 +148,7 @@ describe("createAgentSession tool defaults", () => {
   });
 
   it("keeps custom tools active when only builtin tools are disabled", async () => {
-    const customTool: ToolDefinition = {
-      name: "custom_lookup",
-      label: "Custom Lookup",
-      description: "Looks up a test value.",
-      promptSnippet: "Lookup test values",
-      promptGuidelines: ["Use custom_lookup for test values."],
-      parameters: Type.Object({}),
-      execute: async () => ({
-        content: [{ type: "text", text: "ok" }],
-        details: {},
-      }),
-    };
+    const customTool = createCustomLookupTool();
 
     const { session } = await createAgentSession({
       model: testModel,
@@ -118,18 +169,7 @@ describe("createAgentSession tool defaults", () => {
   });
 
   it("preserves an exact base system prompt when active tools change", async () => {
-    const customTool: ToolDefinition = {
-      name: "custom_lookup",
-      label: "Custom Lookup",
-      description: "Looks up a test value.",
-      promptSnippet: "Lookup test values",
-      promptGuidelines: ["Use custom_lookup for test values."],
-      parameters: Type.Object({}),
-      execute: async () => ({
-        content: [{ type: "text", text: "ok" }],
-        details: {},
-      }),
-    };
+    const customTool = createCustomLookupTool();
 
     const { session } = await createAgentSession({
       model: testModel,
@@ -162,6 +202,143 @@ describe("createAgentSession tool defaults", () => {
       custom_lookup: "Lookup test values",
     });
     expect(exactPromptOptions.promptGuidelines).toEqual(["Use custom_lookup for test values."]);
+  });
+
+  it("quarantines SDK custom tools with unsupported runtime schemas", async () => {
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      customTools: [createUnsupportedSchemaTool(), createCustomLookupTool("healthy_lookup")],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.getActiveToolNames()).toEqual(["healthy_lookup"]);
+    expect(session.getAllTools().map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+  });
+
+  it("quarantines SDK custom tools with unreadable names before startup", async () => {
+    const unreadableName = createCustomLookupTool("broken_lookup");
+    Object.defineProperty(unreadableName, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("custom tool name exploded");
+      },
+    });
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      customTools: [unreadableName, createCustomLookupTool("healthy_lookup")],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.getActiveToolNames()).toEqual(["healthy_lookup"]);
+    expect(session.getAllTools().map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+  });
+
+  it("does not inspect schema fields for disabled SDK custom tools", async () => {
+    let parametersRead = false;
+    const disabledBroken = createCustomLookupTool("disabled_broken_lookup");
+    Object.defineProperty(disabledBroken, "parameters", {
+      enumerable: true,
+      get() {
+        parametersRead = true;
+        throw new Error("disabled tool parameters should not be read");
+      },
+    });
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      tools: ["healthy_lookup"],
+      customTools: [disabledBroken, createCustomLookupTool("healthy_lookup")],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(parametersRead).toBe(false);
+    expect(session.getActiveToolNames()).toEqual(["healthy_lookup"]);
+    expect(session.getAllTools().map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+  });
+
+  it("quarantines extension-registered tools with unsupported runtime schemas", async () => {
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      resourceLoader: createResourceLoaderWithTools([
+        createUnsupportedSchemaTool("extension_broken_lookup"),
+        createCustomLookupTool("extension_healthy_lookup"),
+      ]),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.getActiveToolNames()).toEqual(["extension_healthy_lookup"]);
+    expect(session.getAllTools().map((tool) => tool.name)).toEqual(["extension_healthy_lookup"]);
+  });
+
+  it("preserves method receivers when materializing valid custom tools", async () => {
+    const statefulTool = {
+      ...createCustomLookupTool("stateful_lookup"),
+      value: "receiver-ok",
+      async execute() {
+        return {
+          content: [{ type: "text" as const, text: this.value }],
+          details: {},
+        };
+      },
+    } satisfies ToolDefinition & { value: string };
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      customTools: [statefulTool],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    const tool = session.state.tools.find((entry) => entry.name === "stateful_lookup");
+    await expect(tool?.execute("call_1", {}, undefined, undefined)).resolves.toMatchObject({
+      content: [{ type: "text", text: "receiver-ok" }],
+    });
+  });
+
+  it("keeps client tools without parameter schemas active", async () => {
+    const [clientTool] = toClientToolDefinitions([
+      {
+        type: "function",
+        function: {
+          name: "client_ping",
+          description: "Ping",
+        },
+      },
+    ]);
+    if (!clientTool) {
+      throw new Error("missing client tool definition");
+    }
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      tools: ["client_ping"],
+      customTools: [clientTool],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.getActiveToolNames()).toEqual(["client_ping"]);
+    expect(session.getAllTools().map((tool) => tool.name)).toEqual(["client_ping"]);
   });
 
   it("runs session message persistence under the configured write lock", async () => {

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -128,6 +128,14 @@ export {
 
 // Helper Functions
 
+function readCustomToolName(tool: ToolDefinition): string | undefined {
+  try {
+    return typeof tool.name === "string" && tool.name ? tool.name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function getDefaultAgentDir(): string {
   return getAgentDir();
 }
@@ -283,7 +291,8 @@ export async function createAgentSession(
   }
 
   const defaultActiveToolNames: ToolName[] = ["read", "bash", "edit", "write"];
-  const customToolNames = options.customTools?.map((tool) => tool.name) ?? [];
+  const customToolNames =
+    options.customTools?.flatMap((tool) => readCustomToolName(tool) ?? []) ?? [];
   const allowedToolNames = options.tools ?? (options.noTools === "all" ? [] : undefined);
   const disableBuiltInTools = !options.tools && options.noTools === "builtin";
   const initialActiveToolNames: string[] = options.tools


### PR DESCRIPTION
## Summary

- Quarantines SDK and extension-registered custom tools whose definitions cannot be read safely or whose parameter schemas are unsupported by the runtime projection.
- Materializes session custom tool definitions before registry activation so hostile getters or unsupported schema keywords cannot poison session startup.
- Preserves valid custom tool behavior, including method receivers, disabled-tool allowlist behavior, and client tools that omit a parameter schema.
- Intentionally out of scope: builtin tool schema handling and provider-specific tool projection, which are already covered by the existing runtime filter path.
- Reviewers should focus on the custom-tool materialization boundary in `AgentSession.refreshToolRegistry` and whether the diagnostic surface is the right place to report rejected extension tools.

## Linked context

Closes #

Related https://github.com/openclaw/openclaw/pull/88994

Was this requested by a maintainer or owner?

Maintainer fuzzing follow-up for unsupported runtime/tool schema hardening.

## Real behavior proof (required for external PRs)

- Behavior addressed: unsupported or unreadable SDK/extension custom tool definitions are quarantined before they enter the active session tool registry.
- Real environment tested: local macOS checkout for focused Vitest/lint/format proof; AWS Crabbox Linux remote for changed-gate proof.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts --reporter=dot`
  - `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/agents/sessions/agent-session.ts src/agents/sessions/sdk.ts src/agents/sessions/sdk.test.ts`
  - `./node_modules/.bin/oxfmt --check --threads=1 src/agents/sessions/agent-session.ts src/agents/sessions/sdk.ts src/agents/sessions/sdk.test.ts`
  - `git diff --check origin/main...HEAD`
  - `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`
- Evidence after fix: focused Vitest reported `1 passed` file and `12 passed` tests; oxlint reported `Found 0 warnings and 0 errors`; oxfmt reported all matched files use the correct format; AWS Crabbox run `run_fc68d25ad837` on lease `cbx_9ebbab4a3dfb` exited `0` with `check:changed` lanes `core, coreTests`.
- Observed result after fix: bad SDK and extension custom tools are omitted while healthy custom tools remain active; disabled bad tools are not inspected; method-backed custom tools keep their receiver; no-parameter client tools stay active.
- What was not tested: live provider execution against an external model, and unrelated builtin tool schema behavior.
- Proof limitations or environment constraints: Blacksmith Testbox was unavailable locally because the CLI was not authenticated, so the broad changed gate used direct AWS Crabbox instead.
- Before evidence (optional but encouraged): local fuzzing showed session custom tools bypassed runtime schema projection before this patch.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts --reporter=dot`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/agents/sessions/agent-session.ts src/agents/sessions/sdk.ts src/agents/sessions/sdk.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/sessions/agent-session.ts src/agents/sessions/sdk.ts src/agents/sessions/sdk.test.ts`
- `git diff --check origin/main...HEAD`
- Private marker scrub over touched files and the local fuzzing spec.
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

What regression coverage was added or updated?

- SDK custom tool with unsupported runtime schema is quarantined.
- SDK custom tool with unreadable `name` getter does not crash startup.
- Disabled SDK custom tools are not schema-inspected.
- Extension-registered custom tool with unsupported runtime schema is quarantined.
- Materialized custom tools preserve method receivers.
- Client tools without parameter schemas remain active.

What failed before this fix, if known?

Session custom tools could enter the registry without the runtime-compatible schema filter used by assistant/model tool projection.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes.

What is the highest-risk area?

Accidentally rejecting valid custom tools while quarantining bad definitions.

How is that risk mitigated?

The tests cover valid SDK tools, extension tools, method-backed tools, disabled tools, and client tools with omitted parameter schemas. The filter reuses the existing runtime-compatible tool projection instead of inventing a second schema policy.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI after the draft PR opens.

Which bot or reviewer comments were addressed?

Local autoreview found and the patch addressed three issues before PR creation: method receivers are preserved, disabled tools are not inspected, and client tools without parameter schemas remain active. Final autoreview was clean.

AI-assisted: yes.
