### PR TITLE
fix(agent-runtime): guard provider tool diagnostics

### DIFF
--- a/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
@@ -84,4 +84,102 @@ describe("tool schema runtime diagnostics", () => {
       },
     );
   });
+
+  it("logs provider diagnostics when source tool names are unreadable", () => {
+    const unreadable = { name: "unreadable" };
+    Object.defineProperty(unreadable, "name", {
+      enumerable: true,
+      get(): string {
+        throw new Error("provider diagnostics tool name getter exploded");
+      },
+    });
+    mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([
+      {
+        toolName: "fuzzplugin_move_angles",
+        toolIndex: 0,
+        violations: ["unsupported dynamic schema"],
+      },
+    ]);
+
+    expect(() =>
+      logProviderToolSchemaDiagnostics({
+        provider: "example",
+        tools: [unreadable, { name: "healthy" }] as never,
+      }),
+    ).not.toThrow();
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema diagnostics: 1 tool for example: fuzzplugin_move_angles (1 violation)",
+      expect.objectContaining({
+        tools: ["0:tool[0]", "1:healthy"],
+      }),
+    );
+  });
+
+  it("logs provider inspection failures without throwing", () => {
+    const unreadable = { name: "unreadable" };
+    Object.defineProperty(unreadable, "name", {
+      enumerable: true,
+      get(): string {
+        throw new Error("provider diagnostics tool name getter exploded");
+      },
+    });
+    mocks.inspectProviderToolSchemasWithPlugin.mockImplementationOnce(() => {
+      throw new Error("provider inspector exploded");
+    });
+
+    expect(() =>
+      logProviderToolSchemaDiagnostics({
+        provider: "example",
+        tools: [unreadable, { name: "healthy" }] as never,
+      }),
+    ).not.toThrow();
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema diagnostics failed for example: provider inspector exploded",
+      {
+        provider: "example",
+        toolCount: 2,
+        tools: ["0:tool[0]", "1:healthy"],
+      },
+    );
+  });
+
+  it("logs provider diagnostics when diagnostic descriptors are unreadable", () => {
+    const diagnostic = { toolIndex: 0, toolName: "fuzzplugin_move_angles", violations: ["one"] };
+    Object.defineProperty(diagnostic, "toolName", {
+      enumerable: true,
+      get(): string {
+        throw new Error("provider diagnostic tool name getter exploded");
+      },
+    });
+    Object.defineProperty(diagnostic, "violations", {
+      enumerable: true,
+      get(): string[] {
+        throw new Error("provider diagnostic violations getter exploded");
+      },
+    });
+    mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([diagnostic]);
+
+    expect(() =>
+      logProviderToolSchemaDiagnostics({
+        provider: "example",
+        tools: [{ name: "healthy" }] as never,
+      }),
+    ).not.toThrow();
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema diagnostics: 1 tool for example: tool[0] (1 violation)",
+      expect.objectContaining({
+        diagnostics: [
+          {
+            index: 0,
+            tool: "tool[0]",
+            violations: ["diagnostic violations unreadable"],
+            violationCount: 1,
+          },
+        ],
+      }),
+    );
+  });
 });

