### PR TITLE
fix(agent-core): validate harness tool names

### DIFF
--- a/packages/agent-core/src/harness/agent-harness.test.ts
+++ b/packages/agent-core/src/harness/agent-harness.test.ts
@@ -1,0 +1,113 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import type { Model } from "../../../llm-core/src/index.js";
+import type { AgentTool } from "../types.js";
+import { AgentHarness } from "./agent-harness.js";
+import { InMemorySessionRepo } from "./session/memory-repo.js";
+import { AgentHarnessError, type ExecutionEnv, type Session } from "./types.js";
+
+function createEnv(): ExecutionEnv {
+  return { cwd: "/workspace" } as ExecutionEnv;
+}
+
+function createModel(): Model {
+  return {
+    provider: "test-provider",
+    id: "test-model",
+    api: "openai-responses",
+  } as Model;
+}
+
+function createTool(name: string): AgentTool {
+  return {
+    name,
+    label: name,
+    description: "Test tool.",
+    parameters: Type.Object({}),
+    async execute() {
+      return { content: [{ type: "text", text: "ok" }], details: undefined };
+    },
+  };
+}
+
+async function createSession(): Promise<Session> {
+  return new InMemorySessionRepo().create({ id: "session-1" });
+}
+
+async function createHarness(tools: AgentTool[]): Promise<AgentHarness> {
+  return new AgentHarness({
+    env: createEnv(),
+    session: await createSession(),
+    model: createModel(),
+    tools,
+  });
+}
+
+describe("AgentHarness tool registration", () => {
+  it("rejects tool definitions with non-string names", async () => {
+    const create = createHarness([
+      {
+        ...createTool("valid"),
+        name: 42,
+      } as never,
+    ]);
+
+    await expect(create).rejects.toThrow("Agent tool name must be a non-empty string");
+    await expect(create).rejects.toMatchObject({
+      code: "invalid_argument",
+    } satisfies Partial<AgentHarnessError>);
+  });
+
+  it("wraps unreadable tool name accessors with a harness error", async () => {
+    const create = createHarness([
+      {
+        ...createTool("valid"),
+        get name(): never {
+          throw new Error("tool name getter exploded");
+        },
+      },
+    ]);
+
+    await expect(create).rejects.toThrow("Agent tool name must be readable");
+    await expect(create).rejects.toMatchObject({
+      code: "invalid_argument",
+    } satisfies Partial<AgentHarnessError>);
+  });
+
+  it("reads constructor tool names once while building the registry", async () => {
+    let reads = 0;
+    const tool: AgentTool = {
+      ...createTool("valid"),
+      get name(): string {
+        reads += 1;
+        if (reads > 1) {
+          throw new Error("tool name read twice");
+        }
+        return "single_read";
+      },
+    };
+
+    await expect(createHarness([tool])).resolves.toBeInstanceOf(AgentHarness);
+    expect(reads).toBe(1);
+  });
+
+  it("rejects malformed replacement tool names without changing the harness", async () => {
+    const harness = await createHarness([createTool("valid")]);
+
+    await expect(
+      harness.setTools([
+        {
+          ...createTool("bad"),
+          name: 42,
+        } as never,
+      ]),
+    ).rejects.toMatchObject({
+      code: "invalid_argument",
+      message: "Agent tool name must be a non-empty string",
+    } satisfies Partial<AgentHarnessError>);
+
+    await expect(harness.setTools([createTool("replacement")], ["replacement"])).resolves.toBe(
+      undefined,
+    );
+  });
+});

--- a/packages/agent-core/src/harness/agent-harness.ts
+++ b/packages/agent-core/src/harness/agent-harness.ts
@@ -191,6 +191,39 @@ function normalizeHarnessError(
   return new AgentHarnessError(fallbackCode, cause.message, cause);
 }
 
