### PR TITLE
feat(xai): add grok-composer-2.5-fast model

### DIFF
--- a/extensions/xai/model-definitions.ts
+++ b/extensions/xai/model-definitions.ts
@@ -194,6 +194,15 @@ const XAI_MODEL_CATALOG = [
     maxTokens: 30_000,
     cost: XAI_GROK_420_COST,
   },
+  {
+    id: "grok-composer-2.5-fast",
+    name: "Grok Composer 2.5 Fast",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: XAI_CODE_CONTEXT_WINDOW,
+    maxTokens: 10_000,
+    cost: XAI_CODE_FAST_COST,
+  },
 ] as const satisfies readonly XaiCatalogEntry[];
 
 const XAI_SELECTABLE_MODEL_IDS = new Set<string>([

--- a/extensions/xai/provider-models.ts
+++ b/extensions/xai/provider-models.ts
@@ -8,7 +8,7 @@ import { resolveXaiCatalogEntry, XAI_BASE_URL } from "./model-definitions.js";
 import { normalizeXaiModelId } from "./model-id.js";
 import { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
 
-const XAI_MODERN_MODEL_PREFIXES = ["grok-build-0.1", "grok-4.3", "grok-4.20"] as const;
+const XAI_MODERN_MODEL_PREFIXES = ["grok-build-0.1", "grok-4.3", "grok-4.20", "grok-composer"] as const;
 
 export function isModernXaiModel(modelId: string): boolean {
   const normalized = normalizeXaiModelId(modelId.trim());


### PR DESCRIPTION
## Summary
- Adds `grok-composer-2.5-fast` to xAI model catalog in `extensions/xai/model-definitions.ts`
- Adds `grok-composer` prefix to modern model list in `extensions/xai/provider-models.ts`
- Model is live on xAI `/v1/chat/completions` with `reasoning_content` support
- Grok Build's composer model for agentic code composition

## Test plan
- [ ] Verify model appears in `openclaw models` with xAI provider configured
- [ ] Verify chat completion works with `grok-composer-2.5-fast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)