### PR TITLE
fix(agents): skip unreadable MCP catalog tools

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -144,6 +144,38 @@ function serverAllowsUtilityTool(
   return !exclude.some((pattern) => globMatches(pattern, operation));
 }
 
+function readMcpCatalogTool(tool: McpCatalogTool, index: number): McpCatalogTool | undefined {
+  try {
+    const serverName = tool.serverName;
+    const safeServerName = tool.safeServerName;
+    const toolName = tool.toolName;
+    if (
+      typeof serverName !== "string" ||
+      typeof safeServerName !== "string" ||
+      typeof toolName !== "string"
+    ) {
+      logWarn(`bundle-mcp: skipped tool descriptor ${index} because required names are invalid.`);
+      return undefined;
+    }
+    const title = typeof tool.title === "string" ? tool.title : undefined;
+    const description = typeof tool.description === "string" ? tool.description : undefined;
+    const fallbackDescription =
+      typeof tool.fallbackDescription === "string" ? tool.fallbackDescription : toolName;
+    return {
+      serverName,
+      safeServerName,
+      toolName,
+      ...(title ? { title } : {}),
+      ...(description ? { description } : {}),
+      inputSchema: tool.inputSchema,
+      fallbackDescription,
+    };
+  } catch {
+    logWarn(`bundle-mcp: skipped unreadable tool descriptor ${index}.`);
+    return undefined;
+  }
+}
+
 function addMcpUtilityTool(params: {
   tools: AnyAgentTool[];
   reservedNames: Set<string>;
@@ -202,7 +234,11 @@ export function buildBundleMcpToolsFromCatalog(params: {
 }): AnyAgentTool[] {
   const reservedNames = normalizeReservedToolNames(params.reservedToolNames);
   const tools: AnyAgentTool[] = [];
-  const sortedCatalogTools = [...params.catalog.tools].toSorted((a, b) => {
+  const catalogTools = params.catalog.tools.flatMap((tool, index) => {
+    const readable = readMcpCatalogTool(tool, index);
+    return readable ? [readable] : [];
+  });
+  const sortedCatalogTools = catalogTools.toSorted((a, b) => {
     const serverOrder = a.safeServerName.localeCompare(b.safeServerName);
     if (serverOrder !== 0) {
       return serverOrder;

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -387,6 +387,40 @@ describe("createBundleMcpToolRuntime", () => {
     ]);
   });
 
+  it("skips unreadable MCP catalog tool descriptors without dropping healthy siblings", async () => {
+    const unreadable = {
+      serverName: "multi",
+      safeServerName: "multi",
+      description: "bad",
+      inputSchema: { type: "object", properties: {} },
+      fallbackDescription: "bad",
+    } as unknown as McpCatalogTool;
+    Object.defineProperty(unreadable, "toolName", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin MCP tool name getter exploded");
+      },
+    });
+
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        tools: [
+          unreadable,
+          {
+            serverName: "multi",
+            safeServerName: "multi",
+            toolName: "healthy",
+            description: "healthy",
+            inputSchema: { type: "object", properties: {} },
+            fallbackDescription: "healthy",
+          },
+        ],
+      }),
+    });
+
+    expect(runtime.tools.map((tool) => tool.name)).toEqual(["multi__healthy"]);
+  });
+
   it("normalizes local $ref schemas from MCP tools before exposing them", async () => {
     const runtime = await materializeBundleMcpToolsForRun({
       runtime: makeToolRuntime({


### PR DESCRIPTION
## Summary

- Snapshot readable bundle MCP catalog tool descriptor fields before sorting/materializing them.
- Skip unreadable or invalid catalog tool descriptors instead of letting one bad MCP entry abort all materialization.
- Add focused coverage that a poisoned descriptor is skipped while a healthy sibling remains active.

## Verification

- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-tools.materialize.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/agent-bundle-mcp-materialize.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint src/agents/agent-bundle-mcp-materialize.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox changed gate: `pnpm check:changed`, provider `aws`, run `run_0f642305ed59`, lease `cbx_4bf7c968d8e5`, exit 0, lease stopped.

## Real behavior proof

Behavior addressed: a malformed MCP catalog tool descriptor with an unreadable `toolName` could crash bundle MCP tool materialization before healthy sibling tools were exposed.

Real environment tested: focused Vitest locally in the OpenClaw worktree; broad changed gate on AWS Crabbox Linux.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-tools.materialize.test.ts --reporter=dot`; `pnpm check:changed` through AWS Crabbox run `run_0f642305ed59`.

Evidence after fix: local focused test passed 1 shard / 12 tests; remote changed gate passed lanes `core` and `coreTests` with exit 0.

Observed result after fix: unreadable MCP catalog tool descriptors are skipped before sorting/materialization, and healthy sibling tools still materialize.

What was not tested: true Blacksmith Testbox proof was not retried because local Blacksmith auth was already missing in this work session (`blacksmith auth login` required).
