### PR TITLE
fix(codex): guard prompt report tool metadata

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -77,6 +77,67 @@ describe("Codex app-server attempt context", () => {
     expect(report.tools.schemaChars).toBe(message?.schemaChars);
   });
 
+  it("keeps prompt reports lossy-safe when dynamic tool metadata is unreadable", () => {
+    const unreadableTool = Object.defineProperties(
+      {},
+      {
+        name: {
+          get() {
+            throw new Error("report name getter exploded");
+          },
+        },
+        description: {
+          get() {
+            throw new Error("report description getter exploded");
+          },
+        },
+        inputSchema: {
+          get() {
+            throw new Error("report schema getter exploded");
+          },
+        },
+      },
+    ) as CodexDynamicToolSpec;
+    const tools = [
+      unreadableTool,
+      {
+        name: "message",
+        description: "Send a message.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+    ] as CodexDynamicToolSpec[];
+
+    const report = buildCodexSystemPromptReport({
+      attempt: {
+        sessionId: "session-1",
+        provider: "codex",
+        modelId: "gpt-5.4-codex",
+      } as EmbeddedRunAttemptParams,
+      sessionKey: "agent:main:session-1",
+      workspaceDir: path.join("tmp", "workspace"),
+      developerInstructions: "test developer instructions",
+      workspaceBootstrapContext: {
+        bootstrapFiles: [],
+        contextFiles: [],
+        promptContextFiles: [],
+        developerInstructionFiles: [],
+        heartbeatReferenceFiles: [],
+      },
+      skillsPrompt: "",
+      tools,
+    });
+
+    expect(report.tools.entries.map((tool) => tool.name)).toEqual(["tool[0]", "message"]);
+    expect(report.tools.entries[0]).toMatchObject({
+      summaryChars: 0,
+      schemaChars: 4,
+      propertiesCount: null,
+    });
+  });
+
   it("keeps MEMORY.md injected when sandbox effective workspace differs", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-memory-workspace-"));
     const sandboxWorkspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-memory-sandbox-"));

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -255,7 +255,7 @@ export function buildCodexSystemPromptReport(params: {
   skillsPrompt: string;
   tools: CodexDynamicToolSpec[];
 }): CodexSystemPromptReport {
-  const toolEntries = params.tools.map(buildCodexToolReportEntry);
+  const toolEntries = params.tools.map((tool, index) => buildCodexToolReportEntry(tool, index));
   const schemaChars = toolEntries.reduce((sum, tool) => sum + tool.schemaChars, 0);
   const skillsPrompt = params.skillsPrompt.trim();
   const bootstrapMaxChars = readPositiveNumber(
@@ -319,11 +319,15 @@ function buildCodexSkillReportEntries(
     .filter((entry) => entry.blockChars > 0);
 }
 
-function buildCodexToolReportEntry(tool: CodexDynamicToolSpec): CodexToolReportEntry {
-  const summary = tool.description.trim();
-  if (tool.deferLoading === true) {
+function buildCodexToolReportEntry(
+  tool: CodexDynamicToolSpec,
+  index: number,
+): CodexToolReportEntry {
+  const name = readCodexToolReportName(tool, index);
+  const summary = readCodexToolReportDescription(tool);
+  if (readCodexToolReportDeferred(tool)) {
     return {
-      name: tool.name,
+      name,
       summaryChars: summary.length,
       summaryHash: sha256Text(summary),
       schemaChars: 0,
@@ -332,11 +336,44 @@ function buildCodexToolReportEntry(tool: CodexDynamicToolSpec): CodexToolReportE
     };
   }
   return {
-    name: tool.name,
+    name,
     summaryChars: summary.length,
     summaryHash: sha256Text(summary),
-    ...buildCodexToolSchemaStats(tool.inputSchema),
+    ...buildCodexToolSchemaStats(readCodexToolReportInputSchema(tool)),
   };
+}
+
+function readCodexToolReportName(tool: CodexDynamicToolSpec, index: number): string {
+  try {
+    const name = tool.name.trim();
+    return name || `tool[${index}]`;
+  } catch {
+    return `tool[${index}]`;
+  }
+}
+
+function readCodexToolReportDescription(tool: CodexDynamicToolSpec): string {
+  try {
+    return tool.description.trim();
+  } catch {
+    return "";
+  }
+}
+
+function readCodexToolReportDeferred(tool: CodexDynamicToolSpec): boolean {
+  try {
+    return tool.deferLoading === true;
+  } catch {
+    return false;
+  }
+}
+
+function readCodexToolReportInputSchema(tool: CodexDynamicToolSpec): JsonValue {
+  try {
+    return tool.inputSchema;
+  } catch {
+    return null;
+  }
 }
 
 function buildCodexToolSchemaStats(


### PR DESCRIPTION
## Summary

- make Codex system prompt tool reports tolerate unreadable dynamic-tool metadata
- use fallback `tool[index]`, empty summaries, and null-schema stats when report-only fields throw
- preserve healthy sibling tool report entries instead of aborting the prompt report

## Verification

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-context.test.ts --reporter=dot`
- `node_modules/.bin/oxlint extensions/codex/src/app-server/attempt-context.ts extensions/codex/src/app-server/attempt-context.test.ts`
- `git diff --check HEAD~1..HEAD`
- direct `node --import tsx` repro: a throwing `description` getter no longer aborts `buildCodexSystemPromptReport`; observed `bad_report_probe,message`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: Codex prompt report generation can no longer abort a turn when diagnostic-only dynamic-tool metadata accessors throw.

Real environment tested: local OpenClaw Codex app-server context test via repo wrapper; direct `tsx` repro of `buildCodexSystemPromptReport`.

Exact steps or command run after this patch: ran the focused Codex attempt-context Vitest file, oxlint on both touched files, `git diff --check`, branch autoreview, and a direct `tsx` prompt-report repro with a throwing `description` getter.

Evidence after fix: focused Vitest passed 5 tests in 1 file after final rebase; oxlint and diff check passed; branch autoreview reported no accepted/actionable findings; the direct repro printed `bad_report_probe,message`.

Observed result after fix: the bad tool contributes a lossy report entry and the healthy `message` tool remains present in the system prompt report.

What was not tested: remote `pnpm check:changed` did not run; Blacksmith is unauthenticated locally, and AWS Crabbox was not retried because local disk is too low for the wrapper's temporary full checkout.
