### PR TITLE
fix(agent-runtime): guard provider schema diagnostics

### DIFF
--- a/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   inspectProviderToolSchemasWithPlugin: vi.fn(),
@@ -22,6 +22,13 @@ const { logProviderToolSchemaDiagnostics, normalizeProviderToolSchemas } =
   await import("./tool-schema-runtime.js");
 
 describe("tool schema runtime diagnostics", () => {
+  beforeEach(() => {
+    mocks.inspectProviderToolSchemasWithPlugin.mockReset();
+    mocks.normalizeProviderToolSchemasWithPlugin.mockReset();
+    mocks.log.info.mockClear();
+    mocks.log.warn.mockClear();
+  });
+
   it("stays quiet when a provider reports no diagnostics", () => {
     mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([]);
 
@@ -79,6 +86,58 @@ describe("tool schema runtime diagnostics", () => {
         tools: ["0:alpha", "1:beta"],
         diagnostics: [
           { index: 0, tool: "alpha", violations: ["one", "two"], violationCount: 2 },
+          { index: 1, tool: "beta", violations: ["one"], violationCount: 1 },
+        ],
+      },
+    );
+  });
+
+  it("keeps diagnostic logging lossy-safe when tool metadata is unreadable", () => {
+    const unreadableTool = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("diagnostic tool name getter exploded");
+      },
+    });
+    const unreadableDiagnostic = Object.defineProperties(
+      {},
+      {
+        toolName: {
+          get() {
+            throw new Error("diagnostic tool name field exploded");
+          },
+        },
+        toolIndex: {
+          get() {
+            throw new Error("diagnostic tool index field exploded");
+          },
+        },
+        violations: {
+          get() {
+            throw new Error("diagnostic violations field exploded");
+          },
+        },
+      },
+    );
+    mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([
+      unreadableDiagnostic,
+      { toolName: "beta", toolIndex: 1, violations: ["one"] },
+    ]);
+
+    logProviderToolSchemaDiagnostics({
+      provider: "example",
+      tools: [unreadableTool, { name: "beta" }] as never,
+    });
+
+    expect(mocks.log.warn).toHaveBeenCalledTimes(1);
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema diagnostics: 2 tools for example: unknown (0 violations), beta (1 violation)",
+      {
+        provider: "example",
+        toolCount: 2,
+        diagnosticCount: 2,
+        tools: ["0:tool[0]", "1:beta"],
+        diagnostics: [
+          { index: undefined, tool: undefined, violations: [], violationCount: 0 },
           { index: 1, tool: "beta", violations: ["one"], violationCount: 1 },
         ],
       },

--- a/src/agents/embedded-agent-runner/tool-schema-runtime.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.ts
@@ -11,6 +11,12 @@ import type { AgentTool } from "../runtime/index.js";
 import type { AnyAgentTool } from "../tools/common.js";
 import { log } from "./logger.js";
 
+type NormalizedProviderToolSchemaDiagnostic = {
+  toolName?: string;
+  toolIndex?: number;
+  violations: string[];
+};
+
 type ProviderToolSchemaParams<TSchemaType extends TSchema = TSchema, TResult = unknown> = {
   tools: AgentTool<TSchemaType, TResult>[];
   provider: string;
@@ -84,15 +90,16 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
     return;
   }
 
-  const summary = summarizeProviderToolSchemaDiagnostics(diagnostics);
+  const normalizedDiagnostics = diagnostics.map(normalizeProviderToolSchemaDiagnostic);
+  const summary = summarizeProviderToolSchemaDiagnostics(normalizedDiagnostics);
   log.warn(
     `provider tool schema diagnostics: ${diagnostics.length} ${diagnostics.length === 1 ? "tool" : "tools"} for ${params.provider}: ${summary}`,
     {
       provider: params.provider,
       toolCount: params.tools.length,
       diagnosticCount: diagnostics.length,
-      tools: params.tools.map((tool, index) => `${index}:${tool.name}`),
-      diagnostics: diagnostics.map((diagnostic) => ({
+      tools: params.tools.map((tool, index) => readProviderToolNameForDiagnostics(tool, index)),
+      diagnostics: normalizedDiagnostics.map((diagnostic) => ({
         index: diagnostic.toolIndex,
         tool: diagnostic.toolName,
         violations: diagnostic.violations.slice(0, 12),
@@ -103,7 +110,7 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
 }
 
 function summarizeProviderToolSchemaDiagnostics(
-  diagnostics: readonly ProviderToolSchemaDiagnostic[],
+  diagnostics: readonly NormalizedProviderToolSchemaDiagnostic[],
 ) {
   const visible = diagnostics.slice(0, 6).map((diagnostic) => {
     const violationCount = diagnostic.violations.length;
@@ -111,4 +118,54 @@ function summarizeProviderToolSchemaDiagnostics(
   });
   const remaining = diagnostics.length - visible.length;
   return remaining > 0 ? `${visible.join(", ")}, +${remaining} more` : visible.join(", ");
+}
+
+function readProviderToolNameForDiagnostics(tool: AgentTool, index: number): string {
+  try {
+    const name = tool.name.trim();
+    return `${index}:${name || `tool[${index}]`}`;
+  } catch {
+    return `${index}:tool[${index}]`;
+  }
+}
+
+function normalizeProviderToolSchemaDiagnostic(
+  diagnostic: ProviderToolSchemaDiagnostic,
+): NormalizedProviderToolSchemaDiagnostic {
+  return {
+    toolName: readProviderDiagnosticToolName(diagnostic),
+    toolIndex: readProviderDiagnosticToolIndex(diagnostic),
+    violations: readProviderDiagnosticViolations(diagnostic),
+  };
+}
+
+function readProviderDiagnosticToolName(
+  diagnostic: ProviderToolSchemaDiagnostic,
+): string | undefined {
+  try {
+    const name = diagnostic.toolName?.trim();
+    return name || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readProviderDiagnosticToolIndex(
+  diagnostic: ProviderToolSchemaDiagnostic,
+): number | undefined {
+  try {
+    return typeof diagnostic.toolIndex === "number" ? diagnostic.toolIndex : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readProviderDiagnosticViolations(diagnostic: ProviderToolSchemaDiagnostic): string[] {
+  try {
+    return diagnostic.violations.filter(
+      (violation): violation is string => typeof violation === "string",
+    );
+  } catch {
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary

- make provider tool-schema diagnostic logging tolerate unreadable tool metadata
- normalize provider-returned diagnostic fields before summarizing/logging them
- preserve the structured warning for healthy diagnostics while dropping hostile diagnostic fields to lossy fallbacks

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-schema-runtime.test.ts --reporter=dot`
- `node_modules/.bin/oxlint src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`
- `git diff --check HEAD~1..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: provider tool-schema diagnostic logging can no longer abort when tool names or provider-returned diagnostic fields throw during warning construction.

Real environment tested: local OpenClaw agent runtime diagnostic test via repo wrapper.

Exact steps or command run after this patch: ran the focused tool-schema-runtime Vitest file, oxlint on both touched files, `git diff --check`, and branch autoreview.

Evidence after fix: focused Vitest passed 4 tests in 1 file after final rebase; oxlint and diff check passed; branch autoreview reported no accepted/actionable findings.

Observed result after fix: unreadable tool and diagnostic metadata is normalized to lossy fallback warning fields instead of throwing from the diagnostic logger.

What was not tested: remote `pnpm check:changed` did not run; Blacksmith is unauthenticated locally. Direct live provider diagnostics were not exercised; the focused test covers the provider hook output shape at the runtime diagnostic boundary.
