### PR TITLE
fix(doctor): sanitize provider catalog findings

### DIFF
--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -507,6 +507,20 @@ describe("doctor provider catalog projection checks", () => {
     mocks.resolvePluginProviders.mockReset().mockReturnValue([]);
   });
 
+  it("sanitizes provider catalog discovery failures before rendering doctor output", async () => {
+    mocks.resolvePluginProviders.mockImplementationOnce(() => {
+      throw new Error("provider catalog\n\u001B[31mload failed");
+    });
+
+    await expect(collectProviderCatalogProjectionFindings({})).resolves.toContainEqual({
+      checkId: "core/doctor/provider-catalog-projection",
+      severity: "error",
+      message: "Provider catalog hooks could not be loaded for doctor validation.",
+      requirement: "provider catalogload failed",
+      fixHint: "Fix plugin provider discovery loading, then rerun doctor.",
+    });
+  });
+
   it("reports provider catalog rows that fail unified text projection", async () => {
     const providers = Object.defineProperty(
       {
@@ -557,6 +571,33 @@ describe("doctor provider catalog projection checks", () => {
         discoveryEntriesOnly: true,
       }),
     );
+  });
+
+  it("sanitizes provider catalog projection findings before rendering doctor output", async () => {
+    const provider = {
+      id: "mock\u001B[31m\nprovider",
+      pluginId: "mock\u001B[31m\nplugin",
+      label: "Mock",
+      auth: [],
+    };
+    Object.defineProperty(provider, "staticCatalog", {
+      enumerable: true,
+      get() {
+        throw new Error("provider catalog\n\u001B[31morder failed");
+      },
+    });
+    mocks.resolvePluginProviders.mockReturnValueOnce([provider]);
+
+    await expect(collectProviderCatalogProjectionFindings({})).resolves.toContainEqual({
+      checkId: "core/doctor/provider-catalog-projection",
+      severity: "error",
+      message: "Provider catalog mockprovider order cannot be read during doctor validation.",
+      path: "plugins.entries.mockplugin",
+      target: "mockprovider",
+      requirement: "provider catalogorder failed",
+      fixHint:
+        "Fix the plugin provider catalog hook or disable the plugin, then rerun doctor before relying on model discovery.",
+    });
   });
 
   it("reports provider catalog model rows with invalid ids", async () => {

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -1,3 +1,4 @@
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { TOOL_NAME_SEPARATOR } from "../agents/agent-bundle-mcp-names.js";
 import {
   type McpToolCatalogDiagnostic,
@@ -63,14 +64,16 @@ function providerCatalogProjectionFinding(params: {
   message: string;
   error: unknown;
 }): HealthFinding {
-  const path = providerCatalogPath(params.pluginId);
+  const providerId = sanitizeForLog(params.providerId);
+  const pluginId = params.pluginId ? sanitizeForLog(params.pluginId) : undefined;
+  const path = providerCatalogPath(pluginId);
   return {
     checkId: "core/doctor/provider-catalog-projection",
     severity: "error",
-    message: params.message,
+    message: sanitizeForLog(params.message),
     ...(path ? { path } : {}),
-    target: params.providerId,
-    requirement: formatErrorMessage(params.error),
+    target: providerId,
+    requirement: sanitizeForLog(formatErrorMessage(params.error)),
     fixHint:
       "Fix the plugin provider catalog hook or disable the plugin, then rerun doctor before relying on model discovery.",
   };
@@ -443,7 +446,7 @@ export async function collectProviderCatalogProjectionFindings(
         checkId: "core/doctor/provider-catalog-projection",
         severity: "error",
         message: "Provider catalog hooks could not be loaded for doctor validation.",
-        requirement: formatErrorMessage(error),
+        requirement: sanitizeForLog(formatErrorMessage(error)),
         fixHint: "Fix plugin provider discovery loading, then rerun doctor.",
       },
     ];


### PR DESCRIPTION
## Summary

- Sanitize provider catalog doctor finding messages, targets, plugin paths, and requirements before rendering.
- Sanitize provider catalog discovery failure requirements, which bypass the shared provider catalog finding helper.
- Add focused coverage for ANSI/newline provider ids, plugin ids, and provider catalog error text.

## Verification

- `node scripts/run-vitest.mjs src/flows/doctor-core-checks.runtime.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/flows/doctor-core-checks.runtime.ts src/flows/doctor-core-checks.runtime.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint src/flows/doctor-core-checks.runtime.ts src/flows/doctor-core-checks.runtime.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox changed gate: `pnpm check:changed`, provider `aws`, run `run_5cdea315f1cd`, lease `cbx_2aeade0da5ca`, exit 0, lease stopped.

## Real behavior proof

Behavior addressed: provider catalog projection diagnostics could render plugin-controlled provider ids, plugin ids, and error messages directly into doctor health findings.

Real environment tested: focused Vitest locally in the OpenClaw worktree; broad changed gate on AWS Crabbox Linux.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/flows/doctor-core-checks.runtime.test.ts --reporter=dot`; `pnpm check:changed` through AWS Crabbox run `run_5cdea315f1cd`.

Evidence after fix: local focused test passed 1 shard / 31 tests; remote changed gate passed lanes `core` and `coreTests` with exit 0.

Observed result after fix: provider catalog doctor findings strip ANSI/control text from discovery requirements, helper-backed messages, paths, targets, and requirements.

What was not tested: true Blacksmith Testbox proof was not retried because local Blacksmith auth was already missing in this work session (`blacksmith auth login` required).
