### PR TITLE
fix(memory-core): retry narrative message reads

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -73,6 +73,11 @@ function expectLogExcludes(source: MockCallSource, text: string): void {
   expect(logIncludes(source, text), `Expected log not to include ${text}`).toBe(false);
 }
 
+async function flushNarrativeSettleTimers<T>(operation: Promise<T>): Promise<T> {
+  await vi.runAllTimersAsync();
+  return operation;
+}
+
 async function expectPathMissing(targetPath: string): Promise<void> {
   const accessResult = await fs
     .access(targetPath)
@@ -684,48 +689,85 @@ describe("generateAndAppendDreamNarrative", () => {
   });
 
   it("waits for persisted assistant text before falling back", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.getSessionMessages
-      .mockResolvedValueOnce({
-        messages: [{ role: "user", content: "prompt" }],
-      })
-      .mockResolvedValueOnce({
-        messages: [
-          { role: "user", content: "prompt" },
-          {
-            role: "assistant",
-            content: [{ type: "text", text: "The delayed diary text finally settled." }],
-          },
-        ],
+    vi.useFakeTimers();
+    try {
+      const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+      const subagent = createMockSubagent("");
+      subagent.getSessionMessages
+        .mockResolvedValueOnce({
+          messages: [{ role: "user", content: "prompt" }],
+        })
+        .mockResolvedValueOnce({
+          messages: [
+            { role: "user", content: "prompt" },
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "The delayed diary text finally settled." }],
+            },
+          ],
+        });
+      const logger = createMockLogger();
+
+      const operation = generateAndAppendDreamNarrative({
+        subagent,
+        workspaceDir,
+        data: {
+          phase: "light",
+          snippets: ["The narrative assistant persisted after the run completed."],
+        },
+        nowMs: Date.parse("2026-04-05T03:00:00Z"),
+        timezone: "UTC",
+        logger,
       });
-    const logger = createMockLogger();
+      await flushNarrativeSettleTimers(operation);
 
-    await generateAndAppendDreamNarrative({
-      subagent,
-      workspaceDir,
-      data: {
-        phase: "light",
-        snippets: ["The narrative assistant persisted after the run completed."],
-      },
-      nowMs: Date.parse("2026-04-05T03:00:00Z"),
-      timezone: "UTC",
-      logger,
-    });
+      expect(subagent.getSessionMessages).toHaveBeenCalledTimes(2);
+      expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(1, {
+        sessionKey: expect.stringContaining("dreaming-narrative-light-"),
+        limit: expect.any(Number),
+      });
+      expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(2, {
+        sessionKey: expect.stringContaining("dreaming-narrative-light-"),
+        limit: expect.any(Number),
+      });
+      const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+      expect(content).toContain("The delayed diary text finally settled.");
+      expect(content).not.toContain("A memory trace surfaced");
+      expectLogExcludes(logger.warn, "produced no text");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
-    expect(subagent.getSessionMessages).toHaveBeenCalledTimes(2);
-    expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(1, {
-      sessionKey: expect.stringContaining("dreaming-narrative-light-"),
-      limit: 5,
-    });
-    expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(2, {
-      sessionKey: expect.stringContaining("dreaming-narrative-light-"),
-      limit: 5,
-    });
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(content).toContain("The delayed diary text finally settled.");
-    expect(content).not.toContain("A memory trace surfaced");
-    expectLogExcludes(logger.warn, "produced no text");
+  it("falls back after settled assistant text never appears", async () => {
+    vi.useFakeTimers();
+    try {
+      const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+      const subagent = createMockSubagent("");
+      const logger = createMockLogger();
+
+      const operation = generateAndAppendDreamNarrative({
+        subagent,
+        workspaceDir,
+        data: {
+          phase: "light",
+          snippets: ["The narrative assistant never persisted text."],
+        },
+        nowMs: Date.parse("2026-04-05T03:00:00Z"),
+        timezone: "UTC",
+        logger,
+      });
+      await flushNarrativeSettleTimers(operation);
+
+      expect(subagent.getSessionMessages).toHaveBeenCalledTimes(5);
+      const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+      expect(content).toContain(
+        "A memory trace surfaced, but details were unavailable in this run.",
+      );
+      expectLogIncludes(logger.warn, "produced no text");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("retries with the session default when the configured model cannot start", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -683,6 +683,51 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(logger.info).toHaveBeenCalled();
   });
 
+  it("waits for persisted assistant text before falling back", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("");
+    subagent.getSessionMessages
+      .mockResolvedValueOnce({
+        messages: [{ role: "user", content: "prompt" }],
+      })
+      .mockResolvedValueOnce({
+        messages: [
+          { role: "user", content: "prompt" },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "The delayed diary text finally settled." }],
+          },
+        ],
+      });
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: {
+        phase: "light",
+        snippets: ["The narrative assistant persisted after the run completed."],
+      },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    expect(subagent.getSessionMessages).toHaveBeenCalledTimes(2);
+    expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(1, {
+      sessionKey: expect.stringContaining("dreaming-narrative-light-"),
+      limit: 5,
+    });
+    expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(2, {
+      sessionKey: expect.stringContaining("dreaming-narrative-light-"),
+      limit: 5,
+    });
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("The delayed diary text finally settled.");
+    expect(content).not.toContain("A memory trace surfaced");
+    expectLogExcludes(logger.warn, "produced no text");
+  });
+
   it("retries with the session default when the configured model cannot start", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = createMockSubagent("The default model carried the diary home.");

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -102,7 +102,7 @@ const NARRATIVE_TIMEOUT_MS = 60_000;
 const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // A completed run can reach the session reader before the final assistant text
 // is visible, so retry briefly before falling back to synthetic diary text.
-const NARRATIVE_MESSAGE_SETTLE_DELAYS_MS = [50, 150, 300] as const;
+const NARRATIVE_MESSAGE_SETTLE_DELAYS_MS = [50, 150, 300, 750] as const;
 const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
 const DREAMING_TRANSCRIPT_RUN_MARKER = '"runId":"dreaming-narrative-';
 const DREAMING_ORPHAN_MIN_AGE_MS = 300_000;
@@ -352,19 +352,29 @@ function waitForNarrativeMessagesToSettle(delayMs: number): Promise<void> {
   });
 }
 
