### PR TITLE
fix(ui): clear chat composer after send

### DIFF
--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -297,6 +297,11 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.getByRole("button", { name: "Send message" }).click();
 
       const sendRequest = await gateway.waitForRequest("chat.send");
+      await expect
+        .poll(() => page.locator(".agent-chat__composer-combobox textarea").inputValue(), {
+          timeout: 10_000,
+        })
+        .toBe("");
       const params = requireRecord(sendRequest.params);
       expect(params.message).toBe(prompt);
       expect(params.sessionKey).toBe("global");
@@ -377,6 +382,11 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.getByRole("button", { name: "Send message" }).click();
 
       const sendRequest = await gateway.waitForRequest("chat.send");
+      await expect
+        .poll(() => page.locator(".agent-chat__composer-combobox textarea").inputValue(), {
+          timeout: 10_000,
+        })
+        .toBe("");
       const params = requireRecord(sendRequest.params);
       const runId = requireString(params.idempotencyKey, "chat send idempotency key");
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1144,6 +1144,31 @@ describe("chat slash menu accessibility", () => {
     expect(onSend).toHaveBeenCalledTimes(1);
   });
 
+  it("clears the visible local draft immediately when send clears the host draft", () => {
+    let draft = "";
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const onSend = vi.fn(() => {
+      draft = "";
+    });
+    const renderWithDraft = () => {
+      render(
+        renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
+        container,
+      );
+    };
+
+    renderWithDraft();
+    inputDraft(container, "submitted message");
+    container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+
+    expect(onDraftChange).toHaveBeenCalledWith("submitted message");
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("");
+  });
+
   it("commits local draft input before Enter sends", () => {
     const onDraftChange = vi.fn();
     const onSend = vi.fn();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1388,6 +1388,7 @@ export function renderChat(props: ChatProps) {
   };
   const draftMirror = getComposerDraftMirror(props);
   const visibleDraft = draftMirror.value;
+  let composerTextarea: HTMLTextAreaElement | null = null;
   const pinned = getPinnedMessages(props.sessionKey);
   const deleted = getDeletedMessages(props.sessionKey);
   const hasAttachments = (props.attachments?.length ?? 0) > 0;
@@ -1624,6 +1625,21 @@ export function renderChat(props: ChatProps) {
     </div>
   `;
 
+  const syncComposerDraftAfterSend = (target: HTMLTextAreaElement | null) => {
+    const hostDraft = props.getDraft?.();
+    if (typeof hostDraft !== "string") {
+      return;
+    }
+    // Sends can clear the host draft synchronously before Lit rerenders; keep
+    // the local mirror aligned so the submitted text does not stay editable.
+    draftMirror.hostDraft = hostDraft;
+    draftMirror.value = hostDraft;
+    if (target && target.value !== hostDraft) {
+      target.value = hostDraft;
+      adjustTextareaHeight(target);
+    }
+  };
+
   const handleKeyDown = (e: KeyboardEvent) => {
     // Slash menu navigation — arg mode
     if (vs.slashMenuOpen && vs.slashMenuMode === "args" && vs.slashMenuArgItems.length > 0) {
@@ -1743,6 +1759,7 @@ export function renderChat(props: ChatProps) {
         const target = e.target as HTMLTextAreaElement;
         commitComposerDraft(props, target.value);
         props.onSend();
+        syncComposerDraftAfterSend(target);
       }
     }
   };
@@ -1764,6 +1781,7 @@ export function renderChat(props: ChatProps) {
   const handleSend = () => {
     commitComposerDraft(props, draftMirror.value);
     props.onSend();
+    syncComposerDraftAfterSend(composerTextarea);
   };
   const slashMenuVisible = isSlashMenuVisible();
   const activeSlashMenuOptionId = getActiveSlashMenuOptionId();
@@ -1899,7 +1917,12 @@ export function renderChat(props: ChatProps) {
 
         <div class="agent-chat__composer-combobox">
           <textarea
-            ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
+            ${ref((el) => {
+              composerTextarea = el instanceof HTMLTextAreaElement ? el : null;
+              if (composerTextarea) {
+                adjustTextareaHeight(composerTextarea);
+              }
+            })}
             .value=${visibleDraft}
             dir=${detectTextDirection(visibleDraft)}
             ?disabled=${!props.connected}


### PR DESCRIPTION
## Summary

- Fix the Control UI chat composer keeping the submitted request text live after `chat.send`.
- Resync the local composer draft mirror from the host draft immediately after send clears it.
- Add unit and browser E2E coverage that the textarea clears after send, including delayed ACK paths.

Fixes #89108.

## Behavior

Regression from the local-draft composer path: the host draft is cleared synchronously during send, but the local textarea mirror can keep the submitted text visible/editable until a later render. Users then have to manually delete the old request before sending the next one.

## Real behavior proof

- Behavior addressed: Control UI chat composer clears the submitted request text after send instead of leaving it live/editable in the chat bar.
- Real environment tested: Maintainer local Gateway/Control UI with this fix, plus Blacksmith Testbox browser E2E coverage of the Control UI chat flow using the Gateway WebSocket harness.
- Exact steps or command run after this patch:
  - Manual: start local Gateway/Control UI with this fix, send a request from the chat composer, wait for the assistant reply, and inspect the composer.
  - Testbox E2E: `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "sends the first chat turn|keeps a delayed chat.send ACK" --reporter verbose`
- Evidence after fix: Maintainer confirmed in local Gateway/Control UI that the issue no longer reproduces. Testbox provider `blacksmith-testbox`, id `tbx_01kt1qwvaffnsm9eez5c2qsdey`, Actions run `26759788670`, passed two browser E2E send-flow checks that assert the composer textarea becomes empty after `chat.send`.
- Observed result after fix: After sending, the assistant reply appears and the composer textarea is empty; the delayed ACK path also keeps the pending send visible while the composer stays clear.
- What was not tested: Full release suite and a live provider turn were not run for this PR. The browser E2E proof uses the mocked Gateway WebSocket harness and is supplemented by maintainer local Gateway/Control UI confirmation.

### Screenshots:

Before Fix:
<img width="1392" height="428" alt="Screenshot 2026-06-01 at 10 03 39 AM" src="https://github.com/user-attachments/assets/c225ad9c-25e7-4720-9881-284cdcac6a92" />

After Fix: 
<img width="1179" height="414" alt="Screenshot 2026-06-01 at 10 13 25 AM" src="https://github.com/user-attachments/assets/8c345324-798c-4d95-a104-450e1b6a4bd4" />


## Verification

- Clean-main repro, expected failure:
  - Testbox provider `blacksmith-testbox`, id `tbx_01kt1qgzqxdw4z003ygmqggnqh`, Actions run `26759418348`
  - Command restored `ui/src/ui/views/chat.ts` to `HEAD` while keeping the new repro test.
  - Failed as expected: `expected 'submitted message' to be ''`.
- Patched focused unit proof:
  - Testbox provider `blacksmith-testbox`, id `tbx_01kt1qpmjjkmcq0hpa6ar89cy0`, Actions run `26759593415`
  - `node node_modules/vitest/vitest.mjs run ui/src/ui/views/chat.test.ts -t "clears the visible local draft immediately" --reporter verbose`
  - Passed: 1 test passed.
- Patched browser E2E proof:
  - Testbox provider `blacksmith-testbox`, id `tbx_01kt1qwvaffnsm9eez5c2qsdey`, Actions run `26759788670`
  - `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "sends the first chat turn|keeps a delayed chat.send ACK" --reporter verbose`
  - Passed: 2 tests passed.
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Clean: no accepted/actionable findings.
