### PR TITLE
fix(agents): block message-tool spam loops defeated by volatile message ids

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1,8 +1,18 @@
 // Tool loop detection tests cover repeated-call hashing, ping-pong detection,
 // unknown-tool thresholds, and circuit-breaker escalation.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
+
+// Recognize a provider-docked send tool by name (only "telegram" here) so the
+// volatility strip applies to it without pulling in the channel-plugin registry; the
+// real detector is covered by embedded-agent-messaging's own tests.
+const isMessagingToolSendActionMock = vi.hoisted(() =>
+  vi.fn((toolName: string): boolean => toolName === "telegram"),
+);
+vi.mock("./embedded-agent-messaging.js", () => ({
+  isMessagingToolSendAction: isMessagingToolSendActionMock,
+}));
 import {
   CRITICAL_THRESHOLD,
   GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
@@ -1007,6 +1017,19 @@ describe("tool-loop-detection", () => {
         params,
         enabledLoopDetectionConfig,
       );
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+      }
+    });
+
+    it("escalates provider-docked send-tool loops (e.g. telegram) whose result carries fresh ids", () => {
+      const state = createState();
+      const params = { to: "telegram:123", text: "ping" };
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(state, "telegram", params, sendPayload(i), i);
+      }
+      const loopResult = detectToolCallLoop(state, "telegram", params, enabledLoopDetectionConfig);
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
         expect(loopResult.level).toBe("critical");

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -915,6 +915,322 @@ describe("tool-loop-detection", () => {
     });
   });
 
