### PR TITLE
fix(agents): validate extension tool names

### DIFF
--- a/src/agents/sessions/extensions/loader.test.ts
+++ b/src/agents/sessions/extensions/loader.test.ts
@@ -43,4 +43,75 @@ export default async function(api) {
     expect(result.extensions).toHaveLength(1);
     expect(result.extensions[0]?.commands.has("sdk-subpath-probe")).toBe(true);
   });
+
+  it("rejects extension tools without a readable non-empty string name", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-tool-name-"));
+    tempDirs.push(dir);
+    const extensionPath = join(dir, "extension.ts");
+    await writeFile(
+      extensionPath,
+      `
+export default async function(api) {
+  api.registerTool({
+    name: 123,
+    label: "Broken",
+    description: "broken",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [], details: {} };
+    },
+  });
+}
+`,
+    );
+
+    const result = await loadExtensions([extensionPath], dir);
+
+    expect(result.extensions).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        path: extensionPath,
+        error:
+          "Failed to load extension: Extension tool registration requires a non-empty string name; received 123",
+      },
+    ]);
+  });
+
+  it("rejects extension tools whose name accessor throws", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-tool-name-"));
+    tempDirs.push(dir);
+    const extensionPath = join(dir, "extension.ts");
+    await writeFile(
+      extensionPath,
+      `
+export default async function(api) {
+  const tool = {
+    label: "Broken",
+    description: "broken",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [], details: {} };
+    },
+  };
+  Object.defineProperty(tool, "name", {
+    get() {
+      throw new Error("tool name getter exploded");
+    },
+  });
+  api.registerTool(tool);
+}
+`,
+    );
+
+    const result = await loadExtensions([extensionPath], dir);
+
+    expect(result.extensions).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        path: extensionPath,
+        error:
+          "Failed to load extension: Extension tool registration requires a readable tool name: tool name getter exploded",
+      },
+    ]);
+  });
 });

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -148,6 +148,25 @@ function resolvePath(extPath: string, cwd: string): string {
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
 
+function readRegisteredToolName(tool: ToolDefinition): string {
+  let name: unknown;
+  try {
+    name = tool.name;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Extension tool registration requires a readable tool name: ${message || "unknown error"}`,
+      { cause: error },
+    );
+  }
+  if (typeof name !== "string" || name.trim().length === 0) {
+    throw new Error(
+      `Extension tool registration requires a non-empty string name; received ${JSON.stringify(name)}`,
+    );
+  }
+  return name;
+}
+
 /**
  * Create a runtime with throwing stubs for action methods.
  * Runner.bindCore() replaces these with real implementations.
@@ -226,7 +245,8 @@ function createExtensionAPI(
 
     registerTool(tool: ToolDefinition): void {
       runtime.assertActive();
-      extension.tools.set(tool.name, {
+      const name = readRegisteredToolName(tool);
+      extension.tools.set(name, {
         definition: tool,
         sourceInfo: extension.sourceInfo,
       });


### PR DESCRIPTION
## Summary
- validate extension-registered tool names before inserting tools into the extension registry
- fail closed through the existing extension load error path for non-string, empty, or unreadable names
- add regression coverage for numeric tool names and throwing `name` accessors

## Verification
- `node scripts/run-vitest.mjs src/agents/sessions/extensions/loader.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check src/agents/sessions/extensions/loader.ts src/agents/sessions/extensions/loader.test.ts`
- `node_modules/.bin/oxlint src/agents/sessions/extensions/loader.ts src/agents/sessions/extensions/loader.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed"` (`run_8fd80c3ac42a`, `cbx_3db5b164cc01`, provider `aws`, exit 0)

## Real behavior proof
Behavior addressed: a malformed local session extension can no longer register a tool with a non-string or unreadable name and leave a poisoned entry for later session/runtime paths.
Real environment tested: focused local Vitest on Node 24 plus AWS Crabbox Linux changed gate.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/sessions/extensions/loader.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed"`.
Evidence after fix: focused Vitest passed 3 tests; Crabbox changed gate selected `core` and `coreTests`, completed typecheck/lint/guards, and exited 0 in run `run_8fd80c3ac42a` on lease `cbx_3db5b164cc01`. After one final fast-forward rebase, focused Vitest, oxfmt, oxlint, and `git diff --check` were rerun on pushed head `f372abd07e48f167d80e65efb8b01c6b3c4affc4`.
Observed result after fix: invalid extension tool names now reject the extension through `loadExtensions().errors` with a clear registration message instead of inserting malformed tool entries.
What was not tested: full repository suite on the pushed SHA; GitHub PR checks are expected to cover the final branch head.
