### PR TITLE
fix(crabbox): harden Testbox wrapper preflights

### DIFF
--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -24,12 +24,9 @@ import { resolvePathEnvKey } from "./windows-cmd-helpers.mjs";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const ignoreRepoBinary = process.env.OPENCLAW_CRABBOX_WRAPPER_IGNORE_REPO_BINARY === "1";
 const repoLocal = ignoreRepoBinary ? null : resolveCrabboxBinary(process.env, process.platform);
-const pathLocal = resolvePathBinary("crabbox", process.env, process.platform);
-const binary =
-  repoLocal ??
-  pathLocal ??
-  resolveGitCommonCrabboxBinary(process.env, process.platform) ??
-  "crabbox";
+const pathLocals = resolvePathBinaries("crabbox", process.env, process.platform);
+const binaryCandidates = crabboxBinaryCandidates(process.env, process.platform);
+let binary = binaryCandidates[0] ?? "crabbox";
 const args = process.argv.slice(2);
 
 if (args[0] === "--") {
@@ -61,16 +58,39 @@ function resolveCrabboxBinary(env, platform) {
 }
 
 function resolvePathBinary(command, env, platform) {
+  return resolvePathBinaries(command, env, platform)[0] ?? null;
+}
+
+function resolvePathBinaries(command, env, platform) {
   const pathValue = env[resolvePathEnvKey(env)] ?? "";
+  const paths = [];
   for (const dir of pathValue.split(delimiter).filter(Boolean)) {
     for (const candidate of commandCandidates(command, platform)) {
       const fullPath = resolve(dir, candidate);
       if (isExecutableFile(fullPath, platform)) {
-        return fullPath;
+        paths.push(fullPath);
+        break;
       }
     }
   }
-  return null;
+  return paths;
+}
+
+function pushUnique(values, value) {
+  if (value && !values.includes(value)) {
+    values.push(value);
+  }
+}
+
+function crabboxBinaryCandidates(env, platform) {
+  const candidates = [];
+  pushUnique(candidates, repoLocal);
+  for (const candidate of pathLocals) {
+    pushUnique(candidates, candidate);
+  }
+  pushUnique(candidates, resolveGitCommonCrabboxBinary(env, platform));
+  pushUnique(candidates, "crabbox");
+  return candidates;
 }
 
 function resolveGitCommonCrabboxBinary(env, platform) {
@@ -2137,8 +2157,6 @@ function assertFullCheckoutAvailableBeforeExit(dir) {
   return false;
 }
 
-const version = checkedOutput(binary, ["--version"]);
-const help = checkedOutput(binary, ["run", "--help"]);
 const providerAliases = new Map([
   ["blacksmith", "blacksmith-testbox"],
   ["cf", "cloudflare"],
@@ -2228,8 +2246,34 @@ function isProviderAdvertised(provider, advertisedProviders) {
   );
 }
 
-const providers = parseProvidersFromHelp(help.text);
-const displayBinary = binary === "crabbox" ? "crabbox" : relative(repoRoot, binary);
+function displayBinaryPath(path) {
+  return path === "crabbox" ? "crabbox" : relative(repoRoot, path);
+}
+
+function selectBlacksmithCapableBinary(candidates, currentBinary) {
+  for (const candidate of candidates) {
+    if (candidate === currentBinary) {
+      continue;
+    }
+    const candidateVersion = checkedOutput(candidate, ["--version"]);
+    const candidateHelp = checkedOutput(candidate, ["run", "--help"]);
+    if (candidateVersion.status !== 0 || candidateHelp.status !== 0) {
+      continue;
+    }
+    if (!satisfiesMinimumCrabboxVersion(candidateVersion.text, minimumBlacksmithCrabboxVersion)) {
+      continue;
+    }
+    if (!isProviderAdvertised("blacksmith-testbox", parseProvidersFromHelp(candidateHelp.text))) {
+      continue;
+    }
+    return { binary: candidate, version: candidateVersion, help: candidateHelp };
+  }
+  return null;
+}
+
+let version = checkedOutput(binary, ["--version"]);
+let help = checkedOutput(binary, ["run", "--help"]);
+let providers = parseProvidersFromHelp(help.text);
 const provider = selectedProvider(args, providers);
 const canonicalProvider = providerAliases.get(provider) ?? provider;
 const commandProviderValue = commandProvider(args);
@@ -2237,6 +2281,24 @@ let normalizedArgs = ensureAwsMacOnDemandMarket(
   ensureAzureWindowsProvider(args, provider, providers),
   provider,
 );
+
+if (
+  canonicalProvider === "blacksmith-testbox" &&
+  !satisfiesMinimumCrabboxVersion(version.text, minimumBlacksmithCrabboxVersion)
+) {
+  const alternate = selectBlacksmithCapableBinary(binaryCandidates, binary);
+  if (alternate) {
+    console.error(
+      `[crabbox] selected ${displayBinaryPath(binary)} is too old for blacksmith-testbox; using ${displayBinaryPath(alternate.binary)} instead`,
+    );
+    binary = alternate.binary;
+    version = alternate.version;
+    help = alternate.help;
+    providers = parseProvidersFromHelp(help.text);
+  }
+}
+
+const displayBinary = displayBinaryPath(binary);
 
 console.error(
   `[crabbox] bin=${displayBinary} version=${version.text || "unknown"} provider=${provider || "unknown"} providers=${providers.join(",") || "unknown"}`,

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -188,6 +188,37 @@ function makeSlowVersionCrabbox(helpText: string): string {
   return binDir;
 }
 
+function makeFixedVersionCrabbox(helpText: string, version: string): string {
+  const binDir = mkdtempSync(path.join(tmpdir(), "openclaw-fixed-crabbox-"));
+  tempDirs.push(binDir);
+  const crabboxPath = path.join(binDir, "crabbox");
+  const script = [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    'if (args[0] === "--version") {',
+    `  console.log(${JSON.stringify(version)});`,
+    "  process.exit(0);",
+    "}",
+    'if (args[0] === "run" && args[1] === "--help") {',
+    `  process.stdout.write(${JSON.stringify(helpText)});`,
+    "  process.exit(0);",
+    "}",
+    'if (args[0] === "config" && args[1] === "show" && args.includes("--json")) {',
+    '  process.stdout.write(process.env.OPENCLAW_FAKE_CRABBOX_CONFIG_JSON || \'{"coordinator":"configured-broker","brokerAuth":"configured"}\');',
+    "  process.exit(0);",
+    "}",
+    "console.log(JSON.stringify({ args, cwd: process.cwd() }));",
+  ].join("\n");
+  writeFileSync(crabboxPath, `${script}\n`, "utf8");
+  writeFileSync(
+    `${crabboxPath}.cmd`,
+    `@echo off\r\n"${process.execPath}" "%~dp0crabbox" %*\r\n`,
+    "utf8",
+  );
+  chmodSync(crabboxPath, 0o755);
+  return binDir;
+}
+
 function shellSingleQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -408,6 +439,23 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
     expect(result.stderr).toContain("selected binary reported version=crabbox 0.21.9");
   });
 
+  it("uses a newer PATH Crabbox for Blacksmith Testbox when the first candidate is stale", () => {
+    const helpText = "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n";
+    const staleCrabbox = makeFixedVersionCrabbox(helpText, "crabbox 0.21.9");
+    const result = runWrapper(
+      helpText,
+      ["run", "--provider", "blacksmith-testbox", "--", "echo ok"],
+      {
+        extraPathEntries: [staleCrabbox],
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("is too old for blacksmith-testbox; using");
+    expect(result.stderr).toContain("version=crabbox 0.22.1");
+    expect(parseFakeCrabboxOutput(result).args).toContain("blacksmith-testbox");
+  });
+
   it("applies the Blacksmith version gate to provider aliases", () => {
     const result = runWrapper(
       "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
@@ -597,6 +645,23 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
     expect(result.stderr).toContain(
       "crabbox login --url https://crabbox.openclaw.ai --provider aws",
     );
+  });
+
+  it("preserves direct Azure proof without broker auth", () => {
+    const result = runWrapper(
+      "provider: hetzner, aws, azure, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "azure", "--", "echo ok"],
+      { configJson: { coordinator: "", brokerAuth: "missing" } },
+    );
+
+    expect(result.status).toBe(0);
+    expect(parseFakeCrabboxOutput(result).args).toEqual([
+      "run",
+      "--provider",
+      "azure",
+      "--",
+      "echo ok",
+    ]);
   });
 
   it("allows explicit direct AWS debugging without broker auth", () => {


### PR DESCRIPTION
## Summary

- Let Blacksmith Testbox runs skip a stale selected Crabbox binary when a newer PATH/common-dir binary is available, so a stale sibling checkout does not block Testbox proof unnecessarily.
- Preserve existing direct Azure wrapper behavior when broker auth is missing; this addresses the compatibility feedback from ClawSweeper.
- Add focused wrapper coverage for stale Testbox binary fallback and the Azure compatibility guard.

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts`
- `pnpm exec oxfmt --write --threads=1 scripts/crabbox-wrapper.mjs test/scripts/crabbox-wrapper.test.ts`
- `git diff --check`
- Live Testbox-through-Crabbox proof with a fake stale PATH `crabbox` first, forcing the wrapper fallback path before running a tiny remote command.

## Real behavior proof

Behavior addressed: Rebased the PR onto current `main`, resolved the wrapper conflict, kept the Blacksmith Testbox stale-binary fallback, and removed the Azure fail-closed behavior flagged by review.
Real environment tested: Live Blacksmith Testbox through Crabbox, provider `blacksmith-testbox`, lease `tbx_01ktcbkgthfmrks7cm36kas2jb`, GitHub Actions run `https://github.com/openclaw/openclaw/actions/runs/27028509286`, local wrapper head `66827ed65f`.
Exact steps or command run after this patch: `PATH="/tmp/pr89137-stale-crabbox-bin:$PATH" OPENCLAW_CRABBOX_WRAPPER_IGNORE_REPO_BINARY=1 node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 10m --ttl 30m --timing-json --shell -- "printf 'openclaw-pr-89137-live-proof\n'; node --version"`.
Evidence after fix: Wrapper printed `selected ../../../tmp/pr89137-stale-crabbox-bin/crabbox is too old for blacksmith-testbox; using ../../../Users/wilfred/.openclaw/workspace/core/crabbox/bin/crabbox instead`; it then ran Testbox lease `tbx_01ktcbkgthfmrks7cm36kas2jb` and printed `openclaw-pr-89137-live-proof`, `v24.13.0`, `blacksmith run summary sync=delegated command=35.428s total=42.495s exit=0`, and JSON with `"provider":"blacksmith-testbox"`, `"syncDelegated":true`, `"exitCode":0`.
Observed result after fix: The branch is no longer conflicted, the stale Blacksmith Testbox binary fallback works in a live wrapper run, the remote Testbox command completed successfully, and Azure missing-broker compatibility is covered by a regression test.
What was not tested: No live Azure provider run was exercised; the Azure compatibility feedback is covered by the targeted wrapper regression test that preserves direct Azure behavior without broker auth.

## Notes for @vincentkoc

This PR keeps the repo-owned wrapper fix from the original Crabbox/Testbox smoke friction. A few issues remain outside this wrapper change:

- Blacksmith Testbox SSH/rsync connection refusals happened before OpenClaw commands ran, so those look provider-side or transient rather than fixable in this repo.
- Intentional raw direct-cloud debugging still needs local cloud auth and CLIs; this PR does not change Azure direct-provider behavior.
- If a future Testbox image loses Node/Corepack/pnpm again, that should be handled in the Testbox workflow/hydration image.
