### PR TITLE
fix(plugins): guard plugin tool descriptor accessors

### DIFF
--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -24,25 +24,38 @@ import type {
 import type { AnyAgentTool } from "./tools/common.js";
 
 function resolveEffectiveToolLabel(tool: AnyAgentTool): string {
-  const rawLabel = normalizeOptionalString(tool.label) ?? "";
+  const toolName = readEffectiveToolName(tool);
+  const rawLabel = normalizeOptionalString(readEffectiveToolField(tool, "label")) ?? "";
   if (
     rawLabel &&
-    normalizeLowercaseStringOrEmpty(rawLabel) !== normalizeLowercaseStringOrEmpty(tool.name)
+    normalizeLowercaseStringOrEmpty(rawLabel) !== normalizeLowercaseStringOrEmpty(toolName)
   ) {
     return rawLabel;
   }
-  return resolveToolDisplay({ name: tool.name }).title;
+  return resolveToolDisplay({ name: toolName }).title;
 }
 
 function resolveRawToolDescription(tool: AnyAgentTool): string {
-  return normalizeOptionalString(tool.description) ?? "";
+  return normalizeOptionalString(readEffectiveToolField(tool, "description")) ?? "";
 }
 
 function summarizeToolDescription(tool: AnyAgentTool): string {
   return summarizeToolDescriptionText({
     rawDescription: resolveRawToolDescription(tool),
-    displaySummary: tool.displaySummary,
+    displaySummary: normalizeOptionalString(readEffectiveToolField(tool, "displaySummary")),
   });
+}
+
+function readEffectiveToolField(tool: AnyAgentTool, field: string): unknown {
+  try {
+    return (tool as Record<string, unknown>)[field];
+  } catch {
+    return undefined;
+  }
+}
+
+function readEffectiveToolName(tool: AnyAgentTool, fallback = "tool"): string {
+  return normalizeOptionalString(readEffectiveToolField(tool, "name")) ?? fallback;
 }
 
 function resolveEffectiveToolSource(
@@ -131,7 +144,10 @@ function buildReadableRawToolsByName(
   for (let index = 0; index < toolCount; index += 1) {
     try {
       const tool = tools[index];
-      toolsByName.set(tool.name, tool);
+      const toolName = readEffectiveToolName(tool, "");
+      if (toolName) {
+        toolsByName.set(toolName, tool);
+      }
     } catch {
       // Unreadable entries are reported by the schema projection diagnostics.
     }
@@ -168,14 +184,15 @@ export function buildEffectiveToolInventoryEntries(
 
   return disambiguateLabels(
     tools
-      .map((tool) => {
-        const source = resolveEffectiveToolSource(tool, rawToolsByName.get(tool.name));
+      .map((tool, index) => {
+        const toolName = readEffectiveToolName(tool, `tool[${index}]`);
+        const source = resolveEffectiveToolSource(tool, rawToolsByName.get(toolName));
         const metadata = source.pluginId
-          ? pluginToolMetadata.get(buildPluginToolMetadataKey(source.pluginId, tool.name))
+          ? pluginToolMetadata.get(buildPluginToolMetadataKey(source.pluginId, toolName))
           : undefined;
         return Object.assign(
           {
-            id: tool.name,
+            id: toolName,
             label:
               normalizeOptionalString(metadata?.displayName) ?? resolveEffectiveToolLabel(tool),
             description:

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -861,6 +861,32 @@ describe("resolveEffectiveToolInventory", () => {
     });
   });
 
+  it("falls back to raw description when displaySummary is unreadable", async () => {
+    const tool = mockTool({
+      name: "cron",
+      label: "Cron",
+      description: "Long raw description\n\nACTIONS:\n- status",
+    });
+    Object.defineProperty(tool, "displaySummary", {
+      get() {
+        throw new Error("display summary exploded");
+      },
+    });
+    const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryItem } = await loadHarness({
+      tools: [tool],
+    });
+
+    const result = resolveEffectiveToolInventoryItem({ cfg: {} });
+
+    expect(result.groups[0]?.tools[0]).toEqual({
+      id: "cron",
+      label: "Cron",
+      description: "Long raw description",
+      rawDescription: "Long raw description\n\nACTIONS:\n- status",
+      source: "core",
+    });
+  });
+
   it("falls back to a sanitized summary for multi-line raw descriptions", async () => {
     const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryCandidate } =
       await loadHarness({

--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -16,6 +16,7 @@ vi.mock("../config/runtime-snapshot.js", () => ({
 
 import {
   buildPluginToolDescriptorCacheKey,
+  capturePluginToolDescriptor,
   createPluginToolDescriptorConfigCacheKeyMemo,
   resetPluginToolDescriptorCache,
 } from "./tool-descriptor-cache.js";
@@ -167,5 +168,70 @@ describe("plugin tool descriptor cache keys", () => {
     });
 
     expect(firstKey).toBe(secondKey);
+  });
+
+  it("captures plugin descriptors without reading hostile optional fields", () => {
+    const tool = {
+      name: "healthy_tool",
+      description: "Healthy tool",
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [{ type: "text", text: "ok" }] };
+      },
+    };
+    Object.defineProperty(tool, "displaySummary", {
+      get() {
+        throw new Error("display summary exploded");
+      },
+    });
+    Object.defineProperty(tool, "label", {
+      get() {
+        throw new Error("label exploded");
+      },
+    });
+
+    const captured = capturePluginToolDescriptor({
+      pluginId: "descriptor-fuzz",
+      tool: tool as never,
+      optional: false,
+    });
+
+    expect(captured).toStrictEqual({
+      optional: false,
+      descriptor: {
+        name: "healthy_tool",
+        description: "Healthy tool",
+        inputSchema: { type: "object", properties: {} },
+        owner: { kind: "plugin", pluginId: "descriptor-fuzz" },
+        executor: {
+          kind: "plugin",
+          pluginId: "descriptor-fuzz",
+          toolName: "healthy_tool",
+        },
+      },
+    });
+  });
+
+  it("does not cache descriptors with unreadable required descriptions", () => {
+    const tool = {
+      name: "healthy_tool",
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [{ type: "text", text: "ok" }] };
+      },
+    };
+    Object.defineProperty(tool, "description", {
+      get() {
+        throw new Error("description exploded");
+      },
+    });
+
+    expect(
+      capturePluginToolDescriptor({
+        pluginId: "descriptor-fuzz",
+        tool: tool as never,
+        optional: false,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -141,23 +141,41 @@ function asJsonObject(value: unknown): JsonObject {
   return value as JsonObject;
 }
 
+function readToolDescriptorField(tool: AnyAgentTool, field: string): unknown {
+  try {
+    return (tool as Record<string, unknown>)[field];
+  } catch {
+    return undefined;
+  }
+}
+
 export function capturePluginToolDescriptor(params: {
   pluginId: string;
   tool: AnyAgentTool;
   optional: boolean;
-}): CachedPluginToolDescriptor {
-  const label = (params.tool as { label?: unknown }).label;
+}): CachedPluginToolDescriptor | undefined {
+  const name = readToolDescriptorField(params.tool, "name");
+  const parameters = readToolDescriptorField(params.tool, "parameters");
+  if (typeof name !== "string" || !parameters || typeof parameters !== "object") {
+    return undefined;
+  }
+  const label = readToolDescriptorField(params.tool, "label");
   const title = typeof label === "string" && label.trim() ? label.trim() : undefined;
+  const displaySummary = readToolDescriptorField(params.tool, "displaySummary");
+  const description = readToolDescriptorField(params.tool, "description");
+  if (typeof description !== "string") {
+    return undefined;
+  }
   return {
-    ...(params.tool.displaySummary ? { displaySummary: params.tool.displaySummary } : {}),
+    ...(typeof displaySummary === "string" && displaySummary ? { displaySummary } : {}),
     optional: params.optional,
     descriptor: {
-      name: params.tool.name,
+      name,
       ...(title ? { title } : {}),
-      description: params.tool.description,
-      inputSchema: asJsonObject(params.tool.parameters),
+      description,
+      inputSchema: asJsonObject(parameters),
       owner: { kind: "plugin", pluginId: params.pluginId },
-      executor: { kind: "plugin", pluginId: params.pluginId, toolName: params.tool.name },
+      executor: { kind: "plugin", pluginId: params.pluginId, toolName: name },
     },
   };
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -1938,6 +1938,191 @@ describe("resolvePluginTools optional tools", () => {
     );
   });
 
+  it("skips plugin tools with unreadable required fields while keeping valid siblings", () => {
+    const unreadableTool = {
+      description: "bad",
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [{ type: "text", text: "bad" }] };
+      },
+    };
+    Object.defineProperty(unreadableTool, "name", {
+      get() {
+        throw new Error("name exploded");
+      },
+    });
+    const registry = setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["broken_tool", "valid_tool"],
+        factory: () => [unreadableTool, makeTool("valid_tool")],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+    expectSingleDiagnosticMessage(
+      registry.diagnostics,
+      "plugin tool is malformed (schema-bug): missing non-empty name",
+    );
+  });
+
+  it("skips plugin tools with unreadable execute accessors before wrapping siblings", () => {
+    const unreadableTool = {
+      name: "broken_tool",
+      description: "bad",
+      parameters: { type: "object", properties: {} },
+    };
+    Object.defineProperty(unreadableTool, "execute", {
+      get() {
+        throw new Error("execute exploded");
+      },
+    });
+    const registry = setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["broken_tool", "valid_tool"],
+        factory: () => [unreadableTool, makeTool("valid_tool")],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+    expectSingleDiagnosticMessage(
+      registry.diagnostics,
+      "plugin tool is malformed (schema-bug): broken_tool missing execute function",
+    );
+  });
+
+  it("rejects transient unreadable execute accessors after wrapper probing", () => {
+    let executeReads = 0;
+    const transientTool = {
+      name: "broken_tool",
+      description: "bad",
+      parameters: { type: "object", properties: {} },
+    };
+    Object.defineProperty(transientTool, "execute", {
+      get() {
+        executeReads += 1;
+        if (executeReads === 1) {
+          throw new Error("execute exploded once");
+        }
+        return async () => ({ content: [{ type: "text", text: "bad" }] });
+      },
+    });
+    const registry = setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["broken_tool", "valid_tool"],
+        factory: () => [transientTool, makeTool("valid_tool")],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+    expectSingleDiagnosticMessage(
+      registry.diagnostics,
+      "plugin tool is malformed (schema-bug): broken_tool missing execute function",
+    );
+  });
+
+  it("caches plugin descriptors without reading hostile optional fields", () => {
+    const tool = makeTool("cached_tool");
+    Object.defineProperty(tool, "displaySummary", {
+      get() {
+        throw new Error("display summary exploded");
+      },
+    });
+    Object.defineProperty(tool, "label", {
+      get() {
+        throw new Error("label exploded");
+      },
+    });
+    const factory = vi.fn(() => tool);
+    setRegistry([
+      {
+        pluginId: "cache-test",
+        optional: false,
+        source: "/tmp/cache-test.js",
+        names: ["cached_tool"],
+        factory,
+      },
+    ]);
+
+    const first = resolvePluginTools(createResolveToolsParams());
+    const second = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(first, ["cached_tool"]);
+    expectResolvedToolNames(second, ["cached_tool"]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips plugin tools with unreadable required descriptions", () => {
+    const tool = makeTool("broken_tool");
+    Object.defineProperty(tool, "description", {
+      get() {
+        throw new Error("description exploded");
+      },
+    });
+    const registry = setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["broken_tool", "valid_tool"],
+        factory: () => [tool, makeTool("valid_tool")],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+    expectSingleDiagnosticMessage(
+      registry.diagnostics,
+      "plugin tool is malformed (schema-bug): broken_tool missing description string",
+    );
+  });
+
+  it("skips plugin tools whose required descriptor fields fail during cache capture", () => {
+    let descriptionReads = 0;
+    const tool = makeTool("broken_tool");
+    Object.defineProperty(tool, "description", {
+      get() {
+        descriptionReads += 1;
+        if (descriptionReads === 1) {
+          return "Broken tool";
+        }
+        throw new Error("description exploded during capture");
+      },
+    });
+    const registry = setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["broken_tool", "valid_tool"],
+        factory: () => [tool, makeTool("valid_tool")],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+    expectSingleDiagnosticMessage(
+      registry.diagnostics,
+      "plugin tool is malformed (schema-bug): broken_tool has unreadable descriptor fields",
+    );
+  });
+
   it("warns with plugin factory timing details when a factory is slow", () => {
     vi.useFakeTimers({ now: 0 });
     const warnSpy = installConsoleMethodSpy("warn");

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -76,6 +76,7 @@ const PLUGIN_TOOL_FACTORY_SUMMARY_LIMIT = 20;
 
 const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
 const scopedPluginTools = new WeakMap<AnyAgentTool, Map<string, AnyAgentTool>>();
+const pluginToolFieldReadFailures = new WeakMap<object, Set<string>>();
 
 export function setPluginToolMeta(tool: AnyAgentTool, meta: PluginToolMeta): void {
   pluginToolMeta.set(tool, meta);
@@ -106,12 +107,29 @@ function runWithPluginToolScope<T>(entry: PluginToolRegistration, run: () => T):
   );
 }
 
+function readPluginToolField(tool: unknown, field: string): unknown {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+  try {
+    return tool[field];
+  } catch {
+    const failures = pluginToolFieldReadFailures.get(tool) ?? new Set<string>();
+    failures.add(field);
+    pluginToolFieldReadFailures.set(tool, failures);
+    return undefined;
+  }
+}
+
+function pluginToolFieldReadFailed(tool: unknown, field: string): boolean {
+  return isRecord(tool) && (pluginToolFieldReadFailures.get(tool)?.has(field) ?? false);
+}
+
 function isAgentTool(value: unknown): value is AnyAgentTool {
   return (
-    Boolean(value) &&
-    typeof value === "object" &&
+    isRecord(value) &&
     !Array.isArray(value) &&
-    typeof (value as { execute?: unknown }).execute === "function"
+    typeof readPluginToolField(value, "execute") === "function"
   );
 }
 
@@ -315,8 +333,12 @@ function readPluginToolName(tool: unknown): string {
   if (!isRecord(tool)) {
     return "";
   }
+  if (pluginToolFieldReadFailed(tool, "name")) {
+    return "";
+  }
   // Optional-tool allowlists need a best-effort name before full shape validation.
-  return typeof tool.name === "string" ? tool.name.trim() : "";
+  const name = readPluginToolField(tool, "name");
+  return typeof name === "string" ? name.trim() : "";
 }
 
 function toElapsedMs(value: number): number {
@@ -452,10 +474,16 @@ function describeMalformedPluginTool(tool: unknown): string | undefined {
   if (!name) {
     return "missing non-empty name";
   }
-  if (typeof tool.execute !== "function") {
+  const execute = readPluginToolField(tool, "execute");
+  if (pluginToolFieldReadFailed(tool, "execute") || typeof execute !== "function") {
     return `${name} missing execute function`;
   }
-  if (!isRecord(tool.parameters)) {
+  const description = readPluginToolField(tool, "description");
+  if (pluginToolFieldReadFailed(tool, "description") || typeof description !== "string") {
+    return `${name} missing description string`;
+  }
+  const parameters = readPluginToolField(tool, "parameters");
+  if (pluginToolFieldReadFailed(tool, "parameters") || !isRecord(parameters)) {
     return `${name} missing parameters object`;
   }
   return undefined;
@@ -1284,10 +1312,11 @@ export function resolvePluginTools(params: {
         continue;
       }
       const tool = toolRaw as AnyAgentTool;
+      const toolName = readPluginToolName(tool);
       const undeclared = entry.declaredNames
         ? findUndeclaredPluginToolNames({
             declaredNames: entry.declaredNames,
-            toolNames: [tool.name],
+            toolNames: [toolName],
           })
         : [];
       if (undeclared.length > 0) {
@@ -1301,9 +1330,9 @@ export function resolvePluginTools(params: {
         });
         continue;
       }
-      const normalizedToolName = normalizeToolName(tool.name);
+      const normalizedToolName = normalizeToolName(toolName);
       if (normalizedNameSet.has(normalizedToolName) || existingNormalized.has(normalizedToolName)) {
-        const message = `plugin tool name conflict (${entry.pluginId}): ${tool.name}`;
+        const message = `plugin tool name conflict (${entry.pluginId}): ${toolName}`;
         if (!params.suppressNameConflicts) {
           context.logger.error(message);
           registry.diagnostics.push({
@@ -1315,31 +1344,44 @@ export function resolvePluginTools(params: {
         }
         continue;
       }
-      normalizedNameSet.add(normalizedToolName);
-      existing.add(tool.name);
-      existingNormalized.add(normalizedToolName);
       const optional = isPluginToolOptional({
         entry,
         manifestPlugin,
-        toolName: tool.name,
+        toolName,
       });
+      let capturedDescriptor: CachedPluginToolDescriptor | undefined;
+      if (manifestPlugin) {
+        capturedDescriptor = capturePluginToolDescriptor({
+          pluginId: entry.pluginId,
+          tool,
+          optional,
+        });
+        if (!capturedDescriptor) {
+          const message = `plugin tool is malformed (${entry.pluginId}): ${toolName} has unreadable descriptor fields`;
+          context.logger.error(message);
+          registry.diagnostics.push({
+            level: "error",
+            pluginId: entry.pluginId,
+            source: entry.source,
+            message,
+          });
+          continue;
+        }
+      }
+      normalizedNameSet.add(normalizedToolName);
+      existing.add(toolName);
+      existingNormalized.add(normalizedToolName);
       pluginToolMeta.set(tool, {
         pluginId: entry.pluginId,
         optional,
         trustedLocalMedia: isTrustedManifestLocalMediaTool({
           manifestPlugin,
-          toolName: tool.name,
+          toolName,
         }),
       });
-      if (manifestPlugin) {
+      if (manifestPlugin && capturedDescriptor) {
         const capturedDescriptors = capturedDescriptorsByPluginId.get(entry.pluginId) ?? [];
-        capturedDescriptors.push(
-          capturePluginToolDescriptor({
-            pluginId: entry.pluginId,
-            tool,
-            optional,
-          }),
-        );
+        capturedDescriptors.push(capturedDescriptor);
         capturedDescriptorsByPluginId.set(entry.pluginId, capturedDescriptors);
       }
       tools.push(tool);


### PR DESCRIPTION
## Summary

- Treat unreadable plugin tool required fields as malformed before wrapping, caching, or exposing the tool.
- Keep valid sibling plugin tools available when one tool has hostile `name`, `execute`, `description`, or descriptor-cache accessors.
- Make effective tool inventory tolerate unreadable optional display metadata and fall back to raw descriptions instead of crashing doctor/inventory paths.

Related hardening context:

- https://github.com/openclaw/openclaw/pull/88994
- https://github.com/openclaw/openclaw/pull/89013
- https://github.com/openclaw/openclaw/pull/89016

## Real Behavior Proof

Behavior addressed: A plugin tool with hostile descriptor accessors could crash plugin tool resolution, descriptor caching, or effective tool inventory after earlier shape checks, causing healthy sibling tools or doctor/inventory output to disappear.

Real environment tested: Local focused regression tests plus AWS Crabbox changed-gate proof.

Exact steps or command run after this patch:

- `node scripts/run-vitest.mjs src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.optional.test.ts src/agents/tools-effective-inventory.test.ts --reporter=dot`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/plugins/tools.ts src/plugins/tool-descriptor-cache.ts src/plugins/tools.optional.test.ts src/plugins/tool-descriptor-cache.test.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/tools.ts src/plugins/tool-descriptor-cache.ts src/plugins/tools.optional.test.ts src/plugins/tool-descriptor-cache.test.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

Evidence after fix:

- Focused Vitest passed: 21 agent inventory tests and 79 plugin tests.
- Static checks passed: oxlint, oxfmt, and `git diff --check`.
- Direct repros changed from throwing hostile descriptor/display metadata getters to returning safe descriptors or inventory fallbacks.
- Autoreview: `autoreview clean: no accepted/actionable findings reported`.
- Crabbox: provider `aws`, run `run_2f40fa77f3e2`, lease `cbx_cc78e0a83171`, lanes `core, coreTests`, exit `0`.

Observed result after fix: Malformed plugin tools with unreadable required fields are isolated with diagnostics, valid siblings continue loading, optional descriptor/display metadata no longer crashes descriptor caching or inventory, and required descriptor-cache fields cannot be cached as empty fallbacks.

What was not tested: Blacksmith Testbox could not be used because the local Blacksmith CLI was not authenticated, so the broad changed gate ran through AWS Crabbox instead.
