### PR TITLE
fix(plugin-sdk): validate tool plugin names

### DIFF
--- a/src/plugin-sdk/tool-plugin.test.ts
+++ b/src/plugin-sdk/tool-plugin.test.ts
@@ -166,6 +166,64 @@ describe("defineToolPlugin", () => {
     expect(factory({ sandboxed: false })).toMatchObject({ name: "factory_echo" });
   });
 
+  it("rejects tool definitions with non-string names", () => {
+    expect(() =>
+      defineToolPlugin({
+        id: "bad-tool-name",
+        name: "Bad Tool Name",
+        description: "Bad tool name demo.",
+        tools: (tool) => [
+          tool({
+            name: 42,
+            description: "Bad tool.",
+            parameters: Type.Object({}),
+            execute: () => "bad",
+          } as never),
+        ],
+      }),
+    ).toThrow("tool plugin tool name must be a non-empty string");
+  });
+
+  it("wraps unreadable tool name accessors with a registration error", () => {
+    const badTool = {
+      get name(): never {
+        throw new Error("tool name getter exploded");
+      },
+      description: "Bad tool.",
+      parameters: Type.Object({}),
+      execute: () => "bad",
+    };
+
+    expect(() =>
+      defineToolPlugin({
+        id: "unreadable-tool-name",
+        name: "Unreadable Tool Name",
+        description: "Unreadable tool name demo.",
+        tools: (tool) => [tool(badTool)],
+      }),
+    ).toThrow("tool plugin tool name must be readable");
+  });
+
+  it("validates tool names returned directly from the tools callback", () => {
+    expect(() =>
+      defineToolPlugin({
+        id: "direct-bad-tool-name",
+        name: "Direct Bad Tool Name",
+        description: "Direct bad tool name demo.",
+        tools: () =>
+          [
+            {
+              name: 42,
+              label: "Bad Tool",
+              description: "Bad tool.",
+              parameters: Type.Object({}),
+              execute: () => "bad",
+            },
+          ] as never,
+      }),
+    ).toThrow("tool plugin tool name must be a non-empty string");
+  });
+
   it("defaults author config to a strict empty object schema", () => {
     const entry = defineToolPlugin({
       id: "empty-config",

--- a/src/plugin-sdk/tool-plugin.ts
+++ b/src/plugin-sdk/tool-plugin.ts
@@ -117,15 +117,107 @@ function wrapToolPluginResult(result: unknown): AgentToolResult<unknown> {
 }
 
 function createToolPluginToolFactory<TConfig>(): ToolPluginToolFactory<TConfig> {
-  return ((definition: ToolPluginToolDefinition<TConfig, TSchema>) => ({
-    name: definition.name,
-    label: definition.label ?? definition.name,
-    description: definition.description,
-    parameters: definition.parameters,
-    optional: definition.optional === true,
-    execute: definition.execute as DefinedToolPluginTool["execute"],
-    factory: definition.factory as DefinedToolPluginTool["factory"],
-  })) as ToolPluginToolFactory<TConfig>;
+  return ((definition: ToolPluginToolDefinition<TConfig, TSchema>) =>
+    normalizeDefinedToolPluginTool(definition)) as ToolPluginToolFactory<TConfig>;
+}
+
+function normalizeDefinedToolPluginTool(tool: unknown): DefinedToolPluginTool {
+  const definition = readToolPluginToolObject(tool);
+  const name = readToolPluginToolName(definition);
+  const label = readOptionalToolPluginToolLabel(definition, name);
+  const description = readToolPluginRequiredString(definition, "description");
+  const parameters = readToolPluginParameters(definition);
+  const optional = readToolPluginOptionalFlag(definition);
+  return {
+    name,
+    label,
+    description,
+    parameters,
+    optional,
+    execute: readToolPluginOptionalFunction(definition, "execute") as
+      | DefinedToolPluginTool["execute"]
+      | undefined,
+    factory: readToolPluginOptionalFunction(definition, "factory") as
+      | DefinedToolPluginTool["factory"]
+      | undefined,
+  };
+}
+
+function readToolPluginToolObject(definition: unknown): object {
+  if (!definition || typeof definition !== "object") {
+    throw new Error("tool plugin tool definition must be an object");
+  }
+  return definition;
+}
+
+function readToolPluginToolName(definition: object): string {
+  let name: unknown;
+  try {
+    name = Reflect.get(definition, "name");
+  } catch (cause) {
+    throw new Error("tool plugin tool name must be readable", { cause });
+  }
+  if (typeof name !== "string" || !name.trim()) {
+    throw new Error("tool plugin tool name must be a non-empty string");
+  }
+  return name;
+}
+
+function readOptionalToolPluginToolLabel(definition: object, fallback: string): string {
+  const label = readToolPluginProperty(definition, "label");
+  if (label === undefined) {
+    return fallback;
+  }
+  if (typeof label !== "string") {
+    throw new Error("tool plugin tool label must be a string");
+  }
+  return label;
+}
+
+function readToolPluginRequiredString(definition: object, key: string): string {
+  const value = readToolPluginProperty(definition, key);
+  if (typeof value !== "string") {
+    throw new Error(`tool plugin tool ${key} must be a string`);
+  }
+  return value;
+}
+
+function readToolPluginParameters(definition: object): TSchema {
+  const parameters = readToolPluginProperty(definition, "parameters");
+  if (!parameters || typeof parameters !== "object") {
+    throw new Error("tool plugin tool parameters must be an object");
+  }
+  return parameters as TSchema;
+}
+
+function readToolPluginOptionalFlag(definition: object): boolean {
+  const optional = readToolPluginProperty(definition, "optional");
+  if (optional === undefined) {
+    return false;
+  }
+  if (typeof optional !== "boolean") {
+    throw new Error("tool plugin tool optional flag must be a boolean");
+  }
+  return optional;
+}
+
+function readToolPluginOptionalFunction(definition: object, key: string): unknown {
+  const value = readToolPluginProperty(definition, key);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "function") {
+    throw new Error(`tool plugin tool ${key} must be a function`);
+  }
+  return value;
+}
+
+function readToolPluginProperty(definition: object, key: string): unknown {
+  try {
+    return Reflect.get(definition, key);
+  } catch (cause) {
+    throw new Error(`tool plugin tool ${key} must be readable`, { cause });
+  }
 }
 
 export function defineToolPlugin<TConfigSchema extends TSchema | undefined = undefined>(
@@ -137,7 +229,7 @@ export function defineToolPlugin<TConfigSchema extends TSchema | undefined = und
   const normalizedConfigSchema = pluginConfigSchema.jsonSchema ?? configSchema;
   const tools = [
     ...definition.tools(createToolPluginToolFactory<ToolPluginConfig<TConfigSchema>>()),
-  ];
+  ].map(normalizeDefinedToolPluginTool);
   const activation = definition.activation ?? { onStartup: true };
   const metadata: ToolPluginMetadata = {
     id: definition.id,


### PR DESCRIPTION
## Summary
- Validate tool plugin tool definitions at the consumed list boundary, not only through the `tool(...)` helper.
- Reject non-string/empty names and wrap unreadable name accessors with a clear SDK registration error.
- Preserve valid execute/factory tool registration and metadata behavior while normalizing directly returned tool objects.

## Verification
- `node scripts/run-vitest.mjs src/plugin-sdk/tool-plugin.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugin-sdk/tool-plugin.ts src/plugin-sdk/tool-plugin.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/tool-plugin.ts src/plugin-sdk/tool-plugin.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `run_89846a41a52b`, lease `cbx_974e3a49d87a`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed`

## Real behavior proof
Behavior addressed: `defineToolPlugin()` no longer lets malformed tool names from helper-created or directly returned tool definitions flow into plugin metadata/runtime registration, where later name normalization can crash or leak raw accessor errors.

Real environment tested: local focused plugin SDK tests on this branch, plus Linux AWS Crabbox changed gate on provider `aws` lease `cbx_974e3a49d87a`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugin-sdk/tool-plugin.test.ts --reporter=dot`; `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/tool-plugin.ts src/plugin-sdk/tool-plugin.test.ts`; AWS Crabbox `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed`.

Evidence after fix: focused Vitest passed 9 tests; targeted formatter/lint/diff checks passed on final head `68453542439`; branch autoreview reported no accepted/actionable findings; AWS Crabbox changed gate selected `core`, `coreTests`, `extensions`, and `extensionTests` and exited 0.

Observed result after fix: malformed tool plugin names fail closed with SDK errors before metadata or runtime registration, while valid execute/factory tools still register and expose static metadata as before.

What was not tested: a live third-party plugin package using malformed JavaScript descriptors; the SDK unit coverage exercises the public helper and direct-return callback paths directly.
