### PR TITLE
fix(agent-core): guard harness tool registry

### DIFF
--- a/packages/agent-core/src/harness/agent-harness.test.ts
+++ b/packages/agent-core/src/harness/agent-harness.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { Model } from "../../../llm-core/src/index.js";
+import type { AgentTool } from "../types.js";
+import { AgentHarness } from "./agent-harness.js";
+import type { ExecutionEnv, Session } from "./types.js";
+
+const model: Model = {
+  id: "test-model",
+  name: "Test Model",
+  api: "test-api",
+  provider: "test-provider",
+  baseUrl: "https://example.test",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1000,
+  maxTokens: 1000,
+};
+
+function createTool(name: string): AgentTool {
+  return {
+    name,
+    label: name,
+    description: "test tool",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+    execute: async () => ({ content: [], details: undefined }),
+  } as AgentTool;
+}
+
+function createUnreadableNameTool(): AgentTool {
+  const tool = createTool("placeholder");
+  Object.defineProperty(tool, "name", {
+    get() {
+      throw new Error("tool name getter exploded");
+    },
+  });
+  return tool;
+}
+
+function createHarness(tools: AgentTool[] = []): AgentHarness {
+  return new AgentHarness({
+    env: {} as ExecutionEnv,
+    session: {} as Session,
+    model,
+    tools,
+  });
+}
+
+describe("AgentHarness tool registry", () => {
+  it("ignores tool descriptors with unreadable names during construction", () => {
+    expect(() => createHarness([createUnreadableNameTool(), createTool("healthy")])).not.toThrow();
+  });
+
+  it("treats unreadable tool names as absent when replacing tools", async () => {
+    const harness = createHarness([createTool("healthy")]);
+
+    await expect(harness.setTools([createUnreadableNameTool()], ["broken"])).rejects.toMatchObject({
+      name: "AgentHarnessError",
+      code: "invalid_argument",
+      message: "Unknown tool(s): broken",
+    });
+  });
+});

--- a/packages/agent-core/src/harness/agent-harness.ts
+++ b/packages/agent-core/src/harness/agent-harness.ts
@@ -193,6 +193,27 @@ function normalizeHookError(error: unknown): AgentHarnessError {
   return normalizeHarnessError(error, "hook");
 }
 
+function createToolRegistry<TTool extends AgentTool>(
+  tools: TTool[],
+): { map: Map<string, TTool>; names: string[] } {
+  const map = new Map<string, TTool>();
+  const names: string[] = [];
+  for (const tool of tools) {
+    let name: unknown;
+    try {
+      name = tool.name;
+    } catch {
+      continue;
+    }
+    if (typeof name !== "string" || name.length === 0) {
+      continue;
+    }
+    map.set(name, tool);
+    names.push(name);
+  }
+  return { map, names };
+}
+
 interface AgentHarnessTurnState<
   TSkill extends Skill = Skill,
   TPromptTemplate extends PromptTemplate = PromptTemplate,
@@ -244,13 +265,11 @@ export class AgentHarness<
     this.systemPrompt = options.systemPrompt;
     this.getApiKeyAndHeaders = options.getApiKeyAndHeaders;
     this.runtime = options.runtime;
-    for (const tool of options.tools ?? []) {
-      this.tools.set(tool.name, tool);
-    }
+    const initialToolRegistry = createToolRegistry(options.tools ?? []);
+    this.tools = initialToolRegistry.map;
     this.model = options.model;
     this.thinkingLevel = options.thinkingLevel ?? "off";
-    this.activeToolNames =
-      options.activeToolNames ?? (options.tools ?? []).map((tool) => tool.name);
+    this.activeToolNames = options.activeToolNames ?? initialToolRegistry.names;
     this.steeringQueueMode = options.steeringMode ?? "one-at-a-time";
     this.followUpQueueMode = options.followUpMode ?? "one-at-a-time";
   }
@@ -1113,7 +1132,7 @@ export class AgentHarness<
 
   async setTools(tools: TTool[], activeToolNames?: string[]): Promise<void> {
     try {
-      const nextTools = new Map(tools.map((tool) => [tool.name, tool]));
+      const nextTools = createToolRegistry(tools).map;
       const nextActiveToolNames = activeToolNames ? [...activeToolNames] : this.activeToolNames;
       this.validateToolNames(nextActiveToolNames, nextTools);
       this.tools = nextTools;


### PR DESCRIPTION
## Summary
- build the `AgentHarness` tool registry through a guarded helper that skips descriptors whose `name` cannot be read
- derive default active tool names from readable descriptors and keep `setTools()` validation on the filtered registry
- add regression coverage for construction and tool replacement with hostile tool descriptors

## Verification
- `node scripts/run-vitest.mjs packages/agent-core/src/harness/agent-harness.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check packages/agent-core/src/harness/agent-harness.ts packages/agent-core/src/harness/agent-harness.test.ts`
- `node_modules/.bin/oxlint packages/agent-core/src/harness/agent-harness.ts packages/agent-core/src/harness/agent-harness.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed"` (`run_ea57c2b23baa`, `cbx_c65be8511d70`, provider `aws`, exit 0)

## Real behavior proof
Behavior addressed: `AgentHarness` no longer crashes during tool registry construction or replacement when a malformed descriptor throws from its `name` accessor; healthy sibling tools remain usable and explicit active-name validation reports the unreadable tool as absent.
Real environment tested: focused local Vitest on Node 24 plus AWS Crabbox Linux changed gate.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs packages/agent-core/src/harness/agent-harness.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed"`.
Evidence after fix: focused Vitest passed 2 tests; Crabbox changed gate selected `core` and `coreTests`, completed typecheck/lint/guards, and exited 0 in run `run_ea57c2b23baa` on lease `cbx_c65be8511d70`. After one final fast-forward rebase, focused Vitest, oxfmt, oxlint, and `git diff --check` were rerun on pushed head `36dc305799e84d50aa7bbd5889e511e0a0a9a1ea`.
Observed result after fix: unreadable tool descriptors are skipped at the harness registry boundary instead of throwing raw accessor errors.
What was not tested: full repository suite on the pushed SHA; GitHub PR checks are expected to cover the final branch head.