+async function readNarrativeText(params: {
+  subagent: SubagentSurface;
+  sessionKey: string;
+}): Promise<string | null> {
+  const { messages } = await params.subagent.getSessionMessages({
+    sessionKey: params.sessionKey,
+    limit: NARRATIVE_MESSAGE_FETCH_LIMIT,
+  });
+  return extractNarrativeText(messages);
+}
+
 async function readSettledNarrativeText(params: {
   subagent: SubagentSurface;
   sessionKey: string;
 }): Promise<string | null> {
-  for (let attempt = 0; attempt <= NARRATIVE_MESSAGE_SETTLE_DELAYS_MS.length; attempt += 1) {
-    if (attempt > 0) {
-      await waitForNarrativeMessagesToSettle(NARRATIVE_MESSAGE_SETTLE_DELAYS_MS[attempt - 1]);
-    }
-    const { messages } = await params.subagent.getSessionMessages({
-      sessionKey: params.sessionKey,
-      limit: NARRATIVE_MESSAGE_FETCH_LIMIT,
-    });
-    const narrative = extractNarrativeText(messages);
+  const immediateNarrative = await readNarrativeText(params);
+  if (immediateNarrative) {
+    return immediateNarrative;
+  }
+
+  for (const delayMs of NARRATIVE_MESSAGE_SETTLE_DELAYS_MS) {
+    await waitForNarrativeMessagesToSettle(delayMs);
+    const narrative = await readNarrativeText(params);
     if (narrative) {
       return narrative;
     }

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -99,6 +99,10 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // worst case at one minute, well below the multi-minute stall the original
 // comment warned against.
 const NARRATIVE_TIMEOUT_MS = 60_000;
+const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
+// A completed run can reach the session reader before the final assistant text
+// is visible, so retry briefly before falling back to synthetic diary text.
+const NARRATIVE_MESSAGE_SETTLE_DELAYS_MS = [50, 150, 300] as const;
 const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
 const DREAMING_TRANSCRIPT_RUN_MARKER = '"runId":"dreaming-narrative-';
 const DREAMING_ORPHAN_MIN_AGE_MS = 300_000;
@@ -337,6 +341,32 @@ export function extractNarrativeText(messages: unknown[]): string | null {
       if (text.length > 0) {
         return text;
       }
+    }
+  }
+  return null;
+}
+
+function waitForNarrativeMessagesToSettle(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+async function readSettledNarrativeText(params: {
+  subagent: SubagentSurface;
+  sessionKey: string;
+}): Promise<string | null> {
+  for (let attempt = 0; attempt <= NARRATIVE_MESSAGE_SETTLE_DELAYS_MS.length; attempt += 1) {
+    if (attempt > 0) {
+      await waitForNarrativeMessagesToSettle(NARRATIVE_MESSAGE_SETTLE_DELAYS_MS[attempt - 1]);
+    }
+    const { messages } = await params.subagent.getSessionMessages({
+      sessionKey: params.sessionKey,
+      limit: NARRATIVE_MESSAGE_FETCH_LIMIT,
+    });
+    const narrative = extractNarrativeText(messages);
+    if (narrative) {
+      return narrative;
     }
   }
   return null;
@@ -966,12 +996,10 @@ export async function generateAndAppendDreamNarrative(params: {
         return;
       }
 
-      const { messages } = await params.subagent.getSessionMessages({
+      const narrative = await readSettledNarrativeText({
+        subagent: params.subagent,
         sessionKey: successfulSessionKey,
-        limit: 5,
       });
-
-      const narrative = extractNarrativeText(messages);
       if (!narrative) {
         params.logger.warn(
           `memory-core: narrative generation produced no text for ${params.data.phase} phase; writing fallback diary entry.`,


### PR DESCRIPTION
Refs #87306

## Summary
- Retry the narrative session message read after a successful run when the first read has no extractable assistant text.
- Keep the existing fallback path unchanged after bounded settle attempts: immediate read, then 50 ms, 150 ms, 300 ms, and 750 ms waits.
- Add fake-timer regression coverage for both delayed assistant-text persistence and the all-attempts-empty fallback path.

## Evidence map
- Changed surface: memory-core dreaming narrative post-run message extraction in `extensions/memory-core/src/dreaming-narrative.ts`.
- Entry point and callers: `generateAndAppendDreamNarrative`, called by dreaming phase/session orchestration.
- Owner boundary: uses the existing `SubagentSurface.getSessionMessages` API; no SDK, provider, persistence schema, config, or dependency change.
- Sibling behavior: timeout, unavailable-model retry, cleanup, detached narrative, and fallback diary paths remain covered by existing tests in the touched file.
- Scope: this fixes same-run post-`waitForRun` message visibility lag; archived-session recovery remains out of scope.
- Security/config: no auth, secrets, trust-boundary, filesystem path, dependency, or config changes.

## Verification
- `git diff --check`
- `fnm exec --using 22 ./node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/dreaming-narrative.ts extensions/memory-core/src/dreaming-narrative.test.ts`
- `fnm exec --using 22 ./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core/src/dreaming-narrative.ts extensions/memory-core/src/dreaming-narrative.test.ts`
- `fnm exec --using 22 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `fnm exec --using 22 node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-narrative.test.ts --reporter=verbose`
- `fnm exec --using 22 node scripts/changed-lanes.mjs --base upstream/main --head HEAD --json`
- `OPENCLAW_QA_KEEP_TEMP=1 fnm exec --using 22 node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario memory-dreaming-sweep --concurrency 1 --fast --output-dir .artifacts/qa-e2e/pr-89091-dreaming-proof-final`

## Real behavior proof
Behavior addressed: `memory-core: narrative generation produced no text` warnings could fire, and synthetic fallback diary text could be written, when assistant text existed but was not visible on the first post-run session message read.

Real environment tested: Local OpenClaw source checkout on branch `ben/issue-87306-dreaming-narrative-text-retry` at `b5427da73baac07d7b58f6791d7d9db9fa2856a0`, Node `v22.22.1`, macOS local dev machine, using the repo QA suite with qa-channel + qa-lab bus + real gateway child + mock-openai provider.

Exact steps or command run after this patch: Ran the focused file checks listed in Verification, then ran `OPENCLAW_QA_KEEP_TEMP=1 fnm exec --using 22 node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario memory-dreaming-sweep --concurrency 1 --fast --output-dir .artifacts/qa-e2e/pr-89091-dreaming-proof-final`.

Evidence after fix: The QA report at `.artifacts/qa-e2e/pr-89091-dreaming-proof-final/qa-suite-report.md` reported `Passed: 1`, `Failed: 0`, and `Memory dreaming sweep: pass` with details `{"promotedTotal":1,"shortTermCount":3,"phaseSignalCount":3,"lightSleep":true,"remSleep":true}`. The preserved temp runtime at `/tmp/openclaw/openclaw-qa-suite-vF59oC` showed `workspace/DREAMS.md` contained protocol-note diary entries for light/rem/deep phases, `gateway.stdout.log` contained `memory-core: dream diary entry written for light phase`, `memory-core: dream diary entry written for rem phase`, and `memory-core: dream diary entry written for deep phase`, and `rg "produced no text|A memory trace surfaced"` across `gateway.stdout.log`, `gateway.stderr.log`, and `workspace/DREAMS.md` returned no matches.

Observed result after fix: The real gateway sweep wrote diary entries for light, rem, and deep phases from assistant text. It did not emit the `produced no text` warning and did not write the synthetic fallback text `A memory trace surfaced, but details were unavailable in this run.` The touched-file shard also reported `Test Files 1 passed (1)` and `Tests 53 passed (53)`.

What was not tested: live dreaming cron with a real local LLM/Ollama session, broad Testbox, or archived-session recovery.
