### PR TITLE
fix(agents): guard CLI loopback prompt tools

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1240,6 +1240,112 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("ignores malformed loopback prompt tools during CLI preparation", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      registerMemoryPromptSection(({ availableTools }) =>
+        availableTools.has("memory_search")
+          ? ["## Memory Recall", `tools=${[...availableTools].toSorted().join(",")}`, ""]
+          : [],
+      );
+      const unreadableNameTool = Object.defineProperty({}, "name", {
+        get() {
+          throw new Error("loopback tool name getter exploded");
+        },
+      });
+      const unreadableDescriptionTool = {
+        name: "memory_search",
+        label: "Memory Search",
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(),
+      };
+      Object.defineProperty(unreadableDescriptionTool, "description", {
+        get() {
+          throw new Error("loopback tool description getter exploded");
+        },
+      });
+      const unreadableParametersTool = {
+        name: "memory_lookup",
+        label: "Memory Lookup",
+        description: "Lookup memory",
+        execute: vi.fn(),
+      };
+      Object.defineProperty(unreadableParametersTool, "parameters", {
+        get() {
+          throw new Error("loopback tool parameters getter exploded");
+        },
+      });
+      const getActiveMcpLoopbackRuntime = vi.fn(() => ({
+        port: 31783,
+        ownerToken: "loopback-owner-token",
+        nonOwnerToken: "loopback-non-owner-token",
+      }));
+      const ensureMcpLoopbackServer = vi.fn(createTestMcpLoopbackServer);
+      const createMcpLoopbackServerConfig = vi.fn(createTestMcpLoopbackServerConfig);
+      const resolveMcpLoopbackScopedTools = vi.fn(() => ({
+        agentId: "main",
+        tools: [unreadableNameTool, unreadableDescriptionTool, unreadableParametersTool] as never,
+      }));
+      setCliRunnerPrepareTestDeps({
+        getActiveMcpLoopbackRuntime,
+        ensureMcpLoopbackServer,
+        createMcpLoopbackServerConfig,
+        resolveMcpLoopbackScopedTools,
+      });
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "native-cli",
+            pluginId: "native-plugin",
+            bundleMcp: true,
+            bundleMcpMode: "claude-config-file",
+            config: {
+              command: "native-cli",
+              args: ["--print"],
+              systemPromptArg: "--system-prompt",
+              systemPromptWhen: "first",
+              output: "text",
+              input: "arg",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "native-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-loopback-malformed-prompt-tools",
+        config: createCliBackendConfig({ bundleMcp: true }),
+        cliSessionBinding: {
+          sessionId: "cli-session",
+          promptToolNamesHash: "old-tool-surface",
+        },
+      });
+
+      expect(context.systemPrompt).toContain("## Memory Recall");
+      expect(context.systemPrompt).toContain("tools=memory_search");
+      expect(context.systemPromptReport.tools.entries.map((entry) => entry.name)).toEqual([
+        "memory_search",
+      ]);
+      expect(context.systemPromptReport.tools.entries.map((entry) => entry.summaryChars)).toEqual([
+        "memory_search".length,
+      ]);
+      expect(context.promptToolNamesHash).toBe(
+        hashCliSessionText(JSON.stringify(["memory_search"])),
+      );
+      expect(context.reusableCliSession).toEqual({ invalidatedReason: "system-prompt" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not advertise loopback prompt tools when the runtime is unavailable", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -13,6 +13,7 @@ import {
   resolveMcpLoopbackBearerToken,
 } from "../../gateway/mcp-http.loopback-runtime.js";
 import { resolveMcpLoopbackScopedTools } from "../../gateway/mcp-http.runtime.js";
+import { buildMcpToolSchema, type McpLoopbackTool } from "../../gateway/mcp-http.schema.js";
 import { isClaudeCliProvider } from "../../plugin-sdk/anthropic-cli.js";
 import type {
   CliBackendAuthEpochMode,
@@ -61,6 +62,7 @@ import { composeSystemPromptWithHookContext } from "../embedded-agent-runner/run
 import { buildCurrentInboundPrompt } from "../embedded-agent-runner/run/runtime-context-prompt.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
+import type { AgentTool } from "../runtime/index.js";
 import { ensureSystemPromptCacheBoundary } from "../system-prompt-cache-boundary.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt, buildModelIdentityPromptLine } from "../system-prompt.js";
@@ -106,6 +108,21 @@ const CLAUDE_CLI_CONTEXT_MODEL_ALIASES: Record<string, string> = {
   "sonnet-4.6": "claude-sonnet-4-6",
   "sonnet-4-6": "claude-sonnet-4-6",
 };
+
+const cliPromptToolExecute: AgentTool["execute"] = async () => ({
+  content: [],
+  details: undefined,
+});
+
+function sanitizeCliPromptTools(tools: readonly unknown[]): AgentTool[] {
+  return buildMcpToolSchema(tools as McpLoopbackTool[]).map((tool) => ({
+    name: tool.name,
+    label: tool.name,
+    description: tool.description ?? "",
+    parameters: tool.inputSchema as AgentTool["parameters"],
+    execute: cliPromptToolExecute,
+  }));
+}
 
 function resolveClaudeCliContextModelId(modelId: string): string {
   const trimmed = modelId.trim();
@@ -355,7 +372,7 @@ export async function prepareCliRunContext(
     ...(preparedBackendEnv ? { env: preparedBackendEnv } : {}),
     ...(preparedCleanup ? { cleanup: preparedCleanup } : {}),
   };
-  const promptTools =
+  const promptToolsRaw =
     bundleMcpEnabled && mcpLoopbackRuntime
       ? prepareDeps.resolveMcpLoopbackScopedTools({
           cfg: params.config ?? getRuntimeConfig(),
@@ -370,6 +387,7 @@ export async function prepareCliRunContext(
           senderIsOwner: params.senderIsOwner,
         }).tools
       : [];
+  const promptTools = sanitizeCliPromptTools(promptToolsRaw);
   const promptToolNamesHash =
     bundleMcpEnabled && mcpLoopbackRuntime
       ? hashCliSessionText(JSON.stringify(promptTools.map((tool) => tool.name).toSorted()))


### PR DESCRIPTION
## Summary
- Sanitize bundled MCP loopback prompt tools before CLI prompt construction, prompt-tool session hashing, and system-prompt reporting.
- Reuse the MCP loopback `tools/list` schema projection so unreadable names and unreadable schemas are dropped consistently with runtime availability.
- Add focused coverage for malformed loopback prompt-tool descriptors with throwing `name`, `description`, and `parameters` accessors.

## Verification
- `node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/cli-runner/prepare.ts src/agents/cli-runner/prepare.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/cli-runner/prepare.ts src/agents/cli-runner/prepare.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed"` (`run_2c99ade2d9a2`, provider `azure`, lease `cbx_ab574ce9ceef`, exit 0)

## Real behavior proof
Behavior addressed: CLI backend preparation no longer crashes before backend execution when a bundled MCP loopback prompt tool exposes unreadable descriptor properties.

Real environment tested: local focused CLI runner preparation tests on this branch, plus remote OpenClaw changed gate on Crabbox Azure Linux.

Exact steps or command run after this patch: focused Vitest, targeted oxfmt, targeted oxlint, `git diff --check origin/main...HEAD`, branch autoreview against `origin/main`, and remote `pnpm check:changed` through Crabbox.

Evidence after fix: focused Vitest passed 1 shard / 39 tests; targeted formatter, lint, and diff checks passed; branch autoreview reported no accepted/actionable findings on `54119481fae`; remote changed gate passed lanes `core` and `coreTests` in `run_2c99ade2d9a2`.

Observed result after fix: unreadable loopback tool names are skipped, unreadable optional descriptions do not crash prompt reporting, and unreadable schemas are dropped from the CLI prompt/report/hash surface to match MCP `tools/list` availability.

What was not tested: live CLI backend tool-call execution with a real external MCP client; the changed behavior was covered at CLI preparation and changed-gate level.
