### PR TITLE
test(plugins): cover filtered bundle MCP servers

### DIFF
--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -106,6 +106,9 @@ loader. Cursor command markdown works through the same path.
   default; use `tools.deny: ["bundle-mcp"]` to opt out for an agent or gateway
 - project-local embedded agent settings still apply after bundle defaults, so workspace
   settings can override bundle MCP entries when needed
+- bundle MCP server entries use the same server config shape as configured
+  `mcp.servers`, including per-server `toolFilter.include` and
+  `toolFilter.exclude`
 - bundle MCP tool catalogs are sorted deterministically before registration, so
   upstream `listTools()` order changes do not thrash prompt-cache tool blocks
 
@@ -157,6 +160,34 @@ MCP servers can use stdio or HTTP transport:
   descriptions and logs
 - `connectionTimeoutMs` overrides the default 30-second connection timeout for
   both stdio and HTTP transports
+
+##### Tool filters
+
+Bundle MCP server entries can set `toolFilter.include` and
+`toolFilter.exclude`. Entries are raw MCP tool names or simple `*` globs.
+Filtering runs after the server catalog is read and before provider-safe names
+are registered, so filters match names such as `read_docs`, not exposed names
+such as `my-server__read_docs`.
+
+Use filters in bundle defaults when a server exposes both workflow-level tools
+and direct write/admin tools. Keep defaults narrow; workspace config can
+override the same server key under `mcp.servers` when a project needs a broader
+surface.
+
+```json
+{
+  "mcpServers": {
+    "desktop-maps": {
+      "command": "npx",
+      "args": ["-y", "@example/desktop-mcp", "serve"],
+      "toolFilter": {
+        "include": ["workflow.*", "state.snapshot", "state.verify"],
+        "exclude": ["*.raw_*", "admin_*"]
+      }
+    }
+  }
+}
+```
 
 ##### Tool naming
 

--- a/src/plugins/bundle-mcp.test.ts
+++ b/src/plugins/bundle-mcp.test.ts
@@ -310,6 +310,107 @@ describe("loadEnabledBundleMcpConfig", () => {
     );
   });
 
