### PR TITLE
fix(mcp): validate plugin tool schemas

### DIFF
--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -1,10 +1,16 @@
+import { ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import {
   isToolWrappedWithBeforeToolCallHook,
   rewrapToolWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "../agents/agent-tools.before-tool-call.js";
+import {
+  projectRuntimeToolInputSchema,
+  type RuntimeToolSchemaDiagnostic,
+} from "../agents/tool-schema-projection.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { logWarn } from "../logger.js";
 import { coerceChatContentText } from "../shared/chat-content.js";
 
 type CallPluginToolParams = {
@@ -12,12 +18,124 @@ type CallPluginToolParams = {
   arguments?: unknown;
 };
 
-function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
-  const params = tool.parameters;
-  if (params && typeof params === "object" && "type" in params) {
-    return params as Record<string, unknown>;
-  }
+type ListedPluginMcpTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+type PluginMcpToolEntry =
+  | {
+      ok: true;
+      tool: AnyAgentTool;
+      listedTool: ListedPluginMcpTool;
+    }
+  | {
+      ok: false;
+      diagnostic: RuntimeToolSchemaDiagnostic;
+    };
+
+function emptyObjectInputSchema(): Record<string, unknown> {
   return { type: "object", properties: {} };
+}
+
+function objectInputSchema(schema: unknown): Record<string, unknown> {
+  return { ...(schema as Record<string, unknown>), type: "object" };
+}
+
+function validatePluginMcpTool(
+  tool: AnyAgentTool,
+  toolIndex: number,
+  listedTool: ListedPluginMcpTool,
+): PluginMcpToolEntry {
+  const parsed = ToolSchema.safeParse(listedTool);
+  if (parsed.success) {
+    return { ok: true, tool, listedTool };
+  }
+  return {
+    ok: false,
+    diagnostic: {
+      toolName: listedTool.name,
+      toolIndex,
+      violations: parsed.error.issues.map((issue) => {
+        const path = issue.path.length > 0 ? issue.path.join(".") : "tool";
+        return `${listedTool.name}.${path}: ${issue.message}`;
+      }),
+    },
+  };
+}
+
+function readPluginMcpToolDescription(tool: AnyAgentTool): string {
+  try {
+    return typeof tool.description === "string" ? tool.description : "";
+  } catch {
+    return "";
+  }
+}
+
+function materializePluginMcpTool(tool: AnyAgentTool, toolIndex: number): PluginMcpToolEntry {
+  let toolName: string;
+  try {
+    toolName = tool.name;
+  } catch {
+    return {
+      ok: false,
+      diagnostic: {
+        toolName: `tool[${toolIndex}]`,
+        toolIndex,
+        violations: [`tool[${toolIndex}].name is unreadable`],
+      },
+    };
+  }
+  const description = readPluginMcpToolDescription(tool);
+  let parameters: unknown;
+  try {
+    parameters = tool.parameters;
+  } catch {
+    return {
+      ok: false,
+      diagnostic: {
+        toolName,
+        toolIndex,
+        violations: [`${toolName}.parameters is unreadable`],
+      },
+    };
+  }
+  if (parameters === undefined || parameters === null) {
+    return validatePluginMcpTool(tool, toolIndex, {
+      name: toolName,
+      description,
+      inputSchema: emptyObjectInputSchema(),
+    });
+  }
+  const projection = projectRuntimeToolInputSchema(parameters, `${toolName}.parameters`);
+  if (projection.violations.length > 0) {
+    return {
+      ok: false,
+      diagnostic: {
+        toolName,
+        toolIndex,
+        violations: projection.violations,
+      },
+    };
+  }
+  return validatePluginMcpTool(tool, toolIndex, {
+    name: toolName,
+    description,
+    inputSchema: objectInputSchema(projection.schema),
+  });
+}
+
+function logPluginMcpSchemaQuarantine(diagnostics: readonly RuntimeToolSchemaDiagnostic[]) {
+  if (diagnostics.length === 0) {
+    return;
+  }
+  const summary = diagnostics
+    .map((diagnostic) => `${diagnostic.toolName}: ${diagnostic.violations.join(", ")}`)
+    .join("; ");
+  logWarn(
+    `plugin-tools-mcp: quarantined ${diagnostics.length} unsupported tool schema${diagnostics.length === 1 ? "" : "s"} before MCP tool listing: ${summary}.`,
+  );
 }
 
 export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
@@ -29,18 +147,26 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
     // as the agent and HTTP tool execution paths.
     return wrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
   });
+  const materializedTools: { tool: AnyAgentTool; listedTool: ListedPluginMcpTool }[] = [];
+  const diagnostics: RuntimeToolSchemaDiagnostic[] = [];
+  for (const [toolIndex, tool] of wrappedTools.entries()) {
+    const entry = materializePluginMcpTool(tool, toolIndex);
+    if (entry.ok) {
+      materializedTools.push({ tool: entry.tool, listedTool: entry.listedTool });
+    } else {
+      diagnostics.push(entry.diagnostic);
+    }
+  }
+  logPluginMcpSchemaQuarantine(diagnostics);
+
   const toolMap = new Map<string, AnyAgentTool>();
-  for (const tool of wrappedTools) {
-    toolMap.set(tool.name, tool);
+  for (const entry of materializedTools) {
+    toolMap.set(entry.listedTool.name, entry.tool);
   }
 
   return {
     listTools: async () => ({
-      tools: wrappedTools.map((tool) => ({
-        name: tool.name,
-        description: tool.description ?? "",
-        inputSchema: resolveJsonSchemaForTool(tool),
-      })),
+      tools: materializedTools.map((entry) => entry.listedTool),
     }),
     callTool: async (params: CallPluginToolParams, signal?: AbortSignal) => {
       const tool = toolMap.get(params.name);

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -174,6 +174,123 @@ describe("plugin tools MCP server", () => {
     expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
   });
 
+  it("lists plugin tools without probing proxy schemas through object operators", async () => {
+    const parameters = new Proxy(
+      { type: "object", properties: { query: { type: "string" } } },
+      {
+        has(target, property) {
+          if (property === "type") {
+            throw new Error("schema has trap");
+          }
+          return Reflect.has(target, property);
+        },
+      },
+    );
+    const tool = {
+      name: "neutral_probe",
+      description: "Neutral fixture tool",
+      parameters,
+      execute: vi.fn().mockResolvedValue({ content: "ok" }),
+    } as unknown as AnyAgentTool;
+
+    const handlers = createPluginToolsMcpHandlers([tool]);
+    const listed = await handlers.listTools();
+
+    expect(listed.tools).toHaveLength(1);
+    expect(listed.tools[0]?.name).toBe("neutral_probe");
+    expect(listed.tools[0]?.inputSchema).toEqual({
+      type: "object",
+      properties: { query: { type: "string" } },
+    });
+  });
+
+  it("normalizes plugin MCP input schemas with implicit object roots", async () => {
+    const tool = {
+      name: "implicit_object_probe",
+      description: "Implicit object schema",
+      parameters: {
+        properties: {
+          query: { type: "string" },
+        },
+      },
+      execute: vi.fn().mockResolvedValue({ content: "ok" }),
+    } as unknown as AnyAgentTool;
+
+    const handlers = createPluginToolsMcpHandlers([tool]);
+    const listed = await handlers.listTools();
+
+    expect(listed.tools[0]?.inputSchema).toEqual({
+      properties: { query: { type: "string" } },
+      type: "object",
+    });
+  });
+
+  it("quarantines plugin MCP schemas that fail the MCP tool schema contract", async () => {
+    const invalid = {
+      name: "invalid_properties_probe",
+      description: "Invalid properties fixture tool",
+      parameters: {
+        type: "object",
+        properties: {
+          query: "string",
+        },
+      },
+      execute: vi.fn().mockResolvedValue({ content: "invalid" }),
+    } as unknown as AnyAgentTool;
+    const healthy = {
+      name: "healthy_probe",
+      description: "Healthy fixture tool",
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn().mockResolvedValue({ content: "healthy" }),
+    } as unknown as AnyAgentTool;
+
+    const handlers = createPluginToolsMcpHandlers([invalid, healthy]);
+    const listed = await handlers.listTools();
+
+    expect(listed.tools.map((tool) => tool.name)).toEqual(["healthy_probe"]);
+    const quarantined = await handlers.callTool({
+      name: "invalid_properties_probe",
+      arguments: {},
+    });
+    expect(quarantined).toEqual({
+      content: [{ type: "text", text: "Unknown tool: invalid_properties_probe" }],
+      isError: true,
+    });
+  });
+
+  it("quarantines plugin tools with runtime-incompatible MCP schemas", async () => {
+    const healthy = {
+      name: "healthy_probe",
+      description: "Healthy fixture tool",
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn().mockResolvedValue({ content: "healthy" }),
+    } as unknown as AnyAgentTool;
+    const incompatible = {
+      name: "neutral_probe",
+      description: "Neutral fixture tool",
+      parameters: {
+        type: "object",
+        properties: {
+          target: { $dynamicRef: "#target" },
+        },
+      },
+      execute: vi.fn().mockResolvedValue({ content: "unreachable" }),
+    } as unknown as AnyAgentTool;
+
+    const handlers = createPluginToolsMcpHandlers([incompatible, healthy]);
+    const listed = await handlers.listTools();
+
+    expect(listed.tools.map((tool) => tool.name)).toEqual(["healthy_probe"]);
+    const quarantined = await handlers.callTool({
+      name: "neutral_probe",
+      arguments: {},
+    });
+    expect(quarantined).toEqual({
+      content: [{ type: "text", text: "Unknown tool: neutral_probe" }],
+      isError: true,
+    });
+  });
+
   it("serializes plugin tool results that do not use the MCP content envelope", async () => {
     const execute = vi.fn().mockResolvedValue({
       provider: "kitchen-sink-search",


### PR DESCRIPTION
## Summary

- Hardens the standalone plugin tools MCP bridge so `tools/list` no longer reads plugin `parameters` through brittle object operators.
- Materializes plugin MCP tool descriptors through the existing runtime schema projection, then validates the listed descriptor against the MCP SDK `ToolSchema` contract before exposing it.
- Quarantines incompatible plugin tools from both `listTools` and `callTool`, preserving healthy sibling tools instead of letting one bad schema poison the bridge.
- Intentionally scoped to the standalone plugin tools MCP bridge; broader agent/runtime projection behavior is unchanged.

## Linked context

Closes #

Related #

Requested by maintainer fuzzing of unsupported runtime/tool schema surfaces.

## Real behavior proof (required for external PRs)

- Behavior addressed: a plugin tool whose schema proxy throws from an object-operator trap could crash standalone plugin MCP `tools/list`; unsupported or MCP-invalid schemas could also reach the MCP client surface.
- Real environment tested: local macOS source worktree for focused repro/tests; AWS Crabbox Linux `c7a.8xlarge` for `pnpm check:changed`.
- Exact steps or command run after this patch: `node --import tsx - <<'EOF' ... createPluginToolsMcpHandlers([...proxy parameters...]).listTools() ... EOF`; `node scripts/run-vitest.mjs src/mcp/plugin-tools-serve.test.ts --reporter=dot`; `node_modules/.bin/oxlint src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`; `node_modules/.bin/oxfmt --check src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`; `git diff --check HEAD~1..HEAD`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`.
- Evidence after fix: direct repro printed `{"tools":[{"name":"neutral_probe","description":"neutral fixture tool","inputSchema":{"type":"object","properties":{}}}]}` instead of `schema has trap`; focused Vitest passed 11 tests; AWS Crabbox run `run_402eeadac372`, lease `cbx_3620011b36ee`, exited 0 and stopped cleanly.
- Observed result after fix: proxy-backed valid schemas list successfully, implicit object roots are normalized to MCP-valid `type: "object"`, MCP-invalid `properties` maps are quarantined, `$dynamicRef` runtime-incompatible schemas are quarantined, and healthy sibling tools remain listed/callable.
- What was not tested: a live external plugin process over stdio; this patch is covered at the handler level and by the changed core/type/lint gate.
- Proof limitations or environment constraints: Blacksmith Testbox was unavailable locally due `not authenticated`; an Azure Crabbox attempt timed out before allocation (`run_44d5738f9856`, late-id hint `cbx_51573b3230fd` not present in the later Azure list), so the broad changed gate used direct AWS Crabbox instead.
- Before evidence: the pre-fix direct repro threw `schema has trap` from `tools/list` when `parameters` was a proxy with a throwing `has` trap for `type`.

## Tests and validation

- `node --import tsx - <<'EOF' ... createPluginToolsMcpHandlers([...proxy parameters...]).listTools() ... EOF`
- `node scripts/run-vitest.mjs src/mcp/plugin-tools-serve.test.ts --reporter=dot`
- `node_modules/.bin/oxlint src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`
- `node_modules/.bin/oxfmt --check src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`
- `git diff --check HEAD~1..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` after fixes: clean, no accepted/actionable findings
- AWS Crabbox `run_402eeadac372` / `cbx_3620011b36ee`: `pnpm check:changed` passed

Regression coverage added for proxy-safe schema listing, implicit object-root normalization, MCP `ToolSchema` contract quarantine, and runtime-incompatible dynamic schema quarantine.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Standalone plugin MCP clients will no longer see tools with unsupported or MCP-invalid input schemas.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, narrowly: tool execution routing now only includes tools that were valid enough to list through the MCP bridge.

What is the highest-risk area?

A plugin with a malformed schema that previously appeared in `tools/list` will now be omitted until the plugin fixes its schema.

How is that risk mitigated?

Invalid tools are logged as quarantined, healthy siblings remain available, and the same materialized tool set is used for both listing and calling so clients do not see a tool that the bridge cannot safely represent.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI. No author-side blocker remains.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before PR creation: missing MCP root `type` normalization and MCP-invalid `properties` validation.
