### PR TITLE
fix(agents): stabilize message send loop detection

### DIFF
--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -1140,13 +1140,17 @@ export function wrapToolWithBeforeToolCallHook(
           reason: outcome.reason,
           deniedReason: outcome.deniedReason ?? "plugin-before-tool-call",
         });
-        await recordLoopOutcome({
-          ctx,
-          toolName: normalizedToolName,
-          toolParams: outcome.params ?? hookParams,
-          toolCallId,
-          result: blockedResult,
-        });
+        // A loop detector veto is not tool progress. Recording it would replace
+        // the repeated successful outcome and let the same loop resume.
+        if (outcome.deniedReason !== "tool-loop") {
+          await recordLoopOutcome({
+            ctx,
+            toolName: normalizedToolName,
+            toolParams: outcome.params ?? hookParams,
+            toolCallId,
+            result: blockedResult,
+          });
+        }
         return blockedResult;
       }
       const executeParams = reconcileCodeModeExecBeforeHookParams({

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -623,6 +623,102 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("blocks repeated message sends despite volatile delivery ids", () => {
+      const params = { action: "send", to: "feishu:chat-1", content: "hello" };
+      const cases = [
+        {
+          name: "direct send result",
+          payloadAt: (index: number) => ({
+            channel: "feishu",
+            to: "feishu:chat-1",
+            via: "direct",
+            result: {
+              channel: "feishu",
+              chatId: "oc_stable_chat",
+              messageId: `om_volatile_${index}`,
+            },
+          }),
+        },
+        {
+          name: "gateway send result",
+          payloadAt: (index: number) => ({
+            channel: "feishu",
+            to: "feishu:chat-1",
+            via: "gateway",
+            result: { messageId: `gw_volatile_${index}` },
+          }),
+        },
+        {
+          name: "plugin tool result",
+          payloadAt: (index: number) => ({
+            ok: true,
+            chatId: "oc_stable_chat",
+            messageId: `plugin_volatile_${index}`,
+          }),
+        },
+      ];
+
+      for (const { name, payloadAt } of cases) {
+        const state = createState();
+
+        for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+          const payload = payloadAt(index);
+          recordSuccessfulCall(
+            state,
+            "message",
+            params,
+            {
+              content: [{ type: "text", text: JSON.stringify(payload) }],
+              details: payload,
+            },
+            index,
+          );
+        }
+
+        const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+        expect(loopResult.stuck, name).toBe(true);
+        if (loopResult.stuck) {
+          expect(loopResult.level, name).toBe("critical");
+          expect(loopResult.detector, name).toBe("generic_repeat");
+        }
+      }
+    });
+
+    it("does not block repeated message sends when stable delivery facts change", () => {
+      const state = createState();
+      const params = { action: "send", to: "feishu:chat-1", content: "hello" };
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        const payload = {
+          channel: "feishu",
+          to: "feishu:chat-1",
+          via: "direct",
+          result: {
+            ok: true,
+            chatId: `oc_chat_${index}`,
+            messageId: `om_volatile_${index}`,
+          },
+        };
+        recordSuccessfulCall(
+          state,
+          "message",
+          params,
+          {
+            content: [{ type: "text", text: JSON.stringify(payload) }],
+            details: payload,
+          },
+          index,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("generic_repeat");
+      }
+    });
+
     it("keeps changing exec output below the global no-progress breaker", () => {
       const state = createState();
       const params = { command: "date" };

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -656,6 +656,23 @@ describe("tool-loop-detection", () => {
             messageId: `plugin_volatile_${index}`,
           }),
         },
+        {
+          name: "qa-channel plugin message result",
+          payloadAt: (index: number) => ({
+            message: {
+              id: `qa_volatile_${index}`,
+              accountId: "default",
+              direction: "outbound",
+              conversation: {
+                id: "loop-room",
+                chatType: "channel",
+              },
+              senderId: "openclaw",
+              text: "hello",
+              timestamp: 1_800_000_000_000 + index,
+            },
+          }),
+        },
       ];
 
       for (const { name, payloadAt } of cases) {
@@ -685,37 +702,62 @@ describe("tool-loop-detection", () => {
     });
 
     it("does not block repeated message sends when stable delivery facts change", () => {
-      const state = createState();
       const params = { action: "send", to: "feishu:chat-1", content: "hello" };
+      const cases = [
+        {
+          name: "chat id changes",
+          payloadAt: (index: number) => ({
+            channel: "feishu",
+            to: "feishu:chat-1",
+            via: "direct",
+            result: {
+              ok: true,
+              chatId: `oc_chat_${index}`,
+              messageId: `om_volatile_${index}`,
+            },
+          }),
+        },
+        {
+          name: "qa-channel conversation id changes",
+          payloadAt: (index: number) => ({
+            message: {
+              id: `qa_volatile_${index}`,
+              accountId: "default",
+              direction: "outbound",
+              conversation: {
+                id: `loop-room-${index}`,
+                chatType: "channel",
+              },
+              senderId: "openclaw",
+              text: "hello",
+              timestamp: 1_800_000_000_000 + index,
+            },
+          }),
+        },
+      ];
 
-      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
-        const payload = {
-          channel: "feishu",
-          to: "feishu:chat-1",
-          via: "direct",
-          result: {
-            ok: true,
-            chatId: `oc_chat_${index}`,
-            messageId: `om_volatile_${index}`,
-          },
-        };
-        recordSuccessfulCall(
-          state,
-          "message",
-          params,
-          {
-            content: [{ type: "text", text: JSON.stringify(payload) }],
-            details: payload,
-          },
-          index,
-        );
-      }
+      for (const { name, payloadAt } of cases) {
+        const state = createState();
+        for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+          const payload = payloadAt(index);
+          recordSuccessfulCall(
+            state,
+            "message",
+            params,
+            {
+              content: [{ type: "text", text: JSON.stringify(payload) }],
+              details: payload,
+            },
+            index,
+          );
+        }
 
-      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
-      expect(loopResult.stuck).toBe(true);
-      if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
-        expect(loopResult.detector).toBe("generic_repeat");
+        const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+        expect(loopResult.stuck, name).toBe(true);
+        if (loopResult.stuck) {
+          expect(loopResult.level, name).toBe("warning");
+          expect(loopResult.detector, name).toBe("generic_repeat");
+        }
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -203,6 +203,17 @@ function parseJsonObject(text: string): Record<string, unknown> | undefined {
   }
 }
 
+function isMessageDeliveryObject(value: Record<string, unknown>): boolean {
+  return (
+    typeof value.id === "string" &&
+    typeof value.text === "string" &&
+    (typeof value.direction === "string" ||
+      typeof value.senderId === "string" ||
+      typeof value.accountId === "string" ||
+      isPlainObject(value.conversation))
+  );
+}
+
 function normalizeMessageSendOutcome(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((entry) => normalizeMessageSendOutcome(entry));
@@ -211,6 +222,7 @@ function normalizeMessageSendOutcome(value: unknown): unknown {
     return value;
   }
 
+  const stripMessageObjectId = isMessageDeliveryObject(value);
   const normalized: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
     if (
@@ -218,6 +230,7 @@ function normalizeMessageSendOutcome(value: unknown): unknown {
       key === "messageIds" ||
       key === "platformMessageIds" ||
       key === "receipt" ||
+      (key === "id" && stripMessageObjectId) ||
       key === "timestamp"
     ) {
       continue;

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -191,6 +191,61 @@ function stringField(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
+function parseJsonObject(text: string): Record<string, unknown> | undefined {
+  if (!text) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return isPlainObject(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeMessageSendOutcome(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeMessageSendOutcome(entry));
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (
+      key === "messageId" ||
+      key === "messageIds" ||
+      key === "platformMessageIds" ||
+      key === "receipt" ||
+      key === "timestamp"
+    ) {
+      continue;
+    }
+    normalized[key] = normalizeMessageSendOutcome(entry);
+  }
+  return normalized;
+}
+
+function hashMessageSendToolOutcome(
+  params: unknown,
+  details: Record<string, unknown>,
+  text: string,
+): string | undefined {
+  if (!isPlainObject(params) || params.action !== "send") {
+    return undefined;
+  }
+
+  const source = Object.keys(details).length > 0 ? details : parseJsonObject(text);
+  if (!source) {
+    return undefined;
+  }
+
+  // Delivery ids and receipts are unique per successful send. Loop detection
+  // must compare stable delivery facts so repeated sends can still be blocked.
+  return digestStable(normalizeMessageSendOutcome(source));
+}
+
 function hashExecToolOutcome(details: Record<string, unknown>, text: string): string | undefined {
   const status = stringField(details.status);
   if (!status) {
@@ -249,6 +304,12 @@ function hashToolOutcome(
     const execHash = hashExecToolOutcome(details, text);
     if (execHash) {
       return { resultHash: execHash };
+    }
+  }
+  if (toolName === "message") {
+    const messageHash = hashMessageSendToolOutcome(params, details, text);
+    if (messageHash) {
+      return { resultHash: messageHash };
     }
   }
   if (isKnownPollToolCall(toolName, params) && toolName === "process" && isPlainObject(params)) {

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -4,6 +4,9 @@ import type { ChannelMessageAdapterShape } from "../../channels/message/types.js
 import type { ChannelMessageCapability } from "../../channels/plugins/message-capabilities.js";
 import type { ChannelMessageActionName, ChannelPlugin } from "../../channels/plugins/types.js";
 import type { MessageActionRunResult } from "../../infra/outbound/message-action-runner.js";
+import { resetDiagnosticSessionStateForTest } from "../../logging/diagnostic-session-state.js";
+import { wrapToolWithBeforeToolCallHook } from "../agent-tools.before-tool-call.js";
+import { CRITICAL_THRESHOLD } from "../tool-loop-detection.js";
 type CreateMessageTool = typeof import("./message-tool.js").createMessageTool;
 type CreateOpenClawTools = typeof import("../openclaw-tools.js").createOpenClawTools;
 type ResetPluginRuntimeStateForTest =
@@ -310,6 +313,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   resetPluginRuntimeStateForTest();
+  resetDiagnosticSessionStateForTest();
   mocks.runMessageAction.mockReset();
   mocks.getRuntimeConfig.mockReset().mockReturnValue({});
   mocks.resolveCommandSecretRefsViaGateway.mockReset().mockImplementation(async ({ config }) => ({
@@ -1079,6 +1083,68 @@ describe("message tool explicit target guard", () => {
 
     const call = firstRunMessageActionInput();
     expect(call?.params?.target).toBe("channel:C999");
+  });
+});
+
+describe("message tool loop detection action runner proof", () => {
+  function mockQaChannelGatewayActionRunner() {
+    mocks.runMessageAction.mockImplementation(async ({ params }) => {
+      const callIndex = mocks.runMessageAction.mock.calls.length;
+      const to = typeof params.to === "string" ? params.to : "channel:loop-room";
+      return {
+        kind: "send",
+        action: "send",
+        channel: "qa-channel",
+        to,
+        handledBy: "plugin",
+        payload: {
+          channel: "qa-channel",
+          to,
+          via: "gateway",
+          result: {
+            messageId: `qa-message-${callIndex}`,
+          },
+        },
+        dryRun: false,
+      } satisfies MessageActionRunResult;
+    });
+  }
+
+  it("blocks repeated qa-channel Gateway sends returned by the message tool action runner", async () => {
+    mockQaChannelGatewayActionRunner();
+    const messageTool = createMessageTool({
+      runMessageAction: mocks.runMessageAction as never,
+    });
+    const wrappedTool = wrapToolWithBeforeToolCallHook(messageTool, {
+      agentId: "main",
+      sessionKey: "message-tool-action-runner-loop",
+      sessionId: "message-tool-action-runner-loop-session",
+      runId: "message-tool-action-runner-loop-run",
+      loopDetection: { enabled: true },
+    });
+    const params = {
+      action: "send",
+      channel: "qa-channel",
+      to: "channel:loop-room",
+      content: "same visible reply",
+    };
+
+    for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+      const result = await wrappedTool.execute(`message-tool-send-${i}`, params);
+      expect(result.details).toMatchObject({
+        channel: "qa-channel",
+        to: "channel:loop-room",
+        via: "gateway",
+      });
+    }
+
+    const blocked = await wrappedTool.execute(`message-tool-send-${CRITICAL_THRESHOLD}`, params);
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(CRITICAL_THRESHOLD);
+    expect(blocked.details).toMatchObject({
+      status: "blocked",
+      deniedReason: "tool-loop",
+    });
+    expect(String(blocked.details?.reason)).toContain("CRITICAL");
   });
 });
 

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1144,7 +1144,8 @@ describe("message tool loop detection action runner proof", () => {
       status: "blocked",
       deniedReason: "tool-loop",
     });
-    expect(String(blocked.details?.reason)).toContain("CRITICAL");
+    const blockedDetails = blocked.details as { reason?: unknown } | undefined;
+    expect(String(blockedDetails?.reason)).toContain("CRITICAL");
   });
 });
 

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1098,11 +1098,17 @@ describe("message tool loop detection action runner proof", () => {
         to,
         handledBy: "plugin",
         payload: {
-          channel: "qa-channel",
-          to,
-          via: "gateway",
-          result: {
-            messageId: `qa-message-${callIndex}`,
+          message: {
+            id: `qa-message-${callIndex}`,
+            accountId: "default",
+            direction: "outbound",
+            conversation: {
+              id: "loop-room",
+              chatType: "channel",
+            },
+            senderId: "openclaw",
+            text: "same visible reply",
+            timestamp: 1_800_000_000_000 + callIndex,
           },
         },
         dryRun: false,
@@ -1132,9 +1138,12 @@ describe("message tool loop detection action runner proof", () => {
     for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
       const result = await wrappedTool.execute(`message-tool-send-${i}`, params);
       expect(result.details).toMatchObject({
-        channel: "qa-channel",
-        to: "channel:loop-room",
-        via: "gateway",
+        message: {
+          conversation: {
+            id: "loop-room",
+          },
+          text: "same visible reply",
+        },
       });
     }
 
@@ -1146,6 +1155,16 @@ describe("message tool loop detection action runner proof", () => {
     });
     const blockedDetails = blocked.details as { reason?: unknown } | undefined;
     expect(String(blockedDetails?.reason)).toContain("CRITICAL");
+
+    const blockedAgain = await wrappedTool.execute(
+      `message-tool-send-${CRITICAL_THRESHOLD + 1}`,
+      params,
+    );
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(CRITICAL_THRESHOLD);
+    expect(blockedAgain.details).toMatchObject({
+      status: "blocked",
+      deniedReason: "tool-loop",
+    });
   });
 });
 


### PR DESCRIPTION
AI-assisted: yes (Codex prepared the patch and verification).

## Summary

- Normalize volatile delivery fields from `message(action=send)` tool outcomes before loop-detection result hashing, including qa-channel message-object `id`/`timestamp` fields while preserving stable routing facts such as `conversation.id`.
- Keep loop-detector vetoes out of tool outcome history so a critical `tool-loop` block stays sticky instead of being treated as fresh progress.
- Add focused regression coverage for direct, Gateway-shaped, plugin-shaped, qa-channel message-object, and `createMessageTool()` action-runner send results.

Fixes #89090.

## Linked context

Issue #89090 reports that repeated `message.send` calls can warn forever without escalating to a critical block because each successful send returns a unique delivery id, producing a different `resultHash` every time.

## Real behavior proof

Behavior addressed: Repeated `message(action=send)` calls with identical arguments now escalate to a critical loop block even when every successful send returns a different delivery id, and repeated calls after the first block stay blocked instead of sending more messages.

Real environment tested: Local full QA runtime with qa-lab bus, qa-channel plugin, real Gateway child process, and a local OpenAI-compatible provider that intentionally keeps requesting the same `message.send` tool call. Also tested focused local Vitest coverage for the message tool action-runner and before-tool-call loop-detection runtime paths.

Exact steps or command run after this patch:

```sh
pnpm tsx .artifacts/proof-89143-message-loop-runtime.ts
node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts src/agents/tools/message-tool.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:

```text
proof=message-loop-runtime
provider_requests=27
gateway_observed_block=true
qa_channel_outbound_marker_count=20
run_id=e04535c3-f55c-494d-9620-f94f6fd46292
run_status=critical_block_observed
tool_loop_log_tail:
[agents/tools] Blocking message due to critical loop: CRITICAL: Called message with identical arguments and identical outcomes 20 times. Session execution blocked to prevent runaway loops.
[diagnostic] tool loop: sessionId=bb60d9da-bbdf-40db-b162-1b78f8bacb84 sessionKey=agent:qa:message-loop-proof-89143 tool=message level=critical action=block detector=generic_repeat count=20 message="CRITICAL: Called message with identical arguments and identical outcomes 20 times. Session execution blocked to prevent runaway loops."
```

```text
src/agents/tool-loop-detection.test.ts: 45 passed
src/agents/tools/message-tool.test.ts: 90 passed
src/agents/agent-tools.before-tool-call.e2e.test.ts: 50 passed
tsgo core test tsconfig: passed
git diff --check: clean
autoreview: clean, no accepted/actionable findings reported
```

Observed result after fix: In the full Gateway/qa-channel proof, the first 20 repeated sends were delivered to the qa-channel bus, then Gateway emitted a critical `tool=message level=critical action=block detector=generic_repeat count=20` event. The same looping provider continued requesting `message.send`, and qa-channel delivery stayed at exactly 20 outbound marker messages, proving later retries were blocked rather than sent.

What was not tested: No live Feishu/Lark/Telegram external transport send was run. The real-process proof used qa-channel because it exercises the Gateway child, channel plugin action dispatch, qa-lab bus, and message tool loop detector without live credentials.

## Tests and validation

- `pnpm tsx .artifacts/proof-89143-message-loop-runtime.ts`
- `node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts src/agents/tools/message-tool.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Risk checklist

- [x] No config, env, migration, or public API surface changes.
- [x] No changelog update; normal PR release notes live here.
- [x] No live credentials, transcripts, screenshots, or proof artifacts committed.
- [x] Maintainer edits left enabled by using the GitHub CLI default.

## Current review state

Fresh local autoreview passed with no accepted/actionable findings. The earlier proof gap was closed with full local Gateway/qa-channel runtime proof; the remaining disclosed gap is live external Feishu/Lark/Telegram transport replay.
