### PR TITLE
fix: lazily resolve workspace fs roots for host tools

### DIFF
--- a/src/agents/agent-tools.read.host-edit-access.test.ts
+++ b/src/agents/agent-tools.read.host-edit-access.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createHostWorkspaceEditTool } from "./agent-tools.read.js";
+import { createHostWorkspaceEditTool, createHostWorkspaceWriteTool } from "./agent-tools.read.js";
 
 type CapturedEditOperations = {
   access: (absolutePath: string) => Promise<void>;
@@ -31,6 +31,17 @@ vi.mock("./sessions/index.js", async () => {
 });
 
 describe("createHostWorkspaceEditTool host access mapping", () => {
+  it("does not resolve the workspace root eagerly during tool construction", () => {
+    const missingWorkspaceDir = path.join(os.tmpdir(), `openclaw-missing-${Date.now()}`);
+
+    expect(() =>
+      createHostWorkspaceEditTool(missingWorkspaceDir, { workspaceOnly: true }),
+    ).not.toThrow();
+    expect(() =>
+      createHostWorkspaceWriteTool(missingWorkspaceDir, { workspaceOnly: true }),
+    ).not.toThrow();
+  });
+
   let tmpDir = "";
 
   afterEach(async () => {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -965,12 +965,12 @@ async function statHostFile(absolutePath: string) {
 
 async function writeWorkspaceFile(
   root: string,
-  rootPromise: ReturnType<typeof fsRoot>,
+  getRootPromise: () => ReturnType<typeof fsRoot>,
   absolutePath: string,
   content: string,
 ) {
   const relative = await toCanonicalRelativeWorkspacePath(root, absolutePath);
-  await (await rootPromise).write(relative, content, { mkdir: true });
+  await (await getRootPromise()).write(relative, content, { mkdir: true });
 }
 
 function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {
@@ -992,7 +992,8 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
   }
 
   // When workspaceOnly is true, enforce workspace boundary
-  const rootPromise = fsRoot(root);
+  let rootPromise: ReturnType<typeof fsRoot> | undefined;
+  const getRootPromise = () => (rootPromise ??= fsRoot(root));
   return {
     mkdir: async (dir: string) => {
       const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
@@ -1001,10 +1002,10 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
       await fs.mkdir(resolved, { recursive: true });
     },
     writeFile: (absolutePath: string, content: string) =>
-      writeWorkspaceFile(root, rootPromise, absolutePath, content),
+      writeWorkspaceFile(root, getRootPromise, absolutePath, content),
     readFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
-      return (await (await rootPromise).read(relative)).buffer;
+      return (await (await getRootPromise()).read(relative)).buffer;
     },
     statFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
@@ -1030,15 +1031,16 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
   }
 
   // When workspaceOnly is true, enforce workspace boundary
-  const rootPromise = fsRoot(root);
+  let rootPromise: ReturnType<typeof fsRoot> | undefined;
+  const getRootPromise = () => (rootPromise ??= fsRoot(root));
   return {
     readFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
-      const safeRead = await (await rootPromise).read(relative);
+      const safeRead = await (await getRootPromise()).read(relative);
       return safeRead.buffer;
     },
     writeFile: (absolutePath: string, content: string) =>
-      writeWorkspaceFile(root, rootPromise, absolutePath, content),
+      writeWorkspaceFile(root, getRootPromise, absolutePath, content),
     access: async (absolutePath: string) => {
       let relative: string;
       try {
@@ -1052,7 +1054,7 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
         return;
       }
       try {
-        const opened = await (await rootPromise).open(relative);
+        const opened = await (await getRootPromise()).open(relative);
         await opened.handle.close().catch(() => {});
       } catch (error) {
         if (error instanceof FsSafeError && error.code === "not-found") {


### PR DESCRIPTION
## Summary
- avoid resolving workspace fs roots while host edit/write tools are being constructed
- memoize the fs root on first real filesystem access instead
- cover tool construction for missing workspace directories in a focused test

## Testing
- node scripts/run-vitest.mjs run src/agents/agent-tools.read.host-edit-access.test.ts

Closes #89225