### PR TITLE
fix(agents): guard prompt-cache tool names

### DIFF
--- a/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
@@ -17,6 +17,23 @@ describe("prompt cache observability", () => {
     ).toEqual(["read", "write"]);
   });
 
+  it("ignores malformed tool names without crashing diagnostics", () => {
+    const unreadableToolName = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("tool name getter exploded");
+      },
+    });
+
+    expect(
+      collectPromptCacheToolNames([
+        { name: "read" },
+        { name: 123 } as never,
+        unreadableToolName,
+        { name: " write " },
+      ]),
+    ).toEqual(["read", "write"]);
+  });
+
   it("tracks cache-relevant changes and reports a real cache-read drop", () => {
     const first = beginPromptCacheObservation({
       sessionId: "session-1",

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.ts
@@ -137,8 +137,18 @@ function diffSnapshots(
   return changes.length > 0 ? changes : null;
 }
 
-export function collectPromptCacheToolNames(tools: Array<{ name?: string }>): string[] {
-  return tools.map((tool) => tool.name?.trim()).filter((name): name is string => Boolean(name));
+function readPromptCacheToolName(tool: { name?: unknown }): string | undefined {
+  let name: unknown;
+  try {
+    name = tool.name;
+  } catch {
+    return undefined;
+  }
+  return typeof name === "string" && name.trim() ? name.trim() : undefined;
+}
+
+export function collectPromptCacheToolNames(tools: Array<{ name?: unknown }>): string[] {
+  return tools.map(readPromptCacheToolName).filter((name): name is string => Boolean(name));
 }
 
 export function beginPromptCacheObservation(params: {


### PR DESCRIPTION
## Summary
- Guard prompt-cache tool-name collection against non-string and unreadable `name` values.
- Keep prompt-cache diagnostics from turning malformed runtime descriptors into a turn-failure surface.
- Add focused coverage for numeric names and throwing name accessors while preserving valid trimmed names.

## Verification
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/prompt-cache-observability.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` (`run_e81e78583226`, provider `azure`, lease `cbx_1384a90c83f3`, exit 0)

## Real behavior proof
Behavior addressed: prompt-cache observability no longer crashes when a malformed runtime tool descriptor exposes a non-string or unreadable `name`.

Real environment tested: local focused prompt-cache observability tests on this branch, plus remote OpenClaw changed gate on Crabbox Azure Linux.

Exact steps or command run after this patch: focused Vitest, targeted oxfmt, targeted oxlint, `git diff --check origin/main...HEAD`, branch autoreview against `origin/main`, and remote `pnpm check:changed`.

Evidence after fix: focused Vitest passed 1 shard / 8 tests; targeted formatter, lint, and diff checks passed; branch autoreview reported no accepted/actionable findings on `49758f4cfcae`; remote changed gate passed lanes `core` and `coreTests` in `run_e81e78583226`.

Observed result after fix: numeric and throwing tool-name descriptors are ignored by prompt-cache diagnostics, while valid names are still trimmed and recorded.

What was not tested: live provider agent turns; this change is limited to prompt-cache observability collection and was covered by focused unit proof plus the changed gate.
