### PR TITLE
refactor: add public transcript identity API

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-19bdf1196ec771a00777a16fd1e9c3662b8fd788a81034e705c41a74ee79c7ec  plugin-sdk-api-baseline.json
-43feff80c90adad0f821d1f1e184a9bff1e93d81e6d53a26a26fd9e2972be759  plugin-sdk-api-baseline.jsonl
+15ceed8879fabeecd3e7c87726f121b64ee490b5c92135ecb3915490dc71934a  plugin-sdk-api-baseline.json
+d2be9469fa4952b4861c1a98dc0dee0327057afe98e2ac6b35a90ce5b0091f57  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -166,6 +166,8 @@ two-party event loops that do not go through the shared inbound reply runner.
 
     Prefer `getSessionEntry(...)`, `listSessionEntries(...)`, `patchSessionEntry(...)`, or `upsertSessionEntry(...)` for session workflows. These helpers address sessions by agent/session identity so plugins do not depend on the legacy `sessions.json` storage shape. Use `preserveActivity: true` for metadata-only patches that should not refresh session activity, and `replaceEntry: true` only when the callback returns a complete entry and deleted fields must stay deleted. `loadSessionStore(...)` remains as a deprecated compatibility escape hatch for callers that intentionally need a mutable whole-store clone.
 
