### PR TITLE
fix(agent-tools): skip unreadable tool names in policy

### DIFF
--- a/src/agents/agent-tools.policy.test.ts
+++ b/src/agents/agent-tools.policy.test.ts
@@ -32,6 +32,20 @@ describe("agent-tools.policy", () => {
     expect(filtered.map((tool) => tool.name)).toEqual(["read", "exec"]);
   });
 
+  it("drops unreadable tool names when applying a policy", () => {
+    const unreadable = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("policy filter name getter exploded");
+      },
+    }) as ReturnType<typeof createStubTool>;
+
+    const filtered = filterToolsByPolicy([unreadable, createStubTool("message")], {
+      allow: ["message"],
+    });
+
+    expect(filtered.map((tool) => tool.name)).toEqual(["message"]);
+  });
+
   it("treats * in deny as deny-all", () => {
     const tools = [createStubTool("read"), createStubTool("exec")];
     const filtered = filterToolsByPolicy(tools, { deny: ["*"] });

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -36,6 +36,7 @@ import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import {
   mergeAlsoAllowPolicy,
   normalizeToolName,
+  readToolPolicyName,
   resolveToolProfilePolicy,
 } from "./tool-policy.js";
 
@@ -175,7 +176,10 @@ export function filterToolsByPolicy(tools: AnyAgentTool[], policy?: SandboxToolP
   if (!policy) {
     return tools;
   }
-  return tools.filter((tool) => isToolAllowedByPolicyName(tool.name, policy));
+  return tools.filter((tool) => {
+    const name = readToolPolicyName(tool);
+    return name !== undefined && isToolAllowedByPolicyName(name, policy);
+  });
 }
 
 type ToolPolicyConfig = {

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -1,7 +1,12 @@
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { SandboxConfig } from "./sandbox/types.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
-import { normalizeToolList, normalizeToolName, type ToolPolicyLike } from "./tool-policy.js";
+import {
+  normalizeToolList,
+  normalizeToolName,
+  readToolPolicyName,
+  type ToolPolicyLike,
+} from "./tool-policy.js";
 
 const MAX_AUDIT_TOOL_NAMES = 50;
 const MAX_AUDIT_FIELD_LENGTH = 160;
@@ -27,7 +32,14 @@ function toolPolicyRuleKind(policy: ToolPolicyLike): ToolPolicyRuleKind {
 }
 
 function normalizedToolNames(tools: readonly { name: string }[]): string[] {
-  return normalizeToolList(tools.map((tool) => tool.name));
+  const names: string[] = [];
+  for (const tool of tools) {
+    const name = readToolPolicyName(tool);
+    if (name !== undefined) {
+      names.push(name);
+    }
+  }
+  return normalizeToolList(names);
 }
 
 function removedToolNamesByRule(params: {

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -73,6 +73,30 @@ describe("tool-policy-pipeline", () => {
     expect(names).toEqual(["plugin_tool"]);
   });
 
+  test("drops unreadable tool names before policy audit", () => {
+    const unreadable = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("pipeline name getter exploded");
+      },
+    }) as DummyTool;
+    const tools = [unreadable, { name: "message" }] as unknown as DummyTool[];
+
+    const filtered = applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: () => {},
+      steps: [
+        {
+          policy: { allow: ["message"] },
+          label: "tools.allow",
+        },
+      ],
+      auditLogLevel: "debug",
+    });
+
+    expect(filtered.map((tool) => (tool as unknown as DummyTool).name)).toEqual(["message"]);
+  });
+
   test("warns about unknown allowlist entries", () => {
     const warnings: string[] = [];
     const tools = [{ name: "exec" }] as unknown as DummyTool[];

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -7,6 +7,7 @@ import {
   buildPluginToolGroups,
   expandPolicyWithPluginGroups,
   normalizeToolName,
+  readToolPolicyName,
   type ToolPolicyLike,
 } from "./tool-policy.js";
 
@@ -122,12 +123,16 @@ export function applyToolPolicyPipeline(params: {
   steps: ToolPolicyPipelineStep[];
   auditLogLevel?: ToolPolicyAuditLogLevel;
 }): AnyAgentTool[] {
-  const coreToolNames = new Set(
-    params.tools
-      .filter((tool) => !params.toolMeta(tool))
-      .map((tool) => normalizeToolName(tool.name))
-      .filter(Boolean),
-  );
+  const coreToolNames = new Set<string>();
+  for (const tool of params.tools) {
+    if (params.toolMeta(tool)) {
+      continue;
+    }
+    const name = readToolPolicyName(tool);
+    if (name) {
+      coreToolNames.add(name);
+    }
+  }
 
   const pluginGroups = buildPluginToolGroups({
     tools: params.tools,

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -5,10 +5,12 @@ import { isToolAllowed, resolveSandboxToolPolicyForAgent } from "./sandbox/tool-
 import type { SandboxToolPolicy } from "./sandbox/types.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import {
+  buildPluginToolGroups,
   collectExplicitAllowlist,
   DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
   expandToolGroups,
   normalizeToolName,
+  replaceWithEffectiveToolAllowlist,
   resolveToolProfilePolicy,
   TOOL_GROUPS,
 } from "./tool-policy.js";
@@ -74,6 +76,35 @@ describe("tool-policy", () => {
     expect(collectExplicitAllowlist([pickSandboxToolPolicy({ alsoAllow: [" * "] })])).toEqual([
       "*",
     ]);
+  });
+
+  it("skips unreadable tool names when replacing effective allowlists", () => {
+    const target: string[] = [];
+    const unreadable = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("policy name getter exploded");
+      },
+    }) as { name: string };
+
+    replaceWithEffectiveToolAllowlist(target, [unreadable, { name: "message" }]);
+
+    expect(target).toEqual(["message"]);
+  });
+
+  it("skips unreadable plugin tool names when building plugin groups", () => {
+    const unreadable = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("plugin group name getter exploded");
+      },
+    }) as { name: string };
+
+    const groups = buildPluginToolGroups({
+      tools: [unreadable, { name: "MESSAGE" }],
+      toolMeta: () => ({ pluginId: "demo-plugin" }),
+    });
+
+    expect(groups.all).toEqual(["message"]);
+    expect(groups.byPlugin.get("demo-plugin")).toEqual(["message"]);
   });
 });
 

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -52,7 +52,7 @@ export function replaceWithEffectiveToolAllowlist(
   target.length = 0;
   const seen = new Set<string>();
   for (const tool of tools) {
-    const normalized = normalizeToolName(tool.name);
+    const normalized = readToolPolicyName(tool);
     if (!normalized || seen.has(normalized)) {
       continue;
     }
@@ -105,6 +105,14 @@ export function collectExplicitDenylist(policies: Array<ToolPolicyLike | undefin
   return entries;
 }
 
+export function readToolPolicyName(tool: { name: string }): string | undefined {
+  try {
+    return normalizeToolName(tool.name);
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildPluginToolGroups<T extends { name: string }>(params: {
   tools: T[];
   toolMeta: (tool: T) => { pluginId: string } | undefined;
@@ -116,7 +124,10 @@ export function buildPluginToolGroups<T extends { name: string }>(params: {
     if (!meta) {
       continue;
     }
-    const name = normalizeToolName(tool.name);
+    const name = readToolPolicyName(tool);
+    if (name === undefined) {
+      continue;
+    }
     all.push(name);
     const pluginId = normalizeOptionalLowercaseString(meta.pluginId);
     if (!pluginId) {


### PR DESCRIPTION
## Summary

- add a guarded tool-policy name reader for hostile or unreadable tool name accessors
- drop unreadable tool entries from effective allowlists, plugin groups, policy filtering, and policy audit paths
- cover the full policy pipeline so an unreadable pre-filter tool cannot crash audit after filtering

## Verification

- `node scripts/run-vitest.mjs src/agents/tool-policy.test.ts src/agents/agent-tools.policy.test.ts src/agents/tool-policy-pipeline.test.ts --reporter=dot`
- `node_modules/.bin/oxlint src/agents/tool-policy.ts src/agents/agent-tools.policy.ts src/agents/tool-policy-audit.ts src/agents/tool-policy-pipeline.ts src/agents/tool-policy.test.ts src/agents/agent-tools.policy.test.ts src/agents/tool-policy-pipeline.test.ts`
- `git diff --check HEAD~1..HEAD`
- direct `node --import tsx` repro: policy pipeline with a throwing `name` getter now preserves the healthy `message` tool
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: agent tool-policy filtering can no longer abort when one tool exposes an unreadable `name` getter; unreadable entries are treated as absent while healthy siblings still pass policy.

Real environment tested: local OpenClaw agent policy tests via repo Vitest wrapper; direct `tsx` repro of `applyToolPolicyPipeline`.

Exact steps or command run after this patch: ran the focused policy Vitest files, oxlint on all touched files, `git diff --check`, branch autoreview, and a direct `tsx` pipeline repro with a throwing `name` getter.

Evidence after fix: focused Vitest passed 67 tests across 3 files after final rebase; oxlint and diff check passed; branch autoreview reported no accepted/actionable findings; the direct repro printed `message`.

Observed result after fix: the unreadable tool is dropped from policy filtering and audit inputs, and the readable `message` tool remains available.

What was not tested: remote `pnpm check:changed` did not run; Blacksmith is unauthenticated locally, and AWS Crabbox was not retried because local disk is too low for the wrapper's temporary full checkout. A broad local tsgo lane was also skipped because this linked worktree had only about 233MiB free after proof.
