### PR TITLE
fix(agents): detect truncated API responses to prevent silent session hang

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -15,6 +15,7 @@ function makeOllamaResponse(params: {
   content?: string;
   thinking?: string;
   reasoning?: string;
+  done_reason?: string;
   tool_calls?: Array<{ function: { name: string; arguments: Record<string, unknown> } }>;
 }) {
   return {
@@ -28,6 +29,7 @@ function makeOllamaResponse(params: {
       ...(params.tool_calls ? { tool_calls: params.tool_calls } : {}),
     },
     done: true,
+    ...(params.done_reason ? { done_reason: params.done_reason } : {}),
     prompt_eval_count: 100,
     eval_count: 50,
   };
@@ -85,6 +87,24 @@ describe("buildAssistantMessage", () => {
     const msg = buildAssistantMessage(response, MODEL_INFO);
     expect(msg.content).toHaveLength(1);
     expect(msg.content[0]).toEqual({ type: "text", text: "Just text" });
+  });
+
+  it("preserves output-budget length stops", () => {
+    const response = makeOllamaResponse({
+      content: "Partial answer",
+      done_reason: "length",
+    });
+    const msg = buildAssistantMessage(response, MODEL_INFO);
+    expect(msg.stopReason).toBe("length");
+  });
+
+  it("keeps tool use authoritative over a length stop", () => {
+    const response = makeOllamaResponse({
+      done_reason: "length",
+      tool_calls: [{ function: { name: "read", arguments: { path: "README.md" } } }],
+    });
+    const msg = buildAssistantMessage(response, MODEL_INFO);
+    expect(msg.stopReason).toBe("toolUse");
   });
 });
 
