### PR TITLE
whatsapp: expose connection watchdog tuning in account config

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -165,6 +165,19 @@ handoff path over manual terminal capture.
 - Gateway owns the WhatsApp socket and reconnect loop.
 - The reconnect watchdog uses WhatsApp Web transport activity, not only inbound app-message volume, so a quiet linked-device session is not restarted solely because nobody has sent a message recently. A longer application-silence cap still forces a reconnect if transport frames keep arriving but no application messages are handled for the watchdog window; after a transient reconnect for a recently active session, that application-silence check uses the normal message timeout for the first recovery window.
 - Baileys socket timings are explicit under `web.whatsapp.*`: `keepAliveIntervalMs` controls WhatsApp Web application pings, `connectTimeoutMs` controls the opening handshake timeout, and `defaultQueryTimeoutMs` controls Baileys query timeouts.
+- Reconnect watchdog tuning is explicit under `channels.whatsapp.watchdog.*` (or per-account at `channels.whatsapp.accounts.<id>.watchdog.*`): `messageTimeoutMs` is the app-silence cap (default 1_800_000), `transportTimeoutMs` is the WebSocket-silence cap (default 300_000), `watchdogCheckMs` is the evaluation interval (default 60_000). Raise `messageTimeoutMs` for use patterns with hour-long idle gaps between user-initiated turns; the WebSocket-level `transportTimeoutMs` still catches actually dead connections fast.
+
+  ```json5
+  {
+    channels: {
+      whatsapp: {
+        watchdog: {
+          messageTimeoutMs: 28800000, // 8 hours
+        },
+      },
+    },
+  }
+  ```
 - Outbound sends require an active WhatsApp listener for the target account.
 - Group sends attach native mention metadata for `@+<digits>` and `@<digits>` tokens in text and media captions when the token matches current WhatsApp participant metadata, including LID-backed groups.
 - Status and broadcast chats are ignored (`@status`, `@broadcast`).

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -165,7 +165,7 @@ handoff path over manual terminal capture.
 - Gateway owns the WhatsApp socket and reconnect loop.
 - The reconnect watchdog uses WhatsApp Web transport activity, not only inbound app-message volume, so a quiet linked-device session is not restarted solely because nobody has sent a message recently. A longer application-silence cap still forces a reconnect if transport frames keep arriving but no application messages are handled for the watchdog window; after a transient reconnect for a recently active session, that application-silence check uses the normal message timeout for the first recovery window.
 - Baileys socket timings are explicit under `web.whatsapp.*`: `keepAliveIntervalMs` controls WhatsApp Web application pings, `connectTimeoutMs` controls the opening handshake timeout, and `defaultQueryTimeoutMs` controls Baileys query timeouts.
-- Reconnect watchdog tuning is explicit under `channels.whatsapp.watchdog.*` (or per-account at `channels.whatsapp.accounts.<id>.watchdog.*`): `messageTimeoutMs` is the app-silence cap (default 1_800_000), `transportTimeoutMs` is the WebSocket-silence cap (default 300_000), `watchdogCheckMs` is the evaluation interval (default 60_000). Raise `messageTimeoutMs` for use patterns with hour-long idle gaps between user-initiated turns; the WebSocket-level `transportTimeoutMs` still catches actually dead connections fast.
+- Reconnect watchdog tuning is explicit under `channels.whatsapp.watchdog.*` (or per-account at `channels.whatsapp.accounts.<id>.watchdog.*`): `messageTimeoutMs` is the app-silence cap (default 1_800_000), `transportTimeoutMs` is the WebSocket-silence cap (default 300_000), `watchdogCheckMs` is the evaluation interval (default 60_000). Raise `messageTimeoutMs` for use patterns with hour-long idle gaps between user-initiated turns; the WebSocket-level `transportTimeoutMs` still catches actually dead connections fast. Per-account values override the channel-level default (same precedence as `dmHistoryLimit`, `mediaMaxMb`, and the other common keys), so you can ship a global default and tighten or loosen a single noisy account independently.
 
   ```json5
   {
@@ -178,6 +178,7 @@ handoff path over manual terminal capture.
     },
   }
   ```
+
 - Outbound sends require an active WhatsApp listener for the target account.
 - Group sends attach native mention metadata for `@+<digits>` and `@<digits>` tokens in text and media captions when the token matches current WhatsApp participant metadata, including LID-backed groups.
 - Status and broadcast chats are ignored (`@status`, `@broadcast`).

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -46,6 +46,7 @@ export type ResolvedWhatsAppAccount = {
   direct?: WhatsAppAccountConfig["direct"];
   debounceMs?: number;
   replyToMode?: ReplyToMode;
+  watchdog?: WhatsAppAccountConfig["watchdog"];
 };
 
 export const DEFAULT_WHATSAPP_MEDIA_MAX_MB = 50;
