### PR TITLE
fix(agents): harden bundle MCP catalog projection

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -12,7 +12,9 @@ import {
 import type {
   BundleMcpToolRuntime,
   McpCatalogTool,
+  McpServerCatalog,
   McpToolCatalog,
+  McpToolCatalogDiagnostic,
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
 import { normalizeToolParameterSchema } from "./agent-tools-parameter-schema.js";
@@ -132,16 +134,246 @@ function globMatches(pattern: string, value: string): boolean {
   return new RegExp(`^${trimmed.split("*").map(escapeRegex).join(".*")}$`).test(value);
 }
 
-function serverAllowsUtilityTool(
-  server: McpToolCatalog["servers"][string],
-  operation: string,
-): boolean {
+function serverAllowsUtilityTool(server: MaterializedMcpServerCatalog, operation: string): boolean {
   const include = server.toolFilter?.include ?? [];
   const exclude = server.toolFilter?.exclude ?? [];
   if (include.length > 0 && !include.some((pattern) => globMatches(pattern, operation))) {
     return false;
   }
   return !exclude.some((pattern) => globMatches(pattern, operation));
+}
+
+type MaterializedMcpCatalogTool = {
+  descriptor: McpCatalogTool;
+  serverName: string;
+  safeServerName: string;
+  toolName: string;
+  title?: string;
+  description: string;
+  inputSchema: McpCatalogTool["inputSchema"];
+};
+
+type MaterializedMcpServerCatalog = {
+  serverName: string;
+  safeServerName: string;
+  launchSummary: string;
+  resources?: McpServerCatalog["resources"];
+  prompts?: McpServerCatalog["prompts"];
+  supportsParallelToolCalls?: boolean;
+  toolFilter?: {
+    include?: string[];
+    exclude?: string[];
+  };
+};
+
+export type BundleMcpToolCatalogProjection = {
+  tools: AnyAgentTool[];
+  diagnostics: McpToolCatalogDiagnostic[];
+};
+
+function readCatalogField(
+  value: unknown,
+  field: string,
+): { ok: true; value: unknown } | { ok: false } {
+  if (!value || typeof value !== "object") {
+    return { ok: false };
+  }
+  try {
+    return { ok: true, value: (value as Record<string, unknown>)[field] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function normalizeCatalogString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeCatalogStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = value.filter(
+    (entry): entry is string => typeof entry === "string" && Boolean(entry.trim()),
+  );
+  return entries.length > 0 ? entries : undefined;
+}
+
+function catalogDiagnostic(params: {
+  serverName: string;
+  safeServerName?: string;
+  launchSummary?: string;
+  message: string;
+}): McpToolCatalogDiagnostic {
+  return {
+    serverName: params.serverName,
+    safeServerName: params.safeServerName ?? params.serverName,
+    launchSummary: params.launchSummary ?? params.serverName,
+    message: params.message,
+  };
+}
+
+function materializeMcpServerCatalog(params: { serverKey: string; server: unknown }): {
+  server: MaterializedMcpServerCatalog;
+  diagnostics: McpToolCatalogDiagnostic[];
+} {
+  const diagnostics: McpToolCatalogDiagnostic[] = [];
+  const serverNameRead = readCatalogField(params.server, "serverName");
+  const safeServerNameRead = readCatalogField(params.server, "safeServerName");
+  const launchSummaryRead = readCatalogField(params.server, "launchSummary");
+  const serverName =
+    normalizeCatalogString(serverNameRead.ok ? serverNameRead.value : undefined) ??
+    params.serverKey;
+  const safeServerName =
+    normalizeCatalogString(safeServerNameRead.ok ? safeServerNameRead.value : undefined) ??
+    serverName;
+  const launchSummary =
+    normalizeCatalogString(launchSummaryRead.ok ? launchSummaryRead.value : undefined) ??
+    serverName;
+  const resourcesRead = readCatalogField(params.server, "resources");
+  const promptsRead = readCatalogField(params.server, "prompts");
+  const supportsParallelRead = readCatalogField(params.server, "supportsParallelToolCalls");
+  const toolFilterRead = readCatalogField(params.server, "toolFilter");
+  if (!resourcesRead.ok) {
+    diagnostics.push(
+      catalogDiagnostic({
+        serverName,
+        safeServerName,
+        launchSummary,
+        message: `server "${serverName}" resources metadata is unreadable`,
+      }),
+    );
+  }
+  if (!promptsRead.ok) {
+    diagnostics.push(
+      catalogDiagnostic({
+        serverName,
+        safeServerName,
+        launchSummary,
+        message: `server "${serverName}" prompts metadata is unreadable`,
+      }),
+    );
+  }
+  if (!toolFilterRead.ok) {
+    diagnostics.push(
+      catalogDiagnostic({
+        serverName,
+        safeServerName,
+        launchSummary,
+        message: `server "${serverName}" tool filter metadata is unreadable`,
+      }),
+    );
+  }
+  const includeRead = toolFilterRead.ok
+    ? readCatalogField(toolFilterRead.value, "include")
+    : undefined;
+  const excludeRead = toolFilterRead.ok
+    ? readCatalogField(toolFilterRead.value, "exclude")
+    : undefined;
+  return {
+    server: {
+      serverName,
+      safeServerName,
+      launchSummary,
+      ...(resourcesRead.ok && resourcesRead.value && typeof resourcesRead.value === "object"
+        ? { resources: resourcesRead.value as McpServerCatalog["resources"] }
+        : {}),
+      ...(promptsRead.ok && promptsRead.value && typeof promptsRead.value === "object"
+        ? { prompts: promptsRead.value as McpServerCatalog["prompts"] }
+        : {}),
+      ...(supportsParallelRead.ok && supportsParallelRead.value === true
+        ? { supportsParallelToolCalls: true }
+        : {}),
+      ...(toolFilterRead.ok && toolFilterRead.value && typeof toolFilterRead.value === "object"
+        ? {
+            toolFilter: {
+              ...(includeRead?.ok
+                ? { include: normalizeCatalogStringArray(includeRead.value) ?? [] }
+                : {}),
+              ...(excludeRead?.ok
+                ? { exclude: normalizeCatalogStringArray(excludeRead.value) ?? [] }
+                : {}),
+            },
+          }
+        : {}),
+    },
+    diagnostics,
+  };
+}
+
+function materializeMcpCatalogTool(params: {
+  tool: unknown;
+  toolIndex: number;
+  serversByName: ReadonlyMap<string, MaterializedMcpServerCatalog>;
+}): { tool: MaterializedMcpCatalogTool } | { diagnostic: McpToolCatalogDiagnostic } {
+  const serverNameRead = readCatalogField(params.tool, "serverName");
+  const safeServerNameRead = readCatalogField(params.tool, "safeServerName");
+  const toolNameRead = readCatalogField(params.tool, "toolName");
+  const titleRead = readCatalogField(params.tool, "title");
+  const descriptionRead = readCatalogField(params.tool, "description");
+  const fallbackDescriptionRead = readCatalogField(params.tool, "fallbackDescription");
+  const inputSchemaRead = readCatalogField(params.tool, "inputSchema");
+  const serverName = normalizeCatalogString(serverNameRead.ok ? serverNameRead.value : undefined);
+  const safeServerName = normalizeCatalogString(
+    safeServerNameRead.ok ? safeServerNameRead.value : undefined,
+  );
+  const toolName = normalizeCatalogString(toolNameRead.ok ? toolNameRead.value : undefined);
+  const server = serverName ? params.serversByName.get(serverName) : undefined;
+  const fallbackToolLabel = `tool[${params.toolIndex}]`;
+  const diagnosticBase = {
+    serverName: serverName ?? fallbackToolLabel,
+    safeServerName: safeServerName ?? server?.safeServerName ?? serverName ?? fallbackToolLabel,
+    launchSummary: server?.launchSummary ?? serverName ?? fallbackToolLabel,
+  };
+  const fieldViolations = [
+    ...(serverNameRead.ok && serverName ? [] : ["serverName"]),
+    ...(safeServerNameRead.ok && safeServerName ? [] : ["safeServerName"]),
+    ...(toolNameRead.ok && toolName ? [] : ["toolName"]),
+    ...(inputSchemaRead.ok && inputSchemaRead.value !== undefined ? [] : ["inputSchema"]),
+  ];
+  if (
+    !serverName ||
+    !safeServerName ||
+    !toolName ||
+    !inputSchemaRead.ok ||
+    inputSchemaRead.value === undefined
+  ) {
+    return {
+      diagnostic: catalogDiagnostic({
+        ...diagnosticBase,
+        message: `tools[${params.toolIndex}] has unreadable or missing required field(s): ${fieldViolations.join(", ")}`,
+      }),
+    };
+  }
+  const inputSchema = inputSchemaRead.value as McpCatalogTool["inputSchema"];
+  const fallbackDescription =
+    normalizeCatalogString(
+      fallbackDescriptionRead.ok ? fallbackDescriptionRead.value : undefined,
+    ) ?? `Provided by bundle MCP server "${serverName}".`;
+  const description =
+    normalizeCatalogString(descriptionRead.ok ? descriptionRead.value : undefined) ??
+    fallbackDescription;
+  const title = normalizeCatalogString(titleRead.ok ? titleRead.value : undefined);
+  const descriptor: McpCatalogTool = {
+    serverName,
+    safeServerName,
+    toolName,
+    ...(title ? { title } : {}),
+    description,
+    inputSchema,
+    fallbackDescription,
+  };
+  return {
+    tool: {
+      descriptor,
+      serverName,
+      safeServerName,
+      toolName,
+      ...(descriptor.title ? { title: descriptor.title } : {}),
+      description,
+      inputSchema: descriptor.inputSchema,
+    },
+  };
 }
 
 function addMcpUtilityTool(params: {
@@ -200,9 +432,42 @@ export function buildBundleMcpToolsFromCatalog(params: {
   createPromptListExecute?: (serverName: string) => AnyAgentTool["execute"];
   createPromptGetExecute?: (serverName: string) => AnyAgentTool["execute"];
 }): AnyAgentTool[] {
+  return projectBundleMcpToolsFromCatalog(params).tools;
+}
+
+export function projectBundleMcpToolsFromCatalog(params: {
+  catalog: McpToolCatalog;
+  reservedToolNames?: Iterable<string>;
+  createExecute?: (tool: McpCatalogTool) => AnyAgentTool["execute"];
+  createResourceListExecute?: (serverName: string) => AnyAgentTool["execute"];
+  createResourceReadExecute?: (serverName: string) => AnyAgentTool["execute"];
+  createPromptListExecute?: (serverName: string) => AnyAgentTool["execute"];
+  createPromptGetExecute?: (serverName: string) => AnyAgentTool["execute"];
+}): BundleMcpToolCatalogProjection {
   const reservedNames = normalizeReservedToolNames(params.reservedToolNames);
   const tools: AnyAgentTool[] = [];
-  const sortedCatalogTools = [...params.catalog.tools].toSorted((a, b) => {
+  const diagnostics: McpToolCatalogDiagnostic[] = [];
+  const materializedServers = Object.entries(params.catalog.servers)
+    .toSorted(([a], [b]) => a.localeCompare(b))
+    .map(([serverKey, server]) => materializeMcpServerCatalog({ serverKey, server }));
+  diagnostics.push(...materializedServers.flatMap((entry) => entry.diagnostics));
+  const serversByName = new Map(
+    materializedServers.map(({ server }) => [server.serverName, server] as const),
+  );
+  const materializedTools: MaterializedMcpCatalogTool[] = [];
+  for (const [toolIndex, tool] of params.catalog.tools.entries()) {
+    const materialized = materializeMcpCatalogTool({
+      tool,
+      toolIndex,
+      serversByName,
+    });
+    if ("diagnostic" in materialized) {
+      diagnostics.push(materialized.diagnostic);
+    } else {
+      materializedTools.push(materialized.tool);
+    }
+  }
+  const sortedCatalogTools = materializedTools.toSorted((a, b) => {
     const serverOrder = a.safeServerName.localeCompare(b.safeServerName);
     if (serverOrder !== 0) {
       return serverOrder;
@@ -215,11 +480,11 @@ export function buildBundleMcpToolsFromCatalog(params: {
   });
 
   for (const tool of sortedCatalogTools) {
-    const originalName = tool.toolName.trim();
+    const originalName = tool.toolName;
     if (!originalName) {
       continue;
     }
-    const server = params.catalog.servers[tool.serverName];
+    const server = serversByName.get(tool.serverName);
     const executionMode: AnyAgentTool["executionMode"] =
       server?.supportsParallelToolCalls === true ? "parallel" : "sequential";
     const safeToolName = buildSafeToolName({
@@ -236,11 +501,11 @@ export function buildBundleMcpToolsFromCatalog(params: {
     const agentTool: AnyAgentTool = {
       name: safeToolName,
       label: tool.title ?? tool.toolName,
-      description: tool.description || tool.fallbackDescription,
+      description: tool.description,
       parameters: normalizeToolParameterSchema(tool.inputSchema),
       executionMode,
       execute:
-        params.createExecute?.(tool) ??
+        params.createExecute?.(tool.descriptor) ??
         (async () => {
           throw new Error("bundle-mcp catalog projection cannot execute tools");
         }),
@@ -258,10 +523,8 @@ export function buildBundleMcpToolsFromCatalog(params: {
     tools.push(agentTool);
   }
 
-  for (const server of Object.values(params.catalog.servers).toSorted((a, b) =>
-    a.serverName.localeCompare(b.serverName),
-  )) {
-    const safeServerName = server.safeServerName ?? server.serverName;
+  for (const server of materializedServers.map((entry) => entry.server)) {
+    const safeServerName = server.safeServerName;
     const executionMode: AnyAgentTool["executionMode"] = server.supportsParallelToolCalls
       ? "parallel"
       : "sequential";
@@ -343,7 +606,7 @@ export function buildBundleMcpToolsFromCatalog(params: {
   // turns (defensive — listTools() order is usually stable but not guaranteed).
   // Cannot fix name collisions: collision suffixes above are order-dependent.
   tools.sort((a, b) => a.name.localeCompare(b.name));
-  return tools;
+  return { tools, diagnostics };
 }
 
 export async function materializeBundleMcpToolsForRun(params: {
@@ -361,7 +624,7 @@ export async function materializeBundleMcpToolsForRun(params: {
     releaseLease?.();
     throw error;
   }
-  const tools = buildBundleMcpToolsFromCatalog({
+  const projection = projectBundleMcpToolsFromCatalog({
     catalog,
     reservedToolNames: params.reservedToolNames,
     createExecute: (tool) => async (_toolCallId: string, input: unknown) => {
@@ -420,9 +683,9 @@ export async function materializeBundleMcpToolsForRun(params: {
   });
 
   return {
-    tools,
-    ...(catalog.diagnostics && catalog.diagnostics.length > 0
-      ? { diagnostics: catalog.diagnostics }
+    tools: projection.tools,
+    ...((catalog.diagnostics && catalog.diagnostics.length > 0) || projection.diagnostics.length > 0
+      ? { diagnostics: [...(catalog.diagnostics ?? []), ...projection.diagnostics] }
       : {}),
     dispose: async () => {
       if (disposed) {

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -6,6 +6,7 @@ import {
   buildBundleMcpToolsFromCatalog,
   createBundleMcpToolRuntime,
   materializeBundleMcpToolsForRun,
+  projectBundleMcpToolsFromCatalog,
 } from "./agent-bundle-mcp-materialize.js";
 import type { McpCatalogTool } from "./agent-bundle-mcp-types.js";
 import type { McpToolCatalogDiagnostic } from "./agent-bundle-mcp-types.js";
@@ -182,6 +183,115 @@ describe("createBundleMcpToolRuntime", () => {
     expect(runtime.diagnostics).toEqual(diagnostics);
   });
 
+  it("falls back when MCP catalog optional description fields are unreadable", async () => {
+    const hostileTool = {
+      serverName: "bundleProbe",
+      safeServerName: "bundleProbe",
+      toolName: "bundle_probe",
+      inputSchema: { type: "object", properties: {} },
+      fallbackDescription: "Fallback bundle probe",
+    };
+    Object.defineProperty(hostileTool, "description", {
+      get() {
+        throw new Error("description exploded");
+      },
+    });
+
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({ tools: [hostileTool as never] }),
+    });
+
+    expect(
+      runtime.tools.map((tool) => ({ name: tool.name, description: tool.description })),
+    ).toEqual([
+      {
+        name: "bundleProbe__bundle_probe",
+        description: "Fallback bundle probe",
+      },
+    ]);
+    expect(runtime.diagnostics).toBeUndefined();
+  });
+
+  it("skips MCP catalog tools with unreadable required fields while preserving siblings", async () => {
+    const brokenTool = {
+      serverName: "bundleProbe",
+      safeServerName: "bundleProbe",
+      description: "bad",
+      inputSchema: { type: "object", properties: {} },
+      fallbackDescription: "bad",
+    };
+    Object.defineProperty(brokenTool, "toolName", {
+      get() {
+        throw new Error("toolName exploded");
+      },
+    });
+
+    const projection = projectBundleMcpToolsFromCatalog({
+      catalog: {
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          bundleProbe: {
+            serverName: "bundleProbe",
+            safeServerName: "bundleProbe",
+            launchSummary: "bundleProbe",
+            toolCount: 2,
+          },
+        },
+        tools: [
+          brokenTool as never,
+          {
+            serverName: "bundleProbe",
+            safeServerName: "bundleProbe",
+            toolName: "healthy_probe",
+            description: "Healthy probe",
+            inputSchema: { type: "object", properties: {} },
+            fallbackDescription: "Healthy probe",
+          },
+        ],
+      },
+    });
+
+    expect(projection.tools.map((tool) => tool.name)).toEqual(["bundleProbe__healthy_probe"]);
+    expect(projection.diagnostics).toEqual([
+      {
+        serverName: "bundleProbe",
+        safeServerName: "bundleProbe",
+        launchSummary: "bundleProbe",
+        message: "tools[0] has unreadable or missing required field(s): toolName",
+      },
+    ]);
+  });
+
+  it("returns materialization diagnostics for unreadable MCP catalog input schemas", async () => {
+    const brokenTool = {
+      serverName: "bundleProbe",
+      safeServerName: "bundleProbe",
+      toolName: "broken_probe",
+      description: "Broken probe",
+      fallbackDescription: "Broken probe",
+    };
+    Object.defineProperty(brokenTool, "inputSchema", {
+      get() {
+        throw new Error("inputSchema exploded");
+      },
+    });
+
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({ tools: [brokenTool as never] }),
+    });
+
+    expect(runtime.tools).toEqual([]);
+    expect(runtime.diagnostics).toEqual([
+      {
+        serverName: "bundleProbe",
+        safeServerName: "bundleProbe",
+        launchSummary: "bundleProbe",
+        message: "tools[0] has unreadable or missing required field(s): inputSchema",
+      },
+    ]);
+  });
+
   it("exposes MCP resource and prompt utility tools when advertised", async () => {
     const base = makeToolRuntime({ tools: [], serverName: "knowledge" });
     const runtime = await materializeBundleMcpToolsForRun({
@@ -268,6 +378,51 @@ describe("createBundleMcpToolRuntime", () => {
     });
 
     expect(runtime.tools.map((tool) => tool.name)).toEqual(["knowledge__resources_list"]);
+  });
+
+  it("skips unreadable server utility metadata without dropping healthy servers", async () => {
+    const brokenServer = {
+      serverName: "broken",
+      safeServerName: "broken",
+      launchSummary: "broken",
+      toolCount: 0,
+    };
+    Object.defineProperty(brokenServer, "resources", {
+      get() {
+        throw new Error("resources exploded");
+      },
+    });
+
+    const projection = projectBundleMcpToolsFromCatalog({
+      catalog: {
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          broken: brokenServer as never,
+          healthy: {
+            serverName: "healthy",
+            safeServerName: "healthy",
+            launchSummary: "healthy",
+            toolCount: 0,
+            resources: { listChanged: false },
+          },
+        },
+        tools: [],
+      },
+    });
+
+    expect(projection.tools.map((tool) => tool.name)).toEqual([
+      "healthy__resources_list",
+      "healthy__resources_read",
+    ]);
+    expect(projection.diagnostics).toEqual([
+      {
+        serverName: "broken",
+        safeServerName: "broken",
+        launchSummary: "broken",
+        message: 'server "broken" resources metadata is unreadable',
+      },
+    ]);
   });
 
   it("projects resource and prompt utility tools for inventory-only catalogs", async () => {

--- a/src/agents/agent-bundle-mcp-tools.request-boundary.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.request-boundary.test.ts
@@ -24,18 +24,21 @@ function makeConfiguredRuntime(
   params: {
     serverName?: string;
     toolNames?: string[];
+    tools?: McpCatalogTool[];
   } = {},
 ): SessionMcpRuntime {
   const serverName = params.serverName ?? "userMcp";
   const toolNames = params.toolNames ?? ["list_inbox", "send_reply"];
-  const tools: McpCatalogTool[] = toolNames.map((toolName) => ({
-    serverName,
-    safeServerName: serverName,
-    toolName,
-    description: `${serverName}.${toolName}`,
-    inputSchema: { type: "object", properties: {} },
-    fallbackDescription: `${serverName}.${toolName}`,
-  }));
+  const tools: McpCatalogTool[] =
+    params.tools ??
+    toolNames.map((toolName) => ({
+      serverName,
+      safeServerName: serverName,
+      toolName,
+      description: `${serverName}.${toolName}`,
+      inputSchema: { type: "object", properties: {} },
+      fallbackDescription: `${serverName}.${toolName}`,
+    }));
   return {
     sessionId: "session-request-boundary",
     workspaceDir: "/workspace",
@@ -182,6 +185,52 @@ describe("configured MCP tools reach the request boundary (#76063)", () => {
       "userMcp__alpha_tool",
       "userMcp__mu_tool",
       "userMcp__zeta_tool",
+    ]);
+  });
+
+  it("keeps healthy configured MCP tools at the request boundary when a catalog sibling is unreadable", async () => {
+    const brokenTool = {
+      serverName: "userMcp",
+      safeServerName: "userMcp",
+      description: "bad",
+      inputSchema: { type: "object", properties: {} },
+      fallbackDescription: "bad",
+    };
+    Object.defineProperty(brokenTool, "toolName", {
+      get() {
+        throw new Error("toolName exploded");
+      },
+    });
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeConfiguredRuntime({
+        tools: [
+          brokenTool as never,
+          {
+            serverName: "userMcp",
+            safeServerName: "userMcp",
+            toolName: "send_reply",
+            description: "userMcp.send_reply",
+            inputSchema: { type: "object", properties: {} },
+            fallbackDescription: "userMcp.send_reply",
+          },
+        ],
+      }),
+    });
+    const filtered = applyFinalEffectiveToolPolicy({
+      bundledTools: runtime.tools,
+      config: { tools: { profile: "coding" } },
+      warn: () => {},
+    });
+    const { customTools } = splitSdkTools({ tools: filtered, sandboxEnabled: false });
+
+    expect(customTools.map((tool) => tool.name)).toEqual(["userMcp__send_reply"]);
+    expect(runtime.diagnostics).toEqual([
+      {
+        serverName: "userMcp",
+        safeServerName: "userMcp",
+        launchSummary: "userMcp",
+        message: "tools[0] has unreadable or missing required field(s): toolName",
+      },
     ]);
   });
 });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -6,7 +6,7 @@ import {
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { Command } from "commander";
-import { buildBundleMcpToolsFromCatalog } from "../agents/agent-bundle-mcp-materialize.js";
+import { projectBundleMcpToolsFromCatalog } from "../agents/agent-bundle-mcp-materialize.js";
 import { createSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
 import {
   buildMcpHttpFetch,
@@ -469,7 +469,7 @@ async function buildMcpStatusEntries(
 function formatMcpProbeResult(
   catalog: Awaited<ReturnType<ReturnType<typeof createSessionMcpRuntime>["getCatalog"]>>,
 ) {
-  const projectedTools = buildBundleMcpToolsFromCatalog({
+  const projection = projectBundleMcpToolsFromCatalog({
     catalog,
     createResourceListExecute: () => async () => {
       throw new Error("probe projection cannot execute MCP resources_list");
@@ -515,8 +515,8 @@ function formatMcpProbeResult(
           },
         ]),
     ),
-    tools: projectedTools.map((tool) => tool.name).toSorted(),
-    diagnostics: catalog.diagnostics ?? [],
+    tools: projection.tools.map((tool) => tool.name).toSorted(),
+    diagnostics: [...(catalog.diagnostics ?? []), ...projection.diagnostics],
   };
 }
 


### PR DESCRIPTION
## Summary

- Materialize bundle MCP catalog server/tool descriptors through guarded field reads before sorting, projection, and execution closure creation.
- Keep healthy sibling tools and utility tools when a malformed catalog entry or server metadata accessor throws; surface diagnostics instead of crashing.
- Thread projection diagnostics through runtime materialization and CLI MCP probe output.

## Real behavior proof

Behavior addressed: Bundle MCP catalog descriptors with throwing top-level accessors no longer crash tool projection or request materialization; unreadable required fields are skipped with diagnostics, and optional descriptions fall back.

Real environment tested: local macOS Codex worktree; Azure Crabbox Linux runner `cbx_c84bdac5263f`, run `run_3263f0edb22a`.

Exact steps or command run after this patch:

- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-tools.materialize.test.ts src/agents/agent-bundle-mcp-tools.request-boundary.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/agent-bundle-mcp-materialize.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts src/agents/agent-bundle-mcp-tools.request-boundary.test.ts src/cli/mcp-cli.ts`
- `node_modules/.bin/oxlint src/agents/agent-bundle-mcp-materialize.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts src/agents/agent-bundle-mcp-tools.request-boundary.test.ts src/cli/mcp-cli.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider azure --target linux --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed"`

Evidence after fix: Focused local Vitest passed 2 files / 21 tests; formatter, lint, and diff checks passed; autoreview reported no accepted/actionable findings; Azure Crabbox `run_3263f0edb22a` passed changed-gate guards plus `typecheck core`.

Observed result after fix: Healthy sibling MCP catalog tools remain available, malformed catalog entries produce diagnostics, and CLI probe output includes projection diagnostics.

What was not tested: Full `pnpm check:changed` did not complete because `typecheck core tests` currently fails on untouched gateway test files: `src/gateway/server-plugins.test.ts` and `src/gateway/server-startup.test.ts`. Blacksmith Testbox was unavailable because the local Blacksmith CLI is not authenticated.