+    For transcript reads, import `openclaw/plugin-sdk/session-transcript-runtime` and use `resolveSessionTranscriptIdentity(...)` or `readSessionTranscriptEvents(...)` with `{ agentId, sessionKey, sessionId }`. That API returns stable transcript identity and storage-neutral memory hit keys without exposing `sessionFile` as the identity. File-path helpers such as `resolveSessionFilePath(...)`, `resolveAndPersistSessionFile(...)`, and `readLatestAssistantTextFromSessionTranscript(...)` are legacy compatibility exports for plugins that still own file-backed behavior.
+
   </Accordion>
   <Accordion title="api.runtime.agent.defaults">
     Default model and provider constants:

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -245,6 +245,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/reply-reference` | `createReplyReferencePlanner` |
     | `plugin-sdk/reply-chunking` | Narrow text/markdown chunking helpers |
     | `plugin-sdk/session-store-runtime` | Session workflow helpers (`getSessionEntry`, `listSessionEntries`, `patchSessionEntry`, `upsertSessionEntry`), legacy session store path/session-key helpers, updated-at reads, and deprecated whole-store mutation helpers |
+    | `plugin-sdk/session-transcript-runtime` | Transcript identity, read-events, and storage-neutral memory hit key helpers that do not expose `sessionFile` as identity |
     | `plugin-sdk/cron-store-runtime` | Cron store path/load/save helpers |
     | `plugin-sdk/state-paths` | State/OAuth dir path helpers |
     | `plugin-sdk/plugin-state-runtime` | Plugin sidecar SQLite keyed-state types |

--- a/package.json
+++ b/package.json
@@ -949,6 +949,10 @@
       "types": "./dist/plugin-sdk/session-transcript-hit.d.ts",
       "default": "./dist/plugin-sdk/session-transcript-hit.js"
     },
+    "./plugin-sdk/session-transcript-runtime": {
+      "types": "./dist/plugin-sdk/session-transcript-runtime.d.ts",
+      "default": "./dist/plugin-sdk/session-transcript-runtime.js"
+    },
     "./plugin-sdk/session-visibility": {
       "types": "./dist/plugin-sdk/session-visibility.d.ts",
       "default": "./dist/plugin-sdk/session-visibility.js"

--- a/scripts/lib/plugin-sdk-doc-metadata.ts
+++ b/scripts/lib/plugin-sdk-doc-metadata.ts
@@ -104,6 +104,9 @@ export const pluginSdkDocMetadata = {
   "runtime-store": {
     category: "runtime",
   },
+  "session-transcript-runtime": {
+    category: "runtime",
+  },
   "qa-live-transport-scenarios": {
     category: "utilities",
   },

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -216,6 +216,7 @@
   "session-key-runtime",
   "session-store-runtime",
   "session-transcript-hit",
+  "session-transcript-runtime",
   "session-visibility",
   "ssrf-dispatcher",
   "string-coerce-runtime",

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -10,6 +10,10 @@ import {
   TranscriptFileState,
   writeTranscriptFileAtomic,
 } from "./transcript-file-state.js";
+import {
+  resolveRuntimeTranscriptTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 type ReadonlySessionManagerForRotation = Pick<
   TranscriptFileState,
@@ -91,6 +95,24 @@ export async function rotateTranscriptFileAfterCompaction(params: {
   return rotateTranscriptAfterCompaction({
     sessionManager: state,
     sessionFile: params.sessionFile,
+    ...(params.now ? { now: params.now } : {}),
+  });
+}
+
+/**
+ * Rotates a runtime transcript after compaction using agent/session identity.
+ */
+export async function rotateRuntimeTranscriptAfterCompaction(params: {
+  sessionManager?: ReadonlySessionManagerForRotation;
+  scope: RuntimeTranscriptScope;
+  now?: () => Date;
+}): Promise<CompactionTranscriptRotation> {
+  const target = await resolveRuntimeTranscriptTarget(params.scope);
+  const sessionManager =
+    params.sessionManager ?? (await readTranscriptFileState(target.sessionFile));
+  return await rotateTranscriptAfterCompaction({
+    sessionManager,
+    sessionFile: target.sessionFile,
     ...(params.now ? { now: params.now } : {}),
   });
 }

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -22,6 +22,10 @@ import {
   rewriteTranscriptEntriesInSessionManager,
   rewriteTranscriptEntriesInState,
 } from "./transcript-rewrite.js";
+import {
+  resolveRuntimeTranscriptTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 /**
  * Maximum share of the context window a single tool result should occupy.
@@ -815,6 +819,49 @@ export function truncateOversizedToolResultsInSessionManager(params: {
   }
 }
 
+/**
+ * Truncates oversized tool results for a runtime transcript scope.
+ */
+export async function truncateOversizedToolResultsInRuntimeTranscript(params: {
+  scope: RuntimeTranscriptScope;
+  contextWindowTokens: number;
+  maxCharsOverride?: number;
+  aggregateMaxCharsOverride?: number;
+  config?: SessionWriteLockAcquireTimeoutConfig;
+}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+
+  try {
+    const target = await resolveRuntimeTranscriptTarget(params.scope);
+    sessionLock = await acquireSessionWriteLock({
+      sessionFile: target.sessionFile,
+      ...resolveSessionWriteLockOptions(params.config),
+    });
+    const state = await readTranscriptFileState(target.sessionFile);
+    return await truncateOversizedToolResultsInTranscriptState({
+      state,
+      contextWindowTokens: params.contextWindowTokens,
+      maxCharsOverride: params.maxCharsOverride,
+      aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+      sessionFile: target.sessionFile,
+      sessionId: target.sessionId,
+      sessionKey: target.sessionKey,
+      agentId: target.agentId,
+      config: params.config,
+    });
+  } catch (err) {
+    const errMsg = formatErrorMessage(err);
+    log.warn(`[tool-result-truncation] Failed to truncate: ${errMsg}`);
+    return { truncated: false, truncatedCount: 0, reason: errMsg };
+  } finally {
+    await sessionLock?.release();
+  }
+}
+
+/**
+ * Truncates a named transcript file artifact. Runtime callers should prefer
+ * truncateOversizedToolResultsInRuntimeTranscript with agent/session scope.
+ */
 export async function truncateOversizedToolResultsInSession(params: {
   sessionFile: string;
   contextWindowTokens: number;

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -19,6 +19,11 @@ import {
   readTranscriptFileState,
   type TranscriptFileState,
 } from "./transcript-file-state.js";
+import {
+  persistRuntimeTranscriptStateMutation,
+  resolveRuntimeTranscriptTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 type SessionManagerLike = ReturnType<typeof SessionManager.open>;
 type SessionBranchEntry = ReturnType<SessionManagerLike["getBranch"]>[number];
@@ -369,8 +374,65 @@ export function rewriteTranscriptEntriesInState(params: {
 }
 
 /**
- * Open a transcript file, rewrite message entries on the active branch, and
- * emit a transcript update when the active branch changed.
+ * Rewrites message entries for a runtime transcript without using the
+ * file-backed path as caller identity.
+ */
+export async function rewriteTranscriptEntriesInRuntimeTranscript(params: {
+  scope: RuntimeTranscriptScope;
+  request: TranscriptRewriteRequest;
+  config?: SessionWriteLockAcquireTimeoutConfig;
+}): Promise<TranscriptRewriteResult> {
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+  try {
+    const target = await resolveRuntimeTranscriptTarget(params.scope);
+    sessionLock = await acquireSessionWriteLock({
+      sessionFile: target.sessionFile,
+      ...resolveSessionWriteLockOptions(params.config),
+    });
+    const state = await readTranscriptFileState(target.sessionFile);
+    const result = rewriteTranscriptEntriesInState({
+      state,
+      replacements: params.request.replacements,
+      ...(params.request.allowedRewriteSuffixEntryIds
+        ? { allowedRewriteSuffixEntryIds: params.request.allowedRewriteSuffixEntryIds }
+        : {}),
+    });
+    if (result.changed) {
+      await persistRuntimeTranscriptStateMutation({
+        target,
+        state,
+        appendedEntries: result.appendedEntries,
+      });
+      emitSessionTranscriptUpdate({
+        sessionFile: target.sessionFile,
+        sessionKey: target.sessionKey,
+        agentId: target.agentId,
+      });
+      log.info(
+        `[transcript-rewrite] rewrote ${result.rewrittenEntries} entr` +
+          `${result.rewrittenEntries === 1 ? "y" : "ies"} ` +
+          `bytesFreed=${result.bytesFreed} ` +
+          `sessionKey=${target.sessionKey}`,
+      );
+    }
+    return result;
+  } catch (err) {
+    const reason = formatErrorMessage(err);
+    log.warn(`[transcript-rewrite] failed: ${reason}`);
+    return {
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+      reason,
+    };
+  } finally {
+    await sessionLock?.release();
+  }
+}
+
+/**
+ * Rewrites a named transcript file artifact. Runtime callers should prefer
+ * rewriteTranscriptEntriesInRuntimeTranscript with agent/session scope.
  */
 export async function rewriteTranscriptEntriesInSessionFile(params: {
   sessionFile: string;

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendTranscriptEvent,
+  upsertSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import {
+  deleteRuntimeTranscript,
+  readRuntimeTranscriptState,
+  runtimeTranscriptExists,
+} from "./transcript-runtime-state.js";
+
+describe("runtime transcript state", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-runtime-transcript-"));
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reads and deletes transcript state through runtime scope", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(scope, {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    });
+
+    await expect(runtimeTranscriptExists(scope)).resolves.toBe(true);
+    const { state, target } = await readRuntimeTranscriptState(scope);
+    expect(fs.realpathSync(target.sessionFile)).toBe(
+      fs.realpathSync(path.join(tempDir, "session-1.jsonl")),
+    );
+    expect(state.getBranch()).toEqual([
+      expect.objectContaining({
+        message: expect.objectContaining({ content: "hello" }),
+        type: "message",
+      }),
+    ]);
+
+    await expect(deleteRuntimeTranscript(scope)).resolves.toBe(true);
+    await expect(runtimeTranscriptExists(scope)).resolves.toBe(false);
+  });
+});

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import type {
+  SessionTranscriptRuntimeScope,
+  SessionTranscriptRuntimeTarget,
+} from "../../config/sessions/session-accessor.js";
+import { resolveSessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry, SessionHeader } from "../sessions/index.js";
+import {
+  persistTranscriptStateMutation,
+  readTranscriptFileState,
+  type TranscriptFileState,
+  writeTranscriptFileAtomic,
+} from "./transcript-file-state.js";
+
+export type RuntimeTranscriptScope = SessionTranscriptRuntimeScope;
+export type RuntimeTranscriptTarget = SessionTranscriptRuntimeTarget;
+
+export type RuntimeTranscriptState = {
+  state: TranscriptFileState;
+  target: RuntimeTranscriptTarget;
+};
+
+/**
+ * Resolves the current file-backed transcript target for runtime state
+ * operations. The returned path is an implementation detail, not identity.
+ */
+export async function resolveRuntimeTranscriptTarget(
+  scope: RuntimeTranscriptScope,
+): Promise<RuntimeTranscriptTarget> {
+  return await resolveSessionTranscriptRuntimeTarget(scope);
+}
+
+/**
+ * Reads transcript state through the runtime transcript identity contract.
+ */
+export async function readRuntimeTranscriptState(
+  scope: RuntimeTranscriptScope,
+): Promise<RuntimeTranscriptState> {
+  const target = await resolveRuntimeTranscriptTarget(scope);
+  return {
+    state: await readTranscriptFileState(target.sessionFile),
+    target,
+  };
+}
+
+/**
+ * Persists an append or migration rewrite for a resolved runtime transcript.
+ */
+export async function persistRuntimeTranscriptStateMutation(params: {
+  appendedEntries: SessionEntry[];
+  state: TranscriptFileState;
+  target: RuntimeTranscriptTarget;
+}): Promise<void> {
+  await persistTranscriptStateMutation({
+    sessionFile: params.target.sessionFile,
+    state: params.state,
+    appendedEntries: params.appendedEntries,
+  });
+}
+
+/**
+ * Atomically replaces the file-backed transcript for a runtime transcript.
+ */
+export async function replaceRuntimeTranscriptEntries(params: {
+  entries: Array<SessionHeader | SessionEntry>;
+  target: RuntimeTranscriptTarget;
+}): Promise<void> {
+  await writeTranscriptFileAtomic(params.target.sessionFile, params.entries);
+}
+
+/**
+ * Checks existence of the current runtime transcript without exposing path
+ * identity to callers.
+ */
+export async function runtimeTranscriptExists(scope: RuntimeTranscriptScope): Promise<boolean> {
+  const target = await resolveRuntimeTranscriptTarget(scope);
+  try {
+    const stat = await fs.stat(target.sessionFile);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Deletes the current runtime transcript. This remains file-backed until the
+ * SQLite implementation owns transcript deletion in 3.2.
+ */
+export async function deleteRuntimeTranscript(scope: RuntimeTranscriptScope): Promise<boolean> {
+  const target = await resolveRuntimeTranscriptTarget(scope);
+  try {
+    await fs.unlink(target.sessionFile);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -13,6 +13,7 @@ import {
   upsertSessionEntry,
 } from "./session-accessor.js";
 import { loadSessionStore } from "./store.js";
+import type { SessionEntry } from "./types.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -159,13 +160,18 @@ describe("session accessor file-backed seam", () => {
       sessionKey: "agent:main:main",
       storePath,
     };
+    let missingContextEntry: SessionEntry | undefined;
+    let existingContextEntry: SessionEntry | undefined;
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: "gpt-5.5",
-      }),
+      (entry, context) => {
+        missingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: "gpt-5.5",
+        };
+      },
       {
         fallbackEntry: {
           sessionId: "session-1",
@@ -177,14 +183,19 @@ describe("session accessor file-backed seam", () => {
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: undefined,
-        providerOverride: "openai",
-      }),
+      (entry, context) => {
+        existingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: undefined,
+          providerOverride: "openai",
+        };
+      },
       { replaceEntry: true },
     );
 
+    expect(missingContextEntry).toBeUndefined();
+    expect(existingContextEntry).toMatchObject({ model: "gpt-5.5" });
     expect(loadSessionEntry(scope)).toMatchObject({
       providerOverride: "openai",
       sessionId: "session-1",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -124,6 +125,32 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+  });
+
+  it("replaces entries so deleted fields stay removed", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      providerOverride: "openai",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    await replaceSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 20,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
+    expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
 
@@ -75,6 +76,34 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("updates existing entries without creating missing sessions", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await expect(updateSessionEntry(scope, () => ({ model: "gpt-5.5" }))).resolves.toBeNull();
+    expect(listSessionEntries({ storePath })).toEqual([]);
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const beforeNullUpdate = loadSessionEntry(scope);
+    await expect(updateSessionEntry(scope, () => null)).resolves.toEqual(beforeNullUpdate);
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: beforeNullUpdate?.updatedAt,
+    });
+    await expect(
+      updateSessionEntry(scope, () => ({ model: "gpt-5.5", updatedAt: 20 })),
+    ).resolves.toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendTranscriptEvent,
+  listSessionEntries,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntry,
+} from "./session-accessor.js";
+
+describe("session accessor file-backed seam", () => {
+  let tempDir: string;
+  let storePath: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-accessor-"));
+    storePath = path.join(tempDir, "sessions.json");
+    transcriptPath = path.join(tempDir, "session.jsonl");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("loads, lists, and patches session entries without exposing the file store shape", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(listSessionEntries({ storePath })).toEqual([
+      {
+        sessionKey: "agent:main:main",
+        entry: expect.objectContaining({
+          model: "gpt-5.5",
+          sessionId: "session-1",
+          updatedAt: expect.any(Number),
+        }),
+      },
+    ]);
+
+    await upsertSessionEntry(scope, { model: "sonnet-4.6", updatedAt: 20 });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "sonnet-4.6",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+  });
+
+  it("creates durable session ids for metadata-only inserts", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    const inserted = await upsertSessionEntry(scope, { model: "gpt-5.5" });
+
+    expect(inserted?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(inserted?.sessionId).not.toBe(scope.sessionKey);
+    expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("loads and appends transcript events through a session scope", async () => {
+    const scope = {
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
+    await appendTranscriptEvent(scope, event);
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      { type: "session", sessionId: "session-1" },
+      event,
+    ]);
+    expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("honors thread fallback paths when resolving transcript scope from the store", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:demo-channel:1234:thread:456",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(scope, event);
+
+    const expectedTranscriptPath = path.join(tempDir, "session-1-topic-456.jsonl");
+    expect(fs.existsSync(expectedTranscriptPath)).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "session-1.jsonl"))).toBe(false);
+    expect(fs.realpathSync(loadSessionEntry(scope)?.sessionFile ?? "")).toBe(
+      fs.realpathSync(expectedTranscriptPath),
+    );
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("persists transcript metadata under the normalized session key", async () => {
+    const canonicalScope = {
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(canonicalScope, {
+      sessionId: canonicalScope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(
+      {
+        agentId: "main",
+        sessionId: canonicalScope.sessionId,
+        sessionKey: "AGENT:MAIN:MAIN",
+        storePath,
+      },
+      { id: "msg-1", type: "message" },
+    );
+
+    expect(listSessionEntries({ storePath }).map((entry) => entry.sessionKey)).toEqual([
+      canonicalScope.sessionKey,
+    ]);
+    expect(loadSessionEntry(canonicalScope)?.sessionFile).toBeTruthy();
+  });
+});

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -10,6 +10,7 @@ import {
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
+import { loadSessionStore } from "./store.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -76,6 +77,25 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("can borrow cached entry objects for read-only hot paths", async () => {
+    const scope = {
+      clone: false,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const cachedStore = loadSessionStore(storePath, { clone: false });
+
+    expect(loadSessionEntry(scope)).toBe(cachedStore["agent:main:main"]);
+    expect(listSessionEntries({ clone: false, storePath })[0]?.entry).toBe(
+      cachedStore["agent:main:main"],
+    );
   });
 
   it("updates existing entries without creating missing sessions", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -2,12 +2,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
+  appendTranscriptMessage,
   appendTranscriptEvent,
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
+  publishTranscriptUpdate,
+  readSessionUpdatedAt,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -47,6 +51,7 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+    expect(readSessionUpdatedAt(scope)).toEqual(expect.any(Number));
     expect(listSessionEntries({ storePath })).toEqual([
       {
         sessionKey: "agent:main:main",
@@ -225,6 +230,75 @@ describe("session accessor file-backed seam", () => {
       event,
     ]);
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("appends messages and publishes updates through a session scope", async () => {
+    const scope = {
+      agentId: "main",
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const updates: unknown[] = [];
+    const unsubscribe = onSessionTranscriptUpdate((update) => {
+      updates.push(update);
+    });
+
+    const appended = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    const replayed = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello again",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    await publishTranscriptUpdate(scope, {
+      agentId: "main",
+      message: appended.message,
+      messageId: appended.messageId,
+      sessionKey: scope.sessionKey,
+    });
+    unsubscribe();
+
+    expect(replayed).toMatchObject({
+      appended: false,
+      messageId: appended.messageId,
+      message: expect.objectContaining({
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      }),
+    });
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      expect.objectContaining({ type: "session" }),
+      expect.objectContaining({
+        id: appended.messageId,
+        message: expect.objectContaining({
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        }),
+        type: "message",
+      }),
+    ]);
+    expect(updates).toEqual([
+      {
+        agentId: "main",
+        message: appended.message,
+        messageId: appended.messageId,
+        sessionFile: transcriptPath,
+        sessionKey: scope.sessionKey,
+      },
+    ]);
   });
 
   it("honors thread fallback paths when resolving transcript scope from the store", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  patchSessionEntry,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -151,6 +152,44 @@ describe("session accessor file-backed seam", () => {
     });
     expect(loadSessionEntry(scope)?.model).toBeUndefined();
     expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
+  });
+
+  it("patches entries atomically with a fallback entry", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: "gpt-5.5",
+      }),
+      {
+        fallbackEntry: {
+          sessionId: "session-1",
+          updatedAt: 10,
+        },
+        replaceEntry: true,
+      },
+    );
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: undefined,
+        providerOverride: "openai",
+      }),
+      { replaceEntry: true },
+    );
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      providerOverride: "openai",
+      sessionId: "session-1",
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -13,6 +13,7 @@ import {
   publishTranscriptUpdate,
   readSessionUpdatedAt,
   replaceSessionEntry,
+  resolveSessionTranscriptRuntimeTarget,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -328,6 +329,31 @@ describe("session accessor file-backed seam", () => {
       fs.realpathSync(expectedTranscriptPath),
     );
     await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("resolves runtime transcript targets from scope without caller-owned paths", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+
+    const target = await resolveSessionTranscriptRuntimeTarget(scope);
+
+    expect(target).toMatchObject({
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+    });
+    expect(fs.realpathSync(path.dirname(target.sessionFile))).toBe(fs.realpathSync(tempDir));
+    expect(path.basename(target.sessionFile)).toBe("session-1.jsonl");
+    expect(loadSessionEntry(scope)?.sessionFile).toBe(target.sessionFile);
   });
 
   it("persists transcript metadata under the normalized session key", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { resolveAndPersistSessionFile } from "./session-file.js";
+import {
+  getSessionEntry,
+  listSessionEntries as listFileSessionEntries,
+  loadSessionStore,
+  patchSessionEntry as patchFileSessionEntry,
+  resolveSessionStoreEntry,
+} from "./store.js";
+import { parseSessionThreadInfo } from "./thread-info.js";
+import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import { streamSessionTranscriptLines } from "./transcript-stream.js";
+import { resolveSessionTranscriptFile } from "./transcript.js";
+import type { SessionEntry } from "./types.js";
+
+export type SessionAccessScope = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  hydrateSkillPromptRefs?: boolean;
+  sessionKey: string;
+  storePath?: string;
+};
+
+export type SessionTranscriptAccessScope = SessionAccessScope & {
+  sessionFile?: string;
+  sessionId: string;
+  threadId?: string | number;
+};
+
+export type SessionEntrySummary = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+export type TranscriptEvent = unknown;
+
+/** Loads one session entry through the storage-neutral accessor seam. */
+export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  return getSessionEntry(scope);
+}
+
+/** Lists session entries through the storage-neutral accessor seam. */
+export function listSessionEntries(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+): SessionEntrySummary[] {
+  return listFileSessionEntries(scope);
+}
+
+/** Applies a partial entry update through the storage-neutral accessor seam. */
+export async function upsertSessionEntry(
+  scope: SessionAccessScope,
+  patch: Partial<SessionEntry>,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: createFallbackSessionEntry(patch),
+    update: () => patch,
+  });
+}
+
+/** Loads raw transcript events through the storage-neutral accessor seam. */
+export async function loadTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+): Promise<TranscriptEvent[]> {
+  const transcript = await resolveTranscriptAccess(scope);
+  const events: TranscriptEvent[] = [];
+  for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
+    events.push(JSON.parse(line) as TranscriptEvent);
+  }
+  return events;
+}
+
+/** Appends one raw transcript event through the storage-neutral accessor seam. */
+export async function appendTranscriptEvent(
+  scope: SessionTranscriptAccessScope,
+  event: TranscriptEvent,
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  await appendSessionTranscriptEvent({
+    event,
+    transcriptPath: transcript.sessionFile,
+  });
+}
+
+function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
+  const now = Date.now();
+  return {
+    sessionId: patch.sessionId ?? randomUUID(),
+    updatedAt: patch.updatedAt ?? now,
+    ...patch,
+  };
+}
+
+async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+  sessionFile: string;
+}> {
+  if (scope.sessionFile?.trim()) {
+    return { sessionFile: scope.sessionFile };
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const sessionStore = scope.storePath
+    ? loadSessionStore(scope.storePath, { skipCache: true })
+    : undefined;
+  const resolvedStoreEntry = sessionStore
+    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
+    : undefined;
+  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
+  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
+  if (sessionStore && scope.storePath) {
+    const sessionsDir = path.dirname(path.resolve(scope.storePath));
+    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
+    const fallbackSessionFile =
+      !sessionEntry?.sessionFile && threadId !== undefined
+        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
+        : undefined;
+    return await resolveAndPersistSessionFile({
+      agentId,
+      fallbackSessionFile,
+      sessionEntry,
+      sessionId: scope.sessionId,
+      sessionKey,
+      sessionStore,
+      sessionsDir,
+      storePath: scope.storePath,
+    });
+  }
+  return await resolveSessionTranscriptFile({
+    agentId,
+    sessionEntry,
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    ...(sessionStore ? { sessionStore } : {}),
+    ...(scope.storePath ? { storePath: scope.storePath } : {}),
+    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
+  });
+}

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { getRuntimeConfig } from "../io.js";
+import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
@@ -9,6 +10,7 @@ import {
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
   resolveSessionStoreEntry,
+  updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptEvent } from "./transcript-append.js";
@@ -37,6 +39,11 @@ export type SessionEntrySummary = {
 
 export type TranscriptEvent = unknown;
 
+export type SessionEntryUpdateOptions = {
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   return getSessionEntry(scope);
@@ -58,6 +65,23 @@ export async function upsertSessionEntry(
     ...scope,
     fallbackEntry: createFallbackSessionEntry(patch),
     update: () => patch,
+  });
+}
+
+/** Updates an existing session entry through the storage-neutral accessor seam. */
+export async function updateSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryUpdateOptions = {},
+): Promise<SessionEntry | null> {
+  return await updateFileSessionStoreEntry({
+    storePath: resolveAccessStorePath(scope),
+    sessionKey: scope.sessionKey,
+    skipMaintenance: options.skipMaintenance,
+    takeCacheOwnership: options.takeCacheOwnership,
+    update,
   });
 }
 
@@ -92,6 +116,17 @@ function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry 
     updatedAt: patch.updatedAt ?? now,
     ...patch,
   };
+}
+
+function resolveAccessStorePath(scope: SessionAccessScope): string {
+  if (scope.storePath) {
+    return scope.storePath;
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  return resolveStorePath(getRuntimeConfig().session?.store, {
+    agentId,
+    env: scope.env,
+  });
 }
 
 async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -84,6 +84,19 @@ export async function upsertSessionEntry(
   });
 }
 
+/** Replaces one entry through the storage-neutral accessor seam. */
+export async function replaceSessionEntry(
+  scope: SessionAccessScope,
+  entry: SessionEntry,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: entry,
+    replaceEntry: true,
+    update: () => entry,
+  });
+}
+
 /** Updates an existing session entry through the storage-neutral accessor seam. */
 export async function updateSessionEntry(
   scope: SessionAccessScope,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
@@ -9,11 +12,15 @@ import {
   listSessionEntries as listFileSessionEntries,
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
+  readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
-import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import {
+  appendSessionTranscriptEvent,
+  appendSessionTranscriptMessage,
+} from "./transcript-append.js";
 import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import { resolveSessionTranscriptFile } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
@@ -33,12 +40,34 @@ export type SessionTranscriptAccessScope = SessionAccessScope & {
   threadId?: string | number;
 };
 
+export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
+  sessionId?: string;
+};
+
 export type SessionEntrySummary = {
   sessionKey: string;
   entry: SessionEntry;
 };
 
 export type TranscriptEvent = unknown;
+
+export type TranscriptMessageAppendOptions<TMessage> = {
+  config?: OpenClawConfig;
+  cwd?: string;
+  idempotencyLookup?: "scan" | "caller-checked";
+  message: TMessage;
+  now?: number;
+  prepareMessageAfterIdempotencyCheck?: (message: TMessage) => TMessage | undefined;
+  useRawWhenLinear?: boolean;
+};
+
+export type TranscriptMessageAppendResult<TMessage> = {
+  appended: boolean;
+  message: TMessage;
+  messageId: string;
+};
+
+export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
 
 export type SessionEntryUpdateOptions = {
   skipMaintenance?: boolean;
@@ -79,6 +108,17 @@ export function listSessionEntries(
     ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
   }
   return listFileSessionEntries(scope);
+}
+
+/** Reads a session activity timestamp through the storage-neutral accessor seam. */
+export function readSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
+  if (scope.storePath) {
+    return readFileSessionUpdatedAt({
+      storePath: scope.storePath,
+      sessionKey: scope.sessionKey,
+    });
+  }
+  return loadSessionEntry(scope)?.updatedAt;
 }
 
 /** Applies a partial entry update through the storage-neutral accessor seam. */
@@ -164,6 +204,51 @@ export async function appendTranscriptEvent(
   });
 }
 
+/** Appends one transcript message through the storage-neutral writer seam. */
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage> & {
+    prepareMessageAfterIdempotencyCheck: (message: TMessage) => TMessage | undefined;
+  },
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage>>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
+  const transcript = await resolveTranscriptAccess(scope);
+  return await appendSessionTranscriptMessage({
+    transcriptPath: transcript.sessionFile,
+    message: options.message,
+    ...(scope.sessionId ? { sessionId: scope.sessionId } : {}),
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    ...(options.config ? { config: options.config } : {}),
+    ...(options.idempotencyLookup ? { idempotencyLookup: options.idempotencyLookup } : {}),
+    ...(options.now !== undefined ? { now: options.now } : {}),
+    ...(options.prepareMessageAfterIdempotencyCheck
+      ? { prepareMessageAfterIdempotencyCheck: options.prepareMessageAfterIdempotencyCheck }
+      : {}),
+    ...(options.useRawWhenLinear !== undefined
+      ? { useRawWhenLinear: options.useRawWhenLinear }
+      : {}),
+  });
+}
+
+/** Publishes a transcript update after resolving the current storage target. */
+export async function publishTranscriptUpdate(
+  scope: SessionTranscriptWriteScope,
+  update: TranscriptUpdatePayload = {},
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  emitSessionTranscriptUpdate({
+    ...update,
+    sessionFile: transcript.sessionFile,
+  });
+}
+
 function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
   const now = Date.now();
   return {
@@ -184,11 +269,14 @@ function resolveAccessStorePath(scope: SessionAccessScope): string {
   });
 }
 
-async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Promise<{
   sessionFile: string;
 }> {
   if (scope.sessionFile?.trim()) {
     return { sessionFile: scope.sessionFile };
+  }
+  if (!scope.sessionId) {
+    throw new Error(`Cannot resolve transcript scope without a session id: ${scope.sessionKey}`);
   }
   const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
   if (!agentId) {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -20,6 +20,7 @@ import type { SessionEntry } from "./types.js";
 
 export type SessionAccessScope = {
   agentId?: string;
+  clone?: boolean;
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   sessionKey: string;
@@ -46,6 +47,13 @@ export type SessionEntryUpdateOptions = {
 
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  if (scope.clone === false) {
+    const store = loadSessionStore(resolveAccessStorePath(scope), {
+      clone: false,
+      ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+    });
+    return resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey }).existing;
+  }
   return getSessionEntry(scope);
 }
 
@@ -53,6 +61,14 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
 export function listSessionEntries(
   scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
 ): SessionEntrySummary[] {
+  if (scope.clone === false) {
+    return Object.entries(
+      loadSessionStore(resolveAccessStorePath({ ...scope, sessionKey: "" }), {
+        clone: false,
+        ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+      }),
+    ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
+  }
   return listFileSessionEntries(scope);
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -50,6 +50,10 @@ export type SessionEntryPatchOptions = {
   replaceEntry?: boolean;
 };
 
+export type SessionEntryPatchContext = {
+  existingEntry?: SessionEntry;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -107,6 +111,7 @@ export async function patchSessionEntry(
   scope: SessionAccessScope,
   update: (
     entry: SessionEntry,
+    context: SessionEntryPatchContext,
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
   options: SessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -40,6 +40,11 @@ export type SessionTranscriptAccessScope = SessionAccessScope & {
   threadId?: string | number;
 };
 
+export type SessionTranscriptRuntimeScope = SessionAccessScope & {
+  sessionId: string;
+  threadId?: string | number;
+};
+
 export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
   sessionId?: string;
 };
@@ -68,6 +73,13 @@ export type TranscriptMessageAppendResult<TMessage> = {
 };
 
 export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
+
+export type SessionTranscriptRuntimeTarget = {
+  agentId: string;
+  sessionFile: string;
+  sessionId: string;
+  sessionKey: string;
+};
 
 export type SessionEntryUpdateOptions = {
   skipMaintenance?: boolean;
@@ -249,6 +261,67 @@ export async function publishTranscriptUpdate(
   });
 }
 
+/**
+ * Resolves the current file-backed target for a storage-neutral runtime
+ * transcript scope. Callers use the scope as identity; sessionFile is returned
+ * only for current file-backed implementation details such as locks/events.
+ */
+export async function resolveSessionTranscriptRuntimeTarget(
+  scope: SessionTranscriptRuntimeScope,
+): Promise<SessionTranscriptRuntimeTarget> {
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const sessionStore = scope.storePath
+    ? loadSessionStore(scope.storePath, { skipCache: true })
+    : undefined;
+  const resolvedStoreEntry = sessionStore
+    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
+    : undefined;
+  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
+  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
+  if (sessionStore && scope.storePath) {
+    const sessionsDir = path.dirname(path.resolve(scope.storePath));
+    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
+    const fallbackSessionFile =
+      !sessionEntry?.sessionFile && threadId !== undefined
+        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
+        : undefined;
+    const resolved = await resolveAndPersistSessionFile({
+      agentId,
+      fallbackSessionFile,
+      sessionEntry,
+      sessionId: scope.sessionId,
+      sessionKey,
+      sessionStore,
+      sessionsDir,
+      storePath: scope.storePath,
+    });
+    return {
+      agentId,
+      sessionFile: resolved.sessionFile,
+      sessionId: scope.sessionId,
+      sessionKey,
+    };
+  }
+  const resolved = await resolveSessionTranscriptFile({
+    agentId,
+    sessionEntry,
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    ...(sessionStore ? { sessionStore } : {}),
+    ...(scope.storePath ? { storePath: scope.storePath } : {}),
+    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
+  });
+  return {
+    agentId,
+    sessionFile: resolved.sessionFile,
+    sessionId: scope.sessionId,
+    sessionKey,
+  };
+}
+
 function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
   const now = Date.now();
   return {
@@ -278,43 +351,8 @@ async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Prom
   if (!scope.sessionId) {
     throw new Error(`Cannot resolve transcript scope without a session id: ${scope.sessionKey}`);
   }
-  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
-  if (!agentId) {
-    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
-  }
-  const sessionStore = scope.storePath
-    ? loadSessionStore(scope.storePath, { skipCache: true })
-    : undefined;
-  const resolvedStoreEntry = sessionStore
-    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
-    : undefined;
-  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
-  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
-  if (sessionStore && scope.storePath) {
-    const sessionsDir = path.dirname(path.resolve(scope.storePath));
-    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
-    const fallbackSessionFile =
-      !sessionEntry?.sessionFile && threadId !== undefined
-        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
-        : undefined;
-    return await resolveAndPersistSessionFile({
-      agentId,
-      fallbackSessionFile,
-      sessionEntry,
-      sessionId: scope.sessionId,
-      sessionKey,
-      sessionStore,
-      sessionsDir,
-      storePath: scope.storePath,
-    });
-  }
-  return await resolveSessionTranscriptFile({
-    agentId,
-    sessionEntry,
+  return await resolveSessionTranscriptRuntimeTarget({
+    ...scope,
     sessionId: scope.sessionId,
-    sessionKey: scope.sessionKey,
-    ...(sessionStore ? { sessionStore } : {}),
-    ...(scope.storePath ? { storePath: scope.storePath } : {}),
-    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
   });
 }

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -45,6 +45,11 @@ export type SessionEntryUpdateOptions = {
   takeCacheOwnership?: boolean;
 };
 
+export type SessionEntryPatchOptions = {
+  fallbackEntry?: SessionEntry;
+  replaceEntry?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -94,6 +99,22 @@ export async function replaceSessionEntry(
     fallbackEntry: entry,
     replaceEntry: true,
     update: () => entry,
+  });
+}
+
+/** Patches one entry atomically through the storage-neutral accessor seam. */
+export async function patchSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: options.fallbackEntry,
+    replaceEntry: options.replaceEntry,
+    update,
   });
 }
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1006,6 +1006,7 @@ export async function patchSessionEntry(
     replaceEntry?: boolean;
     update: (
       entry: SessionEntry,
+      context: { existingEntry?: SessionEntry },
     ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
   },
 ): Promise<SessionEntry | null> {
@@ -1017,7 +1018,9 @@ export async function patchSessionEntry(
     if (!existing) {
       return null;
     }
-    const patch = await params.update(cloneSessionEntry(existing));
+    const patch = await params.update(cloneSessionEntry(existing), {
+      existingEntry: resolved.existing ? cloneSessionEntry(resolved.existing) : undefined,
+    });
     if (!patch) {
       return existing;
     }

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -14,6 +14,7 @@ import { redactSecrets } from "../../logging/redact.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   appendJsonlEntry,
+  serializeJsonlEntry,
   serializeJsonlLine,
   writeJsonlEntry,
   writeJsonlLines,
@@ -284,6 +285,31 @@ export async function appendSessionTranscriptMessage<TMessage>(
   );
 }
 
+export type AppendSessionTranscriptEventParams = {
+  config?: OpenClawConfig;
+  event: unknown;
+  transcriptPath: string;
+};
+
+/** Appends a raw transcript event using the same write lock and FIFO as message appends. */
+export async function appendSessionTranscriptEvent(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  const activeLockRunner = resolveOwnedSessionTranscriptWriteLockRunner({
+    sessionFile: params.transcriptPath,
+  });
+  if (activeLockRunner) {
+    return await activeLockRunner(() =>
+      withTranscriptAppendQueue(params.transcriptPath, () =>
+        appendSessionTranscriptEventLocked(params),
+      ),
+    );
+  }
+  return await withTranscriptAppendQueue(params.transcriptPath, () =>
+    withSessionTranscriptWriteLock(params, () => appendSessionTranscriptEventLocked(params)),
+  );
+}
+
 async function withSessionTranscriptWriteLock<T>(
   params: Pick<AppendSessionTranscriptMessageParams, "transcriptPath" | "config">,
   run: () => Promise<T> | T,
@@ -297,6 +323,18 @@ async function withSessionTranscriptWriteLock<T>(
     return await run();
   } finally {
     await lock.release();
+  }
+}
+
+async function appendSessionTranscriptEventLocked(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  await fs.mkdir(path.dirname(params.transcriptPath), { recursive: true });
+  const handle = await fs.open(params.transcriptPath, "a", 0o600);
+  try {
+    await handle.appendFile(serializeJsonlEntry(params.event), "utf-8");
+  } finally {
+    await handle.close();
   }
 }
 

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -13,6 +13,10 @@ import type {
   SessionEntry,
 } from "../config/sessions.js";
 import { isCompactionCheckpointTranscriptFileName } from "../config/sessions/artifacts.js";
+import {
+  resolveSessionTranscriptRuntimeTarget,
+  type SessionTranscriptRuntimeScope,
+} from "../config/sessions/session-accessor.js";
 import { streamSessionTranscriptLines } from "../config/sessions/transcript-stream.js";
 import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -327,6 +331,17 @@ export async function readSessionLeafIdFromTranscriptAsync(
   return null;
 }
 
+/**
+ * Reads the latest leaf id for a runtime transcript scope.
+ */
+export async function readRuntimeSessionLeafIdFromTranscriptAsync(
+  scope: SessionTranscriptRuntimeScope,
+  maxBytes = MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES,
+): Promise<string | null> {
+  const target = await resolveSessionTranscriptRuntimeTarget(scope);
+  return await readSessionLeafIdFromTranscriptAsync(target.sessionFile, maxBytes);
+}
+
 export async function forkCompactionCheckpointTranscriptAsync(params: {
   sourceFile: string;
   sourceLeafId?: string;
@@ -421,6 +436,22 @@ export async function captureCompactionCheckpointSnapshotAsync(params: {
     sessionId,
     leafId,
   };
+}
+
+/**
+ * Captures checkpoint metadata for a runtime transcript scope.
+ */
+export async function captureRuntimeCompactionCheckpointSnapshotAsync(params: {
+  sessionManager?: Pick<SessionManager, "getLeafId">;
+  scope: SessionTranscriptRuntimeScope;
+  maxBytes?: number;
+}): Promise<CapturedCompactionCheckpointSnapshot | null> {
+  const target = await resolveSessionTranscriptRuntimeTarget(params.scope);
+  return await captureCompactionCheckpointSnapshotAsync({
+    sessionManager: params.sessionManager,
+    sessionFile: target.sessionFile,
+    maxBytes: params.maxBytes,
+  });
 }
 
 export async function cleanupCompactionCheckpointSnapshot(

--- a/src/plugin-sdk/session-transcript-hit.test.ts
+++ b/src/plugin-sdk/session-transcript-hit.test.ts
@@ -3,6 +3,9 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import {
   extractTranscriptIdentityFromSessionsMemoryHit,
   extractTranscriptStemFromSessionsMemoryHit,
+  formatSessionTranscriptMemoryHitKey,
+  parseSessionTranscriptMemoryHitKey,
+  resolveSessionTranscriptMemoryHitKeyToSessionKeys,
   resolveTranscriptStemToSessionKeys,
 } from "./session-transcript-hit.js";
 
@@ -270,5 +273,30 @@ describe("resolveTranscriptStemToSessionKeys", () => {
         allowQmdSlugFallback: true,
       }),
     ).toEqual([]);
+  });
+});
+
+describe("session transcript memory hit key compatibility exports", () => {
+  it("exports storage-neutral memory hit key helpers from the legacy hit subpath", () => {
+    const key = formatSessionTranscriptMemoryHitKey({
+      agentId: "main",
+      sessionId: "session:legacy",
+    });
+    const store: Record<string, SessionEntry> = {
+      "agent:main:discord:direct:42": {
+        sessionFile: "/tmp/not-the-identity.jsonl",
+        sessionId: "session:legacy",
+        updatedAt: 10,
+      },
+    };
+
+    expect(key).toBe("transcript:main:session%3Alegacy");
+    expect(parseSessionTranscriptMemoryHitKey(key)).toMatchObject({
+      agentId: "main",
+      sessionId: "session:legacy",
+    });
+    expect(resolveSessionTranscriptMemoryHitKeyToSessionKeys({ key, store })).toEqual([
+      "agent:main:discord:direct:42",
+    ]);
   });
 });

--- a/src/plugin-sdk/session-transcript-hit.ts
+++ b/src/plugin-sdk/session-transcript-hit.ts
@@ -4,6 +4,19 @@ import { uniqueStrings } from "../../packages/normalization-core/src/string-norm
 import { parseUsageCountedSessionIdFromFileName } from "../config/sessions/artifacts.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+export {
+  formatSessionTranscriptMemoryHitKey,
+  parseSessionTranscriptMemoryHitKey,
+  resolveSessionTranscriptMemoryHitKeyToSessionKeys,
+} from "./session-transcript-runtime.js";
+export type {
+  ResolveSessionTranscriptMemoryHitKeyParams,
+  SessionTranscriptIdentity,
+  SessionTranscriptMemoryHitIdentity,
+  SessionTranscriptMemoryHitKey,
+  SessionTranscriptMemoryHitKeyParams,
+  SessionTranscriptReadParams,
+} from "./session-transcript-runtime.js";
 
 export { loadCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
 

--- a/src/plugin-sdk/session-transcript-runtime.test.ts
+++ b/src/plugin-sdk/session-transcript-runtime.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendTranscriptEvent, upsertSessionEntry } from "../config/sessions/session-accessor.js";
+import { loadSessionStore } from "../config/sessions/store.js";
+import {
+  formatSessionTranscriptMemoryHitKey,
+  parseSessionTranscriptMemoryHitKey,
+  readSessionTranscriptEvents,
+  resolveSessionTranscriptIdentity,
+  resolveSessionTranscriptMemoryHitKeyToSessionKeys,
+} from "./session-transcript-runtime.js";
+
+describe("session transcript runtime SDK", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-transcript-"));
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  it("resolves transcript identity and reads events without returning sessionFile", async () => {
+    const scope = {
+      agentId: "Main",
+      sessionId: "session-with-colon",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const event = { id: "event-1", type: "message" };
+
+    await upsertSessionEntry(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+    await appendTranscriptEvent(scope, event);
+
+    const identity = await resolveSessionTranscriptIdentity(scope);
+
+    expect(identity).toEqual({
+      agentId: "main",
+      memoryKey: "transcript:main:session-with-colon",
+      sessionId: scope.sessionId,
+      sessionKey: "agent:main:main",
+    });
+    expect(identity).not.toHaveProperty("sessionFile");
+    await expect(readSessionTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("round-trips encoded memory hit keys with opaque session ids", () => {
+    const key = formatSessionTranscriptMemoryHitKey({
+      agentId: "SECONDARY",
+      sessionId: "my-plugin:task/1",
+    });
+
+    expect(key).toBe("transcript:secondary:my-plugin%3Atask%2F1");
+    expect(parseSessionTranscriptMemoryHitKey(key)).toEqual({
+      agentId: "secondary",
+      key,
+      sessionId: "my-plugin:task/1",
+    });
+  });
+
+  it("resolves memory hit keys by agent and session id instead of transcript basename", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-id",
+      sessionKey: "agent:main:telegram:direct:123",
+      storePath,
+    };
+    await upsertSessionEntry(scope, {
+      sessionFile: path.join(tempDir, "legacy-file-name.jsonl"),
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+
+    const keys = resolveSessionTranscriptMemoryHitKeyToSessionKeys({
+      key: formatSessionTranscriptMemoryHitKey(scope),
+      store: loadSessionStore(storePath),
+    });
+
+    expect(keys).toEqual(["agent:main:telegram:direct:123"]);
+  });
+
+  it("can avoid synthetic fallback keys for strict live-store checks", () => {
+    const key = formatSessionTranscriptMemoryHitKey({
+      agentId: "main",
+      sessionId: "deleted-session",
+    });
+
+    expect(resolveSessionTranscriptMemoryHitKeyToSessionKeys({ key, store: {} })).toEqual([
+      "agent:main:deleted-session",
+    ]);
+    expect(
+      resolveSessionTranscriptMemoryHitKeyToSessionKeys({
+        includeSyntheticFallback: false,
+        key,
+        store: {},
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/plugin-sdk/session-transcript-runtime.ts
+++ b/src/plugin-sdk/session-transcript-runtime.ts
@@ -1,0 +1,151 @@
+import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
+import { uniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
+import {
+  loadTranscriptEvents,
+  resolveSessionTranscriptRuntimeTarget,
+} from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+
+const SESSION_TRANSCRIPT_MEMORY_HIT_PREFIX = "transcript";
+
+export type SessionTranscriptEvent = unknown;
+
+export type SessionTranscriptIdentity = {
+  agentId: string;
+  memoryKey: SessionTranscriptMemoryHitKey;
+  sessionId: string;
+  sessionKey: string;
+};
+
+export type SessionTranscriptMemoryHitIdentity = {
+  agentId: string;
+  key: SessionTranscriptMemoryHitKey;
+  sessionId: string;
+};
+
+export type SessionTranscriptMemoryHitKey = `transcript:${string}:${string}`;
+
+export type SessionTranscriptReadParams = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  hydrateSkillPromptRefs?: boolean;
+  sessionId: string;
+  sessionKey: string;
+  storePath?: string;
+  threadId?: string | number;
+};
+
+export type SessionTranscriptMemoryHitKeyParams = {
+  agentId: string;
+  sessionId: string;
+};
+
+export type ResolveSessionTranscriptMemoryHitKeyParams = {
+  includeSyntheticFallback?: boolean;
+  key: string;
+  store: Record<string, SessionEntry>;
+};
+
+function requireMemoryKeySegment(value: string, label: string): string {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    throw new Error(`Cannot build session transcript memory hit key without ${label}.`);
+  }
+  return encodeURIComponent(normalized);
+}
+
+function decodeMemoryKeySegment(value: string): string | null {
+  try {
+    return normalizeOptionalString(decodeURIComponent(value)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function syntheticSessionKey(identity: SessionTranscriptMemoryHitIdentity): string {
+  return `agent:${identity.agentId}:${identity.sessionId}`;
+}
+
+/**
+ * Builds the storage-neutral memory hit key for one session transcript.
+ */
+export function formatSessionTranscriptMemoryHitKey(
+  params: SessionTranscriptMemoryHitKeyParams,
+): SessionTranscriptMemoryHitKey {
+  const agentId = requireMemoryKeySegment(normalizeAgentId(params.agentId), "agentId");
+  const sessionId = requireMemoryKeySegment(params.sessionId, "sessionId");
+  return `${SESSION_TRANSCRIPT_MEMORY_HIT_PREFIX}:${agentId}:${sessionId}`;
+}
+
+/**
+ * Parses a storage-neutral session transcript memory hit key.
+ */
+export function parseSessionTranscriptMemoryHitKey(
+  key: string,
+): SessionTranscriptMemoryHitIdentity | null {
+  const parts = key.split(":");
+  if (parts.length !== 3 || parts[0] !== SESSION_TRANSCRIPT_MEMORY_HIT_PREFIX) {
+    return null;
+  }
+  const agentId = decodeMemoryKeySegment(parts[1] ?? "");
+  const sessionId = decodeMemoryKeySegment(parts[2] ?? "");
+  if (!agentId || !sessionId) {
+    return null;
+  }
+  return {
+    agentId: normalizeAgentId(agentId),
+    key: formatSessionTranscriptMemoryHitKey({ agentId, sessionId }),
+    sessionId,
+  };
+}
+
+/**
+ * Resolves the public identity for a transcript without returning its file path.
+ */
+export async function resolveSessionTranscriptIdentity(
+  params: SessionTranscriptReadParams,
+): Promise<SessionTranscriptIdentity> {
+  const target = await resolveSessionTranscriptRuntimeTarget(params);
+  const agentId = normalizeAgentId(target.agentId);
+  return {
+    agentId,
+    memoryKey: formatSessionTranscriptMemoryHitKey({ agentId, sessionId: target.sessionId }),
+    sessionId: target.sessionId,
+    sessionKey: target.sessionKey,
+  };
+}
+
+/**
+ * Reads transcript events by public session identity instead of file path.
+ */
+export async function readSessionTranscriptEvents(
+  params: SessionTranscriptReadParams,
+): Promise<SessionTranscriptEvent[]> {
+  return await loadTranscriptEvents(params);
+}
+
+/**
+ * Maps a storage-neutral memory hit key back to visible session store keys.
+ */
+export function resolveSessionTranscriptMemoryHitKeyToSessionKeys(
+  params: ResolveSessionTranscriptMemoryHitKeyParams,
+): string[] {
+  const identity = parseSessionTranscriptMemoryHitKey(params.key);
+  if (!identity) {
+    return [];
+  }
+  const matches = Object.entries(params.store)
+    .filter(([sessionKey, entry]) => {
+      return (
+        entry.sessionId === identity.sessionId &&
+        normalizeAgentId(resolveAgentIdFromSessionKey(sessionKey)) === identity.agentId
+      );
+    })
+    .map(([sessionKey]) => sessionKey);
+  const deduped = uniqueStrings(matches);
+  if (deduped.length > 0) {
+    return deduped;
+  }
+  return params.includeSyntheticFallback === false ? [] : [syntheticSessionKey(identity)];
+}


### PR DESCRIPTION
## What
Adds the public SDK transcript identity API used by Path 3 session/transcript seam work. The PR introduces storage-neutral transcript identity and memory-hit key helpers so plugin and memory consumers can stop deriving transcript identity from file basenames or `sessionFile` paths.

Refs #88838. Stacked on #89201.

## Why
The SQLite migration needs plugin-facing transcript consumers to address transcript state by stable session identity before the storage backend can change. File-path and basename matching are not portable to SQLite, but the compatibility surface still needs an additive SDK path for existing callers.

## Changes
- Add transcript identity SDK subpath
- Add memory hit key helpers
- Update session transcript hit mapping
- Document SDK runtime surface
- Update SDK export metadata
- Add focused identity tests

## Changes Walkthrough

| File | Change |
|------|--------|
| `src/plugin-sdk/session-transcript-runtime.ts` | Adds public transcript identity helpers |
| `src/plugin-sdk/session-transcript-hit.ts` | Routes hit lookup through identity keys |
| `src/config/sessions/session-accessor.ts` | Exposes runtime transcript target resolution |
| `src/config/sessions/transcript-runtime-state.ts` | Adds transcript runtime state contract |
| `docs/plugins/sdk-runtime.md` | Documents transcript identity API |
| `docs/plugins/sdk-subpaths.md` | Lists new SDK subpath |
| `scripts/lib/plugin-sdk-entrypoints.json` | Adds SDK entrypoint metadata |
| `docs/.generated/plugin-sdk-api-baseline.sha256` | Updates public API baseline |

## Testing
- Focused transcript identity/runtime tests were run by the implementation thread.
- SDK export and API baseline checks were run by the implementation thread.
- This PR was opened as draft for stack review; final proof should be refreshed before moving out of draft.
