### PR TITLE
fix(agent-tools): resolve workspace-scoped tool fs root lazily

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -991,8 +991,12 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
     } as const;
   }
 
-  // When workspaceOnly is true, enforce workspace boundary
-  const rootPromise = fsRoot(root);
+  // When workspaceOnly is true, enforce workspace boundary. Resolve the fs-safe
+  // root lazily on first use: constructing the tool (e.g. doctor projecting tool
+  // schemas) must not open an fs handle, and a missing workspace dir must not
+  // orphan a rejecting promise as "Unhandled promise rejection: root dir not found".
+  let rootPromise: ReturnType<typeof fsRoot> | undefined;
+  const getRoot = () => (rootPromise ??= fsRoot(root));
   return {
     mkdir: async (dir: string) => {
       const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
@@ -1001,10 +1005,10 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
       await fs.mkdir(resolved, { recursive: true });
     },
     writeFile: (absolutePath: string, content: string) =>
-      writeWorkspaceFile(root, rootPromise, absolutePath, content),
+      writeWorkspaceFile(root, getRoot(), absolutePath, content),
     readFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
-      return (await (await rootPromise).read(relative)).buffer;
+      return (await (await getRoot()).read(relative)).buffer;
     },
     statFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
@@ -1029,16 +1033,20 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
     } as const;
   }
 
-  // When workspaceOnly is true, enforce workspace boundary
-  const rootPromise = fsRoot(root);
+  // When workspaceOnly is true, enforce workspace boundary. Resolve the fs-safe
+  // root lazily on first use: constructing the tool (e.g. doctor projecting tool
+  // schemas) must not open an fs handle, and a missing workspace dir must not
+  // orphan a rejecting promise as "Unhandled promise rejection: root dir not found".
+  let rootPromise: ReturnType<typeof fsRoot> | undefined;
+  const getRoot = () => (rootPromise ??= fsRoot(root));
   return {
     readFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
-      const safeRead = await (await rootPromise).read(relative);
+      const safeRead = await (await getRoot()).read(relative);
       return safeRead.buffer;
     },
     writeFile: (absolutePath: string, content: string) =>
