### PR TITLE
fix(browser): recover stale managed Chrome CDP listener

### DIFF
--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
+import { createServer as createTcpServer, type AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,11 +11,13 @@ import { WebSocketServer } from "ws";
 import { rawDataToString } from "../infra/ws.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
+    execFile: (...args: unknown[]) => execFileMock(...args),
     spawn: (...args: unknown[]) => spawnMock(...args),
   };
 });
@@ -111,6 +113,55 @@ function requireSpawnOptions(index = 0): { env?: NodeJS.ProcessEnv } {
     throw new Error(`expected spawn options for call #${index + 1}`);
   }
   return options as { env?: NodeJS.ProcessEnv };
+}
+
+function mockChromeProcessProbeExecutables(): void {
+  const realAccessSync = fs.accessSync;
+  vi.spyOn(fs, "accessSync").mockImplementation((p, mode) => {
+    const s = String(p);
+    if (s.endsWith("/lsof") || s.endsWith("/ps")) {
+      return;
+    }
+    return realAccessSync(p, mode);
+  });
+}
+
+async function getAvailableLoopbackPort(): Promise<number> {
+  const server = createTcpServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address() as AddressInfo;
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  return address.port;
+}
+
+function mockLinuxProcCommandLine(
+  pid: number,
+  args: readonly string[],
+  startTime = "123456",
+  isAlive: () => boolean = () => true,
+): void {
+  const realReadFileSync = fs.readFileSync;
+  vi.spyOn(fs, "readFileSync").mockImplementation(((filePath, options) => {
+    if (String(filePath) === `/proc/${pid}/cmdline`) {
+      if (!isAlive()) {
+        throw Object.assign(new Error("no such process"), { code: "ENOENT" });
+      }
+      return args.join("\0");
+    }
+    if (String(filePath) === `/proc/${pid}/stat`) {
+      if (!isAlive()) {
+        throw Object.assign(new Error("no such process"), { code: "ENOENT" });
+      }
+      const fields = ["S", ...Array(18).fill("0"), startTime, "0"];
+      return `${pid} (${path.basename(args[0] ?? "chrome")}) ${fields.join(" ")}`;
+    }
+    return realReadFileSync(filePath, options as never);
+  }) as typeof fs.readFileSync);
 }
 
 function effectiveSpawnCommand(call: unknown[]): unknown {
@@ -214,6 +265,7 @@ describe("chrome.ts internal", () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     spawnMock.mockReset();
+    execFileMock.mockReset();
     ensurePortAvailableMock.mockReset();
     ensurePortAvailableMock.mockImplementation(async () => {});
     registerManagedProxyBrowserCdpBypassMock.mockReset();
@@ -360,6 +412,19 @@ describe("chrome.ts internal", () => {
         userDataDir: "/tmp/foo",
       });
       expect(args).toContain("--no-proxy-server");
+    });
+
+    it("keeps the managed ownership args adjacent at the start of the launch command", () => {
+      const args = buildOpenClawChromeLaunchArgs({
+        resolved: baseResolved(),
+        profile: baseProfile,
+        userDataDir: "/tmp/openclaw profile with spaces",
+      });
+      expect(args.slice(0, 3)).toEqual([
+        "--remote-debugging-port=19222",
+        "--user-data-dir=/tmp/openclaw profile with spaces",
+        "--no-first-run",
+      ]);
     });
   });
 
