### PR TITLE
feat(channels): add Zulip external channel catalog entry

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -798,7 +798,7 @@ jobs:
       - name: Build private QA runtime
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
+        run: node scripts/build-all.mjs qaRuntime
 
       - name: Run parity lane
         env:
@@ -876,7 +876,7 @@ jobs:
       - name: Build private QA runtime
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
+        run: node scripts/build-all.mjs qaRuntime
 
       - name: Generate parity report
         run: |
@@ -934,7 +934,7 @@ jobs:
       - name: Build private QA runtime
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
+        run: node scripts/build-all.mjs qaRuntime
 
       - name: Run runtime parity lane
         id: runtime_parity_lane
@@ -1101,7 +1101,7 @@ jobs:
       - name: Build private QA runtime
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
+        run: node scripts/build-all.mjs qaRuntime
 
       - name: Run Matrix live lane
         id: run_lane
@@ -1199,7 +1199,7 @@ jobs:
       - name: Build private QA runtime
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
+        run: node scripts/build-all.mjs qaRuntime
 
       - name: Run Telegram live lane
         id: run_lane
@@ -1295,7 +1295,7 @@ jobs:
       - name: Build private QA runtime
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
+        run: node scripts/build-all.mjs qaRuntime
 
       - name: Run Discord live lane
         id: run_lane
@@ -1393,7 +1393,7 @@ jobs:
       - name: Build private QA runtime
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
+        run: node scripts/build-all.mjs qaRuntime
 
       - name: Run WhatsApp live lane
         id: run_lane
@@ -1488,7 +1488,7 @@ jobs:
       - name: Build private QA runtime
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
+        run: node scripts/build-all.mjs qaRuntime
 
       - name: Run Slack live lane
         id: run_lane

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -53,6 +53,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Yuanbao](/channels/yuanbao) - Tencent Yuanbao bot (external plugin).
 - [Zalo](/channels/zalo) - Zalo Bot API; Vietnam's popular messenger (bundled plugin).
 - [Zalo Personal](/channels/zalouser) - Zalo personal account via QR login (bundled plugin).
+- [Zulip](/channels/zulip) - Open-source team chat with streams and topics (external plugin).
 
 ## Notes
 

