### PR TITLE
fix: skip platform-incompatible skills in doctor warnings

### DIFF
--- a/src/commands/doctor-skills-core.ts
+++ b/src/commands/doctor-skills-core.ts
@@ -1,13 +1,31 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SkillStatusEntry, SkillStatusReport } from "../skills/discovery/status.js";
 
+function isPlatformIncompatibleSkill(skill: SkillStatusEntry): boolean {
+  return skill.missing.os.length > 0;
+}
+
 export function collectUnavailableAgentSkills(report: SkillStatusReport): SkillStatusEntry[] {
   return report.skills.filter(
     (skill) =>
       !skill.eligible &&
       !skill.disabled &&
       !skill.blockedByAllowlist &&
-      !skill.blockedByAgentFilter,
+      !skill.blockedByAgentFilter &&
+      !isPlatformIncompatibleSkill(skill),
+  );
+}
+
+export function collectPlatformIncompatibleAgentSkills(
+  report: SkillStatusReport,
+): SkillStatusEntry[] {
+  return report.skills.filter(
+    (skill) =>
+      !skill.eligible &&
+      !skill.disabled &&
+      !skill.blockedByAllowlist &&
+      !skill.blockedByAgentFilter &&
+      isPlatformIncompatibleSkill(skill),
   );
 }
 

--- a/src/commands/doctor-skills.test.ts
+++ b/src/commands/doctor-skills.test.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SkillStatusEntry, SkillStatusReport } from "../skills/discovery/status.js";
 import type { GhConfigDiscoveryInput } from "../skills/lifecycle/gh-config-discovery.js";
 import {
+  collectPlatformIncompatibleAgentSkills,
   collectUnavailableAgentSkills,
   describeGhConfigDirHintFromDiscovery,
   disableUnavailableSkillsInConfig,
@@ -50,15 +51,24 @@ describe("doctor skills", () => {
       commandVisible: false,
       missing: { bins: ["tool"], anyBins: [], env: [], config: [], os: [] },
     });
+    const platformMismatch = createSkill({
+      name: "apple-notes",
+      eligible: false,
+      modelVisible: false,
+      commandVisible: false,
+      missing: { bins: [], anyBins: [], env: [], config: [], os: ["darwin"] },
+    });
     const report = createReport([
       createSkill({ name: "ready" }),
       unavailable,
+      platformMismatch,
       createSkill({ name: "disabled", eligible: false, disabled: true }),
       createSkill({ name: "agent-filtered", eligible: true, blockedByAgentFilter: true }),
       createSkill({ name: "bundled-blocked", eligible: false, blockedByAllowlist: true }),
     ]);
 
     expect(collectUnavailableAgentSkills(report)).toEqual([unavailable]);
+    expect(collectPlatformIncompatibleAgentSkills(report)).toEqual([platformMismatch]);
   });
 
   it("formats actionable missing requirement lines without secret values", () => {

--- a/src/commands/doctor-skills.ts
+++ b/src/commands/doctor-skills.ts
@@ -13,11 +13,13 @@ import {
 } from "../skills/lifecycle/gh-config-discovery.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 import {
+  collectPlatformIncompatibleAgentSkills,
   collectUnavailableAgentSkills,
   disableUnavailableSkillsInConfig,
 } from "./doctor-skills-core.js";
 
 export {
+  collectPlatformIncompatibleAgentSkills,
   collectUnavailableAgentSkills,
   disableUnavailableSkillsInConfig,
 } from "./doctor-skills-core.js";
@@ -114,6 +116,13 @@ export async function maybeRepairSkillReadiness(params: {
     note(githubHint.join("\n"), "GitHub CLI");
   }
   const unavailable = collectUnavailableAgentSkills(report);
+  const platformIncompatible = collectPlatformIncompatibleAgentSkills(report);
+  if (platformIncompatible.length > 0) {
+    note(
+      `${platformIncompatible.length} skill${platformIncompatible.length === 1 ? " is" : "s are"} not supported on this platform and will be skipped by doctor.`,
+      "Skills",
+    );
+  }
   if (unavailable.length === 0) {
     return params.cfg;
   }


### PR DESCRIPTION
## Summary
- exclude platform-incompatible skills from the actionable doctor warning list
- keep them visible as a single summary note instead of dozens of false-positive missing-requirement lines
- add coverage for separating actionable vs platform-incompatible skill entries

## Testing
- node scripts/run-vitest.mjs run src/commands/doctor-skills.test.ts

Closes #89232