### PR TITLE
docs(contributing): add pnpm check:test-types to pre-PR checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,7 @@ For coordinated change sets that genuinely need more than 20 PRs, join the **#cl
 - Keep PRs takeover-ready: open them from a branch maintainers can push to. For fork PRs, leave GitHub's **Allow edits by maintainers** option enabled so maintainers can finish urgent fixes, changelog entries, or merge prep when needed. If GitHub shows **Allow edits and access to secrets by maintainers**, enable it only when that workflow/secrets access is acceptable and say so in the PR.
 - Do not edit `CHANGELOG.md` in contributor PRs. Maintainers or ClawSweeper add the changelog entry when landing user-facing changes.
 - Run tests: `pnpm build && pnpm check && pnpm test`
+- If you added or changed test files, also run `pnpm check:test-types` — `pnpm check` covers production source only and will not catch test type errors.
 - For iterative local commits, `scripts/committer --fast "message" <files...>` passes `FAST_COMMIT=1` through to the pre-commit hook so it skips the repo-wide `pnpm check`. Only use it when you've already run equivalent targeted validation for the touched surface.
 - For extension/plugin changes, run the fast local lane first:
   - `pnpm test:extension <extension-name>`


### PR DESCRIPTION
## Summary

- Adds a bullet to the **Before You PR** checklist in `CONTRIBUTING.md` instructing contributors to run `pnpm check:test-types` when they add or change test files.
- `pnpm check` (which the existing checklist line already calls) runs `tsgo:prod` and covers production source only — it does not type-check `*.test.ts` files.
- `pnpm check:test-types` runs `tsgo:test` and is the command CI uses to catch test-file type errors. Contributors who skip it locally will see a CI failure on the first push.
- This change documents the gap so contributors can catch it themselves before CI does.

## Linked context

Closes #

Related #

No linked issue — discovered while preparing a contributor PR where a test file had a missing type field that `pnpm check` did not catch locally but CI failed on.

## Real behavior proof

- Behavior or issue addressed: `CONTRIBUTING.md` pre-PR checklist did not mention `pnpm check:test-types`, leaving contributors unaware that test-file types are checked separately in CI.
- Real environment tested: Local checkout on macOS, `docs/contributing-check-test-types` branch.
- Exact steps or command run after this patch: Read the updated checklist; confirmed `pnpm check:test-types` is defined in `package.json` as `pnpm tsgo:test` (line 1462).
- Evidence after fix: Before/after diff of `CONTRIBUTING.md` — one bullet added under the existing `Run tests:` line.
- Observed result after fix: Checklist now directs contributors to run `pnpm check:test-types` when they add or change test files.
- What was not tested: No runtime behavior to test; docs-only change.
- Proof limitations or environment constraints: N/A.

## Tests and validation

Which commands did you run?

```
git diff --check
```

What regression coverage was added or updated?

None — docs-only change, no code or tests modified.

What failed before this fix, if known?

Contributors who added or changed test files and followed only the existing checklist would hit a CI type error on `pnpm tsgo:test` without any local warning.

If no test was added, why not?

Docs-only change.

## Risk checklist

Did user-visible behavior change? No

Did config, environment, or migration behavior change? No

Did security, auth, secrets, network, or tool execution behavior change? No

What is the highest-risk area? None — single bullet added to contributor checklist.

How is that risk mitigated? N/A.

## Current review state

Ready for review. No open items.
