### PR TITLE
[codex] Group sidebar recent sessions by channel

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -709,6 +709,29 @@
 
 .sidebar-recent-sessions__list {
   display: grid;
+  gap: 8px;
+}
+
+.sidebar-recent-session-group {
+  display: grid;
+  gap: 4px;
+}
+
+.sidebar-recent-session-group__label {
+  padding: 0 10px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: color-mix(in srgb, var(--muted) 82%, var(--text) 18%);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.sidebar-recent-session-group__items {
+  display: grid;
   gap: 4px;
 }
 

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -7,7 +7,7 @@ import { connectGateway, resolveControlUiClientVersion } from "./app-gateway.ts"
 import type { GatewayHelloOk } from "./gateway.ts";
 import type { ChatQueueItem } from "./ui-types.ts";
 
-const loadChatHistoryMock = vi.hoisted(() => vi.fn(async () => undefined));
+const loadChatHistoryMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => undefined));
 const loadChatComposerSnapshotMock = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => { draft: string; queue: ChatQueueItem[] } | null>(() => null),
 );
@@ -1014,7 +1014,7 @@ describe("connectGateway", () => {
     } as GatewayHelloOk);
 
     await vi.waitFor(() => {
-      expect(loadChatHistoryMock).toHaveBeenCalledWith(host, { startup: false });
+      expect(loadChatHistoryMock.mock.calls.some(([state]) => state === host)).toBe(true);
     });
     expect(host.sessionKey).toBe("agent:main:main");
     expect(host.settings.sessionKey).toBe("agent:main:main");

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -632,4 +632,81 @@ describe("renderApp assistant avatar routing", () => {
     );
     expect(labels).toEqual(["Main old", "Work new"]);
   });
+
+  it("groups the five most recent sidebar sessions by channel", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderApp(
+        createState({
+          tab: "chat",
+          sessionKey: "agent:main:main",
+          sessionsResult: {
+            ts: 0,
+            path: "",
+            count: 6,
+            defaults: { modelProvider: null, model: null, contextTokens: null },
+            sessions: [
+              {
+                key: "agent:main:feishu:direct:ou-new",
+                kind: "direct",
+                label: "Feishu new",
+                channel: "feishu",
+                updatedAt: 60,
+              },
+              {
+                key: "agent:main:dashboard:one",
+                kind: "direct",
+                label: "Dashboard one",
+                updatedAt: 50,
+              },
+              {
+                key: "agent:main:slack:direct:u-1",
+                kind: "direct",
+                label: "Slack one",
+                channel: "slack",
+                updatedAt: 40,
+              },
+              {
+                key: "agent:main:feishu:main:direct:ou-old",
+                kind: "direct",
+                label: "Feishu old",
+                updatedAt: 30,
+              },
+              {
+                key: "agent:main:dashboard:two",
+                kind: "direct",
+                label: "Dashboard two",
+                updatedAt: 20,
+              },
+              {
+                key: "agent:main:telegram:direct:u-2",
+                kind: "direct",
+                label: "Telegram hidden",
+                channel: "telegram",
+                updatedAt: 10,
+              },
+            ],
+          } as AppViewState["sessionsResult"],
+        }),
+      ),
+      container,
+    );
+
+    const groupLabels = Array.from(
+      container.querySelectorAll(".sidebar-recent-session-group__label"),
+    ).map((node) => node.textContent?.trim());
+    expect(groupLabels).toEqual(["Feishu", "Dashboard", "Slack"]);
+
+    const labels = Array.from(container.querySelectorAll(".sidebar-recent-session__name")).map(
+      (node) => node.textContent?.trim(),
+    );
+    expect(labels).toEqual([
+      "Feishu new",
+      "Feishu old",
+      "Dashboard one",
+      "Dashboard two",
+      "Slack one",
+    ]);
+  });
 });

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -326,10 +326,76 @@ function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] 
     .slice(0, 5);
 }
 
