### PR TITLE
fix(ci): restore dist cache before artifact builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,7 +605,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-all-v3-
 
+      - name: Restore dist build cache
+        id: dist_build_cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            dist/
+            dist-runtime/
+            extensions/*/src/host/**/.bundle.hash
+            extensions/*/src/host/**/*.bundle.js
+          key: ${{ runner.os }}-dist-build-${{ needs.preflight.outputs.checkout_revision }}
+
       - name: Build dist
+        if: steps.dist_build_cache.outputs.cache-hit != 'true'
         env:
           NODE_OPTIONS: --max-old-space-size=8192
         run: pnpm build:ci-artifacts
@@ -613,14 +625,6 @@ jobs:
       - name: Check Control UI i18n
         if: needs.preflight.outputs.run_control_ui_i18n == 'true'
         run: pnpm ui:i18n:check
-
-      - name: Cache dist build
-        uses: actions/cache@v5
-        with:
-          path: |
-            dist/
-            dist-runtime/
-          key: ${{ runner.os }}-dist-build-${{ needs.preflight.outputs.checkout_revision }}
 
       - name: Pack built runtime artifacts
         run: tar --posix -cf dist-runtime-build.tar.zst --use-compress-program zstdmt dist dist-runtime
@@ -750,6 +754,18 @@ jobs:
             fi
           done
           exit "$failures"
+
+      - name: Save dist build cache
+        if: steps.dist_build_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            dist/
+            dist-runtime/
+            extensions/*/src/host/**/.bundle.hash
+            extensions/*/src/host/**/*.bundle.js
+          key: ${{ steps.dist_build_cache.outputs.cache-primary-key }}
 
       - name: Upload gateway watch regression artifacts
         if: always() && needs.preflight.outputs.run_check_additional == 'true'

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -146,6 +146,35 @@ describe("ci workflow guards", () => {
     expect(buildArtifactSteps.some((step) => step.run === "pnpm ui:build")).toBe(false);
   });
 
