### PR TITLE
fix(tui): keep local slash commands out of model prompts

### DIFF
--- a/scripts/ios-release-signing.mjs
+++ b/scripts/ios-release-signing.mjs
@@ -129,7 +129,7 @@ function runAscJson(args) {
 
   try {
     return JSON.parse(trimmed);
-  } catch (error) {
+  } catch {
     throw new Error(`asc returned non-JSON output for ${args.join(" ")}: ${trimmed.slice(0, 500)}`);
   }
 }
@@ -219,7 +219,9 @@ function ensureAscAvailable() {
   try {
     run("asc", ["--help"]);
   } catch (error) {
-    throw new Error(`asc CLI is required for iOS release signing setup: ${error.message}`);
+    throw new Error(`asc CLI is required for iOS release signing setup: ${error.message}`, {
+      cause: error,
+    });
   }
 }
 
@@ -458,7 +460,7 @@ function localDistributionIdentityFingerprints(manifest) {
     return new Set();
   }
 
-  let output = "";
+  let output;
   try {
     output = run("security", ["find-identity", "-p", "codesigning", "-v"]);
   } catch {

--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -7,6 +7,18 @@ describe("parseCommand", () => {
     expect(parseCommand("/elev full")).toEqual({ name: "elevated", args: "full" });
   });
 
+  it("treats colon-form slash command args as command args", () => {
+    expect(parseCommand("/model: openai/gpt-5.5")).toEqual({
+      name: "model",
+      args: "openai/gpt-5.5",
+    });
+    expect(parseCommand("/think: high")).toEqual({ name: "think", args: "high" });
+    expect(parseCommand("/compact: focus on decisions")).toEqual({
+      name: "compact",
+      args: "focus on decisions",
+    });
+  });
+
   it("normalizes gateway-status aliases", () => {
     expect(parseCommand("/gwstatus")).toEqual({ name: "gateway-status", args: "" });
   });
@@ -95,6 +107,18 @@ describe("getSlashCommands", () => {
       "Enable or disable memory dreaming.",
     );
   });
+
+  it("filters unsupported shared commands from local embedded discovery", () => {
+    const names = getSlashCommands({ local: true }).map((command) => command.name);
+    expect(names).toContain("btw");
+    expect(names).toContain("side");
+    expect(names).toContain("t");
+    expect(names).toContain("stop");
+    expect(names).not.toContain("status");
+    expect(names).not.toContain("commands");
+    expect(names).not.toContain("compact");
+    expect(names).not.toContain("context");
+  });
 });
 
 describe("helpText", () => {
@@ -105,5 +129,11 @@ describe("helpText", () => {
     expect(output).toContain("/gateway-status");
     expect(output).toContain("/gwstatus");
     expect(output).toContain("/crestodian [request]");
+  });
+
+  it("does not advertise /commands in local embedded help", () => {
+    const output = helpText({ local: true });
+    expect(output).not.toContain("/status");
+    expect(output).not.toContain("/commands");
   });
 });

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -33,6 +33,16 @@ const COMMAND_ALIASES: Record<string, string> = {
   gwstatus: "gateway-status",
 };
 
