### PR TITLE
fix(sessions): prevent silent data loss when resuming corrupted header

### DIFF
--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -1,0 +1,198 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadEntriesFromFile, SessionManager } from "./session-manager.js";
+import type { SessionHeader } from "./session-manager.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-mgr-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── loadEntriesFromFile ────────────────────────────────────────────
+
+describe("loadEntriesFromFile", () => {
+  it("loads a normal file with header and messages", () => {
+    const dir = makeTempDir();
+    const file = path.join(dir, "session.jsonl");
+    fs.writeFileSync(
+      file,
+      [
+        '{"type":"session","version":2,"id":"s1","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}',
+        '{"type":"message","id":"m1","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":"hello"}}',
+        '{"type":"message","id":"r1","parentId":"m1","timestamp":"2026-01-01T00:00:02.000Z","message":{"role":"assistant","content":"hi"}}',
+      ].join("\n"),
+    );
+
+    const entries = loadEntriesFromFile(file);
+    expect(entries).toHaveLength(3);
+    expect(entries[0].type).toBe("session");
+    expect((entries[0] as SessionHeader).id).toBe("s1");
+    expect(entries[1].type).toBe("message");
+    expect(entries[2].type).toBe("message");
+  });
+
+  it("preserves messages when header line is truncated (corruption)", () => {
+    const dir = makeTempDir();
+    const file = path.join(dir, "corrupt.jsonl");
+    // Simulate a crash-partial-write: header line is truncated mid-JSON
+    fs.writeFileSync(
+      file,
+      [
+        '{"type":"session","id":"s1","ver', // ← truncated, unparseable
+        '{"type":"message","id":"m1","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":"important question"}}',
+        '{"type":"message","id":"r1","parentId":"m1","timestamp":"2026-01-01T00:00:02.000Z","message":{"role":"assistant","content":"valuable answer"}}',
+      ].join("\n"),
+    );
+
+    const entries = loadEntriesFromFile(file);
+    // 2 messages survived, no session entry
+    expect(entries).toHaveLength(2);
+    expect(entries[0].type).toBe("message");
+    expect(entries[1].type).toBe("message");
+    // Verify actual content is preserved
+    expect((entries[0] as any).message.content).toBe("important question");
+    expect((entries[1] as any).message.content).toBe("valuable answer");
+  });
+
+  it("returns empty array for an empty file", () => {
+    const dir = makeTempDir();
+    const file = path.join(dir, "empty.jsonl");
+    fs.writeFileSync(file, "");
+
+    expect(loadEntriesFromFile(file)).toEqual([]);
+  });
+
+  it("moves header to index 0 when it is not the first valid parsed entry", () => {
+    const dir = makeTempDir();
+    const file = path.join(dir, "shifted.jsonl");
+    // Garbage line first, then a valid session header, then a message
+    fs.writeFileSync(
+      file,
+      [
+        "garbage line that will not parse",
+        '{"type":"session","version":2,"id":"s4","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}',
+        '{"type":"message","id":"m2","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":"hello"}}',
+      ].join("\n"),
+    );
+
+    const entries = loadEntriesFromFile(file);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].type).toBe("session");
+    expect((entries[0] as SessionHeader).id).toBe("s4");
+    expect(entries[1].type).toBe("message");
+  });
+
+  it("skips a session entry with a missing/invalid id", () => {
+    const dir = makeTempDir();
+    const file = path.join(dir, "bad-header.jsonl");
+    fs.writeFileSync(
+      file,
+      [
+        '{"type":"session","version":2}', // no "id" field
+        '{"type":"message","id":"m1","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":"hello"}}',
+      ].join("\n"),
+    );
+
+    const entries = loadEntriesFromFile(file);
+    // The session entry is present but has no valid id, so it is not
+    // recognized as the session header — both entries are returned as-is.
+    // Callers (like setSessionFile) handle this by synthesizing a new header.
+    expect(entries).toHaveLength(2);
+    expect(entries[0].type).toBe("session");
+    expect(entries[1].type).toBe("message");
+  });
+
+  it("returns empty if the file does not exist", () => {
+    expect(loadEntriesFromFile("/nonexistent/path.jsonl")).toEqual([]);
+  });
+});
+
+// ── SessionManager recovery from corrupt header ────────────────────
+
+describe("SessionManager corrupt-header recovery", () => {
+  it("synthesizes a header and preserves messages when recovering from a corrupted session", () => {
+    const dir = makeTempDir();
+    const sessionFile = path.join(dir, "corrupt.jsonl");
+
+    // Corrupted header + two valid messages
+    fs.writeFileSync(
+      sessionFile,
+      [
+        '{"type":"session","id":"orig","ver', // truncated, unparseable
+        '{"type":"message","id":"m1","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":"important data"}}',
+        '{"type":"message","id":"r1","parentId":"m1","timestamp":"2026-01-01T00:00:02.000Z","message":{"role":"assistant","content":"also important"}}',
+      ].join("\n"),
+    );
+
+    // Use persist=false so rewriteFile is a no-op — we only verify
+    // the in-memory state after loading (header synthesis logic).
+    const mgr = new SessionManager(
+      "/tmp/test-cwd",
+      dir,
+      sessionFile,
+      false, // persist = false
+    );
+
+    // A sessionId should be assigned (synthesized, not from the corrupt file)
+    expect(mgr.sessionId).toBeDefined();
+    expect(typeof mgr.sessionId).toBe("string");
+    expect(mgr.sessionId.length).toBeGreaterThan(0);
+
+    // fileEntries[0] should be the synthesized session header
+    expect(mgr.fileEntries).toHaveLength(3);
+    expect(mgr.fileEntries[0].type).toBe("session");
+    const header = mgr.fileEntries[0] as SessionHeader;
+    expect(header.id).toBe(mgr.sessionId);
+    expect(header.type).toBe("session");
+
+    // Messages should be preserved
+    expect(mgr.fileEntries[1].type).toBe("message");
+    expect((mgr.fileEntries[1] as any).message.content).toBe("important data");
+    expect(mgr.fileEntries[2].type).toBe("message");
+    expect((mgr.fileEntries[2] as any).message.content).toBe("also important");
+  });
+
+  it("starts fresh with an empty file", () => {
+    const dir = makeTempDir();
+    const sessionFile = path.join(dir, "empty.jsonl");
+    fs.writeFileSync(sessionFile, "");
+
+    const mgr = new SessionManager("/tmp/test-cwd", dir, sessionFile, false);
+
+    // Empty file should result in a fresh session with one entry (the header)
+    expect(mgr.fileEntries).toHaveLength(1);
+    expect(mgr.fileEntries[0].type).toBe("session");
+    expect(mgr.sessionId).toBeDefined();
+  });
+
+  it("loads a normal session file correctly (no regression)", () => {
+    const dir = makeTempDir();
+    const sessionFile = path.join(dir, "normal.jsonl");
+
+    fs.writeFileSync(
+      sessionFile,
+      [
+        '{"type":"session","version":2,"id":"mysession","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}',
+        '{"type":"message","id":"m1","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":"hello"}}',
+      ].join("\n"),
+    );
+
+    const mgr = new SessionManager("/tmp/test-cwd", dir, sessionFile, false);
+
+    expect(mgr.sessionId).toBe("mysession");
+    expect(mgr.fileEntries).toHaveLength(2);
+    expect(mgr.fileEntries[0].type).toBe("session");
+    expect(mgr.fileEntries[1].type).toBe("message");
+  });
+});

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -402,13 +402,28 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
     }
   }
 
