### PR TITLE
fix(auto-reply): guard missing dispatcher getFailedCounts without weakening the SDK type

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1575,7 +1575,7 @@ export async function handleFeishuMessage(params: {
             turnResult.dispatched &&
             shouldSendNoVisibleReplyFallback({
               ...turnResult.dispatchResult,
-              failedCounts: dispatcher.getFailedCounts(),
+              failedCounts: dispatcher.getFailedCounts?.() ?? { tool: 0, block: 0, final: 0 },
             })
           ) {
             await ensureNoVisibleReplyFallback("broadcast-dispatch-complete-no-visible-reply");
@@ -1771,7 +1771,7 @@ export async function handleFeishuMessage(params: {
       if (
         shouldSendNoVisibleReplyFallback({
           ...dispatchResult,
-          failedCounts: dispatcher.getFailedCounts(),
+          failedCounts: dispatcher.getFailedCounts?.() ?? { tool: 0, block: 0, final: 0 },
         })
       ) {
         await ensureNoVisibleReplyFallback("dispatch-complete-no-visible-reply");

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -16,6 +16,7 @@ import type { FinalizedMsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
+import { readDispatcherFailedCounts } from "./reply-dispatcher.types.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 
 const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
@@ -257,7 +258,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     state.settledDirectVisibleText = true;
     hasPendingDirectBlockReplyDelivery = false;
     await params.dispatcher.waitForIdle();
-    const failedCounts = params.dispatcher.getFailedCounts();
+    const failedCounts = readDispatcherFailedCounts(params.dispatcher);
     const failedVisibleCount = failedCounts.block + failedCounts.final;
     if (failedVisibleCount > 0) {
       state.failedVisibleTextDelivery = true;

--- a/src/auto-reply/reply/dispatch-from-config.final-outcome-counts.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.final-outcome-counts.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getDispatcherFinalOutcomeCounts } from "./dispatch-from-config.js";
+import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
+
+describe("getDispatcherFinalOutcomeCounts (#89116)", () => {
+  it("returns failed: 0 when the dispatcher does not implement getFailedCounts", () => {
+    // Some ReplyDispatcher variants omit the optional count methods entirely; the
+    // previous code called dispatcher.getFailedCounts() unguarded and threw
+    // "TypeError: dispatcher.getFailedCounts is not a function".
+    const dispatcher = {
+      getCancelledCounts: () => ({ tool: 0, block: 0, final: 2 }),
+      // getFailedCounts intentionally absent
+    } as unknown as ReplyDispatcher;
+
+    expect(() => getDispatcherFinalOutcomeCounts(dispatcher)).not.toThrow();
+    expect(getDispatcherFinalOutcomeCounts(dispatcher)).toEqual({ cancelled: 2, failed: 0 });
+  });
+
+  it("returns cancelled: 0 when getCancelledCounts is absent (existing behavior preserved)", () => {
+    const dispatcher = {
+      getFailedCounts: () => ({ tool: 0, block: 1, final: 3 }),
+    } as unknown as ReplyDispatcher;
+
+    expect(getDispatcherFinalOutcomeCounts(dispatcher)).toEqual({ cancelled: 0, failed: 3 });
+  });
+
+  it("uses the real final counts when both methods are present", () => {
+    const dispatcher = {
+      getCancelledCounts: () => ({ tool: 0, block: 0, final: 1 }),
+      getFailedCounts: () => ({ tool: 0, block: 0, final: 5 }),
+    } as unknown as ReplyDispatcher;
+
+    expect(getDispatcherFinalOutcomeCounts(dispatcher)).toEqual({ cancelled: 1, failed: 5 });
+  });
+});

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -132,7 +132,12 @@ import { withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
-import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
+import type {
+  DispatcherOutcomeCountsView,
+  ReplyDispatchKind,
+  ReplyDispatcher,
+} from "./reply-dispatcher.types.js";
+import { readDispatcherFailedCounts } from "./reply-dispatcher.types.js";
 import { replyRunRegistry, type ReplyOperation } from "./reply-run-registry.js";
 import { isReplyProfilerEnabled } from "./reply-timing-tracker.js";
 import { admitReplyTurn, resolveReplyTurnKind } from "./reply-turn-admission.js";
@@ -774,13 +779,13 @@ async function mirrorInternalSourceReplyToTranscript(params: {
   }
 }
 
-function getDispatcherFinalOutcomeCounts(dispatcher: ReplyDispatcher): {
+export function getDispatcherFinalOutcomeCounts(dispatcher: DispatcherOutcomeCountsView): {
   cancelled: number;
   failed: number;
 } {
   return {
     cancelled: dispatcher.getCancelledCounts?.().final ?? 0,
-    failed: dispatcher.getFailedCounts().final,
+    failed: dispatcher.getFailedCounts?.().final ?? 0,
   };
 }
 
@@ -903,7 +908,7 @@ function createAbortAwareDispatcher(params: {
     sendFinalReply: sendIfActive(params.dispatcher.sendFinalReply),
     waitForIdle: () => params.dispatcher.waitForIdle(),
     getQueuedCounts: () => params.dispatcher.getQueuedCounts(),
-    getFailedCounts: () => params.dispatcher.getFailedCounts(),
+    getFailedCounts: () => readDispatcherFailedCounts(params.dispatcher),
     markComplete: () => {
       if (!params.isAborted()) {
         params.dispatcher.markComplete();

--- a/src/auto-reply/reply/reply-dispatcher.types.ts
+++ b/src/auto-reply/reply/reply-dispatcher.types.ts
@@ -18,3 +18,21 @@ export type ReplyDispatcher = {
   getFailedCounts: () => Record<ReplyDispatchKind, number>;
   markComplete: () => void;
 };
+
+/**
+ * Internal view for defensive outcome-count accounting. Some non-conforming
+ * runtime dispatcher variants (for example plugin-provided dispatchers) may omit
+ * these readers even though the public ReplyDispatcher contract requires
+ * getFailedCounts. Read the counters through this view so the guards stay
+ * type-correct without weakening the SDK-visible ReplyDispatcher type.
+ */
+export type DispatcherOutcomeCountsView = {
+  getCancelledCounts?: () => Record<ReplyDispatchKind, number>;
+  getFailedCounts?: () => Record<ReplyDispatchKind, number>;
+};
+
+export function readDispatcherFailedCounts(
+  dispatcher: DispatcherOutcomeCountsView,
+): Record<ReplyDispatchKind, number> {
+  return dispatcher.getFailedCounts?.() ?? { tool: 0, block: 0, final: 0 };
+}


### PR DESCRIPTION
Fixes #89116

## Summary

`getDispatcherFinalOutcomeCounts()` in `src/auto-reply/reply/dispatch-from-config.ts` called `dispatcher.getFailedCounts().final` without optional chaining, while the adjacent `getCancelledCounts?.().final ?? 0` line already guarded against the method being absent. Some `ReplyDispatcher` variants omit count methods at runtime (e.g. plugin-provided dispatchers), so the unguarded call threw `TypeError: dispatcher.getFailedCounts is not a function`.

Per the P1 review feedback, this revision **preserves the public `ReplyDispatcher.getFailedCounts` contract as required** (no plugin-facing SDK break) and tolerates missing readers internally instead:

- `reply-dispatcher.types.ts` — `getFailedCounts` stays **required** in the SDK-visible `ReplyDispatcher` (diff is purely additive vs main); adds an internal `DispatcherOutcomeCountsView` (optional readers) + a `readDispatcherFailedCounts()` helper for tolerant reads
- `dispatch-from-config.ts` — `getDispatcherFinalOutcomeCounts` takes the narrower `DispatcherOutcomeCountsView`; the active-dispatch wrapper falls back to empty counts via the helper
- `dispatch-acp-delivery.ts` — visible-text delivery reads failed counts through the helper
- `bot.ts` — Feishu no-visible-reply fallback reads failed counts defensively

The crash is fixed through tolerant internal reads without changing the exported dispatcher type.

## Real behavior proof

**Behavior addressed:** A `ReplyDispatcher` variant that omits `getFailedCounts` at runtime no longer crashes the final-outcome accounting path; the failed count safely resolves to `0`, while dispatchers that implement it keep using the real counts. The SDK-visible type is unchanged from main.

**Real environment tested:** Linux x86_64, Node.js v22.22.0, HEAD `9a1d408b520a44cfe00abb0538ca039c2460035a` rebased onto `origin/main` `489efc8f5eb15066f007f820ea71398357ad08e8`. The production function `getDispatcherFinalOutcomeCounts` is driven directly via `node --import tsx`, plus the focused Vitest regression.

**Exact steps or command run after this patch:**
```
node --import tsx -e 'import("./src/auto-reply/reply/dispatch-from-config.ts").then((m) => {
  const partial = { getCancelledCounts: () => ({ tool: 0, block: 0, final: 2 }) };
  let beforeErr = "(no error)";
  try { partial.getFailedCounts().final; } catch (e) { beforeErr = e.constructor.name + ": " + e.message; }
  console.log("BEFORE:", beforeErr);
  console.log("AFTER :", JSON.stringify(m.getDispatcherFinalOutcomeCounts(partial)));
  const full = { getCancelledCounts: () => ({ tool:0, block:0, final:1 }), getFailedCounts: () => ({ tool:0, block:0, final:5 }) };
  console.log("FULL  :", JSON.stringify(m.getDispatcherFinalOutcomeCounts(full)));
})'

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  src/auto-reply/reply/dispatch-from-config.final-outcome-counts.test.ts \
  extensions/feishu/src/bot.test.ts --reporter=dot
```

**Evidence after fix:**
```
BEFORE: TypeError: partial.getFailedCounts is not a function
AFTER : {"cancelled":2,"failed":0}
FULL  : {"cancelled":1,"failed":5}

      Tests  73 passed (73)
```

**Observed result after fix:** The unguarded pre-fix call reproduces the reported `TypeError`. After the patch, the production `getDispatcherFinalOutcomeCounts` returns `{cancelled: 2, failed: 0}` for the method-less dispatcher (no throw) and `{cancelled: 1, failed: 5}` for a full dispatcher. The focused regression + Feishu bot suites pass 73/73, and CI `check-test-types` / `check-prod-types` / `check-lint` are green on this head. The public `ReplyDispatcher.getFailedCounts` type is identical to main.

**What was not tested:** End-to-end live dispatch against a real gateway run; the fix is exercised through the production accounting function with representative dispatcher variants and unit tests rather than a full live reply cycle.
