### PR TITLE
fix #88773: [Bug]: Telegram DM exec requires approval despite allowlist + ask:off — works in webchat, not in Telegram

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -144,11 +144,11 @@ when set at the narrower session or agent scope.
 ### `exec.ask`
 
 <ParamField path="ask" type='"off" | "on-miss" | "always"'>
-  Configured ask policy for host exec. Controls when approval prompts
-  appear based on `tools.exec.ask` and host approvals defaults. The
+  Configured ask policy for host exec. Controls the baseline approval
+  prompt behavior from `tools.exec.ask` and host approvals defaults. The
   per-call `ask` tool parameter (see [Exec tool](/tools/exec#parameters))
-  is ignored for normal tool calls; only the configured policy and host
-  approvals set the effective ask mode.
+  can only harden that baseline, and channel-origin model calls ignore it
+  when the effective host ask is `off`.
 
 - `off` - never prompt.
 - `on-miss` - prompt only when the allowlist does not match.

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -144,9 +144,15 @@ when set at the narrower session or agent scope.
 ### `exec.ask`
 
 <ParamField path="ask" type='"off" | "on-miss" | "always"'>
-  - `off` - never prompt.
-  - `on-miss` - prompt only when the allowlist does not match.
-  - `always` - prompt on every command. `allow-always` durable trust does **not** suppress prompts when effective ask mode is `always`.
+  Configured ask policy for host exec. Controls when approval prompts
+  appear based on `tools.exec.ask` and host approvals defaults. The
+  per-call `ask` tool parameter (see [Exec tool](/tools/exec#parameters))
+  is ignored for normal tool calls; only the configured policy and host
+  approvals set the effective ask mode.
+
+- `off` - never prompt.
+- `on-miss` - prompt only when the allowlist does not match.
+- `always` - prompt on every command. `allow-always` durable trust does **not** suppress prompts when effective ask mode is `always`.
 
 </ParamField>
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -52,9 +52,10 @@ force `security=full` only when the operator explicitly grants elevated access.
 </ParamField>
 
 <ParamField path="ask" type="'off' | 'on-miss' | 'always'">
-Ignored for normal tool calls. Exec ask mode is controlled by
-`tools.exec.ask` and host approvals. Approval-required diagnostics
-paths (such as approval-card exec tool construction) that pass an
+The baseline ask mode comes from `tools.exec.ask` and host approvals.
+For channel-origin model calls, per-call `ask` is ignored when the
+effective host ask is `off`; otherwise it can only harden to a stricter
+mode. Trusted internal/API callers that construct exec tools with an
 explicit `ask` value are unchanged.
 </ParamField>
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -52,7 +52,10 @@ force `security=full` only when the operator explicitly grants elevated access.
 </ParamField>
 
 <ParamField path="ask" type="'off' | 'on-miss' | 'always'">
-Approval prompt behavior for `gateway` / `node` execution.
+Ignored for normal tool calls. Exec ask mode is controlled by
+`tools.exec.ask` and host approvals. Approval-required diagnostics
+paths (such as approval-card exec tool construction) that pass an
+explicit `ask` value are unchanged.
 </ParamField>
 
 <ParamField path="node" type="string">

--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -88,6 +88,45 @@ describe("exec security floor", () => {
     ).rejects.toThrow(/exec denied: allowlist miss/i);
   });
 
+  it("ignores model-supplied ask overrides when configured ask is off", async () => {
+    const root = tempRoot ?? os.tmpdir();
+    const binDir = path.join(root, "bin");
+    const openclawDir = path.join(root, ".openclaw");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(openclawDir, { recursive: true });
+    const gogPath = path.join(binDir, "gog");
+    fs.writeFileSync(gogPath, "#!/bin/sh\nprintf 'gog-ok %s\\n' \"$*\"\n", { mode: 0o755 });
+    fs.writeFileSync(
+      path.join(openclawDir, "exec-approvals.json"),
+      `${JSON.stringify({
+        version: 1,
+        defaults: { security: "allowlist", ask: "off", askFallback: "allowlist" },
+        agents: { "*": { allowlist: [{ pattern: gogPath }] } },
+      })}\n`,
+    );
+    const tool = createExecTool({
+      host: "gateway",
+      security: "allowlist",
+      ask: "off",
+      safeBins: [],
+      pathPrepend: [binDir],
+      messageProvider: "telegram",
+      currentChannelId: "telegram:12345",
+      accountId: "default",
+    });
+
+    const result = await tool.execute("call-model-ask-ignored", {
+      command: "gog tasks add tasklist --title test",
+      ask: "always",
+    });
+
+    expect(result.details.status).toBe("completed");
+    expect((result.content[0] as { text?: string }).text ?? "").toContain(
+      "gog-ok tasks add tasklist --title test",
+    );
+    expect(callGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("ignores model-supplied deny security when configured security is allowlist", async () => {
     const tool = createExecTool({
       security: "allowlist",

--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -13,6 +13,24 @@ vi.mock("./tools/gateway.js", () => ({
   readGatewayCallOptions: vi.fn(() => ({})),
 }));
 
+function installAllowlistedGogFixture(root: string): string {
+  const binDir = path.join(root, "bin");
+  const openclawDir = path.join(root, ".openclaw");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(openclawDir, { recursive: true });
+  const gogPath = path.join(binDir, "gog");
+  fs.writeFileSync(gogPath, "#!/bin/sh\nprintf 'gog-ok %s\\n' \"$*\"\n", { mode: 0o755 });
+  fs.writeFileSync(
+    path.join(openclawDir, "exec-approvals.json"),
+    `${JSON.stringify({
+      version: 1,
+      defaults: { security: "allowlist", ask: "off", askFallback: "allowlist" },
+      agents: { "*": { allowlist: [{ pattern: gogPath }] } },
+    })}\n`,
+  );
+  return binDir;
+}
+
 describe("exec security floor", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
   let tempRoot: string | undefined;
@@ -90,20 +108,7 @@ describe("exec security floor", () => {
 
   it("ignores model-supplied ask overrides when configured ask is off", async () => {
     const root = tempRoot ?? os.tmpdir();
-    const binDir = path.join(root, "bin");
-    const openclawDir = path.join(root, ".openclaw");
-    fs.mkdirSync(binDir, { recursive: true });
-    fs.mkdirSync(openclawDir, { recursive: true });
-    const gogPath = path.join(binDir, "gog");
-    fs.writeFileSync(gogPath, "#!/bin/sh\nprintf 'gog-ok %s\\n' \"$*\"\n", { mode: 0o755 });
-    fs.writeFileSync(
-      path.join(openclawDir, "exec-approvals.json"),
-      `${JSON.stringify({
-        version: 1,
-        defaults: { security: "allowlist", ask: "off", askFallback: "allowlist" },
-        agents: { "*": { allowlist: [{ pattern: gogPath }] } },
-      })}\n`,
-    );
+    const binDir = installAllowlistedGogFixture(root);
     const tool = createExecTool({
       host: "gateway",
       security: "allowlist",
@@ -129,21 +134,7 @@ describe("exec security floor", () => {
 
   it("honors per-call ask hardening for trusted callers without messageProvider", async () => {
     const root = tempRoot ?? os.tmpdir();
-    const binDir = path.join(root, "bin");
-    const openclawDir = path.join(root, ".openclaw");
-    fs.mkdirSync(binDir, { recursive: true });
-    fs.mkdirSync(openclawDir, { recursive: true });
-    const gogPath = path.join(binDir, "gog");
-    fs.writeFileSync(gogPath, "#!/bin/sh\nprintf 'gog-ok %s\\n' \"$*\"\n", { mode: 0o755 });
-    fs.writeFileSync(
-      path.join(openclawDir, "exec-approvals.json"),
-      `${JSON.stringify({
-        version: 1,
-        defaults: { security: "allowlist", ask: "off", askFallback: "allowlist" },
-        agents: { "*": { allowlist: [{ pattern: gogPath }] } },
-      })}\n`,
-    );
-    // No messageProvider → direct/trusted caller; per-call ask should be honored.
+    const binDir = installAllowlistedGogFixture(root);
     const tool = createExecTool({
       host: "gateway",
       security: "allowlist",
@@ -157,7 +148,6 @@ describe("exec security floor", () => {
       ask: "always",
     });
 
-    // Trusted caller's per-call ask: "always" triggers an approval request.
     expect(callGatewayTool).toHaveBeenCalled();
     expect(result.details.status).toBe("approval-pending");
   });

--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -127,6 +127,41 @@ describe("exec security floor", () => {
     expect(callGatewayTool).not.toHaveBeenCalled();
   });
 
+  it("honors per-call ask hardening for trusted callers without messageProvider", async () => {
+    const root = tempRoot ?? os.tmpdir();
+    const binDir = path.join(root, "bin");
+    const openclawDir = path.join(root, ".openclaw");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(openclawDir, { recursive: true });
+    const gogPath = path.join(binDir, "gog");
+    fs.writeFileSync(gogPath, "#!/bin/sh\nprintf 'gog-ok %s\\n' \"$*\"\n", { mode: 0o755 });
+    fs.writeFileSync(
+      path.join(openclawDir, "exec-approvals.json"),
+      `${JSON.stringify({
+        version: 1,
+        defaults: { security: "allowlist", ask: "off", askFallback: "allowlist" },
+        agents: { "*": { allowlist: [{ pattern: gogPath }] } },
+      })}\n`,
+    );
+    // No messageProvider → direct/trusted caller; per-call ask should be honored.
+    const tool = createExecTool({
+      host: "gateway",
+      security: "allowlist",
+      ask: "off",
+      safeBins: [],
+      pathPrepend: [binDir],
+    });
+
+    const result = await tool.execute("call-trusted-ask-always", {
+      command: "gog tasks add tasklist --title test",
+      ask: "always",
+    });
+
+    // Trusted caller's per-call ask: "always" triggers an approval request.
+    expect(callGatewayTool).toHaveBeenCalled();
+    expect(result.details.status).toBe("approval-pending");
+  });
+
   it("ignores model-supplied deny security when configured security is allowlist", async () => {
     const tool = createExecTool({
       security: "allowlist",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -16,6 +16,7 @@ import {
   loadExecApprovals,
   maxAsk,
   minSecurity,
+  normalizeExecAsk,
   requireValidExecTarget,
   resolveExecApprovalsFromFile,
   resolveExecModePolicy,
@@ -1610,8 +1611,15 @@ export function createExecTool(
         security = "full";
       }
       // Keep local exec defaults in sync with exec-approvals.json when tools.exec.* is unset.
+      const requestedAsk = normalizeExecAsk(params.ask);
       const hostAsk = maxAsk(modePolicy.ask, approvalPolicy?.ask ?? modePolicy.ask);
       let ask = hostAsk;
+      // Per-call ask hardening is preserved for trusted callers but ignored
+      // for channel-origin model runs so a model-supplied `ask: "always"`
+      // cannot escalate past configured `ask: off` in Telegram/webchat.
+      if (requestedAsk && (hostAsk !== "off" || !defaults?.messageProvider)) {
+        ask = maxAsk(hostAsk, requestedAsk);
+      }
       const bypassApprovals =
         elevatedRequested &&
         elevatedMode === "full" &&

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1613,13 +1613,8 @@ export function createExecTool(
       // Keep local exec defaults in sync with exec-approvals.json when tools.exec.* is unset.
       const requestedAsk = normalizeExecAsk(params.ask);
       const hostAsk = maxAsk(modePolicy.ask, approvalPolicy?.ask ?? modePolicy.ask);
-      let ask = hostAsk;
-      // Per-call ask hardening is preserved for trusted callers but ignored
-      // for channel-origin model runs so a model-supplied `ask: "always"`
-      // cannot escalate past configured `ask: off` in Telegram/webchat.
-      if (requestedAsk && (hostAsk !== "off" || !defaults?.messageProvider)) {
-        ask = maxAsk(hostAsk, requestedAsk);
-      }
+      const trustedAsk = defaults?.messageProvider && hostAsk === "off" ? undefined : requestedAsk;
+      let ask = maxAsk(hostAsk, trustedAsk ?? hostAsk);
       const bypassApprovals =
         elevatedRequested &&
         elevatedMode === "full" &&

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -56,7 +56,6 @@ import {
   type ExecProcessOutcome,
   applyPathPrepend,
   applyShellPath,
-  normalizeExecAsk,
   normalizePathPrepend,
   resolveExecTarget,
   resolveApprovalRunningNoticeMs,
@@ -1611,9 +1610,8 @@ export function createExecTool(
         security = "full";
       }
       // Keep local exec defaults in sync with exec-approvals.json when tools.exec.* is unset.
-      const requestedAsk = normalizeExecAsk(params.ask);
       const hostAsk = maxAsk(modePolicy.ask, approvalPolicy?.ask ?? modePolicy.ask);
-      let ask = maxAsk(hostAsk, requestedAsk ?? hostAsk);
+      let ask = hostAsk;
       const bypassApprovals =
         elevatedRequested &&
         elevatedMode === "full" &&

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -40,7 +40,8 @@ export const execSchema = Type.Object({
   ),
   ask: Type.Optional(
     Type.String({
-      description: "Exec ask mode (off|on-miss|always).",
+      description:
+        "Ignored for normal calls; exec ask mode is set by tools.exec.ask and host approvals.",
     }),
   ),
   node: Type.Optional(

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -41,7 +41,7 @@ export const execSchema = Type.Object({
   ask: Type.Optional(
     Type.String({
       description:
-        "Ignored for normal calls; exec ask mode is set by tools.exec.ask and host approvals.",
+        "Baseline ask comes from tools.exec.ask and host approvals; channel-origin calls ignore per-call ask when effective host ask is off.",
     }),
   ),
   node: Type.Optional(

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -22,7 +22,7 @@ vi.mock("../agents/models-config.js", () => ({
 }));
 
 vi.mock("../agents/embedded-agent-runner/model.js", () => ({
-  resolveModel: (...args: unknown[]) => resolveModelMock(...args),
+  resolveModel: () => resolveModelMock(),
 }));
 
 let prewarmConfiguredPrimaryModel: typeof import("./server-startup-post-attach.js").testing.prewarmConfiguredPrimaryModel;

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -22,7 +22,7 @@ vi.mock("../agents/models-config.js", () => ({
 }));
 
 vi.mock("../agents/embedded-agent-runner/model.js", () => ({
-  resolveModel: () => resolveModelMock(),
+  resolveModel: (...args: unknown[]) => resolveModelMock(...args),
 }));
 
 let prewarmConfiguredPrimaryModel: typeof import("./server-startup-post-attach.js").testing.prewarmConfiguredPrimaryModel;


### PR DESCRIPTION
## Summary

- Problem: Telegram-origin natural-language exec could prompt for approval even when the effective policy was `security=allowlist, ask=off` and the command binary was allowlisted.
- Solution: Model/provider-supplied `ask` tool arguments are now ignored for channel-origin runs when the effective host ask is `off`, while trusted per-call `ask` hardening is preserved for direct/internal callers and when host ask is already elevated.
- What changed: The exec tool resolution now checks whether the call originates from a channel (`messageProvider` is set) and the host ask is `off` before ignoring `params.ask`. Trusted callers (no `messageProvider`) and already-elevated policies still honor per-call `ask` as defense-in-depth. The tool schema and docs now describe that conditional rule instead of saying all normal per-call `ask` values are ignored. Two regression tests cover both paths: Telegram-origin model-supplied `ask: "always"` ignored, and trusted non-channel `ask: "always"` honored with approval request.
- What did NOT change: Host approval files can still tighten policy, configured `tools.exec.ask` still works, approval-required diagnostics paths that construct exec tools with `ask: "always"` still request approval, allowlist enforcement is unchanged, and trusted internal/API callers can still use per-call `ask` hardening.
- Fixes #88773

## Real behavior proof
- **Behavior or issue addressed:** Telegram DM allowlisted exec parity with webchat when effective policy is `security=allowlist, ask=off`; a model/provider-supplied `ask` argument must not create `exec.approval.request` or `exec.approval.waitDecision`.
- **Real environment tested:** Local OpenClaw gateway-host exec path in the PR worktree on Linux, with Telegram-origin exec defaults (`messageProvider: "telegram"`, Telegram target/account fields), a real executable `gog` fixture on PATH, and a real host approvals file containing wildcard allowlist trust for that binary.
- **Exact steps or command run after this patch:** Ran a local OpenClaw exec harness command with `node --import tsx --input-type=module`, creating a temp `~/.openclaw/exec-approvals.json`, a real executable `gog`, and then calling the real `createExecTool(...).execute(...)` path with `ask: "always"` supplied in the tool-call arguments.
- **Evidence after fix:** Copied terminal output from `/media/vdc/code/ai/aispace/openclaw-pr-89035-evidence/real-behavior-proof.log`:

  ```text
  OpenClaw real exec proof
  HOME=/tmp/openclaw-real-exec-proof-GmGFLg
  allowlisted=/tmp/openclaw-real-exec-proof-GmGFLg/bin/gog
  origin=telegram DM target telegram:12345 account default
  configured policy: security=allowlist ask=off askFallback=allowlist
  tool call argument includes ask="always" to simulate provider/model-supplied ask
  result.status=completed
  result.text:
  REAL_GOG_EXEC tasks add MTE4ODI2MDk1MDI4NDA5Njg1NTY6MDow --title REAL-PROOF
  approval_request_observed=no; command completed locally without a gateway approval registration or waitDecision
  ```
- **Observed result after fix:** The real OpenClaw exec call completed with `result.status=completed` and printed `REAL_GOG_EXEC ... --title REAL-PROOF`; because no gateway was running, any attempted approval registration or `waitDecision` path would have failed instead of completing.
- **What was not tested:** A live Telegram Bot API DM was not exercised because this environment has no Telegram credentials; the tested path covers the Telegram-origin exec defaults and the host approval decision before any channel delivery would occur.

## Regression Test Plan
- **Target test file:** `src/agents/bash-tools.exec.security-floor.test.ts`.
- **Scenario 1 locked in (bug fix):** A Telegram-origin exec call for an allowlisted `gog` binary completes under configured `ask: off` even when the model-supplied tool argument asks for `always`, and it does not register an exec approval request.
- **Scenario 2 locked in (trusted hardening preserved):** A non-channel (no `messageProvider`) exec call with `params.ask: "always"` for the same allowlisted binary correctly triggers an approval request, proving trusted per-call hardening still works.
- **Why this is the smallest reliable guardrail:** It isolates the channel mismatch to exec policy resolution without needing external Telegram credentials, while still using the real host exec tool, PATH resolution, approvals file loading, allowlist evaluation, and gateway approval call boundary.

## Latest verification
- `git diff --check`
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec.security-floor.test.ts src/gateway/server-startup.test.ts`

## Root Cause
- **Root cause:** `createExecTool` treated model-supplied `security` as ignored, but still merged model-supplied `ask` with the configured/host policy through `maxAsk(hostAsk, requestedAsk)`. Natural-language channel runs can receive provider-generated tool arguments, so a Telegram run could strengthen `ask` to `always` or `on-miss` even though the user and host approvals had selected `ask: off`.
- **Why this is root-cause fix:** The source of truth for exec approval policy is now consistently the configured `tools.exec.*` policy intersected with host approvals for channel-origin model runs. Model/tool-call arguments can no longer make Telegram-origin exec diverge from webchat for the same allowlisted command. Trusted per-call `ask` hardening is preserved for direct/internal callers (no `messageProvider`) and when host ask is already elevated.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High
- **Patch quality notes:** The policy patch is a targeted 8-line change in the ask resolution block with two conditions: ignore model-supplied `ask` for channel-origin runs when host ask is `off`, else preserve the existing `maxAsk` contract. Two focused regression tests (one for the bug, one for trusted hardening). The schema and docs now match that conditional contract. The additional gateway test edits are type-only CI repairs for current main and do not affect runtime behavior.
- **Architecture / source-of-truth check:** The exec host policy resolver remains the source of truth; Telegram-specific delivery code is not changed because the bug occurs before approval delivery, when the exec tool decides whether an approval is needed.

## Review findings addressed
- **RF-001 — `status: waiting on author`:** addressed by this update. The PR body now maps each review finding to a current-head result and includes the remaining maintainer-decision boundary explicitly.
- **RF-002 — queued/in-progress checks:** stale on the current reviewed head. `ci-checkout-context.json` and `pr-current-checks.json` show the current PR head `b26866edb2db4852e3d5c0ee0e56d9f04e375e98` with CI, CodeQL, OpenGrep, dependency guard, workflow sanity, labeler, and Real behavior proof completed successfully.
- **RF-003 — live Telegram DM proof:** best available local proof is supplied above. It exercises the real OpenClaw exec decision path with Telegram-origin metadata and an allowlisted executable. A live Telegram Bot API DM was not run because this environment has no Telegram credentials; if maintainers require live transport proof before merge, that remains a maintainer/environment decision rather than a code repair.
- **RF-004 — exec approval-boundary change:** acknowledged and intentionally bounded. Only channel-origin model/provider-supplied `ask` is ignored when the effective host ask is already `off`; configured host policy, host approvals, allowlist enforcement, and trusted non-channel per-call hardening are preserved.
- **RF-005 — real behavior proof gap:** partially addressed with the local OpenClaw exec proof. It proves the shared host approval decision no longer creates an approval request or waitDecision for Telegram-origin allowlisted exec under `ask: off`; it does not prove live Telegram Bot API delivery.
- **RF-006 — required checks still queued/in progress:** stale on current head. Current-head check evidence shows the relevant checks have completed; skipped Mantis native Telegram jobs are external/live-proof jobs, not code failures.
- **RF-007 — maintainer acceptance of approval-boundary change:** acknowledged. The patch is ready for maintainer review with the security-boundary tradeoff stated here; no additional automated code repair is being hidden behind the submit.

## Merge risk
- **Why it matters / User impact:** Telegram DM users with `security=allowlist, ask=off` could still get approval prompts for allowlisted exec commands when a provider/model emitted `ask`, while the same policy worked in webchat. That breaks channel parity and can lose or stall user-visible automation.
- **Risk labels considered:** `merge-risk: compatibility`, `merge-risk: security-boundary`.
- **Risk explanation:** This changes an exec approval boundary for channel-origin model calls. The compatibility risk is that any workflow relying on model-supplied `ask` to harden channel exec calls will no longer get that hardening when host ask is `off`. The security-boundary risk is bounded because channel/model arguments are not the trusted policy source; configured `tools.exec.ask`, host approval files, allowlist enforcement, and trusted direct/internal per-call hardening still control approval behavior.
- **Why acceptable:** The fix restores the configured host policy as the source of truth for channel-origin exec, matches the issue’s webchat-vs-Telegram parity requirement, and is covered by regression tests for both the bug path and the preserved trusted-hardening path.
