### PR TITLE
fix(doctor): harden runtime tool schema findings

### DIFF
--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -208,4 +208,27 @@ describe("runtime tool input schema projection", () => {
       ],
     });
   });
+
+  it("quarantines primitive tool descriptors before provider normalization", () => {
+    const healthy = {
+      name: "healthy",
+      parameters: { type: "object", properties: {} },
+    };
+
+    expect(
+      filterProviderNormalizableTools([
+        "fuzzplugin primitive tool entry" as unknown as Pick<AnyAgentTool, "name" | "parameters">,
+        healthy,
+      ]),
+    ).toEqual({
+      tools: [healthy],
+      diagnostics: [
+        {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["tool[0] is not an object tool descriptor"],
+        },
+      ],
+    });
+  });
 });

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -50,6 +50,19 @@ function unreadableRuntimeToolEntry(
   };
 }
 
+function invalidRuntimeToolEntry(
+  toolIndex: number,
+): RuntimeToolEntryRead<Pick<AnyAgentTool, "name" | "parameters">> {
+  return {
+    ok: false,
+    diagnostic: {
+      toolName: `tool[${toolIndex}]`,
+      toolIndex,
+      violations: [`tool[${toolIndex}] is not an object tool descriptor`],
+    },
+  };
+}
+
 function readRuntimeToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
   tools: readonly TTool[],
 ): RuntimeToolEntryRead<TTool>[] {
@@ -62,7 +75,12 @@ function readRuntimeToolEntries<TTool extends Pick<AnyAgentTool, "name" | "param
   const entries: RuntimeToolEntryRead<TTool>[] = [];
   for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
     try {
-      entries.push({ ok: true, tool: tools[toolIndex], toolIndex });
+      const tool = tools[toolIndex];
+      if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
+        entries.push(invalidRuntimeToolEntry(toolIndex) as RuntimeToolEntryRead<TTool>);
+        continue;
+      }
+      entries.push({ ok: true, tool, toolIndex });
     } catch {
       entries.push(unreadableRuntimeToolEntry(toolIndex) as RuntimeToolEntryRead<TTool>);
     }

--- a/src/flows/doctor-core-checks.runtime-errors.test.ts
+++ b/src/flows/doctor-core-checks.runtime-errors.test.ts
@@ -141,6 +141,44 @@ describe("doctor runtime tool schema error handling", () => {
     expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
   });
 
