### PR TITLE
Suppress internal agent failure traces before channel delivery

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2504,7 +2504,7 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 
-  it("delivers tool warning finals when no recovered reply is available", async () => {
+  it("suppresses pure tool warning finals when no recovered reply is available", async () => {
     const draftStream = createMockDraftStreamForTest();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply(createNonTerminalToolWarningPayload());
@@ -2519,18 +2519,10 @@ describe("processDiscordMessage draft streaming", () => {
 
     expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
-    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
-    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
-      replies: [
-        {
-          text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
-          isError: true,
-        },
-      ],
-    });
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 
-  it("delivers tool warning finals when the recovered reply fails to send", async () => {
+  it("suppresses tool warning finals when the recovered reply fails to send", async () => {
     deliverDiscordReply.mockRejectedValueOnce(new Error("send failed"));
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "delivery failed" });
@@ -2549,21 +2541,13 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expect(deliverDiscordReply).toHaveBeenCalledTimes(2);
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
     expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
       replies: [{ text: "delivery failed" }],
     });
-    expect(deliverDiscordReply.mock.calls[1]?.[0]).toMatchObject({
-      replies: [
-        {
-          text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
-          isError: true,
-        },
-      ],
-    });
   });
 
-  it("keeps mutating tool warning finals after successful-looking replies", async () => {
+  it("suppresses mutating tool warning finals after successful-looking replies", async () => {
     const draftStream = createMockDraftStreamForTest();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "Done." });
@@ -2582,15 +2566,7 @@ describe("processDiscordMessage draft streaming", () => {
 
     expectPreviewEditContent("Done.");
     expect(draftStream.clear).not.toHaveBeenCalled();
-    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
-    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
-      replies: [
-        {
-          text: "⚠️ 🛠️ `write file (agent)` failed",
-          isError: true,
-        },
-      ],
-    });
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 
   it("suppresses reasoning payload delivery to Discord", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -66,6 +66,7 @@ import { createDiscordDraftPreviewController } from "./message-handler.draft-pre
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
 import { resolveForwardedMediaList, resolveMediaList } from "./message-utils.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
+import { sanitizeDiscordFrontChannelReplyPayloads } from "./reply-safety.js";
 import { createDiscordReplyTypingFeedback } from "./reply-typing-feedback.js";
 import {
   DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
@@ -111,7 +112,10 @@ function isFallbackOnlyToolWarningFinal(payload: ReplyPayload): boolean {
   return !resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 
-type DiscordReplySkipReason = "aborted before delivery" | "reasoning payload";
+type DiscordReplySkipReason =
+  | "aborted before delivery"
+  | "reasoning payload"
+  | "internal-only payload";
 
 export function formatDiscordReplySkip(params: {
   kind: "tool" | "block" | "final";
@@ -669,10 +673,24 @@ async function processDiscordMessageInner(
           })
         : payload.text;
     const effectivePayload = finalText !== payload.text ? { ...payload, text: finalText } : payload;
+    const [deliverablePayload] = sanitizeDiscordFrontChannelReplyPayloads([effectivePayload], {
+      kind: info.kind,
+    });
+    if (!deliverablePayload) {
+      logVerbose(
+        formatDiscordReplySkip({
+          kind: info.kind,
+          reason: "internal-only payload",
+          target: deliverTarget,
+          sessionKey: ctxPayload.SessionKey,
+        }),
+      );
+      return { visibleReplySent: false };
+    }
     const draftStream = draftPreview.draftStream;
     if (draftStream && draftPreview.isProgressMode && info.kind === "block") {
-      const reply = resolveSendableOutboundReplyParts(effectivePayload);
-      if (!reply.hasMedia && !payload.isError) {
+      const reply = resolveSendableOutboundReplyParts(deliverablePayload);
+      if (!reply.hasMedia && !deliverablePayload.isError) {
         return { visibleReplySent: false };
       }
     }
@@ -680,22 +698,22 @@ async function processDiscordMessageInner(
       draftStream &&
       isFinal &&
       (!draftPreview.isProgressMode || draftPreview.hasProgressDraftStarted) &&
-      !payload.isError;
+      !deliverablePayload.isError;
     if (shouldFinalizeDraftPreview) {
-      const reply = resolveSendableOutboundReplyParts(effectivePayload);
+      const reply = resolveSendableOutboundReplyParts(deliverablePayload);
       const hasMedia = reply.hasMedia;
-      const ttsSupplement = getReplyPayloadTtsSupplement(effectivePayload);
-      const previewSourceText = finalText ?? ttsSupplement?.spokenText;
+      const ttsSupplement = getReplyPayloadTtsSupplement(deliverablePayload);
+      const previewSourceText = deliverablePayload.text ?? ttsSupplement?.spokenText;
       const previewFinalText = draftPreview.resolvePreviewFinalText(previewSourceText);
       const previewReplyToId = replyReference.peek();
       const hasExplicitReplyDirective =
-        Boolean(effectivePayload.replyToTag || effectivePayload.replyToCurrent) ||
+        Boolean(deliverablePayload.replyToTag || deliverablePayload.replyToCurrent) ||
         (typeof previewSourceText === "string" &&
           /\[\[\s*reply_to(?:_current|\s*:)/i.test(previewSourceText));
 
       const result = await deliverWithFinalizableLivePreviewAdapter({
         kind: info.kind,
-        payload: effectivePayload,
+        payload: deliverablePayload,
         adapter: defineFinalizableLivePreviewAdapter({
           draft: {
             flush: () => draftPreview.flush(),
@@ -710,7 +728,7 @@ async function processDiscordMessageInner(
               (hasMedia && !ttsSupplement) ||
               typeof previewFinalText !== "string" ||
               hasExplicitReplyDirective ||
-              payload.isError
+              deliverablePayload.isError
             ) {
               return undefined;
             }
@@ -747,7 +765,7 @@ async function processDiscordMessageInner(
             replyReference.markSent();
           },
           buildSupplementalPayload: () =>
-            ttsSupplement ? buildTtsSupplementMediaPayload(effectivePayload) : undefined,
+            ttsSupplement ? buildTtsSupplementMediaPayload(deliverablePayload) : undefined,
           deliverSupplemental: async (supplementalPayload) => {
             if (isProcessAborted(abortSignal)) {
               return false;
@@ -794,9 +812,9 @@ async function processDiscordMessageInner(
           const fallbackPayload =
             ttsSupplement &&
             ttsSupplement.visibleTextAlreadyDelivered !== true &&
-            !effectivePayload.text?.trim()
-              ? { ...effectivePayload, text: ttsSupplement.spokenText }
-              : effectivePayload;
+            !deliverablePayload.text?.trim()
+              ? { ...deliverablePayload, text: ttsSupplement.spokenText }
+              : deliverablePayload;
           const replyToId = replyReference.use();
           notifyFinalReplyStart();
           await deliverDiscordReply({
@@ -849,7 +867,7 @@ async function processDiscordMessageInner(
     }
     await deliverDiscordReply({
       cfg,
-      replies: [effectivePayload],
+      replies: [deliverablePayload],
       target: deliverTarget,
       token,
       accountId,
@@ -867,7 +885,7 @@ async function processDiscordMessageInner(
       kind: info.kind,
     });
     replyReference.markSent();
-    if (isFinal && payload.isError !== true) {
+    if (isFinal && deliverablePayload.isError !== true) {
       markUserFacingFinalDelivered();
     }
     return { visibleReplySent: true };

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -625,7 +625,7 @@ async function processDiscordMessageInner(
   ) => {
     if (isProcessAborted(abortSignal)) {
       // Surface so operators don't chase missing replies when an abort
-      // drops a model-produced text payload (see PR for the incident).
+      // drops a model-produced text payload.
       logVerbose(
         formatDiscordReplySkip({
           kind: info.kind,

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -183,6 +183,7 @@ describe("deliverDiscordReply", () => {
           text: [
             "📊 Session Status: current",
             "🛠️ run git status",
+            "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
             "🛠️ `gh pr view`",
             "🛠️ `docker compose up`",
             "🛠️ elevated · `cd /tmp && pnpm test`",
@@ -202,6 +203,26 @@ describe("deliverDiscordReply", () => {
     });
 
     expect(firstDeliverParams().payloads).toEqual([{ text: "Visible reply." }]);
+  });
+
+  it("drops pure internal tool failure warnings at the final Discord send boundary", async () => {
+    await deliverDiscordReply({
+      replies: [
+        {
+          text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+          isError: true,
+        },
+      ],
+      target: "channel:101",
+      token: "token",
+      accountId: "default",
+      runtime,
+      cfg,
+      textLimit: 2000,
+      kind: "final",
+    });
+
+    expect(sendDurableMessageBatchMock).not.toHaveBeenCalled();
   });
 
   it("strips serialized tool call blocks at the final Discord send boundary", async () => {
@@ -243,7 +264,7 @@ describe("deliverDiscordReply", () => {
     await deliverDiscordReply({
       replies: [
         {
-          text: "commentary: calling tool\nanalysis: inspect private state",
+          text: "tool_call: calling tool\ntool_result: inspect private state",
           mediaUrl: "https://example.com/result.png",
         },
       ],
@@ -283,7 +304,7 @@ describe("deliverDiscordReply", () => {
     await deliverDiscordReply({
       replies: [
         {
-          text: "analysis: internal only",
+          text: "tool_result: internal only",
           channelData,
         },
       ],
@@ -313,7 +334,7 @@ describe("deliverDiscordReply", () => {
     await deliverDiscordReply({
       replies: [
         {
-          text: "commentary: hidden",
+          text: "function_call: hidden",
           presentation,
         },
       ],

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -176,6 +176,33 @@ describe("deliverDiscordReply", () => {
     );
   });
 
+  it("strips assistant scaffolding from explicit tool progress payloads", async () => {
+    await deliverDiscordReply({
+      replies: [
+        {
+          text: [
+            "<think>private reasoning</think>",
+            '<tool_call>{"name":"x"}</tool_call>',
+            "🛠️ run git status",
+          ].join("\n"),
+        },
+      ],
+      target: "channel:101",
+      token: "token",
+      accountId: "default",
+      runtime,
+      cfg,
+      textLimit: 2000,
+      kind: "tool",
+    });
+
+    expect(sendDurableMessageBatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [{ text: "🛠️ run git status" }],
+      }),
+    );
+  });
+
   it("strips internal execution trace lines at the final Discord send boundary", async () => {
     await deliverDiscordReply({
       replies: [

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -264,7 +264,7 @@ describe("deliverDiscordReply", () => {
     await deliverDiscordReply({
       replies: [
         {
-          text: "tool_call: calling tool\ntool_result: inspect private state",
+          text: "commentary: calling tool\nanalysis: inspect private state",
           mediaUrl: "https://example.com/result.png",
         },
       ],
@@ -304,7 +304,7 @@ describe("deliverDiscordReply", () => {
     await deliverDiscordReply({
       replies: [
         {
-          text: "tool_result: internal only",
+          text: "analysis: internal only",
           channelData,
         },
       ],
@@ -334,7 +334,7 @@ describe("deliverDiscordReply", () => {
     await deliverDiscordReply({
       replies: [
         {
-          text: "function_call: hidden",
+          text: "commentary: hidden",
           presentation,
         },
       ],

--- a/extensions/discord/src/monitor/reply-safety.ts
+++ b/extensions/discord/src/monitor/reply-safety.ts
@@ -1,6 +1,9 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
+import {
+  sanitizeAssistantVisibleText,
+  sanitizeAssistantVisibleTextWithProfile,
+} from "openclaw/plugin-sdk/text-chunking";
 import { stripPlainTextToolCallBlocks } from "openclaw/plugin-sdk/tool-payload";
 
 const DISCORD_INTERNAL_CHANNEL_LINE_RE =
@@ -71,7 +74,9 @@ export function sanitizeDiscordFrontChannelReplyPayloads(
     const safeText =
       typeof payload.text === "string"
         ? preserveVerboseToolProgress
-          ? collapseExcessBlankLines(payload.text).trim()
+          ? collapseExcessBlankLines(
+              sanitizeAssistantVisibleTextWithProfile(payload.text, "tool-progress"),
+            ).trim()
           : sanitizeDiscordFrontChannelText(payload.text)
         : payload.text;
     const nextPayload =

--- a/extensions/discord/src/monitor/reply-safety.ts
+++ b/extensions/discord/src/monitor/reply-safety.ts
@@ -3,6 +3,9 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { stripPlainTextToolCallBlocks } from "openclaw/plugin-sdk/tool-payload";
 
+const DISCORD_INTERNAL_CHANNEL_LINE_RE =
+  /^(?:>\s*)?(?:analysis|commentary|thinking|reasoning)\s*[:=]/i;
+
 function hasNonEmptyRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(
     value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length > 0,
@@ -33,11 +36,29 @@ function collapseExcessBlankLines(text: string): string {
   return text.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n");
 }
 
+function stripDiscordInternalChannelLines(text: string): string {
+  let inFence = false;
+  const kept: string[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      kept.push(line);
+      continue;
+    }
+    if (!inFence && DISCORD_INTERNAL_CHANNEL_LINE_RE.test(line.trim())) {
+      continue;
+    }
+    kept.push(line);
+  }
+  return kept.join("\n");
+}
+
 export function sanitizeDiscordFrontChannelText(text: string): string {
   const withoutToolCallBlocks = stripPlainTextToolCallBlocks(text);
   const withoutAssistantScaffolding = sanitizeAssistantVisibleText(withoutToolCallBlocks);
   const withoutResidualToolCallBlocks = stripPlainTextToolCallBlocks(withoutAssistantScaffolding);
-  return collapseExcessBlankLines(withoutResidualToolCallBlocks).trim();
+  const withoutChannelLines = stripDiscordInternalChannelLines(withoutResidualToolCallBlocks);
+  return collapseExcessBlankLines(withoutChannelLines).trim();
 }
 
 export function sanitizeDiscordFrontChannelReplyPayloads(

--- a/extensions/discord/src/monitor/reply-safety.ts
+++ b/extensions/discord/src/monitor/reply-safety.ts
@@ -3,13 +3,6 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { stripPlainTextToolCallBlocks } from "openclaw/plugin-sdk/tool-payload";
 
-const DISCORD_INTERNAL_TRACE_LINE_RE =
-  /^(?:>\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️)\s*(?:Session Status|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
-const DISCORD_INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE =
-  /^(?:>\s*)?🛠️\s*(?:(?:(?:elevated|pty)\b\s*(?:·|,)\s*)+)?(?:`{1,2}\s*\S|(?:run|check|fetch|pull|push|view|show|list|switch|create|merge|rebase|stage|restore|reset|stash|search|find|print|copy|move|remove|install|start|cd|git|pnpm|npm|yarn|bun|node|python|python3|bash|sh)\b)/i;
-const DISCORD_INTERNAL_CHANNEL_LINE_RE =
-  /^(?:>\s*)?(?:analysis|commentary|tool[-_ ]?call|tool[-_ ]?result|function[-_ ]?call|thinking|reasoning)\s*[:=]/i;
-
 function hasNonEmptyRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(
     value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length > 0,
@@ -36,30 +29,6 @@ function hasNonTextReplyPayloadContent(payload: ReplyPayload): boolean {
   );
 }
 
-function stripDiscordInternalTraceLines(text: string): string {
-  let inFence = false;
-  const kept: string[] = [];
-  for (const line of text.split(/\r?\n/)) {
-    if (/^\s*```/.test(line)) {
-      inFence = !inFence;
-      kept.push(line);
-      continue;
-    }
-    if (!inFence) {
-      const trimmed = line.trim();
-      if (
-        DISCORD_INTERNAL_TRACE_LINE_RE.test(trimmed) ||
-        DISCORD_INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE.test(trimmed) ||
-        DISCORD_INTERNAL_CHANNEL_LINE_RE.test(trimmed)
-      ) {
-        continue;
-      }
-    }
-    kept.push(line);
-  }
-  return kept.join("\n");
-}
-
 function collapseExcessBlankLines(text: string): string {
   return text.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n");
 }
@@ -68,8 +37,7 @@ export function sanitizeDiscordFrontChannelText(text: string): string {
   const withoutToolCallBlocks = stripPlainTextToolCallBlocks(text);
   const withoutAssistantScaffolding = sanitizeAssistantVisibleText(withoutToolCallBlocks);
   const withoutResidualToolCallBlocks = stripPlainTextToolCallBlocks(withoutAssistantScaffolding);
-  const withoutTraceLines = stripDiscordInternalTraceLines(withoutResidualToolCallBlocks);
-  return collapseExcessBlankLines(withoutTraceLines).trim();
+  return collapseExcessBlankLines(withoutResidualToolCallBlocks).trim();
 }
 
 export function sanitizeDiscordFrontChannelReplyPayloads(
@@ -82,7 +50,7 @@ export function sanitizeDiscordFrontChannelReplyPayloads(
     const safeText =
       typeof payload.text === "string"
         ? preserveVerboseToolProgress
-          ? collapseExcessBlankLines(sanitizeAssistantVisibleText(payload.text)).trim()
+          ? collapseExcessBlankLines(payload.text).trim()
           : sanitizeDiscordFrontChannelText(payload.text)
         : payload.text;
     const nextPayload =

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -304,6 +304,37 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Before\n\nAfter");
   });
 
+  it("strips internal tool trace warning lines from error-context delivery text", () => {
+    const input = [
+      "Visible intro.",
+      "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+      "🛠️ run git status",
+      "📖 Read: lines 1-40 from secret.md",
+      "Visible outro.",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input, { errorContext: true })).toBe(
+      "Visible intro.\nVisible outro.",
+    );
+  });
+
+  it("preserves explicit tool progress outside error-context delivery text", () => {
+    const input = "🛠️ Exec: echo queued-progress";
+
+    expect(sanitizeUserFacingText(input)).toBe(input);
+  });
+
+  it("preserves internal trace examples inside fenced code", () => {
+    const input = [
+      "Example:",
+      "```",
+      "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+      "```",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe(input);
+  });
+
   it("strips plural XML function-call wrappers before user-facing delivery", () => {
     const input = [
       "Before",

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -309,6 +309,7 @@ describe("sanitizeUserFacingText", () => {
       "Visible intro.",
       "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
       "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open --no-search-pages.jsonl /tmp/openclaw_open_unlabeled_current.json (agent) failed",
+      "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open (agent) failed: command timed out",
       "🛠️ run git status",
       "📖 Read: lines 1-40 from secret.md",
       "Visible outro.",

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -308,6 +308,7 @@ describe("sanitizeUserFacingText", () => {
     const input = [
       "Visible intro.",
       "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+      "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open --no-search-pages.jsonl /tmp/openclaw_open_unlabeled_current.json (agent) failed",
       "🛠️ run git status",
       "📖 Read: lines 1-40 from secret.md",
       "Visible outro.",

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -1,3 +1,7 @@
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalLowercaseString,
+} from "../../../packages/normalization-core/src/string-coerce.js";
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
 import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import {
@@ -11,10 +15,7 @@ import {
 } from "../../shared/assistant-error-format.js";
 import { coerceChatContentText } from "../../shared/chat-content.js";
 import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
-} from "../../../packages/normalization-core/src/string-coerce.js";
-import {
+  stripAssistantInternalTraceLines,
   stripLegacyBracketToolCallBlocks,
   stripMinimaxToolCallXml,
   stripToolCallXmlTags,
@@ -414,8 +415,11 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   // It is internal scaffolding, so drop standalone placeholder lines before delivery
   // while preserving ordinary inline mentions a user may be discussing.
   const withoutPlaceholder = stripToolCallsOmittedPlaceholderLines(withoutToolCallXml);
+  const withoutInternalTraceLines = errorContext
+    ? stripAssistantInternalTraceLines(withoutPlaceholder)
+    : withoutPlaceholder;
   const withoutToolCallBlocks = stripPlainTextToolCallBlocks(
-    stripLegacyBracketToolCallBlocks(withoutPlaceholder),
+    stripLegacyBracketToolCallBlocks(withoutInternalTraceLines),
   );
   const trimmed = withoutToolCallBlocks.trim();
   if (!trimmed) {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -830,6 +830,34 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
   });
 
+  it("strips internal tool trace warning lines on the delivery path", () => {
+    const input = [
+      "Visible intro.",
+      "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+      "🛠️ run git status",
+      "Visible outro.",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible intro.\nVisible outro.");
+  });
+
+  it("preserves internal tool trace examples inside fenced code", () => {
+    const input = [
+      "Example:",
+      "```",
+      "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+      "```",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
+  it("preserves ordinary analysis headings", () => {
+    const input = ["Analysis:", "This is user-visible reasoning about the result."].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
   it("drops malformed reasoning before orphan close tags when final text follows", () => {
     expect(sanitizeAssistantVisibleText("private chain of thought </think> Visible answer")).toBe(
       "Visible answer",

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -835,6 +835,7 @@ describe("sanitizeAssistantVisibleText", () => {
       "Visible intro.",
       "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
       "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open --no-search-pages.jsonl /tmp/openclaw_open_unlabeled_current.json (agent) failed",
+      "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open (agent) failed: command timed out",
       "🛠️ run git status",
       "Visible outro.",
     ].join("\n");
@@ -903,6 +904,18 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
 
     expect(sanitizeAssistantVisibleTextWithProfile(input, "internal-scaffolding")).toContain(
       "[Tool Call: read (ID: toolu_1)]",
+    );
+  });
+
+  it("uses the tool-progress profile to strip scaffolding while preserving progress lines", () => {
+    const input = [
+      "<think>private reasoning</think>",
+      '<tool_call>{"name":"x"}</tool_call>',
+      "🛠️ run git status",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleTextWithProfile(input, "tool-progress")).toBe(
+      "🛠️ run git status",
     );
   });
 });

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -834,6 +834,7 @@ describe("sanitizeAssistantVisibleText", () => {
     const input = [
       "Visible intro.",
       "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+      "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open --no-search-pages.jsonl /tmp/openclaw_open_unlabeled_current.json (agent) failed",
       "🛠️ run git status",
       "Visible outro.",
     ].join("\n");

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -11,6 +11,14 @@ import {
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
 const LEGACY_BRACKET_TOOL_BLOCK_QUICK_RE = /\[\s*\/?\s*TOOL_(?:CALL|RESULT)\s*\]/i;
+const INTERNAL_TRACE_LINE_QUICK_RE =
+  /(?:📊|🛠️|📖|📝|🔍|🔎|⚙️|tool[-_ ]?call|tool[-_ ]?result|function[-_ ]?call)/i;
+const INTERNAL_TRACE_LINE_RE =
+  /^(?:>\s*)?(?:⚠️\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️)\s*(?:Session Status|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
+const INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE =
+  /^(?:>\s*)?(?:⚠️\s*)?🛠️\s*(?:(?:(?:elevated|pty)\b\s*(?:·|,)\s*)+)?(?:`{1,2}\s*\S|(?:run|check|fetch|pull|push|view|show|list|switch|create|merge|rebase|stage|restore|reset|stash|search|find|print|copy|move|remove|install|start|cd|git|pnpm|npm|yarn|bun|node|python|python3|bash|sh)\b)/i;
+const INTERNAL_CHANNEL_TRACE_LINE_RE =
+  /^(?:>\s*)?(?:tool[-_ ]?call|tool[-_ ]?result|function[-_ ]?call)\s*[:=]/i;
 
 /**
  * Strip XML-style tool call tags that models sometimes emit as plain text.
@@ -760,6 +768,33 @@ function stripRelevantMemoriesTags(text: string): string {
   return result;
 }
 
+export function stripAssistantInternalTraceLines(text: string): string {
+  if (!text || !INTERNAL_TRACE_LINE_QUICK_RE.test(text)) {
+    return text;
+  }
+
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let lineStart = 0;
+  while (lineStart < text.length) {
+    const newlineIndex = text.indexOf("\n", lineStart);
+    const lineEnd = newlineIndex === -1 ? text.length : newlineIndex + 1;
+    const rawLine = text.slice(lineStart, lineEnd);
+    const line = rawLine.endsWith("\n") ? rawLine.slice(0, -1).replace(/\r$/, "") : rawLine;
+    const trimmed = line.trim();
+    const shouldStrip =
+      !isInsideCode(lineStart, codeRegions) &&
+      (INTERNAL_TRACE_LINE_RE.test(trimmed) ||
+        INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE.test(trimmed) ||
+        INTERNAL_CHANNEL_TRACE_LINE_RE.test(trimmed));
+    if (!shouldStrip) {
+      result += rawLine;
+    }
+    lineStart = lineEnd;
+  }
+  return result;
+}
+
 export type AssistantVisibleTextSanitizerProfile = "delivery" | "history" | "internal-scaffolding";
 
 type AssistantVisibleTextPipelineOptions = {
@@ -833,6 +868,7 @@ function applyAssistantVisibleTextStagePipeline(
       stripFunctionCallsXmlPayloads: options.stripFunctionCallsXmlPayloads,
       stripFunctionResponseAfterPluralToolCalls: options.stripFunctionResponseAfterPluralToolCalls,
     });
+    cleaned = stripAssistantInternalTraceLines(cleaned);
     cleaned = stripLegacyBracketToolCallBlocks(cleaned);
     cleaned = stripPlainTextToolCallBlocks(cleaned);
     if (!options.preserveDowngradedToolText) {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -16,7 +16,7 @@ const INTERNAL_TRACE_LINE_QUICK_RE =
 const INTERNAL_TRACE_LINE_RE =
   /^(?:>\s*)?(?:⚠️\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️)\s*(?:Session Status|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
 const INTERNAL_COMPACT_FAILURE_TRACE_LINE_RE =
-  /^(?:>\s*)?⚠️\s*🛠️\s+\S[\s\S]*\s+\(agent\)`{0,2}\s+failed\s*$/i;
+  /^(?:>\s*)?⚠️\s*🛠️\s+\S[\s\S]*\s+\(agent\)`{0,2}\s+failed(?:\s*:.*)?\s*$/i;
 const INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE =
   /^(?:>\s*)?🛠️\s*(?:(?:(?:elevated|pty)\b\s*(?:·|,)\s*)+)?(?:`{1,2}\s*\S|(?:run|check|fetch|pull|push|view|show|list|switch|create|merge|rebase|stage|restore|reset|stash|search|find|print|copy|move|remove|install|start|cd|git|pnpm|npm|yarn|bun|node|python|python3|bash|sh)\b)/i;
 const INTERNAL_CHANNEL_TRACE_LINE_RE =
@@ -798,7 +798,11 @@ export function stripAssistantInternalTraceLines(text: string): string {
   return result;
 }
 
-export type AssistantVisibleTextSanitizerProfile = "delivery" | "history" | "internal-scaffolding";
+export type AssistantVisibleTextSanitizerProfile =
+  | "delivery"
+  | "history"
+  | "internal-scaffolding"
+  | "tool-progress";
 
 type AssistantVisibleTextPipelineOptions = {
   finalTrim: ReasoningTagTrim;
@@ -806,6 +810,7 @@ type AssistantVisibleTextPipelineOptions = {
   preserveMinimaxToolXml?: boolean;
   stripFunctionCallsXmlPayloads?: boolean;
   stripFunctionResponseAfterPluralToolCalls?: boolean;
+  stripInternalTraceLines?: boolean;
   reasoningMode: ReasoningTagMode;
   reasoningTrim: ReasoningTagTrim;
   stageOrder: "reasoning-first" | "reasoning-last";
@@ -835,6 +840,14 @@ const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
     reasoningMode: "preserve",
     reasoningTrim: "start",
     stageOrder: "reasoning-first",
+  },
+  "tool-progress": {
+    finalTrim: "both",
+    stripFunctionCallsXmlPayloads: true,
+    stripInternalTraceLines: false,
+    reasoningMode: "strict",
+    reasoningTrim: "both",
+    stageOrder: "reasoning-last",
   },
 };
 
@@ -871,7 +884,9 @@ function applyAssistantVisibleTextStagePipeline(
       stripFunctionCallsXmlPayloads: options.stripFunctionCallsXmlPayloads,
       stripFunctionResponseAfterPluralToolCalls: options.stripFunctionResponseAfterPluralToolCalls,
     });
-    cleaned = stripAssistantInternalTraceLines(cleaned);
+    if (options.stripInternalTraceLines !== false) {
+      cleaned = stripAssistantInternalTraceLines(cleaned);
+    }
     cleaned = stripLegacyBracketToolCallBlocks(cleaned);
     cleaned = stripPlainTextToolCallBlocks(cleaned);
     if (!options.preserveDowngradedToolText) {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -15,8 +15,10 @@ const INTERNAL_TRACE_LINE_QUICK_RE =
   /(?:📊|🛠️|📖|📝|🔍|🔎|⚙️|tool[-_ ]?call|tool[-_ ]?result|function[-_ ]?call)/i;
 const INTERNAL_TRACE_LINE_RE =
   /^(?:>\s*)?(?:⚠️\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️)\s*(?:Session Status|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
+const INTERNAL_COMPACT_FAILURE_TRACE_LINE_RE =
+  /^(?:>\s*)?⚠️\s*🛠️\s+\S[\s\S]*\s+\(agent\)`{0,2}\s+failed\s*$/i;
 const INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE =
-  /^(?:>\s*)?(?:⚠️\s*)?🛠️\s*(?:(?:(?:elevated|pty)\b\s*(?:·|,)\s*)+)?(?:`{1,2}\s*\S|(?:run|check|fetch|pull|push|view|show|list|switch|create|merge|rebase|stage|restore|reset|stash|search|find|print|copy|move|remove|install|start|cd|git|pnpm|npm|yarn|bun|node|python|python3|bash|sh)\b)/i;
+  /^(?:>\s*)?🛠️\s*(?:(?:(?:elevated|pty)\b\s*(?:·|,)\s*)+)?(?:`{1,2}\s*\S|(?:run|check|fetch|pull|push|view|show|list|switch|create|merge|rebase|stage|restore|reset|stash|search|find|print|copy|move|remove|install|start|cd|git|pnpm|npm|yarn|bun|node|python|python3|bash|sh)\b)/i;
 const INTERNAL_CHANNEL_TRACE_LINE_RE =
   /^(?:>\s*)?(?:tool[-_ ]?call|tool[-_ ]?result|function[-_ ]?call)\s*[:=]/i;
 
@@ -785,6 +787,7 @@ export function stripAssistantInternalTraceLines(text: string): string {
     const shouldStrip =
       !isInsideCode(lineStart, codeRegions) &&
       (INTERNAL_TRACE_LINE_RE.test(trimmed) ||
+        INTERNAL_COMPACT_FAILURE_TRACE_LINE_RE.test(trimmed) ||
         INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE.test(trimmed) ||
         INTERNAL_CHANNEL_TRACE_LINE_RE.test(trimmed));
     if (!shouldStrip) {


### PR DESCRIPTION
## Summary

- Move internal agent/tool trace-line stripping into the shared assistant-visible text sanitizer so non-Discord delivery users get the same suppression for failed-tool payloads.
- Preserve Discord's stricter send-boundary guard for plain internal channel labels such as `analysis:`, `commentary:`, `thinking:`, and `reasoning:`.
- Strip trace-only error-context payloads before user-facing delivery while preserving explicit tool-progress payloads and non-text Discord payloads.

## Verification

- `node scripts/run-vitest.mjs src/shared/text/assistant-visible-text.test.ts src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts extensions/discord/src/monitor/reply-delivery.test.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts -t "tool progress"`
- `git diff --check`

## Real behavior proof

Behavior addressed: Internal agent/tool failure trace lines such as `⚠️ 🛠️ \`run ... (agent)\` failed` are no longer delivered as user-visible Discord messages when they are the only final text. Discord delivery also continues to suppress plain internal channel-label lines such as `analysis:` and `commentary:` while still sending media, channelData, and presentation payloads when their text scrubs empty.

Real environment tested: Local OpenClaw source checkout on current `origin/main` plus real Discord archive evidence from a redacted OpenClaw Discord channel. Discrawl status reported the archive current at `2026-06-01T15:48:21Z` with 1,478,897 messages; the leaked Discord rows below are from May 20-25, 2026. Discord channel names, author identifiers, guild identifiers, channel identifiers, and message identifiers are intentionally redacted from the public PR text.

Exact steps or command run after this patch: Queried the Discord archive for real leaked messages with redacted presentation fields, then invoked the patched Discord sanitizer directly with the same visible failure shape:

```bash
DISCRAWL_NO_AUTO_UPDATE=1 discrawl --json sql "select m.created_at, '<redacted-discord-channel>' as channel, '<redacted-discord-bot>' as author, m.content from messages m where m.content like '%⚠️ 🛠️%' and m.created_at >= '2026-05-20' order by m.created_at desc limit 2;"
node_modules/.bin/tsx -e 'import { sanitizeDiscordFrontChannelReplyPayloads } from "./extensions/discord/src/monitor/reply-safety.ts"; const samples = [{ text: "⚠️ 🛠️ `run python3 inline script (heredoc) (agent)` failed" }, { text: "commentary: calling tool\nanalysis: inspect private state", mediaUrl: "https://example.com/result.png" }]; console.log(JSON.stringify(sanitizeDiscordFrontChannelReplyPayloads(samples, { kind: "final" }), null, 2));'
```

Before evidence: Copied live Discord archive output shows the actual leaked user-visible messages this PR targets, with channel and author identifiers redacted:

```json
{
  "columns": ["created_at", "channel", "author", "content"],
  "rows": [
    [
      "2026-05-25T17:42:52.029Z",
      "<redacted-discord-channel>",
      "<redacted-discord-bot>",
      "⚠️ 🛠️ `run python3 inline script (heredoc) (agent)` failed"
    ],
    [
      "2026-05-25T17:01:58.578Z",
      "<redacted-discord-channel>",
      "<redacted-discord-bot>",
      "⚠️ 🛠️ `pkill -f \"gh pr view\" || true (agent)` failed"
    ]
  ]
}
```

Evidence after fix: The patched Discord sanitizer drops the text-only leaked failure payload and preserves only the media payload after stripping its internal `commentary:`/`analysis:` text:

```json
[
  {
    "mediaUrl": "https://example.com/result.png"
  }
]
```

Observed result after fix: The text-only leaked failure message produced no deliverable Discord payload. The media sample remained deliverable, but the internal channel-label text was removed. Focused sanitizer and Discord tests also passed, including the process test that suppresses warning-only final replies instead of sending them.

What was not tested: A deployed live Discord gateway running this exact branch was not exercised. The proof combines copied output from real Discord archive rows, with public identifiers redacted, and direct execution of the patched Discord send-boundary sanitizer in a local source checkout.
