### PR TITLE
fix: repeat doctor state migration repairs

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -15,6 +15,7 @@ import {
   readPersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndex,
 } from "../plugins/installed-plugin-index-store.js";
+import type { InstalledPluginInstallRecordInfo } from "../plugins/installed-plugin-index.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { loadTaskFlowRegistryStateFromSqlite } from "../tasks/task-flow-registry.store.sqlite.js";
 import { loadTaskRegistryStateFromSqlite } from "../tasks/task-registry.store.sqlite.js";
@@ -297,6 +298,44 @@ function writeLegacyPluginStateSidecar(root: string): string {
     db.close();
   }
   return sourcePath;
+}
+
+async function writeExistingPluginInstallIndex(
+  root: string,
+  installRecords: Record<string, InstalledPluginInstallRecordInfo>,
+): Promise<void> {
+  await writePersistedInstalledPluginIndex(
+    {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
+      policyHash: "test",
+      generatedAtMs: 1,
+      installRecords,
+      plugins: [],
+      diagnostics: [],
+    },
+    { stateDir: root },
+  );
+}
+
+function writeLegacyPluginInstallIndex(
+  root: string,
+  records: Record<string, InstalledPluginInstallRecordInfo>,
+): string {
+  const sourcePath = path.join(root, "plugins", "installs.json");
+  fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+  fs.writeFileSync(sourcePath, JSON.stringify({ records }), "utf8");
+  return sourcePath;
+}
+
+async function runLegacyStateMigrationsForRoot(root: string) {
+  const detected = await detectLegacyStateMigrations({
+    cfg: {},
+    env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+  });
+  return await runLegacyStateMigrations({ detected });
 }
 
 function writeLegacyTaskStateSidecars(root: string): {
@@ -1302,45 +1341,20 @@ describe("doctor legacy state migrations", () => {
 
   it("merges missing legacy plugin install records into an existing SQLite index", async () => {
     const root = await makeTempRoot();
-    await writePersistedInstalledPluginIndex(
-      {
-        version: 1,
-        hostContractVersion: "test",
-        compatRegistryVersion: "test",
-        migrationVersion: 1,
-        policyHash: "test",
-        generatedAtMs: 1,
-        installRecords: {
-          existing: {
-            source: "npm",
-            spec: "existing@1.0.0",
-          },
-        },
-        plugins: [],
-        diagnostics: [],
+    await writeExistingPluginInstallIndex(root, {
+      existing: {
+        source: "npm",
+        spec: "existing@1.0.0",
       },
-      { stateDir: root },
-    );
-    const sourcePath = path.join(root, "plugins", "installs.json");
-    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
-    fs.writeFileSync(
-      sourcePath,
-      JSON.stringify({
-        records: {
-          legacy: {
-            source: "git",
-            spec: "git:file:///tmp/legacy",
-          },
-        },
-      }),
-      "utf8",
-    );
-
-    const detected = await detectLegacyStateMigrations({
-      cfg: {},
-      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
     });
-    const result = await runLegacyStateMigrations({ detected });
+    const sourcePath = writeLegacyPluginInstallIndex(root, {
+      legacy: {
+        source: "git",
+        spec: "git:file:///tmp/legacy",
+      },
+    });
+
+    const result = await runLegacyStateMigrationsForRoot(root);
 
     expect(result.warnings).toStrictEqual([]);
     expect(result.changes).toContain("Merged 1 legacy plugin install record → shared SQLite state");
@@ -1355,53 +1369,28 @@ describe("doctor legacy state migrations", () => {
 
   it("archives legacy plugin install index when SQLite already has richer matching records", async () => {
     const root = await makeTempRoot();
-    await writePersistedInstalledPluginIndex(
-      {
-        version: 1,
-        hostContractVersion: "test",
-        compatRegistryVersion: "test",
-        migrationVersion: 1,
-        policyHash: "test",
-        generatedAtMs: 1,
-        installRecords: {
-          demo: {
-            source: "npm",
-            spec: "demo@1.0.0",
-            version: "1.0.0",
-            resolvedName: "demo",
-            resolvedVersion: "1.0.0",
-            resolvedSpec: "demo@1.0.0",
-            integrity: "sha512-current",
-            shasum: "current",
-            installedAt: "2026-06-01T21:04:35.000Z",
-          },
-        },
-        plugins: [],
-        diagnostics: [],
+    await writeExistingPluginInstallIndex(root, {
+      demo: {
+        source: "npm",
+        spec: "demo@1.0.0",
+        version: "1.0.0",
+        resolvedName: "demo",
+        resolvedVersion: "1.0.0",
+        resolvedSpec: "demo@1.0.0",
+        integrity: "sha512-current",
+        shasum: "current",
+        installedAt: "2026-06-01T21:04:35.000Z",
       },
-      { stateDir: root },
-    );
-    const sourcePath = path.join(root, "plugins", "installs.json");
-    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
-    fs.writeFileSync(
-      sourcePath,
-      JSON.stringify({
-        records: {
-          demo: {
-            source: "npm",
-            spec: "demo@beta",
-            version: "1.0.0",
-          },
-        },
-      }),
-      "utf8",
-    );
-
-    const detected = await detectLegacyStateMigrations({
-      cfg: {},
-      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
     });
-    const result = await runLegacyStateMigrations({ detected });
+    const sourcePath = writeLegacyPluginInstallIndex(root, {
+      demo: {
+        source: "npm",
+        spec: "demo@beta",
+        version: "1.0.0",
+      },
+    });
+
+    const result = await runLegacyStateMigrationsForRoot(root);
 
     expect(result.warnings).toStrictEqual([]);
     expect(fs.existsSync(sourcePath)).toBe(false);
@@ -1418,111 +1407,56 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
-  it("keeps legacy plugin install index when same-version npm records name different packages", async () => {
-    const root = await makeTempRoot();
-    await writePersistedInstalledPluginIndex(
-      {
-        version: 1,
-        hostContractVersion: "test",
-        compatRegistryVersion: "test",
-        migrationVersion: 1,
-        policyHash: "test",
-        generatedAtMs: 1,
-        installRecords: {
-          demo: {
-            source: "npm",
-            spec: "@openclaw/demo@1.0.0",
-            version: "1.0.0",
-            resolvedName: "@openclaw/demo",
-            resolvedVersion: "1.0.0",
-            resolvedSpec: "@openclaw/demo@1.0.0",
-          },
-        },
-        plugins: [],
-        diagnostics: [],
+  for (const fixture of [
+    {
+      label: "name different packages",
+      current: {
+        source: "npm",
+        spec: "@openclaw/demo@1.0.0",
+        version: "1.0.0",
+        resolvedName: "@openclaw/demo",
+        resolvedVersion: "1.0.0",
+        resolvedSpec: "@openclaw/demo@1.0.0",
       },
-      { stateDir: root },
-    );
-    const sourcePath = path.join(root, "plugins", "installs.json");
-    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
-    fs.writeFileSync(
-      sourcePath,
-      JSON.stringify({
-        records: {
-          demo: {
-            source: "npm",
-            spec: "@vendor/demo@1.0.0",
-            version: "1.0.0",
-          },
-        },
-      }),
-      "utf8",
-    );
-
-    const detected = await detectLegacyStateMigrations({
-      cfg: {},
-      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
-    });
-    const result = await runLegacyStateMigrations({ detected });
-
-    expect(result.warnings).toStrictEqual([
-      "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: demo",
-    ]);
-    expect(fs.existsSync(sourcePath)).toBe(true);
-    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
-  });
-
-  it("keeps legacy plugin install index when same-version npm specs are unparseable", async () => {
-    const root = await makeTempRoot();
-    await writePersistedInstalledPluginIndex(
-      {
-        version: 1,
-        hostContractVersion: "test",
-        compatRegistryVersion: "test",
-        migrationVersion: 1,
-        policyHash: "test",
-        generatedAtMs: 1,
-        installRecords: {
-          demo: {
-            source: "npm",
-            spec: "file:../current-demo",
-            version: "1.0.0",
-            resolvedVersion: "1.0.0",
-          },
-        },
-        plugins: [],
-        diagnostics: [],
+      legacy: {
+        source: "npm",
+        spec: "@vendor/demo@1.0.0",
+        version: "1.0.0",
       },
-      { stateDir: root },
-    );
-    const sourcePath = path.join(root, "plugins", "installs.json");
-    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
-    fs.writeFileSync(
-      sourcePath,
-      JSON.stringify({
-        records: {
-          demo: {
-            source: "npm",
-            spec: "file:../legacy-demo",
-            version: "1.0.0",
-          },
-        },
-      }),
-      "utf8",
-    );
+    },
+    {
+      label: "specs are unparseable",
+      current: {
+        source: "npm",
+        spec: "file:../current-demo",
+        version: "1.0.0",
+        resolvedVersion: "1.0.0",
+      },
+      legacy: {
+        source: "npm",
+        spec: "file:../legacy-demo",
+        version: "1.0.0",
+      },
+    },
+  ] satisfies Array<{
+    label: string;
+    current: InstalledPluginInstallRecordInfo;
+    legacy: InstalledPluginInstallRecordInfo;
+  }>) {
+    it(`keeps legacy plugin install index when same-version npm records ${fixture.label}`, async () => {
+      const root = await makeTempRoot();
+      await writeExistingPluginInstallIndex(root, { demo: fixture.current });
+      const sourcePath = writeLegacyPluginInstallIndex(root, { demo: fixture.legacy });
 
-    const detected = await detectLegacyStateMigrations({
-      cfg: {},
-      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+      const result = await runLegacyStateMigrationsForRoot(root);
+
+      expect(result.warnings).toStrictEqual([
+        "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: demo",
+      ]);
+      expect(fs.existsSync(sourcePath)).toBe(true);
+      expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
     });
-    const result = await runLegacyStateMigrations({ detected });
-
-    expect(result.warnings).toStrictEqual([
-      "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: demo",
-    ]);
-    expect(fs.existsSync(sourcePath)).toBe(true);
-    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
-  });
+  }
 
   it("auto-migrates the shipped plugin-state SQLite sidecar by itself", async () => {
     const root = await makeTempRoot();

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1372,7 +1372,7 @@ describe("doctor legacy state migrations", () => {
     await writeExistingPluginInstallIndex(root, {
       demo: {
         source: "npm",
-        spec: "demo@1.0.0",
+        spec: "demo@latest",
         version: "1.0.0",
         resolvedName: "demo",
         resolvedVersion: "1.0.0",
@@ -1385,7 +1385,7 @@ describe("doctor legacy state migrations", () => {
     const sourcePath = writeLegacyPluginInstallIndex(root, {
       demo: {
         source: "npm",
-        spec: "demo@beta",
+        spec: "demo@1.0.0",
         version: "1.0.0",
       },
     });
@@ -1399,7 +1399,7 @@ describe("doctor legacy state migrations", () => {
       installRecords: {
         demo: {
           source: "npm",
-          spec: "demo@1.0.0",
+          spec: "demo@latest",
           resolvedVersion: "1.0.0",
           integrity: "sha512-current",
         },
@@ -1435,6 +1435,22 @@ describe("doctor legacy state migrations", () => {
       legacy: {
         source: "npm",
         spec: "file:../legacy-demo",
+        version: "1.0.0",
+      },
+    },
+    {
+      label: "would pin a legacy floating selector to an exact version",
+      current: {
+        source: "npm",
+        spec: "demo@1.0.0",
+        version: "1.0.0",
+        resolvedName: "demo",
+        resolvedVersion: "1.0.0",
+        resolvedSpec: "demo@1.0.0",
+      },
+      legacy: {
+        source: "npm",
+        spec: "demo@beta",
         version: "1.0.0",
       },
     },

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1471,6 +1471,25 @@ describe("doctor legacy state migrations", () => {
       },
     },
     {
+      label: "keep legacy floating selectors even when resolved specs match",
+      current: {
+        source: "npm",
+        spec: "demo@latest",
+        version: "1.0.0",
+        resolvedName: "demo",
+        resolvedVersion: "1.0.0",
+        resolvedSpec: "demo@1.0.0",
+      },
+      legacy: {
+        source: "npm",
+        spec: "demo@beta",
+        version: "1.0.0",
+        resolvedName: "demo",
+        resolvedVersion: "1.0.0",
+        resolvedSpec: "demo@1.0.0",
+      },
+    },
+    {
       label: "have malformed legacy spec metadata",
       current: {
         source: "npm",

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1472,6 +1472,58 @@ describe("doctor legacy state migrations", () => {
     expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
   });
 
+  it("keeps legacy plugin install index when same-version npm specs are unparseable", async () => {
+    const root = await makeTempRoot();
+    await writePersistedInstalledPluginIndex(
+      {
+        version: 1,
+        hostContractVersion: "test",
+        compatRegistryVersion: "test",
+        migrationVersion: 1,
+        policyHash: "test",
+        generatedAtMs: 1,
+        installRecords: {
+          demo: {
+            source: "npm",
+            spec: "file:../current-demo",
+            version: "1.0.0",
+            resolvedVersion: "1.0.0",
+          },
+        },
+        plugins: [],
+        diagnostics: [],
+      },
+      { stateDir: root },
+    );
+    const sourcePath = path.join(root, "plugins", "installs.json");
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(
+      sourcePath,
+      JSON.stringify({
+        records: {
+          demo: {
+            source: "npm",
+            spec: "file:../legacy-demo",
+            version: "1.0.0",
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([
+      "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: demo",
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
+  });
+
   it("auto-migrates the shipped plugin-state SQLite sidecar by itself", async () => {
     const root = await makeTempRoot();
     const sourcePath = writeLegacyPluginStateSidecar(root);

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1353,6 +1353,125 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
+  it("archives legacy plugin install index when SQLite already has richer matching records", async () => {
+    const root = await makeTempRoot();
+    await writePersistedInstalledPluginIndex(
+      {
+        version: 1,
+        hostContractVersion: "test",
+        compatRegistryVersion: "test",
+        migrationVersion: 1,
+        policyHash: "test",
+        generatedAtMs: 1,
+        installRecords: {
+          demo: {
+            source: "npm",
+            spec: "demo@1.0.0",
+            version: "1.0.0",
+            resolvedName: "demo",
+            resolvedVersion: "1.0.0",
+            resolvedSpec: "demo@1.0.0",
+            integrity: "sha512-current",
+            shasum: "current",
+            installedAt: "2026-06-01T21:04:35.000Z",
+          },
+        },
+        plugins: [],
+        diagnostics: [],
+      },
+      { stateDir: root },
+    );
+    const sourcePath = path.join(root, "plugins", "installs.json");
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(
+      sourcePath,
+      JSON.stringify({
+        records: {
+          demo: {
+            source: "npm",
+            spec: "demo@beta",
+            version: "1.0.0",
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(true);
+    await expect(readPersistedInstalledPluginIndex({ stateDir: root })).resolves.toMatchObject({
+      installRecords: {
+        demo: {
+          source: "npm",
+          spec: "demo@1.0.0",
+          resolvedVersion: "1.0.0",
+          integrity: "sha512-current",
+        },
+      },
+    });
+  });
+
+  it("keeps legacy plugin install index when same-version npm records name different packages", async () => {
+    const root = await makeTempRoot();
+    await writePersistedInstalledPluginIndex(
+      {
+        version: 1,
+        hostContractVersion: "test",
+        compatRegistryVersion: "test",
+        migrationVersion: 1,
+        policyHash: "test",
+        generatedAtMs: 1,
+        installRecords: {
+          demo: {
+            source: "npm",
+            spec: "@openclaw/demo@1.0.0",
+            version: "1.0.0",
+            resolvedName: "@openclaw/demo",
+            resolvedVersion: "1.0.0",
+            resolvedSpec: "@openclaw/demo@1.0.0",
+          },
+        },
+        plugins: [],
+        diagnostics: [],
+      },
+      { stateDir: root },
+    );
+    const sourcePath = path.join(root, "plugins", "installs.json");
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(
+      sourcePath,
+      JSON.stringify({
+        records: {
+          demo: {
+            source: "npm",
+            spec: "@vendor/demo@1.0.0",
+            version: "1.0.0",
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([
+      "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: demo",
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
+  });
+
   it("auto-migrates the shipped plugin-state SQLite sidecar by itself", async () => {
     const root = await makeTempRoot();
     const sourcePath = writeLegacyPluginStateSidecar(root);
@@ -1434,6 +1553,83 @@ describe("doctor legacy state migrations", () => {
         maxEntries: 10,
       });
       await expect(store.lookup("interaction:1")).resolves.toEqual({ ok: false });
+    });
+  });
+
+  it("imports legacy-only plugin-state rows and archives when remaining conflicts are expired", async () => {
+    const root = await makeTempRoot();
+    const sourcePath = path.join(root, "plugin-state", "state.sqlite");
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    const sqlite = requireNodeSqlite();
+    const db = new sqlite.DatabaseSync(sourcePath);
+    try {
+      db.exec(`
+        CREATE TABLE plugin_state_entries (
+          plugin_id TEXT NOT NULL,
+          namespace TEXT NOT NULL,
+          entry_key TEXT NOT NULL,
+          value_json TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          expires_at INTEGER,
+          PRIMARY KEY (plugin_id, namespace, entry_key)
+        );
+      `);
+      const insert = db.prepare(`
+        INSERT INTO plugin_state_entries (
+          plugin_id, namespace, entry_key, value_json, created_at, expires_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `);
+      insert.run(
+        "telegram",
+        "telegram.bot-info-cache",
+        "default",
+        '{"fetchedAt":"2026-05-30T23:20:09.000Z"}',
+        1000,
+        1,
+      );
+      insert.run("telegram", "message-cache", "legacy-only", '{"ok":true}', 2000, null);
+    } finally {
+      db.close();
+    }
+    await withStateDir(root, async () => {
+      seedPluginStateEntriesForTests([
+        {
+          pluginId: "telegram",
+          namespace: "telegram.bot-info-cache",
+          key: "default",
+          value: { fetchedAt: "2026-06-01T21:04:35.000Z" },
+          createdAt: 3000,
+          expiresAt: Date.now() + 60_000,
+        },
+      ]);
+    });
+    resetPluginStateStoreForTests();
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain("Migrated 1 plugin-state sidecar entry → shared SQLite state");
+    expect(result.changes).toContain("Dropped 1 expired plugin-state sidecar entry");
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(true);
+
+    await withStateDir(root, async () => {
+      const botInfoStore = createPluginStateKeyedStore<{ fetchedAt: string }>("telegram", {
+        namespace: "telegram.bot-info-cache",
+        maxEntries: 10,
+      });
+      await expect(botInfoStore.lookup("default")).resolves.toEqual({
+        fetchedAt: "2026-06-01T21:04:35.000Z",
+      });
+      const messageStore = createPluginStateKeyedStore<{ ok: boolean }>("telegram", {
+        namespace: "message-cache",
+        maxEntries: 10,
+      });
+      await expect(messageStore.lookup("legacy-only")).resolves.toEqual({ ok: true });
     });
   });
 

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1438,6 +1438,22 @@ describe("doctor legacy state migrations", () => {
         version: "1.0.0",
       },
     },
+    {
+      label: "use different floating selectors",
+      current: {
+        source: "npm",
+        spec: "demo@latest",
+        version: "1.0.0",
+        resolvedName: "demo",
+        resolvedVersion: "1.0.0",
+        resolvedSpec: "demo@1.0.0",
+      },
+      legacy: {
+        source: "npm",
+        spec: "demo@beta",
+        version: "1.0.0",
+      },
+    },
   ] satisfies Array<{
     label: string;
     current: InstalledPluginInstallRecordInfo;

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1454,6 +1454,22 @@ describe("doctor legacy state migrations", () => {
         version: "1.0.0",
       },
     },
+    {
+      label: "have malformed legacy spec metadata",
+      current: {
+        source: "npm",
+        spec: "demo@1.0.0",
+        version: "1.0.0",
+        resolvedName: "demo",
+        resolvedVersion: "1.0.0",
+        resolvedSpec: "demo@1.0.0",
+      },
+      legacy: {
+        source: "npm",
+        spec: { raw: "demo@beta" },
+        version: "1.0.0",
+      } as unknown as InstalledPluginInstallRecordInfo,
+    },
   ] satisfies Array<{
     label: string;
     current: InstalledPluginInstallRecordInfo;

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1686,6 +1686,70 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
+  it("does not report expired plugin-state sidecar rows as dropped when live conflicts keep the sidecar", async () => {
+    const root = await makeTempRoot();
+    const sourcePath = path.join(root, "plugin-state", "state.sqlite");
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    const sqlite = requireNodeSqlite();
+    const db = new sqlite.DatabaseSync(sourcePath);
+    try {
+      db.exec(`
+        CREATE TABLE plugin_state_entries (
+          plugin_id TEXT NOT NULL,
+          namespace TEXT NOT NULL,
+          entry_key TEXT NOT NULL,
+          value_json TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          expires_at INTEGER,
+          PRIMARY KEY (plugin_id, namespace, entry_key)
+        );
+      `);
+      const insert = db.prepare(`
+        INSERT INTO plugin_state_entries (
+          plugin_id, namespace, entry_key, value_json, created_at, expires_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `);
+      insert.run("telegram", "telegram.bot-info-cache", "default", '{"stale":true}', 1000, 1);
+      insert.run("discord", "components", "interaction:1", '{"ok":true}', 1000, null);
+    } finally {
+      db.close();
+    }
+    await withStateDir(root, async () => {
+      seedPluginStateEntriesForTests([
+        {
+          pluginId: "telegram",
+          namespace: "telegram.bot-info-cache",
+          key: "default",
+          value: { stale: false },
+          createdAt: 3000,
+          expiresAt: Date.now() + 60_000,
+        },
+        {
+          pluginId: "discord",
+          namespace: "components",
+          key: "interaction:1",
+          value: { ok: false },
+          createdAt: 3000,
+          expiresAt: null,
+        },
+      ]);
+    });
+    resetPluginStateStoreForTests();
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toStrictEqual([
+      "Left plugin-state sidecar in place because 1 row already existed in shared state: discord/components/interaction:1",
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
+  });
+
   it("archives the plugin-state sidecar when conflicting rows already match", async () => {
     const root = await makeTempRoot();
     const sourcePath = writeLegacyPluginStateSidecar(root);

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -404,11 +404,12 @@ function legacyInstallRecordHasCurrentResolvedIdentity(params: {
   const currentVersion = readInstallRecordIdentityVersion(params.currentRecord);
   const legacyVersion = readInstallRecordIdentityVersion(params.legacyRecord);
   const sameVersion = Boolean(currentVersion && legacyVersion && currentVersion === legacyVersion);
+  const currentNpmName = readInstallRecordNpmName(params.currentRecord);
+  const legacyNpmName = readInstallRecordNpmName(params.legacyRecord);
   const sameNpmPackage =
     params.currentRecord.source === "npm" &&
     params.legacyRecord.source === "npm" &&
-    readInstallRecordNpmName(params.currentRecord) ===
-      readInstallRecordNpmName(params.legacyRecord);
+    Boolean(currentNpmName && legacyNpmName && currentNpmName === legacyNpmName);
   return Boolean(
     (sameVersion && sameNpmPackage) ||
     (params.legacyRecord.resolvedSpec &&

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -63,6 +63,7 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
+import { parseRegistryNpmSpec } from "./npm-registry-spec.js";
 import { isWithinDir } from "./path-safety.js";
 import {
   ensureDir,
@@ -169,12 +170,6 @@ type LegacyDeliveryQueueFile = {
   status: "pending" | "failed";
 };
 
-class LegacyPluginStateSidecarConflictError extends Error {
-  constructor(readonly conflictedKeys: string[]) {
-    super("legacy plugin-state sidecar conflicts with shared state");
-  }
-}
-
 class LegacyTaskStateSidecarConflictError extends Error {
   constructor(readonly conflictedKeys: string[]) {
     super("legacy task-state sidecar conflicts with shared state");
@@ -265,6 +260,11 @@ function legacyPluginStateRowsMatch(
     normalizeLegacySqliteInteger(existing.expires_at) ===
       normalizeLegacySqliteInteger(legacy.expires_at)
   );
+}
+
+function isLegacyPluginStateRowExpired(row: LegacyPluginStateSidecarRow, now: number): boolean {
+  const expiresAt = normalizeLegacySqliteInteger(row.expires_at);
+  return expiresAt !== null && expiresAt <= now;
 }
 
 function archiveLegacyPluginStateSidecar(params: {
@@ -374,6 +374,82 @@ function legacyInstalledPluginIndexMatches(
   );
 }
 
+function readInstallRecordIdentityVersion(
+  record: InstalledPluginIndex["installRecords"][string],
+): string | undefined {
+  return record.resolvedVersion ?? record.version;
+}
+
+function readInstallRecordNpmName(
+  record: InstalledPluginIndex["installRecords"][string],
+): string | undefined {
+  return (
+    record.resolvedName ??
+    (record.resolvedSpec ? parseRegistryNpmSpec(record.resolvedSpec)?.name : undefined) ??
+    (record.spec ? parseRegistryNpmSpec(record.spec)?.name : undefined)
+  );
+}
+
+function readInstallRecordField(
+  record: InstalledPluginIndex["installRecords"][string],
+  key: string,
+): unknown {
+  return (record as Partial<Record<string, unknown>>)[key];
+}
+
+function legacyInstallRecordHasCurrentResolvedIdentity(params: {
+  currentRecord: InstalledPluginIndex["installRecords"][string];
+  legacyRecord: InstalledPluginIndex["installRecords"][string];
+}): boolean {
+  const currentVersion = readInstallRecordIdentityVersion(params.currentRecord);
+  const legacyVersion = readInstallRecordIdentityVersion(params.legacyRecord);
+  const sameVersion = Boolean(currentVersion && legacyVersion && currentVersion === legacyVersion);
+  const sameNpmPackage =
+    params.currentRecord.source === "npm" &&
+    params.legacyRecord.source === "npm" &&
+    readInstallRecordNpmName(params.currentRecord) ===
+      readInstallRecordNpmName(params.legacyRecord);
+  return Boolean(
+    (sameVersion && sameNpmPackage) ||
+    (params.legacyRecord.resolvedSpec &&
+      params.currentRecord.resolvedSpec === params.legacyRecord.resolvedSpec) ||
+    (params.legacyRecord.spec && params.currentRecord.resolvedSpec === params.legacyRecord.spec),
+  );
+}
+
+function legacyInstallRecordFieldCoveredByCurrent(params: {
+  key: string;
+  currentRecord: InstalledPluginIndex["installRecords"][string];
+  legacyRecord: InstalledPluginIndex["installRecords"][string];
+}): boolean {
+  if (params.key === "spec") {
+    return legacyInstallRecordHasCurrentResolvedIdentity(params);
+  }
+  if (params.key === "resolvedAt" || params.key === "installedAt") {
+    return typeof readInstallRecordField(params.currentRecord, params.key) === "string";
+  }
+  return false;
+}
+
+function legacyInstallRecordCoveredByCurrent(
+  currentRecord: InstalledPluginIndex["installRecords"][string],
+  legacyRecord: InstalledPluginIndex["installRecords"][string],
+): boolean {
+  if (currentRecord.source !== legacyRecord.source) {
+    return false;
+  }
+  for (const key of Object.keys(legacyRecord).toSorted()) {
+    if (readInstallRecordField(currentRecord, key) === readInstallRecordField(legacyRecord, key)) {
+      continue;
+    }
+    if (legacyInstallRecordFieldCoveredByCurrent({ key, currentRecord, legacyRecord })) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 function mergeLegacyInstalledPluginIndexRecords(
   current: InstalledPluginIndex,
   legacy: InstalledPluginIndex,
@@ -388,7 +464,7 @@ function mergeLegacyInstalledPluginIndexRecords(
       addedCount += 1;
       continue;
     }
-    if (JSON.stringify(currentRecord) !== JSON.stringify(legacyRecord)) {
+    if (!legacyInstallRecordCoveredByCurrent(currentRecord, legacyRecord)) {
       conflicts.push(pluginId);
     }
   }
@@ -1315,6 +1391,7 @@ async function migrateLegacyPluginStateSidecar(params: {
     const conflictedKeys: string[] = [];
     const rowsToInsert: LegacyPluginStateSidecarRow[] = [];
     let imported = 0;
+    let skippedExpired = 0;
     const now = Date.now();
     runOpenClawStateWriteTransaction(
       ({ db }) => {
@@ -1339,16 +1416,22 @@ async function migrateLegacyPluginStateSidecar(params: {
               .where("namespace", "=", row.namespace)
               .where("entry_key", "=", row.entry_key),
           );
+          const legacyExpired = isLegacyPluginStateRowExpired(row, now);
           if (existing) {
             if (!legacyPluginStateRowsMatch(existing, row)) {
-              conflictedKeys.push(`${row.plugin_id}/${row.namespace}/${row.entry_key}`);
+              if (legacyExpired) {
+                skippedExpired += 1;
+              } else {
+                conflictedKeys.push(`${row.plugin_id}/${row.namespace}/${row.entry_key}`);
+              }
             }
             continue;
           }
+          if (legacyExpired) {
+            skippedExpired += 1;
+            continue;
+          }
           rowsToInsert.push(row);
-        }
-        if (conflictedKeys.length > 0) {
-          throw new LegacyPluginStateSidecarConflictError(conflictedKeys);
         }
         for (const row of rowsToInsert) {
           executeSqliteQuerySync(
@@ -1377,15 +1460,20 @@ async function migrateLegacyPluginStateSidecar(params: {
         `Migrated ${imported} plugin-state sidecar ${imported === 1 ? "entry" : "entries"} → shared SQLite state`,
       );
     }
-  } catch (err) {
-    if (err instanceof LegacyPluginStateSidecarConflictError) {
+    if (skippedExpired > 0) {
+      changes.push(
+        `Dropped ${skippedExpired} expired plugin-state sidecar ${skippedExpired === 1 ? "entry" : "entries"}`,
+      );
+    }
+    if (conflictedKeys.length > 0) {
       return {
         changes,
         warnings: [
-          `Left plugin-state sidecar in place because ${err.conflictedKeys.length} ${err.conflictedKeys.length === 1 ? "row" : "rows"} already existed in shared state: ${err.conflictedKeys[0]}`,
+          `Left plugin-state sidecar in place because ${conflictedKeys.length} ${conflictedKeys.length === 1 ? "row" : "rows"} already existed in shared state: ${conflictedKeys[0]}`,
         ],
       };
     }
+  } catch (err) {
     return {
       changes,
       warnings: [`Failed migrating plugin-state sidecar ${sourcePath}: ${String(err)}`],

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -374,12 +374,6 @@ function legacyInstalledPluginIndexMatches(
   );
 }
 
-function readInstallRecordIdentityVersion(
-  record: InstalledPluginIndex["installRecords"][string],
-): string | undefined {
-  return record.resolvedVersion ?? record.version;
-}
-
 function readInstallRecordNpmName(
   record: InstalledPluginIndex["installRecords"][string],
 ): string | undefined {
@@ -401,35 +395,24 @@ function legacyInstallRecordHasCurrentResolvedIdentity(params: {
   currentRecord: InstalledPluginIndex["installRecords"][string];
   legacyRecord: InstalledPluginIndex["installRecords"][string];
 }): boolean {
-  const currentVersion = readInstallRecordIdentityVersion(params.currentRecord);
-  const legacyVersion = readInstallRecordIdentityVersion(params.legacyRecord);
-  const sameVersion = Boolean(currentVersion && legacyVersion && currentVersion === legacyVersion);
+  const { currentRecord, legacyRecord } = params;
+  if (legacyRecord.resolvedSpec && currentRecord.resolvedSpec === legacyRecord.resolvedSpec) {
+    return true;
+  }
+  if (legacyRecord.spec && currentRecord.resolvedSpec === legacyRecord.spec) {
+    return true;
+  }
+  if (currentRecord.source !== "npm" || legacyRecord.source !== "npm") {
+    return false;
+  }
   const currentNpmName = readInstallRecordNpmName(params.currentRecord);
   const legacyNpmName = readInstallRecordNpmName(params.legacyRecord);
-  const sameNpmPackage =
-    params.currentRecord.source === "npm" &&
-    params.legacyRecord.source === "npm" &&
-    Boolean(currentNpmName && legacyNpmName && currentNpmName === legacyNpmName);
-  return Boolean(
-    (sameVersion && sameNpmPackage) ||
-    (params.legacyRecord.resolvedSpec &&
-      params.currentRecord.resolvedSpec === params.legacyRecord.resolvedSpec) ||
-    (params.legacyRecord.spec && params.currentRecord.resolvedSpec === params.legacyRecord.spec),
-  );
-}
-
-function legacyInstallRecordFieldCoveredByCurrent(params: {
-  key: string;
-  currentRecord: InstalledPluginIndex["installRecords"][string];
-  legacyRecord: InstalledPluginIndex["installRecords"][string];
-}): boolean {
-  if (params.key === "spec") {
-    return legacyInstallRecordHasCurrentResolvedIdentity(params);
+  if (!currentNpmName || currentNpmName !== legacyNpmName) {
+    return false;
   }
-  if (params.key === "resolvedAt" || params.key === "installedAt") {
-    return typeof readInstallRecordField(params.currentRecord, params.key) === "string";
-  }
-  return false;
+  const currentVersion = currentRecord.resolvedVersion ?? currentRecord.version;
+  const legacyVersion = legacyRecord.resolvedVersion ?? legacyRecord.version;
+  return Boolean(currentVersion && legacyVersion && currentVersion === legacyVersion);
 }
 
 function legacyInstallRecordCoveredByCurrent(
@@ -440,10 +423,17 @@ function legacyInstallRecordCoveredByCurrent(
     return false;
   }
   for (const key of Object.keys(legacyRecord).toSorted()) {
-    if (readInstallRecordField(currentRecord, key) === readInstallRecordField(legacyRecord, key)) {
+    const currentValue = readInstallRecordField(currentRecord, key);
+    if (currentValue === readInstallRecordField(legacyRecord, key)) {
       continue;
     }
-    if (legacyInstallRecordFieldCoveredByCurrent({ key, currentRecord, legacyRecord })) {
+    if (
+      key === "spec" &&
+      legacyInstallRecordHasCurrentResolvedIdentity({ currentRecord, legacyRecord })
+    ) {
+      continue;
+    }
+    if ((key === "resolvedAt" || key === "installedAt") && typeof currentValue === "string") {
       continue;
     }
     return false;

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -377,10 +377,13 @@ function legacyInstalledPluginIndexMatches(
 function readInstallRecordNpmName(
   record: InstalledPluginIndex["installRecords"][string],
 ): string | undefined {
+  const resolvedName = readInstallRecordStringField(record, "resolvedName");
+  const resolvedSpec = readInstallRecordStringField(record, "resolvedSpec");
+  const spec = readInstallRecordStringField(record, "spec");
   return (
-    record.resolvedName ??
-    (record.resolvedSpec ? parseRegistryNpmSpec(record.resolvedSpec)?.name : undefined) ??
-    (record.spec ? parseRegistryNpmSpec(record.spec)?.name : undefined)
+    resolvedName ??
+    (resolvedSpec ? parseRegistryNpmSpec(resolvedSpec)?.name : undefined) ??
+    (spec ? parseRegistryNpmSpec(spec)?.name : undefined)
   );
 }
 
@@ -391,11 +394,22 @@ function readInstallRecordField(
   return (record as Partial<Record<string, unknown>>)[key];
 }
 
+function readInstallRecordStringField(
+  record: InstalledPluginIndex["installRecords"][string],
+  key: string,
+): string | undefined {
+  const value = readInstallRecordField(record, key);
+  return typeof value === "string" ? value : undefined;
+}
+
 function installRecordSpecPinsCurrentVersion(
   record: InstalledPluginIndex["installRecords"][string],
 ): boolean {
-  const parsed = record.spec ? parseRegistryNpmSpec(record.spec) : null;
-  const version = record.resolvedVersion ?? record.version;
+  const spec = readInstallRecordStringField(record, "spec");
+  const parsed = spec ? parseRegistryNpmSpec(spec) : null;
+  const version =
+    readInstallRecordStringField(record, "resolvedVersion") ??
+    readInstallRecordStringField(record, "version");
   return Boolean(
     parsed?.selectorKind === "exact-version" && version && parsed.selector === version,
   );
@@ -406,10 +420,13 @@ function legacyInstallRecordHasCurrentResolvedIdentity(params: {
   legacyRecord: InstalledPluginIndex["installRecords"][string];
 }): boolean {
   const { currentRecord, legacyRecord } = params;
-  if (legacyRecord.resolvedSpec && currentRecord.resolvedSpec === legacyRecord.resolvedSpec) {
+  const currentResolvedSpec = readInstallRecordStringField(currentRecord, "resolvedSpec");
+  const legacyResolvedSpec = readInstallRecordStringField(legacyRecord, "resolvedSpec");
+  if (legacyResolvedSpec && currentResolvedSpec === legacyResolvedSpec) {
     return true;
   }
-  if (legacyRecord.spec && currentRecord.resolvedSpec === legacyRecord.spec) {
+  const legacySpec = readInstallRecordStringField(legacyRecord, "spec");
+  if (legacySpec && currentResolvedSpec === legacySpec) {
     return true;
   }
   if (currentRecord.source !== "npm" || legacyRecord.source !== "npm") {
@@ -420,8 +437,12 @@ function legacyInstallRecordHasCurrentResolvedIdentity(params: {
   if (!currentNpmName || currentNpmName !== legacyNpmName) {
     return false;
   }
-  const currentVersion = currentRecord.resolvedVersion ?? currentRecord.version;
-  const legacyVersion = legacyRecord.resolvedVersion ?? legacyRecord.version;
+  const currentVersion =
+    readInstallRecordStringField(currentRecord, "resolvedVersion") ??
+    readInstallRecordStringField(currentRecord, "version");
+  const legacyVersion =
+    readInstallRecordStringField(legacyRecord, "resolvedVersion") ??
+    readInstallRecordStringField(legacyRecord, "version");
   return Boolean(
     currentVersion &&
     legacyVersion &&

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -63,7 +63,6 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
-import { parseRegistryNpmSpec } from "./npm-registry-spec.js";
 import { isWithinDir } from "./path-safety.js";
 import {
   ensureDir,
@@ -374,19 +373,6 @@ function legacyInstalledPluginIndexMatches(
   );
 }
 
-function readInstallRecordNpmName(
-  record: InstalledPluginIndex["installRecords"][string],
-): string | undefined {
-  const resolvedName = readInstallRecordStringField(record, "resolvedName");
-  const resolvedSpec = readInstallRecordStringField(record, "resolvedSpec");
-  const spec = readInstallRecordStringField(record, "spec");
-  return (
-    resolvedName ??
-    (resolvedSpec ? parseRegistryNpmSpec(resolvedSpec)?.name : undefined) ??
-    (spec ? parseRegistryNpmSpec(spec)?.name : undefined)
-  );
-}
-
 function readInstallRecordField(
   record: InstalledPluginIndex["installRecords"][string],
   key: string,
@@ -400,19 +386,6 @@ function readInstallRecordStringField(
 ): string | undefined {
   const value = readInstallRecordField(record, key);
   return typeof value === "string" ? value : undefined;
-}
-
-function installRecordSpecPinsCurrentVersion(
-  record: InstalledPluginIndex["installRecords"][string],
-): boolean {
-  const spec = readInstallRecordStringField(record, "spec");
-  const parsed = spec ? parseRegistryNpmSpec(spec) : null;
-  const version =
-    readInstallRecordStringField(record, "resolvedVersion") ??
-    readInstallRecordStringField(record, "version");
-  return Boolean(
-    parsed?.selectorKind === "exact-version" && version && parsed.selector === version,
-  );
 }
 
 function legacyInstallRecordHasCurrentResolvedIdentity(params: {
@@ -429,26 +402,7 @@ function legacyInstallRecordHasCurrentResolvedIdentity(params: {
   if (legacySpec && currentResolvedSpec === legacySpec) {
     return true;
   }
-  if (currentRecord.source !== "npm" || legacyRecord.source !== "npm") {
-    return false;
-  }
-  const currentNpmName = readInstallRecordNpmName(params.currentRecord);
-  const legacyNpmName = readInstallRecordNpmName(params.legacyRecord);
-  if (!currentNpmName || currentNpmName !== legacyNpmName) {
-    return false;
-  }
-  const currentVersion =
-    readInstallRecordStringField(currentRecord, "resolvedVersion") ??
-    readInstallRecordStringField(currentRecord, "version");
-  const legacyVersion =
-    readInstallRecordStringField(legacyRecord, "resolvedVersion") ??
-    readInstallRecordStringField(legacyRecord, "version");
-  return Boolean(
-    currentVersion &&
-    legacyVersion &&
-    currentVersion === legacyVersion &&
-    installRecordSpecPinsCurrentVersion(currentRecord),
-  );
+  return false;
 }
 
 function legacyInstallRecordCoveredByCurrent(

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -394,15 +394,12 @@ function legacyInstallRecordHasCurrentResolvedIdentity(params: {
 }): boolean {
   const { currentRecord, legacyRecord } = params;
   const currentResolvedSpec = readInstallRecordStringField(currentRecord, "resolvedSpec");
-  const legacyResolvedSpec = readInstallRecordStringField(legacyRecord, "resolvedSpec");
-  if (legacyResolvedSpec && currentResolvedSpec === legacyResolvedSpec) {
-    return true;
-  }
   const legacySpec = readInstallRecordStringField(legacyRecord, "spec");
-  if (legacySpec && currentResolvedSpec === legacySpec) {
-    return true;
+  if (legacySpec) {
+    return currentResolvedSpec === legacySpec;
   }
-  return false;
+  const legacyResolvedSpec = readInstallRecordStringField(legacyRecord, "resolvedSpec");
+  return Boolean(legacyResolvedSpec && currentResolvedSpec === legacyResolvedSpec);
 }
 
 function legacyInstallRecordCoveredByCurrent(

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -391,6 +391,16 @@ function readInstallRecordField(
   return (record as Partial<Record<string, unknown>>)[key];
 }
 
+function installRecordSpecPinsCurrentVersion(
+  record: InstalledPluginIndex["installRecords"][string],
+): boolean {
+  const parsed = record.spec ? parseRegistryNpmSpec(record.spec) : null;
+  const version = record.resolvedVersion ?? record.version;
+  return Boolean(
+    parsed?.selectorKind === "exact-version" && version && parsed.selector === version,
+  );
+}
+
 function legacyInstallRecordHasCurrentResolvedIdentity(params: {
   currentRecord: InstalledPluginIndex["installRecords"][string];
   legacyRecord: InstalledPluginIndex["installRecords"][string];
@@ -412,7 +422,12 @@ function legacyInstallRecordHasCurrentResolvedIdentity(params: {
   }
   const currentVersion = currentRecord.resolvedVersion ?? currentRecord.version;
   const legacyVersion = legacyRecord.resolvedVersion ?? legacyRecord.version;
-  return Boolean(currentVersion && legacyVersion && currentVersion === legacyVersion);
+  return Boolean(
+    currentVersion &&
+    legacyVersion &&
+    currentVersion === legacyVersion &&
+    installRecordSpecPinsCurrentVersion(currentRecord),
+  );
 }
 
 function legacyInstallRecordCoveredByCurrent(

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -1438,11 +1438,6 @@ async function migrateLegacyPluginStateSidecar(params: {
         `Migrated ${imported} plugin-state sidecar ${imported === 1 ? "entry" : "entries"} → shared SQLite state`,
       );
     }
-    if (skippedExpired > 0) {
-      changes.push(
-        `Dropped ${skippedExpired} expired plugin-state sidecar ${skippedExpired === 1 ? "entry" : "entries"}`,
-      );
-    }
     if (conflictedKeys.length > 0) {
       return {
         changes,
@@ -1450,6 +1445,11 @@ async function migrateLegacyPluginStateSidecar(params: {
           `Left plugin-state sidecar in place because ${conflictedKeys.length} ${conflictedKeys.length === 1 ? "row" : "rows"} already existed in shared state: ${conflictedKeys[0]}`,
         ],
       };
+    }
+    if (skippedExpired > 0) {
+      changes.push(
+        `Dropped ${skippedExpired} expired plugin-state sidecar ${skippedExpired === 1 ? "entry" : "entries"}`,
+      );
     }
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary

- make the legacy plugin-state sidecar migrator import legacy-only rows before reporting remaining conflicts
- let expired legacy plugin-state rows drop during migration so stale cache rows do not keep `doctor --fix` noisy
- let richer shared SQLite plugin install records supersede stale legacy JSON records when they describe the same install identity, while still warning on same-version package-name conflicts

## Verification

- `node scripts/run-vitest.mjs src/commands/doctor-state-migrations.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
