### PR TITLE
refactor: add SQLite session store foundation

### DIFF
--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -971,6 +971,69 @@ describe("sqlite session normalization", () => {
         storePath: paths.sqlitePath,
       }),
     ).toMatchObject({ sessionId: "legacy-alias-session" });
+    const legacyEntry = loadExactSqliteSessionEntry({
+      agentId: "main",
+      env,
+      sessionKey: legacyKey,
+      storePath: paths.sqlitePath,
+    });
+    expect(legacyEntry).toBeDefined();
+    expect(
+      readSqliteSessionUpdatedAt({
+        agentId: "main",
+        env,
+        sessionKey: canonicalKey,
+        storePath: paths.sqlitePath,
+      }),
+    ).toBe(legacyEntry?.entry.updatedAt);
+
+    await patchSqliteSessionEntry(
+      {
+        agentId: "main",
+        env,
+        sessionKey: canonicalKey,
+        storePath: paths.sqlitePath,
+      },
+      () => ({ model: "gpt-5.5", updatedAt: 20 }),
+    );
+
+    expect(
+      loadExactSqliteSessionEntry({
+        agentId: "main",
+        env,
+        sessionKey: legacyKey,
+        storePath: paths.sqlitePath,
+      }),
+    ).toBeUndefined();
+    const canonicalEntry = loadExactSqliteSessionEntry({
+      agentId: "main",
+      env,
+      sessionKey: canonicalKey,
+      storePath: paths.sqlitePath,
+    });
+    expect(canonicalEntry).toMatchObject({
+      entry: {
+        model: "gpt-5.5",
+        sessionId: "legacy-alias-session",
+        updatedAt: expect.any(Number),
+      },
+      sessionKey: canonicalKey,
+    });
+    expect(
+      readSqliteSessionUpdatedAt({
+        agentId: "main",
+        env,
+        sessionKey: canonicalKey,
+        storePath: paths.sqlitePath,
+      }),
+    ).toBe(canonicalEntry?.entry.updatedAt);
+    expect(
+      listSqliteSessionEntries({
+        agentId: "main",
+        env,
+        storePath: paths.sqlitePath,
+      }).map((summary) => summary.sessionKey),
+    ).toEqual([canonicalKey]);
   });
 
   it("normalizes missing entry updatedAt before writing root and entry rows", async () => {

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -289,6 +289,42 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       expect(loadSqliteTranscriptEventsSync(readScope)).toEqual([event]);
     });
 
+    it("maps canonical sessions.json store paths to the agent SQLite database", async () => {
+      const legacyStorePath = path.join(
+        paths.stateDir,
+        "agents",
+        "main",
+        "sessions",
+        "sessions.json",
+      );
+      const sqlitePath = path.join(
+        paths.stateDir,
+        "agents",
+        "main",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const scope = {
+        agentId: "main",
+        env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+        sessionKey: "agent:main:main",
+        storePath: legacyStorePath,
+      };
+
+      await upsertSqliteSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      });
+
+      expect(loadSqliteSessionEntry({ ...scope, storePath: sqlitePath })).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+      });
+      expect(fs.existsSync(sqlitePath)).toBe(true);
+      expect(fs.existsSync(legacyStorePath)).toBe(false);
+    });
+
     it("conforms for transcript message append, idempotency, and update publication", async () => {
       const scope = adapter.transcriptScope(paths, "session-2");
       const updates: unknown[] = [];

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -37,8 +37,11 @@ import {
 } from "./session-accessor.js";
 import {
   appendSqliteTranscriptEvent,
+  appendSqliteTranscriptEvents,
   appendSqliteTranscriptMessage,
+  branchSqliteCompactionCheckpointSession,
   cleanupSqliteSessionLifecycleArtifacts,
+  deleteSqliteTranscript,
   listSqliteSessionEntries,
   loadExactSqliteSessionEntry,
   loadSqliteSessionEntry,
@@ -48,10 +51,13 @@ import {
   publishSqliteTranscriptUpdate,
   readSqliteSessionUpdatedAt,
   replaceSqliteSessionEntry,
+  replaceSqliteTranscriptEvents,
+  restoreSqliteCompactionCheckpointSession,
+  sqliteTranscriptExists,
   updateSqliteSessionEntry,
   upsertSqliteSessionEntry,
 } from "./session-accessor.sqlite.js";
-import type { SessionEntry } from "./types.js";
+import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
 // Keep accessor conformance independent of any real openclaw.json on the machine.
 vi.mock("../config.js", async () => ({
@@ -1258,5 +1264,289 @@ describe("sqlite session normalization", () => {
       updatedAt: expect.any(Number),
     });
     expect(upsertRow?.updated_at).toBe(upsertEntry.updatedAt);
+  });
+
+  it("replaces, appends, checks, and deletes SQLite transcript rows without filesystem artifacts", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const scope = {
+      agentId: "main",
+      env,
+      sessionId: "transcript-state-session",
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+
+    expect(sqliteTranscriptExists(scope)).toBe(false);
+
+    await replaceSqliteTranscriptEvents(scope, [
+      { type: "session", id: "transcript-state-session", cwd: paths.tempDir },
+      { type: "message", id: "msg-1", parentId: null, message: { content: "one" } },
+    ]);
+    await appendSqliteTranscriptEvents(scope, [
+      { type: "message", id: "msg-2", parentId: "msg-1", message: { content: "two" } },
+    ]);
+
+    expect(sqliteTranscriptExists(scope)).toBe(true);
+    await expect(loadSqliteTranscriptEvents(scope)).resolves.toEqual([
+      { type: "session", id: "transcript-state-session", cwd: paths.tempDir },
+      { type: "message", id: "msg-1", parentId: null, message: { content: "one" } },
+      { type: "message", id: "msg-2", parentId: "msg-1", message: { content: "two" } },
+    ]);
+
+    await expect(deleteSqliteTranscript(scope)).resolves.toBe(true);
+    expect(sqliteTranscriptExists(scope)).toBe(false);
+    await expect(loadSqliteTranscriptEvents(scope)).resolves.toEqual([]);
+    expect(fs.existsSync(paths.sqlitePath)).toBe(true);
+    expect(fs.readdirSync(paths.tempDir)).not.toContain("transcript-state-session.jsonl");
+  });
+
+  it("branches a checkpoint by copying SQLite rows and creating the entry transactionally", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const sourceScope = {
+      agentId: "main",
+      env,
+      sessionId: "source-session",
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    const preCompactionScope = {
+      ...sourceScope,
+      sessionId: "pre-compaction-session",
+    };
+    const sourceEntryScope = {
+      agentId: "main",
+      env,
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    const branchKey = "agent:main:checkpoint-branch";
+    const checkpoint: SessionCompactionCheckpoint = {
+      checkpointId: "checkpoint-branch",
+      sessionKey: sourceEntryScope.sessionKey,
+      sessionId: "source-session",
+      createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+      reason: "manual",
+      tokensBefore: 42,
+      tokensAfter: 84,
+      preCompaction: {
+        sessionId: "pre-compaction-session",
+        leafId: "pre-msg",
+      },
+      postCompaction: {
+        sessionId: "source-session",
+        entryId: "msg-2",
+      },
+    };
+
+    await replaceSqliteTranscriptEvents(preCompactionScope, [
+      { type: "session", id: "pre-compaction-session", cwd: paths.tempDir },
+      { type: "message", id: "pre-msg", parentId: null, message: { content: "pre" } },
+    ]);
+    await replaceSqliteTranscriptEvents(sourceScope, [
+      { type: "session", id: "source-session", cwd: paths.tempDir },
+      { type: "message", id: "post-msg-1", parentId: null, message: { content: "post-one" } },
+      {
+        type: "message",
+        id: "post-msg-2",
+        parentId: "post-msg-1",
+        message: { content: "post-two" },
+      },
+    ]);
+    await upsertSqliteSessionEntry(sourceEntryScope, {
+      label: "Source",
+      sessionId: "source-session",
+      updatedAt: 10,
+      compactionCheckpoints: [checkpoint],
+    });
+
+    const result = await branchSqliteCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      storePath: paths.sqlitePath,
+      sourceKey: sourceEntryScope.sessionKey,
+      nextKey: branchKey,
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (result.status !== "created") {
+      throw new Error(`expected branch creation, got ${result.status}`);
+    }
+
+    const branchScope = {
+      ...sourceScope,
+      sessionId: result.entry.sessionId,
+      sessionKey: branchKey,
+    };
+    expect(loadSqliteSessionEntry({ ...sourceEntryScope, sessionKey: branchKey })).toEqual(
+      result.entry,
+    );
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        label: "Source (checkpoint)",
+        parentSessionKey: sourceEntryScope.sessionKey,
+        sessionFile: expect.stringMatching(/^sqlite:main:/),
+        totalTokens: 42,
+        totalTokensFresh: true,
+      }),
+    );
+    await expect(loadSqliteTranscriptEvents(branchScope)).resolves.toEqual([
+      expect.objectContaining({ type: "session", id: result.entry.sessionId }),
+      expect.objectContaining({ id: "pre-msg", type: "message" }),
+    ]);
+    expect(fs.existsSync(path.join(paths.tempDir, `${result.entry.sessionId}.jsonl`))).toBe(false);
+  });
+
+  it("falls back to post-compaction SQLite rows when no pre-compaction rows exist", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const sourceScope = {
+      agentId: "main",
+      env,
+      sessionId: "source-session",
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    const sourceEntryScope = {
+      agentId: "main",
+      env,
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    const checkpoint: SessionCompactionCheckpoint = {
+      checkpointId: "checkpoint-post-fallback",
+      sessionKey: sourceEntryScope.sessionKey,
+      sessionId: "source-session",
+      createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+      reason: "manual",
+      tokensBefore: 100,
+      tokensAfter: 25,
+      preCompaction: {
+        sessionId: "missing-pre-session",
+        leafId: "missing-pre-msg",
+      },
+      postCompaction: {
+        sessionId: "source-session",
+        entryId: "post-msg",
+      },
+    };
+
+    await replaceSqliteTranscriptEvents(sourceScope, [
+      { type: "session", id: "source-session", cwd: paths.tempDir },
+      { type: "message", id: "post-msg", parentId: null, message: { content: "post" } },
+      { type: "message", id: "skipped-msg", parentId: "post-msg", message: { content: "skip" } },
+    ]);
+    await upsertSqliteSessionEntry(sourceEntryScope, {
+      sessionId: "source-session",
+      updatedAt: 10,
+      compactionCheckpoints: [checkpoint],
+    });
+
+    const result = await branchSqliteCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      storePath: paths.sqlitePath,
+      sourceKey: sourceEntryScope.sessionKey,
+      nextKey: "agent:main:checkpoint-post-fallback",
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (result.status !== "created") {
+      throw new Error(`expected fallback branch creation, got ${result.status}`);
+    }
+
+    await expect(
+      loadSqliteTranscriptEvents({
+        ...sourceScope,
+        sessionId: result.entry.sessionId,
+        sessionKey: "agent:main:checkpoint-post-fallback",
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ type: "session", id: result.entry.sessionId }),
+      expect.objectContaining({ id: "post-msg", type: "message" }),
+    ]);
+    expect(result.entry.totalTokens).toBe(25);
+  });
+
+  it("restores a checkpoint by copying SQLite rows and replacing the entry transactionally", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const sourceScope = {
+      agentId: "main",
+      env,
+      sessionId: "source-session",
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    const preCompactionScope = {
+      ...sourceScope,
+      sessionId: "pre-compaction-session",
+    };
+    const sourceEntryScope = {
+      agentId: "main",
+      env,
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    const checkpoint: SessionCompactionCheckpoint = {
+      checkpointId: "checkpoint-restore",
+      sessionKey: sourceEntryScope.sessionKey,
+      sessionId: "current-session",
+      createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+      reason: "manual",
+      tokensBefore: 12,
+      tokensAfter: 24,
+      preCompaction: {
+        sessionId: "pre-compaction-session",
+        leafId: "pre-msg",
+      },
+      postCompaction: {
+        sessionId: "source-session",
+        entryId: "msg-1",
+      },
+    };
+
+    await replaceSqliteTranscriptEvents(preCompactionScope, [
+      { type: "session", id: "pre-compaction-session", cwd: paths.tempDir },
+      { type: "message", id: "pre-msg", parentId: null, message: { content: "restore" } },
+    ]);
+    await replaceSqliteTranscriptEvents(sourceScope, [
+      { type: "session", id: "source-session", cwd: paths.tempDir },
+      { type: "message", id: "post-msg-1", parentId: null, message: { content: "skip" } },
+      { type: "message", id: "post-msg-2", parentId: "post-msg-1", message: { content: "skip" } },
+    ]);
+    await upsertSqliteSessionEntry(sourceEntryScope, {
+      label: "Current",
+      sessionId: "current-session",
+      sessionFile: "sqlite:main:current-session",
+      updatedAt: 10,
+      compactionCheckpoints: [checkpoint],
+    });
+
+    const result = await restoreSqliteCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      storePath: paths.sqlitePath,
+      sessionKey: sourceEntryScope.sessionKey,
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (result.status !== "created") {
+      throw new Error(`expected restore creation, got ${result.status}`);
+    }
+
+    const restoredScope = {
+      ...sourceScope,
+      sessionId: result.entry.sessionId,
+    };
+    expect(loadSqliteSessionEntry(sourceEntryScope)).toEqual(result.entry);
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        label: "Current",
+        compactionCheckpoints: [checkpoint],
+        sessionFile: expect.stringMatching(/^sqlite:main:/),
+        totalTokens: 12,
+        totalTokensFresh: true,
+      }),
+    );
+    await expect(loadSqliteTranscriptEvents(restoredScope)).resolves.toEqual([
+      expect.objectContaining({ type: "session", id: result.entry.sessionId }),
+      expect.objectContaining({ id: "pre-msg", type: "message" }),
+    ]);
+    expect(fs.existsSync(path.join(paths.tempDir, `${result.entry.sessionId}.jsonl`))).toBe(false);
   });
 });

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -538,6 +538,20 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       });
       expect(fs.existsSync(sqlitePath)).toBe(true);
       expect(fs.existsSync(legacyStorePath)).toBe(false);
+      expect(
+        listSqliteSessionEntries({
+          env: scope.env,
+          storePath: sqlitePath,
+        }),
+      ).toEqual([
+        expect.objectContaining({
+          entry: expect.objectContaining({ sessionId: "session-1" }),
+          sessionKey: "voice:123",
+        }),
+      ]);
+      expect(() =>
+        loadSqliteSessionEntry({ ...scope, agentId: "main", storePath: sqlitePath }),
+      ).toThrow("belongs to agent voice; requested agent main");
     });
 
     it("does not treat custom JSON store paths as SQLite database files", async () => {

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -293,21 +293,20 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       const legacyStorePath = path.join(
         paths.stateDir,
         "agents",
-        "main",
+        "voice",
         "sessions",
         "sessions.json",
       );
       const sqlitePath = path.join(
         paths.stateDir,
         "agents",
-        "main",
+        "voice",
         "agent",
         "openclaw-agent.sqlite",
       );
       const scope = {
-        agentId: "main",
         env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
-        sessionKey: "agent:main:main",
+        sessionKey: "voice:123",
         storePath: legacyStorePath,
       };
 
@@ -317,7 +316,9 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
         updatedAt: 10,
       });
 
-      expect(loadSqliteSessionEntry({ ...scope, storePath: sqlitePath })).toMatchObject({
+      expect(
+        loadSqliteSessionEntry({ ...scope, agentId: "voice", storePath: sqlitePath }),
+      ).toMatchObject({
         model: "gpt-5.5",
         sessionId: "session-1",
       });

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
@@ -52,6 +52,14 @@ import {
   upsertSqliteSessionEntry,
 } from "./session-accessor.sqlite.js";
 import type { SessionEntry } from "./types.js";
+
+// Keep accessor conformance independent of any real openclaw.json on the machine.
+vi.mock("../config.js", async () => ({
+  ...(await vi.importActual<typeof import("../config.js")>("../config.js")),
+  getRuntimeConfig: vi.fn().mockReturnValue({}),
+}));
+
+import { getRuntimeConfig } from "../config.js";
 
 type AccessorAdapter = {
   name: string;
@@ -176,6 +184,14 @@ const sqliteAdapter: AccessorAdapter = {
   appendTranscriptMessage: appendSqliteTranscriptMessage,
   publishTranscriptUpdate: publishSqliteTranscriptUpdate,
 };
+
+beforeEach(() => {
+  vi.mocked(getRuntimeConfig).mockReturnValue({});
+});
+
+afterEach(() => {
+  vi.mocked(getRuntimeConfig).mockReset();
+});
 
 describe.each([fileBackedAdapter, sqliteAdapter])(
   "session accessor conformance: $name",
@@ -939,6 +955,128 @@ describe("sqlite session normalization", () => {
         .where("session_key", "=", "agent:main:main"),
     );
     expect(route).toEqual({ session_id: "current-session" });
+  });
+
+  it("applies SQLite session-entry maintenance inside entry write transactions", async () => {
+    vi.mocked(getRuntimeConfig).mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "1d",
+          maxEntries: 2,
+        },
+      },
+    });
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const scopeFor = (sessionKey: string) => ({
+      agentId: "main",
+      env,
+      sessionKey,
+      storePath: paths.sqlitePath,
+    });
+    const oldUpdatedAt = Date.now() - 2 * 24 * 60 * 60 * 1000;
+
+    await patchSqliteSessionEntry(
+      scopeFor("agent:main:stale"),
+      () => ({ sessionId: "stale-session", updatedAt: oldUpdatedAt }),
+      {
+        fallbackEntry: { sessionId: "stale-session", updatedAt: oldUpdatedAt },
+        replaceEntry: true,
+        skipMaintenance: true,
+      },
+    );
+    await patchSqliteSessionEntry(
+      scopeFor("agent:main:older"),
+      () => ({ sessionId: "older-session", updatedAt: oldUpdatedAt + 1 }),
+      {
+        fallbackEntry: { sessionId: "older-session", updatedAt: oldUpdatedAt + 1 },
+        replaceEntry: true,
+        skipMaintenance: true,
+      },
+    );
+    await patchSqliteSessionEntry(
+      scopeFor("agent:main:active"),
+      () => ({ sessionId: "active-session", updatedAt: Date.now() }),
+      {
+        fallbackEntry: { sessionId: "active-session", updatedAt: Date.now() },
+        replaceEntry: true,
+        skipMaintenance: true,
+      },
+    );
+    const staleTranscriptEvent = {
+      id: "stale-event",
+      timestamp: new Date(oldUpdatedAt).toISOString(),
+      type: "metadata",
+    };
+    await appendSqliteTranscriptEvent(
+      { ...scopeFor("agent:main:stale"), sessionId: "stale-session" },
+      staleTranscriptEvent,
+    );
+
+    await updateSqliteSessionEntry(scopeFor("agent:main:active"), () => ({ model: "gpt-5.5" }), {
+      skipMaintenance: true,
+    });
+    await expect(
+      loadSqliteTranscriptEvents({
+        agentId: "main",
+        env,
+        sessionId: "stale-session",
+        storePath: paths.sqlitePath,
+      }),
+    ).resolves.toEqual([staleTranscriptEvent]);
+    expect(
+      listSqliteSessionEntries({
+        agentId: "main",
+        env,
+        storePath: paths.sqlitePath,
+      }).map((summary) => summary.sessionKey),
+    ).toEqual(["agent:main:active", "agent:main:older", "agent:main:stale"]);
+
+    await updateSqliteSessionEntry(scopeFor("agent:main:active"), () => ({
+      providerOverride: "openai",
+    }));
+
+    expect(
+      listSqliteSessionEntries({
+        agentId: "main",
+        env,
+        storePath: paths.sqlitePath,
+      }).map((summary) => summary.sessionKey),
+    ).toEqual(["agent:main:active"]);
+    await expect(
+      loadSqliteTranscriptEvents({
+        agentId: "main",
+        env,
+        sessionId: "stale-session",
+        storePath: paths.sqlitePath,
+      }),
+    ).resolves.toEqual([]);
+
+    await patchSqliteSessionEntry(
+      scopeFor("agent:main:newer"),
+      () => ({ sessionId: "newer-session", updatedAt: Date.now() + 1 }),
+      {
+        fallbackEntry: { sessionId: "newer-session", updatedAt: Date.now() + 1 },
+        replaceEntry: true,
+        skipMaintenance: true,
+      },
+    );
+    await patchSqliteSessionEntry(
+      scopeFor("agent:main:newest"),
+      () => ({ sessionId: "newest-session", updatedAt: Date.now() + 2 }),
+      {
+        fallbackEntry: { sessionId: "newest-session", updatedAt: Date.now() + 2 },
+        replaceEntry: true,
+      },
+    );
+
+    expect(
+      listSqliteSessionEntries({
+        agentId: "main",
+        env,
+        storePath: paths.sqlitePath,
+      }).map((summary) => summary.sessionKey),
+    ).toEqual(["agent:main:newer", "agent:main:newest"]);
   });
 
   it("resolves confirmed lowercased legacy SQLite session aliases", async () => {

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -9,6 +9,7 @@ import {
   appendTranscriptEvent,
   appendTranscriptMessage,
   listSessionEntries,
+  loadExactSessionEntry,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
@@ -17,6 +18,7 @@ import {
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
+  type ExactSessionEntry,
   type SessionAccessScope,
   type SessionEntrySummary,
   type SessionTranscriptAccessScope,
@@ -31,6 +33,7 @@ import {
   appendSqliteTranscriptEvent,
   appendSqliteTranscriptMessage,
   listSqliteSessionEntries,
+  loadExactSqliteSessionEntry,
   loadSqliteSessionEntry,
   loadSqliteTranscriptEvents,
   loadSqliteTranscriptEventsSync,
@@ -48,6 +51,7 @@ type AccessorAdapter = {
   entryScope(paths: TestPaths): SessionAccessScope;
   transcriptReadScope(paths: TestPaths, id?: string): SessionTranscriptReadScope;
   transcriptScope(paths: TestPaths, id?: string): SessionTranscriptAccessScope;
+  loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined;
   loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined;
   listSessionEntries(scope: Partial<Omit<SessionAccessScope, "sessionKey">>): SessionEntrySummary[];
   readSessionUpdatedAt(scope: SessionAccessScope): number | undefined;
@@ -106,6 +110,7 @@ const fileBackedAdapter: AccessorAdapter = {
     storePath: paths.storePath,
   }),
   loadSessionEntry,
+  loadExactSessionEntry,
   listSessionEntries,
   readSessionUpdatedAt,
   upsertSessionEntry,
@@ -140,6 +145,7 @@ const sqliteAdapter: AccessorAdapter = {
     storePath: paths.sqlitePath,
   }),
   loadSessionEntry: loadSqliteSessionEntry,
+  loadExactSessionEntry: loadExactSqliteSessionEntry,
   listSessionEntries: listSqliteSessionEntries,
   readSessionUpdatedAt: readSqliteSessionUpdatedAt,
   upsertSessionEntry: upsertSqliteSessionEntry,
@@ -252,6 +258,30 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
         providerOverride: "anthropic",
         sessionId: "session-1",
         updatedAt: beforePreservePatch?.updatedAt,
+      });
+    });
+
+    it("conforms for exact persisted-key lookup without canonical alias fallback", async () => {
+      const scope = adapter.entryScope(paths);
+      const mixedCaseScope = { ...scope, sessionKey: "AGENT:MAIN:MAIN" };
+
+      await adapter.upsertSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "exact-session",
+        updatedAt: 10,
+      });
+
+      expect(adapter.loadSessionEntry(mixedCaseScope)).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "exact-session",
+      });
+      expect(adapter.loadExactSessionEntry(mixedCaseScope)).toBeUndefined();
+      expect(adapter.loadExactSessionEntry(scope)).toEqual({
+        sessionKey: "agent:main:main",
+        entry: expect.objectContaining({
+          model: "gpt-5.5",
+          sessionId: "exact-session",
+        }),
       });
     });
 

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -55,6 +55,7 @@ import type { SessionEntry } from "./types.js";
 
 type AccessorAdapter = {
   name: string;
+  publishesTranscriptUpdates: boolean;
   entryScope(paths: TestPaths): SessionAccessScope;
   transcriptReadScope(paths: TestPaths, id?: string): SessionTranscriptReadScope;
   transcriptScope(paths: TestPaths, id?: string): SessionTranscriptAccessScope;
@@ -108,6 +109,7 @@ type TestPaths = {
 
 const fileBackedAdapter: AccessorAdapter = {
   name: "file-backed",
+  publishesTranscriptUpdates: true,
   entryScope: (paths) => ({
     sessionKey: "agent:main:main",
     storePath: paths.storePath,
@@ -140,6 +142,7 @@ const fileBackedAdapter: AccessorAdapter = {
 
 const sqliteAdapter: AccessorAdapter = {
   name: "sqlite",
+  publishesTranscriptUpdates: false,
   entryScope: (paths) => ({
     agentId: "main",
     env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
@@ -329,10 +332,9 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
         const timestamp = params.old ? oldTimestamp : nowMs;
         const event = {
           id: `${params.sessionId}-event`,
-          message: { role: "assistant", content: "cleanup" },
-          runId: "lifecycle-marker-run",
+          marker: "lifecycle-marker-run",
           timestamp: new Date(timestamp).toISOString(),
-          type: "message",
+          type: "metadata",
         };
         if (adapter.name === "sqlite") {
           await adapter.appendTranscriptEvent(
@@ -631,9 +633,8 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       const scope = sqliteAdapter.transcriptScope(paths, "session-dedupe");
       const event = {
         id: "event-dedupe",
-        message: { role: "assistant", content: "first" },
-        parentId: null,
-        type: "message",
+        source: "conformance",
+        type: "metadata",
       };
 
       await appendSqliteTranscriptEvent(scope, event);
@@ -663,6 +664,18 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
           type: "message",
         }),
       ]);
+    });
+
+    it("rejects raw message transcript event writes", async () => {
+      const scope = adapter.transcriptScope(paths, "session-raw-message");
+      await expect(
+        adapter.appendTranscriptEvent(scope, {
+          id: "raw-message",
+          message: { role: "assistant", content: "raw" },
+          parentId: null,
+          type: "message",
+        }),
+      ).rejects.toThrow(/use append(?:Sqlite)?TranscriptMessage instead/);
     });
 
     it("does not report success for unchecked duplicate SQLite transcript keys", async () => {
@@ -743,14 +756,18 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
           type: "message",
         }),
       ]);
-      expect(updates).toEqual([
-        expect.objectContaining({
-          agentId: "main",
-          message: appended?.message,
-          messageId: appended?.messageId,
-          sessionKey: scope.sessionKey,
-        }),
-      ]);
+      if (adapter.publishesTranscriptUpdates) {
+        expect(updates).toEqual([
+          expect.objectContaining({
+            agentId: "main",
+            message: appended?.message,
+            messageId: appended?.messageId,
+            sessionKey: scope.sessionKey,
+          }),
+        ]);
+      } else {
+        expect(updates).toEqual([]);
+      }
     });
   },
 );

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -326,6 +326,37 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       expect(fs.existsSync(legacyStorePath)).toBe(false);
     });
 
