### PR TITLE
fix(tts): deliver dynamic tts tool audio in message-tool-only contexts

### DIFF
--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -105,6 +105,26 @@ export function isReplyPayloadTtsSupplement(
   return Boolean(getReplyPayloadTtsSupplement(payload));
 }
 
+/**
+ * True when the payload carries trusted-local audio media staged for
+ * auto-delivery (the dynamic `tts` tool contract). Such audio is the explicit
+ * result of a voice/speech tool call, so it must still reach the originating
+ * surface even when normal assistant text replies are message-tool-only.
+ * sendPolicy deny still wins over this exemption at the call site.
+ */
+export function isReplyPayloadTtsAutoDeliveryAudio(
+  payload: Pick<
+    ReplyPayload,
+    "mediaUrl" | "mediaUrls" | "trustedLocalMedia" | "audioAsVoice"
+  >,
+): boolean {
+  return Boolean(
+    payload.trustedLocalMedia &&
+      payload.audioAsVoice &&
+      hasReplyPayloadMedia(payload),
+  );
+}
+
 export function markReplyPayloadAsTtsSupplement<T extends ReplyPayload>(
   payload: T,
   spokenText: string = payload.spokenText ?? payload.text ?? "",

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1824,6 +1824,109 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("delivers TTS tool audio finals in message_tool_only contexts", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+
+    const ttsAudioFinal = {
+      text: "(spoken) hello there",
+      mediaUrl: "https://example.com/tts-tool.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    } satisfies ReplyPayload;
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      _opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => ttsAudioFinal;
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    const sent = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as ReplyPayload | undefined;
+    expect(sent?.mediaUrl).toBe("https://example.com/tts-tool.opus");
+    expect(sent?.audioAsVoice).toBe(true);
+    // Assistant text stays private in message_tool_only; only audio is delivered.
+    expect(sent?.text).toBeUndefined();
+  });
+
+  it("keeps text-only finals private in message_tool_only contexts", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      _opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => ({ text: "plain text final" }) satisfies ReplyPayload;
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("does not deliver TTS tool audio finals when sendPolicy is deny", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "deny",
+    };
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      _opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) =>
+      ({
+        text: "(spoken) hello there",
+        mediaUrl: "https://example.com/tts-tool.opus",
+        audioAsVoice: true,
+        trustedLocalMedia: true,
+      }) satisfies ReplyPayload;
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("does not synthesize hidden text-only tool summaries into TTS media", async () => {
     setNoAbort();
     ttsMocks.state.synthesizeToolAudio = true;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -107,6 +107,7 @@ import {
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
   isReplyPayloadStatusNotice,
+  isReplyPayloadTtsAutoDeliveryAudio,
   markReplyPayloadAsTtsSupplement,
   type ReplyPayload,
 } from "../reply-payload.js";
@@ -2849,7 +2850,12 @@ export async function dispatchReplyFromConfig(
     const shouldDeliverDespiteSourceReplySuppression = (reply: ReplyPayload) =>
       suppressAutomaticSourceDelivery &&
       !sendPolicyDenied &&
-      getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true &&
+      // Internal notices opt in via metadata; trusted-local TTS audio is the
+      // explicit result of a voice/speech tool call whose contract auto-delivers
+      // the audio, so it must reach the originating surface even when normal
+      // assistant text replies are message-tool-only. sendPolicy deny still wins.
+      (getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true ||
+        isReplyPayloadTtsAutoDeliveryAudio(reply)) &&
       (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
     for (const reply of replies) {
       throwIfDispatchOperationAborted();
@@ -2875,8 +2881,18 @@ export async function dispatchReplyFromConfig(
         }
         continue;
       }
+      // When suppression is bypassed solely to auto-deliver trusted-local TTS
+      // audio, keep the assistant text private (message-tool-only) and deliver
+      // only the audio media, mirroring the tool contract.
+      const deliveryReply =
+        suppressDelivery &&
+        getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression !== true &&
+        isReplyPayloadTtsAutoDeliveryAudio(reply) &&
+        reply.text !== undefined
+          ? { ...reply, text: undefined }
+          : reply;
       attemptedFinalDelivery = true;
-      const finalReply = await sendFinalPayload(reply);
+      const finalReply = await sendFinalPayload(deliveryReply);
       queuedFinal = finalReply.queuedFinal || queuedFinal;
       routedFinalCount += finalReply.routedFinalCount;
       if (!finalReply.queuedFinal && finalReply.routedFinalCount === 0) {


### PR DESCRIPTION
Fixes #83636

When a session's source-reply delivery mode is `message_tool_only` (group chats, room events, plugin-owned UI surfaces), `dispatchReplyFromConfig` suppresses every final reply unless it carries the internal `deliverDespiteSourceReplySuppression` metadata flag.

A dynamic `tts` tool call stages trusted-local audio onto its final reply payload (`trustedLocalMedia: true` + `audioAsVoice: true` + media URL), but that payload is never marked with the bypass flag. The audio is therefore dropped before any channel send is invoked — matching the reported failure boundary "tts tool succeeds → valid local Opus is created → media/outbound copy is staged → no channel provider send is invoked" — even though the tts tool contract auto-delivers the audio.

**Fix:** add `isReplyPayloadTtsAutoDeliveryAudio()` (trusted-local audio media) and exempt such finals from `message_tool_only` suppression in the dispatch loop, stripping the visible assistant text on the exempt delivery so the final text stays private while only the audio is sent. `sendPolicy: deny` still suppresses everything (the bypass keeps the existing `!sendPolicyDenied` guard).

## Real behavior proof

**Behavior addressed:** A dynamic `tts` tool result that stages trusted-local audio is suppressed in `message_tool_only` channel contexts, so the audio is never delivered to the originating surface.

**Real environment tested:** Linux (Rocky 8 / Node 22.22.0), production `dispatchReplyFromConfig` exercised directly via the repo's `dispatch-from-config` vitest harness (real production module under test; only outermost network/IO/session/transcript layers mocked, exactly as the existing suite does). Patched HEAD `efc92fd0bd1e858f39fc71a3ca7ac1b1bc0484f0`; base `origin/main` `d9f6e03e32856117a44625ab413197cb6685e30b`. Plus a `node --import tsx` exercise of the production `isReplyPayloadTtsAutoDeliveryAudio` helper and the dispatch suppression predicate.

**Exact steps:**

```
# BEFORE (revert only the two source files, keep the new test) — reproduce the bug:
git stash push -- src/auto-reply/reply-payload.ts src/auto-reply/reply/dispatch-from-config.ts
./node_modules/.bin/vitest run src/auto-reply/reply/dispatch-from-config.test.ts \
  -t "delivers TTS tool audio finals in message_tool_only contexts"
git stash pop   # restore the fix

# AFTER (patched) — full suite + node-tsx helper proof:
./node_modules/.bin/vitest run src/auto-reply/reply/dispatch-from-config.test.ts
node --import tsx ./proof-83636.mts
```

The node-tsx script builds the production-shaped predicate around the real `isReplyPayloadTtsAutoDeliveryAudio` helper:

```ts
import { isReplyPayloadTtsAutoDeliveryAudio } from "./src/auto-reply/reply-payload.js";
const ttsAudioFinal  = { text: "(spoken) hello there", mediaUrl: "https://example.com/tts-tool.opus", audioAsVoice: true, trustedLocalMedia: true };
const plainTextFinal = { text: "plain text final" };
// message_tool_only env: suppressAutomaticSourceDelivery=true, sendPolicyDenied=false
// deny env: sendPolicyDenied=true
```

**Evidence:**

BEFORE (unpatched source, new test run):
```
 × delivers TTS tool audio finals in message_tool_only contexts 140ms
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
   1860|  expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
 Test Files  1 failed (1)
      Tests  1 failed | 191 skipped (192)
```

AFTER (patched, full dispatch-from-config suite):
```
 Test Files  1 passed (1)
      Tests  192 passed (192)
```

AFTER (node --import tsx ./proof-83636.mts):
```
isReplyPayloadTtsAutoDeliveryAudio(ttsAudioFinal) = true
isReplyPayloadTtsAutoDeliveryAudio(plainTextFinal) = false
[message_tool_only] TTS audio final delivered = true
[message_tool_only] plain text final delivered  = false
[sendPolicy=deny]   TTS audio final delivered = false
```

oxlint on the changed files: clean. `git diff --check origin/main...HEAD`: clean.

**Observed result:** On unpatched source, the production dispatch path calls `dispatcher.sendFinalReply` 0 times for a `message_tool_only` TTS audio final — the audio is suppressed (the bug). With the patch, `sendFinalReply` is called exactly once carrying `mediaUrl: https://example.com/tts-tool.opus` and `audioAsVoice: true` with `text` stripped (audio delivered, assistant text kept private). A plain-text `message_tool_only` final remains suppressed, and under `sendPolicy: deny` the TTS audio is not delivered. All 189 pre-existing tests in the suite continue to pass, including "does not synthesize hidden text-only tool summaries into TTS media".

**What was not tested:** A live Telegram/Discord gateway send of TTS audio with real providers (requires a running gateway + configured TTS/channel providers + live device). The vitest exercise drives the same production `dispatchReplyFromConfig` delivery decision and `dispatcher.sendFinalReply` call that the live channel send path consumes; the network send itself is the only layer mocked.
