### PR TITLE
fix(ui): render skill workshop tab

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3100,6 +3100,16 @@ export function renderApp(state: AppViewState) {
                     : (selectedIndex + delta + visibleProposals.length) % visibleProposals.length;
                 selectSkillWorkshopProposal(state, visibleProposals[nextIndex].key);
               };
+              const selectVisibleFallback = (proposals: typeof visibleProposals) => {
+                if (
+                  proposals.length === 0 ||
+                  proposals.some((proposal) => proposal.key === state.skillWorkshopSelectedKey)
+                ) {
+                  return;
+                }
+                state.skillWorkshopFilePreviewKey = null;
+                selectSkillWorkshopProposal(state, proposals[0].key);
+              };
               return m.renderSkillWorkshop({
                 loading: state.skillWorkshopLoading,
                 error: state.skillWorkshopError,
@@ -3118,8 +3128,26 @@ export function renderApp(state: AppViewState) {
                 revisionDraft: state.skillWorkshopRevisionDraft,
                 assistantName: state.assistantName,
                 counts: countSkillWorkshopProposals(state.skillWorkshopProposals),
-                onStatusFilterChange: (status) => (state.skillWorkshopStatusFilter = status),
-                onQueryChange: (query) => (state.skillWorkshopQuery = query),
+                onStatusFilterChange: (status) => {
+                  state.skillWorkshopStatusFilter = status;
+                  selectVisibleFallback(
+                    m.filterSkillWorkshopProposals(
+                      state.skillWorkshopProposals,
+                      status,
+                      state.skillWorkshopQuery,
+                    ),
+                  );
+                },
+                onQueryChange: (query) => {
+                  state.skillWorkshopQuery = query;
+                  selectVisibleFallback(
+                    m.filterSkillWorkshopProposals(
+                      state.skillWorkshopProposals,
+                      state.skillWorkshopStatusFilter,
+                      query,
+                    ),
+                  );
+                },
                 onFilePreviewQueryChange: (query) => (state.skillWorkshopFilePreviewQuery = query),
                 onQueueWidthChange: (width) => (state.skillWorkshopQueueWidth = width),
                 onModeChange: (mode) => (state.skillWorkshopMode = mode),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3082,23 +3082,30 @@ export function renderApp(state: AppViewState) {
           : nothing}
         ${state.tab === "skillWorkshop"
           ? renderLazyView(lazySkillWorkshop, (m) => {
-              const proposals = state.skillWorkshopProposals;
+              const visibleProposals = m.filterSkillWorkshopProposals(
+                state.skillWorkshopProposals,
+                state.skillWorkshopStatusFilter,
+                state.skillWorkshopQuery,
+              );
               const selectedIndex = Math.max(
                 0,
-                proposals.findIndex((proposal) => proposal.key === state.skillWorkshopSelectedKey),
+                visibleProposals.findIndex(
+                  (proposal) => proposal.key === state.skillWorkshopSelectedKey,
+                ),
               );
               const selectRelativeProposal = (delta: -1 | 1) => {
-                if (proposals.length === 0) {
+                if (visibleProposals.length === 0) {
                   return;
                 }
-                const nextIndex = (selectedIndex + delta + proposals.length) % proposals.length;
-                selectSkillWorkshopProposal(state, proposals[nextIndex].key);
+                const nextIndex =
+                  (selectedIndex + delta + visibleProposals.length) % visibleProposals.length;
+                selectSkillWorkshopProposal(state, visibleProposals[nextIndex].key);
               };
               return m.renderSkillWorkshop({
                 loading: state.skillWorkshopLoading,
                 error: state.skillWorkshopError,
                 inspectingKey: state.skillWorkshopInspectingKey,
-                proposals,
+                proposals: state.skillWorkshopProposals,
                 selectedKey: state.skillWorkshopSelectedKey,
                 statusFilter: state.skillWorkshopStatusFilter,
                 query: state.skillWorkshopQuery,
@@ -3111,7 +3118,7 @@ export function renderApp(state: AppViewState) {
                 revisionKey: state.skillWorkshopRevisionKey,
                 revisionDraft: state.skillWorkshopRevisionDraft,
                 assistantName: state.assistantName,
-                counts: countSkillWorkshopProposals(proposals),
+                counts: countSkillWorkshopProposals(state.skillWorkshopProposals),
                 onStatusFilterChange: (status) => (state.skillWorkshopStatusFilter = status),
                 onQueryChange: (query) => (state.skillWorkshopQuery = query),
                 onFilePreviewQueryChange: (query) => (state.skillWorkshopFilePreviewQuery = query),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -127,6 +127,12 @@ import {
   toggleSessionCompactionCheckpoints,
 } from "./controllers/sessions.ts";
 import {
+  countSkillWorkshopProposals,
+  requestSkillWorkshopRevision,
+  runSkillWorkshopLifecycleAction,
+  selectSkillWorkshopProposal,
+} from "./controllers/skill-workshop.ts";
+import {
   closeClawHubDetail,
   installFromClawHub,
   loadSkillCard,
@@ -451,6 +457,10 @@ const lazyInstances = createLazyView(() => import("./views/instances.ts"), notif
 const lazyLogs = createLazyView(() => import("./views/logs.ts"), notifyLazyViewChanged);
 const lazyNodes = createLazyView(() => import("./views/nodes.ts"), notifyLazyViewChanged);
 const lazySessions = createLazyView(() => import("./views/sessions.ts"), notifyLazyViewChanged);
+const lazySkillWorkshop = createLazyView(
+  () => import("./views/skill-workshop.ts"),
+  notifyLazyViewChanged,
+);
 const lazySkills = createLazyView(() => import("./views/skills.ts"), notifyLazyViewChanged);
 const lazyWorkboard = createLazyView(() => import("./views/workboard.ts"), notifyLazyViewChanged);
 
@@ -2183,7 +2193,12 @@ export function renderApp(state: AppViewState) {
       <main
         class="content ${isChat ? "content--chat" : ""} ${state.tab === "logs"
           ? "content--logs"
-          : ""} ${state.tab === "workboard" ? "content--workboard" : ""}"
+          : ""} ${state.tab === "workboard" ? "content--workboard" : ""} ${state.tab ===
+        "skillWorkshop"
+          ? `content--skill-workshop ${
+              state.skillWorkshopMode === "today" ? "content--skill-workshop-today" : ""
+            }`
+          : ""}"
       >
         ${state.updateStatusBanner
           ? html`<div class="callout ${state.updateStatusBanner.tone}" role="alert">
@@ -3064,6 +3079,77 @@ export function renderApp(state: AppViewState) {
                 onClawHubInstall: (slug) => void installFromClawHub(state, slug),
               }),
             )
+          : nothing}
+        ${state.tab === "skillWorkshop"
+          ? renderLazyView(lazySkillWorkshop, (m) => {
+              const proposals = state.skillWorkshopProposals;
+              const selectedIndex = Math.max(
+                0,
+                proposals.findIndex((proposal) => proposal.key === state.skillWorkshopSelectedKey),
+              );
+              const selectRelativeProposal = (delta: -1 | 1) => {
+                if (proposals.length === 0) {
+                  return;
+                }
+                const nextIndex = (selectedIndex + delta + proposals.length) % proposals.length;
+                selectSkillWorkshopProposal(state, proposals[nextIndex].key);
+              };
+              return m.renderSkillWorkshop({
+                loading: state.skillWorkshopLoading,
+                error: state.skillWorkshopError,
+                inspectingKey: state.skillWorkshopInspectingKey,
+                proposals,
+                selectedKey: state.skillWorkshopSelectedKey,
+                statusFilter: state.skillWorkshopStatusFilter,
+                query: state.skillWorkshopQuery,
+                filePreviewKey: state.skillWorkshopFilePreviewKey,
+                filePreviewQuery: state.skillWorkshopFilePreviewQuery,
+                queueWidth: state.skillWorkshopQueueWidth,
+                mode: state.skillWorkshopMode,
+                actionBusy: state.skillWorkshopActionBusy,
+                actionNotice: state.skillWorkshopActionNotice,
+                revisionKey: state.skillWorkshopRevisionKey,
+                revisionDraft: state.skillWorkshopRevisionDraft,
+                assistantName: state.assistantName,
+                counts: countSkillWorkshopProposals(proposals),
+                onStatusFilterChange: (status) => (state.skillWorkshopStatusFilter = status),
+                onQueryChange: (query) => (state.skillWorkshopQuery = query),
+                onFilePreviewQueryChange: (query) => (state.skillWorkshopFilePreviewQuery = query),
+                onQueueWidthChange: (width) => (state.skillWorkshopQueueWidth = width),
+                onQueueWidthCommit: (width) => (state.skillWorkshopQueueWidth = width),
+                onModeChange: (mode) => (state.skillWorkshopMode = mode),
+                onSelect: (key) => {
+                  state.skillWorkshopFilePreviewKey = null;
+                  selectSkillWorkshopProposal(state, key);
+                },
+                onPrev: () => selectRelativeProposal(-1),
+                onNext: () => selectRelativeProposal(1),
+                onApply: (key) => void runSkillWorkshopLifecycleAction(state, "apply", key),
+                onRevise: (key) => {
+                  state.skillWorkshopRevisionKey = key;
+                  state.skillWorkshopRevisionDraft = "";
+                },
+                onReject: (key) => void runSkillWorkshopLifecycleAction(state, "reject", key),
+                onRevisionDraftChange: (draft) => (state.skillWorkshopRevisionDraft = draft),
+                onRevisionCancel: () => {
+                  state.skillWorkshopRevisionKey = null;
+                  state.skillWorkshopRevisionDraft = "";
+                },
+                onRevisionSubmit: (key) =>
+                  void requestSkillWorkshopRevision(state, key, async (message) => {
+                    state.setTab("chat" as import("./navigation.ts").Tab);
+                    await state.handleSendChat(message, { restoreDraft: true });
+                  }),
+                onPreviewFile: (key, path) => {
+                  state.skillWorkshopSelectedKey = key;
+                  state.skillWorkshopFilePreviewKey = path;
+                },
+                onClosePreview: () => {
+                  state.skillWorkshopFilePreviewKey = null;
+                  state.skillWorkshopFilePreviewQuery = "";
+                },
+              });
+            })
           : nothing}
         ${state.tab === "nodes"
           ? renderLazyView(lazyNodes, (m) =>

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3087,18 +3087,17 @@ export function renderApp(state: AppViewState) {
                 state.skillWorkshopStatusFilter,
                 state.skillWorkshopQuery,
               );
-              const selectedIndex = Math.max(
-                0,
-                visibleProposals.findIndex(
-                  (proposal) => proposal.key === state.skillWorkshopSelectedKey,
-                ),
+              const selectedIndex = visibleProposals.findIndex(
+                (proposal) => proposal.key === state.skillWorkshopSelectedKey,
               );
               const selectRelativeProposal = (delta: -1 | 1) => {
                 if (visibleProposals.length === 0) {
                   return;
                 }
                 const nextIndex =
-                  (selectedIndex + delta + visibleProposals.length) % visibleProposals.length;
+                  selectedIndex < 0
+                    ? 0
+                    : (selectedIndex + delta + visibleProposals.length) % visibleProposals.length;
                 selectSkillWorkshopProposal(state, visibleProposals[nextIndex].key);
               };
               return m.renderSkillWorkshop({
@@ -3123,7 +3122,6 @@ export function renderApp(state: AppViewState) {
                 onQueryChange: (query) => (state.skillWorkshopQuery = query),
                 onFilePreviewQueryChange: (query) => (state.skillWorkshopFilePreviewQuery = query),
                 onQueueWidthChange: (width) => (state.skillWorkshopQueueWidth = width),
-                onQueueWidthCommit: (width) => (state.skillWorkshopQueueWidth = width),
                 onModeChange: (mode) => (state.skillWorkshopMode = mode),
                 onSelect: (key) => {
                   state.skillWorkshopFilePreviewKey = null;
@@ -3144,7 +3142,7 @@ export function renderApp(state: AppViewState) {
                 },
                 onRevisionSubmit: (key) =>
                   void requestSkillWorkshopRevision(state, key, async (message) => {
-                    state.setTab("chat" as import("./navigation.ts").Tab);
+                    state.setTab("chat" as Tab);
                     await state.handleSendChat(message, { restoreDraft: true });
                   }),
                 onPreviewFile: (key, path) => {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -11,6 +11,7 @@ import type { CronModelSuggestionsState, CronState } from "./controllers/cron.ts
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
+import type { SkillWorkshopState } from "./controllers/skill-workshop.ts";
 import type {
   ClawHubSearchResult,
   ClawHubSkillSecurityVerdict,
@@ -51,13 +52,6 @@ import type {
 } from "./types.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
-import type {
-  SkillWorkshopActionBusy,
-  SkillWorkshopActionNotice,
-  SkillWorkshopMode,
-  SkillWorkshopProposal,
-  SkillWorkshopStatusFilter,
-} from "./views/skill-workshop.ts";
 import type { SessionLogEntry } from "./views/usage.ts";
 
 export type AppViewState = {
@@ -432,23 +426,6 @@ export type AppViewState = {
     skillCardContentKeys: Record<string, string>;
     skillCardLoadingKey: string | null;
     skillCardErrors: Record<string, string>;
-    skillWorkshopLoading: boolean;
-    skillWorkshopLoaded: boolean;
-    skillWorkshopError: string | null;
-    skillWorkshopInspectingKey: string | null;
-    skillWorkshopProposals: SkillWorkshopProposal[];
-    skillWorkshopSelectedKey: string | null;
-    skillWorkshopActionBusy: SkillWorkshopActionBusy | null;
-    skillWorkshopActionNotice: SkillWorkshopActionNotice | null;
-    skillWorkshopActionNoticeTimer?: ReturnType<typeof globalThis.setTimeout> | number | null;
-    skillWorkshopRevisionKey: string | null;
-    skillWorkshopRevisionDraft: string;
-    skillWorkshopStatusFilter: SkillWorkshopStatusFilter;
-    skillWorkshopQuery: string;
-    skillWorkshopFilePreviewKey: string | null;
-    skillWorkshopFilePreviewQuery: string;
-    skillWorkshopQueueWidth: number;
-    skillWorkshopMode: SkillWorkshopMode;
     healthLoading: boolean;
     healthResult: HealthSummary | null;
     healthError: string | null;
@@ -576,4 +553,4 @@ export type AppViewState = {
     handleWebPushSubscribe: () => Promise<void>;
     handleWebPushUnsubscribe: () => Promise<void>;
     handleWebPushTest: () => Promise<void>;
-  };
+  } & SkillWorkshopState;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -51,6 +51,13 @@ import type {
 } from "./types.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
+import type {
+  SkillWorkshopActionBusy,
+  SkillWorkshopActionNotice,
+  SkillWorkshopMode,
+  SkillWorkshopProposal,
+  SkillWorkshopStatusFilter,
+} from "./views/skill-workshop.ts";
 import type { SessionLogEntry } from "./views/usage.ts";
 
 export type AppViewState = {
@@ -425,6 +432,23 @@ export type AppViewState = {
     skillCardContentKeys: Record<string, string>;
     skillCardLoadingKey: string | null;
     skillCardErrors: Record<string, string>;
+    skillWorkshopLoading: boolean;
+    skillWorkshopLoaded: boolean;
+    skillWorkshopError: string | null;
+    skillWorkshopInspectingKey: string | null;
+    skillWorkshopProposals: SkillWorkshopProposal[];
+    skillWorkshopSelectedKey: string | null;
+    skillWorkshopActionBusy: SkillWorkshopActionBusy | null;
+    skillWorkshopActionNotice: SkillWorkshopActionNotice | null;
+    skillWorkshopActionNoticeTimer?: ReturnType<typeof globalThis.setTimeout> | number | null;
+    skillWorkshopRevisionKey: string | null;
+    skillWorkshopRevisionDraft: string;
+    skillWorkshopStatusFilter: SkillWorkshopStatusFilter;
+    skillWorkshopQuery: string;
+    skillWorkshopFilePreviewKey: string | null;
+    skillWorkshopFilePreviewQuery: string;
+    skillWorkshopQueueWidth: number;
+    skillWorkshopMode: SkillWorkshopMode;
     healthLoading: boolean;
     healthResult: HealthSummary | null;
     healthError: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -103,6 +103,7 @@ import {
   type ExecApprovalRequest,
 } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
+import type { SkillWorkshopState } from "./controllers/skill-workshop.ts";
 import type {
   ClawHubSearchResult,
   ClawHubSkillSecurityVerdict,
@@ -144,13 +145,6 @@ import type {
 import type { ChatAttachment, ChatQueueItem, CronFormState } from "./ui-types.ts";
 import { generateUUID } from "./uuid.ts";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
-import type {
-  SkillWorkshopActionBusy,
-  SkillWorkshopActionNotice,
-  SkillWorkshopMode,
-  SkillWorkshopProposal,
-  SkillWorkshopStatusFilter,
-} from "./views/skill-workshop.ts";
 
 declare global {
   interface Window {
@@ -637,19 +631,19 @@ export class OpenClawApp extends LitElement {
   @state() skillWorkshopLoaded = false;
   @state() skillWorkshopError: string | null = null;
   @state() skillWorkshopInspectingKey: string | null = null;
-  @state() skillWorkshopProposals: SkillWorkshopProposal[] = [];
+  @state() skillWorkshopProposals: SkillWorkshopState["skillWorkshopProposals"] = [];
   @state() skillWorkshopSelectedKey: string | null = null;
-  @state() skillWorkshopActionBusy: SkillWorkshopActionBusy | null = null;
-  @state() skillWorkshopActionNotice: SkillWorkshopActionNotice | null = null;
+  @state() skillWorkshopActionBusy: SkillWorkshopState["skillWorkshopActionBusy"] = null;
+  @state() skillWorkshopActionNotice: SkillWorkshopState["skillWorkshopActionNotice"] = null;
   skillWorkshopActionNoticeTimer: ReturnType<typeof globalThis.setTimeout> | number | null = null;
   @state() skillWorkshopRevisionKey: string | null = null;
   @state() skillWorkshopRevisionDraft = "";
-  @state() skillWorkshopStatusFilter: SkillWorkshopStatusFilter = "pending";
+  @state() skillWorkshopStatusFilter: SkillWorkshopState["skillWorkshopStatusFilter"] = "pending";
   @state() skillWorkshopQuery = "";
   @state() skillWorkshopFilePreviewKey: string | null = null;
   @state() skillWorkshopFilePreviewQuery = "";
   @state() skillWorkshopQueueWidth = 360;
-  @state() skillWorkshopMode: SkillWorkshopMode = "today";
+  @state() skillWorkshopMode: SkillWorkshopState["skillWorkshopMode"] = "today";
 
   @state() healthLoading = false;
   @state() healthResult: HealthSummary | null = null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -144,6 +144,13 @@ import type {
 import type { ChatAttachment, ChatQueueItem, CronFormState } from "./ui-types.ts";
 import { generateUUID } from "./uuid.ts";
 import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
+import type {
+  SkillWorkshopActionBusy,
+  SkillWorkshopActionNotice,
+  SkillWorkshopMode,
+  SkillWorkshopProposal,
+  SkillWorkshopStatusFilter,
+} from "./views/skill-workshop.ts";
 
 declare global {
   interface Window {
@@ -626,6 +633,23 @@ export class OpenClawApp extends LitElement {
   @state() skillCardContentKeys: Record<string, string> = {};
   @state() skillCardLoadingKey: string | null = null;
   @state() skillCardErrors: Record<string, string> = {};
+  @state() skillWorkshopLoading = false;
+  @state() skillWorkshopLoaded = false;
+  @state() skillWorkshopError: string | null = null;
+  @state() skillWorkshopInspectingKey: string | null = null;
+  @state() skillWorkshopProposals: SkillWorkshopProposal[] = [];
+  @state() skillWorkshopSelectedKey: string | null = null;
+  @state() skillWorkshopActionBusy: SkillWorkshopActionBusy | null = null;
+  @state() skillWorkshopActionNotice: SkillWorkshopActionNotice | null = null;
+  skillWorkshopActionNoticeTimer: ReturnType<typeof globalThis.setTimeout> | number | null = null;
+  @state() skillWorkshopRevisionKey: string | null = null;
+  @state() skillWorkshopRevisionDraft = "";
+  @state() skillWorkshopStatusFilter: SkillWorkshopStatusFilter = "pending";
+  @state() skillWorkshopQuery = "";
+  @state() skillWorkshopFilePreviewKey: string | null = null;
+  @state() skillWorkshopFilePreviewQuery = "";
+  @state() skillWorkshopQueueWidth = 360;
+  @state() skillWorkshopMode: SkillWorkshopMode = "today";
 
   @state() healthLoading = false;
   @state() healthResult: HealthSummary | null = null;

--- a/ui/src/ui/controllers/skill-workshop.ts
+++ b/ui/src/ui/controllers/skill-workshop.ts
@@ -2,7 +2,9 @@ import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
   SkillWorkshopAction,
   SkillWorkshopActionNotice,
+  SkillWorkshopMode,
   SkillWorkshopProposal,
+  SkillWorkshopStatusFilter,
 } from "../views/skill-workshop.ts";
 
 const SKILL_WORKSHOP_NOTICE_MS = 2800;
@@ -84,6 +86,12 @@ export type SkillWorkshopState = {
   skillWorkshopActionNoticeTimer?: ReturnType<typeof globalThis.setTimeout> | number | null;
   skillWorkshopRevisionKey: string | null;
   skillWorkshopRevisionDraft: string;
+  skillWorkshopStatusFilter: SkillWorkshopStatusFilter;
+  skillWorkshopQuery: string;
+  skillWorkshopFilePreviewKey: string | null;
+  skillWorkshopFilePreviewQuery: string;
+  skillWorkshopQueueWidth: number;
+  skillWorkshopMode: SkillWorkshopMode;
 };
 
 function getErrorMessage(err: unknown): string {

--- a/ui/src/ui/views/skill-workshop.ts
+++ b/ui/src/ui/views/skill-workshop.ts
@@ -77,7 +77,6 @@ export type SkillWorkshopProps = {
   onQueryChange: (query: string) => void;
   onFilePreviewQueryChange: (query: string) => void;
   onQueueWidthChange: (width: number) => void;
-  onQueueWidthCommit: (width: number) => void;
   onModeChange: (mode: SkillWorkshopMode) => void;
   onSelect: (key: string) => void;
   onPrev: () => void;
@@ -273,7 +272,6 @@ function startQueueResize(event: PointerEvent, props: SkillWorkshopProps): void 
 
   const startX = event.clientX;
   const startWidth = props.queueWidth;
-  let currentWidth = startWidth;
   const body = document.body;
   const previousCursor = body.style.cursor;
   const previousUserSelect = body.style.userSelect;
@@ -289,13 +287,11 @@ function startQueueResize(event: PointerEvent, props: SkillWorkshopProps): void 
   };
 
   const onMove = (moveEvent: PointerEvent) => {
-    currentWidth = startWidth + moveEvent.clientX - startX;
-    props.onQueueWidthChange(currentWidth);
+    props.onQueueWidthChange(startWidth + moveEvent.clientX - startX);
   };
 
   const onUp = () => {
     cleanup();
-    props.onQueueWidthCommit(currentWidth);
   };
 
   window.addEventListener("pointermove", onMove);
@@ -309,7 +305,7 @@ function resizeQueueWithKeyboard(event: KeyboardEvent, props: SkillWorkshopProps
   }
   event.preventDefault();
   const delta = event.key === "ArrowLeft" ? -24 : 24;
-  props.onQueueWidthCommit(props.queueWidth + delta);
+  props.onQueueWidthChange(props.queueWidth + delta);
 }
 
 function renderLifecycleTabs(props: SkillWorkshopProps) {


### PR DESCRIPTION
## Summary
- Render the Skill Workshop tab through the Control UI app shell.
- Wire the existing Skill Workshop lifecycle actions, revision handoff, file preview, mode, filters, and layout classes into `renderApp`.
- Keep Board Previous/Next navigation scoped to the currently visible visible filtered proposal list.
- Keep filter/search fallback selection aligned with the loaded detail proposal.
- Reuse the Skill Workshop controller state contract from `AppViewState` to avoid duplicating the workshop field list.

## Bug / Behavior
The route and navigation entry for Skill Workshop already existed, and `app-settings.ts` already attempted to load proposals for `skillWorkshop`, but `renderApp` never rendered the lazy Skill Workshop view. Opening `/skills/workshop` selected the tab without any workshop body.

After wiring the view, two Board-state bugs were visible. First, the view filters proposals before displaying a selected item, while the parent Previous/Next handler was navigating the full hidden proposal list. If the selected key was filtered out, for example after applying or rejecting a pending proposal or changing status/search filters, Previous/Next could skip through hidden proposals or appear stuck. Second, the view could visually fall back to the first visible proposal without updating `skillWorkshopSelectedKey`, so the detail pane could show a fallback row while its body/support files were not loaded until the user clicked it again.

## Root Cause
`renderApp` had no `skillWorkshop` render branch or Skill Workshop content layout classes. Once that branch existed, all parent-owned selection callbacks also needed to use the same visible proposal set as `renderSkillWorkshop`, not the raw `state.skillWorkshopProposals` array or a view-only fallback.

## Fix
- Add a lazy Skill Workshop render branch in `ui/src/ui/app-render.ts`.
- Apply `content--skill-workshop` and `content--skill-workshop-today` classes for the existing workshop CSS.
- Pass Skill Workshop state and lifecycle callbacks to the existing view/controller.
- Use `filterSkillWorkshopProposals(...)` for relative proposal navigation and select index `0` when no visible proposal is currently selected.
- When status/search filters hide the current selection, select the first visible fallback proposal through `selectSkillWorkshopProposal(...)` so its detail is loaded.
- Remove the redundant queue width commit callback and use a single width-change handler.
- Extend/reuse `SkillWorkshopState` for app view state typing.

## Verification
- `pnpm format:check -- ui/src/ui/app-render.ts ui/src/ui/views/skill-workshop.ts ui/src/ui/app-view-state.ts ui/src/ui/app.ts ui/src/ui/controllers/skill-workshop.ts`
- `pnpm tsgo:test:ui`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` after the filter fallback fix: clean, no accepted/actionable findings.

## Media proof
![Skill Workshop filtered Board proof](https://gist.githubusercontent.com/Solvely-Colin/0892094345d993c59e87bb50e52d268a/raw/18d97dd91ab2b2a2827f7864e3e0e6e824be02ca/skill-workshop-proof.XXXXXX.svg)

Direct proof asset: https://gist.githubusercontent.com/Solvely-Colin/0892094345d993c59e87bb50e52d268a/raw/18d97dd91ab2b2a2827f7864e3e0e6e824be02ca/skill-workshop-proof.XXXXXX.svg

## Real behavior proof
Behavior addressed: Opening `/skills/workshop` now reaches the `skillWorkshop` route and renders the Skill Workshop surface through the Control UI shell. Board relative navigation now uses the currently visible visible filtered proposal list, and status/search filter fallback now updates the selected proposal and loads its detail.

Real environment tested: Local OpenClaw Control UI on macOS with Playwright Chromium. I tested the live Vite route at `http://127.0.0.1:5174/skills/workshop`, then used the repo's Control UI E2E Gateway helper so the app could connect and render the workshop body with deterministic proposal data.

Exact steps or command run after this patch: Started `pnpm --dir ui dev --host 127.0.0.1 --port 5174`, opened `/skills/workshop` with Playwright Chromium, then ran Playwright Chromium against `startControlUiE2eServer()` plus `installMockGateway()`. The Gateway returned two pending proposals and two applied proposals from `skills.proposals.list`, with detail bodies from `skills.proposals.inspect`. The script opened Skill Workshop, switched to Board, filtered to the `Applied` status, waited for `Applied Alpha`, clicked Next to `Applied Beta`, clicked Previous back to `Applied Alpha`, and saved the screenshot linked below. I also ran the verification commands listed above.

Evidence after fix: ![Skill Workshop filtered Board proof](https://gist.githubusercontent.com/Solvely-Colin/0892094345d993c59e87bb50e52d268a/raw/18d97dd91ab2b2a2827f7864e3e0e6e824be02ca/skill-workshop-proof.XXXXXX.svg)

The live Vite route reported `control-ui.tab.visible {previousTab: chat, tab: skillWorkshop, ...}` and page state `location: "/skills/workshop"`, `appTab: "skillWorkshop"`. With the Gateway connected, the empty-state pass reported `connected: true`, `workshopPresent: true`, `contentClass: "content    content--skill-workshop content--skill-workshop-today"`, `textIncludesNoProposals: true`, and Gateway requests including `skills.proposals.list`. The filtered Board pass reported `afterFilter.selectedKey: "applied-a"`, `afterFilter.bodyHasAppliedAlpha: true`, `afterNext.selectedKey: "applied-b"`, `afterNext.bodyHasAppliedBeta: true`, `afterPrevious.selectedKey: "applied-a"`, `afterPrevious.bodyHasAppliedAlpha: true`, and inspect requests for `pending-1`, `applied-a`, and `applied-b`.

Observed result after fix: The Control UI selected `skillWorkshop` for `/skills/workshop`; with a connected Gateway, the Skill Workshop DOM rendered. Filtering from a pending selection to the Applied status selected and loaded the first visible applied proposal, then Previous/Next stayed inside the visible applied proposal list.

What was not tested: I did not run the full UI suite or validate against a live production Gateway containing real skill proposals.

