### PR TITLE
fix(agents): sanitize provider tool schema logs

### DIFF
--- a/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
@@ -84,4 +84,46 @@ describe("tool schema runtime diagnostics", () => {
       },
     );
   });
+
+  it("sanitizes provider diagnostic logs without reading poisoned tool names", () => {
+    const poisonedTool = {};
+    Object.defineProperty(poisonedTool, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin tool name getter exploded");
+      },
+    });
+    mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([
+      {
+        toolName: "fuzzplugin_\u001B[31mmove\nangles",
+        toolIndex: 0,
+        violations: ["fuzzplugin_\u001B[31mmove\nangles.parameters\nmust be object"],
+      },
+    ]);
+
+    expect(() =>
+      logProviderToolSchemaDiagnostics({
+        provider: "example\u001B[31m\nprovider",
+        tools: [poisonedTool] as never,
+      }),
+    ).not.toThrow();
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema diagnostics: 1 tool for exampleprovider: fuzzplugin_moveangles (1 violation)",
+      {
+        provider: "exampleprovider",
+        toolCount: 1,
+        diagnosticCount: 1,
+        tools: ["0:tool[0]"],
+        diagnostics: [
+          {
+            index: 0,
+            tool: "fuzzplugin_moveangles",
+            violations: ["fuzzplugin_moveangles.parametersmust be object"],
+            violationCount: 1,
+          },
+        ],
+      },
+    );
+  });
 });

--- a/src/agents/embedded-agent-runner/tool-schema-runtime.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.ts
@@ -1,4 +1,5 @@
 import type { TSchema } from "typebox";
+import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
@@ -11,6 +12,8 @@ import type { AgentTool } from "../runtime/index.js";
 import type { AnyAgentTool } from "../tools/common.js";
 import { log } from "./logger.js";
 
+const MAX_LOGGED_PROVIDER_TOOL_SCHEMA_VIOLATIONS = 12;
+
 type ProviderToolSchemaParams<TSchemaType extends TSchema = TSchema, TResult = unknown> = {
   tools: AgentTool<TSchemaType, TResult>[];
   provider: string;
@@ -22,6 +25,13 @@ type ProviderToolSchemaParams<TSchemaType extends TSchema = TSchema, TResult = u
   model?: ProviderRuntimeModel;
   runtimeHandle?: ProviderRuntimePluginHandle;
   allowRuntimePluginLoad?: boolean;
+};
+
+type ProviderToolSchemaLogDiagnostic = {
+  toolName: string;
+  toolIndex?: number;
+  violations: string[];
+  violationCount: number;
 };
 
 function buildProviderToolSchemaContext<TSchemaType extends TSchema = TSchema, TResult = unknown>(
@@ -68,6 +78,7 @@ export function normalizeProviderToolSchemas<
  */
 export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParams): void {
   const provider = params.provider.trim();
+  const providerLabel = sanitizeForLog(provider);
   const diagnostics = inspectProviderToolSchemasWithPlugin({
     provider,
     config: params.config,
@@ -84,29 +95,52 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
     return;
   }
 
-  const summary = summarizeProviderToolSchemaDiagnostics(diagnostics);
+  const sanitizedDiagnostics = diagnostics.map(sanitizeProviderToolSchemaDiagnostic);
+  const summary = summarizeProviderToolSchemaDiagnostics(sanitizedDiagnostics);
   log.warn(
-    `provider tool schema diagnostics: ${diagnostics.length} ${diagnostics.length === 1 ? "tool" : "tools"} for ${params.provider}: ${summary}`,
+    `provider tool schema diagnostics: ${sanitizedDiagnostics.length} ${sanitizedDiagnostics.length === 1 ? "tool" : "tools"} for ${providerLabel}: ${summary}`,
     {
-      provider: params.provider,
+      provider: providerLabel,
       toolCount: params.tools.length,
-      diagnosticCount: diagnostics.length,
-      tools: params.tools.map((tool, index) => `${index}:${tool.name}`),
-      diagnostics: diagnostics.map((diagnostic) => ({
+      diagnosticCount: sanitizedDiagnostics.length,
+      tools: params.tools.map(formatProviderToolLogLabel),
+      diagnostics: sanitizedDiagnostics.map((diagnostic) => ({
         index: diagnostic.toolIndex,
         tool: diagnostic.toolName,
-        violations: diagnostic.violations.slice(0, 12),
-        violationCount: diagnostic.violations.length,
+        violations: diagnostic.violations,
+        violationCount: diagnostic.violationCount,
       })),
     },
   );
 }
 
+function sanitizeProviderToolSchemaDiagnostic(
+  diagnostic: ProviderToolSchemaDiagnostic,
+): ProviderToolSchemaLogDiagnostic {
+  return {
+    toolIndex: diagnostic.toolIndex,
+    toolName: sanitizeForLog(diagnostic.toolName),
+    violations: diagnostic.violations
+      .slice(0, MAX_LOGGED_PROVIDER_TOOL_SCHEMA_VIOLATIONS)
+      .map((violation) => sanitizeForLog(violation)),
+    violationCount: diagnostic.violations.length,
+  };
+}
+
+function formatProviderToolLogLabel(tool: AnyAgentTool, index: number): string {
+  try {
+    const name = tool.name;
+    return `${index}:${typeof name === "string" && name ? sanitizeForLog(name) : `tool[${index}]`}`;
+  } catch {
+    return `${index}:tool[${index}]`;
+  }
+}
+
 function summarizeProviderToolSchemaDiagnostics(
-  diagnostics: readonly ProviderToolSchemaDiagnostic[],
+  diagnostics: readonly ProviderToolSchemaLogDiagnostic[],
 ) {
   const visible = diagnostics.slice(0, 6).map((diagnostic) => {
-    const violationCount = diagnostic.violations.length;
+    const violationCount = diagnostic.violationCount;
     return `${diagnostic.toolName || "unknown"} (${violationCount} ${violationCount === 1 ? "violation" : "violations"})`;
   });
   const remaining = diagnostics.length - visible.length;


### PR DESCRIPTION
## Summary

- Sanitize provider/runtime tool-schema diagnostic warning text and structured log metadata.
- Avoid reading plugin-owned `tool.name` directly while logging diagnostics; unreadable names now fall back to `tool[index]`.
- Preserve the existing 12-violation log cap while keeping the original violation count.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-schema-runtime.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox changed gate: `pnpm check:changed`, provider `aws`, run `run_43e05472a233`, lease `cbx_498c1cf3a500`, exit 0, lease stopped.

## Real behavior proof

Behavior addressed: provider/runtime tool-schema diagnostic logs can contain plugin-controlled provider/tool/violation strings and can read plugin-owned tool names while logging.

Real environment tested: focused Vitest locally in the OpenClaw worktree; broad changed gate on AWS Crabbox Linux.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-schema-runtime.test.ts --reporter=dot`; `pnpm check:changed` through AWS Crabbox run `run_43e05472a233`.

Evidence after fix: local focused test passed 1 shard / 4 tests; remote changed gate passed lanes `core` and `coreTests` with exit 0.

Observed result after fix: provider diagnostic warning messages and structured metadata strip ANSI/control text, poisoned `tool.name` getters no longer abort logging, and hidden violations beyond the log cap are not sanitized.

What was not tested: true Blacksmith Testbox proof was not retried because local Blacksmith auth was already missing in this work session (`blacksmith auth login` required).
