### PR TITLE
fix(imessage): repair DM sender fallback before pairing

### DIFF
--- a/extensions/imessage/src/monitor/conversation-repair.test.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.test.ts
@@ -77,6 +77,52 @@ describe("repairIMessageConversationAnchor", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
+  it("repairs a direct-message sender that initially resolves to the local destination caller", async () => {
+    const peerHandle = "+15555550123";
+    const localSendHandle = "bot-account@example.com";
+    const message = anchorlessMessage({
+      guid: "DM-RACE-GUID-1",
+      chat_id: 1,
+      sender: localSendHandle,
+      destination_caller_id: localSendHandle,
+      chat_guid: `any;-;${peerHandle}`,
+      chat_identifier: peerHandle,
+      participants: [peerHandle],
+      is_group: false,
+    });
+    const client = mockClient([
+      {
+        id: 1,
+        messages: [
+          {
+            guid: "DM-RACE-GUID-1",
+            chat_id: 1,
+            sender: peerHandle,
+            destination_caller_id: localSendHandle,
+            chat_guid: `any;-;${peerHandle}`,
+            chat_identifier: peerHandle,
+            participants: [peerHandle],
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    const repaired = await repairIMessageConversationAnchor({
+      client: client as never,
+      message,
+    });
+
+    expect(repaired).toMatchObject({
+      sender: peerHandle,
+      chat_id: 1,
+      chat_identifier: peerHandle,
+      participants: [peerHandle],
+      is_group: false,
+    });
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
   it("recovers the conversation from recent history by GUID", async () => {
     const message = anchorlessMessage();
     const client = mockClient([

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -64,6 +64,9 @@ function overlayRecoveredConversation(
 ): IMessagePayload {
   const repaired = { ...message };
 
+  if (isNonEmptyString(entry.sender)) {
+    repaired.sender = entry.sender;
+  }
   if (hasPositiveChatId(entry.chat_id)) {
     repaired.chat_id = entry.chat_id;
   }
@@ -89,10 +92,82 @@ function overlayRecoveredConversation(
   return repaired;
 }
 
+function normalizeComparableHandle(value: string | null | undefined): string {
+  return (value ?? "").trim().toLocaleLowerCase();
+}
+
+function resolveDirectMessagePeerSenderCandidate(message: IMessagePayload): string | null {
+  if (message.is_group === true || message.is_from_me === true) {
+    return null;
+  }
+  if (!hasPositiveChatId(message.chat_id) || !isNonEmptyString(message.guid)) {
+    return null;
+  }
+
+  const sender = normalizeComparableHandle(message.sender);
+  const destination = normalizeComparableHandle(message.destination_caller_id);
+  if (!sender || !destination || sender !== destination) {
+    return null;
+  }
+
+  const conversationHandles = [
+    ...(Array.isArray(message.participants) ? message.participants : []),
+    message.chat_identifier,
+  ];
+
+  for (const handle of conversationHandles) {
+    const normalized = normalizeComparableHandle(handle);
+    if (normalized && normalized !== sender) {
+      return handle?.trim() ?? null;
+    }
+  }
+  return null;
+}
+
+async function recoverMessageFromChatHistory(params: {
+  client: IMessageRpcClient;
+  chatId: number;
+  guid: string;
+  attachments: boolean;
+  perChatHistoryLimit: number;
+  rpcTimeoutMs: number;
+}): Promise<Record<string, unknown> | null> {
+  const historyResult = await params.client.request<MessagesHistoryResult>(
+    "messages.history",
+    {
+      attachments: params.attachments,
+      chat_id: params.chatId,
+      limit: params.perChatHistoryLimit,
+    },
+    { timeoutMs: params.rpcTimeoutMs },
+  );
+  const messages = Array.isArray(historyResult?.messages) ? historyResult.messages : [];
+  for (const raw of messages) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      continue;
+    }
+    const entry = raw as Record<string, unknown>;
+    if (entry.guid === params.guid) {
+      return entry;
+    }
+  }
+  return null;
+}
+
 export async function repairIMessageConversationAnchor(
   params: RepairIMessageConversationAnchorParams,
 ): Promise<IMessagePayload | null> {
   const { client, message, runtime } = params;
+  const rpcTimeoutMs = params.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS;
+  const perChatHistoryLimit = params.perChatHistoryLimit ?? DEFAULT_PER_CHAT_HISTORY_LIMIT;
+
+  const peerSender = resolveDirectMessagePeerSenderCandidate(message);
+  if (peerSender) {
+    runtime?.log?.(
+      `imessage: repaired direct message sender GUID=${message.guid} chat_id=${message.chat_id}`,
+    );
+    return { ...message, sender: peerSender };
+  }
 
   if (!isIMessageAnchorless(message)) {
     return message;
@@ -123,31 +198,20 @@ export async function repairIMessageConversationAnchor(
       continue;
     }
 
-    let historyResult: MessagesHistoryResult | undefined;
+    let entry: Record<string, unknown> | null = null;
     try {
-      historyResult = await client.request<MessagesHistoryResult>(
-        "messages.history",
-        {
-          attachments: false,
-          chat_id: chatId,
-          limit: params.perChatHistoryLimit ?? DEFAULT_PER_CHAT_HISTORY_LIMIT,
-        },
-        { timeoutMs: params.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS },
-      );
+      entry = await recoverMessageFromChatHistory({
+        client,
+        chatId,
+        guid,
+        attachments: false,
+        perChatHistoryLimit,
+        rpcTimeoutMs,
+      });
     } catch {
       continue;
     }
-
-    const messages = Array.isArray(historyResult?.messages) ? historyResult.messages : [];
-    for (const raw of messages) {
-      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-        continue;
-      }
-      const entry = raw as Record<string, unknown>;
-      if (entry.guid !== guid) {
-        continue;
-      }
-
+    if (entry) {
       const repaired = overlayRecoveredConversation(message, entry);
       if (isIMessageAnchorless(repaired)) {
         runtime?.error?.(


### PR DESCRIPTION
## Summary
- repair direct-message sender when the watch payload temporarily reports the local `destination_caller_id` as `sender`
- use direct-chat participant / `chat_identifier` data already present on the payload before falling back to history recovery
- keep the repair scoped to non-group, non-from-me direct messages where `sender` equals `destination_caller_id`

## Why
`imsg watch` can surface a just-inserted DM row before `handle_id` has resolved. In that window, the payload can fall back to the local send identity as `sender`. OpenClaw then treats the local account as the inbound sender and emits a bogus pairing challenge for the bot owner/local identity instead of the actual peer.

The watch payload already carries enough direct-chat context to recover the peer sender in this narrow race, so this restores `sender` before access-control/pairing logic sees the message.

I did not find an existing OpenClaw issue matching `destination_caller_id`, sender fallback, or bogus iMessage pairing identity.

## Validation
- `node scripts/run-vitest.mjs extensions/imessage/src/monitor/conversation-repair.test.ts` (8 passed)
