### PR TITLE
fix(agents): materialize OpenAI tool schemas

### DIFF
--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearOpenAIToolSchemaCacheForTest,
   isStrictOpenAIJsonSchemaCompatible,
+  normalizeOpenAIStrictToolParameters,
   normalizeStrictOpenAIJsonSchema,
   resolveOpenAIStrictToolFlagForInventory,
 } from "./openai-tool-schema.js";
@@ -90,5 +91,44 @@ describe("OpenAI strict tool schema normalization", () => {
         unsupportedToolSchemaKeywords: ["minimum"],
       }),
     ).toBe(third);
+  });
+
+  it("shapes OpenAI tool schemas from their JSON view before raw object traversal", () => {
+    const schema = new Proxy(
+      {
+        toJSON() {
+          return {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+            },
+            required: ["query"],
+          };
+        },
+      },
+      {
+        ownKeys() {
+          throw new Error("raw schema traversal");
+        },
+      },
+    );
+
+    expect(normalizeStrictOpenAIJsonSchema(schema)).toEqual({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    });
+    expect(normalizeOpenAIStrictToolParameters(schema, false)).toMatchObject({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+    });
+    expect(
+      resolveOpenAIStrictToolFlagForInventory([{ name: "lookup", parameters: schema }], true),
+    ).toBe(true);
   });
 });

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -14,6 +14,7 @@ type ToolWithParameters = {
 
 const MAX_STRICT_SCHEMA_CACHE_ENTRIES_PER_SCHEMA = 8;
 let strictOpenAISchemaCache = new WeakMap<object, Array<{ key: string; value: unknown }>>();
+let openAISchemaInputCache = new WeakMap<object, unknown>();
 
 function resolveToolSchemaModelCompat(
   compat: ToolSchemaCompatInput | null | undefined,
@@ -63,13 +64,33 @@ function rememberStrictOpenAISchema(schema: object, key: string, value: unknown)
 
 export function clearOpenAIToolSchemaCacheForTest(): void {
   strictOpenAISchemaCache = new WeakMap();
+  openAISchemaInputCache = new WeakMap();
+}
+
+function materializeOpenAIToolSchemaInput(schema: unknown): unknown {
+  const schemaInput = schema ?? {};
+  if (!schemaInput || typeof schemaInput !== "object") {
+    return schemaInput;
+  }
+  if (openAISchemaInputCache.has(schemaInput)) {
+    return openAISchemaInputCache.get(schemaInput);
+  }
+  let materialized: unknown;
+  try {
+    const text = JSON.stringify(schemaInput);
+    materialized = text ? JSON.parse(text) : {};
+  } catch {
+    materialized = {};
+  }
+  openAISchemaInputCache.set(schemaInput, materialized);
+  return materialized;
 }
 
 export function normalizeStrictOpenAIJsonSchema(
   schema: unknown,
   modelCompat?: ToolSchemaCompatInput | null,
 ): unknown {
-  const schemaInput = schema ?? {};
+  const schemaInput = materializeOpenAIToolSchemaInput(schema);
   if (!schemaInput || typeof schemaInput !== "object") {
     return normalizeStrictOpenAIJsonSchemaRecursive(
       normalizeToolParameterSchema(schemaInput, {
@@ -147,10 +168,11 @@ export function normalizeOpenAIStrictToolParameters<T>(
   modelCompat?: ToolSchemaCompatInput | null,
 ): T {
   const toolSchemaCompat = resolveToolSchemaModelCompat(modelCompat);
+  const schemaInput = materializeOpenAIToolSchemaInput(schema);
   if (!strict) {
-    return normalizeToolParameterSchema(schema ?? {}, { modelCompat: toolSchemaCompat }) as T;
+    return normalizeToolParameterSchema(schemaInput ?? {}, { modelCompat: toolSchemaCompat }) as T;
   }
-  return normalizeStrictOpenAIJsonSchema(schema, toolSchemaCompat) as T;
+  return normalizeStrictOpenAIJsonSchema(schemaInput, toolSchemaCompat) as T;
 }
 
 export function isStrictOpenAIJsonSchemaCompatible(schema: unknown): boolean {


### PR DESCRIPTION
## Summary

- Materializes OpenAI tool schemas through their JSON representation before strict/non-strict OpenAI schema shaping.
- Prevents hostile schema objects that serialize cleanly from crashing native OpenAI request conversion during assistant startup.
- Keeps the runtime contract aligned with the existing projection path: downstream provider shaping sees the same JSON-safe schema view that runtime compatibility checks accepted.
- Intentionally out of scope: changing runtime quarantine policy for schemas that are not JSON-serializable.
- Reviewers should focus on whether `openai-tool-schema.ts` is the right OpenAI transport boundary for this materialization.

## Linked context

Closes #

Related https://github.com/openclaw/openclaw/pull/89006

Was this requested by a maintainer or owner?

Maintainer fuzzing follow-up for unsupported runtime/tool schema hardening.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a tool parameter schema with a safe JSON view but hostile raw object traversal no longer crashes OpenAI strict schema normalization before an assistant turn can produce content.
- Real environment tested: local macOS checkout for focused Vitest/lint/format proof; AWS Crabbox Linux remote for changed-gate proof.
- Exact steps or command run after this patch:
  - `node --import tsx` repro for `normalizeStrictOpenAIJsonSchema()` with a proxy schema whose `toJSON()` returns a valid object schema and whose `ownKeys()` throws.
  - `node scripts/run-vitest.mjs src/agents/openai-tool-schema.test.ts --reporter=dot`
  - `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts`
  - `./node_modules/.bin/oxfmt --check --threads=1 src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts`
  - `git diff --check origin/main...HEAD`
  - private marker scrub over touched files and the local fuzzing spec
  - `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`
- Evidence after fix: the direct repro printed the normalized strict schema instead of throwing; focused Vitest reported `1 passed` file and `5 passed` tests; AWS Crabbox run `run_3e9a7b0eb466` on lease `cbx_a5ba7bcdbe0d` exited `0` with `check:changed` lanes `core, coreTests`.
- Observed result after fix: OpenAI strict normalization, non-strict parameter normalization, and strict-flag inventory decisions all use the schema's JSON-safe view before raw traversal.
- What was not tested: live OpenAI provider execution and unrelated non-OpenAI provider schema shaping.
- Proof limitations or environment constraints: Blacksmith Testbox was unavailable locally because the CLI was not authenticated, so the broad changed gate used direct AWS Crabbox instead.
- Before evidence (optional but encouraged): the direct repro threw `raw schema traversal` before this patch.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/openai-tool-schema.test.ts --reporter=dot`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts`
- `git diff --check origin/main...HEAD`
- private marker scrub over touched files and the local fuzzing spec
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

What regression coverage was added or updated?

- Added coverage for a proxy-backed schema whose `toJSON()` returns a valid object schema while raw object key traversal throws.
- The regression covers strict schema normalization, non-strict OpenAI parameter normalization, and strict-flag inventory resolution.

What failed before this fix, if known?

`normalizeStrictOpenAIJsonSchema()` traversed the raw schema object after runtime projection could have accepted its JSON representation, so a hostile schema object could still throw during OpenAI request conversion.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes.

What is the highest-risk area?

Changing the schema object identity that OpenAI-specific normalization receives.

How is that risk mitigated?

Materialization is cached per original schema object and uses the same JSON representation that runtime schema projection already treats as authoritative. Existing stable-object cache coverage still passes.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI after the draft PR opens.

Which bot or reviewer comments were addressed?

Local autoreview reported no accepted/actionable findings.

AI-assisted: yes.
