### PR TITLE
obs(model-fallback): emit `model.fallback.exhausted` counter on chain exhaustion

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1146,6 +1146,60 @@ describe("diagnostics-otel service", () => {
     expect(telemetryState.tracer.startSpan).not.toHaveBeenCalled();
   });
 
+  test("records model.fallback.exhausted counter with reason/provider/model/kind attrs (GH-5632)", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "model.fallback.exhausted",
+      requestedProvider: "google",
+      requestedModel: "gemini-2.5-flash",
+      reason: "auth",
+      kind: "text",
+      totalAttempts: 3,
+      runId: "run-1",
+    });
+
+    const counter = telemetryState.counters.get("openclaw.model.fallback.exhausted");
+    expect(counter).toBeDefined();
+    expect(counter?.add).toHaveBeenCalledWith(1, {
+      "openclaw.requested_provider": "google",
+      "openclaw.requested_model": "gemini-2.5-flash",
+      "openclaw.reason": "auth",
+      "openclaw.kind": "text",
+    });
+
+    // Distinct reason values produce separate label sets (cardinality bounded
+    // by the FailoverReason union, ~10 values).
+    emitDiagnosticEvent({
+      type: "model.fallback.exhausted",
+      requestedProvider: "openai",
+      requestedModel: "gpt-4o-mini",
+      reason: "rate_limit",
+      kind: "text",
+      totalAttempts: 1,
+    });
+    emitDiagnosticEvent({
+      type: "model.fallback.exhausted",
+      requestedProvider: "openai",
+      requestedModel: "dall-e-3",
+      reason: "unknown",
+      kind: "image",
+      totalAttempts: 2,
+    });
+
+    expect(counter?.add).toHaveBeenCalledTimes(3);
+    expect(counter?.add).toHaveBeenLastCalledWith(1, {
+      "openclaw.requested_provider": "openai",
+      "openclaw.requested_model": "dall-e-3",
+      "openclaw.reason": "unknown",
+      "openclaw.kind": "image",
+    });
+
+    await service.stop?.(ctx);
+  });
+
   test("appends signal path when endpoint contains non-signal /v1 segment", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createTraceOnlyContext("https://www.comet.com/opik/api/v1/private/otel");

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1558,6 +1558,18 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         unit: "1",
         description: "Diagnostic telemetry exporter lifecycle and failure events",
       });
+      // GH-5632: per-request counter for in-process model-fallback chain
+      // exhaustion. Labels: `openclaw.requested_provider`,
+      // `openclaw.requested_model`, `openclaw.reason` (FailoverReason),
+      // `openclaw.kind` ("text"|"image"). Powers the ai-central
+      // `AICentralFallbackExhausted{Auth,}` alerts.
+      const modelFallbackExhaustedCounter = meter.createCounter(
+        "openclaw.model.fallback.exhausted",
+        {
+          unit: "1",
+          description: "Model fallback chain exhausted without producing a successful response",
+        },
+      );
 
       let recordLogRecord:
         | ((
@@ -3048,6 +3060,17 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         });
       };
 
