### PR TITLE
fix(agent-core): guard tool lookup descriptors

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { createAssistantMessageEventStream } from "@openclaw/llm-core";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
 import { agentLoop, agentLoopContinue } from "./agent-loop.js";
-import type { Message, Model } from "./llm.js";
-import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, StreamFn } from "./types.js";
+import type { AssistantMessage, Message, Model } from "./llm.js";
+import type {
+  AgentContext,
+  AgentEvent,
+  AgentLoopConfig,
+  AgentMessage,
+  AgentTool,
+  StreamFn,
+} from "./types.js";
 
 const model: Model = {
   id: "test-model",
@@ -24,6 +33,41 @@ const config: AgentLoopConfig = {
 const failingStreamFn: StreamFn = async () => {
   throw new Error("provider exploded");
 };
+
+function assistantToolUse(...names: string[]): AssistantMessage {
+  const content: AssistantMessage["content"] = names.map((name) => ({
+    type: "toolCall",
+    id: `call_${name}`,
+    name,
+    arguments: {},
+  }));
+  return {
+    role: "assistant",
+    content,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    stopReason: "toolUse",
+    timestamp: Date.now(),
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+  };
+}
+
+function toolUseStreamFn(name: string): StreamFn {
+  return async () => {
+    const stream = createAssistantMessageEventStream();
+    const message = assistantToolUse(name);
+    stream.push({ type: "done", reason: "toolUse", message });
+    return stream;
+  };
+}
 
 async function collectEvents(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   const events: AgentEvent[] = [];
@@ -70,5 +114,120 @@ describe("agentLoop EventStream failures", () => {
     const result = await stream.result();
 
     expectTerminalFailure(events, result);
+  });
+});
+
+describe("agentLoop tool descriptor isolation", () => {
+  it("skips unreadable sibling tool names while executing a healthy requested tool", async () => {
+    const execute = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      details: { ok: true },
+      terminate: true,
+    }));
+    const brokenSibling = {
+      get name(): string {
+        throw new Error("sibling tool name exploded");
+      },
+      label: "Broken",
+      description: "broken sibling",
+      parameters: Type.Object({}),
+      execute: vi.fn(),
+    } as unknown as AgentTool;
+    const healthyTool = {
+      name: "healthy_lookup",
+      label: "Healthy Lookup",
+      description: "safe sibling",
+      parameters: Type.Object({}),
+      execute,
+    } satisfies AgentTool;
+
+    const stream = agentLoop(
+      [{ role: "user", content: "call the tool", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [brokenSibling, healthyTool],
+      },
+      {
+        ...config,
+        shouldStopAfterTurn: () => true,
+      },
+      undefined,
+      toolUseStreamFn("healthy_lookup"),
+    );
+
+    const events = await collectEvents(stream);
+    const result = await stream.result();
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(result.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+    expect(result.at(-1)).toMatchObject({
+      role: "toolResult",
+      toolName: "healthy_lookup",
+      isError: false,
+    });
+    expect(JSON.stringify(events)).not.toContain("sibling tool name exploded");
+  });
+
+  it("fails closed to sequential execution when a matched tool execution mode is unreadable", async () => {
+    const order: string[] = [];
+    const guardedTool = {
+      name: "guarded_lookup",
+      label: "Guarded Lookup",
+      description: "mode descriptor is unreadable",
+      parameters: Type.Object({}),
+      get executionMode(): never {
+        throw new Error("execution mode exploded");
+      },
+      execute: vi.fn(async () => {
+        order.push("guarded:start");
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 1);
+        });
+        order.push("guarded:end");
+        return {
+          content: [{ type: "text" as const, text: "guarded" }],
+          details: { ok: true },
+        };
+      }),
+    } as unknown as AgentTool;
+    const siblingTool = {
+      name: "sibling_lookup",
+      label: "Sibling Lookup",
+      description: "safe sibling",
+      parameters: Type.Object({}),
+      execute: vi.fn(async () => {
+        order.push("sibling:start");
+        return {
+          content: [{ type: "text" as const, text: "sibling" }],
+          details: { ok: true },
+        };
+      }),
+    } satisfies AgentTool;
+
+    const stream = agentLoop(
+      [{ role: "user", content: "call both tools", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [guardedTool, siblingTool],
+      },
+      {
+        ...config,
+        shouldStopAfterTurn: () => true,
+      },
+      undefined,
+      async () => {
+        const messageStream = createAssistantMessageEventStream();
+        const message = assistantToolUse("guarded_lookup", "sibling_lookup");
+        messageStream.push({ type: "done", reason: "toolUse", message });
+        return messageStream;
+      },
+    );
+
+    await collectEvents(stream);
+    await stream.result();
+
+    expect(order).toEqual(["guarded:start", "guarded:end", "sibling:start"]);
   });
 });

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -452,8 +452,8 @@ async function executeToolCalls(
   emit: AgentEventSink,
 ): Promise<ExecutedToolCallBatch> {
   const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
-  const hasSequentialToolCall = toolCalls.some(
-    (tc) => currentContext.tools?.find((t) => t.name === tc.name)?.executionMode === "sequential",
+  const hasSequentialToolCall = toolCalls.some((toolCall) =>
+    isSequentialToolCall(currentContext, toolCall),
   );
   if (config.toolExecution === "sequential" || hasSequentialToolCall) {
     return executeToolCallsSequential(
@@ -641,6 +641,32 @@ type FinalizedToolCallOutcome = {
 
 type FinalizedToolCallEntry = FinalizedToolCallOutcome | (() => Promise<FinalizedToolCallOutcome>);
 
+function readToolNameForLookup(tool: AgentTool): string | undefined {
+  try {
+    return typeof tool.name === "string" ? tool.name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function findToolByName(tools: AgentTool[] | undefined, name: string): AgentTool | undefined {
+  for (const tool of tools ?? []) {
+    if (readToolNameForLookup(tool) === name) {
+      return tool;
+    }
+  }
+  return undefined;
+}
+
+function isSequentialToolCall(currentContext: AgentContext, toolCall: AgentToolCall): boolean {
+  const tool = findToolByName(currentContext.tools, toolCall.name);
+  try {
+    return tool?.executionMode === "sequential";
+  } catch {
+    return tool !== undefined;
+  }
+}
+
 function shouldTerminateToolBatch(finalizedCalls: FinalizedToolCallOutcome[]): boolean {
   return (
     finalizedCalls.length > 0 &&
@@ -669,7 +695,7 @@ async function prepareToolCall(
   config: AgentLoopConfig,
   signal: AbortSignal | undefined,
 ): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
-  const tool = currentContext.tools?.find((t) => t.name === toolCall.name);
+  const tool = findToolByName(currentContext.tools, toolCall.name);
   if (!tool) {
     return {
       kind: "immediate",


### PR DESCRIPTION
## Summary

- Guard low-level agent-core tool lookup against unreadable sibling tool names.
- Fail closed to sequential batch execution when the matched tool's `executionMode` descriptor is unreadable.
- Add regressions for both descriptor cases so a bad tool descriptor cannot abort a healthy requested tool call before tool-result handling.

## Verification

- `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent-loop.test.ts`
- `node_modules/.bin/oxlint packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent-loop.test.ts`
- `git diff --check origin/main...HEAD`
- Autoreview: clean, no accepted/actionable findings, `overall: patch is correct (0.83)`
- AWS Crabbox changed gate: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` passed; provider `aws`, run `run_751f5dccbbb7`, lease `cbx_9d3ca4486d0f`, exit 0, lease stopped.
- Blacksmith Testbox was not available in this shell: `blacksmith auth status` reported no authenticated organization.

## Real behavior proof

Behavior addressed: A poisoned tool descriptor in the low-level agent-core loop can no longer abort a healthy requested tool call before the tool-result path. Unreadable sibling names are skipped during lookup, and unreadable execution-mode metadata on the matched tool fails closed to sequential execution.

Real environment tested: Local linked OpenClaw worktree for focused Vitest/format/lint proof, plus AWS Crabbox Linux changed-gate proof.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts --reporter=dot`; `node_modules/.bin/oxfmt --check packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent-loop.test.ts`; `node_modules/.bin/oxlint packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent-loop.test.ts`; `git diff --check origin/main...HEAD`; AWS Crabbox `pnpm check:changed`.

Evidence after fix: Focused Vitest passed 1 shard / 4 tests. Format, lint, and diff checks passed. Autoreview returned no accepted/actionable findings. AWS Crabbox `run_751f5dccbbb7` passed `pnpm check:changed` with lanes `core` and `coreTests`.

Observed result after fix: The regression executes `healthy_lookup` even when a sibling tool's `name` getter throws, and a matched tool with unreadable `executionMode` runs before its sibling instead of being treated as parallel-safe.

What was not tested: No live provider or channel run; this patch is scoped to package-level agent-core tool-call dispatch.
