### PR TITLE
fix: include name field in model_not_found remediation hint

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2240,7 +2240,7 @@ describe("resolveModel", () => {
     });
 
     expect(result.error).toBe(
-      'Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models["microsoft-foundry/Kimi-K2.6-1"], but no matching models.providers["microsoft-foundry"].models[] entry. Add { "id": "Kimi-K2.6-1" } to models.providers["microsoft-foundry"].models[] to register this provider model.',
+      'Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models["microsoft-foundry/Kimi-K2.6-1"], but no matching models.providers["microsoft-foundry"].models[] entry. Add { "id": "Kimi-K2.6-1", "name": "Kimi-K2.6-1" } to models.providers["microsoft-foundry"].models[] to register this provider model.',
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1674,5 +1674,5 @@ function buildMissingProviderModelRegistrationHint(params: {
   if (hasProviderModel) {
     return undefined;
   }
-  return `Found agents.defaults.models["${agentModelKey}"], but no matching models.providers["${params.provider}"].models[] entry. Add { "id": "${params.modelId}" } to models.providers["${params.provider}"].models[] to register this provider model.`;
+  return `Found agents.defaults.models["${agentModelKey}"], but no matching models.providers["${params.provider}"].models[] entry. Add { "id": "${params.modelId}", "name": "${params.modelId}" } to models.providers["${params.provider}"].models[] to register this provider model.`;
 }


### PR DESCRIPTION
## Summary

The `model_not_found` remediation message suggested `{ "id": "..." }` but the `ModelDefinitionSchema` requires both `id` and `name` fields (both `z.string().min(1)`). Following the original message verbatim always fails schema validation.

This fix includes the `name` field in the suggested snippet, making the hint produce a working config when followed verbatim.

## Fix

- `src/agents/embedded-agent-runner/model.ts`: Added `"name": "${params.modelId}"` to the suggested config snippet in the `model_not_found` remediation message.

## Test

- `src/agents/embedded-agent-runner/model.test.ts`: Updated the test assertion to expect the corrected message.

## Verification

- TypeScript syntax check via `tsc --noEmit` (local Node version incompatible with project `engines` requirement — validated via code review and test assertion update)
- Existing unit test updated to match corrected message

Closes #89192
