### PR TITLE
fix: restart gateway after isolated cron setup timeout

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -30,7 +30,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
-import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../process/command-queue.js";
 import type { CommandQueueEnqueueOptions } from "../../process/command-queue.types.js";
 import { createAgentHarnessTaskRuntimeScope } from "../../tasks/agent-harness-task-runtime-scope.js";
 import { resolveUserPath } from "../../utils.js";
@@ -586,12 +586,38 @@ async function runEmbeddedAgentInternal(
       },
       laneTaskTimeoutMs,
     );
+  const withRunLaneWait = (opts?: CommandQueueEnqueueOptions) => {
+    if (!opts?.onWait && !params.onLaneWait) {
+      return opts;
+    }
+    return {
+      ...opts,
+      onWait: (waitMs, queuedAhead) => {
+        opts?.onWait?.(waitMs, queuedAhead);
+        params.onLaneWait?.({ waitMs, queuedAhead, waiting: true });
+      },
+    } satisfies CommandQueueEnqueueOptions;
+  };
+  const noteLaneWaitIfBusy = (lane: string) => {
+    if (!params.onLaneWait) {
+      return;
+    }
+    const snapshot = getCommandLaneSnapshot(lane);
+    if (snapshot.queuedCount > 0 || snapshot.activeCount >= snapshot.maxConcurrent) {
+      params.onLaneWait({
+        waitMs: 0,
+        queuedAhead: snapshot.queuedCount + snapshot.activeCount,
+        waiting: true,
+      });
+    }
+  };
   const enqueueGlobal = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: sessionQueuePriority,
     };
     const taskWithCurrentLifecycle = () => {
+      params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
       throwIfAborted();
       const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
       const existingContext = getAgentRunContext(params.runId);
@@ -618,15 +644,27 @@ async function runEmbeddedAgentInternal(
       });
       return withAgentRunLifecycleGeneration(lifecycleGeneration, task);
     };
-    return params.enqueue
-      ? params.enqueue(taskWithCurrentLifecycle, withLaneTimeout(globalOpts))
-      : enqueueCommandInLane(globalLane, taskWithCurrentLifecycle, withLaneTimeout(globalOpts));
+    if (params.enqueue) {
+      return params.enqueue(taskWithCurrentLifecycle, withLaneTimeout(withRunLaneWait(globalOpts)));
+    }
+    noteLaneWaitIfBusy(globalLane);
+    return enqueueCommandInLane(
+      globalLane,
+      taskWithCurrentLifecycle,
+      withLaneTimeout(withRunLaneWait(globalOpts)),
+    );
   };
   const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
     const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
-    return params.enqueue
-      ? params.enqueue(task, sessionOpts)
-      : enqueueCommandInLane(sessionLane, task, sessionOpts);
+    const taskWithLaneAdmission = () => {
+      params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });
+      return task();
+    };
+    if (params.enqueue) {
+      return params.enqueue(taskWithLaneAdmission, withRunLaneWait(sessionOpts));
+    }
+    noteLaneWaitIfBusy(sessionLane);
+    return enqueueCommandInLane(sessionLane, taskWithLaneAdmission, withRunLaneWait(sessionOpts));
   };
   const channelHint = params.messageChannel ?? params.messageProvider;
   const resolvedToolResultFormat =

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -187,6 +187,7 @@ export type RunEmbeddedAgentParams = {
     itemId?: string;
     firstModelCallStarted?: boolean;
   }) => void;
