### PR TITLE
fix: hide sessions_spawn timeout overrides

### DIFF
--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -469,7 +469,7 @@ Experimental built-in tool flags. Default off unless a strict-agentic GPT-5 auto
 
 - `model`: default model for spawned sub-agents. If omitted, sub-agents inherit the caller's model.
 - `allowAgents`: default allowlist of configured target agent ids for `sessions_spawn` when the requester agent does not set its own `subagents.allowAgents` (`["*"]` = any configured target; default: same agent only). Stale entries whose agent config was deleted are rejected by `sessions_spawn` and omitted from `agents_list`; run `openclaw doctor --fix` to clean them up.
-- `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
+- `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn`. `0` means no timeout.
 - `announceTimeoutMs`: per-call timeout (milliseconds) for gateway `agent` announce delivery attempts. Default: `120000`. Transient retries can make the total announce wait longer than one configured timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -286,8 +286,9 @@ different operation limit:
 openclaw config set plugins.entries.acpx.config.timeoutSeconds 180
 ```
 
-Runtime turns use OpenClaw agent/run timeouts, including `/acp timeout` and
-`sessions_spawn.timeoutSeconds`. Restart the gateway after changing this value.
+Runtime turns use OpenClaw agent/run timeouts, including `/acp timeout`.
+`sessions_spawn` does not accept per-call timeout overrides. Restart the
+gateway after changing this value.
 
 ### Health probe agent configuration
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -549,12 +549,6 @@ Two ways to start an ACP session:
   `streamLogPath` pointing to a session-scoped JSONL log
   (`<sessionId>.acp-stream.jsonl`) you can tail for full relay history.
 </ParamField>
-<ParamField path="runTimeoutSeconds" type="number">
-  Aborts the ACP child turn after N seconds. `0` keeps the turn on the
-  gateway's no-timeout path. The same value is applied to the Gateway
-  run and ACP runtime so stalled/quota-exhausted harnesses do not
-  occupy the parent agent lane indefinitely.
-</ParamField>
 <ParamField path="model" type="string">
   Explicit model override for the ACP child session. Codex ACP spawns
   normalize OpenAI refs such as `openai/gpt-5.4` to Codex ACP startup

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -549,6 +549,11 @@ Two ways to start an ACP session:
   `streamLogPath` pointing to a session-scoped JSONL log
   (`<sessionId>.acp-stream.jsonl`) you can tail for full relay history.
 </ParamField>
+
+ACP `sessions_spawn` runs use `agents.defaults.subagents.runTimeoutSeconds` for
+their default child turn limit. The tool does not accept per-call timeout
+overrides.
+
 <ParamField path="model" type="string">
   Explicit model override for the ACP child session. Codex ACP spawns
   normalize OpenAI refs such as `openai/gpt-5.4` to Codex ACP startup

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -141,7 +141,7 @@ session to confirm the effective tool list.
 
 - **Model:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.list[].subagents.model`). ACP runtime spawns use the same configured subagent model when present; otherwise the ACP harness keeps its own default. An explicit `sessions_spawn.model` still wins.
 - **Thinking:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.list[].subagents.thinking`). ACP runtime spawns also apply `agents.defaults.models["provider/model"].params.thinking` for the selected model. An explicit `sessions_spawn.thinking` still wins.
-- **Run timeout:** if `sessions_spawn.runTimeoutSeconds` is omitted, OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout).
+- **Run timeout:** OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout). `sessions_spawn` does not accept per-call timeout overrides.
 - **Task delivery:** native sub-agents receive the delegated task in their first visible `[Subagent Task]` message. The sub-agent system prompt carries runtime rules and routing context, not a hidden duplicate of the task.
 
 Accepted native sub-agent spawns include the resolved child model metadata in
@@ -207,9 +207,6 @@ Per-agent overrides use `agents.list[].subagents.delegationMode`.
 </ParamField>
 <ParamField path="thinking" type="string">
   Override thinking level for the sub-agent run.
-</ParamField>
-<ParamField path="runTimeoutSeconds" type="number">
-  Defaults to `agents.defaults.subagents.runTimeoutSeconds` when set, otherwise `0`. When set, the sub-agent run is aborted after N seconds.
 </ParamField>
 <ParamField path="thread" type="boolean" default="false">
   When `true`, requests channel thread binding for this sub-agent session.