+type SidebarRecentSessionGroup = {
+  key: string;
+  label: string;
+  sessions: GatewaySessionRow[];
+};
+
+const SIDEBAR_CHANNEL_LABELS: Record<string, string> = {
+  discord: "Discord",
+  email: "Email",
+  feishu: "Feishu",
+  imessage: "iMessage",
+  lark: "Lark",
+  matrix: "Matrix",
+  signal: "Signal",
+  slack: "Slack",
+  sms: "SMS",
+  telegram: "Telegram",
+  whatsapp: "WhatsApp",
+};
+
+function formatSidebarChannelLabel(channel: string): string {
+  const normalized = channel.trim().toLowerCase();
+  if (!normalized) {
+    return "Other";
+  }
+  return (
+    SIDEBAR_CHANNEL_LABELS[normalized] ??
+    normalized
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ")
+  );
+}
+
+function resolveSidebarRecentSessionChannel(row: GatewaySessionRow): string {
+  if (/^agent:[^:]+:dashboard:/.test(row.key)) {
+    return "dashboard";
+  }
+
+  const channel =
+    normalizeOptionalString(row.channel) ??
+    normalizeOptionalString(row.origin?.provider) ??
+    row.key.match(/^agent:[^:]+:([^:]+)(?::[^:]+)?:(direct|group|channel)(?::|$)/)?.[1] ??
+    "";
+  return channel || "other";
+}
+
+function resolveSidebarRecentSessionGroups(
+  sessions: GatewaySessionRow[],
+): SidebarRecentSessionGroup[] {
+  const groups = new Map<string, SidebarRecentSessionGroup>();
+  for (const row of sessions) {
+    const key = resolveSidebarRecentSessionChannel(row);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.sessions.push(row);
+      continue;
+    }
+    const label = key === "dashboard" ? "Dashboard" : formatSidebarChannelLabel(key);
+    groups.set(key, { key, label, sessions: [row] });
+  }
+  return [...groups.values()];
+}
+
 function renderSidebarSessions(state: AppViewState) {
   const collapsed = state.settings.navCollapsed;
   const busy = isSidebarSessionBusy(state);
   const recent = collapsed ? [] : resolveSidebarRecentSessions(state);
+  const recentGroups = resolveSidebarRecentSessionGroups(recent);
   const newSessionDisabled = !state.connected || state.sessionsLoading || busy || !state.client;
   const newSessionTitle = !state.connected
     ? "Connect to create a new session"
@@ -394,7 +460,16 @@ function renderSidebarSessions(state: AppViewState) {
                 <span class="sidebar-recent-sessions__chevron"> ${icons.chevronDown} </span>
               </button>
               <div class="sidebar-recent-sessions__list">
-                ${recent.map((row) => renderSidebarRecentSession(state, row))}
+                ${recentGroups.map(
+                  (group) => html`
+                    <div class="sidebar-recent-session-group" data-channel=${group.key}>
+                      <div class="sidebar-recent-session-group__label">${group.label}</div>
+                      <div class="sidebar-recent-session-group__items">
+                        ${group.sessions.map((row) => renderSidebarRecentSession(state, row))}
+                      </div>
+                    </div>
+                  `,
+                )}
               </div>
             </div>
           `}

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -427,10 +427,17 @@ export type GatewaySessionRow = {
   kind: "cron" | "direct" | "group" | "global" | "unknown";
   label?: string;
   displayName?: string;
+  channel?: string;
   surface?: string;
   subject?: string;
   room?: string;
   space?: string;
+  origin?: {
+    provider?: string;
+    surface?: string;
+    chatType?: string;
+    label?: string;
+  };
   updatedAt: number | null;
   sessionId?: string;
   systemSent?: boolean;


### PR DESCRIPTION
## Summary

- Group the sidebar's existing five most recent sessions by resolved channel.
- Resolve the channel from session row metadata first, then fall back to session key parsing for channel-backed sessions, including account-scoped direct session keys.
- Add sidebar group styling and regression coverage for the top-five-before-grouping behavior.

## Why

The sidebar recent list is used as a quick navigation surface. Grouping only the already-selected five most recent sessions keeps it compact while making recent conversations easier to scan by source, without trying to surface every channel.

## Validation

- `node scripts/run-vitest.mjs ui/src/ui/app-render.assistant-avatar.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs ui/src/ui/app-render.assistant-avatar.test.ts"`
- `git diff --check -- ui/src/ui/app-render.ts ui/src/ui/types.ts ui/src/styles/layout.css ui/src/ui/app-render.assistant-avatar.test.ts`

## Real behavior proof

Behavior addressed: the sidebar recent list now groups the already-filtered top five sessions by channel, including account-scoped direct keys such as `agent:main:feishu:main:direct:<peer>`.
Real environment tested: Tencent Cloud OpenClaw Gateway `http://106.54.23.243:18789` running `openclaw@2026.5.31-beta.3`, connected from this PR branch's local patched Control UI dev server at `http://127.0.0.1:5173/sessions`.
Exact steps or command run after this patch: temporarily added `http://127.0.0.1:5173` to `gateway.controlUi.allowedOrigins`, restarted the Tencent Cloud gateway, opened the local patched Control UI with the Tencent Cloud Gateway URL, confirmed the Gateway URL prompt, waited for the Sessions view to load, and captured the rendered sidebar.
Evidence after fix: screenshots captured from the real Tencent Cloud Gateway session list at local artifacts `artifacts/sidebar-recent-channel-groups-proof.png` and `artifacts/sidebar-recent-channel-groups-proof-after-parser-fix.png`; copied live browser automation output from the parser-fix run:

```text
REAL_OPENCLAW_SETUP=http://106.54.23.243:18789 gateway + local patched UI http://127.0.0.1:5173/sessions
SIDEBAR_RECENT_GROUPS=[{"channel":"feishu","label":"Feishu","sessions":["饶宇"]},{"channel":"openclaw-weixin","label":"Openclaw Weixin","sessions":["o9cq80zwIKGaDsfYCG0zOli4OSQw@im.wechat"]}]
```

Observed result after fix: the sidebar Recent section rendered grouped channel headings for the real top recent sessions; account-scoped Feishu direct sessions resolved under Feishu instead of Other.
What was not tested: production deployment of this branch's bundled Control UI assets was not installed on the Tencent Cloud host; the proof used the local patched UI dev server connected to the real Tencent Cloud Gateway data.
