### PR TITLE
fix: guard in-band macOS LaunchAgent stop

### DIFF
--- a/src/daemon/launchd-current-service.test.ts
+++ b/src/daemon/launchd-current-service.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
+
+describe("isCurrentProcessLaunchdServiceLabel", () => {
+  it("matches launchd-provided service labels", () => {
+    expect(
+      isCurrentProcessLaunchdServiceLabel("ai.openclaw.gateway", {
+        LAUNCH_JOB_LABEL: "ai.openclaw.gateway",
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to OpenClaw service markers when XPC_SERVICE_NAME is inherited", () => {
+    expect(
+      isCurrentProcessLaunchdServiceLabel("ai.openclaw.gateway", {
+        XPC_SERVICE_NAME: "0",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves label-only fallback when launchd exposes no label variables", () => {
+    expect(
+      isCurrentProcessLaunchdServiceLabel("ai.openclaw.gateway", {
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+      }),
+    ).toBe(true);
+  });
+
+  it("can require service markers for label-only fallback", () => {
+    expect(
+      isCurrentProcessLaunchdServiceLabel(
+        "ai.openclaw.gateway",
+        {
+          OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+        },
+        { allowConfiguredLabelFallback: false },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not treat unrelated inherited launchd labels as current services", () => {
+    expect(
+      isCurrentProcessLaunchdServiceLabel("ai.openclaw.gateway", {
+        XPC_SERVICE_NAME: "0",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/daemon/launchd-current-service.ts
+++ b/src/daemon/launchd-current-service.ts
@@ -1,0 +1,36 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+
+export type CurrentProcessLaunchdServiceLabelOptions = {
+  allowConfiguredLabelFallback?: boolean;
+};
+
+export function isCurrentProcessLaunchdServiceLabel(
+  label: string,
+  env: NodeJS.ProcessEnv = process.env,
+  options: CurrentProcessLaunchdServiceLabelOptions = {},
+): boolean {
+  const currentLabels = [env.LAUNCH_JOB_LABEL, env.LAUNCH_JOB_NAME, env.XPC_SERVICE_NAME].flatMap(
+    (value) => {
+      const normalized = normalizeOptionalString(value);
+      return normalized ? [normalized] : [];
+    },
+  );
+
+  for (const currentLabel of currentLabels) {
+    if (currentLabel === label) {
+      return true;
+    }
+  }
+
+  const configuredLabel = normalizeOptionalString(env.OPENCLAW_LAUNCHD_LABEL);
+  if (!configuredLabel || configuredLabel !== label) {
+    return false;
+  }
+  if (
+    normalizeOptionalString(env.OPENCLAW_SERVICE_MARKER) === "openclaw" &&
+    Boolean(normalizeOptionalString(env.OPENCLAW_SERVICE_KIND))
+  ) {
+    return true;
+  }
+  return options.allowConfiguredLabelFallback !== false && currentLabels.length === 0;
+}

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -6,6 +6,7 @@ import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
 import { resolveGatewayLaunchAgentLabel } from "./constants.js";
+export { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
 import { renderPosixRestartLogSetup } from "./restart-logs.js";
 
 type LaunchdRestartHandoffMode = "kickstart" | "reload" | "start-after-exit";
@@ -90,21 +91,6 @@ function resolveLaunchdRestartTarget(
     plistPath,
     serviceTarget: `${domain}/${label}`,
   };
-}
-
-export function isCurrentProcessLaunchdServiceLabel(
-  label: string,
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  const launchdLabel =
-    normalizeOptionalString(env.LAUNCH_JOB_LABEL) ||
-    normalizeOptionalString(env.LAUNCH_JOB_NAME) ||
-    normalizeOptionalString(env.XPC_SERVICE_NAME);
-  if (launchdLabel) {
-    return launchdLabel === label;
-  }
-  const configuredLabel = normalizeOptionalString(env.OPENCLAW_LAUNCHD_LABEL);
-  return Boolean(configuredLabel && configuredLabel === label);
 }
 
 function buildLaunchdRestartScript(

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -87,6 +87,33 @@ function createDefaultLaunchdEnv(): Record<string, string | undefined> {
   };
 }
 
+async function withProcessEnv<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(overrides)) {
+    previous.set(key, process.env[key]);
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 async function runStopLaunchAgentWithFakeTimers(args: Parameters<typeof stopLaunchAgent>[0]) {
   vi.useFakeTimers();
   try {
@@ -1002,6 +1029,76 @@ describe("launchd install", () => {
     expect(output).toContain("Stopped LaunchAgent");
   });
 
+  it("refuses in-band LaunchAgent stop before launchctl bootout", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: "ai.openclaw.gateway",
+      },
+      async () => {
+        await expect(stopLaunchAgent({ env, stdout: new PassThrough() })).rejects.toThrow(
+          "Refusing to stop LaunchAgent ai.openclaw.gateway from inside the same launchd service",
+        );
+      },
+    );
+
+    expect(state.launchctlCalls).toEqual([]);
+  });
+
+  it("refuses in-band LaunchAgent stop when XPC_SERVICE_NAME is inherited", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: "0",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+      },
+      async () => {
+        await expect(stopLaunchAgent({ env, stdout: new PassThrough() })).rejects.toThrow(
+          "Refusing to stop LaunchAgent ai.openclaw.gateway from inside the same launchd service",
+        );
+      },
+    );
+
+    expect(state.launchctlCalls).toEqual([]);
+  });
+
+  it("allows external LaunchAgent label overrides to stop the selected target", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_LAUNCHD_LABEL: "com.example.openclaw.gateway",
+    };
+    const stdout = new PassThrough();
+    let output = "";
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: undefined,
+        OPENCLAW_LAUNCHD_LABEL: undefined,
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+      },
+      async () => {
+        await stopLaunchAgent({ env, stdout });
+      },
+    );
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/com.example.openclaw.gateway`;
+    expect(state.launchctlCalls).toEqual([["bootout", serviceId]]);
+    expect(output).toContain("Stopped LaunchAgent");
+  });
+
   it("verifies the configured gateway port is released before reporting stop success", async () => {
     const env = {
       ...createDefaultLaunchdEnv(),
@@ -1099,6 +1196,25 @@ describe("launchd install", () => {
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19005);
     expect(inspectPortUsage).toHaveBeenCalledWith(19005);
     expect(output).toContain("Stopped LaunchAgent");
+  });
+
+  it("refuses in-band LaunchAgent disable-stop before any launchctl call", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: "ai.openclaw.gateway",
+      },
+      async () => {
+        await expect(
+          stopLaunchAgent({ env, stdout: new PassThrough(), disable: true }),
+        ).rejects.toThrow(
+          "Refusing to stop LaunchAgent ai.openclaw.gateway from inside the same launchd service",
+        );
+      },
+    );
+
+    expect(state.launchctlCalls).toEqual([]);
   });
 
   it("treats already-unloaded services as successfully stopped without bootout fallback (--disable)", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -56,7 +56,6 @@ const state = vi.hoisted(() => ({
   fileWrites: [] as Array<{ path: string; data: string }>,
 }));
 const launchdRestartHandoffState = vi.hoisted(() => ({
-  isCurrentProcessLaunchdServiceLabel: vi.fn<(label: string) => boolean>(() => false),
   scheduleDetachedLaunchdRestartHandoff: vi.fn<
     (_params: unknown) => { ok: boolean; pid?: number; detail?: string }
   >(() => ({ ok: true, pid: 7331 })),
@@ -251,8 +250,6 @@ vi.mock("./exec-file.js", () => ({
 }));
 
 vi.mock("./launchd-restart-handoff.js", () => ({
-  isCurrentProcessLaunchdServiceLabel: (label: string) =>
-    launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel(label),
   scheduleDetachedLaunchdRestartHandoff: (params: unknown) =>
     launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff(params),
 }));
@@ -360,8 +357,6 @@ beforeEach(() => {
   inspectPortUsage.mockResolvedValue({ port: 18789, status: "free", listeners: [], hints: [] });
   formatPortDiagnostics.mockReset();
   formatPortDiagnostics.mockReturnValue(["Port 18789 is already in use."]);
-  launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel.mockReset();
-  launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel.mockReturnValue(false);
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReset();
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReturnValue({
     ok: true,
@@ -1699,12 +1694,13 @@ describe("launchd install", () => {
 
   it("hands restart off to a detached helper when invoked from the current LaunchAgent", async () => {
     const env = createDefaultLaunchdEnv();
-    launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel.mockReturnValue(true);
 
-    const result = await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    const result = await withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+      }),
+    );
 
     expect(result).toEqual({ outcome: "scheduled" });
     expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).toHaveBeenCalledWith({
@@ -1718,7 +1714,6 @@ describe("launchd install", () => {
   it("hands plist reload off when current LaunchAgent needs rewritten paths", async () => {
     const env = createDefaultLaunchdEnv();
     const plistPath = resolveLaunchAgentPlistPath(env);
-    launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel.mockReturnValue(true);
     state.files.set(
       plistPath,
       [
@@ -1739,10 +1734,12 @@ describe("launchd install", () => {
       ].join("\n"),
     );
 
-    const result = await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    const result = await withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+      }),
+    );
 
     expect(result).toEqual({ outcome: "scheduled" });
     expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).toHaveBeenCalledWith({
@@ -1756,18 +1753,70 @@ describe("launchd install", () => {
 
   it("surfaces detached handoff failures", async () => {
     const env = createDefaultLaunchdEnv();
-    launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel.mockReturnValue(true);
     launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReturnValue({
       ok: false,
       detail: "spawn failed",
     });
 
     await expect(
-      restartLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-      }),
+      withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
+        restartLaunchAgent({
+          env,
+          stdout: new PassThrough(),
+        }),
+      ),
     ).rejects.toThrow("launchd restart handoff failed: spawn failed");
+  });
+
+  it("hands restart off when XPC_SERVICE_NAME is inherited", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    const result = await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: "0",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+      },
+      async () =>
+        restartLaunchAgent({
+          env,
+          stdout: new PassThrough(),
+        }),
+    );
+
+    expect(result).toEqual({ outcome: "scheduled" });
+    expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).toHaveBeenCalledWith({
+      env,
+      mode: "kickstart",
+      waitForPid: process.pid,
+    });
+    expect(state.launchctlCalls).toStrictEqual([]);
+  });
+
+  it("does not hand restart off for unrelated inherited XPC service names", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: "0",
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+        OPENCLAW_LAUNCHD_LABEL: undefined,
+      },
+      async () =>
+        restartLaunchAgent({
+          env,
+          stdout: new PassThrough(),
+        }),
+    );
+
+    expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).not.toHaveBeenCalled();
+    expect(launchctlCommandNames()).toContain("kickstart");
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -81,6 +81,22 @@ function isCurrentGatewayLaunchdLabel(label: string, env: NodeJS.ProcessEnv): bo
   return Boolean(configuredLabel && label === configuredLabel);
 }
 
+function isCurrentProcessLaunchdServiceStopTarget(
+  label: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  for (const launchdLabel of [env.LAUNCH_JOB_LABEL, env.LAUNCH_JOB_NAME, env.XPC_SERVICE_NAME]) {
+    if (launchdLabel?.trim() === label) {
+      return true;
+    }
+  }
+  return (
+    env.OPENCLAW_SERVICE_MARKER?.trim() === GATEWAY_SERVICE_MARKER &&
+    Boolean(env.OPENCLAW_SERVICE_KIND?.trim()) &&
+    env.OPENCLAW_LAUNCHD_LABEL?.trim() === label
+  );
+}
+
 export function isOpenClawUpdateLaunchdLabel(label: unknown): label is string {
   return normalizeOpenClawUpdateLaunchdLabel(label) !== null;
 }
@@ -789,6 +805,12 @@ export async function stopLaunchAgent({
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const serviceTarget = `${domain}/${label}`;
+
+  if (isCurrentProcessLaunchdServiceStopTarget(label)) {
+    throw new Error(
+      `Refusing to stop LaunchAgent ${label} from inside the same launchd service; run this command from an external shell.`,
+    );
+  }
 
   if (!persistDisable) {
     // Default: bootout only. Removes the job from the current launchd domain without

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -16,14 +16,12 @@ import {
   resolveLegacyGatewayLaunchAgentLabels,
 } from "./constants.js";
 import { execFileUtf8 } from "./exec-file.js";
+import { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
 import {
   buildLaunchAgentPlist as buildLaunchAgentPlistImpl,
   readLaunchAgentProgramArgumentsFromFile,
 } from "./launchd-plist.js";
-import {
-  isCurrentProcessLaunchdServiceLabel,
-  scheduleDetachedLaunchdRestartHandoff,
-} from "./launchd-restart-handoff.js";
+import { scheduleDetachedLaunchdRestartHandoff } from "./launchd-restart-handoff.js";
 import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
 import { resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
@@ -79,22 +77,6 @@ function isCurrentGatewayLaunchdLabel(label: string, env: NodeJS.ProcessEnv): bo
   }
   const configuredLabel = env.OPENCLAW_LAUNCHD_LABEL?.trim();
   return Boolean(configuredLabel && label === configuredLabel);
-}
-
-function isCurrentProcessLaunchdServiceStopTarget(
-  label: string,
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  for (const launchdLabel of [env.LAUNCH_JOB_LABEL, env.LAUNCH_JOB_NAME, env.XPC_SERVICE_NAME]) {
-    if (launchdLabel?.trim() === label) {
-      return true;
-    }
-  }
-  return (
-    env.OPENCLAW_SERVICE_MARKER?.trim() === GATEWAY_SERVICE_MARKER &&
-    Boolean(env.OPENCLAW_SERVICE_KIND?.trim()) &&
-    env.OPENCLAW_LAUNCHD_LABEL?.trim() === label
-  );
 }
 
 export function isOpenClawUpdateLaunchdLabel(label: unknown): label is string {
@@ -806,7 +788,9 @@ export async function stopLaunchAgent({
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const serviceTarget = `${domain}/${label}`;
 
-  if (isCurrentProcessLaunchdServiceStopTarget(label)) {
+  if (
+    isCurrentProcessLaunchdServiceLabel(label, process.env, { allowConfiguredLabelFallback: false })
+  ) {
     throw new Error(
       `Refusing to stop LaunchAgent ${label} from inside the same launchd service; run this command from an external shell.`,
     );


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- On macOS, OpenClaw could invoke the gateway LaunchAgent stop path from inside the gateway's own managed process tree.
- That path uses `launchctl bootout` for a normal stop. `bootout` is valid when an external operator runs it, but it unloads the job from launchd.
- If the gateway unloads its own LaunchAgent, launchd sends SIGTERM to the gateway and removes the job from the user domain. `KeepAlive=true` can no longer recover it because there is no loaded job left to keep alive.

Why does this matter now?

- Issue #89174 documents a real macOS outage where `ai.openclaw.gateway` was unloaded at `2026-06-01 04:15:09 -0400` and did not start again until manual `launchctl enable` + `launchctl bootstrap` recovery at `2026-06-01 11:22:28 -0400`.
- The important failure shape is not a normal crash. The service was explicitly removed from launchd by an in-band process chain, so passive LaunchAgent recovery could not run.

What is the intended outcome?

- Refuse same-service `stopLaunchAgent` calls before any destructive `launchctl` command runs.
- Preserve external operator stop behavior, including explicit LaunchAgent label overrides.
- Keep restart behavior separate: restart already has a detached handoff path, while stop has no required recovery handoff by definition.

What is intentionally out of scope?

- Banning external `launchctl bootout` or external `openclaw gateway stop`.
- Changing LaunchAgent uninstall behavior, where unloading the job is expected.
- Adding durable bootout/restart sentinels, status/doctor diagnostics, browser-first recovery guidance, or a new stop handoff process.

What does success look like?

- In-band stop and disable-stop throw before `bootout`, `disable`, `stop`, or fallback `bootout` can run.
- External shell/operator stops still target the selected LaunchAgent.
- Label override and inherited launchd-marker edge cases stay covered by tests.

What should reviewers focus on?

- Whether `stopLaunchAgent` is the right lifecycle boundary for this guard.
- Whether the current-process identity check blocks same-service self-stop without blocking legitimate external stop/update flows.

## Linked context

Which issue does this close?

- Closes #89174

Which issues, PRs, or discussions are related?

- Related #89174

Was this requested by a maintainer or owner?

- Requested by @bek91 through issue triage and local validation of the affected macOS setup.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: macOS gateway stop/unload initiated from inside the managed gateway LaunchAgent environment.
- Real environment tested: affected macOS OpenClaw install was used to validate the proposed stop-boundary fix before this PR; this isolated worktree was validated with focused daemon tests.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/daemon/launchd.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[test] starting test/vitest/vitest.daemon.config.ts

 RUN  v4.1.7 /Users/bek/Desktop/openclaw-macos-launch

 Test Files  1 passed (1)
      Tests  83 passed (83)
   Start at  18:08:36
   Duration  412ms (transform 239ms, setup 145ms, import 128ms, tests 52ms, environment 0ms)

[test] passed 1 Vitest shard in 4.21s
```

- Observed result after fix: in-band stop and disable-stop tests throw before launchctl is invoked; external label override still stops the selected LaunchAgent.
- What was not tested: full macOS LaunchAgent integration test suite in this isolated worktree.
- Proof limitations or environment constraints: this PR includes focused mocked regression coverage; the live affected-install validation happened outside this isolated worktree.
- Before evidence (optional but encouraged): issue #89174 documents the production outage and unloaded LaunchAgent state before manual recovery.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/daemon/launchd.test.ts`
- `codex review --base origin/main`

What regression coverage was added or updated?

- Normal in-band stop refuses before `launchctl bootout`.
- In-band disable-stop refuses before `launchctl disable`, `launchctl stop`, or fallback `bootout`.
- Inherited unrelated `XPC_SERVICE_NAME` does not bypass the OpenClaw service-marker fallback.
- External LaunchAgent label overrides still stop the selected target.

What failed before this fix, if known?

- Before the guard, a same-service in-band stop could proceed into `launchctl bootout`/`disable`/`stop`, unloading the active LaunchAgent and leaving no remaining trusted process to bring it back.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- Yes. In-band macOS LaunchAgent self-stop now fails with an explicit error.

Did config, environment, or migration behavior change? (`Yes/No`)

- No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- No.

What is the highest-risk area?

- Over-blocking a legitimate external stop path that happens to pass a LaunchAgent label through environment.

How is that risk mitigated?

- The guard uses current process identity markers rather than treating the target service env alone as proof of being in-band.
- Tests cover external label override behavior and inherited launchd marker behavior.
- The guard lives only in stop, not uninstall, so intentional uninstall semantics remain unchanged.

## Current review state

What is the next action?

- Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on CI and maintainer review.

Which bot or reviewer comments were addressed?

- Local `codex review --base origin/main` findings were addressed; final run reported no actionable correctness issues.

AI-assisted disclosure: This PR was prepared with Codex assistance. I reviewed the generated changes, understand the code submitted, and am responsible for the final patch.
