### PR TITLE
fix(whatsapp): suppress typing for unmentioned group runs regardless of delivery mode

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -1073,7 +1073,7 @@ describe("whatsapp inbound dispatch", () => {
     });
   });
 
-  it("honors automatic visible replies for WhatsApp groups", async () => {
+  it("suppresses typing for automatic-delivery unmentioned group chat", async () => {
     await dispatchBufferedReply({
       cfg: {
         channels: { whatsapp: { blockStreaming: true } },
@@ -1086,7 +1086,7 @@ describe("whatsapp inbound dispatch", () => {
     expectRecordFields(requireRecord(getCapturedReplyOptions(), "reply options"), {
       sourceReplyDeliveryMode: "automatic",
       disableBlockStreaming: false,
-      suppressTyping: false,
+      suppressTyping: true,
     });
   });
 

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -779,10 +779,14 @@ export async function dispatchWhatsAppBufferedReply(params: {
       },
     },
     replyOptions: {
-      // Message-tool-only unmentioned group turns have no automatic visible reply.
-      // Suppress composing there so silent background runs do not leak presence.
+      // Uninvoked unmentioned group turns suppress composing regardless of delivery mode.
+      // Silent background runs must not leak presence; the rare proactive visible
+      // reply in an unmentioned group arrives without a typing indicator (accepted tradeoff).
+      // Authorized commands are explicitly invoked, so they keep their typing indicator.
       suppressTyping:
-        sourceRepliesAreToolOnly && params.msg.chatType === "group" && !params.msg.wasMentioned,
+        params.msg.chatType === "group" &&
+        !params.msg.wasMentioned &&
+        !sourceReplyCommandAuthorized,
       disableBlockStreaming,
       ...(sourceReplyDeliveryMode ? { sourceReplyDeliveryMode } : {}),
       onModelSelected: params.onModelSelected,


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**

On silent agent runs, `signalTextDelta` fires `sendPresenceUpdate("composing")` if the model streams renderable text before the silent-token decision. Once fired, composing is never retracted. Group members see a persistent "typing..." indicator on every background run that ends silently.

The previous fix (commit `5152d8beb4`, `fix(whatsapp): suppress silent-run typing indicators`) added `suppressTyping` with this condition:

```
suppressTyping: sourceRepliesAreToolOnly && chatType === "group" && !wasMentioned
```

`sourceRepliesAreToolOnly` derives from the _configured_ delivery mode (`message_tool_only`). It is not a runtime prediction of whether the current run will produce visible output. Groups configured with `automatic` delivery — the most common case — are entirely excluded by this gate, and those are exactly the groups where silent background runs happen most often.

This PR replaces it with the correct boundary:

```
// Before (5152d8beb4)
suppressTyping: sourceRepliesAreToolOnly && chatType === "group" && !wasMentioned

// After
suppressTyping: chatType === "group" && !wasMentioned && !sourceReplyCommandAuthorized
```

**Why this is the right gate**

The correct question is not "what delivery mode is this group configured for?" It is "was the bot explicitly addressed?" If `wasMentioned` is false and no owner command was invoked, the run is passive. Passive runs can end silently regardless of delivery mode. Composing should not fire for them.

`!sourceReplyCommandAuthorized` carves out owner slash commands (`/status`, `/new`). Those are explicitly directed at the bot and will produce a visible reply — they should keep their typing indicator. This carve-out also satisfies the pre-existing test `"delivers authorized WhatsApp group text slash command replies visibly"` (line 1050 of `inbound-dispatch.test.ts`), which asserts `suppressTyping: false` for authorized commands. Removing `sourceRepliesAreToolOnly` without this carve-out would break that test.

The reason `5152d8beb4` kept `sourceRepliesAreToolOnly`: at the time, the command test had no `suppressTyping` assertion, so the broad `!wasMentioned` condition from an earlier draft was narrowed back to avoid breaking it when the assertion was added. `sourceRepliesAreToolOnly` was the smallest safe gate. This PR replaces it with the semantically correct one.

**What is the intended outcome?**

All passive unmentioned group runs — any delivery mode — produce no composing indicator. @mention runs, direct-chat runs, and authorized commands are unaffected.

**What is intentionally out of scope?**

A structural fix. Fully preventing false composing when the model streams pre-silence text requires collapsing the eager streaming tap and the lazy delivery decision into a single pipeline. `suppressTyping` is the pragmatic mitigation.

**What should reviewers focus on?**

Whether `!sourceReplyCommandAuthorized` covers all explicitly-invoked group paths that should retain composing, or whether any are missing. The tradeoff — rare proactive visible replies in unmentioned groups arrive without a typing flash — is intentional and documented in the comment.

---

## Linked context

Closes #

Related to the investigation documented in #88642.

Self-identified from live session logs.

---

## Current reproducibility

The symptom was observed on 2026-05-27 with OpenClaw `2026.5.24` against a `gemini-3.1-pro-preview` checkpoint that Google has since updated server-side without changing the model ID. That checkpoint emitted `<think>…</think>` XML as a plain text part (no `thought: true` flag) — which `isRenderableText` passes — before `<final>NO_REPLY</final>`, triggering composing. The current checkpoint does not reproduce the symptom; the exact internal change is not known, but the most likely explanation is that reasoning is now routed through `thought: true` parts rather than plain text.

The fix is justified independently of current reproducibility: `sourceRepliesAreToolOnly` is structurally the wrong gate for the reasons above, and any model that emits pre-silence text in a future checkpoint will re-trigger it.

---

## Real behavior proof

- **Behavior addressed:** Spurious WhatsApp "typing..." on silent agent runs in unmentioned groups.
- **Real environment tested:** macOS, OpenClaw `2026.5.31`, `google/gemini-3.1-pro-preview`, WhatsApp group, `requireMention: false`, system prompt instructs silent web search with no reply.
- **Exact steps run after this patch:** Three messages to the group — no @mention (silent), @mention (visible reply), no @mention (silent).
- **Evidence after fix (2026-06-01):**

```
# Run 1 — no mention, silent
15:34:09  embedded run start
15:34:25  embedded run tool start: tool=web_search
15:34:43  Skipping auto-reply: silent token or no text/media returned from resolver
          ← zero [TYPING] sendComposing entries ✓

# Run 2 — @mention, replied
15:34:57  embedded run start
15:34:59  embedded run tool start: tool=web_search
15:35:04  Skipping recent outbound WhatsApp echo 3EB00C…  ← message sent ✓

# Run 3 — no mention, silent
15:35:21  embedded run start
15:35:27  embedded run tool start: tool=web_search
15:35:34  Skipping auto-reply: silent token
          ← zero [TYPING] sendComposing entries ✓
```

- **Observed result:** No composing on silent unmentioned runs; normal typing indicator on @mention run.
- **Before evidence:** Historical only. Session file entry `2026-05-27T15:05:58.321Z`: `TEXT block[1]` (no `thought: true`) is `'<think>The system prompt dictates…</think><final>NO_REPLY</final>'`. `isRenderableText("<think>") = true`. Log shows `[TYPING] sendComposing → 120363406415684625@g.us` followed by `Skipping auto-reply: silent token`.
- **What was not tested:** Live before-state (model behavior changed — see above). Other channels (change is WhatsApp-only).
- **Proof limitations:** Cannot demonstrate Cause 2 before/after live today. The after-fix proof demonstrates correct composing behavior across the three affected scenarios.

---

## Tests and validation

```
pnpm test extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch
pnpm test extensions/whatsapp
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json
```

All pass.

**What regression coverage was added or updated?**

`inbound-dispatch.test.ts`: the test `"honors automatic visible replies for WhatsApp groups"` previously asserted `suppressTyping: false` for an unmentioned `automatic`-delivery group run — asserting the wrong behavior. Updated to `suppressTyping: true` and renamed to `"suppresses typing for automatic-delivery unmentioned group chat"`. All other `suppressTyping` assertions (mentioned group, direct chat, authorized command) pass unchanged.

**What failed before this fix?**

The `sourceRepliesAreToolOnly` gate left all `automatic`-delivery groups exposed to spurious composing. Observed with the Gemini checkpoint described above on 2026-05-27.

---

## Risk checklist

**Did user-visible behavior change?** Yes — WhatsApp group members no longer see a typing indicator on silent unmentioned runs. On rare proactive visible replies in unmentioned groups, the typing flash is also absent (intentional tradeoff).

**Did config, environment, or migration behavior change?** No.

**Did security, auth, secrets, network, or tool execution behavior change?** No.

**What is the highest-risk area?**

Proactive visible replies in unmentioned groups arrive without a preceding typing flash. This is accepted: false indicators on every silent background run erode trust; a missing flash on a rare proactive reply is a minor UX gap.

**How is that risk mitigated?**

Authorized commands and @mention runs retain their typing indicator. Direct-chat runs are unaffected.

---

## Current review state

Ready for review.
