### PR TITLE
fix(agent-runtime): skip unreadable allowlist tool names

### DIFF
--- a/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
@@ -34,6 +34,35 @@ describe("tool name allowlists", () => {
     expect([...names]).toEqual(["read", "memory_search", "image_generate"]);
   });
 
+  it("skips unreadable local and client tool names", () => {
+    const unreadableTool = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("allowlist tool name getter exploded");
+      },
+    });
+    const unreadableClientTool = Object.defineProperty({ type: "function" }, "function", {
+      get() {
+        throw new Error("allowlist client function getter exploded");
+      },
+    }) as ClientToolDefinition;
+
+    const names = collectAllowedToolNames({
+      tools: [unreadableTool, createStubTool("read")] as never,
+      clientTools: [
+        unreadableClientTool,
+        {
+          type: "function",
+          function: {
+            name: "client_pick_file",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    });
+
+    expect([...names]).toEqual(["read", "client_pick_file"]);
+  });
+
   it("builds a stable agent session allowlist from custom tool names", () => {
     const allowlist = toSessionToolAllowlist(new Set(["write", "read", "read", "edit"]));
 
@@ -113,6 +142,30 @@ describe("tool name allowlists", () => {
     );
 
     expect(allowlist).toEqual(["exec", "image_generate", "read"]);
+  });
+
+  it("skips unreadable registered and core tool names", () => {
+    const unreadableTool = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("registered tool name getter exploded");
+      },
+    });
+    const registered = toSessionToolAllowlist(
+      collectRegisteredToolNames([unreadableTool, { name: "exec" }] as never),
+    );
+    const core = toSessionToolAllowlist(
+      collectCoreBuiltinToolNames([unreadableTool, { name: "read" }] as never, {
+        isPluginTool: (tool) => {
+          if (tool === unreadableTool) {
+            throw new Error("plugin classifier exploded");
+          }
+          return false;
+        },
+      }),
+    );
+
+    expect(registered).toEqual(["exec"]);
+    expect(core).toEqual(["read"]);
   });
 
   it("excludes client tool names when Tool Search compacts them into the catalog", () => {

--- a/src/agents/embedded-agent-runner/tool-name-allowlist.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.ts
@@ -23,10 +23,10 @@ export function collectAllowedToolNames(params: {
 }): Set<string> {
   const names = new Set<string>();
   for (const tool of params.tools) {
-    addName(names, tool.name);
+    addName(names, readToolName(tool));
   }
   for (const tool of params.clientTools ?? []) {
-    addName(names, tool.function?.name);
+    addName(names, readClientToolName(tool));
   }
   return names;
 }
@@ -37,7 +37,7 @@ export function collectAllowedToolNames(params: {
 export function collectRegisteredToolNames(tools: Array<{ name?: string }>): Set<string> {
   const names = new Set<string>();
   for (const tool of tools) {
-    addName(names, tool.name);
+    addName(names, readToolName(tool));
   }
   return names;
 }
@@ -48,14 +48,44 @@ export function collectCoreBuiltinToolNames(
 ): Set<string> {
   const names = new Set<string>();
   for (const tool of tools) {
-    if (options?.isPluginTool?.(tool)) {
+    if (isPluginToolForAllowlist(tool, options?.isPluginTool)) {
       continue;
     }
-    addName(names, tool.name);
+    addName(names, readToolName(tool));
   }
   return names;
 }
 
 export function toSessionToolAllowlist(allowedToolNames: Iterable<string>): string[] {
   return [...new Set(allowedToolNames)].toSorted((a, b) => a.localeCompare(b));
+}
+
+function readToolName(tool: { name?: string }): string | undefined {
+  try {
+    return tool.name;
+  } catch {
+    return undefined;
+  }
+}
+
+function readClientToolName(tool: ClientToolDefinition): string | undefined {
+  try {
+    return tool.function?.name;
+  } catch {
+    return undefined;
+  }
+}
+
+function isPluginToolForAllowlist(
+  tool: { name?: string },
+  isPluginTool: ((tool: { name?: string }) => boolean) | undefined,
+): boolean {
+  if (!isPluginTool) {
+    return false;
+  }
+  try {
+    return isPluginTool(tool);
+  } catch {
+    return true;
+  }
 }


### PR DESCRIPTION
## Summary

- make embedded runtime allowlist collection skip unreadable local tool names
- skip unreadable client tool function names while preserving readable client entries
- treat tools whose core/plugin classification throws as non-core for conflict allowlists

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-name-allowlist.test.ts --reporter=dot`
- `node_modules/.bin/oxlint src/agents/embedded-agent-runner/tool-name-allowlist.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts`
- `git diff --check HEAD~1..HEAD`
- direct `node --import tsx` repro: a throwing local tool `name` getter no longer aborts `collectAllowedToolNames`; observed `read`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: embedded runtime tool-name allowlist collection can no longer abort when local or client tool name metadata is unreadable.

Real environment tested: local OpenClaw unit-fast tool-name allowlist test via repo wrapper; direct `tsx` repro of `collectAllowedToolNames`.

Exact steps or command run after this patch: ran the focused tool-name-allowlist Vitest file, oxlint on both touched files, `git diff --check`, branch autoreview, and a direct `tsx` allowlist repro with a throwing `name` getter.

Evidence after fix: focused Vitest passed 10 tests in 1 file after final rebase; oxlint and diff check passed; branch autoreview reported no accepted/actionable findings; the direct repro printed `read`.

Observed result after fix: unreadable tool names are omitted from session/replay allowlists and readable sibling tool names remain present.

What was not tested: remote `pnpm check:changed` did not run; Blacksmith is unauthenticated locally.