+  it("restores the dist build cache before building and saves only cache misses", () => {
+    const workflow = readCiWorkflow();
+    const buildArtifactSteps = workflow.jobs["build-artifacts"].steps;
+    const stepNames = buildArtifactSteps.map((step) => step.name);
+    const restoreStep = buildArtifactSteps.find((step) => step.name === "Restore dist build cache");
+    const buildDistStep = buildArtifactSteps.find((step) => step.name === "Build dist");
+    const saveStep = buildArtifactSteps.find((step) => step.name === "Save dist build cache");
+
+    expect(stepNames.indexOf("Restore dist build cache")).toBeLessThan(
+      stepNames.indexOf("Build dist"),
+    );
+    expect(stepNames.indexOf("Build dist")).toBeLessThan(
+      stepNames.indexOf("Pack built runtime artifacts"),
+    );
+    expect(stepNames.indexOf("Run built artifact checks")).toBeLessThan(
+      stepNames.indexOf("Save dist build cache"),
+    );
+    expect(restoreStep.uses).toBe("actions/cache/restore@v5");
+    expect(buildDistStep.if).toBe("steps.dist_build_cache.outputs.cache-hit != 'true'");
+    expect(saveStep.uses).toBe("actions/cache/save@v5");
+    expect(saveStep.if).toBe("steps.dist_build_cache.outputs.cache-hit != 'true'");
+    expect(saveStep.with.key).toBe("${{ steps.dist_build_cache.outputs.cache-primary-key }}");
+    expect(restoreStep.with.path).toContain("dist/");
+    expect(restoreStep.with.path).toContain("dist-runtime/");
+    expect(restoreStep.with.path).toContain("extensions/*/src/host/**/.bundle.hash");
+    expect(restoreStep.with.path).toContain("extensions/*/src/host/**/*.bundle.js");
+    expect(buildArtifactSteps.map((step) => step.name)).not.toContain("Cache dist build");
+  });
+
   it("gives quiet Node test shards enough no-output runway", () => {
     const workflow = readCiWorkflow();
     const nodeTestJob = workflow.jobs["checks-node-core-test-nondist-shard"];


### PR DESCRIPTION
## Measured Impact

Measured cache impact from a recent CI sample:

- Sample: latest 2,000 CI runs available when measured, spanning roughly 28.5 hours (`2026-05-27 20:07Z` to `2026-05-29 00:38Z`).
- Completed run records fetched: 1,989.
- Runs with a non-skipped `build-artifacts` job: 1,454.
- Unique SHAs among those `build-artifacts` runs: 1,429.
- Same-SHA repeat `build-artifacts` runs: 25 / 1,454 = 1.72%.
- Same-SHA repeats with a prior successful `build-artifacts`: 14 / 1,454 = 0.96%.

| Event | `build-artifacts` runs | Same-SHA prior run | Same-SHA prior successful build |
|---|---:|---:|---:|
| PR | 1,176 | 13 / 1.1% | 4 / 0.34% |
| Push | 235 | 0 / 0% | 0 / 0% |
| Manual dispatch | 43 | 12 / 27.9% | 10 / 23.3% |

Timing from 896 `build-artifacts` jobs with step-level timing:

- Median full `build-artifacts` job: 195s.
- Median `Build dist` step: 102s.
- p75 `Build dist` step: 119s.
- p90 `Build dist` step: 141s.

Expected effect:

- Before this PR, the exact-SHA dist cache was effectively 0% useful for pre-build skipping because the workflow saved it after `pnpm build:ci-artifacts` but never restored it before that build.
- After this PR, useful exact-SHA hits should be roughly 1% overall, up to about 1.7% if prior non-successful runs still saved usable validated output.
- At the measured sample rate, that is roughly 12 to 21 cache-hit build skips per day.
- Each hit avoids about 102s median build time, with repeated prior-success reruns closer to 121s median where step timing was available.
- The benefit is concentrated in manual dispatch/rerun paths; ordinary PR CI sees very few exact-SHA repeats.

Cache saturation note: the repo was already using the dist cache before this PR, but only as a save-after-build cache. GitHub reported about 171 active caches and 12.03GB active cache usage at measurement time, so this PR intentionally keeps the same exact-SHA cache shape and does not broaden the key. The change is meant to make the already-existing cache useful on reruns, not to add a new general-purpose cache layer.

## Summary

Fix the existing `build-artifacts` dist cache so it can be restored before `pnpm build:ci-artifacts` instead of only being saved after the build.

- restore the exact-checkout dist cache before the build step
- skip `pnpm build:ci-artifacts` only on an exact cache hit
- save the cache only on misses, after the existing artifact smoke/check steps have validated the output
- include bundled plugin host bundle outputs in the same cache path so cache-hit runs still preserve the bundled plugin asset upload
- add a CI workflow guard for the restore/build/save ordering and cache paths

This deliberately does not split the built-artifact checks into new jobs. The measured cache-hit population is narrow, so this PR only makes the cache that already exists useful for same-SHA reruns without changing the CI job graph.

## Verification

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`
- `git diff --check HEAD~1..HEAD`
- `node -e "const {readFileSync}=require('fs'); const YAML=require('yaml'); YAML.parse(readFileSync('.github/workflows/ci.yml','utf8')); console.log('ci.yml parsed')"`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/ci.yml`
- `python3 scripts/check-composite-action-input-interpolation.py`
- `node scripts/check-no-conflict-markers.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`

`node scripts/check-workflows.mjs` was attempted, but current local pre-commit setup failed installing `zizmor==1.22.0` under the available Python environment before reaching this patch's workflow checks. The direct actionlint/composite/conflict-marker checks above were run instead.

## Real behavior proof

- Behavior addressed: existing exact-SHA dist cache entries were saved after `build:ci-artifacts` but never restored before that build, so same-SHA reruns rebuilt dist instead of using the cache.
- Real environment tested: local OpenClaw checkout on this branch, rebased onto current `origin/main`.
- Exact steps or command run after this patch: focused workflow guard test, YAML parse, direct actionlint for `.github/workflows/ci.yml`, composite-action interpolation guard, conflict-marker scan, and autoreview.
- Evidence after fix: guard coverage now asserts restore-before-build, build skip on exact cache hit, save-on-miss using the restore primary key, and save after built-artifact checks.
- Observed result after fix: all focused checks listed in Verification passed.
- What was not tested: no live GitHub Actions run has completed on this PR yet, and no cache-hit rerun was executed in GitHub Actions.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":39,"user":19,"assistant":19,"toolCalls":204,"toolOutputsDropped":203,"web":4,"redactions":3,"omittedUnsafe":0,"rawEntries":70}

[user]
Let's pick up where you left off in this branch and first tell me where we're at and what the point of these changes is.

Worktree: [LOCAL_PATH]
Branch: codex/ci-dist-cache-split-built-artifacts
Current observed state: dirty worktree with changes in `.github/workflows/ci.yml` and `test/scripts/ci-workflow-guards.test.ts`, branch behind `origin/main` by ~17 commits.

Original task context:
- This was the stacked PR 2+3 CI fanout task.
- Goal A: make the existing dist build cache useful by restoring it before `pnpm build:ci-artifacts`, building only on cache miss, and saving only after a miss. Preserve artifact upload and current smoke coverage.
- Goal B: if safe, split built-artifact checks out of the monolithic `build-artifacts` job so the build job is no longer the whole critical path. Built checks include things like channels, core-support-boundary, gateway-watch, startup-memory, and launcher smokes, but keep behavior auditable and avoid over-broad speculative graph rewrites.
- Required first step was to search related GitHub issues/PRs and stop if there was an exact duplicate. If you already did this, summarize what you found; otherwise do it now before further implementation.
- Do not open a PR until Dallin reviews. If you get to PR-ready state, stop and ask for review, preferably with `cmux notify`.

Please:
1. `cd` to the worktree above.
2. Inspect `git status`, the diff, recent commands/output if visible, and relevant files.
3. Report where the branch stands: what changed, why, what remains, what verification has/has not run, and whether it is PR-ready.
4. If it is not PR-ready and no exact duplicate exists, continue with the smallest safe next step. Preserve other workers' branches and do not revert unrelated changes.

[assistant]
I’ll rehydrate the branch state first: status, local diff, workflow guard coverage, and any recent shell history available in this worktree. I’ll also use the OpenClaw maintainer skill because this task explicitly requires duplicate PR/issue discovery before continuing.

The local state matches your summary: this branch is dirty with only the CI workflow and its guard test changed, and it is 17 commits behind `origin/main`. The diff already implements both the cache restore/save shape and a new `built-artifact-checks` matrix job, so I’m checking whether this duplicates existing work before I touch anything further.

Duplicate search found no exact live PR/issue from `gh search`, and `gitcrawl` surfaced one related open PR, `#81957`, whose snippet mentions dist-cache save-only hardening. I’m checking that PR’s actual diff now because it could overlap with Goal A even if it is not the same fanout split.

This is not PR-ready yet. The obvious risk is semantic: the split matrix currently runs `channels`, `core-support-boundary`, and `gateway-watch` whenever `run_build_artifacts` is true, while the old in-job script only ran each of those behind its specific preflight gate. I’m going to preserve the fanout but restore those per-check gates in the smallest local change, then run the focused guard test.

The focused guard test is still running through the repo wrapper without output yet. While it runs, I’ve made the narrow correction: the fanout job keeps the new split, but `channels`, `core-support-boundary`, and `gateway-watch` now preserve the old preflight gates instead of becoming unconditional work.

The focused test and YAML parse are green, and `git diff --check` is clean. Since this is a workflow edit, I’m trying the repo workflow checker next; this may fall back to `go run actionlint` because `actionlint` is not installed locally.

[user]
continue

[assistant]
I’ll continue from the current dirty state and avoid rebasing or stashing since the branch has uncommitted workflow edits. Next I’m checking whether the dirty patch would collide with latest `origin/main`, then I’ll close with a concrete handoff/status.

Where we’re at: the branch is still dirty on `codex/ci-dist-cache-split-built-artifacts`, now behind `origin/main` by 18 commits. Only two files are changed: `.github/workflows/ci.yml` and `test/scripts/ci-workflow-guards.test.ts`.

The point of the changes is to make CI stop rebuilding and rechecking built artifacts serially when it does not need to. `build-artifacts` now restores the dist cache before `pnpm build:ci-artifacts`, skips the build on a cache hit, and saves only after a miss. It still uploads the runtime and bundled plugin artifacts. The built-artifact consumers are split into a `built-artifact-checks` matrix for launcher smoke, startup memory, channels, core-support-boundary, and gateway-watch so those checks are no longer inside the producer job’s critical path.

I found no exact duplicate. `gitcrawl` surfaced related PR `#81957`, which overlaps the cache hardening area, but it is a broader supply-chain hardening PR and does not do this branch’s restore-before-build cache flow plus built-artifact fanout split.

I made one additional correction while continuing: the new matrix now preserves the old preflight gates for `channels`, `core-support-boundary`, and `gateway-watch` instead of running them unconditionally whenever build artifacts run.

Verification run:
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` passed: 6 tests.
- `git diff --check` passed.
- YAML parse of `.github/workflows/ci.yml` passed.
- `node scripts/check-workflows.mjs` passed after fetching actionlint.
- Patch applies cleanly to current `origin/main` in a temporary detached worktree.

Not done: no commit, no rebase, no push, no PR opened, and no real CI run yet. I sent a `cmux notify` that this is ready for Dallin review. Next step after review is commit, rebase onto `origin/main`, push, then open the PR.

Related non-duplicate PR: https://github.com/openclaw/openclaw/pull/81957

[user]
how is https://github.com/openclaw/openclaw/pull/81957 related, like does it massively conflict or anything

[assistant]
I’ll compare this branch’s dirty patch against PR 81957’s actual CI workflow changes, focusing on overlap in `build-artifacts` and cache/artifact handling rather than the unrelated release hardening.

PR 81957 is related but not an exact duplicate.

It touches the same `build-artifacts` area in `.github/workflows/ci.yml`, but for a different purpose: supply-chain/cache hardening. In that PR, `build-artifacts` still always runs `pnpm build:ci-artifacts`, then saves the dist cache with `actions/cache/save@...`. It does not restore the cache before building, does not skip the build on cache hit, and does not split the built-artifact smokes/checks into a downstream matrix job.

Conflict-wise: yes, it will conflict mechanically if 81957 lands first. I tested applying this branch’s current `ci.yml` patch onto PR 81957’s head, and it fails at the build-artifacts block around line 545. The conflict is local and understandable, not massive: both patches edit the same ~150-line `build-artifacts` section. The merge resolution would be to keep 81957’s pinned action SHAs/security hardening while applying this branch’s restore-before-build and `built-artifact-checks` split.

One subtle difference: 81957 also has `Build Control UI` still in that block on its head, while this branch is based on a newer main where a guard asserts `build:ci-artifacts` should not be followed by `pnpm ui:build`. So whichever branch lands second will need a normal rebase/resolve, but it’s not a conceptual blocker.

[user]
Okay whatever and now explain what the benefits of this are. What is the behavioral change that we're going for and the real benefit and what are the trade-offs?

[assistant]
The behavior change is: CI builds `dist/` and `dist-runtime/` once, reuses that result when the exact checkout SHA already has a dist cache, and then runs the built-artifact consumers as separate jobs instead of keeping them inside the same `build-artifacts` job.

The real benefit is shorter critical path and less wasted work. Today `build-artifacts` is both the producer and a pile of consumers: build dist, upload artifacts, run launcher smokes, startup memory, channels, core-support-boundary, gateway-watch. That means one job owns too much elapsed time. Splitting the checks lets GitHub/Blacksmith schedule those consumers in parallel after the artifact is produced. The cache restore also makes repeated runs for the same SHA cheaper: reruns, retry jobs, or overlapping CI paths can avoid rebuilding the same dist tree.

In practical terms, the intended outcome is:
- `pnpm build:ci-artifacts` happens only when the exact SHA dist cache is missing.
- artifact upload still happens every run, so downstream jobs get the same `dist-runtime-build` and bundled plugin assets.
- launcher/startup/channel/core-support/gateway-watch checks still run against built artifacts, but as fanout jobs.
- failures become more localized: instead of one big `build-artifacts` job failing after a long serial sequence, you can see `built-artifacts-gateway-watch` or `built-artifacts-startup-memory` fail independently.

Trade-offs:
- More CI jobs appear in the graph, so the UI is noisier.
- Each fanout job does its own checkout/setup/download/unpack, so total aggregate runner minutes may go up even if wall-clock time goes down.
- Artifact download/unpack becomes part of the contract, so if upload/download has transient issues, those checks fail separately.
- The split removes the old in-process parallel shell runner for channels/core-support/gateway-watch and relies on Actions matrix scheduling instead.
- Cache correctness matters more. The key is exact checkout revision, which is conservative, but stale or partial cache behavior would be painful, so the workflow guard test pins the restore/build/save ordering.

The main engineering bet is that wall-clock CI latency and retry efficiency matter more here than minimizing the number of jobs or aggregate runner setup overhead.

[user]
ok give me some real time etc estimates ideally actually measured for figuring out if the tradeoffs are worth it

[assistant]
I’ll pull recent live CI job timings from GitHub rather than guessing. I’ll look at current `build-artifacts` duration and its internal step timing if available, then translate that into an expected before/after wall-clock estimate for this split.

There are a lot of cancelled/failed main runs right now, so I’m using the latest completed successful main CI run as the clean baseline and sampling a few nearby runs for variance. Next I’m pulling job-level timing for `build-artifacts` and related jobs.

Measured from recent live `main` CI:

| Run | `build-artifacts` total | `Build dist` | Artifact upload ready | Built checks inside job |
|---|---:|---:|---:|---:|
| `[REDACTED_PHONE]` failure, same SHA as later rerun | 3m31s | 1m57s | 2m20s | 1m01s |
| `[REDACTED_PHONE]` success | 5m19s | 2m49s | 3m34s | 1m33s |
| `[REDACTED_PHONE]` failure | 3m30s | 1m54s | 2m22s | 0m59s |

So the raw opportunity is:

- Build skip on same-SHA reruns: about **2m saved** normally, **up to ~3m** in the sampled success run.
- Moving consumers out of `build-artifacts`: producer job becomes artifact-ready about **1m to 1m35 earlier**, because launcher/startup/channels/core/gateway checks leave that job.
- Full green run, cold cache: likely **flat to slightly slower** overall, because the old `Run built artifact checks` already parallelized several checks inside one runner, while the new matrix pays separate checkout/setup/download overhead.
- Full green run, warm exact-SHA cache: likely **~2-3m faster** for the built-artifact lane, because it skips `Build dist`.

The strongest measured case is the same-SHA rerun: `[REDACTED_PHONE]` and `[REDACTED_PHONE]` both ran on SHA `7bcef072...`. Under current CI, the second run rebuilt dist for **2m49s** even though the same SHA had already produced artifacts/cache in the prior run. This patch is mainly aimed at that waste.

Trade-off estimate:

- **Best case:** rerun/retry for same SHA hits cache, built-artifact path drops from ~3.5-5.3m to roughly **2-3m** including fanout overhead.
- **Normal first run / cache miss:** probably **no big wall-clock win**, maybe **0-45s slower** for the complete built-artifact check set because of extra job setup/download.
- **Debugging benefit:** better. A failure becomes `built-artifacts-gateway-watch` or `built-artifacts-channels`, not one giant `build-artifacts` job.
- **Cost:** more jobs and likely more aggregate runner minutes. Five fanout jobs means five checkouts/setup/downloads. Wall time may improve on reruns, but total compute consumed can increase.

My read: this is worth it if repeated same-SHA CI runs, reruns, and clearer failure attribution are common pain points. If the only metric is cold-cache full-green wall time, the benefit is weak and may not justify the added graph noise.

[user]
Well with the cache case, does it actually slow things down or is it just the noisy UI that is the problem?

[assistant]
With a **warm exact-SHA dist cache**, it should not slow the built-artifact lane down in wall-clock terms. It should be faster.

Measured current baseline:

- `Build dist` alone costs about **1m54s to 2m49s** in sampled runs.
- The old post-build built checks cost about **0m59s to 1m33s**.
- Old total `build-artifacts` was **3m30s to 5m19s**.

With the patch on a cache hit:

- `Build dist` is skipped.
- `build-artifacts` still does checkout/setup/cache restore/pack/upload.
- downstream fanout jobs each do checkout/setup/download/unpack, then run their check.

So the trade is roughly:

- save **~2-3m** from skipping the build
- add extra fanout setup/download overhead, probably tens of seconds per job, but in parallel
- longest fanout check determines the added wall-clock, not the sum

Net for warm cache should still be positive unless the fanout queue/setup overhead is awful. The bigger concerns are:

1. **Noisier UI:** 5 extra jobs.
2. **More aggregate runner time:** parallel jobs duplicate checkout/setup/download.
3. **Cold cache may not improve:** first run still builds, then pays fanout overhead.

So for cache-hit reruns, the downside is mostly UI noise and aggregate compute, not wall-clock slowdown.

[user]
i mean cold case

[assistant]
Cold case is the weak case.

On a cache miss, this patch still pays the full `Build dist` cost, then adds fanout job overhead. The old workflow already ran the heavier built checks partly in parallel inside one `Run built artifact checks` shell step, so splitting them into Actions matrix jobs does not create as much parallelism as it looks like.

Measured current cold-ish samples:

- `Build dist`: **1m54s to 2m49s**
- artifact upload ready: **2m20s to 3m34s**
- in-job built checks after upload/smokes: **0m59s to 1m33s**
- total `build-artifacts`: **3m30s to 5m19s**

Expected cold case after this patch:

- producer `build-artifacts` likely ends around artifact upload ready: **~2m20s to 3m35s**
- then `built-artifact-checks` fan out
- each fanout job pays checkout/setup/download/unpack before its actual check
- wall-clock likely becomes producer time plus the slowest fanout job

So cold case is probably **roughly flat to somewhat slower** for the complete built-artifact surface. My best estimate: **0-60s slower** if runners start quickly, maybe worse if Blacksmith queues or setup/download is slow.

The cold-case benefit is not speed. It is:
- the producer artifact is available earlier,
- failures are separated by check name,
- reruns can target a failed consumer job more directly,
- future same-SHA reruns can use the saved cache.

If we only care about first-run cold CI wall time, this patch is not clearly a win. The cache-hit/rerun case is the real speed win.

[user]
Let's do some real estimates on this. Go through thousands of runs and figure out exactly how much and how often these would apply. How much of it is warm case versus cold case, et cetera.  Give me some hard numbers.

[assistant]
I’ll measure this from GitHub Actions data rather than extrapolating from a few runs. I’m going to pull a large recent CI sample, then compute repeat-SHA/cache-hit eligibility, current `build-artifacts` timing, post-artifact check timing, and cold/warm proportions.

The run-list query is taking a while at the 2,000-run limit. I’m letting it finish because that gives us the frequency numbers; after that I’ll only fetch detailed job records for runs that actually have a `build-artifacts` job.

The detailed job fetch is still running; it has to call GitHub once per completed run. This is the part that turns the estimate into hard counts: which runs had `build-artifacts`, how many were repeat SHAs, and how long the current job actually spent before and after artifact upload.

We’re at 600 detailed runs with no fetch failures. I’m continuing to the full 1,992 completed-run sample because repeat-SHA frequency is exactly the thing that can be distorted by a small sample.

The 2,000-run sample covers about 28.5 hours of CI history, with 1,461 completed runs that actually had a `build-artifacts` job. I’m now fetching step-level records for those build jobs so we can separate “build time”, “artifact-ready time”, and “consumer-check time” instead of using total job duration only.

I pulled a larger sample from live GitHub Actions.

Data window: latest **2,000 CI runs**, from `[REDACTED_PHONE]:07Z` to `[REDACTED_PHONE]:38Z`.

Usable data:
- **1,989** completed run records fetched.
- **1,454** runs had a non-skipped `build-artifacts` job.
- **896** `build-artifacts` jobs had step-level timing before I hit the GitHub API rate limit.

**Current Timing**
For `build-artifacts` today:

| Metric | Median | p75 | p90 |
|---|---:|---:|---:|
| Whole `build-artifacts` job | **195s** | 223s | 263s |
| `Build dist` step | **102s** | 119s | 141s |
| Time until artifacts uploaded | **131s** | 153s | 185s |
| Time after artifacts upload | **59s** | 64s | 69s |
| `Run built artifact checks` step | **48s** | 54s | 58s |

So cold case today is roughly:

`build/setup + dist build + upload + smokes/checks = ~3m15s median`

**Warm-Cache Frequency**
Exact-SHA repeats are rare.

Out of **1,454** build-artifact runs:

| Warm eligibility definition | Count | Rate |
|---|---:|---:|
| Same SHA had any prior `build-artifacts` run | **25** | **1.72%** |
| Same SHA had prior successful `build-artifacts` run | **14** | **0.96%** |

By event:

| Event | Runs | Repeat any prior | Prior success |
|---|---:|---:|---:|
| PR | 1,176 | 13 / **1.1%** | 4 / **0.34%** |
| Push | 235 | 0 / **0%** | 0 / **0%** |
| Manual dispatch | 43 | 12 / **27.9%** | 10 / **23.3%** |

So the cache-hit benefit mostly applies to **manual reruns/dispatches**, not normal PR CI.

**Expected Benefit**
Warm case:

- Skip `Build dist`: median saving roughly **102s**.
- In repeat-prior-success runs where I had step data, skipped build was median **121s**.
- Aggregate observed opportunity: about **14-25 warm-eligible runs per 1,454**, or roughly **12-21 runs/day** in this high-volume sample.
- Total build time saved across the whole sample is probably only around **25-45 minutes/day** of runner time.

Cold case:

- No build skip.
- Producer job ends earlier because it stops after artifact upload: saves about **59s** from `build-artifacts`.
- But downstream matrix jobs add checkout/setup/download/unpack overhead.
- Existing `Run built artifact checks` already took only **48s median**, and it already parallelized internally.
- Expected complete built-artifact surface is likely **flat to +~10-30s slower** cold, depending on runner queue/setup.

**Critical Path**
`build-artifacts` was the last/tied-last job in:

- **480 / 1,454** build-artifact runs = **33.0%**
- **423 / 1,135** successful `build-artifacts` runs = **37.3%**
- **191 / 489** fully successful workflow runs = **39.1%**

So changing this job can matter to wall-clock CI, but the cold split only helps if downstream fanout setup is cheap enough. The measured data does not prove a cold-speed win.

**Bottom Line**
Hard-number read: **Goal A alone is low-risk but limited upside** because exact-SHA warm hits are under **2%** overall and under **0.5%** for PRs with prior success.

**Goal B, the fanout split, is not a clear latency win cold.** It improves attribution and makes the producer artifact available about **1 minute earlier**, but complete built-artifact validation is probably flat or slightly slower on first runs.

If the purpose is CI speed, I would be cautious about the split. If the purpose is debuggability plus making reruns/manual dispatches cheaper, the current direction is defensible.

[user]
was there already a pr for this?

[assistant]
I’ll re-check live PR search specifically for this optimization shape, not just the earlier broad duplicate search, so the answer is current.

No exact PR for this.

I rechecked live PR search for:
- `dist build cache restore build-artifacts`
- `built-artifact-checks build-artifacts`
- `build:ci-artifacts cache miss`

No matching open PR showed up. One unrelated PR appeared for the broad `build:ci-artifacts cache miss` query, but it is not CI dist-cache/fanout work.

The only related PR I found earlier is `#81957`, but it is not “already this.” It changes the same CI area for supply-chain/cache hardening and would cause a mechanical conflict, but it does not restore the dist cache before build, skip `pnpm build:ci-artifacts` on hit, or split built-artifact checks into a fanout job.

https://github.com/openclaw/openclaw/pull/81957

[user]
You haven't opened a new PR?

[assistant]
Correct. I have **not** opened a new PR.

Current state is still just a dirty local branch:

- Branch: `codex/ci-dist-cache-split-built-artifacts`
- Changed files: `.github/workflows/ci.yml`, `test/scripts/ci-workflow-guards.test.ts`
- No commit
- No push
- No PR

I stopped at “ready for Dallin review” per your original instruction.

[user]
mmm  Let's stop and talk about this for a while. Based on your findings is there a much better approach that we could use to really make CI a lot faster More efficient?  It seems like this approach might not be the best but maybe there's another one we could look at.

[assistant]
Yes. Based on the numbers, this branch is probably optimizing the wrong bottleneck.

The current patch mainly helps exact-SHA reruns, but those are rare: **~1.7%** of `build-artifacts` runs, and only **~1%** had a prior successful build. For normal PR CI, warm hits were basically noise. Cold-case fanout is also not obviously faster because the old job already parallelized the expensive checks inside one runner.

A better direction would be to reduce cold-path work and avoid running expensive lanes when they are not needed.

**Better Targets**
1. **Make `build-artifacts` run less often**
   This is probably the biggest lever. In the sample, `build-artifacts` ran in **1,454 / 1,989 completed CI runs**. If path scope is too broad, tightening `run_build_artifacts` could save the whole median **195s** job, not just the **102s** build step.

2. **Fix why `build-artifacts` is often last**
   It was last/tied-last in about **33%** of sampled runs. But the median job is only **195s**, so this may be a scheduling/dependency issue rather than just build time. The right analysis is: for runs where it is last, what earlier gate caused it to start late, and which steps inside actually dominate?

3. **Move only cheap always-on smokes out, not all checks**
   The current full fanout adds too much job overhead. A smaller split might be better:
   - keep `channels/core-support/gateway-watch` in one job or current shell parallelism
   - move only startup memory or launcher smoke if they block artifact publishing or failure clarity
   But measured `smokeAndStartup` is only **~4s median**, so this is mostly not worth it for speed.

4. **Cache at a broader-but-safe key**
   Exact-SHA cache is safe but rarely reused. A content-addressed key over inputs to `build:ci-artifacts` might hit across reruns and sibling PR updates more often:
   - lockfile/package files
   - build scripts/config
   - source paths that feed dist
   - bundled plugin host assets
   This is harder because incorrect reuse would be bad, but it is the only cache shape likely to matter often.

5. **Make `build:ci-artifacts` itself faster**
   Median `Build dist` is **102s**, p90 **141s**. Cutting that by 30-50% helps every cold run, not just the 1-2% warm runs. Need profiling: which sub-build dominates, whether tsdown/runtime/plugin host bundles are serial, and whether outputs are rebuilt unnecessarily.

6. **Use prior artifacts for reruns instead of Actions cache**
   If the goal is rerun speed, artifacts may be a better primitive than cache. On `workflow_dispatch` or rerun, look up a prior successful run for the same SHA and download `dist-runtime-build` directly. That targets the actual warm population: manual reruns/dispatches. But it does not help normal PR cold runs.

My recommendation: pause this branch as-is. Keep Goal A maybe, drop or defer Goal B, and do a focused CI timing investigation around `run_build_artifacts` scope and `build:ci-artifacts` internals. The best likely PR is either “run build-artifacts less often” or “make cold build-artifacts cheaper,” not “fan out consumers after the same cold build.”

[user]
Goals A and B again.

[assistant]
Goal A: make the existing dist build cache actually useful.

Current behavior:
- `build-artifacts` runs `pnpm build:ci-artifacts`.
- Then it saves/caches `dist/` and `dist-runtime/`.
- But it does **not** restore that cache before building, so the cache is mostly not used to skip work.

Target behavior:
- Restore the dist cache before `pnpm build:ci-artifacts`.
- Run `pnpm build:ci-artifacts` only on cache miss.
- Save the cache only after a miss.
- Preserve artifact upload and smoke coverage.

Real benefit:
- Same-SHA reruns/manual dispatches can skip the ~**102s median** dist build.
- But measured exact-SHA reuse is rare overall: about **1.7%** of build-artifact runs, mostly manual dispatches.

Goal B: split built-artifact consumers out of the monolithic `build-artifacts` job if safe.

Current behavior:
- `build-artifacts` builds dist, uploads artifacts, then also runs launcher smokes, startup memory, channels, core-support-boundary, and gateway-watch.
- This makes `build-artifacts` a large producer+consumer job and often the last CI job.

Target behavior:
- `build-artifacts` produces and uploads built artifacts.
- A downstream `built-artifact-checks` matrix downloads those artifacts and runs the consumer checks separately.
- Keep per-check preflight gates and artifacts.

Real benefit:
- Cleaner failure attribution.
- Producer job finishes around artifact upload time, about **59s median** earlier.
- Potentially better rerun targeting.

Trade-off:
- Cold first runs likely do **not** get much faster and may get slower due to extra job checkout/setup/download overhead.
- More CI jobs and noisier UI.
- More aggregate runner minutes.

Based on measurements: Goal A is small but coherent. Goal B is the questionable one for speed.

[user]
and goal A is what we just did?

[assistant]
Yes. Goal A is already implemented in the local dirty patch.

In `.github/workflows/ci.yml`, `build-artifacts` now does:

1. `Restore dist build cache`
   - `actions/cache/restore@v5`
   - paths: `dist/`, `dist-runtime/`, bundled plugin host bundle files

2. `Build dist`
   - only if `steps.dist_build_cache.outputs.cache-hit != 'true'`

3. `Save dist build cache`
   - `actions/cache/save@v5`
   - only if cache miss
   - uses `steps.dist_build_cache.outputs.cache-primary-key`

Then it still packs/uploads `dist-runtime-build` and bundled plugin assets.

The guard test for that is also added in `test/scripts/ci-workflow-guards.test.ts`.

[user]
I estimate the actual impact, the actual benefit of delay again, in time or seconds or reliability or whatever.

[assistant]
For **Goal A only**: the measured benefit is real but narrow.

From the 2,000-run sample:

- `build-artifacts` ran in **1,454** completed CI runs.
- Exact-SHA repeat runs: **25 / 1,454 = 1.72%**
- Exact-SHA repeat after a prior successful `build-artifacts`: **14 / 1,454 = 0.96%**
- Median `Build dist` time: **102s**
- p75 `Build dist` time: **119s**
- p90 `Build dist` time: **141s**

So expected average savings across all `build-artifacts` runs is roughly:

- optimistic repeat-any basis: `1.72% * 102s = ~1.8s average saved per build-artifacts run`
- stricter prior-success basis: `0.96% * 102s = ~1.0s average saved per build-artifacts run`

That means Goal A is **not a meaningful average CI speedup**.

Where it helps:

- Manual dispatch/retry paths: **10 / 43 workflow_dispatch runs = 23.3%** had a prior successful same-SHA run.
- For those, expected savings is around **2 minutes** per hit.
- In the repeated prior-success subset where step timing was available, median skipped build was **121s**.

So practical benefit:

| Case | Frequency | Expected benefit |
|---|---:|---:|
| Normal PR CI | Very low, prior-success repeat **0.34%** | basically negligible |
| Push CI | **0%** in sample | none |
| Manual dispatch/rerun | prior-success repeat **23.3%** | about **2 minutes saved** when it hits |
| Overall average | **~1% successful warm-hit rate** | about **1 second/run** average |

Reliability impact:

- Slightly more moving parts: cache restore before build and cache save after miss.
- Conservative key is exact checkout SHA, so stale-cache risk is low.
- `save` is `continue-on-error: true`, so cache upload failures should not fail CI.
- Restore/cache corruption risk is still nonzero: if a cache hit produces incomplete `dist/`, build is skipped and downstream artifact checks catch it later. The exact-SHA key keeps this unlikely.

My read: **Goal A is safe-ish but low leverage**. It is worth doing only if we care about manual rerun quality and do not mind extra workflow complexity. It will not materially speed up ordinary PR CI.

[user]
ok but goal A never causes NEGATIVE right? only helps in the case of rerun?

[assistant]
Mostly yes, but not literally zero negative.

**Goal A upside**
- On exact-SHA cache hit, it skips `pnpm build:ci-artifacts`, saving roughly **~100-120s median**.
- On cache miss, behavior is intended to be the same build plus cache save.

**Goal A possible negatives**
- Every cold run adds a cache restore step before build. Usually this is small, but it is still extra network/cache service work.
- Cache hit correctness becomes part of the contract. If the restored cache is incomplete or bad, the build is skipped and failures move to pack/upload/smoke/downstream checks.
- The cache path now includes bundled plugin bundle files too, so the cache is a bit broader than before.
- If `actions/cache/restore` has an outage or latency, cold runs can be delayed or fail before the build. `save` is `continue-on-error`, but `restore` currently is not.
- Slight workflow complexity and another failure mode.

So the honest version is:

For normal healthy GitHub cache behavior, Goal A is near all-upside: cold runs pay only a small restore overhead, warm reruns save ~2 minutes.

But it can be negative if cache restore is slow/flaky or if a cache hit is corrupt/incomplete. To reduce that, we could add `continue-on-error: true` to restore and maybe a cheap post-restore verification before skipping build.

[user]
Where does this cache live? Is this part of the GitHub cache? I think we're probably saturated on cache stuff unless it's like a memcache.

[assistant]
Yes, this is **GitHub Actions cache**, not memcache or runner-local.

Goal A uses:

```yaml
uses: actions/cache/restore@v5
uses: actions/cache/save@v5
```

So the cache lives in GitHub’s Actions cache service for the repo/branch scope, subject to GitHub cache quota and eviction. It is not Blacksmith-local RAM/disk, and it is not a persistent per-runner cache.

That means your saturation concern is valid.

Current key shape in the patch:

```yaml
key: ${{ runner.os }}-dist-build-${{ needs.preflight.outputs.checkout_revision }}
```

So every unique checkout SHA creates a distinct cache entry. Since exact-SHA repeats are rare, this can easily become mostly write-only cache churn:

- many cold runs save a new dist cache,
- very few later runs use that exact SHA,
- cache quota pressure/eviction increases,
- restore checks still hit GitHub’s cache service.

Given the measured warm-hit rate, Goal A may be questionable if the repo is already cache-saturated. It saves ~2 minutes on rare same-SHA reruns, but likely writes a lot of cache entries that never get read.

[user]
Well how about you look into cache saturation and keep in mind that we do like 50,000 GitHub actions a day?

[assistant]
I’ll check the repo’s actual Actions cache usage first, then compare that with the write pattern Goal A would introduce. Since the earlier timing scrape hit the GitHub API rate limit, I’ll start with rate/cache endpoints and keep the queries narrow.

The repo is already over the usual 10GB-scale Actions cache budget: GitHub reports **171 active caches totaling 12.03GB** right now. I’m grouping the active cache keys by prefix next, so we can see whether a per-SHA dist cache would compete with large BuildKit/pnpm/macOS caches.

Yes, cache saturation makes Goal A look less attractive, but there is an important nuance: **the repo is already writing this dist cache today**.

Current repo cache state from GitHub:

- GitHub reports **171 active caches**, **12.03GB** active usage.
- Listing active caches returned **190 entries**, about **10.0GB** visible in that page set.
- GitHub’s default repository cache limit is **10GB**; once over limit, GitHub saves new caches and evicts least-recently-used entries, which can cause cache thrashing. ([docs.github.com](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows?_bhlid=6f7d2bb60e230b6c2f8cb792d804678958c0bde8&utm_source=openai))
- GitHub also documents dependency cache service limits: **200 cache uploads/minute** and **1500 downloads/minute** per repository. ([docs.github.com](https://docs.github.com/en/actions/reference/limits?utm_source=openai))

Current active cache composition:

| Cache group | Count | Size |
|---|---:|---:|
| BuildKit blobs | 165 | **5.20GB** |
| pnpm store | 2 | **1.98GB** |
| macOS Swift build | 1 | **0.97GB** |
| setup-java Gradle | 1 | **0.83GB** |
| SwiftPM | 1 | **0.69GB** |
| Android SDK | 1 | **0.25GB** |
| `dist-build` | 3 | **65MB total** |
| `build-all` | 2 | **5.8MB** |
| extension boundary | 2 | **12MB** |

The dist cache is small per entry: current `Linux-dist-build-<sha>` entries are about **21.7MB** each. But the hit rate is awful.

From the timing sample:
- `build-artifacts` ran about **1,454 times in 28.5 hours**, roughly **1,225/day**.
- At **~21.7MB** per exact-SHA dist cache, that is roughly **26GB/day** of dist-cache writes.
- Only **3 dist-build entries** are active right now, totaling **65MB**, which strongly suggests they are quickly evicted or just not retained long under cache churn.
- Exact-SHA useful reuse was only **~1.7%**, and prior-success reuse was **~1.0%**.

So if we were adding a new per-SHA cache from scratch, I’d say: **don’t do it**. It would be mostly write-only cache churn.

But Goal A is not quite that. The current workflow already has:

```yaml
- name: Cache dist build
  uses: actions/cache@v5
```

after `Build dist`. That means it is already creating per-SHA dist cache entries, but too late to help the build. Goal A changes that existing cache from “mostly useless write churn” into “occasionally useful on exact-SHA reruns.”

So the decision is:

- **Goal A compared to current state:** modest improvement, because the cache already exists and already churns.
- **Goal A compared to deleting the dist cache entirely:** worse, because the exact-SHA hit rate is too low to justify the write pressure.

Given the repo is already cache-saturated and you’re doing huge Actions volume, the better move may be:

1. Either **keep Goal A** only because it makes an existing cache less pointless.
2. Or better: **delete the exact-SHA dist cache entirely** unless manual rerun speed matters.
3. If we want a serious cache win, design a content-addressed dist cache with a much higher hit rate, or avoid GitHub Actions cache and use artifacts/prior-run lookup for manual reruns.

My recommendation after looking at saturation: **do not expand this cache.** If we keep Goal A, keep it strictly as a rearrangement of the existing cache, with no broader paths and no fanout. The current patch adds bundled plugin bundle files to the cache path; I would probably remove that addition to avoid growing the cache footprint.

[user]
ohhhh Add a cache and only improve the usage of the cache then let's go ahead and open a PR with this goal: a fix.

[assistant]
I’ll narrow the branch to Goal A only: restore the existing dist cache before build, skip `build:ci-artifacts` on hit, save only on miss. I’ll remove the fanout split and keep the PR focused on fixing the existing cache usage.

I’m going to keep the bundle files in the cache path because skipping the build still has to preserve the bundled plugin asset upload. The PR will not split jobs or add a broader CI graph; it will only make the existing dist cache restoreable and safe to skip the build on exact-SHA hits.

I’m editing the workflow now to remove the `built-artifact-checks` matrix entirely and put the original smoke/startup/check steps back inside `build-artifacts`. The only remaining workflow behavior change will be cache restore/build-on-miss/save-on-miss.

The diff is now Goal A only: no new jobs, no fanout, no change to built-artifact smokes/check placement. I’m running the narrow guard and workflow validation before committing.

The narrow proof is green: guard test, YAML parse, workflow sanity, and `git diff --check`. Before I commit/open the PR, I’ll run the repo’s required local autoreview pass for pre-PR code changes.

Autoreview is running on the narrowed local patch. While it runs, I’m going to avoid changing files so the review stays against a stable diff.

Autoreview found a real issue: `actions/cache/save` was happening before the later smoke/check steps, which could persist bad build output if a later validation failed. I’m moving the save to after the built-artifact validation step so only validated outputs are cached.

The guard now asserts the important ordering: restore before build, build before packaging, and cache save only after `Run built artifact checks`. I’m rerunning the focused proof and autoreview.

The second autoreview is clean. I’m committing just the two intended files, then rebasing onto current `origin/main` before pushing the branch and creating the PR.

Rebase hit expected conflicts in the workflow and guard test because `origin/main` has moved a lot. I’m resolving them by applying the same Goal A-only shape on top of current main.

The rebase conflict resolution left the guard test syntactically incomplete. I’m fixing that now before continuing the rebase.

Rebase is complete on current `origin/main`; current main had added a `build-all` step cache, and I preserved it alongside the dist restore. I’m rerunning the focused checks on the rebased commit.

The focused Vitest proof is still green. The broad workflow wrapper now fails on current main while installing `zizmor==1.22.0` under an older pre-commit Python environment, before it reaches this patch; I’m going to run direct workflow/YAML checks that cover this change and record that wrapper blocker.

The branch is clean, rebased, and one commit ahead of `origin/main`. I’m pushing it to `origin/codex/ci-dist-cache-split-built-artifacts` and then I’ll create the PR body with the measured cache caveat.

I found local session candidates for an agent transcript, but I’m not adding transcript logs to this PR body so the PR creation doesn’t block on preview/approval. I’m drafting the normal PR body now with the measured scope and proof.

[user]
add the transcript

[assistant]
I’ll add it. First I’m checking whether the PR creation call already completed; if it did, I’ll render and append the sanitized transcript section to the PR body.

[tool summary]
69 read, 2 write, 133 execute; raw tool outputs dropped: 203
````

</details>
<!-- agent-transcript:end -->

