### PR TITLE
Support Gemini Embedding 2 GA

### DIFF
--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -68,11 +68,11 @@ describe("Gemini embedding request helpers", () => {
       buildGeminiTextEmbeddingRequest({
         text: "hello",
         taskType: "RETRIEVAL_DOCUMENT",
-        modelPath: "models/gemini-embedding-2-preview",
+        modelPath: "models/gemini-embedding-2",
         outputDimensionality: 1536,
       }),
     ).toEqual({
-      model: "models/gemini-embedding-2-preview",
+      model: "models/gemini-embedding-2",
       content: { parts: [{ text: "hello" }] },
       taskType: "RETRIEVAL_DOCUMENT",
       outputDimensionality: 1536,
@@ -87,11 +87,11 @@ describe("Gemini embedding request helpers", () => {
           ],
         },
         taskType: "RETRIEVAL_DOCUMENT",
-        modelPath: "models/gemini-embedding-2-preview",
+        modelPath: "models/gemini-embedding-2",
         outputDimensionality: 1536,
       }),
     ).toEqual({
-      model: "models/gemini-embedding-2-preview",
+      model: "models/gemini-embedding-2",
       content: {
         parts: [
           { text: "Image file: diagram.png" },
@@ -101,31 +101,30 @@ describe("Gemini embedding request helpers", () => {
       taskType: "RETRIEVAL_DOCUMENT",
       outputDimensionality: 1536,
     });
+    expect(GEMINI_EMBEDDING_2_MODELS.has("gemini-embedding-2")).toBe(true);
     expect(GEMINI_EMBEDDING_2_MODELS.has("gemini-embedding-2-preview")).toBe(true);
+    expect(isGeminiEmbedding2Model("gemini-embedding-2")).toBe(true);
     expect(isGeminiEmbedding2Model("gemini-embedding-2-preview")).toBe(true);
     expect(isGeminiEmbedding2Model("gemini-embedding-001")).toBe(false);
     expect(isGeminiEmbedding2Model("text-embedding-004")).toBe(false);
     expect(resolveGeminiOutputDimensionality("gemini-embedding-001")).toBeUndefined();
     expect(resolveGeminiOutputDimensionality("text-embedding-004")).toBeUndefined();
-    expect(resolveGeminiOutputDimensionality("gemini-embedding-2-preview")).toBe(3072);
-    expect(resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 768)).toBe(768);
-    expect(resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 1536)).toBe(1536);
-    expect(resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 3072)).toBe(3072);
-    expect(() => resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 512)).toThrow(
-      /Invalid outputDimensionality 512/,
+    expect(resolveGeminiOutputDimensionality("gemini-embedding-2")).toBe(3072);
+    expect(resolveGeminiOutputDimensionality("gemini-embedding-2", 128)).toBe(128);
+    expect(resolveGeminiOutputDimensionality("gemini-embedding-2", 512)).toBe(512);
+    expect(resolveGeminiOutputDimensionality("gemini-embedding-2", 768)).toBe(768);
+    expect(resolveGeminiOutputDimensionality("gemini-embedding-2", 1536)).toBe(1536);
+    expect(resolveGeminiOutputDimensionality("gemini-embedding-2", 3072)).toBe(3072);
+    expect(() => resolveGeminiOutputDimensionality("gemini-embedding-2", 127)).toThrow(
+      /Invalid outputDimensionality 127/,
     );
-    expect(() => resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 1024)).toThrow(
-      /Valid values: 768, 1536, 3072/,
+    expect(() => resolveGeminiOutputDimensionality("gemini-embedding-2", 3073)).toThrow(
+      /Recommended values: 768, 1536, 3072/,
     );
-    expect(normalizeGeminiModel("models/gemini-embedding-2-preview")).toBe(
-      "gemini-embedding-2-preview",
-    );
-    expect(normalizeGeminiModel("gemini/gemini-embedding-2-preview")).toBe(
-      "gemini-embedding-2-preview",
-    );
-    expect(normalizeGeminiModel("google/gemini-embedding-2-preview")).toBe(
-      "gemini-embedding-2-preview",
-    );
+    expect(normalizeGeminiModel("models/gemini-embedding-2")).toBe("gemini-embedding-2");
+    expect(normalizeGeminiModel("gemini/gemini-embedding-2")).toBe("gemini-embedding-2");
+    expect(normalizeGeminiModel("google/gemini-embedding-2")).toBe("gemini-embedding-2");
+    expect(normalizeGeminiModel("models/gemini-embedding-2-preview")).toBe("gemini-embedding-2");
     expect(normalizeGeminiModel("")).toBe(DEFAULT_GEMINI_EMBEDDING_MODEL);
   });
 });
