### PR TITLE
fix(agent-runtime): guard tool definition descriptors

### DIFF
--- a/src/agents/agent-tool-definition-adapter.after-tool-call.test.ts
+++ b/src/agents/agent-tool-definition-adapter.after-tool-call.test.ts
@@ -109,6 +109,46 @@ describe("agent tool definition adapter after_tool_call", () => {
     expect(hookMocks.runner.runAfterToolCall).not.toHaveBeenCalled();
   });
 
+  it("does not crash on unreadable tool definition descriptors", () => {
+    const descriptorTool = {
+      name: "descriptor_probe",
+      get label(): string {
+        throw new Error("tool label getter exploded");
+      },
+      get description(): string {
+        throw new Error("tool description getter exploded");
+      },
+      parameters: Type.Object({}),
+      execute: vi.fn(async () => ({ content: [], details: { ok: true } })),
+    } satisfies AgentTool;
+    const badNameTool = {
+      get name(): string {
+        throw new Error("tool name getter exploded");
+      },
+      label: "Bad",
+      description: "bad",
+      parameters: Type.Object({}),
+      execute: vi.fn(async () => ({ content: [] })),
+    } satisfies AgentTool;
+    const badParametersTool = {
+      name: "bad_parameters",
+      label: "Bad Parameters",
+      description: "bad",
+      get parameters(): AgentTool["parameters"] {
+        throw new Error("tool parameters getter exploded");
+      },
+      execute: vi.fn(async () => ({ content: [] })),
+    } satisfies AgentTool;
+
+    expect(toToolDefinitions([descriptorTool, badNameTool, badParametersTool])).toMatchObject([
+      {
+        name: "descriptor_probe",
+        label: "descriptor_probe",
+        description: "",
+      },
+    ]);
+  });
+
   it("does not consume adjusted params in adapter for wrapped tools", async () => {
     hookMocks.isToolWrappedWithBeforeToolCallHook.mockReturnValue(true);
     const defs = toToolDefinitions([createReadTool()]);

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -317,15 +317,20 @@ export function toToolDefinitions(
   tools: AnyAgentTool[],
   hookContext?: HookContext,
 ): ToolDefinition[] {
-  return tools.map((tool) => {
-    const name = tool.name || "tool";
+  const definitions: ToolDefinition[] = [];
+  for (const tool of tools) {
+    const name = readToolDefinitionName(tool);
+    const parameters = readToolDefinitionParameters(tool);
+    if (!name || !parameters) {
+      continue;
+    }
     const normalizedName = normalizeToolName(name);
     const beforeHookWrapped = isToolWrappedWithBeforeToolCallHook(tool);
-    return {
+    definitions.push({
       name,
-      label: tool.label ?? name,
-      description: tool.description ?? "",
-      parameters: tool.parameters,
+      label: readToolDefinitionString(tool, "label") ?? name,
+      description: readToolDefinitionString(tool, "description") ?? "",
+      parameters,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
         let executeParams = params;
@@ -390,8 +395,41 @@ export function toToolDefinitions(
           });
         }
       },
-    } satisfies ToolDefinition;
-  });
+    } satisfies ToolDefinition);
+  }
+  return definitions;
+}
+
+function readToolDefinitionName(tool: AnyAgentTool): string | undefined {
+  try {
+    const name = tool.name;
+    if (typeof name !== "string") {
+      return undefined;
+    }
+    return name.trim() ? name : "tool";
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolDefinitionString(
+  tool: AnyAgentTool,
+  field: "description" | "label",
+): string | undefined {
+  try {
+    const value = tool[field];
+    return typeof value === "string" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolDefinitionParameters(tool: AnyAgentTool): AnyAgentTool["parameters"] | undefined {
+  try {
+    return tool.parameters;
+  } catch {
+    return undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Guard SDK tool-definition projection against unreadable `name`, `label`, `description`, and `parameters` descriptors.
- Fall back optional descriptor fields while dropping tools whose required name/schema fields cannot be read.
- Add focused coverage for descriptor getter failures before session tool definitions are built.

## Verification

- `node scripts/run-vitest.mjs src/agents/agent-tool-definition-adapter.after-tool-call.test.ts --reporter=dot`
- `node_modules/.bin/oxlint src/agents/agent-tool-definition-adapter.ts src/agents/agent-tool-definition-adapter.after-tool-call.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: a tool with valid `name` and `parameters`, but throwing `label` or `description` getters, could crash `toToolDefinitions()` before assistant session construction.

Real environment tested: local linked Codex worktree with repo `node_modules` symlink.

Exact steps or command run after this patch: ran a direct `node --import tsx` repro that calls `toToolDefinitions()` with a tool whose `label` and `description` getters throw.

Evidence after fix: the repro printed `descriptor_probe:descriptor_probe:`; the focused Vitest file passed 1 file / 4 tests.

Observed result after fix: optional descriptor getter failures fall back to safe defaults, while tools with unreadable required `name` or `parameters` are skipped.

What was not tested: broad `pnpm check:changed`; Blacksmith Testbox is not authenticated in this environment.
