### PR TITLE
fix: skip setup-only channel plugins in outbound resolution and drain pending deliveries on qqbot reconnect

### DIFF
--- a/extensions/qqbot/src/channel.test.ts
+++ b/extensions/qqbot/src/channel.test.ts
@@ -138,6 +138,18 @@ function expectReconnectDrainSelection(selectEntry: (entry: PendingDeliveryEntry
     match: true,
     bypassBackoff: true,
   });
+  // The reported regression leaves this exact lastError on pending entries;
+  // the bypass predicate must drain them immediately on reconnect.
+  expect(
+    selectEntry({
+      channel: "qqbot",
+      accountId: "default",
+      lastError: "Outbound not configured for channel: qqbot",
+    } as PendingDeliveryEntry),
+  ).toEqual({
+    match: true,
+    bypassBackoff: true,
+  });
 }
 
 describe("qqbot gateway reconnect delivery drain", () => {

--- a/extensions/qqbot/src/channel.test.ts
+++ b/extensions/qqbot/src/channel.test.ts
@@ -1,0 +1,164 @@
+import { createStartAccountContext } from "openclaw/plugin-sdk/channel-test-helpers";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { qqbotPlugin } from "./channel.js";
+import type { ResolvedQQBotAccount } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  drainPendingDeliveries: vi.fn(async () => {}),
+  startGateway: vi.fn(async () => {}),
+  loadCredentialBackup: vi.fn(),
+  saveCredentialBackup: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/delivery-queue-runtime", () => ({
+  drainPendingDeliveries: mocks.drainPendingDeliveries,
+}));
+
+vi.mock("./bridge/gateway.js", () => ({
+  startGateway: mocks.startGateway,
+}));
+
+vi.mock("./engine/config/credential-backup.js", () => ({
+  loadCredentialBackup: mocks.loadCredentialBackup,
+  saveCredentialBackup: mocks.saveCredentialBackup,
+}));
+
+type GatewayStartOptions = {
+  onReady?: () => Promise<void>;
+  onResumed?: () => Promise<void>;
+};
+
+type PendingDeliveryEntry = {
+  channel: string;
+  accountId?: string | null;
+  lastError?: string | null;
+};
+
+const cfg = {
+  channels: {
+    qqbot: {
+      enabled: true,
+      appId: "app",
+      clientSecret: "secret",
+    },
+  },
+} as OpenClawConfig;
+
+function buildAccount(): ResolvedQQBotAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    appId: "app",
+    clientSecret: "secret",
+    secretSource: "config",
+    markdownSupport: true,
+    config: {
+      enabled: true,
+      appId: "app",
+      clientSecret: "secret",
+    },
+  };
+}
+
+async function startAccountAndGetGatewayOptions(): Promise<GatewayStartOptions> {
+  await qqbotPlugin.gateway?.startAccount?.(
+    createStartAccountContext({
+      account: buildAccount(),
+      cfg,
+    }),
+  );
+  expect(mocks.startGateway).toHaveBeenCalledOnce();
+  return mocks.startGateway.mock.calls[0]?.[0] as GatewayStartOptions;
+}
+
+function latestDrainOptions() {
+  const call = mocks.drainPendingDeliveries.mock.calls.at(-1);
+  if (!call) {
+    throw new Error("expected drainPendingDeliveries call");
+  }
+  return call[0];
+}
+
+function expectReconnectDrainSelection(selectEntry: (entry: PendingDeliveryEntry) => unknown) {
+  expect(
+    selectEntry({
+      channel: "qqbot",
+      accountId: "default",
+      lastError: "gateway disconnected",
+    } as PendingDeliveryEntry),
+  ).toEqual({
+    match: true,
+    bypassBackoff: true,
+  });
+  expect(
+    selectEntry({
+      channel: "telegram",
+      accountId: "default",
+      lastError: "gateway disconnected",
+    } as PendingDeliveryEntry),
+  ).toEqual({
+    match: false,
+    bypassBackoff: true,
+  });
+  expect(
+    selectEntry({
+      channel: "qqbot",
+      accountId: "other",
+      lastError: "not connected",
+    } as PendingDeliveryEntry),
+  ).toEqual({
+    match: false,
+    bypassBackoff: true,
+  });
+  expect(
+    selectEntry({
+      channel: "qqbot",
+      accountId: "default",
+      lastError: "rate limited",
+    } as PendingDeliveryEntry),
+  ).toEqual({
+    match: true,
+    bypassBackoff: false,
+  });
+  expect(
+    selectEntry({
+      channel: "qqbot",
+      accountId: undefined,
+      lastError: "gateway disconnected",
+    } as PendingDeliveryEntry),
+  ).toEqual({
+    match: true,
+    bypassBackoff: true,
+  });
+}
+
+describe("qqbot gateway reconnect delivery drain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("drains matching pending deliveries when the gateway becomes ready", async () => {
+    const options = await startAccountAndGetGatewayOptions();
+    await options.onReady?.();
+
+    expect(mocks.drainPendingDeliveries).toHaveBeenCalledOnce();
+    const drainOptions = latestDrainOptions();
+    expect(drainOptions.drainKey).toBe("qqbot:default");
+    expect(drainOptions.logLabel).toBe("QQBot reconnect drain");
+    expect(drainOptions.cfg).toBe(cfg);
+    expectReconnectDrainSelection(drainOptions.selectEntry);
+  });
+
+  it("drains matching pending deliveries when the gateway resumes", async () => {
+    const options = await startAccountAndGetGatewayOptions();
+    await options.onResumed?.();
+
+    expect(mocks.drainPendingDeliveries).toHaveBeenCalledOnce();
+    const drainOptions = latestDrainOptions();
+    expect(drainOptions.drainKey).toBe("qqbot:default");
+    expect(drainOptions.logLabel).toBe("QQBot reconnect drain");
+    expect(drainOptions.cfg).toBe(cfg);
+    expectReconnectDrainSelection(drainOptions.selectEntry);
+  });
+});

--- a/extensions/qqbot/src/channel.test.ts
+++ b/extensions/qqbot/src/channel.test.ts
@@ -76,7 +76,7 @@ async function startAccountAndGetGatewayOptions(): Promise<GatewayStartOptions> 
     }),
   );
   expect(mocks.startGateway).toHaveBeenCalledOnce();
