### PR TITLE
fix(agents): guard MCP inventory display fields

### DIFF
--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -259,6 +259,52 @@ describe("resolveEffectiveToolInventory", () => {
     ]);
   });
 
+  it("keeps bundled MCP inventory readable when optional display metadata is unreadable", async () => {
+    const { buildRuntimeCompatibleMcpToolInventory } =
+      await import("./tools-effective-mcp-inventory.js");
+    const tool = mockTool({
+      name: "reproProbe__probe_tool",
+      label: "Probe",
+      description: "Probe MCP",
+    });
+    Object.defineProperties(tool, {
+      label: {
+        get() {
+          throw new Error("label exploded");
+        },
+      },
+      description: {
+        get() {
+          throw new Error("description exploded");
+        },
+      },
+      displaySummary: {
+        get() {
+          throw new Error("display summary exploded");
+        },
+      },
+    });
+
+    const result = buildRuntimeCompatibleMcpToolInventory({
+      tools: [tool],
+      cfg: {},
+    });
+
+    expect(result).toEqual({
+      entries: [
+        {
+          id: "reproProbe__probe_tool",
+          label: "ReproProbe Probe Tool",
+          description: "Tool",
+          rawDescription: "Tool",
+          source: "mcp",
+          pluginId: "bundle-mcp",
+        },
+      ],
+      notices: [],
+    });
+  });
+
   it("disambiguates duplicate labels with source ids", async () => {
     const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal9 } =
       await loadHarness({

--- a/src/agents/tools-effective-mcp-inventory.ts
+++ b/src/agents/tools-effective-mcp-inventory.ts
@@ -20,8 +20,50 @@ import type { AnyAgentTool } from "./tools/common.js";
 
 const BUNDLE_MCP_PLUGIN_ID = "bundle-mcp";
 
-function resolveMcpToolLabel(tool: AnyAgentTool): string {
-  const rawLabel = normalizeOptionalString(tool.label) ?? "";
+type McpInventoryTool = {
+  name: string;
+  label?: string;
+  description?: string;
+  displaySummary?: string;
+};
+
+function readMcpInventoryToolField<TField extends keyof AnyAgentTool>(
+  tool: AnyAgentTool,
+  field: TField,
+): { ok: true; value: AnyAgentTool[TField] } | { ok: false } {
+  try {
+    return { ok: true, value: tool[field] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readMcpInventoryToolString<TField extends keyof AnyAgentTool>(
+  tool: AnyAgentTool,
+  field: TField,
+): string | undefined {
+  const fieldRead = readMcpInventoryToolField(tool, field);
+  return fieldRead.ok ? normalizeOptionalString(fieldRead.value) : undefined;
+}
+
+function materializeMcpInventoryTool(tool: AnyAgentTool): McpInventoryTool | undefined {
+  const name = readMcpInventoryToolString(tool, "name");
+  if (!name) {
+    return undefined;
+  }
+  const label = readMcpInventoryToolString(tool, "label");
+  const description = readMcpInventoryToolString(tool, "description");
+  const displaySummary = readMcpInventoryToolString(tool, "displaySummary");
+  return {
+    name,
+    ...(label ? { label } : {}),
+    ...(description ? { description } : {}),
+    ...(displaySummary ? { displaySummary } : {}),
+  };
+}
+
+function resolveMcpToolLabel(tool: McpInventoryTool): string {
+  const rawLabel = tool.label ?? "";
   if (
     rawLabel &&
     normalizeLowercaseStringOrEmpty(rawLabel) !== normalizeLowercaseStringOrEmpty(tool.name)
@@ -31,11 +73,11 @@ function resolveMcpToolLabel(tool: AnyAgentTool): string {
   return resolveToolDisplay({ name: tool.name }).title;
 }
 
-function resolveRawToolDescription(tool: AnyAgentTool): string {
-  return normalizeOptionalString(tool.description) ?? "";
+function resolveRawToolDescription(tool: McpInventoryTool): string {
+  return tool.description ?? "";
 }
 
-function summarizeToolDescription(tool: AnyAgentTool): string {
+function summarizeToolDescription(tool: McpInventoryTool): string {
   return summarizeToolDescriptionText({
     rawDescription: resolveRawToolDescription(tool),
     displaySummary: tool.displaySummary,
@@ -70,17 +112,23 @@ function buildMcpToolInventoryEntries(
 ): EffectiveToolInventoryEntry[] {
   return disambiguateLabels(
     tools
-      .map(
-        (tool) =>
-          ({
-            id: tool.name,
-            label: resolveMcpToolLabel(tool),
-            description: summarizeToolDescription(tool),
-            rawDescription: resolveRawToolDescription(tool) || summarizeToolDescription(tool),
+      .flatMap((tool) => {
+        const materializedTool = materializeMcpInventoryTool(tool);
+        if (!materializedTool) {
+          return [];
+        }
+        const summary = summarizeToolDescription(materializedTool);
+        return [
+          {
+            id: materializedTool.name,
+            label: resolveMcpToolLabel(materializedTool),
+            description: summary,
+            rawDescription: resolveRawToolDescription(materializedTool) || summary,
             source: "mcp",
             pluginId: BUNDLE_MCP_PLUGIN_ID,
-          }) satisfies EffectiveToolInventoryEntry,
-      )
+          } satisfies EffectiveToolInventoryEntry,
+        ];
+      })
       .toSorted((a, b) => a.label.localeCompare(b.label)),
   );
 }


### PR DESCRIPTION
## Summary

- Guard bundled MCP effective-inventory display field reads after runtime schema projection.
- Preserve healthy MCP inventory entries when optional `label`, `description`, or `displaySummary` accessors throw.
- Add focused regression coverage for unreadable MCP display metadata.

## Real behavior proof

Behavior addressed: A bundled MCP tool with a valid runtime schema but hostile optional display metadata no longer crashes effective inventory projection.

Real environment tested: local macOS Codex worktree.

Exact steps or command run after this patch:

- `node --import tsx` direct repro for `buildRuntimeCompatibleMcpToolInventory` with a throwing `description` getter
- `node scripts/run-vitest.mjs src/agents/tools-effective-inventory.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/tools-effective-mcp-inventory.ts src/agents/tools-effective-inventory.test.ts`
- `node_modules/.bin/oxlint src/agents/tools-effective-mcp-inventory.ts src/agents/tools-effective-inventory.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- attempted remote `pnpm check:changed` through Blacksmith Testbox, Azure Crabbox, and AWS Crabbox

Evidence after fix: The direct repro returned an MCP inventory entry instead of throwing; focused Vitest passed 1 file / 21 tests; formatter, lint, and diff checks passed; autoreview reported no accepted/actionable findings.

Observed result after fix: Effective inventory falls back to the tool name and generic summary when optional MCP display fields are unreadable.

What was not tested: Remote `pnpm check:changed` did not run because Blacksmith Testbox is unauthenticated locally, Azure Crabbox timed out waiting for capacity (`run_241ceee4de38`), and AWS Crabbox hit the active lease limit (`run_d8829ab84a62`, 9/8 active leases).
