### PR TITLE
fix(agents): guard provider tool diagnostic names

### DIFF
--- a/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
@@ -21,6 +21,16 @@ vi.mock("./logger.js", () => ({
 const { logProviderToolSchemaDiagnostics, normalizeProviderToolSchemas } =
   await import("./tool-schema-runtime.js");
 
+function createUnreadableNameTool() {
+  const tool = { name: "placeholder" };
+  Object.defineProperty(tool, "name", {
+    get() {
+      throw new Error("tool name getter exploded");
+    },
+  });
+  return tool;
+}
+
 describe("tool schema runtime diagnostics", () => {
   it("stays quiet when a provider reports no diagnostics", () => {
     mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([]);
@@ -82,6 +92,29 @@ describe("tool schema runtime diagnostics", () => {
           { index: 1, tool: "beta", violations: ["one"], violationCount: 1 },
         ],
       },
+    );
+  });
+
+  it("logs provider diagnostics even when a tool name cannot be read", () => {
+    mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([
+      { toolName: "unknown", toolIndex: 0, violations: ["one"] },
+    ]);
+
+    expect(() =>
+      logProviderToolSchemaDiagnostics({
+        provider: "example",
+        tools: [createUnreadableNameTool(), { name: "beta" }] as never,
+      }),
+    ).not.toThrow();
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema diagnostics: 1 tool for example: unknown (1 violation)",
+      expect.objectContaining({
+        provider: "example",
+        toolCount: 2,
+        diagnosticCount: 1,
+        tools: ["0:<unreadable>", "1:beta"],
+      }),
     );
   });
 });

--- a/src/agents/embedded-agent-runner/tool-schema-runtime.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.ts
@@ -91,7 +91,7 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
       provider: params.provider,
       toolCount: params.tools.length,
       diagnosticCount: diagnostics.length,
-      tools: params.tools.map((tool, index) => `${index}:${tool.name}`),
+      tools: params.tools.map(formatDiagnosticToolName),
       diagnostics: diagnostics.map((diagnostic) => ({
         index: diagnostic.toolIndex,
         tool: diagnostic.toolName,
@@ -100,6 +100,15 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
       })),
     },
   );
+}
+
+function formatDiagnosticToolName(tool: AgentTool, index: number): string {
+  try {
+    const name = tool.name;
+    return `${index}:${typeof name === "string" && name ? name : "<unnamed>"}`;
+  } catch {
+    return `${index}:<unreadable>`;
+  }
 }
 
 function summarizeProviderToolSchemaDiagnostics(


### PR DESCRIPTION
## Summary
- guard provider tool-schema diagnostic log metadata from unreadable tool `name` accessors
- keep diagnostics visible by rendering malformed tool names as `<unreadable>` / `<unnamed>` instead of throwing
- add a focused regression for diagnostic logging with a hostile tool descriptor

## Verification
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-schema-runtime.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`
- `node_modules/.bin/oxlint src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed"` (`run_3a6489ddf24c`, `cbx_f236958b53c0`, provider `aws`, exit 0)

## Real behavior proof
Behavior addressed: provider-owned tool-schema diagnostics no longer crash while trying to log diagnostic metadata for a malformed tool descriptor whose `name` accessor throws.
Real environment tested: focused local Vitest on Node 24 plus AWS Crabbox Linux changed gate.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-schema-runtime.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed"`.
Evidence after fix: focused Vitest passed 4 tests; Crabbox changed gate selected `core` and `coreTests`, completed typecheck/lint/guards, and exited 0 in run `run_3a6489ddf24c` on lease `cbx_f236958b53c0`. After one final fast-forward rebase, focused Vitest, oxfmt, oxlint, and `git diff --check` were rerun on pushed head `d6fc7a6d3f9a897778ce91da80dd775f30384221`.
Observed result after fix: the warning still logs provider diagnostics and reports the hostile descriptor as `0:<unreadable>` instead of throwing before the warning reaches operators.
What was not tested: full repository suite on the pushed SHA; GitHub PR checks are expected to cover the final branch head.
