### PR TITLE
fix(idle-timeout): honor provider timeout for no-timeout runs

### DIFF
--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
@@ -92,6 +92,19 @@ describe("resolveLlmIdleTimeoutMs", () => {
     );
   });
 
+  it("honors provider request timeout when run timeout is the NO_TIMEOUT sentinel", () => {
+    // Regression: when `runTimeoutSeconds` is treated as 0, `resolveAgentTimeoutMs`
+    // hands back NO_TIMEOUT_MS (= MAX_SAFE_TIMEOUT_MS). An explicit per-model idle
+    // timeout must still take effect — "run is unlimited" does not imply "skip
+    // chunk-level hang detection".
+    expect(
+      resolveLlmIdleTimeoutMs({
+        modelRequestTimeoutMs: 180_000,
+        runTimeoutMs: 2_147_000_000,
+      }),
+    ).toBe(180_000);
+  });
+
   it("uses provider request timeout for cron model calls", () => {
     expect(resolveLlmIdleTimeoutMs({ trigger: "cron", modelRequestTimeoutMs: 300_000 })).toBe(
       300_000,

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
@@ -94,13 +94,13 @@ describe("resolveLlmIdleTimeoutMs", () => {
 
   it("honors provider request timeout when run timeout is the NO_TIMEOUT sentinel", () => {
     // Regression: when `runTimeoutSeconds` is treated as 0, `resolveAgentTimeoutMs`
-    // hands back NO_TIMEOUT_MS (= MAX_SAFE_TIMEOUT_MS). An explicit per-model idle
-    // timeout must still take effect — "run is unlimited" does not imply "skip
+    // hands back the max timer sentinel. An explicit per-model idle timeout
+    // must still take effect: "run is unlimited" does not imply "skip
     // chunk-level hang detection".
     expect(
       resolveLlmIdleTimeoutMs({
         modelRequestTimeoutMs: 180_000,
-        runTimeoutMs: 2_147_000_000,
+        runTimeoutMs: MAX_TIMER_TIMEOUT_MS,
       }),
     ).toBe(180_000);
   });

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
@@ -92,6 +92,19 @@ describe("resolveLlmIdleTimeoutMs", () => {
     );
   });
 
+  it("does not bound explicit run timeout by agents.defaults.timeoutSeconds", () => {
+    const cfg = {
+      agents: { defaults: { timeoutSeconds: 45 } },
+    } as OpenClawConfig;
+    expect(
+      resolveLlmIdleTimeoutMs({
+        cfg,
+        modelRequestTimeoutMs: 300_000,
+        runTimeoutMs: 180_000,
+      }),
+    ).toBe(180_000);
+  });
+
   it("honors provider request timeout when run timeout is the NO_TIMEOUT sentinel", () => {
     // Regression: when `runTimeoutSeconds` is treated as 0, `resolveAgentTimeoutMs`
     // hands back the max timer sentinel. An explicit per-model idle timeout
@@ -99,6 +112,19 @@ describe("resolveLlmIdleTimeoutMs", () => {
     // chunk-level hang detection".
     expect(
       resolveLlmIdleTimeoutMs({
+        modelRequestTimeoutMs: 180_000,
+        runTimeoutMs: MAX_TIMER_TIMEOUT_MS,
+      }),
+    ).toBe(180_000);
+  });
+
+  it("does not bound provider request timeout by agent default when run timeout is no-timeout", () => {
+    const cfg = {
+      agents: { defaults: { timeoutSeconds: 45 } },
+    } as OpenClawConfig;
+    expect(
+      resolveLlmIdleTimeoutMs({
+        cfg,
         modelRequestTimeoutMs: 180_000,
         runTimeoutMs: MAX_TIMER_TIMEOUT_MS,
       }),

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
@@ -124,12 +124,6 @@ export function resolveLlmIdleTimeoutMs(params?: {
     clampTimeoutMs(Math.min(valueMs, DEFAULT_LLM_IDLE_TIMEOUT_MS));
 
   const runTimeoutMs = params?.runTimeoutMs;
-  if (typeof runTimeoutMs === "number" && Number.isFinite(runTimeoutMs) && runTimeoutMs > 0) {
-    if (runTimeoutMs >= MAX_TIMER_TIMEOUT_MS) {
-      return 0;
-    }
-  }
-
   const agentTimeoutSeconds = params?.cfg?.agents?.defaults?.timeoutSeconds;
   const agentTimeoutMs = finiteSecondsToTimerSafeMilliseconds(agentTimeoutSeconds);
   const timeoutBounds = [runTimeoutMs, agentTimeoutMs].filter(
@@ -140,6 +134,10 @@ export function resolveLlmIdleTimeoutMs(params?: {
       value < MAX_TIMER_TIMEOUT_MS,
   );
 
+  // Explicit per-model idle timeout (`models.providers.<id>.timeoutSeconds`) wins
+  // over the NO_TIMEOUT_MS sentinel that runTimeoutMs may carry when the caller
+  // declared "run is unlimited". The two are independent: an unlimited run does
+  // not imply opting out of chunk-level hang detection.
   const modelRequestTimeoutMs = params?.modelRequestTimeoutMs;
   if (
     typeof modelRequestTimeoutMs === "number" &&
@@ -161,6 +159,9 @@ export function resolveLlmIdleTimeoutMs(params?: {
   }
 
   if (typeof runTimeoutMs === "number" && Number.isFinite(runTimeoutMs) && runTimeoutMs > 0) {
+    if (runTimeoutMs >= MAX_TIMER_TIMEOUT_MS) {
+      return 0;
+    }
     if (params?.trigger === "cron") {
       return clampTimeoutMs(runTimeoutMs);
     }

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
@@ -126,7 +126,13 @@ export function resolveLlmIdleTimeoutMs(params?: {
   const runTimeoutMs = params?.runTimeoutMs;
   const agentTimeoutSeconds = params?.cfg?.agents?.defaults?.timeoutSeconds;
   const agentTimeoutMs = finiteSecondsToTimerSafeMilliseconds(agentTimeoutSeconds);
-  const timeoutBounds = [runTimeoutMs, agentTimeoutMs].filter(
+  const hasExplicitRunTimeout =
+    typeof runTimeoutMs === "number" && Number.isFinite(runTimeoutMs) && runTimeoutMs > 0;
+  const runTimeoutIsNoTimeout = hasExplicitRunTimeout && runTimeoutMs >= MAX_TIMER_TIMEOUT_MS;
+  const timeoutBounds = [
+    runTimeoutIsNoTimeout ? undefined : runTimeoutMs,
+    hasExplicitRunTimeout ? undefined : agentTimeoutMs,
+  ].filter(
     (value): value is number =>
       typeof value === "number" &&
       Number.isFinite(value) &&


### PR DESCRIPTION
## Summary

- honor explicit provider/model request timeouts even when the run timeout is the max-timer no-timeout sentinel
- avoid re-bounding explicit run timeout overrides by `agents.defaults.timeoutSeconds`
- add regression coverage for no-timeout sentinel and explicit-run/default interactions

The first commit was cherry-picked from internal commit `4fbd3f4d00f` with `-x`, then adjusted for the current `embedded-agent-runner` path and follow-up review feedback.

## Test plan

- `pnpm test src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` — clean, no accepted/actionable findings


## Real behavior proof

Behavior addressed: Explicit `models.providers.<id>.timeoutSeconds` now still resolves to an LLM idle watchdog when the run timeout is the no-timeout sentinel, and explicit run timeouts are no longer capped by `agents.defaults.timeoutSeconds`.

Real environment tested: Maintainer local macOS source checkout, PR branch rebased onto current `origin/main` at `286c8e3632`, Node/pnpm repo test wrapper.

Exact steps or command run after this patch: `pnpm test src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts -- --reporter=verbose`

Evidence after fix: The focused Vitest file passed after the rebase: 1 test file, 75 tests passed, `[test] passed 1 Vitest shard in 3.62s`.

Observed result after fix: Regression cases resolve `MAX_TIMER_TIMEOUT_MS` plus `modelRequestTimeoutMs: 180_000` to `180_000`, and resolve `cfg.agents.defaults.timeoutSeconds: 45` plus explicit `runTimeoutMs: 180_000` to `180_000`.

What was not tested: A live provider call that waits for wall-clock timeout expiration was not run; maintainer is landing with focused helper proof because `resolveLlmIdleTimeoutMs` is the pure owner boundary and the runtime caller already passes both timeout inputs into it.