@@ -154,6 +155,7 @@ export function resolveWhatsAppAccount(params: {
     direct: merged.direct,
     debounceMs: merged.debounceMs,
     replyToMode: merged.replyToMode,
+    watchdog: merged.watchdog,
   };
 }
 

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -313,6 +313,13 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
           const { e164, jid } = (await loadWhatsAppChannelRuntime()).readWebSelfId(account.authDir);
           const identity = e164 ? e164 : jid ? `jid ${jid}` : "unknown";
           ctx.log?.info(`[${account.accountId}] starting provider (${identity})`);
+          // Pass through optional watchdog tuning from openclaw.json. When the
+          // operator hasn't configured `channels.whatsapp.watchdog.*` (or the
+          // per-account override), the receiver applies its internal defaults
+          // (monitor.ts: messageTimeoutMs=30min, transportTimeoutMs=5min,
+          // watchdogCheckMs=1min). See `WhatsAppWatchdogSchema` for guidance
+          // on when to override.
+          const watchdog = account.watchdog;
           return (await loadWhatsAppChannelRuntime()).monitorWebChannel(
             getWhatsAppRuntime().logging.shouldLogVerbose(),
             undefined,
@@ -325,6 +332,15 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
                 ctx.setStatus({ accountId: ctx.accountId, ...next }),
               accountId: account.accountId,
               channelRuntime: ctx.channelRuntime,
+              ...(watchdog?.messageTimeoutMs !== undefined && {
+                messageTimeoutMs: watchdog.messageTimeoutMs,
+              }),
+              ...(watchdog?.transportTimeoutMs !== undefined && {
+                transportTimeoutMs: watchdog.transportTimeoutMs,
+              }),
+              ...(watchdog?.watchdogCheckMs !== undefined && {
+                watchdogCheckMs: watchdog.watchdogCheckMs,
+              }),
             },
           );
         },

--- a/src/config/zod-schema.providers-whatsapp.test.ts
+++ b/src/config/zod-schema.providers-whatsapp.test.ts
@@ -212,4 +212,61 @@ describe("WhatsApp prompt config Zod validation", () => {
       expect(result.data.accounts?.work?.pluginHooks?.messageReceived).toBe(false);
     }
   });
