### PR TITLE
fix(channels): hide tool failure details in public channels

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2935,6 +2935,7 @@ export async function runEmbeddedAgent(
             thinkingLevel: params.thinkLevel,
             toolResultFormat: resolvedToolResultFormat,
             suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+            suppressToolErrorDetails: params.suppressToolErrorDetails,
             inlineToolResultsAllowed: false,
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -140,6 +140,8 @@ export type RunEmbeddedAgentParams = {
   toolProgressDetail?: ToolProgressDetailMode;
   /** If true, suppress tool error warning payloads for this run (including mutating tools). */
   suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+  /** If true, omit system/tool details from user-visible tool failure warnings. */
+  suppressToolErrorDetails?: boolean;
   /** Bootstrap context mode for workspace file injection. */
   bootstrapContextMode?: "full" | "lightweight";
   /** Run kind hint for context mode behavior. */

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -476,6 +476,22 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("omits tool metadata and raw error details when detail suppression is enabled", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "rg secret-token src",
+        error: "Command failed with exit code 1",
+        mutatingAction: true,
+      },
+      suppressToolErrorDetails: true,
+      verboseLevel: "full",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed");
+  });
+
   it("keeps stale full-verbose tool errors compact when live verbose is off", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "write", error: "permission denied" },

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -45,6 +45,7 @@ type ToolMetaEntry = { toolName: string; meta?: string };
 type ToolErrorWarningPolicy = {
   showWarning: boolean;
   includeDetails: boolean;
+  includeToolMeta: boolean;
 };
 
 const RECOVERABLE_TOOL_ERROR_KEYWORDS = [
@@ -152,6 +153,7 @@ function resolveToolErrorWarningPolicy(params: {
   hasUserFacingFailureAcknowledgement: boolean;
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+  suppressToolErrorDetails?: boolean;
   isCronTrigger?: boolean;
   sessionKey: string;
   verboseLevel?: VerboseLevel;
@@ -165,22 +167,26 @@ function resolveToolErrorWarningPolicy(params: {
   } else {
     toolErrorWarningOverride = params.suppressToolErrorWarnings;
   }
-  const includeDetails = shouldIncludeToolErrorDetails({
-    ...params,
-    verboseLevel: dynamicToolErrorWarningsDisabled ? "off" : params.verboseLevel,
-  });
+  const toolErrorDetailsSuppressed = params.suppressToolErrorDetails === true;
+  const includeDetails =
+    !toolErrorDetailsSuppressed &&
+    shouldIncludeToolErrorDetails({
+      ...params,
+      verboseLevel: dynamicToolErrorWarningsDisabled ? "off" : params.verboseLevel,
+    });
+  const includeToolMeta = !toolErrorDetailsSuppressed;
   const suppressToolErrorWarnings = toolErrorWarningOverride === true;
   if (suppressToolErrorWarnings) {
-    return { showWarning: false, includeDetails };
+    return { showWarning: false, includeDetails, includeToolMeta };
   }
   // sessions_send timeouts and errors are transient inter-session communication
   // issues — the message may still have been delivered. Suppress warnings to
   // prevent raw error text from leaking into the chat surface (#23989).
   if (normalizedToolName === "sessions_send") {
-    return { showWarning: false, includeDetails };
+    return { showWarning: false, includeDetails, includeToolMeta };
   }
   if (params.suppressToolErrors) {
-    return { showWarning: false, includeDetails };
+    return { showWarning: false, includeDetails, includeToolMeta };
   }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
@@ -188,14 +194,16 @@ function resolveToolErrorWarningPolicy(params: {
     return {
       showWarning: !params.hasUserFacingErrorReply && !params.hasUserFacingFailureAcknowledgement,
       includeDetails,
+      includeToolMeta,
     };
   }
   if (isExecLikeToolName(params.lastToolError.toolName) && !includeDetails) {
-    return { showWarning: false, includeDetails };
+    return { showWarning: false, includeDetails, includeToolMeta };
   }
   return {
     showWarning: !params.hasUserFacingReply && !isRecoverableToolError(params.lastToolError.error),
     includeDetails,
+    includeToolMeta,
   };
 }
 
@@ -215,6 +223,7 @@ export function buildEmbeddedRunPayloads(params: {
   thinkingLevel?: ThinkLevel;
   toolResultFormat?: ToolResultFormat;
   suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+  suppressToolErrorDetails?: boolean;
   inlineToolResultsAllowed: boolean;
   didSendViaMessagingTool?: boolean;
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
@@ -502,6 +511,7 @@ export function buildEmbeddedRunPayloads(params: {
       hasUserFacingFailureAcknowledgement,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+      suppressToolErrorDetails: params.suppressToolErrorDetails,
       isCronTrigger: params.isCronTrigger,
       sessionKey: params.sessionKey,
       verboseLevel: params.verboseLevel,
@@ -512,7 +522,9 @@ export function buildEmbeddedRunPayloads(params: {
     if (warningPolicy.showWarning) {
       const toolSummary = formatToolAggregate(
         params.lastToolError.toolName,
-        params.lastToolError.meta ? [params.lastToolError.meta] : undefined,
+        warningPolicy.includeToolMeta && params.lastToolError.meta
+          ? [params.lastToolError.meta]
+          : undefined,
         { markdown: useMarkdown },
       );
       const errorSuffix =

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -80,6 +80,8 @@ export type GetReplyOptions = {
   suppressToolErrorWarnings?: boolean;
   /** Dynamic form used when verbose progress visibility can change mid-run. */
   shouldSuppressToolErrorWarnings?: () => boolean | undefined;
+  /** If true, omit system/tool details from user-visible tool failure warnings. */
+  suppressToolErrorDetails?: boolean;
   /** If true, run the model without OpenClaw tools for this turn. */
   disableTools?: boolean;
   /** If true, include the heartbeat response tool for structured heartbeat outcomes. */

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -227,6 +227,7 @@ type FallbackRunnerParams = {
 };
 
 type EmbeddedAgentParams = {
+  suppressToolErrorDetails?: boolean;
   onBlockReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
   onItemEvent?: (payload: {
@@ -1158,6 +1159,43 @@ describe("runAgentTurnWithFallback", () => {
     expect(fallbackCall.abortSignal).toBe(replyOperation.abortSignal);
     expect(fallbackCall.sessionId).toBe("session");
     expect(embeddedCall.abortSignal).toBe(replyOperation.abortSignal);
+  });
+
+  it("keeps tool error details enabled when the resolved verbose level is full", async () => {
+    let capturedParams: EmbeddedAgentParams | undefined;
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      capturedParams = params;
+      return { payloads: [{ text: "ok" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "discord",
+        ChatType: "channel",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {
+        suppressToolErrorDetails: true,
+      } satisfies GetReplyOptions,
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => true,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "full",
+    });
+
+    expect(capturedParams?.suppressToolErrorDetails).toBe(false);
   });
 
   it("rechecks queued auto fallback primary probes before running", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2258,6 +2258,10 @@ export async function runAgentTurnWithFallback(params: {
                 : undefined);
             return (async () => {
               let attemptCompactionCount = 0;
+              const suppressToolErrorDetails =
+                params.resolvedVerboseLevel === "full"
+                  ? false
+                  : params.opts?.suppressToolErrorDetails;
               const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
                 runId,
                 sessionKey: params.sessionKey,
@@ -2320,6 +2324,7 @@ export async function runAgentTurnWithFallback(params: {
                     suppressToolErrorWarnings:
                       params.opts?.shouldSuppressToolErrorWarnings ??
                       params.opts?.suppressToolErrorWarnings,
+                    suppressToolErrorDetails,
                     disableTools: params.opts?.disableTools,
                     enableHeartbeatTool: params.opts?.enableHeartbeatTool,
                     forceHeartbeatTool: params.opts?.forceHeartbeatTool,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2143,6 +2143,7 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
+    expect(receivedOptions?.suppressToolErrorDetails).toBe(true);
     expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(false);
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
@@ -3287,7 +3288,41 @@ describe("dispatchReplyFromConfig", () => {
       status: "failed",
     });
     expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
+    expect(receivedOptions?.suppressToolErrorDetails).toBe(true);
     expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("keeps tool-error details available in group sessions when verbose full is active", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "full",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    let receivedOptions: GetReplyOptions | undefined;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      receivedOptions = opts;
+      return { text: "done" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: automaticGroupReplyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(receivedOptions?.suppressToolErrorDetails).toBe(false);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2353,6 +2353,12 @@ export async function dispatchReplyFromConfig(
       payload.status === "failed" ||
       payload.status === "error" ||
       (typeof payload.exitCode === "number" && payload.exitCode !== 0);
+    const suppressChannelToolErrorDetails =
+      !isInternalWebchatTurn &&
+      (chatType === "group" || chatType === "channel") &&
+      !shouldEmitFullVerboseProgress();
+    const suppressToolErrorDetails =
+      params.replyOptions?.suppressToolErrorDetails ?? suppressChannelToolErrorDetails;
     const shouldSuppressToolErrorWarnings = () => {
       if (params.replyOptions?.suppressToolErrorWarnings !== undefined) {
         return params.replyOptions.suppressToolErrorWarnings;
@@ -2453,6 +2459,7 @@ export async function dispatchReplyFromConfig(
             sourceReplyDeliveryMode,
             suppressToolErrorWarnings,
             shouldSuppressToolErrorWarnings,
+            suppressToolErrorDetails,
             typingPolicy: typing.typingPolicy,
             suppressTyping: typing.suppressTyping,
             onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply),

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2192,8 +2192,10 @@ describe("createFollowupRunner progress forwarding", () => {
       async (args: {
         onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
         suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+        suppressToolErrorDetails?: boolean;
       }) => {
         const shouldSuppress = args.suppressToolErrorWarnings as () => boolean | undefined;
+        expect(args.suppressToolErrorDetails).toBe(false);
         expect(shouldSuppress()).toBeUndefined();
         await args.onAgentEvent?.({
           stream: "command_output",
@@ -2218,6 +2220,7 @@ describe("createFollowupRunner progress forwarding", () => {
 
     await runner(
       createQueuedRun({
+        originatingChatType: "group",
         run: {
           messageProvider: "discord",
           sourceReplyDeliveryMode: "message_tool_only",
@@ -2234,8 +2237,10 @@ describe("createFollowupRunner progress forwarding", () => {
       async (args: {
         onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
         suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+        suppressToolErrorDetails?: boolean;
       }) => {
         const shouldSuppress = args.suppressToolErrorWarnings as () => boolean | undefined;
+        expect(args.suppressToolErrorDetails).toBe(true);
         expect(shouldSuppress()).toBeUndefined();
         await args.onAgentEvent?.({
           stream: "command_output",
@@ -2259,6 +2264,7 @@ describe("createFollowupRunner progress forwarding", () => {
 
     await runner(
       createQueuedRun({
+        originatingChatType: "group",
         run: {
           messageProvider: "discord",
           sourceReplyDeliveryMode: "message_tool_only",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -19,6 +19,7 @@ import {
   buildAgentRuntimeDeliveryPlan,
   buildAgentRuntimeOutcomePlan,
 } from "../../agents/runtime-plan/build.js";
+import { normalizeChatType } from "../../channels/chat-type.js";
 import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
 import { readSessionEntry } from "../../config/sessions/store-load.js";
 import type { TypingMode } from "../../config/types.js";
@@ -478,6 +479,12 @@ export function createFollowupRunner(params: {
           observedVisibleToolErrorProgress = true;
         }
       };
+      const queuedChatType = normalizeChatType(effectiveQueued.originatingChatType);
+      const suppressChannelToolErrorDetails =
+        (queuedChatType === "group" || queuedChatType === "channel") &&
+        resolveCurrentVerboseLevel() !== "full";
+      const suppressToolErrorDetails =
+        opts?.suppressToolErrorDetails ?? suppressChannelToolErrorDetails;
       const shouldSuppressToolErrorWarnings = () => {
         if (opts?.suppressToolErrorWarnings !== undefined) {
           return opts.suppressToolErrorWarnings;
@@ -931,6 +938,7 @@ export function createFollowupRunner(params: {
                 verboseLevel: run.verboseLevel,
                 reasoningLevel: run.reasoningLevel,
                 suppressToolErrorWarnings: shouldSuppressToolErrorWarnings,
+                suppressToolErrorDetails,
                 execOverrides: run.execOverrides,
                 bashElevated: run.bashElevated,
                 timeoutMs: run.timeoutMs,


### PR DESCRIPTION
Problem
- Tool failure warnings in public channel/group surfaces can leak implementation details, including shell command metadata and raw system/tool error text.
- Benign command failures such as search commands returning no matches can therefore expose internal execution details to channel participants.

Changes
- Keep the user-visible tool failure warning so the agent still signals that an action failed.
- Omit command metadata and raw error suffixes from those warnings for external group/channel delivery unless full verbose output is active.
- Preserve complete tool failure details for explicit /verbose full debugging, including inline verbose-full turns where dispatch initially redacted public-channel details.
- Separate tool warning suppression from system-detail suppression in the embedded runner payload policy.

Issue
- https://github.com/openclaw/openclaw/issues/87610

Verification
- node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.test.ts
- node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts
- node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts
- node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts
- git diff --check