### PR TITLE
[Fix] Resolve LaunchAgent plist path for external homes

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -15,8 +15,36 @@ enum GatewayLaunchAgentManager {
     }
 
     private static var plistURL: URL {
-        FileManager().homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/LaunchAgents/\(gatewayLaunchdLabel).plist")
+        self.resolveLaunchAgentPlistURL()
+    }
+
+    static func resolveLaunchAgentPlistURL(
+        homeDirectory: URL = FileManager().homeDirectoryForCurrentUser,
+        shortUserName: String = NSUserName(),
+        label: String = gatewayLaunchdLabel) -> URL
+    {
+        let standardizedHome = homeDirectory.standardizedFileURL
+        let homeComponents = standardizedHome.pathComponents
+        if homeComponents.count == 3, homeComponents[0] == "/", homeComponents[1] == "Users",
+           !homeComponents[2].isEmpty
+        {
+            return standardizedHome
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("LaunchAgents", isDirectory: true)
+                .appendingPathComponent("\(label).plist")
+        }
+        let trimmedUserName = shortUserName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedUserName.isEmpty, !trimmedUserName.contains("/") else {
+            return standardizedHome
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("LaunchAgents", isDirectory: true)
+                .appendingPathComponent("\(label).plist")
+        }
+        return URL(fileURLWithPath: "/Users", isDirectory: true)
+            .appendingPathComponent(trimmedUserName, isDirectory: true)
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("LaunchAgents", isDirectory: true)
+            .appendingPathComponent("\(label).plist")
     }
 
     static func isLaunchAgentWriteDisabled() -> Bool {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -3,6 +3,24 @@ import Testing
 @testable import OpenClaw
 
 struct GatewayLaunchAgentManagerTests {
+    @Test func `launch agent plist URL preserves standard user home`() {
+        let url = GatewayLaunchAgentManager.resolveLaunchAgentPlistURL(
+            homeDirectory: URL(fileURLWithPath: "/Users/test", isDirectory: true),
+            shortUserName: "other",
+            label: "ai.openclaw.gateway")
+
+        #expect(url.path == "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist")
+    }
+
+    @Test func `launch agent plist URL uses boot volume user home for external home`() {
+        let url = GatewayLaunchAgentManager.resolveLaunchAgentPlistURL(
+            homeDirectory: URL(fileURLWithPath: "/Volumes/MainDataDrive/Users/test", isDirectory: true),
+            shortUserName: "test",
+            label: "ai.openclaw.gateway")
+
+        #expect(url.path == "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist")
+    }
+
     @Test func `attach only runtime override does not uninstall gateway launch agent`() throws {
         let dir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-attach-only-\(UUID().uuidString)", isDirectory: true)

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -6,6 +6,7 @@ import {
   resolveGatewayWindowsTaskName,
 } from "../../daemon/constants.js";
 import { resolveDaemonContainerContext } from "../../daemon/container-context.js";
+import { resolveLaunchAgentPlistPathForLabel } from "../../daemon/launchd-path.js";
 import { formatRuntimeStatus } from "../../daemon/runtime-format.js";
 import {
   buildPlatformRuntimeLogHints,
@@ -188,11 +189,13 @@ export function renderRuntimeHints(
 
 export function renderGatewayServiceStartHints(env: NodeJS.ProcessEnv = process.env): string[] {
   const profile = env.OPENCLAW_PROFILE;
+  const launchAgentLabel = resolveGatewayLaunchAgentLabel(profile);
+  const launchAgentEnv = { ...process.env, ...env, OPENCLAW_PROFILE: profile };
   const container = resolveDaemonContainerContext(env);
   const hints = buildPlatformServiceStartHints({
     installCommand: formatCliCommand("openclaw gateway install", env),
     startCommand: formatCliCommand("openclaw gateway", env),
-    launchAgentPlistPath: `~/Library/LaunchAgents/${resolveGatewayLaunchAgentLabel(profile)}.plist`,
+    launchAgentPlistPath: resolveLaunchAgentPlistPathForLabel(launchAgentEnv, launchAgentLabel),
     systemdServiceName: resolveGatewaySystemdServiceName(profile),
     windowsTaskName: resolveGatewayWindowsTaskName(profile),
   });

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -566,6 +566,20 @@ exit 0
       await cleanupScript(scriptPath);
     });
 
+    it("uses boot-volume LaunchAgents plist path when HOME is external", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 502;
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        HOME: "/Volumes/MainDataDrive/Users/test",
+        USER: "test",
+        OPENCLAW_PROFILE: "default",
+      });
+      expect(content).toMatch(/[\\/]Users[\\/]test[\\/]Library[\\/]LaunchAgents[\\/]/);
+      expect(content).not.toContain("/Volumes/MainDataDrive/Users/test/Library/LaunchAgents");
+      await cleanupScript(scriptPath);
+    });
+
     it("shell-escapes the label in the plist path on macOS", async () => {
       Object.defineProperty(process, "platform", { value: "darwin" });
       process.getuid = () => 501;

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -10,6 +10,7 @@ import {
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
 } from "../../daemon/constants.js";
+import { resolveLaunchAgentPlistPathForLabel } from "../../daemon/launchd-path.js";
 import {
   renderPosixRestartLogSetup,
   resolveGatewayRestartLogPath,
@@ -120,10 +121,7 @@ exit "$status"
       const escaped = shellEscape(label);
       // Fallback to 501 if getuid is not available (though it should be on macOS)
       const uid = process.getuid ? process.getuid() : 501;
-      // Resolve HOME at generation time via env/process.env to match launchd.ts,
-      // and shell-escape the label in the plist filename to prevent injection.
-      const home = normalizeOptionalString(env.HOME) || process.env.HOME || os.homedir();
-      const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
+      const plistPath = resolveLaunchAgentPlistPathForLabel({ ...process.env, ...env }, label);
       const escapedPlistPath = shellEscape(plistPath);
       const logSetup = renderPosixRestartLogSetup({ ...process.env, ...env });
       filename = `openclaw-restart-${timestamp}.sh`;

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -8,6 +8,7 @@ import {
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
 } from "./constants.js";
+import { resolveLaunchAgentPlistPathForLabel } from "./launchd-path.js";
 import { resolveHomeDir } from "./paths.js";
 import { execSchtasks } from "./schtasks-exec.js";
 import { parseSystemdExecStart } from "./systemd-unit.js";
@@ -47,7 +48,9 @@ export function renderGatewayServiceCleanupHints(
   switch (process.platform) {
     case "darwin": {
       const label = resolveGatewayLaunchAgentLabel(profile);
-      return [`launchctl bootout gui/$UID/${label}`, `rm ~/Library/LaunchAgents/${label}.plist`];
+      const pathEnv = { ...process.env, ...env, OPENCLAW_PROFILE: profile };
+      const plistPath = resolveLaunchAgentPlistPathForLabel(pathEnv, label);
+      return [`launchctl bootout gui/$UID/${label}`, `rm ${plistPath}`];
     }
     case "linux": {
       const unit = resolveGatewaySystemdServiceName(profile);
@@ -442,8 +445,8 @@ export async function findExtraGatewayServices(
 
   if (process.platform === "darwin") {
     try {
-      const home = resolveHomeDir(env);
-      const userDir = path.join(home, "Library", "LaunchAgents");
+      const label = resolveGatewayLaunchAgentLabel(env.OPENCLAW_PROFILE);
+      const userDir = path.dirname(resolveLaunchAgentPlistPathForLabel(env, label));
       for (const svc of await scanLaunchdDir({
         dir: userDir,
         scope: "user",

--- a/src/daemon/launchd-path.test.ts
+++ b/src/daemon/launchd-path.test.ts
@@ -1,0 +1,110 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const osState = vi.hoisted(() => ({
+  homedir: vi.fn(() => "/actual-home"),
+}));
+
+const pathsState = vi.hoisted(() => ({
+  behavior: "real" as "real" | "throw-missing-home" | "throw-other",
+  otherMessage: "boom",
+}));
+
+vi.mock("node:os", () => ({
+  default: { homedir: osState.homedir },
+  homedir: osState.homedir,
+}));
+
+vi.mock("./paths.js", () => ({
+  resolveHomeDir: (env: Record<string, string | undefined>) => {
+    if (pathsState.behavior === "throw-missing-home") {
+      throw new Error("Missing HOME");
+    }
+    if (pathsState.behavior === "throw-other") {
+      throw new Error(pathsState.otherMessage);
+    }
+    const home = normalizeOptionalString(env.HOME) || normalizeOptionalString(env.USERPROFILE);
+    if (!home) {
+      throw new Error("Missing HOME");
+    }
+    return home;
+  },
+}));
+
+import { resolveLaunchAgentHomeDir, resolveLaunchAgentPlistPathForLabel } from "./launchd-path.js";
+
+describe("resolveLaunchAgentHomeDir", () => {
+  beforeEach(() => {
+    osState.homedir.mockReset();
+    osState.homedir.mockReturnValue("/actual-home");
+    pathsState.behavior = "real";
+    pathsState.otherMessage = "boom";
+  });
+
+  it("preserves the boot-volume user home when HOME is /Users/<name>", () => {
+    expect(resolveLaunchAgentHomeDir({ HOME: "/Users/test" })).toBe("/Users/test");
+  });
+
+  it("remaps external APFS HOME to the boot-volume user home", () => {
+    expect(
+      resolveLaunchAgentHomeDir({ HOME: "/Volumes/MainDataDrive/Users/test", USER: "test" }),
+    ).toBe("/Users/test");
+  });
+
+  it("falls back to os.homedir() when HOME and USERPROFILE are absent", () => {
+    pathsState.behavior = "throw-missing-home";
+    osState.homedir.mockReturnValue("/Users/osfallback");
+    expect(resolveLaunchAgentHomeDir({})).toBe("/Users/osfallback");
+    expect(osState.homedir).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not swallow non-Missing-HOME errors from resolveHomeDir", () => {
+    pathsState.behavior = "throw-other";
+    expect(() => resolveLaunchAgentHomeDir({})).toThrow("boom");
+    expect(osState.homedir).not.toHaveBeenCalled();
+  });
+
+  it("parses the short name from an external HOME path when USER env is absent", () => {
+    expect(resolveLaunchAgentHomeDir({ HOME: "/Volumes/MainDataDrive/Users/test" })).toBe(
+      "/Users/test",
+    );
+  });
+
+  it("prefers the short name parsed from the external HOME path over env.USER", () => {
+    expect(
+      resolveLaunchAgentHomeDir({ HOME: "/Volumes/MainDataDrive/Users/test", USER: "other" }),
+    ).toBe("/Users/test");
+  });
+
+  it("rejects short names containing path separators in the HOME path", () => {
+    expect(resolveLaunchAgentHomeDir({ HOME: "/Volumes/MainDataDrive/Users/te st" })).toBe(
+      "/Volumes/MainDataDrive/Users/te st",
+    );
+    expect(resolveLaunchAgentHomeDir({ HOME: "/Volumes/MainDataDrive/Users/../etc" })).toBe(
+      "/Volumes/MainDataDrive/Users/../etc",
+    );
+  });
+
+  it("ignores HOME paths that do not end in /Users/<name>", () => {
+    expect(resolveLaunchAgentHomeDir({ HOME: "/Volumes/RandomPath" })).toBe("/Volumes/RandomPath");
+    expect(resolveLaunchAgentHomeDir({ HOME: "/home/test" })).toBe("/home/test");
+    expect(resolveLaunchAgentHomeDir({ HOME: "/Volumes/MainDataDrive/Users/test/SubPath" })).toBe(
+      "/Volumes/MainDataDrive/Users/test/SubPath",
+    );
+  });
+});
+
+describe("resolveLaunchAgentPlistPathForLabel", () => {
+  beforeEach(() => {
+    pathsState.behavior = "real";
+  });
+
+  it("returns the boot-volume plist path when HOME is external", () => {
+    expect(
+      resolveLaunchAgentPlistPathForLabel(
+        { HOME: "/Volumes/MainDataDrive/Users/test", USER: "test" },
+        "ai.openclaw.gateway",
+      ),
+    ).toBe("/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist");
+  });
+});

--- a/src/daemon/launchd-path.ts
+++ b/src/daemon/launchd-path.ts
@@ -1,0 +1,95 @@
+import os from "node:os";
+import path from "node:path";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveHomeDir } from "./paths.js";
+
+type LaunchAgentPathEnv = Record<string, string | undefined>;
+
+// `os.homedir()` reads the passwd entry via getpwuid_r, so it still returns
+// a real /Users/<shortName> on macOS even when HOME/USERPROFILE have been
+// stripped from the environment (e.g. by sanitizeHostExecEnv before a
+// detached restart handoff). HEAD fell back to it inline at each restart
+// caller; keep that behavior in one place so install/uninstall fail-fast
+// semantics stay intact and detached restart/update paths stay alive.
+function resolveHomeDirWithOsFallback(env: LaunchAgentPathEnv): string {
+  try {
+    return resolveHomeDir(env);
+  } catch (err) {
+    if (err instanceof Error && err.message === "Missing HOME") {
+      return os.homedir();
+    }
+    throw err;
+  }
+}
+
+function toPosixPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function trimTrailingSlashes(value: string): string {
+  const trimmed = value.replace(/\/+$/g, "");
+  return trimmed || "/";
+}
+
+function isBootVolumeUserHome(home: string): boolean {
+  return /^\/Users\/[^/]+$/.test(home);
+}
+
+function normalizeUserName(value: string | undefined): string | null {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed || trimmed === "." || trimmed === ".." || /[/\\\s]/.test(trimmed)) {
+    return null;
+  }
+  return trimmed;
+}
+
+function resolveShortUserName(env: LaunchAgentPathEnv): string | null {
+  for (const value of [env.USER, env.LOGNAME, env.USERNAME]) {
+    const normalized = normalizeUserName(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+// Parse `<prefix>/Users/<shortName>` out of an external macOS home path.
+// Used as a fallback when USER/LOGNAME/USERNAME env are absent or unreliable
+// (stripped env in detached restart handoffs, CI, sudo contexts): the
+// filesystem path is harder to spoof than env vars, and the segment after
+// the last `/Users/` is the same short name launchd needs on the boot volume.
+// Linux /home/<name> does not match, and the only caller is macOS launchd
+// plumbing, so this stays a macOS-shaped rule.
+function extractUserNameFromHomePath(home: string): string | null {
+  const match = /^\/.*\/Users\/([^/]+)$/.exec(home);
+  if (!match) {
+    return null;
+  }
+  return normalizeUserName(match[1]);
+}
+
+export function resolveLaunchAgentHomeDir(env: LaunchAgentPathEnv): string {
+  const home = trimTrailingSlashes(toPosixPath(resolveHomeDirWithOsFallback(env)));
+  if (isBootVolumeUserHome(home)) {
+    return home;
+  }
+  // External-volume HOME: prefer the <shortName> parsed from the path itself
+  // over env.USER/LOGNAME, which can be missing or stale in stripped envs.
+  // Last-resort fallback to the original external HOME only happens when
+  // neither the path matches `/.../Users/<name>` nor env supplies a name;
+  // surfacing a diagnostic for that case is left to the install flow.
+  const userName = extractUserNameFromHomePath(home) ?? resolveShortUserName(env);
+  return userName ? path.posix.join("/Users", userName) : home;
+}
+
+export function resolveLaunchAgentPlistPathForLabel(
+  env: LaunchAgentPathEnv,
+  label: string,
+): string {
+  return path.posix.join(
+    resolveLaunchAgentHomeDir(env),
+    "Library",
+    "LaunchAgents",
+    `${label}.plist`,
+  );
+}

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -94,6 +94,22 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     expect(args[1]).not.toContain('basename "$service_target"');
   });
 
+  it("uses the boot-volume user LaunchAgents dir when HOME is external", () => {
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+
+    scheduleDetachedLaunchdRestartHandoff({
+      env: {
+        HOME: "/Volumes/MainDataDrive/Users/test",
+        USER: "test",
+        OPENCLAW_PROFILE: "default",
+      },
+      mode: "kickstart",
+    });
+
+    const [, args] = requireSpawnCall();
+    expect(args[5]).toBe("/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist");
+  });
+
   it("polls after bootout and falls back to kickstart on bootstrap failure for reload mode", () => {
     spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
 

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -1,11 +1,10 @@
 import { spawn } from "node:child_process";
-import os from "node:os";
-import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
 import { resolveGatewayLaunchAgentLabel } from "./constants.js";
+import { resolveLaunchAgentPlistPathForLabel } from "./launchd-path.js";
 import { renderPosixRestartLogSetup } from "./restart-logs.js";
 
 type LaunchdRestartHandoffMode = "kickstart" | "reload" | "start-after-exit";
@@ -82,8 +81,7 @@ function resolveLaunchdRestartTarget(
 ): LaunchdRestartTarget {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel(env);
-  const home = normalizeOptionalString(env.HOME) || os.homedir();
-  const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
+  const plistPath = resolveLaunchAgentPlistPathForLabel(env, label);
   return {
     domain,
     label,

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -24,6 +24,7 @@ import {
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
   stopLaunchAgent,
+  uninstallLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -287,6 +288,16 @@ vi.mock("node:fs/promises", async () => {
     }),
     unlink: vi.fn(async (p: string) => {
       state.files.delete(p);
+    }),
+    rename: vi.fn(async (source: string, dest: string) => {
+      const data = state.files.get(source);
+      if (data === undefined) {
+        throw new Error(`ENOENT: no such file or directory, rename '${source}'`);
+      }
+      state.files.delete(source);
+      state.files.set(dest, data);
+      state.fileModes.set(dest, state.fileModes.get(source) ?? 0o666);
+      state.dirs.add(dest.split("/").slice(0, -1).join("/"));
     }),
     writeFile: vi.fn(async (p: string, data: string, opts?: { mode?: number }) => {
       const key = p;
@@ -984,6 +995,30 @@ describe("launchd install", () => {
     expect(state.dirModes.get("/Users/test/Library")).toBe(0o755);
     expect(state.dirModes.get("/Users/test/Library/LaunchAgents")).toBe(0o755);
     expect(state.fileModes.get(plistPath)).toBe(0o600);
+  });
+
+  it("writes the plist under the boot-volume user LaunchAgents dir for external HOME", async () => {
+    const env = {
+      HOME: "/Volumes/MainDataDrive/Users/test",
+      USER: "test",
+      OPENCLAW_PROFILE: "default",
+    };
+
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+    });
+
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    expect(plistPath).toBe("/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist");
+    expect(state.files.has(plistPath)).toBe(true);
+    expect(state.dirs.has("/Volumes/MainDataDrive/Users/test/Library/LaunchAgents")).toBe(false);
+    expect(state.launchctlCalls).toContainEqual([
+      "bootstrap",
+      typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501",
+      plistPath,
+    ]);
   });
 
   it("stops LaunchAgent via bootout by default, preserving KeepAlive for future crashes", async () => {
@@ -1686,11 +1721,62 @@ describe("launchd install", () => {
   });
 });
 
+describe("launchd uninstall", () => {
+  function seedInstalledPlist(env: Record<string, string | undefined>): string {
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set(plistPath, "<plist/>");
+    return plistPath;
+  }
+
+  it("moves the plist into the boot-volume user Trash on external HOME", async () => {
+    const env = {
+      HOME: "/Volumes/MainDataDrive/Users/test",
+      USER: "test",
+      OPENCLAW_PROFILE: "default",
+    };
+    const plistPath = seedInstalledPlist(env);
+    const stdout = new PassThrough();
+    const collected: string[] = [];
+    stdout.on("data", (chunk: Buffer | string) => {
+      collected.push(chunk.toString());
+    });
+
+    await uninstallLaunchAgent({ env, stdout });
+
+    expect(state.files.has(plistPath)).toBe(false);
+    expect(state.files.has("/Users/test/.Trash/ai.openclaw.gateway.plist")).toBe(true);
+    expect(state.dirs.has("/Users/test/.Trash")).toBe(true);
+    expect(state.dirs.has("/Volumes/MainDataDrive/Users/test/.Trash")).toBe(false);
+    expect(collected.join("")).toContain("Moved LaunchAgent to Trash");
+  });
+
+  it("keeps the standard HOME Trash location for /Users homes", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = seedInstalledPlist(env);
+    const stdout = new PassThrough();
+
+    await uninstallLaunchAgent({ env, stdout });
+
+    expect(state.files.has(plistPath)).toBe(false);
+    expect(state.files.has("/Users/test/.Trash/ai.openclaw.gateway.plist")).toBe(true);
+  });
+});
+
 describe("resolveLaunchAgentPlistPath", () => {
   it.each([
     {
       name: "uses default label when OPENCLAW_PROFILE is unset",
       env: { HOME: "/Users/test" },
+      expected: "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist",
+    },
+    {
+      name: "keeps standard /Users HOME even when USER points elsewhere",
+      env: { HOME: "/Users/test", USER: "other" },
+      expected: "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist",
+    },
+    {
+      name: "uses the boot-volume user LaunchAgents dir when HOME is external",
+      env: { HOME: "/Volumes/MainDataDrive/Users/test", USER: "test" },
       expected: "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist",
     },
     {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -16,6 +16,8 @@ import {
   resolveLegacyGatewayLaunchAgentLabels,
 } from "./constants.js";
 import { execFileUtf8 } from "./exec-file.js";
+import { resolveLaunchAgentPlistPathForLabel } from "./launchd-path.js";
+import { resolveLaunchAgentHomeDir } from "./launchd-path.js";
 import {
   buildLaunchAgentPlist as buildLaunchAgentPlistImpl,
   readLaunchAgentProgramArgumentsFromFile,
@@ -24,8 +26,8 @@ import {
   isCurrentProcessLaunchdServiceLabel,
   scheduleDetachedLaunchdRestartHandoff,
 } from "./launchd-restart-handoff.js";
-import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
-import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
+import { formatLine, writeFormattedLines } from "./output.js";
+import { resolveGatewayStateDir } from "./paths.js";
 import { resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
@@ -119,14 +121,6 @@ function resolveLaunchAgentLabel(args?: { env?: Record<string, string | undefine
     return assertValidLaunchAgentLabel(envLabel);
   }
   return assertValidLaunchAgentLabel(resolveGatewayLaunchAgentLabel(args?.env?.OPENCLAW_PROFILE));
-}
-
-function resolveLaunchAgentPlistPathForLabel(
-  env: Record<string, string | undefined>,
-  label: string,
-): string {
-  const home = toPosixPath(resolveHomeDir(env));
-  return path.posix.join(home, "Library", "LaunchAgents", `${label}.plist`);
 }
 
 function resolveLaunchAgentEnvDir(env: GatewayServiceEnv): string {
@@ -654,7 +648,7 @@ export async function uninstallLaunchAgent({
     return;
   }
 
-  const home = toPosixPath(resolveHomeDir(env));
+  const home = resolveLaunchAgentHomeDir(env);
   const trashDir = path.posix.join(home, ".Trash");
   const dest = path.join(trashDir, `${label}.plist`);
   try {
@@ -870,11 +864,12 @@ async function writeLaunchAgentPlist({
   }
 
   const plistPath = resolveLaunchAgentPlistPathForLabel(env, label);
-  const home = toPosixPath(resolveHomeDir(env));
-  const libraryDir = path.posix.join(home, "Library");
-  await ensureSecureDirectory(home);
+  const launchAgentsDir = path.dirname(plistPath);
+  const libraryDir = path.dirname(launchAgentsDir);
+  const launchAgentHomeDir = path.dirname(libraryDir);
+  await ensureSecureDirectory(launchAgentHomeDir);
   await ensureSecureDirectory(libraryDir);
-  await ensureSecureDirectory(path.dirname(plistPath));
+  await ensureSecureDirectory(launchAgentsDir);
   await ensureLaunchAgentEnvironmentDirectories(environment);
   const prepared = await prepareLaunchAgentProgramArguments({
     env,

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -231,6 +231,39 @@ describe("triggerOpenClawRestart", () => {
     });
   });
 
+  it("falls back to the boot-volume LaunchAgents plist when HOME is external", () => {
+    setPlatform("darwin");
+    delete process.env.VITEST;
+    delete process.env.NODE_ENV;
+    process.env.HOME = "/Volumes/MainDataDrive/Users/test";
+    process.env.USER = "test";
+    process.env.OPENCLAW_PROFILE = "default";
+    const uid = typeof process.getuid === "function" ? process.getuid() : 501;
+    spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+      if (command === "/usr/sbin/lsof") {
+        return { error: undefined, status: 1, stdout: "" };
+      }
+      if (command === "launchctl" && args[0] === "kickstart" && args[1] === "-k") {
+        return { error: undefined, status: 113, stderr: "service not loaded" };
+      }
+      if (command === "launchctl" && args[0] === "bootstrap") {
+        return { error: undefined, status: 0, stderr: "" };
+      }
+      return { error: undefined, status: 1, stdout: "" };
+    });
+
+    const result = triggerOpenClawRestart();
+
+    expect(result).toEqual({
+      ok: true,
+      method: "launchctl",
+      tried: [
+        `launchctl kickstart -k gui/${uid}/ai.openclaw.gateway`,
+        `launchctl bootstrap gui/${uid} /Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist`,
+      ],
+    });
+  });
+
   it("continues when launchctl bootstrap reports the service is already loaded", () => {
     setPlatform("darwin");
     delete process.env.VITEST;

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -8,6 +7,7 @@ import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
 } from "../daemon/constants.js";
+import { resolveLaunchAgentPlistPathForLabel } from "../daemon/launchd-path.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { replaceFileAtomicSync } from "./replace-file.js";
@@ -664,9 +664,7 @@ export function triggerOpenClawRestart(): RestartAttempt {
 
   // kickstart fails when the service was previously booted out (deregistered from launchd).
   // Fall back to bootstrap, which loads RunAtLoad agents without a follow-up kickstart.
-  // Use env HOME to match how launchd.ts resolves the plist install path.
-  const home = process.env.HOME?.trim() || os.homedir();
-  const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
+  const plistPath = resolveLaunchAgentPlistPathForLabel(process.env, label);
   const bootstrapArgs = ["bootstrap", domain, plistPath];
   tried.push(`launchctl ${bootstrapArgs.join(" ")}`);
   const boot = spawnSync("launchctl", bootstrapArgs, {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes macOS Gateway LaunchAgent plist resolution when the operator's `HOME` points at an external volume, such as `/Volumes/ExternalDrive/Users/alice`.
- Keeps LaunchAgent install, uninstall, restart fallback, status hints, cleanup hints, and the macOS companion app on the same boot-volume plist path: `/Users/alice/Library/LaunchAgents/ai.openclaw.profile.plist`.
- Centralizes the TypeScript path logic in `src/daemon/launchd-path.ts` and mirrors the behavior in the macOS app LaunchAgent manager.

Why does this matter now?

- launchd user agents are managed from the logged-in user's boot-volume LaunchAgents directory. External-home paths can leave OpenClaw looking at or bootstrapping the wrong plist.

What is the intended outcome?

- Operators with external-home setups can install, restart, inspect, and remove the Gateway LaunchAgent through one canonical boot-volume plist path.

What is intentionally out of scope?

- N/A - this does not change launchd labels, Gateway config shape, service environment storage, or non-macOS service managers.

What does success look like?

- With `HOME=/Volumes/ExternalDrive/Users/alice`, OpenClaw writes and bootstraps `/Users/alice/Library/LaunchAgents/ai.openclaw.profile.plist`; no plist is created under the external HOME LaunchAgents directory.

What should reviewers focus on?

- The short-name derivation for external `/.../Users/alice` homes.
- The call sites now using the shared LaunchAgent path resolver.
- Whether the macOS app and TypeScript daemon paths stay behaviorally aligned.

## Linked context

Which issue does this close?

N/A - no tracked issue.

Which issues, PRs, or discussions are related?

N/A - no related public issue or PR was provided.

Was this requested by a maintainer or owner?

N/A - prepared from a local ship request for this branch.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: macOS Gateway LaunchAgent plist path selection when `HOME` is on an external APFS volume.
- Real environment tested: macOS GUI launchd domain for user `x`, Node v24.14.0, source OpenClaw CLI, temporary APFS disk image mounted at `/Volumes/OpenClawProof-final-1780319982`, isolated `OPENCLAW_PROFILE=proof-1780319414`, isolated config and state directories under `/tmp`.
- Exact steps or command run after this patch: created and mounted a temporary APFS disk image, set `HOME=/Volumes/OpenClawProof-final-1780319982/Users/x`, ran `node --import tsx src/entry.ts gateway install --force --port 19037 --wrapper /tmp/.../openclaw-source-wrapper --json`, checked the boot-volume plist path, checked the external-home plist path, checked `launchctl print gui/$UID/ai.openclaw.proof-1780319414`, and checked `curl -fsS http://127.0.0.1:19037/healthz`. Then ran `gateway uninstall --json`, removed the temp plist/trash artifact if present, and detached the disk image.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
install.ok=true result=installed message=undefined
mounted_home=/Volumes/OpenClawProof-final-1780319982/Users/x
expected_plist=/Users/x/Library/LaunchAgents/ai.openclaw.proof-1780319414.plist
external_home_plist_exists=no
boot_volume_plist_exists=yes
launchctl_registered=yes
healthz=ok port=19037
plist.Label=ai.openclaw.proof-1780319414
```

- Observed result after fix: OpenClaw installed and registered the temporary LaunchAgent from the boot-volume `/Users/x/Library/LaunchAgents` plist, did not create the plist under the mounted external HOME, and the temporary Gateway answered `/healthz`.
- What was not tested: a physical external disk with a migrated macOS account home; the proof used a temporary APFS disk image mounted under `/Volumes`.
- Proof limitations or environment constraints: the proof used an isolated temporary profile and source-wrapper entrypoint so it did not modify the operator's default OpenClaw Gateway service.
- Before evidence (optional but encouraged): before this change, several install/restart/status paths derived the LaunchAgent plist directly from `HOME`, so an external `HOME=/Volumes/ExternalDrive/Users/alice` resolved to `/Volumes/ExternalDrive/Users/alice/Library/LaunchAgents/ai.openclaw.profile.plist` instead of `/Users/alice/Library/LaunchAgents/ai.openclaw.profile.plist`.

## Tests and validation

Which commands did you run?

- `git diff --cached --check`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs --base upstream/main --head HEAD`
- `node scripts/run-vitest.mjs src/daemon/launchd-path.test.ts src/daemon/launchd.test.ts src/daemon/launchd-restart-handoff.test.ts src/infra/restart.test.ts src/cli/update-cli/restart-helper.test.ts`
- `swift test --skip-update --filter GatewayLaunchAgentManagerTests`
- Real launchd proof command described above.

What regression coverage was added or updated?

- Added `src/daemon/launchd-path.test.ts` for boot-volume home preservation, external APFS HOME remapping, missing HOME fallback, invalid short-name fallback, and plist path construction.
- Updated launchd install/uninstall/restart, restart handoff, restart helper, and macOS app tests for external-home plist behavior.

What failed before this fix, if known?

- The old code paths built LaunchAgent plist paths from external `HOME` values, which points at the wrong LaunchAgents directory for the launchd user agent.

If no test was added, why not?

N/A - regression tests were added and updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes - macOS LaunchAgent commands and hints now prefer the boot-volume user LaunchAgents path for external-home setups.

Did config, environment, or migration behavior change? (`Yes/No`)

No - config shape and migration behavior are unchanged.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Incorrectly deriving a short user name from an unusual external-home path.

How is that risk mitigated?

- Standard `/Users/alice` homes are preserved.
- External `/.../Users/alice` homes prefer the short name parsed from the path itself.
- Invalid or non-matching paths fall back without inventing a username.
- The real launchd proof verified the install path, launchctl registration, and Gateway health with an external APFS-mounted HOME.

## Current review state

What is the next action?

- Ready for review.

What is still waiting on author, maintainer, CI, or external proof?

- CI has not run yet on the PR branch.

Which bot or reviewer comments were addressed?

N/A - no review comments yet.