+function readHarnessToolName(tool: unknown): string {
+  if (!tool || typeof tool !== "object") {
+    throw new AgentHarnessError("invalid_argument", "Agent tool definition must be an object");
+  }
+  let name: unknown;
+  try {
+    name = Reflect.get(tool, "name");
+  } catch (cause) {
+    throw new AgentHarnessError(
+      "invalid_argument",
+      "Agent tool name must be readable",
+      toError(cause),
+    );
+  }
+  if (typeof name !== "string" || !name.trim()) {
+    throw new AgentHarnessError("invalid_argument", "Agent tool name must be a non-empty string");
+  }
+  return name;
+}
+
+function createToolRegistry<TTool extends AgentTool>(
+  tools: readonly TTool[],
+): { map: Map<string, TTool>; names: string[] } {
+  const map = new Map<string, TTool>();
+  const names: string[] = [];
+  for (const tool of tools) {
+    const name = readHarnessToolName(tool);
+    map.set(name, tool);
+    names.push(name);
+  }
+  return { map, names };
+}
+
 function normalizeHookError(error: unknown): AgentHarnessError {
   return normalizeHarnessError(error, "hook");
 }
@@ -247,13 +280,12 @@ export class CoreAgentHarness<
     this.systemPrompt = options.systemPrompt;
     this.getApiKeyAndHeaders = options.getApiKeyAndHeaders;
     this.runtime = options.runtime;
-    for (const tool of options.tools ?? []) {
-      this.tools.set(tool.name, tool);
-    }
+    const tools = options.tools ?? [];
+    const toolRegistry = createToolRegistry(tools);
+    this.tools = toolRegistry.map;
     this.model = options.model;
     this.thinkingLevel = options.thinkingLevel ?? "off";
-    this.activeToolNames =
-      options.activeToolNames ?? (options.tools ?? []).map((tool) => tool.name);
+    this.activeToolNames = options.activeToolNames ?? toolRegistry.names;
     this.steeringQueueMode = options.steeringMode ?? "one-at-a-time";
     this.followUpQueueMode = options.followUpMode ?? "one-at-a-time";
   }
@@ -1116,7 +1148,7 @@ export class CoreAgentHarness<
 
   async setTools(tools: TTool[], activeToolNames?: string[]): Promise<void> {
     try {
-      const nextTools = new Map(tools.map((tool) => [tool.name, tool]));
+      const nextTools = createToolRegistry(tools).map;
       const nextActiveToolNames = activeToolNames ? [...activeToolNames] : this.activeToolNames;
       this.validateToolNames(nextActiveToolNames, nextTools);
       this.tools = nextTools;


### PR DESCRIPTION
## Summary
- Validate AgentHarness tool names before constructor registration and `setTools()` replacement.
- Convert malformed/non-string/empty names and unreadable name accessors into `AgentHarnessError("invalid_argument", ...)`.
- Build the constructor tool map and active-name snapshot from one guarded name read per tool, with regression coverage for hostile changing getters.
- Add regression coverage proving failed replacement registration does not mutate the existing harness tool set.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-agent-core-harness-89171 node scripts/run-vitest.mjs run packages/agent-core/src/harness/agent-harness.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `./node_modules/.bin/oxfmt --check --threads=1 packages/agent-core/src/harness/agent-harness.ts packages/agent-core/src/harness/agent-harness.test.ts`
- `node scripts/run-oxlint.mjs packages/agent-core/src/harness/agent-harness.ts packages/agent-core/src/harness/agent-harness.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: local Blacksmith CLI is not authenticated.

## Real behavior proof
Behavior addressed: `AgentHarness` no longer accepts malformed tool names or leaks raw name-accessor errors while registering constructor tools or replacing tools with `setTools()`.

Real environment tested: local focused agent-core harness tests on this branch in a linked Codex worktree. Broad Testbox/Crabbox proof was not available because Blacksmith auth is missing in this environment.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run packages/agent-core/src/harness/agent-harness.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`; `./node_modules/.bin/oxfmt --check --threads=1 packages/agent-core/src/harness/agent-harness.ts packages/agent-core/src/harness/agent-harness.test.ts`; `node scripts/run-oxlint.mjs packages/agent-core/src/harness/agent-harness.ts packages/agent-core/src/harness/agent-harness.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: focused Vitest passed 4 tests; targeted formatter/lint/diff checks passed; branch autoreview reported no accepted/actionable findings with `overall: patch is correct (0.86)`; final head is `5e710a2ac3a49a1bd900d382cb156f5bae2a92e3`.

Observed result after fix: malformed harness tool names fail closed with `AgentHarnessError` before active tool state is poisoned, unreadable name accessors are wrapped in stable harness errors, and constructor registration reads each tool name once while preserving the active-name snapshot.

What was not tested: a full live assistant turn with a deliberately malformed app-supplied `AgentTool`, and broad `pnpm check:changed`/Testbox proof because Blacksmith auth is unavailable here.