+
+  it("accepts channel-level watchdog tuning", () => {
+    const config = {
+      watchdog: {
+        messageTimeoutMs: 28800000,
+        transportTimeoutMs: 300000,
+        watchdogCheckMs: 60000,
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.watchdog?.messageTimeoutMs).toBe(28800000);
+      expect(result.data.watchdog?.transportTimeoutMs).toBe(300000);
+      expect(result.data.watchdog?.watchdogCheckMs).toBe(60000);
+    }
+  });
+
+  it("accepts account-level watchdog override of messageTimeoutMs", () => {
+    const config = {
+      accounts: {
+        work: {
+          watchdog: {
+            messageTimeoutMs: 14400000,
+          },
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accounts?.work?.watchdog?.messageTimeoutMs).toBe(14400000);
+    }
+  });
+
+  it("rejects extra properties in watchdog", () => {
+    const config = {
+      watchdog: {
+        messageTimeoutMs: 28800000,
+        unknownKey: true,
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-positive watchdog values", () => {
+    expect(
+      WhatsAppConfigSchema.safeParse({ watchdog: { messageTimeoutMs: 0 } }).success,
+    ).toBe(false);
+    expect(
+      WhatsAppConfigSchema.safeParse({ watchdog: { transportTimeoutMs: -1 } }).success,
+    ).toBe(false);
+  });
 });

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -56,6 +56,48 @@ const WhatsAppPluginHooksSchema = z
   .strict()
   .optional();
 
+/**
+ * Connection watchdog tuning for WhatsApp Web.
+ *
+ * The plugin's connection watchdog (`extensions/whatsapp/src/connection-controller.ts`)
+ * fires when EITHER:
+ *   - `transportSilentMs > transportTimeoutMs` (WebSocket idle — no ping/pong), OR
+ *   - `appSilentMs > messageTimeoutMs * <1|4>` (no app messages in/out)
+ *
+ * On fire it kills the WhatsApp Web socket with status 499 and reconnects. The
+ * `messageTimeoutMs` default (1_800_000 = 30 min) is too aggressive for use
+ * patterns with hours-long idle gaps between user-initiated turns (personal
+ * assistants, on-call bots) — every 30 min of silence triggers a recycle, and
+ * any in-flight dispatch races the abort (leaving `pendingFinalDelivery` stuck).
+ *
+ * Operators should be able to raise the threshold to fit their workload. All
+ * three knobs are optional — when unset, the existing internal defaults apply.
+ */
+const WhatsAppWatchdogSchema = z
+  .object({
+    /**
+     * App-level silence before forcing a reconnect, in ms.
+     * Internal default: 1_800_000 (30 min). Set higher for idle-prone use
+     * patterns; the WebSocket-level `transportTimeoutMs` still catches actually
+     * dead connections fast.
+     */
+    messageTimeoutMs: z.number().int().positive().optional(),
+    /**
+     * Transport-layer silence before forcing a reconnect, in ms.
+     * Internal default: 300_000 (5 min). Lower this on flaky networks; raise
+     * it on slow links where ping/pong takes longer than typical.
+     */
+    transportTimeoutMs: z.number().int().positive().optional(),
+    /**
+     * How often the watchdog evaluates the thresholds, in ms.
+     * Internal default: 60_000 (1 min). Lower values detect dead connections
+     * faster at the cost of more frequent timer wake-ups.
+     */
+    watchdogCheckMs: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 function stripDeprecatedWhatsAppNoopKeys(value: unknown): unknown {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return value;
@@ -107,6 +149,7 @@ function buildWhatsAppCommonShape(params: { useDefaults: boolean }) {
     heartbeat: ChannelHeartbeatVisibilitySchema,
     healthMonitor: ChannelHealthMonitorSchema,
     pluginHooks: WhatsAppPluginHooksSchema,
+    watchdog: WhatsAppWatchdogSchema,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds optional `channels.whatsapp.watchdog.*` (and per-account override at `channels.whatsapp.accounts.<id>.watchdog.*`) to the WhatsApp channel config schema, plumbed through to the existing `WebMonitorTuning` parameter of `monitorWebChannel`.

Fixes #89210. Significantly reduces the rate at which #89115 fires for operators whose use pattern is idle-prone.

## Background

The `WebMonitorTuning` type at `extensions/whatsapp/src/auto-reply/types.ts:36-50` already includes the three knobs the connection watchdog reads. The gateway caller at `extensions/whatsapp/src/channel.ts:316` constructs the `tuning` object with only `{statusSink, accountId, channelRuntime}`, so the receivers fall back to internal defaults:

| Knob | Internal default | Meaning |
|---|---|---|
| `transportTimeoutMs` | 300_000 (5 min) | WebSocket silent (no ping/pong) |
| `messageTimeoutMs`   | 1_800_000 (30 min) | No app messages in/out |
| `watchdogCheckMs`    | 60_000 (1 min) | Evaluation interval |

When `connection.openedAfterRecentInbound === true` (basically any active chat session per `connection-controller.ts:385`), the app-silence trigger uses `messageTimeoutMs * 1`. Otherwise `messageTimeoutMs * 4`.

For deployments whose use pattern includes hour-long idle gaps between user-initiated turns (personal assistants, on-call bots, infrequent-message workloads), the 30-min default recycles the WhatsApp Web socket on a regular cadence during idle. Any in-flight dispatch that races the abort window leaves `pendingFinalDelivery` stuck on the session — the upstream dispatch race documented in #89115. The race fires roughly as often as the watchdog cycles.

This PR doesn't touch the watchdog mechanism. It only adds the config plumbing so operators can move the trigger out of their normal idle window.

## Changes

| File | What |
|---|---|
| `src/config/zod-schema.providers-whatsapp.ts` | Add `WhatsAppWatchdogSchema` + include in `buildWhatsAppCommonShape` so both channel-root and per-account paths accept it |
| `extensions/whatsapp/src/channel.ts` | Read `account.watchdog` in `startAccount` and spread defined fields into the `tuning` arg of `monitorWebChannel` |
| `extensions/whatsapp/src/accounts.ts` | Add `watchdog?: WhatsAppAccountConfig["watchdog"]` to `ResolvedWhatsAppAccount` + return from the resolver (added in 8dad90fe — the static-type plumbing pair to the zod-inferred type) |
| `docs/channels/whatsapp.md` | New bullet under "Runtime model" with a JSON5 example. Includes explicit precedence note: per-account overrides channel-level, same as `dmHistoryLimit` / `mediaMaxMb` |
| `src/config/zod-schema.providers-whatsapp.test.ts` | 4 new cases: channel-level, account-level, strict-reject extras, reject non-positive values |

## Design notes

- **All three fields optional.** Unset preserves existing behavior — no operator action required on upgrade.
- **`.int().positive()`.** Rejects 0 and negative. An explicit "disable the watchdog" would also disable the transport-dead check, which is the genuinely-useful safety belt. Operators who want the WebSocket-level check but a very lenient app-silence cap can set `messageTimeoutMs` to a large value (e.g., 8h, 24h).
- **`.strict()`.** Surfaces typos in the config; consistent with adjacent schemas (`WhatsAppAckReactionSchema`, `WhatsAppPluginHooksSchema`).
- **Spread pattern in `channel.ts`.** Only spreads fields that are `!== undefined` so an empty `watchdog: {}` and an absent `watchdog` both behave identically (receiver applies its own internal defaults).
- **Channel-root and per-account.** Lives in `buildWhatsAppCommonShape` so both levels accept it; the existing config-merge surface handles precedence (account overrides channel) the same as `dmHistoryLimit` and the other common keys.

## Real behavior proof

Production setup: single-tenant `openclaw 2026.5.28` gateway in Docker, single WhatsApp account, run as a personal assistant with hour-long idle gaps between user turns.

**Before** — 30-min cycle observed under default `messageTimeoutMs`. Container logs `2026-06-01T17:53:37Z` and `T18:23:40Z` (exactly 30 min apart):

```
17:53:37 [whatsapp] watchdog timeout (app-silent) - restarting connection
17:53:37 [whatsapp] Web connection closed (status 499). Retry 1/12 in 2.04s… (status=499)
18:23:40 [whatsapp] watchdog timeout (app-silent) - restarting connection
18:23:40 [whatsapp] Web connection closed (status 499). Retry 1/12 in 2.01s… (status=499)
```

Each disconnect raced the in-flight dispatch and left at least one `pendingFinalDelivery` stuck on either the `openclaw` or `research` agent session (the upstream race in #89115). User-visible: agent "went silent." Our local cron-watchdog auto-flushed the stuck flag after detection, but real time between question and answer regularly hit 2h.

**Bridge** — patched `messageTimeoutMs` default to 28_800_000 (8h) in the bundled `monitor-*.js` to validate `tuning.messageTimeoutMs` flows where this PR expects it to flow:

```dockerfile
RUN sed -i 's|messageTimeoutMs = tuning.messageTimeoutMs ?? 1800 \* 1e3|messageTimeoutMs = tuning.messageTimeoutMs ?? 28800 * 1e3|' \
    /usr/local/lib/node_modules/@openclaw/whatsapp/dist/monitor-*.js
```

The OC gateway loads plugins from the user-local search path `/home/node/.openclaw/npm/node_modules/@openclaw/whatsapp/` BEFORE the bundled `/usr/local/lib/...` path, so we also patch the user-local copy at entrypoint runtime (node user has write access there).

**After** — entrypoint log `2026-06-02T09:29:22Z`:

```
[2026-06-02T09:29:22+00:00] [whatsapp-patch] OK: already patched (8h) in bundled (/usr/local/lib/node_modules/@openclaw/whatsapp/dist/monitor-Ccph7Y8M.js)
[2026-06-02T09:29:22+00:00] [whatsapp-patch] applied 30min → 8h at runtime in user-npm (PRIMARY load path) (/home/node/.openclaw/npm/node_modules/@openclaw/whatsapp/dist/monitor-C5_C_RGJ.js)
```

File contents post-fix:

```
$ grep messageTimeoutMs /home/node/.openclaw/npm/node_modules/@openclaw/whatsapp/dist/monitor-C5_C_RGJ.js
const messageTimeoutMs = tuning.messageTimeoutMs ?? 28800 * 1e3;
$ grep messageTimeoutMs /usr/local/lib/node_modules/@openclaw/whatsapp/dist/monitor-Ccph7Y8M.js
const messageTimeoutMs = tuning.messageTimeoutMs ?? 28800 * 1e3;
```

Live container — zero `watchdog timeout (app-silent)` events since 09:29 UTC:

```
$ sudo docker logs docker-clawdbot-gateway-1 --since 09:29 2>&1 | grep -c "watchdog timeout"
0
```

For reference, before the dual-path patch, the same container reliably logged the `(app-silent)` line every 30 min during chat sessions and every 2h overnight (the `appSilenceTimeoutMs = messageTimeoutMs * 4` fallback). After the dual-path patch, none.

With this PR landed, the bridge above (sed against bundled dist files in two locations) goes away and is replaced by a single config block in `openclaw.json`:

```json5
{
  channels: {
    whatsapp: {
      watchdog: {
        messageTimeoutMs: 28800000,
      },
    },
  },
}
```

## Test plan

- [x] `pnpm test src/config/zod-schema.providers-whatsapp.test.ts` — 4 new tests pass alongside existing 11
- [x] `pnpm tsc --noEmit` — type-check (`account.watchdog` propagates from schema to `WhatsAppAccountConfig` via the existing `OpenClawConfig` inference chain; static `ResolvedWhatsAppAccount` updated in `8dad90fe`)
- [x] `pnpm format:docs:check` — passes after `oxfmt --write` on `docs/channels/whatsapp.md`
- [x] Manual: production patched `monitor-*.js` to 8h, observed absence of `watchdog timeout (app-silent)` log line across multiple chat sessions and idle periods (see Real behavior proof section above)

I haven't run the full local suite — happy to fix anything reviewers flag.