+      const recordModelFallbackExhausted = (
+        evt: Extract<DiagnosticEventPayload, { type: "model.fallback.exhausted" }>,
+      ) => {
+        modelFallbackExhaustedCounter.add(1, {
+          "openclaw.requested_provider": evt.requestedProvider,
+          "openclaw.requested_model": evt.requestedModel,
+          "openclaw.reason": evt.reason,
+          "openclaw.kind": evt.kind,
+        });
+      };
+
       const subscribe = ctx.internalDiagnostics?.onEvent;
       if (!subscribe) {
         ctx.logger.error("diagnostics-otel: internal diagnostics capability unavailable");
@@ -3202,6 +3225,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "model.failover":
               recordModelFailover(evt, metadata);
+              return;
+            case "model.fallback.exhausted":
+              recordModelFallbackExhausted(evt);
           }
         } catch (err) {
           ctx.logger.error(

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2,6 +2,11 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import {
@@ -1781,9 +1786,9 @@ describe("runWithModelFallback", () => {
       { provider: "openai", model: "gpt-4.1-mini" },
       { provider: "tui-pty-mock", model: "gpt-5.5" },
     ]);
-    expect(providerModelNormalizationMock.normalizeProviderModelIdWithRuntime).not.toHaveBeenCalledWith(
-      expect.objectContaining({ provider: "tui-pty-mock" }),
-    );
+    expect(
+      providerModelNormalizationMock.normalizeProviderModelIdWithRuntime,
+    ).not.toHaveBeenCalledWith(expect.objectContaining({ provider: "tui-pty-mock" }));
   });
 
   it("keeps configured fallbacks before configured primary for duplicate provider model ids", () => {
@@ -2202,6 +2207,106 @@ describe("runWithModelFallback", () => {
       { provider: "anthropic", model: "claude-opus-4-5" },
       { provider: "anthropic", model: "claude-haiku-3-5" },
     ]);
+  });
+
+  it("emits model.fallback.exhausted diagnostic event with terminal reason and chain context (GH-5632)", async () => {
+    resetDiagnosticEventsForTest();
+    const events: Extract<DiagnosticEventPayload, { type: "model.fallback.exhausted" }>[] = [];
+    const unsubscribe = onDiagnosticEvent((evt) => {
+      if (evt.type === "model.fallback.exhausted") {
+        events.push(evt);
+      }
+    });
+
+    try {
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "google/gemini-2.5-flash",
+              fallbacks: ["openai/gpt-4o-mini"],
+            },
+          },
+        },
+      });
+      // Each candidate fails with a 401 (auth class) so the terminal reason
+      // should be "auth".
+      const run = vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.reject(Object.assign(new Error("unauthorized"), { status: 401 })),
+        );
+
+      await expect(
+        runWithModelFallback({
+          cfg,
+          provider: "google",
+          model: "gemini-2.5-flash",
+          runId: "run-gh5632",
+          run,
+        }),
+      ).rejects.toMatchObject({ name: "FallbackSummaryError" });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: "model.fallback.exhausted",
+        requestedProvider: "google",
+        requestedModel: "gemini-2.5-flash",
+        reason: "auth",
+        kind: "text",
+        totalAttempts: 2,
+        runId: "run-gh5632",
+      });
+    } finally {
+      unsubscribe();
+      resetDiagnosticEventsForTest();
+    }
+  });
+
+  it("does NOT emit model.fallback.exhausted when only one candidate is attempted (single-attempt path)", async () => {
+    resetDiagnosticEventsForTest();
+    const events: DiagnosticEventPayload[] = [];
+    const unsubscribe = onDiagnosticEvent((evt) => {
+      if (evt.type === "model.fallback.exhausted") {
+        events.push(evt);
+      }
+    });
+
+    try {
+      // No fallbacks configured — only the primary is tried, so we hit the
+      // single-attempt early-return path inside throwFallbackFailureSummary
+      // (which surfaces the underlying error rather than wrapping it). Per
+      // GH-5632 spec, the counter is the equivalent of the
+      // "FallbackSummaryError: All models failed (N)" log line and only fires
+      // when a multi-candidate chain is actually exhausted.
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: { primary: "google/gemini-2.5-flash" },
+          },
+        },
+      });
+      const run = vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.reject(Object.assign(new Error("unauthorized"), { status: 401 })),
+        );
+
+      await expect(
+        runWithModelFallback({
+          cfg,
+          provider: "google",
+          model: "gemini-2.5-flash",
+          fallbacksOverride: [],
+          run,
+        }),
+      ).rejects.toThrow("unauthorized");
+
+      expect(events).toHaveLength(0);
+    } finally {
+      unsubscribe();
+      resetDiagnosticEventsForTest();
+    }
   });
 
   it("refreshes cooldown expiry from persisted auth state before fallback summary", async () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -5,7 +5,7 @@ import {
   resolveAgentModelPrimaryValue,
 } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { emitFailoverEvent } from "../infra/diagnostic-events.js";
+import { emitDiagnosticEvent, emitFailoverEvent } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
@@ -596,8 +596,22 @@ function throwFallbackFailureSummary(params: {
   attribution?: FailoverAttribution;
   cfg?: OpenClawConfig;
   agentDir?: string;
+  /** Provider the caller asked for (primary, pre-fallback). Used for the
+   *  `openclaw.model.fallback.exhausted` observability counter. */
+  requestedProvider: string;
+  /** Model the caller asked for (primary, pre-fallback). Used for the
+   *  `openclaw.model.fallback.exhausted` observability counter. */
+  requestedModel: string;
+  /** Fallback chain kind for the observability counter. */
+  kind: "text" | "image";
+  /** Optional run id propagated through to the diagnostic event. */
+  runId?: string;
 }): never {
   if (params.attempts.length <= 1 && params.lastError) {
+    // Single-attempt path: surface the underlying error directly. The fallback
+    // chain wasn't really exercised (only one configured candidate), so we do
+    // NOT emit the `model.fallback.exhausted` diagnostic event here — that
+    // event semantically means "all candidates in a multi-candidate chain failed".
     throw toLintErrorObject(params.lastError, "Non-Error thrown");
   }
 
@@ -619,6 +633,30 @@ function throwFallbackFailureSummary(params: {
   const message = remediation
     ? `All ${params.label} failed (${params.attempts.length || params.candidates.length}): ${summary}. ${remediation}`
     : `All ${params.label} failed (${params.attempts.length || params.candidates.length}): ${summary}`;
+
+  // Emit fallback-exhaustion counter so operators can alert on auth-class
+  // outages in minutes (real-traffic-derived, sub-minute resolution) rather
+  // than waiting for downstream replica/CrashLoop signals. Reason = terminal
+  // attempt's classification, falling back to "unknown" when the last
+  // candidate failed without a recognised reason.
+  const terminalReason =
+    params.attempts.length > 0
+      ? (params.attempts[params.attempts.length - 1].reason ?? "unknown")
+      : "unknown";
+  try {
+    emitDiagnosticEvent({
+      type: "model.fallback.exhausted",
+      requestedProvider: params.requestedProvider,
+      requestedModel: params.requestedModel,
+      reason: terminalReason,
+      kind: params.kind,
+      totalAttempts: params.attempts.length,
+      ...(params.runId ? { runId: params.runId } : {}),
+    });
+  } catch {
+    // Diagnostic emission must never block the user-visible error path.
+  }
+
   throw new FallbackSummaryError(
     message,
     params.attempts,
@@ -1697,6 +1735,10 @@ export async function runWithModelFallback<T>(
     attribution: { sessionId: params.sessionId, lane: params.lane },
     cfg: params.cfg,
     agentDir: params.agentDir,
+    requestedProvider: params.provider,
+    requestedModel: params.model,
+    kind: "text",
+    ...(params.runId ? { runId: params.runId } : {}),
   });
 }
 
@@ -1757,6 +1799,9 @@ export async function runWithImageModelFallback<T>(params: {
     label: "image models",
     formatAttempt: (attempt) => `${attempt.provider}/${attempt.model}: ${attempt.error}`,
     cfg: params.cfg,
+    requestedProvider: candidates[0]?.provider ?? DEFAULT_PROVIDER,
+    requestedModel: candidates[0]?.model ?? DEFAULT_MODEL,
+    kind: "image",
   });
 }
 export { testing as __testing };

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -1,3 +1,4 @@
+import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { TalkBrain, TalkEventType, TalkMode, TalkTransport } from "../talk/talk-events.js";
 import {
@@ -643,6 +644,41 @@ export type DiagnosticAsyncQueueDroppedEvent = DiagnosticBaseEvent & {
   drainBatchSize: number;
 };
 
+/**
+ * Emitted by the model fallback runner when the entire candidate chain is
+ * exhausted without producing a successful response (i.e. just before
+ * `FallbackSummaryError` is thrown). Surfaces the requested
+ * provider/model the caller asked for, the terminal failure reason from the
+ * last attempted candidate, and total attempt count. Consumed by
+ * `extensions/diagnostics-otel` to emit the
+ * `openclaw.model.fallback.exhausted` counter (sub-minute alertable signal
+ * for in-process fallback chain exhaustion).
+ */
+export type DiagnosticModelFallbackExhaustedEvent = DiagnosticBaseEvent & {
+  type: "model.fallback.exhausted";
+  /** Provider the caller asked for (the primary, before fallback substitution). */
+  requestedProvider: string;
+  /** Model the caller asked for (the primary, before fallback substitution). */
+  requestedModel: string;
+  /**
+   * Terminal reason classification from the last attempted candidate.
+   * Reuses the existing `FailoverReason` union so the taxonomy stays in
+   * lockstep with classification updates. Defaults to `"unknown"` when no
+   * candidate produced a classified reason.
+   */
+  reason: FailoverReason;
+  /**
+   * Fallback chain kind. `"text"` for `runWithModelFallback`, `"image"` for
+   * `runWithImageModelFallback`. Lets dashboards/alerts scope to text-only
+   * traffic without picking up image-generation fallbacks.
+   */
+  kind: "text" | "image";
+  /** Number of candidate attempts the chain actually executed. */
+  totalAttempts: number;
+  /** Optional run identifier propagated from `runWithModelFallback`. */
+  runId?: string;
+};
+
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
   | DiagnosticWebhookReceivedEvent
@@ -693,7 +729,8 @@ export type DiagnosticEventPayload =
   | DiagnosticLogRecordEvent
   | DiagnosticTelemetryExporterEvent
   | DiagnosticAsyncQueueDroppedEvent
-  | DiagnosticFailoverEvent;
+  | DiagnosticFailoverEvent
+  | DiagnosticModelFallbackExhaustedEvent;
 
 export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   ? Event extends DiagnosticEventPayload

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -536,6 +536,11 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.model = event.fromModel;
       assignReasonCode(record, event.reason);
       break;
+    case "model.fallback.exhausted":
+      record.provider = event.requestedProvider;
+      record.model = event.requestedModel;
+      assignReasonCode(record, event.reason);
+      break;
   }
 
   return record;


### PR DESCRIPTION
## Summary

Emit a new `DiagnosticModelFallbackExhaustedEvent` from `throwFallbackFailureSummary` whenever the in-process model fallback chain exhausts every configured candidate without producing a successful response, and translate it to a new `openclaw.model.fallback.exhausted` OTel counter in the `diagnostics-otel` plugin.

Sits alongside the existing per-skip `openclaw.model.failover` counter:
- `openclaw.model.failover` already fires at each `skip_candidate` decision inside the cascade (cardinality: per-candidate-skip).
- `openclaw.model.fallback.exhausted` fires once at terminal exhaustion (cardinality: per-failed-chain). This is the counter you want for "all configured candidates have failed for this primary" alerts — derivable from `model.failover` only via expensive post-hoc aggregation.

## Motivation

A deployment with an expired primary-provider key (no working fallback either, or all fallbacks also failing) currently has no in-process metric distinct from the per-attempt `model.failover` signal. The terminal "all candidates exhausted" point is only visible via structured logs (`FallbackSummaryError: All models failed (N): …`) or by inferring it downstream from absent successes — neither is sub-minute alertable.

This counter is the real-traffic-derived alertable counterpart:

- Sub-minute resolution
- Reflects user-traffic blast radius (not a synthetic probe)
- Labels `openclaw.requested_provider`, `openclaw.requested_model`, `openclaw.reason` (`FailoverReason` taxonomy), `openclaw.kind` (`text`|`image`)
- Costs zero extra LLM calls

## Design

- **Event type** lives in `src/infra/diagnostic-events.ts`. The `reason` field references the existing `FailoverReason` union from `src/agents/embedded-agent-helpers/types.ts` directly (no hardcoded copy) so the taxonomy stays in lockstep with classification updates. Terminal reason = last attempted candidate's reason, falling back to `"unknown"` when the last candidate failed without a recognised reason.
- **Emission** lives inside `throwFallbackFailureSummary` so both `runWithModelFallback` and `runWithImageModelFallback` (`kind: text|image`) are covered from a single source of truth.
- **Single-attempt early-return path** (one candidate, surfaces the underlying error via `toLintErrorObject`) intentionally does **not** emit — the fallback chain wasn't actually exercised. Matches the existing "FallbackSummaryError: All models failed (N)" log-line semantics. Covered by a dedicated unit test.
- **Diagnostic emission is wrapped in try/catch** so a misbehaving listener can never block the user-visible error path.
- **OTel handler** in `extensions/diagnostics-otel/src/service.ts` adds:
  - One `meter.createCounter("openclaw.model.fallback.exhausted", {unit: "1"})` next to the existing `modelFailoverCounter`
  - One `recordModelFallbackExhausted` helper next to `recordModelFailover`
  - One `case "model.fallback.exhausted"` in the event switch
- **Stability log shim** in `src/logging/diagnostic-stability.ts` gets a matching switch case (record-shape mirrors the existing `model.failover` case) for exhaustiveness.

## Cardinality

Bounded by `FailoverReason` (~14 values) × configured providers/models (small in any realistic deployment). For a 3-provider, 5-model deployment with the full reason taxonomy this is ~210 series upper bound — well within typical Prometheus/Mimir tenant limits.

## Verification

- `pnpm tsgo`: clean
- `pnpm lint`: 0 warnings, 0 errors (oxlint:core + extensions + scripts)
- `npx oxfmt --check` on touched files: clean
- `pnpm check:no-conflict-markers`: clean
- `pnpm check:import-cycles`: 0 runtime value cycles
- `vitest src/agents/model-fallback.test.ts`: 78/78 (incl. 2 new tests: emit-on-exhaustion with terminal-reason classification + no-emit on single-attempt path)
- `vitest extensions/diagnostics-otel/src/service.test.ts`: 74/74 (incl. 1 new test for counter labels + multi-reason cardinality)
- `vitest src/logging/diagnostic-stability.test.ts`: clean (no new test added; existing exhaustiveness coverage exercises the new case)

## Files

- `src/infra/diagnostic-events.ts` — new event type
- `src/agents/model-fallback.ts` — 4 new params on `throwFallbackFailureSummary`, emit block; pass-through at both `runWith{Model,ImageModel}Fallback` call sites
- `src/agents/model-fallback.test.ts` — 2 new unit tests
- `src/logging/diagnostic-stability.ts` — matching switch case for exhaustiveness
- `extensions/diagnostics-otel/src/service.ts` — counter + handler + switch case
- `extensions/diagnostics-otel/src/service.test.ts` — 1 new unit test

Total: +277/-5 LOC across 6 files.
