### PR TITLE
fix(agent-core): guard tool-call validation lookup

### DIFF
--- a/packages/agent-core/src/agent-loop.tool-validation.test.ts
+++ b/packages/agent-core/src/agent-loop.tool-validation.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type Model,
+} from "../../llm-core/src/index.js";
+import { runAgentLoop } from "./agent-loop.js";
+import type { AgentEvent, AgentLoopConfig, AgentTool } from "./types.js";
+
+const usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const model = {
+  id: "test-model",
+  name: "test model",
+  api: "test",
+  provider: "test",
+  baseUrl: "",
+  reasoning: false,
+  input: [],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 0,
+  maxTokens: 0,
+} satisfies Model;
+
+function createConfig(): AgentLoopConfig {
+  return {
+    model,
+    convertToLlm: (messages) =>
+      messages.flatMap((message) =>
+        message.role === "user" || message.role === "assistant" || message.role === "toolResult"
+          ? [message]
+          : [],
+      ),
+    shouldStopAfterTurn: () => true,
+  };
+}
+
+function streamToolCall(toolName: string) {
+  const stream = createAssistantMessageEventStream();
+  const message = {
+    role: "assistant",
+    content: [{ type: "toolCall", id: "call-1", name: toolName, arguments: {} }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage,
+    stopReason: "toolUse",
+    timestamp: 0,
+  } satisfies AssistantMessage;
+  stream.push({ type: "done", reason: "toolUse", message });
+  return stream;
+}
+
+function createReadableTool(): AgentTool {
+  return {
+    name: "safe_tool",
+    label: "Safe tool",
+    description: "safe tool",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "ok" }], details: {} };
+    },
+  };
+}
+
+describe("runAgentLoop tool validation", () => {
+  it("skips unreadable sibling tool names when preparing a requested tool call", async () => {
+    const hostileTool = {
+      get name(): string {
+        throw new Error("tool name exploded");
+      },
+      label: "Hostile",
+      description: "hostile sibling",
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [{ type: "text", text: "bad" }], details: {} };
+      },
+    } as AgentTool;
+    const events: AgentEvent[] = [];
+
+    await runAgentLoop(
+      [{ role: "user", content: "call it", timestamp: 0 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [hostileTool, createReadableTool()],
+      },
+      createConfig(),
+      (event) => {
+        events.push(event);
+      },
+      undefined,
+      () => streamToolCall("safe_tool"),
+    );
+
+    const toolEnd = events.find(
+      (event) => event.type === "tool_execution_end" && event.toolName === "safe_tool",
+    );
+    expect(toolEnd).toMatchObject({
+      type: "tool_execution_end",
+      toolCallId: "call-1",
+      isError: false,
+    });
+  });
+});

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -441,6 +441,42 @@ async function streamAssistantResponse(
   return finalMessage;
 }
 
