### PR TITLE
fix(exec): reuse duplicate background sessions

### DIFF
--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -11,6 +11,7 @@ import {
   appendOutput,
   drainSession,
   listFinishedSessions,
+  findMatchingRunningBackgroundSession,
   markBackgrounded,
   markExited,
   resetProcessRegistryForTests,
@@ -138,6 +139,66 @@ describe("bash process registry", () => {
         totalOutputChars: 0,
       },
     ]);
+  });
+
+  it("matches only scoped running background sessions with the same exec identity", () => {
+    const session = createRegistrySession({
+      id: "match",
+      maxOutputChars: 100,
+      pendingMaxOutputChars: 30_000,
+      backgrounded: true,
+    });
+    session.command = "sleep 0.05";
+    session.cwd = "/tmp/project";
+    session.scopeKey = "scope-a";
+    session.sessionKey = "session-a";
+    addSession(session);
+
+    expect(
+      findMatchingRunningBackgroundSession({
+        command: "sleep 0.05",
+        cwd: "/tmp/project",
+        scopeKey: "scope-a",
+      }),
+    ).toBe(session);
+    expect(
+      findMatchingRunningBackgroundSession({
+        command: "sleep 0.05",
+        cwd: "/tmp/project",
+        sessionKey: "session-a",
+      }),
+    ).toBe(session);
+
+    const misses = [
+      { command: "sleep 0.05", cwd: "/tmp/project" },
+      { command: "sleep 0.05", cwd: "/tmp/project", scopeKey: "scope-b" },
+      { command: "sleep 0.05", cwd: "/tmp/project", sessionKey: "session-b" },
+      { command: "sleep 0.1", cwd: "/tmp/project", scopeKey: "scope-a" },
+      { command: "sleep 0.05", cwd: "/tmp/other", scopeKey: "scope-a" },
+    ];
+    for (const params of misses) {
+      expect(findMatchingRunningBackgroundSession(params)).toBeUndefined();
+    }
+  });
+
+  it("does not match foreground sessions", () => {
+    const session = createRegistrySession({
+      id: "foreground",
+      maxOutputChars: 100,
+      pendingMaxOutputChars: 30_000,
+      backgrounded: false,
+    });
+    session.command = "sleep 0.05";
+    session.scopeKey = "scope-a";
+    addSession(session);
+
+    expect(
+      findMatchingRunningBackgroundSession({
+        command: "sleep 0.05",
+        cwd: session.cwd,
+        scopeKey: "scope-a",
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -151,6 +151,7 @@ describe("bash process registry", () => {
     session.command = "sleep 0.05";
     session.cwd = "/tmp/project";
     session.executionKey = "exec-key-a";
+    session.execReuseKey = "default-yield";
     session.scopeKey = "scope-a";
     session.sessionKey = "session-a";
     addSession(session);
@@ -160,6 +161,7 @@ describe("bash process registry", () => {
         command: "sleep 0.05",
         cwd: "/tmp/project",
         executionKey: "exec-key-a",
+        reuseKey: "default-yield",
         scopeKey: "scope-a",
       }),
     ).toBe(session);
@@ -168,41 +170,65 @@ describe("bash process registry", () => {
         command: "sleep 0.05",
         cwd: "/tmp/project",
         executionKey: "exec-key-a",
+        reuseKey: "default-yield",
         sessionKey: "session-a",
       }),
     ).toBe(session);
 
     const misses = [
-      { command: "sleep 0.05", cwd: "/tmp/project", executionKey: "exec-key-a" },
+      {
+        command: "sleep 0.05",
+        cwd: "/tmp/project",
+        executionKey: "exec-key-a",
+        reuseKey: "default-yield",
+      },
       { command: "sleep 0.05", cwd: "/tmp/project", scopeKey: "scope-a" },
       {
         command: "sleep 0.05",
         cwd: "/tmp/project",
-        executionKey: "exec-key-b",
+        executionKey: "exec-key-a",
         scopeKey: "scope-a",
       },
       {
         command: "sleep 0.05",
         cwd: "/tmp/project",
         executionKey: "exec-key-a",
+        reuseKey: "explicit-background",
+        scopeKey: "scope-a",
+      },
+      {
+        command: "sleep 0.05",
+        cwd: "/tmp/project",
+        executionKey: "exec-key-b",
+        reuseKey: "default-yield",
+        scopeKey: "scope-a",
+      },
+      {
+        command: "sleep 0.05",
+        cwd: "/tmp/project",
+        executionKey: "exec-key-a",
+        reuseKey: "default-yield",
         scopeKey: "scope-b",
       },
       {
         command: "sleep 0.05",
         cwd: "/tmp/project",
         executionKey: "exec-key-a",
+        reuseKey: "default-yield",
         sessionKey: "session-b",
       },
       {
         command: "sleep 0.1",
         cwd: "/tmp/project",
         executionKey: "exec-key-a",
+        reuseKey: "default-yield",
         scopeKey: "scope-a",
       },
       {
         command: "sleep 0.05",
         cwd: "/tmp/other",
         executionKey: "exec-key-a",
+        reuseKey: "default-yield",
         scopeKey: "scope-a",
       },
     ];
@@ -220,6 +246,7 @@ describe("bash process registry", () => {
     });
     session.command = "sleep 0.05";
     session.executionKey = "exec-key-a";
+    session.execReuseKey = "default-yield";
     session.scopeKey = "scope-a";
     addSession(session);
 
@@ -228,6 +255,7 @@ describe("bash process registry", () => {
         command: "sleep 0.05",
         cwd: session.cwd,
         executionKey: "exec-key-a",
+        reuseKey: "default-yield",
         scopeKey: "scope-a",
       }),
     ).toBeUndefined();

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -150,6 +150,7 @@ describe("bash process registry", () => {
     });
     session.command = "sleep 0.05";
     session.cwd = "/tmp/project";
+    session.executionKey = "exec-key-a";
     session.scopeKey = "scope-a";
     session.sessionKey = "session-a";
     addSession(session);
@@ -158,6 +159,7 @@ describe("bash process registry", () => {
       findMatchingRunningBackgroundSession({
         command: "sleep 0.05",
         cwd: "/tmp/project",
+        executionKey: "exec-key-a",
         scopeKey: "scope-a",
       }),
     ).toBe(session);
@@ -165,16 +167,44 @@ describe("bash process registry", () => {
       findMatchingRunningBackgroundSession({
         command: "sleep 0.05",
         cwd: "/tmp/project",
+        executionKey: "exec-key-a",
         sessionKey: "session-a",
       }),
     ).toBe(session);
 
     const misses = [
-      { command: "sleep 0.05", cwd: "/tmp/project" },
-      { command: "sleep 0.05", cwd: "/tmp/project", scopeKey: "scope-b" },
-      { command: "sleep 0.05", cwd: "/tmp/project", sessionKey: "session-b" },
-      { command: "sleep 0.1", cwd: "/tmp/project", scopeKey: "scope-a" },
-      { command: "sleep 0.05", cwd: "/tmp/other", scopeKey: "scope-a" },
+      { command: "sleep 0.05", cwd: "/tmp/project", executionKey: "exec-key-a" },
+      { command: "sleep 0.05", cwd: "/tmp/project", scopeKey: "scope-a" },
+      {
+        command: "sleep 0.05",
+        cwd: "/tmp/project",
+        executionKey: "exec-key-b",
+        scopeKey: "scope-a",
+      },
+      {
+        command: "sleep 0.05",
+        cwd: "/tmp/project",
+        executionKey: "exec-key-a",
+        scopeKey: "scope-b",
+      },
+      {
+        command: "sleep 0.05",
+        cwd: "/tmp/project",
+        executionKey: "exec-key-a",
+        sessionKey: "session-b",
+      },
+      {
+        command: "sleep 0.1",
+        cwd: "/tmp/project",
+        executionKey: "exec-key-a",
+        scopeKey: "scope-a",
+      },
+      {
+        command: "sleep 0.05",
+        cwd: "/tmp/other",
+        executionKey: "exec-key-a",
+        scopeKey: "scope-a",
+      },
     ];
     for (const params of misses) {
       expect(findMatchingRunningBackgroundSession(params)).toBeUndefined();
@@ -189,6 +219,7 @@ describe("bash process registry", () => {
       backgrounded: false,
     });
     session.command = "sleep 0.05";
+    session.executionKey = "exec-key-a";
     session.scopeKey = "scope-a";
     addSession(session);
 
@@ -196,6 +227,7 @@ describe("bash process registry", () => {
       findMatchingRunningBackgroundSession({
         command: "sleep 0.05",
         cwd: session.cwd,
+        executionKey: "exec-key-a",
         scopeKey: "scope-a",
       }),
     ).toBeUndefined();

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -43,6 +43,8 @@ export type SessionStdin = {
 export interface ProcessSession {
   id: string;
   command: string;
+  /** Opaque hash of the resolved exec request that created this process. */
+  executionKey?: string;
   scopeKey?: string;
   sessionKey?: string;
   /** `session.mainKey` from the runtime config, snapshotted at exec start.
@@ -326,13 +328,15 @@ export function listFinishedSessions() {
 export function findMatchingRunningBackgroundSession(params: {
   command: string;
   cwd?: string;
+  executionKey?: string;
   scopeKey?: string;
   sessionKey?: string;
 }) {
+  const executionKey = params.executionKey?.trim() || undefined;
   const scopeKey = params.scopeKey?.trim() || undefined;
   const sessionKey = params.sessionKey?.trim() || undefined;
 
-  if (!scopeKey && !sessionKey) {
+  if (!executionKey || (!scopeKey && !sessionKey)) {
     return undefined;
   }
 
@@ -346,6 +350,9 @@ export function findMatchingRunningBackgroundSession(params: {
       continue;
     }
     if (session.cwd !== params.cwd) {
+      continue;
+    }
+    if ((session.executionKey?.trim() || undefined) !== executionKey) {
       continue;
     }
     if (scopeKey && (session.scopeKey?.trim() || undefined) !== scopeKey) {

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -323,6 +323,42 @@ export function listFinishedSessions() {
   return Array.from(finishedSessions.values());
 }
 
+export function findMatchingRunningBackgroundSession(params: {
+  command: string;
+  cwd?: string;
+  scopeKey?: string;
+  sessionKey?: string;
+}) {
+  const scopeKey = params.scopeKey?.trim() || undefined;
+  const sessionKey = params.sessionKey?.trim() || undefined;
+
+  if (!scopeKey && !sessionKey) {
+    return undefined;
+  }
+
+  // Duplicate exec retries should resolve to the session the process tool can manage.
+  // Require a scoped identity so unscoped ad hoc runs cannot collapse unrelated work.
+  for (const session of runningSessions.values()) {
+    if (!session.backgrounded || session.exited) {
+      continue;
+    }
+    if (session.command !== params.command) {
+      continue;
+    }
+    if (session.cwd !== params.cwd) {
+      continue;
+    }
+    if (scopeKey && (session.scopeKey?.trim() || undefined) !== scopeKey) {
+      continue;
+    }
+    if (sessionKey && (session.sessionKey?.trim() || undefined) !== sessionKey) {
+      continue;
+    }
+    return session;
+  }
+  return undefined;
+}
+
 /** Clears retained finished sessions without touching running processes. */
 export function clearFinished() {
   finishedSessions.clear();

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -45,6 +45,7 @@ export interface ProcessSession {
   command: string;
   /** Opaque hash of the resolved exec request that created this process. */
   executionKey?: string;
+  execReuseKey?: string;
   scopeKey?: string;
   sessionKey?: string;
   /** `session.mainKey` from the runtime config, snapshotted at exec start.
@@ -329,14 +330,16 @@ export function findMatchingRunningBackgroundSession(params: {
   command: string;
   cwd?: string;
   executionKey?: string;
+  reuseKey?: string;
   scopeKey?: string;
   sessionKey?: string;
 }) {
   const executionKey = params.executionKey?.trim() || undefined;
+  const reuseKey = params.reuseKey?.trim() || undefined;
   const scopeKey = params.scopeKey?.trim() || undefined;
   const sessionKey = params.sessionKey?.trim() || undefined;
 
-  if (!executionKey || (!scopeKey && !sessionKey)) {
+  if (!executionKey || !reuseKey || (!scopeKey && !sessionKey)) {
     return undefined;
   }
 
@@ -353,6 +356,9 @@ export function findMatchingRunningBackgroundSession(params: {
       continue;
     }
     if ((session.executionKey?.trim() || undefined) !== executionKey) {
+      continue;
+    }
+    if ((session.execReuseKey?.trim() || undefined) !== reuseKey) {
       continue;
     }
     if (scopeKey && (session.scopeKey?.trim() || undefined) !== scopeKey) {

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -27,6 +27,9 @@ vi.mock("../process/supervisor/index.js", () => ({
 }));
 
 let markBackgrounded: typeof import("./bash-process-registry.js").markBackgrounded;
+let listFinishedSessions: typeof import("./bash-process-registry.js").listFinishedSessions;
+let listRunningSessions: typeof import("./bash-process-registry.js").listRunningSessions;
+let resetProcessRegistryForTests: typeof import("./bash-process-registry.js").resetProcessRegistryForTests;
 let buildExecExitOutcome: typeof import("./bash-tools.exec-runtime.js").buildExecExitOutcome;
 let detectCursorKeyMode: typeof import("./bash-tools.exec-runtime.js").detectCursorKeyMode;
 let emitExecSystemEvent: typeof import("./bash-tools.exec-runtime.js").emitExecSystemEvent;
@@ -36,7 +39,8 @@ let resolveExecTarget: typeof import("./bash-tools.exec-runtime.js").resolveExec
 let runExecProcess: typeof import("./bash-tools.exec-runtime.js").runExecProcess;
 
 beforeAll(async () => {
-  ({ markBackgrounded } = await import("./bash-process-registry.js"));
+  ({ listFinishedSessions, listRunningSessions, markBackgrounded, resetProcessRegistryForTests } =
+    await import("./bash-process-registry.js"));
   ({
     buildExecExitOutcome,
     detectCursorKeyMode,
@@ -52,6 +56,7 @@ beforeEach(() => {
   requestHeartbeatMock.mockClear();
   enqueueSystemEventMock.mockClear();
   supervisorMock.spawn.mockReset();
+  resetProcessRegistryForTests();
 });
 
 function expectExecTarget(
@@ -728,6 +733,82 @@ describe("buildExecExitOutcome", () => {
 });
 
 describe("runExecProcess POSIX command wrapper", () => {
+  it("can expose explicit background sessions before spawn resolves", async () => {
+    let releaseSpawn!: () => void;
+    supervisorMock.spawn.mockImplementationOnce(
+      async () =>
+        await new Promise((resolve) => {
+          releaseSpawn = () =>
+            resolve({
+              runId: "mock-run",
+              startedAtMs: Date.now(),
+              wait: async () => ({
+                reason: "exit" as const,
+                exitCode: 0,
+                exitSignal: null,
+                durationMs: 0,
+                stdout: "",
+                stderr: "",
+                timedOut: false,
+                noOutputTimedOut: false,
+              }),
+              cancel: vi.fn(),
+            });
+        }),
+    );
+
+    const runPromise = runExecProcess({
+      command: "sleep 30",
+      workdir: "/tmp",
+      env: { PATH: "/usr/bin" },
+      usePty: false,
+      warnings: [],
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+      notifyOnExit: false,
+      timeoutSec: null,
+      initialBackgrounded: true,
+    });
+
+    await expect.poll(() => supervisorMock.spawn.mock.calls.length).toBe(1);
+    const [session] = listRunningSessions();
+    expect(session?.command).toBe("sleep 30");
+    expect(session?.backgrounded).toBe(true);
+
+    releaseSpawn();
+    const run = await runPromise;
+    await run.promise;
+  });
+
+  it("cleans up explicit background sessions when pre-spawn setup fails", async () => {
+    await expect(
+      runExecProcess({
+        command: "sleep 30",
+        workdir: "/tmp",
+        env: { PATH: "/usr/bin" },
+        sandbox: {
+          containerName: "test-container",
+          workspaceDir: "/tmp",
+          containerWorkdir: "/workspace",
+          buildExecSpec: async () => {
+            throw new Error("backend unavailable");
+          },
+        },
+        usePty: false,
+        warnings: [],
+        maxOutput: 1000,
+        pendingMaxOutput: 1000,
+        notifyOnExit: false,
+        timeoutSec: null,
+        initialBackgrounded: true,
+      }),
+    ).rejects.toThrow("backend unavailable");
+
+    expect(supervisorMock.spawn).not.toHaveBeenCalled();
+    expect(listRunningSessions()).toEqual([]);
+    expect(listFinishedSessions()).toMatchObject([{ command: "sleep 30", status: "failed" }]);
+  });
+
   it("normalizes non-finite and oversized exec timeouts before spawning", async () => {
     supervisorMock.spawn.mockResolvedValue({
       runId: "mock-run",

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -727,6 +727,7 @@ export async function runExecProcess(opts: {
   notifyDeliveryContext?: DeliveryContext;
   timeoutSec: number | null;
   executionKey?: string;
+  execReuseKey?: string;
   initialBackgrounded?: boolean;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
@@ -745,6 +746,7 @@ export async function runExecProcess(opts: {
     id: sessionId,
     command: opts.command,
     executionKey,
+    execReuseKey: opts.execReuseKey,
     scopeKey: opts.scopeKey,
     sessionKey: opts.sessionKey,
     mainKey: opts.mainKey,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -3,6 +3,7 @@
  * Spawns host/sandbox processes, manages session updates/backgrounding,
  * approval messaging constants, environment safety, and exit outcome shaping.
  */
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
@@ -71,6 +72,43 @@ function resolveExecTimeoutMs(timeoutSec: number | null | undefined): number | u
     return undefined;
   }
   return resolveSafeTimeoutDelayMs(timeoutSec * 1000);
+}
+
+function stableStringEntries(record: Record<string, string> | undefined) {
+  return Object.entries(record ?? {}).toSorted(([left], [right]) => left.localeCompare(right));
+}
+
+export function buildExecSessionExecutionKey(params: {
+  command: string;
+  execCommand?: string;
+  workdir: string;
+  env: Record<string, string>;
+  pathPrepend?: string[];
+  sandbox?: BashSandboxConfig;
+  containerWorkdir?: string | null;
+  usePty: boolean;
+  timeoutSec: number | null;
+}) {
+  const payload = {
+    command: params.command,
+    execCommand: params.execCommand ?? params.command,
+    workdir: params.workdir,
+    env: stableStringEntries(params.env),
+    pathPrepend: params.pathPrepend ?? [],
+    sandbox: params.sandbox
+      ? {
+          containerName: params.sandbox.containerName,
+          workspaceDir: params.sandbox.workspaceDir,
+          containerWorkdir: params.sandbox.containerWorkdir,
+          env: stableStringEntries(params.sandbox.env),
+          customExecSpec: typeof params.sandbox.buildExecSpec === "function",
+        }
+      : null,
+    containerWorkdir: params.containerWorkdir ?? null,
+    usePty: params.usePty,
+    timeoutSec: params.timeoutSec,
+  };
+  return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
 }
 
 /**
@@ -688,11 +726,14 @@ export async function runExecProcess(opts: {
   eventRouting?: EventSessionRoutingPolicy;
   notifyDeliveryContext?: DeliveryContext;
   timeoutSec: number | null;
+  executionKey?: string;
+  initialBackgrounded?: boolean;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
   const startedAt = Date.now();
   const sessionId = createSessionSlug();
   const execCommand = opts.execCommand ?? opts.command;
+  const executionKey = opts.executionKey ?? buildExecSessionExecutionKey(opts);
   const diagnosticTarget = opts.sandbox ? "sandbox" : "host";
   const supervisor = getProcessSupervisor();
   const shellRuntimeEnv: Record<string, string> = {
@@ -703,6 +744,7 @@ export async function runExecProcess(opts: {
   const session: ProcessSession = {
     id: sessionId,
     command: opts.command,
+    executionKey,
     scopeKey: opts.scopeKey,
     sessionKey: opts.sessionKey,
     mainKey: opts.mainKey,
@@ -730,7 +772,9 @@ export async function runExecProcess(opts: {
     exitCode: undefined as number | null | undefined,
     exitSignal: undefined as NodeJS.Signals | number | null | undefined,
     truncated: false,
-    backgrounded: false,
+    // Explicit background requests become pollable at registration so overlapping retries reuse this session.
+    // Pre-spawn setup errors are marked failed below to avoid phantom process entries.
+    backgrounded: opts.initialBackgrounded === true,
     cursorKeyMode: opts.usePty ? "unknown" : "normal",
   };
   addSession(session);
@@ -801,7 +845,7 @@ export async function runExecProcess(opts: {
   const timeoutMs = resolveExecTimeoutMs(opts.timeoutSec);
   let sandboxFinalizeToken: unknown;
 
-  const spawnSpec:
+  type ExecSpawnSpec =
     | {
         mode: "child";
         argv: string[];
@@ -814,66 +858,86 @@ export async function runExecProcess(opts: {
         childFallbackArgv: string[];
         env: NodeJS.ProcessEnv;
         stdinMode: "pipe-open";
-      } = await (async () => {
-    if (opts.sandbox) {
-      const backendExecSpec = await opts.sandbox.buildExecSpec?.({
-        command: execCommand,
-        workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
+      };
+
+  let spawnSpec: ExecSpawnSpec;
+  try {
+    spawnSpec = await (async (): Promise<ExecSpawnSpec> => {
+      if (opts.sandbox) {
+        const backendExecSpec = await opts.sandbox.buildExecSpec?.({
+          command: execCommand,
+          workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
+          env: shellRuntimeEnv,
+          usePty: opts.usePty,
+        });
+        sandboxFinalizeToken = backendExecSpec?.finalizeToken;
+        return {
+          mode: "child" as const,
+          argv: backendExecSpec?.argv ?? [
+            "docker",
+            ...buildDockerExecArgs({
+              containerName: opts.sandbox.containerName,
+              command: execCommand,
+              workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
+              env: shellRuntimeEnv,
+              tty: opts.usePty,
+            }),
+          ],
+          env: backendExecSpec?.env ?? process.env,
+          stdinMode:
+            backendExecSpec?.stdinMode ??
+            (opts.usePty ? ("pipe-open" as const) : ("pipe-closed" as const)),
+        };
+      }
+      const { shell, args: shellArgs } = getShellConfig();
+
+      // Wrap the command to enforce PATH prepend precedence over shell RC overrides.
+      const commandWithPathPrepend = wrapPosixCommandWithPathPrepend(
+        execCommand,
+        shellRuntimeEnv,
+        opts.pathPrepend,
+      );
+      const commandWithShellSnapshot = await maybeWrapCommandWithShellSnapshot({
+        command: commandWithPathPrepend,
+        shell,
+        shellArgs,
+        cwd: opts.workdir,
         env: shellRuntimeEnv,
-        usePty: opts.usePty,
       });
-      sandboxFinalizeToken = backendExecSpec?.finalizeToken;
+
+      const childArgv = [shell, ...shellArgs, commandWithShellSnapshot];
+      if (opts.usePty) {
+        return {
+          mode: "pty" as const,
+          ptyCommand: commandWithShellSnapshot,
+          childFallbackArgv: childArgv,
+          env: shellRuntimeEnv,
+          stdinMode: "pipe-open" as const,
+        };
+      }
       return {
         mode: "child" as const,
-        argv: backendExecSpec?.argv ?? [
-          "docker",
-          ...buildDockerExecArgs({
-            containerName: opts.sandbox.containerName,
-            command: execCommand,
-            workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
-            env: shellRuntimeEnv,
-            tty: opts.usePty,
-          }),
-        ],
-        env: backendExecSpec?.env ?? process.env,
-        stdinMode:
-          backendExecSpec?.stdinMode ??
-          (opts.usePty ? ("pipe-open" as const) : ("pipe-closed" as const)),
-      };
-    }
-    const { shell, args: shellArgs } = getShellConfig();
-
-    // Wrap the command to enforce PATH prepend precedence over shell RC overrides.
-    const commandWithPathPrepend = wrapPosixCommandWithPathPrepend(
-      execCommand,
-      shellRuntimeEnv,
-      opts.pathPrepend,
-    );
-    const commandWithShellSnapshot = await maybeWrapCommandWithShellSnapshot({
-      command: commandWithPathPrepend,
-      shell,
-      shellArgs,
-      cwd: opts.workdir,
-      env: shellRuntimeEnv,
-    });
-
-    const childArgv = [shell, ...shellArgs, commandWithShellSnapshot];
-    if (opts.usePty) {
-      return {
-        mode: "pty" as const,
-        ptyCommand: commandWithShellSnapshot,
-        childFallbackArgv: childArgv,
+        argv: childArgv,
         env: shellRuntimeEnv,
-        stdinMode: "pipe-open" as const,
+        stdinMode: "pipe-closed" as const,
       };
-    }
-    return {
-      mode: "child" as const,
-      argv: childArgv,
-      env: shellRuntimeEnv,
-      stdinMode: "pipe-closed" as const,
-    };
-  })();
+    })();
+  } catch (err) {
+    markExited(session, null, null, "failed");
+    maybeNotifyOnExit(session, "failed");
+    emitExecProcessCompleted({
+      command: opts.command,
+      mode: opts.usePty ? "pty" : "child",
+      outcome: buildExecRuntimeErrorOutcome({
+        error: err,
+        aggregated: session.aggregated.trim(),
+        durationMs: Date.now() - startedAt,
+      }),
+      sessionKey: opts.sessionKey,
+      target: diagnosticTarget,
+    });
+    throw err;
+  }
 
   let managedRun: ManagedRun | null = null;
   let usingPty = spawnSpec.mode === "pty";

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -50,7 +50,11 @@ import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import { stripMalformedXmlArgValueSuffixFromKeys } from "./agent-tools.params.js";
-import { markBackgrounded } from "./bash-process-registry.js";
+import {
+  findMatchingRunningBackgroundSession,
+  markBackgrounded,
+  type ProcessSession,
+} from "./bash-process-registry.js";
 import { describeExecTool } from "./bash-tools.descriptions.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
 import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
@@ -1838,11 +1842,41 @@ export function createExecTool(
       const effectiveTimeout = explicitTimeoutSec ?? defaultTimeoutSec;
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
+      const buildRunningResult = (session: ProcessSession): AgentToolResult<ExecToolDetails> => ({
+        content: [
+          {
+            type: "text",
+            text: `${getWarningText()}Command still running (session ${session.id}, pid ${
+              session.pid ?? "n/a"
+            }). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.`,
+          },
+        ],
+        details: {
+          status: "running",
+          sessionId: session.id,
+          pid: session.pid ?? undefined,
+          startedAt: session.startedAt,
+          cwd: session.cwd,
+          tail: session.tail,
+        },
+      });
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.
       if (!shouldSkipExecScriptPreflight({ host, security, ask })) {
         await validateScriptFileForShellBleed({ command: params.command, workdir });
+      }
+
+      if (allowBackground && workdir) {
+        const matchingSession = findMatchingRunningBackgroundSession({
+          command: params.command,
+          cwd: workdir,
+          scopeKey: defaults?.scopeKey,
+          sessionKey: notifySessionKey,
+        });
+        if (matchingSession) {
+          return buildRunningResult(matchingSession);
+        }
       }
 
       const run = await runExecProcess({
@@ -1910,24 +1944,7 @@ export function createExecTool(
       return new Promise<AgentToolResult<ExecToolDetails>>((resolve, reject) => {
         const resolveRunning = () => {
           cleanupToolRunListeners();
-          resolve({
-            content: [
-              {
-                type: "text",
-                text: `${getWarningText()}Command still running (session ${run.session.id}, pid ${
-                  run.session.pid ?? "n/a"
-                }). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.`,
-              },
-            ],
-            details: {
-              status: "running",
-              sessionId: run.session.id,
-              pid: run.session.pid ?? undefined,
-              startedAt: run.startedAt,
-              cwd: run.session.cwd,
-              tail: run.session.tail,
-            },
-          });
+          resolve(buildRunningResult(run.session));
         };
 
         const onYieldNow = () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1880,12 +1880,19 @@ export function createExecTool(
         timeoutSec: effectiveTimeout,
       });
 
-      const duplicateReuseRequested = backgroundRequested || yieldRequested;
-      if (allowBackground && workdir && duplicateReuseRequested) {
+      const execReuseKey = backgroundRequested
+        ? "explicit-background"
+        : yieldRequested
+          ? "explicit-yield"
+          : allowBackground && yieldWindow !== null
+            ? "default-yield"
+            : undefined;
+      if (workdir && execReuseKey) {
         const matchingSession = findMatchingRunningBackgroundSession({
           command: params.command,
           cwd: workdir,
           executionKey,
+          reuseKey: execReuseKey,
           scopeKey: defaults?.scopeKey,
           sessionKey: notifySessionKey,
         });
@@ -1916,6 +1923,7 @@ export function createExecTool(
         notifyDeliveryContext,
         timeoutSec: effectiveTimeout,
         executionKey,
+        execReuseKey,
         initialBackgrounded: backgroundRequested && allowBackground,
         onUpdate,
       });

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -66,6 +66,7 @@ import {
   type ExecProcessOutcome,
   applyPathPrepend,
   applyShellPath,
+  buildExecSessionExecutionKey,
   normalizePathPrepend,
   resolveExecTarget,
   resolveApprovalRunningNoticeMs,
@@ -1867,10 +1868,24 @@ export function createExecTool(
         await validateScriptFileForShellBleed({ command: params.command, workdir });
       }
 
-      if (allowBackground && workdir) {
+      const executionKey = buildExecSessionExecutionKey({
+        command: params.command,
+        execCommand: execCommandOverride,
+        workdir,
+        env,
+        pathPrepend: defaultPathPrepend,
+        sandbox,
+        containerWorkdir,
+        usePty,
+        timeoutSec: effectiveTimeout,
+      });
+
+      const duplicateReuseRequested = backgroundRequested || yieldRequested;
+      if (allowBackground && workdir && duplicateReuseRequested) {
         const matchingSession = findMatchingRunningBackgroundSession({
           command: params.command,
           cwd: workdir,
+          executionKey,
           scopeKey: defaults?.scopeKey,
           sessionKey: notifySessionKey,
         });
@@ -1900,6 +1915,8 @@ export function createExecTool(
         eventRouting: defaults?.eventRouting,
         notifyDeliveryContext,
         timeoutSec: effectiveTimeout,
+        executionKey,
+        initialBackgrounded: backgroundRequested && allowBackground,
         onUpdate,
       });
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -788,6 +788,60 @@ describe("exec tool backgrounding", () => {
     expect(hasSession(sessions, firstSessionId)).toBe(true);
   });
 
+  it("reuses an in-flight scoped background session for identical explicit background commands", async () => {
+    const scopedTools = createScopedToolSet(SCOPE_KEY_ALPHA);
+
+    const [firstResult, secondResult] = await Promise.all([
+      executeExecCommand(scopedTools.exec, SCOPED_BACKGROUND_COMMAND, { background: true }),
+      executeExecCommand(scopedTools.exec, SCOPED_BACKGROUND_COMMAND, { background: true }),
+    ]);
+
+    expect(requireRunningSessionId(secondResult)).toBe(requireRunningSessionId(firstResult));
+  });
+
+  it("does not reuse a running background session for a foreground rerun", async () => {
+    const scopedTools = createScopedToolSet(SCOPE_KEY_ALPHA);
+
+    const firstResult = await executeExecCommand(scopedTools.exec, SCOPED_BACKGROUND_COMMAND, {
+      background: true,
+    });
+    const firstSessionId = requireRunningSessionId(firstResult);
+    const secondResult = await executeExecCommand(scopedTools.exec, SCOPED_BACKGROUND_COMMAND);
+
+    expect((secondResult.details as { sessionId?: string }).sessionId).not.toBe(firstSessionId);
+  });
+
+  it.each([
+    withLabel("env override changes", {
+      first: { env: { OPENCLAW_DUPLICATE_EXEC_TEST: "one" } },
+      second: { env: { OPENCLAW_DUPLICATE_EXEC_TEST: "two" } },
+    }),
+    withLabel("pty mode changes", {
+      first: {},
+      second: { pty: true },
+    }),
+    withLabel("timeout changes", {
+      first: { timeout: 30 },
+      second: { timeout: 31 },
+    }),
+  ])("starts a distinct scoped background session when $label", async ({ first, second }) => {
+    const scopedTools = createScopedToolSet(SCOPE_KEY_ALPHA);
+
+    const firstResult = await executeExecCommand(scopedTools.exec, SCOPED_BACKGROUND_COMMAND, {
+      background: true,
+      ...first,
+    });
+    const firstSessionId = requireRunningSessionId(firstResult);
+
+    const secondResult = await executeExecCommand(scopedTools.exec, SCOPED_BACKGROUND_COMMAND, {
+      background: true,
+      ...second,
+    });
+    const secondSessionId = requireRunningSessionId(secondResult);
+
+    expect(secondSessionId).not.toBe(firstSessionId);
+  });
+
   it("restarts a scoped background command once the previous run completes", async () => {
     const tool = createTestExecTool({ backgroundMs: 0, scopeKey: SCOPE_KEY_ALPHA });
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -21,6 +21,7 @@ import {
   addSession,
   appendOutput,
   getFinishedSession,
+  listRunningSessions,
   markBackgrounded,
   markExited,
   resetProcessRegistryForTests,
@@ -268,6 +269,7 @@ const OUTPUT_EXEC_COMPLETED = "Exec completed";
 const OUTPUT_EXIT_CODE_1 = "Command exited with code 1";
 const shellEcho = (message: string) => (isWin ? `Write-Output ${message}` : `echo ${message}`);
 const COMMAND_NOOP = isWin ? "$null" : ":";
+const SCOPED_BACKGROUND_COMMAND = isWin ? "Start-Sleep -Milliseconds 50" : "sleep 0.05";
 const COMMAND_ECHO_HELLO = shellEcho("hello");
 const COMMAND_PRINT_PATH = isWin ? "Write-Output $env:PATH" : "echo $PATH";
 const COMMAND_EXIT_WITH_ERROR = "exit 1";
@@ -765,6 +767,42 @@ describe("exec tool backgrounding", () => {
     const sessions = await listProcessSessions(processTool);
     expect(hasSession(sessions, sessionId)).toBe(true);
     expect(sessions.find((s) => s.sessionId === sessionId)?.name).toBe(COMMAND_ECHO_HELLO);
+  });
+
+  it("reuses a running scoped background session for identical commands", async () => {
+    const scopedTools = createScopedToolSet(SCOPE_KEY_ALPHA);
+
+    const firstResult = await executeExecCommand(scopedTools.exec, SCOPED_BACKGROUND_COMMAND, {
+      background: true,
+    });
+    const firstSessionId = requireRunningSessionId(firstResult);
+
+    const secondResult = await executeExecCommand(scopedTools.exec, SCOPED_BACKGROUND_COMMAND, {
+      background: true,
+    });
+    const secondSessionId = requireRunningSessionId(secondResult);
+
+    expect(secondSessionId).toBe(firstSessionId);
+    expect(listRunningSessions()).toHaveLength(1);
+    const sessions = await listProcessSessions(scopedTools.process);
+    expect(hasSession(sessions, firstSessionId)).toBe(true);
+  });
+
+  it("restarts a scoped background command once the previous run completes", async () => {
+    const tool = createTestExecTool({ backgroundMs: 0, scopeKey: SCOPE_KEY_ALPHA });
+
+    const firstResult = await executeExecCommand(tool, SCOPED_BACKGROUND_COMMAND, {
+      background: true,
+    });
+    const firstSessionId = requireRunningSessionId(firstResult);
+    await waitForCompletion(firstSessionId);
+
+    const secondResult = await executeExecCommand(tool, SCOPED_BACKGROUND_COMMAND, {
+      background: true,
+    });
+    const secondSessionId = requireRunningSessionId(secondResult);
+
+    expect(secondSessionId).not.toBe(firstSessionId);
   });
 
   it.each<DisallowedElevationCase>(DISALLOWED_ELEVATION_CASES)(

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -201,6 +201,7 @@ vi.mock("../process/supervisor/index.js", () => {
         const exitCode = splitCommands(unwrapSnapshotEvalCommand(command)).includes("exit 1")
           ? 1
           : 0;
+        const waitDelayMs = command.includes("openclaw-delay") ? 30 : 0;
         const stagedOutput = command.includes("after")
           ? output.replace(/after[^\n]*\n?/gu, "")
           : output;
@@ -214,8 +215,14 @@ vi.mock("../process/supervisor/index.js", () => {
           pid: 123,
           stdin: undefined,
           wait: async () => {
-            await immediate();
-            await immediate();
+            if (waitDelayMs > 0) {
+              await new Promise((resolve) => {
+                setTimeout(resolve, waitDelayMs);
+              });
+            } else {
+              await immediate();
+              await immediate();
+            }
             if (deferredOutput) {
               input.onStdout?.(deferredOutput);
             }
@@ -270,6 +277,9 @@ const OUTPUT_EXIT_CODE_1 = "Command exited with code 1";
 const shellEcho = (message: string) => (isWin ? `Write-Output ${message}` : `echo ${message}`);
 const COMMAND_NOOP = isWin ? "$null" : ":";
 const SCOPED_BACKGROUND_COMMAND = isWin ? "Start-Sleep -Milliseconds 50" : "sleep 0.05";
+const SCOPED_AUTO_YIELD_COMMAND = isWin
+  ? "Start-Sleep -Milliseconds 50 # openclaw-delay"
+  : "sleep 0.05 # openclaw-delay";
 const COMMAND_ECHO_HELLO = shellEcho("hello");
 const COMMAND_PRINT_PATH = isWin ? "Write-Output $env:PATH" : "echo $PATH";
 const COMMAND_EXIT_WITH_ERROR = "exit 1";
@@ -786,6 +796,19 @@ describe("exec tool backgrounding", () => {
     expect(listRunningSessions()).toHaveLength(1);
     const sessions = await listProcessSessions(scopedTools.process);
     expect(hasSession(sessions, firstSessionId)).toBe(true);
+  });
+
+  it("reuses a default auto-yielded scoped background session for identical commands", async () => {
+    const scopedTools = createScopedToolSet(SCOPE_KEY_ALPHA);
+
+    const firstResult = await executeExecCommand(scopedTools.exec, SCOPED_AUTO_YIELD_COMMAND);
+    const firstSessionId = requireRunningSessionId(firstResult);
+
+    const secondResult = await executeExecCommand(scopedTools.exec, SCOPED_AUTO_YIELD_COMMAND);
+    const secondSessionId = requireRunningSessionId(secondResult);
+
+    expect(secondSessionId).toBe(firstSessionId);
+    expect(listRunningSessions()).toHaveLength(1);
   });
 
   it("reuses an in-flight scoped background session for identical explicit background commands", async () => {


### PR DESCRIPTION
## Linked context

Closes #62432.

## Summary

- Repeated identical scoped background-capable `exec` retries now reuse the existing running process session instead of launching another child process.
- Reuse covers explicit `background: true`, explicit `yieldMs`, and the default auto-yield path where the model omits both fields.
- The match is conservative: command, resolved cwd, scoped process identity, reuse mode, and resolved execution options must match.
- Plain foreground reruns, completed reruns, env/PTY/timeout/cwd/scope/session drift, and normal `process` polling behavior remain separate.

## AI assistance

This PR was implemented with Codex assistance. I reviewed the change and understand the affected `exec` / `process` runtime path.

## Real behavior proof

Behavior addressed:
Identical scoped `exec` calls with omitted `background` and `yieldMs` reuse the running default auto-yield session instead of spawning duplicate processes.

Real environment tested:
Local OpenClaw source checkout on branch `fix-62432`, using the real `createExecTool` and `createProcessTool` implementations with isolated `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`. No live provider, channel, or credential state was used.

Exact steps or command run after this patch:

```sh
mkdir -p .artifacts/pr-proof
proof_log=".artifacts/pr-proof/62432-20260601T142833Z-default-auto-yield.log"
OPENCLAW_EXEC_SHELL_SNAPSHOT=0 \
OPENCLAW_HOME="$(mktemp -d)" \
OPENCLAW_STATE_DIR="$(mktemp -d)" \
OPENCLAW_CONFIG_PATH="$(mktemp -u)" \
node --import tsx --input-type=module <<'EOF' | tee "$proof_log"
import process from "node:process";
import { createExecTool, createProcessTool } from "./src/agents/bash-tools.js";
import { resetProcessRegistryForTests } from "./src/agents/bash-process-registry.js";

const scopeKey = "issue-62432-default-auto-yield-proof";
const command = "sleep 30";
resetProcessRegistryForTests();

const execTool = createExecTool({
  allowBackground: true,
  backgroundMs: 10,
  cwd: process.cwd(),
  notifyOnExit: false,
  scopeKey,
});
const processTool = createProcessTool({ scopeKey, cleanupMs: 60_000 });

const first = await execTool.execute("proof-default-yield-1", { command });
const second = await execTool.execute("proof-default-yield-2", { command });
const listed = await processTool.execute("proof-list", { action: "list" });
const runningSessions = (listed.details?.sessions ?? []).filter(
  (session) => session.status === "running",
);

console.log(`Evidence after fix: firstSessionId=${first.details?.sessionId}; secondSessionId=${second.details?.sessionId}; runningSessions=${runningSessions.length}`);
console.log(`Observed result after fix: reused=${first.details?.sessionId === second.details?.sessionId}; firstStatus=${first.details?.status}; secondStatus=${second.details?.status}`);

await processTool.execute("proof-remove", {
  action: "remove",
  sessionId: first.details?.sessionId,
});
resetProcessRegistryForTests();
EOF
```

Evidence after fix:

```txt
Behavior addressed: identical exec calls with omitted background/yieldMs reuse the running default auto-yield session
Real environment tested: local OpenClaw exec/process tools via node --import tsx, isolated OPENCLAW_HOME/STATE/CONFIG, scopeKey=issue-62432-default-auto-yield-proof
Exact steps or command run after this patch: createExecTool({backgroundMs:10, scopeKey}).execute({command:"sleep 30"}) twice, then process list
Evidence after fix: firstSessionId=young-mist; secondSessionId=young-mist; runningSessions=1
Observed result after fix: reused=true; firstStatus=running; secondStatus=running
What was not tested: provider UI rendering, remote gateway/node host, and explicit human approval prompts
First response: Command still running (session young-mist, pid 72708). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.
Second response: Command still running (session young-mist, pid 72708). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.
Cleanup: Removed session young-mist (termination requested).
proof_log=.artifacts/pr-proof/62432-20260601T142833Z-default-auto-yield.log
```

Observed result after fix:
Both default auto-yield `exec` calls returned `status: "running"` with the same session id, and `process list` reported one running session.

What was not tested:
No live Xiaomi/MiMo replay or provider-driven agent turn was run. The proof exercises the runtime/tool path directly; GitHub CI covers the broader platform matrix.

## Root Cause

`handleExec` called `runExecProcess` before returning the running-session guidance. `runExecProcess` generated and registered a fresh process session for each call. The registry had id/list lookups, but no scoped same-execution lookup for an already-backgrounded in-flight process.

The issue is easiest to trigger when a model ignores the process follow-up guidance and repeats the same long-running `exec` call. Before this patch, OpenClaw treated that retry as a new launch.

## Dependency contract

External dependencies: none.

Source and docs checked:

- `src/agents/bash-tools.exec.ts`
- `src/agents/bash-tools.exec-runtime.ts`
- `src/agents/bash-process-registry.ts`
- `src/agents/bash-tools.process.ts`
- `docs/gateway/background-process.md`
- `docs/tools/exec.md`

Contract used here: backgrounded sessions are managed through the `process` tool, are scoped by process identity, and are only pollable/listed when backgrounded. This patch stays inside that registry/tool contract and does not change public tool schemas.

## Regression Test Plan

- Added registry coverage for exact command/cwd/execution-key/reuse-key scoped matches, missing execution identity, mismatched reuse mode, mismatched scope/session, different command, different cwd, and foreground sessions.
- Added behavior coverage for repeated identical scoped explicit-background `exec` calls.
- Added behavior coverage for repeated identical scoped default auto-yield `exec` calls with omitted `background` and `yieldMs`.
- Added coverage for overlapping explicit background retries while the first spawn is still in flight.
- Added negative coverage that env, PTY, and timeout drift start distinct sessions.
- Added negative coverage that a plain foreground rerun is not collapsed into an active explicit-background session.
- Added runtime cleanup coverage for pre-spawn setup failures after an explicit background session is registered.

## Security Impact

No new permissions, network calls, credential handling, or approval bypass. The duplicate-session check runs after the existing exec target/security/workdir/approval path. Execution identity is stored as an opaque SHA-256 hash, not raw environment data.

## Human Verification

- Reproduced the pre-fix runtime behavior with two direct `runExecProcess` calls: `before_fix_running_sessions=2`.
- Ran the after-fix runtime proof above and reviewed the exec/process path.
- Confirmed the branch was rebased onto the refreshed `upstream/main` after local `main` and fork `origin/main` were safely fast-forwarded.

## CODEOWNERS / owner review

Checked `.github/CODEOWNERS`; the touched `src/agents/bash-*` files do not match the restricted auth/sandbox/secops entries. Expected review is normal agent runtime maintainer review.

## Changelog

No contributor `CHANGELOG.md` edit.

## Review conversations

- Target issue search found no linked or exact open PR for `62432`.
- Related closed/stale PRs were checked for fix shape and maintainer intent.
- A codex-spark worker was asked to inspect/implement; its partial edits were reviewed and corrected before integration.
- ClawSweeper/local review found concrete issues during drafting: option-drift reuse, pre-spawn phantom sessions, foreground rerun collapse, and missing default auto-yield coverage. This patch addresses them with code and tests.
- Final `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` returned clean.
- Standalone `codex review --base origin/main` was run after the final rebase, but the command timed out after 30 minutes before returning a verdict.

## Risks

An explicit background/yield/default-yield retry that intentionally wants a second identical concurrent process in the same scoped process identity needs a distinct execution option or command text. Plain foreground reruns are preserved.

## Behavior tradeoffs

The guard uses exact execution identity and an explicit reuse-mode key instead of fuzzy command similarity. That keeps the fix narrow and avoids guessing intent from generated text.

## Scope boundaries

- No provider-specific Xiaomi/MiMo routing change.
- No loop-detection threshold or config change.
- No process persistence, schema, docs, or public config change.
- Completed-session reruns and plain foreground reruns remain allowed.
- Unscoped ad hoc exec calls are not coalesced.

## Validation

- `git diff --check upstream/main...HEAD`
- `pnpm exec oxfmt --check --threads=1 src/agents/bash-process-registry.ts src/agents/bash-process-registry.test.ts src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/bash-tools.test.ts src/agents/bash-process-registry.test.ts src/agents/bash-tools.exec-runtime.test.ts` -> 94 tests passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-process-registry.test.ts src/agents/tool-loop-detection.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts` -> 3 Vitest shards passed
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean
- `codex review --base origin/main` -> attempted; timed out after 30 minutes without a verdict
- Real runtime proof above
