### PR TITLE
fix(qqbot): allow RFC2544 benchmark range for token fetch (#88984)

### DIFF
--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -42,6 +42,7 @@ describe("QQBot token manager", () => {
       url: "https://bots.qq.com/app/getAppAccessToken",
       auditContext: "qqbot-token",
       capture: false,
+      policy: { allowRfc2544BenchmarkRange: true },
       init: {
         method: "POST",
         headers: {
@@ -52,6 +53,22 @@ describe("QQBot token manager", () => {
       },
     });
     expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the RFC2544 SSRF allowance to the token fetch (regression for #88984)", async () => {
+    mockGuardedTokenResponse('{"access_token":"token-1","expires_in":7200}', {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(new TokenManager().getAccessToken("app-id", "secret")).resolves.toBe("token-1");
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://bots.qq.com/app/getAppAccessToken",
+        auditContext: "qqbot-token",
+        policy: { allowRfc2544BenchmarkRange: true },
+      }),
+    );
   });
 
   it("does not cache access tokens forever when expires_in is unsafe", async () => {

--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -42,7 +42,10 @@ describe("QQBot token manager", () => {
       url: "https://bots.qq.com/app/getAppAccessToken",
       auditContext: "qqbot-token",
       capture: false,
-      policy: { allowRfc2544BenchmarkRange: true },
+      policy: {
+        hostnameAllowlist: ["bots.qq.com"],
+        allowRfc2544BenchmarkRange: true,
+      },
       init: {
         method: "POST",
         headers: {
@@ -66,7 +69,10 @@ describe("QQBot token manager", () => {
       expect.objectContaining({
         url: "https://bots.qq.com/app/getAppAccessToken",
         auditContext: "qqbot-token",
-        policy: { allowRfc2544BenchmarkRange: true },
+        policy: {
+          hostnameAllowlist: ["bots.qq.com"],
+          allowRfc2544BenchmarkRange: true,
+        },
       }),
     );
   });

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -33,6 +33,7 @@ const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 7200;
  * See https://github.com/openclaw/openclaw/issues/88984.
  */
 const QQBOT_TOKEN_SSRF_POLICY: SsrFPolicy = {
+  hostnameAllowlist: ["bots.qq.com"],
   allowRfc2544BenchmarkRange: true,
 };
 

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -12,12 +12,29 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
   resolveTimestampMsToIsoString,
 } from "openclaw/plugin-sdk/number-runtime";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { EngineLogger } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
 
 const TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
 const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 7200;
+
+/**
+ * Host-scoped SSRF policy for the QQ Bot token endpoint.
+ *
+ * `TOKEN_URL` is a hard-coded `https://bots.qq.com/...` constant, so this
+ * relaxation only ever applies to that single host. Fake-IP proxy stacks
+ * (sing-box, Clash, Surge, WSL2 DNS, etc.) routinely map `bots.qq.com` into
+ * the RFC 2544 benchmark range `198.18.0.0/15`, which the default SSRF
+ * guard blocks. We mirror the existing media-path pattern
+ * (`QQBOT_MEDIA_SSRF_POLICY` in `../utils/file-utils.ts`) so the relaxation
+ * stays narrowly host-scoped instead of weakening the global default.
+ *
+ * See https://github.com/openclaw/openclaw/issues/88984.
+ */
+const QQBOT_TOKEN_SSRF_POLICY: SsrFPolicy = {
+  allowRfc2544BenchmarkRange: true,
+};
 
 interface CachedToken {
   token: string;
@@ -234,6 +251,7 @@ export class TokenManager {
         url: TOKEN_URL,
         auditContext: "qqbot-token",
         capture: false,
+        policy: QQBOT_TOKEN_SSRF_POLICY,
         init: {
           method: "POST",
           headers: {


### PR DESCRIPTION
## Summary

QQ Bot `bots.qq.com` token-fetch path was failing for users whose DNS resolver maps the hostname into the RFC 2544 benchmark range `198.18.0.0/15`. This is the default behavior of fake-IP proxy stacks (sing-box, Clash, Surge) and some WSL2 DNS configurations. The default SSRF guard treats `198.18.0.0/15` as private/special-use and blocks the request, surfacing as:

```
Network error getting access_token: Blocked: resolves to private/internal/special-use IP address
```

The QQ Bot channel cannot come up at all in such environments.

## Fix

Pass a host-scoped `SsrFPolicy` (`allowRfc2544BenchmarkRange: true`) to the single hard-coded `TOKEN_URL` request in `TokenManager.doFetchToken()`. Because `TOKEN_URL` is a `const` (`https://bots.qq.com/app/getAppAccessToken`) and not user-controlled, the relaxation cannot widen the attack surface to any other host.

This mirrors the existing `QQBOT_MEDIA_SSRF_POLICY` pattern used by `extensions/qqbot/src/engine/utils/file-utils.ts`, which already addresses the same fake-IP scenario for the media-download path. The change is intentionally narrow / host-scoped — the global SSRF default stays strict.

## Test plan

- [x] `pnpm exec vitest run extensions/qqbot/src/engine/api/token.test.ts` — 5 / 5 passed
- [x] `pnpm check` — typecheck + oxlint (core/extensions/scripts) + policy guards all clean

Updated the existing equality assertion in `token.test.ts` to include the new `policy` field, and added a dedicated regression test that asserts `policy: { allowRfc2544BenchmarkRange: true }` is forwarded into `fetchWithSsrFGuard`.

## Risk / rollback

- Single-file behavior change limited to the QQ Bot token endpoint.
- No new network paths introduced; URL constant is immutable.
- Trivially reverted (single commit, single logical change).

Fixes #88984
