### PR TITLE
fix(reply): let active turns reach queue policy

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1224,6 +1224,59 @@ describe("dispatchReplyFromConfig", () => {
     }
   });
 
+  it("lets a same-session iMessage turn reach active-run queue policy while another turn is active", async () => {
+    setNoAbort();
+    const sessionKey = "agent:main:imessage:direct:+15551234567";
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+    });
+    activeOperation.setPhase("running");
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "queued for policy" }) satisfies ReplyPayload);
+
+    const resultPromise = dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "imessage",
+        Surface: "imessage",
+        OriginatingChannel: "imessage",
+        OriginatingTo: "imessage:+15551234567",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        BodyForAgent: "steer the active run",
+      }),
+      cfg: {
+        messages: {
+          queue: {
+            mode: "steer",
+            byChannel: {
+              imessage: "steer",
+            },
+          },
+        },
+      } as const satisfies OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    try {
+      const result = await Promise.race([
+        resultPromise,
+        new Promise<"blocked">((resolve) => setTimeout(() => resolve("blocked"), 1_000)),
+      ]);
+
+      expect(result).toMatchObject({
+        queuedFinal: true,
+        counts: { tool: 0, block: 0, final: 0 },
+      });
+      expect(replyResolver).toHaveBeenCalledTimes(1);
+    } finally {
+      activeOperation.complete();
+      await resultPromise;
+    }
+  });
+
   it("keeps non-Slack routed direct turns behind the active reply operation", async () => {
     setNoAbort();
     const sessionKey = "agent:main:telegram:direct:1";

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -238,6 +238,16 @@ function shouldLetSlackRoutedThreadBypassBusyReplyOperation(params: {
   );
 }
 
+function shouldLetActiveReplyOperationReachQueuePolicy(params: {
+  activeOperation?: ReplyOperation;
+  routeThreadId?: string | number;
+}): boolean {
+  return (
+    params.activeOperation !== undefined &&
+    !routeThreadIdsDiffer(params.activeOperation.routeThreadId, params.routeThreadId)
+  );
+}
+
 const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
 const getReplyFromConfigRuntimeLoader = createLazyImportLoader(
   () => import("./get-reply-from-config.runtime.js"),
@@ -1240,10 +1250,18 @@ export async function dispatchReplyFromConfig(
       crypto.randomUUID();
     const replyTurnKind = resolveReplyTurnKind(params.replyOptions);
     const allowActivePreDispatch = phase === "pre_dispatch" && replyTurnKind === "visible";
+    const activeReplyOperation = replyRunRegistry.get(dispatchOperationSessionKey);
+    const allowActiveQueuePolicy =
+      phase === "dispatch" &&
+      replyTurnKind === "visible" &&
+      shouldLetActiveReplyOperationReachQueuePolicy({
+        activeOperation: activeReplyOperation,
+        routeThreadId,
+      });
     const allowSlackRoutedThreadBypass =
       phase === "dispatch" &&
       shouldLetSlackRoutedThreadBypassBusyReplyOperation({
-        activeOperation: replyRunRegistry.get(dispatchOperationSessionKey),
+        activeOperation: activeReplyOperation,
         ctx,
         routeThreadId,
       });
@@ -1254,11 +1272,18 @@ export async function dispatchReplyFromConfig(
       resetTriggered: false,
       routeThreadId,
       upstreamAbortSignal: params.replyOptions?.abortSignal,
-      waitForActive: !allowActivePreDispatch && !allowSlackRoutedThreadBypass,
+      waitForActive:
+        !allowActivePreDispatch && !allowActiveQueuePolicy && !allowSlackRoutedThreadBypass,
     });
     if (admission.status === "skipped") {
       if (allowActivePreDispatch && admission.reason === "active-run") {
         preDispatchAbortOperation = admission.activeOperation;
+        return { status: "ready" };
+      }
+      if (allowActiveQueuePolicy && admission.reason === "active-run") {
+        logVerbose(
+          `dispatch-from-config: allowing visible turn for ${dispatchOperationSessionKey} to reach active-run queue policy while a reply operation is active`,
+        );
         return { status: "ready" };
       }
       if (


### PR DESCRIPTION
## Summary
- let same-session visible turns reach active-run queue policy even while a reply operation is active
- keep the existing Slack routed-thread bypass behavior intact
- preserve serialization for different non-Slack routed threads

## Why
`messages.queue.mode = "steer"` can only work if the inbound visible turn reaches active-run queue policy while the original turn is still active. In the failing path, iMessage could receive and queue the inbound message during the active run, but dispatch admission waited for the active reply operation to go idle before `get-reply-run` could resolve steer/followup/collect behavior.

This does not replace #73365. That PR covers lifecycle-aware injection once a message reaches the active-run steering path. This PR fixes the earlier admission fence that can keep same-session visible turns from reaching that path at all.

Refs #48003.
Refs #54488.

## Validation
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts` (190 passed)
