### PR TITLE
fix(codex): guard dynamic tool descriptors

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -77,6 +77,72 @@ describe("Codex app-server attempt context", () => {
     expect(report.tools.schemaChars).toBe(message?.schemaChars);
   });
 
+  it("reports malformed Codex dynamic tool descriptors without crashing", () => {
+    const unreadableTool = {
+      get name(): never {
+        throw new Error("tool name getter exploded");
+      },
+      get description(): never {
+        throw new Error("tool description getter exploded");
+      },
+      get inputSchema(): never {
+        throw new Error("tool schema getter exploded");
+      },
+      get deferLoading(): never {
+        throw new Error("tool defer flag getter exploded");
+      },
+    };
+    const tools = [
+      null,
+      {
+        name: 42,
+        description: 7,
+        inputSchema: undefined,
+      },
+      unreadableTool,
+      {
+        name: "message",
+        description: "Send a message.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            text: { type: "string" },
+          },
+        },
+      },
+    ] as unknown as CodexDynamicToolSpec[];
+
+    const report = buildCodexSystemPromptReport({
+      attempt: {
+        sessionId: "session-1",
+        provider: "codex",
+        modelId: "gpt-5.4-codex",
+      } as EmbeddedRunAttemptParams,
+      sessionKey: "agent:main:session-1",
+      workspaceDir: path.join("tmp", "workspace"),
+      developerInstructions: "test developer instructions",
+      workspaceBootstrapContext: {
+        bootstrapFiles: [],
+        contextFiles: [],
+        promptContextFiles: [],
+        developerInstructionFiles: [],
+        heartbeatReferenceFiles: [],
+      },
+      skillsPrompt: "",
+      tools,
+    });
+
+    const unnamed = report.tools.entries.find((tool) => tool.name === "<unnamed>");
+    const unreadable = report.tools.entries.find((tool) => tool.name === "<unreadable>");
+    const message = report.tools.entries.find((tool) => tool.name === "message");
+
+    expect(unnamed?.summaryChars).toBe(0);
+    expect(unnamed?.schemaChars).toBe(0);
+    expect(unreadable?.summaryChars).toBe(0);
+    expect(unreadable?.schemaChars).toBe(0);
+    expect(message?.schemaChars).toBeGreaterThan(0);
+  });
+
   it("keeps MEMORY.md injected when sandbox effective workspace differs", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-memory-workspace-"));
     const sandboxWorkspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-memory-sandbox-"));

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -319,11 +319,12 @@ function buildCodexSkillReportEntries(
     .filter((entry) => entry.blockChars > 0);
 }
 
-function buildCodexToolReportEntry(tool: CodexDynamicToolSpec): CodexToolReportEntry {
-  const summary = tool.description.trim();
-  if (tool.deferLoading === true) {
+function buildCodexToolReportEntry(tool: unknown): CodexToolReportEntry {
+  const name = readCodexToolReportName(tool);
+  const summary = readCodexToolDescription(tool);
+  if (isDeferredCodexTool(tool)) {
     return {
-      name: tool.name,
+      name,
       summaryChars: summary.length,
       summaryHash: sha256Text(summary),
       schemaChars: 0,
@@ -332,10 +333,78 @@ function buildCodexToolReportEntry(tool: CodexDynamicToolSpec): CodexToolReportE
     };
   }
   return {
-    name: tool.name,
+    name,
     summaryChars: summary.length,
     summaryHash: sha256Text(summary),
-    ...buildCodexToolSchemaStats(tool.inputSchema),
+    ...buildCodexToolSchemaStatsForTool(tool),
+  };
+}
+
+function readCodexToolReportName(tool: unknown): string {
+  try {
+    if (tool === null || typeof tool !== "object") {
+      return "<unnamed>";
+    }
+    const name = Reflect.get(tool, "name");
+    return typeof name === "string" && name.trim() ? name.trim() : "<unnamed>";
+  } catch {
+    return "<unreadable>";
+  }
+}
+
+function readCodexToolDescription(tool: unknown): string {
+  try {
+    if (tool === null || typeof tool !== "object") {
+      return "";
+    }
+    const description = Reflect.get(tool, "description");
+    return typeof description === "string" ? description.trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+function readCodexToolInputSchema(tool: unknown): JsonValue | undefined {
+  try {
+    if (tool === null || typeof tool !== "object") {
+      return undefined;
+    }
+    const inputSchema = Reflect.get(tool, "inputSchema");
+    return inputSchema === undefined ? undefined : (inputSchema as JsonValue);
+  } catch {
+    return undefined;
+  }
+}
+
+function isDeferredCodexTool(tool: unknown): boolean {
+  try {
+    if (tool === null || typeof tool !== "object") {
+      return false;
+    }
+    const deferLoading = Reflect.get(tool, "deferLoading");
+    return deferLoading === true;
+  } catch {
+    return false;
+  }
+}
+
+function buildCodexToolSchemaStatsForTool(
+  tool: unknown,
+): Pick<CodexToolReportEntry, "schemaChars" | "schemaHash" | "propertiesCount"> {
+  const schema = readCodexToolInputSchema(tool);
+  return schema === undefined
+    ? buildMissingCodexToolSchemaStats()
+    : buildCodexToolSchemaStats(schema);
+}
+
+function buildMissingCodexToolSchemaStats(): Pick<
+  CodexToolReportEntry,
+  "schemaChars" | "schemaHash" | "propertiesCount"
+> {
+  return {
+    schemaChars: 0,
+    schemaHash: stableJsonHash(null),
+    propertiesCount: null,
   };
 }
 
@@ -344,17 +413,32 @@ function buildCodexToolSchemaStats(
 ): Pick<CodexToolReportEntry, "schemaChars" | "schemaHash" | "propertiesCount"> {
   const schemaChars = (() => {
     try {
-      return JSON.stringify(schema).length;
+      const encoded = JSON.stringify(schema);
+      return typeof encoded === "string" ? encoded.length : 0;
     } catch {
       return 0;
     }
   })();
-  const properties =
-    isJsonObject(schema) && isJsonObject(schema.properties) ? schema.properties : null;
+  const schemaHash = (() => {
+    try {
+      return stableJsonHash(schema);
+    } catch {
+      return stableJsonHash(null);
+    }
+  })();
+  const propertiesCount = (() => {
+    try {
+      const properties =
+        isJsonObject(schema) && isJsonObject(schema.properties) ? schema.properties : null;
+      return properties ? Object.keys(properties).length : null;
+    } catch {
+      return null;
+    }
+  })();
   return {
     schemaChars,
-    schemaHash: stableJsonHash(schema),
-    propertiesCount: properties ? Object.keys(properties).length : null,
+    schemaHash,
+    propertiesCount,
   };
 }
 

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { describe, expect, it } from "vitest";
 import { CODEX_GPT5_BEHAVIOR_CONTRACT } from "../../prompt-overlay.js";
+import type { CodexDynamicToolSpec } from "./protocol.js";
 import {
   buildDeveloperInstructions,
   buildTurnCollaborationMode,
@@ -115,6 +116,56 @@ describe("Codex app-server native code mode config", () => {
     expect(instructions).not.toContain("message,");
   });
 
+  it("ignores dynamic tools with unreadable names in developer instructions", () => {
+    const unreadableNameTool = {
+      get name(): never {
+        throw new Error("tool name getter exploded");
+      },
+      description: "Broken tool",
+      inputSchema: { type: "object" },
+      namespace: "openclaw",
+      deferLoading: true,
+    };
+    const unreadableDeferredFlagTool = {
+      name: "image_generate",
+      description: "Create images",
+      inputSchema: { type: "object" },
+      namespace: "openclaw",
+      get deferLoading(): never {
+        throw new Error("tool defer flag getter exploded");
+      },
+    };
+
+    const dynamicTools = [
+      null,
+      unreadableNameTool,
+      unreadableDeferredFlagTool,
+      {
+        name: "music_generate",
+        description: "Create music",
+        inputSchema: { type: "object" },
+        namespace: "openclaw",
+        deferLoading: true,
+      },
+      {
+        name: "message",
+        description: "Send a message",
+        inputSchema: { type: "object" },
+      },
+    ] as unknown as CodexDynamicToolSpec[];
+
+    const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }), {
+      dynamicTools,
+    });
+
+    expect(instructions).toContain(
+      "Deferred searchable OpenClaw dynamic tools available: music_generate.",
+    );
+    expect(instructions).toContain("Use `message` only for explicit out-of-band sends");
+    expect(instructions).not.toContain("image_generate");
+    expect(instructions).not.toContain("tool name getter exploded");
+  });
+
   it("uses the shared Skill Workshop guidance when skill_workshop is available", () => {
     const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }), {
       dynamicTools: [
@@ -178,6 +229,30 @@ describe("Codex app-server native code mode config", () => {
     ]);
 
     expect(searchableFingerprint).toBe(directFingerprint);
+  });
+
+  it("fingerprints malformed dynamic tool descriptors without crashing", () => {
+    const malformedTool = {
+      get name(): never {
+        throw new Error("tool name getter exploded");
+      },
+      get description(): never {
+        throw new Error("tool description getter exploded");
+      },
+      inputSchema: {
+        type: "object",
+        get properties(): never {
+          throw new Error("schema properties getter exploded");
+        },
+      },
+      get deferLoading(): never {
+        throw new Error("tool defer flag getter exploded");
+      },
+    };
+
+    expect(() =>
+      codexDynamicToolsFingerprint([null, malformedTool] as unknown as CodexDynamicToolSpec[]),
+    ).not.toThrow();
   });
 
   it("keeps OpenClaw skill catalogs out of developer instructions", () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -1111,14 +1111,13 @@ function fingerprintDynamicToolSpec(tool: JsonValue): JsonValue {
     return stabilizeJsonValue(tool);
   }
   const stable: JsonObject = {};
-  for (const [key, child] of Object.entries(tool).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
+  for (const key of readStableJsonObjectKeys(tool)) {
     // Tool-search presentation can change per turn without changing the
     // durable app-server execution contract for an existing thread.
     if (key === "description" || key === "deferLoading" || key === "namespace") {
       continue;
     }
+    const child = readStableJsonObjectValue(tool, key);
     stable[key] = stabilizeJsonValue(child);
   }
   return stable;
@@ -1132,12 +1131,28 @@ function stabilizeJsonValue(value: JsonValue): JsonValue {
     return value;
   }
   const stable: JsonObject = {};
-  for (const [key, child] of Object.entries(value).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
+  for (const key of readStableJsonObjectKeys(value)) {
+    const child = readStableJsonObjectValue(value, key);
     stable[key] = stabilizeJsonValue(child);
   }
   return stable;
+}
+
+function readStableJsonObjectKeys(value: JsonObject): string[] {
+  try {
+    return Object.keys(value).toSorted((left, right) => left.localeCompare(right));
+  } catch {
+    return [];
+  }
+}
+
+function readStableJsonObjectValue(value: JsonObject, key: string): JsonValue {
+  try {
+    const child = Reflect.get(value, key);
+    return child === undefined ? null : child;
+  } catch {
+    return null;
+  }
 }
 
 const EMPTY_DYNAMIC_TOOLS_FINGERPRINT = JSON.stringify([]);
@@ -1187,8 +1202,8 @@ function buildDeferredDynamicToolManifest(
   const deferredToolNames = [
     ...new Set(
       (dynamicTools ?? [])
-        .filter((tool) => tool.deferLoading === true)
-        .map((tool) => tool.name.trim())
+        .filter(isDeferredDynamicTool)
+        .map(readDynamicToolInstructionName)
         .filter(Boolean),
     ),
   ].toSorted((left, right) => left.localeCompare(right));
@@ -1202,7 +1217,7 @@ function buildSkillWorkshopInstruction(
   dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
 ): string | undefined {
   const hasSkillWorkshop = (dynamicTools ?? []).some(
-    (tool) => tool.name.trim() === SKILL_WORKSHOP_TOOL_NAME,
+    (tool) => readDynamicToolInstructionName(tool) === SKILL_WORKSHOP_TOOL_NAME,
   );
   if (!hasSkillWorkshop) {
     return undefined;
@@ -1215,7 +1230,7 @@ function buildVisibleReplyInstruction(
   dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
 ): string {
   const messageToolAvailable = dynamicTools
-    ? dynamicTools.some((tool) => tool.name.trim() === "message")
+    ? dynamicTools.some((tool) => readDynamicToolInstructionName(tool) === "message")
     : params.disableMessageTool !== true;
   if (params.sourceReplyDeliveryMode === "message_tool_only" && messageToolAvailable) {
     return "Visible source replies are not automatically delivered for this run. Use `message(action=send)` for user-visible source-channel output. Do not repeat that visible content in your final answer.";
@@ -1224,6 +1239,30 @@ function buildVisibleReplyInstruction(
     return "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation. Use `message` only for explicit out-of-band sends, media/file sends, or sends to a different target.";
   }
   return "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation.";
+}
+
+function readDynamicToolInstructionName(tool: unknown): string {
+  try {
+    if (tool === null || typeof tool !== "object") {
+      return "";
+    }
+    const name = Reflect.get(tool, "name");
+    return typeof name === "string" ? name.trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+function isDeferredDynamicTool(tool: unknown): boolean {
+  try {
+    if (tool === null || typeof tool !== "object") {
+      return false;
+    }
+    const deferLoading = Reflect.get(tool, "deferLoading");
+    return deferLoading === true;
+  } catch {
+    return false;
+  }
 }
 
 function buildUserInput(


### PR DESCRIPTION
## Summary
- Guard Codex dynamic tool descriptor reads used by developer instructions, system prompt reporting, and dynamic tool fingerprinting.
- Skip malformed instruction names/defer flags, emit placeholder report names for malformed descriptors, and keep fingerprint stabilization from invoking throwing getters.
- Add regression coverage for null descriptors, non-string fields, throwing getters, and nested schema getter failures.

## Verification
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/attempt-context.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/attempt-context.ts extensions/codex/src/app-server/attempt-context.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/attempt-context.ts extensions/codex/src/app-server/attempt-context.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `run_931c8ff2b776`, lease `cbx_b0c352ee1100`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed`

## Real behavior proof
Behavior addressed: Codex app-server dynamic tool descriptor handling no longer crashes when descriptor arrays contain null entries, non-string fields, or getters that throw while building instructions, prompt reports, or fingerprints.

Real environment tested: local focused Codex extension tests on this branch, plus Linux AWS Crabbox changed gate on provider `aws` lease `cbx_b0c352ee1100`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/attempt-context.test.ts --reporter=dot`; `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/attempt-context.ts extensions/codex/src/app-server/attempt-context.test.ts`; AWS Crabbox `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed`.

Evidence after fix: focused Vitest passed 53 tests; targeted formatter/lint/diff checks passed; branch autoreview reported no accepted/actionable findings; AWS Crabbox changed gate selected `extensions` and `extensionTests` and exited 0.

Observed result after fix: malformed descriptors are ignored or represented with placeholders/missing-schema stats instead of aborting Codex app-server prompt/report/fingerprint construction.

What was not tested: a live Codex turn with a deliberately malicious external plugin descriptor; the regression coverage exercises the app-server construction paths directly.
