### PR TITLE
fix(msteams): route file attachment sends through thread-aware delivery path

### DIFF
--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -382,6 +382,95 @@ describe("sendMessageMSTeams", () => {
     expect(firstObjectArg(mockState.sendMSTeamsMessages).replyStyle).toBe("top-level");
   });
 
+  it("routes SharePoint file card sends to the channel thread when replyStyle is thread", async () => {
+    const threadRootId = "thread-root-message-1";
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter: {},
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        threadId: threadRootId,
+        activityId: "activity-1",
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      replyStyle: "thread",
+      sdkCloudOptions: { cloud: "Public" },
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024 * 1024,
+      sharePointSiteId: "site-123",
+    });
+    mockSharePointPdfUpload({
+      bufferSize: 100,
+      fileName: "doc.pdf",
+      itemId: "item-1",
+      uniqueId: "{GUID-123}",
+    });
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "here is a file",
+      mediaUrl: "https://example.com/doc.pdf",
+    });
+
+    // The SharePoint file card send must include threadActivityId for thread routing.
+    expect(mockState.sendMSTeamsActivityWithReference).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        threadActivityId: threadRootId,
+      }),
+    );
+  });
+
+  it("routes OneDrive fallback file sends to the channel thread when replyStyle is thread", async () => {
+    const threadRootId = "thread-root-message-2";
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter: {},
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        threadId: threadRootId,
+        activityId: "activity-2",
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      replyStyle: "thread",
+      sdkCloudOptions: { cloud: "Public" },
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024 * 1024,
+      sharePointSiteId: undefined, // No SharePoint → falls back to OneDrive
+    });
+    mockState.loadOutboundMediaFromUrl.mockResolvedValueOnce({
+      buffer: Buffer.alloc(100, "pdf"),
+      contentType: "application/pdf",
+      fileName: "doc.pdf",
+      kind: "file",
+    });
+    mockState.requiresFileConsent.mockReturnValue(false);
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "here is a file",
+      mediaUrl: "https://example.com/doc.pdf",
+    });
+
+    // The OneDrive fallback send must include threadActivityId for thread routing.
+    expect(mockState.sendMSTeamsActivityWithReference).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        threadActivityId: threadRootId,
+      }),
+    );
+  });
+
   it("uses graphChatId instead of conversationId when uploading to SharePoint", async () => {
     // Simulates a group chat where Bot Framework conversationId is valid but we have
     // a resolved Graph chat ID cached from a prior send.

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -20,6 +20,7 @@ const mockState = vi.hoisted(() => ({
   deleteMSTeamsActivityWithReference: vi.fn(async () => {}),
   uploadAndShareSharePoint: vi.fn(),
   getDriveItemProperties: vi.fn(),
+  uploadAndShareOneDrive: vi.fn(),
   buildTeamsFileInfoCard: vi.fn(),
   createMSTeamsTokenProvider: vi.fn(),
 }));
@@ -86,7 +87,7 @@ vi.mock("./runtime.js", () => ({
 vi.mock("./graph-upload.js", () => ({
   uploadAndShareSharePoint: mockState.uploadAndShareSharePoint,
   getDriveItemProperties: mockState.getDriveItemProperties,
-  uploadAndShareOneDrive: vi.fn(),
+  uploadAndShareOneDrive: mockState.uploadAndShareOneDrive,
 }));
 
 vi.mock("./graph-chat.js", () => ({
@@ -237,6 +238,7 @@ describe("sendMessageMSTeams", () => {
     mockState.deleteMSTeamsActivityWithReference.mockReset();
     mockState.uploadAndShareSharePoint.mockReset();
     mockState.getDriveItemProperties.mockReset();
+    mockState.uploadAndShareOneDrive.mockReset();
     mockState.buildTeamsFileInfoCard.mockReset();
 
     mockState.extractFilename.mockResolvedValue("fallback.bin");
@@ -384,8 +386,9 @@ describe("sendMessageMSTeams", () => {
 
   it("routes SharePoint file card sends to the channel thread when replyStyle is thread", async () => {
     const threadRootId = "thread-root-message-1";
+    const app = createMockApp();
     mockState.resolveMSTeamsSendContext.mockResolvedValue({
-      adapter: {},
+      app,
       appId: "app-id",
       conversationId: "19:channel@thread.tacv2",
       ref: {
@@ -417,7 +420,7 @@ describe("sendMessageMSTeams", () => {
 
     // The SharePoint file card send must include threadActivityId for thread routing.
     expect(mockState.sendMSTeamsActivityWithReference).toHaveBeenCalledWith(
-      expect.any(Object),
+      app,
       expect.any(Object),
       expect.any(Object),
       expect.objectContaining({
@@ -428,8 +431,9 @@ describe("sendMessageMSTeams", () => {
 
   it("routes OneDrive fallback file sends to the channel thread when replyStyle is thread", async () => {
     const threadRootId = "thread-root-message-2";
+    const app = createMockApp();
     mockState.resolveMSTeamsSendContext.mockResolvedValue({
-      adapter: {},
+      app,
       appId: "app-id",
       conversationId: "19:channel@thread.tacv2",
       ref: {
@@ -452,6 +456,11 @@ describe("sendMessageMSTeams", () => {
       kind: "file",
     });
     mockState.requiresFileConsent.mockReturnValue(false);
+    mockState.uploadAndShareOneDrive.mockResolvedValueOnce({
+      itemId: "od-item-1",
+      shareUrl: "https://1drv.example.com/share/doc.pdf",
+      name: "doc.pdf",
+    });
 
     await sendMessageMSTeams({
       cfg: {} as OpenClawConfig,
@@ -462,7 +471,7 @@ describe("sendMessageMSTeams", () => {
 
     // The OneDrive fallback send must include threadActivityId for thread routing.
     expect(mockState.sendMSTeamsActivityWithReference).toHaveBeenCalledWith(
-      expect.any(Object),
+      app,
       expect.any(Object),
       expect.any(Object),
       expect.objectContaining({

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -162,10 +162,15 @@ export async function sendMessageMSTeams(
     ref,
     log,
     conversationType,
+    replyStyle,
     tokenProvider,
     sharePointSiteId,
     sdkCloudOptions,
   } = ctx;
+
+  const isChannel = conversationType === "channel";
+  const threadActivityId =
+    isChannel && replyStyle === "thread" ? (ref.threadId ?? ref.activityId) : undefined;
 
   log.debug?.("sending proactive message", {
     conversationId,
@@ -308,6 +313,7 @@ export async function sendMessageMSTeams(
           ref,
           activity,
           serviceUrlBoundary: sdkCloudOptions,
+          threadActivityId,
         });
 
         log.info("sent native file card", {
@@ -352,6 +358,7 @@ export async function sendMessageMSTeams(
         ref,
         activity,
         serviceUrlBoundary: sdkCloudOptions,
+        threadActivityId,
       });
 
       log.info("sent message with OneDrive file link", {
@@ -449,16 +456,20 @@ type ProactiveActivityParams = {
   serviceUrlBoundary: MSTeamsProactiveContext["sdkCloudOptions"];
 };
 
-type ProactiveActivityRawParams = Omit<ProactiveActivityParams, "errorPrefix">;
+type ProactiveActivityRawParams = Omit<ProactiveActivityParams, "errorPrefix"> & {
+  threadActivityId?: string;
+};
 
 async function sendProactiveActivityRaw({
   app,
   ref,
   activity,
   serviceUrlBoundary,
+  threadActivityId,
 }: ProactiveActivityRawParams): Promise<string> {
   const baseRef = buildConversationReference(ref);
   const response = await sendMSTeamsActivityWithReference(app, baseRef, activity, {
+    threadActivityId,
     serviceUrlBoundary,
   });
   return extractMessageId(response) ?? "unknown";


### PR DESCRIPTION
## Summary

Fix Microsoft Teams file attachment sends to route through the thread-aware delivery path when `replyStyle: "thread"` is configured for channel conversations.

SharePoint file card sends and OneDrive file-link fallback sends bypassed the thread-aware `sendMSTeamsMessages` path, calling `sendProactiveActivityRaw` directly without `threadActivityId`. When `replyStyle` resolves to `"thread"` in a channel, attachment replies appeared as top-level messages instead of in-thread replies.

## Root Cause

`sendProactiveActivityRaw` in `extensions/msteams/src/send.ts` did not accept or forward a `threadActivityId` parameter. Two file send branches (SharePoint native file card at line 305, OneDrive file-link fallback at line 349) used this function directly, so attachment sends always lacked thread routing information regardless of the configured `replyStyle`.

The text/inline-media path (`sendTextWithMedia` → `sendMSTeamsMessages`) correctly resolves and forwards the thread root (`ref.threadId ?? ref.activityId`), but the file attachment branches had no equivalent.

## Fix

1. Add `replyStyle` to the destructured context in `sendMessageMSTeams`
2. Compute `threadActivityId` once from `ref.threadId ?? ref.activityId` when the conversation is a channel and `replyStyle` is `"thread"`
3. Add `threadActivityId` as an optional parameter to `sendProactiveActivityRaw` and forward it to `sendMSTeamsActivityWithReference`
4. Pass `threadActivityId` at both the SharePoint file card and OneDrive file-link call sites

## Unit tests

Added 2 tests in `send.test.ts`:
1. SharePoint file card sends include `threadActivityId` when `replyStyle: "thread"` in a channel
2. OneDrive fallback sends include `threadActivityId` when `replyStyle: "thread"` in a channel

## Real behavior proof

Behavior or issue addressed: Microsoft Teams channel replies with file attachments appear as top-level messages instead of in-thread when `replyStyle: "thread"` is configured.

Real environment tested: macOS 15.4 (darwin arm64), Node.js v22.22.3. Unit tests verify the exact code paths identified in the ClawSweeper source-level reproduction.

Exact steps or command run after this patch: Unit tests exercise both the SharePoint file card and OneDrive fallback branches with `replyStyle: "thread"` and `conversationType: "channel"`, asserting that `sendMSTeamsActivityWithReference` receives the correct `threadActivityId` option.

Evidence after fix:
```
✓ routes SharePoint file card sends to the channel thread when replyStyle is thread
✓ routes OneDrive fallback file sends to the channel thread when replyStyle is thread
```

Observed result after fix: `sendMSTeamsActivityWithReference` is called with `threadActivityId` matching `ref.threadId` for both SharePoint and OneDrive attachment sends when `replyStyle === "thread"` and the conversation is a channel. The `threadActivityId` parameter is omitted (undefined) for non-channel conversations and when `replyStyle` is `"top-level"`, preserving existing behavior.

What was not tested: Live Microsoft Teams tenant end-to-end test with actual thread routing verification. The code change follows the exact same thread-root resolution pattern already used by the text/inline-media send path.

## Related

Closes #88836

🤖 Generated with [Claude Code](https://claude.com/claude-code)
