### PR TITLE
Restore GPT-5.3 Codex Spark OAuth routing

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -99,7 +99,7 @@ Official provider plugins publish their own model catalog rows. These providers 
 - Use `params.serviceTier` when you want an explicit tier instead of the shared `/fast` toggle
 - Hidden OpenClaw attribution headers (`originator`, `version`, `User-Agent`) apply only on native OpenAI traffic to `api.openai.com`, not generic OpenAI-compatible proxies
 - Native OpenAI routes also keep Responses `store`, prompt-cache hints, and OpenAI reasoning-compat payload shaping; proxy routes do not
-- `openai/gpt-5.3-codex-spark` is intentionally suppressed in OpenClaw because live OpenAI API requests reject it and the current Codex catalog does not expose it
+- `openai/gpt-5.3-codex-spark` is available through ChatGPT/Codex OAuth subscription auth when your signed-in account exposes it; OpenClaw still suppresses direct OpenAI API-key and Azure API-key routes for this model because those transports reject it
 
 ```json5
 {

--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -56,6 +56,7 @@ const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT_54_LEGACY_MODEL_ID = "gpt-5.4-codex";
 const OPENAI_CODEX_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_CODEX_GPT_54_PRO_MODEL_ID = "gpt-5.4-pro";
+const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT_55_CODEX_CONTEXT_TOKENS = 400_000;
 const OPENAI_CODEX_GPT_55_DEFAULT_RUNTIME_CONTEXT_TOKENS = 272_000;
 const OPENAI_CODEX_GPT_55_PRO_NATIVE_CONTEXT_TOKENS = 1_000_000;
@@ -63,6 +64,7 @@ const OPENAI_CODEX_GPT_55_PRO_DEFAULT_CONTEXT_TOKENS = 272_000;
 const OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS = 272_000;
 const OPENAI_CODEX_GPT_54_MINI_NATIVE_CONTEXT_TOKENS = 400_000;
+const OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_55_PRO_COST = {
   input: 30,
@@ -100,6 +102,14 @@ const OPENAI_CODEX_GPT_55_PRO_TEMPLATE_MODEL_IDS = [
   ...OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS,
 ] as const;
 const OPENAI_CODEX_MODERN_MODEL_IDS = [
+  OPENAI_CODEX_GPT_55_MODEL_ID,
+  OPENAI_CODEX_GPT_55_PRO_MODEL_ID,
+  OPENAI_CODEX_GPT_54_MODEL_ID,
+  OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
+  OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
+  OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
+] as const;
+const OPENAI_CODEX_IMAGE_CAPABLE_MODEL_IDS = [
   OPENAI_CODEX_GPT_55_MODEL_ID,
   OPENAI_CODEX_GPT_55_PRO_MODEL_ID,
   OPENAI_CODEX_GPT_54_MODEL_ID,
@@ -150,13 +160,13 @@ function hasImageInput(input: unknown): boolean {
 function matchesOpenAICodexImageCapableModel(modelId: string, modelName?: string): boolean {
   return [modelId, modelName]
     .filter((value): value is string => typeof value === "string")
-    .some((candidate) => matchesExactOrPrefix(candidate, OPENAI_CODEX_MODERN_MODEL_IDS));
+    .some((candidate) => matchesExactOrPrefix(candidate, OPENAI_CODEX_IMAGE_CAPABLE_MODEL_IDS));
 }
 
 /**
  * Restore native `["text", "image"]` input capability on resolved Codex rows
- * for the known modern model IDs (gpt-5.4, gpt-5.4-mini, gpt-5.4-pro, gpt-5.5,
- * gpt-5.5-pro). Persisted/configured model rows can omit the `input` field
+ * for known image-capable modern model IDs (gpt-5.4, gpt-5.4-mini,
+ * gpt-5.4-pro, gpt-5.5, gpt-5.5-pro). Persisted/configured model rows can omit the `input` field
  * entirely when they were written by older OpenClaw versions. When that row wins
  * the catalog merge, `modelSupportsInput(entry, "image")` returns false and the
  * gateway's `chat.send` handler offloads inbound images as `media://inbound/<id>`
@@ -279,6 +289,15 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
       maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
       cost: OPENAI_CODEX_GPT_54_MINI_COST,
     };
+  } else if (lower === OPENAI_CODEX_GPT_53_SPARK_MODEL_ID) {
+    templateIds = OPENAI_CODEX_GPT_54_CATALOG_SYNTH_TEMPLATE_MODEL_IDS;
+    patch = {
+      input: ["text"],
+      contextWindow: OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS,
+      contextTokens: OPENAI_CODEX_GPT_53_SPARK_CONTEXT_TOKENS,
+      maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+      cost: OPENAI_CODEX_GPT_54_MINI_COST,
+    };
   } else {
     return undefined;
   }
@@ -312,7 +331,7 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
       provider: PROVIDER_ID,
       baseUrl: synthBaseUrl,
       reasoning: true,
-      input: ["text", "image"],
+      input: patch?.input ?? ["text", "image"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: patch?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
       contextTokens: patch?.contextTokens,
@@ -583,6 +602,7 @@ export function buildOpenAICodexProviderHooks(): Pick<
         OPENAI_CODEX_GPT_54_MODEL_ID,
         OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
         OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
+        OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
       ].includes(id);
     },
     ...buildOpenAIResponsesProviderHooks(),

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -831,6 +831,44 @@ describe("buildOpenAIProvider", () => {
     });
   });
 
