### PR TITLE
fix(tui): block unsupported local slash commands

### DIFF
--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -76,6 +76,33 @@ describe("getSlashCommands", () => {
     expect(completions?.length).toBeGreaterThan(0);
   });
 
+  it("drops unsupported shared commands from local autocomplete (#71592)", () => {
+    const localNames = new Set(getSlashCommands({ local: true }).map((command) => command.name));
+    const gatewayNames = new Set(getSlashCommands({ local: false }).map((command) => command.name));
+
+    for (const name of [
+      "status",
+      "compact",
+      "commands",
+      "tools",
+      "whoami",
+      "id",
+      "v",
+      "thinking",
+    ]) {
+      expect(localNames.has(name)).toBe(false);
+      expect(gatewayNames.has(name)).toBe(true);
+    }
+  });
+
+  it("keeps supported routed shared commands in local autocomplete (#71592)", () => {
+    const localNames = new Set(getSlashCommands({ local: true }).map((command) => command.name));
+
+    for (const name of ["context", "goal", "stop", "btw", "side", "verbose", "think"]) {
+      expect(localNames.has(name)).toBe(true);
+    }
+  });
+
   it("merges dynamic gateway commands", () => {
     const commands = getSlashCommands({
       dynamicCommands: [
@@ -104,5 +131,17 @@ describe("helpText", () => {
     expect(output).toContain("/gateway-status");
     expect(output).toContain("/gwstatus");
     expect(output).toContain("/crestodian [request]");
+  });
+
+  it("lists /commands and /status only outside local mode (#71592)", () => {
+    const gatewayLines = helpText({ local: false }).split("\n");
+    expect(gatewayLines).toContain("/commands");
+    expect(gatewayLines).toContain("/status");
+
+    const localLines = helpText({ local: true }).split("\n");
+    expect(localLines).not.toContain("/commands");
+    expect(localLines).not.toContain("/status");
+    expect(localLines).toContain("/help");
+    expect(localLines).toContain("/gateway-status");
   });
 });

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -32,6 +32,80 @@ const COMMAND_ALIASES: Record<string, string> = {
   gwstatus: "gateway-status",
 };
 
+// Shared/gateway command names the local embedded TUI actually executes.
+// Local TUI bypasses gateway `chat.send` command recovery, so any advertised
+// shared command outside this set has no local handler and must not be
+// advertised or routed to the model as user text (#71592). Keep this aligned
+// with the `handleCommand` switch in `tui-command-handlers.ts`.
+const LOCAL_SUPPORTED_SHARED_COMMANDS = new Set<string>([
+  "help",
+  "agents",
+  "context",
+  "goal",
+  "crestodian",
+  "session",
+  "model",
+  "models",
+  "think",
+  "verbose",
+  "trace",
+  "fast",
+  "reasoning",
+  "usage",
+  "elevated",
+  "activation",
+  "new",
+  "reset",
+  "stop",
+  // Routed through sendMessage's btw/side detection, not the model turn path.
+  "btw",
+  "side",
+]);
+
+export function localTuiSupportsSharedCommand(name: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(name).replace(/^\//, "").trim();
+  const canonical = COMMAND_ALIASES[normalized] ?? normalized;
+  return LOCAL_SUPPORTED_SHARED_COMMANDS.has(canonical);
+}
+
+let cachedSharedCommandNames: Set<string> | null = null;
+
+function sharedCommandNames(): Set<string> {
+  // Registry is process-stable for built-in commands; cache the advertised
+  // name set so interception does not rebuild it on every keystroke.
+  if (cachedSharedCommandNames) {
+    return cachedSharedCommandNames;
+  }
+  const names = new Set<string>();
+  for (const command of listChatCommands()) {
+    names.add(command.key);
+    const aliases = command.textAliases.length > 0 ? command.textAliases : [`/${command.key}`];
+    for (const alias of aliases) {
+      names.add(normalizeSlashCommandName(alias));
+    }
+  }
+  cachedSharedCommandNames = names;
+  return names;
+}
+
+// True when a parsed command name is advertised through the shared command
+// registry but has no local TUI handler. Local embedded mode must answer these
+// with an explicit unsupported response instead of sending them to the model
+// as user text (#71592). Truly unknown commands stay out so they keep their
+// existing fallthrough behavior.
+export function isUnsupportedLocalSharedCommand(name: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(name).replace(/^\//, "").trim();
+  if (!normalized) {
+    return false;
+  }
+  const canonical = COMMAND_ALIASES[normalized] ?? normalized;
+  if (localTuiSupportsSharedCommand(canonical)) {
+    return false;
+  }
+  const advertised = sharedCommandNames();
+  return advertised.has(canonical) || advertised.has(normalized);
+}
+
 function createLevelCompletion(
   levels: string[],
 ): NonNullable<SlashCommand["getArgumentCompletions"]> {
@@ -162,6 +236,14 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
   for (const command of gatewayCommands) {
     const aliases = command.textAliases.length > 0 ? command.textAliases : [`/${command.key}`];
     for (const alias of aliases) {
+      // Local embedded TUI routes by the parsed alias name and has no handler
+      // for shared commands outside its supported set, so do not advertise them
+      // in local autocomplete (#71592). Each alias is checked independently
+      // because supported parents (e.g. /verbose) can carry aliases (/v) the
+      // local switch does not resolve.
+      if (options.local && !localTuiSupportsSharedCommand(normalizeSlashCommandName(alias))) {
+        continue;
+      }
       appendSlashCommand(commands, seen, alias, command.description);
     }
   }
@@ -181,8 +263,9 @@ export function helpText(options: SlashCommandOptions = {}): string {
   return [
     "Slash commands:",
     "/help",
-    "/commands",
-    "/status",
+    // /commands and /status are shared commands the local embedded TUI cannot
+    // execute, so they are only advertised when connected to the gateway (#71592).
+    ...(options.local ? [] : ["/commands", "/status"]),
     "/gateway-status",
     "/gwstatus",
     ...(options.local ? ["/auth [provider]"] : []),

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -479,6 +479,86 @@ describe("tui command handlers", () => {
     });
   });
 
+  it.each(["status", "compact", "commands", "tools", "whoami", "id"])(
+    "keeps unsupported local /%s out of the embedded model path",
+    async (name) => {
+      const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+        opts: { local: true },
+      });
+
+      await handleCommand(`/${name}`);
+
+      expect(sendChat).not.toHaveBeenCalled();
+      expect(addUser).not.toHaveBeenCalled();
+      expect(addSystem).toHaveBeenCalledWith(
+        `local embedded TUI mode does not support /${name}; message not sent`,
+      );
+    },
+  );
+
+  it.each(["status", "compact", "commands", "tools", "whoami"])(
+    "still forwards /%s to the gateway when not in local mode",
+    async (name) => {
+      const { handleCommand, sendChat, addUser, addSystem } = createHarness();
+
+      await handleCommand(`/${name}`);
+
+      expect(addSystem).not.toHaveBeenCalled();
+      expect(addUser).toHaveBeenCalledWith(`/${name}`);
+      expectSendChatFields(sendChat, {
+        sessionKey: "agent:main:main",
+        message: `/${name}`,
+      });
+    },
+  );
+
+  it("does not intercept supported local commands routed through the model path", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/context detail");
+
+    expect(addSystem).not.toHaveBeenCalledWith(
+      "local embedded TUI mode does not support /context; message not sent",
+    );
+    expect(addUser).toHaveBeenCalledWith("/context detail");
+    expectSendChatFields(sendChat, {
+      sessionKey: "agent:main:main",
+      message: "/context detail",
+    });
+  });
+
+  it("does not intercept /btw in local mode", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/btw note this");
+
+    expect(addSystem).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expectSendChatFields(sendChat, {
+      sessionKey: "agent:main:main",
+      message: "/btw note this",
+    });
+  });
+
+  it("still forwards unknown non-advertised slash commands in local mode", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/unregistered-command");
+
+    expect(addSystem).not.toHaveBeenCalled();
+    expect(addUser).toHaveBeenCalledWith("/unregistered-command");
+    expectSendChatFields(sendChat, {
+      sessionKey: "agent:main:main",
+      message: "/unregistered-command",
+    });
+  });
+
   it("keeps gateway diagnostics on /gateway-status", async () => {
     const { handleCommand, getGatewayStatus, addSystem, addUser, sendChat } = createHarness({
       getGatewayStatus: vi.fn().mockResolvedValue({

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -16,7 +16,7 @@ import {
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
 import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { helpText, parseCommand } from "./commands.js";
+import { helpText, isUnsupportedLocalSharedCommand, parseCommand } from "./commands.js";
 import type { ChatLog } from "./components/chat-log.js";
 import {
   createFilterableSelectList,
@@ -76,6 +76,10 @@ function isBtwCommand(text: string): boolean {
 function isSlashStopCommand(text: string): boolean {
   const trimmed = text.trim();
   return trimmed.startsWith("/") && isChatStopCommandText(trimmed);
+}
+
+function formatUnsupportedLocalSharedCommand(name: string): string {
+  return `local embedded TUI mode does not support /${name}; message not sent`;
 }
 
 function goalContinuationPrompt(text: string): string | null {
@@ -698,6 +702,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         requestExit();
         break;
       default:
+        // Local embedded mode bypasses gateway command recovery, so advertised
+        // shared commands with no local handler would otherwise become model
+        // turns. Answer them explicitly instead of sending them (#71592).
+        if (opts.local === true && isUnsupportedLocalSharedCommand(name)) {
+          chatLog.addSystem(formatUnsupportedLocalSharedCommand(name));
+          break;
+        }
         await sendMessage(raw);
         break;
     }

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -318,4 +318,44 @@ describe("TUI PTY local mode", () => {
     },
     LOCAL_TEST_TIMEOUT_MS,
   );
+
+  it(
+    "answers unsupported shared slash commands without a model turn (#71592)",
+    async () => {
+      const fixture = await startLocalModeTui();
+      try {
+        await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+
+        for (const name of ["status", "compact", "commands"]) {
+          await fixture.run.write(`/${name}\r`, { delay: false });
+          await fixture.run.waitForOutput(
+            `local embedded TUI mode does not support /${name}; message not sent`,
+          );
+        }
+
+        // The blocked commands must not reach the local embedded model path:
+        // no /v1/responses request, no optimistic user turn.
+        expect(fixture.mockModel.requests()).toEqual([]);
+        expect(fixture.run.output()).not.toContain("LOCAL_PTY_RESPONSE");
+
+        // Positive control: a normal message still drives the real model path.
+        await fixture.run.write("hello from the smoke\r");
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length > 0 ? true : null),
+          onTimeout: () =>
+            new Error(`mock model server did not receive a request\n${fixture.run.output()}`),
+        });
+        expect(fixture.mockModel.requests()[0]?.path).toBe("/v1/responses");
+        await fixture.run.waitForOutput("LOCAL_PTY_RESPONSE");
+
+        await fixture.run.write("/exit\r", { delay: false });
+        const exit = await fixture.run.waitForExit();
+        expect(exit.exitCode).toBe(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary
- Local embedded TUI bypasses the gateway `chat.send` command-recovery path (`EmbeddedTuiBackend.sendChat` runs `agentCommandFromIngress` directly), so every advertised shared slash command that the TUI has no local handler for would fall through to `sendMessage(raw)` and become a model/user turn.
- Block **all** advertised-but-unimplemented shared commands in local mode (not just `/status` and `/compact`): `handleCommand`'s `default` branch now answers them with an explicit unsupported-mode system response instead of sending them to the model.
- Stop advertising those commands in local mode: `getSlashCommands({ local: true })` no longer appends unsupported shared commands/aliases to autocomplete, and `helpText({ local: true })` drops `/commands` and `/status`.
- Locally-supported routed commands (`/context`, `/goal`, `/stop`, `/btw`, `/side`, `/verbose`, `/think`, ...) and plain messages are unaffected; gateway (non-local) mode keeps forwarding every command unchanged.

Fixes #71592

## Real behavior proof

**Behavior addressed:** In `openclaw tui --local`, advertised shared slash commands with no local TUI handler (`/status`, `/compact`, `/commands`, `/tools`, `/whoami`, `/id`, and the rest of the shared registry) no longer create a user/model turn. They render an explicit "not supported in local mode" system line and are dropped from local autocomplete/help, while normal messages and locally-handled commands still work.

**Real environment tested:** Real `openclaw tui --local` driven in a PTY (`@lydell/node-pty`) via the repo's local TUI smoke lane, with only the external model HTTP endpoint mocked (the real local embedded backend boots and runs). Linux, Node 22. PR head `14b1ba0593627237bb86c2e18bc0dbb74c211195`, rebased on `origin/main` `5bd8dbd0b89a6addad7d6ff1cce0897d4c80a3f6`. Plus focused Vitest unit coverage for the interception, autocomplete, and help-text layers.

**Exact steps or command run after this patch:**
```
# Real local TUI PTY smoke (only the model endpoint is mocked):
OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 \
  node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts \
  src/tui/tui-pty-local.e2e.test.ts --reporter=default --testTimeout=150000

# Focused unit lanes:
node scripts/run-vitest.mjs run src/tui/commands.test.ts \
  src/tui/tui-command-handlers.test.ts src/tui/tui.test.ts --reporter=dot
```
The PTY test types `/status`, `/compact`, `/commands` into the live local TUI, asserts the unsupported text appears, asserts `mockModel.requests()` is empty (no `/v1/responses`, no user/model turn), then sends a normal message as a positive control and asserts the real model path still fires.

**Evidence after fix:** Redacted visible terminal output captured from the real local TUI PTY session:
```
 local ready | idle
 local embedded TUI mode does not support /status; message not sent
 local embedded TUI mode does not support /compact; message not sent
 local embedded TUI mode does not support /commands; message not sent
 streaming 0s | local ready
LOCAL_PTY_RESPONSE
```

**Observed result after fix:**
```
 ✓ |tui-pty| src/tui/tui-pty-local.e2e.test.ts (2 tests) 228253ms
     ✓ drives the real local backend with a mocked model endpoint  116077ms
     ✓ answers unsupported shared slash commands without a model turn (#71592)  112172ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```
```
 Test Files  3 passed (3)
      Tests  136 passed (136)   # src/tui/commands.test.ts + tui-command-handlers.test.ts + tui.test.ts
```
In the PTY run the mock model server received zero requests during the three blocked commands (`mockModel.requests()` empty) and exactly one request for the positive-control message, proving the blocked commands never start a local embedded run.

**What was not tested:** No human-interactive full-screen session and no real cloud provider call (the model endpoint is mocked per the repo's `tui --local` smoke lane); gateway-connected mode was exercised only through unit tests, not a live gateway. Provider auth, streaming against a real model, and non-Linux terminals were not exercised.

## Validation
- `oxfmt --check` and `oxlint` clean on all changed files.
- `tsgo:core` typecheck clean.
- `git diff --check` clean.

