### PR TITLE
fix(agents): keep migrated session entry ids unique on v1 upgrade

### DIFF
--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -234,6 +234,7 @@ function migrateV1ToV2(entries: FileEntry[]): void {
     }
 
     entry.id = generateId(ids);
+    ids.add(entry.id);
     entry.parentId = prevId;
     prevId = entry.id;
 

--- a/src/agents/sessions/session-migrate-id-dedup.test.ts
+++ b/src/agents/sessions/session-migrate-id-dedup.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const { uuidQueue } = vi.hoisted(() => ({ uuidQueue: [] as string[] }));
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+  return {
+    ...actual,
+    randomUUID: () =>
+      (uuidQueue.shift() ??
+        actual.randomUUID()) as `${string}-${string}-${string}-${string}-${string}`,
+  };
+});
+
+const { SessionManager } = await import("./session-manager.js");
+
+function writeV1File(dir: string): string {
+  const file = join(dir, "2026-01-01T00-00-00-000Z_sess-v1.jsonl");
+  const header = {
+    type: "session",
+    version: 1,
+    id: "v1-header-id",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    cwd: "/tmp/cwd",
+  };
+  const first = {
+    type: "message",
+    timestamp: "2026-01-01T00:00:01.000Z",
+    message: { role: "user", content: "first" },
+  };
+  const second = {
+    type: "message",
+    timestamp: "2026-01-01T00:00:02.000Z",
+    message: { role: "assistant", content: "second" },
+  };
+  writeFileSync(file, [header, first, second].map((e) => JSON.stringify(e)).join("\n") + "\n");
+  return file;
+}
+
+describe("v1 session migration id assignment", () => {
+  it("keeps migrated entry ids unique even when the id generator first collides", () => {
+    const dir = mkdtempSync(join(tmpdir(), "oc-v1mig-"));
+    const file = writeV1File(dir);
+
+    uuidQueue.length = 0;
+    uuidQueue.push(
+      "deadbeef-0000-4000-8000-000000000000",
+      "deadbeef-0000-4000-8000-000000000000",
+      "cafef00d-0000-4000-8000-000000000000",
+    );
+
+    const sm = SessionManager.open(file, dir);
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => ({
+        id: (e as { id: string }).id,
+        parentId: (e as { parentId: string | null }).parentId,
+      }));
+
+    expect(messages).toHaveLength(2);
+    const ids = messages.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(messages[1].parentId).toBe(messages[0].id);
+    expect(messages[1].parentId).not.toBe(messages[1].id);
+  });
+});


### PR DESCRIPTION
## Summary

`migrateV1ToV2` (`src/agents/sessions/session-manager.ts`) assigns every migrated entry a fresh id via `generateId(ids)`, where `ids` is meant to be the running set of already-assigned ids so the generator can avoid collisions (`generateId` loops `randomUUID().slice(0, 8)` and returns the first value not in the set). But the loop never adds the freshly generated id back into `ids`, so the set stays empty for the entire migration and the collision check is a no-op.

On a v1 to v2 upgrade two entries can therefore be minted with the same 8-hex id. The migration also rebuilds the parent/child tree from those ids (`entry.parentId = prevId; prevId = entry.id`), so a collision makes the second entry adopt the colliding id as both its own id and its `parentId`, leaving an entry parented to itself and a duplicate node in the rebuilt branch.

Root cause: missing `ids.add(entry.id)` after generation. Fix: add the generated id to the running set so subsequent `generateId(ids)` calls actually see it and retry on collision.

Why this is not one-sided (sibling surfaces): `generateId` has one other accumulating caller, `createBranchedSession`, which rebuilds its dedup set on every call from `pathEntryIds` plus the already-written `labelEntries`, so it already feeds the generator the prior ids and is unaffected. `createSessionId` uses `uuidv7()` and is unrelated. `migrateV1ToV2` is the only caller that holds a single running set across a loop and failed to populate it, so the repair is scoped to that one spot.

Impact is low in practice (only v1-only sessions being upgraded, and only when two independent `randomUUID().slice(0, 8)` draws collide within one file, an 8-hex birthday chance), so this is a small correctness fix rather than a user-facing regression.

## Verification

Local (Node 22.19.0):

- `node scripts/run-vitest.mjs src/agents/sessions/session-migrate-id-dedup.test.ts` - 1/1 pass (new regression test).
- Red-proof: reverting only the `ids.add(entry.id)` line makes the new test fail with `AssertionError: expected 1 to be 2` (both migrated entries collapse to one id); with the fix it passes.
- Rebased onto latest `origin/main`; `ui/src/ui/app-gateway.node.test.ts` (the stale-branch failure on the prior head) now passes after the rebase pulled in the updated `loadChatHistory(host, { startup })` expectation.
- Type-aware `oxlint` via `scripts/run-oxlint.mjs` on both changed files - exit 0, clean.
- `oxfmt --check` on both changed files - clean.
- `pnpm tsgo:core` - exit 0.

## Real behavior proof

- **Behavior addressed:** a v1 to v2 session upgrade no longer mints duplicate entry ids (and the self-parented branch that follows) when the id generator's first 8-hex draw collides with an earlier one.
- **Real environment tested:** the real migration path in this checkout, `SessionManager.open(file)` -> `loadEntriesFromFile` -> `migrateToCurrentVersion` -> `migrateV1ToV2` -> `rewriteFile`, exercised end to end against an on-disk v1 `.jsonl` file. Only `node:crypto`'s `randomUUID` is stubbed, and only to make the otherwise-probabilistic 8-hex collision deterministic; the migration, tree rebuild, and file rewrite are the real shipping code.
- **Exact steps or command run after this patch:** wrote a v1 session file (a `version: 1` header plus two id-less message entries) to a temp dir, forced `randomUUID` to return the same first-8 hex twice and then a distinct value, opened the file through `SessionManager.open`, and logged the migrated entries' ids and parentIds to stdout; then reverted the one-line change and re-ran the same path.
- **Evidence after fix:** live stdout captured from running the real `SessionManager.open` migration path against the on-disk v1 file (only the `randomUUID` draws were stubbed to seed the collision):

```
# fix reverted (ids.add removed) -> real migration mints a duplicate id
REPRO migrated message ids: ["deadbeef","deadbeef"]
REPRO unique id count: 1 of 2
REPRO entry[1].parentId: deadbeef
REPRO entry[0].id: deadbeef
REPRO entry[1] self-parented? true

# fix applied -> generator retries on the seeded collision
REPRO migrated message ids: ["deadbeef","cafef00d"]
REPRO unique id count: 2 of 2
REPRO entry[1].parentId: deadbeef
REPRO entry[0].id: deadbeef
REPRO entry[1] self-parented? false
```

- **Observed result after fix:** the migrated on-disk session has two distinct entry ids and `entry[1].parentId` points at `entry[0].id` instead of at itself; before the change the same input produced one shared id and a self-referential `parentId` (a duplicate, self-parented node in the rebuilt branch).
- **What was not tested:** a natural (un-stubbed) collision, which is an 8-hex birthday event and not reproducible on demand without controlling the RNG. The stub only removes that randomness; it does not change the migration code under exercise.
