### PR TITLE
fix: deliver tts tool audio on whatsapp

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { createAssistantMessageEventStream } from "@openclaw/llm-core";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
 import { agentLoop, agentLoopContinue } from "./agent-loop.js";
 import type { Message, Model } from "./llm.js";
-import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, StreamFn } from "./types.js";
+import type {
+  AgentContext,
+  AgentEvent,
+  AgentLoopConfig,
+  AgentMessage,
+  AgentTool,
+  StreamFn,
+} from "./types.js";
 
 const model: Model = {
   id: "test-model",
@@ -70,5 +79,77 @@ describe("agentLoop EventStream failures", () => {
     const result = await stream.result();
 
     expectTerminalFailure(events, result);
+  });
+});
+
+describe("agentLoop tool execution names", () => {
+  it("emits the registered tool name for a tts call", async () => {
+    const assistantMessage: Message = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call-tts",
+          name: "tts",
+          arguments: { text: "hello" },
+        },
+      ],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "toolUse",
+      timestamp: 1,
+    };
+    const ttsTool: AgentTool = {
+      name: "tts",
+      label: "TTS",
+      description: "Text to speech",
+      parameters: Type.Object({
+        text: Type.String(),
+      }),
+      execute: vi.fn(async () => ({
+        content: [{ type: "text", text: "audio generated" }],
+        details: { media: { localPaths: ["/tmp/reply.opus"], trustedLocalMedia: true } },
+      })),
+    };
+    const streamFn: StreamFn = () => {
+      const stream = createAssistantMessageEventStream();
+      stream.push({ type: "done", reason: "toolUse", message: assistantMessage });
+      return stream;
+    };
+    const stream = agentLoop(
+      [{ role: "user", content: "speak this", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [ttsTool] },
+      {
+        ...config,
+        shouldStopAfterTurn: () => true,
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+
+    expect(ttsTool.execute).toHaveBeenCalledWith(
+      "call-tts",
+      { text: "hello" },
+      undefined,
+      expect.any(Function),
+    );
+    expect(
+      events
+        .filter(
+          (event) => event.type === "tool_execution_start" || event.type === "tool_execution_end",
+        )
+        .map((event) => event.toolName),
+    ).toEqual(["tts", "tts"]);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -146,6 +146,7 @@ import {
 } from "../../embedded-agent-helpers.js";
 import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handlers.tools.js";
 import { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
+import { isCoreToolResultMediaTrustedName } from "../../embedded-agent-subscribe.tools.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { runAgentEndSideEffects } from "../../harness/agent-end-side-effects.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
@@ -2120,6 +2121,9 @@ export async function runEmbeddedAttempt(
           return name ? [name] : [];
         }),
       );
+      const trustedLocalMediaToolNames = new Set(
+        Array.from(builtinToolNames).filter(isCoreToolResultMediaTrustedName),
+      );
       // Admission-time conflict check only against non-plugin core tools, to
       // preserve prior behavior where client tools may coexist with unrelated
       // plugin tool names. MEDIA passthrough is still gated by the raw-name
@@ -3109,6 +3113,7 @@ export async function runEmbeddedAttempt(
           sessionId: params.sessionId,
           agentId: sessionAgentId,
           builtinToolNames,
+          trustedLocalMediaToolNames,
           internalEvents: params.internalEvents,
         }),
       );

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -328,34 +328,38 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolMediaUrls).toStrictEqual([]);
   });
 
