### PR TITLE
fix(codex): quarantine unreadable dynamic tools

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -371,6 +371,35 @@ describe("createCodexDynamicToolBridge", () => {
     expect(badExecute).not.toHaveBeenCalled();
   });
 
+  it("quarantines dynamic tools whose schema accessors throw", () => {
+    const badExecute = vi.fn();
+    const badTool = {
+      name: "fuzzplugin_move_angles",
+      description: "Broken dynamic tool",
+      get parameters() {
+        throw new Error("parameters getter exploded");
+      },
+      execute: badExecute,
+    } as unknown as AnyAgentTool;
+
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createTool({ name: "message" }), badTool],
+      signal: new AbortController().signal,
+    });
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.specs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.telemetry.quarantinedTools).toEqual([
+      {
+        tool: "fuzzplugin_move_angles",
+        violations: [
+          "fuzzplugin_move_angles.inputSchema could not be read: parameters getter exploded",
+        ],
+      },
+    ]);
+    expect(badExecute).not.toHaveBeenCalled();
+  });
+
   it("can expose all dynamic tools directly for compatibility", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [createTool({ name: "web_search" }), createTool({ name: "message" })],

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -51,6 +51,8 @@ type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
 
 type ProjectedCodexDynamicTool = {
   tool: AnyAgentTool;
+  name: string;
+  description: string;
   inputSchema: JsonValue;
 };
 
@@ -86,6 +88,7 @@ export const CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE = "openclaw";
 // spawn_agent remains the primary Codex subagent surface.
 const ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES = new Set(["sessions_yield"]);
 const DEFAULT_CODEX_DYNAMIC_TOOL_RESULT_MAX_CHARS = 16_000;
+const UNREADABLE_DYNAMIC_TOOL_NAME = "<unreadable dynamic tool name>";
 
 export function createCodexDynamicToolBridge(params: {
   tools: AnyAgentTool[];
@@ -101,19 +104,19 @@ export function createCodexDynamicToolBridge(params: {
   const registeredProjection = params.registeredTools
     ? projectCodexDynamicTools(params.registeredTools)
     : availableProjection;
-  const availableTools = availableProjection.tools.map(({ tool, inputSchema }) => {
+  const availableTools = availableProjection.tools.map((projectedTool) => {
+    const { tool } = projectedTool;
     if (isToolWrappedWithBeforeToolCallHook(tool)) {
       setBeforeToolCallDiagnosticsEnabled(tool, false);
-      return { tool, inputSchema };
+      return projectedTool;
     }
     return {
+      ...projectedTool,
       tool: wrapToolWithBeforeToolCallHook(tool, params.hookContext, { emitDiagnostics: false }),
-      inputSchema,
     };
   });
-  const toolMap = new Map(availableTools.map(({ tool }) => [tool.name, tool]));
-  const registeredTools = registeredProjection.tools.map(({ tool }) => tool);
-  const registeredToolNames = new Set(registeredTools.map((tool) => tool.name));
+  const toolMap = new Map(availableTools.map((tool) => [tool.name, tool]));
+  const registeredToolNames = new Set(registeredProjection.tools.map((tool) => tool.name));
   const quarantinedTools = dedupeQuarantinedDynamicTools([
     ...availableProjection.quarantinedTools,
     ...registeredProjection.quarantinedTools,
@@ -142,26 +145,28 @@ export function createCodexDynamicToolBridge(params: {
   ]);
 
   return {
-    availableSpecs: availableTools.map(({ tool, inputSchema }) =>
+    availableSpecs: availableTools.map((tool) =>
       createCodexDynamicToolSpec({
-        tool,
-        inputSchema,
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
         loading: params.loading ?? "searchable",
         directToolNames,
       }),
     ),
-    specs: registeredProjection.tools.map(({ tool, inputSchema }) =>
+    specs: registeredProjection.tools.map((tool) =>
       createCodexDynamicToolSpec({
-        tool,
-        inputSchema,
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
         loading: params.loading ?? "searchable",
         directToolNames,
       }),
     ),
     telemetry,
     handleToolCall: async (call, options) => {
-      const tool = toolMap.get(call.tool);
-      if (!tool) {
+      const toolEntry = toolMap.get(call.tool);
+      if (!toolEntry) {
         if (registeredToolNames.has(call.tool)) {
           return {
             contentItems: [
@@ -178,6 +183,7 @@ export function createCodexDynamicToolBridge(params: {
           success: false,
         };
       }
+      const { tool, name: toolName } = toolEntry;
       const args = jsonObjectToRecord(call.arguments);
       const startedAt = Date.now();
       const signal = composeAbortSignals(params.signal, options?.signal);
@@ -191,7 +197,7 @@ export function createCodexDynamicToolBridge(params: {
           threadId: call.threadId,
           turnId: call.turnId,
           toolCallId: call.callId,
-          toolName: tool.name,
+          toolName,
           args,
           isError: rawIsError,
           result: rawResult,
@@ -200,13 +206,13 @@ export function createCodexDynamicToolBridge(params: {
           threadId: call.threadId,
           turnId: call.turnId,
           toolCallId: call.callId,
-          toolName: tool.name,
+          toolName,
           args,
           result: middlewareResult,
         });
         const resultIsError = rawIsError || isToolResultError(result);
         collectToolTelemetry({
-          toolName: tool.name,
+          toolName,
           args,
           result,
           mediaTrustResult: rawResult,
@@ -214,7 +220,7 @@ export function createCodexDynamicToolBridge(params: {
           isError: resultIsError,
         });
         void runAgentHarnessAfterToolCallHook({
-          toolName: tool.name,
+          toolName,
           toolCallId: call.callId,
           runId: toolResultHookContext.runId,
           agentId: toolResultHookContext.agentId,
@@ -247,14 +253,14 @@ export function createCodexDynamicToolBridge(params: {
         return withSideEffectEvidence(response, terminalType !== "blocked");
       } catch (error) {
         collectToolTelemetry({
-          toolName: tool.name,
+          toolName,
           args,
           result: undefined,
           telemetry,
           isError: true,
         });
         void runAgentHarnessAfterToolCallHook({
-          toolName: tool.name,
+          toolName,
           toolCallId: call.callId,
           runId: toolResultHookContext.runId,
           agentId: toolResultHookContext.agentId,
@@ -286,17 +292,18 @@ export function createCodexDynamicToolBridge(params: {
 }
 
 function createCodexDynamicToolSpec(params: {
-  tool: AnyAgentTool;
+  name: string;
+  description: string;
   inputSchema: JsonValue;
   loading: CodexDynamicToolsLoading;
   directToolNames: ReadonlySet<string>;
 }): CodexDynamicToolSpec {
   const base = {
-    name: params.tool.name,
-    description: params.tool.description,
+    name: params.name,
+    description: params.description,
     inputSchema: params.inputSchema,
   };
-  if (params.loading === "direct" || params.directToolNames.has(params.tool.name)) {
+  if (params.loading === "direct" || params.directToolNames.has(params.name)) {
     return base;
   }
   return {
@@ -313,14 +320,90 @@ function projectCodexDynamicTools(tools: readonly AnyAgentTool[]): {
   const projectedTools: ProjectedCodexDynamicTool[] = [];
   const quarantinedTools: CodexDynamicToolSchemaQuarantine[] = [];
   for (const tool of tools) {
-    const projection = projectRuntimeToolInputSchema(tool.parameters, `${tool.name}.inputSchema`);
-    if (projection.violations.length > 0) {
-      quarantinedTools.push({ tool: tool.name, violations: projection.violations });
+    const fields = readCodexDynamicToolFields(tool);
+    if (fields.kind === "quarantined") {
+      quarantinedTools.push({
+        tool: fields.name,
+        violations: fields.violations,
+      });
       continue;
     }
-    projectedTools.push({ tool, inputSchema: projection.schema as JsonValue });
+    const projection = fields.projection;
+    if (projection.violations.length > 0) {
+      quarantinedTools.push({ tool: fields.name, violations: projection.violations });
+      continue;
+    }
+    projectedTools.push({
+      tool,
+      name: fields.name,
+      description: fields.description,
+      inputSchema: projection.schema as JsonValue,
+    });
   }
   return { tools: projectedTools, quarantinedTools };
+}
+
+type ReadCodexDynamicToolFieldsResult =
+  | {
+      kind: "projected";
+      name: string;
+      description: string;
+      projection: ReturnType<typeof projectRuntimeToolInputSchema>;
+    }
+  | {
+      kind: "quarantined";
+      name: string;
+      violations: readonly string[];
+    };
+
+function readCodexDynamicToolFields(tool: AnyAgentTool): ReadCodexDynamicToolFieldsResult {
+  let name = UNREADABLE_DYNAMIC_TOOL_NAME;
+  try {
+    name = tool.name;
+  } catch (error) {
+    return {
+      kind: "quarantined",
+      name,
+      violations: [`${name}.name could not be read: ${formatUnknownError(error)}`],
+    };
+  }
+
+  let description: string;
+  try {
+    description = tool.description;
+  } catch {
+    description = "";
+  }
+
+  let parameters: AnyAgentTool["parameters"];
+  try {
+    parameters = tool.parameters;
+  } catch (error) {
+    return {
+      kind: "quarantined",
+      name,
+      violations: [`${name}.inputSchema could not be read: ${formatUnknownError(error)}`],
+    };
+  }
+
+  try {
+    return {
+      kind: "projected",
+      name,
+      description,
+      projection: projectRuntimeToolInputSchema(parameters, `${name}.inputSchema`),
+    };
+  } catch (error) {
+    return {
+      kind: "quarantined",
+      name,
+      violations: [`${name}.inputSchema could not be projected: ${formatUnknownError(error)}`],
+    };
+  }
+}
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function warnQuarantinedDynamicTools(tools: readonly CodexDynamicToolSchemaQuarantine[]): void {


### PR DESCRIPTION
## Summary

- guard Codex dynamic-tool bridge startup against tools whose descriptor/schema accessors throw
- quarantine unreadable dynamic tools with telemetry/diagnostics instead of aborting bridge creation
- carry projected tool name/description/schema through spec creation and dispatch telemetry so valid tools do not re-read brittle accessors

## Verification

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts --reporter=dot`
- `node_modules/.bin/oxlint extensions/codex/src/app-server/dynamic-tools.ts extensions/codex/src/app-server/dynamic-tools.test.ts`
- `git diff --check HEAD~1..HEAD`
- direct `node --import tsx` repro: bad dynamic tool `parameters` getter no longer aborts `createCodexDynamicToolBridge`; observed available tool list `message` and quarantine reason `bad_dynamic_probe.inputSchema could not be read: parameters getter exploded`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: Codex dynamic-tool startup can continue with healthy tools when a plugin/runtime tool exposes an unreadable schema accessor.

Real environment tested: local OpenClaw Codex extension test lane via repo wrapper; direct `tsx` bridge-construction repro.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts --reporter=dot`; direct `node --import tsx` repro invoking `createCodexDynamicToolBridge`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: focused test passed, 1 file / 37 tests; direct repro printed `message` plus the expected quarantine reason; oxlint and diff check passed; autoreview reported no accepted/actionable findings.

Observed result after fix: the bridge exposes the healthy `message` tool and records the bad dynamic tool in `telemetry.quarantinedTools` instead of throwing during startup.

What was not tested: remote `pnpm check:changed` did not complete. Blacksmith Testbox is not authenticated in this shell. AWS Crabbox did not reach a remote lease because the wrapper needed a temporary full checkout for sync and failed locally with `No space left on device`.