+  onLaneWait?: (info: { waitMs: number; queuedAhead: number; waiting?: boolean }) => void;
   onRunProgress?: (info: {
     reason: string;
     provider?: string;

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -30,6 +30,16 @@ export { markUpdateRestartSentinelFailure } from "../../infra/restart-sentinel.j
 export { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
 export { writeDiagnosticStabilityBundleForFailureSync } from "../../logging/diagnostic-stability-bundle.js";
 export {
+  advanceCronActiveJobGeneration,
+  resetCronActiveJobs,
+  waitForActiveCronJobs,
+} from "../../cron/active-jobs.js";
+export {
+  abortActiveCronTaskRuns,
+  retireActiveCronTaskRunTracking,
+  waitForActiveCronTaskRuns,
+} from "../../tasks/cron-task-cancel.js";
+export {
   getActiveTaskCount,
   markGatewayDraining,
   resetAllLanes,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -54,6 +54,18 @@ const getInspectableActiveTaskRestartBlockers = vi.fn(
 const markGatewayDraining = vi.fn();
 const waitForActiveTasks = vi.fn(async (_timeoutMs?: number) => ({ drained: true }));
 const resetAllLanes = vi.fn();
+const advanceCronActiveJobGeneration = vi.fn();
+const resetCronActiveJobs = vi.fn();
+const abortActiveCronTaskRuns = vi.fn((_reason?: string) => 0);
+const retireActiveCronTaskRunTracking = vi.fn();
+const waitForActiveCronTaskRuns = vi.fn(async (_timeoutMs?: number) => ({
+  drained: true,
+  active: 0,
+}));
+const waitForActiveCronJobs = vi.fn(async (_timeoutMs?: number) => ({
+  drained: true,
+  active: 0,
+}));
 const reloadTaskRegistryFromStore = vi.fn();
 const rotateAgentEventLifecycleGeneration = vi.fn();
 const clearRuntimeConfigSnapshot = vi.fn();
@@ -149,6 +161,18 @@ vi.mock("../../process/command-queue.js", () => ({
   markGatewayDraining: () => markGatewayDraining(),
   waitForActiveTasks: (timeoutMs?: number) => waitForActiveTasks(timeoutMs),
   resetAllLanes: () => resetAllLanes(),
+}));
+
+vi.mock("../../cron/active-jobs.js", () => ({
+  advanceCronActiveJobGeneration: () => advanceCronActiveJobGeneration(),
+  resetCronActiveJobs: () => resetCronActiveJobs(),
+  waitForActiveCronJobs: (timeoutMs: number) => waitForActiveCronJobs(timeoutMs),
+}));
+
+vi.mock("../../tasks/cron-task-cancel.js", () => ({
+  abortActiveCronTaskRuns: (reason?: string) => abortActiveCronTaskRuns(reason),
+  retireActiveCronTaskRunTracking: () => retireActiveCronTaskRunTracking(),
+  waitForActiveCronTaskRuns: (timeoutMs: number) => waitForActiveCronTaskRuns(timeoutMs),
 }));
 
 vi.mock("../../tasks/runtime-internal.js", () => ({
@@ -876,7 +900,13 @@ describe("runGatewayLoop", () => {
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
       expectRestartCloseCall(closeFirst, 1_234);
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
+      expect(abortActiveCronTaskRuns).toHaveBeenCalledWith("Gateway restarting.");
+      expect(waitForActiveCronTaskRuns).toHaveBeenCalledWith(1_000);
+      expect(waitForActiveCronJobs).toHaveBeenCalledWith(1_000);
       expect(resetAllLanes).toHaveBeenCalledTimes(1);
+      expect(advanceCronActiveJobGeneration).toHaveBeenCalledTimes(1);
+      expect(retireActiveCronTaskRunTracking).toHaveBeenCalledTimes(1);
+      expect(resetCronActiveJobs).toHaveBeenCalledTimes(1);
       expect(clearRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(1);
       expect(rotateAgentEventLifecycleGeneration).toHaveBeenCalledTimes(1);
@@ -884,6 +914,18 @@ describe("runGatewayLoop", () => {
       expect(
         rotateAgentEventLifecycleGeneration.mock.invocationCallOrder[0] ?? Infinity,
       ).toBeLessThan(resetAllLanes.mock.invocationCallOrder[0] ?? Infinity);
+      expect(advanceCronActiveJobGeneration.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+        abortActiveCronTaskRuns.mock.invocationCallOrder[0] ?? Infinity,
+      );
+      expect(waitForActiveCronJobs.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+        retireActiveCronTaskRunTracking.mock.invocationCallOrder[0] ?? Infinity,
+      );
+      expect(retireActiveCronTaskRunTracking.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+        resetCronActiveJobs.mock.invocationCallOrder[0] ?? Infinity,
+      );
+      expect(resetCronActiveJobs.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+        resetAllLanes.mock.invocationCallOrder[0] ?? Infinity,
+      );
 
       sigusr1();
 
@@ -894,7 +936,13 @@ describe("runGatewayLoop", () => {
       expectRestartCloseCall(closeSecond, 1_234);
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
       expect(markGatewayDraining).toHaveBeenCalledTimes(2);
+      expect(abortActiveCronTaskRuns).toHaveBeenCalledTimes(2);
+      expect(waitForActiveCronTaskRuns).toHaveBeenCalledTimes(2);
+      expect(waitForActiveCronJobs).toHaveBeenCalledTimes(2);
       expect(resetAllLanes).toHaveBeenCalledTimes(2);
+      expect(advanceCronActiveJobGeneration).toHaveBeenCalledTimes(2);
+      expect(retireActiveCronTaskRunTracking).toHaveBeenCalledTimes(2);
+      expect(resetCronActiveJobs).toHaveBeenCalledTimes(2);
       expect(clearRuntimeConfigSnapshot).toHaveBeenCalledTimes(2);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
       expect(rotateAgentEventLifecycleGeneration).toHaveBeenCalledTimes(2);
@@ -907,6 +955,42 @@ describe("runGatewayLoop", () => {
         reason: "gateway stopping",
         restartExpectedMs: null,
       });
+    });
+  });
+
+  it("advances stale cron active markers after bounded restart cron-run drain", async () => {
+    vi.clearAllMocks();
+    waitForActiveCronJobs.mockResolvedValueOnce({ drained: false, active: 1 });
+    peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
+    respawnGatewayProcessForUpdate.mockReturnValue({
+      mode: "disabled",
+      detail: "OPENCLAW_NO_RESPAWN",
+    });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { start, exited } = await createSignaledLoopHarness();
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigint = captureSignal("SIGINT");
+
+      sigusr1();
+      await waitForLoopCondition(
+        () => start.mock.calls.length >= 2,
+        "expected SIGUSR1 to trigger restart",
+      );
+
+      expect(abortActiveCronTaskRuns).toHaveBeenCalledWith("Gateway restarting.");
+      expect(waitForActiveCronTaskRuns).toHaveBeenCalledWith(1_000);
+      expect(waitForActiveCronJobs).toHaveBeenCalledWith(1_000);
+      expect(resetAllLanes).toHaveBeenCalledTimes(1);
+      expect(advanceCronActiveJobGeneration).toHaveBeenCalledTimes(1);
+      expect(retireActiveCronTaskRunTracking).toHaveBeenCalledTimes(1);
+      expect(resetCronActiveJobs).toHaveBeenCalledTimes(1);
+      expect(gatewayLog.warn).toHaveBeenCalledWith(
+        "cron run drain timed out during restart lifecycle reset after retiring old cron admission; 0 task handle(s) and 1 active marker(s) remain after aborting old cron runs",
+      );
+
+      sigint();
+      await expect(exited).resolves.toBe(0);
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -800,13 +800,30 @@ export async function runGatewayLoop(params: {
       // deferral timers and reloads the task registry from durable state so
       // cancelled/completed work is not kept alive by old in-memory maps.
       const {
+        abortActiveCronTaskRuns,
+        advanceCronActiveJobGeneration,
         reloadTaskRegistryFromStore,
+        retireActiveCronTaskRunTracking,
+        resetCronActiveJobs,
         resetAllLanes,
         resetGatewayRestartStateForInProcessRestart,
         rotateAgentEventLifecycleGeneration,
+        waitForActiveCronJobs,
+        waitForActiveCronTaskRuns,
       } = await loadGatewayLifecycleRuntimeModule();
       // Rotate ownership before reset pumps preserved queue entries.
       rotateAgentEventLifecycleGeneration();
+      advanceCronActiveJobGeneration();
+      abortActiveCronTaskRuns("Gateway restarting.");
+      const cronTaskDrain = await waitForActiveCronTaskRuns(1_000);
+      const cronDrain = await waitForActiveCronJobs(1_000);
+      if (!cronTaskDrain.drained || !cronDrain.drained) {
+        gatewayLog.warn(
+          `cron run drain timed out during restart lifecycle reset after retiring old cron admission; ${cronTaskDrain.active} task handle(s) and ${cronDrain.active} active marker(s) remain after aborting old cron runs`,
+        );
+      }
+      retireActiveCronTaskRunTracking();
+      resetCronActiveJobs();
       resetAllLanes();
       clearRuntimeConfigSnapshot();
       resetGatewayRestartStateForInProcessRestart();

--- a/src/cron/active-jobs-manual-run.test.ts
+++ b/src/cron/active-jobs-manual-run.test.ts
@@ -20,8 +20,15 @@
 // the same `prepareManualRun` → `finishPreparedManualRun` chain that hits
 // production callers.
 
-import { beforeEach, describe, expect, it } from "vitest";
-import { isCronJobActive, resetCronActiveJobsForTests } from "./active-jobs.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  advanceCronActiveJobGeneration,
+  clearCronJobActive,
+  isCronActiveJobMarkerCurrent,
+  isCronJobActive,
+  markCronJobActive,
+  resetCronActiveJobsForTests,
+} from "./active-jobs.js";
 import { CronService } from "./service.js";
 import {
   createDeferred,
@@ -86,6 +93,10 @@ describe("cron activeJobIds — manual-run mark/clear", () => {
     resetCronActiveJobsForTests();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("marks the job active during a manual run and clears it on success", async () => {
     const { cron, entered, release, store } = await createManualRunHarness("manual-isolated-ok");
 
@@ -107,6 +118,49 @@ describe("cron activeJobIds — manual-run mark/clear", () => {
     }
   });
 
+  it("does not let old restart-lifecycle finalizers clear new active markers", () => {
+    const oldMarker = markCronJobActive("manual-generation-reuse");
+
+    advanceCronActiveJobGeneration();
+    const freshMarker = markCronJobActive("manual-generation-reuse");
+
+    clearCronJobActive("manual-generation-reuse", oldMarker);
+
+    expect(isCronJobActive("manual-generation-reuse")).toBe(true);
+
+    clearCronJobActive("manual-generation-reuse", freshMarker);
+
+    expect(isCronJobActive("manual-generation-reuse")).toBe(false);
+  });
+
+  it("does not let same-generation finalizers clear replacement active markers", () => {
+    const oldMarker = markCronJobActive("manual-token-reuse");
+    const freshMarker = markCronJobActive("manual-token-reuse");
+
+    clearCronJobActive("manual-token-reuse", oldMarker);
+
+    expect(isCronJobActive("manual-token-reuse")).toBe(true);
+
+    clearCronJobActive("manual-token-reuse", freshMarker);
+
+    expect(isCronJobActive("manual-token-reuse")).toBe(false);
+  });
+
+  it("retires preserved main-session markers at the lifecycle cutoff", () => {
+    const marker = markCronJobActive("manual-main-cutoff", {
+      preserveAcrossGenerationAdvance: true,
+    });
+
+    advanceCronActiveJobGeneration();
+
+    expect(isCronActiveJobMarkerCurrent(marker)).toBe(true);
+
+    resetCronActiveJobsForTests();
+
+    expect(isCronActiveJobMarkerCurrent(marker)).toBe(false);
+    expect(isCronJobActive("manual-main-cutoff")).toBe(false);
+  });
+
   it("clears the active marker even when the inner agent run throws", async () => {
     const { cron, entered, release, store } = await createManualRunHarness("manual-isolated-throw");
 
@@ -122,6 +176,67 @@ describe("cron activeJobIds — manual-run mark/clear", () => {
       await runPromise;
 
       expect(isCronJobActive("manual-isolated-throw")).toBe(false);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("requests one setup-timeout restart when concurrent manual runs both stall before runner start", async () => {
+    vi.useFakeTimers();
+    const now = Date.parse("2025-12-13T17:00:00.000Z");
+    vi.setSystemTime(now);
+
+    const store = await makeStorePath();
+    const firstJob = createManualIsolatedJob("manual-setup-timeout-first");
+    const secondJob = createManualIsolatedJob("manual-setup-timeout-second");
+    firstJob.payload = { kind: "agentTurn", message: "hi", timeoutSeconds: 120 };
+    secondJob.payload = { kind: "agentTurn", message: "hi", timeoutSeconds: 120 };
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [firstJob, secondJob],
+    });
+
+    const bothStarted = createDeferred<void>();
+    const onIsolatedAgentSetupTimeout = vi.fn();
+    let startedCount = 0;
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: () => {},
+      requestHeartbeat: () => {},
+      onIsolatedAgentSetupTimeout,
+      runIsolatedAgentJob: async ({ abortSignal }) => {
+        startedCount += 1;
+        if (startedCount === 2) {
+          bothStarted.resolve();
+        }
+        abortSignal?.addEventListener("abort", () => undefined, { once: true });
+        return await new Promise<never>(() => {});
+      },
+    });
+
+    try {
+      await cron.start();
+
+      const firstRun = cron.run(firstJob.id, "force");
+      const secondRun = cron.run(secondJob.id, "force");
+      await bothStarted.promise;
+
+      await vi.advanceTimersByTimeAsync(60_100);
+      await Promise.all([firstRun, secondRun]);
+
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledTimes(1);
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledWith({
+        job: expect.objectContaining({
+          id: expect.stringMatching(/^manual-setup-timeout-/),
+        }),
+        error: expect.stringContaining("setup timed out before runner start"),
+        timeoutMs: 60_000,
+      });
+      expect(isCronJobActive(firstJob.id)).toBe(false);
+      expect(isCronJobActive(secondJob.id)).toBe(false);
     } finally {
       cron.stop();
       await store.cleanup();

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -2,33 +2,120 @@
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
 type CronActiveJobState = {
-  activeJobIds: Set<string>;
+  activeJobs: Map<string, CronActiveJobMarker>;
+  generation: number;
+  nextToken: number;
+  emptyWaiters: Set<() => void>;
+  activeJobIds?: Set<string>;
 };
 
 const CRON_ACTIVE_JOB_STATE_KEY = Symbol.for("openclaw.cron.activeJobs");
 
+export type CronActiveJobMarker = {
+  jobId: string;
+  generation: number;
+  token: number;
+  legacy?: boolean;
+  preserveAcrossGenerationAdvance?: boolean;
+};
+
 function getCronActiveJobState(): CronActiveJobState {
   // Cron runs can cross module reload boundaries in tests and dev watch; keep
   // the in-flight job set process-global so duplicate-run guards share state.
-  return resolveGlobalSingleton<CronActiveJobState>(CRON_ACTIVE_JOB_STATE_KEY, () => ({
+  const state = resolveGlobalSingleton<CronActiveJobState>(CRON_ACTIVE_JOB_STATE_KEY, () => ({
+    activeJobs: new Map<string, CronActiveJobMarker>(),
+    generation: 0,
+    nextToken: 1,
+    emptyWaiters: new Set<() => void>(),
     activeJobIds: new Set<string>(),
   }));
+  state.generation ??= 0;
+  state.nextToken ??= 1;
+  state.activeJobs ??= new Map<string, CronActiveJobMarker>();
+  state.emptyWaiters ??= new Set<() => void>();
+  state.activeJobIds ??= new Set<string>();
+  if (state.activeJobIds) {
+    for (const [jobId, marker] of state.activeJobs) {
+      if (marker.legacy === true && !state.activeJobIds.has(jobId)) {
+        state.activeJobs.delete(jobId);
+      }
+    }
+    for (const jobId of state.activeJobIds) {
+      if (!state.activeJobs.has(jobId)) {
+        state.activeJobs.set(jobId, {
+          jobId,
+          generation: state.generation,
+          token: state.nextToken,
+          legacy: true,
+        });
+        state.nextToken += 1;
+      }
+    }
+  }
+  return state;
+}
+
+function getActiveCronJobCountForGeneration(state: CronActiveJobState) {
+  let active = 0;
+  for (const marker of state.activeJobs.values()) {
+    if (isMarkerActiveInGeneration(marker, state.generation)) {
+      active += 1;
+    }
+  }
+  return active;
+}
+
+function isMarkerActiveInGeneration(marker: CronActiveJobMarker, generation: number) {
+  return marker.generation === generation || marker.preserveAcrossGenerationAdvance === true;
+}
+
+function notifyActiveCronJobWaitersIfEmpty(state: CronActiveJobState) {
+  if (getActiveCronJobCountForGeneration(state) > 0) {
+    return;
+  }
+  for (const resolve of state.emptyWaiters) {
+    resolve();
+  }
+  state.emptyWaiters.clear();
 }
 
 /** Marks a cron job id as currently executing for duplicate-run suppression. */
-export function markCronJobActive(jobId: string) {
+export function markCronJobActive(
+  jobId: string,
+  opts?: { preserveAcrossGenerationAdvance?: boolean },
+): CronActiveJobMarker | undefined {
   if (!jobId) {
-    return;
+    return undefined;
   }
-  getCronActiveJobState().activeJobIds.add(jobId);
+  const state = getCronActiveJobState();
+  const token = state.nextToken;
+  state.nextToken += 1;
+  const marker: CronActiveJobMarker = {
+    jobId,
+    generation: state.generation,
+    token,
+    ...(opts?.preserveAcrossGenerationAdvance ? { preserveAcrossGenerationAdvance: true } : {}),
+  };
+  state.activeJobs.set(jobId, marker);
+  state.activeJobIds?.add(jobId);
+  return marker;
 }
 
 /** Clears the active marker when a cron run exits or is abandoned. */
-export function clearCronJobActive(jobId: string) {
+export function clearCronJobActive(jobId: string, marker?: CronActiveJobMarker) {
   if (!jobId) {
     return;
   }
-  getCronActiveJobState().activeJobIds.delete(jobId);
+  const state = getCronActiveJobState();
+  const activeMarker = state.activeJobs.get(jobId);
+  if (
+    activeMarker &&
+    (!marker || (marker.jobId === jobId && marker.token === activeMarker.token))
+  ) {
+    state.activeJobs.delete(jobId);
+    state.activeJobIds?.delete(jobId);
+  }
+  notifyActiveCronJobWaitersIfEmpty(state);
 }
 
 /** Returns whether the given cron job id is currently executing in this process. */
@@ -36,15 +123,96 @@ export function isCronJobActive(jobId: string) {
   if (!jobId) {
     return false;
   }
-  return getCronActiveJobState().activeJobIds.has(jobId);
+  const state = getCronActiveJobState();
+  const marker = state.activeJobs.get(jobId);
+  return marker ? isMarkerActiveInGeneration(marker, state.generation) : false;
+}
+
+export function isCronActiveJobMarkerCurrent(marker: CronActiveJobMarker | undefined) {
+  if (!marker) {
+    return true;
+  }
+  const state = getCronActiveJobState();
+  const activeMarker = state.activeJobs.get(marker.jobId);
+  return (
+    activeMarker?.token === marker.token && isMarkerActiveInGeneration(marker, state.generation)
+  );
+}
+
+/** Returns whether any other cron run is active in this process. */
+export function hasOtherActiveCronJobs(jobId: string) {
+  const state = getCronActiveJobState();
+  for (const [activeJobId, marker] of state.activeJobs) {
+    if (activeJobId !== jobId && isMarkerActiveInGeneration(marker, state.generation)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /** Returns whether any cron run is active in this process. */
 export function hasActiveCronJobs() {
-  return getCronActiveJobState().activeJobIds.size > 0;
+  return getActiveCronJobCountForGeneration(getCronActiveJobState()) > 0;
+}
+
+/** Returns the number of active cron runs in this process. */
+export function getActiveCronJobCount() {
+  return getActiveCronJobCountForGeneration(getCronActiveJobState());
+}
+
+export async function waitForActiveCronJobs(timeoutMs: number): Promise<{
+  drained: boolean;
+  active: number;
+}> {
+  const state = getCronActiveJobState();
+  if (getActiveCronJobCountForGeneration(state) === 0) {
+    return { drained: true, active: 0 };
+  }
+  await new Promise<void>((resolve) => {
+    const waiter = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    const timeout = setTimeout(
+      () => {
+        state.emptyWaiters.delete(waiter);
+        resolve();
+      },
+      Math.max(0, Math.floor(timeoutMs)),
+    );
+    state.emptyWaiters.add(waiter);
+  });
+  const active = getActiveCronJobCountForGeneration(state);
+  return {
+    drained: active === 0,
+    active,
+  };
+}
+
+/** Starts a new process-lifecycle generation without clearing still-finalizing old runs. */
+export function advanceCronActiveJobGeneration() {
+  const state = getCronActiveJobState();
+  state.generation += 1;
+  for (const [jobId, marker] of state.activeJobs) {
+    if (marker.preserveAcrossGenerationAdvance === true) {
+      continue;
+    }
+    if (marker.generation < state.generation - 1) {
+      state.activeJobs.delete(jobId);
+      state.activeJobIds?.delete(jobId);
+    }
+  }
+  notifyActiveCronJobWaitersIfEmpty(state);
+}
+
+/** Clears process-global cron active-job state at process-lifecycle boundaries. */
+export function resetCronActiveJobs() {
+  const state = getCronActiveJobState();
+  state.generation += 1;
+  state.activeJobs.clear();
+  state.activeJobIds?.clear();
+  notifyActiveCronJobWaitersIfEmpty(state);
 }
 
 /** Clears process-global cron active-job state between tests. */
-export function resetCronActiveJobsForTests() {
-  getCronActiveJobState().activeJobIds.clear();
-}
+export const resetCronActiveJobsForTests = resetCronActiveJobs;

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -157,6 +157,7 @@ export function createCronPromptExecutor(params: {
     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
       Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
   ) => void;
+  onLaneWait?: (info?: { waiting?: boolean }) => void;
 }) {
   const sessionFile =
     params.cronSession.sessionEntry.sessionFile?.trim() ||
@@ -336,6 +337,7 @@ export function createCronPromptExecutor(params: {
           abortSignal: params.abortSignal,
           onExecutionStarted: params.onExecutionStarted,
           onExecutionPhase: params.onExecutionPhase,
+          onLaneWait: params.onLaneWait,
           bootstrapPromptWarningSignaturesSeen,
           bootstrapPromptWarningSignature,
         });
@@ -402,6 +404,7 @@ export async function executeCronRun(params: {
     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
       Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
   ) => void;
+  onLaneWait?: (info?: { waiting?: boolean }) => void;
   thinkLevel: ThinkLevel | undefined;
   timeoutMs: number;
   /** Set when the cron payload's `timeoutSeconds` was explicitly configured. */
@@ -447,6 +450,7 @@ export async function executeCronRun(params: {
     abortReason: params.abortReason,
     onExecutionStarted: params.onExecutionStarted,
     onExecutionPhase: params.onExecutionPhase,
+    onLaneWait: params.onLaneWait,
   });
 
   const runStartedAt = params.runStartedAt ?? Date.now();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -458,6 +458,7 @@ type RunCronAgentTurnParams = {
   signal?: AbortSignal;
   onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
   onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+  onLaneWait?: (info?: { waiting?: boolean }) => void;
   sessionKey: string;
   agentId?: string;
   lane?: string;
@@ -1261,6 +1262,7 @@ export async function runCronIsolatedAgentTurn(params: {
   signal?: AbortSignal;
   onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
   onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+  onLaneWait?: (info?: { waiting?: boolean }) => void;
   sessionKey: string;
   agentId?: string;
   lane?: string;
@@ -1379,6 +1381,7 @@ export async function runCronIsolatedAgentTurn(params: {
       abortSignal,
       onExecutionStarted: notifyExecutionStarted,
       onExecutionPhase: notifyExecutionPhase,
+      onLaneWait: params.onLaneWait,
       abortReason,
       isAborted,
       thinkLevel: prepared.context.thinkLevel,

--- a/src/cron/service-contract.ts
+++ b/src/cron/service-contract.ts
@@ -16,8 +16,8 @@ import type { CronJob } from "./types.js";
 
 type CronWakeResult = { ok: true } | { ok: false; reason?: "unwakeable-session-key" };
 
-/** Result shape for direct/queued cron runs, including invalid persisted specs. */
-export type CronServiceRunResult = CronRunResult | { ok: true; ran: false; reason: "invalid-spec" };
+/** Result shape for direct/queued cron runs. */
+export type CronServiceRunResult = CronRunResult;
 
 /** Public cron service facade used by gateway, plugin SDK, and tests. */
 export interface CronServiceContract {

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -233,6 +233,10 @@ export function createMockCronStateForJobs(params: {
   return {
     store: { version: 1, jobs: params.jobs },
     running: false,
+    stopped: false,
+    restartRecoveryPending: false,
+    activeManualRunJobIds: new Set<string>(),
+    manualSetupTimeoutRestartNotified: false,
     timer: null,
     storeLoadedAtMs: nowMs,
     op: Promise.resolve(),

--- a/src/cron/service/agent-watchdog.test.ts
+++ b/src/cron/service/agent-watchdog.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CRON_AGENT_SETUP_WATCHDOG_MS, createCronAgentWatchdog } from "./agent-watchdog.js";
+
+describe("cron agent setup watchdog", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not keep lane-wait suppression after lane admission", async () => {
+    vi.useFakeTimers();
+    const triggerTimeout = vi.fn();
+    const watchdog = createCronAgentWatchdog({
+      deferUntilRunner: true,
+      jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 2,
+      triggerTimeout,
+    });
+
+    watchdog.start();
+    watchdog.noteLaneWait();
+    watchdog.noteLaneAdmitted();
+
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS + 1);
+
+    expect(triggerTimeout).toHaveBeenCalledTimes(1);
+    expect(watchdog.observedLaneWait()).toBe(false);
+  });
+
+  it("keeps lane-wait evidence after setup timeout fires", async () => {
+    vi.useFakeTimers();
+    const triggerTimeout = vi.fn();
+    const watchdog = createCronAgentWatchdog({
+      deferUntilRunner: true,
+      jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 2,
+      triggerTimeout,
+    });
+
+    watchdog.start();
+    watchdog.noteLaneWait();
+
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS + 1);
+
+    watchdog.noteLaneAdmitted();
+
+    expect(triggerTimeout).toHaveBeenCalledTimes(1);
+    expect(watchdog.observedLaneWait()).toBe(true);
+  });
+});

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -13,7 +13,7 @@ import {
 import type { CronServiceState } from "./state.js";
 
 const CRON_TIMEOUT_CLEANUP_GUARD_MS = 20_000;
-const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
+export const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
 const CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 60_000;
 const CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS = 1_000;
 
@@ -48,9 +48,12 @@ const CRON_AGENT_PHASE_WATCHDOG_STAGE = {
 /** Handle for feeding isolated-agent progress into cron timeout watchdogs. */
 export type CronAgentWatchdog = {
   start: () => void;
+  noteLaneWait: () => void;
+  noteLaneAdmitted: () => void;
   noteRunnerStarted: (info?: CronAgentExecutionStarted) => void;
   notePhase: (info: CronAgentExecutionPhaseUpdate) => void;
   activeExecution: () => CronAgentExecutionStarted | undefined;
+  observedLaneWait: () => boolean;
   dispose: () => void;
 };
 
@@ -65,6 +68,7 @@ export function createCronAgentWatchdog(params: {
   let setupTimeoutId: NodeJS.Timeout | undefined;
   let preExecutionTimeoutId: NodeJS.Timeout | undefined;
   let activeExecution: CronAgentExecutionStarted | undefined;
+  let observedLaneWait = false;
 
   const setTimedOut = (reason: string) => {
     if (state === "timed_out" || state === "disposed") {
@@ -143,6 +147,16 @@ export function createCronAgentWatchdog(params: {
       }
       startTimeout();
     },
+    noteLaneWait: () => {
+      if (state === "waiting_for_runner") {
+        observedLaneWait = true;
+      }
+    },
+    noteLaneAdmitted: () => {
+      if (state === "waiting_for_runner") {
+        observedLaneWait = false;
+      }
+    },
     noteRunnerStarted: (info?: CronAgentExecutionStarted) => {
       if (state === "disposed" || state === "timed_out") {
         return;
@@ -162,6 +176,7 @@ export function createCronAgentWatchdog(params: {
       noteExecutionProgress(info);
     },
     activeExecution: () => activeExecution,
+    observedLaneWait: () => observedLaneWait,
     dispose: () => {
       state = "disposed";
       if (timeoutId) {

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -24,6 +24,11 @@ export function setupTimeoutErrorMessage(execution?: CronAgentExecutionStarted):
   return `cron: isolated agent setup timed out before runner start (last phase: ${phase})`;
 }
 
+/** Returns true for the setup-timeout class that fires before the isolated runner starts. */
+export function isSetupTimeoutErrorText(error: string): boolean {
+  return error.startsWith("cron: isolated agent setup timed out before runner start");
+}
+
 /** Formats timeout text for runs that stalled after setup but before execution start. */
 export function preExecutionTimeoutErrorMessage(execution?: CronAgentExecutionStarted): string {
   const phase = formatCronAgentExecutionPhase(execution);

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import {
   clearCommandLane,
+  enqueueCommandInLane,
   setCommandLaneConcurrency,
   waitForActiveTasks,
 } from "../../process/command-queue.js";
@@ -468,6 +469,56 @@ describe("cron service ops regressions", () => {
     const jobs = state.store?.jobs ?? [];
     expect(jobs.find((job) => job.id === first.id)?.state.lastStatus).toBe("ok");
     expect(jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("ok");
+
+    clearCommandLane(CommandLane.Cron);
+  });
+
+  it("skips queued manual runs when the old cron service stops before lane admission", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+
+    const store = opsRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:03.000Z");
+    const job = createDueIsolatedJob({
+      id: "queued-stopped-manual",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const blockerStarted = createDeferred<void>();
+    const releaseBlocker = createDeferred<void>();
+    const blocker = enqueueCommandInLane(CommandLane.Cron, async () => {
+      blockerStarted.resolve();
+      return await releaseBlocker.promise;
+    });
+
+    await blockerStarted.promise;
+
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    const ack = await enqueueRun(state, job.id, "force");
+    expectQueuedRunAck(ack);
+
+    state.stopped = true;
+    releaseBlocker.resolve();
+    await blocker;
+    await waitForActiveTasks(5_000);
+
+    expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    expect(
+      state.store?.jobs.find((entry) => entry.id === job.id)?.state.runningAtMs,
+    ).toBeUndefined();
 
     clearCommandLane(CommandLane.Cron);
   });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -9,7 +9,12 @@ import {
   createRunningTaskRun,
   failTaskRunByRunId,
 } from "../../tasks/detached-task-runtime.js";
-import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
+import {
+  clearCronJobActive,
+  isCronActiveJobMarkerCurrent,
+  markCronJobActive,
+  type CronActiveJobMarker,
+} from "../active-jobs.js";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { createCronExecutionId } from "../run-id.js";
@@ -48,6 +53,8 @@ import {
   armTimer,
   emit,
   executeJobCoreWithTimeout,
+  type IsolatedAgentSetupTimeoutSignal,
+  maybeNotifyIsolatedAgentSetupTimeout,
   runMissedJobs,
   stopTimer,
 } from "./timer.js";
@@ -60,6 +67,45 @@ type InterruptedStartupRun = {
   runAtMs: number;
   durationMs: number;
 };
+
+function markManualCronJobActive(
+  state: CronServiceState,
+  job: CronJob,
+): CronActiveJobMarker | undefined {
+  const jobId = job.id;
+  state.activeManualRunJobIds.add(jobId);
+  return markCronJobActive(jobId, {
+    preserveAcrossGenerationAdvance: job.sessionTarget === "main",
+  });
+}
+
+function clearManualCronJobActive(
+  state: CronServiceState,
+  jobId: string,
+  activeJobMarker?: CronActiveJobMarker,
+): void {
+  state.activeManualRunJobIds.delete(jobId);
+  clearCronJobActive(jobId, activeJobMarker);
+  if (state.activeManualRunJobIds.size === 0) {
+    state.manualSetupTimeoutRestartNotified = false;
+  }
+}
+
+function maybeNotifyManualIsolatedSetupTimeout(
+  state: CronServiceState,
+  result: {
+    jobId: string;
+    job: CronJob;
+    isolatedAgentSetupTimeout?: IsolatedAgentSetupTimeoutSignal;
+  },
+): boolean {
+  if (!result.isolatedAgentSetupTimeout || state.manualSetupTimeoutRestartNotified) {
+    return false;
+  }
+  const notified = maybeNotifyIsolatedAgentSetupTimeout(state, result);
+  state.manualSetupTimeoutRestartNotified ||= notified;
+  return notified;
+}
 
 function resolveInterruptedStartupFailureNotificationStatus(params: {
   state: CronServiceState;
@@ -169,6 +215,7 @@ async function ensureLoadedForRead(state: CronServiceState) {
 
 /** Starts the cron service, recovers interrupted runs, catches up missed jobs, and arms the timer. */
 export async function start(state: CronServiceState) {
+  state.stopped = false;
   if (!state.deps.cronEnabled) {
     state.deps.log.info({ enabled: false }, "cron: disabled");
     return;
@@ -179,6 +226,9 @@ export async function start(state: CronServiceState) {
   let markedAnyInterruptedRun = false;
   await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
+    if (state.stopped) {
+      return;
+    }
     const jobs = state.store?.jobs ?? [];
     for (const job of jobs) {
       job.state ??= {};
@@ -200,6 +250,9 @@ export async function start(state: CronServiceState) {
     }
   });
 
+  if (state.stopped) {
+    return;
+  }
   await runMissedJobs(state, {
     skipJobIds: interruptedJobIds.size > 0 ? interruptedJobIds : undefined,
     deferAgentTurnJobs: true,
@@ -210,6 +263,9 @@ export async function start(state: CronServiceState) {
     // this path runs before the scheduler begins servicing regular timer ticks.
     // Avoid an extra reload/write cycle on startup.
     await ensureLoaded(state, { skipRecompute: true });
+    if (state.stopped) {
+      return;
+    }
     const changed = recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
     if (changed) {
       await persist(state);
@@ -245,6 +301,7 @@ export async function start(state: CronServiceState) {
 
 /** Stops the cron service timer without mutating persisted job state. */
 export function stop(state: CronServiceState) {
+  state.stopped = true;
   stopTimer(state);
 }
 
@@ -542,7 +599,12 @@ type PreparedManualRun =
   | {
       ok: true;
       ran: false;
-      reason: "already-running" | "not-due" | "invalid-spec";
+      reason:
+        | "already-running"
+        | "not-due"
+        | "invalid-spec"
+        | "restart-recovery-pending"
+        | "stopped";
     }
   | {
       ok: true;
@@ -550,6 +612,7 @@ type PreparedManualRun =
       jobId: string;
       runId?: string;
       taskRunId?: string;
+      activeJobMarker?: CronActiveJobMarker;
       startedAt: number;
       executionJob: CronJob;
     }
@@ -713,6 +776,12 @@ async function inspectManualRunPreflight(
   return await locked(state, async () => {
     warnIfDisabled(state, "run");
     await ensureLoaded(state, { skipRecompute: true });
+    if (state.stopped) {
+      return { ok: true, ran: false, reason: "stopped" as const };
+    }
+    if (state.restartRecoveryPending) {
+      return { ok: true, ran: false, reason: "restart-recovery-pending" as const };
+    }
     // Normalize job tick state (clears stale runningAtMs markers) before
     // checking if already running, so a stale marker from a crashed Phase-1
     // persist does not block manual triggers for up to STUCK_RUN_MS (#17554).
@@ -773,6 +842,9 @@ async function prepareManualRun(
   return await locked(state, async () => {
     // Reserve this run under lock, then execute outside lock so read ops
     // (`list`, `status`) stay responsive while the run is in progress.
+    if (state.stopped) {
+      return { ok: true, ran: false, reason: "stopped" as const };
+    }
     const job = findJobOrThrow(state, id);
     if (typeof job.state.runningAtMs === "number") {
       return { ok: true, ran: false, reason: "already-running" as const };
@@ -782,13 +854,22 @@ async function prepareManualRun(
     // Persist the running marker before releasing lock so timer ticks that
     // force-reload from disk cannot start the same job concurrently.
     await persist(state);
+    if (state.stopped) {
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      const persistedJob = state.store?.jobs.find((entry) => entry.id === id);
+      if (persistedJob?.state.runningAtMs === preflight.now) {
+        delete persistedJob.state.runningAtMs;
+        await persist(state);
+      }
+      return { ok: true, ran: false, reason: "stopped" as const };
+    }
     emit(state, { jobId: job.id, action: "started", job, runAtMs: preflight.now });
     const taskRunId = tryCreateManualTaskRun({
       state,
       job,
       startedAt: preflight.now,
     });
-    markCronJobActive(job.id);
+    const activeJobMarker = markManualCronJobActive(state, job);
     // Execute against a snapshot so later reload/merge can preserve delivery
     // target writeback from disk without mutating the running object.
     const executionJob = structuredClone(job);
@@ -798,6 +879,7 @@ async function prepareManualRun(
       jobId: job.id,
       runId: opts?.runId ?? taskRunId,
       taskRunId,
+      activeJobMarker,
       startedAt: preflight.now,
       executionJob,
     } as const;
@@ -818,7 +900,10 @@ async function finishPreparedManualRun(
   try {
     let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
     try {
-      coreResult = await executeJobCoreWithTimeout(state, executionJob, { runId: taskRunId });
+      coreResult = await executeJobCoreWithTimeout(state, executionJob, {
+        runId: taskRunId,
+        activeJobMarker: prepared.activeJobMarker,
+      });
     } catch (err) {
       coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
     }
@@ -828,9 +913,18 @@ async function finishPreparedManualRun(
       coreResult,
       endedAt,
     });
+    if (!isCronActiveJobMarkerCurrent(prepared.activeJobMarker)) {
+      return;
+    }
 
+    let finalized = false;
+    let notifySetupTimeout = coreResult.isolatedAgentSetupTimeout !== undefined;
     await locked(state, async () => {
       await ensureLoaded(state, { skipRecompute: true });
+      if (!isCronActiveJobMarkerCurrent(prepared.activeJobMarker)) {
+        notifySetupTimeout = false;
+        return;
+      }
       const job = state.store?.jobs.find((entry) => entry.id === jobId);
       if (!job) {
         return;
@@ -894,6 +988,10 @@ async function finishPreparedManualRun(
       // Isolated Telegram send can persist target writeback directly to disk.
       // Reload before final persist so manual `cron run` keeps those changes.
       await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      if (!isCronActiveJobMarkerCurrent(prepared.activeJobMarker)) {
+        notifySetupTimeout = false;
+        return;
+      }
       mergeManualRunSnapshotAfterReload({
         state,
         jobId,
@@ -902,10 +1000,20 @@ async function finishPreparedManualRun(
       });
       recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
       await persist(state);
-      armTimer(state);
+      finalized = true;
     });
+    if (notifySetupTimeout && isCronActiveJobMarkerCurrent(prepared.activeJobMarker)) {
+      maybeNotifyManualIsolatedSetupTimeout(state, {
+        jobId,
+        job: executionJob,
+        isolatedAgentSetupTimeout: coreResult.isolatedAgentSetupTimeout,
+      });
+    }
+    if (finalized) {
+      armTimer(state);
+    }
   } finally {
-    clearCronJobActive(jobId);
+    clearManualCronJobActive(state, jobId, prepared.activeJobMarker);
   }
 }
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -134,6 +134,7 @@ export type CronServiceDeps = {
     abortSignal?: AbortSignal;
     onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
     onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+    onLaneWait?: (info?: { waiting?: boolean }) => void;
   }) => Promise<
     {
       summary?: string;
@@ -166,6 +167,11 @@ export type CronServiceDeps = {
     timeoutMs: number;
     execution?: CronAgentExecutionStarted;
   }) => Promise<void>;
+  onIsolatedAgentSetupTimeout?: (params: {
+    job: CronJob;
+    error: string;
+    timeoutMs: number;
+  }) => void | Promise<void>;
   sendCronFailureAlert?: (params: {
     job: CronJob;
     text: string;
@@ -188,6 +194,10 @@ export type CronServiceState = {
   store: CronStoreFile | null;
   timer: NodeJS.Timeout | null;
   running: boolean;
+  stopped: boolean;
+  restartRecoveryPending: boolean;
+  activeManualRunJobIds: Set<string>;
+  manualSetupTimeoutRestartNotified: boolean;
   /** Serializes mutating service operations so store writes and timers stay ordered. */
   op: Promise<unknown>;
   warnedDisabled: boolean;
@@ -208,6 +218,10 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     store: null,
     timer: null,
     running: false,
+    stopped: false,
+    restartRecoveryPending: false,
+    activeManualRunJobIds: new Set<string>(),
+    manualSetupTimeoutRestartNotified: false,
     op: Promise.resolve(),
     warnedDisabled: false,
     warnedInvalidPersistedJobKeys: new Set<string>(),
@@ -242,6 +256,9 @@ export type CronRunResult =
   | { ok: true; enqueued: true; runId: string }
   | { ok: true; ran: false; reason: "not-due" }
   | { ok: true; ran: false; reason: "already-running" }
+  | { ok: true; ran: false; reason: "restart-recovery-pending" }
+  | { ok: true; ran: false; reason: "invalid-spec" }
+  | { ok: true; ran: false; reason: "stopped" }
   | { ok: false };
 
 /** Remove result that distinguishes missing jobs from failed removal. */

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -11,6 +11,8 @@ import {
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { HEARTBEAT_SKIP_LANES_BUSY, type HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
+import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { CommandLane } from "../../process/lanes.js";
 import {
   cancelActiveCronTaskRun,
   resetActiveCronTaskRunsForTests,
@@ -21,6 +23,12 @@ import {
   resetTaskRegistryControlRuntimeForTests,
   resetTaskRegistryForTests,
 } from "../../tasks/task-registry.js";
+import {
+  advanceCronActiveJobGeneration,
+  clearCronJobActive,
+  isCronJobActive,
+  markCronJobActive,
+} from "../active-jobs.js";
 import * as schedule from "../schedule.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type {
@@ -30,12 +38,14 @@ import type {
   CronJob,
 } from "../types.js";
 import { computeJobNextRunAtMs } from "./jobs.js";
+import { run as runManualCronJob } from "./ops.js";
 import { createCronServiceState, type CronEvent } from "./state.js";
 import {
   DEFAULT_JOB_TIMEOUT_MS,
   applyJobResult,
   executeJob,
   executeJobCore,
+  executeJobCoreWithTimeout,
   onTimer,
   runMissedJobs,
 } from "./timer.js";
@@ -1249,6 +1259,107 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("notifies setup-timeout restart after startup catch-up finalization", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-02-15T13:02:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "startup-setup-timeout",
+        name: "startup setup timeout",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const started = createDeferred<void>();
+      let observedAbortSignal: AbortSignal | undefined;
+      const onIsolatedAgentSetupTimeout = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        onIsolatedAgentSetupTimeout,
+        runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+          observedAbortSignal = abortSignal;
+          started.resolve();
+          abortSignal?.addEventListener("abort", () => undefined, { once: true });
+          return await new Promise<never>(() => {});
+        }),
+      });
+
+      const catchupPromise = runMissedJobs(state);
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      await catchupPromise;
+
+      expect(observedAbortSignal?.aborted).toBe(true);
+      const job = state.store?.jobs.find((entry) => entry.id === "startup-setup-timeout");
+      expect(job?.state.lastStatus).toBe("error");
+      expect(job?.state.lastError).toContain("setup timed out before runner start");
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledWith({
+        job: expect.objectContaining({ id: "startup-setup-timeout" }),
+        error: expect.stringContaining("setup timed out before runner start"),
+        timeoutMs: 60_000,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps scheduling after setup timeout when no restart handler is installed", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-02-15T13:03:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "setup-timeout-no-handler",
+        name: "setup timeout no handler",
+        scheduledAt,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const started = createDeferred<void>();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+          started.resolve();
+          abortSignal?.addEventListener("abort", () => undefined, { once: true });
+          return await new Promise<never>(() => {});
+        }),
+      });
+
+      const timerPromise = onTimer(state);
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      await timerPromise;
+
+      expect(state.restartRecoveryPending).toBe(false);
+      expect(state.timer).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("respects abort signals while retrying one-shot main-session wake-now heartbeat runs", async () => {
     const abortController = new AbortController();
     const runHeartbeatOnce = vi.fn(
@@ -1299,7 +1410,7 @@ describe("cron service timer regressions", () => {
     expect(requestHeartbeat).not.toHaveBeenCalled();
   });
 
-  it("does not report main-session cron task rows cancelled while queued work can continue", async () => {
+  it("keeps user cancellation disabled for main-session cron wrappers", async () => {
     vi.useFakeTimers();
     try {
       resetTaskRegistryForTests();
@@ -1397,6 +1508,190 @@ describe("cron service timer regressions", () => {
       resetTaskRegistryForTests();
       vi.useRealTimers();
     }
+  });
+
+  it("keeps main-session cron wrappers visible across restart generation advance", async () => {
+    vi.useFakeTimers();
+    try {
+      resetTaskRegistryForTests();
+
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-02-15T13:03:00.000Z");
+      const cronJob: CronJob = {
+        id: "main-session-generation-visible",
+        name: "main session generation visible",
+        enabled: true,
+        createdAtMs: scheduledAt - 60_000,
+        updatedAtMs: scheduledAt - 60_000,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "queued downstream work" },
+        state: { nextRunAtMs: scheduledAt },
+      };
+      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+      let now = scheduledAt;
+      const heartbeatResult = createDeferred<HeartbeatRunResult>();
+      const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => {
+        return await heartbeatResult.promise;
+      });
+      const requestHeartbeat = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat,
+        runHeartbeatOnce,
+        wakeNowHeartbeatBusyMaxWaitMs: 1_000,
+        wakeNowHeartbeatBusyRetryDelayMs: 50,
+        runIsolatedAgentJob: createDefaultIsolatedRunner(),
+      });
+
+      const timerPromise = onTimer(state);
+      for (
+        let attempt = 0;
+        attempt < 10 && runHeartbeatOnce.mock.calls.length === 0;
+        attempt += 1
+      ) {
+        await vi.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+      }
+      expect(runHeartbeatOnce).toHaveBeenCalledTimes(1);
+
+      expect(isCronJobActive(cronJob.id)).toBe(true);
+      advanceCronActiveJobGeneration();
+      expect(isCronJobActive(cronJob.id)).toBe(true);
+
+      now = scheduledAt + 2_000;
+      heartbeatResult.resolve({ status: "skipped", reason: HEARTBEAT_SKIP_LANES_BUSY });
+      await vi.advanceTimersByTimeAsync(0);
+      await timerPromise;
+
+      expect(requestHeartbeat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "cron:main-session-generation-visible",
+        }),
+      );
+      expect(isCronJobActive(cronJob.id)).toBe(false);
+    } finally {
+      resetActiveCronTaskRunsForTests();
+      resetTaskRegistryControlRuntimeForTests();
+      resetTaskRegistryForTests();
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects cron runner admission after its active marker generation retires", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-05-13T12:30:00.000Z");
+    const cronJob = createDueIsolatedJob({
+      id: "retired-generation-admission",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    const activeJobMarker = markCronJobActive(cronJob.id);
+    advanceCronActiveJobGeneration();
+
+    const runIsolatedAgentJob = vi.fn(createDefaultIsolatedRunner());
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    try {
+      const result = await executeJobCoreWithTimeout(state, cronJob, { activeJobMarker });
+
+      expect(result.status).toBe("error");
+      expect(result.error).toContain("Gateway restarting");
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    } finally {
+      clearCronJobActive(cronJob.id, activeJobMarker);
+    }
+  });
+
+  it("does not persist retired scheduled outcomes after restart generation advance", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-05-13T12:45:00.000Z");
+    const cronJob = createDueIsolatedJob({
+      id: "retired-outcome-skip",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    const entered = createDeferred<void>();
+    const release = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        entered.resolve();
+        return await release.promise;
+      }),
+    });
+
+    const timerPromise = onTimer(state);
+    await entered.promise;
+    expect(isCronJobActive(cronJob.id)).toBe(true);
+
+    advanceCronActiveJobGeneration();
+    release.resolve({ status: "ok", summary: "stale success" });
+    await timerPromise;
+
+    const persisted = await loadCronStore(store.storePath);
+    const persistedJob = persisted.jobs.find((job) => job.id === cronJob.id);
+    expect(persistedJob?.state.lastStatus).not.toBe("ok");
+    expect(persistedJob?.state.runningAtMs).toBe(scheduledAt);
+  });
+
+  it("releases due-job reservations instead of admitting workers after scheduler stop wins", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-05-13T13:00:00.000Z");
+    const cronJob = createDueIsolatedJob({
+      id: "stopped-reservation-release",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    let stopOnNextClockRead = false;
+    let stoppedInjected = false;
+    const runIsolatedAgentJob = vi.fn(createDefaultIsolatedRunner());
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => {
+        if (stopOnNextClockRead && !stoppedInjected) {
+          stoppedInjected = true;
+          state.stopped = true;
+        }
+        return scheduledAt;
+      },
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    stopOnNextClockRead = true;
+    await onTimer(state);
+
+    const persisted = await loadCronStore(store.storePath);
+    const persistedJob = persisted.jobs.find((job) => job.id === cronJob.id);
+    expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    expect(persistedJob?.state.runningAtMs).toBeUndefined();
   });
 
   it("retries recurring wake-now main jobs until temporary lane pressure clears (#75964)", async () => {
@@ -1582,6 +1877,513 @@ describe("cron service timer regressions", () => {
     const jobs = state.store?.jobs ?? [];
     expect(jobs.find((job) => job.id === first.id)?.state.lastStatus).toBe("ok");
     expect(jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("ok");
+  });
+
+  it("requests one setup-timeout restart when a concurrent cron batch stalls before runners start", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:06:01.000Z");
+      const first = createDueIsolatedJob({
+        id: "parallel-setup-timeout-first",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      const second = createDueIsolatedJob({
+        id: "parallel-setup-timeout-second",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      first.payload = { kind: "agentTurn", message: "first", timeoutSeconds: 120 };
+      second.payload = { kind: "agentTurn", message: "second", timeoutSeconds: 120 };
+      await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
+
+      let now = dueAt;
+      let startedCount = 0;
+      const bothStarted = createDeferred<void>();
+      const onIsolatedAgentSetupTimeout = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        cronConfig: { maxConcurrentRuns: 2 },
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        onIsolatedAgentSetupTimeout,
+        runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+          startedCount += 1;
+          if (startedCount === 2) {
+            bothStarted.resolve();
+          }
+          abortSignal?.addEventListener("abort", () => undefined, { once: true });
+          return await new Promise<never>(() => {});
+        }),
+      });
+
+      const timerPromise = onTimer(state);
+      await bothStarted.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      await timerPromise;
+
+      const jobs = state.store?.jobs ?? [];
+      expect(jobs.find((job) => job.id === first.id)?.state.lastStatus).toBe("error");
+      expect(jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("error");
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledTimes(1);
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledWith({
+        job: expect.objectContaining({
+          id: expect.stringMatching(/^parallel-setup-timeout-/),
+        }),
+        error: expect.stringContaining("setup timed out before runner start"),
+        timeoutMs: 60_000,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("requests setup-timeout restart after a prior serial cron job completes", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:07:01.000Z");
+      const first = createDueIsolatedJob({
+        id: "serial-setup-timeout-first",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      const second = createDueIsolatedJob({
+        id: "serial-setup-timeout-second",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      first.payload = { kind: "agentTurn", message: "first", timeoutSeconds: 120 };
+      second.payload = { kind: "agentTurn", message: "second", timeoutSeconds: 120 };
+      await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
+
+      let now = dueAt;
+      const secondStarted = createDeferred<void>();
+      const onIsolatedAgentSetupTimeout = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        cronConfig: { maxConcurrentRuns: 1 },
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        onIsolatedAgentSetupTimeout,
+        runIsolatedAgentJob: vi.fn(
+          async ({ job, abortSignal }: { job: CronJob; abortSignal?: AbortSignal }) => {
+            if (job.id === first.id) {
+              now += 10;
+              return { status: "ok" as const, summary: "first done" };
+            }
+            secondStarted.resolve();
+            abortSignal?.addEventListener("abort", () => undefined, { once: true });
+            return await new Promise<never>(() => {});
+          },
+        ),
+      });
+
+      const timerPromise = onTimer(state);
+      await secondStarted.promise;
+      expect(isCronJobActive(first.id)).toBe(true);
+      expect(isCronJobActive(second.id)).toBe(true);
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      await timerPromise;
+
+      const jobs = state.store?.jobs ?? [];
+      expect(jobs.find((job) => job.id === first.id)?.state.lastStatus).toBe("ok");
+      expect(jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("error");
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledTimes(1);
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledWith({
+        job: expect.objectContaining({ id: second.id }),
+        error: expect.stringContaining("setup timed out before runner start"),
+        timeoutMs: 60_000,
+      });
+      expect(isCronJobActive(first.id)).toBe(false);
+      expect(isCronJobActive(second.id)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("requests setup-timeout restart when manual and scheduled runs both stall", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:08:01.000Z");
+      const scheduledJob = createDueIsolatedJob({
+        id: "mixed-setup-timeout-scheduled",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt,
+      });
+      const manualJob = createDueIsolatedJob({
+        id: "mixed-setup-timeout-manual",
+        nowMs: dueAt,
+        nextRunAtMs: dueAt + 3_600_000,
+      });
+      scheduledJob.payload = { kind: "agentTurn", message: "scheduled", timeoutSeconds: 120 };
+      manualJob.payload = { kind: "agentTurn", message: "manual", timeoutSeconds: 120 };
+      await saveCronStore(store.storePath, { version: 1, jobs: [scheduledJob, manualJob] });
+
+      let now = dueAt;
+      let startedCount = 0;
+      const manualStarted = createDeferred<void>();
+      const bothStarted = createDeferred<void>();
+      const onIsolatedAgentSetupTimeout = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        cronConfig: { maxConcurrentRuns: 1 },
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        onIsolatedAgentSetupTimeout,
+        runIsolatedAgentJob: vi.fn(
+          async ({ job, abortSignal }: { job: CronJob; abortSignal?: AbortSignal }) => {
+            if (job.id === manualJob.id) {
+              manualStarted.resolve();
+            }
+            startedCount += 1;
+            if (startedCount === 2) {
+              bothStarted.resolve();
+            }
+            abortSignal?.addEventListener("abort", () => undefined, { once: true });
+            return await new Promise<never>(() => {});
+          },
+        ),
+      });
+
+      const manualRun = runManualCronJob(state, manualJob.id, "force");
+      await manualStarted.promise;
+      const timerRun = onTimer(state);
+      await bothStarted.promise;
+
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      await Promise.all([manualRun, timerRun]);
+
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalled();
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledWith({
+        job: expect.objectContaining({
+          id: expect.stringMatching(/^mixed-setup-timeout-/),
+        }),
+        error: expect.stringContaining("setup timed out before runner start"),
+        timeoutMs: 60_000,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("suppresses scheduled rearm after manual setup-timeout restart request", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-10T08:58:00.000Z");
+      const manualJob = createDueIsolatedJob({
+        id: "manual-setup-timeout-rearm",
+        nowMs: scheduledAt,
+        nextRunAtMs: scheduledAt,
+      });
+      manualJob.payload = { kind: "agentTurn", message: "manual", timeoutSeconds: 120 };
+      const scheduledJob = createDueIsolatedJob({
+        id: "scheduled-after-manual-setup-timeout",
+        nowMs: scheduledAt,
+        nextRunAtMs: scheduledAt,
+      });
+      scheduledJob.payload = { kind: "agentTurn", message: "scheduled", timeoutSeconds: 120 };
+      await saveCronStore(store.storePath, { version: 1, jobs: [manualJob, scheduledJob] });
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const manualStarted = createDeferred<void>();
+      const scheduledStarted = vi.fn();
+      const onIsolatedAgentSetupTimeout = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        onIsolatedAgentSetupTimeout,
+        runIsolatedAgentJob: vi.fn(async ({ job, abortSignal }) => {
+          if (job.id === manualJob.id) {
+            manualStarted.resolve();
+            abortSignal?.addEventListener("abort", () => undefined, { once: true });
+            return await new Promise<never>(() => {});
+          }
+          scheduledStarted(job.id);
+          return { status: "ok" as const, summary: "scheduled" };
+        }),
+      });
+
+      const manualRun = runManualCronJob(state, manualJob.id, "force");
+      await manualStarted.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      await manualRun;
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledTimes(1);
+      expect(state.restartRecoveryPending).toBe(true);
+      expect(state.timer).toBeNull();
+      expect(scheduledStarted).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips new manual runs while restart recovery is pending", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-05-10T08:58:30.000Z");
+    const manualJob = createDueIsolatedJob({
+      id: "manual-blocked-by-recovery",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [manualJob] });
+
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    state.restartRecoveryPending = true;
+
+    const result = await runManualCronJob(state, manualJob.id, "force");
+
+    expect(result).toEqual({
+      ok: true,
+      ran: false,
+      reason: "restart-recovery-pending",
+    });
+    expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+  });
+
+  it("does not persist stale startup catch-up outcomes after the old service stops", async () => {
+    resetTaskRegistryForTests();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-05-10T08:58:45.000Z");
+    const job = createDueIsolatedJob({
+      id: "stopped-startup-catchup",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    const unstartedJob = createDueIsolatedJob({
+      id: "unstarted-stopped-startup-catchup",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    const replacementClaimedJob = createDueIsolatedJob({
+      id: "replacement-claimed-stopped-startup-catchup",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [job, unstartedJob, replacementClaimedJob],
+    });
+
+    const runStarted = createDeferred<void>();
+    const releaseRun = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: async () => {
+        runStarted.resolve();
+        return await releaseRun.promise;
+      },
+    });
+
+    const missedJobs = runMissedJobs(state);
+    await runStarted.promise;
+
+    state.stopped = true;
+    const replacementReservationMs = scheduledAt + 123;
+    const replacementStore = await loadCronStore(store.storePath);
+    const replacementPersistedJob = replacementStore.jobs.find(
+      (entry) => entry.id === replacementClaimedJob.id,
+    );
+    if (!replacementPersistedJob) {
+      throw new Error("expected replacement-claimed startup job");
+    }
+    replacementPersistedJob.state.runningAtMs = replacementReservationMs;
+    await saveCronStore(store.storePath, replacementStore);
+
+    releaseRun.resolve({ status: "ok", summary: "old service result" });
+    await missedJobs;
+
+    const persisted = await loadCronStore(store.storePath);
+    const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
+    const persistedUnstartedJob = persisted.jobs.find((entry) => entry.id === unstartedJob.id);
+    const persistedReplacementClaimedJob = persisted.jobs.find(
+      (entry) => entry.id === replacementClaimedJob.id,
+    );
+    expect(persistedJob?.state.runningAtMs).toBe(scheduledAt);
+    expect(persistedJob?.state.lastStatus).toBeUndefined();
+    expect(persistedUnstartedJob?.state.runningAtMs).toBeUndefined();
+    expect(persistedUnstartedJob?.state.lastStatus).toBeUndefined();
+    expect(persistedReplacementClaimedJob?.state.runningAtMs).toBe(replacementReservationMs);
+    expect(persistedReplacementClaimedJob?.state.lastStatus).toBeUndefined();
+    expect(
+      listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id)
+        ?.status,
+    ).toBe("succeeded");
+    resetTaskRegistryForTests();
+  });
+
+  it("does not clear replacement reservations when stopped timer cleanup releases unclaimed jobs", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-05-10T08:58:50.000Z");
+    const runningJob = createDueIsolatedJob({
+      id: "stopped-timer-running",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    const replacementClaimedJob = createDueIsolatedJob({
+      id: "stopped-timer-replacement-claimed",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [runningJob, replacementClaimedJob],
+    });
+
+    const runStarted = createDeferred<void>();
+    const releaseRun = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: async () => {
+        runStarted.resolve();
+        return await releaseRun.promise;
+      },
+    });
+
+    const timer = onTimer(state);
+    await runStarted.promise;
+
+    state.stopped = true;
+    const replacementReservationMs = scheduledAt + 222;
+    const replacementStore = await loadCronStore(store.storePath);
+    const replacementPersistedJob = replacementStore.jobs.find(
+      (entry) => entry.id === replacementClaimedJob.id,
+    );
+    if (!replacementPersistedJob) {
+      throw new Error("expected replacement-claimed timer job");
+    }
+    replacementPersistedJob.state.runningAtMs = replacementReservationMs;
+    await saveCronStore(store.storePath, replacementStore);
+
+    releaseRun.resolve({ status: "ok", summary: "old service result" });
+    await timer;
+
+    const persisted = await loadCronStore(store.storePath);
+    expect(
+      persisted.jobs.find((entry) => entry.id === replacementClaimedJob.id)?.state.runningAtMs,
+    ).toBe(replacementReservationMs);
+  });
+
+  it("stops an active scheduled batch from claiming more jobs after manual setup-timeout recovery", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-10T08:59:00.000Z");
+      const manualJob = createDueIsolatedJob({
+        id: "manual-setup-timeout-active-batch",
+        nowMs: scheduledAt,
+        nextRunAtMs: scheduledAt + 3_600_000,
+      });
+      manualJob.payload = { kind: "agentTurn", message: "manual", timeoutSeconds: 120 };
+      const firstScheduledJob = createDueIsolatedJob({
+        id: "scheduled-before-manual-recovery",
+        nowMs: scheduledAt,
+        nextRunAtMs: scheduledAt,
+      });
+      const secondScheduledJob = createDueIsolatedJob({
+        id: "scheduled-blocked-by-manual-recovery",
+        nowMs: scheduledAt,
+        nextRunAtMs: scheduledAt,
+      });
+      await saveCronStore(store.storePath, {
+        version: 1,
+        jobs: [manualJob, firstScheduledJob, secondScheduledJob],
+      });
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const manualStarted = createDeferred<void>();
+      const firstScheduledStarted = createDeferred<void>();
+      const finishFirstScheduled = createDeferred<void>();
+      const secondScheduledStarted = vi.fn();
+      const onIsolatedAgentSetupTimeout = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        cronConfig: { maxConcurrentRuns: 1 },
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        onIsolatedAgentSetupTimeout,
+        runIsolatedAgentJob: vi.fn(async ({ job, abortSignal, onExecutionStarted }) => {
+          if (job.id === manualJob.id) {
+            manualStarted.resolve();
+            abortSignal?.addEventListener("abort", () => undefined, { once: true });
+            return await new Promise<never>(() => {});
+          }
+          if (job.id === firstScheduledJob.id) {
+            firstScheduledStarted.resolve();
+            onExecutionStarted?.();
+            await finishFirstScheduled.promise;
+            return { status: "ok" as const, summary: "first scheduled" };
+          }
+          secondScheduledStarted(job.id);
+          return { status: "ok" as const, summary: "second scheduled" };
+        }),
+      });
+
+      const manualRun = runManualCronJob(state, manualJob.id, "force");
+      await manualStarted.promise;
+      const timerRun = onTimer(state);
+      await firstScheduledStarted.promise;
+
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      await manualRun;
+      expect(state.restartRecoveryPending).toBe(true);
+
+      finishFirstScheduled.resolve();
+      await timerRun;
+
+      const second = requireJob(state, secondScheduledJob.id);
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledTimes(1);
+      expect(secondScheduledStarted).not.toHaveBeenCalled();
+      expect(second.state.runningAtMs).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("finalizes a successful isolated job that removes itself during execution", async () => {
@@ -1889,6 +2691,7 @@ describe("cron service timer regressions", () => {
       const started = createDeferred<void>();
       let abortObserved = false;
       const cleanupTimedOutAgentRun = vi.fn(async () => {});
+      const onIsolatedAgentSetupTimeout = vi.fn();
       const state = createCronServiceState({
         cronEnabled: true,
         storePath: store.storePath,
@@ -1897,6 +2700,7 @@ describe("cron service timer regressions", () => {
         enqueueSystemEvent: vi.fn(),
         requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun,
+        onIsolatedAgentSetupTimeout,
         runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
           started.resolve();
           abortSignal?.addEventListener(
@@ -1925,6 +2729,125 @@ describe("cron service timer regressions", () => {
       expect(requireRecord(cleanupArgs.job).id).toBe("isolated-setup-timeout-74803");
       expect(cleanupArgs.timeoutMs).toBe(120_000);
       expect(cleanupArgs.execution).toBeUndefined();
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledTimes(1);
+      expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledWith({
+        job: expect.objectContaining({ id: "isolated-setup-timeout-74803" }),
+        error: expect.stringContaining("setup timed out before runner start"),
+        timeoutMs: 60_000,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not request setup-timeout restart for cron-nested lane contention", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-10T09:01:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "isolated-setup-timeout-lane-wait",
+        name: "setup timeout lane wait",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const laneEntered = createDeferred<void>();
+      const releaseLane = createDeferred<void>();
+      const laneBlocker = enqueueCommandInLane(CommandLane.CronNested, async () => {
+        laneEntered.resolve();
+        await releaseLane.promise;
+      });
+      await laneEntered.promise;
+
+      const onIsolatedAgentSetupTimeout = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        cleanupTimedOutAgentRun: vi.fn(async () => {}),
+        onIsolatedAgentSetupTimeout,
+        runIsolatedAgentJob: vi.fn(async ({ onLaneWait }) => {
+          onLaneWait?.();
+          return await enqueueCommandInLane(CommandLane.CronNested, async () => {
+            return { status: "ok" as const, summary: "lane released" };
+          });
+        }),
+      });
+
+      const timerPromise = onTimer(state);
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      await timerPromise;
+
+      expect(onIsolatedAgentSetupTimeout).not.toHaveBeenCalled();
+      const job = requireJob(state, cronJob.id);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("setup timed out before runner start");
+
+      releaseLane.resolve();
+      await laneBlocker;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not notify setup-timeout restart for custom-session cron waits", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-10T09:04:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "custom-session-setup-timeout",
+        name: "custom session setup timeout",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await saveCronStore(store.storePath, {
+        version: 1,
+        jobs: [{ ...cronJob, sessionTarget: "session:customCronSession" }],
+      });
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const started = createDeferred<void>();
+      const onIsolatedAgentSetupTimeout = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        cleanupTimedOutAgentRun: vi.fn(async () => {}),
+        onIsolatedAgentSetupTimeout,
+        runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+          started.resolve();
+          abortSignal?.addEventListener("abort", () => undefined, { once: true });
+          return await new Promise<never>(() => {});
+        }),
+      });
+
+      const timerPromise = onTimer(state);
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      await timerPromise;
+
+      const job = requireJob(state, "custom-session-setup-timeout");
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("setup timed out before runner start");
+      expect(onIsolatedAgentSetupTimeout).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
@@ -1950,6 +2873,7 @@ describe("cron service timer regressions", () => {
       const started = createDeferred<void>();
       let abortObserved = false;
       const cleanupTimedOutAgentRun = vi.fn(async () => {});
+      const onIsolatedAgentSetupTimeout = vi.fn();
       const state = createCronServiceState({
         cronEnabled: true,
         storePath: store.storePath,
@@ -1958,6 +2882,7 @@ describe("cron service timer regressions", () => {
         enqueueSystemEvent: vi.fn(),
         requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun,
+        onIsolatedAgentSetupTimeout,
         runIsolatedAgentJob: vi.fn(
           async ({
             abortSignal,
@@ -2013,6 +2938,7 @@ describe("cron service timer regressions", () => {
       const execution = requireRecord(cleanupArgs.execution);
       expect(execution.jobId).toBe("isolated-pre-model-timeout-74803");
       expect(execution.phase).toBe("context_engine");
+      expect(onIsolatedAgentSetupTimeout).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -3,6 +3,7 @@ import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import { readSessionEntry } from "../../config/sessions/store-load.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import {
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
@@ -13,10 +14,19 @@ import {
   normalizeAgentId,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
-import { registerActiveCronTaskRun } from "../../tasks/cron-task-cancel.js";
+import {
+  registerActiveCronTaskRun,
+  startActiveCronTaskRunSettlementGrace,
+  trackActiveCronTaskRunSettlement,
+} from "../../tasks/cron-task-cancel.js";
 import { deliveryContextFromSession } from "../../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
-import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
+import {
+  clearCronJobActive,
+  isCronActiveJobMarkerCurrent,
+  markCronJobActive,
+  type CronActiveJobMarker,
+} from "../active-jobs.js";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
 import { resolveCronExecutionRetryHint } from "../retry-hint.js";
 import {
@@ -37,9 +47,14 @@ import type {
   CronRunStatus,
   CronRunTelemetry,
 } from "../types.js";
-import { cleanupTimedOutCronAgentRun, createCronAgentWatchdog } from "./agent-watchdog.js";
+import {
+  cleanupTimedOutCronAgentRun,
+  createCronAgentWatchdog,
+  CRON_AGENT_SETUP_WATCHDOG_MS,
+} from "./agent-watchdog.js";
 import {
   abortErrorMessage,
+  isSetupTimeoutErrorText,
   normalizeCronRunErrorText,
   timeoutErrorMessage,
 } from "./execution-errors.js";
@@ -100,13 +115,32 @@ type TimedCronRunOutcome = CronRunOutcome &
     taskRunId?: string;
     delivered?: boolean;
     deliveryAttempted?: boolean;
+    isolatedAgentSetupTimeout?: IsolatedAgentSetupTimeoutSignal;
+    activeJobMarker?: CronActiveJobMarker;
     startedAt: number;
     endedAt: number;
   };
 
+export type IsolatedAgentSetupTimeoutSignal = {
+  error: string;
+  timeoutMs: number;
+  otherCronJobsActiveAtTimeout: boolean;
+};
+
+type IsolatedAgentSetupTimeoutResult = {
+  jobId: string;
+  job: CronJob;
+  isolatedAgentSetupTimeout?: IsolatedAgentSetupTimeoutSignal;
+};
+
+type CronCoreRunOutcome = Awaited<ReturnType<typeof executeJobCore>> & {
+  isolatedAgentSetupTimeout?: IsolatedAgentSetupTimeoutSignal;
+};
+
 type StartupCatchupCandidate = {
   jobId: string;
   job: CronJob;
+  reservedAtMs: number;
 };
 
 type StartupDeferredJob = {
@@ -119,12 +153,18 @@ type StartupCatchupPlan = {
   deferredJobs: StartupDeferredJob[];
 };
 
+type ExecuteJobCoreOptions = {
+  onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+  onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+  onLaneWait?: (info?: { waiting?: boolean }) => void;
+};
+
 /** Executes cron job core logic with the configured wall-clock timeout and watchdog cleanup. */
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
-  opts?: { runId?: string },
-): Promise<Awaited<ReturnType<typeof executeJobCore>>> {
+  opts?: { runId?: string; activeJobMarker?: CronActiveJobMarker },
+): Promise<CronCoreRunOutcome> {
   const runAbortController = new AbortController();
   const operatorCancellationMarker = Symbol("cron-operator-cancelled");
   let resolveOperatorCancellation: ((value: typeof operatorCancellationMarker) => void) | undefined;
@@ -141,13 +181,14 @@ export async function executeJobCoreWithTimeout(
       }),
     };
   };
-  // Main-session cron jobs enqueue work into a downstream child session. The
-  // cron wrapper does not own that queued run, so it must not expose a task
-  // cancellation handle that could make the wrapper row lie about child state.
+  if (!isCronActiveJobMarkerCurrent(opts?.activeJobMarker)) {
+    runAbortController.abort("Gateway restarting.");
+    return createOperatorCancellationOutcome();
+  }
   const releaseCronTaskRun =
     job.sessionTarget !== "main"
       ? registerActiveCronTaskRun({
-          runId: opts?.runId,
+          runId: opts?.runId ?? `cron-active:${job.id}`,
           controller: runAbortController,
           onCancel: () => resolveOperatorCancellation?.(operatorCancellationMarker),
         })
@@ -156,6 +197,7 @@ export async function executeJobCoreWithTimeout(
   try {
     if (typeof jobTimeoutMs !== "number") {
       const corePromise = executeJobCore(state, job, runAbortController.signal);
+      trackActiveCronTaskRunSettlement(corePromise);
       void corePromise.catch((err: unknown) => {
         if (runAbortController.signal.aborted) {
           state.deps.log.warn(
@@ -168,6 +210,7 @@ export async function executeJobCoreWithTimeout(
       if (first !== operatorCancellationMarker) {
         return first;
       }
+      startActiveCronTaskRunSettlementGrace();
       return createOperatorCancellationOutcome();
     }
 
@@ -194,10 +237,19 @@ export async function executeJobCoreWithTimeout(
       jobTimeoutMs,
       triggerTimeout,
     });
+    const noteLaneState = (info?: { waiting?: boolean }) => {
+      if (info?.waiting === false) {
+        watchdog.noteLaneAdmitted();
+        return;
+      }
+      watchdog.noteLaneWait();
+    };
     const corePromise = executeJobCore(state, job, runAbortController.signal, {
       onExecutionStarted: deferTimeoutUntilExecutionStart ? watchdog.noteRunnerStarted : undefined,
       onExecutionPhase: deferTimeoutUntilExecutionStart ? watchdog.notePhase : undefined,
+      onLaneWait: deferTimeoutUntilExecutionStart ? noteLaneState : undefined,
     });
+    trackActiveCronTaskRunSettlement(corePromise);
     watchdog.start();
     void corePromise.catch((err: unknown) => {
       if (runAbortController.signal.aborted) {
@@ -210,20 +262,32 @@ export async function executeJobCoreWithTimeout(
     try {
       const first = await Promise.race([corePromise, timeoutPromise, operatorCancellationPromise]);
       if (first === operatorCancellationMarker) {
+        startActiveCronTaskRunSettlementGrace();
         return createOperatorCancellationOutcome();
       }
       if (first !== timeoutMarker) {
         return first;
       }
+      startActiveCronTaskRunSettlementGrace();
       const activeExecution = watchdog.activeExecution();
       await cleanupTimedOutCronAgentRun(state, job, jobTimeoutMs, activeExecution);
       const error = timeoutReason ?? timeoutErrorMessage(activeExecution);
+      const observedLaneWait = watchdog.observedLaneWait();
+      const isolatedAgentSetupTimeout =
+        job.sessionTarget === "isolated" && isSetupTimeoutErrorText(error) && !observedLaneWait
+          ? {
+              error,
+              timeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS,
+              otherCronJobsActiveAtTimeout: false,
+            }
+          : undefined;
       return {
         status: "error",
         error,
         diagnostics: createCronRunDiagnosticsFromError("cron-setup", error, {
           nowMs: state.deps.nowMs,
         }),
+        ...(isolatedAgentSetupTimeout ? { isolatedAgentSetupTimeout } : {}),
       };
     } finally {
       watchdog.dispose();
@@ -231,6 +295,56 @@ export async function executeJobCoreWithTimeout(
   } finally {
     releaseCronTaskRun?.();
   }
+}
+
+function notifyIsolatedAgentSetupTimeout(
+  state: CronServiceState,
+  job: CronJob,
+  error: string,
+  timeoutMs: number,
+): boolean {
+  const notify = state.deps.onIsolatedAgentSetupTimeout;
+  if (!notify) {
+    return false;
+  }
+  try {
+    void Promise.resolve(notify({ job, error, timeoutMs })).catch((err: unknown) => {
+      state.restartRecoveryPending = false;
+      state.deps.log.warn(
+        { jobId: job.id, err: String(err) },
+        "cron: isolated setup timeout handler failed",
+      );
+      armTimer(state);
+    });
+    return true;
+  } catch (err) {
+    state.deps.log.warn(
+      { jobId: job.id, err: String(err) },
+      "cron: isolated setup timeout handler failed",
+    );
+    return false;
+  }
+}
+
+export function maybeNotifyIsolatedAgentSetupTimeout(
+  state: CronServiceState,
+  result: IsolatedAgentSetupTimeoutResult,
+): boolean {
+  const signal = result.isolatedAgentSetupTimeout;
+  if (!signal) {
+    return false;
+  }
+  const notified = notifyIsolatedAgentSetupTimeout(
+    state,
+    result.job,
+    signal.error,
+    signal.timeoutMs,
+  );
+  if (!notified) {
+    return false;
+  }
+  state.restartRecoveryPending = true;
+  return true;
 }
 
 function resolveRunConcurrency(state: CronServiceState): number {
@@ -839,7 +953,6 @@ export function applyJobResult(
 }
 
 function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOutcome): void {
-  clearCronJobActive(result.jobId);
   tryFinishCronTaskRun(state, result);
   const store = state.store;
   if (!store) {
@@ -892,14 +1005,67 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
   }
 }
 
+function clearActiveMarkersForOutcomes(outcomes: readonly TimedCronRunOutcome[]): void {
+  for (const outcome of outcomes) {
+    clearCronJobActive(outcome.jobId, outcome.activeJobMarker);
+  }
+}
+
+function filterCurrentCronRunOutcomes(
+  outcomes: readonly TimedCronRunOutcome[],
+): TimedCronRunOutcome[] {
+  return outcomes.filter((outcome) => isCronActiveJobMarkerCurrent(outcome.activeJobMarker));
+}
+
+function finishRetiredCronTaskRuns(
+  state: CronServiceState,
+  outcomes: readonly TimedCronRunOutcome[],
+  currentOutcomes: readonly TimedCronRunOutcome[],
+): void {
+  const current = new Set(currentOutcomes);
+  for (const outcome of outcomes) {
+    if (!current.has(outcome)) {
+      tryFinishCronTaskRun(state, outcome);
+    }
+  }
+}
+
+function releaseUnstartedStartupCatchupReservations(
+  state: CronServiceState,
+  plan: StartupCatchupPlan,
+  outcomes: readonly TimedCronRunOutcome[],
+): boolean {
+  let changed = false;
+  const startedJobIds = new Set(outcomes.map((outcome) => outcome.jobId));
+  for (const candidate of plan.candidates) {
+    if (startedJobIds.has(candidate.jobId)) {
+      continue;
+    }
+    const job = state.store?.jobs.find((entry) => entry.id === candidate.jobId);
+    if (job?.state && job.state.runningAtMs === candidate.reservedAtMs) {
+      delete job.state.runningAtMs;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 /** Arms the cron timer for the next wake or a maintenance recheck. */
 export function armTimer(state: CronServiceState) {
   if (state.timer) {
     clearTimeout(state.timer);
   }
   state.timer = null;
+  if (state.stopped) {
+    state.deps.log.debug({}, "cron: armTimer skipped - scheduler stopped");
+    return;
+  }
   if (!state.deps.cronEnabled) {
     state.deps.log.debug({}, "cron: armTimer skipped - scheduler disabled");
+    return;
+  }
+  if (state.restartRecoveryPending) {
+    state.deps.log.warn({}, "cron: armTimer skipped - restart recovery pending");
     return;
   }
   const nextAt = nextWakeAtMs(state);
@@ -952,6 +1118,9 @@ export function armTimer(state: CronServiceState) {
 }
 
 function armRunningRecheckTimer(state: CronServiceState) {
+  if (state.stopped) {
+    return;
+  }
   if (state.timer) {
     clearTimeout(state.timer);
   }
@@ -964,6 +1133,13 @@ function armRunningRecheckTimer(state: CronServiceState) {
 
 /** Handles one cron timer tick: load due jobs, reserve them, execute, persist, and re-arm. */
 export async function onTimer(state: CronServiceState) {
+  if (state.stopped) {
+    return;
+  }
+  if (state.restartRecoveryPending) {
+    state.deps.log.warn({}, "cron: timer tick skipped - restart recovery pending");
+    return;
+  }
   if (state.running) {
     // Re-arm the timer so the scheduler keeps ticking even when a job is
     // still executing.  Without this, a long-running job (e.g. an agentTurn
@@ -985,6 +1161,13 @@ export async function onTimer(state: CronServiceState) {
   try {
     const dueJobs = await locked(state, async () => {
       await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      if (state.stopped || state.restartRecoveryPending) {
+        state.deps.log.warn(
+          { stopped: state.stopped, restartRecoveryPending: state.restartRecoveryPending },
+          "cron: due job reservation skipped - scheduler unavailable",
+        );
+        return [];
+      }
       const dueCheckNow = state.deps.nowMs();
       const due = collectRunnableJobs(state, dueCheckNow);
 
@@ -1005,34 +1188,50 @@ export async function onTimer(state: CronServiceState) {
       const now = state.deps.nowMs();
       for (const job of due) {
         job.state.runningAtMs = now;
-        job.state.lastError = undefined;
       }
       await persist(state);
+      if (state.stopped) {
+        for (const job of due) {
+          delete job.state.runningAtMs;
+        }
+        recomputeNextRunsForMaintenance(state);
+        await persist(state);
+        return [];
+      }
 
       return due.map((j) => ({
         id: j.id,
         job: j,
+        reservedAtMs: now,
       }));
     });
 
     const runDueJob = async (params: {
       id: string;
       job: CronJob;
+      reservedAtMs: number;
     }): Promise<TimedCronRunOutcome> => {
       const { id, job } = params;
       const startedAt = state.deps.nowMs();
       job.state.runningAtMs = startedAt;
-      markCronJobActive(job.id);
+      job.state.lastError = undefined;
+      const activeJobMarker = markCronJobActive(job.id, {
+        preserveAcrossGenerationAdvance: job.sessionTarget === "main",
+      });
       emit(state, { jobId: job.id, action: "started", job, runAtMs: startedAt });
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);
       const taskRunId = tryCreateCronTaskRun({ state, job, startedAt });
 
       try {
-        const result = await executeJobCoreWithTimeout(state, job, { runId: taskRunId });
+        const result = await executeJobCoreWithTimeout(state, job, {
+          runId: taskRunId,
+          activeJobMarker,
+        });
         return {
           jobId: id,
           job,
           taskRunId,
+          activeJobMarker,
           ...result,
           startedAt,
           endedAt: state.deps.nowMs(),
@@ -1047,6 +1246,7 @@ export async function onTimer(state: CronServiceState) {
           jobId: id,
           job,
           taskRunId,
+          activeJobMarker,
           status: "error",
           error: errorText,
           diagnostics: createCronRunDiagnosticsFromError("cron-setup", errorText, {
@@ -1058,11 +1258,86 @@ export async function onTimer(state: CronServiceState) {
       }
     };
 
+    const finalizeCompletedResults = async (
+      completedResults: readonly TimedCronRunOutcome[],
+      opts?: { clearOnFailure?: boolean },
+    ): Promise<TimedCronRunOutcome[]> => {
+      if (completedResults.length === 0) {
+        return [];
+      }
+      let finalizedResults: TimedCronRunOutcome[] = [];
+      let finalizationSucceeded = false;
+      try {
+        const currentResults = filterCurrentCronRunOutcomes(completedResults);
+        if (currentResults.length === 0) {
+          finishRetiredCronTaskRuns(state, completedResults, currentResults);
+          return [];
+        }
+        await locked(state, async () => {
+          await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+          finalizedResults = filterCurrentCronRunOutcomes(currentResults);
+          finishRetiredCronTaskRuns(state, completedResults, finalizedResults);
+          for (const result of finalizedResults) {
+            applyOutcomeToStoredJob(state, result);
+          }
+          if (finalizedResults.length === 0) {
+            return;
+          }
+
+          // Use maintenance-only recompute to avoid advancing past-due
+          // nextRunAtMs values that became due between findDueJobs and this
+          // locked block.  The full recomputeNextRuns would silently skip
+          // those jobs (advancing nextRunAtMs without execution), causing
+          // daily cron schedules to jump 48 h instead of 24 h (#17852).
+          recomputeNextRunsForMaintenance(state);
+          await persist(state);
+        });
+        finalizationSucceeded = finalizedResults.length > 0;
+        return finalizedResults;
+      } finally {
+        if (opts?.clearOnFailure !== false || finalizationSucceeded) {
+          clearActiveMarkersForOutcomes(completedResults);
+        }
+      }
+    };
+
     const concurrency = Math.min(resolveRunConcurrency(state), Math.max(1, dueJobs.length));
     const results: (TimedCronRunOutcome | undefined)[] = Array.from({ length: dueJobs.length });
+    const claimedIndexes = new Set<number>();
+    let reservationReleaseError: unknown;
+    let setupTimeoutNotified = false;
+    let stopAdmittingDueJobs = false;
+    const hasSetupTimeoutRecoveryHandler = state.deps.onIsolatedAgentSetupTimeout !== undefined;
+    const releaseUnclaimedDueJobReservations = async () => {
+      if (claimedIndexes.size >= dueJobs.length) {
+        return;
+      }
+      await locked(state, async () => {
+        await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+        for (const [index, due] of dueJobs.entries()) {
+          if (claimedIndexes.has(index)) {
+            continue;
+          }
+          const job = state.store?.jobs.find((entry) => entry.id === due.id);
+          if (job?.state && job.state.runningAtMs === due.reservedAtMs) {
+            delete job.state.runningAtMs;
+          }
+        }
+        recomputeNextRunsForMaintenance(state);
+        await persist(state);
+      });
+    };
+    if (state.stopped) {
+      await releaseUnclaimedDueJobReservations();
+      return;
+    }
     let cursor = 0;
     const workers = Array.from({ length: concurrency }, async () => {
       for (;;) {
+        if (stopAdmittingDueJobs || state.stopped || state.restartRecoveryPending) {
+          stopAdmittingDueJobs = true;
+          return;
+        }
         const index = cursor++;
         if (index >= dueJobs.length) {
           return;
@@ -1071,30 +1346,60 @@ export async function onTimer(state: CronServiceState) {
         if (!due) {
           return;
         }
-        results[index] = await runDueJob(due);
+        claimedIndexes.add(index);
+        const result = await runDueJob(due);
+        if (result.isolatedAgentSetupTimeout) {
+          let finalizedResults: TimedCronRunOutcome[];
+          try {
+            finalizedResults = await finalizeCompletedResults([result], { clearOnFailure: false });
+          } catch {
+            results[index] = result;
+            continue;
+          }
+          if (!hasSetupTimeoutRecoveryHandler || finalizedResults.length === 0) {
+            continue;
+          }
+          if (!setupTimeoutNotified) {
+            setupTimeoutNotified = true;
+            stopAdmittingDueJobs = true;
+            try {
+              await releaseUnclaimedDueJobReservations();
+            } catch (err) {
+              reservationReleaseError = err;
+            }
+            maybeNotifyIsolatedAgentSetupTimeout(state, result);
+          }
+          continue;
+        }
+        results[index] = result;
       }
     });
     await Promise.all(workers);
+    if (reservationReleaseError) {
+      throw reservationReleaseError instanceof Error
+        ? reservationReleaseError
+        : new Error(formatErrorMessage(reservationReleaseError));
+    }
+    if (stopAdmittingDueJobs) {
+      await releaseUnclaimedDueJobReservations();
+    }
 
     const completedResults: TimedCronRunOutcome[] = results.filter(
       (entry): entry is TimedCronRunOutcome => entry !== undefined,
     );
 
     if (completedResults.length > 0) {
-      await locked(state, async () => {
-        await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-        for (const result of completedResults) {
-          applyOutcomeToStoredJob(state, result);
+      const finalizedResults = await finalizeCompletedResults(completedResults);
+      for (const result of finalizedResults) {
+        if (
+          !setupTimeoutNotified &&
+          result.isolatedAgentSetupTimeout &&
+          maybeNotifyIsolatedAgentSetupTimeout(state, result)
+        ) {
+          setupTimeoutNotified = true;
+          break;
         }
-
-        // Use maintenance-only recompute to avoid advancing past-due
-        // nextRunAtMs values that became due between findDueJobs and this
-        // locked block.  The full recomputeNextRuns would silently skip
-        // those jobs (advancing nextRunAtMs without execution), causing
-        // daily cron schedules to jump 48 h instead of 24 h (#17852).
-        recomputeNextRunsForMaintenance(state);
-        await persist(state);
-      });
+      }
     }
   } finally {
     // Piggyback session reaper on timer tick (self-throttled to every 5 min).
@@ -1288,13 +1593,19 @@ export async function runMissedJobs(
   state: CronServiceState,
   opts?: { skipJobIds?: ReadonlySet<string>; deferAgentTurnJobs?: boolean },
 ) {
+  if (state.stopped) {
+    return;
+  }
   const plan = await planStartupCatchup(state, opts);
   if (plan.candidates.length === 0 && plan.deferredJobs.length === 0) {
     return;
   }
 
   const outcomes = await executeStartupCatchupPlan(state, plan);
-  await applyStartupCatchupOutcomes(state, plan, outcomes);
+  const finalizedOutcomes = await applyStartupCatchupOutcomes(state, plan, outcomes);
+  for (const outcome of finalizedOutcomes) {
+    maybeNotifyIsolatedAgentSetupTimeout(state, outcome);
+  }
 }
 
 async function planStartupCatchup(
@@ -1307,7 +1618,7 @@ async function planStartupCatchup(
   );
   return locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
-    if (!state.store) {
+    if (state.stopped || !state.store) {
       return { candidates: [], deferredJobs: [] };
     }
 
@@ -1381,7 +1692,11 @@ async function planStartupCatchup(
     await persist(state);
 
     return {
-      candidates: startupCandidates.map((job) => ({ jobId: job.id, job })),
+      candidates: startupCandidates.map((job) => ({
+        jobId: job.id,
+        job,
+        reservedAtMs: now,
+      })),
       deferredJobs: deferred,
     };
   });
@@ -1393,6 +1708,9 @@ async function executeStartupCatchupPlan(
 ): Promise<TimedCronRunOutcome[]> {
   const outcomes: TimedCronRunOutcome[] = [];
   for (const candidate of plan.candidates) {
+    if (state.stopped) {
+      break;
+    }
     outcomes.push(await runStartupCatchupCandidate(state, candidate));
   }
   return outcomes;
@@ -1408,6 +1726,9 @@ async function runStartupCatchupCandidate(
     job: candidate.job,
     startedAt,
   });
+  const activeJobMarker = markCronJobActive(candidate.job.id, {
+    preserveAcrossGenerationAdvance: candidate.job.sessionTarget === "main",
+  });
   emit(state, {
     jobId: candidate.job.id,
     action: "started",
@@ -1415,11 +1736,15 @@ async function runStartupCatchupCandidate(
     runAtMs: startedAt,
   });
   try {
-    const result = await executeJobCoreWithTimeout(state, candidate.job, { runId: taskRunId });
+    const result = await executeJobCoreWithTimeout(state, candidate.job, {
+      runId: taskRunId,
+      activeJobMarker,
+    });
     return {
       jobId: candidate.jobId,
       job: candidate.job,
       taskRunId,
+      activeJobMarker,
       status: result.status,
       error: result.error,
       summary: result.summary,
@@ -1430,6 +1755,7 @@ async function runStartupCatchupCandidate(
       model: result.model,
       provider: result.provider,
       usage: result.usage,
+      isolatedAgentSetupTimeout: result.isolatedAgentSetupTimeout,
       startedAt,
       endedAt: state.deps.nowMs(),
     };
@@ -1438,6 +1764,7 @@ async function runStartupCatchupCandidate(
       jobId: candidate.jobId,
       job: candidate.job,
       taskRunId,
+      activeJobMarker,
       status: "error",
       error: normalizeCronRunErrorText(err),
       diagnostics: createCronRunDiagnosticsFromError("cron-setup", normalizeCronRunErrorText(err), {
@@ -1453,46 +1780,81 @@ async function applyStartupCatchupOutcomes(
   state: CronServiceState,
   plan: StartupCatchupPlan,
   outcomes: TimedCronRunOutcome[],
-): Promise<void> {
+): Promise<TimedCronRunOutcome[]> {
   const staggerMs = Math.max(0, state.deps.missedJobStaggerMs ?? DEFAULT_MISSED_JOB_STAGGER_MS);
-  await locked(state, async () => {
-    // Startup catch-up runs during service bootstrap, before the timer loop is
-    // armed. Reuse the in-memory store instead of forcing a second reload.
-    await ensureLoaded(state, { skipRecompute: true });
-    if (!state.store) {
-      return;
-    }
-
-    for (const result of outcomes) {
-      applyOutcomeToStoredJob(state, result);
-    }
-
-    if (plan.deferredJobs.length > 0) {
-      const baseNow = state.deps.nowMs();
-      let offset = staggerMs;
-      for (const deferred of plan.deferredJobs) {
-        const jobId = deferred.jobId;
-        const job = state.store.jobs.find((entry) => entry.id === jobId);
-        if (!job || !isJobEnabled(job)) {
-          continue;
-        }
-        if (typeof deferred.delayMs === "number") {
-          job.state.nextRunAtMs = baseNow + deferred.delayMs + offset - staggerMs;
-          offset += staggerMs;
-          continue;
-        }
-        job.state.nextRunAtMs = baseNow + offset;
-        offset += staggerMs;
+  try {
+    const currentOutcomes = filterCurrentCronRunOutcomes(outcomes);
+    let finalizedOutcomes: TimedCronRunOutcome[] = [];
+    await locked(state, async () => {
+      await ensureLoaded(state, {
+        forceReload: state.stopped,
+        skipRecompute: true,
+      });
+      if (!state.store) {
+        return;
       }
-    }
+      if (state.stopped) {
+        finishRetiredCronTaskRuns(state, outcomes, []);
+        const releasedReservations = releaseUnstartedStartupCatchupReservations(
+          state,
+          plan,
+          outcomes,
+        );
+        if (releasedReservations) {
+          recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
+          await persist(state);
+        }
+        return;
+      }
 
-    // Preserve any new past-due nextRunAtMs values that became due while
-    // startup catch-up was running. They should execute on a future tick
-    // instead of being silently advanced. Future repair is disabled here so
-    // startup overflow deferrals survive until their staggered catch-up tick.
-    recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
-    await persist(state);
-  });
+      finalizedOutcomes = filterCurrentCronRunOutcomes(currentOutcomes);
+      finishRetiredCronTaskRuns(state, outcomes, finalizedOutcomes);
+      const releasedReservations = releaseUnstartedStartupCatchupReservations(
+        state,
+        plan,
+        outcomes,
+      );
+      for (const result of finalizedOutcomes) {
+        applyOutcomeToStoredJob(state, result);
+      }
+      if (finalizedOutcomes.length === 0 && plan.deferredJobs.length === 0) {
+        if (releasedReservations) {
+          recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
+          await persist(state);
+        }
+        return;
+      }
+
+      if (plan.deferredJobs.length > 0) {
+        const baseNow = state.deps.nowMs();
+        let offset = staggerMs;
+        for (const deferred of plan.deferredJobs) {
+          const jobId = deferred.jobId;
+          const job = state.store.jobs.find((entry) => entry.id === jobId);
+          if (!job || !isJobEnabled(job)) {
+            continue;
+          }
+          if (typeof deferred.delayMs === "number") {
+            job.state.nextRunAtMs = baseNow + deferred.delayMs + offset - staggerMs;
+            offset += staggerMs;
+            continue;
+          }
+          job.state.nextRunAtMs = baseNow + offset;
+          offset += staggerMs;
+        }
+      }
+
+      // Preserve any new past-due nextRunAtMs values that became due while
+      // startup catch-up was running. They should execute on a future tick
+      // instead of being silently advanced. Future repair is disabled here so
+      // startup overflow deferrals survive until their staggered catch-up tick.
+      recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
+      await persist(state);
+    });
+    return finalizedOutcomes;
+  } finally {
+    clearActiveMarkersForOutcomes(outcomes);
+  }
 }
 
 /** Executes a cron job without mutating persisted job state. */
@@ -1500,10 +1862,7 @@ export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
   abortSignal?: AbortSignal,
-  options?: {
-    onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
-    onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
-  },
+  options?: ExecuteJobCoreOptions,
 ): Promise<
   CronRunOutcome &
     CronRunTelemetry & {
@@ -1608,6 +1967,10 @@ async function executeMainSessionCronJob(
         sessionKey: cronRunSessionKey,
         heartbeat: { target: "last" },
       });
+      if (abortSignal?.aborted) {
+        removeQueuedSystemEventHandle(state, job, queuedSystemEvent);
+        return { status: "error", error: timeoutErrorMessage() };
+      }
       if (
         heartbeatResult.status !== "skipped" ||
         !isRetryableHeartbeatBusySkipReason(heartbeatResult.reason)
@@ -1689,10 +2052,7 @@ async function executeDetachedCronJob(
   job: CronJob,
   abortSignal: AbortSignal | undefined,
   resolveAbortError: () => { status: "error"; error: string },
-  options?: {
-    onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
-    onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
-  },
+  options?: ExecuteJobCoreOptions,
 ): Promise<
   CronRunOutcome &
     CronRunTelemetry & {
@@ -1765,6 +2125,7 @@ async function executeDetachedCronJob(
     abortSignal,
     onExecutionStarted: options?.onExecutionStarted,
     onExecutionPhase: options?.onExecutionPhase,
+    onLaneWait: options?.onLaneWait,
   });
 
   if (abortSignal?.aborted) {
@@ -1807,7 +2168,9 @@ export async function executeJob(
   const startedAt = state.deps.nowMs();
   job.state.runningAtMs = startedAt;
   job.state.lastError = undefined;
-  markCronJobActive(job.id);
+  const activeJobMarker = markCronJobActive(job.id, {
+    preserveAcrossGenerationAdvance: job.sessionTarget === "main",
+  });
   emit(state, { jobId: job.id, action: "started", job, runAtMs: startedAt });
 
   let coreResult: {
@@ -1817,7 +2180,7 @@ export async function executeJob(
   } & CronRunOutcome &
     CronRunTelemetry;
   try {
-    coreResult = await executeJobCoreWithTimeout(state, job);
+    coreResult = await executeJobCoreWithTimeout(state, job, { activeJobMarker });
   } catch (err) {
     coreResult = { status: "error", error: String(err) };
   }
@@ -1839,7 +2202,7 @@ export async function executeJob(
     state.store.jobs = state.store.jobs.filter((j) => j.id !== job.id);
     emit(state, { jobId: job.id, action: "removed", job });
   }
-  clearCronJobActive(job.id);
+  clearCronJobActive(job.id, activeJobMarker);
 }
 
 function emitJobFinished(

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -7,6 +7,10 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
 
+type RunCronIsolatedAgentTurnMock = (params: {
+  abortSignal?: AbortSignal;
+}) => Promise<{ status: "ok"; summary: string }>;
+
 const {
   enqueueSystemEventMock,
   consumeSelectedSystemEventEntriesMock,
@@ -20,6 +24,7 @@ const {
   runCronChangedMock,
   abortAndDrainEmbeddedAgentRunMock,
   retireSessionMcpRuntimeMock,
+  requestSafeGatewayRestartMock,
 } = vi.hoisted(() => ({
   enqueueSystemEventMock: vi.fn(),
   consumeSelectedSystemEventEntriesMock: vi.fn((_sessionKey, entries) => entries ?? []),
@@ -29,7 +34,10 @@ const {
   >(async () => ({ status: "ran", durationMs: 1 })),
   loadConfigMock: vi.fn(),
   fetchWithSsrFGuardMock: vi.fn(),
-  runCronIsolatedAgentTurnMock: vi.fn(async () => ({ status: "ok" as const, summary: "ok" })),
+  runCronIsolatedAgentTurnMock: vi.fn<RunCronIsolatedAgentTurnMock>(async () => ({
+    status: "ok",
+    summary: "ok",
+  })),
   cleanupBrowserSessionsForLifecycleEndMock: vi.fn(async () => {}),
   runCronChangedMock: vi.fn(async () => {}),
   getGlobalHookRunnerMock: vi.fn(() => ({
@@ -42,6 +50,32 @@ const {
     forceCleared: false,
   })),
   retireSessionMcpRuntimeMock: vi.fn(async () => true),
+  requestSafeGatewayRestartMock: vi.fn(() => ({
+    ok: true,
+    status: "scheduled",
+    preflight: {
+      safe: true,
+      counts: {
+        queueSize: 0,
+        pendingReplies: 0,
+        embeddedRuns: 0,
+        activeTasks: 0,
+        totalActive: 0,
+      },
+      blockers: [],
+      summary: "safe to restart now",
+    },
+    restart: {
+      ok: true,
+      pid: 123,
+      signal: "SIGUSR1",
+      delayMs: 0,
+      reason: "cron.isolated_agent_setup_timeout",
+      mode: "emit",
+      coalesced: false,
+      cooldownMsApplied: 0,
+    },
+  })),
 }));
 
 function enqueueSystemEvent(text: string, opts?: unknown) {
@@ -90,6 +124,16 @@ vi.mock("../infra/heartbeat-wake.js", async () => {
 vi.mock("../infra/heartbeat-runner.js", () => ({
   runHeartbeatOnce,
 }));
+
+vi.mock("../infra/restart-coordinator.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/restart-coordinator.js")>(
+    "../infra/restart-coordinator.js",
+  );
+  return {
+    ...actual,
+    requestSafeGatewayRestart: requestSafeGatewayRestartMock,
+  };
+});
 
 vi.mock("../config/config.js", async () => {
   const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
@@ -234,10 +278,53 @@ describe("buildGatewayCronService", () => {
     getGlobalHookRunnerMock.mockClear();
     abortAndDrainEmbeddedAgentRunMock.mockClear();
     retireSessionMcpRuntimeMock.mockClear();
+    requestSafeGatewayRestartMock.mockClear();
     getGlobalHookRunnerMock.mockReturnValue({
       hasHooks: (hookName: string) => hookName === "cron_changed",
       runCronChanged: runCronChangedMock,
     });
+  });
+
+  it("requests a safe gateway restart when isolated cron setup times out", async () => {
+    vi.useFakeTimers();
+    const cfg = createCronConfig("server-cron-isolated-setup-timeout");
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "isolated setup timeout",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(Date.now()).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
+      });
+      runCronIsolatedAgentTurnMock.mockImplementationOnce(
+        async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+          abortSignal?.addEventListener("abort", () => undefined, { once: true });
+          return await new Promise<never>(() => {});
+        },
+      );
+
+      const runPromise = state.cron.run(job.id, "force");
+      await vi.advanceTimersByTimeAsync(60_100);
+      const runResult = await runPromise;
+
+      expect(runResult).toEqual({ ok: true, ran: true });
+      expect(requestSafeGatewayRestartMock).toHaveBeenCalledTimes(1);
+      expect(requestSafeGatewayRestartMock).toHaveBeenCalledWith({
+        reason: "cron.isolated_agent_setup_timeout",
+        delayMs: 0,
+        preservePendingEmitHooks: true,
+      });
+    } finally {
+      state.cron.stop();
+      vi.useRealTimers();
+    }
   });
 
   it("emits cron_changed hooks with computed next run state", async () => {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -32,6 +32,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { resolveMainScopedEventSessionKey } from "../infra/event-session-routing.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
+import { requestSafeGatewayRestart } from "../infra/restart-coordinator.js";
 import {
   consumeSelectedSystemEventEntries,
   enqueueSystemEventEntry,
@@ -388,6 +389,7 @@ export function buildGatewayCronService(params: {
       abortSignal,
       onExecutionStarted,
       onExecutionPhase,
+      onLaneWait,
     }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       const sessionKey = resolveCronSessionTargetSessionKey(job.sessionTarget) ?? `cron:${job.id}`;
@@ -400,6 +402,7 @@ export function buildGatewayCronService(params: {
           abortSignal,
           onExecutionStarted,
           onExecutionPhase,
+          onLaneWait,
           agentId,
           sessionKey,
           lane: "cron",
@@ -542,6 +545,26 @@ export function buildGatewayCronService(params: {
           );
         },
       }).catch(() => {});
+    },
+    onIsolatedAgentSetupTimeout: ({ job, error, timeoutMs }) => {
+      const restart = requestSafeGatewayRestart({
+        reason: "cron.isolated_agent_setup_timeout",
+        delayMs: 0,
+        preservePendingEmitHooks: true,
+      });
+      cronLogger.warn(
+        {
+          jobId: job.id,
+          jobName: job.name,
+          timeoutMs,
+          error,
+          restartStatus: restart.status,
+          restartCoalesced: restart.restart.coalesced,
+          restartSummary: restart.preflight.summary,
+          restartDelayMs: restart.restart.delayMs,
+        },
+        "cron: isolated agent setup timed out before runner start; requested safe gateway restart",
+      );
     },
     sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) =>
       await sendGatewayCronFailureAlert({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -26,6 +26,7 @@ import { isNixMode, normalizeStateDirEnv } from "../config/paths.js";
 import { applyConfigOverrides } from "../config/runtime-overrides.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getActiveCronJobCount } from "../cron/active-jobs.js";
 import {
   isDiagnosticsEnabled,
   setDiagnosticsEnabledForProcess,
@@ -654,6 +655,7 @@ export async function startGatewayServer(
       getTotalQueueSize() +
       getTotalPendingReplies() +
       getActiveEmbeddedRunCount() +
+      getActiveCronJobCount() +
       getActiveTaskCount(),
   );
   // Unconditional startup migration: seed gateway.controlUi.allowedOrigins for existing

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -371,7 +371,7 @@ export async function resolveSessionTranscriptResetArchiveCandidatesAsync(
   ).flatMap((identityArchives) =>
     identityArchives
       .flatMap((archive) => (archive ? [archive] : []))
-      .sort(
+      .toSorted(
         (left, right) => right.timestamp - left.timestamp || right.name.localeCompare(left.name),
       )
       .slice(0, 1),

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -839,7 +839,7 @@ describe("readSessionMessages", () => {
     ]);
     clearSessionTranscriptIndexCache();
 
-    const originalReaddir = fs.promises.readdir.bind(fs.promises) as typeof fs.promises.readdir;
+    const originalReaddir = fs.promises.readdir.bind(fs.promises);
     let wroteActiveTranscript = false;
     const readdirSpy = vi.spyOn(fs.promises, "readdir").mockImplementation((async (
       ...args: unknown[]

--- a/src/infra/restart-coordinator.test.ts
+++ b/src/infra/restart-coordinator.test.ts
@@ -17,6 +17,7 @@ describe("safe gateway restart coordinator", () => {
       getQueueSize: () => 0,
       getPendingReplies: () => 0,
       getEmbeddedRuns: () => 0,
+      getCronRuns: () => 0,
       getActiveTasks: () => 0,
       getTaskBlockers: () => [],
     });
@@ -27,6 +28,7 @@ describe("safe gateway restart coordinator", () => {
         queueSize: 0,
         pendingReplies: 0,
         embeddedRuns: 0,
+        cronRuns: 0,
         activeTasks: 0,
         totalActive: 0,
       },
@@ -40,6 +42,7 @@ describe("safe gateway restart coordinator", () => {
       getQueueSize: () => 2,
       getPendingReplies: () => 1,
       getEmbeddedRuns: () => 1,
+      getCronRuns: () => 1,
       getActiveTasks: () => 1,
       getTaskBlockers: () => [
         {
@@ -54,11 +57,12 @@ describe("safe gateway restart coordinator", () => {
     });
 
     expect(preflight.safe).toBe(false);
-    expect(preflight.counts.totalActive).toBe(5);
+    expect(preflight.counts.totalActive).toBe(6);
     expect(preflight.blockers.map((blocker) => blocker.kind)).toEqual([
       "queue",
       "reply",
       "embedded-run",
+      "cron-run",
       "task",
     ]);
     expect(preflight.summary).toContain("restart deferred");
@@ -82,6 +86,7 @@ describe("safe gateway restart coordinator", () => {
         getQueueSize: () => 1,
         getPendingReplies: () => 0,
         getEmbeddedRuns: () => 0,
+        getCronRuns: () => 0,
         getActiveTasks: () => 0,
         getTaskBlockers: () => [],
       },
@@ -110,6 +115,7 @@ describe("safe gateway restart coordinator", () => {
         getQueueSize: () => 0,
         getPendingReplies: () => 0,
         getEmbeddedRuns: () => 0,
+        getCronRuns: () => 0,
         getActiveTasks: () => 0,
         getTaskBlockers: () => [],
       },
@@ -136,6 +142,7 @@ describe("safe gateway restart coordinator", () => {
         getQueueSize: () => 1,
         getPendingReplies: () => 0,
         getEmbeddedRuns: () => 0,
+        getCronRuns: () => 0,
         getActiveTasks: () => 0,
         getTaskBlockers: () => [],
       },
@@ -168,6 +175,7 @@ describe("safe gateway restart coordinator", () => {
         getQueueSize: () => 0,
         getPendingReplies: () => 0,
         getEmbeddedRuns: () => 0,
+        getCronRuns: () => 0,
         getActiveTasks: () => 0,
         getTaskBlockers: () => [],
       },

--- a/src/infra/restart-coordinator.ts
+++ b/src/infra/restart-coordinator.ts
@@ -1,6 +1,7 @@
 // Coordinates restart requests around active embedded agent runs.
 import { getActiveEmbeddedRunCount } from "../agents/embedded-agent-runner/run-state.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
+import { getActiveCronJobCount } from "../cron/active-jobs.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
 import {
   getInspectableActiveTaskRestartBlockers,
@@ -14,12 +15,13 @@ export type SafeGatewayRestartCounts = {
   queueSize: number;
   pendingReplies: number;
   embeddedRuns: number;
+  cronRuns: number;
   activeTasks: number;
   totalActive: number;
 };
 
 export type SafeGatewayRestartBlocker = {
-  kind: "queue" | "reply" | "embedded-run" | "task";
+  kind: "queue" | "reply" | "embedded-run" | "cron-run" | "task";
   count: number;
   message: string;
   task?: ActiveTaskRestartBlocker;
@@ -43,6 +45,7 @@ type SafeRestartInspectors = {
   getQueueSize: () => number;
   getPendingReplies: () => number;
   getEmbeddedRuns: () => number;
+  getCronRuns: () => number;
   getActiveTasks: () => number;
   getTaskBlockers: () => ActiveTaskRestartBlocker[];
 };
@@ -51,6 +54,7 @@ const defaultInspectors: SafeRestartInspectors = {
   getQueueSize: getTotalQueueSize,
   getPendingReplies: getTotalPendingReplies,
   getEmbeddedRuns: getActiveEmbeddedRunCount,
+  getCronRuns: getActiveCronJobCount,
   getActiveTasks: () => getInspectableActiveTaskRestartBlockers().length,
   getTaskBlockers: getInspectableActiveTaskRestartBlockers,
 };
@@ -88,11 +92,16 @@ export function createSafeGatewayRestartPreflight(
     queueSize: normalizeCount(resolved.getQueueSize()),
     pendingReplies: normalizeCount(resolved.getPendingReplies()),
     embeddedRuns: normalizeCount(resolved.getEmbeddedRuns()),
+    cronRuns: normalizeCount(resolved.getCronRuns()),
     activeTasks: normalizeCount(resolved.getActiveTasks()),
     totalActive: 0,
   };
   counts.totalActive =
-    counts.queueSize + counts.pendingReplies + counts.embeddedRuns + counts.activeTasks;
+    counts.queueSize +
+    counts.pendingReplies +
+    counts.embeddedRuns +
+    counts.cronRuns +
+    counts.activeTasks;
 
   const blockers: SafeGatewayRestartBlocker[] = [];
   if (counts.queueSize > 0) {
@@ -114,6 +123,13 @@ export function createSafeGatewayRestartPreflight(
       kind: "embedded-run",
       count: counts.embeddedRuns,
       message: `${counts.embeddedRuns} active embedded run(s)`,
+    });
+  }
+  if (counts.cronRuns > 0) {
+    blockers.push({
+      kind: "cron-run",
+      count: counts.cronRuns,
+      message: `${counts.cronRuns} active cron run(s)`,
     });
   }
   if (counts.activeTasks > 0) {
@@ -156,6 +172,7 @@ export function requestSafeGatewayRestart(
     reason?: string;
     delayMs?: number;
     skipDeferral?: boolean;
+    preservePendingEmitHooks?: boolean;
     inspect?: Partial<SafeRestartInspectors>;
   } = {},
 ): SafeGatewayRestartRequestResult {
@@ -164,7 +181,9 @@ export function requestSafeGatewayRestart(
   const restart = scheduleGatewaySigusr1Restart({
     delayMs: opts.delayMs ?? 0,
     reason: opts.reason ?? "gateway.restart.safe",
-    ...(skipDeferral ? { preservePendingEmitHooksOnDeferralBypass: true } : {}),
+    ...(opts.preservePendingEmitHooks === true || skipDeferral
+      ? { preservePendingEmitHooksOnDeferralBypass: true }
+      : {}),
     ...(skipDeferral ? { skipDeferral: true } : {}),
   });
   const status = restart.coalesced

--- a/src/tasks/cron-task-cancel.test.ts
+++ b/src/tasks/cron-task-cancel.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CRON_TASK_RUN_SETTLEMENT_TRACKING_MAX_MS,
+  resetActiveCronTaskRunsForTests,
+  retireActiveCronTaskRunTracking,
+  startActiveCronTaskRunSettlementGrace,
+  trackActiveCronTaskRunSettlement,
+  waitForActiveCronTaskRuns,
+} from "./cron-task-cancel.js";
+
+describe("cron task cancellation tracking", () => {
+  it("retires never-settling cron promises at lifecycle cutoff", async () => {
+    resetActiveCronTaskRunsForTests();
+    trackActiveCronTaskRunSettlement(new Promise<never>(() => {}));
+
+    await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
+      drained: false,
+      active: 1,
+    });
+
+    retireActiveCronTaskRunTracking();
+
+    await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
+      drained: true,
+      active: 0,
+    });
+  });
+
+  it("drops never-settling cron promises after a bounded grace period", async () => {
+    vi.useFakeTimers();
+    try {
+      resetActiveCronTaskRunsForTests();
+      trackActiveCronTaskRunSettlement(new Promise<never>(() => {}));
+
+      await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
+        drained: false,
+        active: 1,
+      });
+
+      await vi.advanceTimersByTimeAsync(CRON_TASK_RUN_SETTLEMENT_TRACKING_MAX_MS + 1);
+
+      await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
+        drained: false,
+        active: 1,
+      });
+
+      startActiveCronTaskRunSettlementGrace();
+      await vi.advanceTimersByTimeAsync(CRON_TASK_RUN_SETTLEMENT_TRACKING_MAX_MS + 1);
+
+      await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
+        drained: true,
+        active: 0,
+      });
+    } finally {
+      vi.useRealTimers();
+      resetActiveCronTaskRunsForTests();
+    }
+  });
+});

--- a/src/tasks/cron-task-cancel.ts
+++ b/src/tasks/cron-task-cancel.ts
@@ -5,7 +5,27 @@ type CronTaskCancelHandle = {
   onCancel?: (reason: string) => void;
 };
 
+type SettlingCronTaskRun = {
+  retirementTimer?: NodeJS.Timeout;
+};
+
 const activeCronTaskRunsByRunId = new Map<string, CronTaskCancelHandle>();
+const settlingCronTaskRuns = new Map<Promise<unknown>, SettlingCronTaskRun>();
+const DEFAULT_CRON_TASK_RUN_DRAIN_POLL_MS = 25;
+export const CRON_TASK_RUN_SETTLEMENT_TRACKING_MAX_MS = 60_000;
+
+export function startActiveCronTaskRunSettlementGrace(): void {
+  for (const [promise, entry] of settlingCronTaskRuns) {
+    if (entry.retirementTimer) {
+      continue;
+    }
+    const retirementTimer = setTimeout(() => {
+      settlingCronTaskRuns.delete(promise);
+    }, CRON_TASK_RUN_SETTLEMENT_TRACKING_MAX_MS);
+    retirementTimer.unref?.();
+    entry.retirementTimer = retirementTimer;
+  }
+}
 
 export function registerActiveCronTaskRun(params: {
   runId: string | undefined;
@@ -27,6 +47,64 @@ export function registerActiveCronTaskRun(params: {
   };
 }
 
+export function abortActiveCronTaskRuns(reason = "Gateway restarting."): number {
+  let aborted = 0;
+  for (const handle of activeCronTaskRunsByRunId.values()) {
+    if (handle.controller.signal.aborted) {
+      continue;
+    }
+    handle.controller.abort(reason);
+    handle.onCancel?.(reason);
+    aborted += 1;
+  }
+  if (aborted > 0) {
+    startActiveCronTaskRunSettlementGrace();
+  }
+  return aborted;
+}
+
+export function trackActiveCronTaskRunSettlement(promise: Promise<unknown>): void {
+  settlingCronTaskRuns.set(promise, {});
+  void promise
+    .catch(() => undefined)
+    .finally(() => {
+      const entry = settlingCronTaskRuns.get(promise);
+      if (entry?.retirementTimer) {
+        clearTimeout(entry.retirementTimer);
+      }
+      settlingCronTaskRuns.delete(promise);
+    });
+}
+
+export function retireActiveCronTaskRunTracking(): void {
+  activeCronTaskRunsByRunId.clear();
+  for (const entry of settlingCronTaskRuns.values()) {
+    if (entry.retirementTimer) {
+      clearTimeout(entry.retirementTimer);
+    }
+  }
+  settlingCronTaskRuns.clear();
+}
+
+export async function waitForActiveCronTaskRuns(timeoutMs: number): Promise<{
+  drained: boolean;
+  active: number;
+}> {
+  const deadline = Date.now() + Math.max(0, Math.floor(timeoutMs));
+  while (
+    (activeCronTaskRunsByRunId.size > 0 || settlingCronTaskRuns.size > 0) &&
+    Date.now() < deadline
+  ) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, DEFAULT_CRON_TASK_RUN_DRAIN_POLL_MS);
+    });
+  }
+  return {
+    drained: activeCronTaskRunsByRunId.size === 0 && settlingCronTaskRuns.size === 0,
+    active: activeCronTaskRunsByRunId.size + settlingCronTaskRuns.size,
+  };
+}
+
 export function cancelActiveCronTaskRun(params: {
   runId: string | undefined;
   reason?: string;
@@ -45,9 +123,10 @@ export function cancelActiveCronTaskRun(params: {
   const reason = params.reason?.trim() || "Cancelled by operator.";
   handle.controller.abort(reason);
   handle.onCancel?.(reason);
+  startActiveCronTaskRunSettlementGrace();
   return true;
 }
 
 export function resetActiveCronTaskRunsForTests(): void {
-  activeCronTaskRunsByRunId.clear();
+  retireActiveCronTaskRunTracking();
 }


### PR DESCRIPTION
## Summary
- classify isolated cron setup timeouts as a gateway-health failure class
- notify the gateway cron service when setup stalls before the isolated runner starts
- request a safe gateway restart through the existing restart coordinator so affected recurring jobs can recover centrally
- add cron-service and gateway regression coverage for the restart path

## Root Cause
Cron jobs that use isolated agent turns can fail before the runner starts with `cron: isolated agent setup timed out before runner start`. Today that error is recorded and alerted, but it is not treated as a platform-level gateway/isolated-runner health failure. Individual cron workflows can self-repair around it, but the shared failure mode keeps recurring across unrelated jobs.

## Impact
When this failure class occurs, OpenClaw now asks the existing safe-restart coordinator to restart only after the normal preflight drain says it is safe. This should reduce repeated user-visible cron failure cards without interrupting active work.

## Real behavior proof
- **Behavior or issue addressed:** Recurring isolated-agent cron jobs were repeatedly failing before runner start while the gateway was stale/hot, producing `cron: isolated agent setup timed out before runner start` cards instead of recovering centrally.
- **Real environment tested:** Real local macOS OpenClaw setup, LaunchAgent-managed local gateway on loopback, released OpenClaw `2026.5.28`, with active background workload.
- **Exact steps or command run after this patch:** Verified the PR head `354de1a3b99027027b303c29b8852ec8fef9091d`; ran the PR-head proof command `pnpm test src/gateway/server-cron.test.ts src/cron/service/timer.regression.test.ts src/infra/restart-coordinator.test.ts src/infra/infra-runtime.test.ts --reporter verbose`; ran the production build command `node scripts/build-all.mjs`; then ran the built-runtime proof command `node --import tsx /tmp/openclaw-pr-89055-setup-timeout-proof.mjs`. I also checked the real recovered machine with `openclaw gateway status`, `openclaw status --json`, and `ps -p 93467 -o pid,pcpu,pmem,rss,etime,command`.
- **PR-build restart proof:** `node scripts/build-all.mjs` passed on PR head `354de1a3b99027027b303c29b8852ec8fef9091d`. The built-runtime proof then ran a controlled setup stall through the real cron timeout path and the real safe restart scheduler. Its output showed `productionBuildCompleted=true`, `distContainsGatewayHook=true`, `elapsedMs=60282`, `result.error="cron: isolated agent setup timed out before runner start"`, `restartRequests[0].status="scheduled"`, `restartRequests[0].preflightSafe=true`, `restartRequests[0].restartCoalesced=false`, `restartRequests[0].restartMode="emit"`, `restartRequests[0].restartReason="cron.isolated_agent_setup_timeout"`, `sigusr1Events[0].authorized=true`, `sigusr1Events[0].recovered=true`, and all four assertions true: setup timeout result, safe restart scheduled, gateway run loop recovered, and production dist contains the gateway hook.
- **Evidence after fix:** Copied live output from the recovered real machine showed `openclaw gateway status` with `Runtime: running (pid 93467, state active)`, `Connectivity probe: ok`, `Capability: admin-capable`, and `Gateway version: 2026.5.28`. Copied live `openclaw status --json` output showed `gateway.reachable=true`, `gateway.connectLatencyMs=45`, `queuedSystemEvents=[]`, and `tasks.byStatus.queued=0`. Copied live `ps` output showed gateway pid `93467` around `1.0%` CPU, `3.2%` memory, RSS `534560` KB. Before recovery, the same setup had a stale gateway timeout and a gateway node process around `109%` CPU with roughly `2.8GB` RSS. Supplemental PR-head terminal output also showed `✓ |gateway| ... requests a safe gateway restart when isolated cron setup times out`, `✓ |infra| ... coalesces duplicate scheduled restarts into a single pending timer`, and `✓ |infra| ... defers SIGUSR1 until deferral check returns 0`.
- **Observed result after fix:** The real gateway recovered and stayed reachable instead of continuing the setup-timeout loop. Normal OpenClaw work resumed through the restored gateway: representative background work and inference processes were running successfully after the gateway recovered. On PR head, the selected proof run passed gateway `22/22`, infra `34/34`, and cron `43/43`, proving this patch requests the same safe restart path for the setup-timeout class while the existing coordinator coalesces/defers repeated restart requests.
- **What was not tested:** The exact PR build was not installed into a live released OpenClaw package; the built-runtime proof exercises the PR-head cron timeout path and real safe restart scheduler in-process, while the live machine proof covers the operational recovery path on the released install.

## Testing
- `pnpm test src/gateway/server-cron.test.ts src/cron/service/timer.regression.test.ts src/infra/restart-coordinator.test.ts src/infra/infra-runtime.test.ts --reporter verbose`
- `pnpm test src/cron/service/timer.regression.test.ts src/gateway/server-cron.test.ts`
- `pnpm tsgo:core`
- `git diff --check`

Note: `pnpm check:changed` was also attempted locally before this PR, but the local Blacksmith Testbox wrapper failed its own `--version/--help` sanity check before project checks could run.




