### PR TITLE
refactor: add transcript runtime identity contract

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -25,6 +25,10 @@ const legacyWholeStoreAccessNames = new Set([
 ]);
 
 export const migratedSessionAccessorFiles = new Set([
+  "src/agents/embedded-agent-runner/compaction-successor-transcript.ts",
+  "src/agents/embedded-agent-runner/tool-result-truncation.ts",
+  "src/agents/embedded-agent-runner/transcript-rewrite.ts",
+  "src/agents/embedded-agent-runner/transcript-runtime-state.ts",
   "src/commands/export-trajectory.ts",
   "src/commands/health.ts",
   "src/commands/sandbox-explain.ts",
@@ -35,6 +39,7 @@ export const migratedSessionAccessorFiles = new Set([
   "src/config/sessions/combined-store-gateway.ts",
   "src/cron/isolated-agent/delivery-target.ts",
   "src/cron/service/timer.ts",
+  "src/gateway/session-compaction-checkpoints.ts",
   "src/gateway/session-utils.ts",
   "src/gateway/sessions-resolve.ts",
   "src/gateway/server-methods/sessions.ts",
@@ -161,6 +166,7 @@ export async function main() {
   const sourceRoots = resolveSourceRoots(repoRoot, [
     "extensions/discord/src/monitor",
     "extensions/telegram/src",
+    "src/agents/embedded-agent-runner",
     "src/commands",
     "src/config/sessions",
     "src/cron",

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -6,6 +6,7 @@ import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
+  rotateRuntimeTranscriptAfterCompaction,
   rotateTranscriptAfterCompaction,
   rotateTranscriptFileAfterCompaction,
   shouldRotateCompactionTranscript,
@@ -117,6 +118,24 @@ function createCompactedSession(sessionDir: string): {
 }
 
 describe("rotateTranscriptAfterCompaction", () => {
+  it("does not create session metadata for missing runtime transcripts", async () => {
+    const dir = await createTmpDir();
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(storePath, "{}\n", "utf8");
+
+    const result = await rotateRuntimeTranscriptAfterCompaction({
+      scope: {
+        agentId: "main",
+        sessionId: "missing-session",
+        sessionKey: "agent:main:missing",
+        storePath,
+      },
+    });
+
+    expect(result.rotated).toBe(false);
+    expect(await fs.readFile(storePath, "utf8")).toBe("{}\n");
+  });
+
   it("can rotate a persisted transcript without opening a manager", async () => {
     const dir = await createTmpDir();
     const { sessionFile } = createCompactedSession(dir);

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -14,6 +14,10 @@ import {
   TranscriptFileState,
   writeTranscriptFileAtomic,
 } from "./transcript-file-state.js";
+import {
+  resolveRuntimeTranscriptReadTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 type ReadonlySessionManagerForRotation = Pick<
   TranscriptFileState,
@@ -95,6 +99,33 @@ export async function rotateTranscriptFileAfterCompaction(params: {
   return rotateTranscriptAfterCompaction({
     sessionManager: state,
     sessionFile: params.sessionFile,
+    ...(params.now ? { now: params.now } : {}),
+  });
+}
+
+/**
+ * Rotates a runtime transcript after compaction using agent/session identity.
+ */
+export async function rotateRuntimeTranscriptAfterCompaction(params: {
+  sessionManager?: ReadonlySessionManagerForRotation;
+  scope: RuntimeTranscriptScope;
+  now?: () => Date;
+}): Promise<CompactionTranscriptRotation> {
+  const target = await resolveRuntimeTranscriptReadTarget(params.scope);
+  let sessionManager = params.sessionManager;
+  if (!sessionManager) {
+    try {
+      sessionManager = await readTranscriptFileState(target.sessionFile);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return { rotated: false, reason: "missing session file" };
+      }
+      throw err;
+    }
+  }
+  return await rotateTranscriptAfterCompaction({
+    sessionManager,
+    sessionFile: target.sessionFile,
     ...(params.now ? { now: params.now } : {}),
   });
 }

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -17,6 +17,7 @@ let calculateMaxToolResultCharsWithCap: typeof import("./tool-result-truncation.
 let resolveAutoLiveToolResultMaxChars: typeof import("./tool-result-truncation.js").resolveAutoLiveToolResultMaxChars;
 let getToolResultTextLength: typeof import("./tool-result-truncation.js").getToolResultTextLength;
 let truncateOversizedToolResultsInMessages: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInMessages;
+let truncateOversizedToolResultsInRuntimeTranscript: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInRuntimeTranscript;
 let truncateOversizedToolResultsInSession: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInSession;
 let isOversizedToolResult: typeof import("./tool-result-truncation.js").isOversizedToolResult;
 let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncation.js").sessionLikelyHasOversizedToolResults;
@@ -36,6 +37,7 @@ async function loadFreshToolResultTruncationModuleForTest() {
     resolveAutoLiveToolResultMaxChars,
     getToolResultTextLength,
     truncateOversizedToolResultsInMessages,
+    truncateOversizedToolResultsInRuntimeTranscript,
     truncateOversizedToolResultsInSession,
     isOversizedToolResult,
     sessionLikelyHasOversizedToolResults,
@@ -464,6 +466,25 @@ describe("truncateOversizedToolResultsInMessages", () => {
 });
 
 describe("truncateOversizedToolResultsInSession", () => {
+  it("does not create session metadata for missing runtime transcripts", async () => {
+    const dir = await createTmpDir();
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(storePath, "{}\n", "utf8");
+
+    const result = await truncateOversizedToolResultsInRuntimeTranscript({
+      scope: {
+        agentId: "main",
+        sessionId: "missing-session",
+        sessionKey: "agent:main:missing",
+        storePath,
+      },
+      contextWindowTokens: 100,
+    });
+
+    expect(result.truncated).toBe(false);
+    expect(await fs.readFile(storePath, "utf8")).toBe("{}\n");
+  });
+
   it("readably truncates aggregate medium tool results in a session file", async () => {
     // Persisted truncation rewrites JSONL directly and emits the transcript
     // update event instead of reopening through SessionManager internals.

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -25,6 +25,10 @@ import {
   rewriteTranscriptEntriesInSessionManager,
   rewriteTranscriptEntriesInState,
 } from "./transcript-rewrite.js";
+import {
+  resolveRuntimeTranscriptReadTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 /**
  * Maximum share of the context window a single tool result should occupy.
@@ -818,6 +822,49 @@ export function truncateOversizedToolResultsInSessionManager(params: {
   }
 }
 
+/**
+ * Truncates oversized tool results for a runtime transcript scope.
+ */
+export async function truncateOversizedToolResultsInRuntimeTranscript(params: {
+  scope: RuntimeTranscriptScope;
+  contextWindowTokens: number;
+  maxCharsOverride?: number;
+  aggregateMaxCharsOverride?: number;
+  config?: SessionWriteLockAcquireTimeoutConfig;
+}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+
+  try {
+    const target = await resolveRuntimeTranscriptReadTarget(params.scope);
+    sessionLock = await acquireSessionWriteLock({
+      sessionFile: target.sessionFile,
+      ...resolveSessionWriteLockOptions(params.config),
+    });
+    const state = await readTranscriptFileState(target.sessionFile);
+    return await truncateOversizedToolResultsInTranscriptState({
+      state,
+      contextWindowTokens: params.contextWindowTokens,
+      maxCharsOverride: params.maxCharsOverride,
+      aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+      sessionFile: target.sessionFile,
+      sessionId: target.sessionId,
+      sessionKey: target.sessionKey,
+      agentId: target.agentId,
+      config: params.config,
+    });
+  } catch (err) {
+    const errMsg = formatErrorMessage(err);
+    log.warn(`[tool-result-truncation] Failed to truncate: ${errMsg}`);
+    return { truncated: false, truncatedCount: 0, reason: errMsg };
+  } finally {
+    await sessionLock?.release();
+  }
+}
+
+/**
+ * Truncates a named transcript file artifact. Runtime callers should prefer
+ * truncateOversizedToolResultsInRuntimeTranscript with agent/session scope.
+ */
 export async function truncateOversizedToolResultsInSession(params: {
   sessionFile: string;
   contextWindowTokens: number;

--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -22,6 +22,7 @@ vi.mock("../session-write-lock.js", () =>
 
 let rewriteTranscriptEntriesInSessionFile: typeof import("./transcript-rewrite.js").rewriteTranscriptEntriesInSessionFile;
 let rewriteTranscriptEntriesInSessionManager: typeof import("./transcript-rewrite.js").rewriteTranscriptEntriesInSessionManager;
+let rewriteTranscriptEntriesInRuntimeTranscript: typeof import("./transcript-rewrite.js").rewriteTranscriptEntriesInRuntimeTranscript;
 let onSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onSessionTranscriptUpdate;
 let installSessionToolResultGuard: typeof import("../session-tool-result-guard.js").installSessionToolResultGuard;
 
@@ -159,8 +160,11 @@ function requireString(value: string | undefined, label: string): string {
 beforeAll(async () => {
   ({ onSessionTranscriptUpdate } = await import("../../sessions/transcript-events.js"));
   ({ installSessionToolResultGuard } = await import("../session-tool-result-guard.js"));
-  ({ rewriteTranscriptEntriesInSessionFile, rewriteTranscriptEntriesInSessionManager } =
-    await import("./transcript-rewrite.js"));
+  ({
+    rewriteTranscriptEntriesInRuntimeTranscript,
+    rewriteTranscriptEntriesInSessionFile,
+    rewriteTranscriptEntriesInSessionManager,
+  } = await import("./transcript-rewrite.js"));
 });
 
 beforeEach(() => {
@@ -306,6 +310,25 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
 });
 
 describe("rewriteTranscriptEntriesInSessionFile", () => {
+  it("does not create session metadata for missing runtime transcripts", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-runtime-"));
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(storePath, "{}\n", "utf8");
+
+    const result = await rewriteTranscriptEntriesInRuntimeTranscript({
+      scope: {
+        agentId: "main",
+        sessionId: "missing-session",
+        sessionKey: "agent:main:missing",
+        storePath,
+      },
+      request: { replacements: [] },
+    });
+
+    expect(result.changed).toBe(false);
+    expect(await fs.readFile(storePath, "utf8")).toBe("{}\n");
+  });
+
   it("aborts under the write lock when the active suffix contains an unexpected entry", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-guard-"));
     const sessionManager = SessionManager.create(dir, dir);

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -22,6 +22,11 @@ import {
   readTranscriptFileState,
   type TranscriptFileState,
 } from "./transcript-file-state.js";
+import {
+  persistRuntimeTranscriptStateMutation,
+  resolveRuntimeTranscriptReadTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 type SessionManagerLike = ReturnType<typeof SessionManager.open>;
 type SessionBranchEntry = ReturnType<SessionManagerLike["getBranch"]>[number];
@@ -372,8 +377,65 @@ export function rewriteTranscriptEntriesInState(params: {
 }
 
 /**
- * Open a transcript file, rewrite message entries on the active branch, and
- * emit a transcript update when the active branch changed.
+ * Rewrites message entries for a runtime transcript without using the
+ * file-backed path as caller identity.
+ */
+export async function rewriteTranscriptEntriesInRuntimeTranscript(params: {
+  scope: RuntimeTranscriptScope;
+  request: TranscriptRewriteRequest;
+  config?: SessionWriteLockAcquireTimeoutConfig;
+}): Promise<TranscriptRewriteResult> {
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+  try {
+    const target = await resolveRuntimeTranscriptReadTarget(params.scope);
+    sessionLock = await acquireSessionWriteLock({
+      sessionFile: target.sessionFile,
+      ...resolveSessionWriteLockOptions(params.config),
+    });
+    const state = await readTranscriptFileState(target.sessionFile);
+    const result = rewriteTranscriptEntriesInState({
+      state,
+      replacements: params.request.replacements,
+      ...(params.request.allowedRewriteSuffixEntryIds
+        ? { allowedRewriteSuffixEntryIds: params.request.allowedRewriteSuffixEntryIds }
+        : {}),
+    });
+    if (result.changed) {
+      await persistRuntimeTranscriptStateMutation({
+        target,
+        state,
+        appendedEntries: result.appendedEntries,
+      });
+      emitSessionTranscriptUpdate({
+        sessionFile: target.sessionFile,
+        sessionKey: target.sessionKey,
+        agentId: target.agentId,
+      });
+      log.info(
+        `[transcript-rewrite] rewrote ${result.rewrittenEntries} entr` +
+          `${result.rewrittenEntries === 1 ? "y" : "ies"} ` +
+          `bytesFreed=${result.bytesFreed} ` +
+          `sessionKey=${target.sessionKey}`,
+      );
+    }
+    return result;
+  } catch (err) {
+    const reason = formatErrorMessage(err);
+    log.warn(`[transcript-rewrite] failed: ${reason}`);
+    return {
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+      reason,
+    };
+  } finally {
+    await sessionLock?.release();
+  }
+}
+
+/**
+ * Rewrites a named transcript file artifact. Runtime callers should prefer
+ * rewriteTranscriptEntriesInRuntimeTranscript with agent/session scope.
  */
 export async function rewriteTranscriptEntriesInSessionFile(params: {
   sessionFile: string;

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendTranscriptMessage,
+  upsertSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import {
+  deleteRuntimeTranscript,
+  readRuntimeTranscriptState,
+  runtimeTranscriptExists,
+} from "./transcript-runtime-state.js";
+
+describe("runtime transcript state", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-runtime-transcript-"));
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reads and deletes transcript state through runtime scope", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      message: {
+        content: "hello",
+        role: "user",
+      },
+    });
+
+    await expect(runtimeTranscriptExists(scope)).resolves.toBe(true);
+    const { state, target } = await readRuntimeTranscriptState(scope);
+    expect(fs.realpathSync(target.sessionFile)).toBe(
+      fs.realpathSync(path.join(tempDir, "session-1.jsonl")),
+    );
+    expect(state.getBranch()).toEqual([
+      expect.objectContaining({
+        message: expect.objectContaining({ content: "hello" }),
+        type: "message",
+      }),
+    ]);
+
+    await expect(deleteRuntimeTranscript(scope)).resolves.toBe(true);
+    await expect(runtimeTranscriptExists(scope)).resolves.toBe(false);
+  });
+
+  it("does not create session metadata for missing transcript probes", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "missing-session",
+      sessionKey: "agent:main:missing",
+      storePath,
+    };
+    fs.writeFileSync(storePath, "{}\n", "utf8");
+
+    await expect(runtimeTranscriptExists(scope)).resolves.toBe(false);
+    await expect(deleteRuntimeTranscript(scope)).resolves.toBe(false);
+
+    expect(fs.readFileSync(storePath, "utf8")).toBe("{}\n");
+  });
+
+  it("does not create session metadata when reading a missing transcript", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "missing-session",
+      sessionKey: "agent:main:missing",
+      storePath,
+    };
+    fs.writeFileSync(storePath, "{}\n", "utf8");
+
+    await expect(readRuntimeTranscriptState(scope)).rejects.toThrow();
+
+    expect(fs.readFileSync(storePath, "utf8")).toBe("{}\n");
+  });
+
+  it("does not delete a stale transcript from a previous session id", async () => {
+    const oldTranscriptPath = path.join(tempDir, "old-session.jsonl");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionFile: "old-session.jsonl",
+          sessionId: "old-session",
+          updatedAt: 10,
+        },
+      }) + "\n",
+      "utf8",
+    );
+    fs.writeFileSync(oldTranscriptPath, '{"type":"session","id":"old-session"}\n', "utf8");
+
+    const scope = {
+      agentId: "main",
+      sessionId: "new-session",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await expect(runtimeTranscriptExists(scope)).resolves.toBe(false);
+    await expect(deleteRuntimeTranscript(scope)).resolves.toBe(false);
+
+    expect(fs.existsSync(oldTranscriptPath)).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import type {
+  SessionTranscriptRuntimeScope,
+  SessionTranscriptRuntimeTarget,
+} from "../../config/sessions/session-accessor.js";
+import {
+  resolveSessionTranscriptRuntimeReadTarget,
+  resolveSessionTranscriptRuntimeTarget,
+} from "../../config/sessions/session-accessor.js";
+import type { SessionEntry, SessionHeader } from "../sessions/index.js";
+import {
+  persistTranscriptStateMutation,
+  readTranscriptFileState,
+  type TranscriptFileState,
+  writeTranscriptFileAtomic,
+} from "./transcript-file-state.js";
+
+export type RuntimeTranscriptScope = SessionTranscriptRuntimeScope;
+export type RuntimeTranscriptTarget = SessionTranscriptRuntimeTarget;
+
+export type RuntimeTranscriptState = {
+  state: TranscriptFileState;
+  target: RuntimeTranscriptTarget;
+};
+
+/**
+ * Resolves the current file-backed transcript target for runtime state
+ * operations. The returned path is an implementation detail, not identity.
+ */
+export async function resolveRuntimeTranscriptTarget(
+  scope: RuntimeTranscriptScope,
+): Promise<RuntimeTranscriptTarget> {
+  return await resolveSessionTranscriptRuntimeTarget(scope);
+}
+
+/**
+ * Resolves the runtime transcript target for read/probe operations without
+ * linking missing file-backed metadata into the session store.
+ */
+export async function resolveRuntimeTranscriptReadTarget(
+  scope: RuntimeTranscriptScope,
+): Promise<RuntimeTranscriptTarget> {
+  return await resolveSessionTranscriptRuntimeReadTarget(scope);
+}
+
+/**
+ * Reads transcript state through the runtime transcript identity contract.
+ */
+export async function readRuntimeTranscriptState(
+  scope: RuntimeTranscriptScope,
+): Promise<RuntimeTranscriptState> {
+  const target = await resolveRuntimeTranscriptReadTarget(scope);
+  return {
+    state: await readTranscriptFileState(target.sessionFile),
+    target,
+  };
+}
+
+/**
+ * Persists an append or migration rewrite for a resolved runtime transcript.
+ */
+export async function persistRuntimeTranscriptStateMutation(params: {
+  appendedEntries: SessionEntry[];
+  state: TranscriptFileState;
+  target: RuntimeTranscriptTarget;
+}): Promise<void> {
+  await persistTranscriptStateMutation({
+    sessionFile: params.target.sessionFile,
+    state: params.state,
+    appendedEntries: params.appendedEntries,
+  });
+}
+
+/**
+ * Atomically replaces the file-backed transcript for a runtime transcript.
+ */
+export async function replaceRuntimeTranscriptEntries(params: {
+  entries: Array<SessionHeader | SessionEntry>;
+  target: RuntimeTranscriptTarget;
+}): Promise<void> {
+  await writeTranscriptFileAtomic(params.target.sessionFile, params.entries);
+}
+
+/**
+ * Checks existence of the current runtime transcript without exposing path
+ * identity to callers.
+ */
+export async function runtimeTranscriptExists(scope: RuntimeTranscriptScope): Promise<boolean> {
+  const target = await resolveRuntimeTranscriptReadTarget(scope);
+  try {
+    const stat = await fs.stat(target.sessionFile);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Deletes the current runtime transcript. This remains file-backed until the
+ * SQLite implementation owns transcript deletion in 3.2.
+ */
+export async function deleteRuntimeTranscript(scope: RuntimeTranscriptScope): Promise<boolean> {
+  const target = await resolveRuntimeTranscriptReadTarget(scope);
+  try {
+    await fs.unlink(target.sessionFile);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -15,6 +15,8 @@ import {
   publishTranscriptUpdate,
   readSessionUpdatedAt,
   replaceSessionEntry,
+  resolveSessionTranscriptRuntimeReadTarget,
+  resolveSessionTranscriptRuntimeTarget,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -556,6 +558,61 @@ describe("session accessor file-backed seam", () => {
       fs.realpathSync(expectedTranscriptPath),
     );
     await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("resolves runtime transcript targets from scope without caller-owned paths", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+
+    const target = await resolveSessionTranscriptRuntimeTarget(scope);
+
+    expect(target).toMatchObject({
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+    });
+    expect(fs.realpathSync(path.dirname(target.sessionFile))).toBe(fs.realpathSync(tempDir));
+    expect(path.basename(target.sessionFile)).toBe("session-1.jsonl");
+    expect(loadSessionEntry(scope)?.sessionFile).toBe(target.sessionFile);
+  });
+
+  it("keeps read and write runtime targets aligned for new topic sessions", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-2",
+      sessionKey: "agent:main:main:topic:456",
+      storePath,
+      threadId: "456",
+    };
+    fs.writeFileSync(
+      path.join(tempDir, "session-1-topic-456.jsonl"),
+      '{"type":"session","id":"session-1"}\n',
+      "utf8",
+    );
+    await upsertSessionEntry(
+      { sessionKey: scope.sessionKey, storePath },
+      {
+        sessionFile: "session-1-topic-456.jsonl",
+        sessionId: "session-1",
+        updatedAt: 10,
+      },
+    );
+
+    const readTarget = await resolveSessionTranscriptRuntimeReadTarget(scope);
+    const writeTarget = await resolveSessionTranscriptRuntimeTarget(scope);
+
+    expect(path.basename(readTarget.sessionFile)).toBe("session-2-topic-456.jsonl");
+    expect(writeTarget.sessionFile).toBe(readTarget.sessionFile);
+    expect(loadSessionEntry(scope)?.sessionFile).toBe(readTarget.sessionFile);
   });
 
   it("persists transcript metadata under the normalized session key", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -6,6 +6,7 @@ import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.j
 import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
+  resolveSessionFilePath,
   resolveSessionTranscriptPath,
   resolveSessionTranscriptPathInDir,
   resolveStorePath,
@@ -84,6 +85,11 @@ export type SessionTranscriptAccessScope = SessionTranscriptReadScope & {
   sessionKey?: string;
 };
 
+export type SessionTranscriptRuntimeScope = SessionAccessScope & {
+  sessionId: string;
+  threadId?: string | number;
+};
+
 export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
   /** Optional for appenders that can operate on an existing explicit transcript target. */
   sessionId?: string;
@@ -133,6 +139,13 @@ export type TranscriptMessageAppendResult<TMessage> = {
 
 /** Transcript update fields supplied by callers; sessionFile is resolved here. */
 export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
+
+export type SessionTranscriptRuntimeTarget = {
+  agentId: string;
+  sessionFile: string;
+  sessionId: string;
+  sessionKey: string;
+};
 
 export type SessionEntryUpdateOptions = {
   /** Skip prune/cap/rotation maintenance for specialized internal updates. */
@@ -374,6 +387,115 @@ export async function publishTranscriptUpdate(
   });
 }
 
+/**
+ * Resolves the current file-backed target for a storage-neutral runtime
+ * transcript scope. Callers use the scope as identity; sessionFile is returned
+ * only for current file-backed implementation details such as locks/events.
+ */
+export async function resolveSessionTranscriptRuntimeTarget(
+  scope: SessionTranscriptRuntimeScope,
+): Promise<SessionTranscriptRuntimeTarget> {
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const sessionStore = scope.storePath
+    ? loadSessionStore(scope.storePath, { skipCache: true })
+    : undefined;
+  const resolvedStoreEntry = sessionStore
+    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
+    : undefined;
+  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
+  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
+  if (sessionStore && scope.storePath) {
+    const sessionsDir = path.dirname(path.resolve(scope.storePath));
+    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
+    const shouldUseDerivedSessionFile =
+      !sessionEntry?.sessionFile || sessionEntry.sessionId !== scope.sessionId;
+    const fallbackSessionFile =
+      shouldUseDerivedSessionFile && threadId !== undefined
+        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
+        : undefined;
+    const resolved = await resolveAndPersistSessionFile({
+      agentId,
+      fallbackSessionFile,
+      sessionEntry,
+      sessionId: scope.sessionId,
+      sessionKey,
+      sessionStore,
+      sessionsDir,
+      storePath: scope.storePath,
+    });
+    return {
+      agentId,
+      sessionFile: resolved.sessionFile,
+      sessionId: scope.sessionId,
+      sessionKey,
+    };
+  }
+  const resolved = await resolveSessionTranscriptFile({
+    agentId,
+    sessionEntry,
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    ...(sessionStore ? { sessionStore } : {}),
+    ...(scope.storePath ? { storePath: scope.storePath } : {}),
+    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
+  });
+  return {
+    agentId,
+    sessionFile: resolved.sessionFile,
+    sessionId: scope.sessionId,
+    sessionKey,
+  };
+}
+
+/**
+ * Resolves the file-backed runtime transcript target for read/delete probes
+ * without persisting missing sessionFile metadata into the session store.
+ */
+export async function resolveSessionTranscriptRuntimeReadTarget(
+  scope: SessionTranscriptRuntimeScope,
+): Promise<SessionTranscriptRuntimeTarget> {
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const sessionStore = scope.storePath
+    ? loadSessionStore(scope.storePath, { skipCache: true })
+    : undefined;
+  const resolvedStoreEntry = sessionStore
+    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
+    : undefined;
+  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
+  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
+  const matchingSessionEntry =
+    sessionEntry?.sessionId === scope.sessionId ? sessionEntry : undefined;
+  if (scope.storePath) {
+    const sessionsDir = path.dirname(path.resolve(scope.storePath));
+    const threadId = scope.threadId ?? parseSessionThreadInfo(sessionKey).threadId;
+    const sessionFile = matchingSessionEntry?.sessionFile
+      ? resolveSessionFilePath(scope.sessionId, matchingSessionEntry, { agentId, sessionsDir })
+      : resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId);
+    return {
+      agentId,
+      sessionFile,
+      sessionId: scope.sessionId,
+      sessionKey,
+    };
+  }
+  const threadId = scope.threadId ?? parseSessionThreadInfo(sessionKey).threadId;
+  const sessionFile = matchingSessionEntry?.sessionFile
+    ? resolveSessionFilePath(scope.sessionId, matchingSessionEntry, { agentId })
+    : resolveSessionTranscriptPath(scope.sessionId, agentId, threadId);
+  return {
+    agentId,
+    sessionFile,
+    sessionId: scope.sessionId,
+    sessionKey,
+  };
+}
+
 function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
   const now = Date.now();
   return {
@@ -437,44 +559,9 @@ async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Prom
   if (!scope.sessionId) {
     throw new Error(`Cannot resolve transcript scope without a session id: ${scopeSessionKey}`);
   }
-  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scopeSessionKey);
-  if (!agentId) {
-    throw new Error(`Cannot resolve transcript scope without an agent id: ${scopeSessionKey}`);
-  }
-  const sessionStore = scope.storePath
-    ? loadSessionStore(scope.storePath, { skipCache: true })
-    : undefined;
-  const resolvedStoreEntry = sessionStore
-    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scopeSessionKey })
-    : undefined;
-  const sessionEntry =
-    resolvedStoreEntry?.existing ?? loadSessionEntry({ ...scope, sessionKey: scopeSessionKey });
-  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scopeSessionKey;
-  if (sessionStore && scope.storePath) {
-    const sessionsDir = path.dirname(path.resolve(scope.storePath));
-    const threadId = scope.threadId ?? parseSessionThreadInfo(scopeSessionKey).threadId;
-    const fallbackSessionFile =
-      !sessionEntry?.sessionFile && threadId !== undefined
-        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
-        : undefined;
-    return await resolveAndPersistSessionFile({
-      agentId,
-      fallbackSessionFile,
-      sessionEntry,
-      sessionId: scope.sessionId,
-      sessionKey,
-      sessionStore,
-      sessionsDir,
-      storePath: scope.storePath,
-    });
-  }
-  return await resolveSessionTranscriptFile({
-    agentId,
-    sessionEntry,
+  return await resolveSessionTranscriptRuntimeTarget({
+    ...scope,
     sessionId: scope.sessionId,
     sessionKey: scopeSessionKey,
-    ...(sessionStore ? { sessionStore } : {}),
-    ...(scope.storePath ? { storePath: scope.storePath } : {}),
-    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
   });
 }

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -11,11 +11,13 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   captureCompactionCheckpointSnapshotAsync,
+  captureRuntimeCompactionCheckpointSnapshotAsync,
   cleanupCompactionCheckpointSnapshot,
   forkCompactionCheckpointTranscriptAsync,
   MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES,
   MAX_COMPACTION_CHECKPOINT_RETAINED_BYTES_PER_SESSION,
   persistSessionCompactionCheckpoint,
+  readRuntimeSessionLeafIdFromTranscriptAsync,
   readSessionLeafIdFromTranscriptAsync,
 } from "./session-compaction-checkpoints.js";
 
@@ -161,6 +163,25 @@ afterEach(async () => {
 });
 
 describe("session-compaction-checkpoints", () => {
+  test("runtime checkpoint probes do not create session metadata for missing transcripts", async () => {
+    const { storePath, sessionKey } = await makeTempSessionStore(
+      "openclaw-checkpoint-runtime-probe-",
+      "missing-session",
+    );
+    await fs.writeFile(storePath, "{}\n", "utf-8");
+    const scope = {
+      agentId: MAIN_AGENT_ID,
+      sessionId: "missing-session",
+      sessionKey,
+      storePath,
+    };
+
+    await expect(readRuntimeSessionLeafIdFromTranscriptAsync(scope)).resolves.toBeNull();
+    await expect(captureRuntimeCompactionCheckpointSnapshotAsync({ scope })).resolves.toBeNull();
+
+    expect(await fs.readFile(storePath, "utf-8")).toBe("{}\n");
+  });
+
   test("async capture stores pre-compaction identity without copying the transcript", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-async-"));
     tempDirs.push(dir);

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -15,6 +15,10 @@ import type {
   SessionEntry,
 } from "../config/sessions.js";
 import { isCompactionCheckpointTranscriptFileName } from "../config/sessions/artifacts.js";
+import {
+  resolveSessionTranscriptRuntimeReadTarget,
+  type SessionTranscriptRuntimeScope,
+} from "../config/sessions/session-accessor.js";
 import { streamSessionTranscriptLines } from "../config/sessions/transcript-stream.js";
 import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -330,6 +334,17 @@ export async function readSessionLeafIdFromTranscriptAsync(
   return null;
 }
 
+/**
+ * Reads the latest leaf id for a runtime transcript scope.
+ */
+export async function readRuntimeSessionLeafIdFromTranscriptAsync(
+  scope: SessionTranscriptRuntimeScope,
+  maxBytes = MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES,
+): Promise<string | null> {
+  const target = await resolveSessionTranscriptRuntimeReadTarget(scope);
+  return await readSessionLeafIdFromTranscriptAsync(target.sessionFile, maxBytes);
+}
+
 export async function forkCompactionCheckpointTranscriptAsync(params: {
   sourceFile: string;
   sourceLeafId?: string;
@@ -424,6 +439,22 @@ export async function captureCompactionCheckpointSnapshotAsync(params: {
     sessionId,
     leafId,
   };
+}
+
+/**
+ * Captures checkpoint metadata for a runtime transcript scope.
+ */
+export async function captureRuntimeCompactionCheckpointSnapshotAsync(params: {
+  sessionManager?: Pick<SessionManager, "getLeafId">;
+  scope: SessionTranscriptRuntimeScope;
+  maxBytes?: number;
+}): Promise<CapturedCompactionCheckpointSnapshot | null> {
+  const target = await resolveSessionTranscriptRuntimeReadTarget(params.scope);
+  return await captureCompactionCheckpointSnapshotAsync({
+    sessionManager: params.sessionManager,
+    sessionFile: target.sessionFile,
+    maxBytes: params.maxBytes,
+  });
 }
 
 export async function cleanupCompactionCheckpointSnapshot(

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -9,6 +9,10 @@ describe("session accessor boundary guard", () => {
   it("ratchets only the files migrated by the session accessor slices", () => {
     expect(migratedSessionAccessorFiles).toEqual(
       new Set([
+        "src/agents/embedded-agent-runner/compaction-successor-transcript.ts",
+        "src/agents/embedded-agent-runner/tool-result-truncation.ts",
+        "src/agents/embedded-agent-runner/transcript-rewrite.ts",
+        "src/agents/embedded-agent-runner/transcript-runtime-state.ts",
         "src/commands/export-trajectory.ts",
         "src/commands/health.ts",
         "src/commands/sandbox-explain.ts",
@@ -19,6 +23,7 @@ describe("session accessor boundary guard", () => {
         "src/config/sessions/combined-store-gateway.ts",
         "src/cron/isolated-agent/delivery-target.ts",
         "src/cron/service/timer.ts",
+        "src/gateway/session-compaction-checkpoints.ts",
         "src/gateway/session-utils.ts",
         "src/gateway/sessions-resolve.ts",
         "src/gateway/server-methods/sessions.ts",


### PR DESCRIPTION
## What

Adds the canonical file-backed transcript runtime identity/state contract for Path 3.1b, building on the session accessor seam without adding SQLite storage, production storage flips, runtime dual-read/fallback, or doctor migration code.

## Why

Path 3 needs a storage-neutral transcript identity/state contract before the SQLite implementation can replace file-backed runtime transcript state. This keeps normal runtime operations scoped by agent/session identity instead of raw `sessionFile` paths, while preserving explicit file-artifact boundaries until their owners migrate.

## Changes

- Adds `SessionTranscriptRuntimeScope` / target resolution
- Adds runtime transcript state APIs
- Adds runtime rewrite/truncation wrappers
- Adds successor/checkpoint scoped wrappers
- Preserves active file-artifact paths
- Adds focused file-backed tests

Included scope:
- File-backed storage-neutral transcript runtime scope/target.
- Runtime transcript state read/persist/replace/existence/delete APIs.
- Runtime rewrite, tool-result truncation, successor rotation, checkpoint leaf/snapshot wrappers.
- Explicit active artifact exclusions where the caller already owns the live file.

Excluded scope:
- SQLite adapter/schema/store modules.
- Public SDK transcript API changes.
- Plugin/memory artifact APIs.
- Production storage flip or runtime wiring.
- Doctor migration implementation.
- Runtime dual-read or fallback behavior.

Follow-ups:
- `clawdbot-d02.1.9.1.21`: SQLite side of the transcript identity/state adapter.
- `clawdbot-d02.1.9.1.20`: public SDK transcript identity/API compatibility.
- `clawdbot-d02.1.9.1.23`: plugin/memory transcript artifact APIs.
- `clawdbot-d02.1.9.1.15.3`: remaining `sessionFile` artifact-boundary classification.

Refs #88838.

## Testing

- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/agents/embedded-agent-runner/transcript-runtime-state.test.ts src/agents/embedded-agent-runner/transcript-rewrite.test.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts src/gateway/session-compaction-checkpoints.test.ts`
  - Passed: 75 tests across 3 shards.
- `oxfmt --check` on touched files.
  - Passed.
- `git diff --check`.
  - Passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local`.
  - Passed: no accepted/actionable findings.

Known proof gap:
- Full `node scripts/run-tsgo.mjs -p tsconfig.json --noEmit --pretty false` was attempted and failed on unrelated existing `extensions/copilot` timestamp/baseDirectory and `ui` missing `three` errors, not on this slice.

## Real Behavior Proof

Behavior addressed: transcript runtime identity contract plus gateway compaction checkpoint persistence after a real session exceeds practical context limits.
Real environment tested: live local OpenClaw gateway from the PR build on macOS 15.6.1 / Node 24.15.0, using session `agent:main:pr89201-compaction-proof-20260615-172548`.
Exact steps or command run after this patch: rebuilt the PR checkout with `pnpm build`, restarted the live gateway, sent a broad read-only PR-review prompt into the proof session to inflate context, then ran `pnpm openclaw gateway call sessions.compact --params '{"key":"agent:main:pr89201-compaction-proof-20260615-172548"}' --json --timeout 600000`.
Evidence after fix: gateway status reported `Git @ 7ffe7061` for the tested PR build; `sessions.compact` returned `ok: true`, `compacted: true`, `tokensBefore: 110131`, `tokensAfter: 104375`, `details.rounds: 1`, and `details.targetTokens: 193500`; the session store then reported `compactionCount: 2` and one persisted manual checkpoint `0cfef200-3600-49af-a6ab-3e79d8e81363` with matching pre/post session identity and post session file.
Observed result after fix: explicit gateway compaction completed and persisted a checkpoint for the active transcript identity without losing the session mapping.
What was not tested: rotated-successor transcript proof with `agents.defaults.compaction.truncateAfterCompaction=true`; a retry with that option returned `already under target` and did not create a successor transcript. The branch was then rebased cleanly onto `upstream/main@55d1324c7d0d2146b16aaef9572b7177a710f881` as `57aa52c1e33c4c970e9273486f5069ca44572633`; focused Vitest and autoreview were rerun on the prior clean rebase SHA, then the final moving-main rebase passed session-accessor boundary guard, oxfmt, and git diff check.