-  // Validate session header
   if (entries.length === 0) {
     return entries;
   }
-  const header = entries[0];
-  if (header.type !== "session" || typeof (header as { id?: unknown }).id !== "string") {
-    return [];
+
+  // Find a valid session header — it should be at index 0 but may not be
+  // if the original header line was corrupted and skipped during parsing.
+  const headerIndex = entries.findIndex(
+    (e) => e.type === "session" && typeof (e as SessionHeader).id === "string",
+  );
+
+  if (headerIndex === -1) {
+    // No valid session header found anywhere in the file.
+    // Return the parsed entries so callers can decide whether to
+    // synthesize a header or treat the file as empty.
+    return entries;
+  }
+
+  if (headerIndex !== 0) {
+    // A valid session header exists but not at index 0 — the original
+    // first line (header) was likely corrupted. Move it to the front.
+    const [header] = entries.splice(headerIndex, 1);
+    entries.unshift(header);
   }
 
   return entries;
@@ -722,9 +737,8 @@ export class SessionManager {
     if (existsSync(this.sessionFile)) {
       this.fileEntries = loadEntriesFromFile(this.sessionFile);
 
-      // If file was empty or corrupted (no valid header), truncate and start fresh
-      // to avoid appending messages without a session header (which breaks the session)
       if (this.fileEntries.length === 0) {
+        // File is truly empty (zero parseable lines): start fresh
         const explicitPath = this.sessionFile;
         this.newSession();
         this.sessionFile = explicitPath;
@@ -733,8 +747,30 @@ export class SessionManager {
         return;
       }
 
-      const header = this.fileEntries.find((e) => e.type === "session");
-      this.sessionId = header?.id ?? createSessionId();
+      // Look for a valid session header anywhere in the parsed entries
+      // (not just at index 0 — the original header line may have been
+      // corrupted and skipped by loadEntriesFromFile).
+      const header = this.fileEntries.find((e) => e.type === "session") as
+        | SessionHeader
+        | undefined;
+
+      if (header && typeof header.id === "string") {
+        this.sessionId = header.id;
+      } else {
+        // Valid message entries exist but no session header was found.
+        // Synthesize a new header to preserve existing messages instead
+        // of silently wiping the file (data loss fix).
+        this.sessionId = createSessionId();
+        const syntheticHeader: SessionHeader = {
+          type: "session",
+          version: CURRENT_SESSION_VERSION,
+          id: this.sessionId,
+          timestamp: new Date().toISOString(),
+          cwd: this.cwd,
+        };
+        this.fileEntries.unshift(syntheticHeader);
+        this.rewriteFile();
+      }
 
       if (migrateToCurrentVersion(this.fileEntries)) {
         this.rewriteFile();


### PR DESCRIPTION
## Problem

Resolves #89037

When a session file has a corrupted/truncated header line (e.g. due to crash, partial write, or disk full), the entire transcript is **silently wiped**. The file gets truncated to a single fresh header, losing all conversation history.

## Root Cause

Two compounding issues in `session-manager.ts`:

1. **`loadEntriesFromFile()`**: A corrupted header line fails `JSON.parse` and is silently skipped. `entries[0]` becomes the first message instead of the header. The hardcoded `entries[0]` header check then fails → `return []`, discarding all valid messages.

2. **`setSessionFile()`**: Receiving an empty array, it cannot distinguish "truly empty file" from "header corrupted but messages intact" → unconditionally calls `rewriteFile()`, truncating the file.

## Changes

### `loadEntriesFromFile()`
- Use `findIndex()` to locate a valid session header (`type === "session"` with string `id`) instead of hardcoding `entries[0]`.
- If a valid header exists but not at index 0, move it to the front via `splice` + `unshift`.
- If no valid header is found, **return the parsed entries** instead of discarding them — let callers decide how to handle the situation.

### `setSessionFile()`
- `entries.length === 0` → fresh start (unchanged, correct for truly empty files).
- Entries exist with a valid header → use its `id` (unchanged).
- **Entries exist but no valid header** → synthesize a new session header and prepend it, preserving all existing messages. This is the critical data-loss fix.

### Tests (`session-manager.test.ts` — new file)
- `loadEntriesFromFile`: 6 tests covering normal file, truncated header, empty file, header not at index 0, missing id, nonexistent file.
- `SessionManager`: 3 tests covering corrupt-header recovery (synthesizes header, preserves messages), empty file (fresh start), and normal file (no regression).
- All 18/18 passing (9 tests × 2 vitest projects).

## Edge Cases Considered

| Scenario | Behavior |
|---|---|
| Header truncated (the bug) | Messages preserved, synthetic header prepended |
| Truly empty file | Fresh start (unchanged) |
| Normal file | No change in behavior |
| Header at non-zero index (garbage line before it) | Header moved to index 0 |
| `SessionManager.open` with corrupt file | Synthesizes header via `setSessionFile` |
| `SessionManager.forkFrom` with corrupt source | Throws — refuses to fork without a valid source identity (correct) |
| Header parseable but `id` is not a string | Treated as no valid header → synthesis path |

## Not Included (Future Work)

- **Pre-rewrite backup**: Creating a `.corrupt-<ts>.jsonl` backup before overwriting. Would add defense-in-depth but is outside the scope of this data-loss fix.
- **Logging/warning**: Emitting a warning when a corrupted header is detected and repaired.