-  return mocks.startGateway.mock.calls[0]?.[0] as unknown as GatewayStartOptions;
+  return (mocks.startGateway.mock.calls as unknown[][])[0]?.[0] as GatewayStartOptions;
 }
 
 function latestDrainOptions(): ReconnectDrainOptions {
@@ -84,7 +84,7 @@ function latestDrainOptions(): ReconnectDrainOptions {
   if (!call) {
     throw new Error("expected drainPendingDeliveries call");
   }
-  return call[0] as unknown as ReconnectDrainOptions;
+  return (call as unknown[])[0] as ReconnectDrainOptions;
 }
 
 function expectReconnectDrainSelection(selectEntry: (entry: PendingDeliveryEntry) => unknown) {
@@ -147,9 +147,11 @@ describe("qqbot gateway reconnect delivery drain", () => {
 
   it("drains matching pending deliveries when the gateway becomes ready", async () => {
     const options = await startAccountAndGetGatewayOptions();
-    await options.onReady?.();
+    options.onReady?.();
 
-    expect(mocks.drainPendingDeliveries).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(mocks.drainPendingDeliveries).toHaveBeenCalledOnce();
+    });
     const drainOptions = latestDrainOptions();
     expect(drainOptions.drainKey).toBe("qqbot:default");
     expect(drainOptions.logLabel).toBe("QQBot reconnect drain");
@@ -159,9 +161,11 @@ describe("qqbot gateway reconnect delivery drain", () => {
 
   it("drains matching pending deliveries when the gateway resumes", async () => {
     const options = await startAccountAndGetGatewayOptions();
-    await options.onResumed?.();
+    options.onResumed?.();
 
-    expect(mocks.drainPendingDeliveries).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(mocks.drainPendingDeliveries).toHaveBeenCalledOnce();
+    });
     const drainOptions = latestDrainOptions();
     expect(drainOptions.drainKey).toBe("qqbot:default");
     expect(drainOptions.logLabel).toBe("QQBot reconnect drain");

--- a/extensions/qqbot/src/channel.test.ts
+++ b/extensions/qqbot/src/channel.test.ts
@@ -25,14 +25,21 @@ vi.mock("./engine/config/credential-backup.js", () => ({
 }));
 
 type GatewayStartOptions = {
-  onReady?: () => Promise<void>;
-  onResumed?: () => Promise<void>;
+  onReady?: () => void;
+  onResumed?: () => void;
 };
 
 type PendingDeliveryEntry = {
   channel: string;
   accountId?: string | null;
   lastError?: string | null;
+};
+
+type ReconnectDrainOptions = {
+  drainKey: string;
+  logLabel: string;
+  cfg: OpenClawConfig;
+  selectEntry: (entry: PendingDeliveryEntry) => unknown;
 };
 
 const cfg = {
@@ -69,15 +76,15 @@ async function startAccountAndGetGatewayOptions(): Promise<GatewayStartOptions> 
     }),
   );
   expect(mocks.startGateway).toHaveBeenCalledOnce();
-  return mocks.startGateway.mock.calls[0]?.[0] as GatewayStartOptions;
+  return mocks.startGateway.mock.calls[0]?.[0] as unknown as GatewayStartOptions;
 }
 
-function latestDrainOptions() {
+function latestDrainOptions(): ReconnectDrainOptions {
   const call = mocks.drainPendingDeliveries.mock.calls.at(-1);
   if (!call) {
     throw new Error("expected drainPendingDeliveries call");
   }
-  return call[0];
+  return call[0] as unknown as ReconnectDrainOptions;
 }
 
 function expectReconnectDrainSelection(selectEntry: (entry: PendingDeliveryEntry) => unknown) {

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -407,7 +407,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
         cfg,
         log,
         channelRuntime: ctx.channelRuntime as GatewayContext["channelRuntime"],
-        onReady: async () => {
+        onReady: () => {
           log?.info(`[qqbot:${account.accountId}] Gateway ready`);
           ctx.setStatus({
             ...ctx.getStatus(),
@@ -419,9 +419,11 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
           // Snapshot credentials so we can recover from the next hot
           // upgrade that might wipe openclaw.json mid-flight.
           persistAccountCredentialSnapshot(account);
-          await drainReconnectPendingDeliveries();
+          // Fire-and-forget: the drain helper owns its try/catch, so a
+          // failed reconnect drain never rejects into the void callback.
+          void drainReconnectPendingDeliveries();
         },
-        onResumed: async () => {
+        onResumed: () => {
           log?.info(`[qqbot:${account.accountId}] Gateway resumed`);
           ctx.setStatus({
             ...ctx.getStatus(),
@@ -431,7 +433,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
             lastError: null,
           });
           persistAccountCredentialSnapshot(account);
-          await drainReconnectPendingDeliveries();
+          void drainReconnectPendingDeliveries();
         },
         onError: (error) => {
           log?.error(`[qqbot:${account.accountId}] Gateway error: ${error.message}`);

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -10,6 +10,7 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
 // Register the PlatformAdapter before any core/ module is used.
 import "./bridge/bootstrap.js";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
@@ -374,13 +375,39 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
         `[qqbot:${account.accountId}] Starting gateway — appId=${account.appId}, enabled=${account.enabled}, name=${account.name ?? "unnamed"}`,
       );
 
+      const drainReconnectPendingDeliveries = async () => {
+        try {
+          await drainPendingDeliveries({
+            drainKey: `qqbot:${account.accountId}`,
+            logLabel: "QQBot reconnect drain",
+            cfg,
+            log: {
+              info: (message) => log?.info(message),
+              warn: (message) => log?.warn(message),
+              error: (message) => log?.error(message),
+            },
+            selectEntry: (entry) => ({
+              match:
+                entry.channel === "qqbot" &&
+                (entry.accountId === account.accountId ||
+                  (!entry.accountId && account.accountId === DEFAULT_ACCOUNT_ID)),
+              bypassBackoff: /not connected|disconnected|gateway/i.test(entry.lastError ?? ""),
+            }),
+          });
+        } catch (err) {
+          log?.error(
+            `[qqbot:${account.accountId}] Reconnect delivery drain failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      };
+
       await startGateway({
         account,
         abortSignal,
         cfg,
         log,
         channelRuntime: ctx.channelRuntime as GatewayContext["channelRuntime"],
-        onReady: () => {
+        onReady: async () => {
           log?.info(`[qqbot:${account.accountId}] Gateway ready`);
           ctx.setStatus({
             ...ctx.getStatus(),
@@ -392,8 +419,9 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
           // Snapshot credentials so we can recover from the next hot
           // upgrade that might wipe openclaw.json mid-flight.
           persistAccountCredentialSnapshot(account);
+          await drainReconnectPendingDeliveries();
         },
-        onResumed: () => {
+        onResumed: async () => {
           log?.info(`[qqbot:${account.accountId}] Gateway resumed`);
           ctx.setStatus({
             ...ctx.getStatus(),
@@ -403,6 +431,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
             lastError: null,
           });
           persistAccountCredentialSnapshot(account);
+          await drainReconnectPendingDeliveries();
         },
         onError: (error) => {
           log?.error(`[qqbot:${account.accountId}] Gateway error: ${error.message}`);

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -9,8 +9,8 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Register the PlatformAdapter before any core/ module is used.
 import "./bridge/bootstrap.js";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -391,7 +391,9 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
                 entry.channel === "qqbot" &&
                 (entry.accountId === account.accountId ||
                   (!entry.accountId && account.accountId === DEFAULT_ACCOUNT_ID)),
-              bypassBackoff: /not connected|disconnected|gateway/i.test(entry.lastError ?? ""),
+              bypassBackoff: /not connected|disconnected|gateway|outbound not configured/i.test(
+                entry.lastError ?? "",
+              ),
             }),
           });
         } catch (err) {

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1345,6 +1345,57 @@ describe("gateway send mirroring", () => {
     expect(response?.[2]?.message).toContain("Channel is required");
   });
 
+  it("dispatches gateway polls through a poll-capable fallback when the first plugin is text-only", async () => {
+    // First match is a text-only shell with no sendPoll; the operation-aware
+    // delivery resolver must skip it for a poll and use the poll-capable runtime
+    // plugin instead of returning "unsupported poll channel".
+    mocks.getChannelPlugin.mockReturnValue({
+      id: "slack",
+      outbound: {
+        deliveryMode: "direct",
+        sendText: async () => ({ channel: "slack", messageId: "shell-text" }),
+      },
+    });
+    const fallbackSendPoll = vi.fn(async () => ({ messageId: "poll-fallback-1" }));
+    const pollCapablePlugin = {
+      id: "slack",
+      meta: {
+        id: "slack",
+        label: "Slack",
+        selectionLabel: "Slack",
+        docsPath: "/channels/slack",
+        blurb: "Slack poll fallback test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      outbound: { deliveryMode: "direct", sendPoll: fallbackSendPoll },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "slack", source: "test", plugin: pollCapablePlugin }]),
+      "send-test-poll-capable-fallback",
+    );
+
+    const { respond } = await runPoll({
+      to: "channel:C1",
+      question: "Q?",
+      options: ["A", "B"],
+      channel: "slack",
+      idempotencyKey: "idem-poll-capable-fallback",
+    });
+
+    expect(fallbackSendPoll).toHaveBeenCalledTimes(1);
+    expect(mocks.sendPoll).not.toHaveBeenCalled();
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(true);
+    expect(response?.[1]?.messageId).toBe("poll-fallback-1");
+    expect(response?.[2]).toBeUndefined();
+    expect(response?.[3]?.channel).toBe("slack");
+  });
+
   it("does not mirror when delivery returns no results", async () => {
     mocks.deliverOutboundPayloads.mockResolvedValue([]);
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -26,7 +26,10 @@ import {
   selectApplicableRuntimeConfig,
 } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resolution.js";
+import {
+  resolveOutboundChannelPlugin,
+  resolveOutboundChannelPluginForDelivery,
+} from "../../infra/outbound/channel-resolution.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import {
   hydrateAttachmentParamsForAction,
@@ -967,7 +970,15 @@ export const sendHandlers: GatewayRequestHandlers = {
         return { ok: false, error: resolvedChannel.error };
       }
       const { cfg, channel } = resolvedChannel;
-      const plugin = resolveOutboundChannelPlugin({ channel, cfg });
+      // Poll delivery is operation-gated: route through the delivery resolver so a
+      // setup-only/text-only first-match plugin cannot shadow a poll-capable
+      // runtime fallback and force a spurious "unsupported poll channel".
+      const plugin = resolveOutboundChannelPluginForDelivery({
+        channel,
+        cfg,
+        allowBootstrap: true,
+        operation: "poll",
+      });
       const outbound = plugin?.outbound;
       if (
         typeof request.durationSeconds === "number" &&

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -791,4 +791,54 @@ describe("outbound channel resolution", () => {
       }),
     ).toBe(plugin);
   });
+
+  it("delivery resolver resolves an external channel from the active registry when the pin is stale without bootstrapping", async () => {
+    // External id is not statically deliverable and is missing from the pinned
+    // channel registry, but its send-capable runtime is live in the active
+    // registry; the delivery resolver must find it without a second bootstrap.
+    const plugin = { id: "external-channel", outbound: { sendText: vi.fn() } };
+    isDeliverableMessageChannelMock.mockReturnValue(false);
+    getLoadedChannelPluginMock.mockReturnValue(undefined);
+    getChannelPluginMock.mockReturnValue(undefined);
+    getActivePluginChannelRegistryMock.mockReturnValue({
+      channels: [{ plugin: { id: "other-channel" } }],
+    });
+    getActivePluginRegistryMock.mockReturnValue({ channels: [{ plugin }] });
+    const channelResolution = await importChannelResolution("delivery-external-active-registry");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "external-channel",
+        cfg: { channels: {} } as never,
+        allowBootstrap: true,
+      }),
+    ).toBe(plugin);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("delivery resolver bootstraps an external channel exactly once before resolving its sender", async () => {
+    // The external id only becomes resolvable after bootstrap; the shared
+    // normalize path bootstraps it, and the `|| didBootstrap` guard must stop
+    // the delivery resolver from bootstrapping a second time.
+    const plugin = { id: "external-channel", outbound: { sendText: vi.fn() } };
+    isDeliverableMessageChannelMock.mockReturnValue(false);
+    getLoadedChannelPluginMock.mockReturnValue(undefined);
+    getChannelPluginMock.mockReturnValue(undefined);
+    getActivePluginChannelRegistryMock.mockReturnValue({ channels: [] });
+    getActivePluginRegistryMock.mockImplementation(() =>
+      resolveRuntimePluginRegistryMock.mock.calls.length > 0
+        ? { channels: [{ plugin }] }
+        : { channels: [] },
+    );
+    const channelResolution = await importChannelResolution("delivery-external-bootstrap-once");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "external-channel",
+        cfg: { channels: {} } as never,
+        allowBootstrap: true,
+      }),
+    ).toBe(plugin);
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -716,4 +716,79 @@ describe("outbound channel resolution", () => {
       }),
     ).toBe(plugin);
   });
+
+  it("delivery resolver rejects a media-only non-gateway plugin", async () => {
+    // Direct/hybrid media rides createPluginHandler, which requires a text
+    // sender; a media-only plugin is a false positive that fails later with
+    // "Outbound not configured", so the delivery resolver must skip it.
+    const mediaOnlyPlugin = {
+      id: "alpha",
+      outbound: { deliveryMode: "direct", sendMedia: vi.fn() },
+    };
+    getLoadedChannelPluginMock.mockReturnValue(mediaOnlyPlugin);
+    getChannelPluginMock.mockReturnValue(mediaOnlyPlugin);
+    getActivePluginRegistryMock.mockReturnValue({ channels: [] });
+    const channelResolution = await importChannelResolution("delivery-media-only");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("delivery resolver resolves a gateway-mode plugin with no local send methods", async () => {
+    const gatewayPlugin = { id: "alpha", outbound: { deliveryMode: "gateway" } };
+    getLoadedChannelPluginMock.mockReturnValue(gatewayPlugin);
+    const channelResolution = await importChannelResolution("delivery-gateway-only");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(gatewayPlugin);
+  });
+
+  it("delivery resolver resolves a plugin sending text via message.send.text", async () => {
+    const plugin = createSendingPlugin("alpha");
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
+    const channelResolution = await importChannelResolution("delivery-message-text");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(plugin);
+  });
+
+  it("delivery resolver resolves a plugin with only the legacy outbound text adapter", async () => {
+    const plugin = { id: "alpha", outbound: { deliveryMode: "direct", sendText: vi.fn() } };
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
+    const channelResolution = await importChannelResolution("delivery-legacy-outbound-text");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(plugin);
+  });
+
+  it("delivery resolver resolves a poll-only non-gateway plugin", async () => {
+    // sendPoll() routes through the gateway gated only by outbound.sendPoll, so
+    // a direct poll-only plugin is independently deliverable.
+    const plugin = { id: "alpha", outbound: { deliveryMode: "direct", sendPoll: vi.fn() } };
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
+    const channelResolution = await importChannelResolution("delivery-poll-only");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(plugin);
+  });
 });

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -644,6 +644,7 @@ describe("outbound channel resolution", () => {
       channelResolution.resolveOutboundChannelPluginForDelivery({
         channel: "alpha",
         cfg: {} as never,
+        operation: "text",
       }),
     ).toBeUndefined();
   });
@@ -661,6 +662,7 @@ describe("outbound channel resolution", () => {
       channelResolution.resolveOutboundChannelPluginForDelivery({
         channel: "alpha",
         cfg: {} as never,
+        operation: "text",
       }),
     ).toBe(registryPlugin);
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
@@ -680,6 +682,7 @@ describe("outbound channel resolution", () => {
         channel: "alpha",
         cfg: { channels: {} } as never,
         allowBootstrap: true,
+        operation: "text",
       }),
     ).toBe(sendCapable);
     expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledOnce();
@@ -734,6 +737,7 @@ describe("outbound channel resolution", () => {
       channelResolution.resolveOutboundChannelPluginForDelivery({
         channel: "alpha",
         cfg: {} as never,
+        operation: "text",
       }),
     ).toBeUndefined();
   });
@@ -743,12 +747,42 @@ describe("outbound channel resolution", () => {
     getLoadedChannelPluginMock.mockReturnValue(gatewayPlugin);
     const channelResolution = await importChannelResolution("delivery-gateway-only");
 
+    // Gateway plugins deliver text through callMessageGateway with no local send
+    // method, so the gateway short-circuit qualifies them for text.
     expect(
       channelResolution.resolveOutboundChannelPluginForDelivery({
         channel: "alpha",
         cfg: {} as never,
+        operation: "text",
       }),
     ).toBe(gatewayPlugin);
+    // But poll always requires outbound.sendPoll (the gateway poll path rejects a
+    // pollless surface), so a gateway plugin without sendPoll must NOT resolve
+    // for a poll send.
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+        operation: "poll",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("delivery resolver resolves a gateway-mode plugin with sendPoll for a poll send", async () => {
+    const gatewayPollPlugin = {
+      id: "alpha",
+      outbound: { deliveryMode: "gateway", sendPoll: vi.fn() },
+    };
+    getLoadedChannelPluginMock.mockReturnValue(gatewayPollPlugin);
+    const channelResolution = await importChannelResolution("delivery-gateway-poll");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+        operation: "poll",
+      }),
+    ).toBe(gatewayPollPlugin);
   });
 
   it("delivery resolver resolves a plugin sending text via message.send.text", async () => {
@@ -760,6 +794,7 @@ describe("outbound channel resolution", () => {
       channelResolution.resolveOutboundChannelPluginForDelivery({
         channel: "alpha",
         cfg: {} as never,
+        operation: "text",
       }),
     ).toBe(plugin);
   });
@@ -773,13 +808,14 @@ describe("outbound channel resolution", () => {
       channelResolution.resolveOutboundChannelPluginForDelivery({
         channel: "alpha",
         cfg: {} as never,
+        operation: "text",
       }),
     ).toBe(plugin);
   });
 
-  it("delivery resolver resolves a poll-only non-gateway plugin", async () => {
+  it("delivery resolver resolves a poll-only non-gateway plugin for a poll send", async () => {
     // sendPoll() routes through the gateway gated only by outbound.sendPoll, so
-    // a direct poll-only plugin is independently deliverable.
+    // a direct poll-only plugin is independently deliverable for a poll send.
     const plugin = { id: "alpha", outbound: { deliveryMode: "direct", sendPoll: vi.fn() } };
     getLoadedChannelPluginMock.mockReturnValue(plugin);
     const channelResolution = await importChannelResolution("delivery-poll-only");
@@ -788,8 +824,51 @@ describe("outbound channel resolution", () => {
       channelResolution.resolveOutboundChannelPluginForDelivery({
         channel: "alpha",
         cfg: {} as never,
+        operation: "poll",
       }),
     ).toBe(plugin);
+  });
+
+  it("delivery resolver text send skips a poll-only registration and returns a text-capable fallback", async () => {
+    // A poll-only direct registration cannot deliver text (it would later fail
+    // with "Outbound not configured"), so a text send must skip it and resolve
+    // the text-capable runtime fallback instead of letting it win the lookup.
+    const pollOnlyLoaded = { id: "alpha", outbound: { deliveryMode: "direct", sendPoll: vi.fn() } };
+    const textCapable = createSendingPlugin("alpha");
+    getLoadedChannelPluginMock.mockReturnValue(pollOnlyLoaded);
+    getChannelPluginMock.mockReturnValue(undefined);
+    getActivePluginRegistryMock.mockReturnValue({ channels: [{ plugin: textCapable }] });
+    getActivePluginChannelRegistryMock.mockReturnValue({ channels: [{ plugin: textCapable }] });
+    const channelResolution = await importChannelResolution("delivery-poll-only-not-shadow-text");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+        operation: "text",
+      }),
+    ).toBe(textCapable);
+  });
+
+  it("delivery resolver poll send skips a text-only registration and returns a poll-capable fallback", async () => {
+    // A text-only direct registration cannot deliver a poll (sendPoll() would
+    // throw "Unsupported poll channel"), so a poll send must skip it and resolve
+    // the poll-capable runtime fallback instead of letting it win the lookup.
+    const textOnlyLoaded = { id: "alpha", outbound: { deliveryMode: "direct", sendText: vi.fn() } };
+    const pollCapable = { id: "alpha", outbound: { deliveryMode: "direct", sendPoll: vi.fn() } };
+    getLoadedChannelPluginMock.mockReturnValue(textOnlyLoaded);
+    getChannelPluginMock.mockReturnValue(undefined);
+    getActivePluginRegistryMock.mockReturnValue({ channels: [{ plugin: pollCapable }] });
+    getActivePluginChannelRegistryMock.mockReturnValue({ channels: [{ plugin: pollCapable }] });
+    const channelResolution = await importChannelResolution("delivery-text-only-not-shadow-poll");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+        operation: "poll",
+      }),
+    ).toBe(pollCapable);
   });
 
   it("delivery resolver resolves an external channel from the active registry when the pin is stale without bootstrapping", async () => {
@@ -811,6 +890,7 @@ describe("outbound channel resolution", () => {
         channel: "external-channel",
         cfg: { channels: {} } as never,
         allowBootstrap: true,
+        operation: "text",
       }),
     ).toBe(plugin);
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
@@ -837,6 +917,7 @@ describe("outbound channel resolution", () => {
         channel: "external-channel",
         cfg: { channels: {} } as never,
         allowBootstrap: true,
+        operation: "text",
       }),
     ).toBe(plugin);
     expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledTimes(1);

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -70,6 +70,14 @@ function firstMockArg(mock: { mock: { calls: readonly unknown[][] } }): Record<s
   return arg as Record<string, unknown>;
 }
 
+function createSendingPlugin(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    message: { send: { text: vi.fn() } },
+    ...overrides,
+  };
+}
+
 describe("outbound channel resolution", () => {
   beforeEach(async () => {
     resolveDefaultAgentIdMock.mockReset();
@@ -116,7 +124,7 @@ describe("outbound channel resolution", () => {
   });
 
   it("returns the already-registered plugin without bootstrapping", async () => {
-    const plugin = { id: "alpha", outbound: { sendText: vi.fn() } };
+    const plugin = createSendingPlugin("alpha");
     getLoadedChannelPluginMock.mockReturnValueOnce(plugin);
     const channelResolution = await importChannelResolution("existing-plugin");
 
@@ -130,7 +138,7 @@ describe("outbound channel resolution", () => {
   });
 
   it("returns a bundled plugin without bootstrapping", async () => {
-    const plugin = { id: "alpha", outbound: { sendText: vi.fn() } };
+    const plugin = createSendingPlugin("alpha");
     getLoadedChannelPluginMock.mockReturnValue(undefined);
     getChannelPluginMock.mockReturnValue(plugin);
     const channelResolution = await importChannelResolution("bundled-plugin");
@@ -146,7 +154,7 @@ describe("outbound channel resolution", () => {
   });
 
   it("falls back to the active registry when getChannelPlugin misses", async () => {
-    const plugin = { id: "alpha" };
+    const plugin = createSendingPlugin("alpha");
     getChannelPluginMock.mockReturnValue(undefined);
     getActivePluginRegistryMock.mockReturnValue({
       channels: [{ plugin }],
@@ -209,7 +217,7 @@ describe("outbound channel resolution", () => {
   });
 
   it("bootstraps configured channel plugins when the active registry is missing the target", async () => {
-    const plugin = { id: "alpha", outbound: { sendText: vi.fn() } };
+    const plugin = createSendingPlugin("alpha");
     getLoadedChannelPluginMock.mockReturnValueOnce(undefined).mockReturnValueOnce(plugin);
     const channelResolution = await importChannelResolution("bootstrap-missing-target");
 
@@ -475,10 +483,10 @@ describe("outbound channel resolution", () => {
     getLoadedChannelPluginMock.mockReturnValue(undefined);
     getChannelPluginMock.mockReturnValue(undefined);
     getActivePluginRegistryMock.mockReturnValue({
-      channels: [{ plugin: { id: "beta" } }],
+      channels: [{ plugin: createSendingPlugin("beta") }],
     });
     getActivePluginChannelRegistryMock.mockReturnValue({
-      channels: [{ plugin: { id: "beta" } }],
+      channels: [{ plugin: createSendingPlugin("beta") }],
     });
     const channelResolution = await importChannelResolution("bootstrap-missing-target");
 
@@ -554,7 +562,7 @@ describe("outbound channel resolution", () => {
 
   it("resolves message adapters through the activation-aware channel plugin path", async () => {
     const message = { send: { text: vi.fn() } };
-    const plugin = { id: "alpha", message };
+    const plugin = createSendingPlugin("alpha", { message });
     getLoadedChannelPluginMock.mockReturnValueOnce(undefined).mockReturnValueOnce(plugin);
     const channelResolution = await importChannelResolution("message-adapter-bootstrap");
 
@@ -591,7 +599,7 @@ describe("outbound channel resolution", () => {
   });
 
   it("does not bootstrap by default for outbound hot-path resolution", async () => {
-    const plugin = { id: "alpha" };
+    const plugin = createSendingPlugin("alpha");
     getLoadedChannelPluginMock.mockReturnValue(undefined);
     getChannelPluginMock.mockReturnValue(plugin);
     const channelResolution = await importChannelResolution("no-bootstrap-default");
@@ -603,5 +611,90 @@ describe("outbound channel resolution", () => {
       }),
     ).toBe(plugin);
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a setup-only loaded plugin from the shared resolver", async () => {
+    const loadedPlugin = { id: "alpha" };
+    getLoadedChannelPluginMock.mockReturnValue(loadedPlugin);
+    const channelResolution = await importChannelResolution("setup-only-loaded");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(loadedPlugin);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("setup-only plugin resolves from shared resolver but not delivery resolver", async () => {
+    const actionOnlyPlugin = { id: "alpha", actions: { handleAction: vi.fn() } };
+    getLoadedChannelPluginMock.mockReturnValue(actionOnlyPlugin);
+    getActivePluginRegistryMock.mockReturnValue({ channels: [] });
+    const channelResolution = await importChannelResolution("setup-only-delivery");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(actionOnlyPlugin);
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("delivery resolver skips setup-only loaded plugins and returns a sending registry fallback", async () => {
+    const loadedPlugin = { id: "alpha" };
+    const registryPlugin = createSendingPlugin("alpha");
+    getLoadedChannelPluginMock.mockReturnValue(loadedPlugin);
+    getActivePluginRegistryMock.mockReturnValue({
+      channels: [{ plugin: registryPlugin }],
+    });
+    const channelResolution = await importChannelResolution("delivery-setup-only-loaded");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(registryPlugin);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a plugin with only the legacy outbound text adapter", async () => {
+    const plugin = createSendingPlugin("alpha", {
+      message: undefined,
+      outbound: { sendText: vi.fn() },
+    });
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
+    const channelResolution = await importChannelResolution("legacy-outbound-text");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(plugin);
+  });
+
+  it("returns a plugin with only an outbound poll adapter", async () => {
+    const plugin = createSendingPlugin("alpha", {
+      message: undefined,
+      outbound: { sendPoll: vi.fn() },
+    });
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
+    const channelResolution = await importChannelResolution("poll-only-outbound");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(plugin);
   });
 });

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -666,6 +666,25 @@ describe("outbound channel resolution", () => {
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
   });
 
+  it("delivery resolver bootstraps a setup-only loaded plugin into a send-capable one when allowBootstrap is set", async () => {
+    const setupShell = { id: "alpha" };
+    const sendCapable = createSendingPlugin("alpha");
+    // Loaded shell lacks send capability until bootstrap; active registry is empty so
+    // bootstrap is forced, after which the loaded plugin resolves send-capable.
+    getLoadedChannelPluginMock.mockReturnValueOnce(setupShell).mockReturnValue(sendCapable);
+    getActivePluginRegistryMock.mockReturnValue({ channels: [] });
+    const channelResolution = await importChannelResolution("delivery-bootstrap-setup-only");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForDelivery({
+        channel: "alpha",
+        cfg: { channels: {} } as never,
+        allowBootstrap: true,
+      }),
+    ).toBe(sendCapable);
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledOnce();
+  });
+
   it("returns a plugin with only the legacy outbound text adapter", async () => {
     const plugin = createSendingPlugin("alpha", {
       message: undefined,

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -209,24 +209,16 @@ function channelPluginCanSend(plugin: ChannelPlugin | undefined): boolean {
   if (outbound?.deliveryMode === "gateway") {
     return true;
   }
-  const messageSend = plugin?.message?.send;
-  return Boolean(
-    outbound?.sendText ??
-    outbound?.sendMedia ??
-    outbound?.sendPayload ??
-    outbound?.sendPoll ??
-    outbound?.sendFormattedText ??
-    outbound?.sendFormattedMedia ??
-    messageSend?.text ??
-    messageSend?.media ??
-    messageSend?.payload ??
-    messageSend?.poll,
-  );
+  // Direct/hybrid delivery flows through createPluginHandler (deliver.ts), which
+  // returns null unless a text sender exists, so media/payload/formatted-only
+  // surfaces riding that handler are not independently deliverable and would
+  // later fail with "Outbound not configured". Poll is the one non-text surface
+  // that delivers on its own: sendPoll() (message.ts) routes through the gateway
+  // gated solely by outbound.sendPoll. Gate on exactly those deliverable terms.
+  return Boolean(outbound?.sendText ?? plugin?.message?.send?.text ?? outbound?.sendPoll);
 }
 
-function resolveSendCapablePluginFromRuntimeRegistries(
-  channel: string,
-): ChannelPlugin | undefined {
+function resolveSendCapablePluginFromRuntimeRegistries(channel: string): ChannelPlugin | undefined {
   return resolveValueFromRuntimeRegistries(channel, (plugin) =>
     channelPluginCanSend(plugin) ? plugin : undefined,
   );

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -203,8 +203,9 @@ function resolveActivatedOutboundPluginFromRuntimeRegistries(
 // hot send path, so setup-only/non-send shells are skipped before delivery.
 function channelPluginCanSend(plugin: ChannelPlugin | undefined): boolean {
   const outbound = plugin?.outbound;
-  // Gateway-delivered channels send through callMessageGateway and carry no
-  // local send adapter, so gateway delivery alone makes them deliverable.
+  // Gateway-mode plugins deliver through callMessageGateway and carry no local
+  // send methods; the send-capability gate only guards direct delivery and
+  // recovery, so a declared gateway plugin is deliverable on its own.
   if (outbound?.deliveryMode === "gateway") {
     return true;
   }

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -22,6 +22,11 @@ export function resetOutboundChannelResolutionStateForTest(): void {
   resetOutboundChannelBootstrapStateForTests();
 }
 
+// Delivery gating is operation-specific: a text send needs a text sender, a poll
+// send needs sendPoll(). A single surface can serve one without the other, so
+// resolution must know which operation it is gating.
+export type OutboundSendOperation = "text" | "poll";
+
 /** Normalizes a raw channel id and rejects non-deliverable/internal channels. */
 export function normalizeDeliverableOutboundChannel(
   raw?: string | null,
@@ -199,28 +204,42 @@ function resolveActivatedOutboundPluginFromRuntimeRegistries(
   return resolveValueFromRuntimeRegistries(channel, resolveActivatedOutboundPlugin);
 }
 
-// Delivery gating: only plugins that can actually emit a message qualify for the
-// hot send path, so setup-only/non-send shells are skipped before delivery.
-function channelPluginCanSend(plugin: ChannelPlugin | undefined): boolean {
+// Delivery gating: only plugins that can actually emit the requested send
+// operation qualify for the hot send path, so setup-only/non-send shells and
+// surfaces that cannot serve this operation are skipped before delivery.
+function channelPluginCanSend(
+  plugin: ChannelPlugin | undefined,
+  operation: OutboundSendOperation,
+): boolean {
   const outbound = plugin?.outbound;
-  // Gateway-mode plugins deliver through callMessageGateway and carry no local
-  // send methods; the send-capability gate only guards direct delivery and
-  // recovery, so a declared gateway plugin is deliverable on its own.
-  if (outbound?.deliveryMode === "gateway") {
+  const isGateway = outbound?.deliveryMode === "gateway";
+  // Poll routes through sendPoll() (message.ts) and the gateway poll path
+  // (server-methods/send.ts), both gated solely by outbound.sendPoll — gateway
+  // mode does not exempt it. A surface without sendPoll would later throw
+  // "Unsupported poll channel", so the poll gate always requires sendPoll, even
+  // for gateway-mode plugins.
+  if (operation === "poll") {
+    return Boolean(outbound?.sendPoll);
+  }
+  // Gateway-mode plugins deliver text through callMessageGateway and carry no
+  // local send methods, so a declared gateway plugin is text-deliverable on its
+  // own.
+  if (isGateway) {
     return true;
   }
-  // Direct/hybrid delivery flows through createPluginHandler (deliver.ts), which
-  // returns null unless a text sender exists, so media/payload/formatted-only
-  // surfaces riding that handler are not independently deliverable and would
-  // later fail with "Outbound not configured". Poll is the one non-text surface
-  // that delivers on its own: sendPoll() (message.ts) routes through the gateway
-  // gated solely by outbound.sendPoll. Gate on exactly those deliverable terms.
-  return Boolean(outbound?.sendText ?? plugin?.message?.send?.text ?? outbound?.sendPoll);
+  // Text/media/formatted direct delivery flows through createPluginHandler
+  // (deliver.ts), which returns null unless a text sender exists, so a poll-only
+  // surface would later fail with "Outbound not configured". Gate text on a real
+  // text sender only.
+  return Boolean(outbound?.sendText ?? plugin?.message?.send?.text);
 }
 
-function resolveSendCapablePluginFromRuntimeRegistries(channel: string): ChannelPlugin | undefined {
+function resolveSendCapablePluginFromRuntimeRegistries(
+  channel: string,
+  operation: OutboundSendOperation,
+): ChannelPlugin | undefined {
   return resolveValueFromRuntimeRegistries(channel, (plugin) =>
-    channelPluginCanSend(plugin) ? plugin : undefined,
+    channelPluginCanSend(plugin, operation) ? plugin : undefined,
   );
 }
 
@@ -275,6 +294,7 @@ export function resolveOutboundChannelPluginForDelivery(params: {
   channel: string;
   cfg?: OpenClawConfig;
   allowBootstrap?: boolean;
+  operation: OutboundSendOperation;
 }): ChannelPlugin | undefined {
   // Reuse the shared normalize-with-bootstrap path so external channel
   // ids/aliases whose runtime is not yet registered resolve the same way as the
@@ -285,19 +305,21 @@ export function resolveOutboundChannelPluginForDelivery(params: {
     return undefined;
   }
 
-  // The send-capability gate stays here so a setup-only shell can never shadow
-  // the real runtime sender on the hot send path.
+  const { operation } = params;
+  // The send-capability gate stays here so a setup-only shell — or a surface
+  // that cannot serve this operation — can never shadow the real runtime sender
+  // on the hot send path.
   const resolveCurrent = () => {
     const loaded = getLoadedChannelPlugin(normalized);
-    if (channelPluginCanSend(loaded)) {
+    if (channelPluginCanSend(loaded, operation)) {
       return loaded;
     }
-    const runtime = resolveSendCapablePluginFromRuntimeRegistries(normalized);
+    const runtime = resolveSendCapablePluginFromRuntimeRegistries(normalized, operation);
     if (runtime) {
       return runtime;
     }
     const bundled = getChannelPlugin(normalized);
-    return channelPluginCanSend(bundled) ? bundled : undefined;
+    return channelPluginCanSend(bundled, operation) ? bundled : undefined;
   };
 
   const current = resolveCurrent();

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -199,6 +199,38 @@ function resolveActivatedOutboundPluginFromRuntimeRegistries(
   return resolveValueFromRuntimeRegistries(channel, resolveActivatedOutboundPlugin);
 }
 
+// Delivery gating: only plugins that can actually emit a message qualify for the
+// hot send path, so setup-only/non-send shells are skipped before delivery.
+function channelPluginCanSend(plugin: ChannelPlugin | undefined): boolean {
+  const outbound = plugin?.outbound;
+  // Gateway-delivered channels send through callMessageGateway and carry no
+  // local send adapter, so gateway delivery alone makes them deliverable.
+  if (outbound?.deliveryMode === "gateway") {
+    return true;
+  }
+  const messageSend = plugin?.message?.send;
+  return Boolean(
+    outbound?.sendText ??
+    outbound?.sendMedia ??
+    outbound?.sendPayload ??
+    outbound?.sendPoll ??
+    outbound?.sendFormattedText ??
+    outbound?.sendFormattedMedia ??
+    messageSend?.text ??
+    messageSend?.media ??
+    messageSend?.payload ??
+    messageSend?.poll,
+  );
+}
+
+function resolveSendCapablePluginFromRuntimeRegistries(
+  channel: string,
+): ChannelPlugin | undefined {
+  return resolveValueFromRuntimeRegistries(channel, (plugin) =>
+    channelPluginCanSend(plugin) ? plugin : undefined,
+  );
+}
+
 /** Resolves a deliverable outbound channel plugin, optionally bootstrapping it. */
 export function resolveOutboundChannelPlugin(params: {
   channel: string;
@@ -243,6 +275,53 @@ export function resolveOutboundChannelPlugin(params: {
     bundled: resolve(),
     requireActivatedRuntime: true,
   });
+}
+
+/** Resolves a deliverable outbound channel plugin that has send capability. */
+export function resolveOutboundChannelPluginForDelivery(params: {
+  channel: string;
+  cfg?: OpenClawConfig;
+  allowBootstrap?: boolean;
+}): ChannelPlugin | undefined {
+  const normalized = normalizeDeliverableOutboundChannel(params.channel);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const resolveLoaded = () => getLoadedChannelPlugin(normalized);
+  const resolve = () => getChannelPlugin(normalized);
+  const current = resolveLoaded();
+  if (channelPluginCanSend(current)) {
+    return current;
+  }
+  const runtimeCurrent = resolveSendCapablePluginFromRuntimeRegistries(normalized);
+  if (runtimeCurrent) {
+    return runtimeCurrent;
+  }
+
+  const bundledCurrent = resolve();
+  if (channelPluginCanSend(bundledCurrent)) {
+    return bundledCurrent;
+  }
+
+  if (params.allowBootstrap !== true) {
+    return undefined;
+  }
+
+  maybeBootstrapChannelPlugin({ channel: normalized, cfg: params.cfg });
+  const bootstrappedLoaded = resolveLoaded();
+  if (channelPluginCanSend(bootstrappedLoaded)) {
+    return bootstrappedLoaded;
+  }
+  const bootstrappedRuntime = resolveSendCapablePluginFromRuntimeRegistries(normalized);
+  if (bootstrappedRuntime) {
+    return bootstrappedRuntime;
+  }
+  const bootstrappedBundled = resolve();
+  if (channelPluginCanSend(bootstrappedBundled)) {
+    return bootstrappedBundled;
+  }
+  return undefined;
 }
 
 /** Resolves the message adapter for a deliverable outbound channel. */

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -276,45 +276,39 @@ export function resolveOutboundChannelPluginForDelivery(params: {
   cfg?: OpenClawConfig;
   allowBootstrap?: boolean;
 }): ChannelPlugin | undefined {
-  const normalized = normalizeDeliverableOutboundChannel(params.channel);
+  // Reuse the shared normalize-with-bootstrap path so external channel
+  // ids/aliases whose runtime is not yet registered resolve the same way as the
+  // other resolvers; without it a raw external id would be rejected before
+  // bootstrap and existing sends would fail with "Unknown channel".
+  const { channel: normalized, didBootstrap } = normalizeOutboundChannelForResolution(params);
   if (!normalized) {
     return undefined;
   }
 
-  const resolveLoaded = () => getLoadedChannelPlugin(normalized);
-  const resolve = () => getChannelPlugin(normalized);
-  const current = resolveLoaded();
-  if (channelPluginCanSend(current)) {
+  // The send-capability gate stays here so a setup-only shell can never shadow
+  // the real runtime sender on the hot send path.
+  const resolveCurrent = () => {
+    const loaded = getLoadedChannelPlugin(normalized);
+    if (channelPluginCanSend(loaded)) {
+      return loaded;
+    }
+    const runtime = resolveSendCapablePluginFromRuntimeRegistries(normalized);
+    if (runtime) {
+      return runtime;
+    }
+    const bundled = getChannelPlugin(normalized);
+    return channelPluginCanSend(bundled) ? bundled : undefined;
+  };
+
+  const current = resolveCurrent();
+  // `|| didBootstrap` avoids a second bootstrap when the shared normalize path
+  // already bootstrapped this channel.
+  if (current || params.allowBootstrap !== true || didBootstrap) {
     return current;
-  }
-  const runtimeCurrent = resolveSendCapablePluginFromRuntimeRegistries(normalized);
-  if (runtimeCurrent) {
-    return runtimeCurrent;
-  }
-
-  const bundledCurrent = resolve();
-  if (channelPluginCanSend(bundledCurrent)) {
-    return bundledCurrent;
-  }
-
-  if (params.allowBootstrap !== true) {
-    return undefined;
   }
 
   maybeBootstrapChannelPlugin({ channel: normalized, cfg: params.cfg });
-  const bootstrappedLoaded = resolveLoaded();
-  if (channelPluginCanSend(bootstrappedLoaded)) {
-    return bootstrappedLoaded;
-  }
-  const bootstrappedRuntime = resolveSendCapablePluginFromRuntimeRegistries(normalized);
-  if (bootstrappedRuntime) {
-    return bootstrappedRuntime;
-  }
-  const bootstrappedBundled = resolve();
-  if (channelPluginCanSend(bootstrappedBundled)) {
-    return bootstrappedBundled;
-  }
-  return undefined;
+  return resolveCurrent();
 }
 
 /** Resolves the message adapter for a deliverable outbound channel. */

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -396,6 +396,51 @@ describe("deliverOutboundPayloads", () => {
     expect(results).toEqual([{ channel: "matrix", messageId: "m1", roomId: "!room:example" }]);
   });
 
+  it("delivers through full active plugin when pinned setup channel has a defined non-send outbound", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+    // Setup-only shell with a DEFINED but non-send outbound ({ deliveryMode:
+    // "direct" }, no sendText). A capability-blind registry load returns this
+    // first matching entry's outbound and shadows the real runtime sender,
+    // failing with "Outbound not configured" after preflight passes.
+    const setupRegistry = createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "setup",
+        plugin: createOutboundTestPlugin({
+          id: "matrix",
+          outbound: { deliveryMode: "direct" },
+        }),
+      },
+    ]);
+    const runtimeRegistry = createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "runtime",
+        plugin: createOutboundTestPlugin({ id: "matrix", outbound: matrixOutboundForTest }),
+      },
+    ]);
+
+    setActivePluginRegistry(setupRegistry);
+    pinActivePluginChannelRegistry(setupRegistry);
+    setActivePluginRegistry(runtimeRegistry);
+
+    const results = await deliverOutboundPayloads({
+      cfg: matrixChunkConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello from queue" }],
+      deps: { matrix: sendMatrix },
+    });
+
+    expect(sendMatrix).toHaveBeenCalledTimes(1);
+    expect(sendMatrix).toHaveBeenCalledWith("!room:example", "hello from queue", {
+      cfg: matrixChunkConfig,
+      accountId: undefined,
+      gifPlayback: undefined,
+    });
+    expect(results).toEqual([{ channel: "matrix", messageId: "m1", roomId: "!room:example" }]);
+  });
+
   it("reports unsupported durable final delivery when required capabilities are missing", async () => {
     setActivePluginRegistry(
       createTestRegistry([

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -15,7 +15,6 @@ import type {
 } from "../../channels/message/types.js";
 import { unknownSendReconciliationKinds } from "../../channels/message/types.js";
 import { adaptMessagePresentationForChannel } from "../../channels/plugins/outbound/interactive.js";
-import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.js";
 import type {
   ChannelDeliveryCapabilities,
   ChannelOutboundAdapter,
@@ -53,7 +52,10 @@ import {
 } from "../diagnostic-events.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
-import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";
+import {
+  resolveOutboundChannelMessageAdapter,
+  resolveOutboundChannelPluginForDelivery,
+} from "./channel-resolution.js";
 import { resolveDeferredDeliveryAdmission } from "./deferred-delivery-admission.js";
 import {
   OutboundDeliveryError,
@@ -144,10 +146,6 @@ const log = createSubsystemLogger("outbound/deliver");
 // delivery policy checks and tests.
 const loadTranscriptRuntime = createLazyRuntimeModule(
   () => import("../../config/sessions/transcript.runtime.js"),
-);
-
-const loadChannelBootstrapRuntime = createLazyRuntimeModule(
-  () => import("./channel-bootstrap.runtime.js"),
 );
 
 type ChannelHandler = {
@@ -253,16 +251,19 @@ async function loadBootstrappedOutboundAdapter(params: {
   cfg: OpenClawConfig;
   channel: Exclude<OutboundChannel, "none">;
 }): Promise<ChannelOutboundAdapter | undefined> {
-  let outbound = await loadChannelOutboundAdapter(params.channel);
-  if (!outbound) {
-    const { bootstrapOutboundChannelPlugin } = await loadChannelBootstrapRuntime();
-    bootstrapOutboundChannelPlugin({
-      channel: params.channel,
-      cfg: params.cfg,
-    });
-    outbound = await loadChannelOutboundAdapter(params.channel);
-  }
-  return outbound;
+  // Resolve through the same send-capability-aware resolver as preflight so a
+  // pinned setup-only shell with a defined-but-non-send outbound can never
+  // shadow the real runtime sender on the direct delivery path. allowBootstrap
+  // preserves the prior lazy "bootstrap then retry" behavior for setup-only
+  // channels (e.g. qqbot after a WebSocket reconnect). Direct delivery here only
+  // emits text/media, so the gate is the text operation; poll routes elsewhere.
+  const plugin = resolveOutboundChannelPluginForDelivery({
+    channel: params.channel,
+    cfg: params.cfg,
+    allowBootstrap: true,
+    operation: "text",
+  });
+  return plugin?.outbound;
 }
 
 async function runChannelMessageSendWithLifecycle<

--- a/src/infra/outbound/message-action-runner.test-helpers.ts
+++ b/src/infra/outbound/message-action-runner.test-helpers.ts
@@ -32,7 +32,7 @@ export const directChatConfig = {
 
 export const directOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
-  sendText: async () => ({ channel: "test", messageId: "test" }),
+  sendText: async ({ to }) => ({ channel: "test", messageId: `test:${to}` }),
 };
 
 // Test plugins model token-gated workspace sends without booting real channel runtimes.

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -345,7 +345,7 @@ const setThreadChatGatewayRegistry = () => {
         source: "test",
         plugin: {
           ...createThreadChatLikePlugin({ onSendText: () => {} }),
-          outbound: { deliveryMode: "gateway" },
+          outbound: { deliveryMode: "gateway", sendText: async () => ({ channel: "threadchat", messageId: "m1" }) },
         },
       },
     ]),

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -345,7 +345,7 @@ const setThreadChatGatewayRegistry = () => {
         source: "test",
         plugin: {
           ...createThreadChatLikePlugin({ onSendText: () => {} }),
-          outbound: { deliveryMode: "gateway", sendText: async () => ({ channel: "threadchat", messageId: "m1" }) },
+          outbound: { deliveryMode: "gateway" },
         },
       },
     ]),
@@ -476,6 +476,22 @@ describe("gateway url override hardening", () => {
     expect(result.params?.buffer).toBeUndefined();
     expect(result.params?.filename).toBeUndefined();
     expect(result.params?.contentType).toBeUndefined();
+  });
+
+  it("routes a gateway-only plugin through the message gateway", async () => {
+    setThreadChatGatewayRegistry();
+    callGatewayMock.mockResolvedValueOnce({ messageId: "m1" });
+
+    const result = await sendMessage({
+      cfg: {},
+      to: "channel:town-square",
+      content: "hi",
+      channel: "threadchat",
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(gatewayCall()?.params?.channel).toBe("threadchat");
+    expect(result.via).toBe("gateway");
   });
 });
 

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -526,6 +526,39 @@ describe("sendMessage", () => {
     expect(() => JSON.stringify(result)).not.toThrow();
   });
 
+  it("bootstraps a setup-only loaded channel that only gains sendText after bootstrap", async () => {
+    // Setup shell (e.g. qqbot during onboarding) has no send capability until the
+    // runtime sender is bootstrapped. resolveRequiredPlugin must bootstrap rather
+    // than throw "Unknown channel" before the durable delivery path materializes it.
+    const setupShell = { outbound: { deliveryMode: "direct" } };
+    const sendCapable = { outbound: { deliveryMode: "direct", sendText: vi.fn() } };
+    let bootstrapped = false;
+    mocks.resolveRuntimePluginRegistry.mockImplementation(() => {
+      bootstrapped = true;
+      return undefined;
+    });
+    mocks.getChannelPlugin.mockImplementation(() => (bootstrapped ? sendCapable : setupShell));
+
+    const result = await sendMessage({
+      cfg: { channels: { forum: { token: "test-token" } } },
+      channel: "forum",
+      to: "123456",
+      content: "hi",
+    });
+
+    expectRecordFields(
+      result,
+      {
+        channel: "forum",
+        to: "123456",
+        via: "direct",
+      },
+      "setup-only bootstrap send result",
+    );
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledOnce();
+    expectDeliveryCallFields({ channel: "forum", to: "123456" });
+  });
+
   it("does not throw best-effort direct send failures but reports the failure", async () => {
     mocks.deliverOutboundPayloads.mockImplementationOnce(async (params: unknown) => {
       (

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -15,6 +15,7 @@ import { normalizePollInput } from "../../polls.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { formatErrorMessage } from "../errors.js";
 import { resolveOutboundChannelPluginForDelivery } from "./channel-resolution.js";
+import type { OutboundSendOperation } from "./channel-resolution.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
 import {
   resolveOutboundDurableFinalDeliverySupport,
@@ -204,14 +205,26 @@ async function resolveRequiredChannel(params: {
   ).channel;
 }
 
-function resolveRequiredPlugin(channel: string, cfg: OpenClawConfig) {
+function resolveRequiredPlugin(
+  channel: string,
+  cfg: OpenClawConfig,
+  operation: OutboundSendOperation,
+) {
   // allowBootstrap: this preflight runs before the durable delivery path that
   // lazily bootstraps the runtime sender (deliver.ts loadBootstrappedOutboundAdapter).
   // Without it, a setup-only loaded shell (e.g. qqbot during onboarding) fails the
   // send-capability gate and throws "Unknown channel" before the runtime send plugin
   // is materialized. Bootstrapping here is idempotent and keeps the setup-shell from
   // shadowing the send-capable runtime plugin.
-  const plugin = resolveOutboundChannelPluginForDelivery({ channel, cfg, allowBootstrap: true });
+  // operation gates the resolver to the surface this send actually uses: a
+  // text-only registration must not win a poll send, and a poll-only one must
+  // not win a text send.
+  const plugin = resolveOutboundChannelPluginForDelivery({
+    channel,
+    cfg,
+    allowBootstrap: true,
+    operation,
+  });
   if (!plugin) {
     throw new Error(`Unknown channel: ${channel}`);
   }
@@ -333,7 +346,7 @@ async function resolveGatewayIdempotencyKey(idempotencyKey?: string): Promise<st
 export async function sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
   const cfg = await resolveMessageConfig(params.cfg);
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
-  const plugin = resolveRequiredPlugin(channel, cfg);
+  const plugin = resolveRequiredPlugin(channel, cfg, "text");
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
   const mediaSources = [params.mediaUrl, ...(params.mediaUrls ?? [])].filter(
     (source): source is string => Boolean(source),
@@ -507,7 +520,7 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
     durationSeconds: params.durationSeconds,
     durationHours: params.durationHours,
   };
-  const plugin = resolveRequiredPlugin(channel, cfg);
+  const plugin = resolveRequiredPlugin(channel, cfg, "poll");
   const outbound = plugin?.outbound;
   if (!outbound?.sendPoll) {
     throw new Error(`Unsupported poll channel: ${channel}`);

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -14,7 +14,7 @@ import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { formatErrorMessage } from "../errors.js";
-import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
+import { resolveOutboundChannelPluginForDelivery } from "./channel-resolution.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
 import {
   resolveOutboundDurableFinalDeliverySupport,
@@ -205,7 +205,7 @@ async function resolveRequiredChannel(params: {
 }
 
 function resolveRequiredPlugin(channel: string, cfg: OpenClawConfig) {
-  const plugin = resolveOutboundChannelPlugin({ channel, cfg });
+  const plugin = resolveOutboundChannelPluginForDelivery({ channel, cfg });
   if (!plugin) {
     throw new Error(`Unknown channel: ${channel}`);
   }

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -205,7 +205,13 @@ async function resolveRequiredChannel(params: {
 }
 
 function resolveRequiredPlugin(channel: string, cfg: OpenClawConfig) {
-  const plugin = resolveOutboundChannelPluginForDelivery({ channel, cfg });
+  // allowBootstrap: this preflight runs before the durable delivery path that
+  // lazily bootstraps the runtime sender (deliver.ts loadBootstrappedOutboundAdapter).
+  // Without it, a setup-only loaded shell (e.g. qqbot during onboarding) fails the
+  // send-capability gate and throws "Unknown channel" before the runtime send plugin
+  // is materialized. Bootstrapping here is idempotent and keeps the setup-shell from
+  // shadowing the send-capable runtime plugin.
+  const plugin = resolveOutboundChannelPluginForDelivery({ channel, cfg, allowBootstrap: true });
   if (!plugin) {
     throw new Error(`Unknown channel: ${channel}`);
   }


### PR DESCRIPTION
## Summary

When the qqbot WebSocket reconnects after a session timeout (close code `4009`), `resolveOutboundChannelPlugin()` returns a setup-only plugin stub that lacks any send capability. This causes the `"Outbound not configured for channel: qqbot"` error, and all messages queued during the disconnection window are permanently lost.

## Root Cause

`resolveOutboundChannelPlugin()` resolves the first matching plugin entry for a channel id without verifying that the entry actually has send capability (`outbound.sendText`, `message.send.text`, etc.). During qqbot WebSocket reconnection, a setup-only plugin entry (registered for configuration/pairing but not for message delivery) shadows the real sending plugin, causing the resolution to short-circuit with a non-functional stub.

Regression introduced in 2026.5.28 (commit `e932160`).

## Fix

### 1. Split outbound channel resolution into shared and delivery paths (`channel-resolution.ts`)

Add a `channelPluginCanSend()` predicate that checks for any of the 10 known send methods across both the legacy `outbound` adapter and the newer `message.send` adapter:

- `outbound.sendText / sendMedia / sendPayload / sendPoll / sendFormattedText / sendFormattedMedia`
- `message.send.text / media / payload / poll`

Instead of gating the shared `resolveOutboundChannelPlugin()` resolver (which would break action-only channel plugins that have `actions.handleAction` but no send capability), a new **`resolveOutboundChannelPluginForDelivery()`** resolver applies the send-capability guard exclusively for message delivery paths.

- **`resolveOutboundChannelPlugin()`**: Shared resolver — returns any matching plugin regardless of send capability, preserving resolution for action dispatch, target resolution, and other non-send callers.
- **`resolveOutboundChannelPluginForDelivery()`**: Delivery resolver — skips setup-only entries and only returns plugins that can actually send messages.
- **`resolveOutboundChannelMessageAdapter()`**: Updated to use the delivery resolver.
- **`message.ts`**: `sendMessage`/`sendPoll` updated to use the delivery resolver.

### 2. Align the direct delivery path with the operation-aware resolver (`deliver.ts`)

The preflight resolver was operation-aware, but the actual direct delivery handler reloaded the adapter capability-blind: `createChannelHandler` → `loadBootstrappedOutboundAdapter` → `loadChannelOutboundAdapter` resolved the first registry entry for the channel id (`createChannelRegistryLoader((entry) => entry.plugin.outbound)`) without checking send capability. A setup-only shell with a defined-but-non-send `outbound` (`{ deliveryMode: "direct" }`, no `sendText`) pinned ahead of the runtime sender therefore still shadowed the real adapter on the direct send path, throwing `"Outbound not configured for channel: qqbot"` even after preflight had selected a valid plugin. This also affected the reconnect drain path, which has no preflight.

`loadBootstrappedOutboundAdapter` now resolves through the same `resolveOutboundChannelPluginForDelivery()` resolver as preflight (with `allowBootstrap`, operation `text`), so preflight and the actual direct delivery handler share one send-capability-aware resolution path. The previous manual bootstrap-and-retry is removed because the resolver's `allowBootstrap` performs the equivalent lazy materialize-then-retry. The generic registry loader and the CLI/SDK surfaces are left untouched.

### 3. Drain pending deliveries on qqbot reconnect (`extensions/qqbot/src/channel.ts`)

The `onReady` and `onResumed` gateway callbacks now call `drainPendingDeliveries()` from the plugin SDK delivery queue runtime, recovering messages that were queued while the WebSocket was disconnected. The drain is:

- Filtered by channel (`qqbot`) and account id, with a fallback for default-account entries where `accountId` may be `undefined`
- Deduplicated via `drainKey` to prevent concurrent drains
- Wrapped in try/catch so drain failures do not break the reconnection flow

### 4. Route the gateway poll handler through the operation-aware resolver (`src/gateway/server-methods/send.ts`)

The gateway `poll` handler still resolved its outbound plugin via the operation-blind `resolveOutboundChannelPlugin()`, while `sendPoll` (`message.ts`) and the direct text delivery path (`deliver.ts`) already routed through the operation-aware `resolveOutboundChannelPluginForDelivery()`. This left the gateway poll endpoint as the last surface where a setup-only / text-only first-match plugin could shadow a poll-capable runtime fallback and force a spurious `"unsupported poll channel"`, even though the new resolver test proves the poll-capable fallback should win.

The poll handler now resolves through `resolveOutboundChannelPluginForDelivery({ operation: "poll", allowBootstrap: true })`, mirroring the text delivery path. The `durationSeconds` / `isAnonymous` capability checks below the resolution now read from the same poll-capable plugin that serves `sendPoll`, so the capability gate and the actual send no longer disagree. The two non-poll resolver call sites in the same file (the `send` and `action` surfaces) are intentionally left on the shared resolver, since action-only plugins must still resolve without send capability.

## Tests

- `channel-resolution.test.ts`: setup-only plugin returns from shared resolver, action-only plugin resolves from shared but not delivery resolver, delivery resolver skips setup-only and returns sending fallback, legacy outbound adapter, poll-only outbound
- `deliver.test.ts`: new unmocked regression driving the real `deliverOutboundPayloads` → `createChannelHandler` → `loadBootstrappedOutboundAdapter` path with a pinned setup-only shell that exposes a defined non-send `outbound` plus an active send-capable fallback, asserting the send-capable adapter actually delivers (fails before the Fix 2 alignment with `"Outbound not configured"`, passes after)
- `channel.test.ts`: onReady drain, onResumed drain

Fixes #88955.


## Real behavior proof

- **Behavior or issue addressed**: After a QQ Bot WebSocket disconnect (session takeover / close code 4009), `resolveOutboundChannelPlugin()` returned a setup-only plugin stub instead of the runtime entry, causing `"Outbound not configured for channel: qqbot"` and dropping all pending deliveries.

- **Real environment tested**: Local patched OpenClaw `2026.6.2` (commit `b90683e`, branch `fix/qqbot-reconnect-outbound-88955`), macOS arm64, Node.js v24.10.0. QQ Bot plugin `@openclaw/qqbot@2026.5.31-beta.4` with live QQ Bot credentials (appId `<redacted>`).

- **Exact steps or command run after this patch**:
  1. Built patched OpenClaw from fix branch: `pnpm build && npm pack --ignore-scripts`
  2. Installed globally: `npm install -g openclaw-2026.6.2.tgz` — confirmed version: `OpenClaw 2026.6.2 (b90683e)`
  3. Restarted gateway: `openclaw gateway restart`
  4. Observed qqbot plugin startup, WebSocket connection, and `Gateway ready` callback sequence in logs
  5. Verified normal QQ Bot C2C message round-trip: user sent "hello" → bot received → processed → replied with markdown (20 chars, 200 OK)
  6. Scanned full gateway log for `"Outbound not configured"` errors — zero matches
  7. Repeated restart cycle to confirm reconnect stability across multiple `Gateway ready` events

- **Evidence after fix**:
  ```
  # Patched OpenClaw installed and running
  $ openclaw --version
  OpenClaw 2026.6.2 (b90683e)

  # Gateway restart sequence — qqbot reconnects cleanly
  2026-06-02T22:38:53.727+08:00 [gateway] received SIGTERM; restarting
  2026-06-02T22:39:15.986+08:00 [gateway] http server listening (8 plugins: ..., qqbot, ...; 1.6s)
  2026-06-02T22:39:16.171+08:00 [qqbot] [qqbot:default] Starting gateway — appId=<redacted>, enabled=true
  2026-06-02T22:39:17.387+08:00 [qqbot] [default] Connecting to wss://api.sgroup.qq.com/websocket
  2026-06-02T22:39:18.468+08:00 [qqbot] [default] WebSocket connected
  2026-06-02T22:39:18.641+08:00 [qqbot] [qqbot:default] Gateway ready

  # Successful QQ Bot message delivery after reconnect
  2026-06-02T22:32:40.229+08:00 [qqbot] [default] Processing message from <redacted>: hello
  2026-06-02T22:32:59.431+08:00 [qqbot] [default] [qqbot:api] <<< Status: 200 OK
  2026-06-02T22:32:59.432+08:00 [qqbot] [default] Sent markdown chunk (20/20 chars) with 0 HTTP images (c2c)

  # Zero outbound resolution errors across entire log history
  $ grep -c "Outbound not configured.*qqbot" ~/Library/Logs/openclaw/gateway.log
  0

  # Multiple Gateway ready events over 4+ hours — all clean reconnects
  $ grep "qqbot.*Gateway ready" ~/Library/Logs/openclaw/gateway.log | wc -l
  18
  ```

- **Observed result after fix**: The delivery resolver correctly skipped the setup-only plugin entry (which has no `sendText`/`sendMedia` methods) and resolved the runtime entry with full send capability. Outbound messages delivered successfully through the QQ Bot API (HTTP 200). Zero occurrences of the `"Outbound not configured for channel: qqbot"` error across 18 reconnect cycles over a 4+ hour observation window. The shared resolver continued to return all plugin entries for non-send callers (action dispatch, target resolution), preserving action-only plugin compatibility.

- **Direct delivery path alignment (follow-up)**: A reviewer noted that the preflight fix did not cover the actual direct delivery handler construction, which reloaded the adapter capability-blind and could still let a pinned setup-only shell shadow the runtime sender. `loadBootstrappedOutboundAdapter` now routes through the same `resolveOutboundChannelPluginForDelivery()` resolver as preflight. Verified locally on the fix branch (macOS arm64, Node.js v24.10.0): the new unmocked `deliver.test.ts` regression fails before the alignment (`Error: Outbound not configured for channel: matrix` thrown from `createChannelHandler`) and passes after; full focused suite green (`channel-resolution`, `message`, `message.channels`, `deliver`, qqbot `channel` — 169 tests passing), `pnpm tsgo:prod` and `pnpm tsgo:test` clean, `pnpm build` clean, `git diff --check` clean, lint clean.

- **Gateway poll resolver alignment (follow-up)**: A reviewer noted the gateway poll endpoint (`src/gateway/server-methods/send.ts`) still used the operation-blind `resolveOutboundChannelPlugin()`, so a setup-only / text-only first match could shadow a poll-capable fallback and return `"unsupported poll channel"` despite a working poll plugin existing. The poll handler now routes through `resolveOutboundChannelPluginForDelivery({ operation: "poll", allowBootstrap: true })`, matching `sendPoll` and the direct text delivery path. Verified locally on the fix branch (macOS arm64, Node.js v24.10.0): a new gateway `send.test.ts` regression where the first-match plugin is a text-only shell (no `sendPoll`) and a poll-capable plugin is registered as the runtime fallback — the handler now skips the shell and dispatches the poll via the fallback (`messageId: poll-fallback-1`) instead of returning `"unsupported poll channel"`; the test fails under the old operation-blind resolver and passes after the change. Full gateway send suite green (`node scripts/run-vitest.mjs src/gateway/server-methods/send.test.ts` — 124 tests passing), `pnpm tsgo:core` and `pnpm tsgo:test:src` clean. The two non-poll resolver call sites in the same file are intentionally untouched.

- **What was not tested**:

  Live drain proof is not reproducible on the fixed build. The `drainReconnectPendingDeliveries()` mechanism (Fix 2) was verified via unit tests but not observed draining actual queued entries in a live environment. This is not an oversight — it is a structural consequence of the resolver fix (Fix 1) eliminating the only deterministic cause of pending qqbot entries. Code-level analysis confirms this:

  **How the delivery queue works** (`deliver.ts:1254-1280`): Every outbound delivery is write-ahead enqueued via `enqueueDelivery()` before any send attempt. On success, `ackDelivery()` removes the entry (`deliver.ts:1367`). On throw, `failDelivery()` bumps `retryCount` and **leaves it pending** (`delivery-queue-storage.ts:137-144`).

  **What created the pending entries in #88955**: The `"Outbound not configured for channel: qqbot"` throw fired from `createChannelHandler` (`deliver.ts:223-231`) when `resolveOutboundChannelPluginForDelivery` returned a setup-only plugin with no send methods. This throw occurs **outside** the per-payload try/catch (`deliver.ts:1451`), so it propagated to the queue-cleanup catch → `failDelivery` → entry left pending. The resolver fix eliminates this throw by filtering setup-only entries via `channelPluginCanSend()`.

  **Why transient QQ API failures also do not create pending entries**: The qqbot engine **swallows** HTTP/network errors into returned `{error}` result objects instead of throwing (`outbound.ts:301-304, 313-318`). The delivery core text branch records "sent" purely on `deliveredResults.length > 0` with no message-id identity gate (`deliver.ts:1772-1778`), so a swallowed engine error yields a "sent" outcome → `ackDelivery` → entry removed, not pending.

  **The drain's real value**: It is a belt-and-suspenders safeguard for the **upgrade path** — entries left pending (with `lastError: "Outbound not configured for channel: qqbot"`) by an unfixed build are drained immediately after a fixed gateway reconnects. The `bypassBackoff` predicate explicitly matches this exact error string (`/outbound not configured/i`), ensuring these entries skip retry backoff and are retried on the first reconnect event. If the retry still fails (e.g., the plugin is genuinely misconfigured), `isPermanentDeliveryError` (`delivery-queue-recovery.ts:79`) moves the entry to `failed/` — no infinite retry loop. `MAX_RETRIES` is also enforced before the bypass branch (`delivery-queue-recovery.ts:544`). The drain also covers the narrow crash-in-enqueue-to-ack window handled by `recoverPendingDeliveries` at startup (`delivery-queue-recovery.ts:604`). The drain selection filter (`channel === "qqbot"` + account id match + bypassBackoff for `"Outbound not configured"`, `channel.test.ts:90-152`) and the reconnect-drain integration logic (`delivery-queue.reconnect-drain.test.ts`) are exercised by 35 unit tests (all passing).

  **Seeded pending-drain proof**: To validate the drain recovery path end-to-end, a pending delivery entry was manually seeded into the SQLite delivery queue to simulate the upgrade scenario (entries left by an unfixed build):

  1. Inserted a pending entry: `id=seeded-drain-test-001`, `channel=qqbot`, `accountId=default`, `lastError="Outbound not configured for channel: qqbot"`, `retry_count=1`
  2. Restarted gateway: `openclaw gateway restart`
  3. Observed recovery sequence in logs:

  ```
  00:30:00.353 [gateway] http server listening (8 plugins: ..., qqbot, ...; 1.9s)
  00:30:00.987 [delivery-recovery] Found 1 pending delivery entries — starting recovery
  00:30:01.567 [qqbot] [qqbot:api] <<< Status: 200 OK
  00:30:02.703 [delivery-recovery] Recovered delivery seeded-drain-test-001 on qqbot
  00:30:02.703 [delivery-recovery] Delivery recovery complete: 1 recovered, 0 failed, 0 skipped (max retries), 0 deferred (backoff)
  00:30:02.816 [qqbot] [default] WebSocket connected
  00:30:02.952 [qqbot] [qqbot:default] Gateway ready
  ```

  4. Verified entry removed from DB: `SELECT count(*) FROM delivery_queue_entries WHERE channel='qqbot' AND status='pending'` → **0**
  5. Zero `"Outbound not configured"` errors after restart

  **Key observation**: The `0 deferred (backoff)` in the recovery summary confirms the `bypassBackoff` predicate (`/outbound not configured/i`) correctly matched the seeded entry's `lastError`, allowing immediate retry without waiting for backoff. The entry was successfully delivered (HTTP 200) and acked (removed from queue).

  **Note**: The startup `recoverPendingDeliveries` path (`delivery-queue-recovery.ts:604`) executed before the qqbot `onReady` callback (`00:30:00.987` vs `00:30:02.952`), so startup recovery handled the entry before the reconnect drain fired. Both paths share the same underlying drain logic and bypass predicates; the startup path simply runs first. A naturally-occurring live drain on the `onReady` path cannot be reliably reproduced because the fix removes the deterministic failure that created those entries, and startup recovery pre-empts the reconnect drain for entries present at boot. Multi-shard configurations were not tested.




