### PR TITLE
feat(telegram): resolve pending approvals from message reactions

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -794,13 +794,15 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
   </Accordion>
 
   <Accordion title="Approval reactions (👍 / 👎)">
-    When `approvals.exec.enabled` or `approvals.plugin.enabled` is true and the request routes through Telegram, OpenClaw binds the approval prompt message to Telegram reaction updates and accepts reaction decisions directly:
+    When exec approvals are enabled for Telegram (`channels.telegram.execApprovals.enabled`, or account override `channels.telegram.accounts.<id>.execApprovals.enabled`) and the request routes through Telegram, OpenClaw binds the approval prompt message to Telegram reaction updates and accepts reaction decisions directly:
 
     - `👍` -> `allow-once`
     - `👎` -> `deny`
     - `allow-always` remains a manual fallback via `/approve <id> allow-always`
 
-    Approval reactions are authorized with explicit approval approvers (exec approvers or plugin approvers), not with generic reaction notification settings. This shortcut is checked before generic `reactionNotifications` gates so approval reactions can still resolve when notification mode is `off`.
+    Approval reactions are authorized with explicit approval approvers, not with generic reaction notification settings. For exec approvals, approvers come from `channels.telegram.execApprovals.approvers` (or `channels.telegram.accounts.<id>.execApprovals.approvers`) and fall back to numeric owner IDs from `commands.ownerAllowFrom`. Telegram approver IDs must be numeric Telegram user IDs.
+
+    This shortcut is checked before generic `reactionNotifications` gates so approval reactions can still resolve when notification mode is `off`.
 
     Persistence behavior:
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -793,6 +793,23 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
   </Accordion>
 
+  <Accordion title="Approval reactions (👍 / 👎)">
+    When `approvals.exec.enabled` or `approvals.plugin.enabled` is true and the request routes through Telegram, OpenClaw binds the approval prompt message to Telegram reaction updates and accepts reaction decisions directly:
+
+    - `👍` -> `allow-once`
+    - `👎` -> `deny`
+    - `allow-always` remains a manual fallback via `/approve <id> allow-always`
+
+    Approval reactions are authorized with explicit approval approvers (exec approvers or plugin approvers), not with generic reaction notification settings. This shortcut is checked before generic `reactionNotifications` gates so approval reactions can still resolve when notification mode is `off`.
+
+    Persistence behavior:
+
+    - Approval reaction targets are stored in plugin keyed state and mirrored in a bounded in-memory cache.
+    - The in-memory cache TTL is clamped to the approval expiry, and stale targets are removed when the approval resolves or expires.
+    - This keeps reaction resolution working across normal restart windows while preventing old message reactions from resolving expired approvals.
+
+  </Accordion>
+
   <Accordion title="Ack reactions">
     `ackReaction` sends an acknowledgement emoji while OpenClaw is processing an inbound message. `ackReactionScope` decides *when* that emoji is actually sent.
 

--- a/extensions/telegram/src/approval-handler.runtime.test.ts
+++ b/extensions/telegram/src/approval-handler.runtime.test.ts
@@ -114,6 +114,7 @@ describe("telegramApprovalNativeRuntime", () => {
       messageThreadId: 928,
     });
     expect(entry).toEqual({
+      accountId: "default",
       chatId: "-1003841603622",
       messageId: "m1",
     });

--- a/extensions/telegram/src/approval-handler.runtime.test.ts
+++ b/extensions/telegram/src/approval-handler.runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { telegramApprovalNativeRuntime } from "./approval-handler.runtime.js";
+import * as approvalReactions from "./approval-reactions.js";
 
 type TelegramPayload = {
   text: string;
@@ -118,5 +119,72 @@ describe("telegramApprovalNativeRuntime", () => {
       chatId: "-1003841603622",
       messageId: "m1",
     });
+  });
+
+  it("binds only Telegram-supported reaction decisions", async () => {
+    const registerSpy = vi
+      .spyOn(approvalReactions, "registerTelegramApprovalReactionTarget")
+      .mockReturnValue({
+        approvalId: "req-1",
+        approvalKind: "exec",
+        allowedDecisions: ["allow-once", "deny"],
+      });
+
+    const result = await telegramApprovalNativeRuntime.interactions.bindPending({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        token: "tg-token",
+      },
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "exec",
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-1",
+        commandText: "echo hi",
+        expiresAtMs: 60_000,
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            command: "/approve req-1 allow-once",
+            style: "success",
+          },
+          {
+            decision: "allow-always",
+            label: "Allow Always",
+            command: "/approve req-1 allow-always",
+            style: "primary",
+          },
+          {
+            decision: "deny",
+            label: "Deny",
+            command: "/approve req-1 deny",
+            style: "danger",
+          },
+        ],
+      } as never,
+      entry: {
+        accountId: "default",
+        chatId: "-1001",
+        messageId: "m1",
+      },
+    });
+
+    expect(result).toBe(true);
+    expect(registerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedDecisions: ["allow-once", "deny"],
+      }),
+    );
+
+    registerSpy.mockRestore();
   });
 });