+    it("does not treat custom JSON store paths as SQLite database files", async () => {
+      const customStorePath = path.join(paths.tempDir, "custom-sessions.json");
+      const sqlitePath = path.join(
+        paths.stateDir,
+        "agents",
+        "voice",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const scope = {
+        env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+        sessionKey: "agent:voice:main",
+        storePath: customStorePath,
+      };
+
+      await upsertSqliteSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      });
+
+      expect(
+        loadSqliteSessionEntry({ ...scope, agentId: "voice", storePath: sqlitePath }),
+      ).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+      });
+      expect(fs.existsSync(sqlitePath)).toBe(true);
+      expect(fs.existsSync(customStorePath)).toBe(false);
+    });
+
     it("conforms for transcript message append, idempotency, and update publication", async () => {
       const scope = adapter.transcriptScope(paths, "session-2");
       const updates: unknown[] = [];

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1,0 +1,309 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  listSessionEntries,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  patchSessionEntry,
+  publishTranscriptUpdate,
+  readSessionUpdatedAt,
+  replaceSessionEntry,
+  updateSessionEntry,
+  upsertSessionEntry,
+  type SessionAccessScope,
+  type SessionEntrySummary,
+  type SessionTranscriptAccessScope,
+  type SessionTranscriptWriteScope,
+  type TranscriptEvent,
+  type TranscriptMessageAppendOptions,
+  type TranscriptMessageAppendResult,
+  type TranscriptUpdatePayload,
+} from "./session-accessor.js";
+import {
+  appendSqliteTranscriptEvent,
+  appendSqliteTranscriptMessage,
+  listSqliteSessionEntries,
+  loadSqliteSessionEntry,
+  loadSqliteTranscriptEvents,
+  patchSqliteSessionEntry,
+  publishSqliteTranscriptUpdate,
+  readSqliteSessionUpdatedAt,
+  replaceSqliteSessionEntry,
+  updateSqliteSessionEntry,
+  upsertSqliteSessionEntry,
+} from "./session-accessor.sqlite.js";
+import type { SessionEntry } from "./types.js";
+
+type AccessorAdapter = {
+  name: string;
+  entryScope(paths: TestPaths): SessionAccessScope;
+  transcriptScope(paths: TestPaths, id?: string): SessionTranscriptAccessScope;
+  loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined;
+  listSessionEntries(scope: Partial<Omit<SessionAccessScope, "sessionKey">>): SessionEntrySummary[];
+  readSessionUpdatedAt(scope: SessionAccessScope): number | undefined;
+  upsertSessionEntry(
+    scope: SessionAccessScope,
+    patch: Partial<SessionEntry>,
+  ): Promise<SessionEntry | null>;
+  replaceSessionEntry(scope: SessionAccessScope, entry: SessionEntry): Promise<SessionEntry | null>;
+  patchSessionEntry(
+    scope: SessionAccessScope,
+    update: (
+      entry: SessionEntry,
+      context: { existingEntry?: SessionEntry },
+    ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+    options?: { fallbackEntry?: SessionEntry; replaceEntry?: boolean },
+  ): Promise<SessionEntry | null>;
+  updateSessionEntry(
+    scope: SessionAccessScope,
+    update: (entry: SessionEntry) => Partial<SessionEntry> | null,
+  ): Promise<SessionEntry | null>;
+  loadTranscriptEvents(scope: SessionTranscriptAccessScope): Promise<TranscriptEvent[]>;
+  appendTranscriptEvent(scope: SessionTranscriptAccessScope, event: TranscriptEvent): Promise<void>;
+  appendTranscriptMessage<TMessage>(
+    scope: SessionTranscriptWriteScope,
+    options: TranscriptMessageAppendOptions<TMessage>,
+  ): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+  publishTranscriptUpdate(
+    scope: SessionTranscriptWriteScope,
+    update?: TranscriptUpdatePayload,
+  ): Promise<void>;
+};
+
+type TestPaths = {
+  sqlitePath: string;
+  stateDir: string;
+  storePath: string;
+  tempDir: string;
+  transcriptPath: string;
+};
+
+const fileBackedAdapter: AccessorAdapter = {
+  name: "file-backed",
+  entryScope: (paths) => ({
+    sessionKey: "agent:main:main",
+    storePath: paths.storePath,
+  }),
+  transcriptScope: (paths, id = "session-1") => ({
+    sessionFile: paths.transcriptPath,
+    sessionId: id,
+    sessionKey: "agent:main:main",
+    storePath: paths.storePath,
+  }),
+  loadSessionEntry,
+  listSessionEntries,
+  readSessionUpdatedAt,
+  upsertSessionEntry,
+  replaceSessionEntry,
+  patchSessionEntry,
+  updateSessionEntry,
+  loadTranscriptEvents,
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  publishTranscriptUpdate,
+};
+
+const sqliteAdapter: AccessorAdapter = {
+  name: "sqlite",
+  entryScope: (paths) => ({
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+    sessionKey: "agent:main:main",
+    storePath: paths.sqlitePath,
+  }),
+  transcriptScope: (paths, id = "session-1") => ({
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+    sessionId: id,
+    sessionKey: "agent:main:main",
+    storePath: paths.sqlitePath,
+  }),
+  loadSessionEntry: loadSqliteSessionEntry,
+  listSessionEntries: listSqliteSessionEntries,
+  readSessionUpdatedAt: readSqliteSessionUpdatedAt,
+  upsertSessionEntry: upsertSqliteSessionEntry,
+  replaceSessionEntry: replaceSqliteSessionEntry,
+  patchSessionEntry: patchSqliteSessionEntry,
+  updateSessionEntry: updateSqliteSessionEntry,
+  loadTranscriptEvents: loadSqliteTranscriptEvents,
+  appendTranscriptEvent: appendSqliteTranscriptEvent,
+  appendTranscriptMessage: appendSqliteTranscriptMessage,
+  publishTranscriptUpdate: publishSqliteTranscriptUpdate,
+};
+
+describe.each([fileBackedAdapter, sqliteAdapter])(
+  "session accessor conformance: $name",
+  (adapter) => {
+    let paths: TestPaths;
+
+    beforeEach(() => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-accessor-conf-"));
+      paths = {
+        sqlitePath: path.join(tempDir, "openclaw-agent.sqlite"),
+        stateDir: path.join(tempDir, "state"),
+        storePath: path.join(tempDir, "sessions.json"),
+        tempDir,
+        transcriptPath: path.join(tempDir, "session.jsonl"),
+      };
+    });
+
+    afterEach(() => {
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      fs.rmSync(paths.tempDir, { recursive: true, force: true });
+    });
+
+    it("conforms for entry load/list/timestamp/upsert/update/replace/patch", async () => {
+      const scope = adapter.entryScope(paths);
+
+      await adapter.upsertSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      });
+
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: expect.any(Number),
+      });
+      expect(adapter.readSessionUpdatedAt(scope)).toEqual(expect.any(Number));
+      expect(adapter.listSessionEntries(scope)).toEqual([
+        {
+          sessionKey: "agent:main:main",
+          entry: expect.objectContaining({
+            model: "gpt-5.5",
+            sessionId: "session-1",
+          }),
+        },
+      ]);
+
+      await expect(
+        adapter.updateSessionEntry(scope, () => ({ model: "sonnet-4.6", updatedAt: 20 })),
+      ).resolves.toMatchObject({
+        model: "sonnet-4.6",
+        sessionId: "session-1",
+      });
+
+      await adapter.replaceSessionEntry(scope, {
+        providerOverride: "openai",
+        sessionId: "session-1",
+        updatedAt: 30,
+      });
+
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        providerOverride: "openai",
+        sessionId: "session-1",
+      });
+      expect(adapter.loadSessionEntry(scope)?.model).toBeUndefined();
+
+      let existingContext: SessionEntry | undefined;
+      await adapter.patchSessionEntry(
+        scope,
+        (entry, context) => {
+          existingContext = context.existingEntry;
+          return {
+            ...entry,
+            model: "gpt-5.5",
+          };
+        },
+        { replaceEntry: true },
+      );
+
+      expect(existingContext).toMatchObject({ providerOverride: "openai" });
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+      });
+    });
+
+    it("conforms for raw transcript event load and append", async () => {
+      const scope = adapter.transcriptScope(paths);
+      const event = {
+        id: "event-1",
+        message: { role: "user", content: "hello" },
+        parentId: null,
+        type: "message",
+      };
+
+      await adapter.appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
+      await adapter.appendTranscriptEvent(scope, event);
+
+      await expect(adapter.loadTranscriptEvents(scope)).resolves.toEqual([
+        { type: "session", sessionId: "session-1" },
+        event,
+      ]);
+    });
+
+    it("conforms for transcript message append, idempotency, and update publication", async () => {
+      const scope = adapter.transcriptScope(paths, "session-2");
+      const updates: unknown[] = [];
+      const unsubscribe = onSessionTranscriptUpdate((update) => {
+        updates.push(update);
+      });
+
+      const appended = await adapter.appendTranscriptMessage(scope, {
+        cwd: paths.tempDir,
+        idempotencyLookup: "scan",
+        message: {
+          role: "assistant",
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        },
+      });
+      const replayed = await adapter.appendTranscriptMessage(scope, {
+        cwd: paths.tempDir,
+        idempotencyLookup: "scan",
+        message: {
+          role: "assistant",
+          content: "hello again",
+          idempotencyKey: "assistant-once",
+        },
+      });
+      await adapter.publishTranscriptUpdate(scope, {
+        agentId: "main",
+        message: appended?.message,
+        messageId: appended?.messageId,
+        sessionKey: scope.sessionKey,
+      });
+      unsubscribe();
+
+      expect(appended).toMatchObject({
+        appended: true,
+        message: expect.objectContaining({ content: "hello" }),
+        messageId: expect.any(String),
+      });
+      expect(replayed).toMatchObject({
+        appended: false,
+        message: expect.objectContaining({
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        }),
+        messageId: appended?.messageId,
+      });
+      await expect(adapter.loadTranscriptEvents(scope)).resolves.toEqual([
+        expect.objectContaining({ type: "session" }),
+        expect.objectContaining({
+          id: appended?.messageId,
+          message: expect.objectContaining({ content: "hello" }),
+          type: "message",
+        }),
+      ]);
+      expect(updates).toEqual([
+        expect.objectContaining({
+          agentId: "main",
+          message: appended?.message,
+          messageId: appended?.messageId,
+          sessionKey: scope.sessionKey,
+        }),
+      ]);
+    });
+  },
+);

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -472,9 +472,9 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       const readScope = adapter.transcriptReadScope(paths);
       const event = {
         id: "event-1",
-        message: { role: "user", content: "hello" },
         parentId: null,
-        type: "message",
+        payload: { content: "hello" },
+        type: "metadata",
       };
 
       await adapter.appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
@@ -491,9 +491,9 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       const readScope = sqliteAdapter.transcriptReadScope(paths);
       const event = {
         id: "event-1",
-        message: { role: "user", content: "hello" },
         parentId: null,
-        type: "message",
+        payload: { content: "hello" },
+        type: "metadata",
       };
 
       await sqliteAdapter.appendTranscriptEvent(scope, event);
@@ -868,5 +868,91 @@ describe("sqlite session normalization", () => {
       session_id: "normalized-session",
       updated_at: expect.any(Number),
     });
+  });
+
+  it("normalizes missing entry updatedAt before writing root and entry rows", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    await replaceSqliteSessionEntry(
+      {
+        agentId: "main",
+        env,
+        sessionKey: "agent:main:minimal",
+        storePath: paths.sqlitePath,
+      },
+      {
+        sessionId: "minimal-session",
+        sessionStartedAt: 123,
+      } as SessionEntry,
+    );
+
+    const loaded = loadSqliteSessionEntry({
+      agentId: "main",
+      env,
+      sessionKey: "agent:main:minimal",
+      storePath: paths.sqlitePath,
+    });
+    expect(loaded).toMatchObject({
+      sessionId: "minimal-session",
+      sessionStartedAt: 123,
+      updatedAt: 123,
+    });
+
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env,
+      path: paths.sqlitePath,
+    });
+    const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+    const row = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("sessions as s")
+        .innerJoin("session_entries as se", "se.session_id", "s.session_id")
+        .innerJoin("session_routes as sr", "sr.session_key", "se.session_key")
+        .select([
+          "s.created_at as root_created_at",
+          "s.updated_at as root_updated_at",
+          "se.entry_json",
+          "se.updated_at as entry_updated_at",
+          "sr.updated_at as route_updated_at",
+        ])
+        .where("s.session_id", "=", "minimal-session"),
+    );
+    expect(row).toEqual({
+      entry_json: JSON.stringify({
+        sessionId: "minimal-session",
+        sessionStartedAt: 123,
+        updatedAt: 123,
+      }),
+      entry_updated_at: 123,
+      root_created_at: 123,
+      root_updated_at: 123,
+      route_updated_at: 123,
+    });
+
+    await upsertSqliteSessionEntry(
+      {
+        agentId: "main",
+        env,
+        sessionKey: "agent:main:minimal-upsert",
+        storePath: paths.sqlitePath,
+      },
+      {
+        sessionId: "minimal-upsert-session",
+      },
+    );
+    const upsertRow = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_entries")
+        .select(["entry_json", "updated_at"])
+        .where("session_key", "=", "agent:main:minimal-upsert"),
+    );
+    const upsertEntry = JSON.parse(upsertRow?.entry_json ?? "{}") as Partial<SessionEntry>;
+    expect(upsertEntry).toMatchObject({
+      sessionId: "minimal-upsert-session",
+      updatedAt: expect.any(Number),
+    });
+    expect(upsertRow?.updated_at).toBe(upsertEntry.updatedAt);
   });
 });

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -901,6 +901,78 @@ describe("sqlite session normalization", () => {
     });
   });
 
+  it("does not move current routes back to stale transcript session ids", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const scope = {
+      agentId: "main",
+      env,
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    await upsertSqliteSessionEntry(scope, {
+      sessionId: "current-session",
+      updatedAt: 20,
+    });
+    await appendSqliteTranscriptEvent(
+      {
+        ...scope,
+        sessionId: "stale-session",
+      },
+      {
+        id: "stale-event",
+        timestamp: new Date(10).toISOString(),
+        type: "metadata",
+      },
+    );
+
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env,
+      path: paths.sqlitePath,
+    });
+    const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+    const route = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_routes")
+        .select("session_id")
+        .where("session_key", "=", "agent:main:main"),
+    );
+    expect(route).toEqual({ session_id: "current-session" });
+  });
+
+  it("resolves confirmed lowercased legacy SQLite session aliases", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const canonicalKey = "agent:main:matrix:channel:!MixedCase:example.org";
+    const legacyKey = canonicalKey.toLowerCase();
+    await upsertSqliteSessionEntry(
+      {
+        agentId: "main",
+        env,
+        sessionKey: legacyKey,
+        storePath: paths.sqlitePath,
+      },
+      {
+        deliveryContext: {
+          accountId: "acct-1",
+          channel: "matrix",
+          to: "!MixedCase:example.org",
+        },
+        sessionId: "legacy-alias-session",
+        updatedAt: 10,
+      },
+    );
+
+    expect(
+      loadSqliteSessionEntry({
+        agentId: "main",
+        env,
+        sessionKey: canonicalKey,
+        storePath: paths.sqlitePath,
+      }),
+    ).toMatchObject({ sessionId: "legacy-alias-session" });
+  });
+
   it("normalizes missing entry updatedAt before writing root and entry rows", async () => {
     const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
     await replaceSqliteSessionEntry(

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -357,6 +357,126 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       expect(fs.existsSync(customStorePath)).toBe(false);
     });
 
+    it("serializes concurrent SQLite entry patches and updates", async () => {
+      const scope = sqliteAdapter.entryScope(paths);
+
+      await upsertSqliteSessionEntry(scope, {
+        model: "base",
+        sessionId: "patch-session",
+        updatedAt: 10,
+      });
+
+      let firstPatch!: Promise<SessionEntry | null>;
+      let releasePatch!: () => void;
+      const patchStarted = new Promise<void>((resolve) => {
+        const blockedPatch = new Promise<void>((release) => {
+          releasePatch = release;
+        });
+        firstPatch = patchSqliteSessionEntry(scope, async () => {
+          resolve();
+          await blockedPatch;
+          return { model: "first" };
+        });
+      });
+      await patchStarted;
+      const secondPatch = patchSqliteSessionEntry(scope, () => ({
+        providerOverride: "openai",
+      }));
+      releasePatch();
+      await Promise.all([firstPatch, secondPatch]);
+
+      expect(loadSqliteSessionEntry(scope)).toMatchObject({
+        model: "first",
+        providerOverride: "openai",
+      });
+
+      let firstUpdate!: Promise<SessionEntry | null>;
+      let releaseUpdate!: () => void;
+      const updateStarted = new Promise<void>((resolve) => {
+        const blockedUpdate = new Promise<void>((release) => {
+          releaseUpdate = release;
+        });
+        firstUpdate = updateSqliteSessionEntry(scope, async () => {
+          resolve();
+          await blockedUpdate;
+          return { model: "updated" };
+        });
+      });
+      await updateStarted;
+      const secondUpdate = updateSqliteSessionEntry(scope, () => ({
+        providerOverride: "anthropic",
+      }));
+      releaseUpdate();
+      await Promise.all([firstUpdate, secondUpdate]);
+
+      expect(loadSqliteSessionEntry(scope)).toMatchObject({
+        model: "updated",
+        providerOverride: "anthropic",
+      });
+    });
+
+    it("dedupes SQLite transcript identities inside the writer path", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths, "session-dedupe");
+      const event = {
+        id: "event-dedupe",
+        message: { role: "assistant", content: "first" },
+        parentId: null,
+        type: "message",
+      };
+
+      await appendSqliteTranscriptEvent(scope, event);
+      await appendSqliteTranscriptEvent(scope, {
+        ...event,
+        message: { role: "assistant", content: "duplicate" },
+      });
+      const results = await Promise.all(
+        Array.from({ length: 8 }, () =>
+          appendSqliteTranscriptMessage(scope, {
+            idempotencyLookup: "scan",
+            message: {
+              role: "assistant",
+              content: "keyed",
+              idempotencyKey: "keyed-once",
+            },
+          }),
+        ),
+      );
+
+      expect(new Set(results.map((result) => result?.messageId)).size).toBe(1);
+      expect(results.filter((result) => result?.appended)).toHaveLength(1);
+      await expect(loadSqliteTranscriptEvents(scope)).resolves.toEqual([
+        event,
+        expect.objectContaining({
+          message: expect.objectContaining({ idempotencyKey: "keyed-once" }),
+          type: "message",
+        }),
+      ]);
+    });
+
+    it("does not report success for unchecked duplicate SQLite transcript keys", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths, "session-unchecked-dedupe");
+      const message = {
+        role: "assistant",
+        content: "unchecked",
+        idempotencyKey: "unchecked-once",
+      };
+
+      await appendSqliteTranscriptMessage(scope, { message });
+      await expect(appendSqliteTranscriptMessage(scope, { message })).rejects.toThrow();
+
+      const events = await loadSqliteTranscriptEvents(scope);
+      const keyedEvents = events.filter((event): event is { message: typeof message } => {
+        return (
+          Boolean(event) &&
+          typeof event === "object" &&
+          !Array.isArray(event) &&
+          (event as { message?: { idempotencyKey?: string } }).message?.idempotencyKey ===
+            "unchecked-once"
+        );
+      });
+      expect(keyedEvents).toHaveLength(1);
+    });
+
     it("conforms for transcript message append, idempotency, and update publication", async () => {
       const scope = adapter.transcriptScope(paths, "session-2");
       const updates: unknown[] = [];

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -62,7 +62,7 @@ type AccessorAdapter = {
       entry: SessionEntry,
       context: { existingEntry?: SessionEntry },
     ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
-    options?: { fallbackEntry?: SessionEntry; replaceEntry?: boolean },
+    options?: { fallbackEntry?: SessionEntry; preserveActivity?: boolean; replaceEntry?: boolean },
   ): Promise<SessionEntry | null>;
   updateSessionEntry(
     scope: SessionAccessScope,
@@ -235,6 +235,23 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       expect(adapter.loadSessionEntry(scope)).toMatchObject({
         model: "gpt-5.5",
         sessionId: "session-1",
+      });
+
+      const beforePreservePatch = adapter.loadSessionEntry(scope);
+      await adapter.patchSessionEntry(
+        scope,
+        () => ({
+          providerOverride: "anthropic",
+          updatedAt: 40,
+        }),
+        { preserveActivity: true },
+      );
+
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        model: "gpt-5.5",
+        providerOverride: "anthropic",
+        sessionId: "session-1",
+        updatedAt: beforePreservePatch?.updatedAt,
       });
     });
 

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -2,8 +2,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   appendTranscriptEvent,
@@ -419,6 +424,28 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       });
       if (adapter.name === "sqlite") {
         expect(fs.existsSync(cleanupStorePath)).toBe(false);
+        const database = openOpenClawAgentDatabase({
+          agentId: "main",
+          env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+          path: path.join(paths.stateDir, "agents", "main", "agent", "openclaw-agent.sqlite"),
+        });
+        const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+        const removedRoute = executeSqliteQueryTakeFirstSync(
+          database.db,
+          db
+            .selectFrom("session_routes")
+            .select("session_id")
+            .where("session_key", "=", "agent:main:lifecycle-cleanup-removed"),
+        );
+        expect(removedRoute).toBeUndefined();
+        const freshRoute = executeSqliteQueryTakeFirstSync(
+          database.db,
+          db
+            .selectFrom("session_routes")
+            .select("session_id")
+            .where("session_key", "=", "agent:main:lifecycle-cleanup-fresh"),
+        );
+        expect(freshRoute).toEqual({ session_id: "fresh-lifecycle" });
         await expect(
           adapter.loadTranscriptEvents(scopedTranscript("agent:main:regular", "referenced")),
         ).resolves.not.toEqual([]);
@@ -727,3 +754,119 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
     });
   },
 );
