### PR TITLE
fix(codex): harden diagnostic tool capture

### DIFF
--- a/extensions/codex/src/app-server/attempt-diagnostics.test.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.test.ts
@@ -1,9 +1,180 @@
-import { describe, expect, it } from "vitest";
-import { buildCodexPluginThreadConfigEligibilityLogData } from "./attempt-diagnostics.js";
+import {
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPrivateData,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+import { onTrustedInternalDiagnosticEvent } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildCodexDiagnosticToolDefinitions,
+  buildCodexPluginThreadConfigEligibilityLogData,
+  createCodexModelCallDiagnosticEmitter,
+} from "./attempt-diagnostics.js";
 import { resolveCodexPluginsPolicy } from "./config.js";
 import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
 
 describe("Codex app-server attempt diagnostics", () => {
+  beforeEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
+  it("keeps tool definition capture from throwing on hostile descriptors", () => {
+    let nameReads = 0;
+    const nestedSchema: Record<string, unknown> = {
+      type: "object",
+      properties: {
+        stable: { type: "string" },
+      },
+    };
+    Object.defineProperty(nestedSchema.properties, "explosive", {
+      enumerable: true,
+      get() {
+        throw new Error("nested getter exploded");
+      },
+    });
+    nestedSchema.proxy = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("ownKeys exploded");
+        },
+      },
+    );
+    const hostileArray = ["ok", "bad"];
+    Object.defineProperty(hostileArray, "1", {
+      enumerable: true,
+      get() {
+        throw new Error("array item exploded");
+      },
+    });
+    nestedSchema.list = hostileArray;
+    nestedSchema.self = nestedSchema;
+    nestedSchema.alias = nestedSchema.properties;
+
+    const definitions = buildCodexDiagnosticToolDefinitions([
+      {
+        get name() {
+          nameReads += 1;
+          return "bad_diagnostic_probe";
+        },
+        description: "Broken diagnostic tool",
+        get inputSchema() {
+          throw new Error("inputSchema exploded");
+        },
+      },
+      {
+        get name() {
+          throw new Error("name exploded");
+        },
+        get description() {
+          throw new Error("description exploded");
+        },
+        parameters: { type: "object", properties: {} },
+      },
+      {
+        name: "fallback_parameters_probe",
+        description: "Uses OpenClaw parameter naming.",
+        get parameters() {
+          throw new Error("parameters exploded");
+        },
+      },
+      {
+        name: "message",
+        description: "Send a message.",
+        inputSchema: nestedSchema,
+      },
+    ] as Parameters<typeof buildCodexDiagnosticToolDefinitions>[0]);
+
+    expect(nameReads).toBe(1);
+    expect(definitions).toEqual([
+      {
+        name: "bad_diagnostic_probe",
+        description: "Broken diagnostic tool",
+        parameters: "<unreadable>",
+      },
+      {
+        name: "<unreadable diagnostic tool>",
+        description: "",
+        parameters: { type: "object", properties: {} },
+      },
+      {
+        name: "fallback_parameters_probe",
+        description: "Uses OpenClaw parameter naming.",
+        parameters: "<unreadable>",
+      },
+      {
+        name: "message",
+        description: "Send a message.",
+        parameters: {
+          type: "object",
+          properties: {
+            stable: { type: "string" },
+            explosive: "<unreadable>",
+          },
+          proxy: "<unreadable>",
+          list: ["ok", "<unreadable>"],
+          self: "<truncated>",
+          alias: "<truncated>",
+        },
+      },
+    ]);
+    expect(() => JSON.stringify(definitions)).not.toThrow();
+  });
+
+  it("emits model-call diagnostics with sanitized hostile tool definitions", async () => {
+    const trustedPrivateData: DiagnosticEventPrivateData[] = [];
+    const unsubscribe = onTrustedInternalDiagnosticEvent((event, _metadata, privateData) => {
+      if (event.type === "model.call.started") {
+        trustedPrivateData.push(privateData);
+      }
+    });
+    const tool = {
+      name: "message",
+      description: "Send a message.",
+      inputSchema: {
+        type: "object",
+        get properties() {
+          throw new Error("properties exploded");
+        },
+      },
+    };
+    try {
+      createCodexModelCallDiagnosticEmitter({
+        baseFields: {
+          runId: "run-1",
+          callId: "call-1",
+          provider: "openai",
+          model: "gpt-5.5",
+        },
+        capture: { toolDefinitions: true },
+        tools: [tool],
+        buildInputMessages: () => [],
+        buildSystemPrompt: () => undefined,
+        now: () => 0,
+      }).emitStarted();
+      await waitForDiagnosticEventsDrained();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(trustedPrivateData).toEqual([
+      {
+        modelContent: {
+          toolDefinitions: [
+            {
+              name: "message",
+              description: "Send a message.",
+              parameters: {
+                type: "object",
+                properties: "<unreadable>",
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
   it("redacts plugin thread config eligibility log data", () => {
     const appServer = {
       start: {

--- a/extensions/codex/src/app-server/attempt-diagnostics.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.ts
@@ -10,13 +10,36 @@ import {
 import type { CodexAppServerRuntimeOptions, resolveCodexPluginsPolicy } from "./config.js";
 
 type TrustedDiagnosticEventInput = Parameters<typeof emitTrustedDiagnosticEventWithPrivateData>[0];
+const UNREADABLE_DIAGNOSTIC_VALUE = "<unreadable>";
+const UNREADABLE_DIAGNOSTIC_TOOL_NAME = "<unreadable diagnostic tool>";
+const MAX_DIAGNOSTIC_VALUE_DEPTH = 6;
+const MAX_DIAGNOSTIC_VALUE_NODES = 1_000;
+const MAX_DIAGNOSTIC_ARRAY_ITEMS = 100;
+const MAX_DIAGNOSTIC_OBJECT_KEYS = 100;
+
+type CodexDiagnosticValueState = {
+  seen: WeakSet<object>;
+  nodes: number;
+};
 
 /** Reads a tool schema field in either app-server or OpenClaw naming. */
 export function readCodexDiagnosticToolParameters(tool: {
   inputSchema?: unknown;
   parameters?: unknown;
 }): unknown {
-  return tool.inputSchema ?? tool.parameters;
+  const inputSchema = readCodexDiagnosticToolField(tool, "inputSchema");
+  if (!inputSchema.readable) {
+    return UNREADABLE_DIAGNOSTIC_VALUE;
+  }
+  if (inputSchema.value !== undefined) {
+    return toJsonSafeCodexDiagnosticValue(inputSchema.value);
+  }
+
+  const parameters = readCodexDiagnosticToolField(tool, "parameters");
+  if (!parameters.readable) {
+    return UNREADABLE_DIAGNOSTIC_VALUE;
+  }
+  return toJsonSafeCodexDiagnosticValue(parameters.value);
 }
 
 /** Builds compact diagnostic tool definitions for trusted private telemetry. */
@@ -29,10 +52,131 @@ export function buildCodexDiagnosticToolDefinitions(
   }[],
 ) {
   return tools.map((tool) => ({
-    name: tool.name,
-    description: tool.description,
+    name: readCodexDiagnosticToolName(tool),
+    description: readCodexDiagnosticToolDescription(tool),
     parameters: readCodexDiagnosticToolParameters(tool),
   }));
+}
+
+function readCodexDiagnosticToolName(tool: { name: string }): string {
+  const name = readCodexDiagnosticToolField(tool, "name");
+  if (!name.readable || typeof name.value !== "string" || name.value.trim().length === 0) {
+    return UNREADABLE_DIAGNOSTIC_TOOL_NAME;
+  }
+  return name.value;
+}
+
+function readCodexDiagnosticToolDescription(tool: { description: string }): string {
+  const description = readCodexDiagnosticToolField(tool, "description");
+  return description.readable && typeof description.value === "string" ? description.value : "";
+}
+
+function readCodexDiagnosticToolField<TTool extends object, TField extends keyof TTool & string>(
+  tool: TTool,
+  field: TField,
+): { readable: true; value: TTool[TField] } | { readable: false } {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
+function toJsonSafeCodexDiagnosticValue(
+  value: unknown,
+  depth = 0,
+  state: CodexDiagnosticValueState = { seen: new WeakSet(), nodes: 0 },
+): unknown {
+  state.nodes += 1;
+  if (state.nodes > MAX_DIAGNOSTIC_VALUE_NODES) {
+    return "<truncated>";
+  }
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  ) {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (value === undefined || typeof value === "function" || typeof value === "symbol") {
+    return null;
+  }
+  if (depth >= MAX_DIAGNOSTIC_VALUE_DEPTH) {
+    return "<truncated>";
+  }
+  if (isDiagnosticArray(value)) {
+    if (state.seen.has(value)) {
+      return "<truncated>";
+    }
+    state.seen.add(value);
+    let length: number;
+    try {
+      length = Math.min(value.length, MAX_DIAGNOSTIC_ARRAY_ITEMS);
+    } catch {
+      return UNREADABLE_DIAGNOSTIC_VALUE;
+    }
+    const result: unknown[] = [];
+    for (let index = 0; index < length; index += 1) {
+      result.push(
+        toJsonSafeCodexDiagnosticValue(readDiagnosticArrayItem(value, index), depth + 1, state),
+      );
+    }
+    return result;
+  }
+  if (typeof value === "object") {
+    if (state.seen.has(value)) {
+      return "<truncated>";
+    }
+    state.seen.add(value);
+    let keys: string[];
+    try {
+      keys = Object.keys(value).slice(0, MAX_DIAGNOSTIC_OBJECT_KEYS);
+    } catch {
+      return UNREADABLE_DIAGNOSTIC_VALUE;
+    }
+    const result: Record<string, unknown> = {};
+    for (const key of keys) {
+      result[key] = toJsonSafeCodexDiagnosticValue(
+        readDiagnosticObjectField(value as Record<string, unknown>, key),
+        depth + 1,
+        state,
+      );
+    }
+    return result;
+  }
+  try {
+    return JSON.stringify(value) ?? null;
+  } catch {
+    return UNREADABLE_DIAGNOSTIC_VALUE;
+  }
+}
+
+function isDiagnosticArray(value: unknown): value is unknown[] {
+  try {
+    return Array.isArray(value);
+  } catch {
+    return false;
+  }
+}
+
+function readDiagnosticArrayItem(value: readonly unknown[], index: number): unknown {
+  try {
+    return value[index];
+  } catch {
+    return UNREADABLE_DIAGNOSTIC_VALUE;
+  }
+}
+
+function readDiagnosticObjectField(value: Record<string, unknown>, key: string): unknown {
+  try {
+    return value[key];
+  } catch {
+    return UNREADABLE_DIAGNOSTIC_VALUE;
+  }
 }
 
 /** Returns the serialized UTF-8 byte length for a JSON-compatible value. */


### PR DESCRIPTION
## Summary

- keep Codex model-call diagnostic tool-definition capture from throwing on unreadable tool `name`, `description`, `inputSchema`, or `parameters` accessors
- sanitize captured diagnostic schema payloads before private diagnostic dispatch, including nested getters, proxy `ownKeys` traps, proxy/array item traps, cycles, shared subtrees, and oversized graphs
- preserve readable sibling tool definitions while replacing unreadable or truncated diagnostic payload regions with stable markers

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-attempt-diagnostics node scripts/run-vitest.mjs run extensions/codex/src/app-server/attempt-diagnostics.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/attempt-diagnostics.ts extensions/codex/src/app-server/attempt-diagnostics.test.ts`
- `node scripts/run-oxlint.mjs extensions/codex/src/app-server/attempt-diagnostics.ts extensions/codex/src/app-server/attempt-diagnostics.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: local Blacksmith CLI is not authenticated.
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` blocked before lease allocation: coordinator `POST /v1/runs` and `POST /v1/leases` returned HTTP 401.

## Real behavior proof

Behavior addressed: optional Codex model-call diagnostic capture can no longer abort attempt startup while trying to record malformed or hostile tool definitions.

Real environment tested: local focused Codex extension diagnostic test in an OpenClaw linked Codex worktree. Broad remote proof was attempted through Testbox and AWS Crabbox, but both authenticated remote paths are unavailable from this shell.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run extensions/codex/src/app-server/attempt-diagnostics.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`; `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/attempt-diagnostics.ts extensions/codex/src/app-server/attempt-diagnostics.test.ts`; `node scripts/run-oxlint.mjs extensions/codex/src/app-server/attempt-diagnostics.ts extensions/codex/src/app-server/attempt-diagnostics.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `blacksmith testbox list --all`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: focused Vitest passed 1 file / 3 tests; targeted formatter/lint/diff checks passed; autoreview first reported a real repeated-reference denial-of-service risk, the sanitizer was fixed with revisit and node-budget guards, and final autoreview reported no accepted/actionable findings with `overall: patch is correct (0.83)`; final head is `312c452481c1cd95038b64802f3eacc674aba8d7`.

Observed result after fix: unreadable diagnostic tool names become `"<unreadable diagnostic tool>"`, unreadable descriptions are omitted, unreadable schemas become `"<unreadable>"`, nested hostile payload regions are bounded, cyclic or repeated graph regions truncate, and healthy sibling tool definitions remain captured.

What was not tested: a full live Codex app-server model turn and broad `pnpm check:changed` proof. Testbox is blocked by missing Blacksmith auth; AWS Crabbox is blocked by coordinator HTTP 401 before a lease id is issued.