-  it("queues TTS structured media without leaking spoken text when verbose is full", async () => {
-    const ctx = createMockContext({
-      shouldEmitToolOutput: true,
-      onToolResult: vi.fn(),
-      toolResultFormat: "plain",
-      builtinToolNames: new Set(["tts"]),
-    });
+  it.each(["tts", "openclaw.tts"])(
+    "queues %s structured media without leaking spoken text when verbose is full",
+    async (toolName) => {
+      const ctx = createMockContext({
+        shouldEmitToolOutput: true,
+        onToolResult: vi.fn(),
+        toolResultFormat: "plain",
+        builtinToolNames: new Set(["tts"]),
+      });
 
-    await handleToolExecutionEnd(ctx, {
-      type: "tool_execution_end",
-      toolName: "tts",
-      toolCallId: "tc-1",
-      isError: false,
-      result: {
-        content: [{ type: "text", text: "(spoken) hello" }],
-        details: {
-          media: {
-            mediaUrl: "/tmp/reply.opus",
-            audioAsVoice: true,
+      await handleToolExecutionEnd(ctx, {
+        type: "tool_execution_end",
+        toolName,
+        toolCallId: "tc-1",
+        isError: false,
+        result: {
+          content: [{ type: "text", text: "(spoken) hello" }],
+          details: {
+            media: {
+              mediaUrl: "/tmp/reply.opus",
+              audioAsVoice: true,
+              trustedLocalMedia: true,
+            },
           },
         },
-      },
-    });
+      });
 
-    expect(ctx.emitToolOutput).not.toHaveBeenCalled();
-    expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/reply.opus"]);
-    expect(ctx.state.pendingToolAudioAsVoice).toBe(true);
-  });
+      expect(ctx.emitToolOutput).not.toHaveBeenCalled();
+      expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/reply.opus"]);
+      expect(ctx.state.pendingToolAudioAsVoice).toBe(true);
+    },
+  );
 
   it("queues one voice copy when TTS output text mentions the generated file", async () => {
     const ctx = createMockContext({
@@ -657,35 +661,6 @@ describe("handleToolExecutionEnd media emission", () => {
       toolCallId: "tc-1",
       isError: false,
       result: {
-        details: {
-          media: {
-            mediaUrl: "/tmp/reply.opus",
-            audioAsVoice: true,
-            trustedLocalMedia: true,
-          },
-        },
-      },
-    });
-
-    expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/reply.opus"]);
-    expect(ctx.state.pendingToolAudioAsVoice).toBe(true);
-    expect(ctx.state.pendingToolTrustedLocalMedia).toBe(true);
-  });
-
-  it("queues trusted TTS local media when the exact built-in name is absent", async () => {
-    const ctx = createMockContext({
-      shouldEmitToolOutput: false,
-      onToolResult: vi.fn(),
-      builtinToolNames: new Set(["web_search"]),
-    });
-
-    await handleToolExecutionEnd(ctx, {
-      type: "tool_execution_end",
-      toolName: "tts",
-      toolCallId: "tc-1",
-      isError: false,
-      result: {
-        content: [{ type: "text", text: "(spoken) hello" }],
         details: {
           media: {
             mediaUrl: "/tmp/reply.opus",

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -415,9 +415,12 @@ function shouldSuppressStructuredMediaToolOutput(params: {
   hasDeliverableStructuredMedia: boolean;
   builtinToolNames?: ReadonlySet<string>;
 }): boolean {
+  const rawToolName = params.rawToolName.trim();
+  const ownedTtsTool =
+    (params.toolName === "tts" && rawToolName === "tts") ||
+    (params.toolName === "openclaw.tts" && rawToolName === "openclaw.tts");
   return (
-    params.toolName === "tts" &&
-    params.rawToolName.trim() === "tts" &&
+    ownedTtsTool &&
     params.builtinToolNames?.has("tts") === true &&
     !params.isToolError &&
     params.hasDeliverableStructuredMedia

--- a/src/agents/embedded-agent-subscribe.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.media.test.ts
@@ -298,10 +298,14 @@ describe("extractToolResultMediaPaths", () => {
     ).toEqual(["/tmp/screenshot.png"]);
   });
 
-  it("keeps trusted TTS local media when the raw built-in name is absent", () => {
+  it.each([
+    ["tts", ["/tmp/reply.opus"]],
+    ["openclaw.tts", ["/tmp/reply.opus"]],
+    ["external.tts", []],
+  ])("filters trusted TTS local media for %s", (toolName, expected) => {
     expect(
       filterToolResultMediaUrls(
-        "tts",
+        toolName,
         ["/tmp/reply.opus"],
         {
           details: {
@@ -311,9 +315,9 @@ describe("extractToolResultMediaPaths", () => {
             },
           },
         },
-        new Set(["web_search"]),
+        new Set(["tts"]),
       ),
-    ).toEqual(["/tmp/reply.opus"]);
+    ).toEqual(expected);
   });
 
   it("keeps local media for bundled plugin tool names trusted in this run", () => {

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -356,11 +356,19 @@ function isTrustedOwnedTtsLocalMedia(
   result: unknown,
   trustedLocalMediaToolNames?: ReadonlySet<string>,
 ): boolean {
+  const normalizedToolName = toolName ? normalizeToolName(toolName) : "";
   if (
     !toolName ||
-    !isToolResultMediaTrusted(toolName, result, trustedLocalMediaToolNames) ||
-    normalizeToolName(toolName) !== "tts"
+    isExternalToolResult(result) ||
+    (normalizedToolName !== "tts" && normalizedToolName !== "openclaw.tts")
   ) {
+    return false;
+  }
+  const registeredTtsTool =
+    trustedLocalMediaToolNames === undefined
+      ? normalizedToolName === "tts" && isCoreToolResultMediaTrustedName(toolName)
+      : trustedLocalMediaToolNames.has(toolName.trim()) || trustedLocalMediaToolNames.has("tts");
+  if (!registeredTtsTool) {
     return false;
   }
   const media = readToolResultDetails(result)?.media;
@@ -384,7 +392,10 @@ export function filterToolResultMediaUrls(
     result,
     trustedLocalMediaToolNames,
   );
-  if (isToolResultMediaTrusted(toolName, result, trustedLocalMediaToolNames)) {
+  if (
+    trustedOwnedTtsLocalMedia ||
+    isToolResultMediaTrusted(toolName, result, trustedLocalMediaToolNames)
+  ) {
     // When the current run provides its exact trusted local-media tool names,
     // require the raw emitted tool name to match one of them before allowing
     // local media paths.

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -158,6 +158,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const canShowReasoning = params.thinkingLevel !== "off";
   const toolResultFormat = params.toolResultFormat ?? "markdown";
   const useMarkdown = toolResultFormat === "markdown";
+  const trustedLocalMediaToolNames = params.trustedLocalMediaToolNames;
   const initialPendingToolMediaUrls = collectPendingMediaFromInternalEvents(params.internalEvents);
   const state: EmbeddedAgentSubscribeState = {
     assistantTexts: [],
@@ -613,7 +614,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       toolName,
       mediaArtifact?.mediaUrls ?? [],
       result,
-      params.trustedLocalMediaToolNames,
+      trustedLocalMediaToolNames,
     );
     if (
       params.sourceReplyDeliveryMode === "message_tool_only" &&
@@ -1156,7 +1157,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     blockChunker,
     hookRunner: params.hookRunner,
     builtinToolNames: params.builtinToolNames,
-    trustedLocalMediaToolNames: params.trustedLocalMediaToolNames,
+    trustedLocalMediaToolNames,
     noteLastAssistant,
     shouldEmitToolResult,
     shouldEmitToolOutput,


### PR DESCRIPTION
## Summary

This fixes TTS tool audio delivery for channel-backed runs such as WhatsApp.

Before this change, a successful TTS tool call returned the generated local audio path through `details.media`. Delivery then depended on the subscriber's tool-result media path recognizing that result as trusted local media. That path handled the raw `tts` tool name, but could filter qualified OpenClaw tool names such as `openclaw.tts`, so the transcript could show the spoken text while the generated audio never reached the channel reply.

The fix keeps delivery behind the existing subscriber and final reply-payload path. Successful owned TTS results are queued as pending tool media, merged into the attempt payloads, and delivered through the normal channel reply pipeline. The local-media exception is still narrow: it applies only to owned `tts` / `openclaw.tts` results, requires the result to carry `details.media.trustedLocalMedia`, and rejects external or MCP-backed TTS-looking results.

## What changed

- Pass a run-derived trusted local-media tool-name set into `subscribeEmbeddedAgentSession`.
- Treat both `tts` and `openclaw.tts` as owned TTS tool result names for structured local-media delivery.
- Keep external or MCP-backed TTS-looking results untrusted even if they set `trustedLocalMedia`.
- Preserve exact-name trust for other registered media-producing tools, so normalized aliases and case variants do not inherit local-media trust.
- Continue using pending tool media and final reply payload merging for channel delivery instead of adding a direct WhatsApp/tool send path.

## Safety notes

- TTS media still travels through the existing pending tool-media and reply payload delivery boundary.
- The local-media trust exception stays limited to owned TTS results and still requires `trustedLocalMedia: true` on the structured media details.
- Non-owned tool names such as `external.tts` and MCP-provenance results continue to have local paths filtered out.

## Real behavior proof

Behavior addressed: TTS tool audio generated during a WhatsApp/channel-backed agent run is retained as trusted local media when the emitted tool name is `openclaw.tts`, so it can be merged into the final channel reply payload instead of being filtered out.

Real environment tested: Local unit/integration-level Vitest shards in this worktree, plus PR CI.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts src/agents/embedded-agent-subscribe.tools.media.test.ts`

Evidence after fix: `embedded-agent-subscribe.handlers.tools.media.test.ts` verifies both `tts` and `openclaw.tts` structured media queue without leaking spoken transcript text in full verbose output. `embedded-agent-subscribe.tools.media.test.ts` verifies trusted local media is retained for `tts` and `openclaw.tts`, while `external.tts` is rejected.

Observed result after fix: PR CI is green for the relevant agent/subscriber lanes and Real behavior proof checks on the current head.

What was not tested: Live WhatsApp Web delivery with a real linked account was not run for this PR.
