### PR TITLE
fix(tasks): deliver ACP completions to bound Discord threads

### DIFF
--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -131,7 +131,7 @@ vi.mock("../agents/subagent-control.js", () => ({
 
 vi.mock("../utils/message-channel.js", () => ({
   isDeliverableMessageChannel: (channel: string) =>
-    channel === "notifychat" || channel === "guildchat",
+    channel === "notifychat" || channel === "guildchat" || channel === "discord",
 }));
 
 function configureTaskRegistryMaintenanceRuntimeForTest(params: {
@@ -1336,6 +1336,148 @@ describe("task-registry", () => {
       expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
     });
   });
+
+  it("delivers delegated ACP completion directly to an explicitly bound Discord thread", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const runId = "run-bound-discord-thread-terminal";
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "discord",
+        to: "channel:parent-channel",
+        via: "direct",
+      });
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:discord:guild-123:channel-parent-channel",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:parent-channel",
+          threadId: "thread-84022",
+        },
+        childSessionKey: "agent:main:acp:child",
+        runId,
+        task: "Investigate thread-bound ACP delivery",
+        status: "running",
+        deliveryStatus: "pending",
+        terminalSummary: "ACP final answer",
+        startedAt: 100,
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 250,
+        },
+      });
+
+      await waitForAssertion(() => {
+        const task = findTaskByRunId(runId);
+        if (!task) {
+          throw new Error(`Expected task for run ${runId}`);
+        }
+        expect(task.status).toBe("succeeded");
+        expect(task.deliveryStatus).toBe("delivered");
+      });
+      await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1));
+      const message = sentMessageCall();
+      expectRecordFields(message, {
+        channel: "discord",
+        to: "channel:parent-channel",
+        threadId: "thread-84022",
+      });
+      expect(String(message.content)).toContain(
+        "Background task ready for review: ACP background task",
+      );
+      expect(String(message.content)).toContain("ACP final answer");
+      expect(String(message.content)).toContain(
+        "Next: parent will review/verify before calling it done.",
+      );
+      expect(peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")).toStrictEqual(
+        [],
+      );
+    });
+  });
+
+  it.each([
+    {
+      id: "missing-thread",
+      requesterOrigin: {
+        channel: "discord",
+        to: "channel:parent-channel",
+      },
+    },
+    {
+      id: "non-channel-target",
+      requesterOrigin: {
+        channel: "discord",
+        to: "user:U123",
+        threadId: "thread-84022",
+      },
+    },
+    {
+      id: "non-discord-channel",
+      requesterOrigin: {
+        channel: "guildchat",
+        to: "guildchat:channel:parent-channel",
+        threadId: "thread-84022",
+      },
+    },
+  ])(
+    "keeps delegated ACP completion queued without an explicit bound Discord thread ($id)",
+    async ({ requesterOrigin }) => {
+      await withTaskRegistryTempDir(async (root) => {
+        process.env.OPENCLAW_STATE_DIR = root;
+        resetTaskRegistryForTests();
+        const runId = `run-non-bound-discord-thread-terminal-${requesterOrigin.channel}-${requesterOrigin.to}`;
+        hoisted.sendMessageMock.mockResolvedValue({
+          channel: requesterOrigin.channel,
+          to: requesterOrigin.to,
+          via: "direct",
+        });
+
+        createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:discord:guild-123:channel-parent-channel",
+          scopeKind: "session",
+          requesterOrigin,
+          childSessionKey: "agent:main:acp:child",
+          runId,
+          task: "Investigate thread-bound ACP delivery",
+          status: "running",
+          deliveryStatus: "pending",
+          terminalSummary: "ACP final answer",
+          startedAt: 100,
+        });
+
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "end",
+            endedAt: 250,
+          },
+        });
+
+        await waitForAssertion(() => {
+          const task = findTaskByRunId(runId);
+          if (!task) {
+            throw new Error(`Expected task for run ${runId}`);
+          }
+          expect(task.status).toBe("succeeded");
+          expect(task.deliveryStatus).toBe("session_queued");
+        });
+        expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+        expect(peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")).toEqual([
+          expect.stringContaining("Background task ready for review: ACP background task"),
+        ]);
+      });
+    },
+  );
 
   it.each([
     {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1233,10 +1233,32 @@ function canDeliverTaskToRequesterOrigin(task: TaskRecord): boolean {
   if (shouldRouteCompletionThroughRequesterSession(owner.sessionKey)) {
     return false;
   }
-  const origin = owner.requesterOrigin;
+  return canDeliverToRequesterOrigin(owner.requesterOrigin);
+}
+
+function canDeliverToRequesterOrigin(origin: TaskDeliveryState["requesterOrigin"]): boolean {
   const channel = origin?.channel?.trim();
   const to = origin?.to?.trim();
   return Boolean(channel && to && isDeliverableMessageChannel(channel));
+}
+
+function canDeliverParentReviewTaskToBoundDiscordThread(task: TaskRecord): boolean {
+  if (!shouldUseParentReviewTaskTerminalMessage(task)) {
+    return false;
+  }
+  const owner = resolveTaskDeliveryOwner(task);
+  const origin = owner.requesterOrigin;
+  const channel = origin?.channel?.trim().toLowerCase();
+  const to = origin?.to?.trim().toLowerCase();
+  const threadId = String(origin?.threadId ?? "").trim();
+  // This is a narrow transport exception for explicitly bound Discord threads,
+  // not a general parent-review direct-delivery relaxation.
+  return Boolean(
+    channel === "discord" &&
+    to?.startsWith("channel:") &&
+    threadId &&
+    canDeliverToRequesterOrigin(origin),
+  );
 }
 
 function resolveMissingOwnerDeliveryStatus(task: TaskRecord): TaskDeliveryStatus {
@@ -1322,13 +1344,15 @@ export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<Ta
       });
     }
     const shouldRouteParentReview = shouldUseParentReviewTaskTerminalMessage(latest);
-    const canDeliverDirect = canDeliverTaskToRequesterOrigin(latest);
+    const shouldDeliverParentReviewDirect = canDeliverParentReviewTaskToBoundDiscordThread(latest);
+    const canDeliverDirect =
+      canDeliverTaskToRequesterOrigin(latest) || shouldDeliverParentReviewDirect;
     const directEventText = formatTaskTerminalMessage(latest);
     const sessionEventText = formatTaskTerminalMessage(
       latest,
       shouldRouteParentReview ? { surface: "parent_session" } : undefined,
     );
-    if (shouldRouteParentReview || !canDeliverDirect) {
+    if ((shouldRouteParentReview && !shouldDeliverParentReviewDirect) || !canDeliverDirect) {
       try {
         queueTaskSystemEvent(latest, sessionEventText);
         if (latest.terminalOutcome === "blocked") {
@@ -1360,7 +1384,7 @@ export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<Ta
         to: owner.requesterOrigin?.to ?? "",
         accountId: owner.requesterOrigin?.accountId,
         threadId: owner.requesterOrigin?.threadId,
-        content: directEventText,
+        content: shouldDeliverParentReviewDirect ? sessionEventText : directEventText,
         agentId: requesterAgentId,
         idempotencyKey,
         mirror: {


### PR DESCRIPTION
## Summary

Fixes #84022 by delivering successful parent-review ACP task terminal updates to the explicitly bound Discord thread that originated the request.

This is a narrow replacement shape after #86672 and #88251 were closed:

- does **not** reopen or reuse #86672;
- does **not** change broad `room_event` suppression behavior;
- does **not** add a Discord-owned inbound/run timeout;
- does **not** use `Promise.race` or leave the underlying ACP run alive in the background;
- only permits direct visible terminal delivery when the task requester origin is an explicit Discord bound thread target.

## Behavior change

Before:

- delegated ACP parent-review tasks owned by a Discord channel/group session were always routed back through the requester session;
- for the #84022 thread-bound ACP shape, the ACP/session transcript could contain the terminal answer while the Discord thread stayed silent;
- task delivery could remain `session_queued` even though the originating Discord thread was explicit and deliverable.

After:

- existing parent-session routing is preserved for ordinary group/channel ACP completions;
- a successful ACP parent-review terminal update is delivered directly only when all of these are true:
  - requester origin channel is `discord`;
  - requester origin target starts with `channel:`;
  - requester origin has a concrete `threadId`;
  - the channel is deliverable.

The direct visible text uses the parent-review wording (`Background task ready for review...`) so the thread receives a terminal update without incorrectly implying the child result was fully verified/finalized by the parent.

## Real behavior proof

- **Behavior addressed**: A delegated ACP parent-review completion with an explicit Discord bound-thread requester origin sends the terminal update directly to that `threadId`; non-bound/non-qualifying paths remain queued through the parent session.
- **Real setup tested**: Disposable checkout of PR branch `anyech/openclaw:fix/bound-thread-acp-terminal-delivery-20260602` under `tmp/github-open-work/real-proof-20260603T073207Z/pr-89279`. Two non-production checks were run: (1) the focused task-registry runtime slice for the real ACP terminal delivery path with synthetic delivery runtime, and (2) a one-off harness over the real ACP spawn bootstrap delivery-plan code with synthetic Discord binding metadata. No production Gateway/config/runtime/state or private deployment proof was used.
- **Exact steps or command run after this patch**: Terminal commands run in the disposable checkout were `pnpm install --frozen-lockfile --ignore-scripts`, `node scripts/run-vitest.mjs run --config test/vitest/vitest.tasks.config.ts src/tasks/task-registry.test.ts -t 'bound Discord thread|without an explicit bound Discord thread|routes .* ACP completion through the parent session|delivers non-delegated ACP completion' --reporter=verbose --pool=forks --maxWorkers=1`, and `node --import tsx proof-89279-direct.ts`; full command transcript is in `review/real-proof-build-20260603T073207Z/messaging/exact-commands-used.txt`.
- **Evidence after fix**: Terminal output / runtime log excerpts from `review/real-proof-build-20260603T073207Z/messaging/evidence/proof-89279-task-registry.log` and `review/real-proof-build-20260603T073207Z/messaging/evidence/proof-89279-direct.log`:

  ```text
  ✓ delivers delegated ACP completion directly to an explicitly bound Discord thread
  ✓ keeps delegated ACP completion queued without an explicit bound Discord thread ('missing-thread')
  ✓ keeps delegated ACP completion queued without an explicit bound Discord thread ('non-channel-target')
  ✓ keeps delegated ACP completion queued without an explicit bound Discord thread ('non-discord-channel')
  ✓ routes 'room channel' ACP completion through the parent session
  ✓ routes 'group' ACP completion through the parent session
  ✓ routes 'group topic' ACP completion through the parent session
  ✓ routes 'legacy Discord channel' ACP completion through the parent session
  ✓ routes 'legacy WhatsApp group' ACP completion through the parent session
  Test Files  1 passed (1)
  Tests       10 passed | 68 skipped (78)
  ```

  ```json
  {
    "boundSession": {"channel":"discord","to":"channel:thread-bound-child","accountId":"acct-proof","threadId":"thread-bound-child","deliver":true},
    "nonBoundRun": {"deliver":false},
    "streamedRun": {"deliver":false}
  }
  ```

- **Observed result after fix**: The bound Discord ACP path delivers to the explicit synthetic `threadId` and marks/sends the direct update in the task registry; missing thread, non-channel target, non-Discord, and ordinary parent-session ACP routes stay `session_queued` / `deliver:false` and do not send direct visible thread output.
- **What was not tested**: No live production Gateway, live Discord workspace, real bot token, or private deployment state was used. The outbound provider/transport was substituted at the boundary to keep proof non-production and sanitized. The one-off ACP spawn harness temporarily exported an internal helper only inside the disposable checkout and restored the file afterward; no code was pushed.