@@ -233,6 +253,33 @@ describe("createOllamaStreamFn thinking events", () => {
 
     const textStart = events.find((e) => e.type === "text_start") as { contentIndex?: number };
     expect(textStart?.contentIndex).toBe(0);
+  });
+
+  it("emits length for a token-limited native stream", async () => {
+    const events = await streamOllamaEvents([
+      {
+        model: "qwen3.5",
+        created_at: "2026-01-01T00:00:00Z",
+        message: { role: "assistant", content: "Partial answer" },
+        done: false,
+      },
+      {
+        model: "qwen3.5",
+        created_at: "2026-01-01T00:00:01Z",
+        message: { role: "assistant", content: "" },
+        done: true,
+        done_reason: "length",
+        prompt_eval_count: 10,
+        eval_count: 5,
+      },
+    ]);
+
+    const done = events.find((event) => event.type === "done") as {
+      reason?: string;
+      message?: { stopReason?: string };
+    };
+    expect(done.reason).toBe("length");
+    expect(done.message?.stopReason).toBe("length");
   });
 
   it("uses generic stream timeout for Ollama request timeout", async () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -653,6 +653,13 @@ function estimateTokensFromChars(chars: number): number {
   return Math.max(1, Math.round(chars / CHARS_PER_TOKEN_ESTIMATE));
 }
 
+function resolveOllamaStopReason(response: OllamaChatResponse) {
+  if (response.message.tool_calls?.length) {
+    return "toolUse" as const;
+  }
+  return response.done_reason === "length" ? ("length" as const) : ("stop" as const);
+}
+
 function estimateOllamaPromptTokens(params: {
   messages: OllamaChatMessage[];
   tools: OllamaTool[];
@@ -1061,7 +1068,7 @@ export function buildAssistantMessage(
   return buildStreamAssistantMessage({
     model: modelInfo,
     content,
-    stopReason: toolCalls && toolCalls.length > 0 ? "toolUse" : "stop",
+    stopReason: resolveOllamaStopReason(response),
     usage: buildUsageWithNoCost({
       input: resolveUsageCount(response.prompt_eval_count, usageFallback?.input),
       output: resolveUsageCount(response.eval_count, usageFallback?.output),
@@ -1442,7 +1449,7 @@ function createRawOllamaStreamFn(
 
           stream.push({
             type: "done",
-            reason: assistantMessage.stopReason === "toolUse" ? "toolUse" : "stop",
+            reason: resolveOllamaStopReason(finalResponse),
             message: assistantMessage,
           });
         } finally {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1400,6 +1400,26 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         lastAssistant: { stopReason: "end_turn" },
       }),
     ).toBe(false);
+    expect(
+      isIncompleteTerminalAssistantTurn({
+        hasAssistantVisibleText: true,
+        lastAssistant: { stopReason: "length" },
+      }),
+    ).toBe(true);
+    expect(
+      isIncompleteTerminalAssistantTurn({
+        hasAssistantVisibleText: true,
+        hasTerminalOutput: true,
+        lastAssistant: { stopReason: "length" },
+      }),
+    ).toBe(false);
+    expect(
+      isIncompleteTerminalAssistantTurn({
+        hasAssistantVisibleText: true,
+        hasTerminalOutput: true,
+        lastAssistant: { stopReason: "toolUse" },
+      }),
+    ).toBe(true);
   });
 
   it("surfaces no-visible-answer recovery for app-server interrupted tool-only output", () => {
@@ -2565,6 +2585,109 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(incompleteTurnText).toContain("couldn't generate a response");
+  });
+
+  it("surfaces incomplete-turn text for token-limited partial answers", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Partial answer"],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "length",
+          provider: "ollama",
+          model: "qwen3.5",
+          content: [{ type: "text", text: "Partial answer" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toContain("couldn't generate a response");
+  });
+
+  it("keeps complete visible stop turns successful", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Complete answer"],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "ollama",
+          model: "qwen3.5",
+          content: [{ type: "text", text: "Complete answer" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toBeNull();
+  });
+
+  it("preserves terminal tool media on token-limited turns", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Partial answer"],
+        toolMediaUrls: ["file:///tmp/render.png"],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "length",
+          provider: "ollama",
+          model: "qwen3.5",
+          content: [{ type: "text", text: "Partial answer" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toBeNull();
+  });
+
+  it("preserves tool media already delivered through block replies", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Partial answer"],
+        hasToolMediaBlockReply: true,
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "length",
+          provider: "ollama",
+          model: "qwen3.5",
+          content: [{ type: "text", text: "Partial answer" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toBeNull();
+  });
+
+  it("preserves successful cron progress on token-limited turns", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Partial answer"],
+        successfulCronAdds: 1,
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "length",
+          provider: "ollama",
+          model: "qwen3.5",
+          content: [{ type: "text", text: "Partial answer" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toBeNull();
   });
 
   it.each([

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
@@ -43,12 +43,62 @@ describe("attempt trajectory status", () => {
     ).toEqual({ status: "success" });
   });
 
+  it("marks length-limited visible text as non-deliverable without terminal output", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          assistantTexts: ["Partial answer."],
+          lastAssistantStopReason: "length",
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("does not treat streamed partial payloads as completed length-limited output", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          assistantTexts: ["Partial answer."],
+          synthesizedPayloadCount: 1,
+          lastAssistantStopReason: "length",
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("keeps length-limited turns successful when terminal output was delivered", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          assistantTexts: [],
+          lastAssistantStopReason: "length",
+          hasTerminalOutput: true,
+        }),
+      ),
+    ).toEqual({ status: "success" });
+  });
+
   it("keeps committed messaging tool delivery as success even without assistant text", () => {
     expect(
       resolveAttemptTrajectoryTerminal(
         baseParams({
           didSendViaMessagingTool: true,
           messagingToolSentTargets: [{ channel: "telegram" }],
+        }),
+      ),
+    ).toEqual({ status: "success" });
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          didSendViaMessagingTool: true,
+          messagingToolSentTargets: [{ channel: "telegram" }],
+          lastAssistantStopReason: "length",
         }),
       ),
     ).toEqual({ status: "success" });

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
@@ -46,6 +46,7 @@ export type ResolveAttemptTrajectoryTerminalParams = {
   silentExpected?: boolean;
   emptyAssistantReplyIsSilent?: boolean;
   lastAssistantStopReason?: string;
+  hasTerminalOutput?: boolean;
 };
 
 /**
@@ -118,7 +119,6 @@ export function resolveAttemptTrajectoryTerminal(
     params.didSendDeterministicApprovalPrompt ||
     hasCommittedMessagingDeliveryEvidence(params) ||
     hasAcceptedSessionSpawn(params.acceptedSessionSpawns) ||
-    params.synthesizedPayloadCount > 0 ||
     params.heartbeatToolResponse !== undefined ||
     (params.clientToolCalls?.length ?? 0) > 0 ||
     params.yieldDetected === true ||
@@ -131,9 +131,21 @@ export function resolveAttemptTrajectoryTerminal(
       terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
     };
   }
+  if (
+    params.lastAssistantStopReason === "length" &&
+    !params.hasTerminalOutput &&
+    !hasExplicitTerminalDelivery
+  ) {
+    return {
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    };
+  }
 
   const hasDeliverableOrProgress =
     hasExplicitTerminalDelivery ||
+    params.hasTerminalOutput ||
+    params.synthesizedPayloadCount > 0 ||
     hasNonEmptyAssistantText(params.assistantTexts) ||
     params.successfulCronAdds > 0;
 

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -118,6 +118,7 @@ export function createSubscriptionMock(): SubscriptionMock {
     getMessagingToolSourceReplyPayloads: () => [] as MessagingToolSourceReplyPayload[],
     getHeartbeatToolResponse: () => undefined,
     getPendingToolMediaReply: () => null,
+    hasToolMediaBlockReply: () => false,
     getVisibleBlockReplyCount: () => 0,
     getSuccessfulCronAdds: () => 0,
     getReplayState: () => ({

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -458,6 +458,7 @@ import {
 import { detectAndLoadPromptImages } from "./images.js";
 import {
   buildAttemptReplayMetadata,
+  hasAttemptTerminalState,
   resolveSilentToolResultReplyPayload,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./incomplete-turn.js";
@@ -3488,6 +3489,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSourceReplyPayloads,
         getHeartbeatToolResponse,
         getPendingToolMediaReply,
+        hasToolMediaBlockReply,
         getVisibleBlockReplyCount,
         getSuccessfulCronAdds,
         getReplayState,
@@ -5241,6 +5243,26 @@ export async function runEmbeddedAttempt(
       const lastToolError = getLastToolError?.();
       const heartbeatToolResponse = getHeartbeatToolResponse();
       const messagingToolSourceReplyPayloads = getMessagingToolSourceReplyPayloads();
+      const hasToolMediaBlockReplyNow = hasToolMediaBlockReply();
+      const hasTerminalOutput = hasAttemptTerminalState({
+        clientToolCalls: completedClientToolCallsForAttempt,
+        yieldDetected,
+        didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+        heartbeatToolResponse,
+        lastToolError,
+        toolMediaUrls: pendingToolMediaReply?.mediaUrls,
+        toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
+        toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,
+        hasToolMediaBlockReply: hasToolMediaBlockReplyNow,
+        didDeliverSourceReplyViaMessageTool,
+        messagingToolSourceReplyPayloads,
+        messagingToolSentTexts: getMessagingToolSentTexts(),
+        messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+        messagingToolSentTargets: getMessagingToolSentTargets(),
+        acceptedSessionSpawns,
+        successfulCronAdds: getSuccessfulCronAdds(),
+        toolMetas: toolMetasNormalized,
+      });
       const pendingToolMediaPayloadCount = hasVisiblePendingToolMediaReply(pendingToolMediaReply)
         ? 1
         : 0;
@@ -5316,6 +5338,7 @@ export async function runEmbeddedAttempt(
         silentExpected: params.silentExpected,
         emptyAssistantReplyIsSilent,
         lastAssistantStopReason: lastAssistant?.stopReason,
+        hasTerminalOutput,
       });
       trajectoryRecorder?.recordEvent("model.completed", {
         aborted,
@@ -5415,6 +5438,7 @@ export async function runEmbeddedAttempt(
         toolMediaUrls: pendingToolMediaReply?.mediaUrls,
         toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
         toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,
+        hasToolMediaBlockReply: hasToolMediaBlockReplyNow,
         successfulCronAdds: getSuccessfulCronAdds(),
         cloudCodeAssistFormatError: Boolean(
           lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -49,6 +49,7 @@ type IncompleteTurnAttempt = Pick<
   | "toolMediaUrls"
   | "toolAudioAsVoice"
   | "toolTrustedLocalMedia"
+  | "hasToolMediaBlockReply"
   | "didDeliverSourceReplyViaMessageTool"
   | "messagingToolSourceReplyPayloads"
   | "didSendViaMessagingTool"
@@ -116,14 +117,13 @@ const REPLAY_UNSAFE_FALLBACK_METADATA: EmbeddedRunAttemptResult["replayMetadata"
 
 export function isIncompleteTerminalAssistantTurn(params: {
   hasAssistantVisibleText: boolean;
+  hasTerminalOutput?: boolean;
   lastAssistant?: { stopReason?: string } | null;
 }): boolean {
-  // A tool-use stop reason means the model issued a tool call and expected
-  // to continue after tool results. If the session ended before the
-  // post-tool assistant message arrived, the turn is incomplete regardless
-  // of whether pre-tool text exists — that text is preliminary analysis,
-  // not the final answer. (#76477)
-  return params.lastAssistant?.stopReason === "toolUse";
+  const stopReason = params.lastAssistant?.stopReason;
+  // Tool-use expects a post-tool continuation; length means the output budget
+  // ended before a complete final answer. Partial visible text completes neither.
+  return stopReason === "toolUse" || (stopReason === "length" && !params.hasTerminalOutput);
 }
 
 const PLANNING_ONLY_PROMISE_RE =
@@ -279,11 +279,24 @@ type TerminalAttemptState = Pick<
   | "toolMediaUrls"
   | "toolAudioAsVoice"
   | "toolTrustedLocalMedia"
+  | "hasToolMediaBlockReply"
   | "didDeliverSourceReplyViaMessageTool"
   | "messagingToolSourceReplyPayloads"
->;
+  | "successfulCronAdds"
+> &
+  Partial<
+    Pick<
+      EmbeddedRunAttemptResult,
+      | "acceptedSessionSpawns"
+      | "messagingToolSentTexts"
+      | "messagingToolSentMediaUrls"
+      | "messagingToolSentTargets"
+    >
+  > & {
+    toolMetas?: readonly { asyncStarted?: boolean }[];
+  };
 
-function hasAttemptTerminalState(attempt: TerminalAttemptState): boolean {
+export function hasAttemptTerminalState(attempt: TerminalAttemptState): boolean {
   return Boolean(
     attempt.clientToolCalls ||
     attempt.yieldDetected ||
@@ -293,8 +306,17 @@ function hasAttemptTerminalState(attempt: TerminalAttemptState): boolean {
     attempt.toolMediaUrls?.some((url) => url.trim().length > 0) ||
     attempt.toolAudioAsVoice ||
     attempt.toolTrustedLocalMedia ||
+    attempt.hasToolMediaBlockReply ||
     attempt.didDeliverSourceReplyViaMessageTool ||
-    attempt.messagingToolSourceReplyPayloads?.length,
+    attempt.messagingToolSourceReplyPayloads?.length ||
+    hasCommittedMessagingToolDeliveryEvidence({
+      messagingToolSentTexts: attempt.messagingToolSentTexts ?? [],
+      messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls ?? [],
+      messagingToolSentTargets: attempt.messagingToolSentTargets ?? [],
+    }) ||
+    hasAcceptedSessionSpawn(attempt.acceptedSessionSpawns) ||
+    hasAsyncStartedToolActivity(attempt.toolMetas) ||
+    (attempt.successfulCronAdds ?? 0) > 0,
   );
 }
 
@@ -317,17 +339,25 @@ export function resolveIncompleteTurnPayloadText(params: {
   // produced. (#76477)
   const toolUseTerminal = params.attempt.lastAssistant?.stopReason === "toolUse";
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
+  const hasTerminalOutput = hasAttemptTerminalState(params.attempt);
+  // A length terminal is provider-confirmed output-budget exhaustion. Partial
+  // visible text is not a complete final answer and must not bypass recovery.
+  const lengthTerminal = isIncompleteTerminalAssistantTurn({
+    hasAssistantVisibleText: params.payloadCount > 0,
+    hasTerminalOutput,
+    lastAssistant: assistant,
+  });
   // Thinking payloads can count toward payloadCount but carry no user-visible
   // content; bypass the visible-text guard when thinking was the only output
   // so that incomplete-turn stall detection fires below. (#89787, #91953)
   const thinkingOnlyTerminal =
     params.payloadCount !== 0 &&
     !joinAssistantTexts(params.attempt.assistantTexts).length &&
-    !hasAttemptTerminalState(params.attempt) &&
+    !hasTerminalOutput &&
     Boolean(assistant && hasOnlyAssistantReasoningContent(assistant));
 
   if (
-    (params.payloadCount !== 0 && !toolUseTerminal && !thinkingOnlyTerminal) ||
+    (params.payloadCount !== 0 && !toolUseTerminal && !lengthTerminal && !thinkingOnlyTerminal) ||
     (params.aborted && params.externalAbort) ||
     params.timedOut ||
     params.attempt.clientToolCalls ||
@@ -357,6 +387,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   const stopReason = params.attempt.lastAssistant?.stopReason;
   const incompleteTerminalAssistant = isIncompleteTerminalAssistantTurn({
     hasAssistantVisibleText: params.payloadCount > 0,
+    hasTerminalOutput,
     lastAssistant: params.attempt.lastAssistant,
   });
   const reasoningOnlyAssistant = isReasoningOnlyAssistantTurn(assistant);
@@ -366,6 +397,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   });
   if (
     !incompleteTerminalAssistant &&
+    !lengthTerminal &&
     !reasoningOnlyAssistant &&
     !thinkingOnlyTerminal &&
     !emptyResponseAssistant &&

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -187,6 +187,7 @@ export type EmbeddedRunAttemptResult = {
   toolMediaUrls?: string[];
   toolAudioAsVoice?: boolean;
   toolTrustedLocalMedia?: boolean;
+  hasToolMediaBlockReply?: boolean;
   successfulCronAdds?: number;
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -44,6 +44,8 @@ function createContext(
       pendingCompactionRetry: 0,
       pendingToolMediaUrls: [],
       pendingToolAudioAsVoice: false,
+      pendingToolTrustedLocalMedia: false,
+      deferredBlockReplies: [],
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
       blockState: {
         thinking: true,
@@ -565,6 +567,135 @@ describe("handleAgentEnd", () => {
         stopReason: "toolUse",
         livenessState: "abandoned",
         replayInvalid: true,
+      },
+    });
+  });
+
+  it("keeps tool-use terminal incomplete when tool media is pending", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [],
+      },
+      { onAgentEvent },
+    );
+    ctx.state.livenessState = "working";
+    ctx.state.pendingToolMediaUrls = ["/tmp/render.png"];
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        stopReason: "toolUse",
+        livenessState: "abandoned",
+        replayInvalid: true,
+      },
+    });
+  });
+
+  it("marks token-limited terminal text as abandoned before runner finalization", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "length",
+        content: [{ type: "text", text: "Partial answer" }],
+      },
+      { onAgentEvent },
+    );
+    ctx.state.livenessState = "working";
+    ctx.state.assistantTexts = ["Partial answer"];
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        stopReason: "length",
+        livenessState: "abandoned",
+        replayInvalid: true,
+      },
+    });
+  });
+
+  it("preserves token-limited terminal tool media before runner finalization", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "length",
+        content: [{ type: "text", text: "Partial answer" }],
+      },
+      { onAgentEvent },
+    );
+    ctx.state.livenessState = "working";
+    ctx.state.assistantTexts = ["Partial answer"];
+    ctx.state.pendingToolMediaUrls = ["/tmp/render.png"];
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        stopReason: "length",
+        livenessState: "working",
+      },
+    });
+  });
+
+  it("preserves token-limited deferred media before terminal delivery", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "length",
+        content: [],
+      },
+      { onAgentEvent },
+    );
+    ctx.state.livenessState = "working";
+    ctx.state.deferredBlockReplies = [{ mediaUrls: ["/tmp/render.png"] }];
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        stopReason: "length",
+        livenessState: "working",
+      },
+    });
+  });
+
+  it("preserves token-limited message-tool-only delivery before runner finalization", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "length",
+        content: [],
+      },
+      { onAgentEvent },
+    );
+    ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+    ctx.state.livenessState = "working";
+    ctx.state.messageToolOnlySourceReplyDelivered = true;
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        stopReason: "length",
+        livenessState: "working",
       },
     });
   });

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -16,7 +16,10 @@ import {
   GENERIC_ASSISTANT_ERROR_TEXT,
 } from "./embedded-agent-helpers.js";
 import { hasCommittedMessagingToolDeliveryEvidence } from "./embedded-agent-runner/delivery-evidence.js";
-import { isIncompleteTerminalAssistantTurn } from "./embedded-agent-runner/run/incomplete-turn.js";
+import {
+  hasAttemptTerminalState,
+  isIncompleteTerminalAssistantTurn,
+} from "./embedded-agent-runner/run/incomplete-turn.js";
 import {
   consumePendingToolMediaReply,
   hasAssistantVisibleReply,
@@ -69,10 +72,38 @@ export function handleAgentEnd(
     hasCommittedMessagingToolDeliveryEvidence(ctx.state) ||
     hasAcceptedSessionSpawn(ctx.state.acceptedSessionSpawns) ||
     (ctx.state.successfulCronAdds ?? 0) > 0;
+  const deferredMediaUrls = ctx.state.deferredBlockReplies.flatMap(
+    (payload) => payload.mediaUrls ?? [],
+  );
+  const hasTerminalOutput = hasAttemptTerminalState({
+    yieldDetected: ctx.state.yielded,
+    didSendDeterministicApprovalPrompt: ctx.state.deterministicApprovalPromptSent,
+    heartbeatToolResponse: ctx.state.heartbeatToolResponse,
+    lastToolError: ctx.state.lastToolError,
+    toolMediaUrls: [...ctx.state.pendingToolMediaUrls, ...deferredMediaUrls],
+    toolAudioAsVoice:
+      ctx.state.pendingToolAudioAsVoice ||
+      ctx.state.deferredBlockReplies.some((payload) => payload.audioAsVoice),
+    toolTrustedLocalMedia:
+      ctx.state.pendingToolTrustedLocalMedia ||
+      ctx.state.deferredBlockReplies.some((payload) => payload.trustedLocalMedia),
+    hasToolMediaBlockReply: ctx.state.hasToolMediaBlockReply,
+    didDeliverSourceReplyViaMessageTool:
+      ctx.state.messageToolOnlySourceReplyDelivered ||
+      ctx.params.hasDeliveredMessageToolOnlySourceReply?.() === true,
+    messagingToolSourceReplyPayloads: ctx.state.messagingToolSourceReplyPayloads,
+    messagingToolSentTexts: ctx.state.messagingToolSentTexts,
+    messagingToolSentMediaUrls: ctx.state.messagingToolSentMediaUrls,
+    messagingToolSentTargets: ctx.state.messagingToolSentTargets,
+    successfulCronAdds: ctx.state.successfulCronAdds,
+    acceptedSessionSpawns: ctx.state.acceptedSessionSpawns,
+    toolMetas: ctx.state.toolMetas,
+  });
   const hadBeforeFinalizeSideEffect =
     hadLivenessPreservingSideEffect || ctx.state.replayState.hadPotentialSideEffects;
   const incompleteTerminalAssistant = isIncompleteTerminalAssistantTurn({
     hasAssistantVisibleText,
+    hasTerminalOutput,
     lastAssistant: isAssistantMessage(lastAssistant) ? lastAssistant : null,
   });
   const replayInvalid =
@@ -232,7 +263,11 @@ export function handleAgentEnd(
     if (ctx.params.onBlockReply) {
       const pendingToolMediaReply = consumePendingToolMediaReply(ctx.state);
       if (pendingToolMediaReply && hasAssistantVisibleReply(pendingToolMediaReply)) {
+        const visibleReplyCountBefore = ctx.state.visibleBlockReplyCount;
         ctx.emitBlockReply(pendingToolMediaReply);
+        if (ctx.state.visibleBlockReplyCount > visibleReplyCountBefore) {
+          ctx.state.hasToolMediaBlockReply = true;
+        }
       }
     }
 

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -169,6 +169,7 @@ export type EmbeddedAgentSubscribeState = {
   pendingToolMediaUrls: string[];
   pendingToolAudioAsVoice: boolean;
   pendingToolTrustedLocalMedia: boolean;
+  hasToolMediaBlockReply: boolean;
   visibleBlockReplyCount: number;
   pendingAssistantReplyDirectives?: Pick<
     BlockReplyPayload,

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -61,12 +61,12 @@ describe("subscribeEmbeddedAgentSession", () => {
     // Default trusted media tools to built-ins so tests that opt into custom
     // builtin sets get matching local media trust behavior.
     const { session, emit } = createStubSessionHarness();
-    subscribeEmbeddedAgentSession({
+    const subscription = subscribeEmbeddedAgentSession({
       session,
       ...options,
       trustedLocalMediaToolNames: options.trustedLocalMediaToolNames ?? options.builtinToolNames,
     });
-    return { emit };
+    return { emit, subscription };
   }
 
   function emitAssistantTextDelta(
@@ -501,7 +501,7 @@ describe("subscribeEmbeddedAgentSession", () => {
   it("does not attach generated image media to an early streamed chunk before explicit MEDIA", async () => {
     const onToolResult = vi.fn();
     const onBlockReply = vi.fn();
-    const { emit } = createSubscribedHarness({
+    const { emit, subscription } = createSubscribedHarness({
       runId: "run",
       onToolResult,
       onBlockReply,
@@ -574,6 +574,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       .map(([payload]) => payload)
       .filter((payload) => payload.mediaUrls?.includes("/tmp/generated.png"));
     expect(mediaPayloads).toHaveLength(1);
+    expect(subscription.hasToolMediaBlockReply()).toBe(true);
   });
 
   it("attaches media from internal completion events even when assistant omits MEDIA lines", async () => {
@@ -776,6 +777,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       audioAsVoice: true,
     });
     expect(subscription.getPendingToolMediaReply()).toBeNull();
+    expect(subscription.hasToolMediaBlockReply()).toBe(true);
     expect(subscription.getVisibleBlockReplyCount()).toBe(1);
   });
 

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -232,6 +232,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     pendingToolMediaUrls: initialPendingToolMediaUrls,
     pendingToolAudioAsVoice: false,
     pendingToolTrustedLocalMedia: false,
+    hasToolMediaBlockReply: false,
     visibleBlockReplyCount: 0,
     pendingAssistantReplyDirectives: undefined,
     deterministicApprovalPromptPending: false,
@@ -303,6 +304,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const clearDeferredAssistantEvents = () => {
     state.deferredAssistantEvents.length = 0;
   };
+  const deferredToolMediaReplies = new WeakSet<BlockReplyPayload>();
   const emitBlockReplySafely = (
     payload: Parameters<NonNullable<SubscribeEmbeddedAgentSessionParams["onBlockReply"]>>[0],
     options?: { assistantMessageIndex?: number },
@@ -339,6 +341,8 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     options?: { assistantMessageIndex?: number; consumePendingToolMedia?: boolean },
   ) => {
     const withAssistantDirectives = consumePendingAssistantReplyDirectivesIntoReply(state, payload);
+    const consumesPendingToolMedia =
+      options?.consumePendingToolMedia !== false && readPendingToolMediaReply(state) !== null;
     const withToolMedia =
       options?.consumePendingToolMedia === false
         ? withAssistantDirectives
@@ -350,12 +354,18 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
               assistantMessageIndex: options.assistantMessageIndex,
             })
           : withToolMedia;
+      if (consumesPendingToolMedia) {
+        deferredToolMediaReplies.add(deferredPayload);
+      }
       state.deferredBlockReplies.push(deferredPayload);
       return;
     }
     const emitted = emitBlockReplySafely(withToolMedia, options);
     if (emitted && !withToolMedia.isReasoning && hasAssistantVisibleReply(withToolMedia)) {
       state.visibleBlockReplyCount += 1;
+      if (consumesPendingToolMedia) {
+        state.hasToolMediaBlockReply = true;
+      }
     }
   };
   const flushDeferredBlockReplies = () => {
@@ -367,6 +377,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       const emitted = emitBlockReplySafely(payload);
       if (emitted && !payload.isReasoning && hasAssistantVisibleReply(payload)) {
         state.visibleBlockReplyCount += 1;
+        if (deferredToolMediaReplies.has(payload)) {
+          state.hasToolMediaBlockReply = true;
+        }
       }
     }
   };
@@ -1393,6 +1406,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     getHeartbeatToolResponse: () =>
       state.heartbeatToolResponse ? { ...state.heartbeatToolResponse } : undefined,
     getPendingToolMediaReply: () => readPendingToolMediaReply(state),
+    hasToolMediaBlockReply: () => state.hasToolMediaBlockReply,
     getVisibleBlockReplyCount: () => state.visibleBlockReplyCount,
     getSuccessfulCronAdds: () => state.successfulCronAdds,
     getReplayState: () => ({ ...state.replayState }),


### PR DESCRIPTION
## Summary

Fixes #89051.

- Preserve Ollama's native `done_reason: "length"` instead of collapsing it to `stop`.
- Treat length-limited terminal assistant turns as incomplete across runner, lifecycle, and trajectory decisions, including partial streamed text.
- Preserve successful terminal outcomes when tools already produced durable output, media, messages, cron work, spawned work, or other committed side effects.
- Keep existing `toolUse` semantics unchanged. No OpenAI or Anthropic transport code changed.

## Verification

- Focused test set: 345 passed across Ollama stream handling, incomplete-turn classification, trajectory status, lifecycle handling, subscription delivery, and spawn-workspace suites.
- TypeScript and lint: changed core/extensions production and test typechecks passed; focused oxlint passed.
- Broad Testbox: `tbx_01kv3kmhyx52hb7w9awywk9rjy` passed `pnpm check:changed` for `core`, `coreTests`, `extensions`, and `extensionTests`.
- Autoreview: fresh final review reported no accepted/actionable findings.

## Real behavior proof

- Behavior addressed: Ollama responses ending with `done_reason: "length"` could be normalized to success and leave an embedded run with partial or empty output instead of an incomplete-turn response.
- Real environment tested: local Ollama 0.30.8 with `qwen3.5:9b`; official OpenAI Codex OAuth gateway harness with an MCP/tool probe.
- Exact steps or command run after this patch: forced Ollama truncation with `num_predict: 3`, then exercised the real OpenClaw Ollama stream adapter and incomplete-turn resolver; ran `OPENCLAW_LIVE_CODEX_HARNESS=1 OPENCLAW_LIVE_CODEX_HARNESS_MCP_PROBE=1 OPENCLAW_LIVE_CODEX_HARNESS_MODEL='openai/gpt-5.5' node scripts/test-live.mjs --codex-harness -- src/gateway/gateway-codex-harness.live.test.ts`.
- Evidence after fix: Ollama produced `done_reason: "length"`; OpenClaw returned `stopReason: "length"`, partial text `The color of`, and the incomplete-turn response. The Codex OAuth MCP/tool smoke passed.
- Observed result after fix: token-limited partial/empty Ollama responses no longer silently complete, while durable tool output and existing official OpenAI tool calling remain successful.
- What was not tested: direct Anthropic live tool calling. Available Anthropic credentials reached the official API but failed billing before prompt/tool execution. Anthropic transport code is untouched; shared lifecycle/tool-output behavior is covered by focused tests.
