### PR TITLE
fix(browser): preserve HTTP status in node-proxied browser errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Node-proxied browser retries:** preserve upstream HTTP status in node proxy errors so browser tools retry stale target references instead of surfacing a terminal failure. (#89086) Thanks @rhclaw.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Node-proxied browser retries:** preserve upstream HTTP status in node proxy errors so browser tools retry stale target references instead of surfacing a terminal failure. (#89086) Thanks @rhclaw.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1898,6 +1898,48 @@ describe("browser tool act stale target recovery", () => {
     expect((result?.details as { ok?: unknown } | undefined)?.ok).toBe(true);
   });
 
+  it("retries stale targetIds returned through the node browser proxy", async () => {
+    mockSingleBrowserProxyNode();
+    setResolvedBrowserProfiles({
+      user: { driver: "existing-session", attachOnly: true, color: "#00AA00" },
+    });
+    gatewayMocks.callGatewayTool
+      .mockRejectedValueOnce(new Error("INVALID_REQUEST: Error: 404: tab not found"))
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: { result: { tabs: [{ targetId: "only-tab" }] } },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: { result: { ok: true, targetId: "only-tab" } },
+      });
+
+    const tool = createBrowserTool();
+    const result = await tool.execute?.("call-1", {
+      action: "act",
+      target: "node",
+      profile: "user",
+      request: {
+        kind: "wait",
+        targetId: "stale-tab",
+        timeMs: 1,
+      },
+    });
+
+    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledTimes(3);
+    expect(nodeInvokeCall(0).request.params).toMatchObject({
+      path: "/act",
+      body: { kind: "wait", targetId: "stale-tab", timeMs: 1 },
+    });
+    expect(nodeInvokeCall(1).request.params?.path).toBe("/tabs");
+    expect(nodeInvokeCall(2).request.params).toMatchObject({
+      path: "/act",
+      body: { kind: "wait", timeMs: 1 },
+    });
+    expect(nodeInvokeCall(2).request.params?.body).not.toHaveProperty("targetId");
+    expect(result?.details).toMatchObject({ ok: true, targetId: "only-tab" });
+  });
+
   it("does not retry mutating user-browser act requests without targetId", async () => {
     browserActionsMocks.browserAct.mockRejectedValueOnce(new Error("404: tab not found"));
     browserClientMocks.browserTabs.mockResolvedValueOnce([{ targetId: "only-tab" }]);

--- a/extensions/browser/src/node-host/invoke-browser.test.ts
+++ b/extensions/browser/src/node-host/invoke-browser.test.ts
@@ -289,7 +289,7 @@ describe("runBrowserProxyCommand", () => {
     await result;
   });
 
-  it("keeps non-timeout browser errors intact", async () => {
+  it("prefixes the HTTP status onto non-timeout browser errors", async () => {
     dispatcherMocks.dispatch.mockResolvedValue({
       status: 500,
       body: { error: "tab not found" },
@@ -304,7 +304,27 @@ describe("runBrowserProxyCommand", () => {
           timeoutMs: 50,
         }),
       ),
-    ).rejects.toThrow("tab not found");
+    ).rejects.toThrow("500: tab not found");
+  });
+
+  it("preserves the 404 status so the gateway can classify a stale targetId", async () => {
+    // The gateway's stale-target retry only fires when the surfaced message carries
+    // both "404:" and "tab not found"; the node proxy must not strip the status.
+    dispatcherMocks.dispatch.mockResolvedValue({
+      status: 404,
+      body: { error: 'tab not found: browser tab "abc"' },
+    });
+
+    await expect(
+      runBrowserProxyCommand(
+        JSON.stringify({
+          method: "POST",
+          path: "/act",
+          profile: "openclaw",
+          timeoutMs: 50,
+        }),
+      ),
+    ).rejects.toThrow("404: tab not found");
   });
 
   it("rejects unauthorized query.profile when allowProfiles is configured", async () => {

--- a/extensions/browser/src/node-host/invoke-browser.test.ts
+++ b/extensions/browser/src/node-host/invoke-browser.test.ts
@@ -289,31 +289,16 @@ describe("runBrowserProxyCommand", () => {
     await result;
   });
 
-  it("prefixes the HTTP status onto non-timeout browser errors", async () => {
-    dispatcherMocks.dispatch.mockResolvedValue({
-      status: 500,
-      body: { error: "tab not found" },
-    });
-
-    await expect(
-      runBrowserProxyCommand(
-        JSON.stringify({
-          method: "POST",
-          path: "/act",
-          profile: "openclaw",
-          timeoutMs: 50,
-        }),
-      ),
-    ).rejects.toThrow("500: tab not found");
-  });
-
-  it("preserves the 404 status so the gateway can classify a stale targetId", async () => {
-    // The gateway's stale-target retry only fires when the surfaced message carries
-    // both "404:" and "tab not found"; the node proxy must not strip the status.
-    dispatcherMocks.dispatch.mockResolvedValue({
+  it.each([
+    { status: 500, body: { error: "tab not found" }, expected: "500: tab not found" },
+    {
       status: 404,
       body: { error: 'tab not found: browser tab "abc"' },
-    });
+      expected: "404: tab not found",
+    },
+    { status: 503, body: { error: "" }, expected: "HTTP 503" },
+  ])("preserves browser response status in errors: $expected", async (response) => {
+    dispatcherMocks.dispatch.mockResolvedValue(response);
 
     await expect(
       runBrowserProxyCommand(
@@ -324,7 +309,7 @@ describe("runBrowserProxyCommand", () => {
           timeoutMs: 50,
         }),
       ),
-    ).rejects.toThrow("404: tab not found");
+    ).rejects.toThrow(response.expected);
   });
 
   it("rejects unauthorized query.profile when allowProfiles is configured", async () => {

--- a/extensions/browser/src/node-host/invoke-browser.ts
+++ b/extensions/browser/src/node-host/invoke-browser.ts
@@ -315,16 +315,13 @@ export async function runBrowserProxyCommand(paramsJSON?: string | null): Promis
     );
   }
   if (response.status >= 400) {
-    // Preserve the HTTP status in the message: this error crosses the node.invoke
-    // boundary as a plain string (Error properties are dropped in transit), and the
-    // gateway's stale-target retry classifier keys off the leading `<status>:` token
-    // (e.g. "404: tab not found"). Without it, node-proxied browser errors can't be
-    // classified for retry on the gateway side.
+    // node.invoke preserves only Error.message; keep the status there so gateway
+    // retry classifiers see the same error shape as direct browser requests.
     const detail =
       response.body && typeof response.body === "object" && "error" in response.body
-        ? String((response.body as { error?: unknown }).error)
-        : null;
-    throw new Error(detail !== null ? `${response.status}: ${detail}` : `HTTP ${response.status}`);
+        ? String((response.body as { error?: unknown }).error).trim()
+        : "";
+    throw new Error(detail ? `${response.status}: ${detail}` : `HTTP ${response.status}`);
   }
 
   const result = response.body;

--- a/extensions/browser/src/node-host/invoke-browser.ts
+++ b/extensions/browser/src/node-host/invoke-browser.ts
@@ -315,11 +315,16 @@ export async function runBrowserProxyCommand(paramsJSON?: string | null): Promis
     );
   }
   if (response.status >= 400) {
-    const message =
+    // Preserve the HTTP status in the message: this error crosses the node.invoke
+    // boundary as a plain string (Error properties are dropped in transit), and the
+    // gateway's stale-target retry classifier keys off the leading `<status>:` token
+    // (e.g. "404: tab not found"). Without it, node-proxied browser errors can't be
+    // classified for retry on the gateway side.
+    const detail =
       response.body && typeof response.body === "object" && "error" in response.body
         ? String((response.body as { error?: unknown }).error)
-        : `HTTP ${response.status}`;
-    throw new Error(message);
+        : null;
+    throw new Error(detail !== null ? `${response.status}: ${detail}` : `HTTP ${response.status}`);
   }
 
   const result = response.body;


### PR DESCRIPTION
## Summary

- The node browser proxy (`runBrowserProxyCommand` in `extensions/browser/src/node-host/invoke-browser.ts`) collapsed a `>= 400` browser-route response into `new Error(<body.error>)`, **dropping the HTTP status**.
- That error crosses the `node.invoke` boundary as a plain **string** (Error properties are not preserved over the RPC), so the gateway's stale-target retry classifier — `isChromeStaleTargetError` in `browser-tool.actions.ts`, which requires `msg.includes("404:") && msg.includes("tab not found")` — **never matches** a node-proxied `tab not found`. The existing drop-`targetId` retry never fires and the stale-`targetId` error surfaces to the agent.
- This PR **preserves the status in the message** (`"404: tab not found …"`, `"403: action targetId must match request targetId"`) so the gateway's existing classification/retry works through the node proxy — restoring parity with the local browser path. It is a pure formatting change in the `>= 400` branch; validation and timeout error paths are untouched.

## Out-of-scope follow-ups

The `403 "targetId must match request targetId"` case is now correctly **classifiable** (status preserved) but still has no retry consumer. Adding a retry there is a separate request-normalization concern, intentionally not bundled here.

## Real behavior proof

Behavior or issue addressed: On a gateway with a remote browser node, agents intermittently receive `tab not found` (404) or `action targetId must match request targetId` (403) from the browser tool when a cached `targetId` goes stale (tab closed / target rotated). The gateway already ships a drop-`targetId` retry for the stale-tab case, but it is gated on the surfaced error carrying the `404:` HTTP-status token. Because the node proxy strips the status, that retry never fires for remote-node browsers and the error reaches the agent.

Real environment tested: OpenClaw gateway **v2026.5.27** with a remote macOS Chrome node reached via `browser.proxy` (the `main` code path is unchanged from v5.27). After-fix proof was produced on that gateway host by running its installed runtime code under `/usr/lib/node_modules/openclaw`.

Exact steps or command run after this patch: `node scripts/test-projects.mjs extensions/browser/src/node-host/invoke-browser.test.ts` for the patched producer; plus a live harness `node evidence-89086.mjs` that extracts the shipped gateway classifier verbatim from `/usr/lib/node_modules/openclaw/dist/plugin-service-*.js` (brace-match + `eval`) and runs it against the before/after node-proxied error strings.

Before evidence: live gateway log (remote node; conn/id redacted) — surfaced messages carried no leading status token, so `isChromeStaleTargetError` returned false and no retry was attempted:
```
⇄ res ✗ node.invoke … errorMessage=INVALID_REQUEST: Error: action targetId must match request targetId
⇄ res ✗ node.invoke … errorMessage=INVALID_REQUEST: Error: tab not found: browser tab "…"
```

Evidence after fix: live run (copied console output) of the actual shipped gateway classifier on v2026.5.27, fed the node-proxied error string as formatted by the shipped logic (status dropped) vs this patch (status preserved):
```
404 tab-not-found (stale targetId):
  BEFORE (shipped):  Error("tab not found: …")        isChromeStaleTargetError("user", …) -> false   (retry NOT fired — the bug)
  AFTER  (patched):  Error("404: tab not found: …")    isChromeStaleTargetError("user", …) -> true    (drop-targetId retry now FIRES)
403 targetId-mismatch:
  BEFORE (shipped):  Error("action targetId must match request targetId")          -> false
  AFTER  (patched):  Error("403: action targetId must match request targetId")      -> false   (status preserved/classifiable; 404-retry intentionally not consumed)
RESULT: PASS — fix restores the gateway stale-target retry for node-proxied 404s; 403 unchanged.
node v22.22.0 | classifier sourced verbatim from /usr/lib/node_modules/openclaw (v2026.5.27)
```
The shipped classifier gating this, verbatim from the installed build: `isChromeStaleTargetError("user", err)` returns `String(err).includes("404:") && String(err).includes("tab not found")`. The package tests additionally assert the patched `runBrowserProxyCommand` surfaces `500: tab not found` and `404: tab not found` (14/14 passing) — supplemental to the live run above.

Observed result after fix: node-proxied browser errors retain their HTTP status, so the gateway's existing stale-target classification/retry fires for remote browser nodes — parity with the local browser path. The shipped classifier flips false→true on the 404 string once the status is preserved.

What was not tested: the patched `runBrowserProxyCommand` was not executed inside a full browser-node process against real Chrome with the production gateway↔node RPC hop. The patched producer is covered by the package vitest (real `runBrowserProxyCommand` path); the consumer (shipped gateway `isChromeStaleTargetError`) is run live above. A full gateway + remote-node live-browser capture can follow on request.