@@ -375,7 +372,7 @@ remain spawnable while inheriting defaults.
 - Archive uses `sessions.delete` and renames the transcript to `*.deleted.<timestamp>` (same folder).
 - `cleanup: "delete"` archives immediately after announce (still keeps the transcript via rename).
 - Auto-archive is best-effort; pending timers are lost if the gateway restarts.
-- `runTimeoutSeconds` does **not** auto-archive; it only stops the run. The session remains until auto-archive.
+- Configured run timeouts do **not** auto-archive; they only stop the run. The session remains until auto-archive.
 - Auto-archive applies equally to depth-1 and depth-2 sessions.
 - Browser cleanup is separate from archive cleanup: tracked browser tabs/processes are best-effort closed when the run finishes, even if the transcript/session record is kept.
 
@@ -394,7 +391,7 @@ worker sub-sub-agents.
         maxSpawnDepth: 2, // allow sub-agents to spawn children (default: 1)
         maxChildrenPerAgent: 5, // max active children per agent session (default: 5)
         maxConcurrent: 8, // global concurrency lane cap (default: 8)
-        runTimeoutSeconds: 900, // default timeout for sessions_spawn when omitted (0 = no timeout)
+        runTimeoutSeconds: 900, // default timeout for sessions_spawn (0 = no timeout)
         announceTimeoutMs: 120000, // per-call gateway announce timeout
       },
     },

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1089,6 +1089,7 @@ describe("spawnAcpDirect", () => {
     );
 
     expectAcceptedSpawn(result);
+    expect(result).toHaveProperty("runTimeoutSeconds", 45);
     const initInput = expectInitializeSessionFields({
       agent: "codex",
       runtimeOptions: {
@@ -1126,6 +1127,7 @@ describe("spawnAcpDirect", () => {
     );
 
     expectAcceptedSpawn(result);
+    expect(result).toHaveProperty("runTimeoutSeconds", 120);
     expectInitializeSessionFields({
       agent: "codex",
       runtimeOptions: {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1158,6 +1158,42 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.timeout).toBe(120);
   });
 
+  it("caps configured ACP runtime timeout without shortening spawn tracking", async () => {
+    replaceSpawnConfig({
+      ...createDefaultSpawnConfig(),
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["codex"],
+            maxSpawnDepth: 2,
+            runTimeoutSeconds: 172_800,
+          },
+        },
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+    expect(result).toHaveProperty("runTimeoutSeconds", 172_800);
+    expectInitializeSessionFields({
+      agent: "codex",
+      runtimeOptions: {
+        timeoutSeconds: 86_400,
+      },
+    });
+    const agentCall = findAgentGatewayCall();
+    expect(agentCall?.params?.timeout).toBe(172_800);
+  });
+
   it("rejects OpenClaw config agent ids when runtime=acp targets a native agent", async () => {
     replaceSpawnConfig({
       ...createDefaultSpawnConfig(),

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1101,6 +1101,41 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.timeout).toBe(45);
   });
 
+  it("uses configured subagent timeout for ACP spawns", async () => {
+    replaceSpawnConfig({
+      ...createDefaultSpawnConfig(),
+      agents: {
+        defaults: {
+          subagents: {
+            allowAgents: ["codex"],
+            maxSpawnDepth: 2,
+            runTimeoutSeconds: 120,
+          },
+        },
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+    expectInitializeSessionFields({
+      agent: "codex",
+      runtimeOptions: {
+        timeoutSeconds: 120,
+      },
+    });
+    const agentCall = findAgentGatewayCall();
+    expect(agentCall?.params?.timeout).toBe(120);
+  });
+
   it("rejects OpenClaw config agent ids when runtime=acp targets a native agent", async () => {
     replaceSpawnConfig({
       ...createDefaultSpawnConfig(),

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1102,6 +1102,26 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.timeout).toBe(45);
   });
 
+  it("passes zero timeout through to the gateway no-timeout path", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        runTimeoutSeconds: 0,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+    expect(result).toHaveProperty("runTimeoutSeconds", 0);
+    const initInput = expectInitializeSessionFields({ agent: "codex" });
+    expect(initInput.runtimeOptions).toBeUndefined();
+    const agentCall = findAgentGatewayCall();
+    expect(agentCall?.params?.timeout).toBe(0);
+  });
+
   it("uses configured subagent timeout for ACP spawns", async () => {
     replaceSpawnConfig({
       ...createDefaultSpawnConfig(),

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -109,6 +109,8 @@ import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sess
 
 const log = createSubsystemLogger("agents/acp-spawn");
 
+const ACP_RUNTIME_TIMEOUT_MAX_SECONDS = 24 * 60 * 60;
+
 export const ACP_SPAWN_MODES = ["run", "session"] as const;
 export type SpawnAcpMode = (typeof ACP_SPAWN_MODES)[number];
 export const ACP_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
@@ -999,6 +1001,13 @@ type AcpSpawnRuntimeOptions = {
   timeoutSeconds?: number;
 };
 
+function resolveAcpRuntimeTimeoutSeconds(runTimeoutSeconds?: number): number | undefined {
+  if (!runTimeoutSeconds) {
+    return undefined;
+  }
+  return Math.min(runTimeoutSeconds, ACP_RUNTIME_TIMEOUT_MAX_SECONDS);
+}
+
 function resolveAcpSpawnRuntimeOptions(params: {
   cfg: OpenClawConfig;
   targetAgentId: string;
@@ -1039,12 +1048,13 @@ function resolveAcpSpawnRuntimeOptions(params: {
     }
   }
 
+  const timeoutSeconds = resolveAcpRuntimeTimeoutSeconds(params.runTimeoutSeconds);
   const runtimeOptions =
-    model || thinking || params.runTimeoutSeconds
+    model || thinking || timeoutSeconds
       ? {
           ...(model ? { model } : {}),
           ...(thinking ? { thinking } : {}),
-          ...(params.runTimeoutSeconds ? { timeoutSeconds: params.runTimeoutSeconds } : {}),
+          ...(timeoutSeconds ? { timeoutSeconds } : {}),
         }
       : undefined;
   return { ok: true, runtimeOptions };

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -195,6 +195,7 @@ type SpawnAcpResultFields = {
   childSessionKey?: string;
   runId?: string;
   mode?: SpawnAcpMode;
+  runTimeoutSeconds?: number;
   inlineDelivery?: boolean;
   streamLogPath?: string;
   note?: string;
@@ -1647,6 +1648,7 @@ export async function spawnAcpDirect(
       childSessionKey: sessionKey,
       runId: childRunId,
       mode: spawnMode,
+      runTimeoutSeconds,
       ...(streamLogPath ? { streamLogPath } : {}),
       note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
     };
@@ -1686,6 +1688,7 @@ export async function spawnAcpDirect(
     childSessionKey: sessionKey,
     runId: childRunId,
     mode: spawnMode,
+    runTimeoutSeconds,
     ...(deliveryPlan.useInlineDelivery ? { inlineDelivery: true } : {}),
     note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
   };

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1570,7 +1570,7 @@ export async function spawnAcpDirect(
         deliver: deliveryPlan.useInlineDelivery,
         lane: AGENT_LANE_SUBAGENT,
         acpTurnSource: "manual_spawn",
-        ...(runTimeoutSeconds > 0 ? { timeout: runTimeoutSeconds } : {}),
+        timeout: runTimeoutSeconds,
         label: params.label || undefined,
         ...(gatewayAttachments ? { attachments: gatewayAttachments } : {}),
       },

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -99,7 +99,10 @@ import {
 } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession, getSubagentRunByChildSessionKey } from "./subagent-registry.js";
-import { splitModelRef } from "./subagent-spawn-plan.js";
+import {
+  resolveConfiguredSubagentRunTimeoutSeconds,
+  splitModelRef,
+} from "./subagent-spawn-plan.js";
 import { resolveSubagentThinkingOverride } from "./subagent-spawn-thinking.js";
 import { resolveSubagentTargetPolicy } from "./subagent-target-policy.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
@@ -1252,6 +1255,10 @@ export async function spawnAcpDirect(
   ctx: SpawnAcpContext,
 ): Promise<SpawnAcpResult> {
   const cfg = getRuntimeConfig();
+  const runTimeoutSeconds = resolveConfiguredSubagentRunTimeoutSeconds({
+    cfg,
+    runTimeoutSeconds: params.runTimeoutSeconds,
+  });
   const requesterInternalKey = resolveRequesterInternalSessionKey({
     cfg,
     requesterSessionKey: ctx.agentSessionKey,
@@ -1388,7 +1395,7 @@ export async function spawnAcpDirect(
     configAgentId: targetAgentResult.configAgentId,
     model: params.model,
     thinking: params.thinking,
-    runTimeoutSeconds: params.runTimeoutSeconds,
+    runTimeoutSeconds,
   });
   if (!runtimeOptionsResult.ok) {
     return createAcpSpawnFailure({
@@ -1562,7 +1569,7 @@ export async function spawnAcpDirect(
         deliver: deliveryPlan.useInlineDelivery,
         lane: AGENT_LANE_SUBAGENT,
         acpTurnSource: "manual_spawn",
-        ...(params.runTimeoutSeconds != null ? { timeout: params.runTimeoutSeconds } : {}),
+        ...(runTimeoutSeconds > 0 ? { timeout: runTimeoutSeconds } : {}),
         label: params.label || undefined,
         ...(gatewayAttachments ? { attachments: gatewayAttachments } : {}),
       },

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -92,7 +92,6 @@ async function executeSpawnAndExpectAccepted(params: {
 }) {
   const result = await params.tool.execute(params.callId, {
     task: "do thing",
-    runTimeoutSeconds: RUN_TIMEOUT_SECONDS,
     ...(params.cleanup ? { cleanup: params.cleanup } : {}),
     ...(params.label ? { label: params.label } : {}),
     ...(params.expectsCompletionMessage === false ? { expectsCompletionMessage: false } : {}),
@@ -178,6 +177,13 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
       messages: {
         queue: {
           debounceMs: 0,
+        },
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            runTimeoutSeconds: RUN_TIMEOUT_SECONDS,
+          },
         },
       },
     });
@@ -288,10 +294,20 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
       agentSessionKey: "main",
       agentChannel: "whatsapp",
     });
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      messages: { queue: { debounceMs: 0 } },
+      agents: {
+        defaults: {
+          subagents: {
+            runTimeoutSeconds: 120,
+          },
+        },
+      },
+    });
 
     const result = await tool.execute("call-start-timeout", {
       task: "do thing",
-      runTimeoutSeconds: 120,
     });
 
     expectAcceptedRunDetails(result.details);

--- a/src/agents/subagent-announce.live.test.ts
+++ b/src/agents/subagent-announce.live.test.ts
@@ -332,7 +332,6 @@ describeLive("subagent announce live", () => {
               taskName: "issue_82913_child",
               cleanup: "keep",
               context: "isolated",
-              runTimeoutSeconds: 180,
             })}.`,
             'Step 2: after spawn returns status="accepted", immediately call the bash tool with command exactly: sleep 35; printf ISSUE_82913_PARENT_TOOL_DONE.',
             "Do not call sessions_yield at any point in this scenario.",
@@ -524,7 +523,6 @@ describeLive("subagent announce live", () => {
               taskName: "steered_child",
               cleanup: "keep",
               context: "isolated",
-              runTimeoutSeconds: 300,
             })}.`,
             'Step 2: after spawn returns status="accepted", do not call the subagents tool; the test harness will steer the child.',
             `Step 3: reply exactly ${parentStartedToken}.`,
@@ -744,7 +742,6 @@ describeLive("subagent announce live", () => {
                   taskName: `gemini_stress_${childNumber}`,
                   cleanup: "keep",
                   context: "isolated",
-                  runTimeoutSeconds: 300,
                 },
               )}.`;
             }),

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -736,6 +736,13 @@ describe("sessions_spawn tool", () => {
 
   it("forwards ACP sandbox options", async () => {
     registerAcpBackendForTest();
+    hoisted.spawnAcpDirectMock.mockResolvedValueOnce({
+      status: "accepted",
+      childSessionKey: "agent:codex:acp:1",
+      runId: "run-acp",
+      mode: "run",
+      runTimeoutSeconds: 120,
+    });
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:subagent:parent",
     });
@@ -758,6 +765,7 @@ describe("sessions_spawn tool", () => {
     expect(registration.requesterSessionKey).toBe("agent:main:subagent:parent");
     expect(registration.task).toBe("investigate");
     expect(registration.cleanup).toBe("keep");
+    expect(registration.runTimeoutSeconds).toBe(120);
     expect(registration.spawnMode).toBe("run");
   });
 

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -464,21 +464,25 @@ describe("sessions_spawn tool", () => {
     expect(result.details).not.toHaveProperty("role");
   });
 
-  it("ignores stale timeout override arguments", async () => {
-    const tool = createSessionsSpawnTool({
-      agentSessionKey: "agent:main:main",
-    });
+  it.each(["runTimeoutSeconds", "timeoutSeconds"] as const)(
+    "rejects stale timeout override argument %s",
+    async (timeoutParam) => {
+      const tool = createSessionsSpawnTool({
+        agentSessionKey: "agent:main:main",
+      });
 
-    await tool.execute("call-stale-timeout-override", {
-      task: "do thing",
-      runTimeoutSeconds: 2,
-      timeoutSeconds: 2,
-    });
+      await expect(
+        tool.execute("call-stale-timeout-override", {
+          task: "do thing",
+          [timeoutParam]: 2,
+        }),
+      ).rejects.toThrow(
+        `sessions_spawn does not support per-call "${timeoutParam}". Configure agents.defaults.subagents.runTimeoutSeconds instead.`,
+      );
 
-    const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
-    expect(spawnArgs.task).toBe("do thing");
-    expect(spawnArgs).not.toHaveProperty("runTimeoutSeconds");
-  });
+      expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("passes inherited workspaceDir from tool context, not from tool args", async () => {
     const tool = createSessionsSpawnTool({

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -218,6 +218,19 @@ describe("sessions_spawn tool", () => {
     expect(schema.properties?.runtime?.enum).toEqual(["subagent", "acp"]);
   });
 
+  it("does not expose timeout override fields to the model", () => {
+    const tool = createSessionsSpawnTool();
+    const schema = tool.parameters as {
+      properties?: {
+        runTimeoutSeconds?: unknown;
+        timeoutSeconds?: unknown;
+      };
+    };
+
+    expect(schema.properties?.runTimeoutSeconds).toBeUndefined();
+    expect(schema.properties?.timeoutSeconds).toBeUndefined();
+  });
+
   it("hides thread-bound spawn fields when current channel disables spawnSessions", () => {
     const tool = createSessionsSpawnTool({
       agentChannel: "discord",
@@ -286,7 +299,6 @@ describe("sessions_spawn tool", () => {
       model: "anthropic/claude-sonnet-4-6",
       thinking: "medium",
       cwd: "/workspace/requester",
-      runTimeoutSeconds: 5,
       thread: true,
       mode: "session",
       cleanup: "keep",
@@ -304,7 +316,7 @@ describe("sessions_spawn tool", () => {
     expect(spawnArgs.model).toBe("anthropic/claude-sonnet-4-6");
     expect(spawnArgs.thinking).toBe("medium");
     expect(spawnArgs.cwd).toBe("/workspace/requester");
-    expect(spawnArgs.runTimeoutSeconds).toBe(5);
+    expect(spawnArgs).not.toHaveProperty("runTimeoutSeconds");
     expect(spawnArgs.thread).toBe(true);
     expect(spawnArgs.mode).toBe("session");
     expect(spawnArgs.cleanup).toBe("keep");
@@ -452,37 +464,20 @@ describe("sessions_spawn tool", () => {
     expect(result.details).not.toHaveProperty("role");
   });
 
-  it("supports legacy timeoutSeconds alias", async () => {
+  it("ignores stale timeout override arguments", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
 
-    await tool.execute("call-timeout-alias", {
+    await tool.execute("call-stale-timeout-override", {
       task: "do thing",
+      runTimeoutSeconds: 2,
       timeoutSeconds: 2,
     });
 
     const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
     expect(spawnArgs.task).toBe("do thing");
-    expect(spawnArgs.runTimeoutSeconds).toBe(2);
-  });
-
-  it.each([
-    [{ runTimeoutSeconds: 1.5 }, "runTimeoutSeconds must be a non-negative integer"],
-    [{ runTimeoutSeconds: -1 }, "runTimeoutSeconds must be a non-negative integer"],
-    [{ timeoutSeconds: "1sec" }, "timeoutSeconds must be a non-negative integer"],
-  ])("rejects invalid timeout override %o", async (params, message) => {
-    const tool = createSessionsSpawnTool({
-      agentSessionKey: "agent:main:main",
-    });
-
-    await expect(
-      tool.execute("call-invalid-timeout", {
-        task: "do thing",
-        ...params,
-      }),
-    ).rejects.toThrow(message);
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(spawnArgs).not.toHaveProperty("runTimeoutSeconds");
   });
 
   it("passes inherited workspaceDir from tool context, not from tool args", async () => {
@@ -548,7 +543,6 @@ describe("sessions_spawn tool", () => {
       task: "investigate the failing CI run",
       agentId: "codex",
       cwd: "/workspace",
-      runTimeoutSeconds: 45,
       thread: true,
       mode: "session",
       streamTo: "parent",
@@ -563,7 +557,7 @@ describe("sessions_spawn tool", () => {
     expect(spawnArgs.task).toBe("investigate the failing CI run");
     expect(spawnArgs.agentId).toBe("codex");
     expect(spawnArgs.cwd).toBe("/workspace");
-    expect(spawnArgs.runTimeoutSeconds).toBe(45);
+    expect(spawnArgs).not.toHaveProperty("runTimeoutSeconds");
     expect(spawnArgs.thread).toBe(true);
     expect(spawnArgs.mode).toBe("session");
     expect(spawnArgs.streamTo).toBe("parent");

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -464,25 +464,27 @@ describe("sessions_spawn tool", () => {
     expect(result.details).not.toHaveProperty("role");
   });
 
-  it.each(["runTimeoutSeconds", "timeoutSeconds"] as const)(
-    "rejects stale timeout override argument %s",
-    async (timeoutParam) => {
-      const tool = createSessionsSpawnTool({
-        agentSessionKey: "agent:main:main",
-      });
+  it.each([
+    "runTimeoutSeconds",
+    "timeoutSeconds",
+    "run_timeout_seconds",
+    "timeout_seconds",
+  ] as const)("rejects stale timeout override argument %s", async (timeoutParam) => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
 
-      await expect(
-        tool.execute("call-stale-timeout-override", {
-          task: "do thing",
-          [timeoutParam]: 2,
-        }),
-      ).rejects.toThrow(
-        `sessions_spawn does not support per-call "${timeoutParam}". Configure agents.defaults.subagents.runTimeoutSeconds instead.`,
-      );
+    await expect(
+      tool.execute("call-stale-timeout-override", {
+        task: "do thing",
+        [timeoutParam]: 2,
+      }),
+    ).rejects.toThrow(
+      `sessions_spawn does not support per-call "${timeoutParam}". Configure agents.defaults.subagents.runTimeoutSeconds instead.`,
+    );
 
-      expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
-    },
-  );
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
 
   it("passes inherited workspaceDir from tool context, not from tool args", async () => {
     const tool = createSessionsSpawnTool({

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -54,6 +54,10 @@ const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
   "replyTo",
   "reply_to",
 ] as const;
+const UNSUPPORTED_SESSIONS_SPAWN_TIMEOUT_PARAM_KEYS = [
+  "runTimeoutSeconds",
+  "timeoutSeconds",
+] as const;
 
 type AcpSpawnModule = typeof import("../acp-spawn.js");
 
@@ -277,6 +281,14 @@ export function createSessionsSpawnTool(
       if (unsupportedParam) {
         throw new ToolInputError(
           `sessions_spawn does not support "${unsupportedParam}". Use "message" or "sessions_send" for channel delivery.`,
+        );
+      }
+      const unsupportedTimeoutParam = UNSUPPORTED_SESSIONS_SPAWN_TIMEOUT_PARAM_KEYS.find((key) =>
+        Object.hasOwn(params, key),
+      );
+      if (unsupportedTimeoutParam) {
+        throw new ToolInputError(
+          `sessions_spawn does not support per-call "${unsupportedTimeoutParam}". Configure agents.defaults.subagents.runTimeoutSeconds instead.`,
         );
       }
       const task = readStringParam(params, "task", { required: true });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -447,6 +447,7 @@ export function createSessionsSpawnTool(
               taskName,
               cleanup: trackedCleanup,
               label: label || undefined,
+              runTimeoutSeconds: result.runTimeoutSeconds,
               expectsCompletionMessage: shouldExpectCompletionMessage,
               spawnMode: trackedSpawnMode,
             });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -171,9 +171,6 @@ function createSessionsSpawnToolSchema(params: {
     model: Type.Optional(Type.String()),
     thinking: Type.Optional(Type.String()),
     cwd: Type.Optional(Type.String()),
-    runTimeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
-    // Back-compat: older callers used timeoutSeconds for this tool.
-    timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
     ...(params.threadAvailable
       ? {
           thread: Type.Optional(
@@ -344,10 +341,6 @@ export function createSessionsSpawnTool(
       if (runtime === "acp" && context === "fork") {
         throw new Error('context="fork" is only supported for runtime="subagent".');
       }
-      const runTimeoutSeconds =
-        readNonNegativeIntegerParam(params, "runTimeoutSeconds") ??
-        // Back-compat: older callers used timeoutSeconds for this tool.
-        readNonNegativeIntegerParam(params, "timeoutSeconds");
       const thread = params.thread === true;
       const attachments = Array.isArray(params.attachments)
         ? (params.attachments as Array<{
@@ -379,7 +372,6 @@ export function createSessionsSpawnTool(
             resumeSessionId,
             model: modelOverride,
             thinking: thinkingOverrideRaw,
-            runTimeoutSeconds,
             cwd,
             mode: mode === "run" || mode === "session" ? mode : undefined,
             thread,
@@ -441,7 +433,6 @@ export function createSessionsSpawnTool(
               taskName,
               cleanup: trackedCleanup,
               label: label || undefined,
-              runTimeoutSeconds,
               expectsCompletionMessage: shouldExpectCompletionMessage,
               spawnMode: trackedSpawnMode,
             });
@@ -470,7 +461,6 @@ export function createSessionsSpawnTool(
           model: modelOverride,
           thinking: thinkingOverrideRaw,
           cwd,
-          runTimeoutSeconds,
           thread,
           mode,
           cleanup,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -36,7 +36,6 @@ import type { AnyAgentTool } from "./common.js";
 import {
   jsonResult,
   normalizeToolModelOverride,
-  readNonNegativeIntegerParam,
   readStringParam,
   ToolInputError,
 } from "./common.js";

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -7,6 +7,7 @@ import {
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
+import { resolveSnakeCaseParamKey } from "../../param-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
@@ -284,11 +285,13 @@ export function createSessionsSpawnTool(
         );
       }
       const unsupportedTimeoutParam = UNSUPPORTED_SESSIONS_SPAWN_TIMEOUT_PARAM_KEYS.find((key) =>
-        Object.hasOwn(params, key),
+        resolveSnakeCaseParamKey(params, key),
       );
       if (unsupportedTimeoutParam) {
+        const providedTimeoutParam =
+          resolveSnakeCaseParamKey(params, unsupportedTimeoutParam) ?? unsupportedTimeoutParam;
         throw new ToolInputError(
-          `sessions_spawn does not support per-call "${unsupportedTimeoutParam}". Configure agents.defaults.subagents.runTimeoutSeconds instead.`,
+          `sessions_spawn does not support per-call "${providedTimeoutParam}". Configure agents.defaults.subagents.runTimeoutSeconds instead.`,
         );
       }
       const task = readStringParam(params, "task", { required: true });

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1144,10 +1144,6 @@
           "enum": ["subagent"],
           "type": "string"
         },
-        "runTimeoutSeconds": {
-          "minimum": 0,
-          "type": "integer"
-        },
         "sandbox": {
           "enum": ["inherit", "require"],
           "type": "string"
@@ -1165,10 +1161,6 @@
         "thread": {
           "description": "Bind spawn to new chat thread when supported. `thread=true` defaults mode=\"session\".",
           "type": "boolean"
-        },
-        "timeoutSeconds": {
-          "minimum": 0,
-          "type": "integer"
         }
       },
       "required": ["task"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1180,10 +1180,6 @@
           "enum": ["subagent"],
           "type": "string"
         },
-        "runTimeoutSeconds": {
-          "minimum": 0,
-          "type": "integer"
-        },
         "sandbox": {
           "enum": ["inherit", "require"],
           "type": "string"
@@ -1197,10 +1193,6 @@
         },
         "thinking": {
           "type": "string"
-        },
-        "timeoutSeconds": {
-          "minimum": 0,
-          "type": "integer"
         }
       },
       "required": ["task"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1144,10 +1144,6 @@
           "enum": ["subagent"],
           "type": "string"
         },
-        "runTimeoutSeconds": {
-          "minimum": 0,
-          "type": "integer"
-        },
         "sandbox": {
           "enum": ["inherit", "require"],
           "type": "string"
@@ -1161,10 +1157,6 @@
         },
         "thinking": {
           "type": "string"
-        },
-        "timeoutSeconds": {
-          "minimum": 0,
-          "type": "integer"
         }
       },
       "required": ["task"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44128,
-    "roughTokens": 11032
+    "chars": 43943,
+    "roughTokens": 10986
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71830,
-    "roughTokens": 17958
+    "chars": 71645,
+    "roughTokens": 17912
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 43849,
-    "roughTokens": 10963
+    "chars": 43664,
+    "roughTokens": 10916
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 70027,
-    "roughTokens": 17507
+    "chars": 69842,
+    "roughTokens": 17461
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44944,
-    "roughTokens": 11236
+    "chars": 44759,
+    "roughTokens": 11190
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72065,
-    "roughTokens": 18017
+    "chars": 71880,
+    "roughTokens": 17970
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary

- Remove `runTimeoutSeconds` and legacy `timeoutSeconds` from the model-facing `sessions_spawn` tool schema so agents cannot choose per-call child run timeouts.
- Reject stale camelCase and snake_case timeout override arguments instead of silently ignoring them.
- Keep operator-controlled timeout behavior through `agents.defaults.subagents.runTimeoutSeconds`, including ACP runtime dispatch, registry tracking, and the explicit `0` no-timeout path.
- Refresh Codex prompt snapshots and update docs that previously described per-call `sessions_spawn` timeout overrides.

Original internal timeout-schema patch was authored by chenhaoqiang.

## Verification

- `pnpm docs:list`
- `node scripts/run-vitest.mjs src/agents/tools/sessions-spawn-tool.test.ts src/agents/acp-spawn.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts`
- `node --import tsx -` runtime probe against `src/agents/tools/sessions-spawn-tool.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: `sessions_spawn` no longer advertises model-controlled per-call timeout overrides; configured subagent timeouts remain applied to native and ACP child runs.

Real environment tested: Local OpenClaw worktree on the rebased PR branch, importing the real `sessions_spawn` tool module with `node --import tsx`.

Exact steps or command run after this patch: `node --import tsx -` imported `src/agents/tools/sessions-spawn-tool.ts`, created the real tool, inspected its JSON schema keys, then executed the tool with stale `runTimeoutSeconds` and `timeout_seconds` arguments. Also ran `node scripts/run-vitest.mjs src/agents/tools/sessions-spawn-tool.test.ts src/agents/acp-spawn.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts`; `pnpm docs:list`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `.agents/skills/autoreview/scripts/autoreview --mode local`.

Evidence after fix: Terminal output from the runtime probe:

```text
sessions_spawn schema has runTimeoutSeconds: false
sessions_spawn schema has timeoutSeconds: false
stale runTimeoutSeconds rejected: sessions_spawn does not support per-call "runTimeoutSeconds". Configure agents.defaults.subagents.runTimeoutSeconds instead.
stale timeout_seconds rejected: sessions_spawn does not support per-call "timeout_seconds". Configure agents.defaults.subagents.runTimeoutSeconds instead.
```

Observed result after fix: The live tool schema omits both timeout override fields, stale timeout keys fail before dispatch, focused tests passed with 126 agent/tool tests, and the final autoreview reported no accepted/actionable findings after the ACP timeout cap fix.

What was not tested: A live ACP harness or real messaging-channel run was not exercised for this PR.