--- a/src/agents/embedded-agent-runner/tool-schema-runtime.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.ts
@@ -68,22 +68,38 @@ export function normalizeProviderToolSchemas<
  */
 export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParams): void {
   const provider = params.provider.trim();
-  const diagnostics = inspectProviderToolSchemasWithPlugin({
-    provider,
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    runtimeHandle: params.runtimeHandle,
-    allowRuntimePluginLoad: params.allowRuntimePluginLoad,
-    context: buildProviderToolSchemaContext(params, provider),
-  });
-  if (!Array.isArray(diagnostics)) {
+  let providerDiagnostics: ProviderToolSchemaDiagnostic[] | null | undefined;
+  try {
+    providerDiagnostics = inspectProviderToolSchemasWithPlugin({
+      provider,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      runtimeHandle: params.runtimeHandle,
+      allowRuntimePluginLoad: params.allowRuntimePluginLoad,
+      context: buildProviderToolSchemaContext(params, provider),
+    });
+  } catch (error) {
+    log.warn(
+      `provider tool schema diagnostics failed for ${params.provider}: ${formatError(error)}`,
+      {
+        provider: params.provider,
+        toolCount: params.tools.length,
+        tools: formatProviderToolDiagnosticNames(params.tools),
+      },
+    );
     return;
   }
-  if (diagnostics.length === 0) {
+  if (!Array.isArray(providerDiagnostics)) {
+    return;
+  }
+  if (providerDiagnostics.length === 0) {
     return;
   }
 
+  const diagnostics = providerDiagnostics.map((diagnostic) =>
+    normalizeProviderToolSchemaDiagnostic(diagnostic),
+  );
   const summary = summarizeProviderToolSchemaDiagnostics(diagnostics);
   log.warn(
     `provider tool schema diagnostics: ${diagnostics.length} ${diagnostics.length === 1 ? "tool" : "tools"} for ${params.provider}: ${summary}`,
@@ -91,7 +107,7 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
       provider: params.provider,
       toolCount: params.tools.length,
       diagnosticCount: diagnostics.length,
-      tools: params.tools.map((tool, index) => `${index}:${tool.name}`),
+      tools: formatProviderToolDiagnosticNames(params.tools),
       diagnostics: diagnostics.map((diagnostic) => ({
         index: diagnostic.toolIndex,
         tool: diagnostic.toolName,
@@ -100,6 +116,73 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
       })),
     },
   );
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatProviderToolDiagnosticName(tool: AgentTool, index: number): string {
+  try {
+    const name = tool.name;
+    return `${index}:${typeof name === "string" && name ? name : `tool[${index}]`}`;
+  } catch {
+    return `${index}:tool[${index}]`;
+  }
+}
+
+function formatProviderToolDiagnosticNames(tools: readonly AgentTool[]): string[] {
+  return tools.map((tool, index) => formatProviderToolDiagnosticName(tool, index));
+}
+
+function readProviderDiagnosticToolIndex(
+  diagnostic: ProviderToolSchemaDiagnostic,
+): number | undefined {
+  try {
+    const index = diagnostic.toolIndex;
+    return typeof index === "number" && Number.isFinite(index) ? index : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readProviderDiagnosticToolName(
+  diagnostic: ProviderToolSchemaDiagnostic,
+  toolIndex: number | undefined,
+): string {
+  try {
+    const name = diagnostic.toolName;
+    if (typeof name === "string" && name) {
+      return name;
+    }
+  } catch {
+    // Fall through to the stable index-based fallback below.
+  }
+  return toolIndex === undefined ? "unknown" : `tool[${toolIndex}]`;
+}
+
+function readProviderDiagnosticViolations(diagnostic: ProviderToolSchemaDiagnostic): string[] {
+  try {
+    const violations = diagnostic.violations;
+    return Array.isArray(violations) && violations.length > 0
+      ? violations.map((violation) =>
+          typeof violation === "string" && violation ? violation : "unknown violation",
+        )
+      : ["diagnostic violations unavailable"];
+  } catch {
+    return ["diagnostic violations unreadable"];
+  }
+}
+
+function normalizeProviderToolSchemaDiagnostic(
+  diagnostic: ProviderToolSchemaDiagnostic,
+): ProviderToolSchemaDiagnostic {
+  const toolIndex = readProviderDiagnosticToolIndex(diagnostic);
+  return {
+    toolName: readProviderDiagnosticToolName(diagnostic, toolIndex),
+    ...(toolIndex !== undefined ? { toolIndex } : {}),
+    violations: readProviderDiagnosticViolations(diagnostic),
+  };
 }
 
 function summarizeProviderToolSchemaDiagnostics(


### PR DESCRIPTION
## Summary

- guard provider tool-schema diagnostics logging against unreadable source tool names
- normalize provider diagnostic descriptors before summary/log payload construction
- catch provider inspection failures so non-critical diagnostics cannot abort the run path

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-schema-runtime.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`
- `node_modules/.bin/oxlint src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: provider tool-schema diagnostic logging no longer crashes while trying to warn about bad tool schemas when source tool names, provider diagnostic fields, or the provider inspector itself throw.

Real environment tested: local Codex linked worktree for focused Vitest, formatting, lint, diff check, and branch autoreview; AWS Crabbox Linux attempted for changed-gate proof.

Exact steps or command run after this patch: ran the focused Vitest command above, touched-file `oxfmt`/`oxlint`, `git diff --check`, branch autoreview, and AWS Crabbox `pnpm check:changed`.

Evidence after fix: focused Vitest passed for `src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`; branch autoreview reported no accepted/actionable findings with `overall: patch is correct (0.86)`.

Observed result after fix: diagnostics logging emits bounded warnings with stable `tool[index]` fallbacks instead of throwing from descriptor getters or provider inspection failures.

What was not tested: full suite, Docker, live provider, and E2E lanes. AWS Crabbox `pnpm check:changed` was attempted twice, but both runs failed in unrelated `src/agents/provider-auth-aliases.test.ts` core test typecheck on current `main`; touched-file proof and core production typecheck completed before that unrelated failure. Blacksmith Testbox was unavailable because `blacksmith auth status` reported no authenticated organization.
