### PR TITLE
refactor: route bundled plugin session callers through seam

### DIFF
--- a/extensions/discord/src/monitor/native-command-model-picker-apply.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-apply.ts
@@ -5,7 +5,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { applyModelOverrideToSessionEntry } from "openclaw/plugin-sdk/model-session-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { resolveStorePath, updateSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
+import { patchSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ButtonInteraction, StringSelectMenuInteraction } from "../internal/discord.js";
 import {
@@ -42,34 +42,39 @@ async function persistDiscordModelPickerOverride(params: {
     agentId: params.route.agentId,
   });
   let persisted = false;
-  await updateSessionStore(storePath, (store) => {
-    const entry = store[params.route.sessionKey] ?? {
+  await patchSessionEntry({
+    storePath,
+    sessionKey: params.route.sessionKey,
+    fallbackEntry: {
       sessionId: randomUUID(),
       updatedAt: Date.now(),
-    };
-    store[params.route.sessionKey] = entry;
-    persisted =
-      applyModelOverrideToSessionEntry({
-        entry,
-        selection: {
-          provider: params.provider,
-          model: params.model,
-          isDefault: params.isDefault,
-        },
-        markLiveSwitchPending: true,
-      }).updated || persisted;
-    const runtime = params.runtime?.trim();
-    if (runtime && runtime !== "auto" && runtime !== "default") {
-      if (entry.agentRuntimeOverride !== runtime) {
-        entry.agentRuntimeOverride = runtime;
+    },
+    replaceEntry: true,
+    update: (entry) => {
+      persisted =
+        applyModelOverrideToSessionEntry({
+          entry,
+          selection: {
+            provider: params.provider,
+            model: params.model,
+            isDefault: params.isDefault,
+          },
+          markLiveSwitchPending: true,
+        }).updated || persisted;
+      const runtime = params.runtime?.trim();
+      if (runtime && runtime !== "auto" && runtime !== "default") {
+        if (entry.agentRuntimeOverride !== runtime) {
+          entry.agentRuntimeOverride = runtime;
+          delete entry.agentHarnessId;
+          persisted = true;
+        }
+      } else if (runtime && entry.agentRuntimeOverride) {
+        delete entry.agentRuntimeOverride;
         delete entry.agentHarnessId;
         persisted = true;
       }
-    } else if (runtime && entry.agentRuntimeOverride) {
-      delete entry.agentRuntimeOverride;
-      delete entry.agentHarnessId;
-      persisted = true;
-    }
+      return entry;
+    },
   });
   return persisted;
 }

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -14,7 +14,7 @@ import * as globalsModule from "openclaw/plugin-sdk/runtime-env";
 import {
   loadSessionStore,
   resolveStorePath,
-  saveSessionStore,
+  upsertSessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import * as commandTextModule from "openclaw/plugin-sdk/text-utility-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -814,8 +814,10 @@ describe("Discord model picker interactions", () => {
     });
     const modelCommand = createModelCommandDefinition();
     const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
-    await saveSessionStore(storePath, {
-      "agent:worker:subagent:bound": {
+    await upsertSessionEntry({
+      storePath,
+      sessionKey: "agent:worker:subagent:bound",
+      entry: {
         updatedAt: Date.now(),
         sessionId: "bound-session",
       },
@@ -864,8 +866,10 @@ describe("Discord model picker interactions", () => {
     const pickerData = createDefaultModelPickerData();
     const modelCommand = createModelCommandDefinition();
     const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
-    await saveSessionStore(storePath, {
-      "agent:worker:subagent:bound": {
+    await upsertSessionEntry({
+      storePath,
+      sessionKey: "agent:worker:subagent:bound",
+      entry: {
         updatedAt: Date.now(),
         sessionId: "bound-session",
       },

--- a/extensions/discord/src/monitor/thread-session-close.test.ts
+++ b/extensions/discord/src/monitor/thread-session-close.test.ts
@@ -2,9 +2,10 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => {
-  const updateSessionStore = vi.fn();
+  const listSessionEntries = vi.fn();
+  const patchSessionEntry = vi.fn();
   const resolveStorePath = vi.fn(() => "/tmp/openclaw-sessions.json");
-  return { updateSessionStore, resolveStorePath };
+  return { listSessionEntries, patchSessionEntry, resolveStorePath };
 });
 
 vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
@@ -13,16 +14,37 @@ vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
   );
   return {
     ...actual,
-    updateSessionStore: hoisted.updateSessionStore,
+    listSessionEntries: hoisted.listSessionEntries,
+    patchSessionEntry: hoisted.patchSessionEntry,
     resolveStorePath: hoisted.resolveStorePath,
   };
 });
 
 let closeDiscordThreadSessions: typeof import("./thread-session-close.js").closeDiscordThreadSessions;
 
-function setupStore(store: Record<string, { updatedAt: number }>) {
-  hoisted.updateSessionStore.mockImplementation(
-    async (_storePath: string, mutator: (s: typeof store) => unknown) => mutator(store),
+function setupStore(store: Record<string, { sessionId?: string; updatedAt: number }>) {
+  hoisted.listSessionEntries.mockImplementation(() =>
+    Object.entries(store).map(([sessionKey, entry]) => ({ sessionKey, entry })),
+  );
+  hoisted.patchSessionEntry.mockImplementation(
+    async (params: {
+      sessionKey: string;
+      update: (entry: {
+        sessionId?: string;
+        updatedAt: number;
+      }) => { sessionId?: string; updatedAt: number } | null;
+    }) => {
+      const entry = store[params.sessionKey];
+      if (!entry) {
+        return null;
+      }
+      const next = params.update({ ...entry });
+      if (!next) {
+        return entry;
+      }
+      store[params.sessionKey] = next;
+      return next;
+    },
   );
 }
 
@@ -38,7 +60,8 @@ describe("closeDiscordThreadSessions", () => {
   });
 
   beforeEach(() => {
-    hoisted.updateSessionStore.mockClear();
+    hoisted.listSessionEntries.mockReset();
+    hoisted.patchSessionEntry.mockReset();
     hoisted.resolveStorePath.mockClear();
     hoisted.resolveStorePath.mockReturnValue("/tmp/openclaw-sessions.json");
   });
@@ -143,7 +166,8 @@ describe("closeDiscordThreadSessions", () => {
     });
 
     expect(count).toBe(0);
-    expect(hoisted.updateSessionStore).not.toHaveBeenCalled();
+    expect(hoisted.listSessionEntries).not.toHaveBeenCalled();
+    expect(hoisted.patchSessionEntry).not.toHaveBeenCalled();
   });
 
   it("does not recount sessions that were already reset", async () => {
@@ -162,6 +186,35 @@ describe("closeDiscordThreadSessions", () => {
     expect(count).toBe(0);
     expect(store[MATCHED_KEY].updatedAt).toBe(0);
     expect(store[UNMATCHED_KEY].updatedAt).toBe(1_700_000_000_001);
+  });
+
+  it("does not reset a matching session that changed after the list snapshot", async () => {
+    const store = {
+      [MATCHED_KEY]: {
+        sessionId: "fresh-session",
+        updatedAt: 2_000,
+      },
+    };
+    setupStore(store);
+    hoisted.listSessionEntries.mockReturnValue([
+      {
+        sessionKey: MATCHED_KEY,
+        entry: {
+          sessionId: "old-session",
+          updatedAt: 1_000,
+        },
+      },
+    ]);
+
+    const count = await closeDiscordThreadSessions({
+      cfg: {},
+      accountId: "default",
+      threadId: THREAD_ID,
+    });
+
+    expect(count).toBe(0);
+    expect(store[MATCHED_KEY].updatedAt).toBe(2_000);
+    expect(store[MATCHED_KEY].sessionId).toBe("fresh-session");
   });
 
   it("resolves the store path using cfg.session.store and accountId", async () => {

--- a/extensions/discord/src/monitor/thread-session-close.ts
+++ b/extensions/discord/src/monitor/thread-session-close.ts
@@ -1,6 +1,10 @@
 // Discord plugin module implements thread session close behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resolveStorePath, updateSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  listSessionEntries,
+  patchSessionEntry,
+  resolveStorePath,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 /**
@@ -44,21 +48,32 @@ export async function closeDiscordThreadSessions(params: {
 
   let resetCount = 0;
 
-  await updateSessionStore(storePath, (store) => {
-    for (const [key, entry] of Object.entries(store)) {
-      if (!entry || !sessionKeyContainsThreadId(key)) {
-        continue;
-      }
-      if (entry.updatedAt === 0) {
-        continue;
-      }
-      // Setting updatedAt to 0 signals that this session is stale.
-      // evaluateSessionFreshness will create a new session on the next message.
-      entry.updatedAt = 0;
+  for (const { sessionKey, entry } of listSessionEntries({ storePath })) {
+    if (!sessionKeyContainsThreadId(sessionKey) || entry.updatedAt === 0) {
+      continue;
+    }
+    // Setting updatedAt to 0 signals that this session is stale.
+    // evaluateSessionFreshness will create a new session on the next message.
+    let resetEntry = false;
+    await patchSessionEntry({
+      storePath,
+      sessionKey,
+      replaceEntry: true,
+      update: (current) => {
+        if (current.updatedAt === 0) {
+          return null;
+        }
+        if (current.updatedAt !== entry.updatedAt || current.sessionId !== entry.sessionId) {
+          return null;
+        }
+        resetEntry = true;
+        return { ...current, updatedAt: 0 };
+      },
+    });
+    if (resetEntry) {
       resetCount += 1;
     }
-    return resetCount;
-  });
+  }
 
   return resetCount;
 }

--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -15,7 +15,12 @@ import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/re
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
-import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  getSessionEntry,
+  listSessionEntries,
+  readSessionUpdatedAt,
+  resolveStorePath,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { loadSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
 import { listSkillCommandsForAgents } from "openclaw/plugin-sdk/skill-commands-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
@@ -31,6 +36,8 @@ import { wasSentByBot } from "./sent-message-cache.js";
 export type TelegramBotDeps = {
   getRuntimeConfig: typeof getRuntimeConfig;
   resolveStorePath: typeof resolveStorePath;
+  getSessionEntry?: typeof getSessionEntry;
+  listSessionEntries?: typeof listSessionEntries;
   loadSessionStore?: typeof loadSessionStore;
   readSessionUpdatedAt?: typeof readSessionUpdatedAt;
   recordInboundSession?: typeof recordInboundSession;
@@ -63,6 +70,12 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   },
   get resolveStorePath() {
     return resolveStorePath;
+  },
+  get getSessionEntry() {
+    return getSessionEntry;
+  },
+  get listSessionEntries() {
+    return listSessionEntries;
   },
   get readChannelAllowFromStore() {
     return readChannelAllowFromStore;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,4 +1,5 @@
 // Telegram plugin module implements bot handlers behavior.
+import { randomUUID } from "node:crypto";
 import type { Message, ReactionTypeEmoji } from "grammy/types";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
@@ -36,9 +37,9 @@ import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import {
-  loadSessionStore,
-  resolveSessionStoreEntry,
-  updateSessionStore,
+  getSessionEntry,
+  listSessionEntries,
+  patchSessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
@@ -666,7 +667,7 @@ export const registerTelegramHandlers = ({
     runtimeCfg?: OpenClawConfig;
   }): {
     agentId: string;
-    sessionEntry: ReturnType<typeof resolveSessionStoreEntry>["existing"];
+    sessionEntry: ReturnType<typeof getSessionEntry>;
     sessionKey: string;
     model?: string;
   } => {
@@ -708,8 +709,12 @@ export const registerTelegramHandlers = ({
     const storePath = telegramDeps.resolveStorePath(runtimeCfg.session?.store, {
       agentId: route.agentId,
     });
-    const store = (telegramDeps.loadSessionStore ?? loadSessionStore)(storePath);
-    const entry = resolveSessionStoreEntry({ store, sessionKey }).existing;
+    const entry = (telegramDeps.getSessionEntry ?? getSessionEntry)({ storePath, sessionKey });
+    const store = Object.fromEntries(
+      (telegramDeps.listSessionEntries ?? listSessionEntries)({ storePath }).map(
+        ({ sessionKey: key, entry: value }) => [key, value],
+      ),
+    );
     const storedOverride = resolveStoredModelOverride({
       sessionEntry: entry,
       sessionStore: store,
@@ -2716,18 +2721,25 @@ export const registerTelegramHandlers = ({
               selection.model === resolvedDefault.model;
 
             try {
-              await updateSessionStore(storePath, (store) => {
-                const sessionKey = sessionState.sessionKey;
-                const entry = store[sessionKey] ?? {};
-                store[sessionKey] = entry;
-                applyModelOverrideToSessionEntry({
-                  entry,
-                  selection: {
-                    provider: selection.provider,
-                    model: selection.model,
-                    isDefault: isDefaultSelection,
-                  },
-                });
+              await patchSessionEntry({
+                storePath,
+                sessionKey: sessionState.sessionKey,
+                fallbackEntry: {
+                  sessionId: randomUUID(),
+                  updatedAt: Date.now(),
+                },
+                replaceEntry: true,
+                update: (entry) => {
+                  applyModelOverrideToSessionEntry({
+                    entry,
+                    selection: {
+                      provider: selection.provider,
+                      model: selection.model,
+                      isDefault: isDefaultSelection,
+                    },
+                  });
+                  return entry;
+                },
               });
             } catch (err) {
               throw new TelegramRetryableCallbackError(err);

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -5391,8 +5391,8 @@ describe("createTelegramBot", () => {
       await dispatch(0);
     };
 
-    const updateSessionStoreSpy = vi.spyOn(sessionStoreRuntime, "updateSessionStore");
-    updateSessionStoreSpy.mockRejectedValueOnce(new Error("session store boom"));
+    const patchSessionEntrySpy = vi.spyOn(sessionStoreRuntime, "patchSessionEntry");
+    patchSessionEntrySpy.mockRejectedValueOnce(new Error("session store boom"));
 
     const ctx = {
       update: { update_id: 890 },
@@ -5414,7 +5414,7 @@ describe("createTelegramBot", () => {
       await expect(runMiddlewareChain(ctx)).rejects.toThrow("session store boom");
       await runMiddlewareChain(ctx);
     } finally {
-      updateSessionStoreSpy.mockRestore();
+      patchSessionEntrySpy.mockRestore();
     }
 
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -1,10 +1,11 @@
 // Telegram plugin module implements bot behavior.
+import { getSessionEntry, listSessionEntries } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   createTelegramBotCore,
   getTelegramSequentialKey,
   setTelegramBotRuntimeForTest,
 } from "./bot-core.js";
-import { defaultTelegramBotDeps } from "./bot-deps.js";
+import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 
 export type { TelegramBotOptions } from "./bot.types.js";
@@ -16,6 +17,39 @@ export function createTelegramBot(
 ): ReturnType<typeof createTelegramBotCore> {
   return createTelegramBotCore({
     ...opts,
-    telegramDeps: opts.telegramDeps ?? defaultTelegramBotDeps,
+    telegramDeps: withTelegramSessionAccessorDeps(opts.telegramDeps ?? defaultTelegramBotDeps),
   });
+}
+
+function withTelegramSessionAccessorDeps(deps: TelegramBotDeps): TelegramBotDeps {
+  if (!deps.loadSessionStore) {
+    return {
+      ...deps,
+      getSessionEntry: deps.getSessionEntry ?? getSessionEntry,
+      listSessionEntries: deps.listSessionEntries ?? listSessionEntries,
+    };
+  }
+
+  const listInjectedEntries = (
+    scope: Parameters<NonNullable<TelegramBotDeps["listSessionEntries"]>>[0] = {},
+  ) => {
+    const storePath =
+      scope.storePath ?? deps.resolveStorePath(undefined, { agentId: scope.agentId });
+    return Object.entries(deps.loadSessionStore?.(storePath) ?? {}).map(([sessionKey, entry]) => ({
+      sessionKey,
+      entry,
+    }));
+  };
+
+  return {
+    ...deps,
+    // Existing Telegram tests and custom deps inject loadSessionStore; expose
+    // the same data through the accessor seam consumed by migrated handlers.
+    getSessionEntry:
+      deps.getSessionEntry ??
+      ((scope) =>
+        listInjectedEntries(scope).find(({ sessionKey }) => sessionKey === scope.sessionKey)
+          ?.entry),
+    listSessionEntries: deps.listSessionEntries ?? listInjectedEntries,
+  };
 }

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeMainKey } from "openclaw/plugin-sdk/routing";
-import { saveSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { createTestWebInboundMessage } from "../inbound/test-message.test-helper.js";
@@ -277,8 +277,10 @@ describe("getSessionSnapshot", () => {
         const storePath = path.join(root, "sessions.json");
         const sessionKey = "agent:main:whatsapp:dm:s1";
 
-        await saveSessionStore(storePath, {
-          [sessionKey]: {
+        await upsertSessionEntry({
+          storePath,
+          sessionKey,
+          entry: {
             sessionId: "snapshot-session",
             updatedAt: new Date(2026, 0, 18, 3, 30, 0).getTime(),
             lastChannel: "whatsapp",

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -18,6 +18,11 @@ const legacyReaderNames = new Set([
   "readSessionStoreReadOnly",
   "resolveSessionStoreEntry",
 ]);
+const legacyWholeStoreAccessNames = new Set([
+  ...legacyReaderNames,
+  "saveSessionStore",
+  "updateSessionStore",
+]);
 
 export const migratedSessionAccessorFiles = new Set([
   "src/commands/export-trajectory.ts",
@@ -36,8 +41,25 @@ export const migratedSessionAccessorFiles = new Set([
   "src/infra/outbound/message-action-tts.ts",
 ]);
 
+export const migratedBundledPluginSessionAccessorFiles = new Set([
+  "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
+  "extensions/discord/src/monitor/thread-session-close.ts",
+  "extensions/telegram/src/bot-handlers.runtime.ts",
+]);
+
 function normalizeRelativePath(filePath) {
   return filePath.replaceAll(path.sep, "/");
+}
+
+function legacyNamesForFile(fileName) {
+  const normalized = normalizeRelativePath(fileName);
+  if (
+    fileName === "source.ts" ||
+    [...migratedBundledPluginSessionAccessorFiles].some((filePath) => normalized.endsWith(filePath))
+  ) {
+    return legacyWholeStoreAccessNames;
+  }
+  return legacyReaderNames;
 }
 
 function propertyAccessName(expression) {
@@ -66,6 +88,7 @@ function bindingName(node) {
 
 export function findSessionAccessorBoundaryViolations(content, fileName = "source.ts") {
   const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
+  const legacyNames = legacyNamesForFile(fileName);
   const violations = [];
 
   const visit = (node) => {
@@ -74,10 +97,10 @@ export function findSessionAccessorBoundaryViolations(content, fileName = "sourc
       if (namedBindings && ts.isNamedImports(namedBindings)) {
         for (const specifier of namedBindings.elements) {
           const importedName = specifier.propertyName?.text ?? specifier.name.text;
-          if (legacyReaderNames.has(importedName)) {
+          if (legacyNames.has(importedName)) {
             violations.push({
               line: toLine(sourceFile, specifier),
-              reason: `imports legacy session store reader "${importedName}"`,
+              reason: `imports legacy session store access "${importedName}"`,
             });
           }
         }
@@ -86,29 +109,29 @@ export function findSessionAccessorBoundaryViolations(content, fileName = "sourc
 
     if (ts.isBindingElement(node)) {
       const name = bindingName(node);
-      if (name && legacyReaderNames.has(name)) {
+      if (name && legacyNames.has(name)) {
         violations.push({
           line: toLine(sourceFile, node),
-          reason: `aliases legacy session store reader "${name}"`,
+          reason: `aliases legacy session store access "${name}"`,
         });
       }
     }
 
-    if (ts.isPropertyAccessExpression(node) && legacyReaderNames.has(node.name.text)) {
+    if (ts.isPropertyAccessExpression(node) && legacyNames.has(node.name.text)) {
       violations.push({
         line: toLine(sourceFile, node.name),
-        reason: `references legacy session store reader "${node.name.text}"`,
+        reason: `references legacy session store access "${node.name.text}"`,
       });
     }
 
     if (
       ts.isElementAccessExpression(node) &&
       ts.isStringLiteral(node.argumentExpression) &&
-      legacyReaderNames.has(node.argumentExpression.text)
+      legacyNames.has(node.argumentExpression.text)
     ) {
       violations.push({
         line: toLine(sourceFile, node.argumentExpression),
-        reason: `references legacy session store reader "${node.argumentExpression.text}"`,
+        reason: `references legacy session store access "${node.argumentExpression.text}"`,
       });
     }
 
@@ -116,12 +139,12 @@ export function findSessionAccessorBoundaryViolations(content, fileName = "sourc
       const calleeName = propertyAccessName(node.expression);
       if (
         calleeName &&
-        legacyReaderNames.has(calleeName) &&
+        legacyNames.has(calleeName) &&
         ts.isIdentifier(unwrapExpression(node.expression))
       ) {
         violations.push({
           line: toLine(sourceFile, node.expression),
-          reason: `calls legacy session store reader "${calleeName}"`,
+          reason: `calls legacy session store access "${calleeName}"`,
         });
       }
     }
@@ -136,6 +159,8 @@ export function findSessionAccessorBoundaryViolations(content, fileName = "sourc
 export async function main() {
   const repoRoot = resolveRepoRoot(import.meta.url);
   const sourceRoots = resolveSourceRoots(repoRoot, [
+    "extensions/discord/src/monitor",
+    "extensions/telegram/src",
     "src/commands",
     "src/config/sessions",
     "src/cron",
@@ -145,8 +170,13 @@ export async function main() {
   const violations = await collectFileViolations({
     repoRoot,
     sourceRoots,
-    skipFile: (filePath) =>
-      !migratedSessionAccessorFiles.has(normalizeRelativePath(path.relative(repoRoot, filePath))),
+    skipFile: (filePath) => {
+      const relativePath = normalizeRelativePath(path.relative(repoRoot, filePath));
+      return (
+        !migratedSessionAccessorFiles.has(relativePath) &&
+        !migratedBundledPluginSessionAccessorFiles.has(relativePath)
+      );
+    },
     findViolations: findSessionAccessorBoundaryViolations,
   });
 
@@ -155,12 +185,12 @@ export async function main() {
     return;
   }
 
-  console.error("Found legacy session store reader usage in session-accessor migrated files:");
+  console.error("Found legacy session store access usage in session-accessor migrated files:");
   for (const violation of violations) {
     console.error(`- ${violation.path}:${violation.line}: ${violation.reason}`);
   }
   console.error(
-    "Use src/config/sessions/session-accessor.ts helpers for migrated read/projection paths. Expand this ratchet only after a slice migrates more files.",
+    "Use src/config/sessions/session-accessor.ts helpers for migrated paths. Expand this ratchet only after a slice migrates more files.",
   );
   process.exit(1);
 }

--- a/src/plugin-sdk/config-runtime.test.ts
+++ b/src/plugin-sdk/config-runtime.test.ts
@@ -3,10 +3,26 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  listSessionEntries as listAccessorSessionEntries,
+  loadSessionEntry,
+  readSessionUpdatedAt as readAccessorSessionUpdatedAt,
+} from "../config/sessions/session-accessor.js";
+import {
+  getSessionEntry,
+  listSessionEntries,
+  readSessionUpdatedAt,
   resolveLivePluginConfigObject,
   resolvePluginConfigObject,
   type OpenClawConfig,
 } from "./config-runtime.js";
+
+describe("config-runtime session read exports", () => {
+  it("routes read helpers through the session accessor seam", () => {
+    expect(getSessionEntry).toBe(loadSessionEntry);
+    expect(listSessionEntries).toBe(listAccessorSessionEntries);
+    expect(readSessionUpdatedAt).toBe(readAccessorSessionUpdatedAt);
+  });
+});
 
 describe("resolvePluginConfigObject", () => {
   it("returns the plugin config object for a configured plugin entry", () => {

--- a/src/plugin-sdk/config-runtime.ts
+++ b/src/plugin-sdk/config-runtime.ts
@@ -4,6 +4,11 @@
  * config-mutation, and runtime-config-snapshot.
  */
 
+import {
+  listSessionEntries,
+  loadSessionEntry as getSessionEntry,
+  readSessionUpdatedAt,
+} from "../config/sessions/session-accessor.js";
 import { loadSessionStore as loadSessionStoreImpl } from "../config/sessions/store-load.js";
 
 /**
@@ -12,6 +17,7 @@ import { loadSessionStore as loadSessionStoreImpl } from "../config/sessions/sto
  * legacy mutable whole-store shape and will remain a compatibility escape hatch.
  */
 export const loadSessionStore = loadSessionStoreImpl;
+export { getSessionEntry, listSessionEntries, readSessionUpdatedAt };
 
 export { resolveDefaultAgentId } from "../agents/agent-scope.js";
 export {
@@ -141,10 +147,7 @@ export type {
 } from "../config/types.js";
 export {
   clearSessionStoreCacheForTest,
-  getSessionEntry,
-  listSessionEntries,
   patchSessionEntry,
-  readSessionUpdatedAt,
   recordSessionMetaFromInbound,
   saveSessionStore,
   updateLastRoute,

--- a/src/plugin-sdk/session-store-runtime.test.ts
+++ b/src/plugin-sdk/session-store-runtime.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import {
+  listSessionEntries as listAccessorSessionEntries,
+  loadSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import { getSessionEntry, listSessionEntries } from "./session-store-runtime.js";
+
+describe("session-store-runtime", () => {
+  it("routes read helpers through the session accessor seam", () => {
+    expect(getSessionEntry).toBe(loadSessionEntry);
+    expect(listSessionEntries).toBe(listAccessorSessionEntries);
+  });
+});

--- a/src/plugin-sdk/session-store-runtime.test.ts
+++ b/src/plugin-sdk/session-store-runtime.test.ts
@@ -2,12 +2,18 @@ import { describe, expect, it } from "vitest";
 import {
   listSessionEntries as listAccessorSessionEntries,
   loadSessionEntry,
+  readSessionUpdatedAt as readAccessorSessionUpdatedAt,
 } from "../config/sessions/session-accessor.js";
-import { getSessionEntry, listSessionEntries } from "./session-store-runtime.js";
+import {
+  getSessionEntry,
+  listSessionEntries,
+  readSessionUpdatedAt,
+} from "./session-store-runtime.js";
 
 describe("session-store-runtime", () => {
   it("routes read helpers through the session accessor seam", () => {
     expect(getSessionEntry).toBe(loadSessionEntry);
     expect(listSessionEntries).toBe(listAccessorSessionEntries);
+    expect(readSessionUpdatedAt).toBe(readAccessorSessionUpdatedAt);
   });
 });

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -1,5 +1,9 @@
 // Narrow session-store helpers for channel hot paths.
 
+import {
+  listSessionEntries,
+  loadSessionEntry as getSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { loadSessionStore as loadSessionStoreImpl } from "../config/sessions/store-load.js";
 
 /**
@@ -8,6 +12,7 @@ import { loadSessionStore as loadSessionStoreImpl } from "../config/sessions/sto
  * legacy mutable whole-store shape and will remain a compatibility escape hatch.
  */
 export const loadSessionStore = loadSessionStoreImpl;
+export { getSessionEntry, listSessionEntries };
 
 export { resolveSessionStoreEntry } from "../config/sessions/store-entry.js";
 export {
@@ -22,8 +27,6 @@ export { resolveGroupSessionKey } from "../config/sessions/group.js";
 export { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
 export {
   clearSessionStoreCacheForTest,
-  getSessionEntry,
-  listSessionEntries,
   patchSessionEntry,
   readSessionUpdatedAt,
   recordSessionMetaFromInbound,

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -3,6 +3,7 @@
 import {
   listSessionEntries,
   loadSessionEntry as getSessionEntry,
+  readSessionUpdatedAt,
 } from "../config/sessions/session-accessor.js";
 import { loadSessionStore as loadSessionStoreImpl } from "../config/sessions/store-load.js";
 
@@ -12,7 +13,7 @@ import { loadSessionStore as loadSessionStoreImpl } from "../config/sessions/sto
  * legacy mutable whole-store shape and will remain a compatibility escape hatch.
  */
 export const loadSessionStore = loadSessionStoreImpl;
-export { getSessionEntry, listSessionEntries };
+export { getSessionEntry, listSessionEntries, readSessionUpdatedAt };
 
 export { resolveSessionStoreEntry } from "../config/sessions/store-entry.js";
 export {
@@ -28,7 +29,6 @@ export { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js
 export {
   clearSessionStoreCacheForTest,
   patchSessionEntry,
-  readSessionUpdatedAt,
   recordSessionMetaFromInbound,
   saveSessionStore,
   updateLastRoute,

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -6,6 +6,7 @@ import {
   setRuntimeConfigSnapshot,
   type OpenClawConfig,
 } from "../../config/config.js";
+import { listSessionEntries, loadSessionEntry } from "../../config/sessions/session-accessor.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
 import {
   requestHeartbeat,
@@ -321,6 +322,8 @@ describe("plugin runtime command execution", () => {
           "updateSessionStoreEntry",
           "resolveSessionFilePath",
         ]);
+        expect(runtime.agent.session.getSessionEntry).toBe(loadSessionEntry);
+        expect(runtime.agent.session.listSessionEntries).toBe(listSessionEntries);
       },
     },
     {

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -12,8 +12,10 @@ import { normalizeThinkLevel, resolveThinkingProfile } from "../../auto-reply/th
 import { getRuntimeConfig } from "../../config/config.js";
 import { resolveSessionFilePath, resolveStorePath } from "../../config/sessions/paths.js";
 import {
-  getSessionEntry,
   listSessionEntries,
+  loadSessionEntry as getSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import {
   loadSessionStore,
   patchSessionEntry,
   saveSessionStore,

--- a/src/plugins/runtime/runtime-channel.ts
+++ b/src/plugins/runtime/runtime-channel.ts
@@ -64,11 +64,11 @@ import {
 } from "../../config/group-policy.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import {
-  readSessionUpdatedAt,
   recordSessionMetaFromInbound,
   resolveStorePath,
   updateLastRoute,
 } from "../../config/sessions.js";
+import { readSessionUpdatedAt } from "../../config/sessions/session-accessor.js";
 import { getChannelActivity, recordChannelActivity } from "../../infra/channel-activity.js";
 import {
   fetchRemoteMedia,

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -205,8 +205,8 @@ export type PluginRuntimeCore = {
     ensureAgentWorkspace: typeof import("../../agents/workspace.js").ensureAgentWorkspace;
     session: {
       resolveStorePath: typeof import("../../config/sessions/paths.js").resolveStorePath;
-      getSessionEntry: typeof import("../../config/sessions/store.js").getSessionEntry;
-      listSessionEntries: typeof import("../../config/sessions/store.js").listSessionEntries;
+      getSessionEntry: typeof import("../../config/sessions/session-accessor.js").loadSessionEntry;
+      listSessionEntries: typeof import("../../config/sessions/session-accessor.js").listSessionEntries;
       patchSessionEntry: typeof import("../../config/sessions/store.js").patchSessionEntry;
       upsertSessionEntry: typeof import("../../config/sessions/store.js").upsertSessionEntry;
       /**

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   findSessionAccessorBoundaryViolations,
+  migratedBundledPluginSessionAccessorFiles,
   migratedSessionAccessorFiles,
 } from "../../scripts/check-session-accessor-boundary.mjs";
 
@@ -26,6 +27,16 @@ describe("session accessor boundary guard", () => {
     );
   });
 
+  it("ratchets only the bundled plugin files migrated by this slice", () => {
+    expect(migratedBundledPluginSessionAccessorFiles).toEqual(
+      new Set([
+        "extensions/discord/src/monitor/native-command-model-picker-apply.ts",
+        "extensions/discord/src/monitor/thread-session-close.ts",
+        "extensions/telegram/src/bot-handlers.runtime.ts",
+      ]),
+    );
+  });
+
   it("flags legacy reader imports", () => {
     expect(
       findSessionAccessorBoundaryViolations(`
@@ -33,14 +44,14 @@ describe("session accessor boundary guard", () => {
         import { readSessionEntry, readSessionStoreReadOnly } from "../config/sessions/store-load.js";
       `),
     ).toEqual([
-      { line: 2, reason: 'imports legacy session store reader "loadSessionStore"' },
-      { line: 2, reason: 'imports legacy session store reader "readSessionEntries"' },
-      { line: 3, reason: 'imports legacy session store reader "readSessionEntry"' },
-      { line: 3, reason: 'imports legacy session store reader "readSessionStoreReadOnly"' },
+      { line: 2, reason: 'imports legacy session store access "loadSessionStore"' },
+      { line: 2, reason: 'imports legacy session store access "readSessionEntries"' },
+      { line: 3, reason: 'imports legacy session store access "readSessionEntry"' },
+      { line: 3, reason: 'imports legacy session store access "readSessionStoreReadOnly"' },
     ]);
   });
 
-  it("flags direct and namespace legacy reader calls", () => {
+  it("flags direct and namespace legacy access calls", () => {
     expect(
       findSessionAccessorBoundaryViolations(`
         loadSessionStore(storePath);
@@ -50,11 +61,11 @@ describe("session accessor boundary guard", () => {
         resolveSessionStoreEntry({ store, sessionKey });
       `),
     ).toEqual([
-      { line: 2, reason: 'calls legacy session store reader "loadSessionStore"' },
-      { line: 3, reason: 'references legacy session store reader "readSessionEntries"' },
-      { line: 4, reason: 'references legacy session store reader "loadSessionStore"' },
-      { line: 5, reason: 'calls legacy session store reader "readSessionStoreReadOnly"' },
-      { line: 6, reason: 'calls legacy session store reader "resolveSessionStoreEntry"' },
+      { line: 2, reason: 'calls legacy session store access "loadSessionStore"' },
+      { line: 3, reason: 'references legacy session store access "readSessionEntries"' },
+      { line: 4, reason: 'references legacy session store access "loadSessionStore"' },
+      { line: 5, reason: 'calls legacy session store access "readSessionStoreReadOnly"' },
+      { line: 6, reason: 'calls legacy session store access "resolveSessionStoreEntry"' },
     ]);
   });
 
@@ -66,9 +77,24 @@ describe("session accessor boundary guard", () => {
         const { loadSessionStore } = sessions;
       `),
     ).toEqual([
-      { line: 2, reason: 'references legacy session store reader "loadSessionStore"' },
-      { line: 3, reason: 'aliases legacy session store reader "readSessionEntries"' },
-      { line: 4, reason: 'aliases legacy session store reader "loadSessionStore"' },
+      { line: 2, reason: 'references legacy session store access "loadSessionStore"' },
+      { line: 3, reason: 'aliases legacy session store access "readSessionEntries"' },
+      { line: 4, reason: 'aliases legacy session store access "loadSessionStore"' },
+    ]);
+  });
+
+  it("flags legacy whole-store writes", () => {
+    expect(
+      findSessionAccessorBoundaryViolations(`
+        import { saveSessionStore, updateSessionStore } from "../config/sessions.js";
+        saveSessionStore(storePath, store);
+        updateSessionStore(storePath, update);
+      `),
+    ).toEqual([
+      { line: 2, reason: 'imports legacy session store access "saveSessionStore"' },
+      { line: 2, reason: 'imports legacy session store access "updateSessionStore"' },
+      { line: 3, reason: 'calls legacy session store access "saveSessionStore"' },
+      { line: 4, reason: 'calls legacy session store access "updateSessionStore"' },
     ]);
   });
 


### PR DESCRIPTION
## What

Route the bundled plugin session/transcript consumer slice onto the 3.1a session accessor seam where the behavior is already narrow and entry-scoped. Refs #88838.

## Why

This keeps the Path 3 / 3.1b bundled plugin consumer slice file-backed and behavior-preserving while removing avoidable whole-store mutations before the SQLite storage flip. The remaining true whole-store/partial-entry compatibility cases stay documented as follow-up design work rather than being hidden in source code.

## Changes

- Route plugin session reads through accessor
- Route timestamp reads through accessor
- Patch Discord model picker entries
- Patch Discord thread-close matches
- Patch Telegram model selections
- Use entry setup helpers in tests

## Real behavior proof

- Behavior or issue addressed: Bundled plugin session consumers in PR #89129 still load through the local OpenClaw gateway and preserve the Discord channel/session agent path after routing bundled callers through the session accessor seam.
- Real environment tested: Local OpenClaw gateway on macOS from /Users/phaedrus/Projects/clawdbot, configured live Discord and Telegram accounts, PR head d9511446f1cbe2ac8616ecabd8d0ea5349062c1a built into dist/index.js and loaded through the managed LaunchAgent on port 18789. After resolving the GitHub base conflict, the branch was rebased and pushed as final head 7975bc06ac09f8a77528eebfbdc9da8058caec0a with focused post-rebase proof.
- Exact steps or command run after this patch: Fetched the PR head, checked it out detached, ran pnpm build, restarted the gateway with pnpm openclaw gateway restart, verified pnpm openclaw status --json showed update.git.sha d9511446f1cbe2ac8616ecabd8d0ea5349062c1a, verified pnpm openclaw channels status --json showed Discord and Telegram running/connected, sent and read a Discord proof message with pnpm openclaw message send/read, then ran pnpm openclaw agent --session-key agent:main:discord:channel:1480658992731521298 --deliver --reply-channel discord --reply-to channel:1480658992731521298 --json. Post-rebase at final head 7975bc06ac09f8a77528eebfbdc9da8058caec0a, reran node scripts/check-session-accessor-boundary.mjs, pnpm plugin-sdk:api:check, git diff --check, targeted node scripts/run-vitest.mjs bundled Discord/Telegram/WhatsApp/plugin-SDK/runtime guard tests, targeted oxfmt, targeted oxlint, pnpm tsgo:extensions, and pnpm tsgo:core.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal output showed Discord send messageId 1515787546171412692, Discord readback content "PR #89129 live proof ping from d9511446: Discord bundled plugin is running after branch reload.", agent runId 82ed3ae8-7688-4924-a4e4-3b41f4e5e2d9, sessionId 6e8d619d-10c7-4bef-b866-4f172ed68ee2, deliverySucceeded true, delivered message 1515787692233855147, and readback content "PR 89129 Discord session proof OK." Gateway logs also showed sessionKey agent:main:discord:channel:1480658992731521298 processing -> idle, run_completed, and message.delivery.completed for channel discord. Post-rebase terminal proof showed the accessor guard passed, plugin SDK API baseline check passed, and the targeted Vitest run passed 5 shards / 8 files / 201 tests.
- Observed result after fix: The PR-built gateway started bundled Discord and Telegram plugins, Discord direct send/read worked, and a real model-backed Discord session turn completed and delivered back to the configured Discord channel using the existing bundled channel session. The final rebased head 7975bc06ac09f8a77528eebfbdc9da8058caec0a, rebased onto current main 356385045f8e94329421a5eb7c476875afb2be0b, preserved the bundled-consumer/accessor slice, including the Telegram injected-session dependency adapter, and passed the focused guard/API/unit/type/lint/format proof.
- What was not tested: Native Discord model-picker button selection, Discord thread close UI, native Telegram callback/menu interaction, WhatsApp runtime login, and a second live gateway run on the post-rebase SHA.
- Proof limitations or environment constraints: The live gateway was restored to main fc6d448138fc89b88693a058375f9da915578d52 after live proof. The live behavior proof was collected before the conflict-resolution rebase; the post-rebase branch changed only the same bundled-consumer/accessor slice and its guard resolution, and was covered by focused non-live proof.
- Before evidence (optional but encouraged): Before loading this PR head, the same local gateway was running main fc6d448138fc89b88693a058375f9da915578d52; GitHub reported the pre-rebase PR head as DIRTY/CONFLICTING, which is why the branch was subsequently rebased.

## Testing

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/native-command.model-picker.test.ts extensions/discord/src/monitor/thread-session-close.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/whatsapp/src/auto-reply/monitor/group-activation.test.ts extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts`
  - Passed: 157 tests across 3 shards.
- `node_modules/.bin/oxfmt --check extensions/discord/src/monitor/native-command-model-picker-apply.ts extensions/discord/src/monitor/native-command.model-picker.test.ts extensions/discord/src/monitor/thread-session-close.ts extensions/discord/src/monitor/thread-session-close.test.ts extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts`
  - Passed.
- `node scripts/run-oxlint.mjs extensions/discord/src/monitor/native-command-model-picker-apply.ts extensions/discord/src/monitor/native-command.model-picker.test.ts extensions/discord/src/monitor/thread-session-close.ts extensions/discord/src/monitor/thread-session-close.test.ts extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts`
  - Passed.
- `pnpm --dir . tsgo:extensions`
  - Passed.
- `git diff --check`
  - Passed.
- `/opt/homebrew/bin/timeout 900 /Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode local --no-web-search`
  - First run found a Discord thread-close stale-snapshot race; fixed with an atomic `updatedAt`/`sessionId` guard and regression test.
  - Rerun passed with no accepted/actionable findings.

Known follow-up: public SDK whole-store compatibility and WhatsApp activation-only scoped backfill remain tracked under the Path 3 whole-store design follow-up because they rely on mutable whole-store or partial-entry semantics.