+function readAgentToolName(tool: AgentTool): string | undefined {
+  try {
+    return typeof tool.name === "string" ? tool.name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function findAgentToolByName(
+  tools: readonly AgentTool[] | undefined,
+  name: string,
+): AgentTool | undefined {
+  for (const tool of tools ?? []) {
+    if (readAgentToolName(tool) === name) {
+      return tool;
+    }
+  }
+  return undefined;
+}
+
+function readAgentToolExecutionMode(
+  tool: AgentTool | undefined,
+): AgentTool["executionMode"] | undefined {
+  if (!tool) {
+    return undefined;
+  }
+  try {
+    const mode = tool.executionMode;
+    return mode === "sequential" || mode === "parallel" ? mode : undefined;
+  } catch {
+    // Broken scheduling metadata should not abort the whole assistant turn.
+    // Run the selected tool conservatively one-at-a-time.
+    return "sequential";
+  }
+}
+
 /**
  * Execute tool calls from an assistant message.
  */
@@ -453,7 +489,9 @@ async function executeToolCalls(
 ): Promise<ExecutedToolCallBatch> {
   const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
   const hasSequentialToolCall = toolCalls.some(
-    (tc) => currentContext.tools?.find((t) => t.name === tc.name)?.executionMode === "sequential",
+    (tc) =>
+      readAgentToolExecutionMode(findAgentToolByName(currentContext.tools, tc.name)) ===
+      "sequential",
   );
   if (config.toolExecution === "sequential" || hasSequentialToolCall) {
     return executeToolCallsSequential(
@@ -669,7 +707,7 @@ async function prepareToolCall(
   config: AgentLoopConfig,
   signal: AbortSignal | undefined,
 ): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
-  const tool = currentContext.tools?.find((t) => t.name === toolCall.name);
+  const tool = findAgentToolByName(currentContext.tools, toolCall.name);
   if (!tool) {
     return {
       kind: "immediate",

--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Tool } from "./types.js";
-import { validateToolArguments } from "./validation.js";
+import { validateToolArguments, validateToolCall } from "./validation.js";
 
 const decimalTool = {
   name: "decimal-tool",
@@ -37,5 +37,43 @@ describe("validateToolArguments", () => {
         arguments: { amount: "0x10", count: "0b10" },
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
+  });
+
+  it("skips unreadable sibling tool names during tool-call lookup", () => {
+    const hostileTool = {
+      get name(): string {
+        throw new Error("tool name exploded");
+      },
+      description: "hostile sibling",
+      parameters: { type: "object", properties: {} },
+    } as Tool;
+
+    expect(
+      validateToolCall([hostileTool, decimalTool], {
+        type: "toolCall",
+        id: "call-1",
+        name: "decimal-tool",
+        arguments: { amount: "4", count: "2" },
+      }),
+    ).toEqual({ amount: 4, count: 2 });
+  });
+
+  it("reports unreadable parameter schemas as validation failures", () => {
+    const hostileTool = {
+      name: "hostile-tool",
+      description: "hostile params",
+      get parameters(): Tool["parameters"] {
+        throw new Error("parameters exploded");
+      },
+    } as Tool;
+
+    expect(() =>
+      validateToolArguments(hostileTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "hostile-tool",
+        arguments: {},
+      }),
+    ).toThrow(/Validation failed for tool "hostile-tool": unable to read parameter schema/);
   });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -24,6 +24,38 @@ function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
   return isRecord(value);
 }
 
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readToolName(tool: Tool, fallback?: string): string {
+  try {
+    return typeof tool.name === "string" && tool.name ? tool.name : (fallback ?? "<unknown>");
+  } catch {
+    return fallback ?? "<unknown>";
+  }
+}
+
+function findToolByName(tools: readonly Tool[], name: string): Tool | undefined {
+  for (const tool of tools) {
+    if (readToolName(tool) === name) {
+      return tool;
+    }
+  }
+  return undefined;
+}
+
+function readToolParameters(tool: Tool, toolName: string): Tool["parameters"] {
+  try {
+    return tool.parameters;
+  } catch (error) {
+    throw new Error(
+      `Validation failed for tool "${toolName}": unable to read parameter schema: ${formatErrorMessage(error)}`,
+      { cause: error },
+    );
+  }
+}
+
 function hasTypeBoxMetadata(schema: unknown): boolean {
   return isRecord(schema) && Object.getOwnPropertySymbols(schema).includes(TYPEBOX_KIND);
 }
@@ -283,7 +315,7 @@ function formatValidationPath(error: TLocalizedValidationError): string {
 
 /** Finds the target tool and validates/coerces a model-emitted tool call. */
 export function validateToolCall(tools: Tool[], toolCall: ToolCall): unknown {
-  const tool = tools.find((t) => t.name === toolCall.name);
+  const tool = findToolByName(tools, toolCall.name);
   if (!tool) {
     throw new Error(`Tool "${toolCall.name}" not found`);
   }
@@ -292,24 +324,36 @@ export function validateToolCall(tools: Tool[], toolCall: ToolCall): unknown {
 
 /** Validates tool arguments against TypeBox or plain JSON-schema parameters. */
 export function validateToolArguments(tool: Tool, toolCall: ToolCall): unknown {
+  const toolName = readToolName(tool, toolCall.name);
+  const parameters = readToolParameters(tool, toolName);
   const args = structuredClone(toolCall.arguments);
-  Value.Convert(tool.parameters, args);
+  let validator: ReturnType<typeof Compile>;
 
-  const validator = getValidator(tool.parameters);
-  if (!hasTypeBoxMetadata(tool.parameters) && isJsonSchemaObject(tool.parameters)) {
-    // TypeBox Value.Convert is intentionally conservative for plain JSON schemas;
-    // mirror the provider-facing coercions so model-emitted string numbers validate.
-    const coerced = coerceWithJsonSchema(args, tool.parameters);
-    if (coerced !== args) {
-      if (isRecord(args) && isRecord(coerced)) {
-        for (const key of Object.keys(args)) {
-          delete args[key];
+  try {
+    Value.Convert(parameters, args);
+    validator = getValidator(parameters);
+    if (!hasTypeBoxMetadata(parameters) && isJsonSchemaObject(parameters)) {
+      // TypeBox Value.Convert is intentionally conservative for plain JSON schemas;
+      // mirror the provider-facing coercions so model-emitted string numbers validate.
+      const coerced = coerceWithJsonSchema(args, parameters);
+      if (coerced !== args) {
+        if (isRecord(args) && isRecord(coerced)) {
+          for (const key of Object.keys(args)) {
+            delete args[key];
+          }
+          Object.assign(args, coerced);
+        } else {
+          return validator.Check(coerced) ? coerced : args;
         }
-        Object.assign(args, coerced);
-      } else {
-        return validator.Check(coerced) ? coerced : args;
       }
     }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith(`Validation failed for tool "`)) {
+      throw error;
+    }
+    throw new Error(`Validation failed for tool "${toolName}": ${formatErrorMessage(error)}`, {
+      cause: error,
+    });
   }
 
   if (validator.Check(args)) {
@@ -323,6 +367,6 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): unknown {
       .join("\n") || "Unknown validation error";
 
   throw new Error(
-    `Validation failed for tool "${toolCall.name}":\n${errors}\n\nReceived arguments:\n${JSON.stringify(toolCall.arguments, null, 2)}`,
+    `Validation failed for tool "${toolName}":\n${errors}\n\nReceived arguments:\n${JSON.stringify(toolCall.arguments, null, 2)}`,
   );
 }


### PR DESCRIPTION
## Summary

- guard low-level tool lookup so unreadable sibling tool names cannot abort validation or agent-loop preparation for a healthy requested tool
- turn unreadable selected parameter schemas into normal validation failures with the original error preserved as `cause`
- add focused regression coverage for `validateToolCall()`, `validateToolArguments()`, and `runAgentLoop()`

## Verification

- `node scripts/run-vitest.mjs packages/llm-core/src/validation.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.tool-validation.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check packages/llm-core/src/validation.ts packages/llm-core/src/validation.test.ts packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent-loop.tool-validation.test.ts`
- `node_modules/.bin/oxlint packages/llm-core/src/validation.ts packages/llm-core/src/validation.test.ts packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent-loop.tool-validation.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

## Real behavior proof

Behavior addressed: low-level tool-call lookup and agent-loop preparation no longer crash on unreadable sibling tool `name` getters while handling a healthy requested tool; unreadable selected `parameters` schemas are reported as validation failures instead of raw getter exceptions.

Real environment tested: local Codex linked worktree for focused tests, formatting, lint, diff check, and branch autoreview; AWS Crabbox Linux for changed-gate proof.

Exact steps or command run after this patch: ran the focused Vitest commands above, touched-file `oxfmt`/`oxlint`, `git diff --check`, branch autoreview, and AWS Crabbox `pnpm check:changed`.

Evidence after fix: focused Vitest passed for `packages/llm-core/src/validation.test.ts` and `packages/agent-core/src/agent-loop.tool-validation.test.ts`; branch autoreview reported no accepted/actionable findings with `overall: patch is correct (0.83)`; AWS Crabbox run `run_fa78de382419` on lease `cbx_a0039d561f59` passed lanes `core, coreTests` with exit 0 and stopped the lease.

Observed result after fix: hostile sibling tool descriptors are skipped during lookup, the requested healthy tool call proceeds, and unreadable selected parameter schemas produce bounded validation errors.

What was not tested: full suite, Docker, live provider, and E2E lanes. Blacksmith Testbox was unavailable in this shell because it requires `blacksmith auth login`, so the broad changed proof used AWS Crabbox instead.
