### PR TITLE
fix(agent-core): skip unreadable tool names

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1,7 +1,17 @@
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import { createAssistantMessageEventStream } from "../../llm-core/src/index.js";
 import { agentLoop, agentLoopContinue } from "./agent-loop.js";
 import type { Message, Model } from "./llm.js";
-import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, StreamFn } from "./types.js";
+import type {
+  AgentContext,
+  AgentEvent,
+  AgentLoopConfig,
+  AgentMessage,
+  AgentTool,
+  AgentToolCall,
+  StreamFn,
+} from "./types.js";
 
 const model: Model = {
   id: "test-model",
@@ -25,6 +35,15 @@ const failingStreamFn: StreamFn = async () => {
   throw new Error("provider exploded");
 };
 
+const usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
 async function collectEvents(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   const events: AgentEvent[] = [];
   for await (const event of stream) {
@@ -41,6 +60,57 @@ function expectTerminalFailure(events: AgentEvent[], result: AgentMessage[]): vo
     stopReason: "error",
     errorMessage: "provider exploded",
   });
+}
+
+function toolCallStreamFn(toolCalls: AgentToolCall[]): StreamFn {
+  let streamCalls = 0;
+  return () => {
+    streamCalls += 1;
+    const stream = createAssistantMessageEventStream();
+    queueMicrotask(() => {
+      const message = {
+        role: "assistant",
+        content:
+          streamCalls === 1
+            ? toolCalls
+            : [
+                {
+                  type: "text",
+                  text: "done",
+                },
+              ],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage,
+        stopReason: streamCalls === 1 ? "toolUse" : "stop",
+        timestamp: streamCalls === 1 ? 2 : 4,
+      } satisfies AgentMessage;
+      stream.push({
+        type: "done",
+        reason: streamCalls === 1 ? "toolUse" : "stop",
+        message,
+      });
+    });
+    return stream;
+  };
+}
+
+async function runToolLoop(
+  tools: AgentTool[],
+  toolCalls: AgentToolCall[],
+): Promise<{ events: AgentEvent[]; result: AgentMessage[] }> {
+  const stream = agentLoop(
+    [{ role: "user", content: "hello", timestamp: 1 }],
+    { systemPrompt: "", messages: [], tools },
+    config,
+    undefined,
+    toolCallStreamFn(toolCalls),
+  );
+  return {
+    events: await collectEvents(stream),
+    result: await stream.result(),
+  };
 }
 
 describe("agentLoop EventStream failures", () => {
@@ -70,5 +140,95 @@ describe("agentLoop EventStream failures", () => {
     const result = await stream.result();
 
     expectTerminalFailure(events, result);
+  });
+});
+
+describe("agentLoop tool-call preparation", () => {
+  it("executes a healthy tool when an unreadable sibling tool name is present", async () => {
+    const unreadableTool = {
+      get name() {
+        throw new Error("tool name getter exploded");
+      },
+      label: "Unreadable",
+      description: "Unreadable sibling",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "bad" }],
+        details: undefined,
+      }),
+    } as unknown as AgentTool;
+    const healthyTool = {
+      name: "healthy_probe",
+      label: "Healthy probe",
+      description: "Healthy sibling",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        details: undefined,
+      }),
+    } satisfies AgentTool;
+    const { events, result } = await runToolLoop(
+      [unreadableTool, healthyTool],
+      [{ type: "toolCall", id: "call-1", name: "healthy_probe", arguments: {} }],
+    );
+
+    expect(result.find((message) => message.role === "toolResult")).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "healthy_probe",
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    });
+    expect(result.at(-1)).toMatchObject({
+      role: "assistant",
+      stopReason: "stop",
+    });
+    expect(events.map((event) => event.type)).toContain("tool_execution_end");
+  });
+
+  it("uses sequential execution when a matching tool execution mode is unreadable", async () => {
+    const executionOrder: string[] = [];
+    const guardedTool = {
+      name: "guarded_probe",
+      label: "Guarded probe",
+      description: "Sequential fallback probe",
+      get executionMode() {
+        throw new Error("execution mode getter exploded");
+      },
+      parameters: Type.Object({}),
+      execute: async () => {
+        executionOrder.push("guarded:start");
+        await Promise.resolve();
+        executionOrder.push("guarded:end");
+        return {
+          content: [{ type: "text", text: "guarded" }],
+          details: undefined,
+        };
+      },
+    } satisfies AgentTool;
+    const plainTool = {
+      name: "plain_probe",
+      label: "Plain probe",
+      description: "Parallel-capable sibling",
+      parameters: Type.Object({}),
+      execute: async () => {
+        executionOrder.push("plain:start");
+        executionOrder.push("plain:end");
+        return {
+          content: [{ type: "text", text: "plain" }],
+          details: undefined,
+        };
+      },
+    } satisfies AgentTool;
+
+    await runToolLoop(
+      [guardedTool, plainTool],
+      [
+        { type: "toolCall", id: "call-1", name: "guarded_probe", arguments: {} },
+        { type: "toolCall", id: "call-2", name: "plain_probe", arguments: {} },
+      ],
+    );
+
+    expect(executionOrder).toEqual(["guarded:start", "guarded:end", "plain:start", "plain:end"]);
   });
 });

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -17,6 +17,7 @@ import type {
   AgentTool,
   AgentToolCall,
   AgentToolResult,
+  ToolExecutionMode,
   StreamFn,
 } from "./types.js";
 import { validateToolArguments } from "./validation.js";
