### PR TITLE
test: reset gateway timers at test boundaries

### DIFF
--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => {
   const heartbeatRunner = {
@@ -74,6 +74,10 @@ describe("server-runtime-services", () => {
     hoisted.recoverPendingDeliveries.mockClear();
     hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
     hoisted.deliverOutboundPayloads.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("skips model pricing bootstrap import when pricing is disabled", async () => {

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -312,6 +312,7 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
   });
 

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -459,6 +459,7 @@ export function installGatewayTestHooks(options?: { scope?: "test" | "suite" }) 
   const scope = options?.scope ?? "test";
   if (scope === "suite") {
     beforeAll(async () => {
+      vi.useRealTimers();
       if (activeSuiteHookScopeCount === 0) {
         await setupGatewayTestHome();
         await resetGatewayTestState({ uniqueConfigRoot: false });
@@ -466,6 +467,7 @@ export function installGatewayTestHooks(options?: { scope?: "test" | "suite" }) 
       activeSuiteHookScopeCount += 1;
     });
     beforeEach(async () => {
+      vi.useRealTimers();
       if (activeSuiteGatewayServerCount > 0) {
         await resetGatewayTestRuntimeOnly();
         return;
@@ -489,6 +491,7 @@ export function installGatewayTestHooks(options?: { scope?: "test" | "suite" }) 
   }
 
   beforeEach(async () => {
+    vi.useRealTimers();
     await setupGatewayTestHome();
     await resetGatewayTestState({ uniqueConfigRoot: false });
   }, 60_000);


### PR DESCRIPTION
## Summary

- Reset Vitest timers at gateway test hook boundaries before shared gateway suite setup runs.
- Restore real timers after timer-heavy gateway runtime/startup tests so shared `gateway-server` workers do not leak fake timers into later WebSocket gateway setup.
- Leave production gateway behavior and watchdog timeouts unchanged.

## Real behavior proof

Behavior addressed: CI gateway-server shards intermittently ended with exit code 143 after the existing no-output watchdog killed a silent Vitest process, even though visible tests had already passed. Examples investigated: `checks-node-agentic-control-plane-startup-core` in run `26775926648` and `checks-node-agentic-control-plane-startup-health-runtime` in run `26777129355`.

Real environment tested: local OpenClaw checkout on branch `investigate/flaky-ci-tests`, using the repo Vitest wrapper and the same gateway-server config/file sets used by CI shards.

Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-runtime-config.test.ts src/gateway/server-runtime-services.test.ts src/gateway/server-runtime-state.test.ts src/gateway/server.health.test.ts src/gateway/server.lazy.test.ts src/gateway/server/health-state.test.ts src/gateway/server/readiness.test.ts`

Evidence after fix: the health/runtime shard passed once, then passed three consecutive CI-style repeat runs under the short 120s watchdog.

Observed result after fix: `7 passed (7)`, `67 passed (67)` for each health/runtime run; no post-test silent hang.

What was not tested: full CI matrix; this patch is scoped to the two gateway-server shards that reproduced the no-output watchdog failure.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-runtime-config.test.ts src/gateway/server-runtime-services.test.ts src/gateway/server-runtime-state.test.ts src/gateway/server.health.test.ts src/gateway/server.lazy.test.ts src/gateway/server/health-state.test.ts src/gateway/server/readiness.test.ts`
- Repeated the health/runtime command 3 additional times; all passed.
- `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-startup-log.test.ts src/gateway/server-startup-memory.test.ts src/gateway/server-startup-plugins.test.ts src/gateway/server-startup-post-attach.test.ts src/gateway/server-startup-session-migration.test.ts src/gateway/server-startup-web-fetch-bind.test.ts src/gateway/server-startup.test.ts`
- Repeated the startup-core command 3 additional times; all passed.
- `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs src/gateway/server-runtime-config.test.ts src/gateway/server-runtime-services.test.ts src/gateway/server-runtime-state.test.ts src/gateway/server.health.test.ts src/gateway/server.lazy.test.ts src/gateway/server/health-state.test.ts src/gateway/server/readiness.test.ts -- --reporter=verbose`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.
- `git diff --check`
