### PR TITLE
fix: include nextOffset in sessions JSON output

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -20,8 +20,10 @@ channel connectivity.
 default so large long-lived stores cannot monopolize the CLI process or Gateway
 event loop. The CLI returns the newest 100 sessions by default; pass
 `--limit <n>` for a smaller/larger window or `--limit all` when you intentionally
-need the full store. JSON responses include `totalCount`, `limitApplied`, and
-`hasMore` when callers need to show that more rows exist.
+need the full store. JSON responses include `totalCount`, `limitApplied`,
+`hasMore`, and `nextOffset` when callers need to show that more rows exist.
+`nextOffset` is a numeric cursor when another page is available and `null` on
+the final page.
 
 RPC clients can pass `configuredAgentsOnly: true` to keep the broad combined
 discovery source but return only rows for agents currently present in config.
@@ -94,6 +96,7 @@ JSON examples:
   "totalCount": 2,
   "limitApplied": 100,
   "hasMore": false,
+  "nextOffset": null,
   "activeMinutes": null,
   "sessions": [
     { "agentId": "main", "key": "agent:main:main", "model": "gpt-5" },

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -274,6 +274,7 @@ describe("sessionsCommand", () => {
       count?: number;
       totalCount?: number;
       limitApplied?: number | null;
+      nextOffset?: number | null;
       hasMore?: boolean;
       sessions?: Array<{ key: string }>;
     }>(sessionsCommand, store, { limit: "2" });
@@ -281,6 +282,7 @@ describe("sessionsCommand", () => {
     expect(payload.count).toBe(2);
     expect(payload.totalCount).toBe(3);
     expect(payload.limitApplied).toBe(2);
+    expect(payload.nextOffset).toBe(2);
     expect(payload.hasMore).toBe(true);
     expect(payload.sessions?.map((row) => row.key)).toEqual(["newest", "middle"]);
   });
@@ -298,6 +300,7 @@ describe("sessionsCommand", () => {
       count?: number;
       totalCount?: number;
       limitApplied?: number | null;
+      nextOffset?: number | null;
       hasMore?: boolean;
       sessions?: Array<{ key: string }>;
     }>(sessionsCommand, store, { limit: "all" });
@@ -305,6 +308,7 @@ describe("sessionsCommand", () => {
     expect(payload.count).toBe(2);
     expect(payload.totalCount).toBe(2);
     expect(payload.limitApplied).toBeNull();
+    expect(payload.nextOffset).toBeNull();
     expect(payload.hasMore).toBe(false);
     expect(payload.sessions?.map((row) => row.key)).toEqual(["newest", "oldest"]);
   });

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -408,6 +408,7 @@ export async function sessionsCommand(
   const totalCount = allRows.length;
   const rows = selectNewestSessionRows(allRows, limit);
   const hasMore = rows.length < totalCount;
+  const nextOffset = hasMore ? rows.length : null;
 
   if (opts.json) {
     const multi = targets.length > 1;
@@ -424,6 +425,7 @@ export async function sessionsCommand(
       count: rows.length,
       totalCount,
       limitApplied: limit ?? null,
+      nextOffset,
       hasMore,
       activeMinutes: activeMinutes ?? null,
       sessions: await Promise.all(


### PR DESCRIPTION
## Summary
- include `nextOffset` in `sessions --json` output when `hasMore` is true
- keep `nextOffset` null when the full result set is returned
- cover both limited and unlimited JSON output cases in tests

## Testing
- node scripts/run-vitest.mjs run src/commands/sessions.test.ts

Closes #89249