@@ -147,7 +146,7 @@ describe("Gemini embedding provider", () => {
       config: {} as never,
       provider: "gemini",
       remote: { apiKey: "test-key" },
-      model: "gemini-embedding-2-preview",
+      model: "gemini-embedding-2",
       outputDimensionality: 768,
       taskType: "SEMANTIC_SIMILARITY",
       fallback: "none",
@@ -179,7 +178,7 @@ describe("Gemini embedding provider", () => {
     ]);
 
     expect(requireFirstFetchInput(fetchMock)).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent",
     );
     expect(fetchJsonBody(fetchMock, 0)).toEqual({
       outputDimensionality: 768,
@@ -189,7 +188,7 @@ describe("Gemini embedding provider", () => {
     expect(fetchJsonBody(fetchMock, 1)).toEqual({
       requests: [
         {
-          model: "models/gemini-embedding-2-preview",
+          model: "models/gemini-embedding-2",
           content: {
             parts: [
               { text: "Image file: diagram.png" },
@@ -200,7 +199,7 @@ describe("Gemini embedding provider", () => {
           outputDimensionality: 768,
         },
         {
-          model: "models/gemini-embedding-2-preview",
+          model: "models/gemini-embedding-2",
           content: {
             parts: [
               { text: "Audio file: note.wav" },

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -40,6 +40,7 @@ const DEFAULT_GOOGLE_API_BASE_URL = "https://generativelanguage.googleapis.com/v
 const GEMINI_MAX_INPUT_TOKENS: Record<string, number> = {
   "text-embedding-004": 2048,
   "gemini-embedding-001": 2048,
+  "gemini-embedding-2": 8192,
   "gemini-embedding-2-preview": 8192,
 };
 
@@ -70,15 +71,17 @@ function parseGeminiAuth(apiKey: string): { headers: Record<string, string> } {
 
 type GeminiTaskType = NonNullable<MemoryEmbeddingProviderCreateOptions["taskType"]>;
 
-// --- gemini-embedding-2-preview support ---
+// --- gemini-embedding-2 support ---
 
 export const GEMINI_EMBEDDING_2_MODELS = new Set([
+  "gemini-embedding-2",
+  // The public preview id shipped before GA; keep accepting configs that used it.
   "gemini-embedding-2-preview",
-  // Add the GA model name here once released.
 ]);
 
 const GEMINI_EMBEDDING_2_DEFAULT_DIMENSIONS = 3072;
-const GEMINI_EMBEDDING_2_VALID_DIMENSIONS = [768, 1536, 3072] as const;
+const GEMINI_EMBEDDING_2_MIN_DIMENSIONS = 128;
+const GEMINI_EMBEDDING_2_MAX_DIMENSIONS = 3072;
 
 type GeminiTextPart = { text: string };
 type GeminiInlinePart = {
@@ -198,10 +201,13 @@ export function resolveGeminiOutputDimensionality(
   if (requested == null) {
     return GEMINI_EMBEDDING_2_DEFAULT_DIMENSIONS;
   }
-  const valid: readonly number[] = GEMINI_EMBEDDING_2_VALID_DIMENSIONS;
-  if (!valid.includes(requested)) {
+  if (
+    !Number.isInteger(requested) ||
+    requested < GEMINI_EMBEDDING_2_MIN_DIMENSIONS ||
+    requested > GEMINI_EMBEDDING_2_MAX_DIMENSIONS
+  ) {
     throw new Error(
-      `Invalid outputDimensionality ${requested} for ${model}. Valid values: ${valid.join(", ")}`,
+      `Invalid outputDimensionality ${requested} for ${model}. Valid range: ${GEMINI_EMBEDDING_2_MIN_DIMENSIONS}-${GEMINI_EMBEDDING_2_MAX_DIMENSIONS}. Recommended values: 768, 1536, 3072.`,
     );
   }
   return requested;
@@ -226,13 +232,15 @@ export function normalizeGeminiModel(model: string): string {
     return DEFAULT_GEMINI_EMBEDDING_MODEL;
   }
   const withoutPrefix = trimmed.replace(/^models\//, "");
-  if (withoutPrefix.startsWith("gemini/")) {
-    return withoutPrefix.slice("gemini/".length);
+  const withoutProviderPrefix = withoutPrefix.startsWith("gemini/")
+    ? withoutPrefix.slice("gemini/".length)
+    : withoutPrefix.startsWith("google/")
+      ? withoutPrefix.slice("google/".length)
+      : withoutPrefix;
+  if (withoutProviderPrefix === "gemini-embedding-2-preview") {
+    return "gemini-embedding-2";
   }
-  if (withoutPrefix.startsWith("google/")) {
-    return withoutPrefix.slice("google/".length);
-  }
-  return withoutPrefix;
+  return withoutProviderPrefix;
 }
 
 async function fetchGeminiEmbeddingPayload(params: {

--- a/extensions/google/memory-embedding-adapter.ts
+++ b/extensions/google/memory-embedding-adapter.ts
@@ -10,14 +10,12 @@ import {
   buildGeminiEmbeddingRequest,
   createGeminiEmbeddingProvider,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
+  isGeminiEmbedding2Model,
+  normalizeGeminiModel,
 } from "./embedding-provider.js";
 
 function supportsGeminiMultimodalEmbeddings(model: string): boolean {
-  const normalized = model
-    .trim()
-    .replace(/^models\//, "")
-    .replace(/^(gemini|google)\//, "");
-  return normalized === "gemini-embedding-2-preview";
+  return isGeminiEmbedding2Model(normalizeGeminiModel(model));
 }
 
 export const geminiMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {


### PR DESCRIPTION
## Summary
- add support for the GA `gemini-embedding-2` Gemini API embedding model id
- keep `gemini-embedding-2-preview` configs working by normalizing them to the GA id
- allow Gemini Embedding 2 output dimensions across the documented 128-3072 range while keeping 768/1536/3072 as recommended values
- reuse the same model normalization for multimodal embedding capability checks

## Tests
- `node scripts/run-vitest.mjs extensions/google/embedding-provider.test.ts`
- `git diff --check`