+
+describe("sqlite session normalization", () => {
+  let paths: TestPaths;
+
+  beforeEach(() => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-sqlite-norm-"));
+    paths = {
+      sqlitePath: path.join(tempDir, "openclaw-agent.sqlite"),
+      stateDir: path.join(tempDir, "state"),
+      storePath: path.join(tempDir, "sessions.json"),
+      tempDir,
+      transcriptPath: path.join(tempDir, "session.jsonl"),
+    };
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(paths.tempDir, { recursive: true, force: true });
+  });
+
+  it("maintains normalized session root and route rows", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    await upsertSqliteSessionEntry(
+      {
+        agentId: "main",
+        env,
+        sessionKey: "agent:main:group:example",
+        storePath: paths.sqlitePath,
+      },
+      {
+        agentHarnessId: "codex",
+        chatType: "group",
+        channel: "discord",
+        deliveryContext: {
+          accountId: "acct-1",
+          channel: "discord",
+          threadId: "thread-1",
+          to: "group-1",
+        },
+        displayName: "Example group",
+        endedAt: 90,
+        model: "gpt-5.5",
+        modelProvider: "openai",
+        parentSessionKey: "agent:main:parent",
+        sessionId: "normalized-session",
+        sessionStartedAt: 50,
+        spawnedBy: "agent:main:spawner",
+        startedAt: 60,
+        status: "done",
+        updatedAt: 100,
+      },
+    );
+
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env,
+      path: paths.sqlitePath,
+    });
+    const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+    const session = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("sessions")
+        .select([
+          "account_id",
+          "agent_harness_id",
+          "channel",
+          "chat_type",
+          "created_at",
+          "display_name",
+          "ended_at",
+          "model",
+          "model_provider",
+          "parent_session_key",
+          "session_key",
+          "session_scope",
+          "spawned_by",
+          "started_at",
+          "status",
+          "updated_at",
+        ])
+        .where("session_id", "=", "normalized-session"),
+    );
+    expect(session).toEqual({
+      account_id: "acct-1",
+      agent_harness_id: "codex",
+      channel: "discord",
+      chat_type: "group",
+      created_at: 50,
+      display_name: "Example group",
+      ended_at: 90,
+      model: "gpt-5.5",
+      model_provider: "openai",
+      parent_session_key: "agent:main:parent",
+      session_key: "agent:main:group:example",
+      session_scope: "group",
+      spawned_by: "agent:main:spawner",
+      started_at: 60,
+      status: "done",
+      updated_at: expect.any(Number),
+    });
+
+    const route = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_routes")
+        .select(["session_id", "updated_at"])
+        .where("session_key", "=", "agent:main:group:example"),
+    );
+    expect(route).toEqual({
+      session_id: "normalized-session",
+      updated_at: expect.any(Number),
+    });
+  });
+});

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -20,6 +20,7 @@ import {
   type SessionAccessScope,
   type SessionEntrySummary,
   type SessionTranscriptAccessScope,
+  type SessionTranscriptReadScope,
   type SessionTranscriptWriteScope,
   type TranscriptEvent,
   type TranscriptMessageAppendOptions,
@@ -32,6 +33,7 @@ import {
   listSqliteSessionEntries,
   loadSqliteSessionEntry,
   loadSqliteTranscriptEvents,
+  loadSqliteTranscriptEventsSync,
   patchSqliteSessionEntry,
   publishSqliteTranscriptUpdate,
   readSqliteSessionUpdatedAt,
@@ -44,6 +46,7 @@ import type { SessionEntry } from "./types.js";
 type AccessorAdapter = {
   name: string;
   entryScope(paths: TestPaths): SessionAccessScope;
+  transcriptReadScope(paths: TestPaths, id?: string): SessionTranscriptReadScope;
   transcriptScope(paths: TestPaths, id?: string): SessionTranscriptAccessScope;
   loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined;
   listSessionEntries(scope: Partial<Omit<SessionAccessScope, "sessionKey">>): SessionEntrySummary[];
@@ -65,7 +68,7 @@ type AccessorAdapter = {
     scope: SessionAccessScope,
     update: (entry: SessionEntry) => Partial<SessionEntry> | null,
   ): Promise<SessionEntry | null>;
-  loadTranscriptEvents(scope: SessionTranscriptAccessScope): Promise<TranscriptEvent[]>;
+  loadTranscriptEvents(scope: SessionTranscriptReadScope): Promise<TranscriptEvent[]>;
   appendTranscriptEvent(scope: SessionTranscriptAccessScope, event: TranscriptEvent): Promise<void>;
   appendTranscriptMessage<TMessage>(
     scope: SessionTranscriptWriteScope,
@@ -97,6 +100,11 @@ const fileBackedAdapter: AccessorAdapter = {
     sessionKey: "agent:main:main",
     storePath: paths.storePath,
   }),
+  transcriptReadScope: (paths, id = "session-1") => ({
+    sessionFile: paths.transcriptPath,
+    sessionId: id,
+    storePath: paths.storePath,
+  }),
   loadSessionEntry,
   listSessionEntries,
   readSessionUpdatedAt,
@@ -123,6 +131,12 @@ const sqliteAdapter: AccessorAdapter = {
     env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
     sessionId: id,
     sessionKey: "agent:main:main",
+    storePath: paths.sqlitePath,
+  }),
+  transcriptReadScope: (paths, id = "session-1") => ({
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+    sessionId: id,
     storePath: paths.sqlitePath,
   }),
   loadSessionEntry: loadSqliteSessionEntry,
@@ -226,6 +240,7 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
 
     it("conforms for raw transcript event load and append", async () => {
       const scope = adapter.transcriptScope(paths);
+      const readScope = adapter.transcriptReadScope(paths);
       const event = {
         id: "event-1",
         message: { role: "user", content: "hello" },
@@ -236,10 +251,25 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       await adapter.appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
       await adapter.appendTranscriptEvent(scope, event);
 
-      await expect(adapter.loadTranscriptEvents(scope)).resolves.toEqual([
+      await expect(adapter.loadTranscriptEvents(readScope)).resolves.toEqual([
         { type: "session", sessionId: "session-1" },
         event,
       ]);
+    });
+
+    it("loads raw SQLite transcript events synchronously through a read scope", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths);
+      const readScope = sqliteAdapter.transcriptReadScope(paths);
+      const event = {
+        id: "event-1",
+        message: { role: "user", content: "hello" },
+        parentId: null,
+        type: "message",
+      };
+
+      await sqliteAdapter.appendTranscriptEvent(scope, event);
+
+      expect(loadSqliteTranscriptEventsSync(readScope)).toEqual([event]);
     });
 
     it("conforms for transcript message append, idempotency, and update publication", async () => {

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -8,6 +8,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
+  cleanupSessionLifecycleArtifacts,
   listSessionEntries,
   loadExactSessionEntry,
   loadSessionEntry,
@@ -32,6 +33,7 @@ import {
 import {
   appendSqliteTranscriptEvent,
   appendSqliteTranscriptMessage,
+  cleanupSqliteSessionLifecycleArtifacts,
   listSqliteSessionEntries,
   loadExactSqliteSessionEntry,
   loadSqliteSessionEntry,
@@ -72,6 +74,13 @@ type AccessorAdapter = {
     scope: SessionAccessScope,
     update: (entry: SessionEntry) => Partial<SessionEntry> | null,
   ): Promise<SessionEntry | null>;
+  cleanupSessionLifecycleArtifacts(params: {
+    storePath: string;
+    sessionKeySegmentPrefix: string;
+    transcriptContentMarker: string;
+    orphanTranscriptMinAgeMs: number;
+    nowMs?: number;
+  }): Promise<{ removedEntries: number; archivedTranscriptArtifacts: number }>;
   loadTranscriptEvents(scope: SessionTranscriptReadScope): Promise<TranscriptEvent[]>;
   appendTranscriptEvent(scope: SessionTranscriptAccessScope, event: TranscriptEvent): Promise<void>;
   appendTranscriptMessage<TMessage>(
@@ -117,6 +126,7 @@ const fileBackedAdapter: AccessorAdapter = {
   replaceSessionEntry,
   patchSessionEntry,
   updateSessionEntry,
+  cleanupSessionLifecycleArtifacts,
   loadTranscriptEvents,
   appendTranscriptEvent,
   appendTranscriptMessage,
@@ -152,6 +162,7 @@ const sqliteAdapter: AccessorAdapter = {
   replaceSessionEntry: replaceSqliteSessionEntry,
   patchSessionEntry: patchSqliteSessionEntry,
   updateSessionEntry: updateSqliteSessionEntry,
+  cleanupSessionLifecycleArtifacts: cleanupSqliteSessionLifecycleArtifacts,
   loadTranscriptEvents: loadSqliteTranscriptEvents,
   appendTranscriptEvent: appendSqliteTranscriptEvent,
   appendTranscriptMessage: appendSqliteTranscriptMessage,
@@ -283,6 +294,150 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
           sessionId: "exact-session",
         }),
       });
+    });
+
+    it("conforms for lifecycle entry and transcript cleanup", async () => {
+      const nowMs = Date.now();
+      const oldTimestamp = nowMs - 600_000;
+      const cleanupStorePath =
+        adapter.name === "sqlite"
+          ? path.join(paths.stateDir, "agents", "main", "sessions", "sessions.json")
+          : paths.storePath;
+      const scopedEntry = (sessionKey: string): SessionAccessScope => ({
+        ...adapter.entryScope(paths),
+        sessionKey,
+        storePath: cleanupStorePath,
+      });
+      const scopedTranscript = (
+        sessionKey: string,
+        sessionId: string,
+      ): SessionTranscriptAccessScope => ({
+        ...adapter.transcriptScope(paths, sessionId),
+        sessionKey,
+        storePath: cleanupStorePath,
+      });
+      const writeTranscript = async (params: {
+        sessionKey: string;
+        sessionId: string;
+        old?: boolean;
+      }) => {
+        const timestamp = params.old ? oldTimestamp : nowMs;
+        const event = {
+          id: `${params.sessionId}-event`,
+          message: { role: "assistant", content: "cleanup" },
+          runId: "lifecycle-marker-run",
+          timestamp: new Date(timestamp).toISOString(),
+          type: "message",
+        };
+        if (adapter.name === "sqlite") {
+          await adapter.appendTranscriptEvent(
+            scopedTranscript(params.sessionKey, params.sessionId),
+            event,
+          );
+          return;
+        }
+        const transcriptPath = path.join(
+          path.dirname(cleanupStorePath),
+          `${params.sessionId}.jsonl`,
+        );
+        fs.writeFileSync(transcriptPath, `${JSON.stringify(event)}\n`, "utf-8");
+        if (params.old) {
+          const oldDate = new Date(oldTimestamp);
+          fs.utimesSync(transcriptPath, oldDate, oldDate);
+        }
+      };
+
+      await adapter.upsertSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-missing"), {
+        sessionId: "missing-lifecycle",
+        updatedAt: oldTimestamp,
+      });
+      await adapter.upsertSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-removed"), {
+        sessionId: "removed-lifecycle",
+        updatedAt: oldTimestamp,
+      });
+      await adapter.upsertSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-fresh"), {
+        sessionId: "fresh-lifecycle",
+        updatedAt: nowMs,
+      });
+      await adapter.upsertSessionEntry(
+        scopedEntry("agent:main:telegram:group:lifecycle-cleanup-room"),
+        {
+          sessionId: "kept-by-segment",
+          updatedAt: oldTimestamp,
+        },
+      );
+      await adapter.upsertSessionEntry(scopedEntry("agent:main:regular"), {
+        sessionId: "referenced",
+        updatedAt: oldTimestamp,
+      });
+      await writeTranscript({
+        sessionKey: "agent:main:lifecycle-cleanup-removed",
+        sessionId: "removed-lifecycle",
+        old: true,
+      });
+      await writeTranscript({
+        sessionKey: "agent:main:lifecycle-cleanup-fresh",
+        sessionId: "fresh-lifecycle",
+      });
+      await writeTranscript({
+        sessionKey: "agent:main:regular",
+        sessionId: "referenced",
+        old: true,
+      });
+      await writeTranscript({
+        sessionKey: "agent:main:orphan",
+        sessionId: "orphan-lifecycle",
+        old: true,
+      });
+
+      await expect(
+        adapter.cleanupSessionLifecycleArtifacts({
+          storePath: cleanupStorePath,
+          sessionKeySegmentPrefix: "lifecycle-cleanup-",
+          transcriptContentMarker: "lifecycle-marker-",
+          orphanTranscriptMinAgeMs: 300_000,
+          nowMs,
+        }),
+      ).resolves.toEqual({ removedEntries: 2, archivedTranscriptArtifacts: 2 });
+
+      expect(
+        adapter.loadSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-missing")),
+      ).toBeUndefined();
+      expect(
+        adapter.loadSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-removed")),
+      ).toBeUndefined();
+      expect(
+        adapter.loadSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-fresh")),
+      ).toMatchObject({
+        sessionId: "fresh-lifecycle",
+      });
+      expect(
+        adapter.loadSessionEntry(scopedEntry("agent:main:telegram:group:lifecycle-cleanup-room")),
+      ).toMatchObject({ sessionId: "kept-by-segment" });
+      expect(adapter.loadSessionEntry(scopedEntry("agent:main:regular"))).toMatchObject({
+        sessionId: "referenced",
+      });
+      if (adapter.name === "sqlite") {
+        expect(fs.existsSync(cleanupStorePath)).toBe(false);
+        await expect(
+          adapter.loadTranscriptEvents(scopedTranscript("agent:main:regular", "referenced")),
+        ).resolves.not.toEqual([]);
+        await expect(
+          adapter.loadTranscriptEvents(
+            scopedTranscript("agent:main:lifecycle-cleanup-removed", "removed-lifecycle"),
+          ),
+        ).resolves.toEqual([]);
+      } else {
+        const files = fs.readdirSync(path.dirname(cleanupStorePath));
+        expect(
+          files.filter((file) => file.startsWith("removed-lifecycle.jsonl.deleted.")),
+        ).toHaveLength(1);
+        expect(
+          files.filter((file) => file.startsWith("orphan-lifecycle.jsonl.deleted.")),
+        ).toHaveLength(1);
+        expect(files).toContain("fresh-lifecycle.jsonl");
+        expect(files).toContain("referenced.jsonl");
+      }
     });
 
     it("conforms for raw transcript event load and append", async () => {

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -15,16 +15,13 @@ import {
   appendTranscriptMessage,
   cleanupSessionLifecycleArtifacts,
   listSessionEntries,
-  loadExactSessionEntry,
   loadSessionEntry,
-  loadTranscriptEvents,
   patchSessionEntry,
   publishTranscriptUpdate,
   readSessionUpdatedAt,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
-  type ExactSessionEntry,
   type SessionAccessScope,
   type SessionEntrySummary,
   type SessionTranscriptAccessScope,
@@ -57,6 +54,8 @@ import {
   updateSqliteSessionEntry,
   upsertSqliteSessionEntry,
 } from "./session-accessor.sqlite.js";
+import { loadSessionStore } from "./store.js";
+import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
 // Keep accessor conformance independent of any real openclaw.json on the machine.
@@ -113,6 +112,11 @@ type AccessorAdapter = {
   ): Promise<void>;
 };
 
+type ExactSessionEntry = {
+  entry: SessionEntry;
+  sessionKey: string;
+};
+
 type TestPaths = {
   sqlitePath: string;
   stateDir: string;
@@ -140,7 +144,7 @@ const fileBackedAdapter: AccessorAdapter = {
     storePath: paths.storePath,
   }),
   loadSessionEntry,
-  loadExactSessionEntry,
+  loadExactSessionEntry: loadExactFileSessionEntry,
   listSessionEntries,
   readSessionUpdatedAt,
   upsertSessionEntry,
@@ -148,11 +152,35 @@ const fileBackedAdapter: AccessorAdapter = {
   patchSessionEntry,
   updateSessionEntry,
   cleanupSessionLifecycleArtifacts,
-  loadTranscriptEvents,
+  loadTranscriptEvents: loadFileTranscriptEvents,
   appendTranscriptEvent,
   appendTranscriptMessage,
   publishTranscriptUpdate,
 };
+
+function loadExactFileSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined {
+  const sessionKey = scope.sessionKey.trim();
+  const storePath = scope.storePath?.trim();
+  if (!sessionKey || !storePath) {
+    return undefined;
+  }
+  const entry = loadSessionStore(storePath)[sessionKey];
+  return entry ? { sessionKey, entry: structuredClone(entry) } : undefined;
+}
+
+async function loadFileTranscriptEvents(
+  scope: SessionTranscriptReadScope,
+): Promise<TranscriptEvent[]> {
+  const sessionFile = scope.sessionFile?.trim();
+  if (!sessionFile) {
+    throw new Error("file-backed conformance reads require an explicit session file");
+  }
+  const events: TranscriptEvent[] = [];
+  for await (const line of streamSessionTranscriptLines(sessionFile)) {
+    events.push(JSON.parse(line) as TranscriptEvent);
+  }
+  return events;
+}
 
 const sqliteAdapter: AccessorAdapter = {
   name: "sqlite",

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -607,16 +607,15 @@ function sqliteTranscriptStateHasMarker(params: {
   transcriptContentMarker: string;
 }): boolean {
   const db = getSessionKysely(params.database.db);
-  const row = executeSqliteQueryTakeFirstSync(
+  const rows = executeSqliteQuerySync(
     params.database.db,
     db
       .selectFrom("transcript_events")
-      .select("seq")
+      .select("event_json")
       .where("session_id", "=", params.sessionId)
-      .where("event_json", "like", `%${params.transcriptContentMarker}%`)
-      .limit(1),
-  );
-  return row !== undefined;
+      .orderBy("seq", "asc"),
+  ).rows;
+  return rows.some((row) => row.event_json.includes(params.transcriptContentMarker));
 }
 
 function readReferencedSqliteSessionIds(database: OpenClawAgentDatabase): Set<string> {

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import type { Selectable } from "kysely";
 import type { AgentMessage } from "../../agents/runtime/index.js";
@@ -303,7 +304,7 @@ function resolveSqliteScope(
       ? normalizeAgentId(scope.agentId)
       : resolveAgentIdFromSessionKey(scope.sessionKey),
     ...(scope.env ? { env: scope.env } : {}),
-    ...(scope.storePath ? { path: scope.storePath } : {}),
+    ...(scope.storePath ? { path: resolveSqlitePathFromSessionStorePath(scope.storePath) } : {}),
     sessionKey: normalizeSqliteSessionKey(scope.sessionKey),
   };
 }
@@ -323,9 +324,25 @@ function resolveSqliteReadScope(
   return {
     agentId,
     ...(scope.env ? { env: scope.env } : {}),
-    ...(scope.storePath ? { path: scope.storePath } : {}),
+    ...(scope.storePath ? { path: resolveSqlitePathFromSessionStorePath(scope.storePath) } : {}),
     ...(sessionKey ? { sessionKey } : {}),
   };
+}
+
+function resolveSqlitePathFromSessionStorePath(storePath: string): string {
+  const resolved = path.resolve(storePath);
+  if (path.basename(resolved) !== "sessions.json") {
+    return resolved;
+  }
+  const sessionsDir = path.dirname(resolved);
+  if (path.basename(sessionsDir) !== "sessions") {
+    return resolved;
+  }
+  const agentDir = path.dirname(sessionsDir);
+  if (path.basename(path.dirname(agentDir)) !== "agents") {
+    return resolved;
+  }
+  return path.join(agentDir, "agent", "openclaw-agent.sqlite");
 }
 
 function resolveSqliteTranscriptScope(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -46,7 +46,7 @@ import {
   shouldRunSessionEntryMaintenance,
 } from "./store-maintenance.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
-import type { SessionEntry } from "./types.js";
+import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js";
 
 type SessionSqliteDatabase = Pick<
@@ -94,6 +94,45 @@ type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
 type ResolvedSqliteStoreTarget = {
   agentId?: string;
   path?: string;
+};
+type SqliteCheckpointTranscriptForkSource = {
+  sessionId: string;
+  leafId?: string;
+  totalTokens?: number;
+};
+
+/** Result from SQLite compaction checkpoint branch or restore operations. */
+export type SqliteCompactionCheckpointSessionMutationResult =
+  | {
+      status: "created";
+      key: string;
+      checkpoint: SessionCompactionCheckpoint;
+      entry: SessionEntry;
+    }
+  | { status: "missing-session" }
+  | { status: "missing-checkpoint" }
+  | { status: "missing-boundary" }
+  | { status: "failed" };
+
+/** Parameters for branching a SQLite session from a compaction checkpoint. */
+export type SqliteBranchCheckpointSessionParams = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  storePath?: string;
+  sourceKey: string;
+  sourceStoreKey?: string;
+  nextKey: string;
+  checkpointId: string;
+};
+
+/** Parameters for restoring a SQLite session from a compaction checkpoint. */
+export type SqliteRestoreCheckpointSessionParams = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  storePath?: string;
+  sessionKey: string;
+  sessionStoreKey?: string;
+  checkpointId: string;
 };
 
 const SQLITE_SESSION_WRITER_QUEUES = new Map<string, StoreWriterQueue>();
@@ -312,6 +351,50 @@ export function loadSqliteTranscriptEventsSync(
   return rows.map((row) => JSON.parse(row.event_json) as TranscriptEvent);
 }
 
+/** Checks whether the additive SQLite transcript store has rows for a transcript. */
+export function sqliteTranscriptExists(scope: SessionTranscriptReadScope): boolean {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select("seq")
+      .where("session_id", "=", resolved.sessionId)
+      .limit(1),
+  );
+  return row !== undefined;
+}
+
+/** Deletes rows for one transcript from the additive SQLite transcript store. */
+export async function deleteSqliteTranscript(scope: SessionTranscriptReadScope): Promise<boolean> {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let deleted = false;
+    runOpenClawAgentWriteTransaction((database) => {
+      deleted = deleteSqliteTranscriptEventsInTransaction(database, resolved.sessionId);
+    }, toDatabaseOptions(resolved));
+    return deleted;
+  });
+}
+
+/** Fully replaces rows for one transcript in the additive SQLite transcript store. */
+export async function replaceSqliteTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+  events: TranscriptEvent[],
+): Promise<void> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  await runExclusiveSqliteSessionWrite(resolved, async () => {
+    runOpenClawAgentWriteTransaction((database) => {
+      deleteSqliteTranscriptEventsInTransaction(database, resolved.sessionId);
+      for (const event of events) {
+        appendTranscriptEventInTransaction(database, resolved, event);
+      }
+    }, toDatabaseOptions(resolved));
+  });
+}
+
 /** Appends one raw transcript event to the additive SQLite transcript store. */
 export async function appendSqliteTranscriptEvent(
   scope: SessionTranscriptAccessScope,
@@ -322,6 +405,24 @@ export async function appendSqliteTranscriptEvent(
   await runExclusiveSqliteSessionWrite(resolved, async () => {
     runOpenClawAgentWriteTransaction((database) => {
       appendTranscriptEventInTransaction(database, resolved, event);
+    }, toDatabaseOptions(resolved));
+  });
+}
+
+/** Appends raw transcript events to the additive SQLite transcript store in one transaction. */
+export async function appendSqliteTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+  events: TranscriptEvent[],
+): Promise<void> {
+  if (events.length === 0) {
+    return;
+  }
+  const resolved = resolveSqliteTranscriptScope(scope);
+  await runExclusiveSqliteSessionWrite(resolved, async () => {
+    runOpenClawAgentWriteTransaction((database) => {
+      for (const event of events) {
+        appendTranscriptEventInTransaction(database, resolved, event);
+      }
     }, toDatabaseOptions(resolved));
   });
 }
@@ -402,6 +503,59 @@ export async function appendSqliteTranscriptMessage<TMessage>(
       };
     }, toDatabaseOptions(resolved));
     return result;
