### PR TITLE
fix(usage): return all agent sessions when no agentId specified

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -199,22 +199,27 @@ describe("sessions.usage", () => {
     vi.clearAllMocks();
   });
 
-  it("defaults list-style usage queries without agentId to the default agent", async () => {
+  it("returns all agent sessions when no agentId is specified", async () => {
     const respond = await runSessionsUsage(BASE_USAGE_RANGE);
 
     expect(vi.mocked(loadCombinedSessionStoreForGateway)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      { agentId: "main" },
+      {},
     );
-    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(1);
-    expect((mockArg(vi.mocked(discoverAllSessions), 0, 0) as { agentId?: string }).agentId).toBe(
-      "main",
-    );
+    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
+    expect(
+      vi
+        .mocked(discoverAllSessions)
+        .mock.calls.map((call) => (call[0] as { agentId?: string }).agentId),
+    ).toEqual(["main", "opus"]);
 
     const sessions = expectSuccessfulSessionsUsage(respond);
-    expect(sessions).toHaveLength(1);
-    expect(sessions[0].key).toBe("agent:main:s-main");
-    expect(sessions[0].agentId).toBe("main");
+    expect(sessions).toHaveLength(2);
+    expect(sessions.map((session) => session.key)).toEqual([
+      "agent:opus:s-opus",
+      "agent:main:s-main",
+    ]);
+    expect(sessions.map((session) => session.agentId)).toEqual(["opus", "main"]);
   });
 
   it("uses explicit all-agent scope for list-style usage queries", async () => {
@@ -307,7 +312,7 @@ describe("sessions.usage", () => {
       );
     }
 
-    const respondPromise = runSessionsUsage({ ...BASE_USAGE_RANGE, limit: 3 });
+    const respondPromise = runSessionsUsage({ ...BASE_USAGE_RANGE, limit: 3, agentId: "main" });
     await vi.waitFor(() =>
       expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledTimes(3),
     );

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -992,7 +992,7 @@ export const usageHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const effectiveAgentId = requestedAllAgents
+    const effectiveAgentId = requestedAllAgents || (!requestedAgentId && !specificKey)
       ? undefined
       : normalizeAgentId(requestedAgentId ?? specificKeyAgentId ?? resolveDefaultAgentId(config));
     const groupingMode: UsageGroupingMode =


### PR DESCRIPTION
"From v2026.5.17, sessions.usage API defaulted to only returning sessions for the \"main\" agent when no agentId was provided. This broke the Web UI's agent filter for multi-agent setups.\n\nThis change restores the pre-v2026.5.17 behavior: when no agentId is specified, sessions from all configured agents are returned instead of defaulting to a single agent. When the caller does specify an agentId (or a specific session key that pins to an agent), that scope is still honored.\n\nFixes #87132\n\n## Real behavior proof\n\nBehavior or issue addressed: Restores the pre-v2026.5.17 behavior of `sessions.usage` in `src/gateway/server-methods/usage.ts` where omitting `agentId` (and not pinning a specific session key) returns sessions across all configured agents, instead of being silently scoped to the default agent. See #87132 for the original bug report.\n\nRoot-cause commit (introduced the regression): `6a12c6f7991547c0bf82323392ca327f4de016a3` (\"fix(gateway): scope session data lookups by agent\", PR #81386, merged 2026-05-16).\n\nReal environment tested: openclaw/openclaw base `329fa44d23` (origin/main HEAD at the time of the rebase), head `5f43cf30add86be8423b36c38b4b06b8fc276d76` (this PR). Working copy on Linux 5.10 / Node 24, forked at Jefsky/openclaw.\n\nExact steps or command run after this patch:\n\n```text\n# 1. Verify the PR diff against base\n$ gh pr diff 89034 --repo openclaw/openclaw | head\ndiff --git a/src/gateway/server-methods/usage.sessions-usage.test.ts ...\ndiff --git a/src/gateway/server-methods/usage.ts ...\n  const effectiveAgentId = requestedAllAgents || (!requestedAgentId && !specificKey)\n    ? undefined\n    : normalizeAgentId(requestedAgentId ?? specificKeyAgentId ?? resolveDefaultAgentId(config));\n\n# 2. Live confirm linked PR / commit metadata from GitHub\n$ gh api repos/openclaw/openclaw/commits/6a12c6f7991547c0bf82323392ca327f4de016a3 \\\n    -q '{sha:.sha, message:.commit.message, date:.commit.author.date}'\n{\"sha\":\"6a12c6f7991547c0bf82323392ca327f4de016a3\",\"message\":\"fix(gateway): scope session data lookups by agent [AI] (#81386) ...\",\"date\":\"2026-05-16T16:43:00Z\"}\n\n# 3. Live confirm the original bug is closed by referencing this fix\n$ gh issue view 87132 --repo openclaw/openclaw --json state,title\n{\"state\":\"CLOSED\",\"title\":\"[Bug]: Usage page agent filter broken since v2026.5.17 \u2013 sessions.usage API always scoped to \\\"main\\\" agent\"}\n```\n\nEvidence after fix: The handler change in `src/gateway/server-methods/usage.ts:990-993` is:\n\n```ts\n// Before (regression from #81386):\nconst effectiveAgentId = requestedAllAgents\n  ? undefined\n  : normalizeAgentId(requestedAgentId ?? specificKeyAgentId ?? resolveDefaultAgentId(config));\n\n// After (this PR):\nconst effectiveAgentId = requestedAllAgents || (!requestedAgentId && !specificKey)\n  ? undefined\n  : normalizeAgentId(requestedAgentId ?? specificKeyAgentId ?? resolveDefaultAgentId(config));\n```\n\nThe accompanying test in `src/gateway/server-methods/usage.sessions-usage.test.ts` was also updated to assert that when no `agentId` is passed and no `key` is passed, the handler now invokes `discoverAllSessions` once per configured agent and the response carries one entry per agent.\n\nLinked artifacts:\n\n- PR: https://github.com/openclaw/openclaw/pull/89034\n- Issue: https://github.com/openclaw/openclaw/issues/87132\n- Root-cause PR: https://github.com/openclaw/openclaw/pull/81386\n- Head commit: https://github.com/openclaw/openclaw/pull/89034/commits/5f43cf30add86be8423b36c38b4b06b8fc276d76\n\nObserved result after fix: The handler now returns sessions across all configured agents when no `agentId` and no `key` are passed. The test case \"returns all agent sessions when no agentId is specified\" now expects `discoverAllSessions` to be called twice (once for `main`, once for `opus`) and the response to contain 2 sessions (`agent:opus:s-opus`, `agent:main:s-main`). The test case \"uses explicit all-agent scope for list-style usage queries\" continues to pass unchanged, confirming `agentScope=all` is still honored. The test case for the \"limit 3\" path was updated to include `agentId: \"main\"` in the request to preserve its previous behavior, since that test was exercising a single-agent scenario.\n\nWhat was not tested: A live `openclaw gateway` runtime was not started in this environment (sandbox is a 1.8 GB-RAM container that cannot load the gateway). The fix is verified by the existing test file that drives the handler end-to-end via the existing test harness; the new expectation asserts the call shape and the response contents. The Swift / iOS client path was not exercised; no client-side change is required since the bug was server-side only.\n"