### PR TITLE
fix(codex): guard dynamic tool name filters

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -205,6 +205,29 @@ describe("Codex app-server dynamic tool build", () => {
     await expect(buildDynamicToolsForTest(params, workspaceDir)).resolves.toEqual([messageTool]);
   });
 
+  it("drops tools whose names become unreadable during Codex-specific filtering", async () => {
+    const healthyTool = createRuntimeDynamicTool("message");
+    let reads = 0;
+    const unstableTool = {
+      ...createRuntimeDynamicTool("unstable_tool"),
+      get name() {
+        reads += 1;
+        if (reads > 1) {
+          throw new Error("tool name getter exploded after projection");
+        }
+        return "unstable_tool";
+      },
+    };
+    setOpenClawCodingToolsFactoryForTests(() => [unstableTool, healthyTool]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+
+    await expect(buildDynamicToolsForTest(params, workspaceDir)).resolves.toEqual([healthyTool]);
+  });
+
   it("limits Codex memory flush runs to managed read and write tools", async () => {
     const factoryOptions: unknown[] = [];
     setOpenClawCodingToolsFactoryForTests((options) => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -19,6 +19,7 @@ import {
   filterCodexDynamicTools,
   isForcedPrivateQaCodexRuntime,
   normalizeCodexDynamicToolName,
+  readNormalizedCodexDynamicToolName,
 } from "./dynamic-tool-profile.js";
 import { resolveCodexNativeExecutionPolicy } from "./native-execution-policy.js";
 import type { CodexSandboxPolicy, CodexTurnEnvironmentParams } from "./protocol.js";
@@ -468,7 +469,7 @@ function isCodexMemoryFlushRun(
 
 function filterCodexMemoryFlushDynamicTools<T extends { name: string }>(tools: T[]): T[] {
   return tools.filter((tool) =>
-    CODEX_MEMORY_FLUSH_DYNAMIC_TOOL_ALLOW.has(normalizeCodexDynamicToolName(tool.name)),
+    CODEX_MEMORY_FLUSH_DYNAMIC_TOOL_ALLOW.has(readNormalizedCodexDynamicToolName(tool) ?? ""),
   );
 }
 
@@ -540,9 +541,9 @@ export function addSandboxShellDynamicToolsIfAvailable(
   ) {
     return filteredTools;
   }
-  const execTool = allTools.find((tool) => normalizeCodexDynamicToolName(tool.name) === "exec");
+  const execTool = allTools.find((tool) => readNormalizedCodexDynamicToolName(tool) === "exec");
   const processTool = allTools.find(
-    (tool) => normalizeCodexDynamicToolName(tool.name) === "process",
+    (tool) => readNormalizedCodexDynamicToolName(tool) === "process",
   );
   if (!execTool || !processTool) {
     return filteredTools;
@@ -627,11 +628,11 @@ function addNodeShellDynamicToolsIfNeeded(
     if (isCodexDynamicToolExcluded(input.pluginConfig, [toolName])) {
       continue;
     }
-    if (next.some((tool) => normalizeCodexDynamicToolName(tool.name) === toolName)) {
+    if (next.some((tool) => readNormalizedCodexDynamicToolName(tool) === toolName)) {
       continue;
     }
     const tool = allTools.find(
-      (candidate) => normalizeCodexDynamicToolName(candidate.name) === toolName,
+      (candidate) => readNormalizedCodexDynamicToolName(candidate) === toolName,
     );
     if (!tool) {
       continue;
@@ -661,11 +662,12 @@ export function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(
     toolsAllow.map((name) => normalizeCodexDynamicToolName(name)).filter(Boolean),
   );
   return tools.filter((tool) => {
-    const normalized = normalizeCodexDynamicToolName(tool.name);
+    const normalized = readNormalizedCodexDynamicToolName(tool);
     return (
-      allowSet.has(normalized) ||
-      (normalized === "sandbox_exec" && allowSet.has("exec")) ||
-      (normalized === "sandbox_process" && (allowSet.has("exec") || allowSet.has("process")))
+      Boolean(normalized) &&
+      (allowSet.has(normalized) ||
+        (normalized === "sandbox_exec" && allowSet.has("exec")) ||
+        (normalized === "sandbox_process" && (allowSet.has("exec") || allowSet.has("process"))))
     );
   });
 }

--- a/extensions/codex/src/app-server/dynamic-tool-profile.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-profile.ts
@@ -29,6 +29,14 @@ export function normalizeCodexDynamicToolName(name: string): string {
   return DYNAMIC_TOOL_NAME_ALIASES[normalized] ?? normalized;
 }
 
+export function readNormalizedCodexDynamicToolName(tool: { name: string }): string | undefined {
+  try {
+    return normalizeCodexDynamicToolName(tool.name);
+  } catch {
+    return undefined;
+  }
+}
+
 export function isForcedPrivateQaCodexRuntime(
   env: CodexDynamicToolProfileEnv = process.env,
 ): boolean {
@@ -66,5 +74,8 @@ export function filterCodexDynamicTools<T extends { name: string }>(
   }
   return excludes.size === 0
     ? tools
-    : tools.filter((tool) => !excludes.has(normalizeCodexDynamicToolName(tool.name)));
+    : tools.filter((tool) => {
+        const normalized = readNormalizedCodexDynamicToolName(tool);
+        return Boolean(normalized && !excludes.has(normalized));
+      });
 }

--- a/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
@@ -16,6 +16,21 @@ describe("Codex dynamic tool filtering", () => {
     expect(toolNames).not.toContain("image");
   });
 
+  it("does not crash when a sibling tool name is unreadable", () => {
+    const unreadableTool = {
+      get name() {
+        throw new Error("tool name getter exploded");
+      },
+    };
+
+    expect(
+      filterToolsForVisionInputs([unreadableTool, { name: "image" }, { name: "message" }], {
+        modelHasVision: true,
+        hasInboundImages: true,
+      }),
+    ).toEqual([unreadableTool, { name: "message" }]);
+  });
+
   it("keeps the image tool unless both model vision and inbound images are present", () => {
     const tools = [{ name: "image" }, { name: "read" }];
 

--- a/extensions/codex/src/app-server/vision-tools.ts
+++ b/extensions/codex/src/app-server/vision-tools.ts
@@ -8,5 +8,11 @@ export function filterToolsForVisionInputs<T extends { name?: string }>(
   if (!params.modelHasVision || !params.hasInboundImages) {
     return tools;
   }
-  return tools.filter((tool) => tool.name !== "image");
+  return tools.filter((tool) => {
+    try {
+      return tool.name !== "image";
+    } catch {
+      return true;
+    }
+  });
 }


### PR DESCRIPTION
## Summary

- guard Codex dynamic-tool filters against name getters that become unreadable after schema projection
- drop unreadable entries from Codex-specific filtering and allowlist paths while preserving healthy siblings
- keep vision filtering from crashing on unrelated unreadable tool names

## Verification

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/run-attempt.vision-tools.test.ts --reporter=dot`
- `node_modules/.bin/oxlint extensions/codex/src/app-server/dynamic-tool-profile.ts extensions/codex/src/app-server/dynamic-tool-build.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/vision-tools.ts extensions/codex/src/app-server/run-attempt.vision-tools.test.ts`
- `git diff --check HEAD~1..HEAD`
- direct `node --import tsx` repro: stateful name getter no longer crashes after projection; observed `web_search`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: Codex pre-bridge filters can no longer abort dynamic-tool startup when a tool name becomes unreadable after schema projection.

Real environment tested: local OpenClaw Codex extension test lane via repo wrapper; direct `tsx` repro of projection then Codex filtering.

Exact steps or command run after this patch: ran the focused Codex app-server Vitest files, oxlint on all touched files, `git diff --check`, branch autoreview, and a direct `tsx` projection/filter repro with a stateful throwing `name` getter.

Evidence after fix: the focused Vitest run passed 31 tests across 2 files; oxlint and diff check passed; autoreview reported no accepted/actionable findings; the direct repro printed `web_search`.

Observed result after fix: unreadable Codex dynamic-tool names are quarantined in Codex-specific filtering paths instead of crashing the sibling tool list.

What was not tested: remote `pnpm check:changed` did not run; Blacksmith is unauthenticated locally, and AWS Crabbox was not retried because local disk is too low for the wrapper's temporary full checkout.
