### PR TITLE
fix(cron): reject blank delivery targets

### DIFF
--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -132,6 +132,56 @@ describe("cron protocol validators", () => {
     ).toBe(true);
   });
 
+  it("rejects blank cron delivery target strings", () => {
+    expect(
+      validateCronAddParams({
+        ...minimalAddParams,
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "   ",
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      validateCronUpdateParams({
+        id: "job-1",
+        patch: {
+          delivery: {
+            channel: "\t",
+          },
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      validateCronUpdateParams({
+        id: "job-1",
+        patch: {
+          delivery: {
+            failureDestination: {
+              channel: null,
+              to: " ",
+            },
+          },
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      validateCronUpdateParams({
+        id: "job-1",
+        patch: {
+          failureAlert: {
+            channel: "last",
+            to: "\n\t",
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
   it("accepts remove params for id and jobId selectors", () => {
     expect(validateCronRemoveParams({ id: "job-1" })).toBe(true);
     expect(validateCronRemoveParams({ jobId: "job-2" })).toBe(true);

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -75,6 +75,8 @@ const CronDeliveryStatusSchema = Type.Union([
   Type.Literal("unknown"),
   Type.Literal("not-requested"),
 ]);
+const NonBlankString = Type.String({ minLength: 1, pattern: "\\S" });
+const CronAnnounceChannelSchema = Type.Union([Type.Literal("last"), NonBlankString]);
 const CronFailoverReasonSchema = Type.Union([
   Type.Literal("auth"),
   Type.Literal("auth_permanent"),
@@ -215,8 +217,8 @@ export const CronPayloadPatchSchema = Type.Union([
 export const CronFailureAlertSchema = Type.Object(
   {
     after: Type.Optional(Type.Integer({ minimum: 1 })),
-    channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
-    to: Type.Optional(Type.String()),
+    channel: Type.Optional(CronAnnounceChannelSchema),
+    to: Type.Optional(NonBlankString),
     cooldownMs: Type.Optional(Type.Integer({ minimum: 0 })),
     includeSkipped: Type.Optional(Type.Boolean()),
     mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
@@ -227,8 +229,8 @@ export const CronFailureAlertSchema = Type.Object(
 
 export const CronFailureDestinationSchema = Type.Object(
   {
-    channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
-    to: Type.Optional(Type.String()),
+    channel: Type.Optional(CronAnnounceChannelSchema),
+    to: Type.Optional(NonBlankString),
     accountId: Type.Optional(NonEmptyString),
     mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
   },
@@ -237,8 +239,8 @@ export const CronFailureDestinationSchema = Type.Object(
 
 const CronFailureDestinationPatchSchema = Type.Object(
   {
-    channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString, Type.Null()])),
-    to: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    channel: Type.Optional(Type.Union([CronAnnounceChannelSchema, Type.Null()])),
+    to: Type.Optional(Type.Union([NonBlankString, Type.Null()])),
     accountId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     mode: Type.Optional(
       Type.Union([Type.Literal("announce"), Type.Literal("webhook"), Type.Null()]),
@@ -250,13 +252,13 @@ const CronFailureDestinationPatchSchema = Type.Object(
 export const CronCompletionDestinationSchema = Type.Object(
   {
     mode: Type.Literal("webhook"),
-    to: NonEmptyString,
+    to: NonBlankString,
   },
   { additionalProperties: false },
 );
 
 const CronDeliverySharedProperties = {
-  channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
+  channel: Type.Optional(CronAnnounceChannelSchema),
   threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
   accountId: Type.Optional(NonEmptyString),
   bestEffort: Type.Optional(Type.Boolean()),
@@ -264,7 +266,7 @@ const CronDeliverySharedProperties = {
 };
 
 const CronDeliveryPatchSharedProperties = {
-  channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString, Type.Null()])),
+  channel: Type.Optional(Type.Union([CronAnnounceChannelSchema, Type.Null()])),
   threadId: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
   accountId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   bestEffort: Type.Optional(Type.Boolean()),
@@ -275,7 +277,7 @@ const CronDeliveryNoopSchema = Type.Object(
   {
     mode: Type.Literal("none"),
     ...CronDeliverySharedProperties,
-    to: Type.Optional(Type.String()),
+    to: Type.Optional(NonBlankString),
   },
   { additionalProperties: false },
 );
@@ -285,7 +287,7 @@ const CronDeliveryAnnounceSchema = Type.Object(
     mode: Type.Literal("announce"),
     ...CronDeliverySharedProperties,
     completionDestination: Type.Optional(CronCompletionDestinationSchema),
-    to: Type.Optional(Type.String()),
+    to: Type.Optional(NonBlankString),
   },
   { additionalProperties: false },
 );
@@ -294,7 +296,7 @@ const CronDeliveryWebhookSchema = Type.Object(
   {
     mode: Type.Literal("webhook"),
     ...CronDeliverySharedProperties,
-    to: NonEmptyString,
+    to: NonBlankString,
   },
   { additionalProperties: false },
 );
@@ -314,7 +316,7 @@ export const CronDeliveryPatchSchema = Type.Object(
     completionDestination: Type.Optional(
       Type.Union([CronCompletionDestinationSchema, Type.Null()]),
     ),
-    to: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    to: Type.Optional(Type.Union([NonBlankString, Type.Null()])),
   },
   { additionalProperties: false },
 );

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -633,6 +633,34 @@ describe("cron tool", () => {
     expect(params?.failureAlert).toBe(false);
   });
 
+  it.each([
+    ["delivery.channel", { channel: " ", to: "chat-1" }],
+    ["delivery.to", { mode: "announce", channel: "telegram", to: " \t" }],
+    [
+      "delivery.failureDestination.to",
+      { mode: "announce", failureDestination: { mode: "announce", to: " " } },
+    ],
+    [
+      "delivery.completionDestination.to",
+      { mode: "announce", completionDestination: { mode: "webhook", to: "\n" } },
+    ],
+  ])("rejects blank cron.add %s before gateway normalization", async (field, delivery) => {
+    const tool = createTestCronTool();
+
+    await expect(
+      tool.execute("call-blank-delivery-add", {
+        action: "add",
+        job: {
+          name: "reminder",
+          schedule: { at: new Date(123).toISOString() },
+          payload: { kind: "agentTurn", message: "hello" },
+          delivery,
+        },
+      }),
+    ).rejects.toThrow(`${field} must be a non-empty string`);
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("recovers flattened add params for failureAlert and payload extras", async () => {
     const tool = createTestCronTool();
     await tool.execute("call-flat-add-extras", {
@@ -1334,6 +1362,55 @@ describe("cron tool", () => {
     expect(params?.id).toBe("job-1");
     expect(params?.patch?.name).toBe("new-name");
     expect(params?.patch?.enabled).toBe(false);
+  });
+
+  it.each([
+    ["delivery.channel", { channel: " " }],
+    ["delivery.to", { to: " " }],
+    ["delivery.failureDestination.to", { failureDestination: { to: " " } }],
+    ["delivery.completionDestination.to", { completionDestination: { mode: "webhook", to: " " } }],
+  ])("rejects blank cron.update %s before gateway normalization", async (field, delivery) => {
+    const tool = createTestCronTool();
+
+    await expect(
+      tool.execute("call-blank-delivery-update", {
+        action: "update",
+        id: "job-blank-delivery",
+        patch: { delivery },
+      }),
+    ).rejects.toThrow(`${field} must be a non-empty string`);
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("passes nullable cron.update delivery clears through to the gateway", async () => {
+    const tool = createTestCronTool();
+    await tool.execute("call-null-delivery-update", {
+      action: "update",
+      id: "job-clear-delivery",
+      patch: {
+        delivery: {
+          channel: null,
+          to: null,
+          failureDestination: null,
+          completionDestination: null,
+        },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | { id?: string; patch?: { delivery?: unknown } }
+      | undefined;
+    expect(params).toEqual({
+      id: "job-clear-delivery",
+      patch: {
+        delivery: {
+          channel: null,
+          to: null,
+          failureDestination: null,
+          completionDestination: null,
+        },
+      },
+    });
   });
 
   it("recovers additional flat patch params for update action", async () => {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -2,6 +2,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { Type, type TSchema } from "typebox";
 import { getRuntimeConfig } from "../../config/config.js";
 import { resolveCronCreationDelivery } from "../../cron/delivery-context.js";
+import { assertCronDeliveryInputNonBlankFields } from "../../cron/delivery-target-validation.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
 import type { CronDelivery } from "../../cron/types.js";
 import { normalizeHttpWebhookUrl } from "../../cron/webhook-url.js";
@@ -651,6 +652,7 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
             throw new Error("job required");
           }
           const canonicalJob = canonicalizeCronToolObject(params.job as Record<string, unknown>);
+          assertCronDeliveryInputNonBlankFields(canonicalJob.delivery);
           const job =
             normalizeCronJobCreate(canonicalJob, {
               sessionContext: { sessionKey: opts?.agentSessionKey },
@@ -767,6 +769,7 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
           const canonicalPatch = canonicalizeCronToolObject(
             params.patch as Record<string, unknown>,
           );
+          assertCronDeliveryInputNonBlankFields(canonicalPatch.delivery);
           const patch = normalizeCronJobPatch(canonicalPatch) ?? canonicalPatch;
           if (recoveredFlatPatch && isEmptyRecoveredCronPatch(patch)) {
             throw new Error("patch required");

--- a/src/cron/delivery-target-validation.ts
+++ b/src/cron/delivery-target-validation.ts
@@ -1,0 +1,36 @@
+function assertNonBlankStringField(field: string, value: unknown) {
+  if (value === undefined || value === null || typeof value !== "string") {
+    return;
+  }
+  if (value.trim()) {
+    return;
+  }
+  throw new Error(`${field} must be a non-empty string`);
+}
+
+export function assertCronDeliveryInputNonBlankFields(delivery: unknown, fieldPrefix = "delivery") {
+  if (!delivery || typeof delivery !== "object") {
+    return;
+  }
+  const deliveryRecord = delivery as {
+    channel?: unknown;
+    to?: unknown;
+    failureDestination?: unknown;
+    completionDestination?: unknown;
+  };
+  assertNonBlankStringField(`${fieldPrefix}.channel`, deliveryRecord.channel);
+  assertNonBlankStringField(`${fieldPrefix}.to`, deliveryRecord.to);
+
+  const failureDestination = deliveryRecord.failureDestination;
+  if (failureDestination && typeof failureDestination === "object") {
+    const failureRecord = failureDestination as { channel?: unknown; to?: unknown };
+    assertNonBlankStringField(`${fieldPrefix}.failureDestination.channel`, failureRecord.channel);
+    assertNonBlankStringField(`${fieldPrefix}.failureDestination.to`, failureRecord.to);
+  }
+
+  const completionDestination = deliveryRecord.completionDestination;
+  if (completionDestination && typeof completionDestination === "object") {
+    const completionRecord = completionDestination as { to?: unknown };
+    assertNonBlankStringField(`${fieldPrefix}.completionDestination.to`, completionRecord.to);
+  }
+}

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -118,6 +118,43 @@ function assertCompatibleAnnounceTarget(params: {
   }
 }
 
+function assertNonBlankStringField(field: string, value: unknown) {
+  if (value === undefined || value === null || typeof value !== "string") {
+    return;
+  }
+  if (value.trim()) {
+    return;
+  }
+  throw new Error(`${field} must be a non-empty string`);
+}
+
+function assertDeliveryInputNonBlankFields(delivery: unknown, fieldPrefix = "delivery") {
+  if (!delivery || typeof delivery !== "object") {
+    return;
+  }
+  const deliveryRecord = delivery as {
+    channel?: unknown;
+    to?: unknown;
+    failureDestination?: unknown;
+    completionDestination?: unknown;
+  };
+  assertNonBlankStringField(`${fieldPrefix}.channel`, deliveryRecord.channel);
+  assertNonBlankStringField(`${fieldPrefix}.to`, deliveryRecord.to);
+
+  const failureDestination = deliveryRecord.failureDestination;
+  if (failureDestination && typeof failureDestination === "object") {
+    const failureRecord = failureDestination as { channel?: unknown; to?: unknown };
+    assertNonBlankStringField(`${fieldPrefix}.failureDestination.channel`, failureRecord.channel);
+    assertNonBlankStringField(`${fieldPrefix}.failureDestination.to`, failureRecord.to);
+  }
+
+  const completionDestination = deliveryRecord.completionDestination;
+  if (completionDestination && typeof completionDestination === "object") {
+    const completionRecord = completionDestination as { to?: unknown };
+    assertNonBlankStringField(`${fieldPrefix}.completionDestination.to`, completionRecord.to);
+  }
+}
+
 function assertValidCronAnnounceDelivery(params: { cfg: OpenClawConfig; delivery?: CronDelivery }) {
   if (params.delivery && (params.delivery.mode ?? "announce") === "announce") {
     assertCompatibleAnnounceTarget({
@@ -364,6 +401,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         : undefined;
     let normalized: unknown;
     try {
+      assertDeliveryInputNonBlankFields((params as { delivery?: unknown } | null)?.delivery);
       normalized =
         normalizeCronJobCreate(params, {
           sessionContext: { sessionKey },
@@ -441,7 +479,13 @@ export const cronHandlers: GatewayRequestHandlers = {
   "cron.update": async ({ params, respond, context }) => {
     let normalizedPatch: ReturnType<typeof normalizeCronJobPatch>;
     try {
-      normalizedPatch = normalizeCronJobPatch((params as { patch?: unknown } | null)?.patch);
+      const rawPatch = (params as { patch?: unknown } | null)?.patch;
+      assertDeliveryInputNonBlankFields(
+        rawPatch && typeof rawPatch === "object"
+          ? (rawPatch as { delivery?: unknown }).delivery
+          : undefined,
+      );
+      normalizedPatch = normalizeCronJobPatch(rawPatch);
     } catch (err) {
       respond(
         false,

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveCronDeliveryPreviews } from "../../cron/delivery-preview.js";
+import { assertCronDeliveryInputNonBlankFields } from "../../cron/delivery-target-validation.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
 import {
   isInvalidCronRunLogJobIdError,
@@ -115,43 +116,6 @@ function assertCompatibleAnnounceTarget(params: {
   });
   if (error) {
     throw new Error(`${params.field}: ${error.message}`);
-  }
-}
-
-function assertNonBlankStringField(field: string, value: unknown) {
-  if (value === undefined || value === null || typeof value !== "string") {
-    return;
-  }
-  if (value.trim()) {
-    return;
-  }
-  throw new Error(`${field} must be a non-empty string`);
-}
-
-function assertDeliveryInputNonBlankFields(delivery: unknown, fieldPrefix = "delivery") {
-  if (!delivery || typeof delivery !== "object") {
-    return;
-  }
-  const deliveryRecord = delivery as {
-    channel?: unknown;
-    to?: unknown;
-    failureDestination?: unknown;
-    completionDestination?: unknown;
-  };
-  assertNonBlankStringField(`${fieldPrefix}.channel`, deliveryRecord.channel);
-  assertNonBlankStringField(`${fieldPrefix}.to`, deliveryRecord.to);
-
-  const failureDestination = deliveryRecord.failureDestination;
-  if (failureDestination && typeof failureDestination === "object") {
-    const failureRecord = failureDestination as { channel?: unknown; to?: unknown };
-    assertNonBlankStringField(`${fieldPrefix}.failureDestination.channel`, failureRecord.channel);
-    assertNonBlankStringField(`${fieldPrefix}.failureDestination.to`, failureRecord.to);
-  }
-
-  const completionDestination = deliveryRecord.completionDestination;
-  if (completionDestination && typeof completionDestination === "object") {
-    const completionRecord = completionDestination as { to?: unknown };
-    assertNonBlankStringField(`${fieldPrefix}.completionDestination.to`, completionRecord.to);
   }
 }
 
@@ -401,7 +365,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         : undefined;
     let normalized: unknown;
     try {
-      assertDeliveryInputNonBlankFields((params as { delivery?: unknown } | null)?.delivery);
+      assertCronDeliveryInputNonBlankFields((params as { delivery?: unknown } | null)?.delivery);
       normalized =
         normalizeCronJobCreate(params, {
           sessionContext: { sessionKey },
@@ -480,7 +444,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     let normalizedPatch: ReturnType<typeof normalizeCronJobPatch>;
     try {
       const rawPatch = (params as { patch?: unknown } | null)?.patch;
-      assertDeliveryInputNonBlankFields(
+      assertCronDeliveryInputNonBlankFields(
         rawPatch && typeof rawPatch === "object"
           ? (rawPatch as { delivery?: unknown }).delivery
           : undefined,

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -507,6 +507,48 @@ describe("cron method validation", () => {
     expectCronSuccess(respond);
   });
 
+  it("rejects blank announce delivery fields before normalization", async () => {
+    const { context, respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "blank delivery target",
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "   ",
+        },
+      }),
+    );
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "delivery.to must be a non-empty string",
+    });
+  });
+
+  it("rejects blank failure destination fields before normalization", async () => {
+    const { context, respond } = await invokeCronAdd(
+      agentTurnCronParams({
+        name: "blank failure target",
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:123",
+          failureDestination: {
+            mode: "announce",
+            channel: "   ",
+          },
+        },
+      }),
+    );
+
+    expect(context.cron.add).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "delivery.failureDestination.channel must be a non-empty string",
+    });
+  });
+
   it("rejects announce targets prefixed for a different explicit delivery channel", async () => {
     setRuntimeConfig(telegramSlackConfig());
 
@@ -600,6 +642,53 @@ describe("cron method validation", () => {
     const clearPatch = requireCronUpdatePatch(clearResult.context);
     const clearDelivery = requireRecord(clearPatch.delivery, "delivery");
     expect(clearDelivery.completionDestination).toBeNull();
+  });
+
+  it("rejects blank delivery target patches before normalization", async () => {
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          delivery: {
+            to: "\t",
+          },
+        },
+      },
+      createCronJob({
+        delivery: { mode: "announce", channel: "telegram", to: "telegram:123" },
+      }),
+    );
+
+    expect(context.cron.update).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "delivery.to must be a non-empty string",
+    });
+  });
+
+  it("rejects blank completion destination patches before normalization", async () => {
+    const { context, respond } = await invokeCronUpdate(
+      {
+        id: "cron-1",
+        patch: {
+          delivery: {
+            completionDestination: {
+              mode: "webhook",
+              to: " ",
+            },
+          },
+        },
+      },
+      createCronJob({
+        delivery: { mode: "announce" },
+      }),
+    );
+
+    expect(context.cron.update).not.toHaveBeenCalled();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "delivery.completionDestination.to must be a non-empty string",
+    });
   });
 
   it("accepts nullable delivery target clears on update", async () => {


### PR DESCRIPTION
## Summary

- reject whitespace-only cron delivery target fields in the gateway protocol schema
- add shared pre-normalization validation so blank delivery fields are not silently dropped by either direct gateway calls or the agent cron tool
- keep nullable update clears working for delivery, failure destination, and completion destination fields

Based on internal commit `44ba4113f4c95f046b0687a5bd401f95a02923c3`.

## Verification

- `node scripts/test-projects.mjs src/agents/tools/cron-tool.test.ts packages/gateway-protocol/src/cron-validators.test.ts src/gateway/server-methods/cron.validation.test.ts` - passed 3 Vitest shards, 145 tests
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/test-projects.mjs src/agents/tools/cron-tool.test.ts packages/gateway-protocol/src/cron-validators.test.ts src/gateway/server-methods/cron.validation.test.ts"` - clean, no accepted/actionable findings
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.local.tsbuildinfo` - still fails on current `upstream/main` test typing in untouched files: `src/gateway/server-plugins.test.ts:123` and `src/gateway/server-startup.test.ts:25`

## Real behavior proof

Behavior addressed: Blank cron delivery target strings are rejected instead of being normalized away before validation.

Real environment tested: Local OpenClaw source checkout at `34e2afa9af`, Node v25.8.1, production cron tool and gateway handler modules loaded with `node --import tsx`. No channel credentials were required because the invalid request is rejected before delivery or cron service execution.

Exact steps or command run after this patch:

```bash
node --import tsx --input-type=module <<'EOF'
import { createCronTool } from './src/agents/tools/cron-tool.ts';
import { cronHandlers } from './src/gateway/server-methods/cron.ts';

let gatewayCalled = false;
const tool = createCronTool(undefined, {
  callGatewayTool: async () => {
    gatewayCalled = true;
    throw new Error('callGateway should not be reached');
  },
});

try {
  await tool.execute('proof-tool-add', {
    action: 'add',
    job: {
      name: 'blank delivery proof',
      schedule: { at: new Date(123).toISOString() },
      payload: { kind: 'agentTurn', message: 'hello' },
      delivery: { mode: 'announce', channel: 'telegram', to: '   ' },
    },
  });
  console.log('tool add: unexpected success');
} catch (error) {
  console.log(`tool add rejected: ${error instanceof Error ? error.message : String(error)}`);
  console.log(`tool add gatewayCalled: ${gatewayCalled}`);
}

let response;
await cronHandlers['cron.add']({
  params: {
    name: 'blank delivery proof',
    schedule: { kind: 'at', at: new Date(123).toISOString() },
    payload: { kind: 'agentTurn', message: 'hello' },
    delivery: { mode: 'announce', channel: 'telegram', to: '   ' },
  },
  respond: (ok, result, error) => {
    response = { ok, result, error };
  },
  context: {},
});
console.log(`gateway cron.add ok: ${response?.ok}`);
console.log(`gateway cron.add error code: ${response?.error?.code}`);
console.log(`gateway cron.add error message: ${response?.error?.message}`);
EOF
```

Evidence after fix:

```text
tool add rejected: delivery.to must be a non-empty string
tool add gatewayCalled: false
gateway cron.add ok: false
gateway cron.add error code: INVALID_REQUEST
gateway cron.add error message: invalid cron.add params: delivery.to must be a non-empty string
```

Observed result after fix: The agent cron tool rejects the blank target before calling the gateway, and the direct gateway `cron.add` path returns `INVALID_REQUEST` for the same blank target.

What was not tested: I did not run a live scheduled job or real channel delivery, because this change is an invalid-request validation path that stops before cron persistence or outbound delivery.

🤖 Generated with Codex.

