### PR TITLE
fix(outbound): sanitize message.send arguments to prevent runtime scaffolding leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Outbound: sanitize `message.send` arguments through `stripInboundMetadata` so weak models that echo runtime delivery hints and untrusted-metadata blocks into tool arguments no longer leak internal scaffolding (chat_id, sender_id, inbound_event_kind, sender display name/phone) into real conversations on WhatsApp, Signal, Telegram, and SMS channels. (#89100)
 - Agents/TUI: keep local custom provider runs from loading plugin runtime and auth alias metadata when plugins are disabled.
 - Agents/TUI: restore in-flight TUI run switch-back behavior, keep no-policy native hook fallback available, guard vanished workspaces, and keep lightweight isolated subagents lightweight.
 - Agents/media: keep async image, music, and video generation starts from ending the Codex turn, so mixed requests can continue with summaries or other work while media renders in the background.

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -38,6 +38,7 @@ import { hasPollCreationParams } from "../../poll-params.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import { resolveFirstBoundAccountId } from "../../routing/bound-account-read.js";
 import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citation-control-markers.js";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import {
@@ -983,7 +984,9 @@ async function buildSendPayloadParts(params: {
   mergedMediaUrls.length = 0;
   mergedMediaUrls.push(...normalizedMediaUrls);
 
-  message = stripPlainTextToolCallBlocks(stripUnsupportedCitationControlMarkers(parsed.text));
+  message = stripInboundMetadata(
+    stripPlainTextToolCallBlocks(stripUnsupportedCitationControlMarkers(parsed.text)),
+  );
   actionParams.message = message;
   if (!actionParams.replyTo && parsed.replyToId) {
     actionParams.replyTo = parsed.replyToId;


### PR DESCRIPTION
## Summary

- Weak tool-calling models (MiniMax, Kimi, small Ollama models) can verbatim-echo the runtime `Delivery:` hint and `Conversation info / Sender (untrusted metadata)` JSON envelopes into `message.send` tool arguments.
- The runtime forwarded them unfiltered to channel adapters (WhatsApp, Signal, Telegram, SMS), leaking internal metadata (`chat_id`, `sender_id`, `inbound_event_kind`, sender display name/phone) into real human conversations.
- Apply the existing `stripInboundMetadata` sanitizer to outbound message text. This is the same function already used to strip these sentinel blocks from inbound prompts before they reach the model — now it also strips them from outbound tool-call arguments before they reach the channel adapter.
- If sanitisation empties the message body (model leaked only scaffolding), the existing `hasReplyPayloadContent` guard throws "send requires text or media", preventing empty-message delivery.

## Verification

- All 626 outbound tests pass (36 test files).
- All 45 strip-inbound-meta tests pass.
- Verified with real production code: `stripInboundMetadata` correctly strips the Delivery hint, Conversation info block, and Sender metadata block from a simulated leaked-scaffolding message while preserving the actual reply.

## Real behavior proof

**Behavior addressed:** Weak models echo runtime scaffolding (Delivery hint + Conversation info/Sender metadata JSON blocks) into `message.send` arguments, which are forwarded unfiltered to real chat channels.

**Environment tested:** Node 22.22.0 on Linux, pnpm test.

**Steps run after the patch:**
1. Ran `npx vitest run --config test/vitest/vitest.infra.config.ts src/infra/outbound/` (36 test files, 626 tests — all pass).
2. Called the production `stripInboundMetadata` function with a reconstructed leaked-scaffolding message:

```bash
node --import tsx --no-warnings -e "
const { stripInboundMetadata } = await import('./src/auto-reply/reply/strip-inbound-meta.ts');
const leaked = [
  'Delivery: Final assistant text is not automatically delivered in this run. Use the \`message\` tool to send user-visible output.',
  '',
  'Conversation info (untrusted metadata):',
  '\`\`\`json',
  '{',
  '  \"chat_id\": \"group:VxBYw0KQ\",',
  '  \"sender_id\": \"+447XXXXXXXXX\"',
  '}',
  '\`\`\`',
  '',
  'Sender (untrusted metadata):',
  '\`\`\`json',
  '{',
  '  \"label\": \"Bob (+447XXXXXXXXX)\",',
  '  \"id\": \"+447XXXXXXXXX\"',
  '}',
  '\`\`\`',
  '',
  'Here is the actual response you requested.',
].join('\n');
const cleaned = stripInboundMetadata(leaked);
console.log('Contains Delivery hint?', cleaned.includes('Delivery:'));
console.log('Contains Conversation info?', cleaned.includes('Conversation info'));
console.log('Contains Sender?', cleaned.includes('Sender (untrusted'));
console.log('Contains actual reply?', cleaned.includes('Here is the actual'));
console.log('Cleaned:', JSON.stringify(cleaned));
"
```

**Evidence after fix:**

```
Contains Delivery hint? false
Contains Conversation info? false
Contains Sender? false
Contains actual reply? true
Cleaned: "Here is the actual response you requested."
```

**Observed result:** All scaffolding blocks (Delivery hint, Conversation info, Sender metadata) are stripped; only the actual reply text remains for delivery.

**Not tested:** Live gateway session with MiniMax/Kimi models on WhatsApp/Signal group chats.

Closes #89100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)