### PR TITLE
fix(doctor): sanitize bundle MCP schema diagnostics

### DIFF
--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -211,6 +211,44 @@ describe("doctor runtime tool schema checks", () => {
     expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
   });
 
+  it("sanitizes bundle MCP runtime diagnostics before rendering doctor findings", async () => {
+    mocks.createBundleMcpToolRuntime.mockReturnValueOnce({
+      tools: [],
+      diagnostics: [
+        {
+          serverName: "fuzzplugin_\u001B[31m\nserver",
+          safeServerName: "fuzzplugin_server",
+          launchSummary: "node fuzzplugin-mcp.mjs",
+          message: "tools[0].inputSchema\n\u001B[31mtype: Invalid input: expected object",
+        },
+      ],
+      dispose: mocks.disposeBundleRuntime,
+    });
+
+    await expect(
+      collectRuntimeToolSchemaFindings({
+        mcp: {
+          servers: {
+            "fuzzplugin_\u001B[31m\nserver": {
+              command: "node",
+              args: ["fuzzplugin-mcp.mjs"],
+            },
+          },
+        },
+      }),
+    ).resolves.toContainEqual({
+      checkId: "core/doctor/runtime-tool-schemas",
+      severity: "error",
+      message:
+        'Configured MCP server "fuzzplugin_server" could not expose runtime tools for schema validation.',
+      path: "mcp.servers.fuzzplugin_server",
+      requirement: "tools[0].inputSchematype: Invalid input: expected object",
+      fixHint:
+        "Fix or disable the offending MCP server, then rerun doctor before relying on assistant tool startup.",
+    });
+    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
+  });
+
   it("reports bundle MCP runtime diagnostics for exact MCP tool allowlists", async () => {
     mocks.createBundleMcpToolRuntime.mockReturnValueOnce({
       tools: [],

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -1,3 +1,4 @@
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { TOOL_NAME_SEPARATOR } from "../agents/agent-bundle-mcp-names.js";
 import {
   type McpToolCatalogDiagnostic,
@@ -767,12 +768,14 @@ function bundleMcpRuntimeLoadFailureFinding(error: unknown): HealthFinding {
 }
 
 function bundleMcpRuntimeDiagnosticFinding(diagnostic: McpToolCatalogDiagnostic): HealthFinding {
+  const serverName = sanitizeForLog(diagnostic.serverName);
+  const requirement = sanitizeForLog(diagnostic.message);
   return {
     checkId: "core/doctor/runtime-tool-schemas",
     severity: "error",
-    message: `Configured MCP server "${diagnostic.serverName}" could not expose runtime tools for schema validation.`,
-    path: `mcp.servers.${diagnostic.serverName}`,
-    requirement: diagnostic.message,
+    message: `Configured MCP server "${serverName}" could not expose runtime tools for schema validation.`,
+    path: `mcp.servers.${serverName}`,
+    requirement,
     fixHint:
       "Fix or disable the offending MCP server, then rerun doctor before relying on assistant tool startup.",
   };


### PR DESCRIPTION
## Summary

- Sanitize bundle MCP runtime diagnostic server names before rendering doctor health finding messages and paths.
- Sanitize bundle MCP diagnostic messages before rendering doctor health finding requirements.
- Add focused coverage for ANSI/newline MCP diagnostic text in doctor runtime schema findings.

## Verification

- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.runtime.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/flows/doctor-core-checks.runtime.ts src/flows/doctor-core-checks.runtime.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint src/flows/doctor-core-checks.runtime.ts src/flows/doctor-core-checks.runtime.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox changed gate: `pnpm check:changed`, provider `aws`, run `run_876b4eb1a8e2`, lease `cbx_3d66d4a7398b`, exit 0, lease stopped.

## Real behavior proof

Behavior addressed: bundle MCP runtime diagnostics could render plugin-controlled server names and diagnostic messages directly into doctor health findings.

Real environment tested: focused Vitest locally in the OpenClaw worktree; broad changed gate on AWS Crabbox Linux.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/flows/doctor-core-checks.runtime.test.ts --reporter=dot`; `pnpm check:changed` through AWS Crabbox run `run_876b4eb1a8e2`.

Evidence after fix: local focused test passed 1 shard / 30 tests; remote changed gate passed lanes `core` and `coreTests` with exit 0.

Observed result after fix: doctor runtime schema findings strip ANSI/control text from bundle MCP diagnostic server names and messages before exposing them in `message`, `path`, and `requirement`.

What was not tested: true Blacksmith Testbox proof was not retried because local Blacksmith auth was already missing in this work session (`blacksmith auth login` required).