+const LOCAL_SHARED_COMMAND_DISCOVERY_KEYS = new Set([
+  "btw",
+  "elevated",
+  "goal",
+  "reasoning",
+  "stop",
+  "think",
+  "verbose",
+]);
+
 function createLevelCompletion(
   levels: string[],
 ): NonNullable<SlashCommand["getArgumentCompletions"]> {
@@ -64,11 +74,16 @@ function appendSlashCommand(
 }
 
 export function parseCommand(input: string): ParsedCommand {
-  const trimmed = input.replace(/^\//, "").trim();
+  const inputTrimmed = input.trim();
+  const isSlashInput = inputTrimmed.startsWith("/");
+  const trimmed = isSlashInput ? inputTrimmed.slice(1).trim() : inputTrimmed;
   if (!trimmed) {
     return { name: "", args: "" };
   }
-  const [name, ...rest] = trimmed.split(/\s+/);
+  const commandParts = isSlashInput ? trimmed.match(/^([^\s:]+)(?:(?::\s*|\s+)([\s\S]*))?$/) : null;
+  const [name, ...rest] = commandParts
+    ? [commandParts[1], commandParts[2] ?? ""]
+    : trimmed.split(/\s+/);
   const normalized = normalizeLowercaseStringOrEmpty(name);
   return {
     name: COMMAND_ALIASES[normalized] ?? normalized,
@@ -161,6 +176,9 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
   const seen = new Set(commands.map((command) => command.name));
   const gatewayCommands = options.cfg ? listChatCommandsForConfig(options.cfg) : listChatCommands();
   for (const command of gatewayCommands) {
+    if (options.local && !LOCAL_SHARED_COMMAND_DISCOVERY_KEYS.has(command.key)) {
+      continue;
+    }
     const aliases = command.textAliases.length > 0 ? command.textAliases : [`/${command.key}`];
     for (const alias of aliases) {
       appendSlashCommand(commands, seen, alias, command.description);
@@ -182,8 +200,8 @@ export function helpText(options: SlashCommandOptions = {}): string {
   return [
     "Slash commands:",
     "/help",
-    "/commands",
-    "/status",
+    ...(options.local ? [] : ["/commands"]),
+    ...(options.local ? [] : ["/status"]),
     "/gateway-status",
     "/gwstatus",
     ...(options.local ? ["/auth [provider]"] : []),

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -175,7 +175,7 @@ function createHarness(params?: {
     refreshAgents: vi.fn(),
     abortActive,
     setActivityStatus,
-    formatSessionKey: (key) => key,
+    formatSessionKey: vi.fn(),
     applySessionInfoFromPatch: applySessionInfoFromPatch as never,
     applySessionMutationResult: applySessionMutationResult as never,
     noteLocalRunId,
@@ -1153,21 +1153,6 @@ describe("tui command handlers", () => {
     expect(addUser).not.toHaveBeenCalled();
   });
 
-  it("sends slash stop to the backend when there is no tracked run", async () => {
-    const abortActive = vi.fn().mockResolvedValue(undefined);
-    const { handleCommand, sendChat, addPendingUser } = createHarness({ abortActive });
-
-    await handleCommand("/stop");
-
-    expect(abortActive).not.toHaveBeenCalled();
-    expect(sendChat).toHaveBeenCalledTimes(1);
-    expectSendChatFields(sendChat, {
-      message: "/stop",
-      sessionKey: "agent:main:main",
-    });
-    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/stop");
-  });
-
   it("reports idle local slash stop without sending to the embedded model", async () => {
     const abortActive = vi.fn().mockResolvedValue(undefined);
     const { handleCommand, sendChat, addUser, addSystem } = createHarness({
@@ -1181,6 +1166,21 @@ describe("tui command handlers", () => {
     expect(sendChat).not.toHaveBeenCalled();
     expect(addUser).not.toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith("no active run to stop");
+  });
+
+  it("sends slash stop to the backend when there is no tracked run", async () => {
+    const abortActive = vi.fn().mockResolvedValue(undefined);
+    const { handleCommand, sendChat, addPendingUser } = createHarness({ abortActive });
+
+    await handleCommand("/stop");
+
+    expect(abortActive).not.toHaveBeenCalled();
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expectSendChatFields(sendChat, {
+      message: "/stop",
+      sessionKey: "agent:main:main",
+    });
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/stop");
   });
 
   it("sends broad stop-like text as a normal prompt when idle", async () => {
@@ -1347,6 +1347,68 @@ describe("tui command handlers", () => {
     expect(applySessionInfoFromPatch).toHaveBeenCalledWith({ model: "openrouter/auto" });
     expect(refreshSessionInfo).toHaveBeenCalledTimes(1);
     expect(closeOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows resolved canonical model ref after /model alias, not raw alias string", async () => {
+    // When the user types `/model gpt4` (a bare alias), the gateway resolves it
+    // server-side and returns the canonical ref in result.resolved. The TUI must
+    // display the canonical ref, not the raw alias, so the user knows which model
+    // was actually applied.
+    const patchSession = vi.fn().mockResolvedValue({
+      ok: true,
+      path: "/sessions/patch",
+      key: "agent:main:main",
+      entry: {},
+      resolved: { modelProvider: "openai", model: "gpt-5.5" },
+    });
+    const refreshSessionInfo = vi.fn().mockResolvedValue(undefined);
+    const applySessionInfoFromPatch = vi.fn();
+    const { handleCommand, addSystem } = createHarness({
+      patchSession,
+      refreshSessionInfo,
+      applySessionInfoFromPatch,
+    });
+
+    await handleCommand("/model gpt4");
+
+    expect(patchSession).toHaveBeenCalledWith(expect.objectContaining({ model: "gpt4" }));
+    // Should show the canonical resolved ref, not the raw alias "gpt4"
+    expect(addSystem).toHaveBeenCalledWith("model set to openai/gpt-5.5");
+  });
+
+  it("falls back to raw input in /model confirmation when resolved ref unavailable", async () => {
+    // Older gateway versions may not return resolved; fall back to raw arg.
+    const patchSession = vi.fn().mockResolvedValue({
+      ok: true,
+      path: "/sessions/patch",
+      key: "agent:main:main",
+      entry: {},
+      // No `resolved` field
+    });
+    const { handleCommand, addSystem } = createHarness({ patchSession });
+
+    await handleCommand("/model openai/gpt-5.5");
+
+    expect(addSystem).toHaveBeenCalledWith("model set to openai/gpt-5.5");
+  });
+  it("preserves provider prefix for nested model ids in /model confirmation", async () => {
+    // Some providers route to nested model ids that themselves contain a slash
+    // (e.g. resolved.model: "moonshotai/kimi-k2.5" with modelProvider: "nvidia").
+    // The confirmation must still show the full nvidia/moonshotai/kimi-k2.5 ref
+    // to match the footer/status bar, not strip the provider just because the
+    // model id already contains a slash.
+    const patchSession = vi.fn().mockResolvedValue({
+      ok: true,
+      path: "/sessions/patch",
+      key: "agent:main:main",
+      entry: {},
+      resolved: { modelProvider: "nvidia", model: "moonshotai/kimi-k2.5" },
+    });
+    const { handleCommand, addSystem } = createHarness({ patchSession });
+
+    await handleCommand("/model nvidia/moonshotai/kimi-k2.5");
+
+    expect(addSystem).toHaveBeenCalledWith("model set to nvidia/moonshotai/kimi-k2.5");
   });
 
   it("renders model listing feedback before the backend list resolves", async () => {

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -175,7 +175,7 @@ function createHarness(params?: {
     refreshAgents: vi.fn(),
     abortActive,
     setActivityStatus,
-    formatSessionKey: vi.fn(),
+    formatSessionKey: (key) => key,
     applySessionInfoFromPatch: applySessionInfoFromPatch as never,
     applySessionMutationResult: applySessionMutationResult as never,
     noteLocalRunId,
@@ -418,6 +418,24 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith("Goal: ship");
   });
 
+  it("normalizes colon-form local goal commands before local goal handling", async () => {
+    const runGoalCommand = vi.fn().mockResolvedValue({ text: "Goal: ship" });
+    const { handleCommand, sendChat, addSystem } = createHarness({
+      opts: { local: true },
+      runGoalCommand,
+    });
+
+    await handleCommand("/goal: status");
+
+    expect(runGoalCommand).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      command: "/goal status",
+    });
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("Goal: ship");
+  });
+
   it("wraps command-prefixed local goal resume notes before sending", async () => {
     const runGoalCommand = vi.fn().mockResolvedValue({ text: "Goal resumed: ship" });
     const { handleCommand, sendChat, addPendingUser } = createHarness({
@@ -539,6 +557,157 @@ describe("tui command handlers", () => {
       sessionKey: "agent:main:main",
       message: "/status",
     });
+  });
+
+  it("reports /status as unsupported in local embedded mode", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/status");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("/status is not supported in local embedded mode");
+  });
+
+  it("reports /compact as unsupported in local embedded mode", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/compact");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("/compact is not supported in local embedded mode");
+  });
+
+  it("reports other shared slash commands as unsupported in local embedded mode", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/commands");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("/commands is not supported in local embedded mode");
+  });
+
+  it("reports known shared commands with invalid args as unsupported in local embedded mode", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/commands all");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("/commands is not supported in local embedded mode");
+  });
+
+  it("reports shared slash commands with colon args as unsupported in local embedded mode", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/compact: focus on decisions");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("/compact is not supported in local embedded mode");
+  });
+
+  it("routes colon-form local slash commands through the local handler", async () => {
+    const patchSession = vi.fn().mockResolvedValue({ thinkingLevel: "medium" });
+    const refreshSessionInfo = vi.fn().mockResolvedValue(undefined);
+    const applySessionInfoFromPatch = vi.fn();
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+      patchSession,
+      refreshSessionInfo,
+      applySessionInfoFromPatch,
+    });
+
+    await handleCommand("/think: medium");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(patchSession).toHaveBeenCalledWith({
+      key: "agent:main:main",
+      thinkingLevel: "medium",
+    });
+    expect(applySessionInfoFromPatch).toHaveBeenCalledWith({ thinkingLevel: "medium" });
+    expect(refreshSessionInfo).toHaveBeenCalledTimes(1);
+    expect(addSystem).toHaveBeenCalledWith("thinking set to medium");
+  });
+
+  it("preserves directive-only slash aliases in local embedded mode", async () => {
+    for (const message of [
+      "/t high explain the diff",
+      "/reason stream summarize",
+      "/v on include logs",
+    ]) {
+      const patchSession = vi.fn().mockResolvedValue({});
+      const { handleCommand, sendChat, addSystem } = createHarness({
+        opts: { local: true },
+        patchSession,
+      });
+
+      await handleCommand(message);
+
+      expect(patchSession).not.toHaveBeenCalled();
+      expect(sendChat).toHaveBeenCalledTimes(1);
+      expectSendChatFields(sendChat, {
+        sessionKey: "agent:main:main",
+        message,
+      });
+      expect(addSystem).not.toHaveBeenCalled();
+    }
+  });
+
+  it("continues to forward unknown slash commands in local mode", async () => {
+    const { handleCommand, sendChat, addPendingUser, addSystem, requestRender } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/not-a-real-command");
+
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expectSendChatFields(sendChat, {
+      sessionKey: "agent:main:main",
+      message: "/not-a-real-command",
+    });
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/not-a-real-command");
+    expect(requestRender).toHaveBeenCalled();
+    expect(addSystem).not.toHaveBeenCalled();
+  });
+
+  it("reports /context as unsupported in local embedded mode", async () => {
+    const { handleCommand, sendChat, addUser, addSystem, openOverlay } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/context list");
+
+    expect(openOverlay).not.toHaveBeenCalled();
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("/context is not supported in local embedded mode");
+  });
+
+  it("does not open the /context selector in local embedded mode", async () => {
+    const { handleCommand, sendChat, addUser, addSystem, openOverlay } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/context");
+
+    expect(openOverlay).not.toHaveBeenCalled();
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("/context is not supported in local embedded mode");
   });
 
   it("keeps gateway diagnostics on /gateway-status", async () => {
@@ -690,6 +859,7 @@ describe("tui command handlers", () => {
     const setActivityStatus = vi.fn();
     const { handleCommand, sendChat, addUser, noteLocalRunId, noteLocalBtwRunId, state } =
       createHarness({
+        opts: { local: true },
         activeChatRunId: "run-main",
         setActivityStatus,
       });
@@ -708,6 +878,7 @@ describe("tui command handlers", () => {
   it("sends /side without hijacking the active main run", async () => {
     const { handleCommand, sendChat, addUser, noteLocalRunId, noteLocalBtwRunId, state } =
       createHarness({
+        opts: { local: true },
         activeChatRunId: "run-main",
       });
 
@@ -718,6 +889,20 @@ describe("tui command handlers", () => {
     expect(noteLocalBtwRunId).toHaveBeenCalledTimes(1);
     expect(state.activeChatRunId).toBe("run-main");
     expectSendChatFields(sendChat, { message: "/side what changed?" });
+  });
+
+  it("keeps colon-form local side questions on the side-question path", async () => {
+    const { handleCommand, sendChat, addUser, noteLocalBtwRunId } = createHarness({
+      opts: { local: true },
+      activeChatRunId: "run-main",
+    });
+
+    await handleCommand("/btw: what changed?");
+    await handleCommand("/side: what changed?");
+
+    expect(addUser).not.toHaveBeenCalled();
+    expect(noteLocalBtwRunId).toHaveBeenCalledTimes(2);
+    expectSendChatFields(sendChat, { message: "/side: what changed?" });
   });
 
   it("creates unique session for /new and resets shared session for /reset", async () => {
@@ -918,18 +1103,18 @@ describe("tui command handlers", () => {
       activityStatus: "streaming",
     });
 
-    await handleCommand("/context detail");
+    await handleCommand("/not-a-real-command");
 
     expect(sendChat).toHaveBeenCalledTimes(1);
     expectSendChatFields(sendChat, {
-      message: "/context detail",
+      message: "/not-a-real-command",
       sessionKey: "agent:main:main",
     });
     expect(reserveAssistantSlot).toHaveBeenCalledWith("run-active");
     const reserveCallOrder = reserveAssistantSlot.mock.invocationCallOrder[0];
     const addPendingUserCallOrder = addPendingUser.mock.invocationCallOrder[0];
     expect(reserveCallOrder).toBeLessThan(addPendingUserCallOrder);
-    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/context detail");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/not-a-real-command");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
@@ -983,6 +1168,21 @@ describe("tui command handlers", () => {
     expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/stop");
   });
 
+  it("reports idle local slash stop without sending to the embedded model", async () => {
+    const abortActive = vi.fn().mockResolvedValue(undefined);
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      opts: { local: true },
+      abortActive,
+    });
+
+    await handleCommand("/stop");
+
+    expect(abortActive).not.toHaveBeenCalled();
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith("no active run to stop");
+  });
+
   it("sends broad stop-like text as a normal prompt when idle", async () => {
     const abortActive = vi.fn().mockResolvedValue(undefined);
     const { handleCommand, sendChat, addPendingUser } = createHarness({ abortActive });
@@ -1017,10 +1217,10 @@ describe("tui command handlers", () => {
       activityStatus: "finishing context",
     });
 
-    await handleCommand("/context detail");
+    await handleCommand("/not-a-real-command");
 
     expect(sendChat).toHaveBeenCalledTimes(1);
-    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/context detail");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/not-a-real-command");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
@@ -1147,68 +1347,6 @@ describe("tui command handlers", () => {
     expect(applySessionInfoFromPatch).toHaveBeenCalledWith({ model: "openrouter/auto" });
     expect(refreshSessionInfo).toHaveBeenCalledTimes(1);
     expect(closeOverlay).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows resolved canonical model ref after /model alias, not raw alias string", async () => {
-    // When the user types `/model gpt4` (a bare alias), the gateway resolves it
-    // server-side and returns the canonical ref in result.resolved. The TUI must
-    // display the canonical ref, not the raw alias, so the user knows which model
-    // was actually applied.
-    const patchSession = vi.fn().mockResolvedValue({
-      ok: true,
-      path: "/sessions/patch",
-      key: "agent:main:main",
-      entry: {},
-      resolved: { modelProvider: "openai", model: "gpt-5.5" },
-    });
-    const refreshSessionInfo = vi.fn().mockResolvedValue(undefined);
-    const applySessionInfoFromPatch = vi.fn();
-    const { handleCommand, addSystem } = createHarness({
-      patchSession,
-      refreshSessionInfo,
-      applySessionInfoFromPatch,
-    });
-
-    await handleCommand("/model gpt4");
-
-    expect(patchSession).toHaveBeenCalledWith(expect.objectContaining({ model: "gpt4" }));
-    // Should show the canonical resolved ref, not the raw alias "gpt4"
-    expect(addSystem).toHaveBeenCalledWith("model set to openai/gpt-5.5");
-  });
-
-  it("falls back to raw input in /model confirmation when resolved ref unavailable", async () => {
-    // Older gateway versions may not return resolved; fall back to raw arg.
-    const patchSession = vi.fn().mockResolvedValue({
-      ok: true,
-      path: "/sessions/patch",
-      key: "agent:main:main",
-      entry: {},
-      // No `resolved` field
-    });
-    const { handleCommand, addSystem } = createHarness({ patchSession });
-
-    await handleCommand("/model openai/gpt-5.5");
-
-    expect(addSystem).toHaveBeenCalledWith("model set to openai/gpt-5.5");
-  });
-  it("preserves provider prefix for nested model ids in /model confirmation", async () => {
-    // Some providers route to nested model ids that themselves contain a slash
-    // (e.g. resolved.model: "moonshotai/kimi-k2.5" with modelProvider: "nvidia").
-    // The confirmation must still show the full nvidia/moonshotai/kimi-k2.5 ref
-    // to match the footer/status bar, not strip the provider just because the
-    // model id already contains a slash.
-    const patchSession = vi.fn().mockResolvedValue({
-      ok: true,
-      path: "/sessions/patch",
-      key: "agent:main:main",
-      entry: {},
-      resolved: { modelProvider: "nvidia", model: "moonshotai/kimi-k2.5" },
-    });
-    const { handleCommand, addSystem } = createHarness({ patchSession });
-
-    await handleCommand("/model nvidia/moonshotai/kimi-k2.5");
-
-    expect(addSystem).toHaveBeenCalledWith("model set to nvidia/moonshotai/kimi-k2.5");
   });
 
   it("renders model listing feedback before the backend list resolves", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -528,7 +528,14 @@ export function createCommandHandlers(context: CommandHandlerContext) {
               ...currentSessionPatchTarget(),
               model: args,
             });
-            chatLog.addSystem(`model set to ${args}`);
+            const resolvedModel = result.resolved?.model;
+            const resolvedProvider = result.resolved?.modelProvider;
+            const resolvedModelRef = resolvedModel
+              ? resolvedProvider
+                ? modelKey(resolvedProvider, resolvedModel)
+                : resolvedModel
+              : args;
+            chatLog.addSystem(`model set to ${resolvedModelRef}`);
             applySessionInfoFromPatch(result);
             await refreshSessionInfo();
           } catch (err) {
@@ -762,15 +769,15 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "side":
         await sendMessage(raw);
         break;
-      case "settings":
-        openSettings();
-        break;
       case "compact":
         if (opts.local === true) {
           renderUnsupportedLocalCommand(name);
           break;
         }
         await sendMessage(raw);
+        break;
+      case "settings":
+        openSettings();
         break;
       case "exit":
       case "quit":

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { Component, SelectItem, TUI } from "@earendil-works/pi-tui";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { modelKey } from "../agents/model-ref-shared.js";
+import { listChatCommands, resolveTextCommand } from "../auto-reply/commands-registry.js";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import {
   formatGoalContinuationPrompt,
@@ -78,6 +79,43 @@ function isBtwCommand(text: string): boolean {
 function isSlashStopCommand(text: string): boolean {
   const trimmed = text.trim();
   return trimmed.startsWith("/") && isChatStopCommandText(trimmed);
+}
+
+const LOCAL_DIRECTIVE_ALIAS_COMMAND_KEYS = new Map([
+  ["reason", "reasoning"],
+  ["t", "think"],
+  ["thinking", "think"],
+  ["v", "verbose"],
+]);
+
+function getSharedTextCommandKeysByAlias(): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const command of listChatCommands()) {
+    const textAliases = command.textAliases.length > 0 ? command.textAliases : [`/${command.key}`];
+    for (const alias of textAliases) {
+      const normalized = alias.replace(/^\//, "").trim().toLowerCase();
+      if (normalized && !aliases.has(normalized)) {
+        aliases.set(normalized, command.key);
+      }
+    }
+  }
+  return aliases;
+}
+
+function resolveKnownSharedTextCommandKey(raw: string): string | null {
+  const tokenMatch = raw.trim().match(/^\/([^\s:]+)(?::|\s|$)/);
+  if (!tokenMatch) {
+    return null;
+  }
+  return getSharedTextCommandKeysByAlias().get(tokenMatch[1].toLowerCase()) ?? null;
+}
+
+function isLocalDirectiveAliasCommand(raw: string, sharedCommandKey: string): boolean {
+  const tokenMatch = raw.trim().match(/^\/([^\s:]+)(?::|\s|$)/);
+  if (!tokenMatch) {
+    return false;
+  }
+  return LOCAL_DIRECTIVE_ALIAS_COMMAND_KEYS.get(tokenMatch[1].toLowerCase()) === sharedCommandKey;
 }
 
 function goalContinuationPrompt(text: string): string | null {
@@ -334,6 +372,15 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     if (!name) {
       return;
     }
+    const sharedCommandKey =
+      opts.local === true
+        ? (resolveTextCommand(raw)?.command.key ?? resolveKnownSharedTextCommandKey(raw))
+        : null;
+
+    const renderUnsupportedLocalCommand = (commandName: string) => {
+      chatLog.addSystem(`/${commandName} is not supported in local embedded mode`);
+    };
+
     switch (name) {
       case "help":
         chatLog.addSystem(
@@ -343,6 +390,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             model: state.sessionInfo.model,
           }),
         );
+        break;
+      case "status":
+        if (opts.local === true) {
+          renderUnsupportedLocalCommand(name);
+          break;
+        }
+        await sendMessage(raw);
         break;
       case "auth": {
         if (!runAuthFlow) {
@@ -414,6 +468,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         await openAgentSelector();
         break;
       case "context":
+        if (opts.local === true) {
+          renderUnsupportedLocalCommand(name);
+          break;
+        }
         if (!args) {
           openContextModeSelector();
         } else {
@@ -423,14 +481,15 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "goal":
         if (opts.local === true && client.runGoalCommand) {
           try {
+            const goalCommand = args ? `/${name} ${args}` : `/${name}`;
             const result = await client.runGoalCommand({
               sessionKey: state.currentSessionKey,
               agentId: state.currentAgentId,
-              command: raw,
+              command: goalCommand,
             });
             chatLog.addSystem(result.text);
             await refreshSessionInfo();
-            const continuation = goalContinuationPrompt(raw);
+            const continuation = goalContinuationPrompt(goalCommand);
             if (continuation) {
               await sendMessage(continuation);
             }
@@ -469,14 +528,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
               ...currentSessionPatchTarget(),
               model: args,
             });
-            const resolvedModel = result.resolved?.model;
-            const resolvedProvider = result.resolved?.modelProvider;
-            const resolvedModelRef = resolvedModel
-              ? resolvedProvider
-                ? modelKey(resolvedProvider, resolvedModel)
-                : resolvedModel
-              : args;
-            chatLog.addSystem(`model set to ${resolvedModelRef}`);
+            chatLog.addSystem(`model set to ${args}`);
             applySessionInfoFromPatch(result);
             await refreshSessionInfo();
           } catch (err) {
@@ -700,16 +752,39 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           await abortActive({ preferActive: true });
           break;
         }
+        if (opts.local === true) {
+          chatLog.addSystem("no active run to stop");
+          break;
+        }
+        await sendMessage(raw);
+        break;
+      case "btw":
+      case "side":
         await sendMessage(raw);
         break;
       case "settings":
         openSettings();
+        break;
+      case "compact":
+        if (opts.local === true) {
+          renderUnsupportedLocalCommand(name);
+          break;
+        }
+        await sendMessage(raw);
         break;
       case "exit":
       case "quit":
         requestExit();
         break;
       default:
+        if (opts.local === true && sharedCommandKey) {
+          if (sharedCommandKey === "btw" || isLocalDirectiveAliasCommand(raw, sharedCommandKey)) {
+            await sendMessage(raw);
+            break;
+          }
+          renderUnsupportedLocalCommand(sharedCommandKey);
+          break;
+        }
         await sendMessage(raw);
         break;
     }

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { startPty, waitFor, type PtyRun } from "./tui-pty-test-support.js";
+import { sleep, startPty, waitFor, type PtyRun } from "./tui-pty-test-support.js";
 
 type MockModelServer = {
   baseUrl: string;
@@ -25,6 +25,7 @@ const LOCAL_STARTUP_TIMEOUT_MS = 20_000;
 const LOCAL_OUTPUT_TIMEOUT_MS = 120_000;
 const LOCAL_EXIT_TIMEOUT_MS = 4_000;
 const LOCAL_TEST_TIMEOUT_MS = 150_000;
+const LOCAL_NO_MODEL_SETTLE_MS = 500;
 
 async function readRequestBody(req: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
@@ -309,6 +310,58 @@ describe("TUI PTY local mode", () => {
         expect(request?.path).toBe("/v1/responses");
         expect(request?.body.model).toBe("gpt-5.5");
         await fixture.run.waitForOutput("LOCAL_PTY_RESPONSE");
+
+        await fixture.run.write("/exit\r", { delay: false });
+        const exit = await fixture.run.waitForExit();
+        expect(exit.exitCode).toBe(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "handles local slash commands without sending supported control commands to the model",
+    async () => {
+      const fixture = await startLocalModeTui();
+      try {
+        await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+
+        await fixture.run.write("/status\r", { delay: false });
+        await fixture.run.waitForOutput(
+          "/status is not supported in local embedded mode",
+          LOCAL_OUTPUT_TIMEOUT_MS,
+        );
+        await sleep(LOCAL_NO_MODEL_SETTLE_MS);
+        expect(fixture.mockModel.requests()).toHaveLength(0);
+
+        await fixture.run.write("/compact: focus on decisions\r", { delay: false });
+        await fixture.run.waitForOutput(
+          "/compact is not supported in local embedded mode",
+          LOCAL_OUTPUT_TIMEOUT_MS,
+        );
+        await sleep(LOCAL_NO_MODEL_SETTLE_MS);
+        expect(fixture.mockModel.requests()).toHaveLength(0);
+
+        await fixture.run.write("/commands all\r", { delay: false });
+        await fixture.run.waitForOutput(
+          "/commands is not supported in local embedded mode",
+          LOCAL_OUTPUT_TIMEOUT_MS,
+        );
+        await sleep(LOCAL_NO_MODEL_SETTLE_MS);
+        expect(fixture.mockModel.requests()).toHaveLength(0);
+
+        await fixture.run.write("/not-a-real-command\r", { delay: false });
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
+          onTimeout: () =>
+            new Error(
+              `mock model server did not receive unknown slash input\n${fixture.run.output()}`,
+            ),
+        });
+        await fixture.run.waitForOutput("LOCAL_PTY_RESPONSE", LOCAL_OUTPUT_TIMEOUT_MS);
 
         await fixture.run.write("/exit\r", { delay: false });
         const exit = await fixture.run.waitForExit();


### PR DESCRIPTION
Closes #71592.

## Summary

- Keep known local embedded TUI control commands out of the model path.
- Treat shared commands that local embedded mode cannot execute, including `/status`, `/compact`, `/context`, and `/commands all`, as unsupported local commands instead of forwarding them to the model.
- Keep local embedded help and autocomplete from advertising unsupported shared commands such as `/commands` and `/status`.
- Preserve local `/stop`, `/goal`, `/btw`, `/side`, directive aliases such as `/t ...` and `/reason ...`, and unknown slash commands on their existing local or model-facing paths.
- Normalize colon-form local slash commands so `/goal: status` follows the same command shape as `/goal status`.

## AI assistance disclosure

This PR was implemented with Codex assistance. I reviewed the change and understand the affected local TUI command path.

## Real behavior proof

Behavior addressed: local embedded TUI slash commands no longer fall through to the model when the TUI can handle them locally or knows they are unsupported shared control commands.

Real environment tested: local `openclaw tui --local` PTY run with isolated HOME/config/state/workspace and a mocked OpenAI-compatible model endpoint. No live credentials were used.

Exact steps or command run after this patch:

```bash
OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts
```

Evidence after fix:

```text
RUN  v4.1.7 <worktree>

Test Files  1 passed (1)
Tests       2 passed (2)
Duration    15.11s
```

Observed result after fix: the PTY proof starts `tui --local`, types `/status`, `/compact: focus on decisions`, and `/commands all`, and verifies the mock model endpoint receives zero requests for those commands. It then types `/not-a-real-command` and verifies the model endpoint receives one request and the TUI displays `LOCAL_PTY_RESPONSE`.

What was not tested: live provider credentials, gateway mode TUI behavior, and a real interactive terminal recording outside the PTY harness.

## Root Cause

The local TUI command list already included shared chat commands from the command registry, but `handleCommand()` only implemented a subset of those names. In local embedded mode, unsupported shared commands could hit the default branch and call `sendMessage(raw)`, which hands the text to the embedded run.

The TUI parser also did not mirror the shared registry's colon-form command shape, so inputs such as `/compact: ...` and `/goal: ...` could route differently from the registry contract.

## Dependency contract

This depends on OpenClaw's internal shared command registry, not an external package. `src/auto-reply/commands-registry-normalize.ts` already normalizes `/command: args` to `/command args` and resolves text aliases through the registry. The local TUI now mirrors the command-token part of that contract before deciding whether embedded mode should handle, reject, or forward a slash input.

## Regression Test Plan

Focused tests:

```bash
node scripts/run-vitest.mjs src/tui/commands.test.ts src/tui/tui-command-handlers.test.ts
```

Result:

```text
Test Files  2 passed (2)
Tests       85 passed (85)
```

This includes local discovery coverage for `/stop`, local idle `/stop` behavior, colon-form shared commands, directive-only aliases, unsupported shared commands, and unknown slash forwarding.

Real-path PTY proof:

```bash
OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```

## Security Impact

Low direct security impact. The change reduces accidental model exposure of local control-command text in embedded TUI mode. It does not touch auth, secrets, provider credentials, filesystem access, config, or plugin loading.

## Human Verification

I checked the runtime path from TUI submit through `createCommandHandlers`, `EmbeddedTuiBackend.sendChat`, and the shared command registry. The local PTY proof uses isolated state and a local mock endpoint so the result is reproducible without secrets.

## CODEOWNERS / owner review

No `CODEOWNERS` file is present in this checkout, so there is no CODEOWNERS-mandated reviewer for `src/tui/**`. TUI maintainer review is still welcome.

## Changelog

No `CHANGELOG.md` edit. This is a contributor PR; release-note context is in this PR body.

## Review conversations

- `codex review --base origin/main` on the earlier rebased branch caught an over-merge regression in unrelated TUI model-confirmation behavior. I restored current `upstream/main` file bodies and reapplied only the issue-specific changes.
- The narrowed follow-up removes the earlier local `/status` summary behavior and instead treats `/status` as unsupported in local embedded mode, which is the smaller compatibility surface.
- Fresh `autoreview --mode branch --base upstream/main --model gpt-5.3-codex-spark --stream-engine-output` on this narrowed branch returned a clean structured result with no findings.

## Risks

- Local embedded users who manually type unsupported shared commands now get an explicit local system message instead of model-path fallthrough.

## Behavior tradeoffs

- Known but unsupported shared commands now produce a local system line instead of being sent to the model.
- Unsupported shared commands are no longer advertised by local embedded discovery or `/help`, but manually typed unsupported commands still get an explicit local message.
- Directive-only aliases with prompts stay on the agent/directive path, so `/t high explain the diff` keeps its inline behavior.
- Unknown slash commands still forward as prompts, preserving the old escape hatch for user-defined or future model-facing slash text.

## Scope boundaries

- No change to gateway-mode TUI behavior.
- No embedded-mode implementation for `/status`, `/compact`, or `/context`.
- No shared command registry rewrite.
- No config, migration, plugin, or provider surface change.

## Validation

Completed:

```text
node scripts/run-vitest.mjs src/tui/commands.test.ts src/tui/tui-command-handlers.test.ts
OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --model gpt-5.3-codex-spark --stream-engine-output
```
