### PR TITLE
[AI-assisted] fix(ui): accept short tweakcn theme IDs

### DIFF
--- a/ui/src/ui/custom-theme.test.ts
+++ b/ui/src/ui/custom-theme.test.ts
@@ -113,6 +113,41 @@ describe("custom theme import helpers", () => {
     });
   });
 
+  it("normalizes short built-in tweakcn theme ids", () => {
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/r/themes/claude")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/claude",
+      fetchUrl: "https://tweakcn.com/r/themes/claude",
+      themeId: "claude",
+    });
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/themes/zinc")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/zinc",
+      fetchUrl: "https://tweakcn.com/r/themes/zinc",
+      themeId: "zinc",
+    });
+    expect(normalizeTweakcnThemeUrl("zinc")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/zinc",
+      fetchUrl: "https://tweakcn.com/r/themes/zinc",
+      themeId: "zinc",
+    });
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/editor/theme?theme=slate")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/slate",
+      fetchUrl: "https://tweakcn.com/r/themes/slate",
+      themeId: "slate",
+    });
+  });
+
+  it("keeps rejecting malformed short tweakcn theme ids", () => {
+    expect(() => normalizeTweakcnThemeUrl("https://tweakcn.com/r/themes/abc")).toThrow(
+      "Unsupported tweakcn link",
+    );
+    expect(() => normalizeTweakcnThemeUrl("https://tweakcn.com/r/themes/-bad")).toThrow(
+      "Unsupported tweakcn link",
+    );
+    expect(() => normalizeTweakcnThemeUrl("https://tweakcn.com/r/themes/bad!")).toThrow(
+      "Unsupported tweakcn link",
+    );
+  });
+
   it("maps a tweakcn payload into a normalized imported theme record", () => {
     const imported = createImportedTheme();
 

--- a/ui/src/ui/custom-theme.ts
+++ b/ui/src/ui/custom-theme.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { normalizeOptionalString } from "./string-coerce.ts";
 
 const TWEAKCN_HOSTS = new Set(["tweakcn.com", "www.tweakcn.com"]);
-const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/;
+const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{3,127}$/;
 const CUSTOM_THEME_STYLE_ID = "openclaw-custom-theme";
 const MAX_TWEAKCN_THEME_BYTES = 200_000;
 const MAX_CSS_TOKEN_LENGTH = 240;


### PR DESCRIPTION
## Summary

- Problem: The Control UI tweakcn theme importer rejects valid short built-in theme IDs such as `claude` before it ever fetches the registry payload.
- Solution: Relax the local tweakcn theme ID minimum length from 8 characters to 4 characters while preserving the existing host, path, character, redirect, fetch, payload-size, schema, and CSS-token safety checks.
- What changed: Updated `THEME_ID_PATTERN` and added regression tests for short built-in raw IDs, registry URLs, editor URLs, and malformed short IDs.
- What did NOT change (scope boundary): This does not add a new importer flow, storage behavior, UI surface, dependency, config shape, fallback path, or broader theme validation policy.

## Motivation

- Closes a source-proven Control UI bug where documented/default tweakcn theme names can be blocked by OpenClaw before fetch even when the registry has a valid short-ID theme payload.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #88987
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: Short built-in tweakcn theme IDs are no longer rejected by OpenClaw's local validator before fetch.
- Real environment tested: Disposable Linux testserver checkout on OpenClaw `61574eb5`, Node through repo scripts, pnpm `11.2.2`.
- Exact steps or command run after this patch:

```bash
corepack pnpm install --frozen-lockfile
node scripts/run-vitest.mjs run ui/src/ui/custom-theme.test.ts --reporter=dot
node scripts/run-vitest.mjs run ui/src/ui/views/config.browser.test.ts --reporter=dot
node --input-type=module - <<'NODE'
const required = ["claude", "twitter"];
const observed = ["zinc", "slate"];
for (const id of required) {
  const response = await fetch(`https://tweakcn.com/r/themes/${id}`, { redirect: "error" });
  const json = await response.json();
  const okShape = Boolean(json?.name && json?.cssVars?.light && json?.cssVars?.dark);
  console.log(`${id}: status=${response.status} ok=${response.ok} shape=${okShape} name=${json?.name ?? ""}`);
  if (!response.ok || !okShape) process.exitCode = 1;
}
for (const id of observed) {
  const response = await fetch(`https://tweakcn.com/r/themes/${id}`, { redirect: "error" });
  console.log(`${id}: status=${response.status} ok=${response.ok} observed-only`);
}
NODE
git diff --check
corepack pnpm exec oxlint ui/src/ui/custom-theme.ts ui/src/ui/custom-theme.test.ts
corepack pnpm --dir ui build
node scripts/run-vitest.mjs run ui/src/ui --reporter=dot
```

- Evidence after fix:

```text
$ node scripts/run-vitest.mjs run ui/src/ui/custom-theme.test.ts --reporter=dot
Test Files  1 passed (1)
Tests       15 passed (15)

$ node scripts/run-vitest.mjs run ui/src/ui/views/config.browser.test.ts --reporter=dot
Test Files  1 passed (1)
Tests       26 passed (26)

$ node --input-type=module ...
claude: status=200 ok=true shape=true name=Claude
twitter: status=200 ok=true shape=true name=Twitter
zinc: status=500 ok=false observed-only
slate: status=500 ok=false observed-only

$ git diff --check
passed

$ corepack pnpm exec oxlint ui/src/ui/custom-theme.ts ui/src/ui/custom-theme.test.ts
Found 0 warnings and 0 errors.
Finished in 50ms on 2 files with 208 rules using 2 threads.

$ corepack pnpm --dir ui build
vite v8.0.14 building client environment for production...
✓ 913 modules transformed.
✓ built in 2.81s

$ node scripts/run-vitest.mjs run ui/src/ui --reporter=dot
Test Files  242 passed | 5 skipped (247)
Tests       3281 passed | 32 skipped (3313)
```

- Observed result after fix: `claude`, `zinc`, `slate`, and short editor/registry URL forms normalize to the expected tweakcn source/fetch URLs instead of failing OpenClaw's local validator. Live registry proof confirmed `claude` and `twitter` returned HTTP 200 with valid theme payload shape; `zinc` and `slate` were observed as provider-side HTTP 500 and are not claimed as live-import successes.
- What was not tested: I did not capture a live browser click/screenshot, did not claim full repo `pnpm check` or full repo `pnpm build` green, and did not separately verify Beta 4.
- Before evidence:

```text
Before this patch, current source used:
const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/;

That requires at least 8 characters, so short IDs like `claude`, `zinc`, `slate`, and `twitter` fail local validation before OpenClaw can fetch the tweakcn registry URL.
```

## Root Cause

- Root cause: The local tweakcn theme ID regex required one initial character plus 7 additional characters, so valid short built-in IDs were rejected before fetch.
- Missing detection / guardrail: Existing tests covered long share IDs and `amethyst-haze`, but not shorter built-in/default theme names.
- Contributing context (if known): The importer already supported registry URLs, editor URLs, relative paths, and raw IDs; only the local ID-length guard was too strict.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/custom-theme.test.ts` and `ui/src/ui/views/config.browser.test.ts`.
- Scenario the test should lock in: Short built-in IDs and their registry/editor URL forms normalize correctly, while malformed short IDs still throw `Unsupported tweakcn link`.
- Why this is the smallest reliable guardrail: It exercises the exact local validator/normalizer that rejected the IDs before fetch, without adding network dependency to the unit test.
- Existing test that already covers this (if any): Existing custom-theme tests covered long generated IDs and `amethyst-haze`, but not short built-in IDs.
- If no new test is added, why not: N/A. Regression tests are added.

## User-visible / Behavior Changes

Users can paste short valid tweakcn theme IDs or URLs such as `https://tweakcn.com/r/themes/claude` into the Control UI Appearance importer without OpenClaw rejecting them solely because the ID is shorter than 8 characters.

## Diagram

```text
Before:
short tweakcn ID -> local length guard -> "Unsupported tweakcn link"

After:
short tweakcn ID -> same host/path/character safety checks -> tweakcn registry fetch
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: Existing tweakcn import code can now fetch short valid IDs that were previously blocked locally. The fetch remains restricted to `tweakcn.com` / `www.tweakcn.com`, still uses `redirect: "error"`, still requests JSON, still enforces payload size and timeout limits, and still validates/sanitizes imported CSS tokens.

## Repro + Verification

### Environment

- OS: Linux disposable testserver checkout
- Runtime/container: Node through repo scripts, pnpm `11.2.2`
- Model/provider: N/A
- Integration/channel (if any): Control UI Appearance tweakcn theme import
- Relevant config (redacted): N/A

### Steps

1. Apply the two-file patch to the Control UI theme importer and tests.
2. Run the focused custom-theme regression tests.
3. Run the adjacent Appearance/Config browser test.
4. Probe live tweakcn registry responses for short IDs.
5. Run whitespace, targeted lint, UI production build, and full Control-UI Vitest coverage.

### Expected

- Short valid tweakcn IDs normalize to the expected source/fetch URLs and are not rejected before fetch.
- Malformed short IDs remain rejected.
- Existing Control UI tests and build remain green.

### Actual

- Focused and adjacent tests passed.
- Live `claude` and `twitter` registry payloads returned HTTP 200 with valid shape.
- Malformed short IDs remain rejected in regression coverage.
- UI build and full Control UI Vitest coverage passed.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
The copied terminal output is included in the Real behavior proof section above.
```

## Human Verification

- Verified scenarios: I verified raw short IDs, registry URL forms, editor URL forms, malformed short IDs, live registry shape for `claude` and `twitter`, targeted lint, UI production build, focused tests, adjacent browser tests, and full Control UI Vitest coverage.
- Edge cases checked: `abc` remains too short, `-bad` still fails the first-character rule, and `bad!` still fails allowed-character validation.
- What you did **not** verify: I did not capture a live browser screenshot/recording, did not claim `zinc` or `slate` as live provider successes because the registry returned HTTP 500 during verification, and did not claim full repo `pnpm check` / full repo `pnpm build` green.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No review conversations exist yet for this new draft PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The shorter minimum could accidentally allow IDs that the service does not recognize.
  - Mitigation: Unknown IDs are still handled by the existing bounded tweakcn fetch/schema-validation failure path, while malformed IDs remain locally rejected.
- Risk: Reviewers could read this as claiming every short built-in ID is currently live-valid.
  - Mitigation: The proof explicitly claims live success only for `claude` and `twitter`; `zinc` and `slate` were observed as provider-side HTTP 500 during verification.
- Risk: The broader repo-wide checks were not fully green in this environment.
  - Mitigation: The PR is limited to the Control UI importer; focused, adjacent, targeted lint, UI build, and full Control UI Vitest coverage passed.
