### PR TITLE
fix(plugin-sdk): reject malformed static tool descriptors

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-63d49032a9b4dc4874a0ca17be73ecc97a2df5d1f47b4e72db34868423370558  plugin-sdk-api-baseline.json
-af79f7d711afa0a8563782b8f5cdd7e46b9aea245f5e7ebc464327a8969ed65e  plugin-sdk-api-baseline.jsonl
+be16599e40bdab2d4bbc549df4566bf8858a8beaa4927e367d60290cedee2702  plugin-sdk-api-baseline.json
+ca06e012fd0c24c60d04edada3de663055f5066fbe92d6260665f56957c5dcf7  plugin-sdk-api-baseline.jsonl

--- a/scripts/lib/plugin-sdk-doc-metadata.ts
+++ b/scripts/lib/plugin-sdk-doc-metadata.ts
@@ -44,6 +44,9 @@ export const pluginSdkDocMetadata = {
   "plugin-entry": {
     category: "core",
   },
+  "tool-plugin": {
+    category: "core",
+  },
   "access-groups": {
     category: "channel",
   },

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -265,6 +265,45 @@ describe("plugin authoring commands", () => {
     ).toEqual([]);
   });
 
+  it("reports malformed defineToolPlugin static tool descriptors", () => {
+    const entry = defineToolPlugin({
+      id: "malformed-tools",
+      name: "Malformed Tools",
+      description: "Malformed static tool descriptors.",
+      tools: (tool) => [
+        tool({
+          name: "broken_echo",
+          description: "Broken echo.",
+          parameters: Type.Object({}),
+        } as never),
+        tool({
+          name: "good_echo",
+          description: "Good echo.",
+          parameters: Type.Object({}),
+          execute: () => ({ ok: true }),
+        }),
+      ],
+    });
+    const metadata = getToolPluginMetadata(entry);
+    if (!metadata) {
+      throw new Error("missing metadata");
+    }
+
+    expect(
+      validateToolPluginProject({
+        metadata,
+        entry: "./src/index.ts",
+        manifest: buildToolPluginManifest({
+          metadata,
+          packageManifest: { openclaw: { extensions: ["./src/index.ts"] } },
+        }),
+        packageManifest: { openclaw: { extensions: ["./src/index.ts"] } },
+      }),
+    ).toContain(
+      "defineToolPlugin skipped malformed static tool broken_echo: execute or factory must be a function",
+    );
+  });
+
   it("reports stale manifest contracts", () => {
     const metadata = createDemoMetadata();
 

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -55,6 +55,18 @@ function jsStringLiteral(value: string): string {
   return JSON.stringify(value);
 }
 
+function formatToolPluginDiagnostic(
+  diagnostic: NonNullable<ToolPluginMetadata["diagnostics"]>[number],
+): string {
+  return `defineToolPlugin skipped malformed static tool${
+    diagnostic.toolName ? ` ${diagnostic.toolName}` : ""
+  }: ${diagnostic.message}`;
+}
+
+function collectToolPluginDiagnosticErrors(metadata: ToolPluginMetadata): string[] {
+  return (metadata.diagnostics ?? []).map(formatToolPluginDiagnostic);
+}
+
 function normalizeRelativePath(rootDir: string, targetPath: string): string {
   const relative = path
     .relative(rootDir, path.resolve(rootDir, targetPath))
@@ -214,7 +226,7 @@ export function validateToolPluginProject(params: {
   packageManifest: JsonObject;
   entry: string;
 }): string[] {
-  const errors: string[] = [];
+  const errors = collectToolPluginDiagnosticErrors(params.metadata);
   const expectedManifest = buildToolPluginManifest({
     metadata: params.metadata,
     packageManifest: params.packageManifest,
@@ -268,6 +280,13 @@ export async function runPluginsBuildCommand(opts: PluginsBuildOptions): Promise
   const packagePath = path.join(rootDir, "package.json");
   const packageManifest = readPackageManifest(rootDir);
   const { metadata } = await loadToolPlugin({ rootDir, entryPath });
+  const diagnosticErrors = collectToolPluginDiagnosticErrors(metadata);
+  if (diagnosticErrors.length > 0) {
+    for (const error of diagnosticErrors) {
+      defaultRuntime.error(error);
+    }
+    return defaultRuntime.exit(1);
+  }
   const manifestPath = path.join(rootDir, PLUGIN_MANIFEST_FILENAME);
   const currentManifest = fs.existsSync(manifestPath) ? readJsonFile(manifestPath) : undefined;
   const manifest = buildToolPluginManifest({

--- a/src/plugin-sdk/tool-plugin.test.ts
+++ b/src/plugin-sdk/tool-plugin.test.ts
@@ -210,4 +210,80 @@ describe("defineToolPlugin", () => {
       tools: [{ name: "metadata_tool", description: "Static tool." }],
     });
   });
+
+  it("skips malformed static tool descriptors without dropping valid siblings", () => {
+    const entry = defineToolPlugin({
+      id: "static-tool-fuzz",
+      name: "Static Tool Fuzz",
+      description: "Malformed static tool descriptors.",
+      tools: (tool) => [
+        tool({
+          get name(): string {
+            throw new Error("tool name getter exploded");
+          },
+          description: "Poisoned descriptor.",
+          parameters: Type.Object({}),
+          execute: () => "poisoned",
+        } as never),
+        tool({
+          name: "missing_static_execute",
+          description: "Missing executable entrypoint.",
+          parameters: Type.Object({}),
+        } as never),
+        tool({
+          name: "poisoned_optional",
+          description: "Poisoned optional metadata.",
+          parameters: Type.Object({}),
+          get optional(): boolean {
+            throw new Error("tool optional getter exploded");
+          },
+          execute: () => "poisoned",
+        } as never),
+        tool({
+          name: "good_static_echo",
+          get label(): string {
+            throw new Error("tool label getter exploded");
+          },
+          description: "Good static echo.",
+          parameters: Type.Object({ input: Type.String() }),
+          execute: ({ input }) => input,
+        }),
+      ],
+    });
+    const captured = createCapturedPluginRegistration({ id: "static-tool-fuzz" });
+    const warn = vi.fn();
+    captured.api.logger.warn = warn;
+
+    entry.register(captured.api);
+
+    expect(captured.tools.map((tool) => tool.name)).toEqual(["good_static_echo"]);
+    expect(captured.tools[0]).toMatchObject({
+      label: "good_static_echo",
+      description: "Good static echo.",
+    });
+    expect(warn).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledWith(
+      "tool plugin skipped malformed static tool: tool name must be a non-empty string",
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "tool plugin skipped malformed static tool missing_static_execute: execute or factory must be a function",
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "tool plugin skipped malformed static tool poisoned_optional: optional metadata must be readable",
+    );
+    expect(getToolPluginMetadata(entry)).toMatchObject({
+      tools: [{ name: "good_static_echo", label: "good_static_echo" }],
+      diagnostics: [
+        { message: "tool name must be a non-empty string" },
+        {
+          toolName: "missing_static_execute",
+          message: "execute or factory must be a function",
+        },
+        {
+          toolName: "poisoned_optional",
+          message: "optional metadata must be readable",
+        },
+      ],
+    });
+  });
 });

--- a/src/plugin-sdk/tool-plugin.ts
+++ b/src/plugin-sdk/tool-plugin.ts
@@ -28,6 +28,10 @@ type ToolPluginConfig<TConfigSchema extends TSchema | undefined> = TConfigSchema
 
 type ToolPluginToolFactory<TConfig> = <TParamsSchema extends TSchema>(
   definition: ToolPluginToolDefinition<TConfig, TParamsSchema>,
+) => DefinedToolPluginValidTool;
+
+type InternalToolPluginToolFactory<TConfig> = <TParamsSchema extends TSchema>(
+  definition: ToolPluginToolDefinition<TConfig, TParamsSchema>,
 ) => DefinedToolPluginTool;
 
 export type ToolPluginFactoryContext<TConfig> = {
@@ -65,7 +69,7 @@ export type ToolPluginToolDefinition<
       }
   );
 
-type DefinedToolPluginTool = {
+type DefinedToolPluginValidTool = {
   name: string;
   label: string;
   description: string;
@@ -77,12 +81,24 @@ type DefinedToolPluginTool = {
   ) => AnyAgentTool | AnyAgentTool[] | null | undefined;
 };
 
+type DefinedToolPluginMalformedTool = {
+  name?: string;
+  malformedReason: string;
+};
+
+type DefinedToolPluginTool = DefinedToolPluginValidTool | DefinedToolPluginMalformedTool;
+
 export type ToolPluginStaticToolMetadata = {
   name: string;
   label: string;
   description: string;
   parameters: JsonSchemaObject;
   optional?: boolean;
+};
+
+export type ToolPluginStaticToolDiagnostic = {
+  toolName?: string;
+  message: string;
 };
 
 export type ToolPluginMetadata = {
@@ -92,6 +108,7 @@ export type ToolPluginMetadata = {
   activation: PluginManifestActivation;
   configSchema: JsonSchemaObject;
   tools: ToolPluginStaticToolMetadata[];
+  diagnostics?: ToolPluginStaticToolDiagnostic[];
 };
 
 export type DefineToolPluginOptions<TConfigSchema extends TSchema | undefined = undefined> = {
@@ -116,16 +133,113 @@ function wrapToolPluginResult(result: unknown): AgentToolResult<unknown> {
   return jsonResult(result);
 }
 
-function createToolPluginToolFactory<TConfig>(): ToolPluginToolFactory<TConfig> {
-  return ((definition: ToolPluginToolDefinition<TConfig, TSchema>) => ({
-    name: definition.name,
-    label: definition.label ?? definition.name,
-    description: definition.description,
-    parameters: definition.parameters,
-    optional: definition.optional === true,
-    execute: definition.execute as DefinedToolPluginTool["execute"],
-    factory: definition.factory as DefinedToolPluginTool["factory"],
-  })) as ToolPluginToolFactory<TConfig>;
+function isValidToolPluginTool(tool: DefinedToolPluginTool): tool is DefinedToolPluginValidTool {
+  return !("malformedReason" in tool);
+}
+
+function isMalformedToolPluginTool(
+  tool: DefinedToolPluginTool,
+): tool is DefinedToolPluginMalformedTool {
+  return "malformedReason" in tool;
+}
+
+function isObjectSchema(value: unknown): value is TSchema {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type ToolDefinitionRead = { ok: true; value: unknown } | { ok: false };
+
+function readToolDefinitionValue(
+  definition: ToolPluginToolDefinition<unknown, TSchema>,
+  key: string,
+): ToolDefinitionRead {
+  try {
+    return { ok: true, value: (definition as Record<string, unknown>)[key] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function malformedTool(name: string | undefined, message: string): DefinedToolPluginMalformedTool {
+  return name ? { name, malformedReason: message } : { malformedReason: message };
+}
+
+function staticToolDiagnostic(
+  tool: DefinedToolPluginMalformedTool,
+): ToolPluginStaticToolDiagnostic {
+  return tool.name
+    ? { toolName: tool.name, message: tool.malformedReason }
+    : { message: tool.malformedReason };
+}
+
+function staticToolMetadata(tool: DefinedToolPluginValidTool): ToolPluginStaticToolMetadata {
+  const metadata: ToolPluginStaticToolMetadata = {
+    name: tool.name,
+    label: tool.label,
+    description: tool.description,
+    parameters: tool.parameters as JsonSchemaObject,
+  };
+  if (tool.optional) {
+    metadata.optional = true;
+  }
+  return metadata;
+}
+
+function malformedToolMessage(tool: DefinedToolPluginMalformedTool): string {
+  return `tool plugin skipped malformed static tool${
+    tool.name ? ` ${tool.name}` : ""
+  }: ${tool.malformedReason}`;
+}
+
+function createToolPluginToolFactory<TConfig>(): InternalToolPluginToolFactory<TConfig> {
+  return ((definition: ToolPluginToolDefinition<TConfig, TSchema>) => {
+    const unknownDefinition = definition as ToolPluginToolDefinition<unknown, TSchema>;
+    const rawName = readToolDefinitionValue(unknownDefinition, "name");
+    const name = rawName.ok && typeof rawName.value === "string" ? rawName.value : "";
+    if (!name.trim()) {
+      return malformedTool(undefined, "tool name must be a non-empty string");
+    }
+
+    const description = readToolDefinitionValue(unknownDefinition, "description");
+    if (!description.ok || typeof description.value !== "string") {
+      return malformedTool(name, "description must be a string");
+    }
+
+    const parameters = readToolDefinitionValue(unknownDefinition, "parameters");
+    if (!parameters.ok || !isObjectSchema(parameters.value)) {
+      return malformedTool(name, "parameters must be a schema object");
+    }
+
+    const execute = readToolDefinitionValue(unknownDefinition, "execute");
+    const factory = readToolDefinitionValue(unknownDefinition, "factory");
+    if (!execute.ok || !factory.ok) {
+      return malformedTool(name, "execute and factory metadata must be readable");
+    }
+    const hasExecute = typeof execute.value === "function";
+    const hasFactory = typeof factory.value === "function";
+    if (!hasExecute && !hasFactory) {
+      return malformedTool(name, "execute or factory must be a function");
+    }
+    if (hasExecute && hasFactory) {
+      return malformedTool(name, "define either execute or factory, not both");
+    }
+
+    const label = readToolDefinitionValue(unknownDefinition, "label");
+    const optional = readToolDefinitionValue(unknownDefinition, "optional");
+    if (!optional.ok) {
+      return malformedTool(name, "optional metadata must be readable");
+    }
+    return {
+      name,
+      label: label.ok && typeof label.value === "string" && label.value ? label.value : name,
+      description: description.value,
+      parameters: parameters.value,
+      optional: optional.value === true,
+      ...(hasExecute
+        ? { execute: execute.value as DefinedToolPluginValidTool["execute"] }
+        : { factory: factory.value as DefinedToolPluginValidTool["factory"] }),
+    };
+  }) as InternalToolPluginToolFactory<TConfig>;
 }
 
 export function defineToolPlugin<TConfigSchema extends TSchema | undefined = undefined>(
@@ -135,9 +249,12 @@ export function defineToolPlugin<TConfigSchema extends TSchema | undefined = und
     EMPTY_TOOL_PLUGIN_CONFIG_SCHEMA) as JsonSchemaObject;
   const pluginConfigSchema = buildJsonPluginConfigSchema(configSchema);
   const normalizedConfigSchema = pluginConfigSchema.jsonSchema ?? configSchema;
+  const toolFactory = createToolPluginToolFactory<ToolPluginConfig<TConfigSchema>>();
   const tools = [
-    ...definition.tools(createToolPluginToolFactory<ToolPluginConfig<TConfigSchema>>()),
-  ];
+    ...definition.tools(toolFactory as ToolPluginToolFactory<ToolPluginConfig<TConfigSchema>>),
+  ] as DefinedToolPluginTool[];
+  const validTools = tools.filter(isValidToolPluginTool);
+  const diagnostics = tools.filter(isMalformedToolPluginTool).map(staticToolDiagnostic);
   const activation = definition.activation ?? { onStartup: true };
   const metadata: ToolPluginMetadata = {
     id: definition.id,
@@ -145,13 +262,8 @@ export function defineToolPlugin<TConfigSchema extends TSchema | undefined = und
     description: definition.description,
     activation,
     configSchema: normalizedConfigSchema,
-    tools: tools.map((tool) => ({
-      name: tool.name,
-      label: tool.label,
-      description: tool.description,
-      parameters: tool.parameters as JsonSchemaObject,
-      ...(tool.optional ? { optional: true } : {}),
-    })),
+    tools: validTools.map(staticToolMetadata),
+    ...(diagnostics.length > 0 ? { diagnostics } : {}),
   };
 
   const entry = definePluginEntry({
@@ -162,6 +274,10 @@ export function defineToolPlugin<TConfigSchema extends TSchema | undefined = und
     register(api) {
       const config = (api.pluginConfig ?? {}) as ToolPluginConfig<TConfigSchema>;
       for (const tool of tools) {
+        if (!isValidToolPluginTool(tool)) {
+          api.logger.warn?.(malformedToolMessage(tool));
+          continue;
+        }
         const opts = {
           name: tool.name,
           ...(tool.optional ? { optional: true } : {}),


### PR DESCRIPTION
## Summary

- harden `defineToolPlugin` static tool descriptors so poisoned/malformed entries are skipped with diagnostics instead of crashing plugin definition or registering unsafe defaults
- surface malformed static descriptor diagnostics through `openclaw plugins build/validate` and keep valid sibling tools registered
- add `plugin-sdk/tool-plugin` to the SDK API baseline metadata and refresh the tracked baseline hash

## Verification

- `node scripts/run-vitest.mjs src/plugin-sdk/tool-plugin.test.ts src/cli/plugins-authoring-command.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 scripts/lib/plugin-sdk-doc-metadata.ts src/plugin-sdk/tool-plugin.ts src/plugin-sdk/tool-plugin.test.ts src/cli/plugins-authoring-command.ts src/cli/plugins-authoring-command.test.ts`
- `git diff --check`
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- `./node_modules/.bin/oxlint src/plugin-sdk/tool-plugin.ts src/plugin-sdk/tool-plugin.test.ts src/cli/plugins-authoring-command.ts src/cli/plugins-authoring-command.test.ts scripts/lib/plugin-sdk-doc-metadata.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)
- Remote changed gate: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed` on provider `azure`, run `run_b69a02a7a373`, lease `cbx_b60c032eb14f`, exit `0`, lease stopped

## Real behavior proof

Behavior addressed: malformed `defineToolPlugin` static tool descriptors no longer abort valid sibling tools or silently register tools when safety metadata cannot be read.

Real environment tested: remote Linux validation on provider `azure`, Node `v24.15.0`, pnpm via Corepack, pushed branch `fuzz-plugin-sdk-static-tool-20260602` cloned from GitHub.

Exact steps or command run after this patch: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed`.

Evidence after fix: remote run `run_b69a02a7a373`, lease `cbx_b60c032eb14f`, completed `check:changed` with exit `0`; local focused tests and SDK API baseline check also passed.

Observed result after fix: valid static tools remain registered, malformed descriptors are reported as diagnostics, plugin authoring build/validate fails on those diagnostics, and changed-gate lanes pass.

What was not tested: no live third-party plugin package was installed; coverage uses SDK/unit tests plus the repository changed gate.
