### PR TITLE
fix(llm): guard Anthropic provider tool descriptors

### DIFF
--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -3,12 +3,16 @@ import type { Context, Model } from "../types.js";
 
 const anthropicMockState = vi.hoisted(() => ({
   configs: [] as unknown[],
+  createImpl: null as null | ((params: unknown, options: unknown) => unknown),
 }));
 
 vi.mock("@anthropic-ai/sdk", () => ({
   default: class MockAnthropic {
     messages = {
-      create: vi.fn(() => {
+      create: vi.fn((params: unknown, options: unknown) => {
+        if (anthropicMockState.createImpl) {
+          return anthropicMockState.createImpl(params, options);
+        }
         throw new Error("stop after constructor");
       }),
     };
@@ -22,7 +26,9 @@ vi.mock("@anthropic-ai/sdk", () => ({
 import { streamAnthropic, streamSimpleAnthropic } from "./anthropic.js";
 
 function createSseResponse(events: Record<string, unknown>[] = []): Response {
-  const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+  const body = events
+    .map((event) => `event: ${String(event.type)}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream" },
@@ -48,6 +54,7 @@ function makeAnthropicModel(overrides: Partial<Model<"anthropic-messages">> = {}
 describe("Anthropic provider", () => {
   beforeEach(() => {
     anthropicMockState.configs = [];
+    anthropicMockState.createImpl = null;
   });
 
   it("keeps Cloudflare AI Gateway upstream provider auth on the Anthropic API key", async () => {
@@ -166,6 +173,214 @@ describe("Anthropic provider", () => {
         signature: "reasoning_content",
       },
     ]);
+  });
+
+  it("skips malformed tools when building Anthropic provider payloads", async () => {
+    let capturedPayload: unknown;
+    const tools = [
+      {
+        get name() {
+          throw new Error("legacy anthropic tool name getter exploded");
+        },
+        description: "unreadable name",
+        parameters: { type: "object", properties: {} },
+      },
+      {
+        name: "description_poisoned_tool",
+        get description() {
+          throw new Error("legacy anthropic tool description getter exploded");
+        },
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+        },
+      },
+      {
+        name: "parameters_poisoned_tool",
+        get parameters() {
+          throw new Error("legacy anthropic tool parameters getter exploded");
+        },
+      },
+      {
+        name: "dynamic_schema_tool",
+        description: "unsupported dynamic schema",
+        parameters: {
+          type: "object",
+          properties: {
+            target: { $dynamicRef: "#target" },
+          },
+        },
+      },
+      {
+        name: "tojson_projected_tool",
+        description: "schema projection differs from live properties",
+        parameters: {
+          type: "object",
+          properties: {
+            target: { $dynamicRef: "#target" },
+          },
+          toJSON() {
+            return {
+              type: "object",
+              properties: {
+                safe: { type: "string" },
+              },
+              required: ["safe"],
+            };
+          },
+        },
+      },
+      {
+        name: "dynamic_keyword_field_tool",
+        description: "schema map names can look like dynamic schema keywords",
+        parameters: {
+          type: "object",
+          properties: {
+            $dynamicRef: { type: "string" },
+          },
+          required: ["$dynamicRef"],
+        },
+      },
+      {
+        name: "good_plugin_tool",
+        description: "valid schema",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+      },
+    ];
+
+    const stream = streamAnthropic(
+      makeAnthropicModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools,
+      } as unknown as Context,
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("stop before network");
+    const payloadTools = (capturedPayload as { tools?: Array<Record<string, unknown>> }).tools;
+    expect(payloadTools).toHaveLength(4);
+    expect(payloadTools?.[0]).toMatchObject({
+      name: "description_poisoned_tool",
+      input_schema: {
+        properties: {
+          query: { type: "string" },
+        },
+      },
+    });
+    expect(payloadTools?.[0]).not.toHaveProperty("description");
+    expect(payloadTools?.[1]).toMatchObject({
+      name: "tojson_projected_tool",
+      input_schema: {
+        properties: {
+          safe: { type: "string" },
+        },
+        required: ["safe"],
+      },
+    });
+    expect(payloadTools?.[2]).toMatchObject({
+      name: "dynamic_keyword_field_tool",
+      description: "schema map names can look like dynamic schema keywords",
+      input_schema: {
+        properties: {
+          $dynamicRef: { type: "string" },
+        },
+        required: ["$dynamicRef"],
+      },
+    });
+    expect(payloadTools?.[3]).toMatchObject({
+      name: "good_plugin_tool",
+      description: "valid schema",
+      input_schema: {
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      },
+    });
+  });
+
+  it("remaps OAuth tool-use names without scanning poisoned descriptors", async () => {
+    anthropicMockState.createImpl = () => ({
+      asResponse: () =>
+        Promise.resolve(
+          createSseResponse([
+            {
+              type: "message_start",
+              message: { id: "msg_1", usage: { input_tokens: 1, output_tokens: 0 } },
+            },
+            {
+              type: "content_block_start",
+              index: 0,
+              content_block: {
+                type: "tool_use",
+                id: "toolu_1",
+                name: "Read",
+                input: { file_path: "README.md" },
+              },
+            },
+            { type: "content_block_stop", index: 0 },
+            {
+              type: "message_delta",
+              delta: { stop_reason: "tool_use" },
+              usage: { input_tokens: 1, output_tokens: 1 },
+            },
+            { type: "message_stop" },
+          ]),
+        ),
+    });
+    const tools = [
+      {
+        get name() {
+          throw new Error("legacy anthropic OAuth remap name getter exploded");
+        },
+        description: "unreadable name",
+        parameters: { type: "object", properties: {} },
+      },
+      {
+        name: "read",
+        description: "read a file",
+        parameters: { type: "object", properties: {} },
+      },
+    ];
+
+    const stream = streamAnthropic(
+      makeAnthropicModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools,
+      } as unknown as Context,
+      {
+        apiKey: "sk-ant-oat-example",
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(result.content).toContainEqual(
+      expect.objectContaining({
+        type: "toolCall",
+        name: "read",
+      }),
+    );
   });
 
   it("clamps max adaptive effort when the Claude model does not advertise it", async () => {

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -97,15 +97,50 @@ const ccToolLookup = new Map(claudeCodeTools.map((t) => [t.toLowerCase(), t]));
 // Convert tool name to CC canonical casing if it matches (case-insensitive)
 const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) ?? name;
 const fromClaudeCodeName = (name: string, tools?: Tool[]) => {
-  if (tools && tools.length > 0) {
-    const lowerName = name.toLowerCase();
-    const matchedTool = tools.find((tool) => tool.name.toLowerCase() === lowerName);
-    if (matchedTool) {
-      return matchedTool.name;
+  const toolCount = readToolCount(tools);
+  if (!tools || toolCount === undefined || toolCount <= 0) {
+    return name;
+  }
+  const lowerName = name.toLowerCase();
+  for (let index = 0; index < toolCount; index += 1) {
+    const tool = readToolAt(tools, index);
+    const toolName = tool ? readToolField(tool, "name") : undefined;
+    if (typeof toolName === "string" && toolName.toLowerCase() === lowerName) {
+      return toolName;
     }
   }
   return name;
 };
+
+function readToolCount(tools?: readonly Tool[]): number | undefined {
+  if (!tools) {
+    return undefined;
+  }
+  try {
+    return tools.length;
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolAt(tools: readonly Tool[], index: number): Tool | undefined {
+  try {
+    return tools[index];
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolField<TField extends keyof Tool>(
+  tool: Tool,
+  field: TField,
+): Tool[TField] | undefined {
+  try {
+    return tool[field];
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Convert content blocks to Anthropic API format
@@ -1229,31 +1264,117 @@ function shouldUseFineGrainedToolStreamingBeta(
   );
 }
 
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+const schemaMapKeywords = new Set([
+  "$defs",
+  "definitions",
+  "dependencies",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+
+function hasDynamicSchemaKeyword(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(hasDynamicSchemaKeyword);
+  }
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  if ("$dynamicRef" in value || "$dynamicAnchor" in value) {
+    return true;
+  }
+  for (const [key, childValue] of Object.entries(value)) {
+    if (!childValue || typeof childValue !== "object") {
+      continue;
+    }
+    if (schemaMapKeywords.has(key) && isJsonObject(childValue)) {
+      if (Object.values(childValue).some(hasDynamicSchemaKeyword)) {
+        return true;
+      }
+      continue;
+    }
+    if (hasDynamicSchemaKeyword(childValue)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function projectAnthropicToolSchema(value: unknown): Record<string, unknown> | undefined {
+  let text: string | undefined;
+  try {
+    text = JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+  if (!text) {
+    return undefined;
+  }
+  const parsed = JSON.parse(text) as unknown;
+  if (!isJsonObject(parsed)) {
+    return undefined;
+  }
+  if (parsed.type !== undefined && parsed.type !== "object") {
+    return undefined;
+  }
+  if (hasDynamicSchemaKeyword(parsed)) {
+    return undefined;
+  }
+  return parsed;
+}
+
 function convertTools(
   tools: Tool[],
   isOAuthTokenLocal: boolean,
   supportsEagerToolInputStreaming: boolean,
   cacheControl?: CacheControlEphemeral,
 ): Anthropic.Messages.Tool[] {
-  if (!tools) {
+  const toolCount = readToolCount(tools);
+  if (toolCount === undefined) {
     return [];
   }
 
-  return tools.map((tool, index) => {
-    const schema = tool.parameters as { properties?: unknown; required?: string[] };
-
-    return {
-      name: isOAuthTokenLocal ? toClaudeCodeName(tool.name) : tool.name,
-      description: tool.description,
+  const converted: Anthropic.Messages.Tool[] = [];
+  for (let index = 0; index < toolCount; index += 1) {
+    const tool = readToolAt(tools, index);
+    if (!tool) {
+      continue;
+    }
+    const rawName = readToolField(tool, "name");
+    if (typeof rawName !== "string" || !rawName) {
+      continue;
+    }
+    const schema = projectAnthropicToolSchema(readToolField(tool, "parameters"));
+    if (!schema) {
+      continue;
+    }
+    const description = readToolField(tool, "description");
+    const properties = isJsonObject(schema.properties) ? schema.properties : {};
+    const required = Array.isArray(schema.required)
+      ? schema.required.filter((item): item is string => typeof item === "string")
+      : [];
+    converted.push({
+      name: isOAuthTokenLocal ? toClaudeCodeName(rawName) : rawName,
+      ...(typeof description === "string" ? { description } : {}),
       ...(supportsEagerToolInputStreaming ? { eager_input_streaming: true } : {}),
       input_schema: {
         type: "object",
-        properties: schema.properties ?? {},
-        required: schema.required ?? [],
+        properties,
+        required,
       },
-      ...(cacheControl && index === tools.length - 1 ? { cache_control: cacheControl } : {}),
-    };
-  });
+    });
+  }
+  if (cacheControl && converted.length > 0) {
+    const lastTool = converted.at(-1);
+    if (lastTool) {
+      converted[converted.length - 1] = { ...lastTool, cache_control: cacheControl };
+    }
+  }
+  return converted;
 }
 
 function mapStopReason(reason: string): StopReason {


### PR DESCRIPTION
## Summary

- Guard legacy Anthropic provider tool payload construction against unreadable or provider-incompatible tool descriptors.
- Project Anthropic `input_schema` through a JSON view, skip dynamic-schema keywords, and preserve valid schema-map field names.
- Harden OAuth Claude Code tool-name remapping so poisoned skipped descriptors cannot crash response handling.

## Verification

- `node scripts/run-vitest.mjs src/llm/providers/anthropic.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts`
- `git diff --check HEAD~1..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Crabbox Azure changed gate `run_1d73ae5b8f07`, lease `cbx_77aef4072d7d`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed`

## Real behavior proof

Behavior addressed: Legacy Anthropic provider request/response handling no longer crashes when tool descriptors throw from `name`, `description`, or `parameters`; incompatible dynamic-schema tools are skipped while valid siblings remain available.

Real environment tested: Local focused Vitest wrapper on the provider test file, plus Crabbox Azure Linux changed gate `run_1d73ae5b8f07`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/llm/providers/anthropic.test.ts --reporter=dot`; `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed` in Crabbox.

Evidence after fix: The focused provider test covers poisoned descriptor getters, JSON-projected schemas, dynamic-schema rejection, schema-map field names like `$dynamicRef`, and OAuth tool-use name remapping. The Crabbox changed gate selected `core, coreTests` and exited 0.

Observed result after fix: Malformed tools are skipped, valid tools remain in the Anthropic payload, OAuth `Read` remaps back to the local `read` tool without triggering poisoned getters, and changed core checks pass.

What was not tested: Live Anthropic network traffic; the behavior is covered with captured request payloads and mocked Anthropic SSE responses.
