### PR TITLE
fix(codex): guard dynamic tool descriptors

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -77,6 +77,74 @@ describe("Codex app-server attempt context", () => {
     expect(report.tools.schemaChars).toBe(message?.schemaChars);
   });
 
+  it("skips malformed dynamic tool descriptors in system prompt reports", () => {
+    const tools = [
+      {
+        get name() {
+          throw new Error("report dynamic tool name exploded");
+        },
+        description: "poisoned name",
+        inputSchema: { type: "object" },
+      },
+      {
+        name: "description_poisoned",
+        get description() {
+          throw new Error("report dynamic tool description exploded");
+        },
+        inputSchema: { type: "object" },
+      },
+      {
+        name: "schema_poisoned",
+        description: "poisoned schema",
+        get inputSchema() {
+          throw new Error("report dynamic tool schema exploded");
+        },
+      },
+      {
+        name: "valid_tool",
+        description: " Valid dynamic tool. ",
+        inputSchema: {
+          type: "object",
+          properties: {
+            text: { type: "string" },
+          },
+        },
+      },
+    ] as unknown as CodexDynamicToolSpec[];
+
+    const report = buildCodexSystemPromptReport({
+      attempt: {
+        sessionId: "session-1",
+        provider: "codex",
+        modelId: "gpt-5.4-codex",
+      } as EmbeddedRunAttemptParams,
+      sessionKey: "agent:main:session-1",
+      workspaceDir: path.join("tmp", "workspace"),
+      developerInstructions: "test developer instructions",
+      workspaceBootstrapContext: {
+        bootstrapFiles: [],
+        contextFiles: [],
+      },
+      skillsPrompt: "",
+      tools,
+    });
+
+    expect(report.tools.entries).toHaveLength(2);
+    expect(report.tools.entries[0]).toMatchObject({
+      name: "description_poisoned",
+      summaryChars: 0,
+      propertiesCount: null,
+    });
+    expect(report.tools.entries[1]).toMatchObject({
+      name: "valid_tool",
+      summaryChars: "Valid dynamic tool.".length,
+      propertiesCount: 1,
+    });
+    expect(report.tools.schemaChars).toBe(
+      (report.tools.entries[0]?.schemaChars ?? 0) + (report.tools.entries[1]?.schemaChars ?? 0),
+    );
+  });
+
   it("keeps MEMORY.md injected when sandbox effective workspace differs", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-memory-workspace-"));
     const sandboxWorkspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-memory-sandbox-"));

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -11,6 +11,12 @@ import {
   type EmbeddedRunAttemptResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  isDeferredCodexDynamicTool,
+  readCodexDynamicToolDescription,
+  readCodexDynamicToolInputSchema,
+  readCodexDynamicToolName,
+} from "./dynamic-tool-descriptor.js";
 import type { CodexDynamicToolSpec, JsonValue } from "./protocol.js";
 import { isJsonObject } from "./protocol.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
@@ -255,7 +261,10 @@ export function buildCodexSystemPromptReport(params: {
   skillsPrompt: string;
   tools: CodexDynamicToolSpec[];
 }): CodexSystemPromptReport {
-  const toolEntries = params.tools.map(buildCodexToolReportEntry);
+  const toolEntries = params.tools.flatMap((tool) => {
+    const entry = buildCodexToolReportEntry(tool);
+    return entry ? [entry] : [];
+  });
   const schemaChars = toolEntries.reduce((sum, tool) => sum + tool.schemaChars, 0);
   const skillsPrompt = params.skillsPrompt.trim();
   const bootstrapMaxChars = readPositiveNumber(
@@ -319,11 +328,15 @@ function buildCodexSkillReportEntries(
     .filter((entry) => entry.blockChars > 0);
 }
 
-function buildCodexToolReportEntry(tool: CodexDynamicToolSpec): CodexToolReportEntry {
-  const summary = tool.description.trim();
-  if (tool.deferLoading === true) {
+function buildCodexToolReportEntry(tool: CodexDynamicToolSpec): CodexToolReportEntry | undefined {
+  const name = readCodexDynamicToolName(tool);
+  if (!name) {
+    return undefined;
+  }
+  const summary = readCodexDynamicToolDescription(tool);
+  if (isDeferredCodexDynamicTool(tool)) {
     return {
-      name: tool.name,
+      name,
       summaryChars: summary.length,
       summaryHash: sha256Text(summary),
       schemaChars: 0,
@@ -331,11 +344,15 @@ function buildCodexToolReportEntry(tool: CodexDynamicToolSpec): CodexToolReportE
       propertiesCount: null,
     };
   }
+  const inputSchema = readCodexDynamicToolInputSchema(tool);
+  if (inputSchema === undefined) {
+    return undefined;
+  }
   return {
-    name: tool.name,
+    name,
     summaryChars: summary.length,
     summaryHash: sha256Text(summary),
-    ...buildCodexToolSchemaStats(tool.inputSchema),
+    ...buildCodexToolSchemaStats(inputSchema),
   };
 }
 
@@ -775,7 +792,12 @@ export function hasCodexWorkspaceMemoryTools(tools: readonly { name: string }[])
 }
 
 export function getCodexWorkspaceMemoryToolNames(tools: readonly { name: string }[]): string[] {
-  const availableToolNames = new Set(tools.map((tool) => normalizeCodexDynamicToolName(tool.name)));
+  const availableToolNames = new Set(
+    tools
+      .map((tool) => readCodexDynamicToolName(tool as CodexDynamicToolSpec))
+      .filter((name): name is string => Boolean(name))
+      .map(normalizeCodexDynamicToolName),
+  );
   return Array.from(CODEX_MEMORY_TOOL_NAMES).filter((name) => availableToolNames.has(name));
 }
 

--- a/extensions/codex/src/app-server/dynamic-tool-descriptor.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-descriptor.ts
@@ -1,0 +1,35 @@
+import type { CodexDynamicToolSpec, JsonValue } from "./protocol.js";
+
+export function readCodexDynamicToolName(tool: CodexDynamicToolSpec): string | undefined {
+  try {
+    const name = tool.name;
+    return typeof name === "string" && name.trim() ? name.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readCodexDynamicToolDescription(tool: CodexDynamicToolSpec): string {
+  try {
+    const description = tool.description;
+    return typeof description === "string" ? description.trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+export function readCodexDynamicToolInputSchema(tool: CodexDynamicToolSpec): JsonValue | undefined {
+  try {
+    return tool.inputSchema;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isDeferredCodexDynamicTool(tool: CodexDynamicToolSpec): boolean {
+  try {
+    return tool.deferLoading === true;
+  } catch {
+    return false;
+  }
+}

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -217,6 +217,32 @@ describe("Codex app-server native code mode config", () => {
     expect(searchableFingerprint).toBe(directFingerprint);
   });
 
+  it("fingerprints malformed dynamic tool descriptors without crashing", () => {
+    const malformedTool = {
+      get name(): never {
+        throw new Error("tool name getter exploded");
+      },
+      get description(): never {
+        throw new Error("tool description getter exploded");
+      },
+      inputSchema: {
+        type: "object",
+        get properties(): never {
+          throw new Error("schema properties getter exploded");
+        },
+      },
+      get deferLoading(): never {
+        throw new Error("tool defer flag getter exploded");
+      },
+    };
+
+    expect(
+      codexDynamicToolsFingerprint([null, malformedTool] as unknown as Parameters<
+        typeof codexDynamicToolsFingerprint
+      >[0]),
+    ).toBe('[{"inputSchema":{"type":"object"}},null]');
+  });
+
   it("keeps OpenClaw skill catalogs out of developer instructions", () => {
     const params = createAttemptParams({ provider: "openai" });
     params.skillsSnapshot = {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -115,6 +115,43 @@ describe("Codex app-server native code mode config", () => {
     expect(instructions).not.toContain("message,");
   });
 
+  it("skips malformed deferred dynamic tool names in developer instructions", () => {
+    const dynamicTools = [
+      {
+        get name() {
+          throw new Error("deferred dynamic tool name exploded");
+        },
+        description: "poisoned name",
+        inputSchema: { type: "object" },
+        namespace: "openclaw",
+        deferLoading: true,
+      },
+      {
+        name: 42,
+        description: "numeric name",
+        inputSchema: { type: "object" },
+        namespace: "openclaw",
+        deferLoading: true,
+      },
+      {
+        name: " message ",
+        description: "Send a message",
+        inputSchema: { type: "object" },
+        namespace: "openclaw",
+        deferLoading: true,
+      },
+    ] as unknown as NonNullable<Parameters<typeof buildDeveloperInstructions>[1]>["dynamicTools"];
+
+    const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }), {
+      dynamicTools,
+    });
+
+    expect(instructions).toContain(
+      "Deferred searchable OpenClaw dynamic tools available: message.",
+    );
+    expect(instructions).not.toContain("42");
+  });
+
   it("uses the shared Skill Workshop guidance when skill_workshop is available", () => {
     const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }), {
       dynamicTools: [

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -1112,14 +1112,13 @@ function fingerprintDynamicToolSpec(tool: JsonValue): JsonValue {
     return stabilizeJsonValue(tool);
   }
   const stable: JsonObject = {};
-  for (const [key, child] of Object.entries(tool).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
+  for (const key of readStableJsonObjectKeys(tool)) {
     // Tool-search presentation can change per turn without changing the
     // durable app-server execution contract for an existing thread.
     if (key === "description" || key === "deferLoading" || key === "namespace") {
       continue;
     }
+    const child = readStableJsonObjectValue(tool, key);
     stable[key] = stabilizeJsonValue(child);
   }
   return stable;
@@ -1133,12 +1132,27 @@ function stabilizeJsonValue(value: JsonValue): JsonValue {
     return value;
   }
   const stable: JsonObject = {};
-  for (const [key, child] of Object.entries(value).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
+  for (const key of readStableJsonObjectKeys(value)) {
+    const child = readStableJsonObjectValue(value, key);
     stable[key] = stabilizeJsonValue(child);
   }
   return stable;
+}
+
+function readStableJsonObjectKeys(value: JsonObject): string[] {
+  try {
+    return Object.keys(value).toSorted((left, right) => left.localeCompare(right));
+  } catch {
+    return [];
+  }
+}
+
+function readStableJsonObjectValue(value: JsonObject, key: string): JsonValue {
+  try {
+    return value[key];
+  } catch {
+    return undefined;
+  }
 }
 
 const EMPTY_DYNAMIC_TOOLS_FINGERPRINT = JSON.stringify([]);

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -20,6 +20,7 @@ import {
   resolveCodexContextEngineProjectionMaxChars,
   resolveCodexContextEngineProjectionReserveTokens,
 } from "./context-engine-projection.js";
+import { isDeferredCodexDynamicTool, readCodexDynamicToolName } from "./dynamic-tool-descriptor.js";
 import { invalidInlineImageText, sanitizeInlineImageDataUrl } from "./image-payload-sanitizer.js";
 import {
   isCodexPluginThreadBindingStale,
@@ -1187,9 +1188,9 @@ function buildDeferredDynamicToolManifest(
   const deferredToolNames = [
     ...new Set(
       (dynamicTools ?? [])
-        .filter((tool) => tool.deferLoading === true)
-        .map((tool) => tool.name.trim())
-        .filter(Boolean),
+        .filter(isDeferredCodexDynamicTool)
+        .map(readCodexDynamicToolName)
+        .filter((name): name is string => Boolean(name)),
     ),
   ].toSorted((left, right) => left.localeCompare(right));
   if (deferredToolNames.length === 0) {
@@ -1202,7 +1203,7 @@ function buildSkillWorkshopInstruction(
   dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
 ): string | undefined {
   const hasSkillWorkshop = (dynamicTools ?? []).some(
-    (tool) => tool.name.trim() === SKILL_WORKSHOP_TOOL_NAME,
+    (tool) => readCodexDynamicToolName(tool) === SKILL_WORKSHOP_TOOL_NAME,
   );
   if (!hasSkillWorkshop) {
     return undefined;
@@ -1215,7 +1216,7 @@ function buildVisibleReplyInstruction(
   dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
 ): string {
   const messageToolAvailable = dynamicTools
-    ? dynamicTools.some((tool) => tool.name.trim() === "message")
+    ? dynamicTools.some((tool) => readCodexDynamicToolName(tool) === "message")
     : params.disableMessageTool !== true;
   if (params.sourceReplyDeliveryMode === "message_tool_only" && messageToolAvailable) {
     return "Visible source replies are not automatically delivered for this run. Use `message(action=send)` for user-visible source-channel output. Do not repeat that visible content in your final answer.";


### PR DESCRIPTION
## Summary

- Add guarded readers for Codex app-server dynamic tool descriptor fields.
- Use them in system-prompt reports, deferred tool manifests, skill-workshop/message detection, and memory-tool detection.
- Keep malformed descriptors from crashing report/instruction generation while preserving valid tool report entries.

## Verification

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/attempt-context.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/dynamic-tool-descriptor.ts extensions/codex/src/app-server/attempt-context.ts extensions/codex/src/app-server/attempt-context.test.ts extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/thread-lifecycle.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/dynamic-tool-descriptor.ts extensions/codex/src/app-server/attempt-context.ts extensions/codex/src/app-server/attempt-context.test.ts extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/thread-lifecycle.test.ts`
- `git diff --check HEAD~1..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Crabbox Azure changed gate `run_c714cf1b791e`, lease `cbx_99a9cd599c0d`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed`

## Real behavior proof

Behavior addressed: Codex app-server report and developer-instruction helpers no longer crash when dynamic tool descriptor fields throw, are missing, or are not strings.

Real environment tested: Local focused Vitest wrapper on the Codex app-server helper tests, plus Crabbox Azure Linux changed gate `run_c714cf1b791e`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/attempt-context.test.ts --reporter=dot`; `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed` in Crabbox.

Evidence after fix: Focused tests cover throwing dynamic tool `name`, `description`, and `inputSchema` accessors plus non-string names in developer-instruction and system-prompt-report paths. The Crabbox changed gate selected `extensions, extensionTests` and exited 0.

Observed result after fix: Malformed dynamic tool descriptors are skipped or represented with empty presentation text as appropriate; valid sibling tools remain in reports and deferred-tool instructions.

What was not tested: A live Codex app-server turn with externally malformed dynamic tool descriptors; the behavior is covered through the exported helper paths and changed extension gates.
