### PR TITLE
fix(discord): disable ws 8.21.0 receiver part limits for gateway sockets

### DIFF
--- a/extensions/discord/src/internal/gateway-websocket-options.test.ts
+++ b/extensions/discord/src/internal/gateway-websocket-options.test.ts
@@ -1,4 +1,5 @@
-// Discord tests cover gateway websocket transport options.
+// Discord tests cover gateway websocket transport options, including the disabled
+// ws 8.21 retained-part receiver limits (maxBufferedChunks/maxFragments = 0).
 import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -38,7 +39,7 @@ describe("GatewayPlugin websocket options", () => {
     expect(webSocketCtorCalls).toHaveLength(1);
     expect(webSocketCtorCalls[0]).toEqual({
       url: "wss://gateway.example.test/?v=10&encoding=json",
-      options: { maxPayload: 16 * 1024 * 1024 },
+      options: { maxPayload: 16 * 1024 * 1024, maxBufferedChunks: 0, maxFragments: 0 },
     });
   });
 });

--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -10,6 +10,27 @@ import {
   type GatewaySendPayload,
 } from "discord-api-types/v10";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { WebSocketMock } = vi.hoisted(() => ({
+  WebSocketMock: vi.fn(
+    function MockWebSocket(this: {
+      close: ReturnType<typeof vi.fn>;
+      on: ReturnType<typeof vi.fn>;
+      readyState: number;
+      send: ReturnType<typeof vi.fn>;
+    }) {
+      this.readyState = 0;
+      this.send = vi.fn();
+      this.close = vi.fn();
+      this.on = vi.fn();
+    },
+  ),
+}));
+
+vi.mock("ws", () => ({
+  WebSocket: WebSocketMock,
+}));
+
 import { sharedGatewayIdentifyLimiter } from "./gateway-identify-limiter.js";
 import { GatewayPlugin } from "./gateway.js";
 
@@ -83,6 +104,12 @@ class TestGatewayPlugin extends GatewayPlugin {
   }
 }
 
