### PR TITLE
fix(agents): dispatch auth failures by type

### DIFF
--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -11,6 +11,7 @@ import {
   log,
 } from "./constants.js";
 import { shouldMirrorRefreshedOAuthCredential } from "./oauth-identity.js";
+import { OAuthRefreshFailureError } from "./oauth-refresh-failure.js";
 import {
   buildRefreshContentionError,
   isGlobalRefreshLockTimeoutError,
@@ -61,9 +62,8 @@ export type ResolvedOAuthAccess = {
   credential: OAuthCredential;
 };
 
-export class OAuthManagerRefreshError extends Error {
+export class OAuthManagerRefreshError extends OAuthRefreshFailureError {
   readonly profileId: string;
-  readonly provider: string;
   readonly code?: string;
   readonly lockPath?: string;
   readonly #refreshedStore: AuthProfileStore;
@@ -91,13 +91,14 @@ export class OAuthManagerRefreshError extends Error {
       storedCredential?.type === "oauth" ? storedCredential : undefined,
     );
     const causeMessage = formatRedactedOAuthRefreshError(params.cause, secrets);
-    super(`OAuth token refresh failed for ${params.credential.provider}: ${causeMessage}`, {
+    super({
+      provider: params.credential.provider,
+      message: `OAuth token refresh failed for ${params.credential.provider}: ${causeMessage}`,
       cause: createRedactedOAuthRefreshCause(delegatedCause, secrets),
     });
     this.name = "OAuthManagerRefreshError";
     this.#credential = params.credential;
     this.profileId = params.profileId;
-    this.provider = params.credential.provider;
     this.#refreshedStore = params.refreshedStore;
     if (structuredCause) {
       this.code = typeof structuredCause.code === "string" ? structuredCause.code : undefined;

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildOAuthRefreshFailureLoginCommand,
   classifyOAuthRefreshFailure,
+  classifyOAuthRefreshFailureError,
+  OAuthRefreshFailureError,
 } from "./oauth-refresh-failure.js";
 
 describe("oauth refresh failure hints", () => {
@@ -15,5 +17,19 @@ describe("oauth refresh failure hints", () => {
     expect(buildOAuthRefreshFailureLoginCommand("openai")).toBe(
       "openclaw models auth login --provider openai",
     );
+  });
+
+  it("classifies typed refresh failures without parsing the display message", () => {
+    expect(
+      classifyOAuthRefreshFailureError(
+        new OAuthRefreshFailureError({
+          provider: "openai",
+          message: "invalid_grant",
+        }),
+      ),
+    ).toEqual({
+      provider: "openai",
+      reason: "invalid_grant",
+    });
   });
 });

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -9,6 +9,23 @@ export type OAuthRefreshFailureReason =
   | "invalid_refresh_token"
   | "revoked";
 
+export type OAuthRefreshFailure = {
+  provider: string | null;
+  reason: OAuthRefreshFailureReason | null;
+};
+
+export class OAuthRefreshFailureError extends Error {
+  readonly provider: string;
+  readonly reason: OAuthRefreshFailureReason | null;
+
+  constructor(params: { provider: string; message: string; cause?: unknown }) {
+    super(params.message, { cause: params.cause });
+    this.name = "OAuthRefreshFailureError";
+    this.provider = params.provider;
+    this.reason = classifyOAuthRefreshFailureReason(params.message);
+  }
+}
+
 const OAUTH_REFRESH_FAILURE_PROVIDER_RE = /OAuth token refresh failed for ([^:]+):/i;
 const SAFE_PROVIDER_ID_RE = /^[a-z0-9][a-z0-9._-]*$/;
 
@@ -54,16 +71,23 @@ export function classifyOAuthRefreshFailureReason(
   return null;
 }
 
-export function classifyOAuthRefreshFailure(message: string): {
-  provider: string | null;
-  reason: OAuthRefreshFailureReason | null;
-} | null {
+export function classifyOAuthRefreshFailure(message: string): OAuthRefreshFailure | null {
   if (!isOAuthRefreshFailureMessage(message)) {
     return null;
   }
   return {
     provider: sanitizeOAuthRefreshFailureProvider(extractOAuthRefreshFailureProvider(message)),
     reason: classifyOAuthRefreshFailureReason(message),
+  };
+}
+
+export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFailure | null {
+  if (!(err instanceof OAuthRefreshFailureError)) {
+    return null;
+  }
+  return {
+    provider: sanitizeOAuthRefreshFailureProvider(err.provider),
+    reason: err.reason,
   };
 }
 

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -25,6 +25,7 @@ import {
   readManagedExternalCliCredential,
 } from "./external-cli-sync.js";
 import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
+import { OAuthRefreshFailureError } from "./oauth-refresh-failure.js";
 import { assertNoOAuthSecretRefPolicyViolations } from "./policy.js";
 import { clearLastGoodProfileWithLock } from "./profiles.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
@@ -495,11 +496,13 @@ export async function resolveApiKeyForProfile(
       provider: cred.provider,
       profileId,
     });
-    throw new Error(
-      `OAuth token refresh failed for ${cred.provider}: ${message}. ` +
+    throw new OAuthRefreshFailureError({
+      provider: cred.provider,
+      message:
+        `OAuth token refresh failed for ${cred.provider}: ${message}. ` +
         "Please try again or re-authenticate." +
         (hint ? `\n\n${hint}` : ""),
-      { cause: error },
-    );
+      cause: error,
+    });
   }
 }

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -85,8 +85,8 @@ import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-promp
 import {
   applyAuthHeaderOverride,
   applyLocalNoAuthHeaderOverride,
-  formatMissingAuthError,
   getApiKeyForModel,
+  MissingProviderAuthError,
   resolveModelAuthMode,
 } from "../model-auth.js";
 import { isFallbackSummaryError, runWithModelFallback } from "../model-fallback.js";
@@ -613,7 +613,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
 
     if (!apiKeyInfo.apiKey) {
       if (apiKeyInfo.mode !== "aws-sdk") {
-        throw new Error(formatMissingAuthError(apiKeyInfo, runtimeModel.provider));
+        throw new MissingProviderAuthError(runtimeModel.provider, apiKeyInfo);
       }
     } else {
       const preparedAuth = await prepareProviderRuntimeAuth({

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -16,8 +16,8 @@ import {
 import { FailoverError, resolveFailoverStatus } from "../../failover-error.js";
 import { shouldAllowCooldownProbeForReason } from "../../failover-policy.js";
 import {
-  formatMissingAuthError,
   getApiKeyForModel,
+  MissingProviderAuthError,
   type ResolvedProviderAuth,
 } from "../../model-auth.js";
 import {
@@ -350,6 +350,7 @@ export function createEmbeddedRunAuthController(params: {
         provider,
         model: modelId,
         status: resolveFailoverStatus(reason),
+        authProfileFailure: { allInCooldown: failoverParams.allInCooldown },
         cause: failoverParams.error,
       });
     }
@@ -378,7 +379,7 @@ export function createEmbeddedRunAuthController(params: {
     if (!apiKeyInfo.apiKey) {
       if (apiKeyInfo.mode !== "aws-sdk") {
         const runtimeModel = params.getRuntimeModel();
-        throw new Error(formatMissingAuthError(apiKeyInfo, runtimeModel.provider));
+        throw new MissingProviderAuthError(runtimeModel.provider, apiKeyInfo);
       }
       // AWS SDK auth via IMDS / instance role / ECS task role: no explicit API
       // key is available but the SDK default credential chain can resolve

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -23,6 +23,7 @@ export class FailoverError extends Error {
   readonly status?: number;
   readonly code?: string;
   readonly rawError?: string;
+  readonly authProfileFailure?: { allInCooldown: boolean };
   // Originating request attribution propagated through wrapper errors so
   // structured log ingestion (e.g. api_health_log) can attribute exhausted
   // failover failures back to a session/lane and the last attempted provider.
@@ -41,6 +42,7 @@ export class FailoverError extends Error {
       status?: number;
       code?: string;
       rawError?: string;
+      authProfileFailure?: { allInCooldown: boolean };
       sessionId?: string;
       lane?: string;
       cause?: unknown;
@@ -56,6 +58,7 @@ export class FailoverError extends Error {
     this.status = params.status;
     this.code = params.code;
     this.rawError = params.rawError;
+    this.authProfileFailure = params.authProfileFailure;
     this.sessionId = params.sessionId;
     this.lane = params.lane;
     this.suspend = params.suspend;

--- a/src/agents/model-auth-runtime-shared.ts
+++ b/src/agents/model-auth-runtime-shared.ts
@@ -26,11 +26,27 @@ export class ProviderAuthError extends Error {
   }
 }
 
+export class MissingProviderAuthError extends ProviderAuthError {
+  readonly mode: ResolvedProviderAuth["mode"];
+  readonly source: string;
+
+  constructor(provider: string, auth: ResolvedProviderAuth) {
+    super("missing-api-key", provider, formatMissingAuthError(auth, provider));
+    this.name = "MissingProviderAuthError";
+    this.mode = auth.mode;
+    this.source = auth.source;
+  }
+}
+
 export function isProviderAuthError(
   err: unknown,
   code?: ProviderAuthErrorCode,
 ): err is ProviderAuthError {
   return err instanceof ProviderAuthError && (!code || err.code === code);
+}
+
+export function isMissingProviderAuthError(err: unknown): err is MissingProviderAuthError {
+  return err instanceof MissingProviderAuthError;
 }
 
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {
@@ -55,5 +71,5 @@ export function requireApiKey(auth: ResolvedProviderAuth, provider: string): str
   if (key) {
     return key;
   }
-  throw new ProviderAuthError("missing-api-key", provider, formatMissingAuthError(auth, provider));
+  throw new MissingProviderAuthError(provider, auth);
 }

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -425,6 +425,28 @@ describe("requireApiKey", () => {
       'No API key resolved for provider "openai" (auth mode: api-key, checked: env: OPENAI_API_KEY).',
     );
   });
+
+  it("throws typed missing auth errors with source metadata", () => {
+    let thrown: unknown;
+    try {
+      requireApiKey(
+        {
+          source: "env: OPENAI_API_KEY",
+          mode: "api-key",
+        },
+        "openai",
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toMatchObject({
+      name: "MissingProviderAuthError",
+      code: "missing-api-key",
+      provider: "openai",
+      mode: "api-key",
+      source: "env: OPENAI_API_KEY",
+    });
+  });
 });
 
 describe("resolveUsableCustomProviderApiKey", () => {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -58,7 +58,9 @@ export {
 } from "./auth-profiles.js";
 export {
   formatMissingAuthError,
+  isMissingProviderAuthError,
   isProviderAuthError,
+  MissingProviderAuthError,
   ProviderAuthError,
   requireApiKey,
   resolveAwsSdkEnvVarName,

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OAuthRefreshFailureError } from "../../agents/auth-profiles/oauth-refresh-failure.js";
+import { FailoverError } from "../../agents/failover-error.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
+import { MissingProviderAuthError } from "../../agents/model-auth.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { ModelDefinitionConfig } from "../../config/types.models.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
@@ -5596,6 +5599,25 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("surfaces gateway reauth guidance from typed OAuth refresh failures", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new OAuthRefreshFailureError({
+        provider: "openai",
+        message: "invalid_grant",
+      }),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Model login expired on the gateway for openai. Re-auth with `openclaw models auth login --provider openai`, then try again.",
+      );
+    }
+  });
+
   it("surfaces direct provider auth guidance for missing API keys", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error(
@@ -5632,6 +5654,47 @@ describe("runAgentTurnWithFallback", () => {
       expect(result.payload.text).toBe(
         "⚠️ Missing API key for OpenAI on the gateway. Use `openai/gpt-5.5` with the OpenAI OAuth profile, or set `OPENAI_API_KEY` for direct OpenAI API-key runs.",
       );
+    }
+  });
+
+  it("surfaces typed missing API-key auth guidance without parsing the message", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new MissingProviderAuthError("openai", {
+        mode: "api-key",
+        source: "env: OPENAI_API_KEY",
+      }),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        '⚠️ Missing API key for provider "openai". Run `openclaw doctor --fix` to repair stale OpenAI model/session routes, restart the gateway if doctor asks, then try again. If doctor has nothing to repair or the error persists, re-auth with `openclaw models auth login --provider openai` or run `openclaw configure`.',
+      );
+    }
+  });
+
+  it("formats auth-profile failover copy from typed FailoverError metadata", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError("Auth profile failover exhausted for provider openai", {
+        reason: "auth",
+        provider: "openai",
+        authProfileFailure: { allInCooldown: true },
+        cause: new Error("invalid_grant"),
+      }),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toContain("Couldn't sign in to openai.");
+      expect(result.payload.text).toContain("openclaw configure");
+      expect(result.payload.text).toContain("(invalid_grant)");
+      expect(result.payload.text).not.toContain("Auth profile failover exhausted");
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -17,9 +17,11 @@ import {
   markAutoFallbackPrimaryProbe,
   resolveAutoFallbackPrimaryProbe,
 } from "../../agents/agent-scope.js";
+import { formatAuthProfileFailureMessage } from "../../agents/auth-profiles/failure-copy.js";
 import {
   buildOAuthRefreshFailureLoginCommand,
   classifyOAuthRefreshFailure,
+  classifyOAuthRefreshFailureError,
 } from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
@@ -38,9 +40,11 @@ import {
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import { isMessagingToolSendAction } from "../../agents/embedded-agent-messaging.js";
 import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
+import { isFailoverError } from "../../agents/failover-error.js";
 import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
+import { isMissingProviderAuthError } from "../../agents/model-auth.js";
 import { runWithModelFallback, isFallbackSummaryError } from "../../agents/model-fallback.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import {
@@ -632,6 +636,8 @@ type ExternalRunFailureReply = {
   isGenericRunnerFailure: boolean;
 };
 
+type ExternalRunFailureInput = string | { message: string; error?: unknown };
+
 function isNonDirectConversationContext(ctx: TemplateContext): boolean {
   const chatType = normalizeLowercaseStringOrEmpty(ctx.ChatType);
   return chatType === "group" || chatType === "channel";
@@ -732,10 +738,14 @@ function buildCliBackendTimeoutFailureText(message: string): string | null {
   );
 }
 
-function buildMissingApiKeyFailureText(message: string): string | null {
-  const normalizedMessage = collapseRepeatedFailureDetail(message);
-  const providerMatch = normalizedMessage.match(/No API key found for provider "([^"]+)"/u);
-  const provider = providerMatch?.[1]?.trim().toLowerCase();
+function buildMissingApiKeyFailureText(input: { message: string; error?: unknown }): string | null {
+  const normalizedMessage = collapseRepeatedFailureDetail(input.message);
+  const provider = isMissingProviderAuthError(input.error)
+    ? input.error.provider.trim().toLowerCase()
+    : normalizedMessage
+        .match(/No API key found for provider "([^"]+)"/u)?.[1]
+        ?.trim()
+        .toLowerCase();
   if (!provider) {
     return null;
   }
@@ -749,6 +759,18 @@ function buildMissingApiKeyFailureText(message: string): string | null {
     return `⚠️ Missing API key for provider "${provider}". Configure the gateway auth for that provider, then try again.`;
   }
   return "⚠️ Missing API key for the selected provider on the gateway. Configure provider auth, then try again.";
+}
+
+function buildAuthProfileFailoverFailureText(error: unknown): string | null {
+  if (!isFailoverError(error) || !error.provider || !error.authProfileFailure) {
+    return null;
+  }
+  return formatAuthProfileFailureMessage({
+    reason: error.reason,
+    provider: error.provider,
+    allInCooldown: error.authProfileFailure.allInCooldown,
+    cause: error.cause,
+  });
 }
 
 function formatForwardedExternalRunFailureText(message: string): string {
@@ -768,10 +790,16 @@ function formatForwardedExternalRunFailureText(message: string): string {
 }
 
 function buildExternalRunFailureReply(
-  message: string,
+  input: ExternalRunFailureInput,
   options?: { includeDetails?: boolean; isHeartbeat?: boolean },
 ): ExternalRunFailureReply {
+  const message = typeof input === "string" ? input : input.message;
+  const error = typeof input === "string" ? undefined : input.error;
   const normalizedMessage = collapseRepeatedFailureDetail(message);
+  const authProfileFailoverFailure = buildAuthProfileFailoverFailureText(error);
+  if (authProfileFailoverFailure) {
+    return { text: authProfileFailoverFailure, isGenericRunnerFailure: false };
+  }
   const providerRequestError = classifyProviderRequestError(normalizedMessage);
   if (providerRequestError) {
     return {
@@ -779,11 +807,15 @@ function buildExternalRunFailureReply(
       isGenericRunnerFailure: false,
     };
   }
-  const missingApiKeyFailure = buildMissingApiKeyFailureText(normalizedMessage);
+  const missingApiKeyFailure = buildMissingApiKeyFailureText({
+    message: normalizedMessage,
+    error,
+  });
   if (missingApiKeyFailure) {
     return { text: missingApiKeyFailure, isGenericRunnerFailure: false };
   }
-  const oauthRefreshFailure = classifyOAuthRefreshFailure(normalizedMessage);
+  const oauthRefreshFailure =
+    classifyOAuthRefreshFailureError(error) ?? classifyOAuthRefreshFailure(normalizedMessage);
   if (oauthRefreshFailure) {
     const loginCommand = buildOAuthRefreshFailureLoginCommand(oauthRefreshFailure.provider);
     if (oauthRefreshFailure.reason) {
@@ -889,9 +921,12 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
     });
   }
 
-  const externalRunFailureReply = buildExternalRunFailureReply(message, {
-    includeDetails: isVerboseFailureDetailEnabled(params.resolvedVerboseLevel),
-  });
+  const externalRunFailureReply = buildExternalRunFailureReply(
+    { message, error: params.err },
+    {
+      includeDetails: isVerboseFailureDetailEnabled(params.resolvedVerboseLevel),
+    },
+  );
   if (externalRunFailureReply.isGenericRunnerFailure) {
     return undefined;
   }
@@ -2861,10 +2896,13 @@ export async function runAgentTurnWithFallback(params: {
         !rateLimitOrOverloadedCopy &&
         !isContextOverflow &&
         !shouldSurfaceToControlUi
-          ? buildExternalRunFailureReply(message, {
-              includeDetails: isVerboseFailureDetailEnabled(params.resolvedVerboseLevel),
-              isHeartbeat: params.isHeartbeat,
-            })
+          ? buildExternalRunFailureReply(
+              { message, error: err },
+              {
+                includeDetails: isVerboseFailureDetailEnabled(params.resolvedVerboseLevel),
+                isHeartbeat: params.isHeartbeat,
+              },
+            )
           : undefined;
       const genericFallbackText = params.isHeartbeat
         ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -99,6 +99,7 @@ vi.mock("../../agents/model-fallback.js", () => ({
 }));
 
 vi.mock("../../agents/model-auth.js", () => ({
+  isMissingProviderAuthError: () => false,
   resolveModelAuthMode: () => "api-key",
 }));
 


### PR DESCRIPTION
## Summary

- Follow up #85798 by threading structured failure objects into buildExternalRunFailureReply so direct auto-reply failures can dispatch on typed auth/failover errors before string fallbacks.
- Add typed OAuth refresh and missing-provider-auth errors while preserving existing string classifiers for opaque third-party/log transport failures.
- Mark auth-profile FailoverError instances with structured auth-profile metadata while preserving source messages for non-auto-reply consumers and fallback summaries.

## Verification

- node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-refresh-failure.test.ts src/agents/model-auth.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/agents/embedded-agent-runner/run/auth-controller.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode local (clean after one accepted finding was fixed)
- git diff --check
