### PR TITLE
fix(gateway): guard tools catalog descriptors

### DIFF
--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -32,7 +32,13 @@ vi.mock("../../plugins/tools.js", () => ({
       description: "Matrix room helper\n\nACTIONS:\n- join\n- leave",
     },
   ]),
-  getPluginToolMeta: vi.fn((tool: { name: string }) => pluginToolMetaState.get(tool.name)),
+  getPluginToolMeta: vi.fn((tool: { name: string }) => {
+    try {
+      return pluginToolMetaState.get(tool.name);
+    } catch {
+      return undefined;
+    }
+  }),
 }));
 
 type RespondCall = [boolean, unknown?, { code: number; message: string }?];
@@ -164,6 +170,48 @@ describe("tools.catalog handler", () => {
       .flatMap((group) => group.tools)
       .find((tool) => tool.id === "matrix_room");
     expect(matrixRoom?.description).toBe("Summarized Matrix room helper.");
+  });
+
+  it("does not crash on unreadable plugin tool catalog descriptors", async () => {
+    vi.mocked(resolvePluginTools).mockReturnValueOnce([
+      {
+        name: "descriptor_probe",
+        get label(): string {
+          throw new Error("gateway catalog label getter exploded");
+        },
+        get description(): string {
+          throw new Error("gateway catalog description getter exploded");
+        },
+        get displaySummary(): string {
+          throw new Error("gateway catalog summary getter exploded");
+        },
+      },
+      {
+        get name(): string {
+          throw new Error("gateway catalog name getter exploded");
+        },
+        label: "Bad Name",
+        description: "bad",
+      },
+    ] as never);
+
+    const { respond, invoke } = createInvokeParams({});
+    await invoke();
+    const payload = expectCatalogPayload(respond);
+    const pluginTools = payload.groups
+      .filter((group) => group.source === "plugin")
+      .flatMap((group) => group.tools);
+
+    expect(pluginTools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "descriptor_probe",
+          label: "descriptor_probe",
+          description: "Tool",
+        }),
+      ]),
+    );
+    expect(pluginTools.some((tool) => tool.label === "Bad Name")).toBe(false);
   });
 
   it("opts plugin tool catalog loads into gateway subagent binding", async () => {

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -48,6 +48,13 @@ type ToolCatalogGroup = {
   tools: ToolCatalogEntry[];
 };
 
+type PluginToolDescriptor = {
+  name: string;
+  label?: string;
+  description?: string;
+  displaySummary?: string;
+};
+
 function buildCoreGroups(): ToolCatalogGroup[] {
   // Core catalog rows come from static tool sections so profile chips remain
   // stable even before any runtime agent session exists.
@@ -106,6 +113,10 @@ function buildPluginGroups(params: {
   );
   const seenToolIds = new Set<string>();
   for (const tool of pluginTools) {
+    const descriptor = readPluginToolDescriptor(tool);
+    if (!descriptor) {
+      continue;
+    }
     const meta = getPluginToolMeta(tool);
     const pluginId = meta?.pluginId ?? "plugin";
     const groupId = `plugin:${pluginId}`;
@@ -119,19 +130,17 @@ function buildPluginGroups(params: {
         tools: [],
       } as ToolCatalogGroup);
     const ownedMetadata = meta?.pluginId
-      ? pluginToolMetadata.get(buildPluginToolMetadataKey(meta.pluginId, tool.name))
+      ? pluginToolMetadata.get(buildPluginToolMetadataKey(meta.pluginId, descriptor.name))
       : undefined;
     existing.tools.push({
-      id: tool.name,
+      id: descriptor.name,
       label:
         normalizeOptionalString(ownedMetadata?.displayName) ??
-        normalizeOptionalString(tool.label) ??
-        tool.name,
+        normalizeOptionalString(descriptor.label) ??
+        descriptor.name,
       description: summarizeToolDescriptionText({
-        rawDescription:
-          ownedMetadata?.description ??
-          (typeof tool.description === "string" ? tool.description : undefined),
-        displaySummary: tool.displaySummary,
+        rawDescription: ownedMetadata?.description ?? descriptor.description,
+        displaySummary: descriptor.displaySummary,
       }),
       source: "plugin",
       pluginId,
@@ -140,7 +149,7 @@ function buildPluginGroups(params: {
       tags: ownedMetadata?.tags,
       defaultProfiles: [],
     });
-    seenToolIds.add(tool.name);
+    seenToolIds.add(descriptor.name);
     groups.set(groupId, existing);
   }
   for (const entry of activeRegistry?.tools ?? []) {
@@ -187,6 +196,41 @@ function buildPluginGroups(params: {
       Object.assign({}, group, { tools: group.tools.toSorted((a, b) => a.id.localeCompare(b.id)) }),
     )
     .toSorted((a, b) => a.label.localeCompare(b.label));
+}
+
+function readPluginToolDescriptor(tool: {
+  name: string;
+  label?: string;
+  description?: string;
+  displaySummary?: string;
+}): PluginToolDescriptor | undefined {
+  const name = readPluginToolString(tool, "name");
+  if (!name?.trim()) {
+    return undefined;
+  }
+  return {
+    name,
+    label: readPluginToolString(tool, "label"),
+    description: readPluginToolString(tool, "description"),
+    displaySummary: readPluginToolString(tool, "displaySummary"),
+  };
+}
+
+function readPluginToolString(
+  tool: {
+    name: string;
+    label?: string;
+    description?: string;
+    displaySummary?: string;
+  },
+  field: "description" | "displaySummary" | "label" | "name",
+): string | undefined {
+  try {
+    const value = tool[field];
+    return typeof value === "string" ? value : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function buildToolsCatalogResult(params: {

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -141,23 +141,40 @@ function asJsonObject(value: unknown): JsonObject {
   return value as JsonObject;
 }
 
+function readToolProperty(tool: AnyAgentTool, key: string): unknown {
+  try {
+    return (tool as Record<string, unknown>)[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolString(tool: AnyAgentTool, key: string): string | undefined {
+  const value = readToolProperty(tool, key);
+  return typeof value === "string" ? value : undefined;
+}
+
 export function capturePluginToolDescriptor(params: {
   pluginId: string;
   tool: AnyAgentTool;
+  toolName: string;
   optional: boolean;
 }): CachedPluginToolDescriptor {
-  const label = (params.tool as { label?: unknown }).label;
+  const label = readToolString(params.tool, "label");
   const title = typeof label === "string" && label.trim() ? label.trim() : undefined;
+  const description = readToolString(params.tool, "description") ?? "";
+  const displaySummary = readToolString(params.tool, "displaySummary");
+  const parameters = readToolProperty(params.tool, "parameters");
   return {
-    ...(params.tool.displaySummary ? { displaySummary: params.tool.displaySummary } : {}),
+    ...(displaySummary ? { displaySummary } : {}),
     optional: params.optional,
     descriptor: {
-      name: params.tool.name,
+      name: params.toolName,
       ...(title ? { title } : {}),
-      description: params.tool.description,
-      inputSchema: asJsonObject(params.tool.parameters),
+      description,
+      inputSchema: asJsonObject(parameters),
       owner: { kind: "plugin", pluginId: params.pluginId },
-      executor: { kind: "plugin", pluginId: params.pluginId, toolName: params.tool.name },
+      executor: { kind: "plugin", pluginId: params.pluginId, toolName: params.toolName },
     },
   };
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -163,6 +163,36 @@ function createMalformedTool(name: string) {
   };
 }
 
+function createToolWithThrowingProperty(name: string, propertyName: string) {
+  const tool = makeTool(name);
+  Object.defineProperty(tool, propertyName, {
+    get() {
+      throw new Error(`${propertyName} getter exploded`);
+    },
+  });
+  return tool;
+}
+
+function createToolWithThrowingOptionalDescriptors(name: string) {
+  const tool = makeTool(name);
+  for (const propertyName of ["label", "displaySummary"]) {
+    Object.defineProperty(tool, propertyName, {
+      get() {
+        throw new Error(`${propertyName} getter exploded`);
+      },
+    });
+  }
+  return tool;
+}
+
+function createToolWithThrowingPrototype(name: string) {
+  return new Proxy(makeTool(name), {
+    getPrototypeOf() {
+      throw new Error("prototype getter exploded");
+    },
+  });
+}
+
 function installConsoleMethodSpy(method: "log" | "warn") {
   const spy = vi.fn();
   loggingState.rawConsole = {
@@ -1936,6 +1966,44 @@ describe("resolvePluginTools optional tools", () => {
       registry.diagnostics,
       "plugin tool is malformed (schema-bug): broken_tool missing parameters object",
     );
+  });
+
+  it("quarantines unreadable plugin tool descriptors before manifest policy checks", () => {
+    const registry = setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: [
+          "bad_name",
+          "bad_description",
+          "bad_prepare",
+          "bad_execution_mode",
+          "bad_optional_descriptors",
+          "bad_prototype",
+          "valid_tool",
+        ],
+        factory: () => [
+          createToolWithThrowingProperty("bad_name", "name"),
+          createToolWithThrowingProperty("bad_description", "description"),
+          createToolWithThrowingProperty("bad_prepare", "prepareArguments"),
+          createToolWithThrowingProperty("bad_execution_mode", "executionMode"),
+          createToolWithThrowingOptionalDescriptors("bad_optional_descriptors"),
+          createToolWithThrowingPrototype("bad_prototype"),
+          makeTool("valid_tool"),
+        ],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["bad_optional_descriptors", "bad_prototype", "valid_tool"]);
+    expect(registry.diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      "plugin tool is malformed (schema-bug): missing non-empty name",
+      "plugin tool is malformed (schema-bug): bad_description missing description string",
+      "plugin tool is malformed (schema-bug): bad_prepare unreadable prepareArguments",
+      "plugin tool is malformed (schema-bug): bad_execution_mode unreadable executionMode",
+    ]);
   });
 
   it("warns with plugin factory timing details when a factory is slow", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -69,6 +69,24 @@ type PluginToolFactoryTiming = {
 
 type PluginToolFactoryResult = AnyAgentTool | AnyAgentTool[] | null | undefined;
 
+type ResolvedPluginTool = {
+  tool: AnyAgentTool;
+  name: string;
+};
+
+type PluginToolShape = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: unknown;
+  execute: AnyAgentTool["execute"];
+  prepareArguments?: AnyAgentTool["prepareArguments"];
+  executionMode?: AnyAgentTool["executionMode"];
+  displaySummary?: string;
+};
+
+type PluginToolPropertyRead = { ok: true; value: unknown } | { ok: false; value?: undefined };
+
 const log = createSubsystemLogger("plugins/tools");
 const PLUGIN_TOOL_FACTORY_WARN_TOTAL_MS = 5_000;
 const PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS = 1_000;
@@ -111,7 +129,7 @@ function isAgentTool(value: unknown): value is AnyAgentTool {
     Boolean(value) &&
     typeof value === "object" &&
     !Array.isArray(value) &&
-    typeof (value as { execute?: unknown }).execute === "function"
+    typeof readPluginToolProperty(value as Record<string, unknown>, "execute") === "function"
   );
 }
 
@@ -123,11 +141,13 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
     return cached;
   }
 
-  const prepareArguments = tool.prepareArguments;
-  const scopedPrepareArguments = prepareArguments
-    ? (args: unknown) =>
-        runWithPluginToolScope(entry, () => Reflect.apply(prepareArguments, tool, [args]))
-    : undefined;
+  const prepareArguments = readPluginToolProperty(tool, "prepareArguments");
+  const execute = readPluginToolProperty(tool, "execute") as AnyAgentTool["execute"];
+  const scopedPrepareArguments =
+    typeof prepareArguments === "function"
+      ? (args: unknown) =>
+          runWithPluginToolScope(entry, () => Reflect.apply(prepareArguments, tool, [args]))
+      : undefined;
   const scopedExecute = (
     toolCallId: string,
     params: unknown,
@@ -137,7 +157,7 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
     runWithPluginToolScope(
       entry,
       () =>
-        Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
+        Reflect.apply(execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
           AnyAgentTool["execute"]
         >,
     );
@@ -316,7 +336,43 @@ function readPluginToolName(tool: unknown): string {
     return "";
   }
   // Optional-tool allowlists need a best-effort name before full shape validation.
-  return typeof tool.name === "string" ? tool.name.trim() : "";
+  const name = readPluginToolProperty(tool, "name");
+  return typeof name === "string" ? name.trim() : "";
+}
+
+function readPluginToolPropertyResult(
+  tool: Record<string, unknown>,
+  key: string,
+): PluginToolPropertyRead {
+  try {
+    return { ok: true, value: tool[key] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readPluginToolProperty(tool: Record<string, unknown>, key: string): unknown {
+  const result = readPluginToolPropertyResult(tool, key);
+  return result.ok ? result.value : undefined;
+}
+
+function readPluginToolString(tool: Record<string, unknown>, key: string): string | undefined {
+  const value = readPluginToolProperty(tool, key);
+  return typeof value === "string" ? value : undefined;
+}
+
+function normalizePluginToolExecutionMode(
+  value: unknown,
+): AnyAgentTool["executionMode"] | undefined {
+  return value === "sequential" || value === "parallel" ? value : undefined;
+}
+
+function readPluginToolPrototype(tool: AnyAgentTool): object {
+  try {
+    return Object.getPrototypeOf(tool) ?? Object.prototype;
+  } catch {
+    return Object.prototype;
+  }
 }
 
 function toElapsedMs(value: number): number {
@@ -445,20 +501,136 @@ function shouldWarnPluginToolFactoryTimings(params: {
 }
 
 function describeMalformedPluginTool(tool: unknown): string | undefined {
+  const result = readPluginToolShape(tool);
+  return "malformedReason" in result ? result.malformedReason : undefined;
+}
+
+function readPluginToolShape(
+  tool: unknown,
+): { shape: PluginToolShape } | { malformedReason: string } {
   if (!isRecord(tool)) {
-    return "tool must be an object";
+    return { malformedReason: "tool must be an object" };
   }
   const name = readPluginToolName(tool);
   if (!name) {
-    return "missing non-empty name";
+    return { malformedReason: "missing non-empty name" };
   }
-  if (typeof tool.execute !== "function") {
-    return `${name} missing execute function`;
+  const description = readPluginToolProperty(tool, "description");
+  if (typeof description !== "string") {
+    return { malformedReason: `${name} missing description string` };
   }
-  if (!isRecord(tool.parameters)) {
-    return `${name} missing parameters object`;
+  const execute = readPluginToolProperty(tool, "execute");
+  if (typeof execute !== "function") {
+    return { malformedReason: `${name} missing execute function` };
   }
-  return undefined;
+  const parameters = readPluginToolProperty(tool, "parameters");
+  if (!isRecord(parameters)) {
+    return { malformedReason: `${name} missing parameters object` };
+  }
+  const label = readPluginToolString(tool, "label")?.trim() || name;
+  const displaySummary = readPluginToolString(tool, "displaySummary");
+  const prepareArguments = readPluginToolPropertyResult(tool, "prepareArguments");
+  if (!prepareArguments.ok) {
+    return { malformedReason: `${name} unreadable prepareArguments` };
+  }
+  const executionModeRaw = readPluginToolPropertyResult(tool, "executionMode");
+  if (!executionModeRaw.ok) {
+    return { malformedReason: `${name} unreadable executionMode` };
+  }
+  const executionMode = normalizePluginToolExecutionMode(executionModeRaw.value);
+  return {
+    shape: {
+      name,
+      label,
+      description,
+      parameters,
+      execute: execute as AnyAgentTool["execute"],
+      ...(typeof prepareArguments.value === "function"
+        ? { prepareArguments: prepareArguments.value as AnyAgentTool["prepareArguments"] }
+        : {}),
+      ...(executionMode ? { executionMode } : {}),
+      ...(displaySummary ? { displaySummary } : {}),
+    },
+  };
+}
+
+function materializePluginTool(tool: AnyAgentTool, shape: PluginToolShape): AnyAgentTool {
+  const descriptors: PropertyDescriptorMap = {
+    name: { configurable: true, enumerable: true, value: shape.name, writable: true },
+    label: { configurable: true, enumerable: true, value: shape.label, writable: true },
+    description: {
+      configurable: true,
+      enumerable: true,
+      value: shape.description,
+      writable: true,
+    },
+    parameters: {
+      configurable: true,
+      enumerable: true,
+      value: shape.parameters,
+      writable: true,
+    },
+    execute: { configurable: true, enumerable: true, value: shape.execute, writable: true },
+  };
+  if (shape.prepareArguments) {
+    descriptors.prepareArguments = {
+      configurable: true,
+      enumerable: true,
+      value: shape.prepareArguments,
+      writable: true,
+    };
+  }
+  if (shape.executionMode) {
+    descriptors.executionMode = {
+      configurable: true,
+      enumerable: true,
+      value: shape.executionMode,
+      writable: true,
+    };
+  }
+  if (shape.displaySummary) {
+    descriptors.displaySummary = {
+      configurable: true,
+      enumerable: true,
+      value: shape.displaySummary,
+      writable: true,
+    };
+  }
+  return Object.defineProperties(
+    Object.create(readPluginToolPrototype(tool)) as AnyAgentTool,
+    descriptors,
+  );
+}
+
+function resolveValidPluginTools(params: {
+  pluginId: string;
+  source: string;
+  registry: PluginRegistry;
+  logger: { error(message: string): void };
+  tools: readonly unknown[];
+}): ResolvedPluginTool[] {
+  const tools: ResolvedPluginTool[] = [];
+  for (const toolRaw of params.tools) {
+    // Plugin factories run at request time and can return arbitrary values; isolate
+    // malformed tools before any manifest, policy, or descriptor-cache path reads them.
+    const result = readPluginToolShape(toolRaw);
+    if ("malformedReason" in result) {
+      const message = `plugin tool is malformed (${params.pluginId}): ${result.malformedReason}`;
+      params.logger.error(message);
+      params.registry.diagnostics.push({
+        level: "error",
+        pluginId: params.pluginId,
+        source: params.source,
+        message,
+      });
+      continue;
+    }
+    tools.push({
+      tool: materializePluginTool(toolRaw as AnyAgentTool, result.shape),
+      name: result.shape.name,
+    });
+  }
+  return tools;
 }
 
 function pluginToolNamesMatchAllowlist(params: {
@@ -1209,6 +1381,13 @@ export function resolvePluginTools(params: {
       continue;
     }
     const listRaw: unknown[] = Array.isArray(resolved) ? resolved : [resolved];
+    const resolvedTools = resolveValidPluginTools({
+      pluginId: entry.pluginId,
+      source: entry.source,
+      registry,
+      logger: context.logger,
+      tools: listRaw,
+    });
     const selectedManifestToolNames =
       manifestPlugin && availabilityNames.length > 0
         ? new Set(allowlistNames.map((name) => normalizeToolName(name)))
@@ -1218,13 +1397,12 @@ export function resolvePluginTools(params: {
         ? new Set(availabilityNames.map((name) => normalizeToolName(name)))
         : undefined;
     const availableList = manifestPlugin
-      ? listRaw.filter((tool) => {
-          const toolName = readPluginToolName(tool);
-          const normalizedToolName = normalizeToolName(toolName);
+      ? resolvedTools.filter((resolvedTool) => {
+          const normalizedToolName = normalizeToolName(resolvedTool.name);
           if (
-            isManifestToolOptional(manifestPlugin, toolName) &&
+            isManifestToolOptional(manifestPlugin, resolvedTool.name) &&
             !isOptionalToolAllowed({
-              toolName,
+              toolName: resolvedTool.name,
               pluginId: entry.pluginId,
               allowlist,
             })
@@ -1240,25 +1418,25 @@ export function resolvePluginTools(params: {
           }
           return isManifestToolNameAvailable({
             plugin: manifestPlugin,
-            toolName,
+            toolName: resolvedTool.name,
             config: params.context.runtimeConfig ?? context.config,
             env,
             hasAuthForProvider: params.hasAuthForProvider,
           });
         })
-      : listRaw;
+      : resolvedTools;
     const policyAvailableList = availableList.filter(
-      (tool) =>
+      (resolvedTool) =>
         !denylistBlocksPluginTool({
           pluginId: entry.pluginId,
-          toolName: readPluginToolName(tool),
+          toolName: resolvedTool.name,
           denylist,
         }),
     );
     const list = entry.optional
-      ? policyAvailableList.filter((tool) =>
+      ? policyAvailableList.filter((resolvedTool) =>
           isOptionalToolAllowed({
-            toolName: readPluginToolName(tool),
+            toolName: resolvedTool.name,
             pluginId: entry.pluginId,
             allowlist,
           }),
@@ -1268,26 +1446,11 @@ export function resolvePluginTools(params: {
       continue;
     }
     const normalizedNameSet = new Set<string>();
-    for (const toolRaw of list) {
-      // Plugin factories run at request time and can return arbitrary values; isolate
-      // malformed tools here so one bad plugin tool cannot poison every provider.
-      const malformedReason = describeMalformedPluginTool(toolRaw);
-      if (malformedReason) {
-        const message = `plugin tool is malformed (${entry.pluginId}): ${malformedReason}`;
-        context.logger.error(message);
-        registry.diagnostics.push({
-          level: "error",
-          pluginId: entry.pluginId,
-          source: entry.source,
-          message,
-        });
-        continue;
-      }
-      const tool = toolRaw as AnyAgentTool;
+    for (const { tool, name: toolName } of list) {
       const undeclared = entry.declaredNames
         ? findUndeclaredPluginToolNames({
             declaredNames: entry.declaredNames,
-            toolNames: [tool.name],
+            toolNames: [toolName],
           })
         : [];
       if (undeclared.length > 0) {
@@ -1301,9 +1464,9 @@ export function resolvePluginTools(params: {
         });
         continue;
       }
-      const normalizedToolName = normalizeToolName(tool.name);
+      const normalizedToolName = normalizeToolName(toolName);
       if (normalizedNameSet.has(normalizedToolName) || existingNormalized.has(normalizedToolName)) {
-        const message = `plugin tool name conflict (${entry.pluginId}): ${tool.name}`;
+        const message = `plugin tool name conflict (${entry.pluginId}): ${toolName}`;
         if (!params.suppressNameConflicts) {
           context.logger.error(message);
           registry.diagnostics.push({
@@ -1316,19 +1479,19 @@ export function resolvePluginTools(params: {
         continue;
       }
       normalizedNameSet.add(normalizedToolName);
-      existing.add(tool.name);
+      existing.add(toolName);
       existingNormalized.add(normalizedToolName);
       const optional = isPluginToolOptional({
         entry,
         manifestPlugin,
-        toolName: tool.name,
+        toolName,
       });
       pluginToolMeta.set(tool, {
         pluginId: entry.pluginId,
         optional,
         trustedLocalMedia: isTrustedManifestLocalMediaTool({
           manifestPlugin,
-          toolName: tool.name,
+          toolName,
         }),
       });
       if (manifestPlugin) {
@@ -1337,6 +1500,7 @@ export function resolvePluginTools(params: {
           capturePluginToolDescriptor({
             pluginId: entry.pluginId,
             tool,
+            toolName,
             optional,
           }),
         );


### PR DESCRIPTION
## Summary
- guard Gateway `tools.catalog` rendering against unreadable plugin tool descriptor getters
- quarantine malformed plugin tool factory results before manifest policy, denylist, metadata, or descriptor-cache paths read them
- materialize validated plugin tools with safe descriptor fields while preserving class-backed prototypes and scoped callbacks

## Verification
- `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs src/gateway/server-methods/tools-catalog.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check src/plugins/tools.ts src/plugins/tool-descriptor-cache.ts src/plugins/tools.optional.test.ts src/gateway/server-methods/tools-catalog.ts src/gateway/server-methods/tools-catalog.test.ts`
- `node_modules/.bin/oxlint src/plugins/tools.ts src/plugins/tool-descriptor-cache.ts src/plugins/tools.optional.test.ts src/gateway/server-methods/tools-catalog.ts src/gateway/server-methods/tools-catalog.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

## Real behavior proof
Behavior addressed: Gateway tools catalog and plugin tool resolution no longer crash when plugin factory results expose throwing descriptor getters before assistant content.

Real environment tested: local OpenClaw Codex worktree for focused Vitest/lint/review; AWS Crabbox Linux `c7a.8xlarge` for changed gate.

Exact steps or command run after this patch: focused plugin and Gateway tests, touched-file oxfmt/oxlint, `git diff --check`, local and branch autoreview, then AWS Crabbox `check:changed`.

Evidence after fix: plugin resolver tests passed 68 tests; Gateway catalog tests passed 7 tests; autoreview reported no accepted/actionable findings; AWS Crabbox run `run_b533be20abb9` passed `core` and `coreTests` changed lanes with exit 0 on lease `cbx_01c43fabd395`.

Observed result after fix: malformed required/execution plugin tool fields are diagnosed and skipped, optional UI descriptor getter failures are materialized safely, valid siblings remain available, and `tools.catalog` falls back instead of throwing.

What was not tested: full repo test suite and Docker/live/E2E lanes were not run; Blacksmith Testbox changed gate was blocked by missing local auth (`blacksmith auth login` required), so broad changed proof used AWS Crabbox instead.
