### PR TITLE
fix(exec): expose termination metadata in tool details

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -79,6 +79,7 @@ export interface ProcessSession {
   exitCode?: number | null;
   exitSignal?: NodeJS.Signals | number | null;
   exitReason?: TerminationReason;
+  noOutputTimedOut?: boolean;
   exited: boolean;
   truncated: boolean;
   backgrounded: boolean;
@@ -98,6 +99,7 @@ interface FinishedSession {
   exitCode?: number | null;
   exitSignal?: NodeJS.Signals | number | null;
   exitReason?: TerminationReason;
+  noOutputTimedOut?: boolean;
   aggregated: string;
   tail: string;
   truncated: boolean;
@@ -189,11 +191,13 @@ export function markExited(
   exitSignal: NodeJS.Signals | number | null,
   status: ProcessStatus,
   exitReason?: TerminationReason,
+  noOutputTimedOut?: boolean,
 ) {
   session.exited = true;
   session.exitCode = exitCode;
   session.exitSignal = exitSignal;
   session.exitReason = exitReason;
+  session.noOutputTimedOut = noOutputTimedOut;
   session.tail = tail(session.aggregated, 2000);
   moveToFinished(session, status);
 }
@@ -251,6 +255,9 @@ function moveToFinished(session: ProcessSession, status: ProcessStatus) {
     exitCode: session.exitCode,
     exitSignal: session.exitSignal,
     exitReason: session.exitReason,
+    ...(session.noOutputTimedOut !== undefined
+      ? { noOutputTimedOut: session.noOutputTimedOut }
+      : {}),
     aggregated: session.aggregated,
     tail: session.tail,
     truncated: session.truncated,

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -156,7 +156,7 @@ describe("exec foreground failures", () => {
       wait: vi.fn(async () => ({
         reason: "overall-timeout" as const,
         exitCode: null,
-        exitSignal: null,
+        exitSignal: "SIGKILL" as NodeJS.Signals,
         durationMs: input.timeoutMs ?? 50,
         stdout: "",
         stderr: "",
@@ -178,7 +178,11 @@ describe("exec foreground failures", () => {
     expect(text).toMatch(/re-run with a higher timeout/i);
     const details = requireFailedDetails(result.details);
     expect(details.exitCode).toBeNull();
+    expect(details.exitSignal).toBe("SIGKILL");
+    expect(details.failureKind).toBe("overall-timeout");
+    expect(details.exitReason).toBe("overall-timeout");
     expect(details.timedOut).toBe(true);
+    expect(details.noOutputTimedOut).toBe(false);
     expect(details.aggregated).toBe("");
     expect(details.durationMs).toBeTypeOf("number");
     expect(details.durationMs).toBeGreaterThanOrEqual(0);

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -133,17 +133,21 @@ export type ExecProcessOutcome =
       status: "completed";
       exitCode: number;
       exitSignal: NodeJS.Signals | number | null;
+      exitReason?: TerminationReason;
       durationMs: number;
       aggregated: string;
       timedOut: false;
+      noOutputTimedOut?: boolean;
     }
   | {
       status: "failed";
       exitCode: number | null;
       exitSignal: NodeJS.Signals | number | null;
+      exitReason?: TerminationReason;
       durationMs: number;
       aggregated: string;
       timedOut: boolean;
+      noOutputTimedOut?: boolean;
       failureKind: ExecProcessFailureKind;
       reason: string;
     };
@@ -490,9 +494,11 @@ export function buildExecExitOutcome(params: {
       status: "completed",
       exitCode,
       exitSignal: params.exit.exitSignal,
+      exitReason: params.exit.reason,
       durationMs: params.durationMs,
       aggregated: params.aggregated + exitMsg,
       timedOut: false,
+      noOutputTimedOut: params.exit.noOutputTimedOut,
     };
   }
   const failureKind = classifyExecFailureKind({
@@ -510,9 +516,11 @@ export function buildExecExitOutcome(params: {
     status: "failed",
     exitCode: params.exit.exitCode,
     exitSignal: params.exit.exitSignal,
+    exitReason: params.exit.reason,
     durationMs: params.durationMs,
     aggregated: params.aggregated,
     timedOut: params.exit.timedOut,
+    noOutputTimedOut: params.exit.noOutputTimedOut,
     failureKind,
     reason: joinExecFailureOutput(params.aggregated, reason),
   };
@@ -939,7 +947,14 @@ export async function runExecProcess(opts: {
         timeoutSec: opts.timeoutSec,
       });
 
-      markExited(session, exit.exitCode, exit.exitSignal, outcome.status, exit.reason);
+      markExited(
+        session,
+        exit.exitCode,
+        exit.exitSignal,
+        outcome.status,
+        exit.reason,
+        exit.noOutputTimedOut,
+      );
       maybeNotifyOnExit(session, outcome.status);
       if (!session.child && session.stdin) {
         session.stdin.destroyed = true;

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -16,6 +16,7 @@ import type {
 import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
 import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
+import type { TerminationReason } from "../process/supervisor/types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import type { EmbeddedFullAccessBlockedReason } from "./embedded-agent-runner/types.js";
 import type { ExecReviewerConfig } from "./exec-auto-reviewer.js";
@@ -124,9 +125,13 @@ export type ExecToolDetails =
   | {
       status: "completed" | "failed";
       exitCode: number | null;
+      exitSignal?: NodeJS.Signals | number | null;
+      failureKind?: string;
+      exitReason?: TerminationReason;
       durationMs: number;
       aggregated: string;
       timedOut?: boolean;
+      noOutputTimedOut?: boolean;
       cwd?: string;
     }
   | {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -250,17 +250,24 @@ function buildExecForegroundResult(params: {
     return failedTextResult(`${warningText}${params.outcome.reason}`, {
       status: "failed",
       exitCode: params.outcome.exitCode ?? null,
+      exitSignal: params.outcome.exitSignal,
+      failureKind: params.outcome.failureKind,
+      exitReason: params.outcome.exitReason,
       durationMs: params.outcome.durationMs,
       aggregated: params.outcome.aggregated,
       timedOut: params.outcome.timedOut,
+      noOutputTimedOut: params.outcome.noOutputTimedOut,
       cwd: params.cwd,
     });
   }
   return textResult(`${warningText}${renderExecOutputText(params.outcome.aggregated)}`, {
     status: "completed",
     exitCode: params.outcome.exitCode,
+    exitSignal: params.outcome.exitSignal,
+    exitReason: params.outcome.exitReason,
     durationMs: params.outcome.durationMs,
     aggregated: params.outcome.aggregated,
+    noOutputTimedOut: params.outcome.noOutputTimedOut,
     cwd: params.cwd,
   });
 }

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -201,3 +201,30 @@ test("process poll resets retryInMs when output appears and clears on completion
   expect(pollStatus(pollFinished)).toBe("completed");
   expect(retryMs(pollFinished)).toBeUndefined();
 });
+
+test("process poll exposes finished-session termination metadata", async () => {
+  const sessionId = "sess-signal";
+  const { processTool, session } = createProcessSessionHarness(sessionId);
+
+  appendOutput(session, "stderr", "terminated\n");
+  markExited(session, null, "SIGKILL", "failed", "no-output-timeout", true);
+
+  const poll = await pollSession(processTool, "toolcall-signal", sessionId);
+  const details = poll.details as {
+    status?: string;
+    exitCode?: number | null;
+    exitSignal?: NodeJS.Signals | number | null;
+    exitReason?: string;
+    timedOut?: boolean;
+    noOutputTimedOut?: boolean;
+    aggregated?: string;
+  };
+
+  expect(details.status).toBe("failed");
+  expect(details.exitCode).toBeUndefined();
+  expect(details.exitSignal).toBe("SIGKILL");
+  expect(details.exitReason).toBe("no-output-timeout");
+  expect(details.timedOut).toBe(true);
+  expect(details.noOutputTimedOut).toBe(true);
+  expect(details.aggregated).toContain("terminated");
+});

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -413,6 +413,20 @@ export function createProcessTool(
                   status: scopedFinished.status === "completed" ? "completed" : "failed",
                   sessionId: params.sessionId,
                   exitCode: scopedFinished.exitCode ?? undefined,
+                  ...(scopedFinished.exitSignal != null
+                    ? { exitSignal: scopedFinished.exitSignal }
+                    : {}),
+                  ...(scopedFinished.exitReason
+                    ? {
+                        exitReason: scopedFinished.exitReason,
+                        timedOut:
+                          scopedFinished.exitReason === "overall-timeout" ||
+                          scopedFinished.exitReason === "no-output-timeout",
+                      }
+                    : {}),
+                  ...(scopedFinished.noOutputTimedOut !== undefined
+                    ? { noOutputTimedOut: scopedFinished.noOutputTimedOut }
+                    : {}),
                   aggregated: scopedFinished.aggregated,
                   name: deriveSessionName(scopedFinished.command),
                 },
@@ -442,6 +456,8 @@ export function createProcessTool(
               scopedSession.exitCode ?? null,
               scopedSession.exitSignal ?? null,
               status,
+              scopedSession.exitReason,
+              scopedSession.noOutputTimedOut,
             );
           }
           const status = exited
@@ -475,6 +491,20 @@ export function createProcessTool(
               status,
               sessionId: params.sessionId,
               exitCode: exited ? exitCode : undefined,
+              ...(exited && scopedSession.exitSignal != null
+                ? { exitSignal: scopedSession.exitSignal }
+                : {}),
+              ...(exited && scopedSession.exitReason
+                ? {
+                    exitReason: scopedSession.exitReason,
+                    timedOut:
+                      scopedSession.exitReason === "overall-timeout" ||
+                      scopedSession.exitReason === "no-output-timeout",
+                  }
+                : {}),
+              ...(exited && scopedSession.noOutputTimedOut !== undefined
+                ? { noOutputTimedOut: scopedSession.noOutputTimedOut }
+                : {}),
               aggregated: scopedSession.aggregated,
               name: deriveSessionName(scopedSession.command),
               ...(runtime ? runningSessionInputDetails(runtime) : {}),


### PR DESCRIPTION
## Summary

Refs #69242. This diagnostics-only PR exposes termination metadata that OpenClaw already records internally through the user-visible structured tool details:

- foreground `exec` failed details now include `exitSignal`, `failureKind`, `exitReason`, and `noOutputTimedOut`
- `process.poll` finished-session details now include `exitSignal`, `exitReason`, `timedOut`, and `noOutputTimedOut`
- process registry persists `noOutputTimedOut` when a background session moves to the finished-session store

This is intentionally a diagnostics fix. It does not try to attribute the root cause of intermittent Linux `SIGKILL` events, change timeout behavior, or add recursive-search guardrails.

## Test plan

- [x] `node scripts/run-vitest.mjs src/agents/bash-tools.exec-foreground-failures.test.ts`
- [x] `node scripts/run-vitest.mjs src/agents/bash-tools.process.poll-timeout.test.ts`
- [x] `node scripts/run-vitest.mjs src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.process.poll-timeout.test.ts src/agents/bash-tools.exec-foreground-failures.test.ts`
- [x] `pnpm exec oxfmt --check --threads=1 src/agents/bash-tools.exec-types.ts src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec.ts src/agents/bash-process-registry.ts src/agents/bash-tools.process.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.process.poll-timeout.test.ts`

## Real behavior proof

Behavior or issue addressed:
Foreground exec and `process.poll` structured details previously dropped termination cause fields even though the runtime/supervisor had already recorded them. This made `SIGKILL`, timeout, and no-output-timeout cases harder to diagnose from tool results.

Real environment tested:
Local OpenClaw checkout on macOS via Node/Vitest against the affected exec/process tests.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs src/agents/bash-tools.exec-foreground-failures.test.ts
node scripts/run-vitest.mjs src/agents/bash-tools.process.poll-timeout.test.ts
node scripts/run-vitest.mjs src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.process.poll-timeout.test.ts src/agents/bash-tools.exec-foreground-failures.test.ts
pnpm exec oxfmt --check --threads=1 src/agents/bash-tools.exec-types.ts src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec.ts src/agents/bash-process-registry.ts src/agents/bash-tools.process.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.process.poll-timeout.test.ts
```

Evidence after fix:

```text
Test Files  2 passed (2)
Tests  4 passed (4)

Test Files  2 passed (2)
Tests  16 passed (16)

Test Files  6 passed (6)
Tests  104 passed (104)

All matched files use the correct format.
Finished in 8ms on 7 files using 1 threads.
```

Observed result after fix:
The foreground timeout regression asserts `exitSignal`, `failureKind`, `exitReason`, `timedOut`, and `noOutputTimedOut` are present in failed exec details. The process poll regression asserts a finished session preserves `SIGKILL`, `no-output-timeout`, and `noOutputTimedOut` in structured poll details.

What was not tested:
No live Linux broad `find`/`grep` intermittent `SIGKILL` reproduction was run, and this patch does not claim to identify or prevent the underlying kill trigger.


## Additional real tool-output proof

After ClawSweeper asked for real tool output rather than only Vitest coverage, I ran the patched OpenClaw exec/process tools directly in a local checkout.

Command:

```text
node --import tsx <<'NODE'
import { createExecTool } from './src/agents/bash-tools.exec.ts';
import { createProcessTool } from './src/agents/bash-tools.process.ts';
import { resetProcessRegistryForTests } from './src/agents/bash-process-registry.ts';

resetProcessRegistryForTests();
const foregroundExec = createExecTool({ security: 'full', ask: 'off', allowBackground: false, backgroundMs: 10, timeoutSec: 0.05 });
const foreground = await foregroundExec.execute('proof-foreground-timeout', { command: 'sleep 2' });
console.log(JSON.stringify(foreground.details, null, 2));

resetProcessRegistryForTests();
const execTool = createExecTool({ security: 'full', ask: 'off', allowBackground: true, backgroundMs: 0, timeoutSec: 5 });
const processTool = createProcessTool();
const background = await execTool.execute('proof-background-timeout', { command: 'sleep 2', background: true, timeout: 0.05 });
await new Promise((resolve) => setTimeout(resolve, 250));
const poll = await processTool.execute('proof-background-poll', { action: 'poll', sessionId: background.details.sessionId });
console.log(JSON.stringify(poll.details, null, 2));
NODE
```

Observed foreground exec details after fix:

```json
{
  "status": "failed",
  "exitCode": null,
  "exitSignal": "SIGTERM",
  "failureKind": "overall-timeout",
  "exitReason": "overall-timeout",
  "durationMs": 55,
  "aggregated": "",
  "timedOut": true,
  "noOutputTimedOut": false,
  "cwd": "/Users/stellarfish/.codex/worktrees/5db8/openclaw-work"
}
```

Observed `process.poll` details after fix:

```json
{
  "status": "failed",
  "sessionId": "tidal-bloom",
  "exitSignal": "SIGTERM",
  "exitReason": "overall-timeout",
  "timedOut": true,
  "noOutputTimedOut": false,
  "aggregated": "",
  "name": "sleep 2"
}
```

