### PR TITLE
fix(agents): avoid duplicate generated media fallback

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -2403,6 +2403,60 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("falls back when targetless message-tool media names a different provider", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        messagingToolSentMediaUrls: ["/tmp/generated-night-drive.mp3"],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: undefined,
+            text: "The track is ready.",
+            mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          },
+        ],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceTool: "music_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "music_generation",
+          childSessionKey: "music_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "music generation task",
+          taskLabel: "night-drive synthwave",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 track.\nMEDIA:/tmp/generated-night-drive.mp3",
+          mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          replyInstruction: "Deliver the generated music through the message tool.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        accountId: "acct-1",
+        to: "dm:U123",
+        content: "The generated music is ready.",
+        mediaUrls: ["/tmp/generated-night-drive.mp3"],
+        idempotencyKey: "announce-dm-fallback-empty:generated-media-direct",
+      }),
+    );
+  });
+
   it("falls back when message-tool media went to a different target", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -2357,6 +2357,52 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("does not fallback when current-chat message-tool media also has target telemetry", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        messagingToolSentMediaUrls: ["/tmp/generated-night-drive.mp3"],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "message",
+            to: undefined,
+            threadId: undefined,
+            text: "The track is ready.",
+            mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          },
+        ],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceTool: "music_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "music_generation",
+          childSessionKey: "music_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "music generation task",
+          taskLabel: "night-drive synthwave",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 track.\nMEDIA:/tmp/generated-night-drive.mp3",
+          mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          replyInstruction: "Deliver the generated music through the message tool.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("falls back when message-tool media went to a different target", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1117,6 +1117,15 @@ function collectMessagingToolDeliveredMediaUrlsForTarget(
     const targetRecord = target as Record<string, unknown>;
     const targetTo = typeof targetRecord.to === "string" ? targetRecord.to.trim() : "";
     if (!targetTo) {
+      if (
+        !deliveryTarget.to ||
+        !sourceDeliveryTargetsMatch({ ...targetRecord, to: deliveryTarget.to }, deliveryTarget)
+      ) {
+        for (const url of targetMediaUrls) {
+          targetedUrls.add(url);
+        }
+        continue;
+      }
       for (const url of targetMediaUrls) {
         urls.add(url);
       }

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1111,15 +1111,21 @@ function collectMessagingToolDeliveredMediaUrlsForTarget(
     const targetMediaUrls = collectMessagingToolDeliveredMediaUrls({
       messagingToolSentTargets: [target],
     });
+    if (!target || typeof target !== "object" || Array.isArray(target)) {
+      continue;
+    }
+    const targetRecord = target as Record<string, unknown>;
+    const targetTo = typeof targetRecord.to === "string" ? targetRecord.to.trim() : "";
+    if (!targetTo) {
+      for (const url of targetMediaUrls) {
+        urls.add(url);
+      }
+      continue;
+    }
     for (const url of targetMediaUrls) {
       targetedUrls.add(url);
     }
-    if (
-      !target ||
-      typeof target !== "object" ||
-      Array.isArray(target) ||
-      !sourceDeliveryTargetsMatch(target as Record<string, unknown>, deliveryTarget)
-    ) {
+    if (!sourceDeliveryTargetsMatch(targetRecord, deliveryTarget)) {
       continue;
     }
     for (const url of targetMediaUrls) {


### PR DESCRIPTION
## Summary

- Treat targetless current-chat message-tool media telemetry as delivered for generated-media completion dedupe.
- Keep fallback delivery for targetless telemetry that names a different provider/account/thread.
- Add regression coverage for both the observed duplicate-send shape and the mismatched-provider safety case.

## Verification

- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts`
- `node scripts/run-oxlint.mjs src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts`
- `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts` -> 92 tests passed
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: generated-media completion fallback no longer sends a duplicate `The generated image is ready.` copy when the message tool already delivered media to the current chat but telemetry omitted an explicit `to` target.

Real environment tested: local macOS Messages/iMessage private API with the LaunchAgent gateway running the rebuilt dist that included this patch.

Exact steps or command run after this patch: Sent this real iMessage: `Ok generate a new image now of a Lobster ready to launch like a Rocket into space.` Then inspected `/opt/homebrew/bin/imsg history --chat-id 3 --limit 30 --attachments --json` and `~/.openclaw/logs/openclaw.log`.

Evidence after fix: iMessage DB shows inbound request id `5805` at `2026-06-01T20:55:49.931Z`, followed by exactly one outgoing generated-image reply id `5806` at `2026-06-01T20:57:14.450Z` with one PNG attachment (`upload.png`, `2360236` bytes) and text `🦞 Here’s the rocket-launch lobster image.` The next latest generated-image run before this patch showed duplicate fallback messages such as `The generated image is ready.`; the post-fix run has no such follow-up fallback after id `5806`.

Observed result after fix: requester confirmed the generated-image turn delivered once. Gateway log for the same turn shows the final source reply was suppressed under `sourceReplyDeliveryMode: message_tool_only` after media delivery (`textChars=0 media=1`) and the dispatch completed successfully in about 84s.

What was not tested: CI cannot exercise real Messages.app delivery; live proof is from the local macOS iMessage setup and the requester's observation.