--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -9,7 +9,10 @@ import {
   buildApprovalPresentationFromActionDescriptors,
   buildExecApprovalPendingReplyPayload,
 } from "openclaw/plugin-sdk/approval-reply-runtime";
-import type { ExecApprovalPendingReplyParams } from "openclaw/plugin-sdk/approval-reply-runtime";
+import type {
+  ExecApprovalPendingReplyParams,
+  ExecApprovalReplyDecision,
+} from "openclaw/plugin-sdk/approval-reply-runtime";
 import type {
   ExecApprovalRequest,
   PluginApprovalRequest,
@@ -28,6 +31,10 @@ import {
 import { editMessageReplyMarkupTelegram, sendMessageTelegram, sendTypingTelegram } from "./send.js";
 
 const log = createSubsystemLogger("telegram/approvals");
+const TELEGRAM_REACTION_ALLOWED_DECISIONS = [
+  "allow-once",
+  "deny",
+] as const satisfies readonly ExecApprovalReplyDecision[];
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
 type PendingMessage = {
@@ -39,6 +46,15 @@ type TelegramPendingDelivery = {
   text: string;
   buttons: ReturnType<typeof resolveTelegramInlineButtons>;
 };
+
+function filterTelegramReactionDecisions(
+  actions: PendingApprovalView["actions"],
+): ExecApprovalReplyDecision[] {
+  const allowed = new Set<ExecApprovalReplyDecision>(TELEGRAM_REACTION_ALLOWED_DECISIONS);
+  return actions
+    .map((action) => action.decision)
+    .filter((decision): decision is ExecApprovalReplyDecision => allowed.has(decision));
+}
 
 export type TelegramExecApprovalHandlerDeps = {
   nowMs?: () => number;
@@ -186,7 +202,7 @@ export const telegramApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
         chatId: entry.chatId,
         messageId: entry.messageId,
         approvalId: request.id,
-        allowedDecisions: view.actions.map((action) => action.decision),
+        allowedDecisions: filterTelegramReactionDecisions(view.actions),
         ttlMs: Math.max(1, view.expiresAtMs - Date.now()),
       })
         ? true

--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -16,6 +16,10 @@ import type {
 } from "openclaw/plugin-sdk/approval-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  registerTelegramApprovalReactionTarget,
+  unregisterTelegramApprovalReactionTarget,
+} from "./approval-reactions.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import {
   isTelegramExecApprovalHandlerConfigured,
@@ -27,6 +31,7 @@ const log = createSubsystemLogger("telegram/approvals");
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
 type PendingMessage = {
+  accountId: string;
   chatId: string;
   messageId: string;
 };
@@ -167,12 +172,38 @@ export const telegramApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
           : {}),
       });
       return {
+        accountId: resolved.accountId,
         chatId: result.chatId,
         messageId: result.messageId,
       };
     },
   },
   interactions: {
+    bindPending: ({ entry, request, view }) =>
+      registerTelegramApprovalReactionTarget({
+        accountId: entry.accountId,
+        chatId: entry.chatId,
+        messageId: entry.messageId,
+        approvalId: request.id,
+        allowedDecisions: view.actions.map((action) => action.decision),
+        ttlMs: Math.max(1, view.expiresAtMs - Date.now()),
+      })
+        ? true
+        : null,
+    unbindPending: ({ entry }) => {
+      unregisterTelegramApprovalReactionTarget({
+        accountId: entry.accountId,
+        chatId: entry.chatId,
+        messageId: entry.messageId,
+      });
+    },
+    cancelDelivered: ({ entry }) => {
+      unregisterTelegramApprovalReactionTarget({
+        accountId: entry.accountId,
+        chatId: entry.chatId,
+        messageId: entry.messageId,
+      });
+    },
     clearPendingActions: async ({ cfg, accountId, context, entry }) => {
       const resolved = resolveHandlerContext({ cfg, accountId, context });
       if (!resolved) {

--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -106,6 +106,7 @@ export const telegramApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
   TelegramPendingDelivery,
   { chatId: string; messageThreadId?: number },
   PendingMessage,
+  boolean,
   never
 >({
   eventKinds: ["exec", "plugin"],

--- a/extensions/telegram/src/approval-reactions.ts
+++ b/extensions/telegram/src/approval-reactions.ts
@@ -1,0 +1,140 @@
+import {
+  createApprovalReactionTargetStore,
+  listApprovalReactionBindings,
+  resolveApprovalReactionTarget,
+  type ApprovalReactionTargetRecord,
+} from "openclaw/plugin-sdk/approval-reaction-runtime";
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
+import { getOptionalTelegramRuntime } from "./runtime.js";
+
+const PERSISTENT_NAMESPACE = "telegram.approval-reactions";
+const PERSISTENT_MAX_ENTRIES = 1000;
+const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
+
+type TelegramApprovalReactionTarget = ApprovalReactionTargetRecord;
+
+type TelegramApprovalReactionResolution = {
+  approvalId: string;
+  decision: ExecApprovalReplyDecision;
+};
+
+const telegramApprovalReactionTargets =
+  createApprovalReactionTargetStore<TelegramApprovalReactionTarget>({
+    namespace: PERSISTENT_NAMESPACE,
+    maxEntries: PERSISTENT_MAX_ENTRIES,
+    defaultTtlMs: DEFAULT_REACTION_TARGET_TTL_MS,
+    openStore: (storeParams) => getOptionalTelegramRuntime()?.state.openKeyedStore(storeParams),
+    logPersistentError: reportPersistentApprovalReactionError,
+    readPersistedTarget,
+  });
+
+function buildReactionTargetKey(params: {
+  accountId: string;
+  chatId: string | number;
+  messageId: string | number;
+}): string | null {
+  const accountId = params.accountId.trim();
+  const chatId = String(params.chatId).trim();
+  const messageId = String(params.messageId).trim();
+  if (!accountId || !chatId || !messageId) {
+    return null;
+  }
+  return `${accountId}:${chatId}:${messageId}`;
+}
+
+function reportPersistentApprovalReactionError(error: unknown): void {
+  try {
+    getOptionalTelegramRuntime()
+      ?.logging.getChildLogger({ plugin: "telegram", feature: "approval-reaction-state" })
+      .warn("Telegram persistent approval reaction state failed", { error: String(error) });
+  } catch {
+    // Best effort only: persistent state must never break Telegram reactions.
+  }
+}
+
+function readPersistedTarget(target: unknown): TelegramApprovalReactionTarget | null {
+  const value = target as Partial<TelegramApprovalReactionTarget> | null | undefined;
+  if (!value || typeof value.approvalId !== "string" || !Array.isArray(value.allowedDecisions)) {
+    return null;
+  }
+  return {
+    approvalId: value.approvalId,
+    ...(value.approvalKind === "exec" || value.approvalKind === "plugin"
+      ? { approvalKind: value.approvalKind }
+      : {}),
+    allowedDecisions: value.allowedDecisions,
+  };
+}
+
+export function registerTelegramApprovalReactionTarget(params: {
+  accountId: string;
+  chatId: string | number;
+  messageId: string | number;
+  approvalId: string;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+  ttlMs?: number;
+}): TelegramApprovalReactionTarget | null {
+  const key = buildReactionTargetKey(params);
+  const approvalId = params.approvalId.trim();
+  const allowedDecisions = listApprovalReactionBindings({
+    allowedDecisions: params.allowedDecisions,
+  }).map((binding) => binding.decision);
+  if (!key || !approvalId || allowedDecisions.length === 0) {
+    return null;
+  }
+  const target: TelegramApprovalReactionTarget = {
+    approvalId,
+    approvalKind: approvalId.startsWith("plugin:") ? "plugin" : "exec",
+    allowedDecisions,
+  };
+  telegramApprovalReactionTargets.register(key, target, { ttlMs: params.ttlMs });
+  return target;
+}
+
+export function unregisterTelegramApprovalReactionTarget(params: {
+  accountId: string;
+  chatId: string | number;
+  messageId: string | number;
+}): void {
+  const key = buildReactionTargetKey(params);
+  if (!key) {
+    return;
+  }
+  telegramApprovalReactionTargets.delete(key);
+}
+
+function resolveTarget(params: {
+  target: TelegramApprovalReactionTarget | null | undefined;
+  reactionKey: string;
+}): TelegramApprovalReactionResolution | null {
+  const resolved = resolveApprovalReactionTarget({
+    target: params.target,
+    reactionKey: params.reactionKey,
+  });
+  return resolved
+    ? {
+        approvalId: resolved.approvalId,
+        decision: resolved.decision,
+      }
+    : null;
+}
+
+export async function resolveTelegramApprovalReactionTargetWithPersistence(params: {
+  accountId: string;
+  chatId: string | number;
+  messageId: string | number;
+  reactionKey: string;
+}): Promise<TelegramApprovalReactionResolution | null> {
+  const key = buildReactionTargetKey(params);
+  if (!key) {
+    return null;
+  }
+  return resolveTarget({
+    target: await telegramApprovalReactionTargets.lookup(key),
+    reactionKey: params.reactionKey,
+  });
+}
+
+export function clearTelegramApprovalReactionTargetsForTest(): void {
+  telegramApprovalReactionTargets.clearForTest();
+}

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -44,6 +44,10 @@ import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
 import { resolveTelegramMediaRuntimeOptions } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
+  resolveTelegramApprovalReactionTargetWithPersistence,
+  unregisterTelegramApprovalReactionTarget,
+} from "./approval-reactions.js";
+import {
   normalizeDmAllowFromWithStore,
   firstDefined,
   resolveTelegramEffectiveDmPolicy,
@@ -1616,10 +1620,73 @@ export const registerTelegramHandlers = ({
         parentPeer,
       });
       const sessionKey = route.sessionKey;
+      const runtimeCfg = telegramDeps.getRuntimeConfig();
 
-      // Enqueue system event for each added reaction.
+      // Enqueue system event for each added reaction unless the reaction resolves
+      // a bound approval prompt for this Telegram message.
       for (const r of addedReactions) {
         const emoji = r.emoji;
+        const approvalReaction = await resolveTelegramApprovalReactionTargetWithPersistence({
+          accountId,
+          chatId,
+          messageId,
+          reactionKey: emoji,
+        });
+        if (approvalReaction) {
+          const isPluginApproval = approvalReaction.approvalId.startsWith("plugin:");
+          const pluginApprovalAuthorizedSender = isTelegramExecApprovalApprover({
+            cfg: runtimeCfg,
+            accountId,
+            senderId,
+          });
+          const execApprovalAuthorizedSender = isTelegramExecApprovalAuthorizedSender({
+            cfg: runtimeCfg,
+            accountId,
+            senderId,
+          });
+          const authorizedApprovalSender = isPluginApproval
+            ? pluginApprovalAuthorizedSender
+            : execApprovalAuthorizedSender || pluginApprovalAuthorizedSender;
+          if (!authorizedApprovalSender) {
+            logVerbose(
+              `telegram: approval reaction denied id=${approvalReaction.approvalId} sender=${senderId || "unknown"}`,
+            );
+            continue;
+          }
+          try {
+            await (telegramDeps.resolveExecApproval ?? resolveTelegramExecApproval)({
+              cfg: runtimeCfg,
+              approvalId: approvalReaction.approvalId,
+              decision: approvalReaction.decision,
+              senderId,
+              allowPluginFallback: pluginApprovalAuthorizedSender,
+            });
+            unregisterTelegramApprovalReactionTarget({
+              accountId,
+              chatId,
+              messageId,
+            });
+            logVerbose(
+              `telegram: approval reaction resolved id=${approvalReaction.approvalId} sender=${senderId || "unknown"} decision=${approvalReaction.decision}`,
+            );
+          } catch (resolveErr) {
+            if (isApprovalNotFoundError(resolveErr)) {
+              unregisterTelegramApprovalReactionTarget({
+                accountId,
+                chatId,
+                messageId,
+              });
+              logVerbose(
+                `telegram: approval reaction ignored for expired approval id=${approvalReaction.approvalId} sender=${senderId || "unknown"}`,
+              );
+              continue;
+            }
+            logVerbose(
+              `telegram: approval reaction failed id=${approvalReaction.approvalId} sender=${senderId || "unknown"}: ${String(resolveErr)}`,
+            );
+          }
+          continue;
+        }
         const text = `Telegram reaction added: ${emoji} by ${senderLabel} on msg ${messageId}`;
         telegramDeps.enqueueSystemEvent(text, {
           sessionKey,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1605,6 +1605,7 @@ export const registerTelegramHandlers = ({
           logVerbose(
             `telegram: approval reaction failed id=${approvalReaction.approvalId} sender=${senderId || "unknown"}: ${String(resolveErr)}`,
           );
+          throw resolveErr;
         }
       }
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1524,6 +1524,93 @@ export const registerTelegramHandlers = ({
       const senderUsername = user?.username ?? "";
       const isGroup = reaction.chat.type === "group" || reaction.chat.type === "supergroup";
       const isForum = reaction.chat.is_forum === true;
+      const runtimeCfg = telegramDeps.getRuntimeConfig();
+
+      // Detect added reactions.
+      const oldEmojis = new Set(
+        reaction.old_reaction
+          .filter((r): r is ReactionTypeEmoji => r.type === "emoji")
+          .map((r) => r.emoji),
+      );
+      const addedReactions = reaction.new_reaction
+        .filter((r): r is ReactionTypeEmoji => r.type === "emoji")
+        .filter((r) => !oldEmojis.has(r.emoji));
+
+      if (addedReactions.length === 0) {
+        return;
+      }
+
+      const genericReactions: ReactionTypeEmoji[] = [];
+      for (const added of addedReactions) {
+        const approvalReaction = await resolveTelegramApprovalReactionTargetWithPersistence({
+          accountId,
+          chatId,
+          messageId,
+          reactionKey: added.emoji,
+        });
+        if (!approvalReaction) {
+          genericReactions.push(added);
+          continue;
+        }
+
+        const isPluginApproval = approvalReaction.approvalId.startsWith("plugin:");
+        const pluginApprovalAuthorizedSender = isTelegramExecApprovalApprover({
+          cfg: runtimeCfg,
+          accountId,
+          senderId,
+        });
+        const execApprovalAuthorizedSender = isTelegramExecApprovalAuthorizedSender({
+          cfg: runtimeCfg,
+          accountId,
+          senderId,
+        });
+        const authorizedApprovalSender = isPluginApproval
+          ? pluginApprovalAuthorizedSender
+          : execApprovalAuthorizedSender || pluginApprovalAuthorizedSender;
+        if (!authorizedApprovalSender) {
+          logVerbose(
+            `telegram: approval reaction denied id=${approvalReaction.approvalId} sender=${senderId || "unknown"}`,
+          );
+          continue;
+        }
+
+        try {
+          await (telegramDeps.resolveExecApproval ?? resolveTelegramExecApproval)({
+            cfg: runtimeCfg,
+            approvalId: approvalReaction.approvalId,
+            decision: approvalReaction.decision,
+            senderId,
+            allowPluginFallback: pluginApprovalAuthorizedSender,
+          });
+          unregisterTelegramApprovalReactionTarget({
+            accountId,
+            chatId,
+            messageId,
+          });
+          logVerbose(
+            `telegram: approval reaction resolved id=${approvalReaction.approvalId} sender=${senderId || "unknown"} decision=${approvalReaction.decision}`,
+          );
+        } catch (resolveErr) {
+          if (isApprovalNotFoundError(resolveErr)) {
+            unregisterTelegramApprovalReactionTarget({
+              accountId,
+              chatId,
+              messageId,
+            });
+            logVerbose(
+              `telegram: approval reaction ignored for expired approval id=${approvalReaction.approvalId} sender=${senderId || "unknown"}`,
+            );
+            continue;
+          }
+          logVerbose(
+            `telegram: approval reaction failed id=${approvalReaction.approvalId} sender=${senderId || "unknown"}: ${String(resolveErr)}`,
+          );
+        }
+      }
+
+      if (genericReactions.length === 0) {
+        return;
+      }
 
       // Resolve reaction notification mode (default: "own").
       const reactionMode = telegramCfg.reactionNotifications ?? "own";
@@ -1573,20 +1660,6 @@ export const registerTelegramHandlers = ({
         }
       }
 
-      // Detect added reactions.
-      const oldEmojis = new Set(
-        reaction.old_reaction
-          .filter((r): r is ReactionTypeEmoji => r.type === "emoji")
-          .map((r) => r.emoji),
-      );
-      const addedReactions = reaction.new_reaction
-        .filter((r): r is ReactionTypeEmoji => r.type === "emoji")
-        .filter((r) => !oldEmojis.has(r.emoji));
-
-      if (addedReactions.length === 0) {
-        return;
-      }
-
       // Build sender label.
       const senderName = user
         ? [user.first_name, user.last_name].filter(Boolean).join(" ").trim() || user.username
@@ -1620,77 +1693,14 @@ export const registerTelegramHandlers = ({
         parentPeer,
       });
       const sessionKey = route.sessionKey;
-      const runtimeCfg = telegramDeps.getRuntimeConfig();
 
-      // Enqueue system event for each added reaction unless the reaction resolves
-      // a bound approval prompt for this Telegram message.
-      for (const r of addedReactions) {
-        const emoji = r.emoji;
-        const approvalReaction = await resolveTelegramApprovalReactionTargetWithPersistence({
-          accountId,
-          chatId,
-          messageId,
-          reactionKey: emoji,
-        });
-        if (approvalReaction) {
-          const isPluginApproval = approvalReaction.approvalId.startsWith("plugin:");
-          const pluginApprovalAuthorizedSender = isTelegramExecApprovalApprover({
-            cfg: runtimeCfg,
-            accountId,
-            senderId,
-          });
-          const execApprovalAuthorizedSender = isTelegramExecApprovalAuthorizedSender({
-            cfg: runtimeCfg,
-            accountId,
-            senderId,
-          });
-          const authorizedApprovalSender = isPluginApproval
-            ? pluginApprovalAuthorizedSender
-            : execApprovalAuthorizedSender || pluginApprovalAuthorizedSender;
-          if (!authorizedApprovalSender) {
-            logVerbose(
-              `telegram: approval reaction denied id=${approvalReaction.approvalId} sender=${senderId || "unknown"}`,
-            );
-            continue;
-          }
-          try {
-            await (telegramDeps.resolveExecApproval ?? resolveTelegramExecApproval)({
-              cfg: runtimeCfg,
-              approvalId: approvalReaction.approvalId,
-              decision: approvalReaction.decision,
-              senderId,
-              allowPluginFallback: pluginApprovalAuthorizedSender,
-            });
-            unregisterTelegramApprovalReactionTarget({
-              accountId,
-              chatId,
-              messageId,
-            });
-            logVerbose(
-              `telegram: approval reaction resolved id=${approvalReaction.approvalId} sender=${senderId || "unknown"} decision=${approvalReaction.decision}`,
-            );
-          } catch (resolveErr) {
-            if (isApprovalNotFoundError(resolveErr)) {
-              unregisterTelegramApprovalReactionTarget({
-                accountId,
-                chatId,
-                messageId,
-              });
-              logVerbose(
-                `telegram: approval reaction ignored for expired approval id=${approvalReaction.approvalId} sender=${senderId || "unknown"}`,
-              );
-              continue;
-            }
-            logVerbose(
-              `telegram: approval reaction failed id=${approvalReaction.approvalId} sender=${senderId || "unknown"}: ${String(resolveErr)}`,
-            );
-          }
-          continue;
-        }
-        const text = `Telegram reaction added: ${emoji} by ${senderLabel} on msg ${messageId}`;
+      // Enqueue system events for non-approval reactions after generic reaction
+      // notification and authorization gates.
+      for (const r of genericReactions) {
+        const text = `Telegram reaction added: ${r.emoji} by ${senderLabel} on msg ${messageId}`;
         telegramDeps.enqueueSystemEvent(text, {
           sessionKey,
-          contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${emoji}`,
+          contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${r.emoji}`,
         });
         logVerbose(`telegram: reaction event enqueued: ${text}`);
       }

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -8,6 +8,10 @@ import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { loadSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearTelegramApprovalReactionTargetsForTest,
+  registerTelegramApprovalReactionTarget,
+} from "./approval-reactions.js";
 import type { TelegramInteractiveHandlerContext } from "./interactive-dispatch.js";
 import { buildTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
 const {
@@ -182,6 +186,7 @@ describe("createTelegramBot", () => {
   });
 
   beforeEach(() => {
+    clearTelegramApprovalReactionTargetsForTest();
     setMyCommandsSpy.mockClear();
     clearPluginInteractiveHandlers();
     loadConfig.mockReturnValue({
@@ -3368,6 +3373,176 @@ describe("createTelegramBot", () => {
       `Telegram reaction added: ${THUMBS_UP_EMOJI} by Ada (@ada_bot) on msg 42`,
     );
     expect(String(systemEventOptions().contextKey)).toContain("telegram:reaction:add:1234:42:9");
+  });
+
+  it("resolves a bound approval from a thumbs-up reaction", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+
+    registerTelegramApprovalReactionTarget({
+      accountId: "default",
+      chatId: 1234,
+      messageId: 42,
+      approvalId: "138e9b8c",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          reactionNotifications: "all",
+          execApprovals: {
+            enabled: true,
+            approvers: ["9"],
+            target: "dm",
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 508 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada", username: "ada_bot" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
+      },
+    });
+
+    const approvalCall = execApprovalCall();
+    expect(approvalCall.approvalId).toBe("138e9b8c");
+    expect(approvalCall.decision).toBe("allow-once");
+    expect(approvalCall.allowPluginFallback).toBe(true);
+    expect(approvalCall.senderId).toBe("9");
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve bound approval reactions from unauthorized senders", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+
+    registerTelegramApprovalReactionTarget({
+      accountId: "default",
+      chatId: 1234,
+      messageId: 42,
+      approvalId: "138e9b8c",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          reactionNotifications: "all",
+          execApprovals: {
+            enabled: true,
+            approvers: ["999"],
+            target: "dm",
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 509 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada", username: "ada_bot" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
+      },
+    });
+
+    expect(resolveExecApprovalSpy).not.toHaveBeenCalled();
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("forgets stale bound approval reactions when the approval is no longer pending", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+    resolveExecApprovalSpy.mockRejectedValueOnce(new Error("unknown or expired approval id"));
+
+    registerTelegramApprovalReactionTarget({
+      accountId: "default",
+      chatId: 1234,
+      messageId: 42,
+      approvalId: "138e9b8c",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          reactionNotifications: "all",
+          execApprovals: {
+            enabled: true,
+            approvers: ["9"],
+            target: "dm",
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 510 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada", username: "ada_bot" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
+      },
+    });
+
+    expect(resolveExecApprovalSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+
+    await handler({
+      update: { update_id: 511 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada", username: "ada_bot" },
+        date: 1736380801,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
+      },
+    });
+
+    expect(resolveExecApprovalSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+    expect(firstSystemEventArg(0)).toBe(
+      `Telegram reaction added: ${THUMBS_UP_EMOJI} by Ada (@ada_bot) on msg 42`,
+    );
   });
 
   it.each([

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -3647,6 +3647,58 @@ describe("createTelegramBot", () => {
     );
   });
 
+  it("rethrows bound approval reaction resolver failures so Telegram can retry the update", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+    resolveExecApprovalSpy.mockRejectedValueOnce(new Error("gateway secret detail"));
+
+    registerTelegramApprovalReactionTarget({
+      accountId: "default",
+      chatId: 1234,
+      messageId: 42,
+      approvalId: "138e9b8c",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          reactionNotifications: "all",
+          execApprovals: {
+            enabled: true,
+            approvers: ["9"],
+            target: "dm",
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await expect(
+      handler({
+        update: { update_id: 515 },
+        messageReaction: {
+          chat: { id: 1234, type: "private" },
+          message_id: 42,
+          user: { id: 9, first_name: "Ada", username: "ada_bot" },
+          date: 1736380800,
+          old_reaction: [],
+          new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
+        },
+      }),
+    ).rejects.toThrow("gateway secret detail");
+
+    expect(resolveExecApprovalSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "blocks reaction when dmPolicy is disabled",

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -3428,6 +3428,108 @@ describe("createTelegramBot", () => {
     expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
   });
 
+  it("resolves a bound approval reaction even when reactionNotifications is off", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+
+    registerTelegramApprovalReactionTarget({
+      accountId: "default",
+      chatId: 1234,
+      messageId: 42,
+      approvalId: "138e9b8c",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          reactionNotifications: "off",
+          execApprovals: {
+            enabled: true,
+            approvers: ["9"],
+            target: "dm",
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 512 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada", username: "ada_bot" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
+      },
+    });
+
+    const approvalCall = execApprovalCall();
+    expect(approvalCall.approvalId).toBe("138e9b8c");
+    expect(approvalCall.decision).toBe("allow-once");
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("resolves a bound approval reaction for an approver who is not allowed as a generic reaction sender", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+    resolveExecApprovalSpy.mockClear();
+
+    registerTelegramApprovalReactionTarget({
+      accountId: "default",
+      chatId: 1234,
+      messageId: 42,
+      approvalId: "138e9b8c",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "allowlist",
+          allowFrom: ["12345"],
+          reactionNotifications: "all",
+          execApprovals: {
+            enabled: true,
+            approvers: ["9"],
+            target: "dm",
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 513 },
+      messageReaction: {
+        chat: { id: 1234, type: "private" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada", username: "ada_bot" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
+      },
+    });
+
+    const approvalCall = execApprovalCall();
+    expect(approvalCall.approvalId).toBe("138e9b8c");
+    expect(approvalCall.decision).toBe("allow-once");
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
   it("does not resolve bound approval reactions from unauthorized senders", async () => {
     onSpy.mockClear();
     enqueueSystemEventSpy.mockClear();


### PR DESCRIPTION
## Summary

Add native Telegram approval-reaction support so pending approvals can be resolved by reacting to the approval message (for example 👍 / 👎), instead of requiring only callback buttons or `/approve` text commands.

This mirrors the cross-channel approval-reaction pattern already used by other messaging integrations while preserving existing Telegram behavior for unrelated reactions.

## What changed

- Added a dedicated Telegram approval reaction target runtime:
  - `extensions/telegram/src/approval-reactions.ts`
  - registers/unregisters pending approval targets by `(accountId, chatId, messageId)`
  - resolves reaction keys to approval decisions via shared plugin-sdk approval-reaction runtime
  - supports persistence-backed resolution and stale target cleanup
- Wired approval target binding/unbinding into Telegram approval delivery lifecycle:
  - `extensions/telegram/src/approval-handler.runtime.ts`
- Intercepted Telegram `message_reaction` handling to resolve matching pending approvals before generic reaction event enqueue:
  - `extensions/telegram/src/bot-handlers.runtime.ts`
  - enforces existing authorization checks (exec approvers / plugin approvers)
  - resolves once and unregisters the target on success
  - removes stale bindings when approval no longer exists
  - preserves existing system-event path for non-approval reactions
- Added focused tests:
  - `extensions/telegram/src/bot.test.ts`
  - `extensions/telegram/src/approval-handler.runtime.test.ts`

## Behavior

- 👍 on a bound approval prompt can resolve to `allow-once` when configured/allowed.
- 👎 can resolve to `deny` when configured/allowed.
- Unauthorized reactors do not resolve approvals.
- Reactions on non-bound messages continue through existing reaction notification/system-event flow.

## Validation

Remote clawbox run (one-shot; no watch mode):

- `pnpm build` completed successfully.
- `pnpm vitest run extensions/telegram/src/approval-handler.runtime.test.ts extensions/telegram/src/bot.test.ts` passed.
- Result: **2 test files passed, 80 tests passed**.

## Notes

- This change is additive and backward compatible with current Telegram approval callback and `/approve` command flows.
- The goal is to align Telegram with existing OpenClaw approval-reaction ergonomics on other channels.
