### PR TITLE
fix(logging): requeue stuck session lane after abort

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -385,6 +385,47 @@ describe("stuck session recovery", () => {
     ]);
   });
 
+  it("releases queued lane work after a successful active abort", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:main:main",
+      queuedCount: 1,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("queued-reply-session");
+    expect(mocks.waitForEmbeddedAgentRunEnd).toHaveBeenCalledWith("queued-reply-session", 15_000);
+    expect(mocks.forceClearEmbeddedAgentRun).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      released: 1,
+      queuedCount: 1,
+    });
+    expect(warnLogMessages()).toEqual([
+      "stuck session recovery: sessionId=queued-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=1",
+      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=1 queuedCount=1",
+    ]);
+  });
+
   it("reports queued lane work when aborting active work releases a lane", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -242,7 +242,9 @@ export async function recoverStuckDiagnosticSession(
 
     const queuedCount = sessionLane ? getCommandLaneSnapshot(sessionLane).queuedCount : 0;
     const released =
-      sessionLane && (!activeSessionId || !aborted || !drained) ? resetCommandLane(sessionLane) : 0;
+      sessionLane && (queuedCount > 0 || !activeSessionId || !aborted || !drained)
+        ? resetCommandLane(sessionLane)
+        : 0;
 
     const clearStaleQueuedSession = !aborted && released === 0 && (params.queueDepth ?? 0) > 0;
 


### PR DESCRIPTION
## Summary
- Reset the session command lane when stuck-session recovery finds queued lane work, even if the embedded run aborts and drains successfully.
- Preserve the existing behavior for successful aborts with no queued lane backlog.
- Add regression coverage for the `aborted=true`, `drained=true`, `queuedCount=1` recovery path.

Closes #89208.

## Real behavior proof
- Behavior addressed: queued user messages could remain stuck after recovery aborted a ghost embedded run because the lane was not reset when abort+drain succeeded.
- Real environment tested: focused unit coverage around `recoverStuckDiagnosticSession` with an active embedded run, successful abort/drain, and queued lane work.
- Exact command run: `PNPM_CONFIG_REGISTRY=https://registry.npmjs.org pnpm exec vitest run src/logging/diagnostic-stuck-session-recovery.runtime.test.ts --reporter=dot`.
- Evidence after fix: the regression asserts `resetCommandLane("session:agent:main:main")` is called and the abort outcome reports `released=1` and `queuedCount=1`.
- What was not tested: a live Slack gateway session with real queued messages.

## Tests
- `PNPM_CONFIG_REGISTRY=https://registry.npmjs.org pnpm exec vitest run src/logging/diagnostic-stuck-session-recovery.runtime.test.ts --reporter=dot`
- `pnpm exec oxfmt --check --threads=1 src/logging/diagnostic-stuck-session-recovery.runtime.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`
- `git diff --check -- src/logging/diagnostic-stuck-session-recovery.runtime.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`

## Risk
- User-visible behavior changes only for stuck-session recovery when queued lane work exists after an active run is aborted.
- Config, auth, network, and tool execution behavior are unchanged.
- The highest-risk area is command lane recovery semantics; the change is limited to the existing recovery reset condition and covered by a targeted regression test.