### PR TITLE
fix: allow macOS gateway restart while LaunchAgent owns its port

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -53,15 +53,22 @@ const state = vi.hoisted(() => ({
   files: new Map<string, string>(),
   fileModes: new Map<string, number>(),
   fileWrites: [] as Array<{ path: string; data: string }>,
+  cleanupProtectedPids: [] as Array<number | undefined>,
 }));
 const launchdRestartHandoffState = vi.hoisted(() => ({
   scheduleDetachedLaunchdRestartHandoff: vi.fn<
     (_params: unknown) => { ok: true; value: number | undefined } | { ok: false; error: string }
   >(() => ({ ok: true, value: 7331 })),
 }));
+type CleanStaleGatewayProcessesOptions = {
+  protectedPid?: number;
+  resolveProtectedPid?: () => number | undefined;
+};
+
 const cleanStaleGatewayProcessesSync = vi.hoisted(() =>
-  vi.fn<(port?: number, options?: { protectedPid?: number }) => number[]>(() => []),
+  vi.fn<(port?: number, options?: CleanStaleGatewayProcessesOptions) => number[]>(() => []),
 );
+const launchctlSpawnSync = vi.hoisted(() => vi.fn());
 const inspectPortUsage = vi.hoisted(() =>
   vi.fn<typeof import("../infra/ports-inspect.js").inspectPortUsage>(async () => ({
     port: 18789,
@@ -234,79 +241,89 @@ function normalizeLaunchctlArgs(file: string, args: string[]): string[] {
   return args;
 }
 
-vi.mock("./exec-file.js", () => ({
-  execFileUtf8: vi.fn(async (file: string, args: string[]) => {
-    const call = normalizeLaunchctlArgs(file, args);
-    state.launchctlCalls.push(call);
-    if (call[0] === "list") {
-      return { stdout: state.listOutput, stderr: "", code: 0 };
+function executeLaunchctlMock(file: string, args: string[]) {
+  const call = normalizeLaunchctlArgs(file, args);
+  state.launchctlCalls.push(call);
+  if (call[0] === "list") {
+    return { stdout: state.listOutput, stderr: "", code: 0 };
+  }
+  if (call[0] === "print") {
+    if (state.printNotLoadedRemaining > 0) {
+      state.printNotLoadedRemaining -= 1;
+      return { stdout: "", stderr: "Could not find service", code: 113 };
     }
-    if (call[0] === "print") {
-      if (state.printNotLoadedRemaining > 0) {
-        state.printNotLoadedRemaining -= 1;
-        return { stdout: "", stderr: "Could not find service", code: 113 };
-      }
-      if (state.printError && state.printFailuresRemaining > 0) {
-        state.printFailuresRemaining -= 1;
-        return { stdout: "", stderr: state.printError, code: state.printCode };
-      }
-      if (!state.serviceLoaded) {
-        return { stdout: "", stderr: "Could not find service", code: 113 };
-      }
-      if (state.printOutput) {
-        return { stdout: state.printOutput, stderr: "", code: 0 };
-      }
-      if (!state.serviceRunning) {
-        return { stdout: ["state = waiting", "pid = 0"].join("\n"), stderr: "", code: 0 };
-      }
-      return { stdout: ["state = running", "pid = 4242"].join("\n"), stderr: "", code: 0 };
+    if (state.printError && state.printFailuresRemaining > 0) {
+      state.printFailuresRemaining -= 1;
+      return { stdout: "", stderr: state.printError, code: state.printCode };
     }
-    if (call[0] === "disable" && state.disableError) {
-      return { stdout: "", stderr: state.disableError, code: state.disableCode };
+    if (!state.serviceLoaded) {
+      return { stdout: "", stderr: "Could not find service", code: 113 };
     }
-    if (call[0] === "stop") {
-      if (state.stopError) {
-        return { stdout: "", stderr: state.stopError, code: state.stopCode };
-      }
-      if (!state.stopLeavesRunning) {
-        state.serviceRunning = false;
-      }
-      return { stdout: "", stderr: "", code: 0 };
+    if (state.printOutput) {
+      return { stdout: state.printOutput, stderr: "", code: 0 };
     }
-    if (call[0] === "bootout") {
-      if (state.bootoutError) {
-        return { stdout: "", stderr: state.bootoutError, code: state.bootoutCode };
-      }
-      state.serviceLoaded = false;
+    if (!state.serviceRunning) {
+      return { stdout: ["state = waiting", "pid = 0"].join("\n"), stderr: "", code: 0 };
+    }
+    return { stdout: ["state = running", "pid = 4242"].join("\n"), stderr: "", code: 0 };
+  }
+  if (call[0] === "disable" && state.disableError) {
+    return { stdout: "", stderr: state.disableError, code: state.disableCode };
+  }
+  if (call[0] === "stop") {
+    if (state.stopError) {
+      return { stdout: "", stderr: state.stopError, code: state.stopCode };
+    }
+    if (!state.stopLeavesRunning) {
       state.serviceRunning = false;
-      return { stdout: "", stderr: "", code: 0 };
-    }
-    if (call[0] === "enable") {
-      return { stdout: "", stderr: "", code: 0 };
-    }
-    if (call[0] === "bootstrap") {
-      if (state.bootstrapError) {
-        if (state.bootstrapLoadsServiceOnFailure) {
-          state.serviceLoaded = true;
-          state.serviceRunning = true;
-        }
-        return { stdout: "", stderr: state.bootstrapError, code: state.bootstrapCode };
-      }
-      state.serviceLoaded = true;
-      state.serviceRunning = true;
-      return { stdout: "", stderr: "", code: 0 };
-    }
-    if (call[0] === "kickstart") {
-      if (state.kickstartError && state.kickstartFailuresRemaining > 0) {
-        state.kickstartFailuresRemaining -= 1;
-        return { stdout: "", stderr: state.kickstartError, code: state.kickstartCode };
-      }
-      state.serviceLoaded = true;
-      state.serviceRunning = true;
-      return { stdout: "", stderr: "", code: 0 };
     }
     return { stdout: "", stderr: "", code: 0 };
-  }),
+  }
+  if (call[0] === "bootout") {
+    if (state.bootoutError) {
+      return { stdout: "", stderr: state.bootoutError, code: state.bootoutCode };
+    }
+    state.serviceLoaded = false;
+    state.serviceRunning = false;
+    return { stdout: "", stderr: "", code: 0 };
+  }
+  if (call[0] === "enable") {
+    return { stdout: "", stderr: "", code: 0 };
+  }
+  if (call[0] === "bootstrap") {
+    if (state.bootstrapError) {
+      if (state.bootstrapLoadsServiceOnFailure) {
+        state.serviceLoaded = true;
+        state.serviceRunning = true;
+      }
+      return { stdout: "", stderr: state.bootstrapError, code: state.bootstrapCode };
+    }
+    state.serviceLoaded = true;
+    state.serviceRunning = true;
+    return { stdout: "", stderr: "", code: 0 };
+  }
+  if (call[0] === "kickstart") {
+    if (state.kickstartError && state.kickstartFailuresRemaining > 0) {
+      state.kickstartFailuresRemaining -= 1;
+      return { stdout: "", stderr: state.kickstartError, code: state.kickstartCode };
+    }
+    state.serviceLoaded = true;
+    state.serviceRunning = true;
+    return { stdout: "", stderr: "", code: 0 };
+  }
+  return { stdout: "", stderr: "", code: 0 };
+}
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
+    { spawnSync: (...args: unknown[]) => launchctlSpawnSync(...args) },
+  );
+});
+
+vi.mock("./exec-file.js", () => ({
+  execFileUtf8: vi.fn(async (file: string, args: string[]) => executeLaunchctlMock(file, args)),
 }));
 
 vi.mock("./launchd-restart-handoff.js", () => ({
@@ -315,7 +332,7 @@ vi.mock("./launchd-restart-handoff.js", () => ({
 }));
 
 vi.mock("../infra/restart-stale-pids.js", () => ({
-  cleanStaleGatewayProcessesSync: (port?: number, options?: { protectedPid?: number }) =>
+  cleanStaleGatewayProcessesSync: (port?: number, options?: CleanStaleGatewayProcessesOptions) =>
     options === undefined
       ? cleanStaleGatewayProcessesSync(port)
       : cleanStaleGatewayProcessesSync(port, options),
@@ -418,8 +435,17 @@ beforeEach(() => {
   state.files.clear();
   state.fileModes.clear();
   state.fileWrites.length = 0;
+  state.cleanupProtectedPids.length = 0;
+  launchctlSpawnSync.mockReset();
+  launchctlSpawnSync.mockImplementation((file: string, args: string[]) => {
+    const result = executeLaunchctlMock(file, args);
+    return { ...result, status: result.code, error: undefined };
+  });
   cleanStaleGatewayProcessesSync.mockReset();
-  cleanStaleGatewayProcessesSync.mockReturnValue([]);
+  cleanStaleGatewayProcessesSync.mockImplementation((_port, options) => {
+    state.cleanupProtectedPids.push(options?.resolveProtectedPid?.() ?? options?.protectedPid);
+    return [];
+  });
   inspectPortUsage.mockReset();
   inspectPortUsage.mockResolvedValue({ port: 18789, status: "free", listeners: [], hints: [] });
   probePortUsage.mockReset();
@@ -1354,9 +1380,12 @@ describe("launchd install", () => {
       envFilePath,
       ...defaultProgramArguments,
     ]);
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19007, {
-      protectedPid: 4242,
-    });
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
+      19007,
+      expect.objectContaining({
+        resolveProtectedPid: expect.any(Function),
+      }),
+    );
   });
 
   it("repairs a mangled label-derived service-env wrapper path on restart", async () => {
@@ -2000,9 +2029,12 @@ describe("launchd install", () => {
     const label = "ai.openclaw.gateway";
     const serviceId = `${domain}/${label}`;
     expect(result).toEqual({ outcome: "completed" });
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(18789, {
-      protectedPid: 4242,
-    });
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
+      18789,
+      expect.objectContaining({
+        resolveProtectedPid: expect.any(Function),
+      }),
+    );
     expect(state.launchctlCalls).toEqual([
       ["print", serviceId],
       ["enable", serviceId],
@@ -2244,9 +2276,12 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19001, {
-      protectedPid: 4242,
-    });
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
+      19001,
+      expect.objectContaining({
+        resolveProtectedPid: expect.any(Function),
+      }),
+    );
   });
 
   it("ignores invalid configured gateway ports for stale cleanup", async () => {
@@ -2280,9 +2315,12 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19007, {
-      protectedPid: 4242,
-    });
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
+      19007,
+      expect.objectContaining({
+        resolveProtectedPid: expect.any(Function),
+      }),
+    );
     expect(inspectPortUsage).toHaveBeenCalledWith(19007);
   });
 
@@ -2301,9 +2339,12 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19008, {
-      protectedPid: 4242,
-    });
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
+      19008,
+      expect.objectContaining({
+        resolveProtectedPid: expect.any(Function),
+      }),
+    );
     expect(inspectPortUsage).toHaveBeenCalledWith(19008);
   });
 
@@ -2352,10 +2393,7 @@ describe("launchd install", () => {
         OPENCLAW_GATEWAY_PORT: "19002",
       };
       if (managedPidAfterCleanup !== 4242) {
-        cleanStaleGatewayProcessesSync.mockImplementationOnce(() => {
-          state.printOutput = ["state = running", `pid = ${managedPidAfterCleanup}`].join("\n");
-          return [];
-        });
+        state.printOutput = ["state = running", `pid = ${managedPidAfterCleanup}`].join("\n");
       }
       inspectPortUsage.mockResolvedValue({
         port: 19002,
@@ -2369,9 +2407,11 @@ describe("launchd install", () => {
       const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
       const serviceId = `${domain}/ai.openclaw.gateway`;
       expect(result).toEqual({ outcome: "completed" });
-      expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002, {
-        protectedPid: 4242,
-      });
+      expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
+        19002,
+        expect.objectContaining({ resolveProtectedPid: expect.any(Function) }),
+      );
+      expect(state.cleanupProtectedPids).toEqual([managedPidAfterCleanup]);
       expect(inspectPortUsage).toHaveBeenCalledWith(19002);
       expect(state.launchctlCalls).toEqual([
         ["print", serviceId],
@@ -2435,9 +2475,11 @@ describe("launchd install", () => {
 
       const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
       const serviceId = `${domain}/ai.openclaw.gateway`;
-      expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002, {
-        protectedPid: 4242,
-      });
+      expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
+        19002,
+        expect.objectContaining({ resolveProtectedPid: expect.any(Function) }),
+      );
+      expect(state.cleanupProtectedPids).toEqual([4242]);
       expect(inspectPortUsage).toHaveBeenCalledWith(19002);
       expect(state.launchctlCalls).toEqual([
         ["print", serviceId],

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -2258,7 +2258,7 @@ describe("launchd install", () => {
     });
 
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19007);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19007);
+    expect(inspectPortUsage).not.toHaveBeenCalled();
   });
 
   it("uses the final repeated LaunchAgent port flag for restart stale cleanup", async () => {
@@ -2277,7 +2277,7 @@ describe("launchd install", () => {
     });
 
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19008);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19008);
+    expect(inspectPortUsage).not.toHaveBeenCalled();
   });
 
   it("ignores invalid stored LaunchAgent environment ports for stale cleanup", async () => {
@@ -2299,51 +2299,32 @@ describe("launchd install", () => {
     expect(inspectPortUsage).not.toHaveBeenCalled();
   });
 
-  it("fails restart before kickstart when the configured gateway port remains busy", async () => {
+  it("does not require the configured gateway port to be free before kickstart", async () => {
     const env = {
       ...createDefaultLaunchdEnv(),
       OPENCLAW_GATEWAY_PORT: "19002",
     };
-    const plistPath = resolveLaunchAgentPlistPath(env);
-    const originalPlist = [
-      '<?xml version="1.0" encoding="UTF-8"?>',
-      '<plist version="1.0">',
-      "  <dict>",
-      "    <key>Label</key>",
-      "    <string>ai.openclaw.gateway</string>",
-      "    <key>ProgramArguments</key>",
-      "    <array>",
-      "      <string>node</string>",
-      "      <string>gateway.js</string>",
-      "    </array>",
-      "    <key>StandardOutPath</key>",
-      "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
-      "  </dict>",
-      "</plist>",
-    ].join("\n");
-    state.files.set(plistPath, originalPlist);
     inspectPortUsage.mockResolvedValue({
       port: 19002,
       status: "busy",
       listeners: [],
       hints: [],
     });
-    formatPortDiagnostics.mockReturnValue(["Port 19002 is held by pid 4242."]);
 
-    await expect(
-      restartLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-      }),
-    ).rejects.toThrow(
-      "gateway port 19002 is still busy before LaunchAgent restart\nPort 19002 is held by pid 4242.",
-    );
+    const result = await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
 
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+    expect(result).toEqual({ outcome: "completed" });
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19002);
-    expect(state.files.get(plistPath)).toBe(originalPlist);
-    expect(state.fileWrites).toHaveLength(0);
-    expect(launchctlCommandNames()).not.toContain("kickstart");
+    expect(inspectPortUsage).not.toHaveBeenCalled();
+    expect(state.launchctlCalls).toEqual([
+      ["enable", serviceId],
+      ["kickstart", "-k", serviceId],
+    ]);
   });
 
   it("skips stale cleanup when no explicit launch agent port can be resolved", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -2,6 +2,7 @@
 import { PassThrough } from "node:stream";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PortListener } from "../infra/ports-types.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "./constants.js";
 import {
@@ -2325,110 +2326,131 @@ describe("launchd install", () => {
     expect(inspectPortUsage).not.toHaveBeenCalled();
   });
 
-  it("protects and allows the managed LaunchAgent that owns the gateway port", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19002",
-    };
-    inspectPortUsage.mockResolvedValue({
-      port: 19002,
-      status: "busy",
+  it.each([
+    {
+      name: "managed dual-stack ownership",
+      managedPidAfterCleanup: 4242,
       listeners: [
-        {
-          pid: 4242,
-          command: "node",
-          commandLine: "node openclaw.mjs gateway --port 19002",
-          address: "TCP 127.0.0.1:19002 (LISTEN)",
-        },
-        {
-          pid: 4242,
-          command: "node",
-          commandLine: "node openclaw.mjs gateway --port 19002",
-          address: "TCP [::1]:19002 (LISTEN)",
-        },
+        { pid: 4242, address: "TCP 127.0.0.1:19002 (LISTEN)" },
+        { pid: 4242, address: "TCP [::1]:19002 (LISTEN)" },
       ],
-      hints: [],
-    });
+    },
+    {
+      name: "a changed launchd PID",
+      managedPidAfterCleanup: 4343,
+      listeners: [{ pid: 4343, address: "TCP 127.0.0.1:19002 (LISTEN)" }],
+    },
+  ] satisfies Array<{
+    name: string;
+    managedPidAfterCleanup: number;
+    listeners: PortListener[];
+  }>)(
+    "protects the current service and allows $name",
+    async ({ managedPidAfterCleanup, listeners }) => {
+      const env = {
+        ...createDefaultLaunchdEnv(),
+        OPENCLAW_GATEWAY_PORT: "19002",
+      };
+      if (managedPidAfterCleanup !== 4242) {
+        cleanStaleGatewayProcessesSync.mockImplementationOnce(() => {
+          state.printOutput = ["state = running", `pid = ${managedPidAfterCleanup}`].join("\n");
+          return [];
+        });
+      }
+      inspectPortUsage.mockResolvedValue({
+        port: 19002,
+        status: "busy",
+        listeners,
+        hints: [],
+      });
 
-    const result = await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+      const result = await restartLaunchAgent({ env, stdout: new PassThrough() });
 
-    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-    const serviceId = `${domain}/ai.openclaw.gateway`;
-    expect(result).toEqual({ outcome: "completed" });
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002, {
-      protectedPid: 4242,
-    });
-    expect(inspectPortUsage).toHaveBeenCalledWith(19002);
-    expect(state.launchctlCalls).toEqual([
-      ["print", serviceId],
-      ["print", serviceId],
-      ["enable", serviceId],
-      ["kickstart", "-k", serviceId],
-    ]);
-  });
+      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+      const serviceId = `${domain}/ai.openclaw.gateway`;
+      expect(result).toEqual({ outcome: "completed" });
+      expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002, {
+        protectedPid: 4242,
+      });
+      expect(inspectPortUsage).toHaveBeenCalledWith(19002);
+      expect(state.launchctlCalls).toEqual([
+        ["print", serviceId],
+        ["print", serviceId],
+        ["enable", serviceId],
+        ["kickstart", "-k", serviceId],
+      ]);
+    },
+  );
 
-  it("rejects an unrelated gateway port owner before mutating the LaunchAgent", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19002",
-    };
-    setLaunchAgentPlist({
-      env,
-      label: "ai.openclaw.gateway",
-      programArguments: ["node", "gateway.js"],
-    });
-    const plistPath = resolveLaunchAgentPlistPath(env);
-    const originalPlist = state.files.get(plistPath);
-    inspectPortUsage.mockResolvedValue({
-      port: 19002,
-      status: "busy",
+  it.each([
+    {
+      name: "unrelated",
+      listeners: [{ pid: 5151, address: "TCP 127.0.0.1:19002 (LISTEN)" }],
+    },
+    {
+      name: "mixed",
       listeners: [
-        {
-          pid: 5151,
-          command: "python3",
-          commandLine: "python3 -m http.server 19002",
-          address: "TCP 127.0.0.1:19002 (LISTEN)",
-        },
+        { pid: 4242, address: "TCP 127.0.0.1:19002 (LISTEN)" },
+        { pid: 5151, address: "TCP [::1]:19002 (LISTEN)" },
       ],
-      hints: ["Another process is listening on this port."],
-    });
-    formatPortDiagnostics.mockReturnValue([
-      "Port 19002 is already in use.",
-      "- pid 5151: python3 -m http.server 19002",
-    ]);
-
-    await expect(
-      restartLaunchAgent({
+    },
+    {
+      name: "missing-PID",
+      listeners: [{ address: "TCP 127.0.0.1:19002 (LISTEN)" }],
+    },
+    {
+      name: "unattributed",
+      listeners: [],
+    },
+  ] satisfies Array<{ name: string; listeners: PortListener[] }>)(
+    "rejects $name gateway port ownership before mutating launchd",
+    async ({ listeners }) => {
+      const env = {
+        ...createDefaultLaunchdEnv(),
+        OPENCLAW_GATEWAY_PORT: "19002",
+      };
+      setLaunchAgentPlist({
         env,
-        stdout: new PassThrough(),
-      }),
-    ).rejects.toThrow(
-      [
-        "gateway port 19002 is busy but is not verifiably owned by LaunchAgent ai.openclaw.gateway",
-        "Port 19002 is already in use.",
-        "- pid 5151: python3 -m http.server 19002",
-      ].join("\n"),
-    );
+        label: "ai.openclaw.gateway",
+        programArguments: ["node", "gateway.js"],
+      });
+      const plistPath = resolveLaunchAgentPlistPath(env);
+      const originalPlist = state.files.get(plistPath);
+      inspectPortUsage.mockResolvedValue({
+        port: 19002,
+        status: "busy",
+        listeners,
+        hints: ["Another process is listening on this port."],
+      });
+      formatPortDiagnostics.mockReturnValue(["Port 19002 is already in use."]);
 
-    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-    const serviceId = `${domain}/ai.openclaw.gateway`;
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002, {
-      protectedPid: 4242,
-    });
-    expect(inspectPortUsage).toHaveBeenCalledWith(19002);
-    expect(state.launchctlCalls).toEqual([
-      ["print", serviceId],
-      ["print", serviceId],
-    ]);
-    expect(state.files.get(plistPath)).toBe(originalPlist);
-    expect(state.fileWrites).toHaveLength(0);
-    expect(launchctlCommandNames()).not.toContain("enable");
-    expect(launchctlCommandNames()).not.toContain("bootout");
-    expect(launchctlCommandNames()).not.toContain("kickstart");
-  });
+      await expect(
+        restartLaunchAgent({
+          env,
+          stdout: new PassThrough(),
+        }),
+      ).rejects.toThrow(
+        "gateway port 19002 is busy but is not verifiably owned by LaunchAgent ai.openclaw.gateway",
+      );
+
+      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+      const serviceId = `${domain}/ai.openclaw.gateway`;
+      expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002, {
+        protectedPid: 4242,
+      });
+      expect(inspectPortUsage).toHaveBeenCalledWith(19002);
+      expect(state.launchctlCalls).toEqual([
+        ["print", serviceId],
+        ["print", serviceId],
+      ]);
+      expect(state.files.get(plistPath)).toBe(originalPlist);
+      expect(state.fileWrites).toHaveLength(0);
+      expect(launchctlCommandNames()).not.toContain("enable");
+      expect(launchctlCommandNames()).not.toContain("bootout");
+      expect(launchctlCommandNames()).not.toContain("bootstrap");
+      expect(launchctlCommandNames()).not.toContain("kickstart");
+    },
+  );
 
   it("skips stale cleanup when no explicit launch agent port can be resolved", async () => {
     const env = createDefaultLaunchdEnv();

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -59,10 +59,15 @@ const launchdRestartHandoffState = vi.hoisted(() => ({
   >(() => ({ ok: true, value: 7331 })),
 }));
 const cleanStaleGatewayProcessesSync = vi.hoisted(() =>
-  vi.fn<(port?: number) => number[]>(() => []),
+  vi.fn<(port?: number, options?: { protectedPid?: number }) => number[]>(() => []),
 );
 const inspectPortUsage = vi.hoisted(() =>
-  vi.fn(async () => ({ port: 18789, status: "free", listeners: [], hints: [] })),
+  vi.fn<typeof import("../infra/ports-inspect.js").inspectPortUsage>(async () => ({
+    port: 18789,
+    status: "free",
+    listeners: [],
+    hints: [],
+  })),
 );
 const probePortUsage = vi.hoisted(() =>
   vi.fn<typeof import("../infra/ports-probe.js").probePortUsage>(async () => "free"),
@@ -309,7 +314,10 @@ vi.mock("./launchd-restart-handoff.js", () => ({
 }));
 
 vi.mock("../infra/restart-stale-pids.js", () => ({
-  cleanStaleGatewayProcessesSync: (port?: number) => cleanStaleGatewayProcessesSync(port),
+  cleanStaleGatewayProcessesSync: (port?: number, options?: { protectedPid?: number }) =>
+    options === undefined
+      ? cleanStaleGatewayProcessesSync(port)
+      : cleanStaleGatewayProcessesSync(port, options),
 }));
 
 vi.mock("../infra/ports.js", () => ({
@@ -1345,7 +1353,9 @@ describe("launchd install", () => {
       envFilePath,
       ...defaultProgramArguments,
     ]);
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19007);
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19007, {
+      protectedPid: 4242,
+    });
   });
 
   it("repairs a mangled label-derived service-env wrapper path on restart", async () => {
@@ -1989,8 +1999,11 @@ describe("launchd install", () => {
     const label = "ai.openclaw.gateway";
     const serviceId = `${domain}/${label}`;
     expect(result).toEqual({ outcome: "completed" });
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(18789);
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(18789, {
+      protectedPid: 4242,
+    });
     expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
       ["enable", serviceId],
       ["kickstart", "-k", serviceId],
     ]);
@@ -2113,7 +2126,7 @@ describe("launchd install", () => {
     expect(plist).toContain("<key>StandardInPath</key>");
     expect(plist).toContain("<string>/dev/null</string>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
-    expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap"]);
+    expect(launchctlCommandNames()).toEqual(["print", "enable", "bootout", "enable", "bootstrap"]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
     expect(onMutation.mock.calls).toEqual([
       [{ mode: "enable" }],
@@ -2169,7 +2182,7 @@ describe("launchd install", () => {
       restartLaunchAgent({ env, stdout: new PassThrough(), onMutation }),
     ).resolves.toEqual({ outcome: "completed" });
 
-    expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap"]);
+    expect(launchctlCommandNames()).toEqual(["print", "enable", "bootout", "enable", "bootstrap"]);
     expect(onMutation).toHaveBeenCalledWith({ mode: "bootout" });
     expect(onMutation).toHaveBeenCalledWith({ mode: "bootstrap" });
   });
@@ -2208,7 +2221,14 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap", "print"]);
+    expect(launchctlCommandNames()).toEqual([
+      "print",
+      "enable",
+      "bootout",
+      "enable",
+      "bootstrap",
+      "print",
+    ]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 
@@ -2223,7 +2243,9 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19001);
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19001, {
+      protectedPid: 4242,
+    });
   });
 
   it("ignores invalid configured gateway ports for stale cleanup", async () => {
@@ -2257,8 +2279,10 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19007);
-    expect(inspectPortUsage).not.toHaveBeenCalled();
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19007, {
+      protectedPid: 4242,
+    });
+    expect(inspectPortUsage).toHaveBeenCalledWith(19007);
   });
 
   it("uses the final repeated LaunchAgent port flag for restart stale cleanup", async () => {
@@ -2276,8 +2300,10 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19008);
-    expect(inspectPortUsage).not.toHaveBeenCalled();
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19008, {
+      protectedPid: 4242,
+    });
+    expect(inspectPortUsage).toHaveBeenCalledWith(19008);
   });
 
   it("ignores invalid stored LaunchAgent environment ports for stale cleanup", async () => {
@@ -2299,7 +2325,7 @@ describe("launchd install", () => {
     expect(inspectPortUsage).not.toHaveBeenCalled();
   });
 
-  it("does not require the configured gateway port to be free before kickstart", async () => {
+  it("protects and allows the managed LaunchAgent that owns the gateway port", async () => {
     const env = {
       ...createDefaultLaunchdEnv(),
       OPENCLAW_GATEWAY_PORT: "19002",
@@ -2307,7 +2333,20 @@ describe("launchd install", () => {
     inspectPortUsage.mockResolvedValue({
       port: 19002,
       status: "busy",
-      listeners: [],
+      listeners: [
+        {
+          pid: 4242,
+          command: "node",
+          commandLine: "node openclaw.mjs gateway --port 19002",
+          address: "TCP 127.0.0.1:19002 (LISTEN)",
+        },
+        {
+          pid: 4242,
+          command: "node",
+          commandLine: "node openclaw.mjs gateway --port 19002",
+          address: "TCP [::1]:19002 (LISTEN)",
+        },
+      ],
       hints: [],
     });
 
@@ -2319,12 +2358,76 @@ describe("launchd install", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const serviceId = `${domain}/ai.openclaw.gateway`;
     expect(result).toEqual({ outcome: "completed" });
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002);
-    expect(inspectPortUsage).not.toHaveBeenCalled();
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002, {
+      protectedPid: 4242,
+    });
+    expect(inspectPortUsage).toHaveBeenCalledWith(19002);
     expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
+      ["print", serviceId],
       ["enable", serviceId],
       ["kickstart", "-k", serviceId],
     ]);
+  });
+
+  it("rejects an unrelated gateway port owner before mutating the LaunchAgent", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "19002",
+    };
+    setLaunchAgentPlist({
+      env,
+      label: "ai.openclaw.gateway",
+      programArguments: ["node", "gateway.js"],
+    });
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const originalPlist = state.files.get(plistPath);
+    inspectPortUsage.mockResolvedValue({
+      port: 19002,
+      status: "busy",
+      listeners: [
+        {
+          pid: 5151,
+          command: "python3",
+          commandLine: "python3 -m http.server 19002",
+          address: "TCP 127.0.0.1:19002 (LISTEN)",
+        },
+      ],
+      hints: ["Another process is listening on this port."],
+    });
+    formatPortDiagnostics.mockReturnValue([
+      "Port 19002 is already in use.",
+      "- pid 5151: python3 -m http.server 19002",
+    ]);
+
+    await expect(
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+      }),
+    ).rejects.toThrow(
+      [
+        "gateway port 19002 is busy but is not verifiably owned by LaunchAgent ai.openclaw.gateway",
+        "Port 19002 is already in use.",
+        "- pid 5151: python3 -m http.server 19002",
+      ].join("\n"),
+    );
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19002, {
+      protectedPid: 4242,
+    });
+    expect(inspectPortUsage).toHaveBeenCalledWith(19002);
+    expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
+      ["print", serviceId],
+    ]);
+    expect(state.files.get(plistPath)).toBe(originalPlist);
+    expect(state.fileWrites).toHaveLength(0);
+    expect(launchctlCommandNames()).not.toContain("enable");
+    expect(launchctlCommandNames()).not.toContain("bootout");
+    expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 
   it("skips stale cleanup when no explicit launch agent port can be resolved", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -854,7 +854,7 @@ export async function uninstallLaunchAgent({
   }
 }
 
-function isLaunchctlNotLoaded(res: { stdout: string; stderr: string; code: number }): boolean {
+export function isLaunchctlNotLoaded(res: { stdout: string; stderr: string }): boolean {
   const detail = normalizeLowercaseStringOrEmpty(res.stderr || res.stdout);
   return (
     detail.includes("no such process") ||

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1334,10 +1334,36 @@ export async function restartLaunchAgent({
 
   const cleanupPort = await resolveLaunchAgentGatewayPort(serviceEnv);
   if (cleanupPort !== null) {
-    // During a launchd restart, the active LaunchAgent is expected to own the
-    // port until `kickstart -k` replaces it. Reap stale gateway listeners, but
-    // do not require the port to be free before asking launchd to restart.
-    cleanStaleGatewayProcessesSync(cleanupPort);
+    const runtimeBeforeCleanup = await readLaunchAgentRuntime(serviceEnv);
+    // The supervised process is not stale. Protect its authoritative launchd
+    // PID while still removing any other verified gateway process on the port.
+    if (runtimeBeforeCleanup.pid === undefined) {
+      cleanStaleGatewayProcessesSync(cleanupPort);
+    } else {
+      cleanStaleGatewayProcessesSync(cleanupPort, {
+        protectedPid: runtimeBeforeCleanup.pid,
+      });
+    }
+    const diagnostics = await inspectPortUsage(cleanupPort).catch(() => null);
+    if (diagnostics?.status === "busy") {
+      const runtime = await readLaunchAgentRuntime(serviceEnv);
+      const managedPid = runtime.pid;
+      // Only the current supervised PID may keep the port busy before a
+      // disruptive restart. Re-read after cleanup to close over a concurrent
+      // launchd respawn rather than trusting the protected pre-cleanup PID.
+      const ownedByLaunchAgent =
+        managedPid !== undefined &&
+        diagnostics.listeners.length > 0 &&
+        diagnostics.listeners.every((listener) => listener.pid === managedPid);
+      if (!ownedByLaunchAgent) {
+        throw new Error(
+          [
+            `gateway port ${cleanupPort} is busy but is not verifiably owned by LaunchAgent ${label}`,
+            ...formatPortDiagnostics(diagnostics),
+          ].join("\n"),
+        );
+      }
+    }
   }
   const plistReloadNeeded = await rewriteLaunchAgentPlistForRestart({
     env: serviceEnv,

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1,4 +1,5 @@
 /** macOS LaunchAgent installer, runtime inspection, and lifecycle controls. */
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
@@ -63,6 +64,7 @@ const OPENCLAW_NODE_RUNTIME_NAMES = new Set(["bun", "bun.exe", "node", "node.exe
 const OPENCLAW_SCRIPT_NAMES = new Set(["openclaw.mjs"]);
 const LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS = LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000;
 const LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS = 100;
+const LAUNCHCTL_PROTECTED_PID_TIMEOUT_MS = 2_000;
 
 export type StaleOpenClawUpdateLaunchdJob = {
   label: string;
@@ -376,6 +378,26 @@ async function execLaunchctl(
   const file = isWindows ? getWindowsCmdExePath() : "launchctl";
   const fileArgs = isWindows ? ["/d", "/s", "/c", "launchctl", ...args] : args;
   return await execFileUtf8(file, fileArgs, isWindows ? { windowsHide: true } : {});
+}
+
+function readLaunchAgentPidForCleanupSync(serviceTarget: string): number {
+  const probe = spawnSync("launchctl", ["print", serviceTarget], {
+    encoding: "utf8",
+    timeout: LAUNCHCTL_PROTECTED_PID_TIMEOUT_MS,
+  });
+  const result = {
+    stdout: probe.stdout ?? "",
+    stderr: probe.error?.message ?? probe.stderr ?? "",
+    code: probe.error ? 1 : (probe.status ?? 1),
+  };
+  if (result.code !== 0) {
+    throw new Error(`launchctl print failed: ${formatLaunchctlResultDetail(result)}`);
+  }
+  const pid = parseLaunchctlPrint(result.stdout || result.stderr || "").pid;
+  if (pid === undefined) {
+    throw new Error("launchctl print did not report a running pid");
+  }
+  return pid;
 }
 
 export function parseLaunchctlListOpenClawUpdateJobs(
@@ -1334,16 +1356,11 @@ export async function restartLaunchAgent({
 
   const cleanupPort = await resolveLaunchAgentGatewayPort(serviceEnv);
   if (cleanupPort !== null) {
-    const runtimeBeforeCleanup = await readLaunchAgentRuntime(serviceEnv);
-    // The supervised process is not stale. Protect its authoritative launchd
-    // PID while still removing any other verified gateway process on the port.
-    if (runtimeBeforeCleanup.pid === undefined) {
-      cleanStaleGatewayProcessesSync(cleanupPort);
-    } else {
-      cleanStaleGatewayProcessesSync(cleanupPort, {
-        protectedPid: runtimeBeforeCleanup.pid,
-      });
-    }
+    cleanStaleGatewayProcessesSync(cleanupPort, {
+      // Resolve after lsof captures its listener snapshot. A KeepAlive respawn
+      // during enumeration must be protected before candidate filtering/signals.
+      resolveProtectedPid: () => readLaunchAgentPidForCleanupSync(serviceTarget),
+    });
     const diagnostics = await inspectPortUsage(cleanupPort).catch(() => null);
     if (diagnostics?.status === "busy") {
       const runtime = await readLaunchAgentRuntime(serviceEnv);

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1334,16 +1334,10 @@ export async function restartLaunchAgent({
 
   const cleanupPort = await resolveLaunchAgentGatewayPort(serviceEnv);
   if (cleanupPort !== null) {
+    // During a launchd restart, the active LaunchAgent is expected to own the
+    // port until `kickstart -k` replaces it. Reap stale gateway listeners, but
+    // do not require the port to be free before asking launchd to restart.
     cleanStaleGatewayProcessesSync(cleanupPort);
-    const diagnostics = await inspectPortUsage(cleanupPort).catch(() => null);
-    if (diagnostics?.status === "busy") {
-      throw new Error(
-        [
-          `gateway port ${cleanupPort} is still busy before LaunchAgent restart`,
-          ...formatPortDiagnostics(diagnostics),
-        ].join("\n"),
-      );
-    }
   }
   const plistReloadNeeded = await rewriteLaunchAgentPlistForRestart({
     env: serviceEnv,

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -905,6 +905,91 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(killSpy).not.toHaveBeenCalledWith(protectedPid, expect.anything());
     });
 
+    it("refreshes the protected pid after listener enumeration before filtering", () => {
+      const oldManagedPid = process.pid + 4100;
+      const replacementPid = process.pid + 4101;
+      const stalePid = process.pid + 4102;
+      let listenerSnapshotCaptured = false;
+      let lsofCall = 0;
+      mockSpawnSync.mockImplementation((command: unknown) => {
+        if (command !== "lsof") {
+          return createLsofResult({ status: 1 });
+        }
+        lsofCall += 1;
+        if (lsofCall === 1) {
+          listenerSnapshotCaptured = true;
+          return createLsofResult({
+            stdout: lsofOutput([
+              { pid: replacementPid, cmd: "openclaw-gateway" },
+              { pid: stalePid, cmd: "openclaw-gateway" },
+            ]),
+          });
+        }
+        return createLsofResult({ status: 1 });
+      });
+      const resolveProtectedPid = vi.fn(() => {
+        expect(listenerSnapshotCaptured).toBe(true);
+        return replacementPid;
+      });
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+
+      const result = withStubbedPpid(0, () =>
+        cleanStaleGatewayProcessesSync(18789, {
+          protectedPid: oldManagedPid,
+          resolveProtectedPid,
+        }),
+      );
+
+      expect(result).toEqual([stalePid]);
+      expect(resolveProtectedPid).toHaveBeenCalledOnce();
+      expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+      expect(killSpy).not.toHaveBeenCalledWith(replacementPid, expect.anything());
+      expect(killSpy).not.toHaveBeenCalledWith(oldManagedPid, expect.anything());
+    });
+
+    it("does not signal the replacement when it is the only enumerated listener", () => {
+      const replacementPid = process.pid + 4201;
+      let listenerSnapshotCaptured = false;
+      mockSpawnSync.mockImplementation((command: unknown) => {
+        if (command !== "lsof") {
+          return createLsofResult({ status: 1 });
+        }
+        listenerSnapshotCaptured = true;
+        return createOpenClawBusyResult(replacementPid);
+      });
+      const resolveProtectedPid = vi.fn(() => {
+        expect(listenerSnapshotCaptured).toBe(true);
+        return replacementPid;
+      });
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+
+      const result = withStubbedPpid(0, () =>
+        cleanStaleGatewayProcessesSync(18789, { resolveProtectedPid }),
+      );
+
+      expect(result).toEqual([]);
+      expect(resolveProtectedPid).toHaveBeenCalledOnce();
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+    });
+
+    it("fails closed when the refreshed protected pid cannot be resolved", () => {
+      const listenerPid = process.pid + 4301;
+      mockSpawnSync.mockReturnValue(createOpenClawBusyResult(listenerPid));
+      const resolveProtectedPid = vi.fn(() => {
+        throw new Error("launchctl print failed");
+      });
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+
+      const result = withStubbedPpid(0, () =>
+        cleanStaleGatewayProcessesSync(18789, { resolveProtectedPid }),
+      );
+
+      expect(result).toEqual([]);
+      expect(resolveProtectedPid).toHaveBeenCalledOnce();
+      expect(killSpy).not.toHaveBeenCalled();
+    });
+
     it("escalates to SIGKILL when process survives the SIGTERM window", () => {
       const stalePid = process.pid + 101;
       let call = 0;

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -326,13 +326,30 @@ function filterVerifiedWindowsGatewayPidsResult(
   return { ok: true, pids: verified };
 }
 
-function findVerifiedWindowsGatewayPidsOnPortSync(port: number, protectedPid?: number): number[] {
-  return filterVerifiedWindowsGatewayPids(readWindowsListeningPidsOnPortSync(port), protectedPid);
+type CleanStaleGatewayProcessesOptions = {
+  protectedPid?: number;
+  // Resolve only after listener enumeration so supervisor respawns captured by
+  // that snapshot cannot be mistaken for stale processes. Throw to skip cleanup.
+  resolveProtectedPid?: () => number | undefined;
+};
+
+function resolveProtectedPidAfterEnumeration(
+  options: CleanStaleGatewayProcessesOptions | undefined,
+): number | undefined {
+  return options?.resolveProtectedPid ? options.resolveProtectedPid() : options?.protectedPid;
+}
+
+function findVerifiedWindowsGatewayPidsOnPortSync(
+  port: number,
+  options?: CleanStaleGatewayProcessesOptions,
+): number[] {
+  const rawPids = readWindowsListeningPidsOnPortSync(port);
+  return filterVerifiedWindowsGatewayPids(rawPids, resolveProtectedPidAfterEnumeration(options));
 }
 
 function findVerifiedWindowsGatewayPidsOnPortResultSync(
   port: number,
-  protectedPid?: number,
+  options?: CleanStaleGatewayProcessesOptions,
 ): WindowsListeningPidsResult {
   const result = readWindowsListeningPidsResultSync(port);
   if (!result.ok) {
@@ -341,19 +358,19 @@ function findVerifiedWindowsGatewayPidsOnPortResultSync(
   return filterVerifiedWindowsGatewayPidsResult(
     result.pids,
     (pid) => readWindowsProcessArgsResultSync(pid),
-    protectedPid,
+    resolveProtectedPidAfterEnumeration(options),
   );
 }
 
 function findGatewayPidsOnPortWithProtectedPidSync(
   port: number,
   spawnTimeoutMs: number,
-  protectedPid?: number,
+  options?: CleanStaleGatewayProcessesOptions,
 ): number[] {
   if (process.platform === "win32") {
     // Use the shared Windows port inspection (PowerShell / netstat) with
     // command-line verification to find only openclaw gateway processes.
-    return findVerifiedWindowsGatewayPidsOnPortSync(port, protectedPid);
+    return findVerifiedWindowsGatewayPidsOnPortSync(port, options);
   }
   const lsof = resolveLsofCommandSync();
   const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
@@ -385,7 +402,11 @@ function findGatewayPidsOnPortWithProtectedPidSync(
     );
     return [];
   }
-  return parsePidsFromLsofOutput(res.stdout, spawnTimeoutMs, protectedPid);
+  return parsePidsFromLsofOutput(
+    res.stdout,
+    spawnTimeoutMs,
+    resolveProtectedPidAfterEnumeration(options),
+  );
 }
 
 /**
@@ -617,10 +638,6 @@ function waitForPortFreeSync(port: number): void {
  *
  * Called before service restart commands to prevent port conflicts.
  */
-type CleanStaleGatewayProcessesOptions = {
-  protectedPid?: number;
-};
-
 export function cleanStaleGatewayProcessesSync(
   portOverride?: number,
   options?: CleanStaleGatewayProcessesOptions,
@@ -630,18 +647,17 @@ export function cleanStaleGatewayProcessesSync(
       typeof portOverride === "number" && Number.isFinite(portOverride) && portOverride > 0
         ? Math.floor(portOverride)
         : resolveGatewayPort(undefined, process.env);
-    const protectedPid = options?.protectedPid;
     const stalePids =
       process.platform === "win32"
         ? (() => {
-            const result = findVerifiedWindowsGatewayPidsOnPortResultSync(port, protectedPid);
+            const result = findVerifiedWindowsGatewayPidsOnPortResultSync(port, options);
             if (result.ok) {
               return result.pids;
             }
             waitForPortFreeSync(port);
             return [];
           })()
-        : findGatewayPidsOnPortWithProtectedPidSync(port, SPAWN_TIMEOUT_MS, protectedPid);
+        : findGatewayPidsOnPortWithProtectedPidSync(port, SPAWN_TIMEOUT_MS, options);
     if (stalePids.length === 0) {
       return [];
     }


### PR DESCRIPTION
Related: #88309

## What Problem This Solves

Fixes an issue where users running the gateway as a macOS LaunchAgent could have `openclaw gateway restart` fail with a port-busy error when the current, healthy LaunchAgent gateway was the process listening on that port.

This is a normal restart state, not necessarily a conflict: the service being replaced usually owns the configured port, and launchd's `KeepAlive` policy can also respawn it during stale-process cleanup. The previous code treated every listener that remained after cleanup as a fatal conflict and threw before plist repair, `launchctl enable`, or `launchctl kickstart -k` could run.

The regression comes from the interaction of two otherwise-defensive changes:

- #46290 added targeted stale-gateway cleanup before restart.
- #81732 added a generic “port must be free” precondition.
- On a loaded `KeepAlive` LaunchAgent, cleanup could terminate the managed PID, launchd could immediately replace it, and the generic check would then reject the replacement for owning its own port.

The broader #88309 also discusses SIGTERM intent and in-process restart handoff behavior. This PR deliberately fixes only the external/direct LaunchAgent restart branch, so it uses `Related` rather than `Closes`.

## Why This Change Was Made

The restart preflight now distinguishes the managed listener from an unrelated port owner by authoritative process identity:

1. Resolve the effective gateway port from the installed LaunchAgent configuration, preserving the existing final-`--port` and environment fallback rules.
2. Read the current service PID from `launchctl print` before cleanup and pass it through the existing `protectedPid` cleanup option. A healthy supervised process is not stale and should not be killed merely to create a momentary free-port observation.
3. Run the existing targeted stale-gateway cleanup for any other verified gateway process.
4. Inspect the port. If it is busy, re-read the LaunchAgent runtime after cleanup to account for a concurrent launchd respawn.
5. Continue only when a current managed PID exists, at least one listener was observed, and **every** listener row has that exact PID. Otherwise, fail with the existing detailed port diagnostics before rewriting the plist or mutating launchd state.

The resulting decision is intentionally narrow:

| Port state after cleanup | Restart behavior |
| --- | --- |
| Free | Continue through the existing launchd restart path |
| Busy, and every listener PID equals the current LaunchAgent PID | Continue through the existing launchd restart path |
| Busy with a missing PID, mixed PIDs, no current LaunchAgent PID, or an unrelated PID | Reject before plist writes, `enable`, `bootout`, `bootstrap`, or `kickstart` |

This is the right ownership test and boundary for several reasons:

- **launchd is the authority for service identity.** Command names and command lines are diagnostic metadata; they can be incomplete, wrapper-dependent, or misleading. Comparing listener PIDs to the PID reported for the exact LaunchAgent service avoids relying on a spoofable “looks like OpenClaw” heuristic.
- **All listener rows must match.** A normal dual-stack gateway produces separate IPv4 and IPv6 rows for one PID, which is accepted. Mixed ownership, missing attribution, and partial attribution fail closed.
- **The PID is re-read after cleanup.** If `KeepAlive` replaces the process during the cleanup window, the decision uses the current launchd PID rather than a stale pre-cleanup value.
- **The pre-cleanup PID is protected.** This reuses the `protectedPid` seam already supported by stale cleanup and avoids an unnecessary first termination followed by the requested launchd restart.
- **The PID relationship is supported by the service contract.** OpenClaw's [generated environment wrapper](https://github.com/openclaw/openclaw/blob/17ffdaac8cce928f4d8824be4e74446b7ee2e4b6/src/daemon/launchd.ts#L205-L214) ends with `exec "$@"`, and the [documented custom-wrapper contract](https://github.com/openclaw/openclaw/blob/17ffdaac8cce928f4d8824be4e74446b7ee2e4b6/docs/cli/gateway.md#L482-L498) requires the wrapper to eventually `exec` OpenClaw or Node. The PID supervised by launchd is therefore expected to be the PID holding the gateway listener.
- **The guard lives at the service-owner boundary.** Some internal callers invoke `service.restart` without the CLI readiness wrapper. Rejecting an unrelated owner inside `restartLaunchAgent` protects those callers as well as the CLI.
- **Existing launchd behavior remains in charge after the guard.** Normal restarts still use the lower-downtime `kickstart -k` path; plist changes still use the existing `bootout`/`bootstrap` reload path; launchctl failures still propagate.
- **Stop and restart retain different postconditions.** Stop still requires the port to become free. Restart permits continuous ownership only when that ownership is proven to belong to the service being replaced.

Alternatives considered:

- Removing the busy-port guard entirely would fix the managed-listener case but could disrupt a working gateway and then fail to bind its replacement when an unrelated process owns the port. It is also unsafe for direct callers without the CLI health wait.
- Classifying listeners by command line would be weaker than exact launchd PID ownership and would interact poorly with supported wrappers.
- Unconditionally booting out the LaunchAgent before checking the port would add downtime, change the established no-reload path, and still would not make an unrelated owner safe.
- Polling for a free port cannot establish a stable invariant under `KeepAlive`; launchd is allowed to replace the process immediately.

The change is limited to the macOS LaunchAgent implementation and focused tests. The detached in-process handoff branch returns before this preflight and is unchanged. Stop behavior, systemd, Windows Scheduled Tasks, configuration, authentication, persistence, dependencies, and public APIs are unchanged.

## User Impact

`openclaw gateway restart` can now restart a macOS LaunchAgent when that LaunchAgent's own gateway is listening on the configured port. Users no longer need to manually stop the service or race launchd's `KeepAlive` behavior.

If another process owns any listener on that port, restart still stops safely before touching the plist or service and reports the listener diagnostics. There is no migration, configuration change, new permission, or dependency change.

## Evidence

### Exact-head implementation and regression coverage

Current head: [`17ffdaac8cce`](https://github.com/openclaw/openclaw/commit/17ffdaac8cce928f4d8824be4e74446b7ee2e4b6), rebased onto [`e0206b4967a6`](https://github.com/openclaw/openclaw/commit/e0206b4967a64682422f9886ea63bbf64678bb4f).

- The [ownership-aware restart guard](https://github.com/openclaw/openclaw/blob/17ffdaac8cce928f4d8824be4e74446b7ee2e4b6/src/daemon/launchd.ts#L1335-L1367) protects the managed PID, re-reads runtime state after cleanup, and rejects unverifiable ownership before the first write or launchctl mutation.
- The [managed-owner regression](https://github.com/openclaw/openclaw/blob/17ffdaac8cce928f4d8824be4e74446b7ee2e4b6/src/daemon/launchd.test.ts#L2328-L2371) models IPv4 and IPv6 listeners owned by launchd PID `4242`, verifies cleanup receives `{ protectedPid: 4242 }`, verifies the post-cleanup runtime read, and reaches `enable` plus `kickstart -k`.
- The [unrelated-owner regression](https://github.com/openclaw/openclaw/blob/17ffdaac8cce928f4d8824be4e74446b7ee2e4b6/src/daemon/launchd.test.ts#L2373-L2431) models a Python listener at PID `5151`, verifies the diagnostic error, and proves that the plist is unchanged, no file write occurs, and no `enable`, `bootout`, or `kickstart` mutation is issued.
- Existing focused tests continue to cover effective-port resolution, repeated `--port` flags, invalid stored ports, reload/bootstrap behavior, and the no-explicit-port path.
- `git diff --check origin/main...HEAD` passes.

Exact-head GitHub Actions are complete: **79 checks passed, 36 path/matrix checks were intentionally skipped, and 0 failed**. The primary [CI run 29761958034](https://github.com/openclaw/openclaw/actions/runs/29761958034) concluded successfully, including:

- [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/29761958034/job/88419949702)
- [`check-test-types`](https://github.com/openclaw/openclaw/actions/runs/29761958034/job/88418653471) and [`check-prod-types`](https://github.com/openclaw/openclaw/actions/runs/29761958034/job/88418653743)
- [`check-lint`](https://github.com/openclaw/openclaw/actions/runs/29761958034/job/88418653517)
- [`build-artifacts`](https://github.com/openclaw/openclaw/actions/runs/29761958034/job/88418653320)
- all runnable compact Node test shards and all four QA smoke profiles

The exact-head [Real behavior proof](https://github.com/openclaw/openclaw/actions/runs/29761956137/job/88418484725), security, CodeQL, dependency, workflow-sanity, and OpenGrep checks are also green.

### Real macOS reproduction and supervisor behavior

The original June 1 macOS proof used a disposable profile (`pr89096proof`), disposable LaunchAgent (`ai.openclaw.pr89096proof`), and port `19896`. It is reproduction/supervisor evidence from proof head [`601a25481223`](https://github.com/openclaw/openclaw/commit/601a254812234921b0bd394c66691dfb39e56e82), not a claim that the final ownership guard was live-run on the current head.

Before restart, launchd reported PID `68831`, and `lsof` showed that same PID owning both loopback listeners:

```console
$ launchctl print gui/$(id -u)/ai.openclaw.pr89096proof
state = running
pid = 68831

$ lsof -nP -iTCP:19896 -sTCP:LISTEN
node  68831  shawn  ...  TCP 127.0.0.1:19896 (LISTEN)
node  68831  shawn  ...  TCP [::1]:19896 (LISTEN)
```

The earlier patch reached launchd, which replaced PID `68831` with PID `69148`; deep status and health then passed:

```console
$ node openclaw.mjs --profile pr89096proof gateway restart
Restarted LaunchAgent: gui/501/ai.openclaw.pr89096proof

$ node openclaw.mjs --profile pr89096proof gateway status --deep
Runtime: running (pid 69148, state active)
Connectivity probe: ok
Listening: 127.0.0.1:19896, [::1]:19896

$ node openclaw.mjs --profile pr89096proof gateway health --json
{"ok":true,"eventLoop":{"degraded":false,"reasons":[]},"plugins":{"errors":[]}}
```

That run demonstrates the real `KeepAlive`/busy-port condition and that `kickstart -k` performs the intended replacement. The final patch makes the preflight safer than that proof head: it protects PID `68831` from stale cleanup and permits the restart only because the listener PIDs match launchd's authoritative PID.

AI-assisted: Codex was used to trace callers and platform contracts, inspect the relevant history, implement and review the ownership invariant, and prepare this explanation. Claims above are tied to exact-head source/tests, CI, and the labeled macOS behavior transcript.