-      writeWorkspaceFile(root, rootPromise, absolutePath, content),
+      writeWorkspaceFile(root, getRoot(), absolutePath, content),
     access: async (absolutePath: string) => {
       let relative: string;
       try {
@@ -1052,7 +1060,7 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
         return;
       }
       try {
-        const opened = await (await rootPromise).open(relative);
+        const opened = await (await getRoot()).open(relative);
         await opened.handle.close().catch(() => {});
       } catch (error) {
         if (error instanceof FsSafeError && error.code === "not-found") {

--- a/src/agents/agent-tools.read.workspace-root-lazy.test.ts
+++ b/src/agents/agent-tools.read.workspace-root-lazy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Regression guard: doctor's active-tool schema projection constructs the full
+// coding toolset to inspect tool input schemas. Workspace-scoped edit/write
+// tools used to resolve their fs-safe root eagerly at construction. When the
+// agent's workspace dir does not exist yet (e.g. an unresolved `${ENV}`
+// placeholder in the authored config), that orphaned a rejecting promise:
+//   "[openclaw] Unhandled promise rejection: FsSafeError: root dir not found"
+// The root must only be opened when a read/write/access operation actually runs.
+
+const rootSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../infra/fs-safe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/fs-safe.js")>();
+  return { ...actual, root: rootSpy };
+});
+
+const { createHostWorkspaceEditTool, createHostWorkspaceWriteTool } =
+  await import("./agent-tools.read.js");
+
+describe("workspace-scoped coding tools resolve their fs root lazily", () => {
+  it("does not open the fs-safe root while only constructing the tool", () => {
+    // Resolve to a stub root handle so a lazy call would not reject, yet assert
+    // construction never reaches it.
+    rootSpy.mockReset().mockResolvedValue({
+      read: vi.fn(),
+      write: vi.fn(),
+      open: vi.fn(),
+    });
+    const missingWorkspace = "/openclaw-nonexistent-workspace-zzz/does/not/exist";
+
+    createHostWorkspaceEditTool(missingWorkspace, { workspaceOnly: true });
+    createHostWorkspaceWriteTool(missingWorkspace, { workspaceOnly: true });
+
+    expect(rootSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `openclaw doctor` aborts with `[openclaw] Unhandled promise rejection: FsSafeError: root dir not found` whenever an agent's resolved workspace directory does not exist at doctor time.

Why does this matter now?

- Doctor's active-tool schema projection builds the full coding toolset just to read tool input schemas. Workspace-scoped edit/write tools opened their fs-safe root **eagerly at construction**, so a missing workspace dir orphaned a rejecting promise — polluting every affected doctor run.

What is the intended outcome?

- Constructing a workspace-scoped tool never touches the filesystem. The root is resolved lazily (and memoized) on the first real read/write/access op, so schema-only consumers can't orphan a rejection.

What is intentionally out of scope?

- The config layer where doctor's legacy-migration path (`migrateLegacyConfig(snapshot.parsed)`) operates on the *authored*, un-`${ENV}`-substituted config — the common real-world trigger. With lazy roots, schema projection is workspace-independent, so no doctor-side change is needed.

What does success look like?

- `openclaw doctor` against a config whose agent workspace dir is absent emits zero unhandled rejections.

What should reviewers focus on?

- That lazy, memoized root resolution preserves the workspace boundary semantics for read/write/access (covered by existing host-edit-access and workspace-root-guard tests, which pass unchanged).

## Linked context

Which issue does this close?

Closes #89225

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner? No.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: doctor unhandled promise rejection when an agent's workspace dir does not exist (commonly an unresolved `${ENV}` placeholder reaching the tool factory via the legacy-migration path).
- Real environment tested: multi-agent OpenClaw config with `${OPENCLAW_STATE_DIR}`-templated workspaces plus legacy config keys; macOS, Node 24.
- Exact steps or command run after this patch: `pnpm build && openclaw doctor` (and `OPENCLAW_CONFIG_PATH=<copy> openclaw doctor`).
- Evidence after fix: `openclaw doctor 2>&1 | grep -c "Unhandled promise rejection"` → `0` (was `1` before the patch).
- Observed result after fix: doctor completes normally; no orphaned rejection.
- What was not tested: doctor `--fix` write-back path (preview path only).
- Proof limitations or environment constraints: terminal-capture proof; config contained private values so not attached verbatim.
- Before evidence (optional): same command printed exactly one `Unhandled promise rejection: FsSafeError: root dir not found` line.

## Tests and validation

Which commands did you run?

- `pnpm test src/agents/agent-tools.read.workspace-root-lazy.test.ts` (new)
- `pnpm test` for: `agent-tools.read.host-edit-access`, `agent-tools.read.workspace-root-guard`, `agent-tools.workspace-paths`, `agent-tools.create-openclaw-coding-tools`, `commands/doctor/shared/active-tool-schema-warnings`
- `pnpm format:check`, `node scripts/run-oxlint.mjs <files>`, `pnpm tsgo:core`, `pnpm tsgo:test:src`, `pnpm build`

What regression coverage was added or updated?

- New `src/agents/agent-tools.read.workspace-root-lazy.test.ts`: asserts constructing the workspace-scoped edit/write tools never calls the fs-safe `root`. Verified it **fails** on the pre-fix eager code ("called 1 times") and **passes** after the fix.

What failed before this fix, if known?

- The new regression test, and `openclaw doctor` itself (one unhandled rejection per run).

If no test was added, why not? N/A — regression test added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes — doctor no longer crashes; tool behavior is otherwise unchanged.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No. The workspace boundary enforcement is identical; only the *timing* of root resolution moves from construct-time to first-use.

What is the highest-risk area? Workspace boundary semantics for read/write/access operations.

How is that risk mitigated? The root is memoized, so behavior is identical once an op runs; existing boundary tests (host-edit-access, workspace-root-guard) pass unchanged.

## Current review state

What is the next action? Maintainer review.

What is still waiting on author, maintainer, CI, or external proof? Nothing from the author.

Which bot or reviewer comments were addressed? N/A — initial submission.
