### PR TITLE
fix: prune stale session cleanup archives

### DIFF
--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -495,6 +495,21 @@ export async function runSessionsCleanup(params: {
       const appliedReportRef: { current: SessionMaintenanceApplyReport | null } = {
         current: null,
       };
+      const preCleanupStore = loadSessionStore(target.storePath, { skipCache: true });
+      const preUpdateUnreferencedArtifacts =
+        mode === "warn"
+          ? {
+              scannedFiles: 0,
+              removedFiles: 0,
+              freedBytes: 0,
+              olderThanMs: maintenance.pruneAfterMs,
+            }
+          : await pruneUnreferencedSessionArtifacts({
+              store: preCleanupStore,
+              storePath: target.storePath,
+              olderThanMs: maintenance.pruneAfterMs,
+              dryRun: false,
+            });
       const dmScopeRemovedSessionFiles = new Map<string, string | undefined>();
       let missingApplied = 0;
       let dmScopeRetiredApplied = 0;
@@ -548,7 +563,7 @@ export async function runSessionsCleanup(params: {
         });
       }
       const afterStore = loadSessionStore(target.storePath, { skipCache: true });
-      const unreferencedArtifacts =
+      const postUpdateUnreferencedArtifacts =
         mode === "warn"
           ? {
               scannedFiles: 0,
@@ -562,6 +577,17 @@ export async function runSessionsCleanup(params: {
               olderThanMs: maintenance.pruneAfterMs,
               dryRun: false,
             });
+      const unreferencedArtifacts = {
+        scannedFiles:
+          preUpdateUnreferencedArtifacts.scannedFiles +
+          postUpdateUnreferencedArtifacts.scannedFiles,
+        removedFiles:
+          preUpdateUnreferencedArtifacts.removedFiles +
+          postUpdateUnreferencedArtifacts.removedFiles,
+        freedBytes:
+          preUpdateUnreferencedArtifacts.freedBytes + postUpdateUnreferencedArtifacts.freedBytes,
+        olderThanMs: maintenance.pruneAfterMs,
+      };
       const preview = previewResults.find(
         (result) => result.summary.storePath === target.storePath,
       );

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -411,6 +411,7 @@ async function previewStoreCleanup(params: {
     store: previewStore,
     storePath: params.target.storePath,
     olderThanMs: params.maintenance.pruneAfterMs,
+    resetArchiveRetentionMs: params.maintenance.resetArchiveRetentionMs,
     dryRun: true,
     excludeCanonicalPaths: new Set([...budgetRemovedFilePaths, ...entryCleanupArtifactPaths]),
   });
@@ -508,6 +509,7 @@ export async function runSessionsCleanup(params: {
               store: preCleanupStore,
               storePath: target.storePath,
               olderThanMs: maintenance.pruneAfterMs,
+              resetArchiveRetentionMs: maintenance.resetArchiveRetentionMs,
               dryRun: false,
             });
       const dmScopeRemovedSessionFiles = new Map<string, string | undefined>();
@@ -575,6 +577,7 @@ export async function runSessionsCleanup(params: {
               store: afterStore,
               storePath: target.storePath,
               olderThanMs: maintenance.pruneAfterMs,
+              resetArchiveRetentionMs: maintenance.resetArchiveRetentionMs,
               dryRun: false,
             });
       const unreferencedArtifacts = {

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -606,6 +606,32 @@ describe("pruneUnreferencedSessionArtifacts", () => {
     });
   });
 
+  it("preserves reset archives within resetArchiveRetention even when pruneAfter is shorter", async () => {
+    await withTempDir({ prefix: "openclaw-prune-reset-retention-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const resetArchivePath = path.join(
+        dir,
+        `old-session.jsonl.reset.${formatSessionArchiveTimestamp(
+          Date.now() - 10 * 24 * 60 * 60 * 1000,
+        )}`,
+      );
+      await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf-8");
+      await fs.writeFile(resetArchivePath, "reset archive", "utf-8");
+      const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+      await fs.utimes(resetArchivePath, old, old);
+
+      const result = await pruneUnreferencedSessionArtifacts({
+        store: {},
+        storePath,
+        olderThanMs: 24 * 60 * 60 * 1000,
+        resetArchiveRetentionMs: 30 * 24 * 60 * 60 * 1000,
+      });
+
+      await expectPathExists(resetArchivePath);
+      expect(result.removedFiles).toBe(0);
+    });
+  });
+
   it("reclaims unreferenced skills prompt blobs during normal artifact cleanup", async () => {
     await withTempDir({ prefix: "openclaw-prune-prompt-blob-" }, async (dir) => {
       const storePath = path.join(dir, "sessions.json");

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -500,9 +500,14 @@ export async function pruneUnreferencedSessionArtifacts(params: {
     if (isSessionStoreTempArtifactName(file.name, storeBasename)) {
       return file.mtimeMs <= tempCutoffMs;
     }
+    if (
+      parseSessionArchiveTimestamp(file.name, "deleted") != null ||
+      parseSessionArchiveTimestamp(file.name, "reset") != null
+    ) {
+      return isSessionCleanupArchiveExpired(file.name, cutoffMs, resetArchiveCutoffMs);
+    }
     return (
-      (file.mtimeMs <= cutoffMs && isUnreferencedSessionArtifactFile(file, referencedPaths)) ||
-      isSessionCleanupArchiveExpired(file.name, cutoffMs, resetArchiveCutoffMs)
+      file.mtimeMs <= cutoffMs && isUnreferencedSessionArtifactFile(file, referencedPaths)
     );
   });
   const removablePromptBlobFiles = promptBlobFiles.filter((file) => {

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -299,11 +299,20 @@ function isUnreferencedSessionArtifactFile(
   );
 }
 
-function isSessionCleanupArchiveExpired(fileName: string, cutoffMs: number): boolean {
-  const timestamp =
-    parseSessionArchiveTimestamp(fileName, "deleted") ??
-    parseSessionArchiveTimestamp(fileName, "reset");
-  return timestamp != null && timestamp <= cutoffMs;
+function isSessionCleanupArchiveExpired(
+  fileName: string,
+  deletedCutoffMs: number,
+  resetArchiveCutoffMs: number | null,
+): boolean {
+  const deletedTimestamp = parseSessionArchiveTimestamp(fileName, "deleted");
+  if (deletedTimestamp != null) {
+    return deletedTimestamp <= deletedCutoffMs;
+  }
+  if (resetArchiveCutoffMs == null) {
+    return false;
+  }
+  const resetTimestamp = parseSessionArchiveTimestamp(fileName, "reset");
+  return resetTimestamp != null && resetTimestamp <= resetArchiveCutoffMs;
 }
 
 // An orphaned `sessions.json.<pid>.<uuid>.tmp` older than this is never a live
@@ -445,11 +454,14 @@ export async function pruneUnreferencedSessionArtifacts(params: {
   store: Record<string, SessionEntry>;
   storePath: string;
   olderThanMs: number;
+  resetArchiveRetentionMs?: number | null;
   dryRun?: boolean;
   excludeCanonicalPaths?: ReadonlySet<string>;
 }): Promise<SessionUnreferencedArtifactSweepResult> {
   const olderThanMs =
     Number.isFinite(params.olderThanMs) && params.olderThanMs > 0 ? params.olderThanMs : 0;
+  const resetArchiveRetentionMs =
+    params.resetArchiveRetentionMs === undefined ? olderThanMs : params.resetArchiveRetentionMs;
   const sessionsDir = path.dirname(params.storePath);
   const files = await readSessionsDirFiles(sessionsDir);
   const promptBlobFiles = await readSessionPromptBlobFiles(sessionsDir);
@@ -468,6 +480,13 @@ export async function pruneUnreferencedSessionArtifacts(params: {
     }).store,
   );
   const cutoffMs = Date.now() - olderThanMs;
+  const resetArchiveCutoffMs =
+    resetArchiveRetentionMs == null
+      ? null
+      : Date.now() -
+        (Number.isFinite(resetArchiveRetentionMs) && resetArchiveRetentionMs > 0
+          ? resetArchiveRetentionMs
+          : 0);
   const tempCutoffMs = Date.now() - SESSION_STORE_TEMP_STALE_MS;
   const promptBlobCutoffMs =
     Date.now() - Math.max(olderThanMs, SESSION_PROMPT_BLOB_UNREFERENCED_GRACE_MS);
@@ -483,7 +502,7 @@ export async function pruneUnreferencedSessionArtifacts(params: {
     }
     return (
       (file.mtimeMs <= cutoffMs && isUnreferencedSessionArtifactFile(file, referencedPaths)) ||
-      isSessionCleanupArchiveExpired(file.name, cutoffMs)
+      isSessionCleanupArchiveExpired(file.name, cutoffMs, resetArchiveCutoffMs)
     );
   });
   const removablePromptBlobFiles = promptBlobFiles.filter((file) => {

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -14,6 +14,7 @@ import {
   isSessionArchiveArtifactName,
   isSessionStoreTempArtifactName,
   isTrajectorySessionArtifactName,
+  parseSessionArchiveTimestamp,
 } from "./artifacts.js";
 import { resolveSessionFilePath } from "./paths.js";
 import { projectSessionStoreForPersistence } from "./skill-prompt-blobs.js";
@@ -298,6 +299,13 @@ function isUnreferencedSessionArtifactFile(
   );
 }
 
+function isSessionCleanupArchiveExpired(fileName: string, cutoffMs: number): boolean {
+  const timestamp =
+    parseSessionArchiveTimestamp(fileName, "deleted") ??
+    parseSessionArchiveTimestamp(fileName, "reset");
+  return timestamp != null && timestamp <= cutoffMs;
+}
+
 // An orphaned `sessions.json.<pid>.<uuid>.tmp` older than this is never a live
 // atomic write (those rename within milliseconds), so it is safe to reclaim
 // regardless of the general unreferenced-artifact age threshold (#56827).
@@ -473,7 +481,10 @@ export async function pruneUnreferencedSessionArtifacts(params: {
     if (isSessionStoreTempArtifactName(file.name, storeBasename)) {
       return file.mtimeMs <= tempCutoffMs;
     }
-    return file.mtimeMs <= cutoffMs && isUnreferencedSessionArtifactFile(file, referencedPaths);
+    return (
+      (file.mtimeMs <= cutoffMs && isUnreferencedSessionArtifactFile(file, referencedPaths)) ||
+      isSessionCleanupArchiveExpired(file.name, cutoffMs)
+    );
   });
   const removablePromptBlobFiles = promptBlobFiles.filter((file) => {
     if (params.excludeCanonicalPaths?.has(file.canonicalPath)) {

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -694,6 +694,52 @@ describe("Integration: saveSessionStore with pruning", () => {
     await expectPathExists(freshReset);
   });
 
+  it("sessions cleanup previews and removes stale deleted and reset archives", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      fresh: { sessionId: "fresh-session", updatedAt: now },
+    };
+    const oldDeleted = path.join(
+      testDir,
+      `old-deleted.jsonl.deleted.${archiveTimestamp(now - 10 * DAY_MS)}`,
+    );
+    const oldReset = path.join(
+      testDir,
+      `old-reset.jsonl.reset.${archiveTimestamp(now - 10 * DAY_MS)}`,
+    );
+    const freshDeleted = path.join(
+      testDir,
+      `fresh-deleted.jsonl.deleted.${archiveTimestamp(now - DAY_MS)}`,
+    );
+    await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+    await fs.writeFile(oldDeleted, "old deleted", "utf-8");
+    await fs.writeFile(oldReset, "old reset", "utf-8");
+    await fs.writeFile(freshDeleted, "fresh deleted", "utf-8");
+
+    const dryRun = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, dryRun: true, enforce: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+    expect(dryRun.previewResults[0]?.summary.unreferencedArtifacts.removedFiles).toBe(2);
+    await expectPathExists(oldDeleted);
+    await expectPathExists(oldReset);
+    await expectPathExists(freshDeleted);
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(applied.appliedSummaries[0]?.unreferencedArtifacts.removedFiles).toBe(2);
+    await expectPathMissing(oldDeleted);
+    await expectPathMissing(oldReset);
+    await expectPathExists(freshDeleted);
+  });
+
   it("saveSessionStore skips enforcement when maintenance mode is warn", async () => {
     mockLoadConfig.mockReturnValue({
       session: {

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -740,6 +740,93 @@ describe("Integration: saveSessionStore with pruning", () => {
     await expectPathExists(freshDeleted);
   });
 
+  it("sessions cleanup honors reset archive retention longer than pruneAfter", async () => {
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "7d",
+          resetArchiveRetention: "30d",
+          maxEntries: 500,
+        },
+      },
+    });
+
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      fresh: { sessionId: "fresh-session", updatedAt: now },
+    };
+    const oldDeleted = path.join(
+      testDir,
+      `old-deleted.jsonl.deleted.${archiveTimestamp(now - 10 * DAY_MS)}`,
+    );
+    const retainedReset = path.join(
+      testDir,
+      `retained-reset.jsonl.reset.${archiveTimestamp(now - 10 * DAY_MS)}`,
+    );
+    await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+    await fs.writeFile(oldDeleted, "old deleted", "utf-8");
+    await fs.writeFile(retainedReset, "retained reset", "utf-8");
+
+    const dryRun = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, dryRun: true, enforce: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+    expect(dryRun.previewResults[0]?.summary.unreferencedArtifacts.removedFiles).toBe(1);
+    await expectPathExists(oldDeleted);
+    await expectPathExists(retainedReset);
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(applied.appliedSummaries[0]?.unreferencedArtifacts.removedFiles).toBe(1);
+    await expectPathMissing(oldDeleted);
+    await expectPathExists(retainedReset);
+  });
+
+  it("sessions cleanup leaves reset archives when reset archive cleanup is disabled", async () => {
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "7d",
+          resetArchiveRetention: false,
+          maxEntries: 500,
+        },
+      },
+    });
+
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      fresh: { sessionId: "fresh-session", updatedAt: now },
+    };
+    const oldDeleted = path.join(
+      testDir,
+      `old-deleted.jsonl.deleted.${archiveTimestamp(now - 10 * DAY_MS)}`,
+    );
+    const disabledReset = path.join(
+      testDir,
+      `disabled-reset.jsonl.reset.${archiveTimestamp(now - 60 * DAY_MS)}`,
+    );
+    await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+    await fs.writeFile(oldDeleted, "old deleted", "utf-8");
+    await fs.writeFile(disabledReset, "disabled reset", "utf-8");
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(applied.appliedSummaries[0]?.unreferencedArtifacts.removedFiles).toBe(1);
+    await expectPathMissing(oldDeleted);
+    await expectPathExists(disabledReset);
+  });
+
   it("saveSessionStore skips enforcement when maintenance mode is warn", async () => {
     mockLoadConfig.mockReturnValue({
       session: {


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Preserve the existing split between stale `.deleted.*` archive pruning and `.reset.*` archive pruning.
- Thread `session.maintenance.resetArchiveRetention` into the new unreferenced-artifact cleanup sweeps used by `openclaw sessions cleanup` preview/apply paths.
- Add regression coverage for `resetArchiveRetention` longer than `pruneAfter` and for `resetArchiveRetention: false` so reset archives are not deleted early.

Fixes #75658

## Test Plan
- Added regression tests in `src/config/sessions/store.pruning.integration.test.ts`:
  - `sessions cleanup honors reset archive retention longer than pruneAfter`
  - `sessions cleanup leaves reset archives when reset archive cleanup is disabled`
- Source-level TDD RED probe, run before the implementation change, failed as expected because `pruneUnreferencedSessionArtifacts()` had no reset retention parameter.
- Source-level GREEN proof, run after the implementation change, passed and checked all cleanup call sites thread `resetArchiveRetentionMs`.
- Full OpenClaw Vitest runner was not run in this API-only maintenance workspace because this temporary workspace intentionally contains only fetched source files and has no `package.json` or `node_modules`.

## Real behavior proof
- Behavior or issue addressed: `openclaw sessions cleanup` should remove stale `.deleted.*` archives using `pruneAfter`, while `.reset.*` archives continue to honor the separate `session.maintenance.resetArchiveRetention` contract, including longer retention windows and `false`/disabled reset cleanup.
- Real environment tested: API-only temporary source workspace at `/tmp/openclaw-maint-20260602T133013Z/pr-89288/head`, macOS, Node.js v22.18.0, PR head commit `b93ade7af662548ac26afa715c14b76d4aef439a`. No repository clone was used.
- Exact steps or command run before this patch (RED):
  ```sh
  node /tmp/proof_pr89288_reset_retention.mjs /tmp/openclaw-maint-20260602T133013Z/pr-89288/head
  ```
- Evidence before fix:
  ```text
file:///private/tmp/proof_pr89288_reset_retention.mjs:12
    throw new Error(message);
          ^

Error: disk-budget.ts does not accept resetArchiveRetentionMs for unreferenced archive pruning
    at assert (file:///private/tmp/proof_pr89288_reset_retention.mjs:12:11)
    at file:///private/tmp/proof_pr89288_reset_retention.mjs:34:1
    at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)

Node.js v22.18.0
  ```
- Exact steps or command run after this patch (GREEN):
  ```sh
  node /tmp/proof_pr89288_reset_retention.mjs /tmp/openclaw-maint-20260602T133013Z/pr-89288/head
  ```
- Evidence after fix:
  ```json
{
  "workspace": "/tmp/openclaw-maint-20260602T133013Z/pr-89288/head",
  "officialRunner": "not run: API-only partial workspace has no package.json or node_modules",
  "sourceAssertions": {
    "hasSeparateResetParam": true,
    "hasDisabledResetCutoff": true,
    "helperUsesSeparateCutoffs": true,
    "cleanupPassesPreviewRetention": true,
    "cleanupPassesApplyRetentionCount": 2
  },
  "behaviorMatrix": [
    {
      "label": "deleted archive older than pruneAfter is removed",
      "expired": true
    },
    {
      "label": "reset archive newer than resetArchiveRetention=30d is retained even when older than pruneAfter=7d",
      "expired": false
    },
    {
      "label": "reset archive is retained when resetArchiveRetention=false disables cleanup",
      "expired": false
    },
    {
      "label": "reset archive older than resetArchiveRetention=30d is removed",
      "expired": true
    }
  ],
  "result": "PASS reset archives honor resetArchiveRetention independently from pruneAfter"
}
  ```
- Observed result after fix: source-level proof passed. The patched helper has a separate `resetArchiveCutoffMs`, maps `resetArchiveRetentionMs: null` to disabled reset cleanup, and all three `runSessionsCleanup` preview/apply artifact sweeps pass the resolved reset retention. The behavior matrix retains a 10-day `.reset.*` archive when `pruneAfter=7d` and `resetArchiveRetention=30d`, retains a 60-day `.reset.*` archive when reset cleanup is disabled, and still removes stale `.deleted.*` archives plus reset archives older than the reset retention window.
- What was not tested: the full OpenClaw Vitest suite and package runner were not run because this cron job is constrained to API-only/no-clone maintenance and the temp workspace does not include package metadata or dependencies.

## Risk/Notes
- Risk is low and scoped to session cleanup archive retention logic.
- The change preserves the documented `resetArchiveRetention` contract instead of collapsing it into `pruneAfter`.
- PR remains Draft for maintainer review and CI/proof-gate feedback.
