### PR TITLE
fix(memory-core): reduce Linux watcher fan-out

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -116,6 +116,12 @@ type NativeMemoryWatchPair = {
   dir: string;
   main: fsSync.FSWatcher;
   parent: fsSync.FSWatcher | null;
+  treeWatchers?: Map<string, LinuxMemoryDirectoryWatcher>;
+};
+
+type LinuxMemoryDirectoryWatcher = {
+  watcher: fsSync.FSWatcher;
+  ino: number;
 };
 
 function resolveMemoryWatchFactory(): typeof chokidar.watch {
@@ -499,46 +505,48 @@ export abstract class MemoryManagerSyncOps {
     // Avoids chokidar's per-file fs.watch fan-out that opened ~12k REG FDs
     // on multi-thousand-`.md` memory trees (issue #86613).
     //
-    // Linux is intentionally NOT in the native set: Node's
-    // `fs.watch(dir, { recursive: true })` on non-macOS/non-Windows routes
-    // through `internal/fs/recursive_watch`, which walks the tree and
-    // attaches one watcher per entry under the hood. That defeats the
-    // constant-watcher-profile goal of this fix without throwing (so the
-    // creation-failure fallback below would not catch it). Linux paths
-    // therefore go straight to chokidar, matching pre-PR behavior on that
-    // platform.
+    // Linux is intentionally handled by a separate directory-tree watcher
+    // below: Node's `fs.watch(dir, { recursive: true })` routes through
+    // `internal/fs/recursive_watch` and watches every file. Watching
+    // directories only preserves Linux inotify semantics while avoiding
+    // per-file watch descriptor fan-out.
     //
     // On any other native creation failure (e.g. unsupported filesystem,
     // ERR_FEATURE_UNAVAILABLE_ON_PLATFORM) the directory also falls back to
     // chokidar so freshness is preserved on the degraded path.
     const nativeRecursiveSupported = process.platform === "darwin" || process.platform === "win32";
     for (const dir of dirWatchPaths) {
-      if (!nativeRecursiveSupported) {
-        fileWatchPaths.add(dir);
-        continue;
-      }
-      if (!this.attachNativeMemoryWatchForDir(dir, markDirty)) {
+      const attached = nativeRecursiveSupported
+        ? this.attachNativeMemoryWatchForDir(dir, markDirty)
+        : process.platform === "linux"
+          ? this.attachLinuxMemoryDirectoryTreeWatchForDir(dir, markDirty)
+          : false;
+      if (!attached) {
         // Native creation failed (dir missing, unsupported FS, throw) —
         // fall back to chokidar so directory coverage isn't dropped.
         fileWatchPaths.add(dir);
       }
     }
     if (fileWatchPaths.size > 0) {
-      this.watcher = resolveMemoryWatchFactory()(Array.from(fileWatchPaths), {
-        ignoreInitial: true,
-        ignored: (watchPath, stats) =>
-          shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
-      });
-      this.watcher.on("add", markDirty);
-      this.watcher.on("change", markDirty);
-      this.watcher.on("unlink", markDirty);
-      this.watcher.on("unlinkDir", markDirty);
-      this.watcher.on("error", (err) => {
-        // File watcher errors (e.g., ENOSPC) should not crash the gateway.
-        // Log the error and continue - memory search still works without auto-sync.
-        const message = err instanceof Error ? err.message : String(err);
-        log.warn(`memory watcher error: ${message}`);
-      });
+      if (this.watcher) {
+        this.watcher.add(Array.from(fileWatchPaths));
+      } else {
+        this.watcher = resolveMemoryWatchFactory()(Array.from(fileWatchPaths), {
+          ignoreInitial: true,
+          ignored: (watchPath, stats) =>
+            shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
+        });
+        this.watcher.on("add", markDirty);
+        this.watcher.on("change", markDirty);
+        this.watcher.on("unlink", markDirty);
+        this.watcher.on("unlinkDir", markDirty);
+        this.watcher.on("error", (err) => {
+          // File watcher errors (e.g., ENOSPC) should not crash the gateway.
+          // Log the error and continue - memory search still works without auto-sync.
+          const message = err instanceof Error ? err.message : String(err);
+          log.warn(`memory watcher error: ${message}`);
+        });
+      }
     }
   }
 
@@ -690,11 +698,247 @@ export abstract class MemoryManagerSyncOps {
     return true;
   }
 
-  private closeNativeMemoryWatchPair(pair: NativeMemoryWatchPair): void {
+  // Linux inotify reports direct child changes from a watched directory, but
+  // it has no native recursive primitive. Watch directories only, then attach
+  // newly-created subdirectories on demand; this avoids per-file watchers.
+  protected attachLinuxMemoryDirectoryTreeWatchForDir(
+    dir: string,
+    markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
+  ): boolean {
+    if (this.closed) {
+      return false;
+    }
+    let recordedInode: number | null;
     try {
-      pair.main.close();
+      recordedInode = fsSync.statSync(dir).ino;
     } catch {
-      // ignore close failures
+      return false;
+    }
+
+    let pair: NativeMemoryWatchPair | null = null;
+    const treeWatchers = new Map<string, LinuxMemoryDirectoryWatcher>();
+
+    const closeAndFallback = (message: string) => {
+      log.warn(message);
+      if (pair) {
+        this.closeNativeMemoryWatchPair(pair);
+      }
+      if (this.closed) {
+        return;
+      }
+      markDirty();
+      this.attachMemoryChokidarFallback(dir, markDirty);
+    };
+
+    const closeDirectorySubtree = (watchDir: string) => {
+      const watchDirPrefix = `${watchDir}${path.sep}`;
+      for (const [entryDir, entry] of Array.from(treeWatchers.entries())) {
+        if (entryDir !== watchDir && !entryDir.startsWith(watchDirPrefix)) {
+          continue;
+        }
+        try {
+          entry.watcher.close();
+        } catch {
+          // ignore close failures
+        }
+        treeWatchers.delete(entryDir);
+      }
+    };
+
+    const attachDirectory = (watchDir: string): fsSync.FSWatcher | null => {
+      if (this.closed) {
+        return null;
+      }
+      let currentInode: number;
+      try {
+        const currentStat = fsSync.statSync(watchDir);
+        if (!currentStat.isDirectory()) {
+          return null;
+        }
+        currentInode = currentStat.ino;
+      } catch {
+        return null;
+      }
+      const existing = treeWatchers.get(watchDir);
+      if (existing) {
+        if (existing.ino === currentInode) {
+          return existing.watcher;
+        }
+        closeDirectorySubtree(watchDir);
+      }
+      let watcher: fsSync.FSWatcher;
+      try {
+        watcher = resolveMemoryNativeWatchFactory()(
+          watchDir,
+          { recursive: false },
+          (_eventType, filename) => {
+            if (filename == null) {
+              markDirty();
+              if (!this.attachLinuxMemoryDirectoryTreeSubtree(watchDir, attachDirectory)) {
+                closeAndFallback(
+                  `failed to refresh Linux memory directory watchers under ${watchDir}; falling back to chokidar`,
+                );
+              }
+              return;
+            }
+            const full = path.join(watchDir, filename);
+            let stats: fsSync.Stats | undefined;
+            try {
+              const s = fsSync.lstatSync(full, { throwIfNoEntry: false });
+              stats = s ?? undefined;
+            } catch {
+              stats = undefined;
+            }
+            if (!stats) {
+              closeDirectorySubtree(full);
+            }
+            if (stats?.isDirectory()) {
+              if (!this.attachLinuxMemoryDirectoryTreeSubtree(full, attachDirectory)) {
+                closeAndFallback(
+                  `failed to attach Linux memory directory watcher under ${full}; falling back to chokidar`,
+                );
+                return;
+              }
+            }
+            if (shouldIgnoreMemoryWatchPath(full, stats, this.settings.multimodal)) {
+              return;
+            }
+            markDirty(full, stats);
+          },
+        );
+      } catch (err) {
+        if (watchDir === dir) {
+          log.warn(
+            `failed to start Linux memory directory watcher on ${watchDir}: ${String(err)}; falling back to chokidar`,
+          );
+        }
+        return null;
+      }
+      treeWatchers.set(watchDir, { watcher, ino: currentInode });
+      watcher.on("error", (err) => {
+        const detail = err instanceof Error ? err.message : String(err);
+        closeAndFallback(`memory Linux directory watcher error on ${watchDir}: ${detail}`);
+      });
+      return watcher;
+    };
+
+    const mainWatcher = attachDirectory(dir);
+    if (!mainWatcher) {
+      return false;
+    }
+    pair = { dir, main: mainWatcher, parent: null, treeWatchers };
+    this.nativeMemoryWatchPairs.push(pair);
+    if (!this.attachLinuxMemoryDirectoryTreeSubtree(dir, attachDirectory)) {
+      closeAndFallback(
+        `failed to attach Linux memory directory watcher subtree under ${dir}; falling back to chokidar`,
+      );
+      return true;
+    }
+
+    try {
+      const parentDir = path.dirname(dir);
+      const baseName = path.basename(dir);
+      const parentWatcher = resolveMemoryNativeWatchFactory()(
+        parentDir,
+        { recursive: false },
+        (_eventType, filename) => {
+          if (filename !== null && filename !== baseName) {
+            return;
+          }
+          let currentInode: number | null;
+          try {
+            currentInode = fsSync.statSync(dir).ino;
+          } catch {
+            currentInode = null;
+          }
+          if (currentInode === recordedInode) {
+            return;
+          }
+          this.closeNativeMemoryWatchPair(pair!);
+          if (this.closed) {
+            return;
+          }
+          markDirty();
+          if (currentInode !== null) {
+            if (!this.attachLinuxMemoryDirectoryTreeWatchForDir(dir, markDirty)) {
+              this.attachMemoryChokidarFallback(dir, markDirty);
+            }
+          } else {
+            this.attachMemoryChokidarFallback(dir, markDirty);
+          }
+        },
+      );
+      parentWatcher.on("error", (err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn(`memory Linux parent watcher error on ${path.dirname(dir)}: ${message}`);
+        try {
+          parentWatcher.close();
+        } catch {
+          // ignore
+        }
+        this.removeNativeMemoryParentWatch(parentWatcher);
+        if (pair?.parent === parentWatcher) {
+          pair.parent = null;
+        }
+      });
+      pair.parent = parentWatcher;
+    } catch (err) {
+      log.warn(
+        `memory Linux parent watcher could not start on ${path.dirname(dir)}: ${String(err)}`,
+      );
+    }
+    return true;
+  }
+
+  private attachLinuxMemoryDirectoryTreeSubtree(
+    root: string,
+    attachDirectory: (dir: string) => fsSync.FSWatcher | null,
+  ): boolean {
+    const rootStats = fsSync.lstatSync(root, { throwIfNoEntry: false });
+    if (
+      !rootStats?.isDirectory() ||
+      shouldIgnoreMemoryWatchPath(root, rootStats, this.settings.multimodal)
+    ) {
+      return true;
+    }
+    if (!attachDirectory(root)) {
+      return false;
+    }
+    let entries: fsSync.Dirent[];
+    try {
+      entries = fsSync.readdirSync(root, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.isSymbolicLink()) {
+        continue;
+      }
+      if (
+        !this.attachLinuxMemoryDirectoryTreeSubtree(path.join(root, entry.name), attachDirectory)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private closeNativeMemoryWatchPair(pair: NativeMemoryWatchPair): void {
+    if (pair.treeWatchers) {
+      for (const entry of pair.treeWatchers.values()) {
+        try {
+          entry.watcher.close();
+        } catch {
+          // ignore close failures
+        }
+      }
+      pair.treeWatchers.clear();
+    } else {
+      try {
+        pair.main.close();
+      } catch {
+        // ignore close failures
+      }
     }
     if (pair.parent) {
       try {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -528,8 +528,9 @@ export abstract class MemoryManagerSyncOps {
       }
     }
     if (fileWatchPaths.size > 0) {
-      if (this.watcher) {
-        this.watcher.add(Array.from(fileWatchPaths));
+      const existingWatcher = this.currentMemoryChokidarWatcher();
+      if (existingWatcher) {
+        existingWatcher.add(Array.from(fileWatchPaths));
       } else {
         this.watcher = resolveMemoryWatchFactory()(Array.from(fileWatchPaths), {
           ignoreInitial: true,
@@ -548,6 +549,10 @@ export abstract class MemoryManagerSyncOps {
         });
       }
     }
+  }
+
+  private currentMemoryChokidarWatcher(): FSWatcher | null {
+    return this.watcher;
   }
 
   // Attach a native recursive `fs.watch` to `dir` plus a non-recursive
@@ -854,7 +859,7 @@ export abstract class MemoryManagerSyncOps {
           if (currentInode === recordedInode) {
             return;
           }
-          this.closeNativeMemoryWatchPair(pair!);
+          this.closeNativeMemoryWatchPair(pair);
           if (this.closed) {
             return;
           }

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -899,7 +899,12 @@ export abstract class MemoryManagerSyncOps {
     root: string,
     attachDirectory: (dir: string) => fsSync.FSWatcher | null,
   ): boolean {
-    const rootStats = fsSync.lstatSync(root, { throwIfNoEntry: false });
+    let rootStats: fsSync.Stats | undefined;
+    try {
+      rootStats = fsSync.lstatSync(root, { throwIfNoEntry: false }) ?? undefined;
+    } catch {
+      return false;
+    }
     if (
       !rootStats?.isDirectory() ||
       shouldIgnoreMemoryWatchPath(root, rootStats, this.settings.multimodal)

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -487,12 +487,51 @@ describe("memory watcher config", () => {
     expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
   });
 
-  it("routes directories through chokidar on non-macOS/non-Windows platforms", async () => {
-    // On Linux (and other non-darwin/non-win32 platforms), Node's
-    // `fs.watch({ recursive: true })` falls back to walking the tree and
-    // attaching a watcher per entry, defeating the constant-watcher-profile
-    // goal of this fix. The PR explicitly gates the native path off those
-    // platforms.
+  it("routes Linux directories through directory-only native watchers", async () => {
+    // Node's Linux `fs.watch({ recursive: true })` watches every file via
+    // internal/fs/recursive_watch. OpenClaw watches directories only so
+    // large file-heavy memory trees do not allocate per-file watchers.
+    const originalPlatformValue = process.platform;
+    try {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+      await fs.mkdir(path.join(workspaceDir, "memory", "nested"), { recursive: true });
+      const cfg = createWatcherConfig();
+
+      await expectWatcherManager(cfg);
+
+      // Chokidar should only receive file paths. Linux directories use
+      // non-recursive native directory watches.
+      expect(watchMock).toHaveBeenCalledTimes(1);
+      const [chokidarPathsLinux] = watchMock.mock.calls[0] as unknown as [
+        string[],
+        Record<string, unknown>,
+      ];
+      expect(chokidarPathsLinux).toStrictEqual([path.join(workspaceDir, "MEMORY.md")]);
+
+      const nativeCalls = nativeWatchMock.mock.calls as unknown as [
+        string,
+        { recursive?: boolean },
+        unknown,
+      ][];
+      expect(nativeCalls.every((call) => call[1].recursive !== true)).toBe(true);
+      expect(nativeCalls.map((call) => call[0])).toStrictEqual(
+        expect.arrayContaining([
+          path.join(workspaceDir, "memory"),
+          path.join(workspaceDir, "memory", "nested"),
+          extraDir,
+          workspaceDir,
+        ]),
+      );
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatformValue,
+        configurable: true,
+      });
+    }
+  });
+
+  it("attaches Linux native watchers for new subdirectories", async () => {
     const originalPlatformValue = process.platform;
     try {
       Object.defineProperty(process, "platform", { value: "linux", configurable: true });
@@ -500,23 +539,122 @@ describe("memory watcher config", () => {
       const cfg = createWatcherConfig();
 
       await expectWatcherManager(cfg);
+      vi.useFakeTimers();
+      const syncSpy = vi
+        .spyOn(
+          manager as unknown as {
+            sync: (params?: { reason?: string }) => Promise<void>;
+          },
+          "sync",
+        )
+        .mockResolvedValue(undefined);
 
-      // Native watcher must NOT have been called for any directory.
-      expect(nativeWatchMock).not.toHaveBeenCalled();
-      // Chokidar should receive the file path AND both directory paths
-      // (the bare `memory/` plus `extraDir`).
+      const memoryDir = path.join(workspaceDir, "memory");
+      const newDir = path.join(memoryDir, "new-topic");
+      await fs.mkdir(newDir);
+      const memoryWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir);
+      memoryWatcher?.emit("rename", "new-topic");
+      await vi.advanceTimersByTimeAsync(25);
+
+      expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
+      expect(
+        createdNativeWatchers.some((watcher) => watcher.dir === newDir && !watcher.recursive),
+      ).toBe(true);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatformValue,
+        configurable: true,
+      });
+    }
+  });
+
+  it("reattaches Linux native watchers for recreated subdirectories", async () => {
+    const originalPlatformValue = process.platform;
+    try {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+      const memoryDir = path.join(workspaceDir, "memory");
+      const nestedDir = path.join(memoryDir, "topic");
+      const childDir = path.join(nestedDir, "child");
+      await fs.mkdir(childDir, { recursive: true });
+      const cfg = createWatcherConfig();
+
+      await expectWatcherManager(cfg);
+
+      const originalNestedWatcher = createdNativeWatchers.find((w) => w.dir === nestedDir);
+      const originalChildWatcher = createdNativeWatchers.find((w) => w.dir === childDir);
+      expect(originalNestedWatcher).toBeDefined();
+      expect(originalChildWatcher).toBeDefined();
+      await fs.rm(nestedDir, { recursive: true, force: true });
+      await fs.mkdir(nestedDir);
+
+      const memoryWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir);
+      memoryWatcher?.emit("rename", "topic");
+
+      expect(originalNestedWatcher!.close).toHaveBeenCalled();
+      expect(originalChildWatcher!.close).toHaveBeenCalled();
+      expect(createdNativeWatchers.filter((w) => w.dir === nestedDir)).toHaveLength(2);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatformValue,
+        configurable: true,
+      });
+    }
+  });
+
+  it("closes Linux native watchers for deleted subdirectories", async () => {
+    const originalPlatformValue = process.platform;
+    try {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+      const memoryDir = path.join(workspaceDir, "memory");
+      const nestedDir = path.join(memoryDir, "topic");
+      const childDir = path.join(nestedDir, "child");
+      await fs.mkdir(childDir, { recursive: true });
+      const cfg = createWatcherConfig();
+
+      await expectWatcherManager(cfg);
+
+      const nestedWatcher = createdNativeWatchers.find((w) => w.dir === nestedDir);
+      const childWatcher = createdNativeWatchers.find((w) => w.dir === childDir);
+      expect(nestedWatcher).toBeDefined();
+      expect(childWatcher).toBeDefined();
+      await fs.rm(nestedDir, { recursive: true, force: true });
+
+      const memoryWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir);
+      memoryWatcher?.emit("rename", "topic");
+
+      expect(nestedWatcher!.close).toHaveBeenCalled();
+      expect(childWatcher!.close).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatformValue,
+        configurable: true,
+      });
+    }
+  });
+
+  it("keeps startup chokidar fallback when Linux nested watcher setup fails", async () => {
+    const originalPlatformValue = process.platform;
+    try {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+      const nestedDir = path.join(workspaceDir, "memory", "topic");
+      await fs.mkdir(nestedDir);
+      nativeWatchMockFailingDir.current = nestedDir;
+      const cfg = createWatcherConfig();
+
+      await expectWatcherManager(cfg);
+
       expect(watchMock).toHaveBeenCalledTimes(1);
-      const [chokidarPathsLinux] = watchMock.mock.calls[0] as unknown as [
+      const [fallbackPaths] = watchMock.mock.calls[0] as unknown as [
         string[],
         Record<string, unknown>,
       ];
-      expect(chokidarPathsLinux).toStrictEqual(
-        expect.arrayContaining([
-          path.join(workspaceDir, "MEMORY.md"),
-          path.join(workspaceDir, "memory"),
-          extraDir,
-        ]),
-      );
+      expect(fallbackPaths).toStrictEqual([path.join(workspaceDir, "memory")]);
+      expect(createdChokidarWatchers[0]?.add).toHaveBeenCalledWith([
+        path.join(workspaceDir, "MEMORY.md"),
+      ]);
     } finally {
       Object.defineProperty(process, "platform", {
         value: originalPlatformValue,

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -660,6 +661,55 @@ describe("memory watcher config", () => {
         value: originalPlatformValue,
         configurable: true,
       });
+    }
+  });
+
+  it("falls back to chokidar when Linux subtree lstat races with deletion", async () => {
+    const originalPlatformValue = process.platform;
+    let lstatSpy: { mockRestore: () => void } | undefined;
+    try {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+      const nestedDir = path.join(workspaceDir, "memory", "racy-topic");
+      await fs.mkdir(nestedDir);
+      const originalLstatSync = fsSync.lstatSync.bind(fsSync);
+      const lstatMock = vi.spyOn(fsSync, "lstatSync");
+      lstatSpy = lstatMock;
+      lstatMock.mockImplementation(
+        (
+          target: Parameters<typeof fsSync.lstatSync>[0],
+          options?: Parameters<typeof fsSync.lstatSync>[1],
+        ): ReturnType<typeof fsSync.lstatSync> => {
+          if (path.resolve(String(target)) === nestedDir) {
+            throw Object.assign(new Error("ENOENT: no such file or directory, lstat"), {
+              code: "ENOENT",
+            });
+          }
+          return originalLstatSync(target, options);
+        },
+      );
+      const cfg = createWatcherConfig();
+
+      await expectWatcherManager(cfg);
+
+      expect(watchMock).toHaveBeenCalledTimes(1);
+      const [fallbackPaths] = watchMock.mock.calls[0] as unknown as [
+        string[],
+        Record<string, unknown>,
+      ];
+      expect(fallbackPaths).toStrictEqual([path.join(workspaceDir, "memory")]);
+      expect(createdChokidarWatchers[0]?.add).toHaveBeenCalledWith([
+        path.join(workspaceDir, "MEMORY.md"),
+      ]);
+      expect(memoryLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("failed to attach Linux memory directory watcher subtree"),
+      );
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatformValue,
+        configurable: true,
+      });
+      lstatSpy?.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes #89182.

- Adds a Linux-only memory directory watcher path that uses non-recursive `fs.watch` on directories only, rather than chokidar or Node's non-native recursive watcher for memory directory trees.
- Keeps #86701's macOS/Windows native recursive `fs.watch` behavior intact and keeps chokidar for file paths such as `MEMORY.md` and file-typed `extraPaths`.
- Dynamically attaches newly-created Linux subdirectories and keeps root replacement/error fallback behavior aligned with the existing watcher safety paths.
- Handles Linux subtree scan races by falling back to chokidar when `lstat`/`readdir` races with deletion or an unreadable subtree.

## Related Work

- Follow-up to #86701 and #86613. #86701 fixed the macOS/Windows memory watcher FD fan-out, but current `main` still intentionally excludes Linux because Node's non-macOS/non-Windows recursive watch routes through `internal/fs/recursive_watch` and watches each discovered entry.
- Complements #73357. That PR handles Linux `ENOSPC` watcher exhaustion without crashing the gateway; this PR reduces the watcher allocation pressure that can lead to `ENOSPC` in the memory watcher path.
- Not a duplicate of #86345. That closed PR bounded `INDEX_CACHE` manager lifetime and explicitly framed itself as complementary to #86701; it did not change Linux watcher selection.
- Not a duplicate of #41858. That closed PR proposed chokidar depth limits in an older memory path; this PR targets the current `extensions/memory-core` watcher and preserves recursive memory freshness.
- Not a duplicate of #72748. That closed PR focused on recursive memory search correctness and QMD watcher handling, not Linux memory watcher descriptor fan-out.
- Adjacent to #40088 and #71335. This keeps watcher freshness semantics for `sync.watch` users; it does not change defaults or the broader watcher policy.

## Source / Dependency Proof

- Current `extensions/memory-core/src/memory/manager-sync-ops.ts` routes Linux memory directories through chokidar on `main`.
- Node v22.x `lib/fs.js` routes `fs.watch(..., { recursive: true })` to `internal/fs/recursive_watch` when `options.recursive && !isMacOS && !isWindows`.
- Node v22.x `lib/internal/fs/recursive_watch.js` walks the tree and calls `fs.watch` for each discovered file/directory.
- Chokidar 5.0.0's NodeFS handler calls `fs.watch` for handled files and directories.

## Linux Probe

Synthetic tree: 20 directories, 1,000 `.md` files, Node 22.22.3 in Docker Linux.

```text
baseline fd=18 inotifyWatches=0
chokidar-ready fd=20 inotifyWatches=1021
after-chokidar-close fd=20 inotifyWatches=0
node-recursive-ready fd=20 inotifyWatches=1021
after-node-close fd=20 inotifyWatches=0
```

Directory-only watcher shape for the same tree:

```text
baseline fd=18 inotifyWatches=0
directory-only-ready fd=20 inotifyWatches=21
after-close fd=20 inotifyWatches=0
```

## Targeted Linux Manager Smoke

Local Docker Linux, actual `MemoryIndexManager` with a test FTS-only embedding adapter, 1,001 markdown files across 21 memory directories.

```text
platform=linux
files=1001
directories=21
inotify.before=0
inotify.afterAttach=22
inotify.afterFresh=25
inotify.afterReplace=27
inotify.afterClose=0
freshCount=1
replaceCount=1
```

This verifies the Linux path stays near directory-count watchers rather than file-count watchers, dynamically attaches a newly-created nested directory, handles delete/recreate of a nested directory, indexes the fresh/recreated files, and cleans all inotify watches on close.

## Verification

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.watcher-config.test.ts`
- `pnpm tsgo:core:test`
- `pnpm tsgo:extensions:test`
- `pnpm run lint:extensions:bundled`
- `pnpm tsgo:prod`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Local Docker Linux targeted `MemoryIndexManager` smoke described above.