+  });
+}
+
+/** Branches a SQLite session from a compaction checkpoint in one queued transaction. */
+export async function branchSqliteCompactionCheckpointSession(
+  params: SqliteBranchCheckpointSessionParams,
+): Promise<SqliteCompactionCheckpointSessionMutationResult> {
+  const sourceKey = normalizeSqliteSessionKey(params.sourceStoreKey ?? params.sourceKey);
+  const targetKey = normalizeSqliteSessionKey(params.nextKey);
+  const resolved = resolveSqliteScope({
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(params.env ? { env: params.env } : {}),
+    sessionKey: sourceKey,
+    ...(params.storePath ? { storePath: params.storePath } : {}),
+  });
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: SqliteCompactionCheckpointSessionMutationResult | undefined;
+    runOpenClawAgentWriteTransaction((database) => {
+      result = branchSqliteCompactionCheckpointSessionInTransaction(database, {
+        checkpointId: params.checkpointId,
+        parentSessionKey: normalizeSqliteSessionKey(params.sourceKey),
+        resolved,
+        sourceKey,
+        targetKey,
+      });
+    }, toDatabaseOptions(resolved));
+    return result ?? { status: "failed" };
+  });
+}
+
+/** Restores a SQLite session from a compaction checkpoint in one queued transaction. */
+export async function restoreSqliteCompactionCheckpointSession(
+  params: SqliteRestoreCheckpointSessionParams,
+): Promise<SqliteCompactionCheckpointSessionMutationResult> {
+  const sessionKey = normalizeSqliteSessionKey(params.sessionStoreKey ?? params.sessionKey);
+  const targetKey = normalizeSqliteSessionKey(params.sessionKey);
+  const resolved = resolveSqliteScope({
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(params.env ? { env: params.env } : {}),
+    sessionKey,
+    ...(params.storePath ? { storePath: params.storePath } : {}),
+  });
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: SqliteCompactionCheckpointSessionMutationResult | undefined;
+    runOpenClawAgentWriteTransaction((database) => {
+      result = restoreSqliteCompactionCheckpointSessionInTransaction(database, {
+        checkpointId: params.checkpointId,
+        resolved,
+        sourceKey: sessionKey,
+        targetKey,
+      });
+    }, toDatabaseOptions(resolved));
+    return result ?? { status: "failed" };
   });
 }
 
@@ -738,9 +892,9 @@ function applySqliteSessionEntryMaintenance(
 
   const removedKeys = new Set<string>();
   const removedSessionIds = new Set<string>();
-  const rememberRemovedEntry = (params: { key: string; entry: SessionEntry }) => {
-    removedKeys.add(params.key);
-    removedSessionIds.add(params.entry.sessionId);
+  const rememberRemovedEntry = (removed: { key: string; entry: SessionEntry }) => {
+    removedKeys.add(removed.key);
+    removedSessionIds.add(removed.entry.sessionId);
   };
   const preserveKeys = collectSessionMaintenancePreserveKeys([params.activeSessionKey]);
   pruneStaleEntries(store, maintenance.pruneAfterMs, {
@@ -1219,6 +1373,307 @@ function readNextTranscriptSeq(database: OpenClawAgentDatabase, sessionId: strin
   return maxSeq + 1;
 }
 
+function deleteSqliteTranscriptEventsInTransaction(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): boolean {
+  const db = getSessionKysely(database.db);
+  executeSqliteQuerySync(
+    database.db,
+    db.deleteFrom("transcript_event_identities").where("session_id", "=", sessionId),
+  );
+  const result = executeSqliteQuerySync(
+    database.db,
+    db.deleteFrom("transcript_events").where("session_id", "=", sessionId),
+  );
+  return (result.numAffectedRows ?? 0n) > 0n;
+}
+
+function branchSqliteCompactionCheckpointSessionInTransaction(
+  database: OpenClawAgentDatabase,
+  params: {
+    checkpointId: string;
+    parentSessionKey: string;
+    resolved: ResolvedSqliteScope;
+    sourceKey: string;
+    targetKey: string;
+  },
+): SqliteCompactionCheckpointSessionMutationResult {
+  const currentEntry = readSessionEntryRow(database, params.sourceKey)?.entry;
+  if (!currentEntry?.sessionId) {
+    return { status: "missing-session" };
+  }
+  const checkpoint = readSessionCompactionCheckpoint(currentEntry, params.checkpointId);
+  if (!checkpoint) {
+    return { status: "missing-checkpoint" };
+  }
+  const forked = forkSqliteCheckpointTranscriptInTransaction(database, params.resolved, {
+    checkpoint,
+    targetSessionKey: params.targetKey,
+  });
+  if (forked.status !== "created") {
+    return forked;
+  }
+
+  const label = currentEntry.label?.trim()
+    ? `${currentEntry.label.trim()} (checkpoint)`
+    : "Checkpoint branch";
+  const nextEntry = cloneSqliteCheckpointSessionEntry({
+    currentEntry,
+    label,
+    nextSessionFile: forked.sessionFile,
+    nextSessionId: forked.sessionId,
+    parentSessionKey: params.parentSessionKey,
+    totalTokens: forked.totalTokens,
+  });
+  writeSessionEntry(database, params.targetKey, nextEntry);
+  return {
+    status: "created",
+    key: params.targetKey,
+    checkpoint,
+    entry: nextEntry,
+  };
+}
+
+function restoreSqliteCompactionCheckpointSessionInTransaction(
+  database: OpenClawAgentDatabase,
+  params: {
+    checkpointId: string;
+    resolved: ResolvedSqliteScope;
+    sourceKey: string;
+    targetKey: string;
+  },
+): SqliteCompactionCheckpointSessionMutationResult {
+  const currentEntry = readSessionEntryRow(database, params.sourceKey)?.entry;
+  if (!currentEntry?.sessionId) {
+    return { status: "missing-session" };
+  }
+  const checkpoint = readSessionCompactionCheckpoint(currentEntry, params.checkpointId);
+  if (!checkpoint) {
+    return { status: "missing-checkpoint" };
+  }
+  const restored = forkSqliteCheckpointTranscriptInTransaction(database, params.resolved, {
+    checkpoint,
+    targetSessionKey: params.targetKey,
+  });
+  if (restored.status !== "created") {
+    return restored;
+  }
+
+  const nextEntry = cloneSqliteCheckpointSessionEntry({
+    currentEntry,
+    nextSessionFile: restored.sessionFile,
+    nextSessionId: restored.sessionId,
+    preserveCompactionCheckpoints: true,
+    totalTokens: restored.totalTokens,
+  });
+  writeSessionEntry(database, params.targetKey, nextEntry);
+  return {
+    status: "created",
+    key: params.targetKey,
+    checkpoint,
+    entry: nextEntry,
+  };
+}
+
+function forkSqliteCheckpointTranscriptInTransaction(
+  database: OpenClawAgentDatabase,
+  resolved: ResolvedSqliteScope,
+  params: {
+    checkpoint: SessionCompactionCheckpoint;
+    targetSessionKey: string;
+  },
+):
+  | {
+      status: "created";
+      sessionId: string;
+      sessionFile: string;
+      totalTokens?: number;
+    }
+  | { status: "missing-boundary" }
+  | { status: "failed" } {
+  const sources = resolveSqliteCheckpointTranscriptForkSources(params.checkpoint);
+  if (sources.length === 0) {
+    return { status: "missing-boundary" };
+  }
+  let lastFailure: { status: "missing-boundary" } | { status: "failed" } = {
+    status: "missing-boundary",
+  };
+  let selected:
+    | {
+        source: SqliteCheckpointTranscriptForkSource;
+        rows: TranscriptEvent[];
+      }
+    | undefined;
+  for (const source of sources) {
+    const rows = readSqliteTranscriptRowsForFork(database, source);
+    if (rows.status === "created") {
+      selected = { source, rows: rows.events };
+      break;
+    }
+    lastFailure = rows;
+  }
+  if (!selected) {
+    return lastFailure;
+  }
+
+  const sessionId = randomUUID();
+  const targetScope = {
+    ...resolved,
+    sessionId,
+    sessionKey: params.targetSessionKey,
+  };
+  const sessionFile = formatSqliteTranscriptTarget(targetScope);
+  appendTranscriptEventInTransaction(
+    database,
+    targetScope,
+    createSessionTranscriptHeader({
+      cwd: readTranscriptHeaderCwd(selected.rows),
+      sessionId,
+    }),
+  );
+  for (const event of selected.rows) {
+    if (isSessionTranscriptHeader(event)) {
+      continue;
+    }
+    appendTranscriptEventInTransaction(database, targetScope, event);
+  }
+  return {
+    status: "created",
+    sessionId,
+    sessionFile,
+    ...(typeof selected.source.totalTokens === "number"
+      ? { totalTokens: selected.source.totalTokens }
+      : {}),
+  };
+}
+
+function resolveSqliteCheckpointTranscriptForkSources(
+  checkpoint: SessionCompactionCheckpoint,
+): SqliteCheckpointTranscriptForkSource[] {
+  const sources: SqliteCheckpointTranscriptForkSource[] = [];
+  if (checkpoint.preCompaction.sessionId) {
+    sources.push({
+      sessionId: checkpoint.preCompaction.sessionId,
+      ...(checkpoint.preCompaction.leafId ? { leafId: checkpoint.preCompaction.leafId } : {}),
+      ...(typeof checkpoint.tokensBefore === "number"
+        ? { totalTokens: checkpoint.tokensBefore }
+        : {}),
+    });
+  }
+
+  const postLeafId = checkpoint.postCompaction.leafId ?? checkpoint.postCompaction.entryId;
+  if (checkpoint.postCompaction.sessionId && postLeafId) {
+    sources.push({
+      sessionId: checkpoint.postCompaction.sessionId,
+      leafId: postLeafId,
+      ...(typeof checkpoint.tokensAfter === "number"
+        ? { totalTokens: checkpoint.tokensAfter }
+        : {}),
+    });
+  }
+
+  return sources;
+}
+
+function readSqliteTranscriptRowsForFork(
+  database: OpenClawAgentDatabase,
+  source: { sessionId: string; leafId?: string },
+): { status: "created"; events: TranscriptEvent[] } | { status: "missing-boundary" | "failed" } {
+  const boundarySeq = source.leafId
+    ? readTranscriptIdentityByEventId(database, source.sessionId, source.leafId)?.seq
+    : undefined;
+  if (source.leafId && boundarySeq === undefined) {
+    return { status: "missing-boundary" };
+  }
+
+  const db = getSessionKysely(database.db);
+  const query = db
+    .selectFrom("transcript_events")
+    .select(["event_json", "seq"])
+    .where("session_id", "=", source.sessionId)
+    .orderBy("seq", "asc");
+  const rows = executeSqliteQuerySync(
+    database.db,
+    boundarySeq === undefined ? query : query.where("seq", "<=", boundarySeq),
+  ).rows;
+  if (rows.length === 0) {
+    return { status: "failed" };
+  }
+  try {
+    return {
+      status: "created",
+      events: rows.map((row) => JSON.parse(row.event_json) as TranscriptEvent),
+    };
+  } catch {
+    return { status: "failed" };
+  }
+}
+
+function readSessionCompactionCheckpoint(
+  entry: Pick<SessionEntry, "compactionCheckpoints">,
+  checkpointId: string,
+): SessionCompactionCheckpoint | undefined {
+  const normalizedCheckpointId = checkpointId.trim();
+  if (!normalizedCheckpointId || !Array.isArray(entry.compactionCheckpoints)) {
+    return undefined;
+  }
+  return entry.compactionCheckpoints.find(
+    (checkpoint) => checkpoint.checkpointId === normalizedCheckpointId,
+  );
+}
+
+function cloneSqliteCheckpointSessionEntry(params: {
+  currentEntry: SessionEntry;
+  nextSessionId: string;
+  nextSessionFile: string;
+  label?: string;
+  parentSessionKey?: string;
+  totalTokens?: number;
+  preserveCompactionCheckpoints?: boolean;
+}): SessionEntry {
+  const hasTotalTokens =
+    typeof params.totalTokens === "number" && Number.isFinite(params.totalTokens);
+  return {
+    ...params.currentEntry,
+    sessionId: params.nextSessionId,
+    sessionFile: params.nextSessionFile,
+    updatedAt: Date.now(),
+    systemSent: false,
+    abortedLastRun: false,
+    startedAt: undefined,
+    endedAt: undefined,
+    runtimeMs: undefined,
+    status: undefined,
+    inputTokens: undefined,
+    outputTokens: undefined,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+    estimatedCostUsd: undefined,
+    totalTokens: hasTotalTokens ? params.totalTokens : undefined,
+    totalTokensFresh: hasTotalTokens ? true : undefined,
+    label: params.label ?? params.currentEntry.label,
+    parentSessionKey: params.parentSessionKey ?? params.currentEntry.parentSessionKey,
+    compactionCheckpoints: params.preserveCompactionCheckpoints
+      ? params.currentEntry.compactionCheckpoints
+      : undefined,
+  };
+}
+
+function readTranscriptHeaderCwd(events: readonly TranscriptEvent[]): string | undefined {
+  const header = events.find(isSessionTranscriptHeader) as { cwd?: unknown } | undefined;
+  return typeof header?.cwd === "string" && header.cwd.trim() ? header.cwd : undefined;
+}
+
+function isSessionTranscriptHeader(event: TranscriptEvent): boolean {
+  return Boolean(
+    event &&
+    typeof event === "object" &&
+    !Array.isArray(event) &&
+    (event as { type?: unknown }).type === "session",
+  );
+}
+
 function appendTranscriptEventInTransaction(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
@@ -1453,4 +1908,9 @@ function isTranscriptAgentMessage(value: unknown): value is AgentMessage {
     !Array.isArray(value) &&
     typeof (value as { role?: unknown }).role === "string"
   );
+}
+
+function formatSqliteTranscriptTarget(scope: ResolvedTranscriptScope): string {
+  const pathPart = scope.path ? `:${scope.path}` : "";
+  return `sqlite:${scope.agentId}:${scope.sessionId}${pathPart}`;
 }

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -27,6 +27,8 @@ import type {
   SessionEntryPatchContext,
   SessionEntryPatchOptions,
   SessionEntrySummary,
+  SessionLifecycleArtifactCleanupParams,
+  SessionLifecycleArtifactCleanupResult,
   SessionEntryUpdateOptions,
   SessionTranscriptAccessScope,
   SessionTranscriptReadScope,
@@ -229,6 +231,34 @@ export async function updateSqliteSessionEntry(
       const next = mergeSessionEntry(fresh, patch);
       writeSessionEntry(writeDatabase, resolved.sessionKey, next);
       result = cloneSessionEntry(next);
+    }, toDatabaseOptions(resolved));
+    return result;
+  });
+}
+
+/** Cleans scoped session lifecycle rows and associated SQLite transcript state. */
+export async function cleanupSqliteSessionLifecycleArtifacts(
+  params: SessionLifecycleArtifactCleanupParams,
+): Promise<SessionLifecycleArtifactCleanupResult> {
+  const sessionKeySegmentPrefix = params.sessionKeySegmentPrefix.trim();
+  const transcriptContentMarker = params.transcriptContentMarker;
+  if (!sessionKeySegmentPrefix || !transcriptContentMarker) {
+    return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
+  }
+
+  const resolved = resolveSqliteReadScope({ storePath: params.storePath });
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: SessionLifecycleArtifactCleanupResult = {
+      removedEntries: 0,
+      archivedTranscriptArtifacts: 0,
+    };
+    runOpenClawAgentWriteTransaction((database) => {
+      result = cleanupSqliteSessionLifecycleArtifactsInTransaction(database, {
+        sessionKeySegmentPrefix,
+        transcriptContentMarker,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        nowMs: params.nowMs ?? Date.now(),
+      });
     }, toDatabaseOptions(resolved));
     return result;
   });
@@ -531,6 +561,196 @@ function readExactSessionEntryRow(
   }
   const entry = parseSessionEntryRow(row);
   return entry ? { entry, row } : undefined;