+  it("preserves Codex bundle MCP tool filters and relative data roots", async () => {
+    await withBundleHomeEnv(
+      tempHarness,
+      "openclaw-bundle-filtered-mcp",
+      async ({ homeDir, workspaceDir }) => {
+        const safeTools = [
+          "capsule.*",
+          "vision_map.snapshot",
+          "vision_map.list_apps",
+          "vision_map.list_workflows",
+          "vision_map.describe_workflow",
+          "vision_map.describe",
+          "vision_map.detect_state",
+          "vision_map.list_actions",
+          "vision_map.describe_action",
+          "vision_map.perform_action",
+          "vision_map.run_workflow",
+          "vision_map.verify",
+          "vision_map.repair_minimal",
+          "vision_map.export_trace",
+        ];
+        const pluginRoot = resolveBundlePluginRoot(homeDir, "vision-mcp");
+        const appsRoot = path.join(pluginRoot, "apps");
+        await writeBundleTextFiles(pluginRoot, {
+          ".codex-plugin/plugin.json": `${JSON.stringify(
+            {
+              name: "vision-mcp",
+              skills: "./skills/",
+              mcpServers: "./.mcp.json",
+            },
+            null,
+            2,
+          )}\n`,
+          ".mcp.json": `${JSON.stringify(
+            {
+              mcpServers: {
+                "vision-mcp": {
+                  command: "npx",
+                  args: ["-y", "@vision-mcp/cli@latest", "serve", "--apps-root", "./apps"],
+                  toolFilter: {
+                    include: safeTools,
+                    exclude: [
+                      "vision_map.click_at",
+                      "vision_map.type_text",
+                      "vision_map.press_key",
+                      "vision_map.scroll",
+                      "vision_map.init",
+                      "vision_map.apply_patch",
+                      "vision_map.add_control",
+                      "vision_map.commit_*",
+                      "vision_map.harvest_session",
+                    ],
+                  },
+                },
+              },
+            },
+            null,
+            2,
+          )}\n`,
+        });
+        await fs.mkdir(appsRoot, { recursive: true });
+
+        const loaded = loadEnabledBundleMcpConfig({
+          workspaceDir,
+          cfg: createEnabledBundleConfig(["vision-mcp"]),
+        });
+        const loadedServer = loaded.config.mcpServers["vision-mcp"];
+        const loadedArgs = getServerArgs(loadedServer);
+        const loadedToolFilter = isRecord(loadedServer) ? loadedServer.toolFilter : undefined;
+
+        expectNoDiagnostics(loaded.diagnostics);
+        expect(isRecord(loadedServer) ? loadedServer.command : undefined).toBe("npx");
+        expect(loadedArgs?.slice(0, 4)).toEqual([
+          "-y",
+          "@vision-mcp/cli@latest",
+          "serve",
+          "--apps-root",
+        ]);
+        await expectResolvedPathEqual(loadedArgs?.[4], appsRoot);
+        expect(isRecord(loadedToolFilter) ? loadedToolFilter.include : undefined).toEqual(
+          safeTools,
+        );
+        expect(isRecord(loadedToolFilter) ? loadedToolFilter.exclude : undefined).toEqual([
+          "vision_map.click_at",
+          "vision_map.type_text",
+          "vision_map.press_key",
+          "vision_map.scroll",
+          "vision_map.init",
+          "vision_map.apply_patch",
+          "vision_map.add_control",
+          "vision_map.commit_*",
+          "vision_map.harvest_session",
+        ]);
+        await expectResolvedPathEqual(
+          isRecord(loadedServer) ? loadedServer.cwd : undefined,
+          pluginRoot,
+        );
+      },
+    );
+  });
+
   it("reports malformed file-backed MCP configs instead of silently dropping servers", async () => {
     await withBundleHomeEnv(
       tempHarness,


### PR DESCRIPTION
## Summary

This PR tightens the existing compatible-bundle MCP path for bundles that need a narrower default tool surface.

- Adds regression coverage that a Codex-compatible bundle `.mcp.json` preserves `toolFilter.include`, `toolFilter.exclude`, and a relative bundle data root.
- Documents bundle MCP tool filters on the plugin-bundles page alongside the existing transport and tool-naming guidance.
- Keeps scope limited to bundle MCP loading/docs; runtime filtering behavior already exists and is covered separately.

Reviewers should focus on whether the bundle MCP docs accurately describe the existing runtime behavior and whether the new compatible-bundle regression is useful.

## Linked context

No issue filed.

Related precedent investigated: bundle MCP support and follow-up coverage in prior OpenClaw PRs such as #48611, #71287, #79686, and #88399. This PR follows that existing bundle MCP seam.

## Real behavior proof (required for external PRs)

Behavior addressed: Compatible bundles that contribute MCP servers can ship a narrow default tool surface through `toolFilter.include` and `toolFilter.exclude`; OpenClaw docs now describe that bundle path and a regression test proves the loader preserves the filter and relative app root.

Real environment tested: Local OpenClaw checkout on macOS, branch `test/filtered-bundle-mcp`, commit `d5bffb3dc0`, with an isolated temporary `HOME`, `OPENCLAW_HOME`, and `OPENCLAW_CONFIG_PATH`.

Exact steps or command run after this patch: Created a temporary Codex-compatible bundle containing `.codex-plugin/plugin.json`, `.mcp.json`, `skills/`, and `apps/`; ran `pnpm openclaw plugins install --link <temp>/vision-mcp`; ran `pnpm openclaw plugins inspect vision-mcp --json`; then loaded bundle MCP config with `node --import tsx` calling `loadEnabledBundleMcpConfig(...)` against the isolated home/config.

Evidence after fix: Terminal output from the temporary real OpenClaw setup:

```text
Proof root: /var/folders/.../openclaw-bundle-proof.gE7Fjt
$ node scripts/run-node.mjs plugins install --link /var/folders/.../openclaw-bundle-proof.gE7Fjt/vision-mcp
Linked plugin path: /var/folders/.../openclaw-bundle-proof.gE7Fjt/vision-mcp
Restart the gateway to load plugins.
$ node scripts/run-node.mjs plugins inspect vision-mcp --json
{
  "diagnostics": [],
  "command": "npx",
  "args": [
    "-y",
    "@vision-mcp/cli@latest",
    "serve",
    "--apps-root",
    "/private/var/folders/.../openclaw-bundle-proof.gE7Fjt/vision-mcp/apps"
  ],
  "cwdEndsWith": true,
  "toolFilter": {
    "include": [
      "capsule.*",
      "vision_map.snapshot",
      "vision_map.list_apps",
      "vision_map.list_workflows",
      "vision_map.describe_workflow",
      "vision_map.describe",
      "vision_map.detect_state",
      "vision_map.list_actions",
      "vision_map.describe_action",
      "vision_map.perform_action",
      "vision_map.run_workflow",
      "vision_map.verify",
      "vision_map.repair_minimal",
      "vision_map.export_trace"
    ],
    "exclude": [
      "vision_map.click_at",
      "vision_map.type_text",
      "vision_map.press_key",
      "vision_map.scroll",
      "vision_map.init",
      "vision_map.apply_patch",
      "vision_map.add_control",
      "vision_map.commit_*",
      "vision_map.harvest_session"
    ]
  }
}
```

Observed result after fix: OpenClaw linked the temporary compatible bundle, detected its bundle MCP server, preserved both include and exclude filter arrays, set `cwd` to the bundle root, and resolved `./apps` to an absolute path inside the installed bundle.

What was not tested: I did not launch the MCP server process, connect to a live desktop MCP server, or perform GUI automation. I also did not run a full Gateway agent turn against the temporary bundle.

Proof limitations or environment constraints: The proof uses a temporary local compatible bundle and the real OpenClaw plugin installer/loader, but the MCP server command itself is not started because this PR changes documentation and loader regression coverage, not MCP runtime execution behavior.

## Tests and validation

Commands run:

```text
node scripts/test-projects.mjs -- src/plugins/bundle-mcp.test.ts --reporter=verbose
pnpm format:check src/plugins/bundle-mcp.test.ts
git diff --check
pnpm check:docs
codex review --base origin/main
```

Regression coverage added: `src/plugins/bundle-mcp.test.ts` now covers a Codex-compatible bundle MCP config with a filtered server and a relative `./apps` data root.

Validation results:

```text
src/plugins/bundle-mcp.test.ts: 1 file passed, 8 tests passed
pnpm format:check src/plugins/bundle-mcp.test.ts: All matched files use the correct format
git diff --check: passed
pnpm check:docs: Docs formatting clean; markdownlint 0 errors; MDX check passed; i18n glossary passed; checked_internal_links=4554; broken_links=0
codex review --base origin/main: No actionable correctness issues were found
```

## Risk checklist

Did user-visible behavior change? (`Yes/No`): No runtime behavior change; docs now describe existing bundle MCP filter behavior.

Did config, environment, or migration behavior change? (`Yes/No`): No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`): No runtime change. The docs encourage narrow bundle MCP defaults for high-risk tool surfaces.

What is the highest-risk area? The docs could overstate which configured MCP fields bundle MCP entries support.

How is that risk mitigated? Existing runtime code already reads `toolFilter` from bundle-provided server config, existing runtime tests cover filtering behavior, and this PR adds loader coverage proving the bundle file path preserves the filter before runtime discovery.

## Current review state

AI-assisted: yes.

Next action: maintainer review.
