### PR TITLE
fix(plugins): guard runtime tool descriptors

### DIFF
--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -141,23 +141,47 @@ function asJsonObject(value: unknown): JsonObject {
   return value as JsonObject;
 }
 
+function readOptionalString(value: () => unknown): string | undefined {
+  try {
+    const resolved = value();
+    return typeof resolved === "string" && resolved.trim() ? resolved.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function capturePluginToolDescriptor(params: {
   pluginId: string;
   tool: AnyAgentTool;
   optional: boolean;
+  description?: string;
+  displaySummary?: string;
+  label?: string;
+  toolName?: string;
+  parameters?: unknown;
+  snapshotFields?: boolean;
 }): CachedPluginToolDescriptor {
-  const label = (params.tool as { label?: unknown }).label;
-  const title = typeof label === "string" && label.trim() ? label.trim() : undefined;
+  const title = params.snapshotFields
+    ? params.label
+    : (params.label ?? readOptionalString(() => (params.tool as { label?: unknown }).label));
+  const toolName = params.toolName ?? params.tool.name;
+  const displaySummary = params.snapshotFields
+    ? params.displaySummary
+    : (params.displaySummary ?? readOptionalString(() => params.tool.displaySummary));
+  const description =
+    params.description ??
+    (params.snapshotFields ? undefined : readOptionalString(() => params.tool.description)) ??
+    "";
   return {
-    ...(params.tool.displaySummary ? { displaySummary: params.tool.displaySummary } : {}),
+    ...(displaySummary ? { displaySummary } : {}),
     optional: params.optional,
     descriptor: {
-      name: params.tool.name,
+      name: toolName,
       ...(title ? { title } : {}),
-      description: params.tool.description,
-      inputSchema: asJsonObject(params.tool.parameters),
+      description,
+      inputSchema: asJsonObject(params.parameters ?? params.tool.parameters),
       owner: { kind: "plugin", pluginId: params.pluginId },
-      executor: { kind: "plugin", pluginId: params.pluginId, toolName: params.tool.name },
+      executor: { kind: "plugin", pluginId: params.pluginId, toolName },
     },
   };
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -163,6 +163,66 @@ function createMalformedTool(name: string) {
   };
 }
 
+function createPoisonedToolDescriptors() {
+  return [
+    {
+      get name() {
+        throw new Error("plugin tool name getter exploded");
+      },
+      description: "poisoned name",
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [{ type: "text", text: "bad" }] };
+      },
+    },
+    {
+      name: "poisoned_execute",
+      description: "poisoned execute",
+      parameters: { type: "object", properties: {} },
+      get execute() {
+        throw new Error("plugin tool execute getter exploded");
+      },
+    },
+    {
+      name: "poisoned_parameters",
+      description: "poisoned parameters",
+      get parameters() {
+        throw new Error("plugin tool parameters getter exploded");
+      },
+      async execute() {
+        return { content: [{ type: "text", text: "bad" }] };
+      },
+    },
+    {
+      name: "poisoned_description",
+      get description() {
+        throw new Error("plugin tool description getter exploded");
+      },
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [{ type: "text", text: "bad" }] };
+      },
+    },
+  ];
+}
+
+function createToolWithPoisonedOptionalDescriptorFields(name: string) {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: { type: "object", properties: {} },
+    get displaySummary() {
+      throw new Error("plugin tool displaySummary getter exploded");
+    },
+    get label() {
+      throw new Error("plugin tool label getter exploded");
+    },
+    async execute() {
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  };
+}
+
 function installConsoleMethodSpy(method: "log" | "warn") {
   const spy = vi.fn();
   loggingState.rawConsole = {
@@ -1936,6 +1996,35 @@ describe("resolvePluginTools optional tools", () => {
       registry.diagnostics,
       "plugin tool is malformed (schema-bug): broken_tool missing parameters object",
     );
+  });
+
+  it("skips plugin tools with poisoned descriptor fields while keeping valid sibling tools", () => {
+    const registry = setRegistry([
+      {
+        pluginId: "multi",
+        optional: false,
+        source: "/tmp/multi.js",
+        names: ["message"],
+        factory: () => [
+          ...createPoisonedToolDescriptors(),
+          createToolWithPoisonedOptionalDescriptorFields("message"),
+        ],
+      },
+    ]);
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({ toolAllowlist: ["group:plugins"] }),
+    );
+
+    expectResolvedToolNames(tools, ["message"]);
+    expect(tools[0]?.displaySummary).toBeUndefined();
+    expect(tools[0]?.label).toBeUndefined();
+    expect(registry.diagnostics.map((entry) => entry.message)).toEqual([
+      "plugin tool is malformed (multi): missing non-empty name",
+      "plugin tool is malformed (multi): poisoned_execute missing execute function",
+      "plugin tool is malformed (multi): poisoned_parameters missing parameters object",
+      "plugin tool is malformed (multi): poisoned_description missing description string",
+    ]);
   });
 
   it("warns with plugin factory timing details when a factory is slow", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -69,6 +69,17 @@ type PluginToolFactoryTiming = {
 
 type PluginToolFactoryResult = AnyAgentTool | AnyAgentTool[] | null | undefined;
 
+type PluginToolCandidate = {
+  toolRaw: unknown;
+  name: string;
+  description?: string;
+  displaySummary?: string;
+  execute?: AnyAgentTool["execute"];
+  label?: string;
+  parameters?: unknown;
+  malformedReason?: string;
+};
+
 const log = createSubsystemLogger("plugins/tools");
 const PLUGIN_TOOL_FACTORY_WARN_TOTAL_MS = 5_000;
 const PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS = 1_000;
@@ -111,11 +122,52 @@ function isAgentTool(value: unknown): value is AnyAgentTool {
     Boolean(value) &&
     typeof value === "object" &&
     !Array.isArray(value) &&
-    typeof (value as { execute?: unknown }).execute === "function"
+    typeof readPluginToolExecute(value) === "function"
   );
 }
 
-function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTool): AnyAgentTool {
+function readPluginToolPrepareArguments(tool: unknown): unknown {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+  try {
+    return tool.prepareArguments;
+  } catch {
+    return undefined;
+  }
+}
+
+function readPluginToolDescription(tool: unknown): unknown {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+  try {
+    return tool.description;
+  } catch {
+    return undefined;
+  }
+}
+
+function readOptionalPluginToolString(
+  tool: unknown,
+  key: "displaySummary" | "label",
+): string | undefined {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+  try {
+    const value = tool[key];
+    return typeof value === "string" && value.trim() ? value.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function wrapPluginToolCallbacks(
+  entry: PluginToolRegistration,
+  tool: AnyAgentTool,
+  candidate?: PluginToolCandidate,
+): AnyAgentTool {
   const key = pluginToolScopeKey(entry);
   const scopedByKey = scopedPluginTools.get(tool);
   const cached = scopedByKey?.get(key);
@@ -123,7 +175,19 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
     return cached;
   }
 
-  const prepareArguments = tool.prepareArguments;
+  const descriptorValues = new Map<PropertyKey, unknown>();
+  if (candidate && !candidate.malformedReason) {
+    descriptorValues.set("name", candidate.name);
+    descriptorValues.set("description", candidate.description);
+    descriptorValues.set("parameters", candidate.parameters);
+    descriptorValues.set("displaySummary", candidate.displaySummary);
+    descriptorValues.set("label", candidate.label);
+  }
+  const prepareArgumentsRaw = readPluginToolPrepareArguments(tool);
+  const prepareArguments =
+    typeof prepareArgumentsRaw === "function" ? prepareArgumentsRaw : undefined;
+  const executeRaw = candidate?.execute ?? readPluginToolExecute(tool);
+  const execute = typeof executeRaw === "function" ? executeRaw : undefined;
   const scopedPrepareArguments = prepareArguments
     ? (args: unknown) =>
         runWithPluginToolScope(entry, () => Reflect.apply(prepareArguments, tool, [args]))
@@ -137,12 +201,18 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
     runWithPluginToolScope(
       entry,
       () =>
-        Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
-          AnyAgentTool["execute"]
-        >,
+        Reflect.apply(execute ?? tool.execute, tool, [
+          toolCallId,
+          params,
+          signal,
+          onUpdate,
+        ]) as ReturnType<AnyAgentTool["execute"]>,
     );
   const wrapped = new Proxy<AnyAgentTool>(tool, {
     get(target, prop) {
+      if (descriptorValues.has(prop)) {
+        return descriptorValues.get(prop);
+      }
       if (prop === "prepareArguments" && scopedPrepareArguments) {
         return scopedPrepareArguments;
       }
@@ -165,6 +235,14 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
           configurable: true,
           enumerable: Object.prototype.propertyIsEnumerable.call(target, prop),
           value: scopedExecute,
+          writable: true,
+        };
+      }
+      if (descriptorValues.has(prop)) {
+        return {
+          configurable: true,
+          enumerable: Object.prototype.propertyIsEnumerable.call(target, prop),
+          value: descriptorValues.get(prop),
           writable: true,
         };
       }
@@ -316,7 +394,33 @@ function readPluginToolName(tool: unknown): string {
     return "";
   }
   // Optional-tool allowlists need a best-effort name before full shape validation.
-  return typeof tool.name === "string" ? tool.name.trim() : "";
+  try {
+    return typeof tool.name === "string" ? tool.name.trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+function readPluginToolExecute(tool: unknown): unknown {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+  try {
+    return tool.execute;
+  } catch {
+    return undefined;
+  }
+}
+
+function readPluginToolParameters(tool: unknown): unknown {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+  try {
+    return tool.parameters;
+  } catch {
+    return undefined;
+  }
 }
 
 function toElapsedMs(value: number): number {
@@ -444,21 +548,51 @@ function shouldWarnPluginToolFactoryTimings(params: {
   );
 }
 
-function describeMalformedPluginTool(tool: unknown): string | undefined {
+function readPluginToolNameCandidate(tool: unknown): PluginToolCandidate {
   if (!isRecord(tool)) {
-    return "tool must be an object";
+    return { toolRaw: tool, name: "", malformedReason: "tool must be an object" };
   }
   const name = readPluginToolName(tool);
   if (!name) {
-    return "missing non-empty name";
+    return { toolRaw: tool, name: "", malformedReason: "missing non-empty name" };
   }
-  if (typeof tool.execute !== "function") {
-    return `${name} missing execute function`;
+  return { toolRaw: tool, name };
+}
+
+function inspectPluginToolCandidate(candidate: PluginToolCandidate): PluginToolCandidate {
+  if (candidate.malformedReason) {
+    return candidate;
   }
-  if (!isRecord(tool.parameters)) {
-    return `${name} missing parameters object`;
+  const execute = readPluginToolExecute(candidate.toolRaw);
+  if (typeof execute !== "function") {
+    return {
+      ...candidate,
+      malformedReason: `${candidate.name} missing execute function`,
+    };
   }
-  return undefined;
+  const toolExecute = execute as AnyAgentTool["execute"];
+  const parameters = readPluginToolParameters(candidate.toolRaw);
+  if (!isRecord(parameters)) {
+    return {
+      ...candidate,
+      malformedReason: `${candidate.name} missing parameters object`,
+    };
+  }
+  const description = readPluginToolDescription(candidate.toolRaw);
+  if (typeof description !== "string") {
+    return {
+      ...candidate,
+      malformedReason: `${candidate.name} missing description string`,
+    };
+  }
+  return {
+    ...candidate,
+    description,
+    displaySummary: readOptionalPluginToolString(candidate.toolRaw, "displaySummary"),
+    execute: toolExecute,
+    label: readOptionalPluginToolString(candidate.toolRaw, "label"),
+    parameters,
+  };
 }
 
 function pluginToolNamesMatchAllowlist(params: {
@@ -690,12 +824,12 @@ function createCachedDescriptorPluginTool(params: {
         const resolved = resolvePluginToolFactory(candidate, params.ctx);
         const listRaw: unknown[] = Array.isArray(resolved) ? resolved : resolved ? [resolved] : [];
         for (const toolRaw of listRaw) {
-          const malformedReason = describeMalformedPluginTool(toolRaw);
-          if (malformedReason) {
+          const inspected = inspectPluginToolCandidate(readPluginToolNameCandidate(toolRaw));
+          if (inspected.malformedReason) {
             continue;
           }
-          const runtimeTool = toolRaw as AnyAgentTool;
-          if (normalizeToolName(readPluginToolName(runtimeTool)) === requestedToolName) {
+          const runtimeTool = inspected.toolRaw as AnyAgentTool;
+          if (normalizeToolName(inspected.name) === requestedToolName) {
             return runtimeTool;
           }
         }
@@ -1209,6 +1343,7 @@ export function resolvePluginTools(params: {
       continue;
     }
     const listRaw: unknown[] = Array.isArray(resolved) ? resolved : [resolved];
+    const nameCandidates = listRaw.map(readPluginToolNameCandidate);
     const selectedManifestToolNames =
       manifestPlugin && availabilityNames.length > 0
         ? new Set(allowlistNames.map((name) => normalizeToolName(name)))
@@ -1218,8 +1353,11 @@ export function resolvePluginTools(params: {
         ? new Set(availabilityNames.map((name) => normalizeToolName(name)))
         : undefined;
     const availableList = manifestPlugin
-      ? listRaw.filter((tool) => {
-          const toolName = readPluginToolName(tool);
+      ? nameCandidates.filter((tool) => {
+          if (tool.malformedReason) {
+            return true;
+          }
+          const toolName = tool.name;
           const normalizedToolName = normalizeToolName(toolName);
           if (
             isManifestToolOptional(manifestPlugin, toolName) &&
@@ -1246,19 +1384,19 @@ export function resolvePluginTools(params: {
             hasAuthForProvider: params.hasAuthForProvider,
           });
         })
-      : listRaw;
+      : nameCandidates;
     const policyAvailableList = availableList.filter(
       (tool) =>
         !denylistBlocksPluginTool({
           pluginId: entry.pluginId,
-          toolName: readPluginToolName(tool),
+          toolName: tool.name,
           denylist,
         }),
     );
     const list = entry.optional
       ? policyAvailableList.filter((tool) =>
           isOptionalToolAllowed({
-            toolName: readPluginToolName(tool),
+            toolName: tool.name,
             pluginId: entry.pluginId,
             allowlist,
           }),
@@ -1268,12 +1406,10 @@ export function resolvePluginTools(params: {
       continue;
     }
     const normalizedNameSet = new Set<string>();
-    for (const toolRaw of list) {
-      // Plugin factories run at request time and can return arbitrary values; isolate
-      // malformed tools here so one bad plugin tool cannot poison every provider.
-      const malformedReason = describeMalformedPluginTool(toolRaw);
-      if (malformedReason) {
-        const message = `plugin tool is malformed (${entry.pluginId}): ${malformedReason}`;
+    for (const candidate of list) {
+      const inspected = inspectPluginToolCandidate(candidate);
+      if (inspected.malformedReason) {
+        const message = `plugin tool is malformed (${entry.pluginId}): ${inspected.malformedReason}`;
         context.logger.error(message);
         registry.diagnostics.push({
           level: "error",
@@ -1283,11 +1419,12 @@ export function resolvePluginTools(params: {
         });
         continue;
       }
-      const tool = toolRaw as AnyAgentTool;
+      const tool = inspected.toolRaw as AnyAgentTool;
+      const toolName = inspected.name;
       const undeclared = entry.declaredNames
         ? findUndeclaredPluginToolNames({
             declaredNames: entry.declaredNames,
-            toolNames: [tool.name],
+            toolNames: [toolName],
           })
         : [];
       if (undeclared.length > 0) {
@@ -1301,9 +1438,9 @@ export function resolvePluginTools(params: {
         });
         continue;
       }
-      const normalizedToolName = normalizeToolName(tool.name);
+      const normalizedToolName = normalizeToolName(toolName);
       if (normalizedNameSet.has(normalizedToolName) || existingNormalized.has(normalizedToolName)) {
-        const message = `plugin tool name conflict (${entry.pluginId}): ${tool.name}`;
+        const message = `plugin tool name conflict (${entry.pluginId}): ${toolName}`;
         if (!params.suppressNameConflicts) {
           context.logger.error(message);
           registry.diagnostics.push({
@@ -1316,19 +1453,20 @@ export function resolvePluginTools(params: {
         continue;
       }
       normalizedNameSet.add(normalizedToolName);
-      existing.add(tool.name);
+      existing.add(toolName);
       existingNormalized.add(normalizedToolName);
+      const scopedTool = wrapPluginToolCallbacks(entry, tool, inspected);
       const optional = isPluginToolOptional({
         entry,
         manifestPlugin,
-        toolName: tool.name,
+        toolName,
       });
-      pluginToolMeta.set(tool, {
+      pluginToolMeta.set(scopedTool, {
         pluginId: entry.pluginId,
         optional,
         trustedLocalMedia: isTrustedManifestLocalMediaTool({
           manifestPlugin,
-          toolName: tool.name,
+          toolName,
         }),
       });
       if (manifestPlugin) {
@@ -1336,13 +1474,19 @@ export function resolvePluginTools(params: {
         capturedDescriptors.push(
           capturePluginToolDescriptor({
             pluginId: entry.pluginId,
-            tool,
+            tool: scopedTool,
+            toolName,
+            description: inspected.description,
+            displaySummary: inspected.displaySummary,
+            label: inspected.label,
+            parameters: inspected.parameters,
+            snapshotFields: true,
             optional,
           }),
         );
         capturedDescriptorsByPluginId.set(entry.pluginId, capturedDescriptors);
       }
-      tools.push(tool);
+      tools.push(scopedTool);
     }
   }
 


### PR DESCRIPTION
## Summary

- Harden runtime plugin tool candidate inspection against poisoned descriptor getters for `name`, `execute`, `parameters`, `description`, `label`, and `displaySummary`.
- Return accepted plugin tools through the scoped proxy with snapshotted descriptor fields so poisoned optional getters are not reachable downstream.
- Reuse validated descriptor snapshots when writing manifest tool descriptor cache entries, and cover the runtime behavior with a poisoned-descriptor regression test.

## Verification

- `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts --reporter=dot`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/tools.ts src/plugins/tools.optional.test.ts src/plugins/tool-descriptor-cache.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/tools.ts src/plugins/tools.optional.test.ts src/plugins/tool-descriptor-cache.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Remote proof: azure Crabbox run `run_95ca8a20197a`, lease `cbx_06e2e1c4e590`, `corepack pnpm check:changed`, exit 0

## Real behavior proof

Behavior addressed: Runtime plugin tools with malformed or poisoned descriptor getters are skipped with diagnostics while valid sibling tools remain available and scoped to the owning plugin.

Real environment tested: Azure Linux Crabbox run `run_95ca8a20197a`, lease `cbx_06e2e1c4e590`, cloned branch `fuzz-plugin-runtime-tool-descriptor-20260601`, Node `v24.15.0`.

Exact steps or command run after this patch: Installed Node/Corepack on the raw box, cloned the pushed branch, fetched `origin/main`, then ran `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed`.

Evidence after fix: `check:changed` selected `core` and `coreTests`; typecheck, changed-file lint, import-cycle/runtime guards, and related changed-gate checks passed with exit 0.

Observed result after fix: The focused regression keeps the valid `message` plugin tool, emits malformed diagnostics for poisoned `name`, `execute`, `parameters`, and `description` descriptors, and masks poisoned optional descriptor fields to safe `undefined` values.

What was not tested: Live third-party plugin packages beyond the mocked runtime registry regression.
