### PR TITLE
fix(cli): suppress startup progress for json output

### DIFF
--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -64,6 +64,7 @@ describe("cli progress", () => {
     expect(
       shouldUseInteractiveProgressSpinner({
         streamIsTty: true,
+        stdoutIsTty: true,
         stdinIsRaw: true,
       }),
     ).toBe(false);
@@ -73,9 +74,20 @@ describe("cli progress", () => {
     expect(
       shouldUseInteractiveProgressSpinner({
         streamIsTty: true,
+        stdoutIsTty: true,
         stdinIsRaw: false,
       }),
     ).toBe(true);
+  });
+
+  it("does not use the clack spinner when stdout is not tty-safe", () => {
+    expect(
+      shouldUseInteractiveProgressSpinner({
+        streamIsTty: true,
+        stdoutIsTty: false,
+        stdinIsRaw: false,
+      }),
+    ).toBe(false);
   });
 
   it("does not write terminal controls when raw TUI input suppresses the default spinner", () => {

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -40,10 +40,16 @@ export type ProgressTotalsUpdate = {
 export function shouldUseInteractiveProgressSpinner(params: {
   fallback?: ProgressOptions["fallback"];
   streamIsTty?: boolean;
+  stdoutIsTty?: boolean;
   stdinIsRaw?: boolean;
 }): boolean {
   const spinnerRequested = params.fallback === undefined || params.fallback === "spinner";
-  return spinnerRequested && params.streamIsTty === true && params.stdinIsRaw !== true;
+  return (
+    spinnerRequested &&
+    params.streamIsTty === true &&
+    params.stdoutIsTty === true &&
+    params.stdinIsRaw !== true
+  );
 }
 
 const noopReporter: ProgressReporter = {
@@ -74,6 +80,7 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
   const allowSpinner = shouldUseInteractiveProgressSpinner({
     fallback: options.fallback,
     streamIsTty: isTty,
+    stdoutIsTty: process.stdout.isTTY,
     stdinIsRaw,
   });
   const allowLine = isTty && options.fallback === "line";

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -383,6 +383,25 @@ describe("runCli exit behavior", () => {
     expect(progressDoneMock).toHaveBeenCalledTimes(1);
   });
 
+  it("disables startup progress while loading a json full CLI command", async () => {
+    tryRouteCliMock.mockResolvedValueOnce(false);
+    const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
+    buildProgramMock.mockReturnValueOnce({
+      commands: [{ name: () => "mcp", aliases: () => [] }],
+      parseAsync,
+    });
+
+    await runCli(["node", "openclaw", "mcp", "list", "--json"]);
+
+    expect(createCliProgressMock).toHaveBeenCalledWith({
+      label: "Loading OpenClaw CLI…",
+      indeterminate: true,
+      delayMs: 0,
+      enabled: false,
+    });
+    expect(progressDoneMock).toHaveBeenCalledTimes(1);
+  });
+
   it("pauses non-tty stdin after full CLI command completion", async () => {
     tryRouteCliMock.mockResolvedValueOnce(false);
     const parseAsync = vi.fn().mockResolvedValueOnce(undefined);

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -752,11 +752,15 @@ export async function runCli(argv: string[] = process.argv) {
     }
 
     const { createCliProgress } = await loadProgressModule();
-    const startupProgress = createCliProgress({
+    const startupProgressOptions: Parameters<typeof createCliProgress>[0] = {
       label: "Loading OpenClaw CLI…",
       indeterminate: true,
       delayMs: 0,
-    });
+    };
+    if (hasJsonOutputFlag(normalizedArgv)) {
+      startupProgressOptions.enabled = false;
+    }
+    const startupProgress = createCliProgress(startupProgressOptions);
     let startupProgressStopped = false;
     const stopStartupProgress = () => {
       if (startupProgressStopped) {


### PR DESCRIPTION
Fixes #88602

## Summary
- disable startup progress when a full CLI command is invoked with `--json`
- require stdout to be TTY-safe before using the Clack spinner, since Clack writes spinner frames to stdout
- add regression coverage for JSON startup progress and stdout pipe safety

## Tests
- `pnpm exec vitest run src/cli/progress.test.ts src/cli/run-main.exit.test.ts --reporter=dot`
- `pnpm format:check -- src/cli/progress.ts src/cli/progress.test.ts src/cli/run-main.ts src/cli/run-main.exit.test.ts`
- `pnpm exec oxlint src/cli/progress.ts src/cli/progress.test.ts src/cli/run-main.ts src/cli/run-main.exit.test.ts`

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: JSON commands could still create startup progress output and Clack spinner controls when `--json` was used or stdout was piped, contaminating machine-readable output.
- Real environment tested: macOS local checkout at commit `364f66c5`, Node `v25.8.1`, using the repo's TypeScript runtime.
- Exact steps or command run after this patch:
  ```sh
  node --import tsx -e 'import { shouldUseInteractiveProgressSpinner } from "./src/cli/progress.ts"; const blocked = shouldUseInteractiveProgressSpinner({ streamIsTty: true, stdoutIsTty: false, stdinIsRaw: false }) === false; const allowed = shouldUseInteractiveProgressSpinner({ streamIsTty: true, stdoutIsTty: true, stdinIsRaw: false }) === true; console.log("stdout pipe spinner guard:", blocked ? "PASS" : "FAIL"); console.log("interactive spinner still allowed:", allowed ? "PASS" : "FAIL"); if (!blocked || !allowed) process.exit(1);'
  ```
- Evidence after fix:
  ```text
  stdout pipe spinner guard: PASS
  interactive spinner still allowed: PASS
  ```
- Observed result after fix: the spinner guard refuses to use the Clack stdout spinner when stdout is not TTY-safe, while preserving spinner behavior for interactive stdout.
- What was not tested: a full `mcp list --json` run against a configured MCP environment; my fresh local checkout hung during MCP initialization, so this PR uses targeted CLI startup/guard regression tests plus the production helper proof above.
