### PR TITLE
fix(auto-reply): guard context prompt tool names

### DIFF
--- a/src/auto-reply/reply/commands-system-prompt.test.ts
+++ b/src/auto-reply/reply/commands-system-prompt.test.ts
@@ -279,4 +279,33 @@ describe("resolveCommandsSystemPromptBundle", () => {
     expect(promptParams.subagentDelegationMode).toBe("prefer");
     expect(promptParams.toolNames).toEqual(["sessions_spawn"]);
   });
+
+  it("skips unreadable command prompt tool names while preserving healthy siblings", async () => {
+    const unreadableTool = Object.defineProperty(
+      {
+        description: "malformed descriptor",
+        execute: vi.fn(),
+        parameters: { type: "object", properties: {} },
+      },
+      "name",
+      {
+        get() {
+          throw new Error("context prompt tool name getter exploded");
+        },
+      },
+    );
+    createOpenClawCodingToolsMock.mockReturnValue([
+      unreadableTool,
+      { name: "sessions_spawn" },
+    ] as never);
+
+    const bundle = await resolveCommandsSystemPromptBundle(makeParams());
+
+    const promptParams = requireFirstArg(
+      vi.mocked(buildAgentSystemPrompt),
+      "buildAgentSystemPrompt",
+    );
+    expect(promptParams.toolNames).toEqual(["sessions_spawn"]);
+    expect(bundle.tools.map((tool) => tool.name)).toEqual(["sessions_spawn"]);
+  });
 });

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -27,6 +27,38 @@ export type CommandsSystemPromptBundle = {
   sandboxRuntime: ReturnType<typeof resolveSandboxRuntimeStatus>;
 };
 
+function collectReadableTools(tools: readonly AgentTool[]): {
+  tools: AgentTool[];
+  toolNames: string[];
+} {
+  const safeTools: AgentTool[] = [];
+  const names: string[] = [];
+  for (const tool of tools) {
+    try {
+      const name = tool.name;
+      if (typeof name === "string") {
+        names.push(name);
+        safeTools.push(withResolvedToolName(tool, name));
+      }
+    } catch {
+      // Prompt/report estimation should survive one malformed descriptor.
+    }
+  }
+  return { tools: safeTools, toolNames: names };
+}
+
+function withResolvedToolName(tool: AgentTool, name: string): AgentTool {
+  return Object.create(Object.getPrototypeOf(tool), {
+    ...Object.getOwnPropertyDescriptors(tool),
+    name: {
+      configurable: true,
+      enumerable: true,
+      value: name,
+      writable: true,
+    },
+  }) as AgentTool;
+}
+
 export async function resolveCommandsSystemPromptBundle(
   params: HandleCommandsParams,
 ): Promise<CommandsSystemPromptBundle> {
@@ -80,7 +112,7 @@ export async function resolveCommandsSystemPromptBundle(
     }
   })();
   const skillsPrompt = skillsSnapshot.snapshot.prompt ?? "";
-  const tools = (() => {
+  const createdTools = (() => {
     try {
       return createOpenClawCodingTools({
         config: params.cfg,
@@ -104,7 +136,7 @@ export async function resolveCommandsSystemPromptBundle(
       return [];
     }
   })();
-  const toolNames = tools.map((t) => t.name);
+  const { tools, toolNames } = collectReadableTools(createdTools);
   const promptSurface = resolveAgentPromptSurfaceForSessionKey(params.sessionKey);
   const defaultModelRef = resolveDefaultModelForAgent({
     cfg: params.cfg,


### PR DESCRIPTION
## Summary

- harden the command system-prompt bundle against tool descriptors whose `name` property throws
- return the same readable-name tool set used for prompt generation so `/context` and `/export-session` metadata readers do not re-hit a poisoned descriptor
- add regression coverage for one malformed tool preserving a healthy sibling tool

## Verification

- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-system-prompt.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/commands-system-prompt.ts src/auto-reply/reply/commands-system-prompt.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint src/auto-reply/reply/commands-system-prompt.ts src/auto-reply/reply/commands-system-prompt.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"` (`aws`, `cbx_67953bdced42`, `run_38f100c0ac6a`, exit 0)
- post-rebase sanity: `node scripts/run-vitest.mjs src/auto-reply/reply/commands-system-prompt.test.ts --reporter=dot`

## Real behavior proof

Behavior addressed: `/context` and `/export-session` prompt/report metadata should not crash when a tool descriptor has an unreadable `name`; readable sibling tools should still be included.

Real environment tested: local targeted Vitest on macOS plus AWS Crabbox Linux changed gate.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/reply/commands-system-prompt.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: the regression test maps returned bundle tools after a throwing `name` getter and receives only `sessions_spawn`; AWS Crabbox `cbx_67953bdced42` / `run_38f100c0ac6a` completed `pnpm check:changed` with exit 0.

Observed result after fix: focused suite passed 7 tests; changed gate passed lanes `core, coreTests`.

What was not tested: live Telegram or desktop command roundtrip.
