### PR TITLE
fix(agent-runtime): skip unreadable construction tool names

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -162,6 +162,31 @@ describe("applyEmbeddedAttemptToolsAllow", () => {
     ).toEqual(["strict__strict_probe", "loose__extra_probe"]);
   });
 
+  it("skips unreadable tool names before policy and plugin group matching", () => {
+    const unreadable = {
+      get name(): string {
+        throw new Error("tool name getter exploded");
+      },
+    };
+    const memoryTool = { name: "memory_search" };
+    const tools = [unreadable, memoryTool, { name: "read" }];
+    const toolMeta = (tool: (typeof tools)[number]) =>
+      tool === memoryTool ? { pluginId: "active-memory" } : undefined;
+
+    expect(applyEmbeddedAttemptToolsAllow(tools, ["read"]).map((tool) => tool.name)).toEqual([
+      "read",
+    ]);
+    expect(applyEmbeddedAttemptToolsAllow(tools, ["*"]).map((tool) => tool.name)).toEqual([
+      "memory_search",
+      "read",
+    ]);
+    expect(
+      applyEmbeddedAttemptToolsAllow(tools, ["active-memory"], { toolMeta }).map(
+        (tool) => tool.name,
+      ),
+    ).toEqual(["memory_search"]);
+  });
+
   it("treats an explicit empty toolsAllow as no tools", () => {
     const tools = [{ name: "exec" }, { name: "read" }, { name: "message" }];
 

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -63,6 +63,11 @@ const NO_CODING_TOOL_CONSTRUCTION_PLAN: OpenClawCodingToolConstructionPlan = {
   includePluginTools: false,
 };
 
+type ReadableTool<T extends { name: string }> = {
+  tool: T;
+  name: string;
+};
+
 function cloneCodingToolConstructionPlan(
   plan: OpenClawCodingToolConstructionPlan,
 ): OpenClawCodingToolConstructionPlan {
@@ -89,6 +94,26 @@ function isKnownLocalCodingToolName(normalized: string): boolean {
   );
 }
 
+function readToolName<T extends { name: string }>(tool: T): string | undefined {
+  try {
+    const name = tool.name;
+    return typeof name === "string" && normalizeToolName(name) ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function collectReadableTools<T extends { name: string }>(tools: T[]): Array<ReadableTool<T>> {
+  const readable: Array<ReadableTool<T>> = [];
+  for (const tool of tools) {
+    const name = readToolName(tool);
+    if (name) {
+      readable.push({ tool, name });
+    }
+  }
+  return readable;
+}
+
 export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
   tools: T[],
   toolsAllow?: string[],
@@ -102,16 +127,22 @@ export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
   if (toolsAllow.length === 0) {
     return [];
   }
+  const readableTools = collectReadableTools(tools);
   if (hasWildcardToolAllowlist(toolsAllow)) {
-    return tools;
+    return readableTools.map((entry) => entry.tool);
   }
   const pluginGroups = options?.toolMeta
-    ? buildPluginToolGroups({ tools, toolMeta: options.toolMeta })
+    ? buildPluginToolGroups({
+        tools: readableTools,
+        toolMeta: (entry) => options.toolMeta?.(entry.tool),
+      })
     : undefined;
   const policy = pluginGroups
     ? expandPolicyWithPluginGroups({ allow: toolsAllow }, pluginGroups)
     : { allow: toolsAllow };
-  return tools.filter((tool) => isToolAllowedByPolicyName(tool.name, policy));
+  return readableTools
+    .filter((entry) => isToolAllowedByPolicyName(entry.name, policy))
+    .map((entry) => entry.tool);
 }
 
 export function mergeForcedEmbeddedAttemptToolsAllow(


### PR DESCRIPTION
## Summary

- Skip tools whose `name` accessor cannot be read before embedded construction-plan allowlist filtering.
- Reuse the readable name snapshot for wildcard, explicit-name, and plugin-id group matching so one hostile tool does not abort the assistant turn setup path.
- Add focused coverage for unreadable tool names across direct allowlists, wildcard allowlists, and plugin-group expansion.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts --reporter=dot`
- `node_modules/.bin/oxlint src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: an unreadable tool `name` getter could crash `applyEmbeddedAttemptToolsAllow()` during embedded construction-plan allowlist filtering before healthy tools were kept.

Real environment tested: local linked Codex worktree with repo `node_modules` symlink.

Exact steps or command run after this patch: ran a direct `node --import tsx` repro that calls `applyEmbeddedAttemptToolsAllow()` with a throwing `name` getter plus a healthy `read` tool.

Evidence after fix: the repro printed `read`; the focused Vitest file passed 1 file / 22 tests.

Observed result after fix: unreadable tool names are skipped for explicit allowlists, wildcard allowlists, and plugin-id group expansion while readable sibling tools remain usable.

What was not tested: broad `pnpm check:changed`; Blacksmith Testbox is not authenticated in this environment.
