### PR TITLE
fix(browser): honor tab timeout for Chrome MCP

### DIFF
--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
 
@@ -112,9 +113,17 @@ function baseProfileContext() {
   };
 }
 
-function createRouteContext(profileCtx: ProfileContext, options?: { ssrfPolicy?: unknown }) {
+function createRouteContext(
+  profileCtx: ProfileContext,
+  options?: { actionTimeoutMs?: number; ssrfPolicy?: unknown },
+) {
   return {
-    state: () => ({ resolved: { ssrfPolicy: options?.ssrfPolicy } }),
+    state: () => ({
+      resolved: {
+        actionTimeoutMs: options?.actionTimeoutMs ?? 45_000,
+        ssrfPolicy: options?.ssrfPolicy,
+      },
+    }),
     forProfile: () => profileCtx,
     listProfiles: vi.fn(async () => []),
     mapTabError: vi.fn((err: unknown) => {
@@ -143,31 +152,51 @@ async function callTabsRoute(params: {
   path: "/tabs" | "/tabs/action" | "/tabs/focus";
   body?: Record<string, unknown>;
   profileCtx: ProfileContext;
+  actionTimeoutMs?: number;
+  signal?: AbortSignal;
   ssrfPolicy?: unknown;
 }) {
   const { app, getHandlers, postHandlers } = createBrowserRouteApp();
   registerBrowserTabRoutes(
     app,
-    createRouteContext(params.profileCtx, { ssrfPolicy: params.ssrfPolicy }) as never,
+    createRouteContext(params.profileCtx, {
+      actionTimeoutMs: params.actionTimeoutMs,
+      ssrfPolicy: params.ssrfPolicy,
+    }) as never,
   );
   const handler =
     params.method === "get" ? getHandlers.get(params.path) : postHandlers.get(params.path);
   expect(handler).toBeTypeOf("function");
 
   const response = createBrowserRouteResponse();
-  await handler?.({ params: {}, query: {}, body: params.body ?? {} }, response.res);
+  await handler?.(
+    {
+      params: {},
+      query: {},
+      body: params.body ?? {},
+      ...(params.signal ? { signal: params.signal } : {}),
+    },
+    response.res,
+  );
   return response;
 }
 
 async function callTabsAction(params: {
   body: Record<string, unknown>;
   profileCtx: ProfileContext;
+  actionTimeoutMs?: number;
+  signal?: AbortSignal;
   ssrfPolicy?: unknown;
 }) {
   return await callTabsRoute({ ...params, method: "post", path: "/tabs/action" });
 }
 
-async function callTabsList(params: { profileCtx: ProfileContext; ssrfPolicy?: unknown }) {
+async function callTabsList(params: {
+  profileCtx: ProfileContext;
+  actionTimeoutMs?: number;
+  signal?: AbortSignal;
+  ssrfPolicy?: unknown;
+}) {
   return await callTabsRoute({ ...params, method: "get", path: "/tabs" });
 }
 
@@ -195,6 +224,62 @@ describe("browser tab routes", () => {
 
   it("returns browser-not-running for select when the browser is not reachable", async () => {
     await expectBrowserNotRunningAction("select");
+  });
+
+  it("uses the configured action timeout for existing-session tab reachability", async () => {
+    const isReachable = vi.fn(async () => true);
+    const abort = new AbortController();
+    const profileCtx = createProfileContext({
+      profile: {
+        ...baseProfileContext().profile,
+        driver: "existing-session",
+      } as never,
+      isReachable,
+    });
+
+    const listResponse = await callTabsList({ profileCtx, signal: abort.signal });
+    const actionResponse = await callTabsAction({
+      profileCtx,
+      body: { action: "list" },
+      signal: abort.signal,
+    });
+
+    expect(listResponse.statusCode).toBe(200);
+    expect(actionResponse.statusCode).toBe(200);
+    expect(isReachable).toHaveBeenNthCalledWith(1, 45_000, { signal: abort.signal });
+    expect(isReachable).toHaveBeenNthCalledWith(2, 45_000, { signal: abort.signal });
+  });
+
+  it("keeps the short reachability probe for non-Chrome-MCP tab routes", async () => {
+    const isReachable = vi.fn(async () => true);
+    const profileCtx = createProfileContext({ isReachable });
+
+    const response = await callTabsList({ profileCtx });
+
+    expect(response.statusCode).toBe(200);
+    expect(isReachable).toHaveBeenCalledWith(300);
+  });
+
+  it("normalizes configured existing-session tab reachability timeouts", async () => {
+    const isReachable = vi.fn(async () => true);
+    const profileCtx = createProfileContext({
+      profile: {
+        ...baseProfileContext().profile,
+        driver: "existing-session",
+      } as never,
+      isReachable,
+    });
+
+    const zeroResponse = await callTabsList({ profileCtx, actionTimeoutMs: 0 });
+    expect(zeroResponse.statusCode).toBe(200);
+    expect(isReachable).toHaveBeenLastCalledWith(300);
+
+    const hugeResponse = await callTabsList({
+      profileCtx,
+      actionTimeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+    expect(hugeResponse.statusCode).toBe(200);
+    expect(isReachable).toHaveBeenLastCalledWith(MAX_TIMER_TIMEOUT_MS);
   });
 
   it("redacts blocked tab URLs from GET /tabs", async () => {

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -1,3 +1,4 @@
+import { clampPositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   BrowserProfileUnavailableError,
   BrowserTabNotFoundError,
@@ -8,12 +9,15 @@ import {
   assertBrowserNavigationResultAllowed,
   withBrowserNavigationPolicy,
 } from "../navigation-guard.js";
+import { getBrowserProfileCapabilities } from "../profile-capabilities.js";
 import type { BrowserRouteContext, ProfileContext } from "../server-context.js";
 import { resolveTargetIdFromTabs } from "../target-id.js";
 import { browserNavigationPolicyForProfile, resolveProfileContext } from "./agent.shared.js";
 import { readRouteNonNegativeInteger } from "./route-numeric.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
 import { asyncBrowserRoute, jsonError, toStringOrEmpty } from "./utils.js";
+
+const DEFAULT_TAB_REACHABILITY_TIMEOUT_MS = 300;
 
 function handleTabsRouteError(
   ctx: BrowserRouteContext,
@@ -48,8 +52,37 @@ async function withTabsProfileRoute(params: {
   }
 }
 
-async function ensureBrowserRunning(profileCtx: ProfileContext, res: BrowserResponse) {
-  if (!(await profileCtx.isReachable(300))) {
+function resolveTabReachabilityTimeoutMs(
+  ctx: BrowserRouteContext,
+  profileCtx: ProfileContext,
+): number {
+  if (!getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+    return DEFAULT_TAB_REACHABILITY_TIMEOUT_MS;
+  }
+  return (
+    clampPositiveTimerTimeoutMs(ctx.state().resolved.actionTimeoutMs) ??
+    DEFAULT_TAB_REACHABILITY_TIMEOUT_MS
+  );
+}
+
+async function checkTabReachability(
+  ctx: BrowserRouteContext,
+  profileCtx: ProfileContext,
+  signal?: AbortSignal,
+) {
+  const timeoutMs = resolveTabReachabilityTimeoutMs(ctx, profileCtx);
+  return signal
+    ? await profileCtx.isReachable(timeoutMs, { signal })
+    : await profileCtx.isReachable(timeoutMs);
+}
+
+async function ensureBrowserRunning(
+  ctx: BrowserRouteContext,
+  profileCtx: ProfileContext,
+  res: BrowserResponse,
+  signal?: AbortSignal,
+) {
+  if (!(await checkTabReachability(ctx, profileCtx, signal))) {
     jsonError(
       res,
       new BrowserProfileUnavailableError("browser not running").status,
@@ -149,7 +182,7 @@ async function runTabTargetMutation(params: {
     ctx: params.ctx,
     mapTabError: true,
     run: async (profileCtx) => {
-      if (!(await ensureBrowserRunning(profileCtx, params.res))) {
+      if (!(await ensureBrowserRunning(params.ctx, profileCtx, params.res, params.req.signal))) {
         return;
       }
       await params.mutate(profileCtx, params.targetId);
@@ -167,7 +200,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
         res,
         ctx,
         run: async (profileCtx) => {
-          const reachable = await profileCtx.isReachable(300);
+          const reachable = await checkTabReachability(ctx, profileCtx, req.signal);
           if (!reachable) {
             return res.json({ running: false, tabs: [] as unknown[] });
           }
@@ -277,7 +310,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
         mapTabError: true,
         run: async (profileCtx) => {
           if (action === "list") {
-            const reachable = await profileCtx.isReachable(300);
+            const reachable = await checkTabReachability(ctx, profileCtx, req.signal);
             if (!reachable) {
               return res.json({ ok: true, tabs: [] as unknown[] });
             }
@@ -297,7 +330,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
           }
 
           if (action === "label") {
-            if (!(await ensureBrowserRunning(profileCtx, res))) {
+            if (!(await ensureBrowserRunning(ctx, profileCtx, res, req.signal))) {
               return;
             }
             const targetId = parseRequiredTargetId(
@@ -316,7 +349,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
           }
 
           if (action === "close") {
-            if (!(await ensureBrowserRunning(profileCtx, res))) {
+            if (!(await ensureBrowserRunning(ctx, profileCtx, res, req.signal))) {
               return;
             }
             const index = readTabIndex(res, req.body);
@@ -337,7 +370,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
             if (index === null || index === undefined) {
               return;
             }
-            if (!(await ensureBrowserRunning(profileCtx, res))) {
+            if (!(await ensureBrowserRunning(ctx, profileCtx, res, req.signal))) {
               return;
             }
             const tabs = await profileCtx.listTabs();


### PR DESCRIPTION
## Summary
- Use the configured browser action timeout for Chrome MCP existing-session tab reachability probes instead of the hardcoded 300ms probe.
- Keep the short 300ms probe for non-Chrome-MCP tab routes.
- Clamp invalid or oversized configured timeouts before passing them to reachability checks.

Fixes #88213.

## Real behavior proof
Behavior addressed: Existing-session Chrome MCP `/tabs` and `/tabs/action` could report timeout even though browser status and doctor showed the profile was reachable.
Real environment tested: Local OpenClaw browser route context with real Chrome MCP client path and a controlled slow Chrome MCP server.
Exact steps or command run after this patch: `TMPDIR=/private/tmp /Users/fallmonkey/Developer/openclaw/node_modules/.bin/tsx /private/tmp/openclaw-88213-proof/prove-88213.ts /private/tmp/openclaw-88213-proof/fake-slow-chrome-mcp.cjs`
Evidence after fix: copied live terminal output from the after-fix run:

```text
STATUS {"statusCode":200,"body":{"enabled":true,"profile":"user","driver":"existing-session","transport":"chrome-mcp","running":true,"cdpReady":true,"cdpHttp":true,"pageReady":true,"pid":null,"cdpPort":null,"cdpUrl":null,"chosenBrowser":null,"detectedBrowser":"chrome","detectedExecutablePath":"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome","detectError":null,"userDataDir":null,"color":"#4285F4","headless":false,"headlessSource":"default","noSandbox":false,"executablePath":null,"attachOnly":true},"elapsedMs":6321}
DOCTOR {"statusCode":200,"body":{"ok":true,"profile":"user","transport":"chrome-mcp","checks":[{"id":"plugin-enabled","label":"Browser plugin","status":"pass","summary":"enabled"},{"id":"profile","label":"Profile","status":"pass","summary":"user via chrome-mcp"},{"id":"attach-target","label":"Existing browser attach","status":"pass","summary":"Chrome MCP target is reachable"}],"status":{"enabled":true,"profile":"user","driver":"existing-session","transport":"chrome-mcp","running":true,"cdpReady":true,"cdpHttp":true,"pageReady":true,"pid":null,"cdpPort":null,"cdpUrl":null,"chosenBrowser":null,"detectedBrowser":"chrome","detectedExecutablePath":"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome","detectError":null,"userDataDir":null,"color":"#4285F4","headless":false,"headlessSource":"default","noSandbox":false,"executablePath":null,"attachOnly":true}},"elapsedMs":6323}
TABS {"statusCode":200,"body":{"running":true,"tabs":[{"targetId":"1","title":"","url":"https://example.com/","type":"page","suggestedTargetId":"t1","tabId":"t1"}]},"elapsedMs":1142}
TABS_ACTION_LIST {"statusCode":200,"body":{"ok":true,"tabs":[{"targetId":"1","title":"","url":"https://example.com/","type":"page","suggestedTargetId":"t1","tabId":"t1"}]},"elapsedMs":8}
```

Observed result after fix: The slow existing-session attach succeeds within the configured action timeout instead of failing at the previous 300ms tab-route probe.
What was not tested: Full browser extension suite, broad changed checks, and autoreview were not run per maintainer instruction.

## Verification
- `git diff --check`
- `PNPM_CONFIG_MODULES_DIR=/Users/fallmonkey/Developer/openclaw/node_modules node scripts/run-vitest.mjs extensions/browser/src/browser/routes/tabs.test.ts`