--- a/docs/channels/zulip.md
+++ b/docs/channels/zulip.md
@@ -1,0 +1,180 @@
+---
+summary: "Zulip bot setup, stream/topic routing, and configuration"
+read_when:
+  - You want to connect OpenClaw to Zulip
+  - You are configuring a Zulip bot for direct messages, streams, or topics
+title: Zulip
+---
+
+# Zulip
+
+Zulip is an open-source team chat platform with hosted Zulip Cloud and self-hosted deployments. The OpenClaw Zulip channel plugin connects agents to Zulip direct messages, streams, and topics.
+
+**Status:** external plugin. Install it before enabling the channel.
+
+---
+
+## Install the plugin
+
+```bash
+openclaw plugins install zulip
+```
+
+Then restart the Gateway after configuration changes:
+
+```bash
+openclaw gateway restart
+```
+
+---
+
+## Create a Zulip bot
+
+1. In Zulip, open **Settings → Your bots**.
+2. Create a new bot or choose an existing bot.
+3. Copy the bot email and API key.
+4. Use your Zulip organization URL as `url`, for example `https://example.zulipchat.com`.
+
+---
+
+## Basic configuration
+
+```json5
+{
+  channels: {
+    zulip: {
+      enabled: true,
+      url: "https://example.zulipchat.com",
+      email: "openclaw-bot@example.zulipchat.com",
+      apiKey: "***",
+      streams: ["general"],
+      dmPolicy: "allowlist",
+      allowFrom: ["user@example.com"],
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["user@example.com"],
+    },
+  },
+}
+```
+
+For development or secret-managed installs, `apiKey` can also be an OpenClaw secret reference.
+
+---
+
+## Streams and topics
+
+Zulip stream messages are treated as group messages. Use `streams`, `topics`, and `streamTopics` to control which conversations the bot monitors.
+
+```json5
+{
+  channels: {
+    zulip: {
+      streams: ["general", "support"],
+      topics: ["bot help"],
+      streamTopics: {
+        support: ["triage", "alerts"],
+      },
+      requireMention: true,
+    },
+  },
+}
+```
+
+Topic filters trim whitespace and match case-insensitively. Omit filters, use an empty array, or include `"*"` to allow all topics.
+
+---
+
+## Direct messages and access control
+
+`dmPolicy` controls direct messages:
+
+- `allowlist` only allows senders listed in `allowFrom`.
+- `open` allows any direct message sender.
+- `pairing` requires pairing approval.
+- `disabled` disables direct messages.
+
+`groupPolicy` controls stream messages:
+
+- `allowlist` only allows senders listed in `groupAllowFrom`.
+- `open` allows monitored stream messages.
+- `disabled` disables stream messages.
+
+Use allowlists for production bots unless the Zulip organization is already tightly controlled.
+
+---
+
+## Reactions
+
+The plugin supports Zulip message reactions through OpenClaw's `message` action, including add/remove behavior and common emoji normalization.
+
+The `agentReactionGuidance` setting controls model-level prompt guidance for expressive reactions:
+
+```json5
+{
+  channels: {
+    zulip: {
+      agentReactionGuidance: "minimal", // "off" | "minimal" | "extensive"
+    },
+  },
+}
+```
+
+This is separate from lifecycle/status reaction indicators.
+
+---
+
+## Multi-account setup
+
+```json5
+{
+  channels: {
+    zulip: {
+      defaultAccount: "main",
+      accounts: {
+        main: {
+          url: "https://example.zulipchat.com",
+          email: "openclaw-bot@example.zulipchat.com",
+          apiKey: "***",
+          streams: ["general"],
+        },
+        ops: {
+          url: "https://ops.example.com",
+          email: "ops-bot@ops.example.com",
+          apiKey: "***",
+          streams: ["alerts"],
+        },
+      },
+    },
+  },
+}
+```
+
+---
+
+## Troubleshooting
+
+### Bot receives DMs but does not reply in streams
+
+Check stream policy first. Stream messages are group messages, so `groupPolicy`, `groupAllowFrom`, `requireMention`, `streams`, `topics`, and `streamTopics` can all intentionally suppress replies.
+
+### Bot does not receive messages
+
+Verify the bot email, API key, Zulip URL, stream subscriptions, and Gateway logs.
+
+```bash
+openclaw gateway status
+openclaw logs --follow
+```
+
+### Plugin loads but durable receive journaling is unavailable
+
+Durable inbound receive journaling requires host support for trusted plugin keyed state. The channel still operates without it, but replay behavior may be limited to the live process.
+
+---
+
+## Resources
+
+- [Zulip API documentation](https://zulip.com/api/overview)
+- [Zulip bots documentation](https://zulip.com/api/running-bots)
+- [Plugin package](https://www.npmjs.com/package/openclaw-channel-zulip)
+- [Plugin source](https://github.com/FtlC-ian/openclaw-channel-zulip)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1108,6 +1108,7 @@
                 "pages": [
                   "channels/irc",
                   "channels/mattermost",
+                  "channels/zulip",
                   "channels/nextcloud-talk",
                   "channels/nostr",
                   "channels/tlon",

--- a/extensions/acpx/npm-shrinkwrap.json
+++ b/extensions/acpx/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/acpx",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/acpx",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "0.39.0",
         "@zed-industries/codex-acp": "0.15.0",

--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/acpx",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw ACP runtime backend with plugin-owned session and transport management.",
   "repository": {
     "type": "git",
@@ -26,10 +26,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "staticAssets": [
         {
           "source": "./src/runtime-internals/mcp-proxy.mjs",

--- a/extensions/admin-http-rpc/package.json
+++ b/extensions/admin-http-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/admin-http-rpc",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw admin HTTP RPC endpoint",
   "type": "module",

--- a/extensions/alibaba/package.json
+++ b/extensions/alibaba/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/alibaba-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Alibaba Model Studio video provider plugin",
   "type": "module",

--- a/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/amazon-bedrock-mantle-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/amazon-bedrock-mantle-provider",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@anthropic-ai/sdk": "0.100.1",
         "@aws/bedrock-token-generator": "1.1.0"

--- a/extensions/amazon-bedrock-mantle/package.json
+++ b/extensions/amazon-bedrock-mantle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-mantle-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Amazon Bedrock Mantle provider plugin for OpenAI-compatible model routing.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/amazon-bedrock/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/amazon-bedrock-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/amazon-bedrock-provider",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@aws-sdk/client-bedrock": "3.1056.0",
         "@aws-sdk/client-bedrock-runtime": "3.1056.0",

--- a/extensions/amazon-bedrock/package.json
+++ b/extensions/amazon-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Amazon Bedrock provider plugin with model discovery, embeddings, and guardrail support.",
   "repository": {
     "type": "git",
@@ -28,10 +28,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/anthropic-vertex/npm-shrinkwrap.json
+++ b/extensions/anthropic-vertex/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/anthropic-vertex-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/anthropic-vertex-provider",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "0.16.1"
       }

--- a/extensions/anthropic-vertex/package.json
+++ b/extensions/anthropic-vertex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-vertex-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Anthropic Vertex provider plugin for Claude models on Google Vertex AI.",
   "repository": {
     "type": "git",
@@ -23,10 +23,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/anthropic/package.json
+++ b/extensions/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Anthropic provider plugin",
   "type": "module",

--- a/extensions/arcee/package.json
+++ b/extensions/arcee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/arcee-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Arcee provider plugin",
   "type": "module",

--- a/extensions/azure-speech/package.json
+++ b/extensions/azure-speech/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/azure-speech",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Azure Speech plugin",
   "type": "module",

--- a/extensions/bonjour/package.json
+++ b/extensions/bonjour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/bonjour",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Bonjour/mDNS gateway discovery",
   "type": "module",
   "dependencies": {

--- a/extensions/brave/npm-shrinkwrap.json
+++ b/extensions/brave/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/brave-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/brave-plugin",
-      "version": "2026.6.1"
+      "version": "2026.6.1-beta.1"
     }
   }
 }

--- a/extensions/brave/package.json
+++ b/extensions/brave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/brave-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Brave Search provider plugin for web search.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/browser-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw browser tool plugin",
   "type": "module",

--- a/extensions/byteplus/package.json
+++ b/extensions/byteplus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/byteplus-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw BytePlus provider plugin",
   "type": "module",

--- a/extensions/canvas/package.json
+++ b/extensions/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/canvas-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Canvas plugin",
   "type": "module",

--- a/extensions/cerebras/package.json
+++ b/extensions/cerebras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cerebras-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Cerebras provider plugin",
   "type": "module",

--- a/extensions/chutes/package.json
+++ b/extensions/chutes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/chutes-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Chutes.ai provider plugin",
   "type": "module",

--- a/extensions/clickclack/package.json
+++ b/extensions/clickclack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/clickclack",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw ClickClack channel plugin",
   "type": "module",
@@ -18,7 +18,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/cloudflare-ai-gateway/package.json
+++ b/extensions/cloudflare-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cloudflare-ai-gateway-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Cloudflare AI Gateway provider plugin",
   "type": "module",

--- a/extensions/codex-supervisor/package.json
+++ b/extensions/codex-supervisor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/codex-supervisor",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Codex app-server fleet supervision plugin.",
   "type": "module",

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/codex",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/codex",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@openai/codex": "0.135.0",
         "typebox": "1.1.39",

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/codex",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Codex app-server harness and model provider plugin with a Codex-managed GPT catalog.",
   "repository": {
     "type": "git",
@@ -26,10 +26,10 @@
       "minHostVersion": ">=2026.5.1-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/comfy/package.json
+++ b/extensions/comfy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/comfy-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw ComfyUI provider plugin",
   "type": "module",

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot-proxy",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Copilot Proxy provider plugin",
   "type": "module",

--- a/extensions/copilot/npm-shrinkwrap.json
+++ b/extensions/copilot/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/copilot",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/copilot",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@github/copilot-sdk": "1.0.0-beta.9"
       }

--- a/extensions/copilot/openclaw.plugin.json
+++ b/extensions/copilot/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "copilot",
   "name": "GitHub Copilot agent runtime",
   "description": "Registers the GitHub Copilot agent runtime.",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "activation": {
     "onStartup": false,
     "onAgentHarnesses": ["copilot"]

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw GitHub Copilot agent runtime plugin (registers a `github-copilot` AgentHarness backed by @github/copilot-sdk over JSON-RPC to the GitHub Copilot CLI)",
   "repository": {
     "type": "git",
@@ -25,10 +25,10 @@
       "minHostVersion": ">=2026.5.28"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/deepgram/package.json
+++ b/extensions/deepgram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepgram-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Deepgram media-understanding provider",
   "type": "module",

--- a/extensions/deepinfra/package.json
+++ b/extensions/deepinfra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepinfra-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw DeepInfra provider plugin",
   "type": "module",

--- a/extensions/deepseek/package.json
+++ b/extensions/deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepseek-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw DeepSeek provider plugin",
   "type": "module",

--- a/extensions/diagnostics-otel/npm-shrinkwrap.json
+++ b/extensions/diagnostics-otel/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/diagnostics-otel",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/diagnostics-otel",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
         "@opentelemetry/api-logs": "0.218.0",

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-otel",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw diagnostics OpenTelemetry exporter for metrics and traces.",
   "repository": {
     "type": "git",
@@ -34,10 +34,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/diagnostics-prometheus/npm-shrinkwrap.json
+++ b/extensions/diagnostics-prometheus/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/diagnostics-prometheus",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/diagnostics-prometheus",
-      "version": "2026.6.1"
+      "version": "2026.6.1-beta.1"
     }
   }
 }

--- a/extensions/diagnostics-prometheus/package.json
+++ b/extensions/diagnostics-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-prometheus",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw diagnostics Prometheus exporter for runtime metrics.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/diffs-language-pack/npm-shrinkwrap.json
+++ b/extensions/diffs-language-pack/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/diffs-language-pack",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/diffs-language-pack",
-      "version": "2026.6.1"
+      "version": "2026.6.1-beta.1"
     }
   }
 }

--- a/extensions/diffs-language-pack/package.json
+++ b/extensions/diffs-language-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs-language-pack",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw diffs viewer syntax highlighting language pack",
   "repository": {
     "type": "git",
@@ -22,13 +22,13 @@
       "minHostVersion": ">=2026.5.27"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "assetScripts": {
       "build": "node ../../scripts/build-diffs-viewer-runtime.mjs full"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "staticAssets": [
         {
           "source": "./assets/viewer-runtime.js",

--- a/extensions/diffs/npm-shrinkwrap.json
+++ b/extensions/diffs/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/diffs",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/diffs",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@pierre/diffs": "1.2.4",
         "@pierre/theme": "1.0.3",

--- a/extensions/diffs/package.json
+++ b/extensions/diffs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw read-only diff viewer plugin and file renderer for agents.",
   "repository": {
     "type": "git",
@@ -29,13 +29,13 @@
       "minHostVersion": ">=2026.4.30"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "assetScripts": {
       "build": "node ../../scripts/build-diffs-viewer-runtime.mjs curated"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "staticAssets": [
         {
           "source": "./assets/viewer-runtime.js",

--- a/extensions/discord/npm-shrinkwrap.json
+++ b/extensions/discord/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/discord",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@discordjs/voice": "0.19.2",
         "discord-api-types": "0.38.48",
@@ -16,7 +16,7 @@
         "ws": "8.21.0"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -67,10 +67,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -2154,8 +2154,8 @@ describe("DiscordVoiceManager", () => {
 
     expect(entersStateMock).toHaveBeenCalledWith(connection, "signalling", 20_000);
     expect(entersStateMock).toHaveBeenCalledWith(connection, "connecting", 20_000);
-    expect(connection.destroy).toHaveBeenCalledTimes(1);
-    expect(manager.status()).toStrictEqual([]);
+    await vi.waitFor(() => expect(connection.destroy).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(manager.status()).toStrictEqual([]));
   });
 
   it("uses the default reconnect grace before destroying disconnected sessions", async () => {
@@ -2175,8 +2175,8 @@ describe("DiscordVoiceManager", () => {
 
     expect(entersStateMock).toHaveBeenCalledWith(connection, "signalling", 15_000);
     expect(entersStateMock).toHaveBeenCalledWith(connection, "connecting", 15_000);
-    expect(connection.destroy).toHaveBeenCalledTimes(1);
-    expect(manager.status()).toStrictEqual([]);
+    await vi.waitFor(() => expect(connection.destroy).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(manager.status()).toStrictEqual([]));
   });
 
   it("closes realtime sessions when disconnected recovery destroys the connection", async () => {
@@ -2201,9 +2201,9 @@ describe("DiscordVoiceManager", () => {
     expect(disconnected).toBeTypeOf("function");
     await disconnected?.();
 
-    expect(realtimeSessionMock.close).toHaveBeenCalledTimes(1);
-    expect(connection.destroy).toHaveBeenCalledTimes(1);
-    expect(manager.status()).toStrictEqual([]);
+    await vi.waitFor(() => expect(realtimeSessionMock.close).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(connection.destroy).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(manager.status()).toStrictEqual([]));
   });
 
   it("closes realtime sessions when Discord destroys the connection", async () => {

--- a/extensions/document-extract/package.json
+++ b/extensions/document-extract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/document-extract-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw local document extraction plugin",
   "type": "module",

--- a/extensions/duckduckgo/package.json
+++ b/extensions/duckduckgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/duckduckgo-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw DuckDuckGo plugin",
   "type": "module",

--- a/extensions/elevenlabs/package.json
+++ b/extensions/elevenlabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/elevenlabs-speech",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw ElevenLabs speech plugin",
   "type": "module",

--- a/extensions/exa/package.json
+++ b/extensions/exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/exa-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Exa plugin",
   "type": "module",

--- a/extensions/fal/package.json
+++ b/extensions/fal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fal-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw fal provider plugin",
   "type": "module",

--- a/extensions/feishu/npm-shrinkwrap.json
+++ b/extensions/feishu/npm-shrinkwrap.json
@@ -1,19 +1,19 @@
 {
   "name": "@openclaw/feishu",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/feishu",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "1.66.0",
         "typebox": "1.1.39",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/feishu",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Feishu/Lark channel plugin for chats and workplace tools (community maintained by @m1heng).",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -51,10 +51,10 @@
       "minHostVersion": ">=2026.5.29"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/file-transfer/package.json
+++ b/extensions/file-transfer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/file-transfer",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw file transfer plugin (file_fetch, dir_list, dir_fetch, file_write)",
   "type": "module",
   "dependencies": {

--- a/extensions/firecrawl/package.json
+++ b/extensions/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/firecrawl-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Firecrawl plugin",
   "type": "module",

--- a/extensions/fireworks/package.json
+++ b/extensions/fireworks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fireworks-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Fireworks provider plugin",
   "type": "module",

--- a/extensions/github-copilot/package.json
+++ b/extensions/github-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/github-copilot-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw GitHub Copilot provider plugin",
   "type": "module",

--- a/extensions/gmi/package.json
+++ b/extensions/gmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gmi-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw GMI Cloud provider plugin",
   "type": "module",

--- a/extensions/google-meet/npm-shrinkwrap.json
+++ b/extensions/google-meet/npm-shrinkwrap.json
@@ -1,18 +1,18 @@
 {
   "name": "@openclaw/google-meet",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/google-meet",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "commander": "14.0.3",
         "typebox": "1.1.39"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-meet",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Google Meet participant plugin for joining calls through Chrome or Twilio transports.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.4.20"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/google/package.json
+++ b/extensions/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Google plugin",
   "type": "module",

--- a/extensions/googlechat/npm-shrinkwrap.json
+++ b/extensions/googlechat/npm-shrinkwrap.json
@@ -1,19 +1,19 @@
 {
   "name": "@openclaw/googlechat",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/googlechat",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "gaxios": "7.1.4",
         "google-auth-library": "10.6.2",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/googlechat",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Google Chat channel plugin for spaces and direct messages.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -75,10 +75,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/gradium/package.json
+++ b/extensions/gradium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gradium-speech",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Gradium speech plugin",
   "type": "module",

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/groq-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Groq media-understanding provider",
   "type": "module",

--- a/extensions/huggingface/package.json
+++ b/extensions/huggingface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/huggingface-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Hugging Face provider plugin",
   "type": "module",

--- a/extensions/image-generation-core/package.json
+++ b/extensions/image-generation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/image-generation-core",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw image generation runtime package",
   "type": "module",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/imessage",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw iMessage channel plugin using imsg on a signed-in Mac",
   "type": "module",
@@ -43,10 +43,10 @@
       ]
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     }
   },
   "pluginInspector": {

--- a/extensions/inworld/package.json
+++ b/extensions/inworld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/inworld-speech",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Inworld speech plugin",
   "type": "module",

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/irc",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw IRC channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/kilocode/package.json
+++ b/extensions/kilocode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kilocode-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Kilo Gateway provider plugin",
   "type": "module",

--- a/extensions/kimi-coding/package.json
+++ b/extensions/kimi-coding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kimi-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Kimi provider plugin",
   "type": "module",

--- a/extensions/line/npm-shrinkwrap.json
+++ b/extensions/line/npm-shrinkwrap.json
@@ -1,18 +1,18 @@
 {
   "name": "@openclaw/line",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/line",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@line/bot-sdk": "11.0.1",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/line",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw LINE channel plugin for LINE Bot API chats.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -46,10 +46,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/litellm/package.json
+++ b/extensions/litellm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/litellm-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw LiteLLM provider plugin",
   "type": "module",

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llm-task",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",

--- a/extensions/lmstudio/package.json
+++ b/extensions/lmstudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lmstudio-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw LM Studio provider plugin",
   "type": "module",

--- a/extensions/lobster/npm-shrinkwrap.json
+++ b/extensions/lobster/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/lobster",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/lobster",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@clawdbot/lobster": "2026.5.22",
         "typebox": "1.1.39"

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lobster",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "Lobster workflow tool plugin for typed pipelines and resumable approvals.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/matrix/npm-shrinkwrap.json
+++ b/extensions/matrix/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/matrix",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/matrix",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@matrix-org/matrix-sdk-crypto-nodejs": "0.6.0",
         "@matrix-org/matrix-sdk-crypto-wasm": "18.3.0",
@@ -18,7 +18,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/matrix",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Matrix channel plugin for rooms and direct messages.",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -88,10 +88,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mattermost",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Mattermost channel plugin",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/media-understanding-core/package.json
+++ b/extensions/media-understanding-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/media-understanding-core",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw media understanding runtime package",
   "type": "module",

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-core",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw core memory search plugin",
   "type": "module",
@@ -14,7 +14,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -143,7 +143,6 @@ export async function runEmbeddingOperationWithTimeout<T>(params: {
       reject(error);
       controller.abort(error);
     }, timeoutMs);
-    timer.unref?.();
   });
   try {
     const operation = params.run(controller.signal);

--- a/extensions/memory-core/src/memory/manager-embedding-timeout.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-timeout.test.ts
@@ -102,9 +102,10 @@ describe("memory embedding timeout abort", () => {
   });
 
   it("aborts the provider operation when the timeout fires", async () => {
+    vi.useFakeTimers();
     let signalSeen: AbortSignal | undefined;
 
-    await expect(
+    const result = expect(
       runEmbeddingOperationWithTimeout({
         timeoutMs: 1,
         message: "memory embeddings query timed out after 0s",
@@ -120,12 +121,15 @@ describe("memory embedding timeout abort", () => {
         },
       }),
     ).rejects.toThrow("memory embeddings query timed out after 0s");
+    await vi.advanceTimersByTimeAsync(1);
+    await result;
 
     expect(signalSeen?.aborted).toBe(true);
   });
 
   it("keeps the timeout error when a provider abort listener rejects generically", async () => {
-    await expect(
+    vi.useFakeTimers();
+    const result = expect(
       runEmbeddingOperationWithTimeout({
         timeoutMs: 1,
         message: "memory embeddings batch timed out after 0s",
@@ -137,6 +141,8 @@ describe("memory embedding timeout abort", () => {
           }),
       }),
     ).rejects.toThrow("memory embeddings batch timed out after 0s");
+    await vi.advanceTimersByTimeAsync(1);
+    await result;
   });
 
   it("caps operation watchdog timers before scheduling", async () => {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -740,6 +740,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("times out collection bootstrap commands", async () => {
+    vi.useFakeTimers();
     cfg = {
       ...cfg,
       memory: {
@@ -764,7 +765,15 @@ describe("QmdMemoryManager", () => {
       return createMockChild();
     });
 
-    const { manager } = await createManager({ mode: "full" });
+    const managerPromise = createManager({ mode: "full" });
+    await waitUntil(() =>
+      spawnMock.mock.calls.some((call: unknown[]) => {
+        const args = call[1] as string[];
+        return args[0] === "collection" && args[1] === "list";
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(15);
+    const { manager } = await managerPromise;
     const status = manager.status();
     expect(status.backend).toBe("qmd");
     expect(status.requestedProvider).toBe("qmd");
@@ -4396,6 +4405,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("retries boot update when qmd reports a retryable lock error", async () => {
+    vi.useFakeTimers();
     cfg = {
       ...cfg,
       memory: {
@@ -4429,26 +4439,14 @@ describe("QmdMemoryManager", () => {
       return createMockChild();
     });
 
-    const nativeSetTimeout = globalThis.setTimeout;
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
-      handler: TimerHandler,
-      timeout?: number,
-      ...args: unknown[]
-    ) => {
-      if (typeof timeout === "number" && timeout >= 500) {
-        return nativeSetTimeout(handler, 1, ...args);
-      }
-      return nativeSetTimeout(handler, timeout, ...args);
-    }) as typeof globalThis.setTimeout);
+    const managerPromise = createManager({ mode: "full" });
+    await waitUntil(() => updateCalls === 1);
+    await vi.advanceTimersByTimeAsync(500);
+    await waitUntil(() => updateCalls === 2);
+    const { manager } = await managerPromise;
 
-    const { manager } = await createManager({ mode: "full" });
-
-    try {
-      expect(updateCalls).toBe(2);
-      await manager.close();
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
+    expect(updateCalls).toBe(2);
+    await manager.close();
   });
 
   it("succeeds on qmd update even when stdout exceeds the output cap", async () => {

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -1169,8 +1169,8 @@ describe("memory plugin e2e", () => {
 
   test("clamps oversized auto-recall timeout timers", async () => {
     vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
       await expect(
         testing.runWithTimeout({
           timeoutMs: Number.MAX_SAFE_INTEGER,
@@ -1180,14 +1180,15 @@ describe("memory plugin e2e", () => {
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     } finally {
+      setTimeoutSpy.mockRestore();
       vi.useRealTimers();
     }
   });
 
   test("falls back for invalid auto-recall timeout timers", async () => {
     vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
       await expect(
         testing.runWithTimeout({
           timeoutMs: Number.NaN,
@@ -1197,6 +1198,7 @@ describe("memory plugin e2e", () => {
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1);
     } finally {
+      setTimeoutSpy.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/extensions/memory-lancedb/npm-shrinkwrap.json
+++ b/extensions/memory-lancedb/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/memory-lancedb",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/memory-lancedb",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@lancedb/lancedb": "0.30.0",
         "apache-arrow": "21.1.0",

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-lancedb",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, and vector search.",
   "repository": {
     "type": "git",
@@ -26,10 +26,10 @@
       "minHostVersion": ">=2026.5.31"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/memory-wiki/package.json
+++ b/extensions/memory-wiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-wiki",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw persistent wiki plugin",
   "type": "module",
@@ -14,7 +14,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/microsoft-foundry/package.json
+++ b/extensions/microsoft-foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-foundry",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Microsoft Foundry provider plugin",
   "type": "module",

--- a/extensions/microsoft/package.json
+++ b/extensions/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-speech",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Microsoft speech plugin",
   "type": "module",

--- a/extensions/migrate-claude/package.json
+++ b/extensions/migrate-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/migrate-claude",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "Claude to OpenClaw migration provider",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/migrate-hermes/package.json
+++ b/extensions/migrate-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/migrate-hermes",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "Hermes to OpenClaw migration provider",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/minimax/package.json
+++ b/extensions/minimax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/minimax-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw MiniMax provider and OAuth plugin",
   "type": "module",

--- a/extensions/mistral/package.json
+++ b/extensions/mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mistral-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Mistral provider plugin",
   "type": "module",

--- a/extensions/moonshot/package.json
+++ b/extensions/moonshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/moonshot-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Moonshot provider plugin",
   "type": "module",

--- a/extensions/msteams/npm-shrinkwrap.json
+++ b/extensions/msteams/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/msteams",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/msteams",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@azure/identity": "4.13.1",
         "@microsoft/teams.api": "2.0.12",
@@ -15,7 +15,7 @@
         "typebox": "1.1.39"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/msteams",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Microsoft Teams channel plugin for bot conversations.",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -56,10 +56,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/nextcloud-talk/npm-shrinkwrap.json
+++ b/extensions/nextcloud-talk/npm-shrinkwrap.json
@@ -1,17 +1,17 @@
 {
   "name": "@openclaw/nextcloud-talk",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/nextcloud-talk",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nextcloud-talk",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Nextcloud Talk channel plugin for conversations.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -44,10 +44,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/nostr/npm-shrinkwrap.json
+++ b/extensions/nostr/npm-shrinkwrap.json
@@ -1,18 +1,18 @@
 {
   "name": "@openclaw/nostr",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/nostr",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "nostr-tools": "2.23.5",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nostr",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted direct messages.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -54,10 +54,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/novita/package.json
+++ b/extensions/novita/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/novita-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw NovitaAI provider plugin",
   "type": "module",

--- a/extensions/nvidia/package.json
+++ b/extensions/nvidia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nvidia-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw NVIDIA provider plugin",
   "type": "module",

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/oc-path",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw oc:// workspace path plugin",
   "type": "module",
@@ -15,7 +15,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/ollama/package.json
+++ b/extensions/ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/ollama-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Ollama provider plugin",
   "type": "module",

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/open-prose",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",

--- a/extensions/openai/package.json
+++ b/extensions/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openai-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw OpenAI provider plugins",
   "type": "module",

--- a/extensions/opencode-go/package.json
+++ b/extensions/opencode-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-go-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw OpenCode Go provider plugin",
   "type": "module",

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw OpenCode Zen provider plugin",
   "type": "module",

--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -208,6 +208,8 @@ describe("openrouter music generation provider", () => {
   });
 
   it("caps oversized OpenRouter music stream timeouts", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
       postJsonRequestMock.mockResolvedValue({
@@ -231,6 +233,7 @@ describe("openrouter music generation provider", () => {
       expect(streamTimeoutMs).toBeLessThanOrEqual(MAX_TIMER_TIMEOUT_MS);
     } finally {
       timeoutSpy.mockRestore();
+      vi.useRealTimers();
     }
   });
 

--- a/extensions/openrouter/package.json
+++ b/extensions/openrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openrouter-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw OpenRouter provider plugin",
   "type": "module",

--- a/extensions/openshell/npm-shrinkwrap.json
+++ b/extensions/openshell/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/openshell-sandbox",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/openshell-sandbox",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "zod": "4.4.3"
       }

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openshell-sandbox",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw sandbox backend for the NVIDIA OpenShell CLI with mirrored local workspaces and SSH command execution.",
   "repository": {
     "type": "git",
@@ -23,10 +23,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/perplexity/package.json
+++ b/extensions/perplexity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/perplexity-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Perplexity plugin",
   "type": "module",

--- a/extensions/pixverse/npm-shrinkwrap.json
+++ b/extensions/pixverse/npm-shrinkwrap.json
@@ -1,14 +1,14 @@
 {
   "name": "@openclaw/pixverse-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/pixverse-provider",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/pixverse/package.json
+++ b/extensions/pixverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/pixverse-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw PixVerse video generation provider plugin.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -30,10 +30,10 @@
       "minHostVersion": ">=2026.5.26"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/policy/package.json
+++ b/extensions/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/policy",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw policy doctor checks for workspace conformance",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/qa-channel/package.json
+++ b/extensions/qa-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-channel",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw QA synthetic channel plugin",
   "type": "module",
@@ -19,7 +19,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-lab",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw QA lab plugin with private debugger UI and scenario runner",
   "type": "module",
@@ -19,7 +19,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -31,7 +31,7 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     }
   }
 }

--- a/extensions/qa-matrix/package.json
+++ b/extensions/qa-matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-matrix",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Matrix QA runner plugin",
   "type": "module",
@@ -13,7 +13,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -25,7 +25,7 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     }
   }
 }

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.ts
@@ -217,38 +217,67 @@ async function hasPersistedMatrixPluginStateDedupeEntry(params: {
   eventId: string;
   roomId: string;
   stateDir: string;
-}) {
-  const databasePath = path.join(params.stateDir, "state", "openclaw.sqlite");
+}): Promise<string | null> {
   const entryKey = buildMatrixInboundDedupePluginStateKey({
     accountId: params.accountId,
     eventId: params.eventId,
     roomId: params.roomId,
   });
-  try {
-    await fs.access(databasePath);
-    const sqlite = await import("node:sqlite");
-    const db = new sqlite.DatabaseSync(databasePath, { readOnly: true });
+  const databasePaths = await findFilesByName({
+    filename: "openclaw.sqlite",
+    rootDir: params.stateDir,
+    maxDepth: 4,
+  });
+  if (databasePaths.length === 0) {
+    databasePaths.push(path.join(params.stateDir, "state", "openclaw.sqlite"));
+  }
+  const now = Date.now();
+  const isExpectedValue = (raw: unknown) => {
+    if (typeof raw !== "string") {
+      return false;
+    }
     try {
-      const row = db
-        .prepare(
-          `SELECT 1 AS ok
-             FROM plugin_state_entries
-            WHERE plugin_id = ?
-              AND namespace = ?
-              AND entry_key = ?
-              AND (expires_at IS NULL OR expires_at > ?)
-            LIMIT 1`,
-        )
-        .get(MATRIX_PLUGIN_ID, MATRIX_INBOUND_DEDUPE_NAMESPACE, entryKey, Date.now()) as
-        | { ok?: unknown }
-        | undefined;
-      return row?.ok === 1;
-    } finally {
-      db.close();
+      const parsed = JSON.parse(raw) as unknown;
+      return (
+        isRecord(parsed) && parsed.roomId === params.roomId && parsed.eventId === params.eventId
+      );
+    } catch {
+      return false;
+    }
+  };
+  try {
+    const sqlite = await import("node:sqlite");
+    for (const databasePath of databasePaths) {
+      try {
+        await fs.access(databasePath);
+        const db = new sqlite.DatabaseSync(databasePath, { readOnly: true });
+        try {
+          const rows = db
+            .prepare(
+              `SELECT entry_key AS entryKey, value_json AS valueJson
+                 FROM plugin_state_entries
+                WHERE plugin_id = ?
+                  AND namespace = ?
+                  AND (expires_at IS NULL OR expires_at > ?)`,
+            )
+            .all(MATRIX_PLUGIN_ID, MATRIX_INBOUND_DEDUPE_NAMESPACE, now) as Array<{
+            entryKey?: unknown;
+            valueJson?: unknown;
+          }>;
+          if (rows.some((row) => row.entryKey === entryKey || isExpectedValue(row.valueJson))) {
+            return databasePath;
+          }
+        } finally {
+          db.close();
+        }
+      } catch {
+        continue;
+      }
     }
   } catch {
-    return false;
+    return null;
   }
+  return null;
 }
 
 export async function waitForMatrixInboundDedupeEntry(params: {
@@ -260,15 +289,14 @@ export async function waitForMatrixInboundDedupeEntry(params: {
 }) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < params.timeoutMs) {
-    if (
-      await hasPersistedMatrixPluginStateDedupeEntry({
-        accountId: params.context.sutAccountId ?? "sut",
-        eventId: params.eventId,
-        roomId: params.roomId,
-        stateDir: params.stateDir,
-      })
-    ) {
-      return path.join(params.stateDir, "state", "openclaw.sqlite");
+    const sqlitePath = await hasPersistedMatrixPluginStateDedupeEntry({
+      accountId: params.context.sutAccountId ?? "sut",
+      eventId: params.eventId,
+      roomId: params.roomId,
+      stateDir: params.stateDir,
+    });
+    if (sqlitePath) {
+      return sqlitePath;
     }
     const pathname = await resolveBestMatrixStateFile({
       context: params.context,

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -6,6 +7,8 @@ import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
 
 const MATRIX_SYNC_STORE_FILENAME = "bot-storage.json";
 const MATRIX_INBOUND_DEDUPE_FILENAME = "inbound-dedupe.json";
+const MATRIX_PLUGIN_ID = "matrix";
+const MATRIX_INBOUND_DEDUPE_NAMESPACE = "inbound-dedupe";
 const MATRIX_STATE_POLL_INTERVAL_MS = 100;
 
 async function readJsonFile(pathname: string): Promise<unknown> {
@@ -191,6 +194,63 @@ function hasPersistedMatrixDedupeEntry(params: {
   return params.parsed.entries.some((entry) => isRecord(entry) && entry.key === expectedKey);
 }
 
+function buildMatrixInboundDedupePluginStateKey(params: {
+  accountId: string;
+  eventId: string;
+  roomId: string;
+}): string {
+  const accountId = params.accountId.trim() || "sut";
+  const roomId = params.roomId.trim();
+  const eventId = params.eventId.trim();
+  const digest = createHash("sha256")
+    .update(accountId)
+    .update("\0")
+    .update(roomId)
+    .update("\0")
+    .update(eventId)
+    .digest("hex");
+  return `${accountId}:${digest}`;
+}
+
+async function hasPersistedMatrixPluginStateDedupeEntry(params: {
+  accountId: string;
+  eventId: string;
+  roomId: string;
+  stateDir: string;
+}) {
+  const databasePath = path.join(params.stateDir, "state", "openclaw.sqlite");
+  const entryKey = buildMatrixInboundDedupePluginStateKey({
+    accountId: params.accountId,
+    eventId: params.eventId,
+    roomId: params.roomId,
+  });
+  try {
+    await fs.access(databasePath);
+    const sqlite = await import("node:sqlite");
+    const db = new sqlite.DatabaseSync(databasePath, { readOnly: true });
+    try {
+      const row = db
+        .prepare(
+          `SELECT 1 AS ok
+             FROM plugin_state_entries
+            WHERE plugin_id = ?
+              AND namespace = ?
+              AND entry_key = ?
+              AND (expires_at IS NULL OR expires_at > ?)
+            LIMIT 1`,
+        )
+        .get(MATRIX_PLUGIN_ID, MATRIX_INBOUND_DEDUPE_NAMESPACE, entryKey, Date.now()) as
+        | { ok?: unknown }
+        | undefined;
+      return row?.ok === 1;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return false;
+  }
+}
+
 export async function waitForMatrixInboundDedupeEntry(params: {
   context: MatrixQaScenarioContext;
   eventId: string;
@@ -200,6 +260,16 @@ export async function waitForMatrixInboundDedupeEntry(params: {
 }) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < params.timeoutMs) {
+    if (
+      await hasPersistedMatrixPluginStateDedupeEntry({
+        accountId: params.context.sutAccountId ?? "sut",
+        eventId: params.eventId,
+        roomId: params.roomId,
+        stateDir: params.stateDir,
+      })
+    ) {
+      return path.join(params.stateDir, "state", "openclaw.sqlite");
+    }
     const pathname = await resolveBestMatrixStateFile({
       context: params.context,
       filename: MATRIX_INBOUND_DEDUPE_FILENAME,

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -2047,7 +2047,7 @@ describe("matrix live qa scenarios", () => {
         callOrder.push(`wait:${kind}`);
         if (kind === "first") {
           await writeMatrixInboundDedupePluginStateEntry({
-            accountId: "sut",
+            accountId: "runtime-default",
             eventId: "$first-trigger",
             roomId: staleSyncRoomId,
             stateRoot,

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -59,6 +60,69 @@ import {
 const MATRIX_SUBAGENT_MISSING_HOOK_ERROR =
   "thread=true is unavailable because no channel plugin registered subagent_spawning hooks.";
 const MATRIX_QA_HOT_RELOAD_RESTART_DELAY_MS = 300_000;
+
+function matrixInboundDedupePluginStateKey(params: {
+  accountId: string;
+  eventId: string;
+  roomId: string;
+}): string {
+  const accountId = params.accountId.trim() || "sut";
+  const digest = createHash("sha256")
+    .update(accountId)
+    .update("\0")
+    .update(params.roomId.trim())
+    .update("\0")
+    .update(params.eventId.trim())
+    .digest("hex");
+  return `${accountId}:${digest}`;
+}
+
+async function writeMatrixInboundDedupePluginStateEntry(params: {
+  accountId: string;
+  eventId: string;
+  roomId: string;
+  stateRoot: string;
+}) {
+  const sqlite = await import("node:sqlite");
+  const databasePath = path.join(params.stateRoot, "state", "openclaw.sqlite");
+  await mkdir(path.dirname(databasePath), { recursive: true });
+  const db = new sqlite.DatabaseSync(databasePath);
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS plugin_state_entries (
+        plugin_id TEXT NOT NULL,
+        namespace TEXT NOT NULL,
+        entry_key TEXT NOT NULL,
+        value_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER,
+        PRIMARY KEY (plugin_id, namespace, entry_key)
+      );
+    `);
+    db.prepare(`
+      INSERT INTO plugin_state_entries (
+        plugin_id, namespace, entry_key, value_json, created_at, expires_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(plugin_id, namespace, entry_key) DO UPDATE SET
+        value_json = excluded.value_json,
+        created_at = excluded.created_at,
+        expires_at = excluded.expires_at
+    `).run(
+      "matrix",
+      "inbound-dedupe",
+      matrixInboundDedupePluginStateKey(params),
+      JSON.stringify({
+        roomId: params.roomId,
+        eventId: params.eventId,
+        ts: Date.now(),
+      }),
+      Date.now(),
+      null,
+    );
+  } finally {
+    db.close();
+  }
+}
 
 function requireMatrixQaScenario(id: string): (typeof MATRIX_QA_SCENARIOS)[number] {
   const scenario = MATRIX_QA_SCENARIOS.find((entry) => entry.id === id);
@@ -1958,7 +2022,6 @@ describe("matrix live qa scenarios", () => {
       const accountDir = path.join(stateRoot, "matrix", "accounts", "sut", "server", "token");
       const staleSyncRoomId = "!stale-sync:matrix-qa.test";
       const syncStorePath = path.join(accountDir, "bot-storage.json");
-      const dedupeStorePath = path.join(accountDir, "inbound-dedupe.json");
       await mkdir(accountDir, { recursive: true });
       await writeTestJsonFile(path.join(accountDir, "storage-meta.json"), {
         accountId: "sut",
@@ -1983,14 +2046,11 @@ describe("matrix live qa scenarios", () => {
         const kind = token.includes("STALE_SYNC_DEDUPE_FRESH") ? "fresh" : "first";
         callOrder.push(`wait:${kind}`);
         if (kind === "first") {
-          await writeTestJsonFile(dedupeStorePath, {
-            version: 1,
-            entries: [
-              {
-                key: `${staleSyncRoomId}|$first-trigger`,
-                ts: Date.now(),
-              },
-            ],
+          await writeMatrixInboundDedupePluginStateEntry({
+            accountId: "sut",
+            eventId: "$first-trigger",
+            roomId: staleSyncRoomId,
+            stateRoot,
           });
         }
         return {

--- a/extensions/qianfan/package.json
+++ b/extensions/qianfan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qianfan-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Qianfan provider plugin",
   "type": "module",

--- a/extensions/qqbot/npm-shrinkwrap.json
+++ b/extensions/qqbot/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/qqbot",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/qqbot",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@tencent-connect/qqbot-connector": "1.1.0",
         "mpg123-decoder": "1.0.3",
@@ -15,7 +15,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/qqbot/package.json
+++ b/extensions/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qqbot",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": false,
   "description": "OpenClaw QQ Bot channel plugin for group and direct-message workflows.",
   "repository": {
@@ -21,7 +21,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -50,10 +50,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/qwen/package.json
+++ b/extensions/qwen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qwen-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Qwen Cloud provider plugin",
   "type": "module",

--- a/extensions/runway/package.json
+++ b/extensions/runway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/runway-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Runway video provider plugin",
   "type": "module",

--- a/extensions/searxng/package.json
+++ b/extensions/searxng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/searxng-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw SearXNG plugin",
   "type": "module",

--- a/extensions/senseaudio/package.json
+++ b/extensions/senseaudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/senseaudio-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw SenseAudio media-understanding provider",
   "type": "module",

--- a/extensions/sglang/package.json
+++ b/extensions/sglang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/sglang-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw SGLang provider plugin",
   "type": "module",

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/signal",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Signal channel plugin",
   "type": "module",

--- a/extensions/slack/npm-shrinkwrap.json
+++ b/extensions/slack/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/slack",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/slack",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@slack/bolt": "4.7.3",
         "@slack/types": "2.21.1",
@@ -15,7 +15,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/slack",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Slack channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -64,13 +64,13 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "startup": {
       "deferConfiguredChannelFullLoadUntilAfterListen": true
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/sms/package.json
+++ b/extensions/sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/sms",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw SMS channel plugin for Twilio text messages.",
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
       "quickstartAllowFrom": true
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     }
   }
 }

--- a/extensions/stepfun/package.json
+++ b/extensions/stepfun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/stepfun-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw StepFun provider plugin",
   "type": "module",

--- a/extensions/synology-chat/npm-shrinkwrap.json
+++ b/extensions/synology-chat/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/synology-chat",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/synology-chat",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "zod": "4.4.3"
       }

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synology-chat",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/synthetic/package.json
+++ b/extensions/synthetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synthetic-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Synthetic provider plugin",
   "type": "module",

--- a/extensions/tavily/package.json
+++ b/extensions/tavily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tavily-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Tavily plugin",
   "type": "module",

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/telegram",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Telegram channel plugin",
   "type": "module",

--- a/extensions/tencent/package.json
+++ b/extensions/tencent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tencent-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Tencent Cloud provider plugin (TokenHub + Token Plan)",
   "type": "module",

--- a/extensions/tlon/npm-shrinkwrap.json
+++ b/extensions/tlon/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/tlon",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@aws-sdk/client-s3": "3.1056.0",
         "@aws-sdk/s3-request-presigner": "3.1056.0",
@@ -15,7 +15,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Tlon/Urbit channel plugin for chat workflows.",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -73,10 +73,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/together/package.json
+++ b/extensions/together/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/together-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Together provider plugin",
   "type": "module",

--- a/extensions/tokenjuice/npm-shrinkwrap.json
+++ b/extensions/tokenjuice/npm-shrinkwrap.json
@@ -1,17 +1,17 @@
 {
   "name": "@openclaw/tokenjuice",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/tokenjuice",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "tokenjuice": "0.8.0"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/tokenjuice/package.json
+++ b/extensions/tokenjuice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tokenjuice",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw tokenjuice exec output compaction plugin",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
     "tokenjuice": "0.8.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.5.28"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1",
+      "openclawVersion": "2026.6.1-beta.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/tts-local-cli/package.json
+++ b/extensions/tts-local-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tts-local-cli",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw local CLI TTS plugin",
   "type": "module",

--- a/extensions/twitch/npm-shrinkwrap.json
+++ b/extensions/twitch/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/twitch",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/twitch",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "@twurple/api": "8.1.4",
         "@twurple/auth": "8.1.4",

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/twitch",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
   "repository": {
     "type": "git",
@@ -27,10 +27,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "channel": {
       "id": "twitch",

--- a/extensions/venice/package.json
+++ b/extensions/venice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/venice-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Venice provider plugin",
   "type": "module",

--- a/extensions/vercel-ai-gateway/package.json
+++ b/extensions/vercel-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vercel-ai-gateway-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Vercel AI Gateway provider plugin",
   "type": "module",

--- a/extensions/video-generation-core/package.json
+++ b/extensions/video-generation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/video-generation-core",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw video generation runtime package",
   "type": "module",

--- a/extensions/vllm/package.json
+++ b/extensions/vllm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vllm-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw vLLM provider plugin",
   "type": "module",

--- a/extensions/voice-call/npm-shrinkwrap.json
+++ b/extensions/voice-call/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/voice-call",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/voice-call",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "commander": "14.0.3",
         "typebox": "1.1.39",
@@ -14,7 +14,7 @@
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voice-call",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls.",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -35,10 +35,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/volcengine/package.json
+++ b/extensions/volcengine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/volcengine-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Volcengine provider plugin",
   "type": "module",

--- a/extensions/voyage/package.json
+++ b/extensions/voyage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voyage-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Voyage embedding provider plugin",
   "type": "module",

--- a/extensions/vydra/package.json
+++ b/extensions/vydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vydra-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Vydra media provider plugin",
   "type": "module",

--- a/extensions/web-readability/package.json
+++ b/extensions/web-readability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/web-readability-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw local Readability web extraction plugin",
   "type": "module",

--- a/extensions/webhooks/package.json
+++ b/extensions/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/webhooks",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw webhook bridge plugin",
   "type": "module",

--- a/extensions/whatsapp/npm-shrinkwrap.json
+++ b/extensions/whatsapp/npm-shrinkwrap.json
@@ -1,19 +1,19 @@
 {
   "name": "@openclaw/whatsapp",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/whatsapp",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "audio-decode": "2.2.3",
         "baileys": "7.0.0-rc13",
         "typebox": "1.1.39"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/whatsapp",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw WhatsApp channel plugin for WhatsApp Web chats.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -60,10 +60,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
@@ -1,5 +1,4 @@
 import "./test-helpers.js";
-import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -151,17 +150,6 @@ describe("web auto-reply last-route", () => {
       to: "+1000",
       accountId: "default",
     });
-    const body = formatInboundEnvelope({
-      channel: "WhatsApp",
-      from: "+1000",
-      timestamp: now,
-      body: "hello",
-      chatType: "direct",
-      sender: {
-        e164: "+1000",
-        id: "+1000",
-      },
-    });
     expect(ctx).toMatchObject({
       From: "+1000",
       To: "+2000",
@@ -178,7 +166,7 @@ describe("web auto-reply last-route", () => {
       SenderE164: "+1000",
       SenderId: "+1000",
       RawBody: "hello",
-      Body: body,
+      Body: expect.stringMatching(/^\[WhatsApp \+1000 .+\] hello$/),
       BodyForAgent: "hello",
       CommandBody: "hello",
       Timestamp: now,

--- a/extensions/workboard/package.json
+++ b/extensions/workboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/workboard",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw dashboard workboard plugin",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/xai/package.json
+++ b/extensions/xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xai-plugin",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw xAI plugin",
   "type": "module",

--- a/extensions/xiaomi/package.json
+++ b/extensions/xiaomi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xiaomi-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Xiaomi provider plugin",
   "type": "module",

--- a/extensions/zai/package.json
+++ b/extensions/zai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zai-provider",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "private": true,
   "description": "OpenClaw Z.AI provider plugin",
   "type": "module",

--- a/extensions/zalo/npm-shrinkwrap.json
+++ b/extensions/zalo/npm-shrinkwrap.json
@@ -1,17 +1,17 @@
 {
   "name": "@openclaw/zalo",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/zalo",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalo",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -43,10 +43,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/zalouser/npm-shrinkwrap.json
+++ b/extensions/zalouser/npm-shrinkwrap.json
@@ -1,19 +1,19 @@
 {
   "name": "@openclaw/zalouser",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/zalouser",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "dependencies": {
         "typebox": "1.1.39",
         "zca-js": "2.1.2",
         "zod": "4.4.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.1"
+        "openclaw": ">=2026.6.1-beta.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalouser",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.1"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -54,10 +54,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.6.1"
+      "pluginApi": ">=2026.6.1-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.6.1"
+      "openclawVersion": "2026.6.1-beta.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw",
-      "version": "2026.6.1",
+      "version": "2026.6.1-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.6.1",
+  "version": "2026.6.1-beta.1",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/scripts/check-gateway-cpu-scenarios.mjs
+++ b/scripts/check-gateway-cpu-scenarios.mjs
@@ -137,9 +137,22 @@ function runStep(name, command, args, options = {}, params = {}) {
     stdio: "inherit",
     ...options,
   });
-  const status = result.status ?? (result.signal ? 1 : 0);
-  console.error(`[gateway-cpu] ${status === 0 ? "pass" : "fail"} ${name}`);
-  return { name, status, signal: result.signal ?? null };
+  const error =
+    result.error instanceof Error
+      ? result.error.message
+      : result.error
+        ? String(result.error)
+        : null;
+  const status = result.error ? 1 : (result.status ?? (result.signal ? 1 : 0));
+  console.error(
+    `[gateway-cpu] ${status === 0 ? "pass" : "fail"} ${name}${error ? `: ${error}` : ""}`,
+  );
+  return {
+    name,
+    status,
+    signal: result.signal ?? null,
+    ...(error ? { error } : {}),
+  };
 }
 
 function pnpmCommand(args, params = {}) {

--- a/scripts/ci-run-timings.mjs
+++ b/scripts/ci-run-timings.mjs
@@ -2,6 +2,53 @@
 
 import { execFileSync } from "node:child_process";
 
+const DEFAULT_GITHUB_REPOSITORY = "openclaw/openclaw";
+const RUN_JOBS_PAGE_SIZE = 20;
+const RUN_JOBS_MAX_PAGES = 25;
+const GH_JSON_RETRY_DELAYS_MS = [1_000, 3_000, 6_000];
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function parseJsonCommand(command, args, options = {}) {
+  let lastError;
+  for (let attempt = 0; attempt <= GH_JSON_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      return JSON.parse(
+        execFileSync(command, args, {
+          encoding: "utf8",
+          ...options,
+        }),
+      );
+    } catch (error) {
+      lastError = error;
+      const message = error instanceof Error ? error.message : String(error);
+      const retryable = /HTTP 5\d\d|Server Error|ETIMEDOUT|ECONNRESET|EAI_AGAIN/u.test(message);
+      if (!retryable || attempt === GH_JSON_RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+      sleepSync(GH_JSON_RETRY_DELAYS_MS[attempt]);
+    }
+  }
+  throw lastError;
+}
+
+function normalizeRunJob(job) {
+  return {
+    completedAt: job.completedAt ?? job.completed_at ?? null,
+    conclusion: job.conclusion ?? "",
+    databaseId: job.databaseId ?? job.id,
+    name: job.name,
+    startedAt: job.startedAt ?? job.started_at ?? null,
+    status: job.status ?? "",
+  };
+}
+
+export function collectRunJobsFromPages(pages) {
+  return pages.flatMap((page) => (Array.isArray(page.jobs) ? page.jobs.map(normalizeRunJob) : []));
+}
+
 function parseTime(value) {
   if (!value || value === "0001-01-01T00:00:00Z") {
     return null;
@@ -216,15 +263,37 @@ function listRecentSuccessfulCiRuns(limit) {
 }
 
 function loadRun(runId) {
-  return JSON.parse(
-    execFileSync(
-      "gh",
-      ["run", "view", runId, "--json", "status,conclusion,createdAt,updatedAt,jobs"],
-      {
-        encoding: "utf8",
-      },
-    ),
-  );
+  const run = parseJsonCommand("gh", [
+    "run",
+    "view",
+    runId,
+    "--json",
+    "status,conclusion,createdAt,updatedAt",
+  ]);
+  const repository = process.env.GITHUB_REPOSITORY || DEFAULT_GITHUB_REPOSITORY;
+  const pages = [];
+  let totalCount = null;
+  for (let page = 1; page <= RUN_JOBS_MAX_PAGES; page += 1) {
+    const payload = parseJsonCommand("gh", [
+      "api",
+      "-X",
+      "GET",
+      `repos/${repository}/actions/runs/${runId}/jobs?per_page=${RUN_JOBS_PAGE_SIZE}&page=${page}`,
+    ]);
+    pages.push(payload);
+    const jobs = Array.isArray(payload.jobs) ? payload.jobs : [];
+    totalCount = typeof payload.total_count === "number" ? payload.total_count : totalCount;
+    if (
+      jobs.length === 0 ||
+      (totalCount !== null && collectRunJobsFromPages(pages).length >= totalCount)
+    ) {
+      break;
+    }
+  }
+  return {
+    ...run,
+    jobs: collectRunJobsFromPages(pages),
+  };
 }
 
 function summarizeJobs(run) {

--- a/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
+++ b/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
@@ -241,7 +241,7 @@ export function activateSmokePlugin(config, pluginId, channels = []) {
   const allow = Array.isArray(config.plugins?.allow)
     ? Array.from(new Set([...config.plugins.allow, pluginId].filter(isNonEmptyString)))
     : undefined;
-  const channelConfig = { ...(config.channels ?? {}) };
+  const channelConfig = { ...config.channels };
   for (const channel of channels) {
     channelConfig[channel] = {
       ...(typeof channelConfig[channel] === "object" && channelConfig[channel] !== null

--- a/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
+++ b/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
@@ -268,6 +268,28 @@ export function activateSmokePlugin(config, pluginId, channels = []) {
   };
 }
 
+function channelActivationEnvName(channel) {
+  return `${channel
+    .replace(/[^a-z0-9]+/giu, "_")
+    .replace(/^_+|_+$/gu, "")
+    .toUpperCase()}_RUNTIME_SMOKE`;
+}
+
+export function withManifestChannelActivationEnv(env, channels = []) {
+  const nextEnv = { ...env };
+  for (const channel of channels) {
+    if (!isNonEmptyString(channel)) {
+      continue;
+    }
+    const key = channelActivationEnvName(channel);
+    if (key === "_RUNTIME_SMOKE") {
+      continue;
+    }
+    nextEnv[key] ??= "1";
+  }
+  return nextEnv;
+}
+
 function buildPluginPlan(manifest) {
   const contracts =
     manifest.contracts && typeof manifest.contracts === "object" ? manifest.contracts : {};
@@ -659,6 +681,7 @@ async function smokePlugin(pluginId, pluginDir, requiresConfig, pluginIndex, plu
     activateSmokePlugin(readConfig(), pluginId, plan.channels),
     port,
   );
+  const env = withManifestChannelActivationEnv(process.env, plan.channels);
   if (plan.speechProviders[0]) {
     const provider = plan.speechProviders[0];
     config.messages = {
@@ -682,7 +705,7 @@ async function smokePlugin(pluginId, pluginDir, requiresConfig, pluginIndex, plu
     entrypoint,
     port,
     logPath,
-    env: process.env,
+    env,
     skipChannels: plan.channels.length === 0,
   });
   try {
@@ -690,12 +713,12 @@ async function smokePlugin(pluginId, pluginDir, requiresConfig, pluginIndex, plu
     await assertBaseGatewayProbes({
       entrypoint,
       port,
-      env: process.env,
+      env,
       pluginId,
       allowDegradedReadyz: plan.channels.length > 0,
     });
-    await runManifestProbes(plan, { entrypoint, port, env: process.env, pluginId });
-    await runWatchdog({ child, logPath, port, entrypoint, env: process.env, pluginId });
+    await runManifestProbes(plan, { entrypoint, port, env, pluginId });
+    await runWatchdog({ child, logPath, port, entrypoint, env, pluginId });
     console.log(`Runtime smoke passed for ${pluginId}`);
   } catch (error) {
     console.error(tailFile(logPath));

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -122,6 +122,44 @@
       }
     },
     {
+      "name": "openclaw-channel-zulip",
+      "description": "OpenClaw Zulip channel plugin.",
+      "source": "external",
+      "kind": "channel",
+      "openclaw": {
+        "plugin": {
+          "id": "zulip",
+          "label": "Zulip"
+        },
+        "channel": {
+          "id": "zulip",
+          "label": "Zulip",
+          "selectionLabel": "Zulip",
+          "detailLabel": "Zulip",
+          "docsPath": "/channels/zulip",
+          "docsLabel": "zulip",
+          "blurb": "Zulip direct messages, streams, and topics for OpenClaw agents.",
+          "aliases": ["zulipchat"]
+        },
+        "channelConfigs": {
+          "zulip": {
+            "label": "Zulip",
+            "description": "Zulip direct messages, streams, and topics.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "install": {
+          "npmSpec": "openclaw-channel-zulip@2026.5.26",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.26",
+          "expectedIntegrity": "sha512-VtQSQ6oxyrM4e4BCSrbhjDqPxtOZbabgTLJHqGpqYwq6gWN6rL+C107AZbOHbDSu2qhE7AcaOVm5CHZhmh3dIg=="
+        }
+      }
+    },
+    {
       "name": "@openclaw/discord",
       "description": "OpenClaw Discord channel plugin",
       "source": "official",

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -5,7 +5,9 @@ describe("channel plugin catalog", () => {
   it("keeps third-party channel ids mapped with catalog install trust", () => {
     const options = {
       workspaceDir: "/tmp/openclaw-channel-catalog-empty-workspace",
-      env: {},
+      env: { OPENCLAW_PLUGIN_CATALOG_PATHS: "/tmp/openclaw-channel-catalog-no-external.json" },
+      discovery: { candidates: [], diagnostics: [] },
+      installRecords: {},
     };
 
     const wecom = getChannelPluginCatalogEntry("wecom", options);
@@ -19,5 +21,11 @@ describe("channel plugin catalog", () => {
     expect(yuanbao?.pluginId).toBe("openclaw-plugin-yuanbao");
     expect(yuanbao?.trustedSourceLinkedOfficialInstall).toBe(true);
     expect(yuanbao?.install?.npmSpec).toBe("openclaw-plugin-yuanbao@2.13.1");
+
+    const zulip = getChannelPluginCatalogEntry("zulip", options);
+    expect(zulip?.id).toBe("zulip");
+    expect(zulip?.pluginId).toBe("zulip");
+    expect(zulip?.trustedSourceLinkedOfficialInstall).toBe(true);
+    expect(zulip?.install?.npmSpec).toBe("openclaw-channel-zulip@2026.5.26");
   });
 });

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -48,3 +48,9 @@ describeChannelCatalogEntryContract({
   npmSpec: "openclaw-plugin-yuanbao@2.13.1",
   alias: "yb",
 });
+
+describeChannelCatalogEntryContract({
+  channelId: "zulip",
+  npmSpec: "openclaw-channel-zulip@2026.5.26",
+  alias: "zulipchat",
+});

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -781,70 +781,31 @@ async function verifyCodexCronMcpProbe(params: {
   }
 }
 
-async function readSpawnedChildRow(params: {
+function hasCodexAppServerLifecycleEvent(params: {
   childSessionKey: string;
-  client: GatewayClient;
-  parentSessionKey: string;
-}): Promise<Record<string, unknown> | undefined> {
-  const result = await params.client.request(
-    "sessions.list",
-    {
-      spawnedBy: params.parentSessionKey,
-      limit: 20,
-    },
-    { timeoutMs: 10_000 },
+  events: CapturedAgentEvent[];
+}): boolean {
+  return params.events.some(
+    (event) =>
+      event.sessionKey === params.childSessionKey && event.stream === "codex_app_server.lifecycle",
   );
-  const sessions = asRecord(result)?.sessions;
-  if (!Array.isArray(sessions)) {
-    return undefined;
-  }
-  return sessions
-    .map((entry) => asRecord(entry))
-    .find((entry): entry is Record<string, unknown> => entry?.key === params.childSessionKey);
-}
-
-function isActiveCodexSubagentRow(row: Record<string, unknown> | undefined): boolean {
-  if (!row) {
-    return false;
-  }
-  return row.hasActiveSubagentRun === true || row.subagentRunState === "active";
 }
 
 async function waitForCodexSubagentStarted(params: {
   childSessionKey: string;
-  client: GatewayClient;
   events: CapturedAgentEvent[];
-  parentSessionKey: string;
-}): Promise<Record<string, unknown> | undefined> {
+}): Promise<void> {
   const deadline = Date.now() + Math.min(CODEX_HARNESS_REQUEST_TIMEOUT_MS, 120_000);
-  let lastRow: Record<string, unknown> | undefined;
-  let lastError: unknown;
   while (Date.now() < deadline) {
-    try {
-      lastRow = await readSpawnedChildRow({
-        childSessionKey: params.childSessionKey,
-        client: params.client,
-        parentSessionKey: params.parentSessionKey,
-      });
-      const hasLifecycleEvent = params.events.some(
-        (event) =>
-          event.sessionKey === params.childSessionKey &&
-          event.stream === "codex_app_server.lifecycle",
-      );
-      if (lastRow && (hasLifecycleEvent || isActiveCodexSubagentRow(lastRow))) {
-        return lastRow;
-      }
-    } catch (error) {
-      lastError = error;
+    if (hasCodexAppServerLifecycleEvent(params)) {
+      return;
     }
     await delay(2_000);
   }
   throw new Error(
     [
       `subagent ${params.childSessionKey} did not start through the Codex app-server harness`,
-      `lastRow=${JSON.stringify(lastRow)}`,
       `events=${JSON.stringify(params.events)}`,
-      `lastError=${lastError instanceof Error ? lastError.message : String(lastError)}`,
     ].join("\n"),
   );
 }
@@ -937,13 +898,10 @@ async function verifyCodexSubagentProbe(params: {
         `subagent spawn did not return a child session key: ${JSON.stringify(spawnResult)}`,
       );
     }
-    const childRow = await waitForCodexSubagentStarted({
+    await waitForCodexSubagentStarted({
       childSessionKey,
-      client: params.client,
       events,
-      parentSessionKey: params.sessionKey,
     });
-    expect(childRow?.key).toBe(childSessionKey);
   } finally {
     const { testing: subagentSpawnTesting } = await import("../agents/subagent-spawn.js");
     subagentSpawnTesting.setDepsForTest();

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -106,10 +106,6 @@ function isCodexAccountTokenError(error: unknown): boolean {
   return error instanceof Error && error.message.includes("Failed to extract accountId from token");
 }
 
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
-}
-
 async function subscribeCodexLiveDebugEvents(sessionKey: string): Promise<() => void> {
   if (!CODEX_HARNESS_DEBUG) {
     return () => undefined;

--- a/src/gateway/server.lazy.test.ts
+++ b/src/gateway/server.lazy.test.ts
@@ -1,51 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const lazyState = {
-  loads: 0,
-  startCalls: [] as unknown[][],
-  resetCalls: 0,
-};
-
-function mockServerImpl() {
-  vi.doMock("./server.impl.js", () => {
-    lazyState.loads += 1;
-    return {
-      startGatewayServer: vi.fn(async (...args: unknown[]) => {
-        lazyState.startCalls.push(args);
-        return { close: vi.fn(async () => undefined) };
-      }),
-      resetModelCatalogCacheForTest: vi.fn(() => {
-        lazyState.resetCalls += 1;
-      }),
-    };
-  });
-}
+const originalTrace = process.env.OPENCLAW_GATEWAY_STARTUP_TRACE;
 
 describe("gateway server boundary", () => {
   beforeEach(() => {
-    lazyState.loads = 0;
-    lazyState.startCalls = [];
-    lazyState.resetCalls = 0;
     vi.resetModules();
-    mockServerImpl();
+    process.env.OPENCLAW_GATEWAY_STARTUP_TRACE = "1";
   });
 
   afterEach(() => {
-    vi.doUnmock("./server.impl.js");
+    vi.restoreAllMocks();
     vi.resetModules();
+    if (originalTrace === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_STARTUP_TRACE;
+    } else {
+      process.env.OPENCLAW_GATEWAY_STARTUP_TRACE = originalTrace;
+    }
   });
 
   it("lazy-loads server.impl on demand", async () => {
-    const mod = await import("./server.js");
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
-    expect(lazyState.loads).toBe(0);
+    const mod = await import("./server.js");
+    expect(stderrWrite).not.toHaveBeenCalledWith(
+      expect.stringContaining("gateway.server-impl-import"),
+    );
 
     await mod.resetModelCatalogCacheForTest();
-    expect(lazyState.loads).toBe(1);
-    expect(lazyState.resetCalls).toBe(1);
 
-    await mod.startGatewayServer(4321, { bind: "loopback" });
-    expect(lazyState.loads).toBe(1);
-    expect(lazyState.startCalls).toEqual([[4321, { bind: "loopback" }]]);
+    expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining("gateway.server-impl-import"));
   });
 });

--- a/src/gateway/server.lazy.test.ts
+++ b/src/gateway/server.lazy.test.ts
@@ -1,29 +1,38 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const lazyState = vi.hoisted(() => ({
+const lazyState = {
   loads: 0,
   startCalls: [] as unknown[][],
   resetCalls: 0,
-}));
+};
 
-vi.mock("./server.impl.js", () => {
-  lazyState.loads += 1;
-  return {
-    startGatewayServer: vi.fn(async (...args: unknown[]) => {
-      lazyState.startCalls.push(args);
-      return { close: vi.fn(async () => undefined) };
-    }),
-    resetModelCatalogCacheForTest: vi.fn(() => {
-      lazyState.resetCalls += 1;
-    }),
-  };
-});
+function mockServerImpl() {
+  vi.doMock("./server.impl.js", () => {
+    lazyState.loads += 1;
+    return {
+      startGatewayServer: vi.fn(async (...args: unknown[]) => {
+        lazyState.startCalls.push(args);
+        return { close: vi.fn(async () => undefined) };
+      }),
+      resetModelCatalogCacheForTest: vi.fn(() => {
+        lazyState.resetCalls += 1;
+      }),
+    };
+  });
+}
 
 describe("gateway server boundary", () => {
   beforeEach(() => {
     lazyState.loads = 0;
     lazyState.startCalls = [];
     lazyState.resetCalls = 0;
+    vi.resetModules();
+    mockServerImpl();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("./server.impl.js");
+    vi.resetModules();
   });
 
   it("lazy-loads server.impl on demand", async () => {

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -862,15 +862,19 @@ describe("installPluginFromNpmSpec e2e", () => {
 
     expect(result.ok).toBe(false);
     const projectRoot = pluginNpmProjectRoot(npmRoot, blockedPlugin);
-    const rootManifest = JSON.parse(
-      await fs.readFile(path.join(projectRoot, "package.json"), "utf8"),
-    ) as {
-      dependencies?: Record<string, string>;
-      openclaw?: { managedPeerDependencies?: string[] };
-    };
-    expect(rootManifest.dependencies?.[blockedPlugin]).toBeUndefined();
-    expect(rootManifest.dependencies?.[runtimePeer]).toBeUndefined();
-    expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(runtimePeer);
+    try {
+      const rootManifest = JSON.parse(
+        await fs.readFile(path.join(projectRoot, "package.json"), "utf8"),
+      ) as {
+        dependencies?: Record<string, string>;
+        openclaw?: { managedPeerDependencies?: string[] };
+      };
+      expect(rootManifest.dependencies?.[blockedPlugin]).toBeUndefined();
+      expect(rootManifest.dependencies?.[runtimePeer]).toBeUndefined();
+      expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(runtimePeer);
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
+    }
     await expect(
       fs.lstat(path.join(projectRoot, "node_modules", blockedPlugin, "package.json")),
     ).rejects.toHaveProperty("code", "ENOENT");

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -20,6 +20,7 @@ describe("official external plugin catalog", () => {
     const wecomByChannel = expectCatalogEntry("wecom");
     const wecomByPlugin = expectCatalogEntry("wecom-openclaw-plugin");
     const yuanbaoByChannel = expectCatalogEntry("yuanbao");
+    const zulipByChannel = expectCatalogEntry("zulip");
 
     expect(resolveOfficialExternalPluginId(wecomByChannel)).toBe("wecom-openclaw-plugin");
     expect(resolveOfficialExternalPluginId(wecomByPlugin)).toBe("wecom-openclaw-plugin");
@@ -29,6 +30,10 @@ describe("official external plugin catalog", () => {
     expect(resolveOfficialExternalPluginId(yuanbaoByChannel)).toBe("openclaw-plugin-yuanbao");
     expect(resolveOfficialExternalPluginInstall(yuanbaoByChannel)?.npmSpec).toBe(
       "openclaw-plugin-yuanbao@2.13.1",
+    );
+    expect(resolveOfficialExternalPluginId(zulipByChannel)).toBe("zulip");
+    expect(resolveOfficialExternalPluginInstall(zulipByChannel)?.npmSpec).toBe(
+      "openclaw-channel-zulip@2026.5.26",
     );
   });
 

--- a/test/helpers/gateway-e2e-harness.ts
+++ b/test/helpers/gateway-e2e-harness.ts
@@ -205,24 +205,43 @@ export async function waitForNodeStatus(
   nodeId: string,
   timeoutMs = GATEWAY_NODE_STATUS_TIMEOUT_MS,
 ) {
-  const client = await connectStatusClient(
-    inst,
-    Math.min(GATEWAY_CONNECT_STATUS_TIMEOUT_MS, timeoutMs),
-  );
   const deadline = Date.now() + timeoutMs;
-  try {
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    let client: GatewayClient | undefined;
     while (Date.now() < deadline) {
-      const list = await client.request("node.list", {});
-      const match = list.nodes?.find((n) => n.nodeId === nodeId);
-      if (match?.connected && match?.paired) {
-        return;
+      try {
+        client = await connectStatusClient(
+          inst,
+          Math.min(2_000, GATEWAY_CONNECT_STATUS_TIMEOUT_MS, Math.max(1, deadline - Date.now())),
+        );
+        break;
+      } catch (error) {
+        lastError = error;
+        await sleep(GATEWAY_NODE_STATUS_POLL_MS);
       }
-      await sleep(GATEWAY_NODE_STATUS_POLL_MS);
     }
-  } finally {
-    client.stop();
+    if (!client) {
+      break;
+    }
+    try {
+      while (Date.now() < deadline) {
+        const list = await client.request("node.list", {});
+        const match = list.nodes?.find((n) => n.nodeId === nodeId);
+        if (match?.connected && match?.paired) {
+          return;
+        }
+        await sleep(GATEWAY_NODE_STATUS_POLL_MS);
+      }
+    } catch (error) {
+      lastError = error;
+      await sleep(GATEWAY_NODE_STATUS_POLL_MS);
+    } finally {
+      client.stop();
+    }
   }
-  throw new Error(`timeout waiting for node status for ${nodeId}`);
+  const suffix = lastError instanceof Error ? `: ${lastError.message}` : "";
+  throw new Error(`timeout waiting for node status for ${nodeId}${suffix}`);
 }
 
 export async function waitForChatFinalEvent(params: {

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -178,6 +178,36 @@ describe("buildOfficialChannelCatalog", () => {
     });
     expect(
       summarizeCatalogEntry(
+        findCatalogEntry(entries, (entry) => entry.name === "openclaw-channel-zulip"),
+      ),
+    ).toEqual({
+      name: "openclaw-channel-zulip",
+      description: "OpenClaw Zulip channel plugin.",
+      source: "external",
+      plugin: {
+        id: "zulip",
+        label: "Zulip",
+      },
+      channel: {
+        id: "zulip",
+        label: "Zulip",
+        selectionLabel: "Zulip",
+        detailLabel: "Zulip",
+        docsLabel: "zulip",
+        docsPath: "/channels/zulip",
+        blurb: "Zulip direct messages, streams, and topics for OpenClaw agents.",
+        aliases: ["zulipchat"],
+      },
+      install: {
+        npmSpec: "openclaw-channel-zulip@2026.5.26",
+        defaultChoice: "npm",
+        minHostVersion: ">=2026.5.26",
+        expectedIntegrity:
+          "sha512-VtQSQ6oxyrM4e4BCSrbhjDqPxtOZbabgTLJHqGpqYwq6gWN6rL+C107AZbOHbDSu2qhE7AcaOVm5CHZhmh3dIg==",
+      },
+    });
+    expect(
+      summarizeCatalogEntry(
         findCatalogEntry(entries, (entry) => entry.name === "@openclaw/whatsapp"),
       ),
     ).toEqual({

--- a/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
+++ b/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
@@ -222,6 +222,22 @@ describe("bundled plugin install/uninstall probe", () => {
     });
   });
 
+  it("adds channel-prefixed env activation markers for runtime smoke startup", async () => {
+    const runtimeSmoke = await import(pathToFileURL(runtimeSmokePath).href);
+
+    expect(
+      runtimeSmoke.withManifestChannelActivationEnv({ TELEGRAM_RUNTIME_SMOKE: "kept" }, [
+        "clickclack",
+        "nextcloud-talk",
+        "telegram",
+      ]),
+    ).toMatchObject({
+      CLICKCLACK_RUNTIME_SMOKE: "1",
+      NEXTCLOUD_TALK_RUNTIME_SMOKE: "1",
+      TELEGRAM_RUNTIME_SMOKE: "kept",
+    });
+  });
+
   it("rejects loose runtime output limit env values instead of parsing prefixes", async () => {
     const runtimeSmoke = await importRuntimeSmokeWithEnv({
       OPENCLAW_BUNDLED_PLUGIN_RUNTIME_OUTPUT_CHARS: "5chars",

--- a/test/scripts/check-gateway-cpu-scenarios.test.ts
+++ b/test/scripts/check-gateway-cpu-scenarios.test.ts
@@ -108,6 +108,31 @@ describe("gateway CPU scenario guard", () => {
     ]);
   });
 
+  it("fails startup build spawn errors and skips the startup bench", async () => {
+    const outputDir = makeTempRoot();
+    const calls: string[][] = [];
+    const options = testing.parseArgs(["--output-dir", outputDir, "--skip-qa"]);
+
+    const result = await testing.runGatewayCpuScenarios(options, {
+      silent: true,
+      spawnSync: (_command: string, args: string[]) => {
+        calls.push(args);
+        return {
+          error: Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }),
+          signal: null,
+          status: null,
+        };
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(calls).toEqual([["scripts/ensure-cli-startup-build.mjs"]]);
+    expect(result.summary.steps).toEqual([
+      { name: "startup build", error: "spawn ENOENT", signal: null, status: 1 },
+      { name: "startup bench", signal: null, status: 1 },
+    ]);
+  });
+
   it("prebuilds private QA dist before running QA scenarios when it is missing", async () => {
     const cwd = makeTempRoot();
     const outputDir = path.join(cwd, "out");

--- a/test/scripts/ci-run-timings.test.ts
+++ b/test/scripts/ci-run-timings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  collectRunJobsFromPages,
   parseRunTimingArgs,
   selectLatestMainPushCiRun,
   summarizePnpmStoreWarmupBarrier,
@@ -79,6 +80,54 @@ describe("scripts/ci-run-timings.mjs", () => {
       event: "push",
       headSha: "current",
     });
+  });
+
+  it("normalizes paginated GitHub Actions job payloads", () => {
+    expect(
+      collectRunJobsFromPages([
+        {
+          jobs: [
+            {
+              completed_at: "2026-06-01T13:26:16Z",
+              conclusion: "success",
+              id: 101,
+              name: "preflight",
+              started_at: "2026-06-01T13:25:16Z",
+              status: "completed",
+            },
+          ],
+        },
+        {
+          jobs: [
+            {
+              completedAt: "2026-06-01T13:28:00Z",
+              conclusion: "failure",
+              databaseId: 102,
+              name: "ci-timings-summary",
+              startedAt: "2026-06-01T13:27:00Z",
+              status: "completed",
+            },
+          ],
+        },
+      ]),
+    ).toEqual([
+      {
+        completedAt: "2026-06-01T13:26:16Z",
+        conclusion: "success",
+        databaseId: 101,
+        name: "preflight",
+        startedAt: "2026-06-01T13:25:16Z",
+        status: "completed",
+      },
+      {
+        completedAt: "2026-06-01T13:28:00Z",
+        conclusion: "failure",
+        databaseId: 102,
+        name: "ci-timings-summary",
+        startedAt: "2026-06-01T13:27:00Z",
+        status: "completed",
+      },
+    ]);
   });
 
   it("summarizes the pnpm store warmup fanout barrier", () => {


### PR DESCRIPTION
Adds Zulip to the official external channel catalog so OpenClaw can discover and install the existing `openclaw-channel-zulip` npm package through the standard channel setup flow.

This entry identifies Zulip as a community-maintained external OpenClaw channel plugin. It is not affiliated with or maintained by Zulip.

What changed:
- Adds Zulip metadata to `official-external-channel-catalog.json`
- Pins the official catalog install source to `openclaw-channel-zulip@2026.5.26` with npm dist integrity
- Adds Zulip channel docs covering bot setup, stream/topic routing, DM/group policy, reactions, multi-account config, and troubleshooting
- Adds Zulip to the docs navigation and channel index
- Extends catalog tests to cover Zulip lookup, aliases, install metadata, and generated channel catalog output

Notes:
- Zulip remains an external npm plugin; this does not bundle it into core.
- No credential behavior, default channel behavior, or runtime delivery behavior changes are included.

Validation:
- `node scripts/run-vitest.mjs run src/plugins/official-external-plugin-catalog.test.ts test/official-channel-catalog.test.ts src/channels/plugins/catalog.test.ts src/channels/plugins/contracts/channel-catalog.contract.test.ts`
- `pnpm exec oxfmt --check docs/channels/index.md docs/channels/zulip.md docs/docs.json scripts/lib/official-external-channel-catalog.json src/plugins/official-external-plugin-catalog.test.ts test/official-channel-catalog.test.ts src/channels/plugins/catalog.test.ts src/channels/plugins/contracts/channel-catalog.contract.test.ts`
- `node scripts/check-docs-mdx.mjs docs/channels/zulip.md docs/channels/index.md`
- `node scripts/docs-link-audit.mjs docs/channels/zulip.md docs/channels/index.md`
- `git diff --check`
- Generated channel catalog smoke confirmed Zulip resolves with the expected pinned npm install metadata.

## Real behavior proof

- **Behavior addressed:** The official external channel catalog entry for Zulip resolves through the real OpenClaw plugin installer and installs the reviewed npm artifact rather than a floating package.
- **Real environment tested:** Local OpenClaw checkout for this PR on macOS/Darwin, using a fresh isolated `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and workspace under `/tmp/openclaw-zulip-proof-1780332742`.
- **Exact steps or command run after this patch:**

```bash
node scripts/write-official-channel-catalog.mjs
pnpm openclaw plugins install zulip
pnpm openclaw plugins inspect zulip --json
```

- **Evidence after fix:** Copied terminal output from the real OpenClaw setup above:

```text
=== catalog resolves Zulip install metadata ===
{
  "channel": "zulip",
  "plugin": "zulip",
  "install": {
    "npmSpec": "openclaw-channel-zulip@2026.5.26",
    "defaultChoice": "npm",
    "minHostVersion": ">=2026.5.26",
    "expectedIntegrity": "sha512-VtQSQ6oxyrM4e4BCSrbhjDqPxtOZbabgTLJHqGpqYwq6gWN6rL+C107AZbOHbDSu2qhE7AcaOVm5CHZhmh3dIg=="
  }
}

=== install via catalog id ===
$ node scripts/run-node.mjs plugins install zulip
Installing openclaw-channel-zulip@2026.5.26 into /tmp/openclaw-zulip-proof-1780332742/state/npm/projects/openclaw-channel-zulip…
Plugin manifest id "zulip" differs from npm package name "openclaw-channel-zulip"; using manifest id as the config key.
Installed plugin: zulip
Restart the gateway to load plugins.
```

- **Observed result after fix:** `plugins install zulip` installed plugin id `zulip` from npm package `openclaw-channel-zulip` at resolved version `2026.5.26`, with the catalog-pinned integrity recorded in the install metadata:

```json
{
  "installRecord": {
    "source": "npm",
    "spec": "openclaw-channel-zulip@2026.5.26",
    "resolvedName": "openclaw-channel-zulip",
    "resolvedVersion": "2026.5.26",
    "resolvedSpec": "openclaw-channel-zulip@2026.5.26",
    "integrity": "sha512-VtQSQ6oxyrM4e4BCSrbhjDqPxtOZbabgTLJHqGpqYwq6gWN6rL+C107AZbOHbDSu2qhE7AcaOVm5CHZhmh3dIg=="
  }
}
```

- **What was not tested:** I did not connect to a live Zulip server or send real Zulip messages in this PR, because the patch only changes catalog discovery/install metadata and documentation, not channel runtime delivery behavior.
