### PR TITLE
feat(android): add installed apps node command

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -218,6 +218,7 @@ Current OpenClaw Android implication:
 - Google Play build excludes SMS send/search, Call Log search, and recent-photo access unless the product is intentionally positioned and approved under the relevant policy exception.
 - The repo now ships this split as Android product flavors:
   - `play`: removes `READ_SMS`, `SEND_SMS`, `READ_CALL_LOG`, `READ_MEDIA_IMAGES`, `READ_MEDIA_VISUAL_USER_SELECTED`, and `READ_EXTERNAL_STORAGE`; hides SMS, Call Log, and Photos surfaces in onboarding, settings, and advertised node capabilities.
+  - Installed-app listing is user controlled. `device.apps` is advertised only after the user enables **Settings > Phone Capabilities > Installed Apps**. The command defaults to launcher-visible apps and does not require `QUERY_ALL_PACKAGES`.
   - `thirdParty`: keeps the full permission set and the existing SMS / Call Log / Photos functionality.
 
 Policy links:

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -148,6 +148,7 @@ class MainViewModel(
   val gatewayBootstrapToken: StateFlow<String> = prefs.gatewayBootstrapToken
   val onboardingCompleted: StateFlow<Boolean> = prefs.onboardingCompleted
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
+  val installedAppsSharingEnabled: StateFlow<Boolean> = prefs.installedAppsSharingEnabled
   val speakerEnabled: StateFlow<Boolean> = prefs.speakerEnabled
   val voiceCaptureMode: StateFlow<VoiceCaptureMode> = runtimeState(initial = VoiceCaptureMode.Off) { it.voiceCaptureMode }
   val micEnabled: StateFlow<Boolean> = runtimeState(initial = false) { it.micEnabled }
@@ -297,6 +298,10 @@ class MainViewModel(
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {
     prefs.setCanvasDebugStatusEnabled(value)
+  }
+
+  fun setInstalledAppsSharingEnabled(value: Boolean) {
+    ensureRuntime().setInstalledAppsSharingEnabled(value)
   }
 
   fun setNotificationForwardingEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -207,6 +207,7 @@ class NodeRuntime(
       callLogAvailable = { SensitiveFeatureConfig.callLogEnabled },
       photosAvailable = { SensitiveFeatureConfig.photosEnabled },
       hasRecordAudioPermission = { hasRecordAudioPermission() },
+      installedAppsSharingEnabled = { installedAppsSharingEnabled.value },
       manualTls = { manualTls.value },
     )
 
@@ -245,6 +246,7 @@ class NodeRuntime(
       smsTelephonyAvailable = { sms.hasTelephonyFeature() },
       callLogAvailable = { SensitiveFeatureConfig.callLogEnabled },
       photosAvailable = { SensitiveFeatureConfig.photosEnabled },
+      installedAppsSharingEnabled = { installedAppsSharingEnabled.value },
       debugBuild = { BuildConfig.DEBUG },
       onCanvasA2uiPush = {
         _canvasA2uiHydrated.value = true
@@ -866,6 +868,7 @@ class NodeRuntime(
 
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
+  val installedAppsSharingEnabled: StateFlow<Boolean> = prefs.installedAppsSharingEnabled
   val notificationForwardingEnabled: StateFlow<Boolean> = prefs.notificationForwardingEnabled
   val notificationForwardingMode: StateFlow<NotificationPackageFilterMode> =
     prefs.notificationForwardingMode
@@ -1075,6 +1078,12 @@ class NodeRuntime(
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {
     prefs.setCanvasDebugStatusEnabled(value)
+  }
+
+  fun setInstalledAppsSharingEnabled(value: Boolean) {
+    if (prefs.installedAppsSharingEnabled.value == value) return
+    prefs.setInstalledAppsSharingEnabled(value)
+    refreshNodeSurfaceAfterSharingChange()
   }
 
   fun setNotificationForwardingEnabled(value: Boolean) {
@@ -1411,6 +1420,11 @@ class NodeRuntime(
       }
     operatorStatusText = "Connecting…"
     updateStatus()
+    connectWithAuth(endpoint = endpoint, auth = resolveGatewayConnectAuth(), reconnect = true)
+  }
+
+  private fun refreshNodeSurfaceAfterSharingChange() {
+    val endpoint = connectedEndpoint ?: return
     connectWithAuth(endpoint = endpoint, auth = resolveGatewayConnectAuth(), reconnect = true)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -40,11 +40,13 @@ class SecurePrefs(
     private const val notificationsForwardingMaxEventsPerMinuteKey =
       "notifications.forwarding.maxEventsPerMinute"
     private const val notificationsForwardingSessionKeyKey = "notifications.forwarding.sessionKey"
+    private const val installedAppsSharingEnabledKey = "device.apps.sharing.enabled"
     private const val voiceMicEnabledKey = "voice.micEnabled"
   }
 
   private val appContext = context.applicationContext
   private val json = Json { ignoreUnknownKeys = true }
+
   // Non-secret UI/runtime preferences stay readable for migration and backup behavior.
   private val plainPrefs: SharedPreferences =
     appContext.getSharedPreferences(plainPrefsName, Context.MODE_PRIVATE)
@@ -113,6 +115,10 @@ class SecurePrefs(
   private val _canvasDebugStatusEnabled =
     MutableStateFlow(plainPrefs.getBoolean("canvas.debugStatusEnabled", false))
   val canvasDebugStatusEnabled: StateFlow<Boolean> = _canvasDebugStatusEnabled
+
+  private val _installedAppsSharingEnabled =
+    MutableStateFlow(plainPrefs.getBoolean(installedAppsSharingEnabledKey, false))
+  val installedAppsSharingEnabled: StateFlow<Boolean> = _installedAppsSharingEnabled
 
   private val _notificationForwardingEnabled =
     MutableStateFlow(plainPrefs.getBoolean(notificationsForwardingEnabledKey, defaultNotificationForwardingEnabled))
@@ -250,6 +256,11 @@ class SecurePrefs(
   fun setCanvasDebugStatusEnabled(value: Boolean) {
     plainPrefs.edit { putBoolean("canvas.debugStatusEnabled", value) }
     _canvasDebugStatusEnabled.value = value
+  }
+
+  fun setInstalledAppsSharingEnabled(value: Boolean) {
+    plainPrefs.edit { putBoolean(installedAppsSharingEnabledKey, value) }
+    _installedAppsSharingEnabled.value = value
   }
 
   internal fun getNotificationForwardingPolicy(appPackageName: String): NotificationForwardingPolicy {

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -28,6 +28,7 @@ class ConnectionManager(
   private val callLogAvailable: () -> Boolean,
   private val photosAvailable: () -> Boolean,
   private val hasRecordAudioPermission: () -> Boolean,
+  private val installedAppsSharingEnabled: () -> Boolean,
   private val manualTls: () -> Boolean,
 ) {
   companion object {
@@ -115,6 +116,7 @@ class ConnectionManager(
       voiceWakeEnabled = voiceWakeMode() != VoiceWakeMode.Off && hasRecordAudioPermission(),
       motionActivityAvailable = motionActivityAvailable(),
       motionPedometerAvailable = motionPedometerAvailable(),
+      installedAppsSharingEnabled = installedAppsSharingEnabled(),
       debugBuild = BuildConfig.DEBUG,
     )
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
@@ -27,6 +27,11 @@ import java.util.Locale
 
 private const val DEFAULT_DEVICE_APPS_LIMIT = 100
 private const val MAX_DEVICE_APPS_LIMIT = 200
+private const val DEVICE_APPS_SYSTEM_FLAGS =
+  ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_UPDATED_SYSTEM_APP
+
+internal fun isSystemDeviceApp(appInfo: ApplicationInfo): Boolean =
+  (appInfo.flags and DEVICE_APPS_SYSTEM_FLAGS) != 0
 
 internal data class DeviceAppEntry(
   val label: String,
@@ -77,7 +82,7 @@ private class AndroidDeviceAppSource(
             DeviceAppEntry(
               label = label.ifEmpty { packageName },
               packageName = packageName,
-              system = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0,
+              system = isSystemDeviceApp(appInfo),
               enabled = appInfo.enabled,
               launchable = packageName in launchablePackages,
             )
@@ -175,7 +180,6 @@ class DeviceHandler private constructor(
   /** Returns coarse device health for memory, power, thermal, battery, and security patch state. */
   fun handleDeviceHealth(_paramsJson: String?): GatewaySession.InvokeResult = GatewaySession.InvokeResult.ok(healthPayloadJson())
 
-  /** Returns apps visible to the Android node without requesting broad package visibility. */
   fun handleDeviceApps(paramsJson: String?): GatewaySession.InvokeResult {
     val request = parseDeviceAppsRequest(paramsJson)
     val matchingApps =

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
@@ -8,6 +8,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
@@ -24,16 +25,116 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.util.Locale
 
+private const val DEFAULT_DEVICE_APPS_LIMIT = 100
+private const val MAX_DEVICE_APPS_LIMIT = 200
+
+internal data class DeviceAppEntry(
+  val label: String,
+  val packageName: String,
+  val system: Boolean,
+  val enabled: Boolean,
+  val launchable: Boolean,
+)
+
+internal interface DeviceAppSource {
+  fun listApps(includeNonLaunchable: Boolean): List<DeviceAppEntry>
+}
+
+private class AndroidDeviceAppSource(
+  private val appContext: Context,
+) : DeviceAppSource {
+  override fun listApps(includeNonLaunchable: Boolean): List<DeviceAppEntry> {
+    val packageManager = appContext.packageManager
+    val launcherIntent = Intent(Intent.ACTION_MAIN).apply { addCategory(Intent.CATEGORY_LAUNCHER) }
+    val launchablePackages =
+      packageManager
+        .queryIntentActivities(launcherIntent, PackageManager.MATCH_ALL)
+        .asSequence()
+        .mapNotNull {
+          it.activityInfo
+            ?.packageName
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+        }.toSet()
+
+    val appInfos =
+      if (includeNonLaunchable) {
+        packageManager.getInstalledApplications(PackageManager.MATCH_ALL)
+      } else {
+        launchablePackages.mapNotNull { packageName ->
+          runCatching { packageManager.getApplicationInfo(packageName, 0) }.getOrNull()
+        }
+      }
+
+    return appInfos
+      .asSequence()
+      .mapNotNull { appInfo ->
+        appInfo.packageName
+          ?.trim()
+          ?.takeIf(String::isNotEmpty)
+          ?.let { packageName ->
+            val label = packageManager.getApplicationLabel(appInfo).toString().trim()
+            DeviceAppEntry(
+              label = label.ifEmpty { packageName },
+              packageName = packageName,
+              system = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0,
+              enabled = appInfo.enabled,
+              launchable = packageName in launchablePackages,
+            )
+          }
+      }.distinctBy { it.packageName }
+      .sortedWith(compareBy<DeviceAppEntry> { it.label.lowercase() }.thenBy { it.packageName })
+      .toList()
+  }
+}
+
+private data class DeviceAppsRequest(
+  val includeSystem: Boolean,
+  val includeDisabled: Boolean,
+  val includeNonLaunchable: Boolean,
+  val query: String?,
+  val limit: Int,
+)
+
 /**
  * Gateway device command adapter for Android status, info, permission, and health snapshots.
  */
-class DeviceHandler(
+class DeviceHandler private constructor(
   private val appContext: Context,
   private val smsEnabled: Boolean = SensitiveFeatureConfig.smsEnabled,
   private val callLogEnabled: Boolean = SensitiveFeatureConfig.callLogEnabled,
   private val photosEnabled: Boolean = SensitiveFeatureConfig.photosEnabled,
+  private val appSource: DeviceAppSource = AndroidDeviceAppSource(appContext),
 ) {
+  constructor(
+    appContext: Context,
+    smsEnabled: Boolean = SensitiveFeatureConfig.smsEnabled,
+    callLogEnabled: Boolean = SensitiveFeatureConfig.callLogEnabled,
+    photosEnabled: Boolean = SensitiveFeatureConfig.photosEnabled,
+  ) : this(
+    appContext = appContext,
+    smsEnabled = smsEnabled,
+    callLogEnabled = callLogEnabled,
+    photosEnabled = photosEnabled,
+    appSource = AndroidDeviceAppSource(appContext),
+  )
+
   companion object {
+    internal fun forTesting(
+      appContext: Context,
+      appSource: DeviceAppSource,
+      smsEnabled: Boolean = SensitiveFeatureConfig.smsEnabled,
+      callLogEnabled: Boolean = SensitiveFeatureConfig.callLogEnabled,
+      photosEnabled: Boolean = SensitiveFeatureConfig.photosEnabled,
+    ): DeviceHandler =
+      DeviceHandler(
+        appContext = appContext,
+        smsEnabled = smsEnabled,
+        callLogEnabled = callLogEnabled,
+        photosEnabled = photosEnabled,
+        appSource = appSource,
+      )
+
     /**
      * SMS is available only when the feature flag, telephony hardware, and at least one SMS permission align.
      */
@@ -73,6 +174,49 @@ class DeviceHandler(
 
   /** Returns coarse device health for memory, power, thermal, battery, and security patch state. */
   fun handleDeviceHealth(_paramsJson: String?): GatewaySession.InvokeResult = GatewaySession.InvokeResult.ok(healthPayloadJson())
+
+  /** Returns apps visible to the Android node without requesting broad package visibility. */
+  fun handleDeviceApps(paramsJson: String?): GatewaySession.InvokeResult {
+    val request = parseDeviceAppsRequest(paramsJson)
+    val matchingApps =
+      appSource
+        .listApps(includeNonLaunchable = request.includeNonLaunchable)
+        .asSequence()
+        .filter { request.includeSystem || !it.system }
+        .filter { request.includeDisabled || it.enabled }
+        .filter { app ->
+          val query = request.query ?: return@filter true
+          app.label.contains(query, ignoreCase = true) || app.packageName.contains(query, ignoreCase = true)
+        }.toList()
+    val limitedApps = matchingApps.take(request.limit)
+
+    return GatewaySession.InvokeResult.ok(
+      buildJsonObject {
+        put("count", JsonPrimitive(limitedApps.size))
+        put("totalMatched", JsonPrimitive(matchingApps.size))
+        put("truncated", JsonPrimitive(matchingApps.size > limitedApps.size))
+        put("visibility", JsonPrimitive(if (request.includeNonLaunchable) "android-visible" else "launcher"))
+        put("includeSystem", JsonPrimitive(request.includeSystem))
+        put("includeDisabled", JsonPrimitive(request.includeDisabled))
+        put(
+          "apps",
+          buildJsonArray {
+            for (app in limitedApps) {
+              add(
+                buildJsonObject {
+                  put("label", JsonPrimitive(app.label))
+                  put("packageName", JsonPrimitive(app.packageName))
+                  put("system", JsonPrimitive(app.system))
+                  put("enabled", JsonPrimitive(app.enabled))
+                  put("launchable", JsonPrimitive(app.launchable))
+                },
+              )
+            }
+          },
+        )
+      }.toString(),
+    )
+  }
 
   private fun statusPayloadJson(): String {
     val battery = readBatterySnapshot()
@@ -363,6 +507,24 @@ class DeviceHandler(
         },
       )
     }.toString()
+  }
+
+  private fun parseDeviceAppsRequest(paramsJson: String?): DeviceAppsRequest {
+    val params = parseJsonParamsObject(paramsJson)
+    val includeSystem = parseJsonBooleanFlag(params, "includeSystem") ?: false
+    val includeDisabled = parseJsonBooleanFlag(params, "includeDisabled") ?: false
+    val includeNonLaunchable = parseJsonBooleanFlag(params, "includeNonLaunchable") ?: false
+    val query = parseJsonString(params, "query")?.trim()?.takeIf { it.isNotEmpty() }
+    val limit =
+      (parseJsonInt(params, "limit") ?: DEFAULT_DEVICE_APPS_LIMIT)
+        .coerceIn(1, MAX_DEVICE_APPS_LIMIT)
+    return DeviceAppsRequest(
+      includeSystem = includeSystem,
+      includeDisabled = includeDisabled,
+      includeNonLaunchable = includeNonLaunchable,
+      query = query,
+      limit = limit,
+    )
   }
 
   private fun readBatterySnapshot(): BatterySnapshot {

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
@@ -28,6 +28,7 @@ data class NodeRuntimeFlags(
   val voiceWakeEnabled: Boolean,
   val motionActivityAvailable: Boolean,
   val motionPedometerAvailable: Boolean,
+  val installedAppsSharingEnabled: Boolean,
   val debugBuild: Boolean,
 )
 
@@ -43,6 +44,7 @@ enum class InvokeCommandAvailability {
   PhotosAvailable,
   MotionActivityAvailable,
   MotionPedometerAvailable,
+  InstalledAppsSharingEnabled,
   DebugBuild,
 }
 
@@ -194,6 +196,10 @@ object InvokeCommandRegistry {
         name = OpenClawDeviceCommand.Health.rawValue,
       ),
       InvokeCommandSpec(
+        name = OpenClawDeviceCommand.Apps.rawValue,
+        availability = InvokeCommandAvailability.InstalledAppsSharingEnabled,
+      ),
+      InvokeCommandSpec(
         name = OpenClawNotificationsCommand.List.rawValue,
       ),
       InvokeCommandSpec(
@@ -281,6 +287,7 @@ object InvokeCommandRegistry {
           InvokeCommandAvailability.PhotosAvailable -> flags.photosAvailable
           InvokeCommandAvailability.MotionActivityAvailable -> flags.motionActivityAvailable
           InvokeCommandAvailability.MotionPedometerAvailable -> flags.motionPedometerAvailable
+          InvokeCommandAvailability.InstalledAppsSharingEnabled -> flags.installedAppsSharingEnabled
           InvokeCommandAvailability.DebugBuild -> flags.debugBuild
         }
       }.map { it.name }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
@@ -85,6 +85,7 @@ class InvokeDispatcher(
   private val smsTelephonyAvailable: () -> Boolean,
   private val callLogAvailable: () -> Boolean,
   private val photosAvailable: () -> Boolean,
+  private val installedAppsSharingEnabled: () -> Boolean,
   private val debugBuild: () -> Boolean,
   private val onCanvasA2uiPush: () -> Unit,
   private val onCanvasA2uiReset: () -> Unit,
@@ -193,6 +194,7 @@ class InvokeDispatcher(
       OpenClawDeviceCommand.Info.rawValue -> deviceHandler.handleDeviceInfo(paramsJson)
       OpenClawDeviceCommand.Permissions.rawValue -> deviceHandler.handleDevicePermissions(paramsJson)
       OpenClawDeviceCommand.Health.rawValue -> deviceHandler.handleDeviceHealth(paramsJson)
+      OpenClawDeviceCommand.Apps.rawValue -> deviceHandler.handleDeviceApps(paramsJson)
 
       // Notifications command
       OpenClawNotificationsCommand.List.rawValue -> notificationsHandler.handleNotificationsList(paramsJson)
@@ -346,6 +348,15 @@ class InvokeDispatcher(
           GatewaySession.InvokeResult.error(
             code = "PHOTOS_UNAVAILABLE",
             message = "PHOTOS_UNAVAILABLE: photos not available on this build",
+          )
+        }
+      InvokeCommandAvailability.InstalledAppsSharingEnabled ->
+        if (installedAppsSharingEnabled()) {
+          null
+        } else {
+          GatewaySession.InvokeResult.error(
+            code = "INSTALLED_APPS_SHARING_DISABLED",
+            message = "INSTALLED_APPS_SHARING_DISABLED: enable Installed Apps in Settings",
           )
         }
       InvokeCommandAvailability.DebugBuild ->

--- a/apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt
@@ -112,6 +112,7 @@ enum class OpenClawDeviceCommand(
   Info("device.info"),
   Permissions("device.permissions"),
   Health("device.health"),
+  Apps("device.apps"),
   ;
 
   companion object {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -714,6 +714,7 @@ private fun PhoneCapabilitiesScreen(
   val locationPreciseEnabled by viewModel.locationPreciseEnabled.collectAsState()
   val preventSleep by viewModel.preventSleep.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
+  val installedAppsSharingEnabled by viewModel.installedAppsSharingEnabled.collectAsState()
   val cameraPermissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
       viewModel.setCameraEnabled(granted)
@@ -768,6 +769,13 @@ private fun PhoneCapabilitiesScreen(
         listOf(
           SettingsToggleRow("Camera", "Allow camera tools when requested.", Icons.Default.CameraAlt, cameraEnabled, ::setCameraAccess),
           SettingsToggleRow("Precise Location", "Share precise location while location is enabled.", Icons.Default.LocationOn, locationPreciseEnabled, ::setPreciseLocation),
+          SettingsToggleRow(
+            "Installed Apps",
+            if (installedAppsSharingEnabled) "OpenClaw can list launcher-visible apps." else "App list stays on this phone.",
+            Icons.Default.Storage,
+            installedAppsSharingEnabled,
+            viewModel::setInstalledAppsSharingEnabled,
+          ),
           SettingsToggleRow("Keep Awake", "Keep the node available during active work.", Icons.Default.Bolt, preventSleep, viewModel::setPreventSleep),
           SettingsToggleRow("Canvas Status", "Show screen-sharing debug state.", Icons.AutoMirrored.Filled.ScreenShare, canvasDebugStatusEnabled, viewModel::setCanvasDebugStatusEnabled),
         ),

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -63,6 +63,21 @@ class SecurePrefsTest {
   }
 
   @Test
+  fun installedAppsSharing_defaultsOffAndPersistsOptIn() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().commit()
+    val prefs = SecurePrefs(context)
+
+    assertFalse(prefs.installedAppsSharingEnabled.value)
+
+    prefs.setInstalledAppsSharingEnabled(true)
+
+    assertTrue(prefs.installedAppsSharingEnabled.value)
+    assertTrue(plainPrefs.getBoolean("device.apps.sharing.enabled", false))
+  }
+
+  @Test
   fun saveGatewayBootstrapToken_persistsSeparatelyFromSharedToken() {
     val context = RuntimeEnvironment.getApplication()
     val securePrefs = context.getSharedPreferences("openclaw.node.secure.test", Context.MODE_PRIVATE)

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -9,6 +9,7 @@ import ai.openclaw.app.gateway.isLoopbackGatewayHost
 import ai.openclaw.app.protocol.OpenClawCallLogCommand
 import ai.openclaw.app.protocol.OpenClawCameraCommand
 import ai.openclaw.app.protocol.OpenClawCapability
+import ai.openclaw.app.protocol.OpenClawDeviceCommand
 import ai.openclaw.app.protocol.OpenClawLocationCommand
 import ai.openclaw.app.protocol.OpenClawMotionCommand
 import ai.openclaw.app.protocol.OpenClawPhotosCommand
@@ -476,6 +477,15 @@ class ConnectionManagerTest {
   }
 
   @Test
+  fun buildNodeConnectOptions_advertisesDeviceAppsOnlyWhenUserOptedIn() {
+    val disabled = newManager(installedAppsSharingEnabled = false).buildNodeConnectOptions()
+    val enabled = newManager(installedAppsSharingEnabled = true).buildNodeConnectOptions()
+
+    assertFalse(disabled.commands.contains(OpenClawDeviceCommand.Apps.rawValue))
+    assertTrue(enabled.commands.contains(OpenClawDeviceCommand.Apps.rawValue))
+  }
+
+  @Test
   fun buildNodeConnectOptions_omitsVoiceWakeWithoutMicrophonePermission() {
     val options =
       newManager(
@@ -546,6 +556,7 @@ class ConnectionManagerTest {
     callLogAvailable: Boolean = false,
     photosAvailable: Boolean = false,
     hasRecordAudioPermission: Boolean = false,
+    installedAppsSharingEnabled: Boolean = false,
   ): ConnectionManager {
     val context = RuntimeEnvironment.getApplication()
     val prefs =
@@ -567,6 +578,7 @@ class ConnectionManagerTest {
       callLogAvailable = { callLogAvailable },
       photosAvailable = { photosAvailable },
       hasRecordAudioPermission = { hasRecordAudioPermission },
+      installedAppsSharingEnabled = { installedAppsSharingEnabled },
       manualTls = { false },
     )
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.node
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
@@ -410,6 +411,16 @@ class DeviceHandlerTest {
     assertTrue(app.getValue("system").jsonPrimitive.boolean)
     assertTrue(!app.getValue("launchable").jsonPrimitive.boolean)
     assertTrue(source.includeNonLaunchableRequests.single())
+  }
+
+  @Test
+  fun isSystemDeviceApp_treatsUpdatedBuiltInsAsSystemApps() {
+    val appInfo =
+      ApplicationInfo().apply {
+        flags = ApplicationInfo.FLAG_UPDATED_SYSTEM_APP
+      }
+
+    assertTrue(isSystemDeviceApp(appInfo))
   }
 
   private fun appContext(): Context = RuntimeEnvironment.getApplication()

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
@@ -320,10 +320,113 @@ class DeviceHandlerTest {
     system["securityPatchLevel"]?.jsonPrimitive?.content
   }
 
+  @Test
+  fun handleDeviceApps_filtersAndLimitsVisibleApps() {
+    val handler =
+      DeviceHandler.forTesting(
+        appContext = appContext(),
+        appSource =
+          FakeDeviceAppSource(
+            listOf(
+              DeviceAppEntry(
+                label = "Calendar",
+                packageName = "com.google.android.calendar",
+                system = false,
+                enabled = true,
+                launchable = true,
+              ),
+              DeviceAppEntry(
+                label = "Android System",
+                packageName = "android",
+                system = true,
+                enabled = true,
+                launchable = false,
+              ),
+              DeviceAppEntry(
+                label = "Disabled App",
+                packageName = "com.example.disabled",
+                system = false,
+                enabled = false,
+                launchable = true,
+              ),
+              DeviceAppEntry(
+                label = "Gmail",
+                packageName = "com.google.android.gm",
+                system = false,
+                enabled = true,
+                launchable = true,
+              ),
+            ),
+          ),
+      )
+
+    val result = handler.handleDeviceApps("""{"query":"google","limit":1}""")
+
+    assertTrue(result.ok)
+    val payload = parsePayload(result.payloadJson)
+    assertEquals("1", payload.getValue("count").jsonPrimitive.content)
+    assertEquals("2", payload.getValue("totalMatched").jsonPrimitive.content)
+    assertTrue(payload.getValue("truncated").jsonPrimitive.boolean)
+    assertEquals("launcher", payload.getValue("visibility").jsonPrimitive.content)
+    val apps = payload.getValue("apps").jsonArray
+    assertEquals(1, apps.size)
+    val app = apps.first().jsonObject
+    assertEquals("Calendar", app.getValue("label").jsonPrimitive.content)
+    assertEquals("com.google.android.calendar", app.getValue("packageName").jsonPrimitive.content)
+    assertTrue(!app.getValue("system").jsonPrimitive.boolean)
+    assertTrue(app.getValue("enabled").jsonPrimitive.boolean)
+    assertTrue(app.getValue("launchable").jsonPrimitive.boolean)
+  }
+
+  @Test
+  fun handleDeviceApps_canIncludeSystemAndNonLaunchableApps() {
+    val source =
+      FakeDeviceAppSource(
+        listOf(
+          DeviceAppEntry(
+            label = "Android System",
+            packageName = "android",
+            system = true,
+            enabled = true,
+            launchable = false,
+          ),
+        ),
+      )
+    val handler = DeviceHandler.forTesting(appContext = appContext(), appSource = source)
+
+    val result = handler.handleDeviceApps("""{"includeSystem":true,"includeNonLaunchable":true}""")
+
+    assertTrue(result.ok)
+    val payload = parsePayload(result.payloadJson)
+    assertEquals("android-visible", payload.getValue("visibility").jsonPrimitive.content)
+    assertTrue(payload.getValue("includeSystem").jsonPrimitive.boolean)
+    val app =
+      payload
+        .getValue("apps")
+        .jsonArray
+        .first()
+        .jsonObject
+    assertEquals("android", app.getValue("packageName").jsonPrimitive.content)
+    assertTrue(app.getValue("system").jsonPrimitive.boolean)
+    assertTrue(!app.getValue("launchable").jsonPrimitive.boolean)
+    assertTrue(source.includeNonLaunchableRequests.single())
+  }
+
   private fun appContext(): Context = RuntimeEnvironment.getApplication()
 
   private fun parsePayload(payloadJson: String?): JsonObject {
     val jsonString = payloadJson ?: error("expected payload")
     return Json.parseToJsonElement(jsonString).jsonObject
+  }
+}
+
+private class FakeDeviceAppSource(
+  private val apps: List<DeviceAppEntry>,
+) : DeviceAppSource {
+  val includeNonLaunchableRequests = mutableListOf<Boolean>()
+
+  override fun listApps(includeNonLaunchable: Boolean): List<DeviceAppEntry> {
+    includeNonLaunchableRequests += includeNonLaunchable
+    return apps
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryTest.kt
@@ -116,6 +116,15 @@ class InvokeCommandRegistryTest {
   }
 
   @Test
+  fun advertisedCommands_includesDeviceAppsOnlyWhenUserOptedIn() {
+    val disabled = InvokeCommandRegistry.advertisedCommands(defaultFlags(installedAppsSharingEnabled = false))
+    val enabled = InvokeCommandRegistry.advertisedCommands(defaultFlags(installedAppsSharingEnabled = true))
+
+    assertFalse(disabled.contains(OpenClawDeviceCommand.Apps.rawValue))
+    assertTrue(enabled.contains(OpenClawDeviceCommand.Apps.rawValue))
+  }
+
+  @Test
   fun advertisedCommands_includesFeatureCommandsWhenEnabled() {
     val commands =
       InvokeCommandRegistry.advertisedCommands(
@@ -151,6 +160,7 @@ class InvokeCommandRegistryTest {
           voiceWakeEnabled = false,
           motionActivityAvailable = true,
           motionPedometerAvailable = false,
+          installedAppsSharingEnabled = false,
           debugBuild = false,
         ),
       )
@@ -262,6 +272,7 @@ class InvokeCommandRegistryTest {
     voiceWakeEnabled: Boolean = false,
     motionActivityAvailable: Boolean = false,
     motionPedometerAvailable: Boolean = false,
+    installedAppsSharingEnabled: Boolean = false,
     debugBuild: Boolean = false,
   ): NodeRuntimeFlags =
     NodeRuntimeFlags(
@@ -275,6 +286,7 @@ class InvokeCommandRegistryTest {
       voiceWakeEnabled = voiceWakeEnabled,
       motionActivityAvailable = motionActivityAvailable,
       motionPedometerAvailable = motionPedometerAvailable,
+      installedAppsSharingEnabled = installedAppsSharingEnabled,
       debugBuild = debugBuild,
     )
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.protocol.OpenClawCallLogCommand
 import ai.openclaw.app.protocol.OpenClawCameraCommand
+import ai.openclaw.app.protocol.OpenClawDeviceCommand
 import ai.openclaw.app.protocol.OpenClawLocationCommand
 import ai.openclaw.app.protocol.OpenClawMotionCommand
 import ai.openclaw.app.protocol.OpenClawPhotosCommand
@@ -171,6 +172,20 @@ class InvokeDispatcherTest {
     }
 
   @Test
+  fun handleInvoke_blocksDeviceAppsWhenSharingDisabled() =
+    runTest {
+      val result =
+        newDispatcher(installedAppsSharingEnabled = false)
+          .handleInvoke(OpenClawDeviceCommand.Apps.rawValue, """{"limit":1}""")
+
+      assertEquals("INSTALLED_APPS_SHARING_DISABLED", result.error?.code)
+      assertEquals(
+        "INSTALLED_APPS_SHARING_DISABLED: enable Installed Apps in Settings",
+        result.error?.message,
+      )
+    }
+
+  @Test
   fun handleInvoke_blocksMotionActivityWhenUnavailable() =
     runTest {
       val result =
@@ -250,6 +265,7 @@ class InvokeDispatcherTest {
     smsTelephonyAvailable: Boolean = true,
     callLogAvailable: Boolean = false,
     photosAvailable: Boolean = true,
+    installedAppsSharingEnabled: Boolean = true,
     debugBuild: Boolean = false,
     motionActivityAvailable: Boolean = false,
     motionPedometerAvailable: Boolean = false,
@@ -297,6 +313,7 @@ class InvokeDispatcherTest {
       smsTelephonyAvailable = { smsTelephonyAvailable },
       callLogAvailable = { callLogAvailable },
       photosAvailable = { photosAvailable },
+      installedAppsSharingEnabled = { installedAppsSharingEnabled },
       debugBuild = { debugBuild },
       onCanvasA2uiPush = {},
       onCanvasA2uiReset = {},

--- a/apps/android/app/src/test/java/ai/openclaw/app/protocol/OpenClawProtocolConstantsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/protocol/OpenClawProtocolConstantsTest.kt
@@ -57,6 +57,7 @@ class OpenClawProtocolConstantsTest {
     assertEquals("device.info", OpenClawDeviceCommand.Info.rawValue)
     assertEquals("device.permissions", OpenClawDeviceCommand.Permissions.rawValue)
     assertEquals("device.health", OpenClawDeviceCommand.Health.rawValue)
+    assertEquals("device.apps", OpenClawDeviceCommand.Apps.rawValue)
   }
 
   @Test

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -329,6 +329,7 @@ Android nodes can advertise additional command families when the corresponding c
 Available families:
 
 - `device.status`, `device.info`, `device.permissions`, `device.health`
+- `device.apps` when Installed Apps sharing is enabled in Android Settings
 - `notifications.list`, `notifications.actions`
 - `photos.latest`
 - `contacts.search`, `contacts.add`
@@ -341,12 +342,14 @@ Example invokes:
 
 ```bash
 openclaw nodes invoke --node <idOrNameOrIp> --command device.status --params '{}'
+openclaw nodes invoke --node <idOrNameOrIp> --command device.apps --params '{"limit":10}'
 openclaw nodes invoke --node <idOrNameOrIp> --command notifications.list --params '{}'
 openclaw nodes invoke --node <idOrNameOrIp> --command photos.latest --params '{"limit":1}'
 ```
 
 Notes:
 
+- `device.apps` is opt-in and returns launcher-visible apps by default.
 - Motion commands are capability-gated by available sensors.
 
 ## System commands (node host / mac node)

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -219,8 +219,9 @@ See [Camera node](/nodes/camera) for parameters and CLI helpers.
 - By default, Android Talk uses native speech recognition, Gateway chat, and `talk.speak` through the configured gateway Talk provider. Local system TTS is used only when `talk.speak` is unavailable.
 - Android Talk uses realtime Gateway relay only when `talk.realtime.mode` is `realtime` and `talk.realtime.transport` is `gateway-relay`.
 - Voice wake remains disabled in the Android UX/runtime.
-- Additional Android command families (availability depends on device + permissions):
+- Additional Android command families (availability depends on device, permissions, and user settings):
   - `device.status`, `device.info`, `device.permissions`, `device.health`
+  - `device.apps` only when **Settings > Phone Capabilities > Installed Apps** is enabled; it lists launcher-visible apps by default.
   - `notifications.list`, `notifications.actions` (see [Notification forwarding](#notification-forwarding) below)
   - `photos.latest`
   - `contacts.search`, `contacts.add`

--- a/src/gateway/android-node.capabilities.live.test.ts
+++ b/src/gateway/android-node.capabilities.live.test.ts
@@ -220,6 +220,15 @@ const COMMAND_PROFILES: Record<string, CommandProfile> = {
       expectRecord(obj.memory, "device.health memory payload");
     },
   },
+  "device.apps": {
+    buildParams: () => ({ query: "calendar", includeSystem: true, limit: 5 }),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("device.apps", payload);
+      expect(Array.isArray(obj.apps)).toBe(true);
+    },
+  },
   "notifications.list": {
     buildParams: () => ({}),
     timeoutMs: 20_000,

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -824,6 +824,7 @@ describe("resolveNodeCommandAllowlist", () => {
       "notifications.actions",
       "device.permissions",
       "device.health",
+      "device.apps",
       "callLog.search",
       "system.notify",
     ]);

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -21,7 +21,12 @@ const NOTIFICATION_COMMANDS = ["notifications.list"];
 const ANDROID_NOTIFICATION_COMMANDS = [...NOTIFICATION_COMMANDS, "notifications.actions"];
 
 const DEVICE_COMMANDS = ["device.info", "device.status"];
-const ANDROID_DEVICE_COMMANDS = [...DEVICE_COMMANDS, "device.permissions", "device.health"];
+const ANDROID_DEVICE_COMMANDS = [
+  ...DEVICE_COMMANDS,
+  "device.permissions",
+  "device.health",
+  "device.apps",
+];
 
 const CONTACTS_COMMANDS = ["contacts.search"];
 const CONTACTS_DANGEROUS_COMMANDS = ["contacts.add"];


### PR DESCRIPTION
## Summary

- Adds a read-only Android node command, `device.apps`, so a paired Android phone can report installed app metadata when the user explicitly opts in.
- Keeps installed-app sharing default-off behind **Settings > Phone Capabilities > Installed Apps**; when disabled, Android does not advertise `device.apps` and dispatcher calls are rejected.
- Limits default command output to launcher-visible, enabled, non-system apps, with explicit request flags for system, disabled, or non-launchable inventory.
- Updates the gateway Android command policy so approved Android nodes can use `device.apps` when advertised.
- AI-assisted: implemented and validated with Codex/Nabu, then manually inspected and tested in a local Android/OpenClaw setup.

## Linked context

Which issue does this close?

No issue.

Which issues, PRs, or discussions are related?

No related issue or PR.

Was this requested by a maintainer or owner?

No maintainer issue yet. This is a narrow Android node capability PR opened as a draft because app inventory is privacy-sensitive and should get maintainer shape review before it is treated as ready.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Android can now expose installed apps through `device.apps`, but only after the Android user enables the Installed Apps capability.
- Real environment tested: local Android emulator for the Settings UI and preference persistence; Android phone paired to a local OpenClaw gateway with this branch's Android command policy applied for live node command invocation.
- Exact steps or command run after this patch: installed the third-party debug APK, opened **Settings > Phone Capabilities**, toggled Installed Apps off and on, checked the app preference value, reconnected the Android node, approved the node capability update, then ran `openclaw nodes invoke --node <android-node> --command device.apps --params '{"limit":5}' --json --invoke-timeout 10000` and `openclaw nodes invoke --node <android-node> --command device.apps --params '{"query":"calendar","limit":10,"includeSystem":true}' --json --invoke-timeout 10000`.
- Evidence after fix: screenshots from the local Android emulator show Installed Apps disabled and enabled, and copied live output below shows the persisted pref and redacted command output.

| Installed Apps disabled | Installed Apps enabled |
| --- | --- |
| ![Installed Apps disabled](https://raw.githubusercontent.com/Tosko4/openclaw/pr-device-apps-optin-screenshots/pr-proof/device-apps-optin/device-apps-sharing-disabled-setting.png) | ![Installed Apps enabled](https://raw.githubusercontent.com/Tosko4/openclaw/pr-device-apps-optin-screenshots/pr-proof/device-apps-optin/device-apps-sharing-enabled-setting.png) |

```text
# Android app preference, filtered to the new key
<boolean name="device.apps.sharing.enabled" value="false" />
<boolean name="device.apps.sharing.enabled" value="true" />

# Android node command surface after enabling Installed Apps and approving the node update
commands include:
  device.apps
  device.health
  device.info
  device.permissions
  device.status
```

```json
{
  "ok": true,
  "command": "device.apps",
  "payload": {
    "count": 5,
    "totalMatched": 122,
    "truncated": true,
    "visibility": "launcher",
    "includeSystem": false,
    "includeDisabled": false,
    "apps": "[redacted launcher-visible app rows]"
  }
}
```

```json
{
  "ok": true,
  "command": "device.apps",
  "payload": {
    "count": 2,
    "totalMatched": 2,
    "truncated": false,
    "visibility": "launcher",
    "includeSystem": true,
    "includeDisabled": false,
    "apps": [
      {
        "label": "Agenda",
        "packageName": "com.google.android.calendar",
        "system": false,
        "enabled": true,
        "launchable": true
      },
      {
        "label": "Agenda",
        "packageName": "com.samsung.android.calendar",
        "system": false,
        "enabled": true,
        "launchable": true
      }
    ]
  }
}
```

- Observed result after fix: the UI toggle persists, `device.apps` is only advertised when installed-app sharing is enabled, the gateway policy allows the command for Android nodes, and live invocation returns a bounded app list.
- What was not tested: Play flavor behavior, full repository `pnpm build && pnpm check && pnpm test`, and unrestricted full-device app inventory.
- Proof limitations or environment constraints: local pnpm/vitest gateway test execution is currently blocked by the workspace dependency install failing with `ERR_PNPM_UNUSED_PATCH` for `@agentclientprotocol/claude-agent-acp@0.39.0`; Android Gradle tests/build did run. The live app-list proof is redacted to avoid publishing private installed-app inventory. The screenshots were inspected before posting and only show the OpenClaw Android Settings UI.
- Before evidence (optional but encouraged): before the gateway policy and Android opt-in were present together, `device.apps` was not available from Android nodes. With sharing disabled after this patch, the command is again intentionally absent from the advertised Android command surface.

## Tests and validation

Which commands did you run?

```bash
ANDROID_HOME=/home/nabu/Android/Sdk ANDROID_SDK_ROOT=/home/nabu/Android/Sdk \
  ./gradlew :app:testThirdPartyDebugUnitTest :app:assembleThirdPartyDebug
```

Result: passed.

```bash
git diff --check upstream/main...HEAD
```

Result: passed.

```bash
ANDROID_HOME=/home/nabu/Android/Sdk ANDROID_SDK_ROOT=/home/nabu/Android/Sdk \
  ./gradlew :app:ktlintCheck
```

Result: failed on pre-existing Android ktlint findings outside this patch in `ChatController.kt`, `GatewayDiscovery.kt`, `PermissionRequester.kt`, `MicCaptureManager.kt`, and `TalkModeManager.kt`. No ktlint findings remained in the files changed by this PR after local formatting cleanup.

```bash
corepack pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts \
  src/gateway/gateway-misc.test.ts src/gateway/android-node.capabilities.live.test.ts \
  --testNamePattern 'device.apps|Android notifications and device diagnostics|android node live command registry'
```

Result: did not run; pnpm dependency setup stopped with `ERR_PNPM_UNUSED_PATCH` for `@agentclientprotocol/claude-agent-acp@0.39.0`.

```bash
codex review --base upstream/main
```

Result: attempted, but local Codex review could not connect because the Codex/OpenAI websocket returned `401 Unauthorized`.

What regression coverage was added or updated?

- `DeviceHandlerTest` covers default launcher-visible filtering, query/limit behavior, and explicit include-system/non-launchable behavior.
- `InvokeCommandRegistryTest` covers `device.apps` hidden by default and advertised only when installed-app sharing is enabled.
- `ConnectionManagerTest` covers Android node connect options omitting/including `device.apps` based on the opt-in flag.
- `InvokeDispatcherTest` covers rejecting `device.apps` when installed-app sharing is disabled.
- `SecurePrefsTest` covers default-off persistence for installed-app sharing.
- Gateway command-policy tests and Android live capability expectations were updated for `device.apps`.

What failed before this fix, if known?

Android had no installed-app node command, and the gateway Android allowlist did not include `device.apps`, so Android nodes could not serve this capability.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Android Settings gains an Installed Apps capability toggle, and opted-in Android nodes can expose `device.apps`.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes. A new plain Android preference, `device.apps.sharing.enabled`, defaults to `false`.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This adds a privacy-sensitive read-only node command and updates the gateway Android command allowlist.

What is the highest-risk area?

Installed-app inventory can reveal sensitive user context.

How is that risk mitigated?

The command is default-off, user-controlled in Android Settings, not advertised when disabled, guarded again in the dispatcher, and still subject to the gateway node update/approval flow. Default output is launcher-visible enabled apps only, with no `QUERY_ALL_PACKAGES` permission and no disabled/full system inventory unless explicit request parameters are provided.

## Current review state

What is the next action?

Draft PR opened for maintainer shape review, especially around privacy defaults and whether `device.apps` is the desired command name/surface.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on maintainer/bot review and CI. The PR already includes screenshots plus copied, redacted runtime/prefs proof.

Which bot or reviewer comments were addressed?

None yet.