+  it("restores gpt-5.3-codex-spark only through ChatGPT/Codex OAuth routing", () => {
+    const provider = buildOpenAIProvider();
+
+    const oauthModel = provider.resolveDynamicModel?.({
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+      modelRegistry: { find: () => null },
+      authProfileId: "openai:work",
+      authProfileMode: "oauth",
+    } as never);
+    const apiKeyModel = provider.resolveDynamicModel?.({
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+      modelRegistry: { find: () => null },
+      providerConfig: {
+        auth: "api-key",
+      },
+    } as never);
+    const unknownModelHint = provider.buildUnknownModelHint?.({
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+    } as never);
+
+    expectFields(oauthModel, {
+      provider: "openai",
+      id: "gpt-5.3-codex-spark",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      input: ["text"],
+      contextWindow: 128_000,
+      contextTokens: 128_000,
+      maxTokens: 128_000,
+    });
+    expect(apiKeyModel).toBeUndefined();
+    expect(unknownModelHint).toContain("ChatGPT/Codex OAuth");
+    expect(unknownModelHint).toContain("OpenAI API-key auth cannot use this model");
+  });
+
   it("resolves chat-latest as an explicit direct API model override", () => {
     const provider = buildOpenAIProvider();
 
@@ -1056,6 +1094,12 @@ describe("buildOpenAIProvider", () => {
         modelId: "gpt-5.2-codex",
       } as never),
     ).toBe(false);
+    expect(
+      codexProvider.isModernModelRef?.({
+        provider: "openai",
+        modelId: "gpt-5.3-codex-spark",
+      } as never),
+    ).toBe(true);
     expect(
       codexProvider.isModernModelRef?.({
         provider: "openai",

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -849,6 +849,20 @@ describe("buildOpenAIProvider", () => {
         auth: "api-key",
       },
     } as never);
+    const runtimeModel = provider.resolveDynamicModel?.({
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+      modelRegistry: { find: () => null },
+      agentRuntimeId: "codex",
+    } as never);
+    const apiKeyRuntimeModel = provider.resolveDynamicModel?.({
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+      modelRegistry: { find: () => null },
+      agentRuntimeId: "codex",
+      authProfileId: "openai:api-key",
+      authProfileMode: "api_key",
+    } as never);
     const unknownModelHint = provider.buildUnknownModelHint?.({
       provider: "openai",
       modelId: "gpt-5.3-codex-spark",
@@ -864,7 +878,18 @@ describe("buildOpenAIProvider", () => {
       contextTokens: 128_000,
       maxTokens: 128_000,
     });
+    expectFields(runtimeModel, {
+      provider: "openai",
+      id: "gpt-5.3-codex-spark",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      input: ["text"],
+      contextWindow: 128_000,
+      contextTokens: 128_000,
+      maxTokens: 128_000,
+    });
     expect(apiKeyModel).toBeUndefined();
+    expect(apiKeyRuntimeModel).toBeUndefined();
     expect(unknownModelHint).toContain("ChatGPT/Codex OAuth");
     expect(unknownModelHint).toContain("OpenAI API-key auth cannot use this model");
   });

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -56,6 +56,7 @@ const OPENAI_GPT_54_MODEL_ID = "gpt-5.4";
 const OPENAI_GPT_54_PRO_MODEL_ID = "gpt-5.4-pro";
 const OPENAI_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_GPT_54_NANO_MODEL_ID = "gpt-5.4-nano";
+const OPENAI_GPT_53_CODEX_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_GPT_55_CONTEXT_WINDOW = 1_000_000;
 const OPENAI_GPT_55_CONTEXT_TOKENS = 272_000;
 const OPENAI_GPT_55_PRO_CONTEXT_TOKENS = 1_000_000;
@@ -104,6 +105,7 @@ const OPENAI_MODERN_MODEL_IDS = [
   OPENAI_GPT_54_PRO_MODEL_ID,
   OPENAI_GPT_54_MINI_MODEL_ID,
   OPENAI_GPT_54_NANO_MODEL_ID,
+  OPENAI_GPT_53_CODEX_SPARK_MODEL_ID,
 ] as const;
 const OPENAI_UNKNOWN_MODEL_COST = {
   input: 0,
@@ -516,6 +518,14 @@ function shouldResolveDynamicModelThroughCodex(ctx: ProviderResolveDynamicModelC
   return resolveConfiguredAuthTransport(ctx) === "codex";
 }
 
+function buildOpenAIUnknownModelHint(modelId: string): string | undefined {
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  if (normalized !== OPENAI_GPT_53_CODEX_SPARK_MODEL_ID) {
+    return undefined;
+  }
+  return "gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.";
+}
+
 function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelContext) {
   const trimmedModelId = ctx.modelId.trim();
   const lower = normalizeLowercaseStringOrEmpty(trimmedModelId);
@@ -780,6 +790,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
     resolveUsageAuth: codexHooks.resolveUsageAuth,
     fetchUsageSnapshot: codexHooks.fetchUsageSnapshot,
     refreshOAuth: codexHooks.refreshOAuth,
+    buildUnknownModelHint: ({ modelId }) => buildOpenAIUnknownModelHint(modelId),
     buildMissingAuthMessage: (ctx) => {
       if (normalizeProviderId(ctx.provider) !== PROVIDER_ID) {
         return undefined;

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -515,7 +515,11 @@ function shouldResolveDynamicModelThroughCodex(ctx: ProviderResolveDynamicModelC
   if (ctx.providerConfig?.baseUrl && !isOpenAIApiBaseUrl(ctx.providerConfig.baseUrl)) {
     return false;
   }
-  return resolveConfiguredAuthTransport(ctx) === "codex";
+  const authTransport = resolveConfiguredAuthTransport(ctx);
+  if (authTransport) {
+    return authTransport === "codex";
+  }
+  return ctx.agentRuntimeId === "codex";
 }
 
 function buildOpenAIUnknownModelHint(modelId: string): string | undefined {

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -215,12 +215,15 @@
       {
         "provider": "openai",
         "model": "gpt-5.3-codex-spark",
-        "reason": "gpt-5.3-codex-spark is not exposed by the OpenAI API catalog. Use openai/gpt-5.5."
+        "reason": "gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
+        "when": {
+          "baseUrlHosts": ["api.openai.com"]
+        }
       },
       {
         "provider": "azure-openai-responses",
         "model": "gpt-5.3-codex-spark",
-        "reason": "gpt-5.3-codex-spark is not exposed by the OpenAI API catalog. Use openai/gpt-5.5."
+        "reason": "gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; Azure/OpenAI API-key auth cannot use this model."
       }
     ]
   },

--- a/extensions/openai/openclaw.plugin.test.ts
+++ b/extensions/openai/openclaw.plugin.test.ts
@@ -30,6 +30,16 @@ const manifest = JSON.parse(
   setup?: {
     providers?: Array<{ id: string }>;
   };
+  modelCatalog?: {
+    suppressions?: Array<{
+      provider?: string;
+      model?: string;
+      when?: {
+        baseUrlHosts?: string[];
+        providerConfigApiIn?: string[];
+      };
+    }>;
+  };
   providerEndpoints?: Array<{
     endpointClass?: string;
     hosts?: string[];
@@ -172,6 +182,17 @@ describe("OpenAI plugin manifest", () => {
     );
     expect(choices.map((choice) => choice.groupHint)).not.toContain("Codex OAuth + API key");
     expect(choices.map((choice) => choice.groupHint)).not.toContain("API key or Codex sign-in");
+  });
+
+  it("keeps Spark suppression conditional on direct OpenAI API rows", () => {
+    const sparkSuppression = manifest.modelCatalog?.suppressions?.find(
+      (suppression) =>
+        suppression.provider === "openai" && suppression.model === "gpt-5.3-codex-spark",
+    );
+
+    expect(sparkSuppression?.when).toEqual({
+      baseUrlHosts: ["api.openai.com"],
+    });
   });
 
   it("keeps auth choice copy aligned with provider wizard metadata", () => {

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -20,9 +20,30 @@ vi.mock("../../plugins/provider-runtime.js", async () => {
 });
 
 vi.mock("../model-suppression.js", () => ({
-  shouldSuppressBuiltInModel: ({ provider, id }: { provider?: string; id?: string }) =>
-    (provider === "openai" || provider === "azure-openai-responses") &&
-    id?.trim().toLowerCase() === "gpt-5.3-codex-spark",
+  shouldSuppressBuiltInModel: ({
+    provider,
+    id,
+    baseUrl,
+  }: {
+    provider?: string;
+    id?: string;
+    baseUrl?: string;
+  }) => {
+    if (
+      (provider !== "openai" && provider !== "azure-openai-responses") ||
+      id?.trim().toLowerCase() !== "gpt-5.3-codex-spark"
+    ) {
+      return false;
+    }
+    if (provider === "azure-openai-responses") {
+      return true;
+    }
+    if (!baseUrl) {
+      return true;
+    }
+    return new URL(baseUrl).hostname.toLowerCase() === "api.openai.com";
+  },
+  shouldUnconditionallySuppress: () => false,
   buildSuppressedBuiltInModelError: ({ provider, id }: { provider?: string; id?: string }) => {
     if (
       (provider !== "openai" && provider !== "azure-openai-responses") ||
@@ -30,7 +51,7 @@ vi.mock("../model-suppression.js", () => ({
     ) {
       return undefined;
     }
-    return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.`;
+    return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run \`openclaw models auth login --provider openai\` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.`;
   },
 }));
 
@@ -47,6 +68,7 @@ import {
 } from "./model.forward-compat.test-support.js";
 import { resolveModel } from "./model.js";
 import {
+  buildOpenAICodexForwardCompatExpectation,
   makeModel,
   mockDiscoveredModel,
   mockOpenAICodexTemplateModel,
@@ -147,7 +169,7 @@ describe("resolveModel forward-compat errors and overrides", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
     );
   });
 
@@ -168,8 +190,203 @@ describe("resolveModel forward-compat errors and overrides", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
     );
+  });
+
+  it("resolves suppressed openai gpt-5.3-codex-spark through ChatGPT/Codex routing", () => {
+    mockOpenAICodexTemplateModel(discoverModels);
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(
+      buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex-spark"),
+    );
+  });
+
+  it("keeps suppressed stale direct openai gpt-5.3-codex-spark catalog rows blocked", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+      templateModel: {
+        ...makeModel("gpt-5.3-codex-spark"),
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      },
+    });
+
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent");
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toContain("ChatGPT/Codex OAuth");
+  });
+
+  it("keeps stale persisted openai gpt-5.3-codex-spark rows blocked without transport metadata", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+      templateModel: {
+        ...makeModel("gpt-5.3-codex-spark"),
+        provider: "openai",
+      },
+    });
+
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent");
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toContain("ChatGPT/Codex OAuth");
+  });
+
+  it("keeps configured custom openai gpt-5.3-codex-spark rows when not direct OpenAI API", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses",
+            baseUrl: "https://proxy.example/v1",
+            models: [
+              {
+                ...makeModel("gpt-5.3-codex-spark"),
+                api: "openai-responses",
+                baseUrl: "https://proxy.example/v1",
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.3-codex-spark",
+      api: "openai-responses",
+      baseUrl: "https://proxy.example/v1",
+    });
+  });
+
+  it("rejects configured direct openai gpt-5.3-codex-spark rows", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [
+              {
+                ...makeModel("gpt-5.3-codex-spark"),
+                api: "openai-responses",
+                baseUrl: "https://api.openai.com/v1",
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent", cfg);
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toContain("ChatGPT/Codex OAuth");
+    expect(result.error).toContain("OpenAI API-key auth cannot use this model");
+  });
+
+  it("keeps configured custom openai gpt-5.3-codex-spark rows that omit api", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses",
+            models: [
+              {
+                ...makeModel("gpt-5.3-codex-spark"),
+                baseUrl: "https://proxy.example/v1",
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.3-codex-spark",
+      api: "openai-responses",
+      baseUrl: "https://proxy.example/v1",
+    });
+  });
+
+  it("keeps registry openai gpt-5.3-codex-spark rows on custom provider endpoints", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+      templateModel: {
+        ...makeModel("gpt-5.3-codex-spark"),
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      },
+    });
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses",
+            baseUrl: "https://proxy.example/v1",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.3-codex-spark",
+      api: "openai-responses",
+      baseUrl: "https://proxy.example/v1",
+    });
+  });
+
+  it("checks registry baseUrl before suppressing openai gpt-5.3-codex-spark rows", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "openai",
+      modelId: "gpt-5.3-codex-spark",
+      templateModel: {
+        ...makeModel("gpt-5.3-codex-spark"),
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://proxy.example/v1",
+      },
+    });
+
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.3-codex-spark",
+      api: "openai-responses",
+      baseUrl: "https://proxy.example/v1",
+    });
   });
 
   it("rejects azure openai gpt-5.3-codex-spark with a codex-only hint", () => {
@@ -181,7 +398,7 @@ describe("resolveModel forward-compat errors and overrides", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -163,8 +163,6 @@ describe("resolveModel forward-compat errors and overrides", () => {
   });
 
   it("rejects direct openai gpt-5.3-codex-spark with a codex-only hint", () => {
-    // Spark is intentionally suppressed from direct OpenAI routing; falling back
-    // would make a removed catalog row appear usable.
     const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent");
 
     expect(result.model).toBeUndefined();

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -213,6 +213,58 @@ describe("resolveModel forward-compat errors and overrides", () => {
     );
   });
 
+  it("resolves suppressed openai gpt-5.3-codex-spark through model-scoped Codex runtime", () => {
+    mockOpenAICodexTemplateModel(discoverModels);
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.3-codex-spark": {
+              agentRuntime: { id: "codex" },
+            },
+          },
+        },
+      },
+    };
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(
+      buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex-spark"),
+    );
+  });
+
+  it("keeps model-scoped Codex runtime blocked for explicit OpenAI API-key provider config", () => {
+    mockOpenAICodexTemplateModel(discoverModels);
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.3-codex-spark": {
+              agentRuntime: { id: "codex" },
+            },
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            auth: "api-key",
+            api: "openai-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+          },
+        },
+      },
+    };
+    const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent", cfg);
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toContain("OpenAI API-key auth cannot use this model");
+  });
+
   it("keeps suppressed stale direct openai gpt-5.3-codex-spark catalog rows blocked", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "openai",

--- a/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
@@ -294,6 +294,7 @@ function buildDynamicModel(
     }
     case "openai": {
       const isLegacyGpt54Alias = lower === "gpt-5.4-codex";
+      const isSparkModel = lower === "gpt-5.3-codex-spark";
       const exactModel = params.modelRegistry.find("openai", modelId) as ResolvedModelLike | null;
       const providerConfigSelectsChatGpt =
         params.providerConfig?.api === "openai-chatgpt-responses" ||
@@ -343,11 +344,12 @@ function buildDynamicModel(
             : lower === "gpt-5.3-codex-spark"
               ? findTemplate(params, "openai", ["gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex"])
               : findTemplate(params, "openai", ["gpt-5.4"]);
+      const templateSelectsChatGpt = !isSparkModel && isOpenAIChatGptModelTemplate(codexTemplate);
       if (
         isLegacyGpt54Alias ||
-        lower.includes("-codex") ||
+        (lower.includes("-codex") && !isSparkModel) ||
         providerConfigSelectsChatGpt ||
-        isOpenAIChatGptModelTemplate(codexTemplate)
+        templateSelectsChatGpt
       ) {
         const templateBaseUrl =
           typeof codexTemplate?.baseUrl === "string" ? codexTemplate.baseUrl : undefined;
@@ -715,7 +717,7 @@ export function createProviderRuntimeTestMock(options: ProviderRuntimeTestMockOp
       context: { modelId: string };
     }) =>
       params.provider === "openai" &&
-      ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-pro"].includes(
+      ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-pro", "gpt-5.3-codex-spark"].includes(
         params.context.modelId.trim().toLowerCase(),
       ),
     prepareProviderDynamicModel: async (params: {

--- a/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.provider-runtime.test-support.ts
@@ -39,7 +39,13 @@ type DynamicModelContext = {
   provider: string;
   modelId: string;
   modelRegistry: ModelRegistryLike;
-  providerConfig?: { api?: string | null; baseUrl?: string };
+  agentRuntimeId?: string;
+  authProfileMode?: "api_key" | "aws-sdk" | "oauth" | "token";
+  providerConfig?: {
+    api?: string | null;
+    auth?: "api-key" | "aws-sdk" | "oauth" | "token";
+    baseUrl?: string;
+  };
 };
 
 type ResolvedModelLike = Record<string, unknown>;
@@ -296,9 +302,22 @@ function buildDynamicModel(
       const isLegacyGpt54Alias = lower === "gpt-5.4-codex";
       const isSparkModel = lower === "gpt-5.3-codex-spark";
       const exactModel = params.modelRegistry.find("openai", modelId) as ResolvedModelLike | null;
+      const explicitResponsesAuth =
+        params.authProfileMode === "api_key" ||
+        params.authProfileMode === "aws-sdk" ||
+        params.providerConfig?.auth === "api-key" ||
+        params.providerConfig?.auth === "aws-sdk";
+      const explicitCodexAuth =
+        params.authProfileMode === "oauth" ||
+        params.authProfileMode === "token" ||
+        params.providerConfig?.auth === "oauth" ||
+        params.providerConfig?.auth === "token";
       const providerConfigSelectsChatGpt =
-        params.providerConfig?.api === "openai-chatgpt-responses" ||
-        isNativeOpenAICodexBaseUrl(params.providerConfig?.baseUrl);
+        !explicitResponsesAuth &&
+        (explicitCodexAuth ||
+          params.providerConfig?.api === "openai-chatgpt-responses" ||
+          isNativeOpenAICodexBaseUrl(params.providerConfig?.baseUrl) ||
+          params.agentRuntimeId === "codex");
       if (
         lower === "gpt-5.5" &&
         (providerConfigSelectsChatGpt || isOpenAIChatGptModelTemplate(exactModel))
@@ -695,7 +714,13 @@ export function createProviderRuntimeTestMock(options: ProviderRuntimeTestMockOp
       context: {
         modelId: string;
         modelRegistry: ModelRegistryLike;
-        providerConfig?: { api?: string | null; baseUrl?: string };
+        agentRuntimeId?: string;
+        authProfileMode?: "api_key" | "aws-sdk" | "oauth" | "token";
+        providerConfig?: {
+          api?: string | null;
+          auth?: "api-key" | "aws-sdk" | "oauth" | "token";
+          baseUrl?: string;
+        };
       };
     }) =>
       handledDynamicProviders.has(params.provider)
@@ -704,6 +729,8 @@ export function createProviderRuntimeTestMock(options: ProviderRuntimeTestMockOp
               provider: params.provider,
               modelId: params.context.modelId,
               modelRegistry: params.context.modelRegistry,
+              agentRuntimeId: params.context.agentRuntimeId,
+              authProfileMode: params.context.authProfileMode,
               providerConfig: params.context.providerConfig,
             },
             {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -114,7 +114,7 @@ vi.mock("../model-suppression.js", () => {
         (provider === "openai" || provider === "azure-openai-responses" || provider === "openai") &&
         id?.trim().toLowerCase() === "gpt-5.3-codex-spark"
       ) {
-        return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.`;
+        return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run \`openclaw models auth login --provider openai\` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.`;
       }
       return undefined;
     },
@@ -3447,7 +3447,7 @@ describe("resolveModel", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
     );
   });
 
@@ -3466,7 +3466,7 @@ describe("resolveModel", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
     );
   });
 
@@ -3876,7 +3876,7 @@ describe("resolveModel", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe(
-      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -880,8 +880,6 @@ function shouldSuppressInlineConfiguredModel(params: {
   ) {
     return false;
   }
-  // Spark is a ChatGPT/Codex OAuth-only OpenAI model. Inline custom endpoints
-  // may still opt in, but direct/default OpenAI API transports must fail here.
   return shouldSuppressBuiltInModel({
     provider: params.provider,
     id: params.modelId,
@@ -1213,8 +1211,6 @@ function resolveRuntimePreferredSuppressedModel(params: {
   ) {
     return undefined;
   }
-  // Runtime-preferred providers may restore an auth-bound model while the
-  // suppression still blocks stale static catalog rows for other auth modes.
   return resolvePluginDynamicModelWithRegistry({ ...params, runtimeHooks });
 }
 

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -2,6 +2,7 @@
  * Resolves embedded-agent provider/model selections from config, registry, and catalogs.
  */
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ModelCompatConfig, ModelMediaInputConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ModelRegistry as CoreModelRegistry } from "../../llm/model-registry.js";
@@ -851,6 +852,45 @@ function applyConfiguredProviderOverrides(params: {
     providerConfig.localService,
   );
 }
+type ExplicitModelResolution =
+  | { kind: "resolved"; model: Model; source: "configured" }
+  | { kind: "resolved"; dropOnRuntimeMiss: boolean; model: Model; source: "registry" }
+  | { kind: "suppressed" };
+
+function shouldSuppressInlineConfiguredModel(params: {
+  provider: string;
+  modelId: string;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  baseUrl?: string;
+}): boolean {
+  if (
+    shouldUnconditionallySuppress({
+      provider: params.provider,
+      id: params.modelId,
+      ...(params.cfg ? { config: params.cfg } : {}),
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    })
+  ) {
+    return true;
+  }
+  if (
+    normalizeProviderId(params.provider) !== "openai" ||
+    normalizeLowercaseStringOrEmpty(params.modelId) !== "gpt-5.3-codex-spark"
+  ) {
+    return false;
+  }
+  // Spark is a ChatGPT/Codex OAuth-only OpenAI model. Inline custom endpoints
+  // may still opt in, but direct/default OpenAI API transports must fail here.
+  return shouldSuppressBuiltInModel({
+    provider: params.provider,
+    id: params.modelId,
+    ...(params.cfg ? { config: params.cfg } : {}),
+    ...(params.baseUrl ? { baseUrl: params.baseUrl } : {}),
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+  });
+}
+
 function resolveExplicitModelWithRegistry(params: {
   provider: string;
   modelId: string;
@@ -859,7 +899,7 @@ function resolveExplicitModelWithRegistry(params: {
   agentDir?: string;
   workspaceDir?: string;
   runtimeHooks?: ProviderRuntimeHooks;
-}): { kind: "resolved"; model: Model } | { kind: "suppressed" } | undefined {
+}): ExplicitModelResolution | undefined {
   const { provider, modelId, modelRegistry, cfg, agentDir, workspaceDir, runtimeHooks } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const requestTimeoutMs = resolveProviderRequestTimeoutMs(providerConfig?.timeoutSeconds);
@@ -869,17 +909,21 @@ function resolveExplicitModelWithRegistry(params: {
     modelId,
   });
   if (inlineMatch?.api) {
-    // Unconditional suppressions (no `when` clause) represent absolute provider
-    // capability blocks that cannot be overridden by inline user configuration.
-    // Conditional suppressions (e.g. baseUrlHosts-gated qwen restrictions) are
-    // intentionally bypassable when the user has explicitly configured the model.
-    // (#74451)
+    const transport = resolveProviderTransport({
+      provider,
+      api: inlineMatch.api,
+      baseUrl: inlineMatch.baseUrl ?? providerConfig?.baseUrl,
+      cfg,
+      workspaceDir,
+      runtimeHooks,
+    });
     if (
-      shouldUnconditionallySuppress({
+      shouldSuppressInlineConfiguredModel({
         provider,
-        id: modelId,
-        ...(cfg ? { config: cfg } : {}),
-        ...(workspaceDir ? { workspaceDir } : {}),
+        modelId,
+        cfg,
+        workspaceDir,
+        baseUrl: transport.baseUrl,
       })
     ) {
       return { kind: "suppressed" };
@@ -893,6 +937,7 @@ function resolveExplicitModelWithRegistry(params: {
     }) as StaticCatalogFallbackModel | undefined;
     return {
       kind: "resolved",
+      source: "configured",
       model: normalizeResolvedModel({
         provider,
         cfg,
@@ -913,11 +958,10 @@ function resolveExplicitModelWithRegistry(params: {
     };
   }
   if (
-    shouldSuppressBuiltInModel({
+    shouldUnconditionallySuppress({
       provider,
       id: modelId,
       ...(cfg ? { config: cfg } : {}),
-      ...(providerConfig?.baseUrl ? { baseUrl: providerConfig.baseUrl } : {}),
       ...(workspaceDir ? { workspaceDir } : {}),
     })
   ) {
@@ -926,8 +970,31 @@ function resolveExplicitModelWithRegistry(params: {
   const model = modelRegistry.find(provider, modelId) as Model | null;
 
   if (model) {
+    const configuredBaseUrl =
+      typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl : undefined;
+    const discoveredBaseUrl =
+      typeof (model as { baseUrl?: unknown }).baseUrl === "string"
+        ? (model as { baseUrl: string }).baseUrl
+        : undefined;
+    const effectiveBaseUrl = configuredBaseUrl ?? discoveredBaseUrl;
+    if (
+      shouldSuppressBuiltInModel({
+        provider,
+        id: modelId,
+        ...(cfg ? { config: cfg } : {}),
+        ...(effectiveBaseUrl ? { baseUrl: effectiveBaseUrl } : {}),
+        ...(workspaceDir ? { workspaceDir } : {}),
+      })
+    ) {
+      return { kind: "suppressed" };
+    }
     return {
       kind: "resolved",
+      source: "registry",
+      dropOnRuntimeMiss:
+        normalizeProviderId(provider) === "openai" &&
+        modelId.trim().toLowerCase() === "gpt-5.3-codex-spark" &&
+        !effectiveBaseUrl,
       model: normalizeResolvedModel({
         provider,
         cfg,
@@ -963,6 +1030,7 @@ function resolveExplicitModelWithRegistry(params: {
     });
     return {
       kind: "resolved",
+      source: "configured",
       model: normalizeResolvedModel({
         provider,
         cfg,
@@ -981,6 +1049,21 @@ function resolveExplicitModelWithRegistry(params: {
         runtimeHooks,
       }),
     };
+  }
+  if (fallbackInlineMatch) {
+    return undefined;
+  }
+
+  if (
+    shouldSuppressBuiltInModel({
+      provider,
+      id: modelId,
+      ...(cfg ? { config: cfg } : {}),
+      ...(providerConfig?.baseUrl ? { baseUrl: providerConfig.baseUrl } : {}),
+      ...(workspaceDir ? { workspaceDir } : {}),
+    })
+  ) {
+    return { kind: "suppressed" };
   }
 
   return undefined;
@@ -1106,6 +1189,47 @@ function resolvePluginDynamicModelWithRegistry(params: {
   });
 }
 
+function resolveRuntimePreferredSuppressedModel(params: {
+  provider: string;
+  modelId: string;
+  modelRegistry: CoreModelRegistry;
+  cfg?: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+  authProfileId?: string;
+  preferredProfile?: string;
+  runtimeHooks?: ProviderRuntimeHooks;
+}): Model | undefined {
+  const runtimeHooks = params.runtimeHooks ?? DEFAULT_PROVIDER_RUNTIME_HOOKS;
+  if (
+    !shouldCompareProviderRuntimeResolvedModel({
+      provider: params.provider,
+      modelId: params.modelId,
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      runtimeHooks,
+    })
+  ) {
+    return undefined;
+  }
+  // Runtime-preferred providers may restore an auth-bound model while the
+  // suppression still blocks stale static catalog rows for other auth modes.
+  return resolvePluginDynamicModelWithRegistry({ ...params, runtimeHooks });
+}
+
+function shouldDropRuntimePreferredExplicitMiss(params: {
+  provider: string;
+  modelId: string;
+  explicitModel: ExplicitModelResolution;
+}): boolean {
+  return (
+    params.explicitModel.kind === "resolved" &&
+    params.explicitModel.source === "registry" &&
+    params.explicitModel.dropOnRuntimeMiss
+  );
+}
+
 function resolveConfiguredFallbackModel(params: {
   provider: string;
   modelId: string;
@@ -1176,6 +1300,18 @@ function resolveConfiguredFallbackModel(params: {
     workspaceDir,
     runtimeHooks,
   });
+  if (
+    configuredModel &&
+    shouldSuppressInlineConfiguredModel({
+      provider,
+      modelId,
+      cfg,
+      workspaceDir,
+      baseUrl: fallbackTransport.baseUrl,
+    })
+  ) {
+    return undefined;
+  }
   const requestConfig = resolveProviderRequestConfig({
     provider,
     api: fallbackTransport.api ?? "openai-responses",
@@ -1345,16 +1481,6 @@ function mergeModelCompat(
   return { ...base, ...override };
 }
 
-function preferProviderRuntimeResolvedModel(params: {
-  explicitModel: Model;
-  runtimeResolvedModel?: Model;
-}): Model {
-  if (params.runtimeResolvedModel) {
-    return params.runtimeResolvedModel;
-  }
-  return params.explicitModel;
-}
-
 function normalizeProviderModelRef(params: {
   provider: string;
   modelId: string;
@@ -1398,7 +1524,7 @@ export function resolveModelWithRegistry(params: {
   };
   const explicitModel = resolveExplicitModelWithRegistry(scopedParams);
   if (explicitModel?.kind === "suppressed") {
-    return undefined;
+    return resolveRuntimePreferredSuppressedModel(scopedParams);
   }
   if (explicitModel?.kind === "resolved") {
     if (
@@ -1413,11 +1539,16 @@ export function resolveModelWithRegistry(params: {
     ) {
       return explicitModel.model;
     }
-    const pluginDynamicModel = resolvePluginDynamicModelWithRegistry(scopedParams);
-    return preferProviderRuntimeResolvedModel({
-      explicitModel: explicitModel.model,
-      runtimeResolvedModel: pluginDynamicModel,
-    });
+    return (
+      resolvePluginDynamicModelWithRegistry(scopedParams) ??
+      (shouldDropRuntimePreferredExplicitMiss({
+        provider: scopedParams.provider,
+        modelId: scopedParams.modelId,
+        explicitModel,
+      })
+        ? undefined
+        : explicitModel.model)
+    );
   }
   const pluginDynamicModel = resolvePluginDynamicModelWithRegistry(scopedParams);
   if (pluginDynamicModel) {
@@ -1546,6 +1677,20 @@ export async function resolveModelAsync(
     runtimeHooks,
   });
   if (explicitModel?.kind === "suppressed") {
+    const suppressedRuntimeModel = resolveRuntimePreferredSuppressedModel({
+      provider: normalizedRef.provider,
+      modelId: normalizedRef.model,
+      modelRegistry,
+      cfg,
+      agentDir: resolvedAgentDir,
+      workspaceDir,
+      authProfileId: options?.authProfileId,
+      preferredProfile: options?.preferredProfile,
+      runtimeHooks,
+    });
+    if (suppressedRuntimeModel) {
+      return { model: suppressedRuntimeModel, authStorage, modelRegistry };
+    }
     return {
       error: buildUnknownModelError({
         provider: normalizedRef.provider,

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -22,6 +22,7 @@ import { resolveDefaultAgentDir } from "../agent-scope.js";
 import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../auth-profiles.js";
 import type { AuthProfileCredential } from "../auth-profiles/types.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
+import { resolveAgentHarnessPolicy } from "../harness/policy.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { resolveModelWorkspaceDir } from "../model-discovery-context.js";
 import { modelKey, normalizeStaticProviderModelId } from "../model-ref-shared.js";
@@ -1134,6 +1135,12 @@ function resolvePluginDynamicModelWithRegistry(params: {
   const { provider, modelId, modelRegistry, cfg, agentDir, workspaceDir } = params;
   const runtimeHooks = params.runtimeHooks ?? DEFAULT_PROVIDER_RUNTIME_HOOKS;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
+  const agentHarnessPolicy = resolveAgentHarnessPolicy({ provider, modelId, config: cfg });
+  const agentRuntimeId =
+    agentHarnessPolicy.runtimeSource !== "implicit" ||
+    cfg?.plugins?.entries?.codex?.enabled === true
+      ? agentHarnessPolicy.runtime
+      : undefined;
   const authProfile = resolveDynamicModelAuthProfile({
     provider,
     cfg,
@@ -1157,6 +1164,7 @@ function resolvePluginDynamicModelWithRegistry(params: {
       config: cfg,
       agentDir,
       workspaceDir,
+      ...(agentRuntimeId ? { agentRuntimeId } : {}),
       provider,
       modelId,
       modelRegistry,

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -25,21 +25,37 @@ let readCachedAgentModelCatalogMock: ReturnType<typeof vi.fn>;
 let writeCachedAgentModelCatalogMock: ReturnType<typeof vi.fn>;
 
 vi.mock("./model-suppression.runtime.js", () => ({
-  shouldSuppressBuiltInModel: (params: { provider?: string; id?: string }) =>
-    isSuppressedModel(params.provider, params.id),
-  buildShouldSuppressBuiltInModel: () => (params: { provider?: string; id?: string }) =>
-    isSuppressedModel(params.provider, params.id),
+  shouldSuppressBuiltInModel: (params: { provider?: string; id?: string; baseUrl?: string }) =>
+    isSuppressedModel(params.provider, params.id, params.baseUrl),
+  buildShouldSuppressBuiltInModel:
+    () => (params: { provider?: string; id?: string; baseUrl?: string }) =>
+      isSuppressedModel(params.provider, params.id, params.baseUrl),
 }));
 
-function isSuppressedModel(provider?: string, id?: string): boolean {
+function isDirectOpenAiBaseUrl(baseUrl?: string): boolean {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return true;
+  }
+  try {
+    return new URL(trimmed).hostname.toLowerCase().replace(/\.+$/, "") === "api.openai.com";
+  } catch {
+    return false;
+  }
+}
+
+function isSuppressedModel(provider?: string, id?: string, baseUrl?: string): boolean {
   const modelId = id?.trim().toLowerCase();
   if (!modelId) {
     return false;
   }
-  return (
-    (provider === "openai" || provider === "azure-openai-responses" || provider === "openai") &&
-    modelId === "gpt-5.3-codex-spark"
-  );
+  if (modelId !== "gpt-5.3-codex-spark") {
+    return false;
+  }
+  if (provider === "azure-openai-responses") {
+    return true;
+  }
+  return provider === "openai" && isDirectOpenAiBaseUrl(baseUrl);
 }
 
 function mockCatalogImportFailThenRecover() {
@@ -1308,6 +1324,31 @@ describe("loadModelCatalog", () => {
     expectNoCatalogEntry(result, "openai", "gpt-5.3-codex-spark");
     expectNoCatalogEntry(result, "azure-openai-responses", "gpt-5.3-codex-spark");
     expectNoCatalogEntry(result, "openai", "gpt-5.3-codex-spark");
+  });
+
+  it("keeps custom endpoint gpt-5.3-codex-spark rows in the catalog", async () => {
+    mockAgentDiscoveryModels([
+      {
+        id: "gpt-5.3-codex-spark",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        name: "GPT-5.3 Codex Spark",
+        contextWindow: 128000,
+        input: ["text"],
+      },
+      {
+        id: "gpt-5.3-codex-spark",
+        provider: "openai",
+        baseUrl: "https://proxy.example.com/v1",
+        name: "GPT-5.3 Codex Spark Proxy",
+        contextWindow: 128000,
+        input: ["text"],
+      },
+    ]);
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    const entry = requireCatalogEntry(result, "openai", "gpt-5.3-codex-spark");
+    expect(entry.name).toBe("GPT-5.3 Codex Spark Proxy");
   });
 
   it("keeps available openai 5.1/5.2/5.3 built-ins in the catalog", async () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -72,6 +72,7 @@ type DiscoveredModel = {
   input?: ModelInputType[];
   params?: ModelCatalogEntry["params"];
   compat?: ModelCatalogEntry["compat"];
+  baseUrl?: string;
 };
 
 type AgentDiscoveryModule = typeof import("./agent-model-discovery.js");
@@ -674,7 +675,8 @@ export async function loadModelCatalog(params?: {
         const id = normalizeConfiguredProviderCatalogModelId(provider, rawId, {
           manifestPlugins: getManifestPlugins(),
         });
-        if (shouldSuppressBuiltInModel({ provider, id })) {
+        const baseUrl = normalizeOptionalString(entry?.baseUrl);
+        if (shouldSuppressBuiltInModel({ provider, id, baseUrl })) {
           continue;
         }
         const name = normalizeOptionalString(entry?.name ?? id) || id;

--- a/src/agents/model-suppression.ts
+++ b/src/agents/model-suppression.ts
@@ -125,6 +125,7 @@ function resolveBuiltInModelSuppression(params: {
 export function shouldSuppressBuiltInModelFromManifest(params: {
   provider?: string | null;
   id?: string | null;
+  baseUrl?: string | null;
   config?: OpenClawConfig;
   workspaceDir?: string;
 }) {

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -71,6 +71,7 @@ function loadAvailableModels(
         ? !shouldSuppressBuiltInModelFromManifest({
             provider: model.provider,
             id: model.id,
+            baseUrl: model.baseUrl,
             config: cfg,
           })
         : !shouldSuppressBuiltInModel({
@@ -113,6 +114,7 @@ export async function loadModelRegistry(
       : !shouldSuppressBuiltInModelFromManifest({
           provider: model.provider,
           id: model.id,
+          baseUrl: model.baseUrl,
           config: cfg,
         }),
   );

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -74,6 +74,7 @@ describe("appendProviderCatalogRows", () => {
     expect(mocks.shouldSuppressBuiltInModelFromManifest).toHaveBeenCalledWith({
       provider: "codex",
       id: "gpt-5.5",
+      baseUrl: "https://chatgpt.com/backend-api",
       config: {
         agents: { defaults: { model: { primary: "codex/gpt-5.5" } } },
         models: { providers: {} },
@@ -128,6 +129,7 @@ describe("appendProviderCatalogRows", () => {
     expect(mocks.shouldSuppressBuiltInModelFromManifest).toHaveBeenCalledWith({
       provider: "openai",
       id: "gpt-5.3-codex-spark",
+      baseUrl: "https://api.openai.com/v1",
       config: {
         agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
         models: { providers: {} },

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -126,6 +126,7 @@ function shouldSuppressListModel(params: {
     return shouldSuppressBuiltInModelFromManifest({
       provider: params.model.provider,
       id: params.model.id,
+      baseUrl: params.model.baseUrl,
       config: params.context.cfg,
     });
   }

--- a/src/plugins/manifest-model-suppression.test.ts
+++ b/src/plugins/manifest-model-suppression.test.ts
@@ -195,6 +195,13 @@ describe("manifest model suppression", () => {
       resolveManifestBuiltInModelSuppression({
         provider: "qwen",
         id: "qwen3.6-plus",
+        env: process.env,
+      })?.suppress,
+    ).toBe(true);
+    expect(
+      resolveManifestBuiltInModelSuppression({
+        provider: "qwen",
+        id: "qwen3.6-plus",
         baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         env: process.env,
       }),

--- a/src/plugins/manifest-model-suppression.ts
+++ b/src/plugins/manifest-model-suppression.ts
@@ -105,6 +105,11 @@ function manifestSuppressionMatchesConditions(params: {
   }
   if (when.baseUrlHosts?.length) {
     const baseUrlHost = normalizeBaseUrlHost(params.baseUrl ?? configuredProvider?.baseUrl);
+    // Missing transport metadata usually means a stale/default catalog row.
+    // Suppress it unless config names a custom base URL to check.
+    if (!baseUrlHost && !params.baseUrl && !configuredProvider?.baseUrl) {
+      return true;
+    }
     if (!baseUrlHost) {
       return false;
     }

--- a/src/plugins/manifest-model-suppression.ts
+++ b/src/plugins/manifest-model-suppression.ts
@@ -105,8 +105,6 @@ function manifestSuppressionMatchesConditions(params: {
   }
   if (when.baseUrlHosts?.length) {
     const baseUrlHost = normalizeBaseUrlHost(params.baseUrl ?? configuredProvider?.baseUrl);
-    // Missing transport metadata usually means a stale/default catalog row.
-    // Suppress it unless config names a custom base URL to check.
     if (!baseUrlHost && !params.baseUrl && !configuredProvider?.baseUrl) {
       return true;
     }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -510,6 +510,7 @@ export type ProviderResolveDynamicModelContext = {
   config?: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
+  agentRuntimeId?: string;
   provider: string;
   modelId: string;
   modelRegistry: ModelRegistry;


### PR DESCRIPTION
## Summary

- Restore `openai/gpt-5.3-codex-spark` only through ChatGPT/Codex OAuth/subscription-backed routing on the canonical `openai` provider.
- Keep direct OpenAI API-key and Azure API-key routes blocked with an OAuth-specific error that tells users to run `openclaw models auth login --provider openai`. This model is still supported for ChatGPT/Codex OAuth subscription access, not for the public OpenAI API.
- Keep `openai-codex/*` as legacy input only; this PR does not restore a live `openai-codex` provider/object because OpenClaw’s current provider boundary folds Codex into `openai`.
- Restore Spark as a text-only Codex runtime model with 128k context metadata, while preserving explicitly configured custom OpenAI-compatible endpoints.
- Suppress stale/default Spark catalog rows without hiding valid configured custom endpoint rows.

## Support Boundary

Per upstream OpenAI guidance from Tibo, `gpt-5.3-codex-spark` remains supported for ChatGPT/Codex OAuth subscription access and is not expected to be removed when general `gpt-5.3` access is removed. That support does not extend to the public OpenAI API, so OpenClaw should expose it only as `openai/gpt-5.3-codex-spark` through OAuth-backed Codex routing and should fail direct API-key/Azure attempts with a clear OAuth-only message.

## Root Cause

Before this patch, `gpt-5.3-codex-spark` was still treated as a stale direct OpenAI/Azure catalog model and the error path pointed users away from it instead of explaining the OAuth-only route. The model is still supported through ChatGPT/Codex OAuth subscription access but is not usable through the public OpenAI API-key transport. OpenClaw did not have a current ChatGPT/Codex OAuth forward-compat branch for Spark that could resolve it before direct catalog suppression.

RCA proof from OpenClaw:
- `extensions/openai/openclaw.plugin.json` suppressed Spark as a model-catalog row.
- `src/agents/embedded-agent-runner/model.ts` resolved explicit/static rows before it had enough transport metadata to distinguish OAuth, direct OpenAI API, stale rows, and custom endpoints.
- `extensions/openai/openai-provider.ts` had no Spark-specific unknown-model hint for the OAuth-only contract.
- `extensions/openai/openai-chatgpt-provider.ts` did not expose Spark as a current Codex OAuth runtime model.

Dependency/Codex proof checked in sibling upstream Codex source:
- `codex-rs/model-provider/src/models_endpoint.rs:81-90` passes the auth mode into provider resolution before fetching models.
- `codex-rs/model-provider-info/src/lib.rs:35-38` defines the ChatGPT/Codex backend URL, and `codex-rs/model-provider-info/src/lib.rs:237-245` chooses that backend only for ChatGPT/Codex auth modes; otherwise it uses `https://api.openai.com/v1`.
- `codex-rs/model-provider/src/auth.rs:78-90` and `codex-rs/model-provider/src/auth.rs:107-118` resolve API-key versus ChatGPT token bearer auth.

## Real behavior proof

Behavior addressed: `openai/gpt-5.3-codex-spark` resolves through ChatGPT/Codex OAuth metadata only; direct OpenAI/Azure API-key rows and stale catalog rows return an OAuth-specific error instead of attempting an unsupported API-key request.

Real environment tested: fresh temp OpenClaw checkout from latest `main` plus a fresh sibling OpenAI Codex checkout for dependency-source inspection. Live Spark behavior was tested through an existing redacted ChatGPT/Codex OAuth profile on a local agent configured with the canonical `openai/gpt-5.3-codex-spark` model id.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/plugins/manifest-model-suppression.test.ts src/commands/models/list.rows.test.ts src/agents/model-catalog.test.ts src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts extensions/openai/openai-provider.test.ts extensions/openai/openclaw.plugin.test.ts -- --reporter=verbose
```

Evidence after fix:

```text
[test] passed 4 Vitest shards in 18.75s
commands: Test Files 1 passed; Tests 3 passed
agents: Test Files 2 passed; Tests 65 passed
plugins: Test Files 1 passed; Tests 8 passed
extension-provider-openai: Test Files 2 passed; Tests 35 passed
```

Exact steps or command run after this patch:

```bash
git diff --check origin/main...HEAD
```

Evidence after fix: no output, exit 0.

Exact steps or command run after this patch:

```bash
pnpm openclaw agent --agent main --model openai/gpt-5.3-codex-spark --message 'Reply with exactly: spark-ok' --timeout 180 --json
```

Evidence after fix, redacted to remove local paths, session ids, and account details:

```text
status: ok
finalAssistantVisibleText: spark-ok
provider/model: openai/gpt-5.3-codex-spark
agentHarnessId: codex
contextTokens: 128000
requestShaping.authMode: auth-profile
executionTrace: openai/gpt-5.3-codex-spark success, fallbackUsed=false
```

Exact steps or command run after this patch:

```bash
pnpm docs:list
pnpm docs:check-mdx
pnpm format:docs:check -- docs/concepts/model-providers.md
```

Evidence after fix:

```text
docs:list completed successfully
Docs MDX check passed (675 files)
Docs formatting clean (660 files)
```

Exact steps or command run after this patch:

```bash
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Evidence after fix:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.82)
```

Observed result after fix: focused tests cover OAuth Spark resolution, direct API-key rejection, stale no-metadata rows, inline configured direct rows, inline configured custom rows with and without `api`, registry custom endpoints, custom provider endpoints, text-only Spark metadata, and the existing Qwen explicit-override compatibility path.

What was not tested: Direct OpenAI API-key and Azure API-key live requests were not run; focused tests cover those OAuth-only rejection paths without sending unsupported live traffic. Broad/full CI was not run locally; GitHub CI is running on the rebased PR head.

## Verification

- `node scripts/run-vitest.mjs src/plugins/manifest-model-suppression.test.ts src/commands/models/list.rows.test.ts src/agents/model-catalog.test.ts src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts extensions/openai/openai-provider.test.ts extensions/openai/openclaw.plugin.test.ts -- --reporter=verbose`
- `pnpm openclaw agent --agent main --model openai/gpt-5.3-codex-spark --message 'Reply with exactly: spark-ok' --timeout 180 --json`
- `pnpm docs:list`
- `pnpm docs:check-mdx`
- `pnpm format:docs:check -- docs/concepts/model-providers.md`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## What was not tested

- Direct OpenAI API-key and Azure API-key live requests were not run; focused tests cover those OAuth-only rejection paths without sending unsupported live traffic.
- Broad/full CI was not run locally; this PR uses focused resolver/provider/catalog tests plus autoreview.