+}
+
+function sessionKeySegmentStartsWith(sessionKey: string, prefix: string): boolean {
+  const firstSeparator = sessionKey.indexOf(":");
+  if (firstSeparator < 0) {
+    return sessionKey.startsWith(prefix);
+  }
+  const secondSeparator = sessionKey.indexOf(":", firstSeparator + 1);
+  const sessionSegment = secondSeparator < 0 ? sessionKey : sessionKey.slice(secondSeparator + 1);
+  return sessionSegment.startsWith(prefix);
+}
+
+function readSessionTranscriptUpdatedAt(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): number | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select((eb) => eb.fn.max<number | bigint>("created_at").as("updated_at"))
+      .where("session_id", "=", sessionId),
+  );
+  if (row?.updated_at === null || row?.updated_at === undefined) {
+    return undefined;
+  }
+  return normalizeSqliteNumber(row.updated_at);
+}
+
+function sqliteTranscriptStateIsReclaimable(params: {
+  database: OpenClawAgentDatabase;
+  sessionId: string;
+  nowMs: number;
+  orphanTranscriptMinAgeMs: number;
+}): boolean {
+  const updatedAt = readSessionTranscriptUpdatedAt(params.database, params.sessionId);
+  return updatedAt === undefined || params.nowMs - updatedAt >= params.orphanTranscriptMinAgeMs;
+}
+
+function sqliteTranscriptStateHasMarker(params: {
+  database: OpenClawAgentDatabase;
+  sessionId: string;
+  transcriptContentMarker: string;
+}): boolean {
+  const db = getSessionKysely(params.database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    params.database.db,
+    db
+      .selectFrom("transcript_events")
+      .select("seq")
+      .where("session_id", "=", params.sessionId)
+      .where("event_json", "like", `%${params.transcriptContentMarker}%`)
+      .limit(1),
+  );
+  return row !== undefined;
+}
+
+function readReferencedSqliteSessionIds(database: OpenClawAgentDatabase): Set<string> {
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db.selectFrom("session_entries").select("session_id"),
+  ).rows;
+  return new Set(rows.map((row) => row.session_id));
+}
+
+function deleteSqliteSessionStateIfUnreferenced(params: {
+  database: OpenClawAgentDatabase;
+  referencedSessionIds: ReadonlySet<string>;
+  sessionId: string;
+}): number {
+  if (params.referencedSessionIds.has(params.sessionId)) {
+    return 0;
+  }
+  const hadTranscriptState =
+    readSessionTranscriptUpdatedAt(params.database, params.sessionId) !== undefined;
+  const db = getSessionKysely(params.database.db);
+  executeSqliteQuerySync(
+    params.database.db,
+    db.deleteFrom("sessions").where("session_id", "=", params.sessionId),
+  );
+  return hadTranscriptState ? 1 : 0;
+}
+
+function cleanupSqliteOrphanLifecycleTranscriptState(params: {
+  database: OpenClawAgentDatabase;
+  referencedSessionIds: ReadonlySet<string>;
+  transcriptContentMarker: string;
+  orphanTranscriptMinAgeMs: number;
+  nowMs: number;
+}): number {
+  const db = getSessionKysely(params.database.db);
+  const rows = executeSqliteQuerySync(
+    params.database.db,
+    db.selectFrom("sessions").select("session_id").orderBy("session_id", "asc"),
+  ).rows;
+
+  let removed = 0;
+  // Orphan transcript state is represented by a sessions row without a live
+  // session entry. The marker keeps this scoped to the caller-owned lifecycle.
+  for (const row of rows) {
+    if (params.referencedSessionIds.has(row.session_id)) {
+      continue;
+    }
+    if (
+      !sqliteTranscriptStateIsReclaimable({
+        database: params.database,
+        sessionId: row.session_id,
+        nowMs: params.nowMs,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+      }) ||
+      !sqliteTranscriptStateHasMarker({
+        database: params.database,
+        sessionId: row.session_id,
+        transcriptContentMarker: params.transcriptContentMarker,
+      })
+    ) {
+      continue;
+    }
+    executeSqliteQuerySync(
+      params.database.db,
+      db.deleteFrom("sessions").where("session_id", "=", row.session_id),
+    );
+    removed += 1;
+  }
+  return removed;
+}
+
+function cleanupSqliteSessionLifecycleArtifactsInTransaction(
+  database: OpenClawAgentDatabase,
+  params: {
+    sessionKeySegmentPrefix: string;
+    transcriptContentMarker: string;
+    orphanTranscriptMinAgeMs: number;
+    nowMs: number;
+  },
+): SessionLifecycleArtifactCleanupResult {
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .select(["session_key", "session_id"])
+      .orderBy("session_key", "asc"),
+  ).rows;
+
+  const removedSessionIds = new Set<string>();
+  let removedEntries = 0;
+  // Delete matching lifecycle entries first; session/transcript state is only
+  // removed after we rebuild the post-delete reference set below.
+  for (const row of rows) {
+    if (!sessionKeySegmentStartsWith(row.session_key, params.sessionKeySegmentPrefix)) {
+      continue;
+    }
+    if (
+      !sqliteTranscriptStateIsReclaimable({
+        database,
+        sessionId: row.session_id,
+        nowMs: params.nowMs,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+      })
+    ) {
+      continue;
+    }
+    executeSqliteQuerySync(
+      database.db,
+      db.deleteFrom("session_entries").where("session_key", "=", row.session_key),
+    );
+    removedSessionIds.add(row.session_id);
+    removedEntries += 1;
+  }
+
+  const referencedSessionIds = readReferencedSqliteSessionIds(database);
+  let archivedTranscriptArtifacts = 0;
+  for (const sessionId of removedSessionIds) {
+    archivedTranscriptArtifacts += deleteSqliteSessionStateIfUnreferenced({
+      database,
+      referencedSessionIds,
+      sessionId,
+    });
+  }
+  archivedTranscriptArtifacts += cleanupSqliteOrphanLifecycleTranscriptState({
+    database,
+    referencedSessionIds,
+    transcriptContentMarker: params.transcriptContentMarker,
+    orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+    nowMs: params.nowMs,
+  });
+  return { removedEntries, archivedTranscriptArtifacts };
 }
 
 function writeSessionEntry(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -38,6 +38,13 @@ import type {
   TranscriptUpdatePayload,
 } from "./session-accessor.js";
 import { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
+import { collectSessionMaintenancePreserveKeys } from "./store-maintenance-preserve.js";
+import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
+import {
+  capEntryCount,
+  pruneStaleEntries,
+  shouldRunSessionEntryMaintenance,
+} from "./store-maintenance.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import type { SessionEntry } from "./types.js";
 import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js";
@@ -57,6 +64,9 @@ type ResolvedSessionEntryRow = {
   entry: SessionEntry;
   legacyKeys: string[];
   row: SessionEntryRow;
+};
+type SqliteSessionEntryPatchOptions = SessionEntryPatchOptions & {
+  skipMaintenance?: boolean;
 };
 
 type ResolvedSqliteScope = {
@@ -167,7 +177,7 @@ export async function patchSqliteSessionEntry(
     entry: SessionEntry,
     context: SessionEntryPatchContext,
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
-  options: SessionEntryPatchOptions = {},
+  options: SqliteSessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {
   const resolved = resolveSqliteScope(scope);
   return await runExclusiveSqliteSessionWrite(resolved, async () => {
@@ -199,6 +209,10 @@ export async function patchSqliteSessionEntry(
           : mergeSessionEntry(writeBase, patch);
       writeSessionEntry(writeDatabase, resolved.sessionKey, next);
       deleteLegacySessionEntryRows(writeDatabase, fresh?.legacyKeys ?? [], resolved.sessionKey);
+      applySqliteSessionEntryMaintenance(writeDatabase, {
+        activeSessionKey: resolved.sessionKey,
+        skipMaintenance: options.skipMaintenance,
+      });
       result = cloneSessionEntry(next);
     }, toDatabaseOptions(resolved));
     return result;
@@ -211,7 +225,7 @@ export async function updateSqliteSessionEntry(
   update: (
     entry: SessionEntry,
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
-  _options: SessionEntryUpdateOptions = {},
+  options: SessionEntryUpdateOptions = {},
 ): Promise<SessionEntry | null> {
   const resolved = resolveSqliteScope(scope);
   return await runExclusiveSqliteSessionWrite(resolved, async () => {
@@ -235,6 +249,10 @@ export async function updateSqliteSessionEntry(
       const next = mergeSessionEntry(fresh.entry, patch);
       writeSessionEntry(writeDatabase, resolved.sessionKey, next);
       deleteLegacySessionEntryRows(writeDatabase, fresh.legacyKeys, resolved.sessionKey);
+      applySqliteSessionEntryMaintenance(writeDatabase, {
+        activeSessionKey: resolved.sessionKey,
+        skipMaintenance: options.skipMaintenance,
+      });
       result = cloneSessionEntry(next);
     }, toDatabaseOptions(resolved));
     return result;
@@ -690,6 +708,76 @@ function deleteLegacySessionEntryRows(
       database.db,
       db.deleteFrom("session_entries").where("session_key", "=", legacyKey),
     );
+  }
+}
+
+function applySqliteSessionEntryMaintenance(
+  database: OpenClawAgentDatabase,
+  params: { activeSessionKey: string; skipMaintenance?: boolean },
+): void {
+  if (params.skipMaintenance) {
+    return;
+  }
+  const maintenance = resolveMaintenanceConfig();
+  if (maintenance.mode === "warn") {
+    return;
+  }
+
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db.selectFrom("session_entries").select(["session_key", "entry_json"]).orderBy("session_key"),
+  ).rows;
+  const store: Record<string, SessionEntry> = {};
+  for (const row of rows) {
+    const entry = parseSessionEntryRow(row);
+    if (entry) {
+      store[row.session_key] = entry;
+    }
+  }
+
+  const removedKeys = new Set<string>();
+  const removedSessionIds = new Set<string>();
+  const rememberRemovedEntry = (params: { key: string; entry: SessionEntry }) => {
+    removedKeys.add(params.key);
+    removedSessionIds.add(params.entry.sessionId);
+  };
+  const preserveKeys = collectSessionMaintenancePreserveKeys([params.activeSessionKey]);
+  pruneStaleEntries(store, maintenance.pruneAfterMs, {
+    log: false,
+    onPruned: rememberRemovedEntry,
+    preserveKeys,
+  });
+  if (
+    shouldRunSessionEntryMaintenance({
+      entryCount: Object.keys(store).length,
+      maxEntries: maintenance.maxEntries,
+    })
+  ) {
+    capEntryCount(store, maintenance.maxEntries, {
+      log: false,
+      onCapped: rememberRemovedEntry,
+      preserveKeys,
+    });
+  }
+
+  for (const sessionKey of removedKeys) {
+    executeSqliteQuerySync(
+      database.db,
+      db.deleteFrom("session_routes").where("session_key", "=", sessionKey),
+    );
+    executeSqliteQuerySync(
+      database.db,
+      db.deleteFrom("session_entries").where("session_key", "=", sessionKey),
+    );
+  }
+  const referencedSessionIds = readReferencedSqliteSessionIds(database);
+  for (const sessionId of removedSessionIds) {
+    deleteSqliteSessionStateIfUnreferenced({
+      database,
+      referencedSessionIds,
+      sessionId,
+    });
   }
 }
 

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -486,8 +486,16 @@ function resolveSqliteTranscriptScope(
       `Cannot resolve SQLite transcript scope without a session id: ${scope.sessionKey}`,
     );
   }
+  if (!scope.sessionKey) {
+    throw new Error(
+      `Cannot resolve SQLite transcript scope without a session key: ${scope.sessionId}`,
+    );
+  }
   return {
-    ...resolveSqliteScope(scope),
+    ...resolveSqliteScope({
+      ...scope,
+      sessionKey: scope.sessionKey,
+    }),
     sessionId: scope.sessionId,
   };
 }

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,0 +1,643 @@
+import { randomUUID } from "node:crypto";
+import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import type { Selectable } from "kysely";
+import type { AgentMessage } from "../../agents/runtime/index.js";
+import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import { redactSecrets } from "../../logging/redact.js";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import {
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+  type OpenClawAgentDatabase,
+  type OpenClawAgentDatabaseOptions,
+} from "../../state/openclaw-agent-db.js";
+import type {
+  SessionAccessScope,
+  SessionEntryPatchContext,
+  SessionEntryPatchOptions,
+  SessionEntrySummary,
+  SessionEntryUpdateOptions,
+  SessionTranscriptAccessScope,
+  SessionTranscriptWriteScope,
+  TranscriptEvent,
+  TranscriptMessageAppendOptions,
+  TranscriptMessageAppendResult,
+  TranscriptUpdatePayload,
+} from "./session-accessor.js";
+import { normalizeStoreSessionKey } from "./store-entry.js";
+import { createSessionTranscriptHeader } from "./transcript-header.js";
+import type { SessionEntry } from "./types.js";
+import { mergeSessionEntry } from "./types.js";
+
+type SessionSqliteDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "session_entries" | "sessions" | "transcript_event_identities" | "transcript_events"
+>;
+type SessionEntryRow = Selectable<OpenClawAgentKyselyDatabase["session_entries"]>;
+
+type ResolvedSqliteScope = {
+  agentId: string;
+  env?: NodeJS.ProcessEnv;
+  path?: string;
+  sessionKey: string;
+};
+
+type ResolvedTranscriptScope = ResolvedSqliteScope & {
+  sessionId: string;
+};
+
+/** Loads one session entry from the additive SQLite session store. */
+export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  const resolved = resolveSqliteScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  return readSessionEntryRow(database, resolved.sessionKey)?.entry;
+}
+
+/** Lists session entries from the additive SQLite session store. */
+export function listSqliteSessionEntries(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+): SessionEntrySummary[] {
+  const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .select(["session_key", "entry_json", "session_id", "updated_at"])
+      .orderBy("session_key", "asc"),
+  ).rows;
+  return rows
+    .map((row) => {
+      const entry = parseSessionEntryRow(row);
+      return entry ? { sessionKey: row.session_key, entry } : undefined;
+    })
+    .filter((entry): entry is SessionEntrySummary => entry !== undefined);
+}
+
+/** Reads a session activity timestamp from the additive SQLite session store. */
+export function readSqliteSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
+  const resolved = resolveSqliteScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .select("updated_at")
+      .where("session_key", "=", resolved.sessionKey),
+  );
+  return row ? normalizeSqliteNumber(row.updated_at) : undefined;
+}
+
+/** Applies a partial entry update to the additive SQLite session store. */
+export async function upsertSqliteSessionEntry(
+  scope: SessionAccessScope,
+  patch: Partial<SessionEntry>,
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntry(scope, () => patch, {
+    fallbackEntry: createFallbackSessionEntry(patch),
+  });
+}
+
+/** Replaces one entry in the additive SQLite session store. */
+export async function replaceSqliteSessionEntry(
+  scope: SessionAccessScope,
+  entry: SessionEntry,
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntry(scope, () => entry, {
+    fallbackEntry: entry,
+    replaceEntry: true,
+  });
+}
+
+/** Patches one entry in the additive SQLite session store. */
+export async function patchSqliteSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+    context: SessionEntryPatchContext,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  const resolved = resolveSqliteScope(scope);
+  const existing = loadSqliteSessionEntry(scope);
+  const base = existing ?? options.fallbackEntry;
+  if (!base) {
+    return null;
+  }
+  const patch = await update(cloneSessionEntry(base), {
+    existingEntry: existing ? cloneSessionEntry(existing) : undefined,
+  });
+  if (!patch) {
+    return cloneSessionEntry(base);
+  }
+  const next = options.replaceEntry
+    ? cloneSessionEntry(patch as SessionEntry)
+    : mergeSessionEntry(base, patch);
+  runOpenClawAgentWriteTransaction((database) => {
+    writeSessionEntry(database, resolved.sessionKey, next);
+  }, toDatabaseOptions(resolved));
+  return cloneSessionEntry(next);
+}
+
+/** Updates an existing entry in the additive SQLite session store. */
+export async function updateSqliteSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  _options: SessionEntryUpdateOptions = {},
+): Promise<SessionEntry | null> {
+  const existing = loadSqliteSessionEntry(scope);
+  if (!existing) {
+    return null;
+  }
+  const patch = await update(cloneSessionEntry(existing));
+  if (!patch) {
+    return cloneSessionEntry(existing);
+  }
+  const next = mergeSessionEntry(existing, patch);
+  const resolved = resolveSqliteScope(scope);
+  runOpenClawAgentWriteTransaction((database) => {
+    writeSessionEntry(database, resolved.sessionKey, next);
+  }, toDatabaseOptions(resolved));
+  return cloneSessionEntry(next);
+}
+
+/** Loads raw transcript events from the additive SQLite transcript store. */
+export async function loadSqliteTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+): Promise<TranscriptEvent[]> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select(["event_json"])
+      .where("session_id", "=", resolved.sessionId)
+      .orderBy("seq", "asc"),
+  ).rows;
+  return rows.map((row) => JSON.parse(row.event_json) as TranscriptEvent);
+}
+
+/** Appends one raw transcript event to the additive SQLite transcript store. */
+export async function appendSqliteTranscriptEvent(
+  scope: SessionTranscriptAccessScope,
+  event: TranscriptEvent,
+): Promise<void> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  runOpenClawAgentWriteTransaction((database) => {
+    appendTranscriptEventInTransaction(database, resolved, event);
+  }, toDatabaseOptions(resolved));
+}
+
+/** Appends one transcript message to the additive SQLite transcript store. */
+export async function appendSqliteTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage> & {
+    prepareMessageAfterIdempotencyCheck: (message: TMessage) => TMessage | undefined;
+  },
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+export async function appendSqliteTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage>>;
+export async function appendSqliteTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  const idempotencyKey = readMessageIdempotencyKey(options.message);
+  if (idempotencyKey && options.idempotencyLookup === "scan") {
+    const existing = readTranscriptMessageByIdempotencyKey(resolved, idempotencyKey);
+    if (existing) {
+      return {
+        appended: false,
+        message: existing.message as TMessage,
+        messageId: existing.messageId,
+      };
+    }
+  }
+
+  const prepared = options.prepareMessageAfterIdempotencyCheck
+    ? options.prepareMessageAfterIdempotencyCheck(options.message)
+    : options.message;
+  if (prepared === undefined) {
+    return undefined;
+  }
+
+  const messageId = randomUUID();
+  const now = options.now ?? Date.now();
+  const finalMessage = redactTranscriptMessageForStorage(prepared, options);
+  runOpenClawAgentWriteTransaction((database) => {
+    ensureTranscriptHeader(database, resolved, options.cwd, now);
+    const parentId = readLatestTranscriptMessageId(database, resolved.sessionId);
+    const event = {
+      type: "message",
+      id: messageId,
+      parentId: parentId ?? null,
+      timestamp: resolveTimestampMsToIsoString(now),
+      message: finalMessage,
+    };
+    appendTranscriptEventInTransaction(database, resolved, event);
+  }, toDatabaseOptions(resolved));
+  return {
+    appended: true,
+    message: finalMessage,
+    messageId,
+  };
+}
+
+/** Publishes a transcript update using the SQLite transcript scope target. */
+export async function publishSqliteTranscriptUpdate(
+  scope: SessionTranscriptWriteScope,
+  update: TranscriptUpdatePayload = {},
+): Promise<void> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  emitSessionTranscriptUpdate({
+    ...update,
+    sessionFile: formatSqliteTranscriptTarget(resolved),
+  });
+}
+
+function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
+  return getNodeSqliteKysely<SessionSqliteDatabase>(database);
+}
+
+function resolveSqliteScope(
+  scope: Pick<SessionAccessScope, "agentId" | "env" | "sessionKey" | "storePath">,
+): ResolvedSqliteScope {
+  return {
+    agentId: scope.agentId
+      ? normalizeAgentId(scope.agentId)
+      : resolveAgentIdFromSessionKey(scope.sessionKey),
+    ...(scope.env ? { env: scope.env } : {}),
+    ...(scope.storePath ? { path: scope.storePath } : {}),
+    sessionKey: normalizeSqliteSessionKey(scope.sessionKey),
+  };
+}
+
+function resolveSqliteTranscriptScope(
+  scope: Pick<
+    SessionTranscriptWriteScope,
+    "agentId" | "env" | "sessionId" | "sessionKey" | "storePath"
+  >,
+): ResolvedTranscriptScope {
+  if (!scope.sessionId) {
+    throw new Error(
+      `Cannot resolve SQLite transcript scope without a session id: ${scope.sessionKey}`,
+    );
+  }
+  return {
+    ...resolveSqliteScope(scope),
+    sessionId: scope.sessionId,
+  };
+}
+
+function toDatabaseOptions(
+  scope: Pick<ResolvedSqliteScope, "agentId" | "env" | "path">,
+): OpenClawAgentDatabaseOptions {
+  return {
+    agentId: scope.agentId,
+    ...(scope.env ? { env: scope.env } : {}),
+    ...(scope.path ? { path: scope.path } : {}),
+  };
+}
+
+function normalizeSqliteSessionKey(sessionKey: string): string {
+  return normalizeStoreSessionKey(sessionKey);
+}
+
+function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
+  const now = Date.now();
+  return {
+    sessionId: patch.sessionId ?? randomUUID(),
+    updatedAt: patch.updatedAt ?? now,
+    ...patch,
+  };
+}
+
+function cloneSessionEntry(entry: SessionEntry): SessionEntry {
+  return structuredClone(entry);
+}
+
+function normalizeSqliteNumber(value: number | bigint): number {
+  return typeof value === "bigint" ? Number(value) : value;
+}
+
+function parseSessionEntryRow(row: Pick<SessionEntryRow, "entry_json">): SessionEntry | null {
+  try {
+    const parsed = JSON.parse(row.entry_json) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as SessionEntry)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readSessionEntryRow(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): { entry: SessionEntry; row: SessionEntryRow } | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .selectAll()
+      .where("session_key", "=", normalizeSqliteSessionKey(sessionKey)),
+  );
+  if (!row) {
+    return undefined;
+  }
+  const entry = parseSessionEntryRow(row);
+  return entry ? { entry, row } : undefined;
+}
+
+function writeSessionEntry(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+  entry: SessionEntry,
+): void {
+  const db = getSessionKysely(database.db);
+  const updatedAt = entry.updatedAt;
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("sessions")
+      .values({
+        session_id: entry.sessionId,
+        session_key: sessionKey,
+        created_at: entry.sessionStartedAt ?? updatedAt,
+        updated_at: updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_id").doUpdateSet({
+          session_key: sessionKey,
+          updated_at: updatedAt,
+        }),
+      ),
+  );
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("session_entries")
+      .values({
+        session_key: sessionKey,
+        session_id: entry.sessionId,
+        entry_json: JSON.stringify(entry),
+        updated_at: updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_key").doUpdateSet({
+          session_id: entry.sessionId,
+          entry_json: JSON.stringify(entry),
+          updated_at: updatedAt,
+        }),
+      ),
+  );
+}
+
+function ensureTranscriptSessionRoot(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  updatedAt: number,
+): void {
+  const db = getSessionKysely(database.db);
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("sessions")
+      .values({
+        session_id: scope.sessionId,
+        session_key: scope.sessionKey,
+        created_at: updatedAt,
+        updated_at: updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_id").doUpdateSet({
+          session_key: scope.sessionKey,
+          updated_at: updatedAt,
+        }),
+      ),
+  );
+}
+
+function readNextTranscriptSeq(database: OpenClawAgentDatabase, sessionId: string): number {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select((eb) => eb.fn.max<number | bigint>("seq").as("max_seq"))
+      .where("session_id", "=", sessionId),
+  );
+  const maxSeq =
+    row?.max_seq === null || row?.max_seq === undefined ? -1 : normalizeSqliteNumber(row.max_seq);
+  return maxSeq + 1;
+}
+
+function appendTranscriptEventInTransaction(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  event: TranscriptEvent,
+): void {
+  const db = getSessionKysely(database.db);
+  const createdAt = readEventTimestamp(event) ?? Date.now();
+  ensureTranscriptSessionRoot(database, scope, createdAt);
+  const seq = readNextTranscriptSeq(database, scope.sessionId);
+  executeSqliteQuerySync(
+    database.db,
+    db.insertInto("transcript_events").values({
+      session_id: scope.sessionId,
+      seq,
+      event_json: JSON.stringify(event),
+      created_at: createdAt,
+    }),
+  );
+  const identity = readTranscriptEventIdentity(event);
+  if (!identity) {
+    return;
+  }
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("transcript_event_identities")
+      .values({
+        session_id: scope.sessionId,
+        event_id: identity.eventId,
+        seq,
+        event_type: identity.eventType,
+        parent_id: identity.parentId,
+        message_idempotency_key: identity.messageIdempotencyKey,
+        created_at: createdAt,
+      })
+      .onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
+  );
+}
+
+function ensureTranscriptHeader(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  cwd: string | undefined,
+  now: number,
+): void {
+  const db = getSessionKysely(database.db);
+  const existing = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select("seq")
+      .where("session_id", "=", scope.sessionId)
+      .limit(1),
+  );
+  if (existing) {
+    return;
+  }
+  appendTranscriptEventInTransaction(
+    database,
+    scope,
+    createSessionTranscriptHeader({
+      cwd,
+      sessionId: scope.sessionId,
+    }),
+  );
+  ensureTranscriptSessionRoot(database, scope, now);
+}
+
+function readLatestTranscriptMessageId(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): string | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select(["event_id"])
+      .where("session_id", "=", sessionId)
+      .where("event_type", "=", "message")
+      .orderBy("seq", "desc")
+      .limit(1),
+  );
+  return row?.event_id;
+}
+
+function readTranscriptMessageByIdempotencyKey(
+  scope: ResolvedTranscriptScope,
+  idempotencyKey: string,
+): { messageId: string; message: unknown } | undefined {
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(scope));
+  const db = getSessionKysely(database.db);
+  const identity = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select(["event_id", "seq"])
+      .where("session_id", "=", scope.sessionId)
+      .where("message_idempotency_key", "=", idempotencyKey)
+      .orderBy("seq", "desc")
+      .limit(1),
+  );
+  if (!identity) {
+    return undefined;
+  }
+  const eventRow = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select(["event_json"])
+      .where("session_id", "=", scope.sessionId)
+      .where("seq", "=", identity.seq),
+  );
+  if (!eventRow) {
+    return undefined;
+  }
+  const event = JSON.parse(eventRow.event_json) as { message?: unknown };
+  return {
+    messageId: identity.event_id,
+    message: event.message,
+  };
+}
+
+function readTranscriptEventIdentity(event: unknown):
+  | {
+      eventId: string;
+      eventType: string | null;
+      parentId: string | null;
+      messageIdempotencyKey: string | null;
+    }
+  | undefined {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return undefined;
+  }
+  const record = event as Record<string, unknown>;
+  const eventId = typeof record.id === "string" && record.id.trim() ? record.id.trim() : undefined;
+  if (!eventId) {
+    return undefined;
+  }
+  return {
+    eventId,
+    eventType: typeof record.type === "string" ? record.type : null,
+    parentId: typeof record.parentId === "string" ? record.parentId : null,
+    messageIdempotencyKey: readMessageIdempotencyKey(record.message),
+  };
+}
+
+function readMessageIdempotencyKey(message: unknown): string | null {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return null;
+  }
+  const value = (message as { idempotencyKey?: unknown }).idempotencyKey;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readEventTimestamp(event: unknown): number | undefined {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return undefined;
+  }
+  const value = (event as { timestamp?: unknown }).timestamp;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function redactTranscriptMessageForStorage<TMessage>(
+  message: TMessage,
+  options: Pick<TranscriptMessageAppendOptions<TMessage>, "config">,
+): TMessage {
+  if (isTranscriptAgentMessage(message)) {
+    return redactTranscriptMessage(message, options.config) as TMessage;
+  }
+  return redactSecrets(message);
+}
+
+function isTranscriptAgentMessage(value: unknown): value is AgentMessage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { role?: unknown }).role === "string"
+  );
+}
+
+function formatSqliteTranscriptTarget(scope: ResolvedTranscriptScope): string {
+  const pathPart = scope.path ? `:${scope.path}` : "";
+  return `sqlite:${scope.agentId}:${scope.sessionId}${pathPart}`;
+}

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -25,6 +25,7 @@ import type {
   SessionEntrySummary,
   SessionEntryUpdateOptions,
   SessionTranscriptAccessScope,
+  SessionTranscriptReadScope,
   SessionTranscriptWriteScope,
   TranscriptEvent,
   TranscriptMessageAppendOptions,
@@ -49,7 +50,18 @@ type ResolvedSqliteScope = {
   sessionKey: string;
 };
 
+type ResolvedSqliteReadScope = {
+  agentId: string;
+  env?: NodeJS.ProcessEnv;
+  path?: string;
+  sessionKey?: string;
+};
+
 type ResolvedTranscriptScope = ResolvedSqliteScope & {
+  sessionId: string;
+};
+
+type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
   sessionId: string;
 };
 
