### PR TITLE
fix(doctor): skip shared auth symlink shadows

### DIFF
--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
@@ -266,6 +266,42 @@ describe("stale OAuth profile shadow doctor repair", () => {
     expect(childStore?.lastGood?.anthropic).toBeUndefined();
   });
 
+  it("does not prune main OAuth profiles through child auth store symlinks", async () => {
+    const profileId = "openai-codex:default";
+    const now = Date.now();
+    const mainAgentDir = path.join(stateDir, "agents", "main", "agent");
+    const childAgentDir = path.join(stateDir, "agents", "telegram", "agent");
+    await writeRawAuthStore(
+      mainAgentDir,
+      storeWith(
+        profileId,
+        oauthCredential({
+          provider: "openai-codex",
+          access: "main-access",
+          refresh: "main-refresh",
+          expires: now + 60 * 60 * 1000,
+          accountId: "acct-shared",
+        }),
+      ),
+    );
+    await fs.mkdir(childAgentDir, { recursive: true });
+    await fs.symlink(resolveAuthStorePath(mainAgentDir), resolveAuthStorePath(childAgentDir));
+
+    const hits = await scanStaleOAuthProfileShadows({
+      cfg: { agents: { list: [{ id: "telegram" }] } } satisfies OpenClawConfig,
+      now,
+    });
+    const result = await repairStaleOAuthProfileShadows({
+      cfg: { agents: { list: [{ id: "telegram" }] } } satisfies OpenClawConfig,
+      now,
+    });
+
+    expect(hits).toEqual([]);
+    expect(result).toEqual({ changes: [], warnings: [] });
+    expect(loadPersistedAuthProfileStore(mainAgentDir)?.profiles[profileId]).toBeDefined();
+    expect((await fs.lstat(resolveAuthStorePath(childAgentDir))).isSymbolicLink()).toBe(true);
+  });
+
   it("does not remove a child OAuth profile for a different account", async () => {
     const profileId = "anthropic:default";
     const now = Date.now();

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
@@ -75,6 +75,22 @@ async function pathExists(targetPath: string): Promise<boolean> {
   }
 }
 
+async function resolveExistingRealPath(targetPath: string): Promise<string | null> {
+  try {
+    return path.resolve(await fs.realpath(targetPath));
+  } catch {
+    return null;
+  }
+}
+
+async function pathsResolveToSameFile(leftPath: string, rightPath: string): Promise<boolean> {
+  const [leftRealPath, rightRealPath] = await Promise.all([
+    resolveExistingRealPath(leftPath),
+    resolveExistingRealPath(rightPath),
+  ]);
+  return leftRealPath !== null && rightRealPath !== null && leftRealPath === rightRealPath;
+}
+
 async function collectStateAgentDirs(env: NodeJS.ProcessEnv): Promise<string[]> {
   const agentsRoot = path.join(resolveStateDir(env), "agents");
   const entries = await fs.readdir(agentsRoot, { withFileTypes: true }).catch(() => []);
@@ -135,6 +151,7 @@ export async function scanStaleOAuthProfileShadows(params: {
   const now = params.now ?? Date.now();
   const mainAgentDir = resolveDefaultAgentDir({}, env);
   const mainAuthPath = path.resolve(resolveAuthStorePath(mainAgentDir));
+  const mainAuthRealPath = await resolveExistingRealPath(mainAuthPath);
   const mainStore = loadPersistedAuthProfileStore(mainAgentDir);
   if (!mainStore) {
     return [];
@@ -143,6 +160,10 @@ export async function scanStaleOAuthProfileShadows(params: {
   for (const agentDir of await collectCandidateAgentDirs(params.cfg, env)) {
     const authPath = path.resolve(resolveAuthStorePath(agentDir));
     if (authPath === mainAuthPath || !(await pathExists(authPath))) {
+      continue;
+    }
+    const authRealPath = await resolveExistingRealPath(authPath);
+    if (authRealPath === null || authRealPath === mainAuthRealPath) {
       continue;
     }
     const rawLocalStore = await loadRawAuthProfileStore(authPath);
@@ -218,21 +239,32 @@ function formatProfileList(profileIds: string[]): string {
 
 async function repairStaleOAuthProfilesForAgent(params: {
   agentDir: string;
+  mainAgentDir?: string;
   mainStore: AuthProfileStore;
   profileIds: Set<string>;
   now: number;
 }): Promise<
   { status: "changed"; removedProfileIds: string[] } | { status: "missing" | "unchanged" }
 > {
+  const authPath = resolveAuthStorePath(params.agentDir);
+  const mainAuthPath = resolveAuthStorePath(
+    params.mainAgentDir ?? resolveDefaultAgentDir({}, process.env),
+  );
+  if (await pathsResolveToSameFile(authPath, mainAuthPath)) {
+    return { status: "unchanged" };
+  }
   return await withFileLock(
-    resolveAuthStorePath(params.agentDir),
+    authPath,
     AUTH_STORE_LOCK_OPTIONS,
     async () => {
+      if (await pathsResolveToSameFile(authPath, mainAuthPath)) {
+        return { status: "unchanged" };
+      }
       const store = loadPersistedAuthProfileStore(params.agentDir);
       if (!store) {
         return { status: "missing" };
       }
-      const rawStore = await loadRawAuthProfileStore(resolveAuthStorePath(params.agentDir));
+      const rawStore = await loadRawAuthProfileStore(authPath);
       const profileIds = new Set(
         [...params.profileIds].filter(
           (profileId) => !hasLegacyOAuthSidecarRef(rawStore, profileId),
@@ -296,6 +328,7 @@ export async function repairStaleOAuthProfileShadows(params: {
     try {
       const repair = await repairStaleOAuthProfilesForAgent({
         agentDir,
+        mainAgentDir: resolveDefaultAgentDir({}, env),
         mainStore,
         profileIds,
         now,


### PR DESCRIPTION
Fixes #89048

### Summary

- Resolve auth-store real paths before stale OAuth shadow repair treats an agent store as local.
- Skip child `auth-profiles.json` stores that resolve to the main agent auth store.
- Re-check the symlink/realpath condition before saving during repair.
- Add a regression test for child agent auth stores symlinked to main.

### Root cause

The stale OAuth profile shadow repair compared `auth-profiles.json` locations by normalized path strings. That misses the deployment shape where:

```text
~/.openclaw/agents/<agent>/agent/auth-profiles.json
  -> ~/.openclaw/agents/main/agent/auth-profiles.json
```

The child path and main path are different strings, but the same file after symlink resolution. Without a realpath guard, doctor can treat the shared main store as a local child shadow and save a pruned profile set through the symlink.

### What changed

- Added realpath-aware auth-store identity checks to stale OAuth profile shadow scan/repair.
- Preserved existing behavior for real local child auth stores.
- Left legacy sidecar OAuth migration behavior unchanged.
- Added a regression test proving symlinked child auth stores are skipped and the main OAuth profile remains intact.

### Test plan

```bash
node scripts/run-vitest.mjs src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts
# passed: 1 file, 9 tests

git diff --check origin/main...HEAD
# passed
```

`node scripts/run-tsgo.mjs` was also attempted locally, but I stopped it after it ran silently for more than seven minutes. GitHub CI `check-prod-types` and `check-test-types` passed on this PR.

### Real behavior proof

- Behavior or issue addressed: Prevent `openclaw doctor --fix` stale OAuth shadow repair from treating a non-main agent `auth-profiles.json` symlink as a separate local child store and pruning the shared main OAuth profile through that symlink.
- Real environment tested: PR branch `fix/doctor-auth-symlink-guard` at head `9e61d5087074`, running OpenClaw from source with `node scripts/run-node.mjs` on macOS. The proof uses an isolated temporary OpenClaw state directory, a valid `openai/gpt-5.5` agent config, a main OAuth auth store, and a non-main `telegram` agent whose `auth-profiles.json` is a real filesystem symlink to the main auth store. I used provider `openai` for the branch-level proof because current doctor migrates legacy `openai-codex:*` profile IDs to `openai:*`; using the post-migration provider isolates the stale-shadow symlink write path under test.
- Exact steps or command run after this patch:

```bash
# Create isolated state.
tmp=$(mktemp -d /tmp/openclaw-doctor-symlink-proof.openai.XXXXXX)
state="$tmp/state"
home="$tmp/home"
profile='openai:proof@example.test'
main="$state/agents/main/agent"
child="$state/agents/telegram/agent"
mkdir -p "$main" "$child" "$home"

# Write a valid config with a registered non-main agent.
cat > "$state/openclaw.json" <<'JSON'
{
  "agents": {
    "defaults": {
      "model": "openai/gpt-5.5"
    },
    "list": [
      { "id": "telegram" }
    ]
  },
  "plugins": {
    "entries": {
      "openai": { "enabled": true },
      "codex": { "enabled": true }
    }
  }
}
JSON

# Write main OAuth auth store, then make child auth store a symlink to main.
node - "$main/auth-profiles.json" <<'NODE'
const fs = require('fs');
const file = process.argv[2];
const profile = 'openai:proof@example.test';
const store = {
  version: 1,
  profiles: {
    [profile]: {
      type: 'oauth',
      provider: 'openai',
      access: 'redacted-access-token',
      refresh: 'redacted-refresh-token',
      expires: Date.now() + 60 * 60 * 1000,
      email: 'proof@example.test',
      accountId: 'acct-proof'
    }
  },
  order: { openai: [profile] },
  lastGood: { openai: profile }
};
fs.writeFileSync(file, `${JSON.stringify(store, null, 2)}\n`);
NODE
ln -s "$main/auth-profiles.json" "$child/auth-profiles.json"

before_hash=$(shasum -a 256 "$main/auth-profiles.json" | awk '{print $1}')

HOME="$home" \
OPENCLAW_STATE_DIR="$state" \
OPENCLAW_CONFIG_PATH="$state/openclaw.json" \
OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY=1 \
node scripts/run-node.mjs doctor --fix --non-interactive --yes

after_hash=$(shasum -a 256 "$main/auth-profiles.json" | awk '{print $1}')
```

- Evidence after fix:

```text
proof_root=/tmp/openclaw-doctor-symlink-proof.openai.oCmP28
branch_head=9e61d5087074
openclaw_version=OpenClaw 2026.6.1 (9e61d50)
before_main_profile_present=true
before_child_is_symlink=true
before_child_link_target=<tmp>/state/agents/main/agent/auth-profiles.json
before_main_sha256=0e0a549dd71e975634031e3feb710346ffc17d8a6923f9a39575c2900cfa2f9f

doctor_exit=0
doctor_stdout_relevant:
261: Gateway service not installed.
271: Updated config: <tmp>/state/openclaw.json
275: Doctor complete.
doctor_stderr_relevant:
1: Health check failed: GatewayCredentialsRequiredError: gateway status requires credentials before opening a websocket
2: Fix: configure gateway.auth token/password, pair this device, or pass --token/--password.

after_child_is_symlink=true
after_child_link_target=<tmp>/state/agents/main/agent/auth-profiles.json
after_main_profile_present=true
after_main_profile_type=oauth
after_main_profile_provider=openai
after_main_sha256=0e0a549dd71e975634031e3feb710346ffc17d8a6923f9a39575c2900cfa2f9f
main_store_unchanged=true
```

- Observed result after fix: On this PR branch, `doctor --fix --non-interactive --yes` exits `0` against a child auth-store symlink layout. The child `auth-profiles.json` remains a symlink to the main store, the main OAuth profile remains present with type `oauth`, and the main auth store SHA-256 is unchanged before and after doctor. The gateway warning is expected in this isolated temp state because no gateway token/service was configured; it did not make doctor fail and did not touch the auth store.
- What was not tested: I did not install this PR branch onto the production VPS. The production deployment was repaired with the local workaround and separately verified with redacted `models status`/`models auth list` output; the branch-level proof above isolates the changed `doctor --fix` behavior on the PR head.

### Production incident context

On the affected VPS, non-main agents inherit auth from the main store via symlinks. After the local workaround isolated child auth-store symlinks before doctor, restored OAuth, and re-linked agents, the repaired deployment showed:

```text
openclaw_version=OpenClaw 2026.5.28 (e932160)
main_auth_store=present
registered_agent_auth_links
builder: symlink-to-main-auth-store
guard: symlink-to-main-auth-store
harvey: symlink-to-main-auth-store
jobs: symlink-to-main-auth-store
kt: symlink-to-main-auth-store
rand: symlink-to-main-auth-store
ryan: symlink-to-main-auth-store
streamsathi: symlink-to-main-auth-store
trader: symlink-to-main-auth-store

models status --json redacted summary:
{
  "defaultModel": "openai/gpt-5.5",
  "imageModel": "openai/gpt-image-2",
  "authStorePath": "/home/ubuntu/.openclaw/agents/main/agent/auth-profiles.json",
  "runtimeAuthRoutes": [
    {
      "provider": "openai",
      "runtime": "codex",
      "authProvider": "openai-codex",
      "status": "usable"
    }
  ],
  "unusableProfiles": []
}
```

### Risk

Low. The change should only prevent doctor from treating a shared/symlinked main auth store as a removable local child shadow. Normal stale local child OAuth shadows should still be detected and repaired.
