### PR TITLE
fix(agents): guard Anthropic tool descriptors

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -623,6 +623,16 @@ describe("anthropic transport stream", () => {
           messages: [{ role: "user", content: "Read the file" }],
           tools: [
             {
+              get name() {
+                throw new Error("anthropic oauth tool name getter exploded");
+              },
+              description: "unreadable name",
+              parameters: {
+                type: "object",
+                properties: {},
+              },
+            },
+            {
               name: "read",
               description: "Read a file",
               parameters: {
@@ -1186,11 +1196,75 @@ describe("anthropic transport stream", () => {
   });
 
   it("skips malformed tools when building Anthropic payloads", async () => {
+    const unreadableName = {
+      get name() {
+        throw new Error("anthropic tool name getter exploded");
+      },
+      description: "unreadable name",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+    };
+    const unreadableDescription = {
+      name: "description_poisoned_tool",
+      get description() {
+        throw new Error("anthropic tool description getter exploded");
+      },
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+      },
+    };
+    const unreadableParameters = {
+      name: "parameters_poisoned_tool",
+      description: "unreadable parameters",
+      get parameters() {
+        throw new Error("anthropic tool parameters getter exploded");
+      },
+    };
+    const dynamicSchema = {
+      name: "dynamic_schema_tool",
+      description: "unsupported dynamic schema",
+      parameters: {
+        type: "object",
+        properties: {
+          target: { $dynamicRef: "#target" },
+        },
+      },
+    };
+    const toJsonProjectedSchema = {
+      name: "tojson_projected_tool",
+      description: "schema projection differs from live properties",
+      parameters: {
+        type: "object",
+        properties: {
+          target: { $dynamicRef: "#target" },
+        },
+        toJSON() {
+          return {
+            type: "object",
+            properties: {
+              safe: { type: "string" },
+            },
+            required: ["safe"],
+          };
+        },
+      },
+    };
+
     await runTransportStream(
       makeAnthropicTransportModel(),
       {
         messages: [{ role: "user", content: "hello" }],
         tools: [
+          unreadableName,
+          unreadableDescription,
+          unreadableParameters,
+          dynamicSchema,
+          toJsonProjectedSchema,
           {
             name: "bad_plugin_tool",
             description: "missing schema",
@@ -1215,10 +1289,24 @@ describe("anthropic transport stream", () => {
     );
 
     const tools = requireArray(latestAnthropicRequest().payload.tools, "tools");
-    expect(tools).toHaveLength(1);
-    const tool = requireRecord(tools[0], "tool");
-    expect(tool.name).toBe("good_plugin_tool");
-    expect(requireRecord(tool.input_schema, "input schema").properties).toEqual({
+    expect(tools).toHaveLength(3);
+    const descriptionPoisonedTool = requireRecord(tools[0], "description poisoned tool");
+    expect(descriptionPoisonedTool.name).toBe("description_poisoned_tool");
+    expect(descriptionPoisonedTool).not.toHaveProperty("description");
+    expect(requireRecord(descriptionPoisonedTool.input_schema, "input schema").properties).toEqual({
+      query: { type: "string" },
+    });
+    const projectedTool = requireRecord(tools[1], "projected tool");
+    expect(projectedTool.name).toBe("tojson_projected_tool");
+    expect(requireRecord(projectedTool.input_schema, "input schema")).toMatchObject({
+      properties: {
+        safe: { type: "string" },
+      },
+      required: ["safe"],
+    });
+    const goodTool = requireRecord(tools[2], "good tool");
+    expect(goodTool.name).toBe("good_plugin_tool");
+    expect(requireRecord(goodTool.input_schema, "input schema").properties).toEqual({
       query: { type: "string" },
     });
   });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -14,6 +14,7 @@ import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
 import type { StreamFn } from "./runtime/index.js";
+import { projectRuntimeToolInputSchema } from "./tool-schema-projection.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
   coerceTransportToolCallArguments,
@@ -241,13 +242,22 @@ function toClaudeCodeName(name: string): string {
 }
 
 function fromClaudeCodeName(name: string, tools: Context["tools"] | undefined): string {
-  if (tools && tools.length > 0) {
-    const lowerName = normalizeLowercaseStringOrEmpty(name);
-    const matchedTool = tools.find(
-      (tool) => normalizeLowercaseStringOrEmpty(tool.name) === lowerName,
-    );
-    if (matchedTool) {
-      return matchedTool.name;
+  if (!tools) {
+    return name;
+  }
+  const toolCount = readAnthropicToolCount(tools);
+  if (!toolCount) {
+    return name;
+  }
+  const lowerName = normalizeLowercaseStringOrEmpty(name);
+  for (let toolIndex = 0; toolIndex < toolCount; toolIndex += 1) {
+    const tool = readAnthropicToolAt(tools, toolIndex);
+    if (!tool) {
+      continue;
+    }
+    const toolName = readAnthropicToolField(tool, "name");
+    if (typeof toolName === "string" && normalizeLowercaseStringOrEmpty(toolName) === lowerName) {
+      return toolName;
     }
   }
   return name;
@@ -474,8 +484,46 @@ function ensureNonEmptyAnthropicMessages(messages: Array<Record<string, unknown>
     : [{ role: "user", content: EMPTY_ANTHROPIC_MESSAGES_FALLBACK_TEXT }];
 }
 
+function readAnthropicToolField<TField extends keyof NonNullable<Context["tools"]>[number]>(
+  tool: NonNullable<Context["tools"]>[number],
+  field: TField,
+): NonNullable<Context["tools"]>[number][TField] | undefined {
+  try {
+    return tool[field];
+  } catch {
+    return undefined;
+  }
+}
+
+function isAnthropicObjectSchema(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function readAnthropicToolCount(tools: NonNullable<Context["tools"]>): number | undefined {
+  try {
+    return tools.length;
+  } catch {
+    return undefined;
+  }
+}
+
+function readAnthropicToolAt(
+  tools: NonNullable<Context["tools"]>,
+  index: number,
+): NonNullable<Context["tools"]>[number] | undefined {
+  try {
+    return tools[index];
+  } catch {
+    return undefined;
+  }
+}
+
 function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
   if (!tools) {
+    return [];
+  }
+  const toolCount = readAnthropicToolCount(tools);
+  if (toolCount === undefined) {
     return [];
   }
   const converted: Array<{
@@ -487,24 +535,38 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
       required: unknown;
     };
   }> = [];
-  for (const tool of tools) {
+  for (let toolIndex = 0; toolIndex < toolCount; toolIndex += 1) {
     // Main quarantine happens when plugin tools materialize; this keeps Anthropic
     // safe for direct/custom tool arrays that bypass the plugin registry.
-    const parameters =
-      tool.parameters && typeof tool.parameters === "object" && !Array.isArray(tool.parameters)
-        ? (tool.parameters as Record<string, unknown>)
-        : undefined;
-    if (!parameters) {
+    const tool = readAnthropicToolAt(tools, toolIndex);
+    if (!tool) {
       continue;
     }
-    converted.push({
-      name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
-      description: tool.description,
+    const rawName = readAnthropicToolField(tool, "name");
+    const parameters = readAnthropicToolField(tool, "parameters");
+    const description = readAnthropicToolField(tool, "description");
+    if (typeof rawName !== "string" || !rawName) {
+      continue;
+    }
+    const projectedSchema = projectRuntimeToolInputSchema(parameters, `${rawName}.parameters`);
+    if (projectedSchema.violations.length > 0) {
+      continue;
+    }
+    if (!isAnthropicObjectSchema(projectedSchema.schema)) {
+      continue;
+    }
+    const parametersRecord = projectedSchema.schema;
+    const convertedTool = {
+      name: isOAuthToken ? toClaudeCodeName(rawName) : rawName,
       input_schema: {
-        type: "object",
-        properties: parameters.properties || {},
-        required: parameters.required || [],
+        type: "object" as const,
+        properties: parametersRecord.properties || {},
+        required: parametersRecord.required || [],
       },
+    };
+    converted.push({
+      ...convertedTool,
+      ...(typeof description === "string" ? { description } : {}),
     });
   }
   return converted;


### PR DESCRIPTION
## Summary
- Guard Anthropic tool payload construction against unreadable tool arrays and descriptor fields.
- Build Anthropic `input_schema` from the same runtime-projected JSON schema that is inspected for unsupported dynamic schemas.
- Harden OAuth Claude-Code tool-name remapping so skipped malformed descriptors cannot crash returned tool calls.

## Verification
- `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --idle-timeout 90m --ttl 240m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed"` (`run_f1156640d9ad`, provider `azure`, lease `cbx_4aba2b40b8eb`, exit 0)

## Real behavior proof
Behavior addressed: Anthropic-family request construction and OAuth response tool-name remapping no longer crash when direct/custom tool descriptors expose unreadable fields or unsupported dynamic schemas.

Real environment tested: local focused Anthropic transport tests on this branch, plus remote OpenClaw changed gate on Crabbox Azure Linux.

Exact steps or command run after this patch: focused Vitest, targeted oxfmt, targeted oxlint, `git diff --check origin/main...HEAD`, branch autoreview against `origin/main`, and remote `pnpm check:changed` through Crabbox.

Evidence after fix: focused Vitest passed 1 shard / 49 tests; targeted formatter, lint, and diff checks passed; branch autoreview reported no accepted/actionable findings on `d5addd7bce7`; remote changed gate passed lanes `core` and `coreTests` in `run_f1156640d9ad`.

Observed result after fix: unreadable tool names and parameter schemas are skipped, unreadable optional descriptions are omitted, `$dynamicRef` schemas are not sent, projected `toJSON()` schemas are emitted consistently, and OAuth `Read` tool-use responses still remap to the original `read` tool without scanning poisoned descriptors.

What was not tested: live Anthropic provider execution with real credentials; the changed behavior was covered at transport payload/remapping and changed-gate level.