+class BaseWebSocketGatewayPlugin extends GatewayPlugin {
+  open(url: string) {
+    return this.createWebSocket(url);
+  }
+}
+
 type GatewaySessionState = {
   sessionId: string | null;
   resumeGatewayUrl: string | null;
@@ -96,7 +123,20 @@ function gatewaySessionState(gateway: GatewayPlugin): GatewaySessionState {
 describe("GatewayPlugin", () => {
   afterEach(() => {
     vi.useRealTimers();
+    WebSocketMock.mockClear();
     sharedGatewayIdentifyLimiter.reset();
+  });
+
+  it("disables ws receiver buffered-part limits for base gateway sockets", () => {
+    const gateway = new BaseWebSocketGatewayPlugin({ autoInteractions: false });
+
+    gateway.open("wss://gateway.example.test/?v=10&encoding=json");
+
+    expect(WebSocketMock).toHaveBeenCalledWith("wss://gateway.example.test/?v=10&encoding=json", {
+      maxPayload: 16 * 1024 * 1024,
+      maxBufferedChunks: 0,
+      maxFragments: 0,
+    });
   });
 
   it("does not auto-handle interactions when autoInteractions is disabled", async () => {

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -49,9 +49,15 @@ const DEFAULT_GATEWAY_URL = "wss://gateway.discord.gg/";
 const DISCORD_GATEWAY_PAYLOAD_LIMIT_BYTES = 4096;
 // Discord can send multi-megabyte member chunks. Keep generous headroom while
 // bounding ws's 100 MiB default before an inbound payload reaches JSON parsing.
+// ws 8.21.0 added receiver retained-part limits (maxBufferedChunks/maxFragments)
+// that reject large fragmented gateway frames with WS_ERR_TOO_MANY_BUFFERED_PARTS;
+// disable them (0 = unlimited) since maxPayload already bounds inbound size.
 export const DISCORD_GATEWAY_WS_CLIENT_OPTIONS = Object.freeze({
   maxPayload: 16 * 1024 * 1024,
-}) satisfies ws.ClientOptions;
+  maxBufferedChunks: 0,
+  maxFragments: 0,
+  // @types/ws 8.18 lacks the receiver part limits ws 8.21 accepts at runtime.
+}) satisfies ws.ClientOptions & { maxBufferedChunks: number; maxFragments: number };
 const INVALID_SESSION_MIN_DELAY_MS = 1_000;
 const INVALID_SESSION_JITTER_MS = 4_000;
 

--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -54,7 +54,11 @@ const { GatewayIntents, GatewayPlugin } = vi.hoisted(() => {
 });
 
 vi.mock("../internal/gateway.js", () => ({
-  DISCORD_GATEWAY_WS_CLIENT_OPTIONS: { maxPayload: 16 * 1024 * 1024 },
+  DISCORD_GATEWAY_WS_CLIENT_OPTIONS: {
+    maxPayload: 16 * 1024 * 1024,
+    maxBufferedChunks: 0,
+    maxFragments: 0,
+  },
   GatewayIntents,
   GatewayPlugin,
 }));
@@ -257,6 +261,31 @@ describe("createDiscordGatewayPlugin", () => {
       (plugin as unknown as { options?: { gatewayInfoTimeoutMs?: number } }).options
         ?.gatewayInfoTimeoutMs,
     ).toBeUndefined();
+  });
+
+  it("disables ws receiver buffered-part limits for Discord gateway sockets", () => {
+    const socket = new EventEmitter() as EventEmitter & { binaryType?: string };
+    const webSocketCtor = vi.fn(function WebSocketCtor() {
+      return socket;
+    });
+    const plugin = createPlugin({
+      webSocketCtor: webSocketCtor as unknown as NonNullable<
+        Parameters<typeof createDiscordGatewayPlugin>[0]["testing"]
+      >["webSocketCtor"],
+    });
+
+    (plugin as unknown as { createWebSocket: (url: string) => typeof socket }).createWebSocket(
+      "wss://gateway.discord.gg",
+    );
+
+    expect(webSocketCtor).toHaveBeenCalledWith(
+      "wss://gateway.discord.gg",
+      expect.objectContaining({
+        handshakeTimeout: 30_000,
+        maxBufferedChunks: 0,
+        maxFragments: 0,
+      }),
+    );
   });
 
   it("emits transport activity for current gateway socket messages", () => {

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -37,7 +37,15 @@ const DISCORD_GATEWAY_WS_RECEIVER_LIMIT_CODE = "WS_ERR_TOO_MANY_BUFFERED_PARTS";
 const DISCORD_GATEWAY_CLOSE_REASON_LOG_MAX_CHARS = 240;
 const discordDnsLookup = createDiscordDnsLookup();
 
-type DiscordGatewayWebSocketCtor = typeof ws.WebSocket;
+type DiscordGatewayWebSocketCtor = new (
+  url: string,
+  options?: {
+    agent?: unknown;
+    handshakeTimeout?: number;
+    maxBufferedChunks?: number;
+    maxFragments?: number;
+  },
+) => ws.WebSocket;
 type DiscordGatewayWebSocketAgent = InstanceType<typeof HttpsAgent> | HttpAgent;
 const registrationPromises = new WeakMap<discordGateway.GatewayPlugin, Promise<void>>();
 type DiscordGatewayClient = Parameters<discordGateway.GatewayPlugin["registerClient"]>[0];

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -146,7 +146,11 @@ const {
 
 // Unit test: don't import the real gateway just to check the prototype chain.
 vi.mock("../internal/gateway.js", () => ({
-  DISCORD_GATEWAY_WS_CLIENT_OPTIONS: { maxPayload: 16 * 1024 * 1024 },
+  DISCORD_GATEWAY_WS_CLIENT_OPTIONS: {
+    maxPayload: 16 * 1024 * 1024,
+    maxBufferedChunks: 0,
+    maxFragments: 0,
+  },
   GatewayIntents,
   GatewayPlugin,
 }));
@@ -396,6 +400,8 @@ describe("createDiscordGatewayPlugin", () => {
       agent: getLastAgent(),
       handshakeTimeout: 30_000,
       maxPayload: 16 * 1024 * 1024,
+      maxBufferedChunks: 0,
+      maxFragments: 0,
     });
     expect(wsProxyAgentSpy).not.toHaveBeenCalled();
   });
@@ -514,6 +520,8 @@ describe("createDiscordGatewayPlugin", () => {
       agent: getLastProxyAgent(),
       handshakeTimeout: 30_000,
       maxPayload: 16 * 1024 * 1024,
+      maxBufferedChunks: 0,
+      maxFragments: 0,
     });
     expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
     expect(runtime.error).not.toHaveBeenCalled();
@@ -537,6 +545,8 @@ describe("createDiscordGatewayPlugin", () => {
       agent: getLastProxyAgent(),
       handshakeTimeout: 30_000,
       maxPayload: 16 * 1024 * 1024,
+      maxBufferedChunks: 0,
+      maxFragments: 0,
     });
     expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
     expect(runtime.error).not.toHaveBeenCalled();
@@ -560,6 +570,8 @@ describe("createDiscordGatewayPlugin", () => {
       agent: getLastProxyAgent(),
       handshakeTimeout: 30_000,
       maxPayload: 16 * 1024 * 1024,
+      maxBufferedChunks: 0,
+      maxFragments: 0,
     });
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
@@ -582,6 +594,8 @@ describe("createDiscordGatewayPlugin", () => {
       agent: getLastAgent(),
       handshakeTimeout: 30_000,
       maxPayload: 16 * 1024 * 1024,
+      maxBufferedChunks: 0,
+      maxFragments: 0,
     });
     expect(runtime.log).not.toHaveBeenCalled();
   });
@@ -603,6 +617,8 @@ describe("createDiscordGatewayPlugin", () => {
       agent: getLastProxyAgent(),
       handshakeTimeout: 30_000,
       maxPayload: 16 * 1024 * 1024,
+      maxBufferedChunks: 0,
+      maxFragments: 0,
     });
     expect(runtime.log).toHaveBeenCalledTimes(1);
     expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
@@ -695,6 +711,8 @@ describe("createDiscordGatewayPlugin", () => {
       agent: getLastProxyAgent(),
       handshakeTimeout: 30_000,
       maxPayload: 16 * 1024 * 1024,
+      maxBufferedChunks: 0,
+      maxFragments: 0,
     });
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");


### PR DESCRIPTION
## Summary

ws 8.21.0 introduced `maxBufferedChunks` and `maxFragments` receiver limits (commit `[security] Limit retained message parts`) that can trigger `WS_ERR_TOO_MANY_BUFFERED_PARTS` and close connections with code 1008 under certain traffic patterns.

This PR explicitly sets both limits to `0` (disabled) for Discord gateway WebSocket connections, restoring the ws 8.20.0 behavior for the trusted Discord gateway peer while preserving the security fix for all other WebSocket usage.

## Changes

- **`extensions/discord/src/internal/gateway.ts`**: Base class `createWebSocket()` now passes `maxBufferedChunks: 0, maxFragments: 0` with a `ws.ClientOptions` cast (since `@types/ws` 8.18.1 does not yet expose these fields).
- **`extensions/discord/src/monitor/gateway-plugin.ts`**: Extended `DiscordGatewayWebSocketCtor` type to include the new options; monitor gateway creation path passes the same disabled limits.
- **`extensions/discord/src/internal/gateway.test.ts`**: Added test verifying base class WebSocket receives the expected options.
- **`extensions/discord/src/monitor/gateway-plugin.test.ts`**: Added test verifying monitor plugin WebSocket receives the expected options.
- **`extensions/discord/src/monitor/provider.proxy.test.ts`**: Updated two existing exact-match assertions to include the new options.

## Why `0` instead of raising the limits

- ws 8.21.0 treats `0` as disabled (`receiver.js:61`, `receiver.js:98`: `if (this._maxBufferedChunks > 0 && ...)`), matching the pre-8.21.0 behavior exactly.
- Discord gateway is a trusted peer; the security limits are designed to protect against untrusted senders.
- Choosing an arbitrary higher threshold would be fragile without real production traffic data to calibrate against.

## Real behavior proof

- **Behavior or issue addressed**: ws 8.21.0's retained-part receiver limits (`maxFragments` default 131072 / `maxBufferedChunks` default 1048576) abort a Discord gateway socket with `WS_ERR_TOO_MANY_BUFFERED_PARTS` / close `1008`; this PR sets both to `0` (disabled) on the Discord gateway sockets, restoring ws 8.20.0 behavior for that trusted peer.
- **Real environment tested**: Live Discord gateway connection from a Docker `node:22-bookworm-slim` container (Node `v22.22.3`) with the repo-pinned `ws@8.21.0` installed exactly, using a real bot token (redacted), connecting to `wss://gateway.discord.gg/?v=10&encoding=json`.
- **Exact steps or command run after this patch**: build a `node:22-bookworm-slim` image with `npm install ws@8.21.0`, then run a client that constructs the gateway socket with this patch's options (`new ws.WebSocket(url, { handshakeTimeout: 30000, maxBufferedChunks: 0, maxFragments: 0 })`), completes the HELLO/IDENTIFY/READY handshake against the real Discord gateway, sends heartbeats, holds a 60s stable window, then closes with code 1000.
- **Evidence after fix**: Live Discord gateway run with this patch's options applied (token, `session_id`, and `resume_gateway_url` redacted):

```
[env] node=v22.22.3 ws=8.21.0
[discord] connecting wss://gateway.discord.gg (maxBufferedChunks:0, maxFragments:0)
[discord] open
[discord] HELLO heartbeat_interval=41250ms
[discord] IDENTIFY sent (token redacted)
[discord] READY received (session_id/resume_gateway_url redacted)
[discord] HEARTBEAT_ACK #1
[discord] stable window 60000ms complete
[discord] close code=1000 reason=<empty>
[result] PASS live: READY + 1 heartbeat ACK; no WS_ERR_TOO_MANY_BUFFERED_PARTS during stable window
```

Supplemental deterministic mechanism repro against a local ws 8.21.0 gateway streaming one message in 131073 fragments (one over the client default `maxFragments`), exercising the same `ws.WebSocket` receiver path:

```
# default ws.WebSocket (ws 8.21 defaults)
[before] open
[before] error code=WS_ERR_TOO_MANY_BUFFERED_PARTS message=Too many message fragments
[before] close code=1006 reason=<empty>

# this patch's options applied
[after] open
[after] message received: 131073 bytes - NO receiver-limit close
```

- **Observed result after fix**: On the real Discord gateway, with the disabled limits applied, the connection reaches `READY`, exchanges heartbeats, and stays connected through the 60s window with no `WS_ERR_TOO_MANY_BUFFERED_PARTS` and no `1008` close; the only close is the intentional client-initiated `1000`. The deterministic repro confirms the same constructor options remove the receiver-limit close that the default ws 8.21 client hits.
- **What was not tested**: the live run confirms a real gateway session stays healthy with the patched options, but does not force Discord's production fragmentation pattern on demand, does not exercise the `zlib-stream` transport, and does not drive the full OpenClaw plugin wiring end-to-end. The deterministic repro proves the ws 8.21 retained-part mechanism and that this patch's options disable the exact receiver checks, but uses a local peer rather than Discord's live framing.

## Tests

- `gateway.test.ts`: 25 passed
- `gateway-plugin.test.ts`: 17 passed  
- `provider.proxy.test.ts`: 21 passed
- TypeScript check (tsgo): clean

Fixes #88330