+  it("reports primitive agent runtime tool entries without aborting doctor", async () => {
+    mocks.createOpenClawCodingTools.mockReturnValueOnce([
+      "fuzzplugin primitive tool entry" as unknown as AnyAgentTool,
+      tool("healthy", { type: "object", properties: {} }),
+    ]);
+
+    await expect(collectRuntimeToolSchemaFindings({})).resolves.toContainEqual({
+      checkId: "core/doctor/runtime-tool-schemas",
+      severity: "error",
+      message: "Agent main tool tool[0] has an unsupported input schema for runtime projection.",
+      path: "tools.tool[0]",
+      target: "tool[0]",
+      requirement: "tool[0] is not an object tool descriptor",
+      fixHint:
+        "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.",
+    });
+    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("sanitizes plugin-controlled runtime tool schema finding text", async () => {
+    mocks.createOpenClawCodingTools.mockReturnValueOnce([
+      tool("fuzzplugin_\u001B[31mmove\nangles", { type: "array", items: { type: "number" } }),
+    ]);
+
+    await expect(collectRuntimeToolSchemaFindings({})).resolves.toContainEqual({
+      checkId: "core/doctor/runtime-tool-schemas",
+      severity: "error",
+      message:
+        "Agent main tool fuzzplugin_moveangles has an unsupported input schema for runtime projection.",
+      path: "tools.fuzzplugin_moveangles",
+      target: "fuzzplugin_moveangles",
+      requirement: 'fuzzplugin_moveangles.parameters.type must be "object"',
+      fixHint:
+        "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.",
+    });
+    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
+  });
+
   it("reports bundle MCP runtime tool normalization failures without aborting doctor", async () => {
     mocks.createBundleMcpToolRuntime.mockResolvedValueOnce({
       tools: [bundleMcpTool("fuzzplugin__move_angles", { type: "object", properties: {} })],

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -1,3 +1,4 @@
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { TOOL_NAME_SEPARATOR } from "../agents/agent-bundle-mcp-names.js";
 import {
   type McpToolCatalogDiagnostic,
@@ -553,26 +554,29 @@ function toolSchemaDiagnosticToFinding(params: {
   } catch {
     tool = undefined;
   }
-  const pluginId = tool ? getPluginToolMeta(tool)?.pluginId : undefined;
+  const rawPluginId = tool ? getPluginToolMeta(tool)?.pluginId : undefined;
+  const pluginId = rawPluginId ? sanitizeForLog(rawPluginId) : undefined;
+  const toolName = sanitizeForLog(params.diagnostic.toolName);
+  const requirement = sanitizeForLog(params.diagnostic.violations.join(", "));
   const owner = pluginId ? ` from plugin ${pluginId}` : "";
   const agent = `Agent ${params.agentId} `;
   const path =
-    pluginId === "bundle-mcp"
+    rawPluginId === "bundle-mcp"
       ? "mcp.servers"
       : pluginId
         ? `plugins.entries.${pluginId}`
-        : `tools.${params.diagnostic.toolName}`;
+        : `tools.${toolName}`;
   const fixHint =
-    pluginId === "bundle-mcp"
+    rawPluginId === "bundle-mcp"
       ? "Disable or update the offending MCP server/tool so its parameters are a JSON object schema, then rerun doctor."
       : "Disable or update the offending plugin/tool so its parameters are a JSON object schema, then rerun doctor.";
   return {
     checkId: "core/doctor/runtime-tool-schemas",
     severity: "error",
-    message: `${agent}tool ${params.diagnostic.toolName}${owner} has an unsupported input schema for runtime projection.`,
+    message: `${agent}tool ${toolName}${owner} has an unsupported input schema for runtime projection.`,
     path,
-    target: params.diagnostic.toolName,
-    requirement: params.diagnostic.violations.join(", "),
+    target: toolName,
+    requirement,
     fixHint,
   };
 }


### PR DESCRIPTION
## Summary

- Quarantine primitive/array runtime tool descriptors before provider normalization so invalid entries cannot be normalized into apparently valid schemas.
- Sanitize plugin-controlled runtime tool schema diagnostics before rendering doctor health findings.
- Add focused coverage for primitive runtime descriptors and ANSI/newline tool names in doctor schema findings.

## Verification

- `node scripts/run-vitest.mjs src/agents/tool-schema-projection.test.ts src/flows/doctor-core-checks.runtime-errors.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/tool-schema-projection.ts src/agents/tool-schema-projection.test.ts src/flows/doctor-core-checks.runtime.ts src/flows/doctor-core-checks.runtime-errors.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint src/agents/tool-schema-projection.ts src/agents/tool-schema-projection.test.ts src/flows/doctor-core-checks.runtime.ts src/flows/doctor-core-checks.runtime-errors.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox changed gate: `pnpm check:changed`, provider `aws`, run `run_686bafdecc90`, lease `cbx_7d6fbaa53b59`, exit 0, lease stopped.

## Real behavior proof

Behavior addressed: malformed runtime tool descriptors and plugin-controlled schema diagnostic text in doctor/runtime tool-schema projection.

Real environment tested: focused Vitest locally in the OpenClaw worktree; broad changed gate on AWS Crabbox Linux.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tool-schema-projection.test.ts src/flows/doctor-core-checks.runtime-errors.test.ts --reporter=dot`; `pnpm check:changed` through AWS Crabbox run `run_686bafdecc90`.

Evidence after fix: local focused tests passed 2 shards / 17 tests; remote changed gate passed lanes `core` and `coreTests` with exit 0.

Observed result after fix: primitive runtime tool entries are reported before provider normalization, healthy sibling tools remain available, and doctor findings render sanitized tool names/requirements.

What was not tested: true Blacksmith Testbox proof was blocked by missing local Blacksmith auth; Azure Crabbox allocation failed before command execution with coordinator HTTP 500/1101, so AWS Crabbox was used for broad proof.