@@ -1078,6 +1143,1730 @@ describe("chrome.ts internal", () => {
   });
 
   describe("launchOpenClawChrome remaining branches", () => {
+    it("stops an unresponsive Chrome that owns the managed profile before retrying the CDP port", async () => {
+      const profileName = `owned-stale-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      let staleAlive = true;
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(
+        stalePid,
+        [
+          "/usr/bin/google-chrome",
+          `--remote-debugging-port=${cdpPort}`,
+          `--user-data-dir=${userDataDir}`,
+          "--no-first-run",
+        ],
+        "123456",
+        () => staleAlive,
+      );
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid) {
+          if (signal === 0 || signal == null) {
+            if (staleAlive) {
+              return true;
+            }
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          staleAlive = false;
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+
+      ensurePortAvailableMock
+        .mockRejectedValueOnce(
+          Object.assign(new Error("Port 18800 is already in use."), {
+            name: "PortInUseError",
+            code: "EADDRINUSE",
+          }),
+        )
+        .mockResolvedValueOnce(undefined);
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        const args = _args as string[];
+        if (cmd.endsWith("/lsof")) {
+          if (args.includes("-d")) {
+            callback(null, `p${stalePid}\nftxt\nn/usr/bin/google-chrome\n`, "");
+            return;
+          }
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        if (cmd.endsWith("/ps")) {
+          if (args.includes("lstart=")) {
+            if (staleAlive) {
+              callback(null, "Mon Jun  1 15:00:00 2026\n", "");
+              return;
+            }
+            callback(new Error("no such process"), "", "");
+            return;
+          }
+          callback(
+            null,
+            `/usr/bin/google-chrome --remote-debugging-port=${cdpPort} --user-data-dir=${userDataDir} --no-first-run\n`,
+            "",
+          );
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+      spawnMock.mockImplementation(() => makeFakeProc());
+
+      try {
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Failed to start Chrome CDP on port ${cdpPort}`,
+        );
+
+        expect(processKillSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(execFileMock).toHaveBeenCalledWith(
+          expect.stringMatching(/\/lsof$/),
+          ["-nP", `-iTCP:${cdpPort}`, "-sTCP:LISTEN", "-Fp"],
+          expect.objectContaining({ timeout: expect.any(Number) }),
+          expect.any(Function),
+        );
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(2);
+        expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
+      } finally {
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not stop an owned Chrome that becomes CDP-ready during recovery grace", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `owned-starting-${Date.now()}`;
+      const stalePid = 76543;
+      const wsPath = "/devtools/browser/starting";
+      let versionRequests = 0;
+      const server = createServer((req, res) => {
+        if (req.url === "/json/version") {
+          versionRequests += 1;
+          if (versionRequests === 1) {
+            res.writeHead(503);
+            res.end("starting");
+            return;
+          }
+          const addr = server.address() as AddressInfo;
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              webSocketDebuggerUrl: `ws://127.0.0.1:${addr.port}${wsPath}`,
+            }),
+          );
+          return;
+        }
+        res.writeHead(404);
+        res.end();
+      });
+      const wss = new WebSocketServer({ noServer: true });
+      wss.on("connection", (ws) => {
+        ws.on("message", (raw) => {
+          const message = JSON.parse(rawDataToString(raw)) as {
+            id?: unknown;
+            method?: unknown;
+          };
+          if (message.method === "Browser.getVersion" && typeof message.id === "number") {
+            ws.send(
+              JSON.stringify({
+                id: message.id,
+                result: { product: "Chrome/Mock", userAgent: "OpenClawTest" },
+              }),
+            );
+          }
+        });
+      });
+      server.on("upgrade", (req, socket, head) => {
+        if (req.url !== wsPath) {
+          socket.destroy();
+          return;
+        }
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          wss.emit("connection", ws, req);
+        });
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve());
+      });
+      const cdpPort = (server.address() as AddressInfo).port;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      const staleAlive = true;
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(
+        stalePid,
+        [
+          "/usr/bin/google-chrome",
+          `--remote-debugging-port=${cdpPort}`,
+          `--user-data-dir=${userDataDir}`,
+          "--no-first-run",
+        ],
+        "123456",
+        () => staleAlive,
+      );
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null)) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        Object.defineProperty(process, "platform", { value: "linux" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+          localLaunchTimeoutMs: 50,
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(versionRequests).toBeGreaterThanOrEqual(2);
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await new Promise<void>((resolve) => {
+          wss.close(() => resolve());
+        });
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("accepts Linux Chrome wrapper processes when the live binary replaces the launcher path", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `linux-wrapper-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      let staleAlive = true;
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(
+        stalePid,
+        [
+          "/opt/google/chrome/chrome",
+          `--remote-debugging-port=${cdpPort}`,
+          `--user-data-dir=${userDataDir}`,
+          "--no-first-run",
+        ],
+        "123456",
+        () => staleAlive,
+      );
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome") || s.includes("/opt/google/chrome/chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid) {
+          if (signal === 0 || signal == null) {
+            if (staleAlive) {
+              return true;
+            }
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          staleAlive = false;
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+
+      ensurePortAvailableMock
+        .mockRejectedValueOnce(
+          Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+            name: "PortInUseError",
+            code: "EADDRINUSE",
+          }),
+        )
+        .mockResolvedValueOnce(undefined);
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+      spawnMock.mockImplementation(() => makeFakeProc());
+
+      try {
+        Object.defineProperty(process, "platform", { value: "linux" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Failed to start Chrome CDP on port ${cdpPort}`,
+        );
+
+        expect(processKillSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(2);
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("accepts supported Linux stable wrapper processes when the live binary replaces the launcher path", async () => {
+      const originalPlatform = process.platform;
+      const cases = [
+        {
+          configured: "/usr/bin/brave-browser-stable",
+          live: "/opt/brave.com/brave/brave-browser",
+        },
+        {
+          configured: "/usr/bin/microsoft-edge-stable",
+          live: "/usr/bin/microsoft-edge",
+        },
+        {
+          configured: "/usr/bin/vivaldi-stable",
+          live: "/opt/vivaldi/vivaldi",
+        },
+        {
+          configured: "/usr/bin/opera-stable",
+          live: "/usr/lib/x86_64-linux-gnu/opera/opera",
+        },
+        {
+          configured: "/usr/bin/yandex-browser",
+          live: "/opt/yandex/browser/yandex-browser",
+        },
+      ];
+      let currentStalePid = 0;
+      const staleAlive = new Map<number, boolean>();
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (staleAlive.has(pid)) {
+          if (signal === 0 || signal == null) {
+            if (staleAlive.get(pid)) {
+              return true;
+            }
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          staleAlive.set(pid, false);
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (cases.some(({ configured, live }) => s.includes(configured) || s.includes(live))) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+      mockChromeProcessProbeExecutables();
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${currentStalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+      spawnMock.mockImplementation(() => makeFakeProc());
+      mockExpiredLaunchPollingClock();
+
+      try {
+        Object.defineProperty(process, "platform", { value: "linux" });
+        for (const [index, candidate] of cases.entries()) {
+          const profileName = `linux-stable-wrapper-${index}-${Date.now()}`;
+          const cdpPort = await getAvailableLoopbackPort();
+          currentStalePid = 77000 + index;
+          staleAlive.set(currentStalePid, true);
+          const userDataDir = resolveOpenClawUserDataDir(profileName);
+          await fsp.mkdir(userDataDir, { recursive: true });
+          await fsp.symlink(
+            `${os.hostname()}-${currentStalePid}`,
+            path.join(userDataDir, "SingletonLock"),
+          );
+          mockLinuxProcCommandLine(
+            currentStalePid,
+            [
+              candidate.live,
+              `--remote-debugging-port=${cdpPort}`,
+              `--user-data-dir=${userDataDir}`,
+              "--no-first-run",
+            ],
+            "123456",
+            () => staleAlive.get(currentStalePid) ?? false,
+          );
+          ensurePortAvailableMock
+            .mockRejectedValueOnce(
+              Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+                name: "PortInUseError",
+                code: "EADDRINUSE",
+              }),
+            )
+            .mockResolvedValueOnce(undefined);
+          const profile = {
+            name: profileName,
+            color: "#FF4500",
+            cdpPort,
+            cdpUrl: `http://127.0.0.1:${cdpPort}`,
+            cdpIsLoopback: true,
+          } as unknown as ResolvedBrowserProfile;
+          const resolved = {
+            executablePath: candidate.configured,
+            headless: true,
+            noSandbox: true,
+            extraArgs: [],
+          } as unknown as ResolvedBrowserConfig;
+
+          try {
+            await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+              `Failed to start Chrome CDP on port ${cdpPort}`,
+            );
+            expect(processKillSpy).toHaveBeenCalledWith(currentStalePid, "SIGTERM");
+          } finally {
+            await fsp.rm(userDataDir, { recursive: true, force: true });
+          }
+        }
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+      }
+    });
+
+    it("does not accept a different Linux Chromium family as the managed executable", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `linux-cross-family-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(stalePid, [
+        "/opt/brave.com/brave/brave-browser",
+        `--remote-debugging-port=${cdpPort}`,
+        `--user-data-dir=${userDataDir}`,
+        "--no-first-run",
+      ]);
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome") || s.includes("/opt/brave.com/brave/brave-browser")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null)) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        Object.defineProperty(process, "platform", { value: "linux" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not escalate to SIGKILL when the singleton PID stops matching before escalation", async () => {
+      const profileName = `sigkill-recheck-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(stalePid, [
+        "/usr/bin/google-chrome",
+        `--remote-debugging-port=${cdpPort}`,
+        `--user-data-dir=${userDataDir}`,
+        "--no-first-run",
+      ]);
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null || signal === "SIGTERM")) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      let lsofCalls = 0;
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        const args = _args as string[];
+        if (cmd.endsWith("/lsof")) {
+          if (args.includes("-d")) {
+            callback(null, `p${stalePid}\nftxt\nn/usr/bin/google-chrome\n`, "");
+            return;
+          }
+          lsofCalls += 1;
+          callback(null, lsofCalls < 4 ? `p${stalePid}\n` : "p87654\n", "");
+          return;
+        }
+        if (cmd.endsWith("/ps")) {
+          callback(
+            null,
+            `/usr/bin/google-chrome --remote-debugging-port=${cdpPort} --user-data-dir=${userDataDir} --no-first-run\n`,
+            "",
+          );
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+      mockExpiredLaunchPollingClock();
+
+      try {
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(processKillSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+      } finally {
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not clear singleton artifacts when another owner appears after stop", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `owner-changed-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const newOwnerPid = 87654;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      const lockPath = path.join(userDataDir, "SingletonLock");
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, lockPath);
+      mockLinuxProcCommandLine(stalePid, [
+        "/usr/bin/google-chrome",
+        `--remote-debugging-port=${cdpPort}`,
+        `--user-data-dir=${userDataDir}`,
+        "--no-first-run",
+      ]);
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+      const realReadlinkSync = fs.readlinkSync;
+
+      let staleAlive = true;
+      vi.spyOn(fs, "readlinkSync").mockImplementation((p, options) => {
+        if (String(p) === lockPath) {
+          return `${os.hostname()}-${staleAlive ? stalePid : newOwnerPid}`;
+        }
+        return realReadlinkSync(p, options as never);
+      });
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid) {
+          if (signal === 0 || signal == null) {
+            if (staleAlive) {
+              return true;
+            }
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          staleAlive = false;
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        Object.defineProperty(process, "platform", { value: "linux" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(processKillSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(fs.readlinkSync(lockPath)).toBe(`${os.hostname()}-${newOwnerPid}`);
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not clear singleton artifacts when the stopped PID is reused before cleanup", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `pid-reused-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      const lockPath = path.join(userDataDir, "SingletonLock");
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, lockPath);
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+      const realReadFileSync = fs.readFileSync;
+      let staleAlive = true;
+      vi.spyOn(fs, "readFileSync").mockImplementation(((filePath, options) => {
+        const s = String(filePath);
+        if (s === `/proc/${stalePid}/cmdline`) {
+          return [
+            "/usr/bin/google-chrome",
+            `--remote-debugging-port=${cdpPort}`,
+            `--user-data-dir=${userDataDir}`,
+            "--no-first-run",
+          ].join("\0");
+        }
+        if (s === `/proc/${stalePid}/stat`) {
+          const startTime = staleAlive ? "123456" : "999999";
+          const fields = ["S", ...Array(18).fill("0"), startTime, "0"];
+          return `${stalePid} (google-chrome) ${fields.join(" ")}`;
+        }
+        return realReadFileSync(filePath, options as never);
+      }) as typeof fs.readFileSync);
+
+      const realKill = process.kill.bind(process);
+      let stoppedPidZeroProbes = 0;
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid) {
+          if (signal === 0 || signal == null) {
+            if (staleAlive) {
+              return true;
+            }
+            stoppedPidZeroProbes += 1;
+            if (stoppedPidZeroProbes >= 3) {
+              return true;
+            }
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          staleAlive = false;
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        Object.defineProperty(process, "platform", { value: "linux" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(processKillSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(fs.readlinkSync(lockPath)).toBe(`${os.hostname()}-${stalePid}`);
+        expect(await fsp.lstat(lockPath)).toBeTruthy();
+        expect(stoppedPidZeroProbes).toBeGreaterThanOrEqual(3);
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not accept parsed argv when managed launch flags are not adjacent", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `argv-order-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(stalePid, [
+        "/usr/bin/google-chrome",
+        `--remote-debugging-port=${cdpPort}`,
+        "--no-first-run",
+        `--user-data-dir=${userDataDir}`,
+      ]);
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null)) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        Object.defineProperty(process, "platform", { value: "linux" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not stop a singleton PID when the listener is not the managed profile process", async () => {
+      const profileName = `wrong-cmdline-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(stalePid, [
+        "/usr/bin/google-chrome-beta",
+        `--remote-debugging-port=${cdpPort}0`,
+        `--user-data-dir=${userDataDir}-old`,
+      ]);
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null)) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error("Port 18800 is already in use."), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        if (cmd.endsWith("/ps")) {
+          callback(
+            null,
+            `/usr/bin/google-chrome-beta --remote-debugging-port=${cdpPort}0 --user-data-dir=${userDataDir}-old\n`,
+            "",
+          );
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          "Port 18800 is already in use.",
+        );
+
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+      } finally {
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects ambiguous ps user-data-dir prefixes before stopping a stale PID", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `ps-prefix-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null)) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        if (cmd.endsWith("/ps")) {
+          callback(
+            null,
+            `/usr/bin/google-chrome --remote-debugging-port=${cdpPort} --user-data-dir=${userDataDir} old --no-first-run\n`,
+            "",
+          );
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        Object.defineProperty(process, "platform", { value: "darwin" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not probe CDP before proving the port listener owns the managed profile", async () => {
+      const profileName = `probe-after-owner-${Date.now()}`;
+      const stalePid = 76543;
+      let discoveryHits = 0;
+      const server = createServer((req, res) => {
+        if (req.url === "/json/version") {
+          discoveryHits += 1;
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ webSocketDebuggerUrl: "ws://127.0.0.1:9/devtools/browser/test" }));
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve());
+      });
+      const cdpPort = (server.address() as AddressInfo).port;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(stalePid, [
+        "/usr/bin/google-chrome",
+        `--remote-debugging-port=${cdpPort}`,
+        `--user-data-dir=${userDataDir}-other`,
+      ]);
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null)) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(discoveryHits).toBe(0);
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+      } finally {
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not probe CDP in the loopback-held branch before ownership proof", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `loopback-probe-after-owner-${Date.now()}`;
+      const stalePid = 76543;
+      let discoveryHits = 0;
+      const server = createServer((req, res) => {
+        if (req.url === "/json/version") {
+          discoveryHits += 1;
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ webSocketDebuggerUrl: "ws://127.0.0.1:9/devtools/browser/test" }));
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve());
+      });
+      const cdpPort = (server.address() as AddressInfo).port;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(stalePid, [
+        "/usr/bin/google-chrome",
+        `--remote-debugging-port=${cdpPort}`,
+        `--user-data-dir=${userDataDir}-other`,
+      ]);
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null)) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockResolvedValue(undefined);
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        Object.defineProperty(process, "platform", { value: "linux" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(discoveryHits).toBe(0);
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("requires the raw ps executable match at the command head before stopping a stale PID", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `ps-exe-head-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null)) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        if (cmd.endsWith("/ps")) {
+          callback(
+            null,
+            `/usr/bin/node --remote-debugging-port=${cdpPort} --user-data-dir=${userDataDir} --no-first-run --wrapper=/usr/bin/google-chrome\n`,
+            "",
+          );
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+
+      try {
+        Object.defineProperty(process, "platform", { value: "darwin" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("accepts macOS ps output for managed executable and profile paths that contain spaces", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `ps space profile ${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      const executablePath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s === executablePath || s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      let staleAlive = true;
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid) {
+          if (signal === 0 || signal == null) {
+            if (staleAlive) {
+              return true;
+            }
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          staleAlive = false;
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Port ${cdpPort} is already in use.`), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        const args = _args as string[];
+        if (cmd.endsWith("/lsof")) {
+          if (args.includes("-d")) {
+            callback(null, `p${stalePid}\nftxt\nn${executablePath}\n`, "");
+            return;
+          }
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        if (cmd.endsWith("/ps") && args.includes("lstart=")) {
+          if (staleAlive) {
+            callback(null, "Mon Jun  1 15:00:00 2026\n", "");
+            return;
+          }
+          callback(new Error("no such process"), "", "");
+          return;
+        }
+        if (cmd.endsWith("/ps")) {
+          callback(
+            null,
+            `${executablePath} --remote-debugging-port=${cdpPort} --user-data-dir=${userDataDir} --no-first-run\n`,
+            "",
+          );
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+      spawnMock.mockImplementation(() => makeFakeProc());
+      mockExpiredLaunchPollingClock();
+
+      try {
+        Object.defineProperty(process, "platform", { value: "darwin" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath,
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Failed to start Chrome CDP on port ${cdpPort}`,
+        );
+
+        expect(processKillSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(2);
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not stop a singleton PID that is not the CDP port listener", async () => {
+      const profileName = `pid-reused-${Date.now()}`;
+      const cdpPort = await getAvailableLoopbackPort();
+      const stalePid = 76543;
+      const listenerPid = 76544;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid && (signal === 0 || signal == null)) {
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error("Port 18800 is already in use."), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        callback(null, `p${listenerPid}\n`, "");
+      });
+
+      try {
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          "Port 18800 is already in use.",
+        );
+
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(processKillSpy).not.toHaveBeenCalledWith(stalePid, "SIGKILL");
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+      } finally {
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("clears a proven stale lock before surfacing a still-held loopback port", async () => {
+      const originalPlatform = process.platform;
+      const profileName = `loopback-held-${Date.now()}`;
+      const stalePid = 76543;
+      const server = createServer((_req, res) => {
+        res.writeHead(404);
+        res.end();
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve());
+      });
+      let serverClosed = false;
+      const cdpPort = (server.address() as AddressInfo).port;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
+      mockLinuxProcCommandLine(stalePid, [
+        "/usr/bin/google-chrome",
+        `--remote-debugging-port=${cdpPort}`,
+        `--user-data-dir=${userDataDir}`,
+        "--no-first-run",
+      ]);
+      mockChromeProcessProbeExecutables();
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.includes("google-chrome")) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+
+      let staleAlive = true;
+      const realKill = process.kill.bind(process);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
+        pid: number,
+        signal?: NodeJS.Signals | number,
+      ) => {
+        if (pid === stalePid) {
+          if (signal === 0 || signal == null) {
+            if (staleAlive) {
+              return true;
+            }
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          staleAlive = false;
+          if (!serverClosed) {
+            serverClosed = true;
+            server.closeAllConnections?.();
+            server.closeIdleConnections?.();
+            server.close();
+          }
+          return true;
+        }
+        return realKill(pid, signal as NodeJS.Signals);
+      }) as typeof process.kill);
+      ensurePortAvailableMock.mockResolvedValue(undefined);
+      execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+        const cmd = String(_cmd);
+        if (cmd.endsWith("/lsof")) {
+          callback(null, `p${stalePid}\n`, "");
+          return;
+        }
+        callback(new Error(`unexpected command: ${cmd}`), "", "");
+      });
+      spawnMock.mockImplementation(() => makeFakeProc());
+
+      try {
+        Object.defineProperty(process, "platform", { value: "linux" });
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          executablePath: "/usr/bin/google-chrome",
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+          localLaunchTimeoutMs: 1,
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          `Port ${cdpPort} is already in use.`,
+        );
+
+        expect(processKillSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+        expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+        if (!serverClosed) {
+          serverClosed = true;
+          await new Promise<void>((resolve) => {
+            server.close(() => resolve());
+          });
+        }
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not run managed port recovery for non-loopback profiles", async () => {
+      const processKillSpy = vi.spyOn(process, "kill");
+      const profile = {
+        name: "remote-profile",
+        color: "#FF4500",
+        cdpPort: 18800,
+        cdpUrl: "http://10.0.0.42:18800",
+        cdpIsLoopback: false,
+      } as unknown as ResolvedBrowserProfile;
+      const resolved = {
+        executablePath: "/usr/bin/google-chrome",
+        headless: true,
+        noSandbox: true,
+        extraArgs: [],
+      } as unknown as ResolvedBrowserConfig;
+
+      await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+        'Profile "remote-profile" is remote; cannot launch local Chrome.',
+      );
+
+      expect(ensurePortAvailableMock).not.toHaveBeenCalled();
+      expect(execFileMock).not.toHaveBeenCalled();
+      expect(processKillSpy).not.toHaveBeenCalled();
+    });
+
+    it("leaves an occupied managed port alone when no local singleton owner is present", async () => {
+      const profileName = `unowned-port-${Date.now()}`;
+      const userDataDir = resolveOpenClawUserDataDir(profileName);
+      await fsp.mkdir(userDataDir, { recursive: true });
+
+      const realExistsSync = fs.existsSync;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
+          return true;
+        }
+        return realExistsSync(p);
+      });
+      const processKillSpy = vi.spyOn(process, "kill");
+      ensurePortAvailableMock.mockRejectedValueOnce(
+        Object.assign(new Error("Port 18800 is already in use."), {
+          name: "PortInUseError",
+          code: "EADDRINUSE",
+        }),
+      );
+
+      try {
+        const profile = {
+          name: profileName,
+          color: "#FF4500",
+          cdpPort: 18800,
+          cdpUrl: "http://127.0.0.1:18800",
+          cdpIsLoopback: true,
+        } as unknown as ResolvedBrowserProfile;
+        const resolved = {
+          headless: true,
+          noSandbox: true,
+          extraArgs: [],
+        } as unknown as ResolvedBrowserConfig;
+
+        await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+          "Port 18800 is already in use.",
+        );
+
+        expect(processKillSpy).not.toHaveBeenCalled();
+        expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+      } finally {
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
     it("skips decoration entirely when the profile is already decorated", async () => {
       // Covers the `needsDecorate` false branch by writing a real,
       // properly-shaped Local State + Preferences pair that matches

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -2687,7 +2687,7 @@ describe("chrome.ts internal", () => {
       }
     });
 
-    it("clears a proven stale lock before surfacing a still-held loopback port", async () => {
+    it("clears a proven stale lock before surfacing launch readiness failure", async () => {
       const originalPlatform = process.platform;
       const profileName = `loopback-held-${Date.now()}`;
       const stalePid = 76543;
@@ -2704,12 +2704,18 @@ describe("chrome.ts internal", () => {
       const userDataDir = resolveOpenClawUserDataDir(profileName);
       await fsp.mkdir(userDataDir, { recursive: true });
       await fsp.symlink(`${os.hostname()}-${stalePid}`, path.join(userDataDir, "SingletonLock"));
-      mockLinuxProcCommandLine(stalePid, [
-        "/usr/bin/google-chrome",
-        `--remote-debugging-port=${cdpPort}`,
-        `--user-data-dir=${userDataDir}`,
-        "--no-first-run",
-      ]);
+      let staleAlive = true;
+      mockLinuxProcCommandLine(
+        stalePid,
+        [
+          "/usr/bin/google-chrome",
+          `--remote-debugging-port=${cdpPort}`,
+          `--user-data-dir=${userDataDir}`,
+          "--no-first-run",
+        ],
+        "123456",
+        () => staleAlive,
+      );
       mockChromeProcessProbeExecutables();
 
       const realExistsSync = fs.existsSync;
@@ -2720,8 +2726,6 @@ describe("chrome.ts internal", () => {
         }
         return realExistsSync(p);
       });
-
-      let staleAlive = true;
       const realKill = process.kill.bind(process);
       const processKillSpy = vi.spyOn(process, "kill").mockImplementation(((
         pid: number,
@@ -2774,11 +2778,12 @@ describe("chrome.ts internal", () => {
         } as unknown as ResolvedBrowserConfig;
 
         await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
-          `Port ${cdpPort} is already in use.`,
+          `Failed to start Chrome CDP on port ${cdpPort}`,
         );
 
         expect(processKillSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
         expect(ensurePortAvailableMock).toHaveBeenCalledTimes(1);
+        expect(serverClosed).toBe(true);
         expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
       } finally {
         Object.defineProperty(process, "platform", { value: originalPlatform });

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -205,7 +205,7 @@ async function withMockChromeCdpServer(params: {
     res.writeHead(404);
     res.end();
   });
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
   server.on("upgrade", (req, socket, head) => {
     if (req.url !== params.wsPath) {
       socket.destroy();
@@ -1293,7 +1293,7 @@ describe("chrome.ts internal", () => {
         res.writeHead(404);
         res.end();
       });
-      const wss = new WebSocketServer({ noServer: true });
+      const wss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
       wss.on("connection", (ws) => {
         ws.on("message", (raw) => {
           const message = JSON.parse(rawDataToString(raw)) as {

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -90,7 +90,7 @@ async function withMockChromeCdpServer(params: {
     res.writeHead(404);
     res.end();
   });
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
   server.on("upgrade", (req, socket, head) => {
     if (!req.url?.startsWith(params.wsPath)) {
       socket.destroy();
@@ -740,7 +740,7 @@ describe("browser chrome helpers", () => {
       res.writeHead(404);
       res.end();
     });
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
     server.on("upgrade", (req, socket, head) => {
       if (req.url?.startsWith("/e/bad")) {
         socket.destroy();

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -312,6 +312,16 @@ describe("browser chrome profile decoration", () => {
     expect(fs.lstatSync(path.join(userDataDir, "SingletonLock")).isSymbolicLink()).toBe(true);
   });
 
+  it("keeps singleton artifacts when the lock owner is malformed", async () => {
+    const userDataDir = await createUserDataDir();
+    await fsp.writeFile(path.join(userDataDir, "SingletonCookie"), "cookie");
+    await fsp.symlink("-12345", path.join(userDataDir, "SingletonLock"));
+
+    expect(clearStaleChromeSingletonLocks(userDataDir, os.hostname())).toBe(false);
+    expect(fs.lstatSync(path.join(userDataDir, "SingletonLock")).isSymbolicLink()).toBe(true);
+    expect(fs.existsSync(path.join(userDataDir, "SingletonCookie"))).toBe(true);
+  });
+
   it("keeps singleton artifacts when the lock PID exists but cannot be signaled", async () => {
     const userDataDir = await createUserDataDir();
     await fsp.symlink(`${os.hostname()}-12345`, path.join(userDataDir, "SingletonLock"));

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -4,8 +4,14 @@
  * Builds launch args, starts/stops managed Chrome, probes CDP readiness, and
  * resolves WebSocket endpoints for browser control.
  */
-import { type ChildProcess, type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import {
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams,
+  execFile,
+  spawn,
+} from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { prepareOomScoreAdjustedSpawn } from "openclaw/plugin-sdk/process-runtime";
@@ -80,6 +86,35 @@ const CHROME_SINGLETON_LOCK_PATHS = [
 ] as const;
 const CHROME_SINGLETON_IN_USE_PATTERN = /profile appears to be in use by another chromium process/i;
 const CHROME_MISSING_DISPLAY_PATTERN = /missing x server|\$DISPLAY/i;
+const LSOF_CANDIDATES =
+  process.platform === "darwin"
+    ? ["/usr/sbin/lsof", "/usr/bin/lsof"]
+    : ["/usr/bin/lsof", "/usr/sbin/lsof"];
+const PS_CANDIDATES =
+  process.platform === "darwin" || process.platform === "linux" ? ["/bin/ps", "/usr/bin/ps"] : [];
+const LINUX_CHROMIUM_PROCESS_FAMILIES: ReadonlyMap<string, string> = new Map([
+  ["brave", "brave"],
+  ["brave-browser", "brave"],
+  ["brave-browser-stable", "brave"],
+  ["chrome", "chrome"],
+  ["google-chrome", "chrome"],
+  ["google-chrome-beta", "chrome"],
+  ["google-chrome-stable", "chrome"],
+  ["google-chrome-unstable", "chrome"],
+  ["chromium", "chromium"],
+  ["chromium-browser", "chromium"],
+  ["microsoft-edge", "edge"],
+  ["microsoft-edge-beta", "edge"],
+  ["microsoft-edge-canary", "edge"],
+  ["microsoft-edge-dev", "edge"],
+  ["microsoft-edge-stable", "edge"],
+  ["opera", "opera"],
+  ["opera-gx", "opera"],
+  ["opera-stable", "opera"],
+  ["vivaldi", "vivaldi"],
+  ["vivaldi-stable", "vivaldi"],
+  ["yandex-browser", "yandex"],
+]);
 const CHROME_HTTP_DISCOVERY_FAILURE_CODES = new Set([
   "ssrf_blocked",
   "http_unreachable",
@@ -149,27 +184,65 @@ function clearChromeSingletonArtifacts(userDataDir: string) {
   }
 }
 
-/** Remove stale Chrome singleton lock files from a user-data-dir. */
-export function clearStaleChromeSingletonLocks(
+async function clearChromeSingletonArtifactsForOwner(
   userDataDir: string,
-  hostname = os.hostname(),
-): boolean {
+  owner: ChromeSingletonOwner,
+  ownerIdentity: string,
+): Promise<boolean> {
+  const currentOwner = readChromeSingletonOwner(userDataDir);
+  if (!currentOwner) {
+    return true;
+  }
+  if (currentOwner.host !== owner.host || currentOwner.pid !== owner.pid) {
+    return false;
+  }
+  // Keep the PID liveness check adjacent to the unlink calls: a reused PID with
+  // the same lock owner string must not lose its new Chrome singleton files.
+  if (processExists(owner.pid) || (await processIdentityMatches(owner.pid, ownerIdentity))) {
+    return false;
+  }
+  clearChromeSingletonArtifacts(userDataDir);
+  return true;
+}
+
+type ChromeSingletonOwner = {
+  host: string;
+  pid: number;
+};
+
+function readChromeSingletonOwner(userDataDir: string): ChromeSingletonOwner | null {
   const lockPath = path.join(userDataDir, "SingletonLock");
   let target: string;
   try {
     target = fs.readlinkSync(lockPath);
   } catch {
-    return false;
+    return null;
   }
 
   const match = /^(?<lockHost>.+)-(?<pid>\d+)$/.exec(target);
   if (!match?.groups) {
-    return false;
+    return null;
   }
 
-  const lockHost = normalizeOptionalString(match.groups.lockHost) ?? "";
+  const host = normalizeOptionalString(match.groups.lockHost) ?? "";
   const pid = Number.parseInt(match.groups.pid ?? "", 10);
-  if (lockHost === hostname && processExists(pid)) {
+  if (!host || !Number.isInteger(pid) || pid <= 0) {
+    // Malformed lock targets do not prove local ownership. Leave them in
+    // place instead of deleting an unknown profile owner's lock.
+    return null;
+  }
+  return { host, pid };
+}
+
+export function clearStaleChromeSingletonLocks(
+  userDataDir: string,
+  hostname = os.hostname(),
+): boolean {
+  const owner = readChromeSingletonOwner(userDataDir);
+  if (!owner) {
+    return false;
+  }
+  if (owner.host === hostname && processExists(owner.pid)) {
     return false;
   }
 
@@ -204,6 +277,417 @@ async function terminateChromeForRetry(proc: ChildProcess, userDataDir: string) 
   }
   await waitForChromeProcessExit(proc, CHROME_BOOTSTRAP_EXIT_TIMEOUT_MS);
   clearStaleChromeSingletonLocks(userDataDir);
+}
+
+function isPortInUseError(err: unknown): boolean {
+  const maybeError = err as { name?: unknown; code?: unknown };
+  return maybeError.name === "PortInUseError" || maybeError.code === "EADDRINUSE";
+}
+
+function resolveExecutableCandidate(candidates: readonly string[]): string | null {
+  for (const candidate of candidates) {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // keep trying
+    }
+  }
+  return null;
+}
+
+function execFileText(
+  executable: string,
+  args: readonly string[],
+  maxBuffer = 64 * 1024,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      executable,
+      [...args],
+      { timeout: CHROME_STOP_PROBE_TIMEOUT_MS, maxBuffer },
+      (err, stdout) => resolve(err ? null : stdout),
+    );
+  });
+}
+
+async function inspectTcpListenPids(port: number): Promise<Set<number> | null> {
+  if (process.platform !== "darwin" && process.platform !== "linux") {
+    return null;
+  }
+  const lsof = resolveExecutableCandidate(LSOF_CANDIDATES);
+  if (!lsof) {
+    return null;
+  }
+  const stdout = await execFileText(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fp"]);
+  if (!stdout) {
+    return null;
+  }
+  const pids = new Set<number>();
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = /^p(?<pid>\d+)$/.exec(line);
+    const pid = Number.parseInt(match?.groups?.pid ?? "", 10);
+    if (Number.isInteger(pid) && pid > 0) {
+      pids.add(pid);
+    }
+  }
+  return pids.size > 0 ? pids : null;
+}
+
+type ProcessCommandLine = {
+  args: string[];
+  executablePath?: string | null;
+  lossy?: boolean;
+  raw?: string;
+};
+
+async function inspectProcessExecutablePath(pid: number): Promise<string | null> {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  const lsof = resolveExecutableCandidate(LSOF_CANDIDATES);
+  if (!lsof) {
+    return null;
+  }
+  const stdout = await execFileText(lsof, ["-p", String(pid), "-a", "-d", "txt", "-Fn"]);
+  for (const line of (stdout ?? "").split(/\r?\n/)) {
+    if (line.startsWith("n/") && !line.includes("/usr/lib/dyld")) {
+      return line.slice(1);
+    }
+  }
+  return null;
+}
+
+async function readProcessIdentity(pid: number): Promise<string | null> {
+  if (process.platform === "linux") {
+    try {
+      const raw = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+      const fields = raw
+        .slice(raw.lastIndexOf(")") + 2)
+        .trim()
+        .split(/\s+/);
+      return fields[19] ? `linux:${fields[19]}` : null;
+    } catch {
+      return null;
+    }
+  }
+  const ps = resolveExecutableCandidate(PS_CANDIDATES);
+  if (!ps || process.platform !== "darwin") {
+    return null;
+  }
+  const stdout = await execFileText(ps, ["-p", String(pid), "-o", "lstart="], 4 * 1024);
+  const startedAt = normalizeOptionalString(stdout?.trim() ?? "");
+  return startedAt ? `ps:${startedAt}` : null;
+}
+
+async function processIdentityMatches(pid: number, identity: string): Promise<boolean> {
+  return (await readProcessIdentity(pid)) === identity;
+}
+
+async function readProcessCommandLine(pid: number): Promise<ProcessCommandLine | null> {
+  if (process.platform === "linux") {
+    try {
+      const args = fs.readFileSync(`/proc/${pid}/cmdline`, "utf8").split("\0").filter(Boolean);
+      return args.length > 0 ? { args } : null;
+    } catch {
+      return null;
+    }
+  }
+  const ps = resolveExecutableCandidate(PS_CANDIDATES);
+  if (!ps) {
+    return null;
+  }
+  const raw = (await execFileText(ps, ["-ww", "-p", String(pid), "-o", "command="]))?.trim();
+  if (!raw) {
+    return null;
+  }
+  return {
+    args: raw.split(/\s+/),
+    executablePath: await inspectProcessExecutablePath(pid),
+    lossy: true,
+    raw,
+  };
+}
+
+function hasRawCommandLineUnsafeChars(value: string): boolean {
+  return /\s|["']/.test(value);
+}
+
+function argsHaveAdjacentPair(args: readonly string[], first: string, second: string): boolean {
+  return args.some((arg, index) => arg === first && args[index + 1] === second);
+}
+
+function linuxChromiumProcessFamily(executablePath: string): string | null {
+  return LINUX_CHROMIUM_PROCESS_FAMILIES.get(path.basename(executablePath).toLowerCase()) ?? null;
+}
+
+function commandLineMatchesResolvedExecutable(
+  cmdline: ProcessCommandLine,
+  executablePath: string,
+): boolean {
+  if (cmdline.lossy) {
+    if (process.platform === "darwin") {
+      return (
+        cmdline.executablePath === executablePath &&
+        typeof cmdline.raw === "string" &&
+        (cmdline.raw === executablePath || cmdline.raw.startsWith(`${executablePath} `))
+      );
+    }
+    if (hasRawCommandLineUnsafeChars(executablePath)) {
+      return false;
+    }
+  }
+  if (cmdline.args[0] === executablePath) {
+    return true;
+  }
+  if (process.platform !== "linux") {
+    return false;
+  }
+  const actualExecutable = cmdline.args[0];
+  if (!actualExecutable) {
+    return false;
+  }
+  const expectedFamily = linuxChromiumProcessFamily(executablePath);
+  return expectedFamily !== null && expectedFamily === linuxChromiumProcessFamily(actualExecutable);
+}
+
+function rawCommandLineHasManagedLaunchPrefix(params: {
+  executablePath: string;
+  raw: string;
+  remoteDebuggingPortArg: string;
+  userDataDirArg: string;
+}): boolean {
+  const expectedPrefix = `${params.executablePath} ${params.remoteDebuggingPortArg} ${params.userDataDirArg} --no-first-run`;
+  return params.raw === expectedPrefix || params.raw.startsWith(`${expectedPrefix} `);
+}
+
+async function isManagedChromeProcessForProfile(params: {
+  executablePath: string;
+  pid: number;
+  profile: ResolvedBrowserProfile;
+  userDataDir: string;
+}): Promise<boolean> {
+  const cmdline = await readProcessCommandLine(params.pid);
+  if (!cmdline) {
+    return false;
+  }
+  const remoteDebuggingPortArg = `--remote-debugging-port=${params.profile.cdpPort}`;
+  const userDataDirArg = `--user-data-dir=${params.userDataDir}`;
+  if (cmdline.lossy && process.platform === "darwin" && typeof cmdline.raw === "string") {
+    return (
+      commandLineMatchesResolvedExecutable(cmdline, params.executablePath) &&
+      rawCommandLineHasManagedLaunchPrefix({
+        executablePath: params.executablePath,
+        raw: cmdline.raw,
+        remoteDebuggingPortArg,
+        userDataDirArg,
+      })
+    );
+  }
+  // Recovery relies on the canonical launch-arg ordering from
+  // buildOpenClawChromeLaunchArgs(); a reordered process is not safe to signal.
+  return (
+    commandLineMatchesResolvedExecutable(cmdline, params.executablePath) &&
+    argsHaveAdjacentPair(cmdline.args, remoteDebuggingPortArg, userDataDirArg) &&
+    argsHaveAdjacentPair(cmdline.args, userDataDirArg, "--no-first-run")
+  );
+}
+
+async function isLoopbackPortAccepting(port: number, timeoutMs: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port }, () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("error", () => resolve(false));
+    socket.setTimeout(timeoutMs, () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForProcessExitByPid(pid: number, timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!processExists(pid)) {
+      return true;
+    }
+    const remainingMs = timeoutMs - (Date.now() - start);
+    await new Promise((r) => {
+      setTimeout(r, Math.max(1, Math.min(CHROME_BOOTSTRAP_EXIT_POLL_MS, remainingMs)));
+    });
+  }
+  return !processExists(pid);
+}
+
+async function stopOwnedChromePid(
+  pid: number,
+  isStillOwnedChrome: () => Promise<boolean>,
+): Promise<boolean> {
+  if (!(await isStillOwnedChrome())) {
+    return false;
+  }
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // ignore; the second port check below is the source of truth
+  }
+  if (await waitForProcessExitByPid(pid, CHROME_BOOTSTRAP_EXIT_TIMEOUT_MS)) {
+    return true;
+  }
+  if (!(await isStillOwnedChrome())) {
+    return false;
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // ignore; the second port check below is the source of truth
+  }
+  return await waitForProcessExitByPid(pid, CHROME_BOOTSTRAP_EXIT_TIMEOUT_MS);
+}
+
+async function waitForLoopbackPortClosed(port: number, timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!(await isLoopbackPortAccepting(port, CHROME_STOP_PROBE_TIMEOUT_MS))) {
+      return true;
+    }
+    const remainingMs = timeoutMs - (Date.now() - start);
+    await new Promise((r) => {
+      setTimeout(r, Math.max(1, Math.min(CHROME_BOOTSTRAP_EXIT_POLL_MS, remainingMs)));
+    });
+  }
+  return !(await isLoopbackPortAccepting(port, CHROME_STOP_PROBE_TIMEOUT_MS));
+}
+
+async function waitForOwnedChromeCdpToStayUnready(params: {
+  profile: ResolvedBrowserProfile;
+  isStillOwnedChrome: () => Promise<boolean>;
+  timeoutMs: number;
+}): Promise<boolean> {
+  const timeoutMs = Math.max(1, params.timeoutMs);
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    if (!(await params.isStillOwnedChrome())) {
+      return false;
+    }
+    if (
+      await isChromeCdpReady(
+        params.profile.cdpUrl,
+        CHROME_REACHABILITY_TIMEOUT_MS,
+        CHROME_WS_READY_TIMEOUT_MS,
+      )
+    ) {
+      return false;
+    }
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return true;
+    }
+    await new Promise((r) => {
+      setTimeout(r, Math.max(1, Math.min(CHROME_LAUNCH_READY_POLL_MS, remainingMs)));
+    });
+  }
+}
+
+async function recoverOwnedChromePortBlocker(params: {
+  executablePath: string;
+  profile: ResolvedBrowserProfile;
+  readinessTimeoutMs: number;
+  userDataDir: string;
+}): Promise<boolean> {
+  if (!params.profile.cdpIsLoopback) {
+    return false;
+  }
+  const owner = readChromeSingletonOwner(params.userDataDir);
+  if (!owner || owner.host !== os.hostname() || !processExists(owner.pid)) {
+    return false;
+  }
+  const ownerIdentity = await readProcessIdentity(owner.pid);
+  if (!ownerIdentity) {
+    return false;
+  }
+  const isStillOwnedChrome = async () => {
+    if (!(await processIdentityMatches(owner.pid, ownerIdentity))) {
+      return false;
+    }
+    const listenerPids = await inspectTcpListenPids(params.profile.cdpPort);
+    if (!listenerPids?.has(owner.pid)) {
+      return false;
+    }
+    return await isManagedChromeProcessForProfile({
+      executablePath: params.executablePath,
+      pid: owner.pid,
+      profile: params.profile,
+      userDataDir: params.userDataDir,
+    });
+  };
+  if (!(await isStillOwnedChrome())) {
+    return false;
+  }
+  if (
+    !(await waitForOwnedChromeCdpToStayUnready({
+      profile: params.profile,
+      isStillOwnedChrome,
+      timeoutMs: params.readinessTimeoutMs,
+    }))
+  ) {
+    return false;
+  }
+
+  log.warn(
+    `Stopping unresponsive managed Chrome for profile "${params.profile.name}" on port ${params.profile.cdpPort} (pid ${owner.pid}) before relaunch.`,
+  );
+  if (!(await stopOwnedChromePid(owner.pid, isStillOwnedChrome))) {
+    return false;
+  }
+  if (
+    !(await waitForLoopbackPortClosed(params.profile.cdpPort, CHROME_BOOTSTRAP_EXIT_TIMEOUT_MS))
+  ) {
+    return false;
+  }
+  if (processExists(owner.pid)) {
+    return false;
+  }
+  return await clearChromeSingletonArtifactsForOwner(params.userDataDir, owner, ownerIdentity);
+}
+
+async function ensureManagedLoopbackPortAvailable(params: {
+  executablePath: string;
+  profile: ResolvedBrowserProfile;
+  readinessTimeoutMs: number;
+  userDataDir: string;
+}): Promise<void> {
+  if (!params.profile.cdpIsLoopback) {
+    await ensurePortAvailable(params.profile.cdpPort);
+    return;
+  }
+  try {
+    await ensurePortAvailable(params.profile.cdpPort);
+  } catch (err) {
+    if (!isPortInUseError(err) || !(await recoverOwnedChromePortBlocker(params))) {
+      throw err;
+    }
+    await ensurePortAvailable(params.profile.cdpPort);
+  }
+
+  const owner = readChromeSingletonOwner(params.userDataDir);
+  if (!owner || owner.host !== os.hostname() || !processExists(owner.pid)) {
+    return;
+  }
+  // Some hosts can accept a generic listen probe while 127.0.0.1 is still
+  // held. Only use the exact loopback probe after SingletonLock proves local
+  // managed-profile ownership, so external CDP services are not killed by port.
+  if (!(await isLoopbackPortAccepting(params.profile.cdpPort, CHROME_STOP_PROBE_TIMEOUT_MS))) {
+    return;
+  }
+  const err = new Error(`Port ${params.profile.cdpPort} is already in use.`);
+  err.name = "PortInUseError";
+  if (await recoverOwnedChromePortBlocker(params)) {
+    return;
+  }
+  throw err;
 }
 
 function chromeLaunchHints(params: {
@@ -467,8 +951,6 @@ export async function launchOpenClawChrome(
     );
   }
 
-  await ensurePortAvailable(profile.cdpPort);
-
   const exe = resolveBrowserExecutable(resolved, profile);
   if (!exe) {
     throw new Error(
@@ -478,6 +960,12 @@ export async function launchOpenClawChrome(
 
   const userDataDir = resolveOpenClawUserDataDir(profile.name);
   fs.mkdirSync(userDataDir, { recursive: true });
+  await ensureManagedLoopbackPortAvailable({
+    executablePath: exe.path,
+    profile,
+    readinessTimeoutMs: resolved.localLaunchTimeoutMs ?? CHROME_LAUNCH_READY_WINDOW_MS,
+    userDataDir,
+  });
   await ensureOutputDirectory(DEFAULT_DOWNLOAD_DIR);
 
   const needsDecorate = !isProfileDecorated(


### PR DESCRIPTION
## Summary

Fixes #41750.

This adds a guarded recovery path for the managed local browser profile when its loopback CDP port is still held by an unresponsive Chrome-family process from the same OpenClaw-managed profile. Instead of immediately failing launch with a port-in-use or CDP-timeout error, OpenClaw now proves local ownership of the blocker, gives it the normal launch readiness window to become healthy, and only then terminates the stale process before relaunching.

The recovery is intentionally narrow:

- only applies to loopback managed profiles
- requires the local `SingletonLock` owner host to match this host
- requires the lock PID to still be alive and keep the same process identity before signaling
- requires `lsof` to show that same PID listening on the exact CDP port
- requires the process command line to match the configured browser executable family and the managed launch args
- revalidates ownership before `SIGTERM`, before `SIGKILL`, and before deleting singleton artifacts
- leaves malformed or unowned singleton locks in place rather than guessing

## Root cause and user impact

Issue #41750 reports a failure mode where a prior OpenClaw-managed Chrome process can keep the configured CDP port bound while no useful CDP endpoint is available. The next browser launch sees the port as occupied or waits for CDP readiness until it times out, so browser tooling remains unavailable until the stale process/profile is cleaned up manually.

The previous launch path treated an occupied loopback port as a hard blocker. That is correct for arbitrary processes, but too strict for a process that can be proven to be the exact stale browser instance OpenClaw launched for the same managed profile.

## Implementation notes

The fix adds a recovery branch inside the managed Chrome launch path. When the configured loopback CDP port is in use, OpenClaw attempts recovery only after proving all of these facts from current machine state:

1. The profile has a parseable `SingletonLock` owner for this hostname.
2. The owner PID exists and has a stable identity snapshot.
3. The same PID is listening on the exact requested TCP port according to `lsof`.
4. The process command line matches the configured Chromium-family executable.
5. The process was launched with the adjacent managed args: `--remote-debugging-port`, `--user-data-dir`, and `--no-first-run`.
6. The CDP endpoint does not become ready during the configured local launch timeout window.

Only after those checks pass does recovery send `SIGTERM`, wait for the loopback port to close, escalate to `SIGKILL` only if the same process identity is still present, and then clear singleton artifacts only if the same lock owner is still present and the old PID identity is gone.

Linux browser-family matching covers the resolver-supported Chromium families where the wrapper path can differ from the live binary path: Chrome, Chromium, Brave, Edge, Vivaldi, Opera, and Yandex Browser. macOS keeps stricter executable proof by requiring the `lsof -d txt` executable path plus a raw `ps` command prefix match.

## Real behavior proof

Behavior addressed: a stale, OpenClaw-owned managed Chrome process can keep the loopback CDP port bound but fail CDP readiness, blocking later browser launches.

Real environment tested: local macOS checkout with a controlled compiled fake browser binary launched as a real child process, real loopback TCP port binding, real process signaling, real profile singleton files, and the OpenClaw browser launch path.

Exact steps or command run after this patch: ran a local proof fixture that created a temporary OpenClaw browser profile, wrote a `SingletonLock` for a stale managed process, started that process on the profile CDP port returning HTTP 503 for `/json/version`, then called `launchOpenClawChrome` with the same profile and executable path.

Evidence after fix:

```json
{
  "port": 50648,
  "stalePid": 68025,
  "beforeStatus": 503,
  "staleAliveAfterLaunch": false,
  "launchedPid": 68107,
  "cdpVersionServed": true,
  "singletonExists": false
}
```

Observed result after fix: OpenClaw logged that it stopped the unresponsive managed Chrome process for the profile, relaunched the browser on the same loopback CDP port, the stale PID was no longer alive, the relaunched process served CDP `/json/version`, and the stale singleton lock was gone.

What was not tested: I did not run this proof against real installed Google Chrome, Brave, Edge, Vivaldi, Opera, or Yandex Browser binaries across every OS. The real-behavior proof used a controlled browser binary so the stale-port and CDP-failure state could be reproduced deterministically without depending on a specific local browser install.

## Regression tests

Added focused coverage for the recovery and safety boundaries, including:

- recovering an unresponsive owned managed profile and retrying launch
- not signaling when the owned browser becomes CDP-ready during the recovery grace window
- Linux wrapper/live-binary matching for Chrome-family browsers
- rejecting cross-family Linux executable matches
- not escalating when the listener changes before `SIGKILL`
- not clearing singleton artifacts when a different owner appears
- not clearing singleton artifacts when the stopped PID is reused before cleanup
- rejecting non-adjacent managed launch args
- not stopping unrelated listeners or non-loopback profiles
- avoiding CDP probes before ownership is established in the occupied-port paths
- preserving malformed singleton locks instead of deleting unknown ownership state

## Verification

Commands run on the rebased head:

```bash
pnpm exec vitest run extensions/browser/src/browser/chrome.test.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts --reporter dot
pnpm tsgo:extensions
pnpm exec oxfmt --check extensions/browser/src/browser/chrome.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.test.ts
node scripts/run-oxlint.mjs extensions/browser/src/browser/chrome.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.test.ts
git diff --check
```

Results:

- focused Vitest command passed: 3 files, 135 tests
- extension typecheck passed
- formatting check passed
- oxlint check passed
- diff whitespace check passed

## Duplicate and overlap check

Before publishing, I checked open and all-state PRs for the issue and affected symbols/files. I did not find an open PR closing #41750 or implementing this owned stale-CDP recovery. The only direct all-state hit was closed PR #41758, which targeted the old `src/browser/chrome.ts` path and did not provide this guarded ownership shape.

Nearby open PRs touched broader browser or process areas, but did not close #41750 and did not implement recovery for a proven owned managed browser process holding the CDP port.

## Risks

The main risk is process ownership safety. The fix is conservative: if any proof step is missing or ambiguous, it does not signal the process and falls back to the existing failure behavior. This can leave some stale real-world states unrecovered, but avoids terminating unrelated local processes.

The malformed-lock behavior changes from opportunistic cleanup to preservation. That is intentional: a malformed `SingletonLock` target does not prove local ownership, so this patch leaves it in place instead of deleting unknown profile ownership state.

Dead-PID stale singleton cleanup without a live port owner is still out of scope for this patch. This only handles the issue's blocking case where a live stale managed process owns the profile and is holding the CDP port.


## Follow-up proof and scan fix

After the first CI run, `Scan changed paths (precise)` flagged the touched test-only CDP WebSocket mocks because they used `WebSocketServer({ noServer: true })` without a `maxPayload` cap. I updated the four touched mock WebSocket servers to use `maxPayload: 1024 * 1024`:

- `extensions/browser/src/browser/chrome.internal.test.ts`
- `extensions/browser/src/browser/chrome.test.ts`

I also ran an installed-browser smoke with local Google Chrome to reduce the remaining process-ownership proof risk. The smoke used an isolated temporary OpenClaw state dir, launched real installed Google Chrome with the managed profile/CDP arguments, waited for CDP HTTP 200, sent `SIGSTOP` to make that owned Chrome process unresponsive while it still held the port, then called `launchOpenClawChrome` and verified recovery. A separate unrelated TCP listener stayed reachable during the recovery.

Installed-browser smoke evidence:

```json
{
  "stateDir": "/tmp/openclaw-state-smoke.wl4KOF",
  "chromePath": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
  "unrelatedPort": 53819,
  "unrelatedStillListening": true,
  "stalePort": 53820,
  "stalePid": 24903,
  "staleAliveAfterLaunch": false,
  "launchedPid": 25026,
  "beforeStopStatus": "200",
  "afterStatus": "200"
}
```

Additional commands run after the follow-up fix:

```bash
pnpm exec vitest run extensions/browser/src/browser/chrome.test.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts --reporter dot
pnpm tsgo:extensions
pnpm exec oxfmt --check extensions/browser/src/browser/chrome.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.test.ts
node scripts/run-oxlint.mjs extensions/browser/src/browser/chrome.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.test.ts
git diff --check
```

Follow-up results:

- focused Vitest command passed: 3 files, 135 tests
- extension typecheck passed
- formatting check passed
- oxlint check passed
- diff whitespace check passed
- local targeted check confirmed no touched browser test `WebSocketServer({ noServer: true })` remains without `maxPayload`