@@ -453,7 +454,7 @@ async function executeToolCalls(
 ): Promise<ExecutedToolCallBatch> {
   const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
   const hasSequentialToolCall = toolCalls.some(
-    (tc) => currentContext.tools?.find((t) => t.name === tc.name)?.executionMode === "sequential",
+    (tc) => readToolExecutionMode(findToolByName(currentContext.tools, tc.name)) === "sequential",
   );
   if (config.toolExecution === "sequential" || hasSequentialToolCall) {
     return executeToolCallsSequential(
@@ -662,6 +663,33 @@ function prepareToolCallArguments(tool: AgentTool, toolCall: AgentToolCall): Age
   };
 }
 
+function findToolByName(
+  tools: readonly AgentTool[] | undefined,
+  name: string,
+): AgentTool | undefined {
+  for (const tool of tools ?? []) {
+    try {
+      if (tool.name === name) {
+        return tool;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+function readToolExecutionMode(tool: AgentTool | undefined): ToolExecutionMode | undefined {
+  if (!tool) {
+    return undefined;
+  }
+  try {
+    return tool.executionMode;
+  } catch {
+    return "sequential";
+  }
+}
+
 async function prepareToolCall(
   currentContext: AgentContext,
   assistantMessage: AssistantMessage,
@@ -669,7 +697,7 @@ async function prepareToolCall(
   config: AgentLoopConfig,
   signal: AbortSignal | undefined,
 ): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
-  const tool = currentContext.tools?.find((t) => t.name === toolCall.name);
+  const tool = findToolByName(currentContext.tools, toolCall.name);
   if (!tool) {
     return {
       kind: "immediate",

--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Tool } from "./types.js";
-import { validateToolArguments } from "./validation.js";
+import { validateToolArguments, validateToolCall } from "./validation.js";
 
 const decimalTool = {
   name: "decimal-tool",
@@ -37,5 +37,24 @@ describe("validateToolArguments", () => {
         arguments: { amount: "0x10", count: "0b10" },
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
+  });
+
+  it("skips unreadable sibling tool names when resolving a tool call", () => {
+    const unreadableTool = {
+      get name() {
+        throw new Error("tool name getter exploded");
+      },
+      description: "unreadable sibling",
+      parameters: { type: "object", properties: {} },
+    } as unknown as Tool;
+
+    expect(
+      validateToolCall([unreadableTool, decimalTool], {
+        type: "toolCall",
+        id: "call-1",
+        name: "decimal-tool",
+        arguments: { amount: "1e3", count: "+3" },
+      }),
+    ).toEqual({ amount: 1000, count: 3 });
   });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -281,9 +281,22 @@ function formatValidationPath(error: TLocalizedValidationError): string {
   return path || "root";
 }
 
+function findToolByName(tools: readonly Tool[], name: string): Tool | undefined {
+  for (const tool of tools) {
+    try {
+      if (tool.name === name) {
+        return tool;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
 /** Finds the target tool and validates/coerces a model-emitted tool call. */
 export function validateToolCall(tools: Tool[], toolCall: ToolCall): unknown {
-  const tool = tools.find((t) => t.name === toolCall.name);
+  const tool = findToolByName(tools, toolCall.name);
   if (!tool) {
     throw new Error(`Tool "${toolCall.name}" not found`);
   }


### PR DESCRIPTION
## Summary

- guard tool-name lookup in agent-core tool execution and llm-core validation so unreadable sibling tool names do not abort healthy tool calls
- preserve the per-tool sequential safety contract by treating unreadable `executionMode` on a matched tool as sequential
- add regression coverage for healthy tool execution, llm-core validation, and the sequential fallback path

## Verification

- `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts packages/llm-core/src/validation.test.ts --reporter=dot`
- `node_modules/.bin/oxlint packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent-loop.test.ts packages/llm-core/src/validation.ts packages/llm-core/src/validation.test.ts`
- `git diff --check HEAD~1..HEAD`
- direct `node --import tsx` repro: unreadable sibling `name` getter no longer blocks `healthy_probe`; observed tool result text `ok`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: model-emitted tool calls can execute the requested healthy tool even when another registered tool has an unreadable `name` accessor; unreadable `executionMode` on the matched tool fails closed to sequential execution.

Real environment tested: local OpenClaw worktree on Node/Vitest via repo wrappers; remote changed-gate proof attempted via Testbox and AWS Crabbox.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts packages/llm-core/src/validation.test.ts --reporter=dot`; direct `node --import tsx` repro invoking `runAgentLoop`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`; retry with `--debug`.

Evidence after fix: focused tests passed, 2 files / 7 tests; direct repro printed `ok`; oxlint and diff check passed; autoreview reported no accepted/actionable findings.

Observed result after fix: the healthy requested tool returns a non-error `toolResult`; the sequential fallback regression test proves the guarded tool finishes before its sibling starts.

What was not tested: `pnpm check:changed` did not complete remotely. Blacksmith Testbox was not authenticated and the non-interactive auth path opened an interactive browser flow. AWS Crabbox first failed before usable proof with coordinator HTTP 500 (`Durable Object's isolate exceeded its memory limit and was reset`), then the debug retry failed with HTTP 429 `cost_limit_exceeded` / active lease limit exceeded.