@@ -174,9 +186,16 @@ export async function updateSqliteSessionEntry(
 
 /** Loads raw transcript events from the additive SQLite transcript store. */
 export async function loadSqliteTranscriptEvents(
-  scope: SessionTranscriptAccessScope,
+  scope: SessionTranscriptReadScope,
 ): Promise<TranscriptEvent[]> {
-  const resolved = resolveSqliteTranscriptScope(scope);
+  return loadSqliteTranscriptEventsSync(scope);
+}
+
+/** Loads raw transcript events synchronously from the additive SQLite transcript store. */
+export function loadSqliteTranscriptEventsSync(
+  scope: SessionTranscriptReadScope,
+): TranscriptEvent[] {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   const db = getSessionKysely(database.db);
   const rows = executeSqliteQuerySync(
@@ -287,6 +306,26 @@ function resolveSqliteScope(
   };
 }
 
+function resolveSqliteReadScope(
+  scope: Pick<SessionTranscriptReadScope, "agentId" | "env" | "sessionKey" | "storePath">,
+): ResolvedSqliteReadScope {
+  const sessionKey = scope.sessionKey ? normalizeSqliteSessionKey(scope.sessionKey) : undefined;
+  const agentId = scope.agentId
+    ? normalizeAgentId(scope.agentId)
+    : sessionKey
+      ? resolveAgentIdFromSessionKey(sessionKey)
+      : undefined;
+  if (!agentId) {
+    throw new Error("Cannot resolve SQLite transcript read scope without an agent id");
+  }
+  return {
+    agentId,
+    ...(scope.env ? { env: scope.env } : {}),
+    ...(scope.storePath ? { path: scope.storePath } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+  };
+}
+
 function resolveSqliteTranscriptScope(
   scope: Pick<
     SessionTranscriptWriteScope,
@@ -304,8 +343,20 @@ function resolveSqliteTranscriptScope(
   };
 }
 
+function resolveSqliteTranscriptReadScope(
+  scope: Pick<
+    SessionTranscriptReadScope,
+    "agentId" | "env" | "sessionId" | "sessionKey" | "storePath"
+  >,
+): ResolvedTranscriptReadScope {
+  return {
+    ...resolveSqliteReadScope(scope),
+    sessionId: scope.sessionId,
+  };
+}
+
 function toDatabaseOptions(
-  scope: Pick<ResolvedSqliteScope, "agentId" | "env" | "path">,
+  scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
 ): OpenClawAgentDatabaseOptions {
   return {
     agentId: scope.agentId,

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -11,7 +11,6 @@ import {
 } from "../../infra/kysely-sync.js";
 import { redactSecrets } from "../../logging/redact.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { runQueuedStoreWrite, type StoreWriterQueue } from "../../shared/store-writer-queue.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
@@ -300,6 +299,7 @@ export async function appendSqliteTranscriptEvent(
   scope: SessionTranscriptAccessScope,
   event: TranscriptEvent,
 ): Promise<void> {
+  assertNonMessageTranscriptEvent(event);
   const resolved = resolveSqliteTranscriptScope(scope);
   await runExclusiveSqliteSessionWrite(resolved, async () => {
     runOpenClawAgentWriteTransaction((database) => {
@@ -392,11 +392,10 @@ export async function publishSqliteTranscriptUpdate(
   scope: SessionTranscriptWriteScope,
   update: TranscriptUpdatePayload = {},
 ): Promise<void> {
-  const resolved = resolveSqliteTranscriptScope(scope);
-  emitSessionTranscriptUpdate({
-    ...update,
-    sessionFile: formatSqliteTranscriptTarget(resolved),
-  });
+  void scope;
+  void update;
+  // SessionTranscriptUpdate.sessionFile is still a real file-path contract.
+  // SQLite updates stay quiet until listeners support typed SQLite targets.
 }
 
 function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
@@ -562,6 +561,19 @@ function parseSessionEntryRow(row: Pick<SessionEntryRow, "entry_json">): Session
       : null;
   } catch {
     return null;
+  }
+}
+
+function assertNonMessageTranscriptEvent(event: TranscriptEvent): void {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return;
+  }
+  // Message records require parent-link, idempotency, and redaction handling
+  // from appendSqliteTranscriptMessage; raw event writes would bypass those invariants.
+  if ((event as { type?: unknown }).type === "message") {
+    throw new Error(
+      "appendSqliteTranscriptEvent cannot write message transcript records; use appendSqliteTranscriptMessage instead.",
+    );
   }
 }
 
@@ -1240,9 +1252,4 @@ function isTranscriptAgentMessage(value: unknown): value is AgentMessage {
     !Array.isArray(value) &&
     typeof (value as { role?: unknown }).role === "string"
   );
-}
-
-function formatSqliteTranscriptTarget(scope: ResolvedTranscriptScope): string {
-  const pathPart = scope.path ? `:${scope.path}` : "";
-  return `sqlite:${scope.agentId}:${scope.sessionId}${pathPart}`;
 }

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -12,9 +12,11 @@ import {
 import { redactSecrets } from "../../logging/redact.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { runQueuedStoreWrite, type StoreWriterQueue } from "../../shared/store-writer-queue.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,
@@ -70,6 +72,8 @@ type ResolvedSqliteStoreTarget = {
   agentId?: string;
   path?: string;
 };
+
+const SQLITE_SESSION_WRITER_QUEUES = new Map<string, StoreWriterQueue>();
 
 /** Loads one session entry from the additive SQLite session store. */
 export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
@@ -146,26 +150,38 @@ export async function patchSqliteSessionEntry(
   options: SessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {
   const resolved = resolveSqliteScope(scope);
-  const existing = loadSqliteSessionEntry(scope);
-  const base = existing ?? options.fallbackEntry;
-  if (!base) {
-    return null;
-  }
-  const patch = await update(cloneSessionEntry(base), {
-    existingEntry: existing ? cloneSessionEntry(existing) : undefined,
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    const existing = readSessionEntryRow(database, resolved.sessionKey)?.entry;
+    const base = existing ?? options.fallbackEntry;
+    if (!base) {
+      return null;
+    }
+    const patch = await update(cloneSessionEntry(base), {
+      existingEntry: existing ? cloneSessionEntry(existing) : undefined,
+    });
+    if (!patch) {
+      return cloneSessionEntry(base);
+    }
+
+    let result: SessionEntry | null = null;
+    runOpenClawAgentWriteTransaction((writeDatabase) => {
+      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey)?.entry;
+      const writeBase = fresh ?? options.fallbackEntry;
+      if (!writeBase) {
+        result = null;
+        return;
+      }
+      const next = options.replaceEntry
+        ? cloneSessionEntry(patch as SessionEntry)
+        : options.preserveActivity
+          ? mergeSessionEntryPreserveActivity(writeBase, patch)
+          : mergeSessionEntry(writeBase, patch);
+      writeSessionEntry(writeDatabase, resolved.sessionKey, next);
+      result = cloneSessionEntry(next);
+    }, toDatabaseOptions(resolved));
+    return result;
   });
-  if (!patch) {
-    return cloneSessionEntry(base);
-  }
-  const next = options.replaceEntry
-    ? cloneSessionEntry(patch as SessionEntry)
-    : options.preserveActivity
-      ? mergeSessionEntryPreserveActivity(base, patch)
-      : mergeSessionEntry(base, patch);
-  runOpenClawAgentWriteTransaction((database) => {
-    writeSessionEntry(database, resolved.sessionKey, next);
-  }, toDatabaseOptions(resolved));
-  return cloneSessionEntry(next);
 }
 
 /** Updates an existing entry in the additive SQLite session store. */
@@ -176,20 +192,31 @@ export async function updateSqliteSessionEntry(
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
   _options: SessionEntryUpdateOptions = {},
 ): Promise<SessionEntry | null> {
-  const existing = loadSqliteSessionEntry(scope);
-  if (!existing) {
-    return null;
-  }
-  const patch = await update(cloneSessionEntry(existing));
-  if (!patch) {
-    return cloneSessionEntry(existing);
-  }
-  const next = mergeSessionEntry(existing, patch);
   const resolved = resolveSqliteScope(scope);
-  runOpenClawAgentWriteTransaction((database) => {
-    writeSessionEntry(database, resolved.sessionKey, next);
-  }, toDatabaseOptions(resolved));
-  return cloneSessionEntry(next);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    const existing = readSessionEntryRow(database, resolved.sessionKey)?.entry;
+    if (!existing) {
+      return null;
+    }
+    const patch = await update(cloneSessionEntry(existing));
+    if (!patch) {
+      return cloneSessionEntry(existing);
+    }
+
+    let result: SessionEntry | null = null;
+    runOpenClawAgentWriteTransaction((writeDatabase) => {
+      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey)?.entry;
+      if (!fresh) {
+        result = null;
+        return;
+      }
+      const next = mergeSessionEntry(fresh, patch);
+      writeSessionEntry(writeDatabase, resolved.sessionKey, next);
+      result = cloneSessionEntry(next);
+    }, toDatabaseOptions(resolved));
+    return result;
+  });
 }
 
 /** Loads raw transcript events from the additive SQLite transcript store. */
@@ -223,9 +250,11 @@ export async function appendSqliteTranscriptEvent(
   event: TranscriptEvent,
 ): Promise<void> {
   const resolved = resolveSqliteTranscriptScope(scope);
-  runOpenClawAgentWriteTransaction((database) => {
-    appendTranscriptEventInTransaction(database, resolved, event);
-  }, toDatabaseOptions(resolved));
+  await runExclusiveSqliteSessionWrite(resolved, async () => {
+    runOpenClawAgentWriteTransaction((database) => {
+      appendTranscriptEventInTransaction(database, resolved, event);
+    }, toDatabaseOptions(resolved));
+  });
 }
 
 /** Appends one transcript message to the additive SQLite transcript store. */
@@ -244,45 +273,67 @@ export async function appendSqliteTranscriptMessage<TMessage>(
   options: TranscriptMessageAppendOptions<TMessage>,
 ): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
   const resolved = resolveSqliteTranscriptScope(scope);
-  const idempotencyKey = readMessageIdempotencyKey(options.message);
-  if (idempotencyKey && options.idempotencyLookup === "scan") {
-    const existing = readTranscriptMessageByIdempotencyKey(resolved, idempotencyKey);
-    if (existing) {
-      return {
-        appended: false,
-        message: existing.message as TMessage,
-        messageId: existing.messageId,
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: TranscriptMessageAppendResult<TMessage> | undefined;
+    runOpenClawAgentWriteTransaction((database) => {
+      const idempotencyKey = readMessageIdempotencyKey(options.message);
+      if (idempotencyKey && options.idempotencyLookup === "scan") {
+        const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
+        if (existing) {
+          result = {
+            appended: false,
+            message: existing.message as TMessage,
+            messageId: existing.messageId,
+          };
+          return;
+        }
+      }
+
+      const prepared = options.prepareMessageAfterIdempotencyCheck
+        ? options.prepareMessageAfterIdempotencyCheck(options.message)
+        : options.message;
+      if (prepared === undefined) {
+        result = undefined;
+        return;
+      }
+
+      const messageId = randomUUID();
+      const now = options.now ?? Date.now();
+      const finalMessage = redactTranscriptMessageForStorage(prepared, options);
+      ensureTranscriptHeader(database, resolved, options.cwd, now);
+      const parentId = readLatestTranscriptMessageId(database, resolved.sessionId);
+      const event = {
+        type: "message",
+        id: messageId,
+        parentId: parentId ?? null,
+        timestamp: resolveTimestampMsToIsoString(now),
+        message: finalMessage,
       };
-    }
-  }
-
-  const prepared = options.prepareMessageAfterIdempotencyCheck
-    ? options.prepareMessageAfterIdempotencyCheck(options.message)
-    : options.message;
-  if (prepared === undefined) {
-    return undefined;
-  }
-
-  const messageId = randomUUID();
-  const now = options.now ?? Date.now();
-  const finalMessage = redactTranscriptMessageForStorage(prepared, options);
-  runOpenClawAgentWriteTransaction((database) => {
-    ensureTranscriptHeader(database, resolved, options.cwd, now);
-    const parentId = readLatestTranscriptMessageId(database, resolved.sessionId);
-    const event = {
-      type: "message",
-      id: messageId,
-      parentId: parentId ?? null,
-      timestamp: resolveTimestampMsToIsoString(now),
-      message: finalMessage,
-    };
-    appendTranscriptEventInTransaction(database, resolved, event);
-  }, toDatabaseOptions(resolved));
-  return {
-    appended: true,
-    message: finalMessage,
-    messageId,
-  };
+      const appended = appendTranscriptEventInTransaction(database, resolved, event, {
+        dedupeByMessageIdempotency: options.idempotencyLookup === "scan",
+      });
+      if (!appended && idempotencyKey && options.idempotencyLookup === "scan") {
+        const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
+        if (existing) {
+          result = {
+            appended: false,
+            message: existing.message as TMessage,
+            messageId: existing.messageId,
+          };
+          return;
+        }
+      }
+      if (!appended) {
+        throw new Error(`SQLite transcript append did not insert message ${messageId}.`);
+      }
+      result = {
+        appended: true,
+        message: finalMessage,
+        messageId,
+      };
+    }, toDatabaseOptions(resolved));
+    return result;
+  });
 }
 
 /** Publishes a transcript update using the SQLite transcript scope target. */
@@ -299,6 +350,19 @@ export async function publishSqliteTranscriptUpdate(
 
 function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<SessionSqliteDatabase>(database);
+}
+
+async function runExclusiveSqliteSessionWrite<T>(
+  scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const databaseOptions = toDatabaseOptions(scope);
+  return await runQueuedStoreWrite({
+    queues: SQLITE_SESSION_WRITER_QUEUES,
+    storePath: resolveOpenClawAgentSqlitePath(databaseOptions),
+    label: "runExclusiveSqliteSessionWrite",
+    fn,
+  });
 }
 
 function resolveSqliteScope(
@@ -537,10 +601,26 @@ function appendTranscriptEventInTransaction(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   event: TranscriptEvent,
-): void {
+  options: { dedupeByMessageIdempotency?: boolean } = {},
+): boolean {
   const db = getSessionKysely(database.db);
   const createdAt = readEventTimestamp(event) ?? Date.now();
   ensureTranscriptSessionRoot(database, scope, createdAt);
+  const identity = readTranscriptEventIdentity(event);
+  if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
+    return false;
+  }
+  if (
+    identity?.messageIdempotencyKey &&
+    options.dedupeByMessageIdempotency &&
+    readTranscriptIdentityByMessageIdempotencyKey(
+      database,
+      scope.sessionId,
+      identity.messageIdempotencyKey,
+    )
+  ) {
+    return false;
+  }
   const seq = readNextTranscriptSeq(database, scope.sessionId);
   executeSqliteQuerySync(
     database.db,
@@ -551,9 +631,8 @@ function appendTranscriptEventInTransaction(
       created_at: createdAt,
     }),
   );
-  const identity = readTranscriptEventIdentity(event);
   if (!identity) {
-    return;
+    return true;
   }
   executeSqliteQuerySync(
     database.db,
@@ -570,6 +649,7 @@ function appendTranscriptEventInTransaction(
       })
       .onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
   );
+  return true;
 }
 
 function ensureTranscriptHeader(
@@ -619,25 +699,56 @@ function readLatestTranscriptMessageId(
   return row?.event_id;
 }
 
-function readTranscriptMessageByIdempotencyKey(
-  scope: ResolvedTranscriptScope,
-  idempotencyKey: string,
-): { messageId: string; message: unknown } | undefined {
-  const database = openOpenClawAgentDatabase(toDatabaseOptions(scope));
+function readTranscriptIdentityByEventId(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  eventId: string,
+): { eventId: string; seq: number } | undefined {
   const db = getSessionKysely(database.db);
-  const identity = executeSqliteQueryTakeFirstSync(
+  const row = executeSqliteQueryTakeFirstSync(
     database.db,
     db
       .selectFrom("transcript_event_identities")
       .select(["event_id", "seq"])
-      .where("session_id", "=", scope.sessionId)
+      .where("session_id", "=", sessionId)
+      .where("event_id", "=", eventId),
+  );
+  return row ? { eventId: row.event_id, seq: row.seq } : undefined;
+}
+
+function readTranscriptIdentityByMessageIdempotencyKey(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  idempotencyKey: string,
+): { eventId: string; seq: number } | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select(["event_id", "seq"])
+      .where("session_id", "=", sessionId)
       .where("message_idempotency_key", "=", idempotencyKey)
       .orderBy("seq", "desc")
       .limit(1),
   );
+  return row ? { eventId: row.event_id, seq: row.seq } : undefined;
+}
+
+function readTranscriptMessageByIdempotencyKey(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  idempotencyKey: string,
+): { messageId: string; message: unknown } | undefined {
+  const identity = readTranscriptIdentityByMessageIdempotencyKey(
+    database,
+    scope.sessionId,
+    idempotencyKey,
+  );
   if (!identity) {
     return undefined;
   }
+  const db = getSessionKysely(database.db);
   const eventRow = executeSqliteQueryTakeFirstSync(
     database.db,
     db
@@ -651,7 +762,7 @@ function readTranscriptMessageByIdempotencyKey(
   }
   const event = JSON.parse(eventRow.event_json) as { message?: unknown };
   return {
-    messageId: identity.event_id,
+    messageId: identity.eventId,
     message: event.message,
   };
 }

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -22,6 +22,7 @@ import {
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import type {
+  ExactSessionEntry,
   SessionAccessScope,
   SessionEntryPatchContext,
   SessionEntryPatchOptions,
@@ -80,6 +81,20 @@ export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry 
   const resolved = resolveSqliteScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   return readSessionEntryRow(database, resolved.sessionKey)?.entry;
+}
+
+/** Loads one exact persisted-key entry from the additive SQLite session store. */
+export function loadExactSqliteSessionEntry(
+  scope: SessionAccessScope,
+): ExactSessionEntry | undefined {
+  const sessionKey = scope.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const resolved = resolveSqliteScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const row = readExactSessionEntryRow(database, sessionKey);
+  return row ? { sessionKey, entry: row.entry } : undefined;
 }
 
 /** Lists session entries from the additive SQLite session store. */
@@ -499,13 +514,17 @@ function readSessionEntryRow(
   database: OpenClawAgentDatabase,
   sessionKey: string,
 ): { entry: SessionEntry; row: SessionEntryRow } | undefined {
+  return readExactSessionEntryRow(database, normalizeSqliteSessionKey(sessionKey));
+}
+
+function readExactSessionEntryRow(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): { entry: SessionEntry; row: SessionEntryRow } | undefined {
   const db = getSessionKysely(database.db);
   const row = executeSqliteQueryTakeFirstSync(
     database.db,
-    db
-      .selectFrom("session_entries")
-      .selectAll()
-      .where("session_key", "=", normalizeSqliteSessionKey(sessionKey)),
+    db.selectFrom("session_entries").selectAll().where("session_key", "=", sessionKey),
   );
   if (!row) {
     return undefined;

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -35,7 +35,7 @@ import type {
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import type { SessionEntry } from "./types.js";
-import { mergeSessionEntry } from "./types.js";
+import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js";
 
 type SessionSqliteDatabase = Pick<
   OpenClawAgentKyselyDatabase,
@@ -153,7 +153,9 @@ export async function patchSqliteSessionEntry(
   }
   const next = options.replaceEntry
     ? cloneSessionEntry(patch as SessionEntry)
-    : mergeSessionEntry(base, patch);
+    : options.preserveActivity
+      ? mergeSessionEntryPreserveActivity(base, patch)
+      : mergeSessionEntry(base, patch);
   runOpenClawAgentWriteTransaction((database) => {
     writeSessionEntry(database, resolved.sessionKey, next);
   }, toDatabaseOptions(resolved));

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -68,7 +68,7 @@ type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
 
 type ResolvedSqliteStoreTarget = {
   agentId?: string;
-  path: string;
+  path?: string;
 };
 
 /** Loads one session entry from the additive SQLite session store. */
@@ -340,16 +340,19 @@ function resolveSqliteReadScope(
 
 function resolveSqliteTargetFromSessionStorePath(storePath: string): ResolvedSqliteStoreTarget {
   const resolved = path.resolve(storePath);
-  if (path.basename(resolved) !== "sessions.json") {
+  if (path.basename(resolved) === "openclaw-agent.sqlite" || resolved.endsWith(".sqlite")) {
     return { path: resolved };
+  }
+  if (path.basename(resolved) !== "sessions.json") {
+    return {};
   }
   const sessionsDir = path.dirname(resolved);
   if (path.basename(sessionsDir) !== "sessions") {
-    return { path: resolved };
+    return {};
   }
   const agentDir = path.dirname(sessionsDir);
   if (path.basename(path.dirname(agentDir)) !== "agents") {
-    return { path: resolved };
+    return {};
   }
   return {
     agentId: normalizeAgentId(path.basename(agentDir)),

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -53,7 +53,11 @@ type SessionSqliteDatabase = Pick<
   | "transcript_events"
 >;
 type SessionEntryRow = Selectable<OpenClawAgentKyselyDatabase["session_entries"]>;
-type ResolvedSessionEntryRow = { entry: SessionEntry; row: SessionEntryRow };
+type ResolvedSessionEntryRow = {
+  entry: SessionEntry;
+  legacyKeys: string[];
+  row: SessionEntryRow;
+};
 
 type ResolvedSqliteScope = {
   agentId: string;
@@ -131,14 +135,7 @@ export function listSqliteSessionEntries(
 export function readSqliteSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
   const resolved = resolveSqliteScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  const db = getSessionKysely(database.db);
-  const row = executeSqliteQueryTakeFirstSync(
-    database.db,
-    db
-      .selectFrom("session_entries")
-      .select("updated_at")
-      .where("session_key", "=", resolved.sessionKey),
-  );
+  const row = readSessionEntryRow(database, resolved.sessionKey)?.row;
   return row ? normalizeSqliteNumber(row.updated_at) : undefined;
 }
 
@@ -189,8 +186,8 @@ export async function patchSqliteSessionEntry(
 
     let result: SessionEntry | null = null;
     runOpenClawAgentWriteTransaction((writeDatabase) => {
-      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey)?.entry;
-      const writeBase = fresh ?? options.fallbackEntry;
+      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey);
+      const writeBase = fresh?.entry ?? options.fallbackEntry;
       if (!writeBase) {
         result = null;
         return;
@@ -201,6 +198,7 @@ export async function patchSqliteSessionEntry(
           ? mergeSessionEntryPreserveActivity(writeBase, patch)
           : mergeSessionEntry(writeBase, patch);
       writeSessionEntry(writeDatabase, resolved.sessionKey, next);
+      deleteLegacySessionEntryRows(writeDatabase, fresh?.legacyKeys ?? [], resolved.sessionKey);
       result = cloneSessionEntry(next);
     }, toDatabaseOptions(resolved));
     return result;
@@ -229,13 +227,14 @@ export async function updateSqliteSessionEntry(
 
     let result: SessionEntry | null = null;
     runOpenClawAgentWriteTransaction((writeDatabase) => {
-      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey)?.entry;
+      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey);
       if (!fresh) {
         result = null;
         return;
       }
-      const next = mergeSessionEntry(fresh, patch);
+      const next = mergeSessionEntry(fresh.entry, patch);
       writeSessionEntry(writeDatabase, resolved.sessionKey, next);
+      deleteLegacySessionEntryRows(writeDatabase, fresh.legacyKeys, resolved.sessionKey);
       result = cloneSessionEntry(next);
     }, toDatabaseOptions(resolved));
     return result;
@@ -640,7 +639,7 @@ function readSessionEntryRow(
       continue;
     }
     store[row.session_key] = entry;
-    entries.set(row.session_key, { entry, row });
+    entries.set(row.session_key, { entry, legacyKeys: [], row });
   }
   const resolved = resolveSessionStoreEntry({ store, sessionKey });
   if (!resolved.existing) {
@@ -648,7 +647,7 @@ function readSessionEntryRow(
   }
   for (const value of entries.values()) {
     if (value.entry === resolved.existing) {
-      return value;
+      return { ...value, legacyKeys: resolved.legacyKeys };
     }
   }
   return undefined;
@@ -667,7 +666,31 @@ function readExactSessionEntryRow(
     return undefined;
   }
   const entry = parseSessionEntryRow(row);
-  return entry ? { entry, row } : undefined;
+  return entry ? { entry, legacyKeys: [], row } : undefined;
+}
+
+function deleteLegacySessionEntryRows(
+  database: OpenClawAgentDatabase,
+  legacyKeys: string[],
+  sessionKey: string,
+): void {
+  if (legacyKeys.length === 0) {
+    return;
+  }
+  const db = getSessionKysely(database.db);
+  for (const legacyKey of legacyKeys) {
+    if (legacyKey === sessionKey) {
+      continue;
+    }
+    executeSqliteQuerySync(
+      database.db,
+      db.deleteFrom("session_routes").where("session_key", "=", legacyKey),
+    );
+    executeSqliteQuerySync(
+      database.db,
+      db.deleteFrom("session_entries").where("session_key", "=", legacyKey),
+    );
+  }
 }
 
 function sessionKeySegmentStartsWith(sessionKey: string, prefix: string): boolean {

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -66,6 +66,11 @@ type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
   sessionId: string;
 };
 
+type ResolvedSqliteStoreTarget = {
+  agentId?: string;
+  path: string;
+};
+
 /** Loads one session entry from the additive SQLite session store. */
 export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   const resolved = resolveSqliteScope(scope);
@@ -299,12 +304,15 @@ function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
 function resolveSqliteScope(
   scope: Pick<SessionAccessScope, "agentId" | "env" | "sessionKey" | "storePath">,
 ): ResolvedSqliteScope {
+  const storeTarget = scope.storePath
+    ? resolveSqliteTargetFromSessionStorePath(scope.storePath)
+    : undefined;
   return {
     agentId: scope.agentId
       ? normalizeAgentId(scope.agentId)
-      : resolveAgentIdFromSessionKey(scope.sessionKey),
+      : (storeTarget?.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey)),
     ...(scope.env ? { env: scope.env } : {}),
-    ...(scope.storePath ? { path: resolveSqlitePathFromSessionStorePath(scope.storePath) } : {}),
+    ...(storeTarget ? { path: storeTarget.path } : {}),
     sessionKey: normalizeSqliteSessionKey(scope.sessionKey),
   };
 }
@@ -312,37 +320,41 @@ function resolveSqliteScope(
 function resolveSqliteReadScope(
   scope: Pick<SessionTranscriptReadScope, "agentId" | "env" | "sessionKey" | "storePath">,
 ): ResolvedSqliteReadScope {
+  const storeTarget = scope.storePath
+    ? resolveSqliteTargetFromSessionStorePath(scope.storePath)
+    : undefined;
   const sessionKey = scope.sessionKey ? normalizeSqliteSessionKey(scope.sessionKey) : undefined;
   const agentId = scope.agentId
     ? normalizeAgentId(scope.agentId)
-    : sessionKey
-      ? resolveAgentIdFromSessionKey(sessionKey)
-      : undefined;
+    : (storeTarget?.agentId ?? (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined));
   if (!agentId) {
     throw new Error("Cannot resolve SQLite transcript read scope without an agent id");
   }
   return {
     agentId,
     ...(scope.env ? { env: scope.env } : {}),
-    ...(scope.storePath ? { path: resolveSqlitePathFromSessionStorePath(scope.storePath) } : {}),
+    ...(storeTarget ? { path: storeTarget.path } : {}),
     ...(sessionKey ? { sessionKey } : {}),
   };
 }
 
-function resolveSqlitePathFromSessionStorePath(storePath: string): string {
+function resolveSqliteTargetFromSessionStorePath(storePath: string): ResolvedSqliteStoreTarget {
   const resolved = path.resolve(storePath);
   if (path.basename(resolved) !== "sessions.json") {
-    return resolved;
+    return { path: resolved };
   }
   const sessionsDir = path.dirname(resolved);
   if (path.basename(sessionsDir) !== "sessions") {
-    return resolved;
+    return { path: resolved };
   }
   const agentDir = path.dirname(sessionsDir);
   if (path.basename(path.dirname(agentDir)) !== "agents") {
-    return resolved;
+    return { path: resolved };
   }
-  return path.join(agentDir, "agent", "openclaw-agent.sqlite");
+  return {
+    agentId: normalizeAgentId(path.basename(agentDir)),
+    path: path.join(agentDir, "agent", "openclaw-agent.sqlite"),
+  };
 }
 
 function resolveSqliteTranscriptScope(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -45,7 +45,13 @@ import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js
 
 type SessionSqliteDatabase = Pick<
   OpenClawAgentKyselyDatabase,
-  "session_entries" | "sessions" | "transcript_event_identities" | "transcript_events"
+  | "conversations"
+  | "session_conversations"
+  | "session_entries"
+  | "session_routes"
+  | "sessions"
+  | "transcript_event_identities"
+  | "transcript_events"
 >;
 type SessionEntryRow = Selectable<OpenClawAgentKyselyDatabase["session_entries"]>;
 
@@ -525,6 +531,17 @@ function cloneSessionEntry(entry: SessionEntry): SessionEntry {
   return structuredClone(entry);
 }
 
+function normalizeSqliteText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizeSqliteChatType(value: unknown): "direct" | "group" | "channel" | null {
+  if (value === "direct" || value === "group" || value === "channel") {
+    return value;
+  }
+  return null;
+}
+
 function normalizeSqliteNumber(value: number | bigint): number {
   return typeof value === "bigint" ? Number(value) : value;
 }
@@ -727,6 +744,10 @@ function cleanupSqliteSessionLifecycleArtifactsInTransaction(
     }
     executeSqliteQuerySync(
       database.db,
+      db.deleteFrom("session_routes").where("session_key", "=", row.session_key),
+    );
+    executeSqliteQuerySync(
+      database.db,
       db.deleteFrom("session_entries").where("session_key", "=", row.session_key),
     );
     removedSessionIds.add(row.session_id);
@@ -759,23 +780,37 @@ function writeSessionEntry(
 ): void {
   const db = getSessionKysely(database.db);
   const updatedAt = entry.updatedAt;
+  const sessionRow = bindSqliteSessionRoot({ entry, sessionKey, updatedAt });
   executeSqliteQuerySync(
     database.db,
     db
       .insertInto("sessions")
-      .values({
-        session_id: entry.sessionId,
-        session_key: sessionKey,
-        created_at: entry.sessionStartedAt ?? updatedAt,
-        updated_at: updatedAt,
-      })
+      .values(sessionRow)
       .onConflict((conflict) =>
         conflict.column("session_id").doUpdateSet({
           session_key: sessionKey,
+          session_scope: sessionRow.session_scope,
           updated_at: updatedAt,
+          started_at: sessionRow.started_at,
+          ended_at: sessionRow.ended_at,
+          status: sessionRow.status,
+          chat_type: sessionRow.chat_type,
+          channel: sessionRow.channel,
+          account_id: sessionRow.account_id,
+          model_provider: sessionRow.model_provider,
+          model: sessionRow.model,
+          agent_harness_id: sessionRow.agent_harness_id,
+          parent_session_key: sessionRow.parent_session_key,
+          spawned_by: sessionRow.spawned_by,
+          display_name: sessionRow.display_name,
         }),
       ),
   );
+  writeSessionRoute(database, {
+    sessionId: sessionRow.session_id,
+    sessionKey,
+    updatedAt,
+  });
   executeSqliteQuerySync(
     database.db,
     db
@@ -809,6 +844,7 @@ function ensureTranscriptSessionRoot(
       .values({
         session_id: scope.sessionId,
         session_key: scope.sessionKey,
+        session_scope: "conversation",
         created_at: updatedAt,
         updated_at: updatedAt,
       })
@@ -818,6 +854,118 @@ function ensureTranscriptSessionRoot(
           updated_at: updatedAt,
         }),
       ),
+  );
+  writeSessionRoute(database, {
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    updatedAt,
+  });
+}
+
+function bindSqliteSessionRoot(params: {
+  entry: SessionEntry;
+  sessionKey: string;
+  updatedAt: number;
+}) {
+  const updatedAt = Number.isFinite(params.entry.updatedAt)
+    ? params.entry.updatedAt
+    : params.updatedAt;
+  return {
+    session_id: params.entry.sessionId,
+    session_key: params.sessionKey,
+    session_scope: resolveSqliteSessionScope(params.entry, params.sessionKey),
+    created_at: resolveSqliteSessionCreatedAt(params.entry, updatedAt),
+    updated_at: updatedAt,
+    started_at: finiteSqliteNumber(params.entry.startedAt),
+    ended_at: finiteSqliteNumber(params.entry.endedAt),
+    status: normalizeSqliteText(params.entry.status),
+    chat_type: normalizeSqliteChatType(params.entry.chatType),
+    channel: resolveSqliteSessionChannel(params.entry),
+    account_id: resolveSqliteSessionAccountId(params.entry),
+    primary_conversation_id: null,
+    model_provider: normalizeSqliteText(params.entry.modelProvider),
+    model: normalizeSqliteText(params.entry.model),
+    agent_harness_id: normalizeSqliteText(params.entry.agentHarnessId),
+    parent_session_key: normalizeSqliteText(params.entry.parentSessionKey),
+    spawned_by: normalizeSqliteText(params.entry.spawnedBy),
+    display_name: resolveSqliteSessionDisplayName(params.entry),
+  };
+}
+
+function writeSessionRoute(
+  database: OpenClawAgentDatabase,
+  params: { sessionId: string; sessionKey: string; updatedAt: number },
+): void {
+  const db = getSessionKysely(database.db);
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("session_routes")
+      .values({
+        session_key: params.sessionKey,
+        session_id: params.sessionId,
+        updated_at: params.updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_key").doUpdateSet({
+          session_id: params.sessionId,
+          updated_at: params.updatedAt,
+        }),
+      ),
+  );
+}
+
+function resolveSqliteSessionScope(
+  entry: Pick<SessionEntry, "chatType">,
+  sessionKey: string,
+): "conversation" | "shared-main" | "group" | "channel" {
+  const chatType = normalizeSqliteChatType(entry.chatType);
+  const normalizedKey = sessionKey.trim().toLowerCase();
+  if (chatType === "direct" && (normalizedKey === "main" || normalizedKey.endsWith(":main"))) {
+    return "shared-main";
+  }
+  if (chatType === "group" || chatType === "channel") {
+    return chatType;
+  }
+  return "conversation";
+}
+
+function resolveSqliteSessionCreatedAt(entry: SessionEntry, updatedAt: number): number {
+  for (const candidate of [entry.sessionStartedAt, entry.startedAt, entry.updatedAt, updatedAt]) {
+    if (typeof candidate === "number" && Number.isFinite(candidate) && candidate >= 0) {
+      return candidate;
+    }
+  }
+  return updatedAt;
+}
+
+function finiteSqliteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function resolveSqliteSessionChannel(entry: SessionEntry): string | null {
+  return (
+    normalizeSqliteText(entry.channel) ??
+    normalizeSqliteText(entry.deliveryContext?.channel) ??
+    normalizeSqliteText(entry.lastChannel) ??
+    normalizeSqliteText(entry.origin?.provider)
+  );
+}
+
+function resolveSqliteSessionAccountId(entry: SessionEntry): string | null {
+  return (
+    normalizeSqliteText(entry.deliveryContext?.accountId) ??
+    normalizeSqliteText(entry.lastAccountId) ??
+    normalizeSqliteText(entry.origin?.accountId)
+  );
+}
+
+function resolveSqliteSessionDisplayName(entry: SessionEntry): string | null {
+  return (
+    normalizeSqliteText(entry.displayName) ??
+    normalizeSqliteText(entry.label) ??
+    normalizeSqliteText(entry.subject) ??
+    normalizeSqliteText(entry.groupId)
   );
 }
 

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -421,10 +421,16 @@ function resolveSqliteScope(
   const storeTarget = scope.storePath
     ? resolveSqliteTargetFromSessionStorePath(scope.storePath)
     : undefined;
+  const agentId = resolveSqliteAgentId({
+    scopedAgentId: scope.agentId,
+    sessionKey: scope.sessionKey,
+    storeAgentId: storeTarget?.agentId,
+  });
+  if (!agentId) {
+    throw new Error("Cannot resolve SQLite session scope without an agent id");
+  }
   return {
-    agentId: scope.agentId
-      ? normalizeAgentId(scope.agentId)
-      : (storeTarget?.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey)),
+    agentId,
     ...(scope.env ? { env: scope.env } : {}),
     ...(storeTarget ? { path: storeTarget.path } : {}),
     sessionKey: normalizeSqliteSessionKey(scope.sessionKey),
@@ -438,9 +444,11 @@ function resolveSqliteReadScope(
     ? resolveSqliteTargetFromSessionStorePath(scope.storePath)
     : undefined;
   const sessionKey = scope.sessionKey ? normalizeSqliteSessionKey(scope.sessionKey) : undefined;
-  const agentId = scope.agentId
-    ? normalizeAgentId(scope.agentId)
-    : (storeTarget?.agentId ?? (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined));
+  const agentId = resolveSqliteAgentId({
+    scopedAgentId: scope.agentId,
+    sessionKey,
+    storeAgentId: storeTarget?.agentId,
+  });
   if (!agentId) {
     throw new Error("Cannot resolve SQLite transcript read scope without an agent id");
   }
@@ -455,7 +463,11 @@ function resolveSqliteReadScope(
 function resolveSqliteTargetFromSessionStorePath(storePath: string): ResolvedSqliteStoreTarget {
   const resolved = path.resolve(storePath);
   if (path.basename(resolved) === "openclaw-agent.sqlite" || resolved.endsWith(".sqlite")) {
-    return { path: resolved };
+    const agentId = resolveAgentIdFromSqliteDatabasePath(resolved);
+    return {
+      path: resolved,
+      ...(agentId ? { agentId } : {}),
+    };
   }
   if (path.basename(resolved) !== "sessions.json") {
     return {};
@@ -472,6 +484,39 @@ function resolveSqliteTargetFromSessionStorePath(storePath: string): ResolvedSql
     agentId: normalizeAgentId(path.basename(agentDir)),
     path: path.join(agentDir, "agent", "openclaw-agent.sqlite"),
   };
+}
+
+function resolveSqliteAgentId(params: {
+  scopedAgentId?: string;
+  sessionKey?: string;
+  storeAgentId?: string;
+}): string | undefined {
+  const scopedAgentId = params.scopedAgentId ? normalizeAgentId(params.scopedAgentId) : undefined;
+  if (scopedAgentId && params.storeAgentId && scopedAgentId !== params.storeAgentId) {
+    throw new Error(
+      `SQLite session store path belongs to agent ${params.storeAgentId}; requested agent ${scopedAgentId}.`,
+    );
+  }
+  return (
+    scopedAgentId ??
+    params.storeAgentId ??
+    (params.sessionKey !== undefined ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined)
+  );
+}
+
+function resolveAgentIdFromSqliteDatabasePath(databasePath: string): string | undefined {
+  if (path.basename(databasePath) !== "openclaw-agent.sqlite") {
+    return undefined;
+  }
+  const agentDbDir = path.dirname(databasePath);
+  if (path.basename(agentDbDir) !== "agent") {
+    return undefined;
+  }
+  const agentDir = path.dirname(agentDbDir);
+  if (path.basename(path.dirname(agentDir)) !== "agents") {
+    return undefined;
+  }
+  return normalizeAgentId(path.basename(agentDir));
 }
 
 function resolveSqliteTranscriptScope(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -37,7 +37,7 @@ import type {
   TranscriptMessageAppendResult,
   TranscriptUpdatePayload,
 } from "./session-accessor.js";
-import { normalizeStoreSessionKey } from "./store-entry.js";
+import { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import type { SessionEntry } from "./types.js";
 import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js";
@@ -53,6 +53,7 @@ type SessionSqliteDatabase = Pick<
   | "transcript_events"
 >;
 type SessionEntryRow = Selectable<OpenClawAgentKyselyDatabase["session_entries"]>;
+type ResolvedSessionEntryRow = { entry: SessionEntry; row: SessionEntryRow };
 
 type ResolvedSqliteScope = {
   agentId: string;
@@ -625,14 +626,38 @@ function assertNonMessageTranscriptEvent(event: TranscriptEvent): void {
 function readSessionEntryRow(
   database: OpenClawAgentDatabase,
   sessionKey: string,
-): { entry: SessionEntry; row: SessionEntryRow } | undefined {
-  return readExactSessionEntryRow(database, normalizeSqliteSessionKey(sessionKey));
+): ResolvedSessionEntryRow | undefined {
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db.selectFrom("session_entries").selectAll().orderBy("session_key", "asc"),
+  ).rows;
+  const entries = new Map<string, ResolvedSessionEntryRow>();
+  const store: Record<string, SessionEntry> = {};
+  for (const row of rows) {
+    const entry = parseSessionEntryRow(row);
+    if (!entry) {
+      continue;
+    }
+    store[row.session_key] = entry;
+    entries.set(row.session_key, { entry, row });
+  }
+  const resolved = resolveSessionStoreEntry({ store, sessionKey });
+  if (!resolved.existing) {
+    return undefined;
+  }
+  for (const value of entries.values()) {
+    if (value.entry === resolved.existing) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function readExactSessionEntryRow(
   database: OpenClawAgentDatabase,
   sessionKey: string,
-): { entry: SessionEntry; row: SessionEntryRow } | undefined {
+): ResolvedSessionEntryRow | undefined {
   const db = getSessionKysely(database.db);
   const row = executeSqliteQueryTakeFirstSync(
     database.db,
@@ -935,7 +960,7 @@ function ensureTranscriptSessionRoot(
         }),
       ),
   );
-  writeSessionRoute(database, {
+  writeTranscriptSessionRoute(database, {
     sessionId: scope.sessionId,
     sessionKey: scope.sessionKey,
     updatedAt,
@@ -993,6 +1018,26 @@ function writeSessionRoute(
         }),
       ),
   );
+}
+
+function writeTranscriptSessionRoute(
+  database: OpenClawAgentDatabase,
+  params: { sessionId: string; sessionKey: string; updatedAt: number },
+): void {
+  const db = getSessionKysely(database.db);
+  const existing = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_routes")
+      .select("session_id")
+      .where("session_key", "=", params.sessionKey),
+  );
+  // Transcript-only appends may arrive late from an old run. They can create
+  // missing routes, but must not move a current session key back to a stale id.
+  if (existing && existing.session_id !== params.sessionId) {
+    return;
+  }
+  writeSessionRoute(database, params);
 }
 
 function resolveSqliteSessionScope(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -779,8 +779,9 @@ function writeSessionEntry(
   entry: SessionEntry,
 ): void {
   const db = getSessionKysely(database.db);
-  const updatedAt = entry.updatedAt;
-  const sessionRow = bindSqliteSessionRoot({ entry, sessionKey, updatedAt });
+  const normalizedEntry = normalizeSqliteSessionEntryTimestamp(entry);
+  const updatedAt = normalizedEntry.updatedAt;
+  const sessionRow = bindSqliteSessionRoot({ entry: normalizedEntry, sessionKey, updatedAt });
   executeSqliteQuerySync(
     database.db,
     db
@@ -817,18 +818,32 @@ function writeSessionEntry(
       .insertInto("session_entries")
       .values({
         session_key: sessionKey,
-        session_id: entry.sessionId,
-        entry_json: JSON.stringify(entry),
+        session_id: normalizedEntry.sessionId,
+        entry_json: JSON.stringify(normalizedEntry),
         updated_at: updatedAt,
       })
       .onConflict((conflict) =>
         conflict.column("session_key").doUpdateSet({
-          session_id: entry.sessionId,
-          entry_json: JSON.stringify(entry),
+          session_id: normalizedEntry.sessionId,
+          entry_json: JSON.stringify(normalizedEntry),
           updated_at: updatedAt,
         }),
       ),
   );
+}
+
+function normalizeSqliteSessionEntryTimestamp(entry: SessionEntry): SessionEntry {
+  if (typeof entry.updatedAt === "number" && Number.isFinite(entry.updatedAt)) {
+    return entry;
+  }
+  const updatedAt =
+    typeof entry.sessionStartedAt === "number" && Number.isFinite(entry.sessionStartedAt)
+      ? entry.sessionStartedAt
+      : Date.now();
+  return {
+    ...entry,
+    updatedAt,
+  };
 }
 
 function ensureTranscriptSessionRoot(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -21,7 +21,6 @@ import {
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import type {
-  ExactSessionEntry,
   SessionAccessScope,
   SessionEntryPatchContext,
   SessionEntryPatchOptions,
@@ -67,6 +66,10 @@ type ResolvedSessionEntryRow = {
 };
 type SqliteSessionEntryPatchOptions = SessionEntryPatchOptions & {
   skipMaintenance?: boolean;
+};
+export type SqliteExactSessionEntry = {
+  entry: SessionEntry;
+  sessionKey: string;
 };
 
 type ResolvedSqliteScope = {
@@ -147,7 +150,7 @@ export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry 
 /** Loads one exact persisted-key entry from the additive SQLite session store. */
 export function loadExactSqliteSessionEntry(
   scope: SessionAccessScope,
-): ExactSessionEntry | undefined {
+): SqliteExactSessionEntry | undefined {
   const sessionKey = scope.sessionKey.trim();
   if (!sessionKey) {
     return undefined;

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -82,6 +82,37 @@ export interface SchemaMeta {
   updated_at: number;
 }
 
+export interface SessionEntries {
+  entry_json: string;
+  session_id: string;
+  session_key: string;
+  updated_at: number;
+}
+
+export interface Sessions {
+  created_at: number;
+  session_id: string;
+  session_key: string;
+  updated_at: number;
+}
+
+export interface TranscriptEventIdentities {
+  created_at: number;
+  event_id: string;
+  event_type: string | null;
+  message_idempotency_key: string | null;
+  parent_id: string | null;
+  seq: number;
+  session_id: string;
+}
+
+export interface TranscriptEvents {
+  created_at: number;
+  event_json: string;
+  seq: number;
+  session_id: string;
+}
+
 export interface DB {
   auth_profile_state: AuthProfileState;
   auth_profile_store: AuthProfileStore;
@@ -92,4 +123,8 @@ export interface DB {
   memory_index_sources: MemoryIndexSources;
   memory_index_state: MemoryIndexState;
   schema_meta: SchemaMeta;
+  session_entries: SessionEntries;
+  sessions: Sessions;
+  transcript_event_identities: TranscriptEventIdentities;
+  transcript_events: TranscriptEvents;
 }

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -31,6 +31,22 @@ export interface CacheEntries {
   value_json: string | null;
 }
 
+export interface Conversations {
+  account_id: string;
+  channel: string;
+  conversation_id: string;
+  created_at: number;
+  kind: string;
+  label: string | null;
+  metadata_json: string | null;
+  native_channel_id: string | null;
+  native_direct_user_id: string | null;
+  parent_conversation_id: string | null;
+  peer_id: string;
+  thread_id: string | null;
+  updated_at: number;
+}
+
 export interface MemoryEmbeddingCache {
   dims: number | null;
   embedding: string;
@@ -82,6 +98,14 @@ export interface SchemaMeta {
   updated_at: number;
 }
 
+export interface SessionConversations {
+  conversation_id: string;
+  first_seen_at: number;
+  last_seen_at: number;
+  role: Generated<string>;
+  session_id: string;
+}
+
 export interface SessionEntries {
   entry_json: string;
   session_id: string;
@@ -89,10 +113,30 @@ export interface SessionEntries {
   updated_at: number;
 }
 
-export interface Sessions {
-  created_at: number;
+export interface SessionRoutes {
   session_id: string;
   session_key: string;
+  updated_at: number;
+}
+
+export interface Sessions {
+  account_id: string | null;
+  agent_harness_id: string | null;
+  channel: string | null;
+  chat_type: string | null;
+  created_at: number;
+  display_name: string | null;
+  ended_at: number | null;
+  model: string | null;
+  model_provider: string | null;
+  parent_session_key: string | null;
+  primary_conversation_id: string | null;
+  session_id: string;
+  session_key: string;
+  session_scope: Generated<string>;
+  spawned_by: string | null;
+  started_at: number | null;
+  status: string | null;
   updated_at: number;
 }
 
@@ -117,13 +161,16 @@ export interface DB {
   auth_profile_state: AuthProfileState;
   auth_profile_store: AuthProfileStore;
   cache_entries: CacheEntries;
+  conversations: Conversations;
   memory_embedding_cache: MemoryEmbeddingCache;
   memory_index_chunks: MemoryIndexChunks;
   memory_index_meta: MemoryIndexMeta;
   memory_index_sources: MemoryIndexSources;
   memory_index_state: MemoryIndexState;
   schema_meta: SchemaMeta;
+  session_conversations: SessionConversations;
   session_entries: SessionEntries;
+  session_routes: SessionRoutes;
   sessions: Sessions;
   transcript_event_identities: TranscriptEventIdentities;
   transcript_events: TranscriptEvents;

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -111,7 +111,7 @@ describe("openclaw agent database", () => {
     expect(registered).toMatchObject({
       agentId: "worker-1",
       path: database.path,
-      schemaVersion: 1,
+      schemaVersion: 2,
     });
     expect(registered?.sizeBytes).toBeGreaterThan(0);
   });
@@ -352,7 +352,7 @@ describe("openclaw agent database", () => {
     expect(readSqliteNumberPragma(database.db, "busy_timeout")).toBe(30_000);
     expect(readSqliteNumberPragma(database.db, "foreign_keys")).toBe(1);
     expect(readSqliteNumberPragma(database.db, "synchronous")).toBe(1);
-    expect(readSqliteNumberPragma(database.db, "user_version")).toBe(1);
+    expect(readSqliteNumberPragma(database.db, "user_version")).toBe(2);
     expect(readSqliteNumberPragma(database.db, "wal_autocheckpoint")).toBe(1000);
     const journalMode = database.db.prepare("PRAGMA journal_mode").get() as
       | { journal_mode?: string }
@@ -375,9 +375,123 @@ describe("openclaw agent database", () => {
       ),
     ).toEqual({
       role: "agent",
-      schema_version: 1,
+      schema_version: 2,
       agent_id: "worker-1",
     });
+  });
+
+  it("migrates compact v1 session tables before applying normalized indexes", () => {
+    const stateDir = createTempStateDir();
+    const databasePath = path.join(
+      stateDir,
+      "agents",
+      "worker-1",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(databasePath);
+    db.exec(`
+      CREATE TABLE schema_meta (
+        meta_key TEXT NOT NULL PRIMARY KEY,
+        role TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        agent_id TEXT,
+        app_version TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO schema_meta
+        (meta_key, role, schema_version, agent_id, app_version, created_at, updated_at)
+      VALUES ('primary', 'agent', 1, 'worker-1', NULL, 1, 1);
+      CREATE TABLE sessions (
+        session_id TEXT NOT NULL PRIMARY KEY,
+        session_key TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO sessions (session_id, session_key, created_at, updated_at)
+      VALUES ('session-1', 'agent:worker-1:main', 10, 20);
+      CREATE TABLE session_entries (
+        session_key TEXT NOT NULL PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        entry_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+      );
+      INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
+      VALUES (
+        'agent:worker-1:group:example',
+        'session-1',
+        '{"sessionId":"session-1","updatedAt":20,"startedAt":11,"endedAt":19,"status":"done","chatType":"group","channel":"discord","deliveryContext":{"accountId":"acct-1"},"modelProvider":"openai","model":"gpt-5.5","agentHarnessId":"codex","parentSessionKey":"agent:worker-1:parent","spawnedBy":"agent:worker-1:spawner","displayName":"Example group"}',
+        20
+      );
+      PRAGMA user_version = 1;
+    `);
+    db.close();
+
+    const database = openOpenClawAgentDatabase({
+      agentId: "worker-1",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+
+    expect(readSqliteNumberPragma(database.db, "user_version")).toBe(2);
+    const session = database.db
+      .prepare(
+        `
+          SELECT
+            account_id,
+            agent_harness_id,
+            channel,
+            chat_type,
+            display_name,
+            ended_at,
+            model,
+            model_provider,
+            parent_session_key,
+            session_scope,
+            spawned_by,
+            started_at,
+            status
+          FROM sessions
+          WHERE session_id = ?
+        `,
+      )
+      .get("session-1");
+    expect(session).toEqual({
+      account_id: "acct-1",
+      agent_harness_id: "codex",
+      channel: "discord",
+      chat_type: "group",
+      display_name: "Example group",
+      ended_at: 19,
+      model: "gpt-5.5",
+      model_provider: "openai",
+      parent_session_key: "agent:worker-1:parent",
+      session_scope: "group",
+      spawned_by: "agent:worker-1:spawner",
+      started_at: 11,
+      status: "done",
+    });
+    const route = database.db
+      .prepare("SELECT session_id, updated_at FROM session_routes WHERE session_key = ?")
+      .get("agent:worker-1:group:example");
+    expect(route).toEqual({
+      session_id: "session-1",
+      updated_at: 20,
+    });
+    const sessionForeignKeys = database.db.prepare("PRAGMA foreign_key_list(sessions)").all() as
+      | Array<{ from?: unknown; on_delete?: unknown; table?: unknown; to?: unknown }>
+      | undefined;
+    expect(sessionForeignKeys).toContainEqual(
+      expect.objectContaining({
+        from: "primary_conversation_id",
+        on_delete: "SET NULL",
+        table: "conversations",
+        to: "conversation_id",
+      }),
+    );
   });
 
   it("refuses to open newer per-agent schema versions", () => {
@@ -392,7 +506,7 @@ describe("openclaw agent database", () => {
     fs.mkdirSync(path.dirname(databasePath), { recursive: true });
     const { DatabaseSync } = requireNodeSqlite();
     const db = new DatabaseSync(databasePath);
-    db.exec("PRAGMA user_version = 2;");
+    db.exec("PRAGMA user_version = 3;");
     db.close();
 
     expect(() =>
@@ -400,6 +514,6 @@ describe("openclaw agent database", () => {
         agentId: "worker-1",
         env: { OPENCLAW_STATE_DIR: stateDir },
       }),
-    ).toThrow(/newer schema version 2/);
+    ).toThrow(/newer schema version 3/);
   });
 });

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -34,7 +34,7 @@ export { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
  * per pathname, protected with private file modes, and registered in the shared
  * OpenClaw state database for discovery and maintenance.
  */
-const OPENCLAW_AGENT_SCHEMA_VERSION = 1;
+const OPENCLAW_AGENT_SCHEMA_VERSION = 2;
 const OPENCLAW_AGENT_DB_DIR_MODE = 0o700;
 const OPENCLAW_AGENT_DB_FILE_MODE = 0o600;
 
@@ -61,11 +61,300 @@ type ExistingSchemaMeta = {
   role: string | null;
 };
 
+type MigratedSessionEntry = Record<string, unknown>;
 function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: string): void {
   const userVersion = readSqliteUserVersion(db);
   if (userVersion > OPENCLAW_AGENT_SCHEMA_VERSION) {
     throw new Error(
       `OpenClaw agent database ${pathname} uses newer schema version ${userVersion}; this OpenClaw build supports ${OPENCLAW_AGENT_SCHEMA_VERSION}.`,
+    );
+  }
+}
+
+function readSqliteSessionColumns(db: DatabaseSync): Set<string> | null {
+  const table = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get("sessions");
+  if (!table) {
+    return null;
+  }
+  const rows = db.prepare("PRAGMA table_info(sessions)").all() as Array<{
+    name?: unknown;
+  }>;
+  return new Set(rows.flatMap((row) => (typeof row.name === "string" ? [row.name] : [])));
+}
+
+function migratedSessionColumn(
+  columns: ReadonlySet<string>,
+  columnName: string,
+  fallback: string,
+): string {
+  return columns.has(columnName) ? columnName : fallback;
+}
+
+function migrateOpenClawAgentSchema(db: DatabaseSync): void {
+  const userVersion = readSqliteUserVersion(db);
+  if (userVersion >= OPENCLAW_AGENT_SCHEMA_VERSION) {
+    return;
+  }
+  const columns = readSqliteSessionColumns(db);
+  if (userVersion > 1 || !columns) {
+    return;
+  }
+  const copyColumns = [
+    "session_id",
+    "session_key",
+    "session_scope",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "ended_at",
+    "status",
+    "chat_type",
+    "channel",
+    "account_id",
+    "primary_conversation_id",
+    "model_provider",
+    "model",
+    "agent_harness_id",
+    "parent_session_key",
+    "spawned_by",
+    "display_name",
+  ];
+  const selectColumns = [
+    "session_id",
+    "session_key",
+    migratedSessionColumn(columns, "session_scope", "'conversation'"),
+    "created_at",
+    "updated_at",
+    migratedSessionColumn(columns, "started_at", "NULL"),
+    migratedSessionColumn(columns, "ended_at", "NULL"),
+    migratedSessionColumn(columns, "status", "NULL"),
+    migratedSessionColumn(columns, "chat_type", "NULL"),
+    migratedSessionColumn(columns, "channel", "NULL"),
+    migratedSessionColumn(columns, "account_id", "NULL"),
+    migratedSessionColumn(columns, "primary_conversation_id", "NULL"),
+    migratedSessionColumn(columns, "model_provider", "NULL"),
+    migratedSessionColumn(columns, "model", "NULL"),
+    migratedSessionColumn(columns, "agent_harness_id", "NULL"),
+    migratedSessionColumn(columns, "parent_session_key", "NULL"),
+    migratedSessionColumn(columns, "spawned_by", "NULL"),
+    migratedSessionColumn(columns, "display_name", "NULL"),
+  ];
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS conversations (
+      conversation_id TEXT NOT NULL PRIMARY KEY,
+      channel TEXT NOT NULL,
+      account_id TEXT NOT NULL,
+      kind TEXT NOT NULL CHECK (kind IN ('direct', 'group', 'channel')),
+      peer_id TEXT NOT NULL,
+      parent_conversation_id TEXT,
+      thread_id TEXT,
+      native_channel_id TEXT,
+      native_direct_user_id TEXT,
+      label TEXT,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  db.exec("PRAGMA foreign_keys = OFF;");
+  try {
+    db.exec(`
+      DROP TABLE IF EXISTS sessions_new;
+      CREATE TABLE sessions_new (
+        session_id TEXT NOT NULL PRIMARY KEY,
+        session_key TEXT NOT NULL,
+        session_scope TEXT NOT NULL DEFAULT 'conversation' CHECK (session_scope IN ('conversation', 'shared-main', 'group', 'channel')),
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        started_at INTEGER,
+        ended_at INTEGER,
+        status TEXT CHECK (status IS NULL OR status IN ('running', 'done', 'failed', 'killed', 'timeout')),
+        chat_type TEXT CHECK (chat_type IS NULL OR chat_type IN ('direct', 'group', 'channel')),
+        channel TEXT,
+        account_id TEXT,
+        primary_conversation_id TEXT,
+        model_provider TEXT,
+        model TEXT,
+        agent_harness_id TEXT,
+        parent_session_key TEXT,
+        spawned_by TEXT,
+        display_name TEXT,
+        FOREIGN KEY (primary_conversation_id) REFERENCES conversations(conversation_id) ON DELETE SET NULL
+      );
+      INSERT INTO sessions_new (${copyColumns.join(", ")})
+      SELECT ${selectColumns.join(", ")} FROM sessions;
+      DROP TABLE sessions;
+      ALTER TABLE sessions_new RENAME TO sessions;
+    `);
+  } finally {
+    db.exec("PRAGMA foreign_keys = ON;");
+  }
+}
+
+function parseMigratedSessionEntry(value: unknown): MigratedSessionEntry | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as MigratedSessionEntry)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function migratedObjectField(
+  entry: MigratedSessionEntry,
+  key: string,
+): MigratedSessionEntry | null {
+  const value = entry[key];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as MigratedSessionEntry)
+    : null;
+}
+
+function migratedText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function migratedNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function migratedChatType(value: unknown): "direct" | "group" | "channel" | null {
+  if (value === "direct" || value === "group" || value === "channel") {
+    return value;
+  }
+  return null;
+}
+
+function migratedStatus(
+  value: unknown,
+): "running" | "done" | "failed" | "killed" | "timeout" | null {
+  if (
+    value === "running" ||
+    value === "done" ||
+    value === "failed" ||
+    value === "killed" ||
+    value === "timeout"
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function migratedSessionScope(
+  entry: MigratedSessionEntry,
+  sessionKey: string,
+): "conversation" | "shared-main" | "group" | "channel" {
+  const chatType = migratedChatType(entry.chatType);
+  const normalizedKey = sessionKey.trim().toLowerCase();
+  if (chatType === "direct" && (normalizedKey === "main" || normalizedKey.endsWith(":main"))) {
+    return "shared-main";
+  }
+  if (chatType === "group" || chatType === "channel") {
+    return chatType;
+  }
+  return "conversation";
+}
+
+function migratedEntryChannel(entry: MigratedSessionEntry): string | null {
+  const deliveryContext = migratedObjectField(entry, "deliveryContext");
+  const origin = migratedObjectField(entry, "origin");
+  return (
+    migratedText(entry.channel) ??
+    migratedText(deliveryContext?.channel) ??
+    migratedText(entry.lastChannel) ??
+    migratedText(origin?.provider)
+  );
+}
+
+function migratedEntryAccountId(entry: MigratedSessionEntry): string | null {
+  const deliveryContext = migratedObjectField(entry, "deliveryContext");
+  const origin = migratedObjectField(entry, "origin");
+  return (
+    migratedText(deliveryContext?.accountId) ??
+    migratedText(entry.lastAccountId) ??
+    migratedText(origin?.accountId)
+  );
+}
+
+function migratedEntryDisplayName(entry: MigratedSessionEntry): string | null {
+  return (
+    migratedText(entry.displayName) ??
+    migratedText(entry.label) ??
+    migratedText(entry.subject) ??
+    migratedText(entry.groupId)
+  );
+}
+
+function backfillOpenClawAgentSchema(db: DatabaseSync, previousVersion: number): void {
+  if (previousVersion >= 2) {
+    return;
+  }
+  db.exec(`
+    INSERT OR REPLACE INTO session_routes (session_key, session_id, updated_at)
+    SELECT se.session_key, se.session_id, se.updated_at
+    FROM session_entries AS se
+    INNER JOIN sessions AS s ON s.session_id = se.session_id;
+  `);
+  const rows = db
+    .prepare(
+      `
+        SELECT se.session_key, se.session_id, se.entry_json
+        FROM session_entries AS se
+        INNER JOIN sessions AS s ON s.session_id = se.session_id;
+      `,
+    )
+    .all() as Array<{
+    entry_json?: unknown;
+    session_id?: unknown;
+    session_key?: unknown;
+  }>;
+  const update = db.prepare(`
+    UPDATE sessions
+    SET
+      session_scope = ?,
+      started_at = ?,
+      ended_at = ?,
+      status = ?,
+      chat_type = ?,
+      channel = ?,
+      account_id = ?,
+      model_provider = ?,
+      model = ?,
+      agent_harness_id = ?,
+      parent_session_key = ?,
+      spawned_by = ?,
+      display_name = ?
+    WHERE session_id = ?;
+  `);
+  for (const row of rows) {
+    const sessionKey = migratedText(row.session_key);
+    const sessionId = migratedText(row.session_id);
+    const entry = parseMigratedSessionEntry(row.entry_json);
+    if (!sessionKey || !sessionId || !entry) {
+      continue;
+    }
+    update.run(
+      migratedSessionScope(entry, sessionKey),
+      migratedNumber(entry.startedAt),
+      migratedNumber(entry.endedAt),
+      migratedStatus(entry.status),
+      migratedChatType(entry.chatType),
+      migratedEntryChannel(entry),
+      migratedEntryAccountId(entry),
+      migratedText(entry.modelProvider),
+      migratedText(entry.model),
+      migratedText(entry.agentHarnessId),
+      migratedText(entry.parentSessionKey),
+      migratedText(entry.spawnedBy),
+      migratedEntryDisplayName(entry),
+      sessionId,
     );
   }
 }
@@ -139,7 +428,10 @@ function assertExistingSchemaOwner(
 function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string): void {
   assertSupportedAgentSchemaVersion(db, pathname);
   assertExistingSchemaOwner(readExistingSchemaMeta(db), agentId, pathname);
+  const previousVersion = readSqliteUserVersion(db);
+  migrateOpenClawAgentSchema(db);
   db.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+  backfillOpenClawAgentSchema(db, previousVersion);
   const kysely = getNodeSqliteKysely<OpenClawAgentMetadataDatabase>(db);
   db.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};`);
   const now = Date.now();

--- a/src/state/openclaw-agent-schema.generated.ts
+++ b/src/state/openclaw-agent-schema.generated.ts
@@ -16,12 +16,94 @@ export const OPENCLAW_AGENT_SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS schema_meta
 CREATE TABLE IF NOT EXISTS sessions (
   session_id TEXT NOT NULL PRIMARY KEY,
   session_key TEXT NOT NULL,
+  session_scope TEXT NOT NULL DEFAULT 'conversation' CHECK (session_scope IN ('conversation', 'shared-main', 'group', 'channel')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  started_at INTEGER,
+  ended_at INTEGER,
+  status TEXT CHECK (status IS NULL OR status IN ('running', 'done', 'failed', 'killed', 'timeout')),
+  chat_type TEXT CHECK (chat_type IS NULL OR chat_type IN ('direct', 'group', 'channel')),
+  channel TEXT,
+  account_id TEXT,
+  primary_conversation_id TEXT,
+  model_provider TEXT,
+  model TEXT,
+  agent_harness_id TEXT,
+  parent_session_key TEXT,
+  spawned_by TEXT,
+  display_name TEXT,
+  FOREIGN KEY (primary_conversation_id) REFERENCES conversations(conversation_id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated_at
+  ON sessions(updated_at DESC, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_created_at
+  ON sessions(created_at DESC, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_conversation
+  ON sessions(primary_conversation_id, updated_at DESC, session_id)
+  WHERE primary_conversation_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS session_routes (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_routes_session_id
+  ON session_routes(session_id);
+
+CREATE TABLE IF NOT EXISTS conversations (
+  conversation_id TEXT NOT NULL PRIMARY KEY,
+  channel TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('direct', 'group', 'channel')),
+  peer_id TEXT NOT NULL,
+  parent_conversation_id TEXT,
+  thread_id TEXT,
+  native_channel_id TEXT,
+  native_direct_user_id TEXT,
+  label TEXT,
+  metadata_json TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
-  ON sessions(updated_at DESC, session_id);
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_lookup
+  ON conversations(channel, account_id, kind, peer_id, thread_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_conversations_identity
+  ON conversations(
+    channel,
+    account_id,
+    kind,
+    peer_id,
+    IFNULL(parent_conversation_id, ''),
+    IFNULL(thread_id, '')
+  );
+
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_updated
+  ON conversations(updated_at DESC, conversation_id);
+
+CREATE TABLE IF NOT EXISTS session_conversations (
+  session_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'primary' CHECK (role IN ('primary', 'participant', 'related')),
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, conversation_id, role),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_conversations_conversation
+  ON session_conversations(conversation_id, last_seen_at DESC, session_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_session_conversations_primary
+  ON session_conversations(session_id)
+  WHERE role = 'primary';
 
 CREATE TABLE IF NOT EXISTS session_entries (
   session_key TEXT NOT NULL PRIMARY KEY,
@@ -31,7 +113,7 @@ CREATE TABLE IF NOT EXISTS session_entries (
   FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated_at
   ON session_entries(updated_at DESC, session_key);
 
 CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id

--- a/src/state/openclaw-agent-schema.generated.ts
+++ b/src/state/openclaw-agent-schema.generated.ts
@@ -13,6 +13,62 @@ export const OPENCLAW_AGENT_SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS schema_meta
   updated_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
+  ON sessions(updated_at DESC, session_id);
+
+CREATE TABLE IF NOT EXISTS session_entries (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  entry_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+  ON session_entries(updated_at DESC, session_key);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id
+  ON session_entries(session_id);
+
+CREATE TABLE IF NOT EXISTS transcript_events (
+  session_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, seq),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_events_session
+  ON transcript_events(session_id, seq);
+
+CREATE TABLE IF NOT EXISTS transcript_event_identities (
+  session_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_type TEXT,
+  parent_id TEXT,
+  message_idempotency_key TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, event_id),
+  FOREIGN KEY (session_id, seq) REFERENCES transcript_events(session_id, seq) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_message_idempotency
+  ON transcript_event_identities(session_id, message_idempotency_key)
+  WHERE message_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_parent
+  ON transcript_event_identities(session_id, parent_id)
+  WHERE parent_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS cache_entries (
   scope TEXT NOT NULL,
   key TEXT NOT NULL,

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -11,12 +11,94 @@ CREATE TABLE IF NOT EXISTS schema_meta (
 CREATE TABLE IF NOT EXISTS sessions (
   session_id TEXT NOT NULL PRIMARY KEY,
   session_key TEXT NOT NULL,
+  session_scope TEXT NOT NULL DEFAULT 'conversation' CHECK (session_scope IN ('conversation', 'shared-main', 'group', 'channel')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  started_at INTEGER,
+  ended_at INTEGER,
+  status TEXT CHECK (status IS NULL OR status IN ('running', 'done', 'failed', 'killed', 'timeout')),
+  chat_type TEXT CHECK (chat_type IS NULL OR chat_type IN ('direct', 'group', 'channel')),
+  channel TEXT,
+  account_id TEXT,
+  primary_conversation_id TEXT,
+  model_provider TEXT,
+  model TEXT,
+  agent_harness_id TEXT,
+  parent_session_key TEXT,
+  spawned_by TEXT,
+  display_name TEXT,
+  FOREIGN KEY (primary_conversation_id) REFERENCES conversations(conversation_id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated_at
+  ON sessions(updated_at DESC, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_created_at
+  ON sessions(created_at DESC, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_conversation
+  ON sessions(primary_conversation_id, updated_at DESC, session_id)
+  WHERE primary_conversation_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS session_routes (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_routes_session_id
+  ON session_routes(session_id);
+
+CREATE TABLE IF NOT EXISTS conversations (
+  conversation_id TEXT NOT NULL PRIMARY KEY,
+  channel TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('direct', 'group', 'channel')),
+  peer_id TEXT NOT NULL,
+  parent_conversation_id TEXT,
+  thread_id TEXT,
+  native_channel_id TEXT,
+  native_direct_user_id TEXT,
+  label TEXT,
+  metadata_json TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
-  ON sessions(updated_at DESC, session_id);
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_lookup
+  ON conversations(channel, account_id, kind, peer_id, thread_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_conversations_identity
+  ON conversations(
+    channel,
+    account_id,
+    kind,
+    peer_id,
+    IFNULL(parent_conversation_id, ''),
+    IFNULL(thread_id, '')
+  );
+
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_updated
+  ON conversations(updated_at DESC, conversation_id);
+
+CREATE TABLE IF NOT EXISTS session_conversations (
+  session_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'primary' CHECK (role IN ('primary', 'participant', 'related')),
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, conversation_id, role),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_conversations_conversation
+  ON session_conversations(conversation_id, last_seen_at DESC, session_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_session_conversations_primary
+  ON session_conversations(session_id)
+  WHERE role = 'primary';
 
 CREATE TABLE IF NOT EXISTS session_entries (
   session_key TEXT NOT NULL PRIMARY KEY,
@@ -26,7 +108,7 @@ CREATE TABLE IF NOT EXISTS session_entries (
   FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated_at
   ON session_entries(updated_at DESC, session_key);
 
 CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -8,6 +8,62 @@ CREATE TABLE IF NOT EXISTS schema_meta (
   updated_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
+  ON sessions(updated_at DESC, session_id);
+
+CREATE TABLE IF NOT EXISTS session_entries (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  entry_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+  ON session_entries(updated_at DESC, session_key);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id
+  ON session_entries(session_id);
+
+CREATE TABLE IF NOT EXISTS transcript_events (
+  session_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, seq),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_events_session
+  ON transcript_events(session_id, seq);
+
+CREATE TABLE IF NOT EXISTS transcript_event_identities (
+  session_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_type TEXT,
+  parent_id TEXT,
+  message_idempotency_key TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, event_id),
+  FOREIGN KEY (session_id, seq) REFERENCES transcript_events(session_id, seq) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_message_idempotency
+  ON transcript_event_identities(session_id, message_idempotency_key)
+  WHERE message_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_parent
+  ON transcript_event_identities(session_id, parent_id)
+  WHERE parent_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS cache_entries (
   scope TEXT NOT NULL,
   key TEXT NOT NULL,


### PR DESCRIPTION
## What

Path 3 / PR 3.2 for #88838 adds the unused, additive SQLite session/transcript store foundation behind the 3.1a/3.1b accessor seam. It introduces the per-agent SQLite schema, generated Kysely types, SQLite-backed session/transcript helper module, SQLite checkpoint branch/restore support for validation branches, and shared conformance coverage while preserving the current file-backed runtime behavior.

## Why

The SQLite storage flip should not land in the same PR as caller rewrites or legacy migration work. This foundation lets disposable validation branches exercise the future SQLite backend against the existing accessor seam while production runtime remains file-backed until later Path 3 slices complete caller adoption, doctor migration, and the atomic storage flip.

## Changes

- Added per-agent session/transcript SQLite schema
- Added file/SQLite accessor conformance tests
- Added transcript read-scope SQLite support
- Added canonical `sessions.json` path parity
- Added `preserveActivity` parity for SQLite patches
- Serialized SQLite entry and transcript writes
- Added exact-key SQLite session lookup
- Added SQLite transcript row mutation helpers
- Added SQLite checkpoint branch/restore helpers
- Excluded runtime storage wiring and migration

| File | Change |
|------|--------|
| `src/state/openclaw-agent-schema.sql` | Adds session/transcript tables |
| `src/state/openclaw-agent-db.ts` | Adds per-agent DB lifecycle and schema migration/backfill |
| `src/config/sessions/session-accessor.sqlite.ts` | Implements additive SQLite helper surface for the current foundation slice |
| `src/config/sessions/session-accessor.conformance.test.ts` | Shares file/SQLite behavior and checkpoint branch/restore coverage |

## Schema Audit

The refreshed schema has durable homes for the data currently needed by this foundation slice: `sessions` stores normalized session identity/status/routing fields, `session_routes` maps persisted keys to session ids, `session_entries.entry_json` preserves the full `SessionEntry` object, `transcript_events` stores ordered transcript rows, `transcript_event_identities` stores event ids/parent links/message idempotency keys, and `conversations` plus `session_conversations` cover future conversation linkage.

The current 3.1b accessor seam is broader than this helper module. Newer storage-sized operations such as transcript-turn persistence, manual trim, reset/delete lifecycle, restart recovery, reply-session initialization, and plugin-host cleanup can be represented with the existing tables, mostly through `session_entries.entry_json` plus transcript rows, but they still need SQLite adapter methods before the production storage flip. That is adapter coverage work, not a schema gap found in this refresh.

## Out Of Scope

Production storage flip/runtime wiring, doctor migration/import, runtime dual-read/fallback, and complete SQLite implementations for every post-3.1b accessor operation remain out of scope for this additive foundation PR.

## Evidence

- Rebased onto `upstream/main` `3ab8d6aa609ab7f1a6bee14500694bd7ca243489`
- `node scripts/generate-kysely-types.mjs --verify`
- `node scripts/check-kysely-guardrails.mjs`
- `node scripts/check-session-accessor-boundary.mjs`
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.conformance.test.ts src/state/openclaw-agent-db.test.ts`
- `node scripts/run-oxlint.mjs src/config/sessions/session-accessor.sqlite.ts src/config/sessions/session-accessor.conformance.test.ts src/state/openclaw-agent-db.ts src/state/openclaw-agent-db.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/config/sessions/session-accessor.sqlite.ts src/config/sessions/session-accessor.conformance.test.ts src/state/openclaw-agent-db.ts src/state/openclaw-agent-db.test.ts src/state/openclaw-agent-schema.sql src/state/openclaw-agent-schema.generated.ts src/state/openclaw-agent-db.generated.d.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --engine codex --no-web-search --thinking codex=low` returned clean