+  describe("message send loop detection (#89090)", () => {
+    // Mirror jsonResult(payload): text is the stringified payload (so it carries the
+    // volatile id too) and details is the payload — the shape a real send returns.
+    function sendResult(payload: Record<string, unknown>) {
+      return {
+        content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+        details: payload,
+      };
+    }
+
+    function recordSend(
+      state: SessionState,
+      toolName: string,
+      params: unknown,
+      payload: Record<string, unknown>,
+      index: number,
+    ): void {
+      const toolCallId = `${toolName}-${index}`;
+      recordToolCall(state, toolName, params, toolCallId, enabledLoopDetectionConfig);
+      recordToolCallOutcome(state, {
+        toolName,
+        toolParams: params,
+        toolCallId,
+        result: sendResult(payload),
+        config: enabledLoopDetectionConfig,
+      });
+    }
+
+    function sendPayload(index: number): Record<string, unknown> {
+      return {
+        ok: true,
+        channel: "feishu",
+        chatId: "oc_chat",
+        runId: `run_${index}`,
+        messageId: `om_${index}`,
+        receipt: { platformMessageId: `p_${index}` },
+      };
+    }
+
+    it("gives duplicate sends a stable result hash despite per-call ids in details and text", () => {
+      const state = createState();
+      const params = { action: "send", target: "feishu:oc_chat", text: "ping" };
+      recordSend(state, "message", params, sendPayload(0), 0);
+      recordSend(state, "message", params, sendPayload(1), 1);
+      const hashes = state.toolCallHistory
+        ?.filter((call) => call.toolName === "message")
+        .map((call) => call.resultHash);
+      expect(hashes?.[0]).toBeTypeOf("string");
+      expect(hashes?.[0]).toBe(hashes?.[1]);
+    });
+
+    it("strips nested ids so broadcast results with per-call ids share a result hash", () => {
+      const state = createState();
+      const params = { action: "broadcast", text: "ping" };
+      const broadcast = (index: number) => ({
+        results: [
+          { channel: "feishu", ok: true, result: { messageId: `om_${index}`, receipt: index } },
+        ],
+      });
+      recordSend(state, "message", params, broadcast(0), 0);
+      recordSend(state, "message", params, broadcast(1), 1);
+      const hashes = state.toolCallHistory
+        ?.filter((call) => call.toolName === "message")
+        .map((call) => call.resultHash);
+      expect(hashes?.[0]).toBe(hashes?.[1]);
+    });
+
+    it("escalates identical-arg send loops to critical even though every id differs", () => {
+      const state = createState();
+      const params = { action: "send", target: "feishu:oc_chat", text: "ping" };
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(state, "message", params, sendPayload(i), i);
+      }
+      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+      }
+    });
+
+    it("also blocks sessions_send loops whose result carries a fresh runId", () => {
+      const state = createState();
+      const params = { sessionKey: "agent:main:peer", text: "ping" };
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(state, "sessions_send", params, { ok: true, runId: `run_${i}` }, i);
+      }
+      const loopResult = detectToolCallLoop(
+        state,
+        "sessions_send",
+        params,
+        enabledLoopDetectionConfig,
+      );
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+      }
+    });
+
+    it("escalates sibling delivery actions (reply) the same as send", () => {
+      const state = createState();
+      const params = { action: "reply", target: "feishu:oc_chat", text: "ping" };
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(state, "message", params, sendPayload(i), i);
+      }
+      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+      }
+    });
+
+    it("blocks upload-file loops whose result carries a fresh file id", () => {
+      const state = createState();
+      const params = { action: "upload-file", target: "feishu:oc_chat", media: "img.png" };
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(
+          state,
+          "message",
+          params,
+          { ok: true, channel: "feishu", fileId: `f_${i}`, messageId: `om_${i}` },
+          i,
+        );
+      }
+      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+      }
+    });
+
+    it("blocks poll loops whose result carries a fresh poll id", () => {
+      const state = createState();
+      const params = { action: "poll", target: "tg:chat-1", question: "?" };
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(
+          state,
+          "message",
+          params,
+          { ok: true, channel: "telegram", messageId: `om_${i}`, chatId: "c1", pollId: `pl_${i}` },
+          i,
+        );
+      }
+      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+      }
+    });
+
+    it("does not flag distinct messages (different args) as a no-progress loop", () => {
+      const state = createState();
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(
+          state,
+          "message",
+          { action: "send", target: "feishu:oc_chat", text: `line ${i}` },
+          sendPayload(i),
+          i,
+        );
+      }
+      const loopResult = detectToolCallLoop(
+        state,
+        "message",
+        { action: "send", target: "feishu:oc_chat", text: "line final" },
+        enabledLoopDetectionConfig,
+      );
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("keeps full result hashing for non-send message actions so id/timestamp progress is not masked", () => {
+      const state = createState();
+      const params = { action: "read", target: "feishu:oc_chat" };
+      // Results differ only in id/timestamp: a non-send action must still treat that as
+      // progress (distinct hashes), unlike a send where those are stripped as volatile.
+      recordSend(state, "message", params, { ok: true, messageId: "m_0", ts: 1000 }, 0);
+      recordSend(state, "message", params, { ok: true, messageId: "m_1", ts: 2000 }, 1);
+      const hashes = state.toolCallHistory
+        ?.filter((call) => call.toolName === "message")
+        .map((call) => call.resultHash);
+      expect(hashes?.[0]).toBeTypeOf("string");
+      expect(hashes?.[0]).not.toBe(hashes?.[1]);
+    });
+
+    it("preserves stable nested route ids so distinct routes stay distinguishable", () => {
+      const state = createState();
+      const params = { action: "send", target: "feishu:oc_chat", text: "ping" };
+      // messageId is volatile (stripped); a nested route id is a stable fact that must survive,
+      // so two sends resolving to different routes keep distinct hashes.
+      recordSend(
+        state,
+        "message",
+        params,
+        { ok: true, messageId: "om_0", route: { id: "conv-A" } },
+        0,
+      );
+      recordSend(
+        state,
+        "message",
+        params,
+        { ok: true, messageId: "om_1", route: { id: "conv-B" } },
+        1,
+      );
+      const hashes = state.toolCallHistory
+        ?.filter((call) => call.toolName === "message")
+        .map((call) => call.resultHash);
+      expect(hashes?.[0]).not.toBe(hashes?.[1]);
+    });
+
+    it("keeps a critical send block sticky after the veto result is recorded", () => {
+      const state = createState();
+      const params = { action: "send", target: "feishu:oc_chat", text: "ping" };
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(state, "message", params, sendPayload(i), i);
+      }
+      expect(detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig).stuck).toBe(
+        true,
+      );
+      // The loop veto records a blocked result (buildBlockedToolResult, deniedReason "tool-loop");
+      // it must not reset the no-progress streak, so the next identical send is still blocked.
+      recordToolCall(state, "message", params, "message-veto", enabledLoopDetectionConfig);
+      recordToolCallOutcome(state, {
+        toolName: "message",
+        toolParams: params,
+        toolCallId: "message-veto",
+        result: {
+          content: [{ type: "text", text: "blocked" }],
+          details: { status: "blocked", deniedReason: "tool-loop" },
+        },
+        config: enabledLoopDetectionConfig,
+      });
+      const after = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(after.stuck).toBe(true);
+      if (after.stuck) {
+        expect(after.level).toBe("critical");
+      }
+    });
+
+    it("still escalates repeated plugin/approval vetoes to a critical loop", () => {
+      const state = createState();
+      const params = { action: "read", target: "feishu:oc_chat" };
+      // A non-loop veto (plugin/approval) keeps a stable result hash, so repeated identical
+      // denials still accumulate a no-progress streak and reach a critical block.
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordToolCall(state, "message", params, `veto-${i}`, enabledLoopDetectionConfig);
+        recordToolCallOutcome(state, {
+          toolName: "message",
+          toolParams: params,
+          toolCallId: `veto-${i}`,
+          result: {
+            content: [{ type: "text", text: "blocked" }],
+            details: { status: "blocked", deniedReason: "plugin-before-tool-call" },
+          },
+          config: enabledLoopDetectionConfig,
+        });
+      }
+      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+      }
+    });
+
+    it("blocks plugin-shaped send results whose message object carries a bare per-send id", () => {
+      const state = createState();
+      const params = { action: "send", to: "feishu:chat-1", content: "hello" };
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        // The volatile id is the message object's own `id`; conversation.id is stable.
+        recordSend(
+          state,
+          "message",
+          params,
+          {
+            message: {
+              id: `qa_${i}`,
+              accountId: "default",
+              direction: "outbound",
+              conversation: { id: "loop-room", chatType: "channel" },
+              senderId: "openclaw",
+              text: "hello",
+              timestamp: 1_800_000_000_000 + i,
+            },
+          },
+          i,
+        );
+      }
+      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+      }
+    });
+
+    it("does not escalate when a stable conversation id changes between sends", () => {
+      const state = createState();
+      const params = { action: "send", to: "feishu:chat-1", content: "hello" };
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(
+          state,
+          "message",
+          params,
+          {
+            message: {
+              id: `qa_${i}`,
+              direction: "outbound",
+              conversation: { id: `loop-room-${i}`, chatType: "channel" },
+              text: "hello",
+            },
+          },
+          i,
+        );
+      }
+      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck && loopResult.level).not.toBe("critical");
+    });
+  });
+
   describe("getToolCallStats", () => {
     it("returns zero stats for empty history", () => {
       const state = createState();

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -12,6 +12,7 @@ import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import type { SessionState, ToolCallRecord } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isPlainObject } from "../utils.js";
+import { isMessagingToolSendAction } from "./embedded-agent-messaging.js";
 import { stableStringify } from "./stable-stringify.js";
 
 const log = createSubsystemLogger("agents/loop-detection");
@@ -245,10 +246,15 @@ const SEND_LIKE_MESSAGE_ACTIONS = new Set([
   "sticker",
   "poll",
 ]);
+// Denylist of per-call volatile delivery ids/timestamps stripped before hashing. Must
+// cover the id/timestamp fields a channel's delivery result can carry; a new channel
+// emitting a volatile field name outside this set silently regresses its loop blocking.
 const VOLATILE_SEND_RESULT_KEYS = new Set([
   "messageId",
   "message_id",
   "messageIds",
+  "platformMessageId",
+  "platformMessageIds",
   "fileId",
   "file_id",
   "fileKey",
@@ -299,10 +305,14 @@ function isVolatileSendResult(toolName: string, params: unknown): boolean {
   if (toolName === "sessions_send") {
     return true;
   }
-  if (toolName !== "message" || !isPlainObject(params)) {
-    return false;
+  const args = isPlainObject(params) ? params : {};
+  if (toolName === "message") {
+    return typeof args.action === "string" && SEND_LIKE_MESSAGE_ACTIONS.has(args.action);
   }
-  return typeof params.action === "string" && SEND_LIKE_MESSAGE_ACTIONS.has(params.action);
+  // Provider-docked send tools (telegram/discord/...) return the same volatile-id shape.
+  // SEND_LIKE_MESSAGE_ACTIONS stays broader than the terminal-send set on purpose:
+  // broadcast/reply/sticker/poll carry volatile ids but are not terminal sends.
+  return isMessagingToolSendAction(toolName, args);
 }
 
 // Only the loop detector's own veto must not reset the streak; other blocked results

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -231,6 +231,86 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
   return undefined;
 }
 
+// Delivery results carry fresh per-call ids (messageId/runId) in details and text, so
+// hashing them defeats no-progress loop blocking (#89090). Hash only id-stripped facts
+// for outbound-message actions; other `message` actions keep full hashing (real progress).
+const SEND_LIKE_MESSAGE_ACTIONS = new Set([
+  "send",
+  "broadcast",
+  "reply",
+  "thread-reply",
+  "sendWithEffect",
+  "sendAttachment",
+  "upload-file",
+  "sticker",
+  "poll",
+]);
+const VOLATILE_SEND_RESULT_KEYS = new Set([
+  "messageId",
+  "message_id",
+  "messageIds",
+  "fileId",
+  "file_id",
+  "fileKey",
+  "pollId",
+  "poll_id",
+  "receipt",
+  "runId",
+  "idempotencyKey",
+  "ts",
+  "timestamp",
+  "sentAt",
+  "deliveredAt",
+  "createdAt",
+]);
+
+// A message object's own `id` is its volatile per-send id; a bare `id` elsewhere
+// (route/conversation) is a stable fact, so only strip `id` on the message object.
+function isMessageDeliveryObject(value: Record<string, unknown>): boolean {
+  return (
+    typeof value.id === "string" &&
+    typeof value.text === "string" &&
+    (typeof value.direction === "string" ||
+      typeof value.senderId === "string" ||
+      typeof value.accountId === "string" ||
+      isPlainObject(value.conversation))
+  );
+}
+
+function stripVolatileSendIds(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripVolatileSendIds);
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const dropMessageObjectId = isMessageDeliveryObject(value);
+  const stripped: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    if (VOLATILE_SEND_RESULT_KEYS.has(key) || (key === "id" && dropMessageObjectId)) {
+      continue;
+    }
+    stripped[key] = stripVolatileSendIds(nested);
+  }
+  return stripped;
+}
+
+function isVolatileSendResult(toolName: string, params: unknown): boolean {
+  if (toolName === "sessions_send") {
+    return true;
+  }
+  if (toolName !== "message" || !isPlainObject(params)) {
+    return false;
+  }
+  return typeof params.action === "string" && SEND_LIKE_MESSAGE_ACTIONS.has(params.action);
+}
+
+// Only the loop detector's own veto must not reset the streak; other blocked results
+// (plugin/approval vetoes) keep a hash so repeated identical denials still escalate.
+function isLoopVetoResult(details: Record<string, unknown>): boolean {
+  return details.status === "blocked" && details.deniedReason === "tool-loop";
+}
+
 function hashToolOutcome(
   toolName: string,
   params: unknown,
@@ -250,6 +330,11 @@ function hashToolOutcome(
 
   const details = isPlainObject(result.details) ? result.details : {};
   const text = extractTextContent(result);
+  // The loop detector's own veto is not real progress; giving it no result hash keeps a
+  // critical loop block sticky instead of letting the block reset the streak (#89090).
+  if (isLoopVetoResult(details)) {
+    return { resultHash: undefined };
+  }
   if (toolName === "exec") {
     const execHash = hashExecToolOutcome(details, text);
     if (execHash) {
@@ -284,6 +369,10 @@ function hashToolOutcome(
         }),
       };
     }
+  }
+
+  if (isVolatileSendResult(toolName, params)) {
+    return { resultHash: digestStable(stripVolatileSendIds(details)) };
   }
 
   return {

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -6,6 +6,9 @@ import type { ChannelMessageAdapterShape } from "../../channels/message/types.js
 import type { ChannelMessageCapability } from "../../channels/plugins/message-capabilities.js";
 import type { ChannelMessageActionName, ChannelPlugin } from "../../channels/plugins/types.js";
 import type { MessageActionRunResult } from "../../infra/outbound/message-action-runner.js";
+import { resetDiagnosticSessionStateForTest } from "../../logging/diagnostic-session-state.js";
+import { wrapToolWithBeforeToolCallHook } from "../agent-tools.before-tool-call.js";
+import { CRITICAL_THRESHOLD } from "../tool-loop-detection.js";
 type CreateMessageTool = typeof import("./message-tool.js").createMessageTool;
 type CreateOpenClawTools = typeof import("../openclaw-tools.js").createOpenClawTools;
 type ResetPluginRuntimeStateForTest =
@@ -315,6 +318,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   resetPluginRuntimeStateForTest();
+  resetDiagnosticSessionStateForTest();
   mocks.runMessageAction.mockReset();
   mocks.getRuntimeConfig.mockReset().mockReturnValue({});
   mocks.resolveCommandSecretRefsViaGateway.mockReset().mockImplementation(async ({ config }) => ({
@@ -1236,6 +1240,86 @@ describe("message tool explicit target guard", () => {
 
     const call = firstRunMessageActionInput();
     expect(call?.params?.target).toBe("channel:C999");
+  });
+});
+
+describe("message tool loop detection action runner proof", () => {
+  function mockQaChannelGatewayActionRunner() {
+    mocks.runMessageAction.mockImplementation(async ({ params }) => {
+      const callIndex = mocks.runMessageAction.mock.calls.length;
+      return {
+        kind: "send",
+        action: "send",
+        channel: "qa-channel",
+        to: typeof params?.target === "string" ? params.target : "channel:loop-room",
+        handledBy: "plugin",
+        payload: {
+          message: {
+            id: `qa-message-${callIndex}`,
+            accountId: "default",
+            direction: "outbound",
+            conversation: {
+              id: "loop-room",
+              chatType: "channel",
+            },
+            senderId: "openclaw",
+            text: "same visible reply",
+            timestamp: 1_800_000_000_000 + callIndex,
+          },
+        },
+        dryRun: false,
+      } satisfies MessageActionRunResult;
+    });
+  }
+
+  it("blocks repeated qa-channel sends returned by the wrapped message tool", async () => {
+    mockQaChannelGatewayActionRunner();
+    const messageTool = createMessageTool({
+      runMessageAction: mocks.runMessageAction as never,
+    });
+    const wrappedTool = wrapToolWithBeforeToolCallHook(messageTool, {
+      agentId: "main",
+      sessionKey: "message-tool-action-runner-loop",
+      sessionId: "message-tool-action-runner-loop-session",
+      runId: "message-tool-action-runner-loop-run",
+      loopDetection: { enabled: true },
+    });
+    const params = {
+      action: "send",
+      target: "channel:loop-room",
+      message: "same visible reply",
+    };
+
+    for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+      const result = await wrappedTool.execute(`message-tool-send-${i}`, params);
+      expect(result.details).toMatchObject({
+        message: {
+          conversation: {
+            id: "loop-room",
+          },
+          text: "same visible reply",
+        },
+      });
+    }
+
+    const blocked = await wrappedTool.execute(`message-tool-send-${CRITICAL_THRESHOLD}`, params);
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(CRITICAL_THRESHOLD);
+    expect(blocked.details).toMatchObject({
+      status: "blocked",
+      deniedReason: "tool-loop",
+    });
+    const blockedDetails = blocked.details as { reason?: unknown } | undefined;
+    expect(String(blockedDetails?.reason)).toContain("CRITICAL");
+
+    const blockedAgain = await wrappedTool.execute(
+      `message-tool-send-${CRITICAL_THRESHOLD + 1}`,
+      params,
+    );
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(CRITICAL_THRESHOLD);
+    expect(blockedAgain.details).toMatchObject({
+      status: "blocked",
+      deniedReason: "tool-loop",
+    });
   });
 });
 


### PR DESCRIPTION
### Summary

- **Problem**: Issue #89090 reports that `loopDetection` detects repeated `message.send` calls (`ping_pong`, warning level) but can never escalate to a **block**. A model stuck in a tool-call loop keeps sending duplicate messages — 30+ duplicates reported — until `runRetries.max` (default 160) is exhausted; the user only sees a flood of identical messages and the warning the model ignores.
- **Root Cause**: In `tool-loop-detection.ts`, `hashToolOutcome` hashes the full result for the send tools. A successful send returns through `jsonResult(payload)`, so the per-call delivery ids land in **both** the result `details` (e.g. `messageId`, `receipt`, the gateway `runId`) **and** the result `text` (the stringified payload). The hash therefore differs on every call. All three critical-block paths — the global circuit breaker, `ping_pong` critical, and generic no-progress — require consecutive **identical** `resultHash` values (`getNoProgressStreak` / `noProgressEvidence`), which is structurally impossible for a tool whose result carries a unique id. Detection fires only at warning level because it also keys on `argsHash`, which is stable.
- **Fix**: Hash a stable, id-stripped projection of the result, scoped to delivery results only — `sessions_send` and the outbound-message actions (`send`, `broadcast`, `reply`, `thread-reply`, `sendWithEffect`, `sendAttachment`, `upload-file`, `sticker`, `poll`) of the multi-action `message` tool.
  - `isVolatileSendResult` gates the path: `sessions_send` and the outbound-message actions above on the multi-action `message` tool get the stripped hash, while `message`'s mutate/query actions (`read`, `search`, `edit`, `react`, `unsend`, `list-pins`, `thread-list`, …) keep full-result hashing because their ids/timestamps are real progress. Provider-docked send tools (channel plugins registered as named tools, e.g. `telegram`/`discord`) return the same volatile-id shape and are matched via the shared `isMessagingToolSendAction` detector, so loops on them escalate too; `SEND_LIKE_MESSAGE_ACTIONS` stays intentionally broader than that helper's terminal-send set (`broadcast`/`reply`/`sticker`/`poll` are volatile but not terminal sends).
  - `stripVolatileSendIds` recursively removes `VOLATILE_SEND_RESULT_KEYS` (`messageId`, `message_id`, `messageIds`, `platformMessageId`, `platformMessageIds`, `fileId`, `fileKey`, `pollId`, `receipt`, `runId`, `idempotencyKey`, `ts`, `timestamp`, `sentAt`, `deliveredAt`, `createdAt`) from `details` at any depth — so it also neutralizes the nested ids in a `broadcast` payload (`results[].result.messageId`).
  - It also drops a message object's own bare `id` (detected via `isMessageDeliveryObject`: a string `id` + `text` plus `conversation`/`direction`/`senderId`/`accountId`) so plugin-shaped delivery results normalize too, while a stable nested route/`conversation.id` is preserved.
  - The stringified `text` is **not** hashed for delivery results (it is the payload restated and carries the same volatile ids); the stable delivery facts (`ok` / status / channel / target) remain.
  - The loop detector's own veto result (`buildBlockedToolResult` with `deniedReason: "tool-loop"`) gets no result hash, so a critical block stays sticky instead of the block resetting the streak. Other blocked results (plugin/approval vetoes) keep their hash, so repeated identical denials still escalate normally.
  - This runs at the shared `hashToolOutcome` layer, so it covers the `message` tool, `sessions_send`, and provider-docked channel tools uniformly (direct, gateway, and plugin-handled send results). Repeated identical-args sends now produce a stable `resultHash`, so the no-progress / critical paths fire and the loop is blocked.
  - **Why this is safe (no false positives)**: no-progress requires BOTH `argsHash` and `resultHash` to repeat. The args hash already carries the message content and target, so two genuinely different messages have different `argsHash` and are never flagged — dropping the volatile ids only restores detection for true same-args resends.
- **What changed**:
  - `src/agents/tool-loop-detection.ts` — add `SEND_LIKE_MESSAGE_ACTIONS`, `VOLATILE_SEND_RESULT_KEYS`, `stripVolatileSendIds`, `isVolatileSendResult`, `isMessageDeliveryObject`, and `isLoopVetoResult`; branch delivery results to the id-stripped hash inside `hashToolOutcome` and give blocked/veto results no hash. `isVolatileSendResult` delegates provider-docked tool names to the shared `isMessagingToolSendAction` (from `embedded-agent-messaging.ts`), unifying the send-action source of truth; the denylist also covers `platformMessageId`/`platformMessageIds`.
  - `src/agents/tool-loop-detection.test.ts` — fifteen regression cases on the real `jsonResult` result shape (stable hash across ids in details+text, nested broadcast ids, escalation to critical for `message` `send`, sibling `reply` and `upload-file` (fresh file id) actions, `sessions_send`, and a provider-docked `telegram` send, no false-positive on distinct messages, a non-send `message` `read` whose id/timestamp progress must stay distinct, a stable nested route id that must survive the strip, and a critical block that stays sticky after the veto result is recorded).
- **What did NOT change (scope boundary)**:
  - Generic / exec / process / poll detector semantics, non-send `message` action hashing, thresholds, and retry caps are untouched — nothing was loosened or raised; this restores the existing block behavior for delivery results only.
  - No config surface (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - No plugin surface (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Configure an agent with a model prone to tool-call loops on a channel that returns a per-send message id (e.g. Feishu).
2. The model loops on `message.send` with identical arguments.
3. **Before this PR**: `ping_pong` fires at warning level but never reaches critical/block; the user receives 30+ duplicate messages until run-retries are exhausted.
4. **After this PR**: the repeated identical send is recognized as no-progress and escalates to a critical block.

Deterministic source reproduction (added as regression tests): record repeated sends with identical args but changing delivery ids in the result, then call `detectToolCallLoop` — before the fix it can never reach a critical branch.

### Real behavior proof

**Behavior addressed (#89090 — send loops can now be blocked, not just warned)**: repeated identical `message.send` (and `sessions_send`) escalates to a critical block instead of spamming until run-retry exhaustion.

**Real environment tested (Linux, Node — Vitest against the production loop-detection module using the real `jsonResult` result shape; no live channel run)**: verified via `tool-loop-detection.test.ts`, plus core production type-check and a scoped test type-check over the two changed files, plus format check. A live multi-channel gateway loop was not run.

**Exact steps or command run after this patch (repo-root)**: `node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts`; `node scripts/run-tsgo.mjs -p tsconfig.core.json` (core types) and a scoped `tsgo` over the changed production + test files (test types); `oxfmt --check` on the changed files.

**Evidence after fix (Vitest output for the touched test file)**:

```text
 tool-loop-detection.test.ts   Tests  58 passed (58)
```

Fifteen new cases pass, all built on the real `jsonResult` result shape (volatile id present in both `details` and the stringified `text`): a stable result hash across two sends whose ids differ; stable hash across `broadcast` results with per-call nested ids; escalation to `critical` for `message` `send`, `reply`, `upload-file`, `sessions_send`, and a provider-docked `telegram` send despite every id differing; a plugin-shaped result whose message object carries a bare per-send `id`; no `stuck` result when the sends carry distinct content (different args); a non-send `message` `read` whose results differ only by id/timestamp staying distinct (full hashing preserved); a stable nested route id that survives the strip; a changing `conversation.id` that stays below critical; and a critical block that stays sticky after the veto result is recorded.

**Observed result after fix (identical-args send loops reach critical/block)**: `detectToolCallLoop` reports `stuck` at `critical` for repeated identical sends, while distinct-content sends remain unflagged.

**What was not tested (live channel/gateway runaway loop)**: a real Feishu/gateway loop session was not reproduced live; the proof is the deterministic module-level reproduction the issue itself describes.

**Repro confirmation**: with the production delivery branch removed on an otherwise-identical tree, the four send behavior cases fail (stable-hash, nested-broadcast, and both escalation cases); and when the branch is instead broadened to every `message` action (dropping the `params.action` gate), the non-send `read` case fails — so both the fix and its action-scoping are covered by tests that fail on the shape the runtime actually produces rather than passing vacuously. All cases pass with the scoped fix.

### Risk / Mitigation

- **Risk**: over-stripping result fields could collide distinct outcomes. **Mitigation**: only a fixed set of volatile delivery-id keys is removed (recursively); stable facts (status, channel, target, action) and the `argsHash` gate remain, so distinct messages stay distinguishable (covered by the no-false-positive regression test).
- **Risk**: behavior change could surface previously-hidden blocks. **Mitigation**: the change is scoped to the send family and merely lets the *existing* critical/no-progress thresholds apply as designed; no threshold, cap, or other detector/tool is altered.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents / tools

### Linked Issue/PR

Fixes #89090
