### PR TITLE
fix(agent-runtime): quarantine normalized tool descriptors

### DIFF
--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -222,6 +222,74 @@ describe("AgentRuntimePlan tool policy helpers", () => {
     });
   });
 
+  it("quarantines unreadable provider-normalized tools before preserving metadata", () => {
+    const tool = createParameterFreeTool("fixture__lookup_note") as AgentTool;
+    setPluginToolMeta(tool, {
+      pluginId: "bundle-mcp",
+      optional: false,
+      mcp: {
+        serverName: "fixture",
+        safeServerName: "fixture",
+        toolName: "lookup_note",
+        operation: "tool",
+      },
+    });
+    const unreadableNormalized = {
+      ...createParameterFreeTool("fuzzplugin_unreadable_normalized"),
+      parameters: normalizedParameterFreeSchema(),
+    } as unknown as AgentTool;
+    Object.defineProperty(unreadableNormalized, "name", {
+      enumerable: true,
+      get(): string {
+        throw new Error("provider normalized tool name getter exploded");
+      },
+    });
+    const healthyNormalized = {
+      ...tool,
+      parameters: normalizedParameterFreeSchema(),
+    };
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    const diagnosticTools: AgentTool[][] = [];
+    mocks.normalizeProviderToolSchemas.mockReturnValueOnce([
+      unreadableNormalized,
+      healthyNormalized,
+    ]);
+
+    const result = normalizeAgentRuntimeTools({
+      tools: [tool],
+      provider: "openai",
+      onPreNormalizationSchemaDiagnostics: (entries, sourceTools) => {
+        diagnostics.push([...entries]);
+        diagnosticTools.push([...sourceTools]);
+      },
+    });
+
+    expect(result).toEqual([healthyNormalized]);
+    expect(getPluginToolMeta(result[0])).toMatchObject({
+      pluginId: "bundle-mcp",
+      mcp: {
+        serverName: "fixture",
+        toolName: "lookup_note",
+      },
+    });
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["tool[0].name is unreadable"],
+        },
+      ],
+    ]);
+    expect(getPluginToolMeta(diagnosticTools[0]?.[0])).toMatchObject({
+      pluginId: "bundle-mcp",
+      mcp: {
+        serverName: "fixture",
+        toolName: "lookup_note",
+      },
+    });
+  });
+
   it("does not reread quarantined tools while preserving normalized metadata", () => {
     const unreadableName = {
       ...createParameterFreeTool("fuzzplugin_unreadable_name"),

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -11,6 +11,7 @@ import {
 import type { AgentTool } from "../runtime/index.js";
 import {
   filterProviderNormalizableTools,
+  filterRuntimeCompatibleTools,
   type RuntimeToolSchemaDiagnostic,
 } from "../tool-schema-projection.js";
 import type { AgentRuntimePlan } from "./types.js";
@@ -53,6 +54,15 @@ function copyRuntimeToolMetadata(source: AgentTool, target: AgentTool): void {
   copyChannelAgentToolMeta(source as never, target as never);
 }
 
+function readRuntimeToolName(tool: AgentTool): string | undefined {
+  try {
+    const name = tool.name;
+    return typeof name === "string" && name ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TResult = unknown>(
   sourceTools: AgentTool<TSchemaType, TResult>[],
   normalizedTools: AgentTool<TSchemaType, TResult>[],
@@ -60,7 +70,10 @@ function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TRes
   const sourcesByUniqueName = new Map<string, AgentTool<TSchemaType, TResult>>();
   const duplicateNames = new Set<string>();
   for (const source of sourceTools) {
-    const name = source.name;
+    const name = readRuntimeToolName(source);
+    if (!name) {
+      continue;
+    }
     if (sourcesByUniqueName.has(name)) {
       duplicateNames.add(name);
       sourcesByUniqueName.delete(name);
@@ -72,8 +85,16 @@ function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TRes
   }
   for (const [index, target] of normalizedTools.entries()) {
     const indexedSource = sourceTools[index];
+    const targetName = readRuntimeToolName(target);
+    if (!targetName) {
+      if (indexedSource) {
+        copyRuntimeToolMetadata(indexedSource, target);
+      }
+      continue;
+    }
+    const indexedSourceName = indexedSource ? readRuntimeToolName(indexedSource) : undefined;
     const source =
-      indexedSource?.name === target.name ? indexedSource : sourcesByUniqueName.get(target.name);
+      indexedSourceName === targetName ? indexedSource : sourcesByUniqueName.get(targetName);
     if (source) {
       copyRuntimeToolMetadata(source, target);
     }
@@ -112,7 +133,19 @@ export function normalizeAgentRuntimeTools<
       allowRuntimePluginLoad: params.allowProviderRuntimePluginLoad,
     });
   const normalizedTools = Array.isArray(normalized) ? normalized : normalizableTools;
-  return preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
+  const metadataPreservedTools = preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
+  const runtimeCompatibleProjection = filterRuntimeCompatibleTools(metadataPreservedTools);
+  if (runtimeCompatibleProjection.diagnostics.length > 0) {
+    params.onPreNormalizationSchemaDiagnostics?.(
+      runtimeCompatibleProjection.diagnostics,
+      metadataPreservedTools,
+    );
+  }
+  const runtimeCompatibleTools =
+    runtimeCompatibleProjection.diagnostics.length > 0
+      ? ([...runtimeCompatibleProjection.tools] as AgentTool<TSchemaType, TResult>[])
+      : metadataPreservedTools;
+  return runtimeCompatibleTools;
 }
 
 export function logAgentRuntimeToolDiagnostics(params: AgentRuntimeToolPolicyParams): void {


### PR DESCRIPTION
## Summary

- filter provider/runtime-plan normalized tools through runtime-compatible schema inspection before metadata preservation
- preserve plugin/channel metadata on normalized descriptors before quarantine diagnostics are emitted
- make runtime tool metadata preservation tolerate unreadable normalized `name` descriptors while keeping the healthy-path array identity contract

## Verification

- `node scripts/run-vitest.mjs src/agents/runtime-plan/tools.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts`
- `node_modules/.bin/oxlint src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

## Real behavior proof

Behavior addressed: provider/runtime-plan tool normalization can no longer return an unreadable or runtime-incompatible normalized descriptor that crashes metadata preservation before the assistant turn can continue.

Real environment tested: local Codex linked worktree for focused Vitest, formatting, lint, diff check, and branch autoreview; AWS Crabbox Linux for changed-gate proof.

Exact steps or command run after this patch: ran the focused Vitest command above, touched-file `oxfmt`/`oxlint`, `git diff --check`, branch autoreview, and AWS Crabbox `pnpm check:changed`.

Evidence after fix: focused Vitest passed for `src/agents/runtime-plan/tools.test.ts`; branch autoreview reported no accepted/actionable findings with `overall: patch is correct (0.86)`; AWS Crabbox run `run_7865bb3dc188` on lease `cbx_1d123e4cc6da` passed lanes `core, coreTests` with exit 0 and stopped the lease.

Observed result after fix: poisoned normalized tool descriptors are quarantined through the runtime-compatible projection path, diagnostics receive metadata-preserved normalized tools for owner attribution, and surviving healthy normalized tools keep copied plugin metadata.

What was not tested: full suite, Docker, live provider, and E2E lanes. Blacksmith Testbox was unavailable in this shell because `blacksmith auth status` reported no authenticated organization, so the broad changed proof used AWS Crabbox instead.
