### PR TITLE
fix(agent-tools): guard system prompt tool reports

### DIFF
--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -184,6 +184,63 @@ describe("buildSystemPromptReport", () => {
     expect(sameLengthChangedPrompt.systemPrompt.hash).not.toBe(report.systemPrompt.hash);
   });
 
+  it("keeps tool reporting lossy-safe when tool metadata is unreadable", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
+    const unreadableTool = Object.defineProperties(
+      {},
+      {
+        name: {
+          get() {
+            throw new Error("system report name getter exploded");
+          },
+        },
+        description: {
+          get() {
+            throw new Error("system report description getter exploded");
+          },
+        },
+        label: {
+          get() {
+            throw new Error("system report label getter exploded");
+          },
+        },
+        parameters: {
+          get() {
+            throw new Error("system report parameters getter exploded");
+          },
+        },
+      },
+    );
+
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [],
+      skillsPrompt: "",
+      tools: [
+        unreadableTool,
+        {
+          name: "read",
+          description: "Read files",
+          parameters: {
+            type: "object",
+            properties: {},
+          },
+        },
+      ] as never,
+    });
+
+    expect(report.tools.entries.map((tool) => tool.name)).toEqual(["tool[0]", "read"]);
+    expect(report.tools.entries[0]).toMatchObject({
+      summaryChars: 0,
+      schemaChars: 0,
+      propertiesCount: null,
+    });
+  });
+
   it("keeps reporting when a tool schema cannot be stringified", () => {
     const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
     const circularSchema: Record<string, unknown> = {

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -43,7 +43,7 @@ function parseSkillBlocks(skillsPrompt: string): Array<{ name: string; blockChar
 }
 
 function buildToolSchemaStats(
-  parameters: AgentTool["parameters"],
+  parameters: AgentTool["parameters"] | undefined,
 ): Pick<ToolReportEntry, "propertiesCount" | "schemaChars" | "schemaHash"> {
   if (!parameters || typeof parameters !== "object") {
     return { schemaChars: 0, schemaHash: sha256(""), propertiesCount: null };
@@ -75,19 +75,52 @@ function buildToolSchemaStats(
 }
 
 function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools"]["entries"] {
-  return tools.map((tool) => {
+  return tools.map((tool, index) => {
     const cached = toolReportEntryCache.get(tool);
     if (cached) {
       return cached;
     }
-    const name = tool.name;
-    const summary = tool.description?.trim() || tool.label?.trim() || "";
+    const name = readToolReportName(tool, index);
+    const summary = readToolReportSummary(tool);
     const summaryChars = summary.length;
-    const schemaStats = buildToolSchemaStats(tool.parameters);
+    const schemaStats = buildToolSchemaStats(readToolReportParameters(tool));
     const entry = { name, summaryChars, summaryHash: sha256(summary), ...schemaStats };
     toolReportEntryCache.set(tool, entry);
     return entry;
   });
+}
+
+function readToolReportName(tool: AgentTool, index: number): string {
+  try {
+    const name = tool.name.trim();
+    return name || `tool[${index}]`;
+  } catch {
+    return `tool[${index}]`;
+  }
+}
+
+function readToolReportSummary(tool: AgentTool): string {
+  try {
+    const description = tool.description?.trim();
+    if (description) {
+      return description;
+    }
+  } catch {
+    return "";
+  }
+  try {
+    return tool.label?.trim() || "";
+  } catch {
+    return "";
+  }
+}
+
+function readToolReportParameters(tool: AgentTool): AgentTool["parameters"] | undefined {
+  try {
+    return tool.parameters;
+  } catch {
+    return undefined;
+  }
 }
 
 function measureRenderedProjectContextChars(systemPrompt: string): number {


### PR DESCRIPTION
## Summary

- make generic system prompt tool reports tolerate unreadable tool metadata
- use fallback `tool[index]`, empty summaries, and empty schema stats when report-only fields throw
- preserve healthy sibling tool report entries instead of aborting report generation

## Verification

- `node scripts/run-vitest.mjs src/agents/system-prompt-report.test.ts --reporter=dot`
- `node_modules/.bin/oxlint src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `git diff --check HEAD~1..HEAD`
- direct `node --import tsx` repro: a throwing `description` getter no longer aborts `buildSystemPromptReport`; observed `bad_report_probe,read`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: generic OpenClaw system prompt reporting can no longer abort when diagnostic-only tool metadata accessors throw.

Real environment tested: local OpenClaw unit-fast system prompt report test via repo wrapper; direct `tsx` repro of `buildSystemPromptReport`.

Exact steps or command run after this patch: ran the focused system-prompt-report Vitest file, oxlint on both touched files, `git diff --check`, branch autoreview, and a direct `tsx` system-prompt-report repro with a throwing `description` getter.

Evidence after fix: focused Vitest passed 11 tests in 1 file after final rebase; oxlint and diff check passed; branch autoreview reported no accepted/actionable findings; the direct repro printed `bad_report_probe,read`.

Observed result after fix: the bad tool contributes a lossy report entry and the healthy `read` tool remains present in the system prompt report.

What was not tested: remote `pnpm check:changed` did not run; Blacksmith is unauthenticated locally, and AWS Crabbox was not retried because local disk is too low for the wrapper's temporary full checkout.
