### PR TITLE
fix(agents): quarantine malformed normalized tools

### DIFF
--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -275,6 +275,49 @@ describe("AgentRuntimePlan tool policy helpers", () => {
     ]);
   });
 
+  it("quarantines malformed provider-normalized tools before metadata preservation", () => {
+    const source = createParameterFreeTool("fixture__lookup_note") as AgentTool;
+    setPluginToolMeta(source, {
+      pluginId: "bundle-mcp",
+      optional: false,
+      mcp: {
+        serverName: "fixture",
+        safeServerName: "fixture",
+        toolName: "lookup_note",
+        operation: "tool",
+      },
+    });
+    const malformedNormalized = {
+      ...source,
+      parameters: normalizedParameterFreeSchema(),
+    };
+    Object.defineProperty(malformedNormalized, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin normalized name getter exploded");
+      },
+    });
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    mocks.normalizeProviderToolSchemas.mockReturnValueOnce([malformedNormalized]);
+
+    let result: AgentTool[] | undefined;
+    expect(() => {
+      result = normalizeAgentRuntimeTools({
+        tools: [source],
+        provider: "openai",
+        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+      });
+    }).not.toThrow();
+    expect(result).toEqual([]);
+    expect(diagnostics).toContainEqual([
+      {
+        toolName: "tool[0]",
+        toolIndex: 0,
+        violations: ["tool[0].name is unreadable"],
+      },
+    ]);
+  });
+
   it("quarantines unreadable tools before provider schema normalization", () => {
     const healthy = { ...createParameterFreeTool(), name: "healthy" } as AgentTool;
     const unreadable = { ...createParameterFreeTool(), name: "fuzzplugin_unreadable" } as AgentTool;

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -112,7 +112,18 @@ export function normalizeAgentRuntimeTools<
       allowRuntimePluginLoad: params.allowProviderRuntimePluginLoad,
     });
   const normalizedTools = Array.isArray(normalized) ? normalized : normalizableTools;
-  return preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
+  const normalizedToolProjection = filterProviderNormalizableTools(normalizedTools);
+  if (normalizedToolProjection.diagnostics.length > 0) {
+    params.onPreNormalizationSchemaDiagnostics?.(
+      normalizedToolProjection.diagnostics,
+      normalizedTools,
+    );
+  }
+  const runtimeTools =
+    normalizedToolProjection.diagnostics.length > 0
+      ? ([...normalizedToolProjection.tools] as AgentTool<TSchemaType, TResult>[])
+      : normalizedTools;
+  return preserveRuntimeToolMetadata(normalizableTools, runtimeTools);
 }
 
 export function logAgentRuntimeToolDiagnostics(params: AgentRuntimeToolPolicyParams): void {


### PR DESCRIPTION
## Summary

- Re-project provider/runtime-plan normalized tools before runtime metadata preservation.
- Quarantine malformed normalized outputs, including tools with unreadable `name` fields, instead of letting metadata preservation crash the turn.
- Preserve clean normalized array identity when no diagnostics are produced.

## Verification

- `node scripts/run-vitest.mjs src/agents/runtime-plan/tools.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox changed gate: `pnpm check:changed`, provider `aws`, run `run_600bc3427218`, lease `cbx_badf94069c97`, exit 0, lease stopped.

## Real behavior proof

Behavior addressed: provider/runtime-plan normalization output could include a malformed cloned tool whose `name` getter throws, causing runtime metadata preservation to fail before the assistant turn can continue.

Real environment tested: focused Vitest locally in the OpenClaw worktree; broad changed gate on AWS Crabbox Linux.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/runtime-plan/tools.test.ts --reporter=dot`; `pnpm check:changed` through AWS Crabbox run `run_600bc3427218`.

Evidence after fix: local focused test passed 1 shard / 11 tests; remote changed gate passed lanes `core` and `coreTests` with exit 0.

Observed result after fix: malformed normalized tools are quarantined before metadata preservation, diagnostics are emitted, and clean normalized arrays keep their previous identity.

What was not tested: true Blacksmith Testbox proof was not retried because local Blacksmith auth was already missing in this work session (`blacksmith auth login` required).
